### PR TITLE
CI/CD reliability: seed-templates triggers + Deploy VMD wait + migration order check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,43 @@ jobs:
             git diff
             exit 1
           fi
+
+  migration-order:
+    name: Migration Order
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject migrations dated at or before the highest on main
+        run: |
+          git fetch origin main
+          HIGHEST_MAIN=$(git ls-tree -r origin/main --name-only \
+            | grep '^supabase/migrations/' \
+            | grep -oE '[0-9]{14}' \
+            | sort -n | tail -n1)
+          if [ -z "$HIGHEST_MAIN" ]; then
+            echo "no migrations on main yet; nothing to compare against"
+            exit 0
+          fi
+          echo "highest version on main: $HIGHEST_MAIN"
+
+          NEW=$(git diff --name-status origin/main...HEAD -- supabase/migrations/ \
+            | awk '$1=="A" {print $2}')
+          if [ -z "$NEW" ]; then
+            echo "no new migrations in this PR"
+            exit 0
+          fi
+
+          fail=0
+          for file in $NEW; do
+            v=$(basename "$file" | grep -oE '^[0-9]{14}')
+            if [ "$v" -le "$HIGHEST_MAIN" ]; then
+              echo "::error file=$file::migration $v is at or before highest-on-main $HIGHEST_MAIN — supabase db push will refuse without --include-all; bump the timestamp"
+              fail=1
+            fi
+          done
+          [ $fail -eq 0 ] && echo "all new migrations are correctly ordered"
+          exit $fail

--- a/.github/workflows/seed-templates.yml
+++ b/.github/workflows/seed-templates.yml
@@ -20,6 +20,10 @@
 
 name: CD — Seed Templates
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -74,6 +78,34 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # If Deploy VMD was triggered by the same commit, wait for it to finish.
+      # Seeding while vmd is being redeployed kills in-flight builds.
+      - name: Wait for Deploy VMD
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DEADLINE=$(( $(date +%s) + 900 ))
+          while true; do
+            RUN=$(gh run list --workflow=deploy-vmd.yml --commit="${{ github.sha }}" --limit 1 --json status,conclusion --jq '.[0]')
+            if [ -z "$RUN" ] || [ "$RUN" = "null" ]; then
+              echo "no Deploy VMD run for this commit — proceeding"
+              exit 0
+            fi
+            STATUS=$(echo "$RUN" | jq -r .status)
+            CONCLUSION=$(echo "$RUN" | jq -r .conclusion)
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Deploy VMD complete — proceeding"
+                exit 0
+              fi
+              echo "Deploy VMD finished with conclusion=$CONCLUSION; refusing to seed"
+              exit 1
+            fi
+            echo "Deploy VMD status=$STATUS; waiting 30s..."
+            sleep 30
+            [ $(date +%s) -lt "$DEADLINE" ] || { echo "timeout waiting for Deploy VMD"; exit 1; }
+          done
+
       # Detect whether this run was triggered by a change that invalidates
       # existing template snapshots (boxd, proto, builder internals). If so,
       # force-rebuild so every template gets refreshed. workflow_dispatch
@@ -120,6 +152,32 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Wait for Deploy VMD
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DEADLINE=$(( $(date +%s) + 900 ))
+          while true; do
+            RUN=$(gh run list --workflow=deploy-vmd.yml --commit="${{ github.sha }}" --limit 1 --json status,conclusion --jq '.[0]')
+            if [ -z "$RUN" ] || [ "$RUN" = "null" ]; then
+              echo "no Deploy VMD run for this commit — proceeding"
+              exit 0
+            fi
+            STATUS=$(echo "$RUN" | jq -r .status)
+            CONCLUSION=$(echo "$RUN" | jq -r .conclusion)
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "Deploy VMD complete — proceeding"
+                exit 0
+              fi
+              echo "Deploy VMD finished with conclusion=$CONCLUSION; refusing to seed"
+              exit 1
+            fi
+            echo "Deploy VMD status=$STATUS; waiting 30s..."
+            sleep 30
+            [ $(date +%s) -lt "$DEADLINE" ] || { echo "timeout waiting for Deploy VMD"; exit 1; }
+          done
 
       - name: Detect stale snapshots
         id: stale

--- a/.github/workflows/seed-templates.yml
+++ b/.github/workflows/seed-templates.yml
@@ -49,7 +49,6 @@ on:
       - 'cmd/template-builder/**'
       - 'proto/boxdpb/**'
       - 'internal/builder/**'
-      - 'internal/vm/**'
 
 # Serialize runs so two concurrent pushes don't double-trigger the
 # build supervisor with the same specs. In-progress runs complete before
@@ -89,7 +88,7 @@ jobs:
             echo "force=${{ github.event.inputs.force_rebuild }}" >> "$GITHUB_OUTPUT"
           elif [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo "force=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -qE '^(cmd/boxd/|cmd/template-builder/|proto/boxdpb/|internal/builder/|internal/vm/)'; then
+          elif git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -qE '^(cmd/boxd/|cmd/template-builder/|proto/boxdpb/|internal/builder/)'; then
             echo "force=true" >> "$GITHUB_OUTPUT"
           else
             echo "force=false" >> "$GITHUB_OUTPUT"
@@ -132,7 +131,7 @@ jobs:
             echo "force=${{ github.event.inputs.force_rebuild }}" >> "$GITHUB_OUTPUT"
           elif [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo "force=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -qE '^(cmd/boxd/|cmd/template-builder/|proto/boxdpb/|internal/builder/|internal/vm/)'; then
+          elif git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -qE '^(cmd/boxd/|cmd/template-builder/|proto/boxdpb/|internal/builder/)'; then
             echo "force=true" >> "$GITHUB_OUTPUT"
           else
             echo "force=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Three independent CI/CD reliability fixes from today's templates-v1 + snapshot-gc post-mortem.

**1. Drop `internal/vm/**` from seed-templates triggers.**
That package contains the reconciler, network manager, RPC adapters, and build cleanup — none of which affect the produced rootfs. Including it fired Seed Templates + force-rebuild on every backend PR.

**2. Wait for Deploy VMD on the same commit before seeding.**
The "vmd has no record of this build" failures we kept seeing were caused by Deploy VMD restarting vmd mid-build (when both workflows fired from the same push). New step in seed-staging and seed-prod polls the matching Deploy VMD run; proceeds on success, refuses on failure, ignores when no run exists.

**3. Migration order check in CI.**
Adapted from `e2b-dev/infra` (`out-of-order-migrations.yml`). Rejects PRs that add a migration dated at or before the highest on main — `supabase db push` refuses out-of-order migrations and forces manual `--include-all`. We hit this on templates-v1.

## Commits

- `5a85bca` seed-templates trigger narrowing
- `f2e22c0` Wait for Deploy VMD step
- `5c23e41` CI migration order check