### PR TITLE
fix: security hardening and staleness fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Supabase Postgres
-DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
+# PostgreSQL
+DATABASE_URL=postgresql://user:password@localhost:5432/sandbox
 
 # S3 (checkpoint cold storage)
 AWS_REGION=us-east-1
-S3_BUCKET=agentbox-checkpoints
+S3_BUCKET=your-sandbox-checkpoints-bucket
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
@@ -15,9 +15,9 @@ API_KEY=your-api-key-here
 VMD_GRPC_PORT=50051
 FIRECRACKER_BIN=/usr/local/bin/firecracker
 JAILER_BIN=/usr/local/bin/jailer
-KERNEL_PATH=/var/lib/agentbox/vmlinux
-BASE_ROOTFS_PATH=/var/lib/agentbox/base.ext4
+KERNEL_PATH=/var/lib/sandbox/vmlinux
+BASE_ROOTFS_PATH=/var/lib/sandbox/base.ext4
 
 # Storage
-SNAPSHOT_DIR=/mnt/nvme/agentbox/snapshots
-RUN_DIR=/mnt/nvme/agentbox/rundir
+SNAPSHOT_DIR=/mnt/nvme/sandbox/snapshots
+RUN_DIR=/mnt/nvme/sandbox/rundir

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- Build stage ---
-FROM golang:alpine AS build
+FROM golang:1.25-alpine3.21 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -1,4 +1,4 @@
-// Command controlplane starts the AgentBox control plane API server.
+// Command controlplane starts the Superserve Sandbox control plane API server.
 package main
 
 import (
@@ -12,11 +12,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/superserve-ai/sandbox/db"
 	"github.com/superserve-ai/sandbox/internal/api"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
@@ -39,6 +41,23 @@ func run() error {
 	}
 	log.Info().Str("port", cfg.Port).Str("vmd_address", cfg.VMDAddress).Msg("configuration loaded")
 
+	// Connect to PostgreSQL.
+	ctx := context.Background()
+	dbPool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("connect to database: %w", err)
+	}
+	defer dbPool.Close()
+	if err := dbPool.Ping(ctx); err != nil {
+		return fmt.Errorf("ping database: %w", err)
+	}
+	log.Info().Msg("connected to database")
+
+	// Apply migrations.
+	if err := db.MigrateUp(ctx, dbPool); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+
 	// Connect to VMD via gRPC.
 	grpcConn, err := grpc.NewClient(cfg.VMDAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -52,14 +71,14 @@ func run() error {
 	// Build handlers and router.
 	vmdClient := newGRPCVMDClient(grpcConn)
 	handlers := api.NewHandlers(vmdClient, cfg)
-	router := api.SetupRouter(handlers)
+	router := api.SetupRouter(handlers, dbPool)
 
 	// Start HTTP server.
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,
 		Handler:           router,
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      0,
+		WriteTimeout:      0, // 0 = no timeout; required for streaming exec responses
 		IdleTimeout:       60 * time.Second,
 	}
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/vm"
@@ -139,7 +138,6 @@ func main() {
 		grpc.MaxRecvMsgSize(64<<20), // 64 MiB
 	)
 	vmdpb.RegisterVMDaemonServer(grpcServer, vm.NewGRPCAdapter(mgr))
-	reflection.Register(grpcServer)
 
 	// Serve in a goroutine so we can handle shutdown signals.
 	go func() {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,14 +2,16 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // SetupRouter creates and configures the Gin router with all route groups.
-func SetupRouter(h *Handlers) *gin.Engine {
+func SetupRouter(h *Handlers, pool *pgxpool.Pool) *gin.Engine {
 	r := gin.New()
 	r.Use(RequestLogger(), ErrorHandler())
 
 	api := r.Group("/")
+	api.Use(APIKeyAuth(pool))
 	{
 		api.POST("/instances", h.CreateInstance)
 		api.GET("/instances", h.ListInstances)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,21 +2,28 @@
 package config
 
 import (
+	"fmt"
 	"os"
 )
 
-// Config holds all configuration for the AgentBox control plane.
+// Config holds all configuration for the Superserve Sandbox control plane.
 type Config struct {
-	Port       string // API_PORT, default "8080"
-	VMDAddress string // VMD_GRPC_ADDRESS, default "localhost:50051"
+	Port        string // API_PORT, default "8080"
+	VMDAddress  string // VMD_GRPC_ADDRESS, default "localhost:50051"
+	DatabaseURL string // DATABASE_URL, required
 }
 
 // Load reads configuration from environment variables, applying defaults where
 // appropriate.
 func Load() (*Config, error) {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		return nil, fmt.Errorf("DATABASE_URL is required")
+	}
 	cfg := &Config{
-		Port:       envOrDefault("API_PORT", "8080"),
-		VMDAddress: envOrDefault("VMD_GRPC_ADDRESS", "localhost:50051"),
+		Port:        envOrDefault("API_PORT", "8080"),
+		VMDAddress:  envOrDefault("VMD_GRPC_ADDRESS", "localhost:50051"),
+		DatabaseURL: dbURL,
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary

- Apply `APIKeyAuth` middleware to all API routes — was defined but never wired up, leaving every endpoint unauthenticated
- Reinstate database connection in controlplane: `DATABASE_URL` config, `pgxpool` init, migrations on startup
- Remove gRPC reflection from VMD (was exposing full service schema to any client with network access)
- Pin Dockerfile Go base image (`golang:alpine` → `golang:1.25-alpine3.21`)
- Fix `.env.example`: generic DB URL, remove provider-specific hostname, update paths from `agentbox` → `sandbox`

## What's not in this PR (architectural, needs discussion)

- **mTLS between controlplane ↔ VMD**: currently uses `insecure.NewCredentials()` — requires cert management strategy
- **TLS for controlplane HTTP**: deployment concern, typically handled at load balancer/reverse proxy layer
- **Rate limiting**: needs library choice
- **Salted API key hashing**: switching from SHA256 to bcrypt would be a breaking change for existing keys

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Control plane fails fast on startup if `DATABASE_URL` is unset
- [ ] All API endpoints return 401 without a valid `X-API-Key` header
- [ ] `/health` still returns 200 without auth
- [ ] VMD starts without gRPC reflection enabled