### PR TITLE
feat: CD workflows for API and VMD deploy

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -27,13 +27,10 @@ jobs:
   deploy-staging:
     if: github.event.inputs.environment != 'production'
     runs-on: ubuntu-latest
+    environment: staging
     permissions:
       contents: read
       id-token: write
-    env:
-      REGION: us-central1
-      PROJECT: rayai-dev
-      SERVICE: superserve-api
     steps:
       - uses: actions/checkout@v4
 
@@ -47,39 +44,35 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Configure Docker
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push
         run: |
-          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane"
+          IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane"
           docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
           docker push ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
       - name: Deploy to Cloud Run
         run: |
-          gcloud run services update ${{ env.SERVICE }} \
-            --image ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ env.REGION }} \
-            --project ${{ env.PROJECT }}
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
+            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ vars.GCP_REGION }} \
+            --project ${{ vars.GCP_PROJECT }}
 
       - name: Verify
         run: |
-          URL=$(gcloud run services describe ${{ env.SERVICE }} --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format 'value(status.url)')
-          echo "Staging: $URL"
+          URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} --region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }} --format 'value(status.url)')
           curl -sf "$URL/health"
 
   deploy-production:
     if: github.event.inputs.environment != 'staging'
     needs: [deploy-staging]
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
       id-token: write
-    env:
-      REGION: us-central1
-      PROJECT: rayai-prod
-      SERVICE: superserve-api
     steps:
       - uses: actions/checkout@v4
 
@@ -93,24 +86,23 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Configure Docker
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push
         run: |
-          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane"
+          IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane"
           docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
           docker push ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
       - name: Deploy to Cloud Run
         run: |
-          gcloud run services update ${{ env.SERVICE }} \
-            --image ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ env.REGION }} \
-            --project ${{ env.PROJECT }}
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
+            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ vars.GCP_REGION }} \
+            --project ${{ vars.GCP_PROJECT }}
 
       - name: Verify
         run: |
-          URL=$(gcloud run services describe ${{ env.SERVICE }} --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format 'value(status.url)')
-          echo "Production: $URL"
+          URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} --region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }} --format 'value(status.url)')
           curl -sf "$URL/health"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,116 @@
+name: Deploy API
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy to a specific environment only'
+        required: false
+        type: choice
+        options:
+          - both
+          - staging
+          - production
+
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/controlplane/**'
+      - 'internal/api/**'
+      - 'internal/config/**'
+      - 'proto/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+
+jobs:
+  deploy-staging:
+    if: github.event.inputs.environment != 'production'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGION: us-central1
+      PROJECT: rayai-dev
+      SERVICE: superserve-api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push
+        run: |
+          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane"
+          docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
+          docker push ${IMAGE}:latest
+          docker push ${IMAGE}:${{ github.sha }}
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run services update ${{ env.SERVICE }} \
+            --image ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT }}
+
+      - name: Verify
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE }} --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format 'value(status.url)')
+          echo "Staging: $URL"
+          curl -sf "$URL/health"
+
+  deploy-production:
+    if: github.event.inputs.environment != 'staging'
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGION: us-central1
+      PROJECT: rayai-prod
+      SERVICE: superserve-api
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push
+        run: |
+          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane"
+          docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
+          docker push ${IMAGE}:latest
+          docker push ${IMAGE}:${{ github.sha }}
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run services update ${{ env.SERVICE }} \
+            --image ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT }}
+
+      - name: Verify
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE }} --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format 'value(status.url)')
+          echo "Production: $URL"
+          curl -sf "$URL/health"

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -11,11 +11,6 @@ on:
         options:
           - rayai-dev
           - rayai-prod
-      deploy:
-        description: 'Roll out new image after build'
-        required: false
-        default: 'true'
-        type: boolean
 
   push:
     branches: [main]
@@ -24,17 +19,18 @@ on:
       - 'cmd/boxd/**'
       - 'internal/vm/**'
       - 'internal/network/**'
-      - 'images/base/**'
-      - 'infra/packer/**'
+
+# VMD instances are discovered at deploy time via the GCP label component=vmd.
+# To add a new host to the deploy fleet, label it:
+#   gcloud compute instances add-labels <name> --labels=component=vmd --zone=<zone>
+# No instance names, zones, or IPs are hardcoded here.
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    env:
-      REGION: us-central1
 
     steps:
       - uses: actions/checkout@v4
@@ -61,65 +57,105 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Install Packer
-        run: |
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update -qq && sudo apt-get install -y packer
-
-      - name: Init Packer
-        working-directory: infra/packer
-        run: packer init agentbox-vmd.pkr.hcl
-
-      - name: Build GCE Image
-        id: packer
-        working-directory: infra/packer
+      - name: Discover VMD instances
+        id: discover
         run: |
           PROJECT="${{ github.event.inputs.project_id || 'rayai-dev' }}"
-          packer build \
-            -var "project_id=${PROJECT}" \
-            agentbox-vmd.pkr.hcl
-          # Retrieve the newly built image name for the rollout step
-          IMAGE=$(gcloud compute images list \
+
+          # Find all RUNNING instances labelled component=vmd.
+          INSTANCES=$(gcloud compute instances list \
             --project="${PROJECT}" \
-            --filter="family=superserve-vmd" \
-            --sort-by=~creationTimestamp \
-            --limit=1 \
-            --format='value(name)')
-          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+            --filter="labels.component=vmd AND status=RUNNING" \
+            --format="csv[no-heading](name,zone)")
+
+          if [[ -z "${INSTANCES}" ]]; then
+            echo "No instances with label component=vmd found in ${PROJECT}" >&2
+            exit 1
+          fi
+
+          echo "Deploying to:"
+          echo "${INSTANCES}"
+
+          # Encode as JSON array [{name, zone}, ...] for the next step.
+          MATRIX=$(echo "${INSTANCES}" | python3 -c "
+          import sys, json
+          rows = [line.strip().split(',') for line in sys.stdin if line.strip()]
+          print(json.dumps([{'name': r[0], 'zone': r[1]} for r in rows]))
+          ")
+
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "project=${PROJECT}" >> "$GITHUB_OUTPUT"
-          echo "Built image: ${IMAGE}"
 
-      - name: Roll out new image to instance group
-        if: github.event.inputs.deploy != 'false'
+      - name: Deploy to all VMD instances in parallel
+        env:
+          PROJECT: ${{ steps.discover.outputs.project }}
+          MATRIX: ${{ steps.discover.outputs.matrix }}
+          SHA: ${{ github.sha }}
         run: |
-          PROJECT="${{ steps.packer.outputs.project }}"
-          IMAGE="${{ steps.packer.outputs.image }}"
+          python3 - <<'PYEOF'
+          import os, sys, json, subprocess
+          from concurrent.futures import ThreadPoolExecutor, as_completed
 
-          # Create a new instance template pointing at the freshly built image
-          TEMPLATE="superserve-vmd-${GITHUB_SHA::8}"
-          gcloud compute instance-templates create "${TEMPLATE}" \
-            --project="${PROJECT}" \
-            --region="${{ env.REGION }}" \
-            --source-instance-template="$(gcloud compute instance-templates list \
-                --project="${PROJECT}" \
-                --filter="name~superserve-vmd" \
-                --sort-by=~creationTimestamp \
-                --limit=1 \
-                --format='value(name)')" \
-            --image="${IMAGE}" \
-            --image-project="${PROJECT}"
+          project   = os.environ['PROJECT']
+          sha       = os.environ['SHA'][:8]
+          instances = json.loads(os.environ['MATRIX'])
 
-          # Rolling replace — one instance at a time, 90s health window
-          gcloud compute instance-groups managed rolling-action start-update superserve-vmd \
-            --project="${PROJECT}" \
-            --region="${{ env.REGION }}" \
-            --version="template=${TEMPLATE}" \
-            --max-unavailable=1 \
-            --max-surge=0
+          def deploy(inst):
+              name = inst['name']
+              zone = inst['zone']
+              tag  = f'{name}/{zone}'
 
-          gcloud compute instance-groups managed wait-until superserve-vmd \
-            --project="${PROJECT}" \
-            --region="${{ env.REGION }}" \
-            --stable \
-            --timeout=600
+              # Upload binaries to a temp path to avoid replacing the running
+              # binary while it is in use.
+              for binary in ('vmd', 'boxd'):
+                  subprocess.run([
+                      'gcloud', 'compute', 'scp',
+                      f'bin/{binary}',
+                      f'{name}:/tmp/{binary}-{sha}',
+                      f'--zone={zone}',
+                      f'--project={project}',
+                      '--quiet',
+                  ], check=True, capture_output=True)
+              print(f'[{tag}] binaries uploaded')
+
+              # Atomically replace and restart.
+              remote_cmd = '; '.join([
+                  f'sudo mv /tmp/vmd-{sha}  /usr/local/bin/vmd',
+                  f'sudo mv /tmp/boxd-{sha} /usr/local/bin/boxd',
+                  'sudo chmod +x /usr/local/bin/vmd /usr/local/bin/boxd',
+                  'sudo systemctl restart superserve-vmd',
+                  'sleep 2',
+                  'sudo systemctl is-active --quiet superserve-vmd',
+              ])
+              result = subprocess.run([
+                  'gcloud', 'compute', 'ssh', name,
+                  f'--zone={zone}',
+                  f'--project={project}',
+                  '--quiet',
+                  '--command', remote_cmd,
+              ], capture_output=True, text=True)
+              if result.returncode != 0:
+                  raise RuntimeError(
+                      f'service not healthy after restart:\n'
+                      f'stdout: {result.stdout}\nstderr: {result.stderr}'
+                  )
+              print(f'[{tag}] superserve-vmd active ✓')
+
+          failed = []
+          with ThreadPoolExecutor(max_workers=len(instances)) as ex:
+              futures = {ex.submit(deploy, inst): inst for inst in instances}
+              for f in as_completed(futures):
+                  inst = futures[f]
+                  tag  = f"{inst['name']}/{inst['zone']}"
+                  try:
+                      f.result()
+                  except Exception as e:
+                      print(f'[{tag}] FAILED: {e}', file=sys.stderr)
+                      failed.append(tag)
+
+          if failed:
+              print(f'\nDeploy failed on: {", ".join(failed)}', file=sys.stderr)
+              sys.exit(1)
+
+          print(f'\nDeployed to {len(instances)} instance(s). sha={sha}')
+          PYEOF

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -2,16 +2,6 @@ name: Deploy VMD
 
 on:
   workflow_dispatch:
-    inputs:
-      project_id:
-        description: 'GCP Project ID'
-        required: true
-        default: 'rayai-dev'
-        type: choice
-        options:
-          - rayai-dev
-          - rayai-prod
-
   push:
     branches: [main]
     paths:
@@ -20,14 +10,10 @@ on:
       - 'internal/vm/**'
       - 'internal/network/**'
 
-# VMD instances are discovered at deploy time via the GCP label component=vmd.
-# To add a new host to the deploy fleet, label it:
-#   gcloud compute instances add-labels <name> --labels=component=vmd --zone=<zone>
-# No instance names, zones, or IPs are hardcoded here.
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: staging
     permissions:
       contents: read
       id-token: write
@@ -46,7 +32,6 @@ jobs:
           mkdir -p bin
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/vmd ./cmd/vmd
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/boxd ./cmd/boxd
-          ls -lh bin/
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -57,56 +42,49 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Discover VMD instances
-        id: discover
-        run: |
-          PROJECT="${{ github.event.inputs.project_id || 'rayai-dev' }}"
-
-          # Find all RUNNING instances labelled component=vmd.
-          INSTANCES=$(gcloud compute instances list \
-            --project="${PROJECT}" \
-            --filter="labels.component=vmd AND status=RUNNING" \
-            --format="csv[no-heading](name,zone)")
-
-          if [[ -z "${INSTANCES}" ]]; then
-            echo "No instances with label component=vmd found in ${PROJECT}" >&2
-            exit 1
-          fi
-
-          echo "Deploying to:"
-          echo "${INSTANCES}"
-
-          # Encode as JSON array [{name, zone}, ...] for the next step.
-          MATRIX=$(echo "${INSTANCES}" | python3 -c "
-          import sys, json
-          rows = [line.strip().split(',') for line in sys.stdin if line.strip()]
-          print(json.dumps([{'name': r[0], 'zone': r[1]} for r in rows]))
-          ")
-
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-          echo "project=${PROJECT}" >> "$GITHUB_OUTPUT"
-
-      - name: Deploy to all VMD instances in parallel
+      - name: Discover and deploy to VMD instances
         env:
-          PROJECT: ${{ steps.discover.outputs.project }}
-          MATRIX: ${{ steps.discover.outputs.matrix }}
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
         run: |
           python3 - <<'PYEOF'
           import os, sys, json, subprocess
           from concurrent.futures import ThreadPoolExecutor, as_completed
 
-          project   = os.environ['PROJECT']
-          sha       = os.environ['SHA'][:8]
-          instances = json.loads(os.environ['MATRIX'])
+          project     = os.environ['GCP_PROJECT']
+          label       = os.environ.get('VMD_LABEL', 'component=vmd')
+          service     = os.environ.get('VMD_SERVICE', 'vmd')
+          install_dir = os.environ.get('VMD_INSTALL_DIR', '/usr/local/bin')
+          sha         = os.environ['SHA'][:8]
+
+          # Discover instances by label.
+          result = subprocess.run([
+              'gcloud', 'compute', 'instances', 'list',
+              f'--project={project}',
+              f'--filter=labels.{label} AND status=RUNNING',
+              '--format=csv[no-heading](name,zone)',
+          ], capture_output=True, text=True, check=True)
+
+          instances = [
+              {'name': r[0], 'zone': r[1]}
+              for line in result.stdout.strip().splitlines()
+              if line.strip()
+              for r in [line.strip().split(',')]
+          ]
+
+          if not instances:
+              print(f'No instances with label {label} found in {project}', file=sys.stderr)
+              sys.exit(1)
+
+          print(f'Deploying to {len(instances)} instance(s)')
 
           def deploy(inst):
-              name = inst['name']
-              zone = inst['zone']
-              tag  = f'{name}/{zone}'
+              name, zone = inst['name'], inst['zone']
+              tag = f'{name}/{zone}'
 
-              # Upload binaries to a temp path to avoid replacing the running
-              # binary while it is in use.
               for binary in ('vmd', 'boxd'):
                   subprocess.run([
                       'gcloud', 'compute', 'scp',
@@ -118,44 +96,38 @@ jobs:
                   ], check=True, capture_output=True)
               print(f'[{tag}] binaries uploaded')
 
-              # Atomically replace and restart.
               remote_cmd = '; '.join([
-                  f'sudo mv /tmp/vmd-{sha}  /usr/local/bin/vmd',
-                  f'sudo mv /tmp/boxd-{sha} /usr/local/bin/boxd',
-                  'sudo chmod +x /usr/local/bin/vmd /usr/local/bin/boxd',
-                  'sudo systemctl restart superserve-vmd',
+                  f'sudo mv /tmp/vmd-{sha}  {install_dir}/vmd',
+                  f'sudo mv /tmp/boxd-{sha} {install_dir}/boxd',
+                  f'sudo chmod +x {install_dir}/vmd {install_dir}/boxd',
+                  f'sudo systemctl restart {service}',
                   'sleep 2',
-                  'sudo systemctl is-active --quiet superserve-vmd',
+                  f'sudo systemctl is-active --quiet {service}',
               ])
-              result = subprocess.run([
+              r = subprocess.run([
                   'gcloud', 'compute', 'ssh', name,
-                  f'--zone={zone}',
-                  f'--project={project}',
-                  '--quiet',
-                  '--command', remote_cmd,
+                  f'--zone={zone}', f'--project={project}',
+                  '--quiet', '--command', remote_cmd,
               ], capture_output=True, text=True)
-              if result.returncode != 0:
-                  raise RuntimeError(
-                      f'service not healthy after restart:\n'
-                      f'stdout: {result.stdout}\nstderr: {result.stderr}'
-                  )
-              print(f'[{tag}] superserve-vmd active ✓')
+              if r.returncode != 0:
+                  raise RuntimeError(f'service not healthy: {r.stderr}')
+              print(f'[{tag}] active')
 
           failed = []
           with ThreadPoolExecutor(max_workers=len(instances)) as ex:
               futures = {ex.submit(deploy, inst): inst for inst in instances}
               for f in as_completed(futures):
                   inst = futures[f]
-                  tag  = f"{inst['name']}/{inst['zone']}"
                   try:
                       f.result()
                   except Exception as e:
+                      tag = f"{inst['name']}/{inst['zone']}"
                       print(f'[{tag}] FAILED: {e}', file=sys.stderr)
                       failed.append(tag)
 
           if failed:
-              print(f'\nDeploy failed on: {", ".join(failed)}', file=sys.stderr)
+              print(f'Deploy failed on: {", ".join(failed)}', file=sys.stderr)
               sys.exit(1)
 
-          print(f'\nDeployed to {len(instances)} instance(s). sha={sha}')
+          print(f'Deployed to {len(instances)} instance(s). sha={sha}')
           PYEOF

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -1,0 +1,125 @@
+name: Deploy VMD
+
+on:
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: 'GCP Project ID'
+        required: true
+        default: 'rayai-dev'
+        type: choice
+        options:
+          - rayai-dev
+          - rayai-prod
+      deploy:
+        description: 'Roll out new image after build'
+        required: false
+        default: 'true'
+        type: boolean
+
+  push:
+    branches: [main]
+    paths:
+      - 'cmd/vmd/**'
+      - 'cmd/boxd/**'
+      - 'internal/vm/**'
+      - 'internal/network/**'
+      - 'images/base/**'
+      - 'infra/packer/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      REGION: us-central1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build VMD and boxd binaries
+        run: |
+          mkdir -p bin
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/vmd ./cmd/vmd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/boxd ./cmd/boxd
+          ls -lh bin/
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install Packer
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update -qq && sudo apt-get install -y packer
+
+      - name: Init Packer
+        working-directory: infra/packer
+        run: packer init agentbox-vmd.pkr.hcl
+
+      - name: Build GCE Image
+        id: packer
+        working-directory: infra/packer
+        run: |
+          PROJECT="${{ github.event.inputs.project_id || 'rayai-dev' }}"
+          packer build \
+            -var "project_id=${PROJECT}" \
+            agentbox-vmd.pkr.hcl
+          # Retrieve the newly built image name for the rollout step
+          IMAGE=$(gcloud compute images list \
+            --project="${PROJECT}" \
+            --filter="family=superserve-vmd" \
+            --sort-by=~creationTimestamp \
+            --limit=1 \
+            --format='value(name)')
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "project=${PROJECT}" >> "$GITHUB_OUTPUT"
+          echo "Built image: ${IMAGE}"
+
+      - name: Roll out new image to instance group
+        if: github.event.inputs.deploy != 'false'
+        run: |
+          PROJECT="${{ steps.packer.outputs.project }}"
+          IMAGE="${{ steps.packer.outputs.image }}"
+
+          # Create a new instance template pointing at the freshly built image
+          TEMPLATE="superserve-vmd-${GITHUB_SHA::8}"
+          gcloud compute instance-templates create "${TEMPLATE}" \
+            --project="${PROJECT}" \
+            --region="${{ env.REGION }}" \
+            --source-instance-template="$(gcloud compute instance-templates list \
+                --project="${PROJECT}" \
+                --filter="name~superserve-vmd" \
+                --sort-by=~creationTimestamp \
+                --limit=1 \
+                --format='value(name)')" \
+            --image="${IMAGE}" \
+            --image-project="${PROJECT}"
+
+          # Rolling replace — one instance at a time, 90s health window
+          gcloud compute instance-groups managed rolling-action start-update superserve-vmd \
+            --project="${PROJECT}" \
+            --region="${{ env.REGION }}" \
+            --version="template=${TEMPLATE}" \
+            --max-unavailable=1 \
+            --max-surge=0
+
+          gcloud compute instance-groups managed wait-until superserve-vmd \
+            --project="${PROJECT}" \
+            --region="${{ env.REGION }}" \
+            --stable \
+            --timeout=600


### PR DESCRIPTION
## Summary
Cherry-picked from #15 (dropping the now-superseded migration CD and cmd/migrate).

- **deploy-api.yml**: Builds Docker image, pushes to Artifact Registry, deploys to Cloud Run — staging (`rayai-dev`) then prod (`rayai-prod`). Includes `/health` verification. Manual `workflow_dispatch` to target one env.
- **deploy-vmd.yml**: Builds vmd/boxd binaries, discovers hosts via `component=vmd` GCP label, deploys in parallel with atomic binary replacement and service health check.

## Infra verified
- Cloud Run service `superserve-api` exists in `rayai-dev/us-central1`
- Artifact Registry `superserve` exists in `rayai-dev/us-central1`
- `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT` secrets are set

## Test plan
- [ ] Merge, then trigger `Deploy API` via workflow_dispatch → staging
- [ ] Verify `/health` returns 200 on Cloud Run URL
- [ ] Map `api-staging.superserve.ai` to Cloud Run service

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)