### PR TITLE
feat: environment variables at sandbox creation

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -2,6 +2,14 @@ name: Deploy VMD
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment (staging always runs first)'
+        required: false
+        type: choice
+        options:
+          - staging
+          - production
   push:
     branches: [main]
     paths:
@@ -14,7 +22,7 @@ on:
       - 'deploy/proxy.service'
 
 jobs:
-  deploy:
+  deploy-staging:
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -56,224 +64,52 @@ jobs:
           SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_STAGING }}
           TERMINAL_ALLOWED_ORIGINS: ${{ vars.TERMINAL_ALLOWED_ORIGINS_STAGING }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_STAGING }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_STAGING }}
+        run: python3 deploy/deploy-proxy.py
+
+  deploy-production:
+    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries
         run: |
-          python3 - <<'PYEOF'
-          import os, sys, json, subprocess, textwrap
-          from concurrent.futures import ThreadPoolExecutor, as_completed
+          mkdir -p bin
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/vmd ./cmd/vmd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/boxd ./cmd/boxd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o bin/proxy ./cmd/proxy
 
-          project     = os.environ['GCP_PROJECT']
-          label       = os.environ.get('VMD_LABEL', 'component=vmd')
-          service     = os.environ.get('VMD_SERVICE', 'vmd')
-          install_dir = os.environ.get('VMD_INSTALL_DIR', '/usr/local/bin')
-          sha         = os.environ['SHA'][:8]
-          import re as _re
-          # HMAC seed for per-sandbox access tokens. Hex-encoded, >= 32 bytes.
-          # Shared with the control plane. Lives in GitHub secrets (sensitive).
-          access_seed = os.environ.get('SANDBOX_ACCESS_TOKEN_SEED', '')
-          if access_seed:
-              # Mask the seed so GitHub Actions redacts it from all log output.
-              print(f'::add-mask::{access_seed}')
-          if access_seed and not _re.fullmatch(r'[0-9a-fA-F]{64,}', access_seed):
-              print('ERROR: SANDBOX_ACCESS_TOKEN_SEED must be hex-encoded, >= 32 bytes (64 hex chars)', file=sys.stderr)
-              sys.exit(1)
-          # Allowed browser origins for the WS terminal upgrade.
-          terminal_origins = os.environ.get('TERMINAL_ALLOWED_ORIGINS', '')
-          if terminal_origins and not _re.fullmatch(r'[A-Za-z0-9.,:/*\-]+', terminal_origins):
-              print('ERROR: TERMINAL_ALLOWED_ORIGINS contains disallowed characters', file=sys.stderr)
-              sys.exit(1)
-          require_data_plane = os.environ.get('REQUIRE_DATA_PLANE', '')
-          if require_data_plane not in ('', '0', '1'):
-              print('ERROR: REQUIRE_DATA_PLANE must be empty, "0", or "1"', file=sys.stderr)
-              sys.exit(1)
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-          # Discover instances by label.
-          result = subprocess.run([
-              'gcloud', 'compute', 'instances', 'list',
-              f'--project={project}',
-              f'--filter=labels.{label} AND status=RUNNING',
-              '--format=csv[no-heading](name,zone)',
-          ], capture_output=True, text=True, check=True)
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
 
-          instances = [
-              {'name': r[0], 'zone': r[1]}
-              for line in result.stdout.strip().splitlines()
-              if line.strip()
-              for r in [line.strip().split(',')]
-          ]
-
-          if not instances:
-              print(f'No instances with label {label} found in {project}', file=sys.stderr)
-              sys.exit(1)
-
-          print(f'Deploying to {len(instances)} instance(s)')
-
-          def deploy(inst):
-              name, zone = inst['name'], inst['zone']
-              tag = f'{name}/{zone}'
-
-              for binary in ('vmd', 'boxd', 'proxy'):
-                  subprocess.run([
-                      'gcloud', 'compute', 'scp',
-                      f'bin/{binary}',
-                      f'{name}:/tmp/{binary}-{sha}',
-                      f'--zone={zone}',
-                      f'--project={project}',
-                      '--quiet',
-                      '--tunnel-through-iap',
-                  ], check=True, capture_output=True)
-              subprocess.run([
-                  'gcloud', 'compute', 'scp',
-                  'deploy/proxy.service',
-                  f'{name}:/tmp/proxy.service',
-                  f'--zone={zone}',
-                  f'--project={project}',
-                  '--quiet',
-                  '--tunnel-through-iap',
-              ], check=True, capture_output=True)
-              print(f'[{tag}] binaries uploaded')
-
-              # Inject updated boxd into the base rootfs atomically:
-              #   1. copy ROOTFS -> ROOTFS.new on the same filesystem
-              #   2. mount the copy, cp boxd into it, umount
-              #   3. mv ROOTFS.new -> ROOTFS (rename is atomic on POSIX)
-              # The original rootfs is untouched until the final rename, so a
-              # failure at any earlier step leaves the system in its
-              # previous working state. The trap ensures we clean up any
-              # staging file/mount on failure.
-              #
-              # textwrap.dedent is used so we can keep the script indented
-              # consistently with the enclosing Python code (which YAML
-              # requires) without leaking that indentation into the shell.
-              # NOTE on braces: GitHub Actions scans the YAML for its own
-              # expression syntax (dollar-double-brace) EVERYWHERE in the
-              # file, including inside Python heredocs and string literals.
-              # We cannot use doubled curly braces in f-strings here because
-              # the raw YAML characters would get parsed as a GitHub
-              # expression and fail with "Unrecognized named-value: ROOTFS".
-              # Workaround: use $ROOTFS / $STAGING without curly braces.
-              # Bash terminates variable names at non-identifier chars
-              # (dot, space, slash), so $ROOTFS.new.$$ works identically.
-              # The cleanup callback is inlined into trap so we avoid any
-              # standalone curly-brace pairs from a bash function body.
-              inject_script = textwrap.dedent(f'''
-                  set -euo pipefail
-
-                  sudo mv /tmp/vmd-{sha}  {install_dir}/vmd
-                  sudo mv /tmp/boxd-{sha} {install_dir}/boxd
-                  sudo chmod +x {install_dir}/vmd {install_dir}/boxd
-
-                  # Resolve the base rootfs path from whichever env file is
-                  # present. We cannot use `grep -s ... file1 file2` because
-                  # grep exits with 2 when ANY listed file is missing (even
-                  # with -s), and `set -euo pipefail` treats that as a fatal
-                  # error via the pipeline. Enumerate candidate files safely.
-                  ROOTFS=""
-                  for env_file in /etc/superserve/vmd.env /etc/agentbox/vmd.env; do
-                      if [ -f "$env_file" ]; then
-                          candidate=$(grep "^BASE_ROOTFS_PATH=" "$env_file" | head -1 | cut -d= -f2) || true
-                          if [ -n "$candidate" ]; then
-                              ROOTFS="$candidate"
-                              break
-                          fi
-                      fi
-                  done
-
-                  if [ -n "$ROOTFS" ] && [ -f "$ROOTFS" ]; then
-                      STAGING="$ROOTFS.new.$$"
-                      MNT=$(mktemp -d)
-                      trap '\''if mountpoint -q "$MNT" 2>/dev/null; then sudo umount "$MNT" || true; fi; rmdir "$MNT" 2>/dev/null || true; sudo rm -f "$STAGING" 2>/dev/null || true'\'' EXIT
-
-                      sudo cp --reflink=auto "$ROOTFS" "$STAGING"
-                      sudo mount -o loop "$STAGING" "$MNT"
-                      sudo cp {install_dir}/boxd "$MNT/usr/local/bin/boxd"
-                      sudo chmod +x "$MNT/usr/local/bin/boxd"
-                      sudo umount "$MNT"
-                      rmdir "$MNT"
-                      sudo mv "$STAGING" "$ROOTFS"
-                      trap - EXIT
-                      echo "boxd injected into rootfs atomically"
-                  else
-                      echo "WARNING: BASE_ROOTFS_PATH not found or not readable; skipping rootfs inject"
-                  fi
-
-                  sudo systemctl restart {service}
-                  sleep 3
-                  sudo systemctl is-active --quiet {service} || (
-                      echo "ERROR: {service} failed to become active after restart" >&2
-                      sudo systemctl status --no-pager {service} >&2 || true
-                      sudo journalctl -u {service} --no-pager -n 40 >&2 || true
-                      exit 1
-                  )
-
-                  # Deploy proxy binary and service
-                  sudo mv /tmp/proxy-{sha} {install_dir}/proxy
-                  sudo chmod +x {install_dir}/proxy
-
-                  # Install or update the systemd service file
-                  sudo mv /tmp/proxy.service /etc/systemd/system/proxy.service
-                  sudo systemctl daemon-reload
-                  sudo systemctl enable proxy
-
-                  # Write the proxy env file. The seed is passed via
-                  # _PROXY_SEED env var (set on the ssh command) to avoid
-                  # embedding it in the script string where it could be logged.
-                  sudo mkdir -p /etc/superserve
-                  if [ -n "$_PROXY_SEED" ]; then
-                      sudo tee /etc/superserve/proxy.env > /dev/null <<PROXYENV
-                  SANDBOX_ACCESS_TOKEN_SEED=$_PROXY_SEED
-                  TERMINAL_ALLOWED_ORIGINS={terminal_origins}
-                  REQUIRE_DATA_PLANE={require_data_plane}
-                  PROXYENV
-                      sudo chmod 0600 /etc/superserve/proxy.env
-                  fi
-
-                  sudo systemctl restart proxy
-                  sleep 3
-                  sudo systemctl is-active --quiet proxy || (
-                      echo "ERROR: proxy failed to become active after restart" >&2
-                      sudo systemctl status --no-pager proxy >&2 || true
-                      sudo journalctl -u proxy --no-pager -n 40 >&2 || true
-                      exit 1
-                  )
-              ''')
-              import shlex
-              full_script = f'export _PROXY_SEED={shlex.quote(access_seed)}\n{inject_script}'
-              r = subprocess.run([
-                  'gcloud', 'compute', 'ssh', name,
-                  f'--zone={zone}', f'--project={project}',
-                  '--quiet', '--tunnel-through-iap',
-                  '--command', full_script,
-              ], capture_output=True, text=True)
-              if r.returncode != 0:
-                  # Surface both stdout and stderr so deploy failures are
-                  # actually debuggable from the GitHub Actions log. The
-                  # inject script prints journalctl output to stderr on
-                  # service failure; silently swallowing it was a source of
-                  # long debug sessions.
-                  raise RuntimeError(
-                      f'service not healthy\n'
-                      f'--- stdout ---\n{r.stdout}\n'
-                      f'--- stderr ---\n{r.stderr}'
-                  )
-              print(f'[{tag}] active')
-              if r.stdout.strip():
-                  print(f'[{tag}] {r.stdout.strip()}')
-
-          failed = []
-          with ThreadPoolExecutor(max_workers=len(instances)) as ex:
-              futures = {ex.submit(deploy, inst): inst for inst in instances}
-              for f in as_completed(futures):
-                  inst = futures[f]
-                  try:
-                      f.result()
-                  except Exception as e:
-                      tag = f"{inst['name']}/{inst['zone']}"
-                      print(f'[{tag}] FAILED: {e}', file=sys.stderr)
-                      failed.append(tag)
-
-          if failed:
-              print(f'Deploy failed on: {", ".join(failed)}', file=sys.stderr)
-              sys.exit(1)
-
-          print(f'Deployed to {len(instances)} instance(s). sha={sha}')
-          PYEOF
+      - name: Discover and deploy to VMD instances
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
+          TERMINAL_ALLOWED_ORIGINS: ${{ vars.TERMINAL_ALLOWED_ORIGINS_PROD }}
+          REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
+        run: python3 deploy/deploy-proxy.py

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -421,6 +421,18 @@ components:
             env: prod
             owner: agent-7
             run_id: 7f3c-21
+        env_vars:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Environment variables injected into every process inside the
+            sandbox (terminal sessions, exec calls). Not persisted in the
+            database — they live in the VM agent's memory for the sandbox's
+            lifetime and survive pause/resume via snapshot.
+          example:
+            OPENAI_API_KEY: sk-...
+            DEBUG: "1"
         network:
           $ref: "#/components/schemas/NetworkConfig"
 

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -56,15 +56,19 @@ func main() {
 
 	mux := http.NewServeMux()
 
+	env := &sandboxEnv{}
+
 	// Connect RPC services.
 	procService := &processService{
 		processes: &sync.Map{},
+		env:       env,
 	}
 	mux.Handle(boxdpbconnect.NewProcessServiceHandler(procService))
 	mux.Handle(boxdpbconnect.NewFilesystemServiceHandler(&filesystemService{}))
 
-	// Raw HTTP endpoints (file content transfer + health).
+	// Raw HTTP endpoints (file content transfer + health + init).
 	mux.HandleFunc("/files", handleFiles)
+	mux.HandleFunc("/init", handleInit(env))
 	mux.HandleFunc("/health", handleHealth)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", httpPort)
@@ -87,6 +91,32 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok"}`)
 }
 
+func handleInit(env *sandboxEnv) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body struct {
+			EnvVars map[string]string `json:"env_vars"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+			return
+		}
+
+		if len(body.EnvVars) > 0 {
+			env.set(body.EnvVars)
+			log.Printf("init: set %d env var(s)", len(body.EnvVars))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok"}`)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Process service (Connect RPC)
 // ---------------------------------------------------------------------------
@@ -96,9 +126,50 @@ type runningProcess struct {
 	tty *os.File // nil for non-PTY processes.
 }
 
+// sandboxEnv holds sandbox-level environment variables set via POST /init.
+// These are injected into every process boxd spawns, underneath per-request
+// overrides from StartRequest.envs.
+type sandboxEnv struct {
+	mu   sync.RWMutex
+	vars map[string]string
+}
+
+func (e *sandboxEnv) set(vars map[string]string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.vars = vars
+}
+
+func (e *sandboxEnv) environ() []string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]string, 0, len(e.vars))
+	for k, v := range e.vars {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
 type processService struct {
 	boxdpbconnect.UnimplementedProcessServiceHandler
 	processes *sync.Map // pid → *runningProcess
+	env       *sandboxEnv
+}
+
+// buildEnv assembles the environment for a child process. Layers (last wins):
+// 1. OS base env  2. system defaults (PATH, HOME, USER)  3. sandbox-level
+// env vars from /init  4. per-request env vars from StartRequest.envs.
+func (s *processService) buildEnv(requestEnvs map[string]string) []string {
+	env := append(os.Environ(),
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME="+defaultHome,
+		"USER=user",
+	)
+	env = append(env, s.env.environ()...)
+	for k, v := range requestEnvs {
+		env = append(env, k+"="+v)
+	}
+	return env
 }
 
 func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
@@ -116,14 +187,7 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 		cmd.Dir = defaultHome
 	}
 
-	cmd.Env = append(os.Environ(),
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"HOME="+defaultHome,
-		"USER=user",
-	)
-	for k, v := range msg.GetEnvs() {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
+	cmd.Env = s.buildEnv(msg.GetEnvs())
 
 	timeout := time.Duration(msg.GetTimeoutMs()) * time.Millisecond
 	if timeout > 0 {
@@ -135,14 +199,7 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 		if cmd.Dir == "" {
 			cmd.Dir = defaultHome
 		}
-		cmd.Env = append(os.Environ(),
-			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"HOME="+defaultHome,
-			"USER=user",
-		)
-		for k, v := range msg.GetEnvs() {
-			cmd.Env = append(cmd.Env, k+"="+v)
-		}
+		cmd.Env = s.buildEnv(msg.GetEnvs())
 	}
 
 	isPTY := msg.GetPty() != nil

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -103,7 +103,7 @@ func handleInit(env *sandboxEnv) http.HandlerFunc {
 			EnvVars map[string]string `json:"env_vars"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
 			return
 		}
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -136,10 +136,11 @@ func newGRPCVMDClient(conn *grpc.ClientConn) *grpcVMDClient {
 	}
 }
 
-func (c *grpcVMDClient) CreateInstance(ctx context.Context, vmID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) CreateInstance(ctx context.Context, vmID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string, envVars map[string]string) (string, uint32, uint32, error) {
 	resp, err := c.client.CreateVM(ctx, &vmdpb.CreateVMRequest{
 		VmId:     vmID,
 		Metadata: metadata,
+		EnvVars:  envVars,
 		ResourceLimits: &vmdpb.ResourceLimits{
 			VcpuCount:   vcpu,
 			MemoryMib:   memMiB,
@@ -179,11 +180,12 @@ func (c *grpcVMDClient) PauseInstance(ctx context.Context, vmID, snapshotDir str
 	return resp.SnapshotPath, resp.MemFilePath, nil
 }
 
-func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string, envVars map[string]string) (string, uint32, uint32, error) {
 	resp, err := c.client.ResumeVM(ctx, &vmdpb.ResumeVMRequest{
 		VmId:         vmID,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
+		EnvVars:      envVars,
 	})
 	if err != nil {
 		return "", 0, 0, fmt.Errorf("gRPC ResumeVM: %w", err)

--- a/deploy/deploy-proxy.py
+++ b/deploy/deploy-proxy.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Deploy proxy + boxd binaries to VMD instances and inject boxd into rootfs.
+
+All configuration is read from environment variables (set by the GitHub
+Actions workflow). The script discovers instances by GCE label, uploads
+binaries via SCP, injects boxd into the rootfs atomically, and restarts
+the proxy and VMD services.
+"""
+import os, sys, subprocess, textwrap, shlex, re
+
+# ---------------------------------------------------------------------------
+# Config from env
+# ---------------------------------------------------------------------------
+project     = os.environ['GCP_PROJECT']
+label       = os.environ.get('VMD_LABEL', 'component=vmd')
+service     = os.environ.get('VMD_SERVICE', 'vmd')
+install_dir = os.environ.get('VMD_INSTALL_DIR', '/usr/local/bin')
+sha         = os.environ['SHA'][:8]
+
+# HMAC seed for per-sandbox access tokens.
+access_seed = os.environ.get('SANDBOX_ACCESS_TOKEN_SEED', '')
+if access_seed:
+    print(f'::add-mask::{access_seed}')
+if access_seed and not re.fullmatch(r'[0-9a-fA-F]{64,}', access_seed):
+    print('ERROR: SANDBOX_ACCESS_TOKEN_SEED must be hex-encoded, >= 32 bytes (64 hex chars)', file=sys.stderr)
+    sys.exit(1)
+
+# Allowed browser origins for the WS terminal upgrade.
+terminal_origins = os.environ.get('TERMINAL_ALLOWED_ORIGINS', '')
+if terminal_origins and not re.fullmatch(r'[A-Za-z0-9.,:/*\-]+', terminal_origins):
+    print('ERROR: TERMINAL_ALLOWED_ORIGINS contains disallowed characters', file=sys.stderr)
+    sys.exit(1)
+
+require_data_plane = os.environ.get('REQUIRE_DATA_PLANE', '')
+if require_data_plane not in ('', '0', '1'):
+    print('ERROR: REQUIRE_DATA_PLANE must be empty, "0", or "1"', file=sys.stderr)
+    sys.exit(1)
+
+proxy_domain = os.environ.get('PROXY_DOMAIN', '')
+if not proxy_domain:
+    print('ERROR: PROXY_DOMAIN is required', file=sys.stderr)
+    sys.exit(1)
+if not re.fullmatch(r'[A-Za-z0-9.\-]+', proxy_domain):
+    print('ERROR: PROXY_DOMAIN contains disallowed characters', file=sys.stderr)
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Discover instances
+# ---------------------------------------------------------------------------
+result = subprocess.run([
+    'gcloud', 'compute', 'instances', 'list',
+    f'--project={project}',
+    f'--filter=labels.{label} AND status=RUNNING',
+    '--format=csv[no-heading](name,zone)',
+], capture_output=True, text=True, check=True)
+
+instances = [
+    {'name': r[0], 'zone': r[1]}
+    for line in result.stdout.strip().splitlines()
+    if line.strip()
+    for r in [line.strip().split(',')]
+]
+
+if not instances:
+    print(f'No instances with label {label} found in {project}', file=sys.stderr)
+    sys.exit(1)
+
+print(f'Deploying to {len(instances)} instance(s)')
+
+# ---------------------------------------------------------------------------
+# Deploy
+# ---------------------------------------------------------------------------
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def deploy(inst):
+    name, zone = inst['name'], inst['zone']
+    tag = f'{name}/{zone}'
+
+    for binary in ('vmd', 'boxd', 'proxy'):
+        subprocess.run([
+            'gcloud', 'compute', 'scp',
+            f'bin/{binary}',
+            f'{name}:/tmp/{binary}-{sha}',
+            f'--zone={zone}',
+            f'--project={project}',
+            '--quiet',
+            '--tunnel-through-iap',
+        ], check=True, capture_output=True)
+    subprocess.run([
+        'gcloud', 'compute', 'scp',
+        'deploy/proxy.service',
+        f'{name}:/tmp/proxy.service',
+        f'--zone={zone}',
+        f'--project={project}',
+        '--quiet',
+        '--tunnel-through-iap',
+    ], check=True, capture_output=True)
+    print(f'[{tag}] binaries uploaded')
+
+    # Inject updated boxd into the base rootfs atomically:
+    #   1. copy ROOTFS -> ROOTFS.new on the same filesystem
+    #   2. mount the copy, cp boxd into it, umount
+    #   3. mv ROOTFS.new -> ROOTFS (rename is atomic on POSIX)
+    inject_script = textwrap.dedent(f'''
+        set -euo pipefail
+
+        sudo mv /tmp/vmd-{sha}  {install_dir}/vmd
+        sudo mv /tmp/boxd-{sha} {install_dir}/boxd
+        sudo chmod +x {install_dir}/vmd {install_dir}/boxd
+
+        ROOTFS=""
+        for env_file in /etc/superserve/vmd.env /etc/agentbox/vmd.env; do
+            if [ -f "$env_file" ]; then
+                candidate=$(grep "^BASE_ROOTFS_PATH=" "$env_file" | head -1 | cut -d= -f2) || true
+                if [ -n "$candidate" ]; then
+                    ROOTFS="$candidate"
+                    break
+                fi
+            fi
+        done
+
+        if [ -n "$ROOTFS" ] && [ -f "$ROOTFS" ]; then
+            STAGING="$ROOTFS.new.$$"
+            MNT=$(mktemp -d)
+            trap 'if mountpoint -q "$MNT" 2>/dev/null; then sudo umount "$MNT" || true; fi; rmdir "$MNT" 2>/dev/null || true; sudo rm -f "$STAGING" 2>/dev/null || true' EXIT
+
+            sudo cp --reflink=auto "$ROOTFS" "$STAGING"
+            sudo mount -o loop "$STAGING" "$MNT"
+            sudo cp {install_dir}/boxd "$MNT/usr/local/bin/boxd"
+            sudo chmod +x "$MNT/usr/local/bin/boxd"
+            sudo umount "$MNT"
+            rmdir "$MNT"
+            sudo mv "$STAGING" "$ROOTFS"
+            trap - EXIT
+            echo "boxd injected into rootfs atomically"
+        else
+            echo "WARNING: BASE_ROOTFS_PATH not found or not readable; skipping rootfs inject"
+        fi
+
+        sudo systemctl restart {service}
+        sleep 3
+        sudo systemctl is-active --quiet {service} || (
+            echo "ERROR: {service} failed to become active after restart" >&2
+            sudo systemctl status --no-pager {service} >&2 || true
+            sudo journalctl -u {service} --no-pager -n 40 >&2 || true
+            exit 1
+        )
+
+        sudo mv /tmp/proxy-{sha} {install_dir}/proxy
+        sudo chmod +x {install_dir}/proxy
+
+        sudo mv /tmp/proxy.service /etc/systemd/system/proxy.service
+        sudo systemctl daemon-reload
+        sudo systemctl enable proxy
+
+        sudo mkdir -p /etc/superserve
+        if [ -n "$_PROXY_SEED" ]; then
+            sudo tee /etc/superserve/proxy.env > /dev/null <<PROXYENV
+        PROXY_DOMAIN={proxy_domain}
+        SANDBOX_ACCESS_TOKEN_SEED=$_PROXY_SEED
+        TERMINAL_ALLOWED_ORIGINS={terminal_origins}
+        REQUIRE_DATA_PLANE={require_data_plane}
+        PROXYENV
+            sudo chmod 0600 /etc/superserve/proxy.env
+        fi
+
+        sudo systemctl restart proxy
+        sleep 3
+        sudo systemctl is-active --quiet proxy || (
+            echo "ERROR: proxy failed to become active after restart" >&2
+            sudo systemctl status --no-pager proxy >&2 || true
+            sudo journalctl -u proxy --no-pager -n 40 >&2 || true
+            exit 1
+        )
+    ''')
+    full_script = f'export _PROXY_SEED={shlex.quote(access_seed)}\n{inject_script}'
+    r = subprocess.run([
+        'gcloud', 'compute', 'ssh', name,
+        f'--zone={zone}', f'--project={project}',
+        '--quiet', '--tunnel-through-iap',
+        '--command', full_script,
+    ], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f'service not healthy\n'
+            f'--- stdout ---\n{r.stdout}\n'
+            f'--- stderr ---\n{r.stderr}'
+        )
+    print(f'[{tag}] active')
+    if r.stdout.strip():
+        print(f'[{tag}] {r.stdout.strip()}')
+
+failed = []
+with ThreadPoolExecutor(max_workers=len(instances)) as ex:
+    futures = {ex.submit(deploy, inst): inst for inst in instances}
+    for f in as_completed(futures):
+        inst = futures[f]
+        try:
+            f.result()
+        except Exception as e:
+            tag = f"{inst['name']}/{inst['zone']}"
+            print(f'[{tag}] FAILED: {e}', file=sys.stderr)
+            failed.append(tag)
+
+if failed:
+    print(f'Deploy failed on: {", ".join(failed)}', file=sys.stderr)
+    sys.exit(1)
+
+print(f'Deployed to {len(instances)} instance(s). sha={sha}')

--- a/deploy/proxy.service
+++ b/deploy/proxy.service
@@ -13,9 +13,8 @@ Environment=PROXY_ADDR=:5007
 Environment=PROXY_REDIRECT_ADDR=:5008
 Environment=VMD_ADDR=http://127.0.0.1:9090
 Environment=PROXY_DOMAIN=sandbox.superserve.ai
-
-# Load host-local overrides (SANDBOX_ACCESS_TOKEN_SEED, TERMINAL_ALLOWED_ORIGINS,
-# REQUIRE_DATA_PLANE) from an env file. Leading `-` makes the file optional —
+# Load environment from env file. Overrides PROXY_DOMAIN above and adds SANDBOX_ACCESS_TOKEN_SEED,
+# TERMINAL_ALLOWED_ORIGINS, REQUIRE_DATA_PLANE. Leading `-` makes the file optional —
 # the proxy still starts without it, but data-plane endpoints will be disabled.
 EnvironmentFile=-/etc/superserve/proxy.env
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -24,10 +24,10 @@ import (
 // VMDClient defines the subset of the VM daemon gRPC interface used by the
 // control plane. This is satisfied by the gRPC adapter in cmd/controlplane.
 type VMDClient interface {
-	CreateInstance(ctx context.Context, instanceID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	CreateInstance(ctx context.Context, instanceID string, vcpu, memMiB, diskMiB uint32, metadata map[string]string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
 	DestroyInstance(ctx context.Context, instanceID string, force bool) error
 	PauseInstance(ctx context.Context, instanceID, snapshotDir string) (snapshotPath, memPath string, err error)
-	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
 	ExecCommand(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (stdout, stderr string, exitCode int32, err error)
 	ExecCommandStream(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32, onChunk func(stdout, stderr []byte, exitCode int32, finished bool)) error
 	UpdateSandboxNetwork(ctx context.Context, instanceID string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
@@ -136,7 +136,7 @@ func (h *Handlers) AutoWake() gin.HandlerFunc {
 		case db.SandboxStatusIdle:
 			vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 			defer vmdCancel()
-			if _, _, _, err := h.VMD.ResumeInstance(vmdCtx, sandboxID.String(), "", ""); err != nil {
+			if _, _, _, err := h.VMD.ResumeInstance(vmdCtx, sandboxID.String(), "", "", nil); err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("auto-wake ResumeInstance failed")
 				respondError(c, ErrInternal)
 				c.Abort()
@@ -321,7 +321,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	// context — if the client hangs up mid-resume, abort the VMD call.
 	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 	defer vmdCancel()
-	ipAddress, actualVcpu, actualMemMiB, err := h.VMD.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath)
+	ipAddress, actualVcpu, actualMemMiB, err := h.VMD.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath, nil)
 	if err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
 		respondError(c, ErrInternal)
@@ -471,6 +471,12 @@ type createSandboxRequest struct {
 	// 2 KB values, 16 KB total. Keys starting with `superserve.` or
 	// `_superserve` are reserved for platform use and rejected.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// EnvVars are environment variables injected into every process inside
+	// the sandbox (terminal sessions, exec calls). Not stored in the DB —
+	// they live in boxd's memory for the sandbox's lifetime and survive
+	// pause/resume via snapshot.
+	EnvVars map[string]string `json:"env_vars,omitempty"`
 }
 
 type sandboxResponse struct {
@@ -704,6 +710,10 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
 	}
+	if err := validateEnvVars(req.EnvVars); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
 	// Marshal once into the canonical jsonb shape. Empty / nil maps are
 	// stored as the empty object so the column is never NULL.
 	metadataJSON, err := json.Marshal(req.Metadata)
@@ -779,10 +789,10 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	var actualVcpu, actualMemMiB uint32
 	var vmdErr error
 	if req.FromSnapshot != nil {
-		ipAddress, actualVcpu, actualMemMiB, vmdErr = h.VMD.ResumeInstance(vmdCtx, sandbox.ID.String(), snapshotPath, snapshotMemPath)
+		ipAddress, actualVcpu, actualMemMiB, vmdErr = h.VMD.ResumeInstance(vmdCtx, sandbox.ID.String(), snapshotPath, snapshotMemPath, req.EnvVars)
 	} else {
 		ipAddress, actualVcpu, actualMemMiB, vmdErr = h.VMD.CreateInstance(vmdCtx, sandbox.ID.String(),
-			0, 0, 0, nil)
+			0, 0, 0, nil, req.EnvVars)
 	}
 	if vmdErr != nil {
 		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Msg("VMD create/resume failed")
@@ -1318,6 +1328,39 @@ func validateMetadata(md map[string]string) error {
 		totalBytes += len(k) + len(v)
 		if totalBytes > metadataMaxTotalBytes {
 			return fmt.Errorf("metadata exceeds %d bytes total", metadataMaxTotalBytes)
+		}
+	}
+	return nil
+}
+
+const (
+	envVarsMaxKeys       = 64
+	envVarsMaxKeyLen     = 256
+	envVarsMaxValueLen   = 8192  // 8 KB — API keys, tokens, DSNs
+	envVarsMaxTotalBytes = 65536 // 64 KB
+)
+
+func validateEnvVars(env map[string]string) error {
+	if len(env) == 0 {
+		return nil
+	}
+	if len(env) > envVarsMaxKeys {
+		return fmt.Errorf("env_vars has %d keys, max is %d", len(env), envVarsMaxKeys)
+	}
+	totalBytes := 0
+	for k, v := range env {
+		if k == "" {
+			return fmt.Errorf("env_vars keys cannot be empty")
+		}
+		if len(k) > envVarsMaxKeyLen {
+			return fmt.Errorf("env_vars key %q is %d bytes, max is %d", k, len(k), envVarsMaxKeyLen)
+		}
+		if len(v) > envVarsMaxValueLen {
+			return fmt.Errorf("env_vars value for key %q is %d bytes, max is %d", k, len(v), envVarsMaxValueLen)
+		}
+		totalBytes += len(k) + len(v)
+		if totalBytes > envVarsMaxTotalBytes {
+			return fmt.Errorf("env_vars exceeds %d bytes total", envVarsMaxTotalBytes)
 		}
 	}
 	return nil

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1352,6 +1352,11 @@ func validateEnvVars(env map[string]string) error {
 		if k == "" {
 			return fmt.Errorf("env_vars keys cannot be empty")
 		}
+		for _, c := range k {
+			if c == '=' || c == 0 {
+				return fmt.Errorf("env_vars key %q contains invalid character", k)
+			}
+		}
 		if len(k) > envVarsMaxKeyLen {
 			return fmt.Errorf("env_vars key %q is %d bytes, max is %d", k, len(k), envVarsMaxKeyLen)
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -32,7 +32,7 @@ type stubVMD struct {
 	execFn    func(ctx context.Context, id, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error)
 }
 
-func (s *stubVMD) CreateInstance(ctx context.Context, id string, vcpu, memMiB, diskMiB uint32, metadata map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) CreateInstance(ctx context.Context, id string, vcpu, memMiB, diskMiB uint32, metadata map[string]string, envVars map[string]string) (string, uint32, uint32, error) {
 	if s.createFn != nil {
 		ip, err := s.createFn(ctx, id, vcpu, memMiB, diskMiB, metadata)
 		return ip, 1, 1024, err
@@ -51,7 +51,7 @@ func (s *stubVMD) PauseInstance(ctx context.Context, id, snapshotDir string) (st
 	}
 	return "/snapshots/vmstate.snap", "/snapshots/mem.snap", nil
 }
-func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string) (string, uint32, uint32, error) {
+func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string, envVars map[string]string) (string, uint32, uint32, error) {
 	if s.resumeFn != nil {
 		ip, err := s.resumeFn(ctx, id, snapshotPath, memPath)
 		return ip, 1, 1024, err

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -200,7 +200,7 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 		Logger()
 
 	vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
-	_, _, _, err := h.VMD.ResumeInstance(vmdCtx, sbx.ID.String(), snapshotPath, memPath)
+	_, _, _, err := h.VMD.ResumeInstance(vmdCtx, sbx.ID.String(), snapshotPath, memPath, nil)
 	vmdCancel()
 	if err != nil {
 		rl.Error().Err(err).Msg("reaper: rollback resume failed")

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -114,14 +114,14 @@ func applyMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 // values so that HTTP handlers can complete and write to the DB.
 type stubVMD struct{}
 
-func (s *stubVMD) CreateInstance(_ context.Context, _ string, _, _, _ uint32, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) CreateInstance(_ context.Context, _ string, _, _, _ uint32, _ map[string]string, _ map[string]string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (s *stubVMD) DestroyInstance(_ context.Context, _ string, _ bool) error { return nil }
 func (s *stubVMD) PauseInstance(_ context.Context, _, _ string) (string, string, error) {
 	return "/snapshots/disk.snap", "/snapshots/mem.snap", nil
 }
-func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string) (string, uint32, uint32, error) {
+func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (s *stubVMD) ExecCommand(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -48,6 +48,10 @@ func (a *GRPCAdapter) CreateVM(ctx context.Context, req *vmdpb.CreateVMRequest) 
 		return nil, err
 	}
 
+	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars()); err != nil {
+		a.mgr.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to post env vars to boxd")
+	}
+
 	return &vmdpb.CreateVMResponse{
 		VmId:       inst.ID,
 		SocketPath: inst.SocketPath,
@@ -89,6 +93,11 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 	if err != nil {
 		return nil, err
 	}
+
+	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars()); err != nil {
+		a.mgr.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to post env vars to boxd on resume")
+	}
+
 	return &vmdpb.ResumeVMResponse{
 		VmId:       inst.ID,
 		SocketPath: inst.SocketPath,

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -49,7 +49,7 @@ func (a *GRPCAdapter) CreateVM(ctx context.Context, req *vmdpb.CreateVMRequest) 
 	}
 
 	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars()); err != nil {
-		a.mgr.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to post env vars to boxd")
+		return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", err)
 	}
 
 	return &vmdpb.CreateVMResponse{
@@ -95,7 +95,7 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 	}
 
 	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars()); err != nil {
-		a.mgr.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to post env vars to boxd on resume")
+		return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", err)
 	}
 
 	return &vmdpb.ResumeVMResponse{

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -1,7 +1,9 @@
 package vm
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -174,6 +176,43 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("boxd health check not ready after %s", timeout)
+}
+
+// postBoxdInit sends sandbox-level environment variables to boxd's /init
+// endpoint. These vars are injected into every process boxd spawns.
+func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string) error {
+	if len(envVars) == 0 {
+		return nil
+	}
+
+	body := struct {
+		EnvVars map[string]string `json:"env_vars"`
+	}{EnvVars: envVars}
+
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal init body: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s:%d/init", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return fmt.Errorf("create init request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST /init: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST /init: status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // boxdFilesystemClient returns a Connect RPC client for boxd's

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -178,6 +178,8 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 	return fmt.Errorf("boxd health check not ready after %s", timeout)
 }
 
+var boxdInitClient = &http.Client{Timeout: 5 * time.Second}
+
 // postBoxdInit sends sandbox-level environment variables to boxd's /init
 // endpoint. These vars are injected into every process boxd spawns.
 func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string) error {
@@ -201,8 +203,7 @@ func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string) e
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := boxdInitClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("POST /init: %w", err)
 	}

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -84,6 +84,7 @@ message CreateVMRequest {
   NetworkConfig network_config = 6;
   map<string, string> metadata = 7;   // Arbitrary key-value pairs.
   SandboxNetworkConfig sandbox_network = 8;  // Per-sandbox egress rules (optional).
+  map<string, string> env_vars = 9;   // Environment variables injected into every process in the VM.
 }
 
 message CreateVMResponse {
@@ -133,6 +134,7 @@ message ResumeVMRequest {
   string snapshot_path = 2;
   string mem_file_path = 3;
   SandboxNetworkConfig sandbox_network = 4;  // Reapply egress rules after resume.
+  map<string, string> env_vars = 5;          // Re-inject env vars after resume.
 }
 
 message ResumeVMResponse {

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -329,8 +329,9 @@ type CreateVMRequest struct {
 	KernelArgs     string                 `protobuf:"bytes,4,opt,name=kernel_args,json=kernelArgs,proto3" json:"kernel_args,omitempty"`               // Boot arguments for the kernel.
 	ResourceLimits *ResourceLimits        `protobuf:"bytes,5,opt,name=resource_limits,json=resourceLimits,proto3" json:"resource_limits,omitempty"`
 	NetworkConfig  *NetworkConfig         `protobuf:"bytes,6,opt,name=network_config,json=networkConfig,proto3" json:"network_config,omitempty"`
-	Metadata       map[string]string      `protobuf:"bytes,7,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Arbitrary key-value pairs.
-	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,8,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`                                         // Per-sandbox egress rules (optional).
+	Metadata       map[string]string      `protobuf:"bytes,7,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`              // Arbitrary key-value pairs.
+	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,8,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`                                                      // Per-sandbox egress rules (optional).
+	EnvVars        map[string]string      `protobuf:"bytes,9,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Environment variables injected into every process in the VM.
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -417,6 +418,13 @@ func (x *CreateVMRequest) GetMetadata() map[string]string {
 func (x *CreateVMRequest) GetSandboxNetwork() *SandboxNetworkConfig {
 	if x != nil {
 		return x.SandboxNetwork
+	}
+	return nil
+}
+
+func (x *CreateVMRequest) GetEnvVars() map[string]string {
+	if x != nil {
+		return x.EnvVars
 	}
 	return nil
 }
@@ -726,7 +734,8 @@ type ResumeVMRequest struct {
 	VmId           string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
 	SnapshotPath   string                 `protobuf:"bytes,2,opt,name=snapshot_path,json=snapshotPath,proto3" json:"snapshot_path,omitempty"`
 	MemFilePath    string                 `protobuf:"bytes,3,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
-	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,4,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"` // Reapply egress rules after resume.
+	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,4,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`                                                      // Reapply egress rules after resume.
+	EnvVars        map[string]string      `protobuf:"bytes,5,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Re-inject env vars after resume.
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -785,6 +794,13 @@ func (x *ResumeVMRequest) GetMemFilePath() string {
 func (x *ResumeVMRequest) GetSandboxNetwork() *SandboxNetworkConfig {
 	if x != nil {
 		return x.SandboxNetwork
+	}
+	return nil
+}
+
+func (x *ResumeVMRequest) GetEnvVars() map[string]string {
+	if x != nil {
+		return x.EnvVars
 	}
 	return nil
 }
@@ -1690,7 +1706,7 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x1aSandboxNetworkEgressConfig\x12#\n" +
 	"\rallowed_cidrs\x18\x01 \x03(\tR\fallowedCidrs\x12!\n" +
 	"\fdenied_cidrs\x18\x02 \x03(\tR\vdeniedCidrs\x12'\n" +
-	"\x0fallowed_domains\x18\x03 \x03(\tR\x0eallowedDomains\"\x84\x04\n" +
+	"\x0fallowed_domains\x18\x03 \x03(\tR\x0eallowedDomains\"\x8c\x05\n" +
 	"\x0fCreateVMRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12(\n" +
 	"\x10base_rootfs_path\x18\x02 \x01(\tR\x0ebaseRootfsPath\x12\x1f\n" +
@@ -1701,8 +1717,12 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12G\n" +
 	"\x0enetwork_config\x18\x06 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\x12L\n" +
 	"\bmetadata\x18\a \x03(\v20.superserve.vmd.v1.CreateVMRequest.MetadataEntryR\bmetadata\x12P\n" +
-	"\x0fsandbox_network\x18\b \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x1a;\n" +
+	"\x0fsandbox_network\x18\b \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x12J\n" +
+	"\benv_vars\x18\t \x03(\v2/.superserve.vmd.v1.CreateVMRequest.EnvVarsEntryR\aenvVars\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
+	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe4\x01\n" +
 	"\x10CreateVMResponse\x12\x13\n" +
@@ -1728,12 +1748,16 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x0fPauseVMResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
-	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\"\xc1\x01\n" +
+	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\"\xc9\x02\n" +
 	"\x0fResumeVMRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12P\n" +
-	"\x0fsandbox_network\x18\x04 \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\"\xc5\x01\n" +
+	"\x0fsandbox_network\x18\x04 \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x12J\n" +
+	"\benv_vars\x18\x05 \x03(\v2/.superserve.vmd.v1.ResumeVMRequest.EnvVarsEntryR\aenvVars\x1a:\n" +
+	"\fEnvVarsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc5\x01\n" +
 	"\x10ResumeVMResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vsocket_path\x18\x02 \x01(\tR\n" +
@@ -1846,7 +1870,7 @@ func file_proto_vmd_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_vmd_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_vmd_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_proto_vmd_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_proto_vmd_proto_goTypes = []any{
 	(VMStatus)(0),                        // 0: superserve.vmd.v1.VMStatus
 	(*ResourceLimits)(nil),               // 1: superserve.vmd.v1.ResourceLimits
@@ -1874,8 +1898,10 @@ var file_proto_vmd_proto_goTypes = []any{
 	(*UpdateSandboxNetworkRequest)(nil),  // 23: superserve.vmd.v1.UpdateSandboxNetworkRequest
 	(*UpdateSandboxNetworkResponse)(nil), // 24: superserve.vmd.v1.UpdateSandboxNetworkResponse
 	nil,                                  // 25: superserve.vmd.v1.CreateVMRequest.MetadataEntry
-	nil,                                  // 26: superserve.vmd.v1.ExecCommandRequest.EnvEntry
-	nil,                                  // 27: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	nil,                                  // 26: superserve.vmd.v1.CreateVMRequest.EnvVarsEntry
+	nil,                                  // 27: superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	nil,                                  // 28: superserve.vmd.v1.ExecCommandRequest.EnvEntry
+	nil,                                  // 29: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
 }
 var file_proto_vmd_proto_depIdxs = []int32{
 	4,  // 0: superserve.vmd.v1.SandboxNetworkConfig.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
@@ -1883,42 +1909,44 @@ var file_proto_vmd_proto_depIdxs = []int32{
 	2,  // 2: superserve.vmd.v1.CreateVMRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
 	25, // 3: superserve.vmd.v1.CreateVMRequest.metadata:type_name -> superserve.vmd.v1.CreateVMRequest.MetadataEntry
 	3,  // 4: superserve.vmd.v1.CreateVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
-	1,  // 5: superserve.vmd.v1.CreateVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	3,  // 6: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
-	1,  // 7: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	1,  // 8: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	2,  // 9: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	26, // 10: superserve.vmd.v1.ExecCommandRequest.env:type_name -> superserve.vmd.v1.ExecCommandRequest.EnvEntry
-	0,  // 11: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
-	1,  // 12: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	27, // 13: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
-	2,  // 14: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	4,  // 15: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	5,  // 16: superserve.vmd.v1.VMDaemon.CreateVM:input_type -> superserve.vmd.v1.CreateVMRequest
-	7,  // 17: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
-	9,  // 18: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
-	11, // 19: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
-	13, // 20: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
-	15, // 21: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
-	17, // 22: superserve.vmd.v1.VMDaemon.ExecCommand:input_type -> superserve.vmd.v1.ExecCommandRequest
-	19, // 23: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
-	21, // 24: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
-	23, // 25: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
-	6,  // 26: superserve.vmd.v1.VMDaemon.CreateVM:output_type -> superserve.vmd.v1.CreateVMResponse
-	8,  // 27: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
-	10, // 28: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
-	12, // 29: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
-	14, // 30: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
-	16, // 31: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
-	18, // 32: superserve.vmd.v1.VMDaemon.ExecCommand:output_type -> superserve.vmd.v1.ExecCommandResponse
-	20, // 33: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
-	22, // 34: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
-	24, // 35: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
-	26, // [26:36] is the sub-list for method output_type
-	16, // [16:26] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	26, // 5: superserve.vmd.v1.CreateVMRequest.env_vars:type_name -> superserve.vmd.v1.CreateVMRequest.EnvVarsEntry
+	1,  // 6: superserve.vmd.v1.CreateVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	3,  // 7: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
+	27, // 8: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	1,  // 9: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	1,  // 10: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	2,  // 11: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	28, // 12: superserve.vmd.v1.ExecCommandRequest.env:type_name -> superserve.vmd.v1.ExecCommandRequest.EnvEntry
+	0,  // 13: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
+	1,  // 14: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	29, // 15: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	2,  // 16: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	4,  // 17: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	5,  // 18: superserve.vmd.v1.VMDaemon.CreateVM:input_type -> superserve.vmd.v1.CreateVMRequest
+	7,  // 19: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
+	9,  // 20: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
+	11, // 21: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
+	13, // 22: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
+	15, // 23: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
+	17, // 24: superserve.vmd.v1.VMDaemon.ExecCommand:input_type -> superserve.vmd.v1.ExecCommandRequest
+	19, // 25: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
+	21, // 26: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
+	23, // 27: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
+	6,  // 28: superserve.vmd.v1.VMDaemon.CreateVM:output_type -> superserve.vmd.v1.CreateVMResponse
+	8,  // 29: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
+	10, // 30: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
+	12, // 31: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
+	14, // 32: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
+	16, // 33: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
+	18, // 34: superserve.vmd.v1.VMDaemon.ExecCommand:output_type -> superserve.vmd.v1.ExecCommandResponse
+	20, // 35: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
+	22, // 36: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
+	24, // 37: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
+	28, // [28:38] is the sub-list for method output_type
+	18, // [18:28] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_proto_vmd_proto_init() }
@@ -1932,7 +1960,7 @@ func file_proto_vmd_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_vmd_proto_rawDesc), len(file_proto_vmd_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   27,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
## Summary

- Accept `env_vars` map in `POST /sandboxes` request
- Pass through VMD gRPC → boxd's new `POST /init` endpoint
- boxd stores env vars in memory, injects into every process (terminal, exec)
- Per-request env vars in exec override sandbox-level ones
- Env vars survive pause/resume via VM snapshot

## Staging verification

- Create with `env_vars: {MY_VAR: hello, DEBUG: 1}` → exec `echo $MY_VAR $DEBUG` → `hello 1`
- Per-request override: exec with `env: {MY_VAR: overridden}` → `overridden`
- Pause → resume → exec → env vars still present
- Installed and ran Claude Code inside a sandbox with `ANTHROPIC_API_KEY` set via env vars

## Test plan

- [x] Unit tests pass
- [x] Create sandbox with `env_vars`, verify via exec
- [x] Per-request env vars override sandbox-level
- [x] Env vars persist across pause/resume
- [x] Claude Code works inside sandbox with API key set via env vars