### PR TITLE
PTY terminal fix + deploy-vmd trigger for internal/builder

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -24,6 +24,7 @@ on:
       - 'cmd/template-builder/**'
       - 'internal/vm/**'
       - 'internal/network/**'
+      - 'internal/builder/**'
       - 'deploy/superserve-vmd.service'
       - 'deploy/firecracker@.service'
       - 'deploy/firecracker-netns@.service'

--- a/internal/builder/inject.go
+++ b/internal/builder/inject.go
@@ -155,6 +155,7 @@ mount -t devtmpfs dev /dev 2>/dev/null
 mount -t tmpfs tmpfs /run 2>/dev/null
 mount -t tmpfs tmpfs /tmp 2>/dev/null
 mkdir -p /dev/pts /home/user
+mount -t devpts devpts /dev/pts -o gid=5,mode=620,ptmxmode=666 2>/dev/null
 
 # Seed the kernel entropy pool. Firecracker VMs lack virtio-rng and
 # RDRAND, so getrandom() blocks until entropy is credited. The


### PR DESCRIPTION
## Summary

Two fixes that go together — the devpts mount in the rootfs, and the workflow trigger that ensures the new template-builder ships when this kind of code changes.

**1. Mount devpts in the template init script.**
Templates-v1's simplified init mounts proc/sysfs/devtmpfs/tmpfs but skips devpts. Without it, `/dev/ptmx` returns ENODEV when boxd tries to allocate a PTY, so the WebSocket terminal returns 1011 ("shell did not start") on every sandbox. Confirmed end-to-end working on staging after rebuilding `superserve/code-interpreter` with this fix.

**2. Add `internal/builder/**` to deploy-vmd triggers.**
That package is compiled into the `template-builder` binary that deploy-vmd ships. Without it in the trigger paths, a fix like (1) wouldn't auto-redeploy template-builder, and the next seed run would rebuild with the old code.

## Rollout after merge

Both workflows will auto-fire on merge:
- Deploy VMD ships new template-builder.
- Seed Templates re-runs with the new template-builder.
- The "Wait for Deploy VMD" step in seed-templates (from PR #37) ensures order.

System templates need to be rebuilt to pick up the new init. Re-dispatch **CD — Seed Templates** with `force_rebuild=true` post-merge to refresh all 6 templates on staging + prod (the auto-fired seed runs without force-rebuild and skips already-ready templates).