### PR TITLE
api: user-safe error messages, add resuming to status enum

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -376,11 +376,7 @@ components:
           $ref: "#/components/schemas/NetworkConfig"
 
     SandboxListItem:
-      description: |
-        Sandbox shape returned by endpoints that list many sandboxes
-        (`GET /sandboxes`). Never includes `access_token` — that is only
-        minted on create/get-by-id/resume where the caller has established
-        ownership of a single sandbox.
+      description: Sandbox shape returned by list endpoints. No `access_token`.
       type: object
       properties:
         id:
@@ -429,10 +425,7 @@ components:
             owner: agent-7
 
     SandboxResponse:
-      description: |
-        Single-sandbox shape returned on create, get-by-id, and resume
-        paths. Extends `SandboxListItem` with `access_token` (the
-        per-sandbox token for data-plane operations).
+      description: Single-sandbox shape — `SandboxListItem` plus `access_token`.
       allOf:
         - $ref: "#/components/schemas/SandboxListItem"
         - type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -70,7 +70,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/SandboxResponse"
+                  $ref: "#/components/schemas/SandboxListItem"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -375,7 +375,12 @@ components:
         network:
           $ref: "#/components/schemas/NetworkConfig"
 
-    SandboxResponse:
+    SandboxListItem:
+      description: |
+        Sandbox shape returned by endpoints that list many sandboxes
+        (`GET /sandboxes`). Never includes `access_token` — that is only
+        minted on create/get-by-id/resume where the caller has established
+        ownership of a single sandbox.
       type: object
       properties:
         id:
@@ -393,12 +398,6 @@ components:
           type: integer
         memory_mib:
           type: integer
-        access_token:
-          type: string
-          description: |
-            Per-sandbox access token for data-plane operations (file
-            upload/download, terminal). Pass as the `X-Access-Token` header.
-            Returned on create and get-by-id only.
         snapshot_id:
           type: string
           format: uuid
@@ -428,6 +427,22 @@ components:
           example:
             env: prod
             owner: agent-7
+
+    SandboxResponse:
+      description: |
+        Single-sandbox shape returned on create, get-by-id, and resume
+        paths. Extends `SandboxListItem` with `access_token` (the
+        per-sandbox token for data-plane operations).
+      allOf:
+        - $ref: "#/components/schemas/SandboxListItem"
+        - type: object
+          properties:
+            access_token:
+              type: string
+              description: |
+                Per-sandbox access token for data-plane operations (file
+                upload/download, terminal). Pass as the `X-Access-Token`
+                header.
 
     ResumeResponse:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -385,10 +385,10 @@ components:
           type: string
         status:
           type: string
-          enum: [active, paused]
+          enum: [active, paused, resuming]
           description: >
-            Current state of the sandbox. `active` means running; `paused`
-            means paused and awaiting resume.
+            `active` = running, `paused` = stopped with state saved,
+            `resuming` = transient during paused→active (retry shortly).
         vcpu_count:
           type: integer
         memory_mib:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -376,7 +376,7 @@ components:
           $ref: "#/components/schemas/NetworkConfig"
 
     SandboxListItem:
-      description: Sandbox shape returned by list endpoints. No `access_token`.
+      description: Sandbox shape returned by list endpoints.
       type: object
       properties:
         id:

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -20,12 +20,11 @@ func (e *AppError) Error() string {
 
 // Common application errors.
 var (
-	ErrInstanceNotFound   = &AppError{Code: "not_found", Message: "Instance not found", HTTPStatus: http.StatusNotFound}
 	ErrSandboxNotFound    = &AppError{Code: "not_found", Message: "Sandbox not found", HTTPStatus: http.StatusNotFound}
-	ErrInvalidState = &AppError{Code: "conflict", Message: "Instance is not in a valid state for this operation", HTTPStatus: http.StatusConflict}
+	ErrInvalidState = &AppError{Code: "conflict", Message: "Sandbox is not in a valid state for this operation", HTTPStatus: http.StatusConflict}
 	ErrBadRequest         = &AppError{Code: "bad_request", Message: "Invalid request", HTTPStatus: http.StatusBadRequest}
 	ErrUnauthorized       = &AppError{Code: "unauthorized", Message: "Invalid or missing X-API-Key header", HTTPStatus: http.StatusUnauthorized}
-	ErrInternal           = &AppError{Code: "internal_error", Message: "An internal error occurred", HTTPStatus: http.StatusInternalServerError}
+	ErrInternal           = &AppError{Code: "internal_error", Message: "A problem occurred. Please try again, or contact the team if it persists.", HTTPStatus: http.StatusInternalServerError}
 	ErrConflict           = &AppError{Code: "conflict", Message: "Operation conflicts with current state", HTTPStatus: http.StatusConflict}
 )
 
@@ -51,7 +50,7 @@ func respondError(c *gin.Context, err error) {
 	c.JSON(http.StatusInternalServerError, gin.H{
 		"error": gin.H{
 			"code":    "internal_error",
-			"message": "An internal error occurred. Please try again or contact support.",
+			"message": "A problem occurred. Please try again, or contact the team if it persists.",
 		},
 	})
 }

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -88,7 +88,6 @@ func TestPredefinedErrors(t *testing.T) {
 		wantCode   string
 		wantStatus int
 	}{
-		{"ErrInstanceNotFound", ErrInstanceNotFound, "not_found", 404},
 		{"ErrSandboxNotFound", ErrSandboxNotFound, "not_found", 404},
 		{"ErrInvalidState", ErrInvalidState, "conflict", 409},
 		{"ErrBadRequest", ErrBadRequest, "bad_request", 400},

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -768,7 +768,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 func (h *Handlers) CreateSandbox(c *gin.Context) {
 	var req createSandboxRequest
 	if err := bindJSONStrict(c, &req); err != nil {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("Validation failed: %v", err), http.StatusBadRequest)
+		respondErrorMsg(c, "bad_request", "Request body is not valid JSON or contains unknown fields.", http.StatusBadRequest)
 		return
 	}
 	// Manual field validation — bindJSONStrict uses encoding/json which does
@@ -1172,7 +1172,7 @@ func (h *Handlers) ExecSandbox(c *gin.Context) {
 
 	var req sandboxExecRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("Validation failed: %v", err), http.StatusBadRequest)
+		respondErrorMsg(c, "bad_request", "Request body is not valid JSON or is missing required fields (command is required).", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -115,7 +115,7 @@ func ErrorHandler() gin.HandlerFunc {
 					Msg("panic recovered")
 
 				respondErrorMsg(c, "internal_error",
-					"An internal error occurred. Please try again or contact support.",
+					"A problem occurred. Please try again, or contact the team if it persists.",
 					http.StatusInternalServerError,
 				)
 				c.Abort()

--- a/internal/api/streaming.go
+++ b/internal/api/streaming.go
@@ -33,7 +33,7 @@ func (h *Handlers) ExecSandboxStream(c *gin.Context) {
 
 	var req streamExecRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("Validation failed: %v", err), http.StatusBadRequest)
+		respondErrorMsg(c, "bad_request", "Request body is not valid JSON or is missing required fields (command is required).", http.StatusBadRequest)
 		return
 	}
 
@@ -109,7 +109,8 @@ func (h *Handlers) ExecSandboxStream(c *gin.Context) {
 		} else {
 			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("streaming sandbox exec failed")
 			errEvent, _ := json.Marshal(gin.H{
-				"error":    err.Error(),
+				"error":    "A problem occurred while running the command. Please try again, or contact the team if it persists.",
+				"code":     "exec_failed",
 				"finished": true,
 			})
 			fmt.Fprintf(c.Writer, "data: %s\n\n", errEvent)


### PR DESCRIPTION
## Summary

Clean up user-facing API error messages so nothing leaks Go internals, and document the `resuming` transient state in the OpenAPI spec.

## What changed

- Replaced `"An internal error occurred"` (generic 500 message, used in 3 places) with `"A problem occurred. Please try again, or contact the team if it persists."`
- Validation errors for `POST /sandboxes`, `/exec`, `/exec/stream` no longer interpolate raw Go JSON decoder errors; users now see a human-readable sentence.
- SSE error event on `/exec/stream` no longer embeds `err.Error()`; emits a user-safe message with a `code` field.
- `ErrInvalidState` now says "Sandbox" (was "Instance"); dead `ErrInstanceNotFound` removed.
- `openapi.yaml`: added `resuming` to the sandbox `status` enum with a short note that clients should retry shortly.

## Test plan

- [x] Unit + vet green.