### PR TITLE
templates,sandboxes: per-team resource and count caps

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -143,8 +143,9 @@ paths:
           description: |
             Rate-limited or quota reached. The `error.code` distinguishes:
             - `rate_limited` — request rate exceeded; retry after a short backoff.
-            - `too_many_sandboxes` — team has reached its sandbox count limit;
-              pause/delete existing sandboxes or contact support to raise the cap.
+            - `too_many_sandboxes` — team has reached its sandbox count limit
+              (paused sandboxes count toward this cap; only DELETE frees a slot);
+              delete existing sandboxes or contact support to raise the cap.
           content:
             application/json:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -140,7 +140,15 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
         "429":
-          $ref: "#/components/responses/TooManyRequests"
+          description: |
+            Rate-limited or quota reached. The `error.code` distinguishes:
+            - `rate_limited` — request rate exceeded; retry after a short backoff.
+            - `too_many_sandboxes` — team has reached its sandbox count limit;
+              pause/delete existing sandboxes or contact support to raise the cap.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -434,10 +442,12 @@ paths:
         "409":
           $ref: "#/components/responses/Conflict"
         "429":
-          description: >
-            Team has reached the per-team concurrent build limit. Wait for
-            an active build to finish, or contact support to raise the cap.
-            Response body uses error code `too_many_builds`.
+          description: |
+            Quota reached. The `error.code` distinguishes:
+            - `too_many_builds` — team has reached its concurrent build
+              limit; wait for an active build to finish.
+            - `too_many_templates` — team has reached its total template
+              count limit; delete templates or contact support to raise the cap.
           content:
             application/json:
               schema:
@@ -1197,10 +1207,11 @@ components:
       description: |
         Error envelope. `error.code` is a stable, machine-readable identifier
         (e.g. `bad_request`, `not_found`, `conflict`, `rate_limited`,
-        `too_many_builds`, `image_pull_failed`, `step_failed`,
-        `snapshot_failed`, `start_cmd_failed`, `ready_cmd_failed`,
-        `build_failed`). `error.message` is human-readable and may change
-        between releases; clients should branch on `code`, not `message`.
+        `too_many_builds`, `too_many_templates`, `too_many_sandboxes`,
+        `image_pull_failed`, `step_failed`, `snapshot_failed`,
+        `start_cmd_failed`, `ready_cmd_failed`, `build_failed`).
+        `error.message` is human-readable and may change between releases;
+        clients should branch on `code`, not `message`.
       properties:
         error:
           type: object

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -29,9 +29,10 @@ SELECT * FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL;
 
 -- name: CountActiveSandboxesForTeam :one
--- Active = non-destroyed (active + paused).
+-- Active = consumes host resources. Excludes failed (VM is gone) and
+-- destroyed (row is dead). Includes starting/active/pausing/paused/resuming.
 SELECT COUNT(*)::bigint FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL;
+WHERE team_id = $1 AND destroyed_at IS NULL AND status != 'failed';
 
 -- name: ListSandboxesByTeam :many
 SELECT * FROM sandbox

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -28,6 +28,11 @@ RETURNING *;
 SELECT * FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL;
 
+-- name: CountActiveSandboxesForTeam :one
+-- Active = non-destroyed (active + paused).
+SELECT COUNT(*)::bigint FROM sandbox
+WHERE team_id = $1 AND destroyed_at IS NULL;
+
 -- name: ListSandboxesByTeam :many
 SELECT * FROM sandbox
 WHERE team_id = $1 AND destroyed_at IS NULL

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -57,6 +57,10 @@ WHERE name = $1
 ORDER BY (team_id = $2) DESC
 LIMIT 1;
 
+-- name: CountActiveTemplatesForTeam :one
+SELECT COUNT(*)::bigint FROM template
+WHERE team_id = $1 AND deleted_at IS NULL;
+
 -- name: ListTemplatesForTeam :many
 -- Return the caller's team's templates plus all system-team templates
 -- (curated base set visible to everyone). Ordered by created_at desc.

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -58,8 +58,11 @@ ORDER BY (team_id = $2) DESC
 LIMIT 1;
 
 -- name: CountActiveTemplatesForTeam :one
+-- Active = not deleted and not in a terminal-failure state. Failed
+-- templates don't hold a snapshot, so they shouldn't consume the count
+-- cap (matches CountInFlightBuildsForTeam, which also excludes failed).
 SELECT COUNT(*)::bigint FROM template
-WHERE team_id = $1 AND deleted_at IS NULL;
+WHERE team_id = $1 AND deleted_at IS NULL AND status != 'failed';
 
 -- name: ListTemplatesForTeam :many
 -- Return the caller's team's templates plus all system-team templates

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -914,6 +914,32 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	}
 
+	// Per-team sandbox count cap. System team is exempt.
+	if teamID != h.systemTeamID() {
+		team, err := h.DB.GetTeam(c.Request.Context(), teamID)
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB GetTeam failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		count, err := h.DB.CountActiveSandboxesForTeam(c.Request.Context(), teamID)
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountActiveSandboxesForTeam failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		effMaxSandboxes := int64(defaultMaxSandboxes)
+		if team.MaxSandboxes != nil {
+			effMaxSandboxes = int64(*team.MaxSandboxes)
+		}
+		if count >= effMaxSandboxes {
+			respondErrorMsg(c, "too_many_sandboxes",
+				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", effMaxSandboxes),
+				http.StatusTooManyRequests)
+			return
+		}
+	}
+
 	// Default the create to the `superserve/base` template so every sandbox
 	// has a consistent baseline image. Callers can opt out by setting
 	// from_template to some other name/UUID; today the API always routes

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1124,7 +1124,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		}
 		if quotaExceeded {
 			respondErrorMsg(c, "too_many_sandboxes",
-				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", quotaErr.limit),
+				fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", quotaErr.limit),
 				http.StatusTooManyRequests)
 			return
 		}
@@ -1144,7 +1144,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		}
 		if quotaExceeded {
 			respondErrorMsg(c, "too_many_sandboxes",
-				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", quotaErr.limit),
+				fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", quotaErr.limit),
 				http.StatusTooManyRequests)
 			return
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1006,7 +1006,51 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		err     error
 	}
 	insertCh := make(chan insertResult, 1)
+	// runInsert performs the INSERT against the supplied tx-bound queries.
+	// Closure captures sandboxID/teamID/req/templateID/hostID/metadataJSON.
+	runInsert := func(q *db.Queries) (db.Sandbox, error) {
+		if templateID.Valid {
+			// CreateSandboxFromTemplate holds FOR KEY SHARE on the template
+			// row, serializing with SoftDeleteTemplateIfUnused's FOR UPDATE
+			// so a concurrent template delete is either blocked (we win,
+			// INSERT succeeds) or completes before us (we lose, 0 rows back).
+			return q.CreateSandboxFromTemplate(insertCtx, db.CreateSandboxFromTemplateParams{
+				ID:             sandboxID,
+				TeamID:         teamID,
+				Name:           req.Name,
+				Status:         db.SandboxStatusStarting,
+				VcpuCount:      1, // placeholders; real values land via ActivateSandbox
+				MemoryMib:      1,
+				HostID:         hostID,
+				TimeoutSeconds: req.TimeoutSeconds,
+				Metadata:       metadataJSON,
+				ID_2:           uuid.UUID(templateID.Bytes),
+				TeamID_2:       teamID,
+				TeamID_3:       h.systemTeamID(),
+			})
+		}
+		return q.CreateSandbox(insertCtx, db.CreateSandboxParams{
+			ID:             sandboxID,
+			TeamID:         teamID,
+			Name:           req.Name,
+			Status:         db.SandboxStatusStarting,
+			VcpuCount:      1,
+			MemoryMib:      1,
+			HostID:         hostID,
+			TimeoutSeconds: req.TimeoutSeconds,
+			Metadata:       metadataJSON,
+			TemplateID:     pgtype.UUID{Valid: false},
+		})
+	}
 	go func() {
+		// Test path: when no Pool is wired (unit tests with a mock DBTX),
+		// skip the count check and just do the INSERT.
+		if h.Pool == nil {
+			sb, err := runInsert(h.DB)
+			insertCh <- insertResult{sandbox: sb, err: err}
+			return
+		}
+
 		// Wrap count + insert in a tx with the per-team advisory lock so
 		// concurrent submits can't both pass at limit-1.
 		tx, err := h.Pool.BeginTx(insertCtx, pgx.TxOptions{})
@@ -1044,41 +1088,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			}
 		}
 
-		var sb db.Sandbox
-		var insertErr error
-		if templateID.Valid {
-			// CreateSandboxFromTemplate holds FOR KEY SHARE on the template
-			// row, serializing with SoftDeleteTemplateIfUnused's FOR UPDATE
-			// so a concurrent template delete is either blocked (we win,
-			// INSERT succeeds) or completes before us (we lose, 0 rows back).
-			sb, insertErr = q.CreateSandboxFromTemplate(insertCtx, db.CreateSandboxFromTemplateParams{
-				ID:             sandboxID,
-				TeamID:         teamID,
-				Name:           req.Name,
-				Status:         db.SandboxStatusStarting,
-				VcpuCount:      1, // placeholders; real values land via ActivateSandbox
-				MemoryMib:      1,
-				HostID:         hostID,
-				TimeoutSeconds: req.TimeoutSeconds,
-				Metadata:       metadataJSON,
-				ID_2:           uuid.UUID(templateID.Bytes),
-				TeamID_2:       teamID,
-				TeamID_3:       h.systemTeamID(),
-			})
-		} else {
-			sb, insertErr = q.CreateSandbox(insertCtx, db.CreateSandboxParams{
-				ID:             sandboxID,
-				TeamID:         teamID,
-				Name:           req.Name,
-				Status:         db.SandboxStatusStarting,
-				VcpuCount:      1,
-				MemoryMib:      1,
-				HostID:         hostID,
-				TimeoutSeconds: req.TimeoutSeconds,
-				Metadata:       metadataJSON,
-				TemplateID:     pgtype.UUID{Valid: false},
-			})
-		}
+		sb, insertErr := runInsert(q)
 		if insertErr == nil {
 			insertErr = tx.Commit(insertCtx)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -28,6 +28,17 @@ import (
 // VMDClient is the interface for talking to a VM daemon.
 type VMDClient = vmdclient.Client
 
+// sandboxQuotaError is the sentinel returned from CreateSandbox's INSERT
+// goroutine when the per-team count cap is reached. Carries the cap so
+// the handler can include it in the user-facing error.
+type sandboxQuotaError struct{ limit int64 }
+
+func (e sandboxQuotaError) Error() string {
+	return fmt.Sprintf("sandbox quota exceeded (limit=%d)", e.limit)
+}
+
+func errSandboxQuotaExceeded(limit int64) error { return sandboxQuotaError{limit: limit} }
+
 // Scheduler selects a host for new sandboxes.
 type Scheduler interface {
 	SelectHost(ctx context.Context) (hostID string, err error)
@@ -914,32 +925,6 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	}
 
-	// Per-team sandbox count cap. System team is exempt.
-	if teamID != h.systemTeamID() {
-		team, err := h.DB.GetTeam(c.Request.Context(), teamID)
-		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB GetTeam failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		count, err := h.DB.CountActiveSandboxesForTeam(c.Request.Context(), teamID)
-		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountActiveSandboxesForTeam failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		effMaxSandboxes := int64(defaultMaxSandboxes)
-		if team.MaxSandboxes != nil {
-			effMaxSandboxes = int64(*team.MaxSandboxes)
-		}
-		if count >= effMaxSandboxes {
-			respondErrorMsg(c, "too_many_sandboxes",
-				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", effMaxSandboxes),
-				http.StatusTooManyRequests)
-			return
-		}
-	}
-
 	// Default the create to the `superserve/base` template so every sandbox
 	// has a consistent baseline image. Callers can opt out by setting
 	// from_template to some other name/UUID; today the API always routes
@@ -1022,6 +1007,43 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	}
 	insertCh := make(chan insertResult, 1)
 	go func() {
+		// Wrap count + insert in a tx with the per-team advisory lock so
+		// concurrent submits can't both pass at limit-1.
+		tx, err := h.Pool.BeginTx(insertCtx, pgx.TxOptions{})
+		if err != nil {
+			insertCh <- insertResult{err: err}
+			return
+		}
+		defer tx.Rollback(insertCtx)
+
+		if _, err := tx.Exec(insertCtx, "SELECT pg_advisory_xact_lock(hashtext($1))", teamID.String()); err != nil {
+			insertCh <- insertResult{err: err}
+			return
+		}
+		q := h.DB.WithTx(tx)
+
+		// Per-team sandbox count cap. System team is exempt.
+		if teamID != h.systemTeamID() {
+			team, err := q.GetTeam(insertCtx, teamID)
+			if err != nil {
+				insertCh <- insertResult{err: err}
+				return
+			}
+			count, err := q.CountActiveSandboxesForTeam(insertCtx, teamID)
+			if err != nil {
+				insertCh <- insertResult{err: err}
+				return
+			}
+			effMaxSandboxes := int64(defaultMaxSandboxes)
+			if team.MaxSandboxes != nil {
+				effMaxSandboxes = int64(*team.MaxSandboxes)
+			}
+			if count >= effMaxSandboxes {
+				insertCh <- insertResult{err: errSandboxQuotaExceeded(effMaxSandboxes)}
+				return
+			}
+		}
+
 		var sb db.Sandbox
 		var insertErr error
 		if templateID.Valid {
@@ -1029,7 +1051,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			// row, serializing with SoftDeleteTemplateIfUnused's FOR UPDATE
 			// so a concurrent template delete is either blocked (we win,
 			// INSERT succeeds) or completes before us (we lose, 0 rows back).
-			sb, insertErr = h.DB.CreateSandboxFromTemplate(insertCtx, db.CreateSandboxFromTemplateParams{
+			sb, insertErr = q.CreateSandboxFromTemplate(insertCtx, db.CreateSandboxFromTemplateParams{
 				ID:             sandboxID,
 				TeamID:         teamID,
 				Name:           req.Name,
@@ -1044,7 +1066,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				TeamID_3:       h.systemTeamID(),
 			})
 		} else {
-			sb, insertErr = h.DB.CreateSandbox(insertCtx, db.CreateSandboxParams{
+			sb, insertErr = q.CreateSandbox(insertCtx, db.CreateSandboxParams{
 				ID:             sandboxID,
 				TeamID:         teamID,
 				Name:           req.Name,
@@ -1056,6 +1078,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				Metadata:       metadataJSON,
 				TemplateID:     pgtype.UUID{Valid: false},
 			})
+		}
+		if insertErr == nil {
+			insertErr = tx.Commit(insertCtx)
 		}
 		insertCh <- insertResult{sandbox: sb, err: insertErr}
 	}()
@@ -1085,12 +1110,22 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// 0 rows from CreateSandboxFromTemplate = template deleted mid-create.
 	templateRace := templateID.Valid && errors.Is(dbErr, pgx.ErrNoRows)
 
+	// Per-team sandbox count cap; surfaced from the goroutine via sentinel.
+	var quotaErr sandboxQuotaError
+	quotaExceeded := errors.As(dbErr, &quotaErr)
+
 	switch {
 	case dbErr != nil && vmdErr != nil:
 		// Both failed — nothing persisted, nothing to clean up.
 		log.Error().Err(dbErr).AnErr("vmd_err", vmdErr).Msg("CreateSandbox: DB and VMD both failed")
 		if templateRace {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
+			return
+		}
+		if quotaExceeded {
+			respondErrorMsg(c, "too_many_sandboxes",
+				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", quotaErr.limit),
+				http.StatusTooManyRequests)
 			return
 		}
 		respondError(c, ErrInternal)
@@ -1105,6 +1140,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		cleanupCancel()
 		if templateRace {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
+			return
+		}
+		if quotaExceeded {
+			respondErrorMsg(c, "too_many_sandboxes",
+				fmt.Sprintf("team has reached the limit of %d sandboxes; pause/delete some or contact support@superserve.ai for higher", quotaErr.limit),
+				http.StatusTooManyRequests)
 			return
 		}
 		respondError(c, ErrInternal)

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -90,10 +90,20 @@ type templateBuildResponse struct {
 // ---------------------------------------------------------------------------
 
 const (
-	maxName         = 128
-	maxVcpu         = 4
-	maxMemoryMib    = 4096
-	maxDiskMib      = 8192
+	maxName = 128
+
+	// Platform ceiling — applies to every team including system.
+	absoluteMaxVcpu      = 4
+	absoluteMaxMemoryMib = 4096
+	absoluteMaxDiskMib   = 8192
+
+	// Customer-team defaults (overridable via team.max_template_*).
+	defaultMaxVcpu      = 2
+	defaultMaxMemoryMib = 2048
+	defaultMaxDiskMib   = 8192
+	defaultMaxTemplates = 10
+	defaultMaxSandboxes = 50
+
 	defaultVcpu     = 1
 	defaultMemoryMi = 1024
 	defaultDiskMib  = 4096
@@ -102,6 +112,44 @@ const (
 // templateNameRE restricts template names to lowercase alphanumeric with
 // `.`, `_`, `/`, `-` in the middle. URL-safe, shell-safe, no Unicode.
 var templateNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?$`)
+
+// validateTemplateShape returns a user-facing error message on failure, "" on pass.
+func validateTemplateShape(team db.Team, systemTeamID uuid.UUID, vcpu, memMib, diskMib int32) string {
+	if vcpu < 1 || vcpu > absoluteMaxVcpu {
+		return fmt.Sprintf("vcpu must be 1-%d", absoluteMaxVcpu)
+	}
+	if memMib < 256 || memMib > absoluteMaxMemoryMib {
+		return fmt.Sprintf("memory_mib must be 256-%d", absoluteMaxMemoryMib)
+	}
+	if diskMib < 1024 || diskMib > absoluteMaxDiskMib {
+		return fmt.Sprintf("disk_mib must be 1024-%d", absoluteMaxDiskMib)
+	}
+	if team.ID == systemTeamID {
+		return ""
+	}
+	effMaxVcpu := int32(defaultMaxVcpu)
+	if team.MaxTemplateVcpu != nil {
+		effMaxVcpu = *team.MaxTemplateVcpu
+	}
+	if vcpu > effMaxVcpu {
+		return fmt.Sprintf("vcpu must be 1-%d (your team's limit); contact support@superserve.ai for higher", effMaxVcpu)
+	}
+	effMaxMem := int32(defaultMaxMemoryMib)
+	if team.MaxTemplateMemoryMib != nil {
+		effMaxMem = *team.MaxTemplateMemoryMib
+	}
+	if memMib > effMaxMem {
+		return fmt.Sprintf("memory_mib must be 256-%d (your team's limit); contact support@superserve.ai for higher", effMaxMem)
+	}
+	effMaxDisk := int32(defaultMaxDiskMib)
+	if team.MaxTemplateDiskMib != nil {
+		effMaxDisk = *team.MaxTemplateDiskMib
+	}
+	if diskMib > effMaxDisk {
+		return fmt.Sprintf("disk_mib must be 1024-%d (your team's limit); contact support@superserve.ai for higher", effMaxDisk)
+	}
+	return ""
+}
 
 // validateBuildSpec enforces base-image policy and step-shape invariants.
 // Catches obvious problems (alpine, distroless, bad step shape) before we
@@ -369,21 +417,39 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 	if req.DiskMib != nil {
 		diskMib = *req.DiskMib
 	}
-	if vcpu < 1 || vcpu > maxVcpu {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("vcpu must be 1-%d", maxVcpu), http.StatusBadRequest)
+	team, err := h.DB.GetTeam(c.Request.Context(), teamID)
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB GetTeam failed")
+		respondError(c, ErrInternal)
 		return
 	}
-	if memMib < 256 || memMib > maxMemoryMib {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("memory_mib must be 256-%d", maxMemoryMib), http.StatusBadRequest)
-		return
-	}
-	if diskMib < 1024 || diskMib > maxDiskMib {
-		respondErrorMsg(c, "bad_request", fmt.Sprintf("disk_mib must be 1024-%d", maxDiskMib), http.StatusBadRequest)
+	if msg := validateTemplateShape(team, h.systemTeamID(), vcpu, memMib, diskMib); msg != "" {
+		respondErrorMsg(c, "bad_request", msg, http.StatusBadRequest)
 		return
 	}
 	if err := validateBuildSpec(req.BuildSpec); err != nil {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	// Per-team template count cap. System team is exempt.
+	if teamID != h.systemTeamID() {
+		count, err := h.DB.CountActiveTemplatesForTeam(c.Request.Context(), teamID)
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountActiveTemplatesForTeam failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		effMaxTemplates := int64(defaultMaxTemplates)
+		if team.MaxTemplates != nil {
+			effMaxTemplates = int64(*team.MaxTemplates)
+		}
+		if count >= effMaxTemplates {
+			respondErrorMsg(c, "too_many_templates",
+				fmt.Sprintf("team has reached the limit of %d templates; delete some or contact support@superserve.ai for higher", effMaxTemplates),
+				http.StatusTooManyRequests)
+			return
+		}
 	}
 
 	specJSON, err := json.Marshal(req.BuildSpec)

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -432,26 +432,6 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 		return
 	}
 
-	// Per-team template count cap. System team is exempt.
-	if teamID != h.systemTeamID() {
-		count, err := h.DB.CountActiveTemplatesForTeam(c.Request.Context(), teamID)
-		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountActiveTemplatesForTeam failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		effMaxTemplates := int64(defaultMaxTemplates)
-		if team.MaxTemplates != nil {
-			effMaxTemplates = int64(*team.MaxTemplates)
-		}
-		if count >= effMaxTemplates {
-			respondErrorMsg(c, "too_many_templates",
-				fmt.Sprintf("team has reached the limit of %d templates; delete some or contact support@superserve.ai for higher", effMaxTemplates),
-				http.StatusTooManyRequests)
-			return
-		}
-	}
-
 	specJSON, err := json.Marshal(req.BuildSpec)
 	if err != nil {
 		log.Error().Err(err).Msg("marshal build_spec")
@@ -477,6 +457,27 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 		return
 	}
 	defer tx.Rollback(ctx)
+
+	// Per-team template count cap. Inside the advisory lock so concurrent
+	// submits at limit-1 don't both pass. System team is exempt.
+	if teamID != h.systemTeamID() {
+		count, err := q.CountActiveTemplatesForTeam(ctx, teamID)
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountActiveTemplatesForTeam failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		effMaxTemplates := int64(defaultMaxTemplates)
+		if team.MaxTemplates != nil {
+			effMaxTemplates = int64(*team.MaxTemplates)
+		}
+		if count >= effMaxTemplates {
+			respondErrorMsg(c, "too_many_templates",
+				fmt.Sprintf("team has reached the limit of %d templates; delete some or contact support@superserve.ai for higher", effMaxTemplates),
+				http.StatusTooManyRequests)
+			return
+		}
+	}
 
 	row, err := q.CreateTemplateWithBuild(ctx, db.CreateTemplateWithBuildParams{
 		TeamID:        teamID,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -270,11 +270,16 @@ type Snapshot struct {
 }
 
 type Team struct {
-	ID               uuid.UUID `json:"id"`
-	Name             string    `json:"name"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
-	BuildConcurrency int32     `json:"build_concurrency"`
+	ID                   uuid.UUID `json:"id"`
+	Name                 string    `json:"name"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+	BuildConcurrency     int32     `json:"build_concurrency"`
+	MaxTemplateVcpu      *int32    `json:"max_template_vcpu"`
+	MaxTemplateMemoryMib *int32    `json:"max_template_memory_mib"`
+	MaxTemplateDiskMib   *int32    `json:"max_template_disk_mib"`
+	MaxTemplates         *int32    `json:"max_templates"`
+	MaxSandboxes         *int32    `json:"max_sandboxes"`
 }
 
 type TeamMember struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -190,6 +190,20 @@ func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]Cla
 	return items, nil
 }
 
+const countActiveSandboxesForTeam = `-- name: CountActiveSandboxesForTeam :one
+SELECT COUNT(*)::bigint FROM sandbox
+WHERE team_id = $1 AND destroyed_at IS NULL
+`
+
+// Counts non-destroyed sandboxes (active + paused) owned by this team. Used
+// to enforce the per-team sandbox count cap on POST /sandboxes.
+func (q *Queries) CountActiveSandboxesForTeam(ctx context.Context, teamID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countActiveSandboxesForTeam, teamID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const createSandbox = `-- name: CreateSandbox :one
 INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -192,11 +192,11 @@ func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]Cla
 
 const countActiveSandboxesForTeam = `-- name: CountActiveSandboxesForTeam :one
 SELECT COUNT(*)::bigint FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL
+WHERE team_id = $1 AND destroyed_at IS NULL AND status != 'failed'
 `
 
-// Counts non-destroyed sandboxes (active + paused) owned by this team. Used
-// to enforce the per-team sandbox count cap on POST /sandboxes.
+// Active = consumes host resources. Excludes failed (VM is gone) and
+// destroyed (row is dead). Includes starting/active/pausing/paused/resuming.
 func (q *Queries) CountActiveSandboxesForTeam(ctx context.Context, teamID uuid.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, countActiveSandboxesForTeam, teamID)
 	var column_1 int64

--- a/internal/db/teams.sql.go
+++ b/internal/db/teams.sql.go
@@ -14,7 +14,7 @@ import (
 const createTeam = `-- name: CreateTeam :one
 INSERT INTO team (name)
 VALUES ($1)
-RETURNING id, name, created_at, updated_at, build_concurrency
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes
 `
 
 func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
@@ -26,6 +26,11 @@ func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BuildConcurrency,
+		&i.MaxTemplateVcpu,
+		&i.MaxTemplateMemoryMib,
+		&i.MaxTemplateDiskMib,
+		&i.MaxTemplates,
+		&i.MaxSandboxes,
 	)
 	return i, err
 }
@@ -41,7 +46,7 @@ func (q *Queries) DeleteTeam(ctx context.Context, id uuid.UUID) error {
 }
 
 const getTeam = `-- name: GetTeam :one
-SELECT id, name, created_at, updated_at, build_concurrency FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
 WHERE id = $1
 `
 
@@ -54,6 +59,11 @@ func (q *Queries) GetTeam(ctx context.Context, id uuid.UUID) (Team, error) {
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BuildConcurrency,
+		&i.MaxTemplateVcpu,
+		&i.MaxTemplateMemoryMib,
+		&i.MaxTemplateDiskMib,
+		&i.MaxTemplates,
+		&i.MaxSandboxes,
 	)
 	return i, err
 }
@@ -71,7 +81,7 @@ func (q *Queries) GetTeamBuildConcurrency(ctx context.Context, id uuid.UUID) (in
 }
 
 const getTeamByName = `-- name: GetTeamByName :one
-SELECT id, name, created_at, updated_at, build_concurrency FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
 WHERE name = $1
 `
 
@@ -84,12 +94,17 @@ func (q *Queries) GetTeamByName(ctx context.Context, name string) (Team, error) 
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BuildConcurrency,
+		&i.MaxTemplateVcpu,
+		&i.MaxTemplateMemoryMib,
+		&i.MaxTemplateDiskMib,
+		&i.MaxTemplates,
+		&i.MaxSandboxes,
 	)
 	return i, err
 }
 
 const listTeams = `-- name: ListTeams :many
-SELECT id, name, created_at, updated_at, build_concurrency FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
 ORDER BY created_at DESC
 `
 
@@ -108,6 +123,11 @@ func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.BuildConcurrency,
+			&i.MaxTemplateVcpu,
+			&i.MaxTemplateMemoryMib,
+			&i.MaxTemplateDiskMib,
+			&i.MaxTemplates,
+			&i.MaxSandboxes,
 		); err != nil {
 			return nil, err
 		}
@@ -123,7 +143,7 @@ const updateTeamName = `-- name: UpdateTeamName :one
 UPDATE team
 SET name = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, name, created_at, updated_at, build_concurrency
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes
 `
 
 type UpdateTeamNameParams struct {
@@ -140,6 +160,11 @@ func (q *Queries) UpdateTeamName(ctx context.Context, arg UpdateTeamNameParams) 
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.BuildConcurrency,
+		&i.MaxTemplateVcpu,
+		&i.MaxTemplateMemoryMib,
+		&i.MaxTemplateDiskMib,
+		&i.MaxTemplates,
+		&i.MaxSandboxes,
 	)
 	return i, err
 }

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -72,6 +72,20 @@ func (q *Queries) CancelBuild(ctx context.Context, arg CancelBuildParams) (int64
 	return result.RowsAffected(), nil
 }
 
+const countActiveTemplatesForTeam = `-- name: CountActiveTemplatesForTeam :one
+SELECT COUNT(*)::bigint FROM template
+WHERE team_id = $1 AND deleted_at IS NULL
+`
+
+// Counts non-deleted templates owned by this team. Used to enforce the
+// per-team template count cap on POST /templates.
+func (q *Queries) CountActiveTemplatesForTeam(ctx context.Context, teamID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countActiveTemplatesForTeam, teamID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const countInFlightBuildsForTeam = `-- name: CountInFlightBuildsForTeam :one
 SELECT COUNT(*) FROM template_build
 WHERE team_id = $1 AND status IN ('pending', 'building', 'snapshotting')

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -74,11 +74,12 @@ func (q *Queries) CancelBuild(ctx context.Context, arg CancelBuildParams) (int64
 
 const countActiveTemplatesForTeam = `-- name: CountActiveTemplatesForTeam :one
 SELECT COUNT(*)::bigint FROM template
-WHERE team_id = $1 AND deleted_at IS NULL
+WHERE team_id = $1 AND deleted_at IS NULL AND status != 'failed'
 `
 
-// Counts non-deleted templates owned by this team. Used to enforce the
-// per-team template count cap on POST /templates.
+// Active = not deleted and not in a terminal-failure state. Failed
+// templates don't hold a snapshot, so they shouldn't consume the count
+// cap (matches CountInFlightBuildsForTeam, which also excludes failed).
 func (q *Queries) CountActiveTemplatesForTeam(ctx context.Context, teamID uuid.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, countActiveTemplatesForTeam, teamID)
 	var column_1 int64

--- a/supabase/migrations/20260430000001_team_template_limits.sql
+++ b/supabase/migrations/20260430000001_team_template_limits.sql
@@ -1,0 +1,8 @@
+-- Per-team limit overrides. NULL means "use code default."
+
+ALTER TABLE team
+  ADD COLUMN max_template_vcpu       int,
+  ADD COLUMN max_template_memory_mib int,
+  ADD COLUMN max_template_disk_mib   int,
+  ADD COLUMN max_templates           int,
+  ADD COLUMN max_sandboxes           int;


### PR DESCRIPTION
## Summary

Two-layer limit system on POST /templates and POST /sandboxes:

1. **Platform ceiling** (code constants): every team — including system — must fit under `absoluteMax{Vcpu,MemoryMib,DiskMib}` = 4 / 4096 / 8192. Defense against typos in curated specs.

2. **Per-team caps** (nullable columns on `team`): `max_template_{vcpu,memory_mib,disk_mib}` (shape) and `max_templates` / `max_sandboxes` (count). NULL → use code default (2 vcpu / 2 GB / 8 GB / 10 templates / 50 sandboxes). Override is one SQL UPDATE per team.

System team bypasses customer caps but respects the absolute.

## Behavior

- POST /templates: shape check + count check; 429 `too_many_templates` at count limit.
- POST /sandboxes: count check (active + paused, excludes failed); 429 `too_many_sandboxes` at limit.
- Both count checks run inside the per-team advisory lock so concurrent submits at limit-1 can't both pass.
- Failed sandboxes/templates don't consume the cap.

## Verified on staging

With test team's caps lowered to `max_templates=2, max_sandboxes=2`:

- Template count cap: 3rd POST returns 429 `too_many_templates` ✓
- Sandbox count cap: 3rd POST returns 429 `too_many_sandboxes` ✓
- 5 concurrent POSTs at-limit: 0 succeed, 5 return 429 ✓
- 3 concurrent POSTs at limit-1: exactly 1 succeeds ✓ (advisory lock holds)
- Default vcpu cap: vcpu=3 returns 400 with team-limit message ✓
- Absolute ceiling: vcpu=8 returns 400 with platform-ceiling message ✓