### PR TITLE
exec: auto-resume paused sandboxes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -249,8 +249,8 @@ paths:
       summary: Execute a command inside a sandbox
       description: |
         Runs a command inside the sandbox and waits for it to finish, returning
-        stdout, stderr, and exit code. Paused sandboxes are rejected with 409;
-        resume explicitly via POST /sandboxes/{sandbox_id}/resume first.
+        stdout, stderr, and exit code. A paused sandbox is resumed automatically
+        before the command runs and stays active afterward.
       security:
         - apiKey: []
       requestBody:
@@ -286,8 +286,8 @@ paths:
       description: |
         Runs a command and streams stdout/stderr chunks as Server-Sent Events.
         Each event is a JSON payload. The final event includes `exit_code` and
-        `finished: true`. Paused sandboxes are rejected with 409; resume
-        explicitly via POST /sandboxes/{sandbox_id}/resume first.
+        `finished: true`. A paused sandbox is resumed automatically before the
+        command runs and stays active afterward.
       security:
         - apiKey: []
       requestBody:

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -88,6 +88,24 @@ SET status = 'pausing', updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'active'
 RETURNING *;
 
+-- name: BeginResume :one
+-- Atomic claim for resume: transitions 'paused' to 'resuming' in one
+-- statement. A 0-row result means another resume (explicit or auto) has
+-- already claimed the sandbox, or it's not in paused state. Used to
+-- serialize concurrent /exec and /resume requests.
+UPDATE sandbox
+SET status = 'resuming', updated_at = now()
+WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
+RETURNING *;
+
+-- name: RevertResumeToPaused :exec
+-- Compensate a failed resume attempt by flipping status back to 'paused'.
+-- Guarded on status = 'resuming' so we never clobber a concurrent transition
+-- (e.g., ActivateSandbox has already flipped to 'active').
+UPDATE sandbox
+SET status = 'paused', updated_at = now()
+WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
+
 -- name: FinalizePause :one
 -- Upsert the sandbox's live snapshot row and flip status to 'paused'.
 -- Returns 0 rows if the sandbox is missing or soft-deleted (→ ErrSandboxGone).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -177,8 +177,10 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
 	}
 }
 
-// resumePausedSandbox restores the VM, marks the sandbox active, and reapplies
-// network config. Writes an error response and returns false on failure.
+// resumePausedSandbox restores the VM, reapplies network config, and flips
+// the sandbox to active. Starts with an atomic paused→resuming DB claim so
+// concurrent resumes don't both call VMD; the loser gets 409. On any failure
+// after VMD resume succeeds, destroys the VM + reverts to paused.
 func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, teamID uuid.UUID) bool {
 	sandboxID := sandbox.ID
 
@@ -188,12 +190,42 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		return false
 	}
 
+	claimed, err := h.DB.BeginResume(c.Request.Context(), db.BeginResumeParams{
+		ID:     sandboxID,
+		TeamID: teamID,
+	})
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			// Someone else is already resuming, or the sandbox is no longer
+			// in paused state. Surface as conflict; client retries.
+			respondError(c, ErrInvalidState)
+			return false
+		}
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB BeginResume failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+	*sandbox = claimed
+
+	revertCtx := context.WithoutCancel(c.Request.Context())
+	revertToPaused := func() {
+		rctx, rcancel := context.WithTimeout(revertCtx, asyncTimeout)
+		defer rcancel()
+		if err := h.DB.RevertResumeToPaused(rctx, db.RevertResumeToPausedParams{
+			ID:     sandboxID,
+			TeamID: teamID,
+		}); err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")
+		}
+	}
+
 	snapshot, err := h.DB.GetSnapshot(c.Request.Context(), db.GetSnapshotParams{
 		ID:     sandbox.SnapshotID.Bytes,
 		TeamID: teamID,
 	})
 	if err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
+		revertToPaused()
 		respondError(c, ErrInternal)
 		return false
 	}
@@ -204,6 +236,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 	if vmdLookupErr != nil {
 		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for resume failed")
+		revertToPaused()
 		respondError(c, ErrInternal)
 		return false
 	}
@@ -218,21 +251,24 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath)
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
+				revertToPaused()
 				respondError(c, ErrInternal)
 				return false
 			}
+			// RestoreSnapshot's proto doesn't carry ResourceLimits yet; it returns
+			// 0 for vcpu/mem. Keep the DB values so we don't overwrite them with 0.
+			if actualVcpu == 0 {
+				actualVcpu = uint32(sandbox.VcpuCount)
+			}
+			if actualMemMiB == 0 {
+				actualMemMiB = uint32(sandbox.MemoryMib)
+			}
 		} else {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
+			revertToPaused()
 			respondError(c, ErrInternal)
 			return false
 		}
-	}
-
-	if actualVcpu == 0 {
-		actualVcpu = uint32(sandbox.VcpuCount)
-	}
-	if actualMemMiB == 0 {
-		actualMemMiB = uint32(sandbox.MemoryMib)
 	}
 
 	// Detach from cancellation so a client disconnect can't leave the sandbox
@@ -247,32 +283,33 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	// ActivateSandbox (DB) and reapplyNetworkConfig (VMD) share no state and
-	// both only need the VMD restore to have completed. Run them in parallel.
-	activateErr := make(chan error, 1)
-	networkErr := make(chan error, 1)
-	go func() {
-		activateErr <- h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
-			ID:        sandboxID,
-			VcpuCount: int32(actualVcpu),
-			MemoryMib: int32(actualMemMiB),
-			IpAddress: ipAddr,
-			TeamID:    teamID,
-		})
-	}()
-	go func() {
-		networkErr <- h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig)
-	}()
+	destroyAndRevert := func() {
+		dctx, dcancel := context.WithTimeout(revertCtx, vmdTimeout)
+		defer dcancel()
+		if err := vmd.DestroyInstance(dctx, sandboxID.String(), true); err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("destroy VM after resume failure failed")
+		}
+		revertToPaused()
+	}
 
-	aErr := <-activateErr
-	nErr := <-networkErr
-	if aErr != nil {
-		log.Error().Err(aErr).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
+	// Apply egress rules before committing to 'active' so "active ⇒ rules
+	// applied" holds by construction.
+	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
+		destroyAndRevert()
 		respondError(c, ErrInternal)
 		return false
 	}
-	if nErr != nil {
-		log.Error().Err(nErr).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
+
+	if err := h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
+		ID:        sandboxID,
+		VcpuCount: int32(actualVcpu),
+		MemoryMib: int32(actualMemMiB),
+		IpAddress: ipAddr,
+		TeamID:    teamID,
+	}); err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
+		destroyAndRevert()
 		respondError(c, ErrInternal)
 		return false
 	}
@@ -300,12 +337,11 @@ type persistedEgressConfig struct {
 	} `json:"egress"`
 }
 
-// reapplyNetworkConfig reads the sandbox's persisted egress config from the DB
-// record and pushes it back to VMD. Called after every resume path (explicit
-// /resume, post-restore in CreateSandbox) because the nftables rules and
-// proxy state are fresh after a snapshot restore.
+// reapplyNetworkConfig reads the sandbox's persisted egress config and pushes
+// it to VMD. Called after every snapshot restore (explicit /resume, auto-resume
+// via /exec, and CreateSandbox's from-snapshot path) because nftables rules
+// and proxy state are fresh after restore.
 //
-// Uses a caller-supplied context so the caller controls timeout/cancellation.
 // Silently returns nil if there is no persisted config (default allow-all).
 func (h *Handlers) reapplyNetworkConfig(ctx context.Context, vmd VMDClient, sandboxID string, raw []byte) error {
 	if len(raw) == 0 {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -138,6 +138,149 @@ func (h *Handlers) loadActiveSandbox(c *gin.Context) *db.Sandbox {
 	return &sandbox
 }
 
+// loadActiveOrResumeSandbox is like loadActiveSandbox but auto-resumes a
+// paused sandbox. Any other non-active state returns 409.
+func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
+	sandboxID, err := parseSandboxID(c)
+	if err != nil {
+		return nil
+	}
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return nil
+	}
+	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+		ID:     sandboxID,
+		TeamID: teamID,
+	})
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			respondError(c, ErrSandboxNotFound)
+		} else {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+			respondError(c, ErrInternal)
+		}
+		return nil
+	}
+	switch sandbox.Status {
+	case db.SandboxStatusActive:
+		return &sandbox
+	case db.SandboxStatusPaused:
+		if !h.resumePausedSandbox(c, &sandbox, teamID) {
+			return nil
+		}
+		sandbox.Status = db.SandboxStatusActive
+		return &sandbox
+	default:
+		respondError(c, ErrInvalidState)
+		return nil
+	}
+}
+
+// resumePausedSandbox restores the VM, marks the sandbox active, and reapplies
+// network config. Writes an error response and returns false on failure.
+func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, teamID uuid.UUID) bool {
+	sandboxID := sandbox.ID
+
+	if !sandbox.SnapshotID.Valid {
+		log.Error().Str("sandbox_id", sandboxID.String()).Msg("paused sandbox has no snapshot_id")
+		respondError(c, ErrInternal)
+		return false
+	}
+
+	snapshot, err := h.DB.GetSnapshot(c.Request.Context(), db.GetSnapshotParams{
+		ID:     sandbox.SnapshotID.Bytes,
+		TeamID: teamID,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+
+	snapshotPath := snapshot.Path
+	memPath := resolveMemPath(snapshot)
+
+	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
+	if vmdLookupErr != nil {
+		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for resume failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+
+	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
+	defer vmdCancel()
+	ipAddress, actualVcpu, actualMemMiB, err := vmd.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath, nil)
+	if err != nil {
+		if isVMDNotFound(err) {
+			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).
+				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
+			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath)
+			if err != nil {
+				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
+				respondError(c, ErrInternal)
+				return false
+			}
+		} else {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
+			respondError(c, ErrInternal)
+			return false
+		}
+	}
+
+	if actualVcpu == 0 {
+		actualVcpu = uint32(sandbox.VcpuCount)
+	}
+	if actualMemMiB == 0 {
+		actualMemMiB = uint32(sandbox.MemoryMib)
+	}
+
+	// Detach from cancellation so a client disconnect can't leave the sandbox
+	// marked paused while the VM is up. Keep the trace/span context.
+	postCtx, postCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
+	defer postCancel()
+
+	var ipAddr *netip.Addr
+	if ipAddress != "" {
+		if addr, parseErr := netip.ParseAddr(ipAddress); parseErr == nil {
+			ipAddr = &addr
+		}
+	}
+
+	// ActivateSandbox (DB) and reapplyNetworkConfig (VMD) share no state and
+	// both only need the VMD restore to have completed. Run them in parallel.
+	activateErr := make(chan error, 1)
+	networkErr := make(chan error, 1)
+	go func() {
+		activateErr <- h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
+			ID:        sandboxID,
+			VcpuCount: int32(actualVcpu),
+			MemoryMib: int32(actualMemMiB),
+			IpAddress: ipAddr,
+			TeamID:    teamID,
+		})
+	}()
+	go func() {
+		networkErr <- h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig)
+	}()
+
+	aErr := <-activateErr
+	nErr := <-networkErr
+	if aErr != nil {
+		log.Error().Err(aErr).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+	if nErr != nil {
+		log.Error().Err(nErr).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+
+	h.logActivityAsync(c.Request.Context(), sandboxID, teamID, "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
+	return true
+}
+
 // resolveMemPath returns the memory snapshot path from a Snapshot record.
 // Uses the stored mem_path column if set, otherwise falls back to the
 // convention of placing mem.snap alongside the vmstate snapshot.
@@ -244,7 +387,6 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 
-	// Verify sandbox exists and belongs to this team.
 	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
 		ID:     sandboxID,
 		TeamID: teamID,
@@ -259,105 +401,14 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 
-	// Only paused sandboxes can be resumed.
 	if sandbox.Status != db.SandboxStatusPaused {
 		respondError(c, ErrInvalidState)
 		return
 	}
 
-	// Read the snapshot to get paths for VMD.
-	if !sandbox.SnapshotID.Valid {
-		log.Error().Str("sandbox_id", sandboxID.String()).Msg("paused sandbox has no snapshot_id")
-		respondError(c, ErrInternal)
+	if !h.resumePausedSandbox(c, &sandbox, teamID) {
 		return
 	}
-
-	snapshot, err := h.DB.GetSnapshot(c.Request.Context(), db.GetSnapshotParams{
-		ID:     sandbox.SnapshotID.Bytes,
-		TeamID: teamID,
-	})
-	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
-	snapshotPath := snapshot.Path
-	memPath := resolveMemPath(snapshot)
-
-	// Resolve the VMD client for this sandbox's host.
-	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
-	if vmdLookupErr != nil {
-		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for resume failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
-	// Resume the VM. Cancellation of this call still follows the request
-	// context — if the client hangs up mid-resume, abort the VMD call.
-	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-	defer vmdCancel()
-	ipAddress, actualVcpu, actualMemMiB, err := vmd.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath, nil)
-	if err != nil {
-		if isVMDNotFound(err) {
-			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).
-				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
-			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath)
-			if err != nil {
-				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
-				respondError(c, ErrInternal)
-				return
-			}
-		} else {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
-			respondError(c, ErrInternal)
-			return
-		}
-	}
-
-	// The fallback may have returned 0 for vcpu/mem. Fall back to the DB values.
-	if actualVcpu == 0 {
-		actualVcpu = uint32(sandbox.VcpuCount)
-	}
-	if actualMemMiB == 0 {
-		actualMemMiB = uint32(sandbox.MemoryMib)
-	}
-
-	// Past this point the VM is running. Detach from cancellation so a
-	// client disconnect cannot leave the sandbox stuck in "paused" while
-	// the VM is actually up, but preserve the trace/span context so
-	// these DB writes still appear in the request trace.
-	postCtx, postCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-	defer postCancel()
-
-	var ipAddr *netip.Addr
-	if ipAddress != "" {
-		if addr, parseErr := netip.ParseAddr(ipAddress); parseErr == nil {
-			ipAddr = &addr
-		}
-	}
-	if err := h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
-		ID:        sandboxID,
-		VcpuCount: int32(actualVcpu),
-		MemoryMib: int32(actualMemMiB),
-		IpAddress: ipAddr,
-		TeamID:    teamID,
-	}); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
-	// Reapply persisted egress rules — the nftables rules and proxy state
-	// are fresh after a snapshot restore, so user rules must be re-pushed.
-	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
-	// Async observability writes.
-	h.logActivityAsync(c.Request.Context(), sandboxID, teamID, "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 
 	resp := gin.H{
 		"id":     sandboxID.String(),
@@ -1075,10 +1126,10 @@ type sandboxExecRequest struct {
 }
 
 // ExecSandbox runs a command inside a sandbox and returns the result.
-// The sandbox must already be active — callers must resume a paused sandbox
-// via POST /sandboxes/:id/resume first.
+// A paused sandbox is resumed transparently before the command runs and is
+// left active afterward.
 func (h *Handlers) ExecSandbox(c *gin.Context) {
-	sandbox := h.loadActiveSandbox(c)
+	sandbox := h.loadActiveOrResumeSandbox(c)
 	if sandbox == nil {
 		return
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -837,35 +837,67 @@ func TestExecSandbox_InvalidState(t *testing.T) {
 	}
 }
 
-// Paused sandboxes must be resumed explicitly via POST /resume before exec
-// works — there is no implicit auto-wake.
-func TestExecSandbox_PausedRejected(t *testing.T) {
+// A paused sandbox is auto-resumed when exec is called; the command runs and
+// the sandbox is left active.
+func TestExecSandbox_PausedAutoResume(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
-	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "paused-sb", Status: db.SandboxStatusPaused}
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{
+		ID:        snapshotID,
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+		Path:      "/snapshots/test/vmstate.snap",
+		Saved:     false,
+		Trigger:   "pause",
+	}
 
-	var execCalled bool
+	var resumeCalled, execCalled bool
 	vmd := &stubVMD{
-		execFn: func(context.Context, string, string, []string, map[string]string, string, uint32) (string, string, int32, error) {
+		resumeFn: func(_ context.Context, id, _, _ string) (string, error) {
+			resumeCalled = true
+			if id != sandboxID.String() {
+				t.Errorf("ResumeInstance id = %q, want %q", id, sandboxID)
+			}
+			return "10.0.0.7", nil
+		},
+		execFn: func(_ context.Context, id, cmd string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {
 			execCalled = true
-			return "", "", 0, nil
+			if id != sandboxID.String() {
+				t.Errorf("ExecCommand id = %q, want %q", id, sandboxID)
+			}
+			return cmd + " output", "", 0, nil
 		},
 	}
 
 	mock := &mockDBTX{
-		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
-		execFn:     func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
 	}
 
 	h := &Handlers{VMD: vmd, DB: db.New(mock)}
 	w := httptest.NewRecorder()
 	setupTestRouter(h, teamID.String()).ServeHTTP(w, sandboxExecReq(sandboxID.String(), `{"command":"echo"}`))
 
-	if w.Code != http.StatusConflict {
-		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusConflict, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
-	if execCalled {
-		t.Error("VMD.ExecCommand should not be called on a paused sandbox")
+	if !resumeCalled {
+		t.Error("VMD.ResumeInstance was not called before exec")
+	}
+	if !execCalled {
+		t.Error("VMD.ExecCommand was not called after auto-resume")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ type stubVMD struct {
 	restoreFn        func(ctx context.Context, id, snapshotPath, memPath string) (string, error)
 	deleteSnapshotFn func(ctx context.Context, id, snapshotPath, memPath string) error
 	execFn           func(ctx context.Context, id, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error)
+	updateNetworkFn  func(ctx context.Context, id string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
 }
 
 func (s *stubVMD) CreateInstance(ctx context.Context, id string, vcpu, memMiB, diskMiB uint32, metadata map[string]string, envVars map[string]string) (string, uint32, uint32, error) {
@@ -82,7 +85,10 @@ func (s *stubVMD) ExecCommand(ctx context.Context, id, command string, args []st
 func (s *stubVMD) ExecCommandStream(context.Context, string, string, []string, map[string]string, string, uint32, func([]byte, []byte, int32, bool)) error {
 	return nil
 }
-func (s *stubVMD) UpdateSandboxNetwork(_ context.Context, _ string, _, _, _ []string) error {
+func (s *stubVMD) UpdateSandboxNetwork(ctx context.Context, id string, allowed, denied, domains []string) error {
+	if s.updateNetworkFn != nil {
+		return s.updateNetworkFn(ctx, id, allowed, denied, domains)
+	}
 	return nil
 }
 
@@ -493,11 +499,11 @@ func TestResumeSandbox_Success(t *testing.T) {
 		},
 	}
 
-	queryRowCall := 0
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			queryRowCall++
 			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb) // BeginResume RETURNING *
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -643,14 +649,16 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 		},
 	}
 
-	queryRowCall := 0
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			queryRowCall++
-			if strings.Contains(sql, "FROM sandbox") {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return snapshotRow(snap)
 			}
-			return snapshotRow(snap)
 		},
 		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
 			return pgconn.NewCommandTag(""), nil
@@ -663,6 +671,171 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+// Network-reapply failure after VMD resume must destroy the VM, revert DB to
+// paused, and never flip status to active.
+func TestResumeSandbox_NetworkReapplyFailure_DestroysAndReverts(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	sb.NetworkConfig = []byte(`{"egress":{"allowed_cidrs":["10.0.0.0/8"]}}`)
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
+	}
+
+	var destroyCalled, updateNetworkCalled int32
+	vmd := &stubVMD{
+		resumeFn: func(context.Context, string, string, string) (string, error) {
+			return "10.0.0.5", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			atomic.AddInt32(&destroyCalled, 1)
+			return nil
+		},
+		updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
+			atomic.AddInt32(&updateNetworkCalled, 1)
+			return fmt.Errorf("nftables push failed")
+		},
+	}
+
+	var activateCalled, revertCalled int32
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "'active'") {
+				atomic.AddInt32(&activateCalled, 1)
+			}
+			if strings.Contains(sql, "SET status = 'paused'") {
+				atomic.AddInt32(&revertCalled, 1)
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if got := atomic.LoadInt32(&updateNetworkCalled); got != 1 {
+		t.Errorf("reapplyNetworkConfig calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&destroyCalled); got != 1 {
+		t.Errorf("DestroyInstance calls = %d, want 1 (on failure)", got)
+	}
+	if got := atomic.LoadInt32(&activateCalled); got != 0 {
+		t.Errorf("ActivateSandbox calls = %d, want 0 (network failed before commit)", got)
+	}
+	if got := atomic.LoadInt32(&revertCalled); got != 1 {
+		t.Errorf("RevertResumeToPaused calls = %d, want 1", got)
+	}
+}
+
+// DB activate failure after network reapply must also destroy the VM + revert.
+func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
+	}
+
+	var destroyCalled int32
+	vmd := &stubVMD{
+		resumeFn: func(context.Context, string, string, string) (string, error) {
+			return "10.0.0.5", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			atomic.AddInt32(&destroyCalled, 1)
+			return nil
+		},
+	}
+
+	var revertCalled int32
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "'active'") {
+				return pgconn.CommandTag{}, fmt.Errorf("db connection lost")
+			}
+			if strings.Contains(sql, "SET status = 'paused'") {
+				atomic.AddInt32(&revertCalled, 1)
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if got := atomic.LoadInt32(&destroyCalled); got != 1 {
+		t.Errorf("DestroyInstance calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&revertCalled); got != 1 {
+		t.Errorf("RevertResumeToPaused calls = %d, want 1", got)
+	}
+}
+
+// Exec on a sandbox in 'pausing' state returns 409 (auto-resume only fires
+// from 'paused').
+func TestExecSandbox_PausingStateRejected(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusPausing}
+
+	vmd := &stubVMD{
+		resumeFn: func(context.Context, string, string, string) (string, error) {
+			t.Error("ResumeInstance must not be called on a pausing sandbox")
+			return "", nil
+		},
+		execFn: func(context.Context, string, string, []string, map[string]string, string, uint32) (string, string, int32, error) {
+			t.Error("ExecCommand must not be called on a pausing sandbox")
+			return "", "", 0, nil
+		},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+		execFn:     func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, sandboxExecReq(sandboxID.String(), `{"command":"echo"}`))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
 	}
 }
 
@@ -683,11 +856,11 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 		},
 	}
 
-	queryRowCall := 0
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			queryRowCall++
 			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -874,6 +1047,8 @@ func TestExecSandbox_PausedAutoResume(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -898,6 +1073,136 @@ func TestExecSandbox_PausedAutoResume(t *testing.T) {
 	}
 	if !execCalled {
 		t.Error("VMD.ExecCommand was not called after auto-resume")
+	}
+}
+
+// Loser of a concurrent BeginResume race returns 409 without calling VMD.
+func TestExecSandbox_ConcurrentResumeLoserReturns409(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+
+	vmd := &stubVMD{
+		resumeFn: func(context.Context, string, string, string) (string, error) {
+			t.Error("VMD.ResumeInstance must not be called when BeginResume lost the race")
+			return "", nil
+		},
+		execFn: func(context.Context, string, string, []string, map[string]string, string, uint32) (string, string, int32, error) {
+			t.Error("VMD.ExecCommand must not be called when BeginResume lost the race")
+			return "", "", 0, nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return notFoundRow() // simulate BeginResume 0-row (loser)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag(""), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, sandboxExecReq(sandboxID.String(), `{"command":"echo"}`))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+}
+
+// Two concurrent /exec requests on the same paused sandbox: exactly one
+// VMD resume, one ActivateSandbox, one exec; the loser gets 409.
+func TestExecSandbox_ConcurrentResumeSerializes(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	paused := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{
+		ID:        snapshotID,
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+		Path:      "/snapshots/test/vmstate.snap",
+		Saved:     false,
+		Trigger:   "pause",
+	}
+
+	var resumeCalls, activateCalls, execCalls int32
+	vmd := &stubVMD{
+		resumeFn: func(context.Context, string, string, string) (string, error) {
+			atomic.AddInt32(&resumeCalls, 1)
+			return "10.0.0.7", nil
+		},
+		execFn: func(context.Context, string, string, []string, map[string]string, string, uint32) (string, string, int32, error) {
+			atomic.AddInt32(&execCalls, 1)
+			return "ok", "", 0, nil
+		},
+	}
+
+	var claimed int32 // only first BeginResume wins
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				if atomic.CompareAndSwapInt32(&claimed, 0, 1) {
+					return sandboxRow(paused)
+				}
+				return notFoundRow()
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(paused)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "'active'") {
+				atomic.AddInt32(&activateCalls, 1)
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	router := setupTestRouter(h, teamID.String())
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, sandboxExecReq(sandboxID.String(), `{"command":"echo"}`))
+			codes[idx] = w.Code
+		}(i)
+	}
+	wg.Wait()
+
+	// One 200 (winner: exec ran), one 409 (loser: BeginResume lost).
+	got := map[int]int{}
+	for _, c := range codes {
+		got[c]++
+	}
+	if got[http.StatusOK] != 1 || got[http.StatusConflict] != 1 {
+		t.Fatalf("unexpected status distribution: %v (codes=%v)", got, codes)
+	}
+
+	if got := atomic.LoadInt32(&resumeCalls); got != 1 {
+		t.Errorf("ResumeInstance calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&activateCalls); got != 1 {
+		t.Errorf("ActivateSandbox calls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&execCalls); got != 1 {
+		t.Errorf("ExecCommand calls = %d, want 1", got)
 	}
 }
 

--- a/internal/api/streaming.go
+++ b/internal/api/streaming.go
@@ -23,10 +23,10 @@ type streamExecRequest struct {
 }
 
 // ExecSandboxStream runs a command inside a sandbox and streams output via SSE.
-// The sandbox must already be active — callers must resume a paused sandbox
-// via POST /sandboxes/:id/resume first.
+// A paused sandbox is resumed transparently before the command runs and is
+// left active afterward.
 func (h *Handlers) ExecSandboxStream(c *gin.Context) {
-	sandbox := h.loadActiveSandbox(c)
+	sandbox := h.loadActiveOrResumeSandbox(c)
 	if sandbox == nil {
 		return
 	}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -23,6 +23,7 @@ const (
 	SandboxStatusPaused   SandboxStatus = "paused"
 	SandboxStatusDeleted  SandboxStatus = "deleted"
 	SandboxStatusFailed   SandboxStatus = "failed"
+	SandboxStatusResuming SandboxStatus = "resuming"
 )
 
 func (e *SandboxStatus) Scan(src interface{}) error {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -85,6 +85,46 @@ func (q *Queries) BeginPause(ctx context.Context, arg BeginPauseParams) (Sandbox
 	return i, err
 }
 
+const beginResume = `-- name: BeginResume :one
+UPDATE sandbox
+SET status = 'resuming', updated_at = now()
+WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata
+`
+
+type BeginResumeParams struct {
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
+}
+
+// Atomic claim for resume: transitions 'paused' to 'resuming' in one
+// statement. A 0-row result means another resume (explicit or auto) has
+// already claimed the sandbox, or it's not in paused state. Used to
+// serialize concurrent /exec and /resume requests.
+func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandbox, error) {
+	row := q.db.QueryRow(ctx, beginResume, arg.ID, arg.TeamID)
+	var i Sandbox
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.Name,
+		&i.Status,
+		&i.VcpuCount,
+		&i.MemoryMib,
+		&i.HostID,
+		&i.IpAddress,
+		&i.Pid,
+		&i.SnapshotID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DestroyedAt,
+		&i.NetworkConfig,
+		&i.TimeoutSeconds,
+		&i.Metadata,
+	)
+	return i, err
+}
+
 const claimExpiredSandboxes = `-- name: ClaimExpiredSandboxes :many
 WITH expired AS (
   SELECT id, team_id, name, snapshot_id, host_id
@@ -493,6 +533,25 @@ WHERE id = $1 AND destroyed_at IS NULL
 // not team scope.
 func (q *Queries) MarkSandboxFailed(ctx context.Context, id uuid.UUID) error {
 	_, err := q.db.Exec(ctx, markSandboxFailed, id)
+	return err
+}
+
+const revertResumeToPaused = `-- name: RevertResumeToPaused :exec
+UPDATE sandbox
+SET status = 'paused', updated_at = now()
+WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
+`
+
+type RevertResumeToPausedParams struct {
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
+}
+
+// Compensate a failed resume attempt by flipping status back to 'paused'.
+// Guarded on status = 'resuming' so we never clobber a concurrent transition
+// (e.g., ActivateSandbox has already flipped to 'active').
+func (q *Queries) RevertResumeToPaused(ctx context.Context, arg RevertResumeToPausedParams) error {
+	_, err := q.db.Exec(ctx, revertResumeToPaused, arg.ID, arg.TeamID)
 	return err
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -603,8 +603,8 @@ func TestIntegration_ExecSandbox_Success(t *testing.T) {
 	}
 }
 
-// Exec on a paused sandbox must be rejected — callers must resume explicitly
-// via POST /resume. There is no implicit auto-wake on traffic.
+// Exec on a paused sandbox transparently resumes it, runs the command, and
+// leaves the sandbox active.
 func TestIntegration_ExecSandbox_PausedAutoResume(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)
@@ -629,6 +629,69 @@ func TestIntegration_ExecSandbox_PausedAutoResume(t *testing.T) {
 	status, _ := mustJSON(t, gw)["status"].(string)
 	if status != "active" {
 		t.Errorf("sandbox status after auto-resume = %q, want %q", status, "active")
+	}
+}
+
+// Baseline: /exec/stream on an active sandbox emits a valid SSE response
+// ending with finished=true and exit_code=0.
+func TestIntegration_ExecSandboxStream_Success(t *testing.T) {
+	_, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"stream-box"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d", cw.Code)
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+
+	ew := do(r, "POST", "/sandboxes/"+sid+"/exec/stream", apiKey, `{"command":"echo hi"}`)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("exec/stream: expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+	body := ew.Body.String()
+	if !strings.HasPrefix(body, "data: ") {
+		t.Errorf("body does not start with SSE data frame; got: %q", body)
+	}
+	if !strings.Contains(body, `"finished":true`) {
+		t.Errorf("SSE body missing finished event; got: %s", body)
+	}
+	if !strings.Contains(body, `"exit_code":0`) {
+		t.Errorf("SSE body missing exit_code=0; got: %s", body)
+	}
+}
+
+// Same auto-resume behavior on the SSE streaming endpoint.
+func TestIntegration_ExecSandboxStream_PausedAutoResume(t *testing.T) {
+	_, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"paused-stream-box"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d", cw.Code)
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+
+	pw := do(r, "POST", "/sandboxes/"+sid+"/pause", apiKey, "")
+	if pw.Code != http.StatusNoContent {
+		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
+	}
+
+	ew := do(r, "POST", "/sandboxes/"+sid+"/exec/stream", apiKey, `{"command":"echo hi"}`)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("exec/stream on paused (auto-resume): expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+	body := ew.Body.String()
+	if !strings.Contains(body, `"finished":true`) {
+		t.Errorf("SSE body missing finished event; got: %s", body)
+	}
+	if !strings.Contains(body, `"exit_code":0`) {
+		t.Errorf("SSE body missing exit_code=0; got: %s", body)
+	}
+
+	gw := do(r, "GET", "/sandboxes/"+sid, apiKey, "")
+	status, _ := mustJSON(t, gw)["status"].(string)
+	if status != "active" {
+		t.Errorf("sandbox status after stream auto-resume = %q, want %q", status, "active")
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -605,7 +605,7 @@ func TestIntegration_ExecSandbox_Success(t *testing.T) {
 
 // Exec on a paused sandbox must be rejected — callers must resume explicitly
 // via POST /resume. There is no implicit auto-wake on traffic.
-func TestIntegration_ExecSandbox_PausedRejected(t *testing.T) {
+func TestIntegration_ExecSandbox_PausedAutoResume(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)
 
@@ -621,8 +621,14 @@ func TestIntegration_ExecSandbox_PausedRejected(t *testing.T) {
 	}
 
 	ew := do(r, "POST", "/sandboxes/"+sid+"/exec", apiKey, `{"command":"echo hello"}`)
-	if ew.Code != http.StatusConflict {
-		t.Fatalf("exec on paused: expected 409, got %d: %s", ew.Code, ew.Body.String())
+	if ew.Code != http.StatusOK {
+		t.Fatalf("exec on paused (auto-resume): expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+
+	gw := do(r, "GET", "/sandboxes/"+sid, apiKey, "")
+	status, _ := mustJSON(t, gw)["status"].(string)
+	if status != "active" {
+		t.Errorf("sandbox status after auto-resume = %q, want %q", status, "active")
 	}
 }
 

--- a/supabase/migrations/20260421000002_add_resuming_status.sql
+++ b/supabase/migrations/20260421000002_add_resuming_status.sql
@@ -1,0 +1,4 @@
+-- Add 'resuming' to the sandbox_status enum so resume operations can claim
+-- a sandbox atomically (paused -> resuming) before calling VMD, preventing
+-- concurrent resume requests from racing.
+ALTER TYPE sandbox_status ADD VALUE IF NOT EXISTS 'resuming';


### PR DESCRIPTION
## Summary

`POST /exec` and `POST /exec/stream` on a paused sandbox now auto-resume it, run the command, and leave it active. Callers no longer need to issue `POST /resume` first.

## What changed

- Extract `resumePausedSandbox` — shared by explicit `/resume` and the auto-resume path.
- `loadActiveOrResumeSandbox`: `active` → use; `paused` → auto-resume; anything else → 409.
- Atomic `BeginResume` (new `resuming` enum value, migration `20260421000002`) serializes concurrent resumes at the DB — losers get 409.
- Serialize network reapply before DB activate so "active ⇒ rules applied" holds by construction. Failure after VMD resume destroys the VM + reverts DB to paused.

## Test plan

- [x] Unit + integration + race all green.
- [x] Tested on staging.