### PR TITLE
templates: rename alias to name; free the name on soft-delete

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1040,11 +1040,14 @@ components:
           type: string
           minLength: 1
           maxLength: 128
+          pattern: "^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?$"
           description: >
             Human-readable name, unique per team. Used as the
-            `from_template` value when creating sandboxes. Names
-            starting with `superserve/` are reserved for curated system templates
-            and rejected for team-owned templates.
+            `from_template` value when creating sandboxes. Lowercase
+            letters, digits, and `.` `_` `/` `-` only; must start and
+            end with a letter or digit. Names starting with `superserve/`
+            are reserved for curated system templates and rejected for
+            team-owned templates.
           example: my-python-env
         vcpu:
           type: integer

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27,7 +27,7 @@ info:
     By default sandboxes boot from the curated `superserve/base` template (Ubuntu 24.04,
     1 vCPU, 1 GB RAM, 4 GB disk, with Python 3.12, Node.js 22, npm, git, curl,
     and build-essential pre-installed). Callers can override with any template
-    alias (e.g. `superserve/python-3.11`, `superserve/node-22`) or a team-owned template UUID
+    name (e.g. `superserve/python-3.11`, `superserve/node-22`) or a team-owned template UUID
     via the `from_template` field on `POST /sandboxes`.
   contact:
     name: Superserve Team
@@ -371,13 +371,13 @@ paths:
       summary: List templates visible to the caller
       description: |
         Returns the caller's team's templates plus the curated system
-        templates (available to everyone, identified by the `superserve/` alias
+        templates (available to everyone, identified by the `superserve/` name
         prefix — e.g. `superserve/base`, `superserve/python-3.11`, `superserve/node-22`). Filter
-        by `alias_prefix=<text>`.
+        by `name_prefix=<text>`.
       security:
         - apiKey: []
       parameters:
-        - name: alias_prefix
+        - name: name_prefix
           in: query
           required: false
           schema:
@@ -697,10 +697,10 @@ components:
           type: string
           description: >
             Boot the sandbox from a template. Accepts either a template UUID
-            or an alias (e.g. `superserve/base`, `superserve/python-3.11`, `superserve/node-22`, or
-            a team-owned alias like `my-python-env`). The template must be
+            or a name (e.g. `superserve/base`, `superserve/python-3.11`, `superserve/node-22`, or
+            a team-owned name like `my-python-env`). The template must be
             owned by the caller's team OR be a curated system template
-            (curated templates use the `superserve/` alias prefix). The template's
+            (curated templates use the `superserve/` name prefix). The template's
             vCPU, memory, and disk values are inherited by the sandbox —
             they cannot be overridden per-sandbox because the snapshot
             dictates VM shape. When omitted, defaults to `superserve/base`.
@@ -1034,15 +1034,15 @@ components:
 
     CreateTemplateRequest:
       type: object
-      required: [alias, build_spec]
+      required: [name, build_spec]
       properties:
-        alias:
+        name:
           type: string
           minLength: 1
           maxLength: 128
           description: >
             Human-readable name, unique per team. Used as the
-            `from_template` value when creating sandboxes. Aliases
+            `from_template` value when creating sandboxes. Names
             starting with `superserve/` are reserved for curated system templates
             and rejected for team-owned templates.
           example: my-python-env
@@ -1078,7 +1078,7 @@ components:
         team_id:
           type: string
           format: uuid
-        alias:
+        name:
           type: string
         status:
           type: string
@@ -1106,7 +1106,7 @@ components:
         team_id:
           type: string
           format: uuid
-        alias:
+        name:
           type: string
         status:
           type: string

--- a/cmd/seed-templates/main.go
+++ b/cmd/seed-templates/main.go
@@ -4,7 +4,7 @@
 //
 // Flow per run:
 //   1. Upsert each JSON under superserve_templates/ into the template table
-//      owned by SYSTEM_TEAM_ID (idempotent on alias).
+//      owned by SYSTEM_TEAM_ID (idempotent on name).
 //   2. Decide whether to enqueue a build for each template:
 //        - Template row just inserted → enqueue.
 //        - Previous build failed / never ran → enqueue.
@@ -98,7 +98,7 @@ func main() {
 		log.Warn().Str("dir", dir).Msg("no seed files found")
 		return
 	}
-	sort.Slice(specs, func(i, j int) bool { return specs[i].Alias < specs[j].Alias })
+	sort.Slice(specs, func(i, j int) bool { return specs[i].Name < specs[j].Name })
 
 	var queued []uuid.UUID
 	var seedFailures int
@@ -106,15 +106,15 @@ func main() {
 		buildID, queuedIt, err := seedOne(ctx, pool, systemTeamID, s, forceRebuild)
 		if err != nil {
 			seedFailures++
-			log.Error().Err(err).Str("alias", s.Alias).Msg("seed failed")
+			log.Error().Err(err).Str("name", s.Name).Msg("seed failed")
 			continue
 		}
 		if !queuedIt {
-			log.Info().Str("alias", s.Alias).Msg("already up-to-date; nothing to build (pass --force-rebuild to override)")
+			log.Info().Str("name", s.Name).Msg("already up-to-date; nothing to build (pass --force-rebuild to override)")
 			continue
 		}
 		queued = append(queued, buildID)
-		log.Info().Str("alias", s.Alias).Str("build_id", buildID.String()).Msg("build queued")
+		log.Info().Str("name", s.Name).Str("build_id", buildID.String()).Msg("build queued")
 	}
 
 	if noWait || len(queued) == 0 {
@@ -139,7 +139,7 @@ func main() {
 // seedSpec mirrors the wire shape users POST to /templates. Kept local so
 // this binary doesn't pull in the HTTP handler package.
 type seedSpec struct {
-	Alias     string          `json:"alias"`
+	Name      string          `json:"name"`
 	Vcpu      *int32          `json:"vcpu,omitempty"`
 	MemoryMib *int32          `json:"memory_mib,omitempty"`
 	DiskMib   *int32          `json:"disk_mib,omitempty"`
@@ -168,8 +168,8 @@ func loadSpecs(dir string) ([]seedSpec, error) {
 		if err := dec.Decode(&s); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)
 		}
-		if s.Alias == "" {
-			return nil, fmt.Errorf("%s: alias is required", path)
+		if s.Name == "" {
+			return nil, fmt.Errorf("%s: name is required", path)
 		}
 		if len(s.BuildSpec) == 0 {
 			return nil, fmt.Errorf("%s: build_spec is required", path)
@@ -193,9 +193,9 @@ func seedOne(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, s seedSp
 	// Upsert and capture the resulting status so we can decide whether to
 	// enqueue a build in one follow-up query.
 	const upsertQ = `
-		INSERT INTO template (team_id, alias, build_spec, vcpu, memory_mib, disk_mib)
+		INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (team_id, alias) DO UPDATE
+		ON CONFLICT (team_id, name) WHERE deleted_at IS NULL DO UPDATE
 		SET build_spec = EXCLUDED.build_spec,
 		    vcpu = EXCLUDED.vcpu,
 		    memory_mib = EXCLUDED.memory_mib,
@@ -206,7 +206,7 @@ func seedOne(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, s seedSp
 	var tplID uuid.UUID
 	var tplStatus string
 	if err := pool.QueryRow(ctx, upsertQ,
-		teamID, s.Alias, []byte(s.BuildSpec), vcpu, memMib, diskMib,
+		teamID, s.Name, []byte(s.BuildSpec), vcpu, memMib, diskMib,
 	).Scan(&tplID, &tplStatus); err != nil {
 		return uuid.Nil, false, fmt.Errorf("upsert template: %w", err)
 	}

--- a/cmd/seed-templates/main.go
+++ b/cmd/seed-templates/main.go
@@ -191,7 +191,8 @@ func seedOne(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, s seedSp
 	}
 
 	// Upsert and capture the resulting status so we can decide whether to
-	// enqueue a build in one follow-up query.
+	// enqueue a build in one follow-up query. ON CONFLICT only matches live
+	// rows; a soft-deleted template would be re-inserted rather than updated.
 	const upsertQ = `
 		INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib)
 		VALUES ($1, $2, $3, $4, $5, $6)

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -3,7 +3,7 @@
 -- for ops-side seeding that wants to stage rows without triggering builds;
 -- the public API uses CreateTemplateWithBuild to auto-enqueue the first
 -- build in a single transaction.
-INSERT INTO template (team_id, alias, build_spec, vcpu, memory_mib, disk_mib)
+INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib)
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING *;
 
@@ -17,9 +17,9 @@ RETURNING *;
 -- idempotency index on template_build catches duplicate submits. Returns
 -- the template row plus the build id so the handler can echo both.
 WITH new_template AS (
-  INSERT INTO template (team_id, alias, build_spec, vcpu, memory_mib, disk_mib, status)
+  INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib, status)
   VALUES ($1, $2, $3, $4, $5, $6, 'building')
-  RETURNING id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib,
+  RETURNING id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib,
             rootfs_path, snapshot_path, mem_path, size_bytes, error_message,
             created_at, updated_at, built_at, deleted_at
 ),
@@ -46,12 +46,12 @@ WHERE id = $1
 SELECT * FROM template
 WHERE id = $1 AND team_id = $2 AND deleted_at IS NULL;
 
--- name: GetTemplateByAlias :one
--- Resolve alias to a template visible to the caller. Aliases are unique per
--- team, so the same alias can exist in both the caller's team and the system
+-- name: GetTemplateByName :one
+-- Resolve name to a template visible to the caller. Names are unique per
+-- team, so the same name can exist in both the caller's team and the system
 -- team — prefer the caller's own (ORDER BY) so overrides work naturally.
 SELECT * FROM template
-WHERE alias = $1
+WHERE name = $1
   AND deleted_at IS NULL
   AND (team_id = $2 OR team_id = $3)
 ORDER BY (team_id = $2) DESC
@@ -66,13 +66,13 @@ WHERE deleted_at IS NULL
 ORDER BY created_at DESC;
 
 -- name: ListTemplatesForTeamFiltered :many
--- Same as ListTemplatesForTeam with an optional alias prefix filter. Pass
+-- Same as ListTemplatesForTeam with an optional name prefix filter. Pass
 -- NULL to get the unfiltered list (but prefer the unfiltered query then).
 SELECT * FROM template
 WHERE deleted_at IS NULL
   AND (team_id = $1 OR team_id = $2)
-  AND (sqlc.narg('alias_prefix')::text IS NULL
-       OR alias LIKE sqlc.narg('alias_prefix') || '%')
+  AND (sqlc.narg('name_prefix')::text IS NULL
+       OR name LIKE sqlc.narg('name_prefix') || '%')
 ORDER BY created_at DESC;
 
 -- name: SoftDeleteTemplateIfUnused :one

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -916,7 +916,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 
 	// Default the create to the `superserve/base` template so every sandbox
 	// has a consistent baseline image. Callers can opt out by setting
-	// from_template to some other alias/UUID; today the API always routes
+	// from_template to some other name/UUID; today the API always routes
 	// through the template/snapshot-restore path.
 	if req.FromTemplate == nil {
 		defaultTpl := "superserve/base"
@@ -933,7 +933,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// snapshot was built with exactly these values, so they're the
 	// authoritative shape.
 	var templateVcpu, templateMemMiB uint32
-	var fromTemplateAlias, fromTemplateID string
+	var fromTemplateName, fromTemplateID string
 	if req.FromTemplate != nil {
 		tpl, err := h.lookupTemplateForCreate(c, teamID, *req.FromTemplate)
 		if err != nil {
@@ -955,7 +955,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		templateID = pgtype.UUID{Bytes: tpl.ID, Valid: true}
 		templateVcpu = uint32(tpl.Vcpu)
 		templateMemMiB = uint32(tpl.MemoryMib)
-		fromTemplateAlias = tpl.Alias
+		fromTemplateName = tpl.Name
 		fromTemplateID = tpl.ID.String()
 	}
 
@@ -1191,9 +1191,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	wg.Wait()
 
 	var createdMeta []byte
-	if fromTemplateAlias != "" {
+	if fromTemplateName != "" {
 		createdMeta, _ = json.Marshal(map[string]string{
-			"from_template": fromTemplateAlias,
+			"from_template": fromTemplateName,
 			"template_id":   fromTemplateID,
 		})
 	}

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -52,7 +52,7 @@ type buildSpec struct {
 }
 
 type createTemplateRequest struct {
-	Alias     string     `json:"alias"`
+	Name      string     `json:"name"`
 	Vcpu      *int32     `json:"vcpu,omitempty"`
 	MemoryMib *int32     `json:"memory_mib,omitempty"`
 	DiskMib   *int32     `json:"disk_mib,omitempty"`
@@ -62,7 +62,7 @@ type createTemplateRequest struct {
 type templateResponse struct {
 	ID           uuid.UUID `json:"id"`
 	TeamID       uuid.UUID `json:"team_id"`
-	Alias        string    `json:"alias"`
+	Name         string    `json:"name"`
 	Status       string    `json:"status"`
 	Vcpu         int32     `json:"vcpu"`
 	MemoryMib    int32     `json:"memory_mib"`
@@ -89,7 +89,7 @@ type templateBuildResponse struct {
 // ---------------------------------------------------------------------------
 
 const (
-	maxAlias        = 128
+	maxName         = 128
 	maxVcpu         = 4
 	maxMemoryMib    = 4096
 	maxDiskMib      = 8192
@@ -261,7 +261,7 @@ func toTemplateResponse(t db.Template) templateResponse {
 	resp := templateResponse{
 		ID:        t.ID,
 		TeamID:    t.TeamID,
-		Alias:     t.Alias,
+		Name:      t.Name,
 		Status:    string(t.Status),
 		Vcpu:      t.Vcpu,
 		MemoryMib: t.MemoryMib,
@@ -332,20 +332,20 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 	}
 
 	// Field validation (manual; bindJSONStrict doesn't honor `binding` tags).
-	req.Alias = strings.TrimSpace(req.Alias)
-	if req.Alias == "" || len(req.Alias) > maxAlias {
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" || len(req.Name) > maxName {
 		respondErrorMsg(c, "bad_request",
-			fmt.Sprintf("alias is required and must be 1-%d characters", maxAlias),
+			fmt.Sprintf("name is required and must be 1-%d characters", maxName),
 			http.StatusBadRequest)
 		return
 	}
 	// `superserve/` is reserved for curated templates owned by the system
-	// team. Other teams cannot create aliases in this namespace — doing so
+	// team. Other teams cannot create names in this namespace — doing so
 	// would shadow the real curated template for their own members. Match
 	// is case-insensitive to block squat variants like `SuperServe/foo`.
-	if strings.HasPrefix(strings.ToLower(req.Alias), "superserve/") && teamID != h.systemTeamID() {
+	if strings.HasPrefix(strings.ToLower(req.Name), "superserve/") && teamID != h.systemTeamID() {
 		respondErrorMsg(c, "bad_request",
-			"aliases starting with 'superserve/' are reserved",
+			"names starting with 'superserve/' are reserved",
 			http.StatusBadRequest)
 		return
 	}
@@ -406,7 +406,7 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 
 	row, err := q.CreateTemplateWithBuild(ctx, db.CreateTemplateWithBuildParams{
 		TeamID:        teamID,
-		Alias:         req.Alias,
+		Name:          req.Name,
 		BuildSpec:     specJSON,
 		Vcpu:          vcpu,
 		MemoryMib:     memMib,
@@ -416,7 +416,7 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 	if err != nil {
 		if isUniqueViolation(err) {
 			respondErrorMsg(c, "conflict",
-				fmt.Sprintf("a template with alias %q already exists for this team", req.Alias),
+				fmt.Sprintf("a template with name %q already exists for this team", req.Name),
 				http.StatusConflict)
 			return
 		}
@@ -437,7 +437,7 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 	respBody := gin.H{
 		"id":            resp.ID,
 		"team_id":       resp.TeamID,
-		"alias":         resp.Alias,
+		"name":          resp.Name,
 		"status":        resp.Status,
 		"vcpu":          resp.Vcpu,
 		"memory_mib":    resp.MemoryMib,
@@ -463,7 +463,7 @@ func templateFromWithBuild(r db.CreateTemplateWithBuildRow) db.Template {
 	return db.Template{
 		ID:           r.ID,
 		TeamID:       r.TeamID,
-		Alias:        r.Alias,
+		Name:         r.Name,
 		Status:       r.Status,
 		BuildSpec:    r.BuildSpec,
 		Vcpu:         r.Vcpu,
@@ -515,19 +515,19 @@ func (h *Handlers) ListTemplates(c *gin.Context) {
 		return
 	}
 
-	aliasPrefix := c.Query("alias_prefix")
+	namePrefix := c.Query("name_prefix")
 
 	var rows []db.Template
-	if aliasPrefix == "" {
+	if namePrefix == "" {
 		rows, err = h.DB.ListTemplatesForTeam(c.Request.Context(), db.ListTemplatesForTeamParams{
 			TeamID:   teamID,
 			TeamID_2: h.systemTeamID(),
 		})
 	} else {
 		rows, err = h.DB.ListTemplatesForTeamFiltered(c.Request.Context(), db.ListTemplatesForTeamFilteredParams{
-			TeamID:      teamID,
-			TeamID_2:    h.systemTeamID(),
-			AliasPrefix: &aliasPrefix,
+			TeamID:     teamID,
+			TeamID_2:   h.systemTeamID(),
+			NamePrefix: &namePrefix,
 		})
 	}
 	if err != nil {
@@ -808,7 +808,7 @@ func (h *Handlers) CancelTemplateBuild(c *gin.Context) {
 		buildMetadata(buildID))
 }
 
-// lookupTemplateForCreate resolves a from_template ref (UUID or alias) to a
+// lookupTemplateForCreate resolves a from_template ref (UUID or name) to a
 // Template row that is visible to teamID. Writes a 4xx response and returns
 // a non-nil error on failure so callers can early-return.
 func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref string) (db.Template, error) {
@@ -834,8 +834,8 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 		}
 		return tpl, nil
 	}
-	tpl, err := h.DB.GetTemplateByAlias(c.Request.Context(), db.GetTemplateByAliasParams{
-		Alias:    ref,
+	tpl, err := h.DB.GetTemplateByName(c.Request.Context(), db.GetTemplateByNameParams{
+		Name:     ref,
 		TeamID:   teamID,
 		TeamID_2: h.systemTeamID(),
 	})
@@ -844,7 +844,7 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
 			return db.Template{}, err
 		}
-		log.Error().Err(err).Str("alias", ref).Msg("DB GetTemplateByAlias failed")
+		log.Error().Err(err).Str("name", ref).Msg("DB GetTemplateByName failed")
 		respondError(c, ErrInternal)
 		return db.Template{}, err
 	}

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -97,6 +98,10 @@ const (
 	defaultMemoryMi = 1024
 	defaultDiskMib  = 4096
 )
+
+// templateNameRE restricts template names to lowercase alphanumeric with
+// `.`, `_`, `/`, `-` in the middle. URL-safe, shell-safe, no Unicode.
+var templateNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?$`)
 
 // validateBuildSpec enforces base-image policy and step-shape invariants.
 // Catches obvious problems (alpine, distroless, bad step shape) before we
@@ -339,11 +344,14 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 			http.StatusBadRequest)
 		return
 	}
-	// `superserve/` is reserved for curated templates owned by the system
-	// team. Other teams cannot create names in this namespace — doing so
-	// would shadow the real curated template for their own members. Match
-	// is case-insensitive to block squat variants like `SuperServe/foo`.
-	if strings.HasPrefix(strings.ToLower(req.Name), "superserve/") && teamID != h.systemTeamID() {
+	if !templateNameRE.MatchString(req.Name) {
+		respondErrorMsg(c, "bad_request",
+			"name must be lowercase, start and end with a letter or digit, and contain only letters, digits, '.', '_', '/', '-'",
+			http.StatusBadRequest)
+		return
+	}
+	// `superserve/` is reserved for curated templates owned by the system team.
+	if strings.HasPrefix(req.Name, "superserve/") && teamID != h.systemTeamID() {
 		respondErrorMsg(c, "bad_request",
 			"names starting with 'superserve/' are reserved",
 			http.StatusBadRequest)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -165,7 +165,7 @@ func templateRow(t db.Template) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
 		*dest[0].(*uuid.UUID) = t.ID
 		*dest[1].(*uuid.UUID) = t.TeamID
-		*dest[2].(*string) = t.Alias
+		*dest[2].(*string) = t.Name
 		*dest[3].(*db.TemplateStatus) = t.Status
 		*dest[4].(*[]byte) = t.BuildSpec
 		*dest[5].(*int32) = t.Vcpu
@@ -192,7 +192,7 @@ func defaultReadyTemplate() db.Template {
 	mem := "/snap/mem.snap"
 	return db.Template{
 		ID:           uuid.New(),
-		Alias:        "superserve/base",
+		Name:         "superserve/base",
 		Status:       db.TemplateStatusReady,
 		Vcpu:         1,
 		MemoryMib:    1024,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -287,7 +287,7 @@ type TeamMember struct {
 type Template struct {
 	ID           uuid.UUID          `json:"id"`
 	TeamID       uuid.UUID          `json:"team_id"`
-	Alias        string             `json:"alias"`
+	Name         string             `json:"name"`
 	Status       TemplateStatus     `json:"status"`
 	BuildSpec    []byte             `json:"build_spec"`
 	Vcpu         int32              `json:"vcpu"`

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -88,14 +88,14 @@ func (q *Queries) CountInFlightBuildsForTeam(ctx context.Context, teamID uuid.UU
 }
 
 const createTemplate = `-- name: CreateTemplate :one
-INSERT INTO template (team_id, alias, build_spec, vcpu, memory_mib, disk_mib)
+INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at
+RETURNING id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at
 `
 
 type CreateTemplateParams struct {
 	TeamID    uuid.UUID `json:"team_id"`
-	Alias     string    `json:"alias"`
+	Name      string    `json:"name"`
 	BuildSpec []byte    `json:"build_spec"`
 	Vcpu      int32     `json:"vcpu"`
 	MemoryMib int32     `json:"memory_mib"`
@@ -109,7 +109,7 @@ type CreateTemplateParams struct {
 func (q *Queries) CreateTemplate(ctx context.Context, arg CreateTemplateParams) (Template, error) {
 	row := q.db.QueryRow(ctx, createTemplate,
 		arg.TeamID,
-		arg.Alias,
+		arg.Name,
 		arg.BuildSpec,
 		arg.Vcpu,
 		arg.MemoryMib,
@@ -119,7 +119,7 @@ func (q *Queries) CreateTemplate(ctx context.Context, arg CreateTemplateParams) 
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -176,9 +176,9 @@ func (q *Queries) CreateTemplateBuild(ctx context.Context, arg CreateTemplateBui
 
 const createTemplateWithBuild = `-- name: CreateTemplateWithBuild :one
 WITH new_template AS (
-  INSERT INTO template (team_id, alias, build_spec, vcpu, memory_mib, disk_mib, status)
+  INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib, status)
   VALUES ($1, $2, $3, $4, $5, $6, 'building')
-  RETURNING id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib,
+  RETURNING id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib,
             rootfs_path, snapshot_path, mem_path, size_bytes, error_message,
             created_at, updated_at, built_at, deleted_at
 ),
@@ -187,13 +187,13 @@ new_build AS (
   SELECT id, team_id, $7 FROM new_template
   RETURNING id AS build_id
 )
-SELECT new_template.id, new_template.team_id, new_template.alias, new_template.status, new_template.build_spec, new_template.vcpu, new_template.memory_mib, new_template.disk_mib, new_template.rootfs_path, new_template.snapshot_path, new_template.mem_path, new_template.size_bytes, new_template.error_message, new_template.created_at, new_template.updated_at, new_template.built_at, new_template.deleted_at, new_build.build_id::uuid AS build_id
+SELECT new_template.id, new_template.team_id, new_template.name, new_template.status, new_template.build_spec, new_template.vcpu, new_template.memory_mib, new_template.disk_mib, new_template.rootfs_path, new_template.snapshot_path, new_template.mem_path, new_template.size_bytes, new_template.error_message, new_template.created_at, new_template.updated_at, new_template.built_at, new_template.deleted_at, new_build.build_id::uuid AS build_id
 FROM new_template, new_build
 `
 
 type CreateTemplateWithBuildParams struct {
 	TeamID        uuid.UUID `json:"team_id"`
-	Alias         string    `json:"alias"`
+	Name          string    `json:"name"`
 	BuildSpec     []byte    `json:"build_spec"`
 	Vcpu          int32     `json:"vcpu"`
 	MemoryMib     int32     `json:"memory_mib"`
@@ -204,7 +204,7 @@ type CreateTemplateWithBuildParams struct {
 type CreateTemplateWithBuildRow struct {
 	ID           uuid.UUID          `json:"id"`
 	TeamID       uuid.UUID          `json:"team_id"`
-	Alias        string             `json:"alias"`
+	Name         string             `json:"name"`
 	Status       TemplateStatus     `json:"status"`
 	BuildSpec    []byte             `json:"build_spec"`
 	Vcpu         int32              `json:"vcpu"`
@@ -233,7 +233,7 @@ type CreateTemplateWithBuildRow struct {
 func (q *Queries) CreateTemplateWithBuild(ctx context.Context, arg CreateTemplateWithBuildParams) (CreateTemplateWithBuildRow, error) {
 	row := q.db.QueryRow(ctx, createTemplateWithBuild,
 		arg.TeamID,
-		arg.Alias,
+		arg.Name,
 		arg.BuildSpec,
 		arg.Vcpu,
 		arg.MemoryMib,
@@ -244,7 +244,7 @@ func (q *Queries) CreateTemplateWithBuild(ctx context.Context, arg CreateTemplat
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -280,7 +280,7 @@ SET status = 'failed',
     updated_at = now()
 FROM build_done
 WHERE template.id = build_done.template_id
-RETURNING template.id, template.team_id, template.alias, template.status, template.build_spec, template.vcpu, template.memory_mib, template.disk_mib, template.rootfs_path, template.snapshot_path, template.mem_path, template.size_bytes, template.error_message, template.created_at, template.updated_at, template.built_at, template.deleted_at
+RETURNING template.id, template.team_id, template.name, template.status, template.build_spec, template.vcpu, template.memory_mib, template.disk_mib, template.rootfs_path, template.snapshot_path, template.mem_path, template.size_bytes, template.error_message, template.created_at, template.updated_at, template.built_at, template.deleted_at
 `
 
 type FailBuildParams struct {
@@ -296,7 +296,7 @@ func (q *Queries) FailBuild(ctx context.Context, arg FailBuildParams) (Template,
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -335,7 +335,7 @@ SET status = 'ready',
     error_message = NULL
 FROM build_done
 WHERE template.id = build_done.template_id
-RETURNING template.id, template.team_id, template.alias, template.status, template.build_spec, template.vcpu, template.memory_mib, template.disk_mib, template.rootfs_path, template.snapshot_path, template.mem_path, template.size_bytes, template.error_message, template.created_at, template.updated_at, template.built_at, template.deleted_at
+RETURNING template.id, template.team_id, template.name, template.status, template.build_spec, template.vcpu, template.memory_mib, template.disk_mib, template.rootfs_path, template.snapshot_path, template.mem_path, template.size_bytes, template.error_message, template.created_at, template.updated_at, template.built_at, template.deleted_at
 `
 
 type FinalizeBuildParams struct {
@@ -362,7 +362,7 @@ func (q *Queries) FinalizeBuild(ctx context.Context, arg FinalizeBuildParams) (T
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -420,7 +420,7 @@ func (q *Queries) GetExistingInflightBuild(ctx context.Context, arg GetExistingI
 }
 
 const getTemplate = `-- name: GetTemplate :one
-SELECT id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
 WHERE id = $1
   AND deleted_at IS NULL
   AND (team_id = $2 OR team_id = $3)
@@ -441,7 +441,7 @@ func (q *Queries) GetTemplate(ctx context.Context, arg GetTemplateParams) (Templ
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -493,31 +493,31 @@ func (q *Queries) GetTemplateBuild(ctx context.Context, arg GetTemplateBuildPara
 	return i, err
 }
 
-const getTemplateByAlias = `-- name: GetTemplateByAlias :one
-SELECT id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
-WHERE alias = $1
+const getTemplateByName = `-- name: GetTemplateByName :one
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
+WHERE name = $1
   AND deleted_at IS NULL
   AND (team_id = $2 OR team_id = $3)
 ORDER BY (team_id = $2) DESC
 LIMIT 1
 `
 
-type GetTemplateByAliasParams struct {
-	Alias    string    `json:"alias"`
+type GetTemplateByNameParams struct {
+	Name     string    `json:"name"`
 	TeamID   uuid.UUID `json:"team_id"`
 	TeamID_2 uuid.UUID `json:"team_id_2"`
 }
 
-// Resolve alias to a template visible to the caller. Aliases are unique per
-// team, so the same alias can exist in both the caller's team and the system
+// Resolve name to a template visible to the caller. Names are unique per
+// team, so the same name can exist in both the caller's team and the system
 // team — prefer the caller's own (ORDER BY) so overrides work naturally.
-func (q *Queries) GetTemplateByAlias(ctx context.Context, arg GetTemplateByAliasParams) (Template, error) {
-	row := q.db.QueryRow(ctx, getTemplateByAlias, arg.Alias, arg.TeamID, arg.TeamID_2)
+func (q *Queries) GetTemplateByName(ctx context.Context, arg GetTemplateByNameParams) (Template, error) {
+	row := q.db.QueryRow(ctx, getTemplateByName, arg.Name, arg.TeamID, arg.TeamID_2)
 	var i Template
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -537,7 +537,7 @@ func (q *Queries) GetTemplateByAlias(ctx context.Context, arg GetTemplateByAlias
 }
 
 const getTemplateForOwner = `-- name: GetTemplateForOwner :one
-SELECT id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
 WHERE id = $1 AND team_id = $2 AND deleted_at IS NULL
 `
 
@@ -554,7 +554,7 @@ func (q *Queries) GetTemplateForOwner(ctx context.Context, arg GetTemplateForOwn
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,
-		&i.Alias,
+		&i.Name,
 		&i.Status,
 		&i.BuildSpec,
 		&i.Vcpu,
@@ -707,7 +707,7 @@ func (q *Queries) ListPendingBuildsOrdered(ctx context.Context, limit int32) ([]
 }
 
 const listTemplatesForTeam = `-- name: ListTemplatesForTeam :many
-SELECT id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
 WHERE deleted_at IS NULL
   AND (team_id = $1 OR team_id = $2)
 ORDER BY created_at DESC
@@ -732,7 +732,7 @@ func (q *Queries) ListTemplatesForTeam(ctx context.Context, arg ListTemplatesFor
 		if err := rows.Scan(
 			&i.ID,
 			&i.TeamID,
-			&i.Alias,
+			&i.Name,
 			&i.Status,
 			&i.BuildSpec,
 			&i.Vcpu,
@@ -759,24 +759,24 @@ func (q *Queries) ListTemplatesForTeam(ctx context.Context, arg ListTemplatesFor
 }
 
 const listTemplatesForTeamFiltered = `-- name: ListTemplatesForTeamFiltered :many
-SELECT id, team_id, alias, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at FROM template
 WHERE deleted_at IS NULL
   AND (team_id = $1 OR team_id = $2)
   AND ($3::text IS NULL
-       OR alias LIKE $3 || '%')
+       OR name LIKE $3 || '%')
 ORDER BY created_at DESC
 `
 
 type ListTemplatesForTeamFilteredParams struct {
-	TeamID      uuid.UUID `json:"team_id"`
-	TeamID_2    uuid.UUID `json:"team_id_2"`
-	AliasPrefix *string   `json:"alias_prefix"`
+	TeamID     uuid.UUID `json:"team_id"`
+	TeamID_2   uuid.UUID `json:"team_id_2"`
+	NamePrefix *string   `json:"name_prefix"`
 }
 
-// Same as ListTemplatesForTeam with an optional alias prefix filter. Pass
+// Same as ListTemplatesForTeam with an optional name prefix filter. Pass
 // NULL to get the unfiltered list (but prefer the unfiltered query then).
 func (q *Queries) ListTemplatesForTeamFiltered(ctx context.Context, arg ListTemplatesForTeamFilteredParams) ([]Template, error) {
-	rows, err := q.db.Query(ctx, listTemplatesForTeamFiltered, arg.TeamID, arg.TeamID_2, arg.AliasPrefix)
+	rows, err := q.db.Query(ctx, listTemplatesForTeamFiltered, arg.TeamID, arg.TeamID_2, arg.NamePrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -787,7 +787,7 @@ func (q *Queries) ListTemplatesForTeamFiltered(ctx context.Context, arg ListTemp
 		if err := rows.Scan(
 			&i.ID,
 			&i.TeamID,
-			&i.Alias,
+			&i.Name,
 			&i.Status,
 			&i.BuildSpec,
 			&i.Vcpu,

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -93,7 +93,7 @@ func seedSystemTemplate(ctx context.Context, q *db.Queries) error {
 
 	tpl, err := q.CreateTemplate(ctx, db.CreateTemplateParams{
 		TeamID:    team.ID,
-		Alias:     "superserve/base",
+		Name:      "superserve/base",
 		BuildSpec: []byte(`{"from":"test","steps":[]}`),
 		Vcpu:      1,
 		MemoryMib: 1024,

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1354,3 +1354,133 @@ func TestIntegration_RateLimit_Headers(t *testing.T) {
 		t.Error("missing RateLimit-Remaining header")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+// TestIntegration_CreateTemplate_NameReusableAfterDelete verifies the partial
+// unique index on (team_id, name) WHERE deleted_at IS NULL: once a template
+// is soft-deleted its name can be reused for a fresh template.
+func TestIntegration_CreateTemplate_NameReusableAfterDelete(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	const name = "reuse-me"
+
+	// Insert a template directly and mark it soft-deleted, simulating the
+	// state after DELETE /templates/{id}. We bypass POST /templates here
+	// because that path queues a build, which would block deletion.
+	old, err := testQueries.CreateTemplate(ctx, db.CreateTemplateParams{
+		TeamID:    teamID,
+		Name:      name,
+		BuildSpec: []byte(`{"from":"debian:12-slim","steps":[]}`),
+		Vcpu:      1,
+		MemoryMib: 1024,
+		DiskMib:   4096,
+	})
+	if err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE template SET deleted_at = now() WHERE id = $1`, old.ID); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	// Same name on a fresh POST /templates must succeed.
+	body := fmt.Sprintf(`{"name":%q,"build_spec":{"from":"debian:12-slim","steps":[]}}`, name)
+	w := do(r, "POST", "/templates", apiKey, body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := mustJSON(t, w)
+	if resp["name"] != name {
+		t.Errorf("name = %q, want %q", resp["name"], name)
+	}
+
+	newID, _ := uuid.Parse(resp["id"].(string))
+	if newID == old.ID {
+		t.Fatal("expected a fresh template id; got the soft-deleted row's id")
+	}
+
+	// Both rows exist in DB: the old one with deleted_at set, the new one without.
+	var liveCount, deletedCount int
+	if err := testPool.QueryRow(ctx,
+		`SELECT
+		   COUNT(*) FILTER (WHERE deleted_at IS NULL),
+		   COUNT(*) FILTER (WHERE deleted_at IS NOT NULL)
+		 FROM template WHERE team_id = $1 AND name = $2`,
+		teamID, name,
+	).Scan(&liveCount, &deletedCount); err != nil {
+		t.Fatalf("count check: %v", err)
+	}
+	if liveCount != 1 || deletedCount != 1 {
+		t.Errorf("DB state: live=%d deleted=%d, want 1/1", liveCount, deletedCount)
+	}
+}
+
+// TestIntegration_CreateTemplate_NameCharSet rejects names that don't match
+// the lowercase/`._/-` allowlist with a 400.
+func TestIntegration_CreateTemplate_NameCharSet(t *testing.T) {
+	_, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cases := []struct {
+		name    string
+		ok      bool
+		comment string
+	}{
+		{"foo", true, "lowercase ok"},
+		{"my-python-env", true, "hyphens ok"},
+		{"a/b/c", true, "slashes ok"},
+		{"foo.bar", true, "dot ok"},
+		{"f", true, "single char ok"},
+		{"Foo", false, "capitals rejected"},
+		{"foo bar", false, "space rejected"},
+		{"-foo", false, "leading hyphen rejected"},
+		{"foo-", false, "trailing hyphen rejected"},
+		{"/foo", false, "leading slash rejected"},
+		{"foo/", false, "trailing slash rejected"},
+		{"foo!", false, "punctuation rejected"},
+		{"", false, "empty rejected"},
+	}
+	for _, tc := range cases {
+		body := fmt.Sprintf(`{"name":%q,"build_spec":{"from":"debian:12-slim","steps":[]}}`, tc.name)
+		w := do(r, "POST", "/templates", apiKey, body)
+		if tc.ok {
+			if w.Code != http.StatusAccepted {
+				t.Errorf("%s: expected 202, got %d (%s)", tc.comment, w.Code, w.Body.String())
+			}
+		} else {
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("%s: name=%q expected 400, got %d", tc.comment, tc.name, w.Code)
+			}
+		}
+	}
+}
+
+// TestIntegration_CreateTemplate_DuplicateLiveNameReturns409 is the negative
+// case: a non-deleted template's name still blocks a duplicate.
+func TestIntegration_CreateTemplate_DuplicateLiveNameReturns409(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	const name = "taken"
+	if _, err := testQueries.CreateTemplate(ctx, db.CreateTemplateParams{
+		TeamID:    teamID,
+		Name:      name,
+		BuildSpec: []byte(`{"from":"debian:12-slim","steps":[]}`),
+		Vcpu:      1,
+		MemoryMib: 1024,
+		DiskMib:   4096,
+	}); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"name":%q,"build_spec":{"from":"debian:12-slim","steps":[]}}`, name)
+	w := do(r, "POST", "/templates", apiKey, body)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/supabase/migrations/20260429000001_template_alias_to_name.sql
+++ b/supabase/migrations/20260429000001_template_alias_to_name.sql
@@ -1,0 +1,11 @@
+-- Rename template.alias → template.name (more intuitive, matches sandbox.name).
+-- Replace the full UNIQUE (team_id, alias) with a partial unique index that
+-- only enforces uniqueness on non-soft-deleted rows, so a deleted template's
+-- name is reusable.
+
+ALTER TABLE template RENAME COLUMN alias TO name;
+
+ALTER TABLE template DROP CONSTRAINT template_alias_unique_per_team;
+
+CREATE UNIQUE INDEX template_name_unique_per_team_active
+  ON template (team_id, name) WHERE deleted_at IS NULL;

--- a/supabase/migrations/20260429000001_template_alias_to_name.sql
+++ b/supabase/migrations/20260429000001_template_alias_to_name.sql
@@ -5,7 +5,7 @@
 
 ALTER TABLE template RENAME COLUMN alias TO name;
 
-ALTER TABLE template DROP CONSTRAINT template_alias_unique_per_team;
+ALTER TABLE template DROP CONSTRAINT IF EXISTS template_alias_unique_per_team;
 
 CREATE UNIQUE INDEX template_name_unique_per_team_active
   ON template (team_id, name) WHERE deleted_at IS NULL;

--- a/superserve_templates/superserve-base.json
+++ b/superserve_templates/superserve-base.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/base",
+  "name": "superserve/base",
   "vcpu": 1,
   "memory_mib": 1024,
   "disk_mib": 4096,

--- a/superserve_templates/superserve-claude-code.json
+++ b/superserve_templates/superserve-claude-code.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/claude-code",
+  "name": "superserve/claude-code",
   "vcpu": 2,
   "memory_mib": 2048,
   "disk_mib": 8192,

--- a/superserve_templates/superserve-code-interpreter.json
+++ b/superserve_templates/superserve-code-interpreter.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/code-interpreter",
+  "name": "superserve/code-interpreter",
   "vcpu": 2,
   "memory_mib": 2048,
   "disk_mib": 8192,

--- a/superserve_templates/superserve-node-22.json
+++ b/superserve_templates/superserve-node-22.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/node-22",
+  "name": "superserve/node-22",
   "vcpu": 1,
   "memory_mib": 1024,
   "disk_mib": 4096,

--- a/superserve_templates/superserve-python-3.11.json
+++ b/superserve_templates/superserve-python-3.11.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/python-3.11",
+  "name": "superserve/python-3.11",
   "vcpu": 1,
   "memory_mib": 1024,
   "disk_mib": 4096,

--- a/superserve_templates/superserve-python-ml.json
+++ b/superserve_templates/superserve-python-ml.json
@@ -1,5 +1,5 @@
 {
-  "alias": "superserve/python-ml",
+  "name": "superserve/python-ml",
   "vcpu": 2,
   "memory_mib": 2048,
   "disk_mib": 4096,


### PR DESCRIPTION
## Summary

Two related changes that bring the template API in line with how users expect it to work.

**1. Rename for templates `alias` → `name` everywhere.** More intuitive, matches `sandbox.name`, no more "alias is jargony" friction.

**2. Free the name slot on soft-delete.** Replace the full `UNIQUE (team_id, alias)` constraint with a partial unique index on `(team_id, name) WHERE deleted_at IS NULL`. After this, the user-visible flow is:

- `POST /templates {name: "abc"}` → 202
- `DELETE /templates/{id}` → 204
- `POST /templates {name: "abc"}` → **202** (was 409)

Soft-delete still happens internally (audit trail, foreign-key safety with sandboxes/builds). User just sees: created, deleted, created — name reusable.

## Touched

- `supabase/migrations/20260429000001_template_alias_to_name.sql` — rename column + replace constraint with partial index.
- `db/queries/templates.sql` — column references, `GetTemplateByAlias` → `GetTemplateByName`, list-filter param.
- `internal/db/{models,templates.sql}.go` — sqlc regen.
- `internal/api/handlers{,_template,_test}.go` — request/response struct fields, validation, error messages.
- `cmd/seed-templates/main.go` — `seedSpec.Name`, upsert SQL with new partial-index ON CONFLICT.
- `superserve_templates/*.json` — 6 system templates use `"name"` instead of `"alias"`.
- `api/openapi.yaml` — request/response schemas, list filter, descriptions.
- `internal/integration/integration_test.go` — test seed fixture.

## Breaking change

API field renamed without compat shim. Pre-existing template rows are migrated by `RENAME COLUMN`. SDK callers using `alias` will need to switch to `name`.