### PR TITLE
supervisor: poll every 1s instead of 30s

### DIFF
--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -30,8 +30,7 @@ import (
 
 // BuildSupervisorConfig controls the supervisor's ticker cadence and bounds.
 type BuildSupervisorConfig struct {
-	// Interval is the poll period. 30s matches the sandbox timeout reaper
-	// and trades "a bit of dispatch latency" for "low DB/vmd chatter."
+	// Interval is the poll period.
 	Interval time.Duration
 
 	// BatchSize caps how many pending rows we evaluate per tick. Bounds the
@@ -66,7 +65,7 @@ type BuildSupervisorConfig struct {
 // DefaultBuildSupervisorConfig returns sensible defaults.
 func DefaultBuildSupervisorConfig(hostID string) BuildSupervisorConfig {
 	return BuildSupervisorConfig{
-		Interval:                  30 * time.Second,
+		Interval:                  1 * time.Second,
 		BatchSize:                 20,
 		GlobalMaxConcurrentBuilds: 10,
 		HostID:                    hostID,


### PR DESCRIPTION
## Summary

The build supervisor polls vmd's in-memory build registry every 30s, then writes terminal status to the DB. The /logs SSE stream pulls events directly from vmd, so SDKs see \`status=ready\` the instant vmd marks the build done — but the DB stays \`building\` for up to 30s until the supervisor's next tick. POST /sandboxes during that window returns 409 \"template is not ready\".

Tightening the supervisor loop to 1s shrinks the race to ~1s.