### PR TITLE
feat: CD — run DB migrations on staging then prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,51 @@
+name: CD — Migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'db/migrations/**'
+      - 'db/migrate.go'
+      - 'cmd/migrate/**'
+
+jobs:
+  migrate-staging:
+    name: Migrate Staging
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build migrate binary
+        run: go build -o migrate ./cmd/migrate
+
+      - name: Run migrations (staging)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
+        run: ./migrate
+
+  migrate-prod:
+    name: Migrate Production
+    runs-on: ubuntu-latest
+    environment: production
+    needs: migrate-staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build migrate binary
+        run: go build -o migrate ./cmd/migrate
+
+      - name: Run migrations (production)
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: ./migrate

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,46 @@
+// Command migrate applies pending SQL migrations to the target database.
+// DATABASE_URL must be set in the environment.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/db"
+)
+
+func main() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
+		With().Timestamp().Logger()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Fatal().Msg("DATABASE_URL is required")
+	}
+
+	ctx := context.Background()
+
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to connect to database")
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		log.Fatal().Err(err).Msg("failed to ping database")
+	}
+
+	log.Info().Msg("running migrations")
+	if err := db.MigrateUp(ctx, pool); err != nil {
+		log.Fatal().Err(err).Msg("migration failed")
+	}
+
+	fmt.Println("migrations complete")
+}


### PR DESCRIPTION
## Summary
- **`cmd/migrate`** — thin binary that reads `DATABASE_URL` and runs `db.MigrateUp`
- **`.github/workflows/cd.yml`** — triggers on push to main when migration files change; runs staging first, prod only on staging success

## Setup required
Add these secrets to GitHub Environments:
- **`staging`** environment → `DATABASE_URL_STAGING` (Supabase staging connection string)
- **`production`** environment → `DATABASE_URL_PROD` (Supabase prod connection string)

## Flow
```
push to main (migrations changed)
  → migrate-staging  (DATABASE_URL_STAGING)
      ↓ success only
  → migrate-prod     (DATABASE_URL_PROD)
```

Production migrations only run if staging succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)