### PR TITLE
test: CI, error/middleware/integration tests, instance handler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: go test -short -count=1 -race ./...
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sandbox_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run integration tests
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/sandbox_test?sslmode=disable
+        run: go test -tags integration -count=1 -race -timeout 10m ./internal/integration/
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build all binaries
+        run: |
+          go build -ldflags "-s -w" -o /dev/null ./cmd/controlplane
+          go build -ldflags "-s -w" -o /dev/null ./cmd/vmd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o /dev/null ./cmd/boxd
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Go vet
+        run: go vet ./...

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -70,6 +70,12 @@ func MigrateUp(ctx context.Context, pool *pgxpool.Pool) error {
 			return fmt.Errorf("read migration %s: %w", name, err)
 		}
 
+		// Strip goose-style Down section so only the Up SQL is executed.
+		sql := string(data)
+		if idx := strings.Index(sql, "-- +goose Down"); idx >= 0 {
+			sql = sql[:idx]
+		}
+
 		log.Info().Str("migration", name).Msg("applying migration")
 
 		tx, err := pool.Begin(ctx)
@@ -77,7 +83,7 @@ func MigrateUp(ctx context.Context, pool *pgxpool.Pool) error {
 			return fmt.Errorf("begin tx for %s: %w", name, err)
 		}
 
-		if _, err := tx.Exec(ctx, string(data)); err != nil {
+		if _, err := tx.Exec(ctx, sql); err != nil {
 			_ = tx.Rollback(ctx)
 			return fmt.Errorf("exec migration %s: %w", name, err)
 		}

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAppError_Error(t *testing.T) {
+	err := &AppError{Code: "test", Message: "test message", HTTPStatus: 400}
+	if err.Error() != "test message" {
+		t.Errorf("expected 'test message', got %q", err.Error())
+	}
+}
+
+func TestNewAppError(t *testing.T) {
+	err := NewAppError("custom", "custom message", 422)
+	if err.Code != "custom" || err.Message != "custom message" || err.HTTPStatus != 422 {
+		t.Errorf("NewAppError fields mismatch: %+v", err)
+	}
+}
+
+func TestRespondError_AppError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	respondError(c, ErrSandboxNotFound)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj := resp["error"].(map[string]interface{})
+	if errObj["code"] != "not_found" {
+		t.Errorf("expected code=not_found, got %v", errObj["code"])
+	}
+}
+
+func TestRespondError_GenericError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	respondError(c, errors.New("something went wrong"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj := resp["error"].(map[string]interface{})
+	if errObj["code"] != "internal_error" {
+		t.Errorf("expected code=internal_error, got %v", errObj["code"])
+	}
+}
+
+func TestRespondErrorMsg(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	respondErrorMsg(c, "validation_error", "field X is required", 422)
+
+	if w.Code != 422 {
+		t.Fatalf("expected 422, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj := resp["error"].(map[string]interface{})
+	if errObj["code"] != "validation_error" {
+		t.Errorf("expected code=validation_error, got %v", errObj["code"])
+	}
+	if errObj["message"] != "field X is required" {
+		t.Errorf("unexpected message: %v", errObj["message"])
+	}
+}
+
+func TestPredefinedErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *AppError
+		wantCode   string
+		wantStatus int
+	}{
+		{"ErrInstanceNotFound", ErrInstanceNotFound, "not_found", 404},
+		{"ErrSandboxNotFound", ErrSandboxNotFound, "not_found", 404},
+		{"ErrInvalidState", ErrInvalidState, "conflict", 409},
+		{"ErrBadRequest", ErrBadRequest, "bad_request", 400},
+		{"ErrUnauthorized", ErrUnauthorized, "unauthorized", 401},
+		{"ErrInternal", ErrInternal, "internal_error", 500},
+		{"ErrConflict", ErrConflict, "conflict", 409},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err.Code != tt.wantCode {
+				t.Errorf("code: got %q, want %q", tt.err.Code, tt.wantCode)
+			}
+			if tt.err.HTTPStatus != tt.wantStatus {
+				t.Errorf("status: got %d, want %d", tt.err.HTTPStatus, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -884,5 +886,546 @@ func TestExecSandbox_MissingTeamID(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Instance handler mock (separate from sandbox stubVMD above)
+// ---------------------------------------------------------------------------
+
+type mockVMD struct {
+	createInstanceFn    func(ctx context.Context, instanceID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (string, error)
+	destroyInstanceFn   func(ctx context.Context, instanceID string, force bool) error
+	pauseInstanceFn     func(ctx context.Context, instanceID, snapshotDir string) (string, string, error)
+	resumeInstanceFn    func(ctx context.Context, instanceID, snapshotPath, memPath string) (string, error)
+	execCommandFn       func(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error)
+	execCommandStreamFn func(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32, onChunk func([]byte, []byte, int32, bool)) error
+	uploadFileFn        func(ctx context.Context, instanceID, path string, content io.Reader) (int64, error)
+	downloadFileFn      func(ctx context.Context, instanceID, path string) (io.ReadCloser, error)
+}
+
+func (m *mockVMD) CreateInstance(ctx context.Context, instanceID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (string, error) {
+	if m.createInstanceFn != nil {
+		return m.createInstanceFn(ctx, instanceID, vcpu, memMiB, diskMiB, metadata)
+	}
+	return "10.0.0.1", nil
+}
+func (m *mockVMD) DestroyInstance(ctx context.Context, instanceID string, force bool) error {
+	if m.destroyInstanceFn != nil {
+		return m.destroyInstanceFn(ctx, instanceID, force)
+	}
+	return nil
+}
+func (m *mockVMD) PauseInstance(ctx context.Context, instanceID, snapshotDir string) (string, string, error) {
+	if m.pauseInstanceFn != nil {
+		return m.pauseInstanceFn(ctx, instanceID, snapshotDir)
+	}
+	return "/snap/path", "/mem/path", nil
+}
+func (m *mockVMD) ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string) (string, error) {
+	if m.resumeInstanceFn != nil {
+		return m.resumeInstanceFn(ctx, instanceID, snapshotPath, memPath)
+	}
+	return "10.0.0.1", nil
+}
+func (m *mockVMD) ExecCommand(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error) {
+	if m.execCommandFn != nil {
+		return m.execCommandFn(ctx, instanceID, command, args, env, workingDir, timeoutS)
+	}
+	return "hello\n", "", 0, nil
+}
+func (m *mockVMD) ExecCommandStream(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32, onChunk func([]byte, []byte, int32, bool)) error {
+	if m.execCommandStreamFn != nil {
+		return m.execCommandStreamFn(ctx, instanceID, command, args, env, workingDir, timeoutS, onChunk)
+	}
+	onChunk([]byte("hello\n"), nil, 0, true)
+	return nil
+}
+func (m *mockVMD) UploadFile(ctx context.Context, instanceID, path string, content io.Reader) (int64, error) {
+	if m.uploadFileFn != nil {
+		return m.uploadFileFn(ctx, instanceID, path, content)
+	}
+	return 42, nil
+}
+func (m *mockVMD) DownloadFile(ctx context.Context, instanceID, path string) (io.ReadCloser, error) {
+	if m.downloadFileFn != nil {
+		return m.downloadFileFn(ctx, instanceID, path)
+	}
+	return io.NopCloser(strings.NewReader("file-content")), nil
+}
+
+func newTestHandlers(vmd VMDClient) *Handlers { return &Handlers{VMD: vmd} }
+
+func jsonBody(v interface{}) *bytes.Buffer { b, _ := json.Marshal(v); return bytes.NewBuffer(b) }
+
+func setupInstanceTestRouter(h *Handlers, teamID string) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if teamID != "" {
+			c.Set("team_id", teamID)
+		}
+		c.Next()
+	})
+	r.GET("/health", h.Health)
+	r.POST("/instances", h.CreateInstance)
+	r.GET("/instances/:instance_id", h.GetInstance)
+	r.GET("/instances", h.ListInstances)
+	r.DELETE("/instances/:instance_id", h.DeleteInstance)
+	r.POST("/instances/:instance_id/pause", h.PauseInstance)
+	r.POST("/instances/:instance_id/resume", h.ResumeInstance)
+	r.POST("/instances/:instance_id/exec", h.ExecCommand)
+	r.POST("/instances/:instance_id/exec/stream", h.ExecCommandStream)
+	r.PUT("/instances/:instance_id/files/*path", h.UploadFile)
+	r.GET("/instances/:instance_id/files/*path", h.DownloadFile)
+	return r
+}
+
+func TestHealth(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), "")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/health", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := parseJSON(t, w)
+	if body["status"] != "ok" {
+		t.Errorf("status=%v want ok", body["status"])
+	}
+}
+
+func TestCreateInstance_Success(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances", jsonBody(map[string]string{"name": "test-box"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateInstance_BadRequest_MissingName(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances", jsonBody(map[string]string{}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateInstance_BadRequest_EmptyBody(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances", nil)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateInstance_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{createInstanceFn: func(_ context.Context, _ string, _, _, _ uint32, _ map[string]string) (string, error) {
+		return "", errors.New("vmd unavailable")
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances", jsonBody(map[string]string{"name": "fail-box"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestDeleteInstance_Success(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/instances/"+uuid.New().String(), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteInstance_InvalidUUID(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/instances/not-a-uuid", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteInstance_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{destroyInstanceFn: func(_ context.Context, _ string, _ bool) error { return errors.New("destroy failed") }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/instances/"+uuid.New().String(), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestPauseInstance_Success(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/pause", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if parseJSON(t, w)["status"] != "PAUSED" {
+		t.Errorf("expected status=PAUSED")
+	}
+}
+
+func TestPauseInstance_InvalidUUID(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/bad/pause", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPauseInstance_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{pauseInstanceFn: func(_ context.Context, _, _ string) (string, string, error) { return "", "", errors.New("pause failed") }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/pause", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestResumeInstance_Success(t *testing.T) {
+	vmd := &mockVMD{resumeInstanceFn: func(_ context.Context, _, _, _ string) (string, error) { return "10.0.0.42", nil }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/resume", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if parseJSON(t, w)["ip_address"] != "10.0.0.42" {
+		t.Errorf("expected ip_address=10.0.0.42")
+	}
+}
+
+func TestResumeInstance_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{resumeInstanceFn: func(_ context.Context, _, _, _ string) (string, error) { return "", errors.New("resume failed") }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/resume", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestExecCommand_Success(t *testing.T) {
+	vmd := &mockVMD{execCommandFn: func(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {
+		return "hello world\n", "", 0, nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec",
+		jsonBody(map[string]interface{}{"command": "echo"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if parseJSON(t, w)["stdout"] != "hello world\n" {
+		t.Errorf("unexpected stdout")
+	}
+}
+
+func TestExecCommand_BadRequest_MissingCommand(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec", jsonBody(map[string]interface{}{}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestExecCommand_DefaultTimeout(t *testing.T) {
+	var capturedTimeout uint32
+	vmd := &mockVMD{execCommandFn: func(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, timeoutS uint32) (string, string, int32, error) {
+		capturedTimeout = timeoutS
+		return "", "", 0, nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec", jsonBody(map[string]interface{}{"command": "ls"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if capturedTimeout != 30 {
+		t.Errorf("expected default timeout=30, got %d", capturedTimeout)
+	}
+}
+
+func TestExecCommand_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{execCommandFn: func(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {
+		return "", "", 0, errors.New("exec failed")
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec", jsonBody(map[string]interface{}{"command": "fail"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestExecCommand_NonZeroExit(t *testing.T) {
+	vmd := &mockVMD{execCommandFn: func(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {
+		return "", "not found\n", 127, nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec", jsonBody(map[string]interface{}{"command": "missing"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if parseJSON(t, w)["exit_code"] != float64(127) {
+		t.Errorf("expected exit_code=127")
+	}
+}
+
+func TestUploadFile_Success(t *testing.T) {
+	vmd := &mockVMD{uploadFileFn: func(_ context.Context, _, _ string, content io.Reader) (int64, error) {
+		data, _ := io.ReadAll(content)
+		return int64(len(data)), nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/instances/"+uuid.New().String()+"/files/home/user/test.txt", strings.NewReader("file content here"))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if parseJSON(t, w)["path"] != "/home/user/test.txt" {
+		t.Errorf("unexpected path")
+	}
+}
+
+func TestUploadFile_PathTraversal(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/instances/"+uuid.New().String()+"/files/../etc/passwd", strings.NewReader("bad"))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUploadFile_VMDFailure(t *testing.T) {
+	vmd := &mockVMD{uploadFileFn: func(_ context.Context, _, _ string, _ io.Reader) (int64, error) { return 0, errors.New("upload failed") }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/instances/"+uuid.New().String()+"/files/test.txt", strings.NewReader("data"))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestDownloadFile_Success(t *testing.T) {
+	vmd := &mockVMD{downloadFileFn: func(_ context.Context, _, _ string) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("downloaded-content")), nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/instances/"+uuid.New().String()+"/files/data.txt", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != "downloaded-content" {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+func TestDownloadFile_NotFound(t *testing.T) {
+	vmd := &mockVMD{downloadFileFn: func(_ context.Context, _, _ string) (io.ReadCloser, error) { return nil, errors.New("404 not found") }}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/instances/"+uuid.New().String()+"/files/missing.txt", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDownloadFile_PathTraversal(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/instances/"+uuid.New().String()+"/files/../../../etc/shadow", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExecCommandStream_Success(t *testing.T) {
+	vmd := &mockVMD{execCommandStreamFn: func(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32, onChunk func([]byte, []byte, int32, bool)) error {
+		onChunk([]byte("line1\n"), nil, 0, false)
+		onChunk(nil, nil, 0, true)
+		return nil
+	}}
+	r := setupInstanceTestRouter(newTestHandlers(vmd), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec/stream", jsonBody(map[string]interface{}{"command": "echo"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected text/event-stream")
+	}
+	if !strings.Contains(w.Body.String(), "line1") {
+		t.Errorf("expected stdout in SSE stream")
+	}
+}
+
+func TestExecCommandStream_BadRequest(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/instances/"+uuid.New().String()+"/exec/stream", jsonBody(map[string]interface{}{}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetInstance_NotImplemented(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/instances/"+uuid.New().String(), nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", w.Code)
+	}
+}
+
+func TestListInstances_NotImplemented(t *testing.T) {
+	r := setupInstanceTestRouter(newTestHandlers(&mockVMD{}), uuid.New().String())
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/instances", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", w.Code)
+	}
+}
+
+func TestCleanFilePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"simple file", "/test.txt", "/test.txt", false},
+		{"nested path", "/home/user/data.csv", "/home/user/data.csv", false},
+		{"strips leading slash", "test.txt", "/test.txt", false},
+		{"empty path", "/", "", true},
+		{"traversal blocked", "/../etc/passwd", "", true},
+		{"double dot in middle", "/foo/../bar", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cleanFilePath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("cleanFilePath(%q): err=%v, wantErr=%v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("cleanFilePath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseInstanceID_Valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "instance_id", Value: uuid.New().String()}}
+	if _, err := parseInstanceID(c); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestParseInstanceID_Invalid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "instance_id", Value: "bad"}}
+	if _, err := parseInstanceID(c); err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+}
+
+func TestParseSandboxID_Valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "sandbox_id", Value: uuid.New().String()}}
+	if _, err := parseSandboxID(c); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestParseSandboxID_Invalid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "sandbox_id", Value: "bad"}}
+	if _, err := parseSandboxID(c); err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+}
+
+func TestTeamIDFromContext_Valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	teamID := uuid.New().String()
+	c.Set("team_id", teamID)
+	got, err := teamIDFromContext(c)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got.String() != teamID {
+		t.Errorf("expected %s, got %s", teamID, got.String())
+	}
+}
+
+func TestTeamIDFromContext_Missing(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	if _, err := teamIDFromContext(c); err == nil {
+		t.Fatal("expected error for missing team_id")
+	}
+}
+
+func TestTeamIDFromContext_InvalidUUID(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("team_id", "not-a-uuid")
+	if _, err := teamIDFromContext(c); err == nil {
+		t.Fatal("expected error for invalid team_id UUID")
 	}
 }

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,179 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ---------------------------------------------------------------------------
+// APIKeyAuth middleware tests
+// ---------------------------------------------------------------------------
+
+// We can't easily mock pgxpool.Pool (it's a concrete type), so we test the
+// auth middleware through the full router using a real test DB in integration
+// tests. Here we test the middleware's observable behavior via HTTP:
+// missing header, empty header, etc.
+
+func newAuthTestRouter(pool *pgxpool.Pool) *gin.Engine {
+	r := gin.New()
+	r.Use(APIKeyAuth(pool))
+	r.GET("/test", func(c *gin.Context) {
+		teamID, _ := c.Get("team_id")
+		c.JSON(http.StatusOK, gin.H{"team_id": teamID})
+	})
+	return r
+}
+
+func TestAPIKeyAuth_MissingHeader(t *testing.T) {
+	// Pass nil pool — middleware should reject before touching DB.
+	r := newAuthTestRouter(nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error object, got %v", resp)
+	}
+	if errObj["code"] != "auth_failed" {
+		t.Errorf("expected code=auth_failed, got %v", errObj["code"])
+	}
+}
+
+func TestAPIKeyAuth_EmptyHeader(t *testing.T) {
+	r := newAuthTestRouter(nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-Key", "")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequestLogger middleware tests
+// ---------------------------------------------------------------------------
+
+func TestRequestLogger_DoesNotBreakResponse(t *testing.T) {
+	r := gin.New()
+	r.Use(RequestLogger())
+	r.GET("/ok", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ok", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequestLogger_LogsQueryParams(t *testing.T) {
+	r := gin.New()
+	r.Use(RequestLogger())
+	r.GET("/search", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"q": c.Query("q")})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/search?q=test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ErrorHandler middleware tests
+// ---------------------------------------------------------------------------
+
+func TestErrorHandler_RecoversPanic(t *testing.T) {
+	r := gin.New()
+	r.Use(ErrorHandler())
+	r.GET("/panic", func(c *gin.Context) {
+		panic("test panic!")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/panic", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, ok := resp["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error object in response")
+	}
+	if errObj["code"] != "internal_error" {
+		t.Errorf("expected code=internal_error, got %v", errObj["code"])
+	}
+}
+
+func TestErrorHandler_PassesThrough(t *testing.T) {
+	r := gin.New()
+	r.Use(ErrorHandler())
+	r.GET("/ok", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/ok", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SHA256 key hashing (unit test for the auth logic)
+// ---------------------------------------------------------------------------
+
+func TestAPIKeyHash(t *testing.T) {
+	apiKey := "sk-test-" + uuid.New().String()
+	hash := sha256.Sum256([]byte(apiKey))
+	keyHash := hex.EncodeToString(hash[:])
+
+	if len(keyHash) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars", len(keyHash))
+	}
+
+	// Same key produces same hash.
+	hash2 := sha256.Sum256([]byte(apiKey))
+	keyHash2 := hex.EncodeToString(hash2[:])
+	if keyHash != keyHash2 {
+		t.Error("same key should produce same hash")
+	}
+
+	// Different key produces different hash.
+	hash3 := sha256.Sum256([]byte("sk-different"))
+	keyHash3 := hex.EncodeToString(hash3[:])
+	if keyHash == keyHash3 {
+		t.Error("different keys should produce different hashes")
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,0 +1,484 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"io"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbmigrate "github.com/superserve-ai/sandbox/db"
+	"github.com/superserve-ai/sandbox/internal/api"
+	"github.com/superserve-ai/sandbox/internal/config"
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+var (
+	testPool    *pgxpool.Pool
+	testQueries *db.Queries
+)
+
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgres://postgres:postgres@localhost:5432/sandbox_test?sslmode=disable"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var err error
+	testPool, err = pgxpool.New(ctx, dbURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot connect to test database: %v\n", err)
+		os.Exit(1)
+	}
+	defer testPool.Close()
+
+	if err := testPool.Ping(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot ping test database: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Run migrations.
+	if err := dbmigrate.MigrateUp(ctx, testPool); err != nil {
+		fmt.Fprintf(os.Stderr, "migration failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	testQueries = db.New(testPool)
+
+	os.Exit(m.Run())
+}
+
+// seedTeamAndKey creates a team and API key, returns (teamID, rawAPIKey).
+func seedTeamAndKey(t *testing.T, ctx context.Context) (uuid.UUID, string) {
+	t.Helper()
+
+	team, err := testQueries.CreateTeam(ctx, "test-team-"+uuid.New().String()[:8])
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	rawKey := "sk-test-" + uuid.New().String()
+	hash := sha256.Sum256([]byte(rawKey))
+	keyHash := hex.EncodeToString(hash[:])
+
+	_, err = testQueries.CreateAPIKeyV2(ctx, db.CreateAPIKeyV2Params{
+		TeamID:  team.ID,
+		KeyHash: keyHash,
+		Name:    "test-key",
+		Scopes:  []string{},
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	return team.ID, rawKey
+}
+
+// stubVMD is a minimal VMDClient for integration tests that does not call a real VMD.
+type stubVMD struct{}
+
+func (s *stubVMD) CreateInstance(ctx context.Context, instanceID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (string, error) {
+	return "10.0.0.1", nil
+}
+func (s *stubVMD) DestroyInstance(ctx context.Context, instanceID string, force bool) error {
+	return nil
+}
+func (s *stubVMD) PauseInstance(ctx context.Context, instanceID, snapshotDir string) (string, string, error) {
+	return "/snap", "/mem", nil
+}
+func (s *stubVMD) ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string) (string, error) {
+	return "10.0.0.1", nil
+}
+func (s *stubVMD) ExecCommand(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error) {
+	return "ok\n", "", 0, nil
+}
+func (s *stubVMD) ExecCommandStream(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32, onChunk func([]byte, []byte, int32, bool)) error {
+	onChunk([]byte("ok\n"), nil, 0, true)
+	return nil
+}
+func (s *stubVMD) UploadFile(ctx context.Context, instanceID, path string, content io.Reader) (int64, error) {
+	return 0, nil
+}
+func (s *stubVMD) DownloadFile(ctx context.Context, instanceID, path string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func setupIntegrationRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	cfg := &config.Config{Port: "0", VMDAddress: "localhost:0"}
+	h := api.NewHandlers(&stubVMD{}, testQueries, cfg)
+	return api.SetupRouter(h, testPool)
+}
+
+func doRequest(r *gin.Engine, method, path, apiKey string, body string) *httptest.ResponseRecorder {
+	var reader *strings.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	var req *http.Request
+	if reader != nil {
+		req, _ = http.NewRequest(method, path, reader)
+	} else {
+		req, _ = http.NewRequest(method, path, nil)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func parseBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &m); err != nil {
+		t.Fatalf("parse JSON: %v\nbody: %s", err, w.Body.String())
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// Auth integration tests
+// ---------------------------------------------------------------------------
+
+func TestIntegration_AuthValidKey(t *testing.T) {
+	ctx := context.Background()
+	_, apiKey := seedTeamAndKey(t, ctx)
+
+	r := setupIntegrationRouter(t)
+	w := doRequest(r, "GET", "/health", "", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("health check failed: %d", w.Code)
+	}
+
+	// Auth-protected endpoint with valid key.
+	w = doRequest(r, "POST", "/instances", apiKey, `{"name":"int-test"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegration_AuthMissingKey(t *testing.T) {
+	r := setupIntegrationRouter(t)
+	w := doRequest(r, "POST", "/instances", "", `{"name":"no-auth"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestIntegration_AuthInvalidKey(t *testing.T) {
+	r := setupIntegrationRouter(t)
+	w := doRequest(r, "POST", "/instances", "sk-fake-does-not-exist", `{"name":"bad-key"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestIntegration_AuthRevokedKey(t *testing.T) {
+	ctx := context.Background()
+	_, apiKey := seedTeamAndKey(t, ctx)
+
+	// Revoke the key.
+	hash := sha256.Sum256([]byte(apiKey))
+	keyHash := hex.EncodeToString(hash[:])
+	keyRecord, err := testQueries.GetAPIKeyByHashV2(ctx, keyHash)
+	if err != nil {
+		t.Fatalf("get key: %v", err)
+	}
+	if err := testQueries.RevokeAPIKeyV2(ctx, keyRecord.ID); err != nil {
+		t.Fatalf("revoke key: %v", err)
+	}
+
+	r := setupIntegrationRouter(t)
+	w := doRequest(r, "POST", "/instances", apiKey, `{"name":"revoked"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for revoked key, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox lifecycle: create → delete
+// ---------------------------------------------------------------------------
+
+func TestIntegration_SandboxLifecycle(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t, ctx)
+
+	r := setupIntegrationRouter(t)
+
+	// Create a sandbox in DB.
+	sandbox, err := testQueries.CreateSandbox(ctx, db.CreateSandboxParams{
+		TeamID:    teamID,
+		Name:      "lifecycle-test",
+		Status:    db.SandboxStatusActive,
+		VcpuCount: 1,
+		MemoryMib: 512,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	// Delete it via API.
+	w := doRequest(r, "DELETE", "/sandboxes/"+sandbox.ID.String(), apiKey, "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify soft-deleted.
+	_, err = testQueries.GetSandbox(ctx, db.GetSandboxParams{
+		ID:     sandbox.ID,
+		TeamID: teamID,
+	})
+	if err == nil {
+		t.Fatal("expected sandbox to be soft-deleted (not found)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Team isolation
+// ---------------------------------------------------------------------------
+
+func TestIntegration_TeamIsolation(t *testing.T) {
+	ctx := context.Background()
+	teamA, apiKeyA := seedTeamAndKey(t, ctx)
+	_, _ = seedTeamAndKey(t, ctx) // teamB (unused key)
+
+	r := setupIntegrationRouter(t)
+
+	// Create sandbox owned by teamA.
+	sandbox, err := testQueries.CreateSandbox(ctx, db.CreateSandboxParams{
+		TeamID:    teamA,
+		Name:      "team-a-box",
+		Status:    db.SandboxStatusActive,
+		VcpuCount: 1,
+		MemoryMib: 256,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	// TeamB's key trying to delete teamA's sandbox.
+	_, apiKeyB := seedTeamAndKey(t, ctx)
+	w := doRequest(r, "DELETE", "/sandboxes/"+sandbox.ID.String(), apiKeyB, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (team isolation), got %d: %s", w.Code, w.Body.String())
+	}
+
+	// TeamA's key works.
+	w = doRequest(r, "DELETE", "/sandboxes/"+sandbox.ID.String(), apiKeyA, "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Activity logging
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ActivityLogOnDelete(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t, ctx)
+
+	r := setupIntegrationRouter(t)
+
+	sandbox, err := testQueries.CreateSandbox(ctx, db.CreateSandboxParams{
+		TeamID:    teamID,
+		Name:      "activity-test",
+		Status:    db.SandboxStatusActive,
+		VcpuCount: 1,
+		MemoryMib: 256,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	w := doRequest(r, "DELETE", "/sandboxes/"+sandbox.ID.String(), apiKey, "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	// Check activity was logged.
+	activities, err := testQueries.ListActivityBySandbox(ctx, db.ListActivityBySandboxParams{
+		SandboxID: sandbox.ID,
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("list activities: %v", err)
+	}
+	if len(activities) == 0 {
+		t.Fatal("expected at least one activity record after delete")
+	}
+
+	found := false
+	for _, a := range activities {
+		if a.Action == "deleted" && a.Category == "sandbox" {
+			found = true
+			if a.Status == nil || *a.Status != "success" {
+				t.Errorf("expected status=success, got %v", a.Status)
+			}
+			if a.SandboxName == nil || *a.SandboxName != "activity-test" {
+				t.Errorf("expected sandbox_name=activity-test, got %v", a.SandboxName)
+			}
+		}
+	}
+	if !found {
+		t.Error("did not find 'deleted' activity record")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete non-existent sandbox
+// ---------------------------------------------------------------------------
+
+func TestIntegration_DeleteNonExistentSandbox(t *testing.T) {
+	ctx := context.Background()
+	_, apiKey := seedTeamAndKey(t, ctx)
+
+	r := setupIntegrationRouter(t)
+	w := doRequest(r, "DELETE", "/sandboxes/"+uuid.New().String(), apiKey, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot visibility
+// ---------------------------------------------------------------------------
+
+func TestIntegration_SnapshotSavedFlag(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t, ctx)
+
+	// Create a sandbox to reference.
+	sandbox, err := testQueries.CreateSandbox(ctx, db.CreateSandboxParams{
+		TeamID:    teamID,
+		Name:      "snap-test",
+		Status:    db.SandboxStatusActive,
+		VcpuCount: 1,
+		MemoryMib: 256,
+	})
+	if err != nil {
+		t.Fatalf("create sandbox: %v", err)
+	}
+
+	// Auto-snapshot (saved=false).
+	autoSnap, err := testQueries.CreateSnapshot(ctx, db.CreateSnapshotParams{
+		SandboxID: sandbox.ID,
+		TeamID:    teamID,
+		Path:      "/snap/auto",
+		SizeBytes: 1024,
+		Saved:     false,
+		Trigger:   "auto-pause",
+	})
+	if err != nil {
+		t.Fatalf("create auto snapshot: %v", err)
+	}
+
+	// Manual snapshot (saved=true).
+	manualSnap, err := testQueries.CreateSnapshot(ctx, db.CreateSnapshotParams{
+		SandboxID: sandbox.ID,
+		TeamID:    teamID,
+		Path:      "/snap/manual",
+		SizeBytes: 2048,
+		Saved:     true,
+		Trigger:   "user",
+	})
+	if err != nil {
+		t.Fatalf("create manual snapshot: %v", err)
+	}
+
+	// Verify auto-snapshot is not saved.
+	got, err := testQueries.GetSnapshot(ctx, autoSnap.ID)
+	if err != nil {
+		t.Fatalf("get auto snapshot: %v", err)
+	}
+	if got.Saved {
+		t.Error("auto-snapshot should not be saved")
+	}
+
+	// Verify manual snapshot is saved.
+	got, err = testQueries.GetSnapshot(ctx, manualSnap.ID)
+	if err != nil {
+		t.Fatalf("get manual snapshot: %v", err)
+	}
+	if !got.Saved {
+		t.Error("manual snapshot should be saved")
+	}
+
+	// Mark auto snapshot as saved.
+	if err := testQueries.MarkSnapshotSaved(ctx, autoSnap.ID); err != nil {
+		t.Fatalf("mark saved: %v", err)
+	}
+	got, err = testQueries.GetSnapshot(ctx, autoSnap.ID)
+	if err != nil {
+		t.Fatalf("get updated snapshot: %v", err)
+	}
+	if !got.Saved {
+		t.Error("snapshot should now be saved after MarkSnapshotSaved")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent sandbox creation
+// ---------------------------------------------------------------------------
+
+func TestIntegration_ConcurrentSandboxCreation(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t, ctx)
+
+	const n = 10
+	errs := make(chan error, n)
+
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			_, err := testQueries.CreateSandbox(ctx, db.CreateSandboxParams{
+				TeamID:    teamID,
+				Name:      fmt.Sprintf("concurrent-%d", i),
+				Status:    db.SandboxStatusStarting,
+				VcpuCount: 1,
+				MemoryMib: 256,
+			})
+			errs <- err
+		}(i)
+	}
+
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent create %d: %v", i, err)
+		}
+	}
+
+	// All 10 should be listed.
+	sandboxes, err := testQueries.ListSandboxesByTeam(ctx, teamID)
+	if err != nil {
+		t.Fatalf("list sandboxes: %v", err)
+	}
+	if len(sandboxes) < n {
+		t.Errorf("expected at least %d sandboxes, got %d", n, len(sandboxes))
+	}
+}

--- a/proto/boxdpb/boxd.pb.go
+++ b/proto/boxdpb/boxd.pb.go
@@ -1345,28 +1345,28 @@ var File_proto_boxd_proto protoreflect.FileDescriptor
 
 const file_proto_boxd_proto_rawDesc = "" +
 	"\n" +
-	"\x10proto/boxd.proto\x12\x10superserve.boxd.v1\"\x8b\x02\n" +
+	"\x10proto/boxd.proto\x12\x12superserve.boxd.v1\"\x8f\x02\n" +
 	"\fStartRequest\x12\x10\n" +
 	"\x03cmd\x18\x01 \x01(\tR\x03cmd\x12\x12\n" +
-	"\x04args\x18\x02 \x03(\tR\x04args\x12<\n" +
-	"\x04envs\x18\x03 \x03(\v2(.superserve.boxd.v1.StartRequest.EnvsEntryR\x04envs\x12\x10\n" +
-	"\x03cwd\x18\x04 \x01(\tR\x03cwd\x12-\n" +
-	"\x03pty\x18\x05 \x01(\v2\x1b.superserve.boxd.v1.PtyConfigR\x03pty\x12\x1d\n" +
+	"\x04args\x18\x02 \x03(\tR\x04args\x12>\n" +
+	"\x04envs\x18\x03 \x03(\v2*.superserve.boxd.v1.StartRequest.EnvsEntryR\x04envs\x12\x10\n" +
+	"\x03cwd\x18\x04 \x01(\tR\x03cwd\x12/\n" +
+	"\x03pty\x18\x05 \x01(\v2\x1d.superserve.boxd.v1.PtyConfigR\x03pty\x12\x1d\n" +
 	"\n" +
 	"timeout_ms\x18\x06 \x01(\rR\ttimeoutMs\x1a7\n" +
 	"\tEnvsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"?\n" +
-	"\tPtyConfig\x122\n" +
-	"\x04size\x18\x01 \x01(\v2\x1e.superserve.boxd.v1.TerminalSizeR\x04size\"6\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"A\n" +
+	"\tPtyConfig\x124\n" +
+	"\x04size\x18\x01 \x01(\v2 .superserve.boxd.v1.TerminalSizeR\x04size\"6\n" +
 	"\fTerminalSize\x12\x12\n" +
 	"\x04cols\x18\x01 \x01(\rR\x04cols\x12\x12\n" +
-	"\x04rows\x18\x02 \x01(\rR\x04rows\"\xed\x01\n" +
-	"\fProcessEvent\x124\n" +
-	"\x05start\x18\x01 \x01(\v2\x1c.superserve.boxd.v1.StartEventH\x00R\x05start\x121\n" +
-	"\x04data\x18\x02 \x01(\v2\x1b.superserve.boxd.v1.DataEventH\x00R\x04data\x12.\n" +
-	"\x03end\x18\x03 \x01(\v2\x1a.superserve.boxd.v1.EndEventH\x00R\x03end\x12;\n" +
-	"\tkeepalive\x18\x04 \x01(\v2\x1b.superserve.boxd.v1.KeepAliveH\x00R\tkeepaliveB\a\n" +
+	"\x04rows\x18\x02 \x01(\rR\x04rows\"\xf5\x01\n" +
+	"\fProcessEvent\x126\n" +
+	"\x05start\x18\x01 \x01(\v2\x1e.superserve.boxd.v1.StartEventH\x00R\x05start\x123\n" +
+	"\x04data\x18\x02 \x01(\v2\x1d.superserve.boxd.v1.DataEventH\x00R\x04data\x120\n" +
+	"\x03end\x18\x03 \x01(\v2\x1c.superserve.boxd.v1.EndEventH\x00R\x03end\x12=\n" +
+	"\tkeepalive\x18\x04 \x01(\v2\x1d.superserve.boxd.v1.KeepAliveH\x00R\tkeepaliveB\a\n" +
 	"\x05event\"\x1e\n" +
 	"\n" +
 	"StartEvent\x12\x10\n" +
@@ -1385,10 +1385,10 @@ const file_proto_boxd_proto_rawDesc = "" +
 	"\x10SendInputRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\rR\x03pid\x12\x12\n" +
 	"\x04data\x18\x02 \x01(\fR\x04data\"\x13\n" +
-	"\x11SendInputResponse\"U\n" +
+	"\x11SendInputResponse\"W\n" +
 	"\rResizeRequest\x12\x10\n" +
-	"\x03pid\x18\x01 \x01(\rR\x03pid\x122\n" +
-	"\x04size\x18\x02 \x01(\v2\x1e.superserve.boxd.v1.TerminalSizeR\x04size\"\x10\n" +
+	"\x03pid\x18\x01 \x01(\rR\x03pid\x124\n" +
+	"\x04size\x18\x02 \x01(\v2 .superserve.boxd.v1.TerminalSizeR\x04size\"\x10\n" +
 	"\x0eResizeResponse\"9\n" +
 	"\rSignalRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\rR\x03pid\x12\x16\n" +
@@ -1403,9 +1403,9 @@ const file_proto_boxd_proto_rawDesc = "" +
 	"\x04mode\x18\x04 \x01(\tR\x04mode\x12#\n" +
 	"\rmodified_unix\x18\x05 \x01(\x03R\fmodifiedUnix\"$\n" +
 	"\x0eListDirRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\"H\n" +
-	"\x0fListDirResponse\x125\n" +
-	"\aentries\x18\x01 \x03(\v2\x1b.superserve.boxd.v1.FileEntryR\aentries\"J\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\"J\n" +
+	"\x0fListDirResponse\x127\n" +
+	"\aentries\x18\x01 \x03(\v2\x1d.superserve.boxd.v1.FileEntryR\aentries\"J\n" +
 	"\tFileEntry\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x15\n" +
 	"\x06is_dir\x18\x02 \x01(\bR\x05isDir\x12\x12\n" +
@@ -1419,18 +1419,18 @@ const file_proto_boxd_proto_rawDesc = "" +
 	"\vMoveRequest\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12 \n" +
 	"\vdestination\x18\x02 \x01(\tR\vdestination\"\x0e\n" +
-	"\fMoveResponse2\xcb\x02\n" +
-	"\x0eProcessService\x12I\n" +
-	"\x05Start\x12\x1e.superserve.boxd.v1.StartRequest\x1a\x1e.superserve.boxd.v1.ProcessEvent0\x01\x12T\n" +
-	"\tSendInput\x12\".superserve.boxd.v1.SendInputRequest\x1a#.superserve.boxd.v1.SendInputResponse\x12K\n" +
-	"\x06Resize\x12\x1f.superserve.boxd.v1.ResizeRequest\x1a .superserve.boxd.v1.ResizeResponse\x12K\n" +
-	"\x06Signal\x12\x1f.superserve.boxd.v1.SignalRequest\x1a .superserve.boxd.v1.SignalResponse2\x8e\x03\n" +
-	"\x11FilesystemService\x12E\n" +
-	"\x04Stat\x12\x1d.superserve.boxd.v1.StatRequest\x1a\x1e.superserve.boxd.v1.StatResponse\x12N\n" +
-	"\aListDir\x12 .superserve.boxd.v1.ListDirRequest\x1a!.superserve.boxd.v1.ListDirResponse\x12N\n" +
-	"\aMakeDir\x12 .superserve.boxd.v1.MakeDirRequest\x1a!.superserve.boxd.v1.MakeDirResponse\x12K\n" +
-	"\x06Remove\x12\x1f.superserve.boxd.v1.RemoveRequest\x1a .superserve.boxd.v1.RemoveResponse\x12E\n" +
-	"\x04Move\x12\x1d.superserve.boxd.v1.MoveRequest\x1a\x1e.superserve.boxd.v1.MoveResponseB0Z.github.com/superserve-ai/sandbox/proto/boxdpbb\x06proto3"
+	"\fMoveResponse2\xdb\x02\n" +
+	"\x0eProcessService\x12M\n" +
+	"\x05Start\x12 .superserve.boxd.v1.StartRequest\x1a .superserve.boxd.v1.ProcessEvent0\x01\x12X\n" +
+	"\tSendInput\x12$.superserve.boxd.v1.SendInputRequest\x1a%.superserve.boxd.v1.SendInputResponse\x12O\n" +
+	"\x06Resize\x12!.superserve.boxd.v1.ResizeRequest\x1a\".superserve.boxd.v1.ResizeResponse\x12O\n" +
+	"\x06Signal\x12!.superserve.boxd.v1.SignalRequest\x1a\".superserve.boxd.v1.SignalResponse2\xa2\x03\n" +
+	"\x11FilesystemService\x12I\n" +
+	"\x04Stat\x12\x1f.superserve.boxd.v1.StatRequest\x1a .superserve.boxd.v1.StatResponse\x12R\n" +
+	"\aListDir\x12\".superserve.boxd.v1.ListDirRequest\x1a#.superserve.boxd.v1.ListDirResponse\x12R\n" +
+	"\aMakeDir\x12\".superserve.boxd.v1.MakeDirRequest\x1a#.superserve.boxd.v1.MakeDirResponse\x12O\n" +
+	"\x06Remove\x12!.superserve.boxd.v1.RemoveRequest\x1a\".superserve.boxd.v1.RemoveResponse\x12I\n" +
+	"\x04Move\x12\x1f.superserve.boxd.v1.MoveRequest\x1a .superserve.boxd.v1.MoveResponseB/Z-github.com/superserve-ai/sandbox/proto/boxdpbb\x06proto3"
 
 var (
 	file_proto_boxd_proto_rawDescOnce sync.Once

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -1635,7 +1635,7 @@ var File_proto_vmd_proto protoreflect.FileDescriptor
 
 const file_proto_vmd_proto_rawDesc = "" +
 	"\n" +
-	"\x0fproto/vmd.proto\x12\x0fsuperserve.vmd.v1\"\xa8\x01\n" +
+	"\x0fproto/vmd.proto\x12\x11superserve.vmd.v1\"\xa8\x01\n" +
 	"\x0eResourceLimits\x12\x1d\n" +
 	"\n" +
 	"vcpu_count\x18\x01 \x01(\rR\tvcpuCount\x12\x1d\n" +
@@ -1650,17 +1650,17 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\n" +
 	"gateway_ip\x18\x03 \x01(\tR\tgatewayIp\x12\x1d\n" +
 	"\n" +
-	"enable_nat\x18\x04 \x01(\bR\tenableNat\"\xac\x03\n" +
+	"enable_nat\x18\x04 \x01(\bR\tenableNat\"\xb2\x03\n" +
 	"\x0fCreateVMRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12(\n" +
 	"\x10base_rootfs_path\x18\x02 \x01(\tR\x0ebaseRootfsPath\x12\x1f\n" +
 	"\vkernel_path\x18\x03 \x01(\tR\n" +
 	"kernelPath\x12\x1f\n" +
 	"\vkernel_args\x18\x04 \x01(\tR\n" +
-	"kernelArgs\x12H\n" +
-	"\x0fresource_limits\x18\x05 \x01(\v2\x1f.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12E\n" +
-	"\x0enetwork_config\x18\x06 \x01(\v2\x1e.superserve.vmd.v1.NetworkConfigR\rnetworkConfig\x12J\n" +
-	"\bmetadata\x18\a \x03(\v2..superserve.vmd.v1.CreateVMRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"kernelArgs\x12J\n" +
+	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12G\n" +
+	"\x0enetwork_config\x18\x06 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\x12L\n" +
+	"\bmetadata\x18\a \x03(\v20.superserve.vmd.v1.CreateVMRequest.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x98\x01\n" +
@@ -1705,26 +1705,26 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12&\n" +
-	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xaa\x02\n" +
+	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xae\x02\n" +
 	"\x16RestoreSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12!\n" +
-	"\foverlay_path\x18\x04 \x01(\tR\voverlayPath\x12H\n" +
-	"\x0fresource_limits\x18\x05 \x01(\v2\x1f.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12E\n" +
-	"\x0enetwork_config\x18\x06 \x01(\v2\x1e.superserve.vmd.v1.NetworkConfigR\rnetworkConfig\"\x80\x01\n" +
+	"\foverlay_path\x18\x04 \x01(\tR\voverlayPath\x12J\n" +
+	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12G\n" +
+	"\x0enetwork_config\x18\x06 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\"\x80\x01\n" +
 	"\x17RestoreSnapshotResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vsocket_path\x18\x02 \x01(\tR\n" +
 	"socketPath\x12\x1d\n" +
 	"\n" +
 	"ip_address\x18\x03 \x01(\tR\tipAddress\x12\x10\n" +
-	"\x03pid\x18\x04 \x01(\rR\x03pid\"\x99\x02\n" +
+	"\x03pid\x18\x04 \x01(\rR\x03pid\"\x9b\x02\n" +
 	"\x12ExecCommandRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x18\n" +
 	"\acommand\x18\x02 \x01(\tR\acommand\x12\x12\n" +
-	"\x04args\x18\x03 \x03(\tR\x04args\x12>\n" +
-	"\x03env\x18\x04 \x03(\v2,.superserve.vmd.v1.ExecCommandRequest.EnvEntryR\x03env\x12\x1f\n" +
+	"\x04args\x18\x03 \x03(\tR\x04args\x12@\n" +
+	"\x03env\x18\x04 \x03(\v2..superserve.vmd.v1.ExecCommandRequest.EnvEntryR\x03env\x12\x1f\n" +
 	"\vworking_dir\x18\x05 \x01(\tR\n" +
 	"workingDir\x12'\n" +
 	"\x0ftimeout_seconds\x18\x06 \x01(\rR\x0etimeoutSeconds\x1a6\n" +
@@ -1737,25 +1737,25 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\texit_code\x18\x03 \x01(\x05R\bexitCode\x12\x1a\n" +
 	"\bfinished\x18\x04 \x01(\bR\bfinished\"'\n" +
 	"\x10GetVMInfoRequest\x12\x13\n" +
-	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\"\xd1\x03\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\"\xd7\x03\n" +
 	"\x11GetVMInfoResponse\x12\x13\n" +
-	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x121\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x19.superserve.vmd.v1.VMStatusR\x06status\x12\x1f\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x123\n" +
+	"\x06status\x18\x02 \x01(\x0e2\x1b.superserve.vmd.v1.VMStatusR\x06status\x12\x1f\n" +
 	"\vsocket_path\x18\x03 \x01(\tR\n" +
 	"socketPath\x12\x1d\n" +
 	"\n" +
 	"ip_address\x18\x04 \x01(\tR\tipAddress\x12\x10\n" +
-	"\x03pid\x18\x05 \x01(\rR\x03pid\x12H\n" +
-	"\x0fresource_limits\x18\x06 \x01(\v2\x1f.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12L\n" +
-	"\bmetadata\x18\a \x03(\v20.superserve.vmd.v1.GetVMInfoResponse.MetadataEntryR\bmetadata\x12&\n" +
+	"\x03pid\x18\x05 \x01(\rR\x03pid\x12J\n" +
+	"\x0fresource_limits\x18\x06 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12N\n" +
+	"\bmetadata\x18\a \x03(\v22.superserve.vmd.v1.GetVMInfoResponse.MetadataEntryR\bmetadata\x12&\n" +
 	"\x0fcreated_at_unix\x18\b \x01(\x03R\rcreatedAtUnix\x12%\n" +
 	"\x0euptime_seconds\x18\t \x01(\x03R\ruptimeSeconds\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"q\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"s\n" +
 	"\x13SetupNetworkRequest\x12\x13\n" +
-	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12E\n" +
-	"\x0enetwork_config\x18\x02 \x01(\v2\x1e.superserve.vmd.v1.NetworkConfigR\rnetworkConfig\"\x9f\x01\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12G\n" +
+	"\x0enetwork_config\x18\x02 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\"\x9f\x01\n" +
 	"\x14SetupNetworkResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1d\n" +
 	"\n" +
@@ -1782,20 +1782,20 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x11VM_STATUS_RUNNING\x10\x02\x12\x14\n" +
 	"\x10VM_STATUS_PAUSED\x10\x03\x12\x15\n" +
 	"\x11VM_STATUS_STOPPED\x10\x04\x12\x13\n" +
-	"\x0fVM_STATUS_ERROR\x10\x052\xd9\a\n" +
-	"\bVMDaemon\x12O\n" +
-	"\bCreateVM\x12 .superserve.vmd.v1.CreateVMRequest\x1a!.superserve.vmd.v1.CreateVMResponse\x12R\n" +
-	"\tDestroyVM\x12!.superserve.vmd.v1.DestroyVMRequest\x1a\".superserve.vmd.v1.DestroyVMResponse\x12L\n" +
-	"\aPauseVM\x12\x1f.superserve.vmd.v1.PauseVMRequest\x1a .superserve.vmd.v1.PauseVMResponse\x12O\n" +
-	"\bResumeVM\x12 .superserve.vmd.v1.ResumeVMRequest\x1a!.superserve.vmd.v1.ResumeVMResponse\x12a\n" +
-	"\x0eCreateSnapshot\x12&.superserve.vmd.v1.CreateSnapshotRequest\x1a'.superserve.vmd.v1.CreateSnapshotResponse\x12d\n" +
-	"\x0fRestoreSnapshot\x12'.superserve.vmd.v1.RestoreSnapshotRequest\x1a(.superserve.vmd.v1.RestoreSnapshotResponse\x12Z\n" +
-	"\vExecCommand\x12#.superserve.vmd.v1.ExecCommandRequest\x1a$.superserve.vmd.v1.ExecCommandResponse0\x01\x12R\n" +
-	"\tGetVMInfo\x12!.superserve.vmd.v1.GetVMInfoRequest\x1a\".superserve.vmd.v1.GetVMInfoResponse\x12[\n" +
-	"\fSetupNetwork\x12$.superserve.vmd.v1.SetupNetworkRequest\x1a%.superserve.vmd.v1.SetupNetworkResponse\x12W\n" +
+	"\x0fVM_STATUS_ERROR\x10\x052\x85\b\n" +
+	"\bVMDaemon\x12S\n" +
+	"\bCreateVM\x12\".superserve.vmd.v1.CreateVMRequest\x1a#.superserve.vmd.v1.CreateVMResponse\x12V\n" +
+	"\tDestroyVM\x12#.superserve.vmd.v1.DestroyVMRequest\x1a$.superserve.vmd.v1.DestroyVMResponse\x12P\n" +
+	"\aPauseVM\x12!.superserve.vmd.v1.PauseVMRequest\x1a\".superserve.vmd.v1.PauseVMResponse\x12S\n" +
+	"\bResumeVM\x12\".superserve.vmd.v1.ResumeVMRequest\x1a#.superserve.vmd.v1.ResumeVMResponse\x12e\n" +
+	"\x0eCreateSnapshot\x12(.superserve.vmd.v1.CreateSnapshotRequest\x1a).superserve.vmd.v1.CreateSnapshotResponse\x12h\n" +
+	"\x0fRestoreSnapshot\x12).superserve.vmd.v1.RestoreSnapshotRequest\x1a*.superserve.vmd.v1.RestoreSnapshotResponse\x12^\n" +
+	"\vExecCommand\x12%.superserve.vmd.v1.ExecCommandRequest\x1a&.superserve.vmd.v1.ExecCommandResponse0\x01\x12V\n" +
+	"\tGetVMInfo\x12#.superserve.vmd.v1.GetVMInfoRequest\x1a$.superserve.vmd.v1.GetVMInfoResponse\x12_\n" +
+	"\fSetupNetwork\x12&.superserve.vmd.v1.SetupNetworkRequest\x1a'.superserve.vmd.v1.SetupNetworkResponse\x12[\n" +
 	"\n" +
-	"UploadFile\x12\".superserve.vmd.v1.UploadFileRequest\x1a#.superserve.vmd.v1.UploadFileResponse(\x01\x12Z\n" +
-	"\fDownloadFile\x12$.superserve.vmd.v1.DownloadFileRequest\x1a\".superserve.vmd.v1.DownloadFileChunk0\x01B/Z-github.com/superserve-ai/sandbox/proto/vmdpbb\x06proto3"
+	"UploadFile\x12$.superserve.vmd.v1.UploadFileRequest\x1a%.superserve.vmd.v1.UploadFileResponse(\x01\x12^\n" +
+	"\fDownloadFile\x12&.superserve.vmd.v1.DownloadFileRequest\x1a$.superserve.vmd.v1.DownloadFileChunk0\x01B.Z,github.com/superserve-ai/sandbox/proto/vmdpbb\x06proto3"
 
 var (
 	file_proto_vmd_proto_rawDescOnce sync.Once


### PR DESCRIPTION
## Summary
- **CI** (`.github/workflows/ci.yml`): unit tests with `-race`, integration tests against Postgres 16 service container, build check, go vet
- **Error tests** (`errors_test.go`): all `AppError` sentinels, `respondError`, `respondErrorMsg`
- **Middleware tests** (`middleware_test.go`): `APIKeyAuth` (missing/empty/invalid/revoked key, SHA-256 hashing), `RequestLogger`, `ErrorHandler` panic recovery
- **Instance handler tests** (appended to `handlers_test.go`): Health, CreateInstance, DeleteInstance, PauseInstance, ResumeInstance, ExecCommand (success/bad-request/default-timeout/vmd-failure/non-zero-exit), UploadFile, DownloadFile, ExecCommandStream, 501 stubs — plus `cleanFilePath`, `parseInstanceID`, `parseSandboxID`, `teamIDFromContext` helper tests
- **Integration tests** (`integration_test.go`): real Postgres auth (valid/missing/invalid/revoked key), sandbox lifecycle, team isolation, activity logging, concurrent creates (10 goroutines)

Rebased onto current main — no conflict with PR #12 (sandbox CRUD tests live there).

## Test plan
- [x] All unit tests pass locally (`go test ./internal/api/` — all PASS)
- [x] Build clean (`go build ./...`)
- [ ] Integration tests run via CI on PR (requires Postgres service container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)