### PR TITLE
Per-sandbox hostname in terminal prompt

### DIFF
--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -122,7 +122,8 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 //	{
 //	  "env_vars":        {"KEY":"VALUE", ...}, // optional
 //	  "default_user":    "appuser",             // optional
-//	  "default_workdir": "/srv/app"             // optional
+//	  "default_workdir": "/srv/app",            // optional
+//	  "hostname":        "sandbox-abc12345"     // optional
 //	}
 func handleInit(ctx *sandboxContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -136,6 +137,7 @@ func handleInit(ctx *sandboxContext) http.HandlerFunc {
 			EnvVars        map[string]string `json:"env_vars"`
 			DefaultUser    string            `json:"default_user"`
 			DefaultWorkdir string            `json:"default_workdir"`
+			Hostname       string            `json:"hostname"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
@@ -146,9 +148,28 @@ func handleInit(ctx *sandboxContext) http.HandlerFunc {
 		log.Printf("init: merged %d env var(s) user=%q workdir=%q",
 			len(body.EnvVars), body.DefaultUser, body.DefaultWorkdir)
 
+		if body.Hostname != "" {
+			if err := setHostname(body.Hostname); err != nil {
+				log.Printf("init: set hostname %q failed: %v", body.Hostname, err)
+			} else {
+				log.Printf("init: hostname set to %q", body.Hostname)
+			}
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"status":"ok"}`)
 	}
+}
+
+// setHostname sets the kernel hostname and writes /etc/hostname.
+func setHostname(name string) error {
+	if err := syscall.Sethostname([]byte(name)); err != nil {
+		return fmt.Errorf("sethostname: %w", err)
+	}
+	if err := os.WriteFile("/etc/hostname", []byte(name+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write /etc/hostname: %w", err)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
@@ -59,6 +60,21 @@ func newFCClient(socketPath string) *fcclient.Firecracker {
 func strPtr(s string) *string { return &s }
 func boolPtr(b bool) *bool    { return &b }
 func int64Ptr(i int64) *int64 { return &i }
+
+// vmHostname returns a short hostname for a VM.
+func vmHostname(vmID string) string {
+	if rest, ok := strings.CutPrefix(vmID, "build-"); ok {
+		return "build-" + shortID(rest)
+	}
+	return "sandbox-" + shortID(vmID)
+}
+
+func shortID(s string) string {
+	if len(s) >= 8 {
+		return s[:8]
+	}
+	return s
+}
 
 // ---------------------------------------------------------------------------
 // configureMachine configures the Firecracker instance via its HTTP API.

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -53,7 +53,7 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 		return nil, err
 	}
 
-	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars()); err != nil {
+	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars(), vmHostname(inst.ID)); err != nil {
 		return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", err)
 	}
 
@@ -107,16 +107,12 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 		return nil, err
 	}
 
-	// Merge caller env vars on top of whatever context the template baked
-	// into the snapshot. Skipping on empty preserves the template's
-	// defaults (boxd already has them loaded from the restored memory).
-	if envVars := req.GetEnvVars(); len(envVars) > 0 {
-		if initErr := postBoxdInit(ctx, inst.IP, envVars); initErr != nil {
-			// Tear the VM down — a sandbox whose env vars weren't applied
-			// would silently serve stale/missing secrets to the user.
-			_ = a.mgr.DestroyVM(ctx, inst.ID, true)
-			return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", initErr)
-		}
+	// Apply caller env vars and the per-sandbox hostname.
+	if initErr := postBoxdInit(ctx, inst.IP, req.GetEnvVars(), vmHostname(inst.ID)); initErr != nil {
+		// Tear the VM down — a sandbox whose env vars weren't applied
+		// would silently serve stale/missing secrets to the user.
+		_ = a.mgr.DestroyVM(ctx, inst.ID, true)
+		return nil, status.Errorf(codes.Internal, "post-restore init failed: %v", initErr)
 	}
 
 	return &vmdpb.RestoreSnapshotResponse{

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -221,16 +221,17 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 var boxdInitClient = &http.Client{Timeout: 5 * time.Second}
 
 
-// postBoxdInit sends sandbox-level environment variables to boxd's /init
-// endpoint. These vars are injected into every process boxd spawns.
-func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string) error {
-	if len(envVars) == 0 {
+// postBoxdInit sends sandbox-level configuration (env vars, hostname) to
+// boxd's /init endpoint.
+func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, hostname string) error {
+	if len(envVars) == 0 && hostname == "" {
 		return nil
 	}
 
 	body := struct {
-		EnvVars map[string]string `json:"env_vars"`
-	}{EnvVars: envVars}
+		EnvVars  map[string]string `json:"env_vars,omitempty"`
+		Hostname string            `json:"hostname,omitempty"`
+	}{EnvVars: envVars, Hostname: hostname}
 
 	buf, err := json.Marshal(body)
 	if err != nil {


### PR DESCRIPTION
## Summary

Today the console terminal shows \`root@169:~#\` for every sandbox — bash's \`\h\` resolves to the kernel hostname, and the kernel uses the VM's internal IP \`169.254.0.21\` (truncated at the first \`.\`).

The kernel-cmdline approach doesn't help: sandboxes restore from a snapshot, and the snapshot captures the build VM's kernel state, so every sandbox from the same template would inherit the same hostname.

This sets the hostname **after restore** via boxd:

1. boxd's \`/init\` endpoint accepts an optional \`hostname\` field and applies it via \`Sethostname\` + \`/etc/hostname\`.
2. vmd's RestoreSnapshot / ResumeVM always include \`hostname=sandbox-<8 hex of vm_id>\` in the post-restore init call.

After this lands, prompt becomes \`root@sandbox-XXXXXXXX:~#\` matching the actual sandbox UUID.