### PR TITLE
templates: forbid '/' in customer names + add by-name lookup

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -456,6 +456,37 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /templates/names/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Template name (e.g. `my-python-env` or `superserve/python-3.11`).
+
+    get:
+      operationId: getTemplateByName
+      tags: [Templates]
+      summary: Get a template by name
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Template details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /templates/{template_id}:
     parameters:
       - $ref: "#/components/parameters/TemplateId"
@@ -1051,14 +1082,11 @@ components:
           type: string
           minLength: 1
           maxLength: 128
-          pattern: "^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?$"
+          pattern: "^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$"
           description: >
-            Human-readable name, unique per team. Used as the
-            `from_template` value when creating sandboxes. Lowercase
-            letters, digits, and `.` `_` `/` `-` only; must start and
-            end with a letter or digit. Names starting with `superserve/`
-            are reserved for curated system templates and rejected for
-            team-owned templates.
+            Unique name for this template within your team. Used as the
+            `from_template` value when creating sandboxes. Lowercase letters,
+            digits, and `.` `_` `-`; must start and end with a letter or digit.
           example: my-python-env
         vcpu:
           type: integer

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -398,10 +398,10 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 			http.StatusBadRequest)
 		return
 	}
-	// `superserve/` is reserved for curated templates owned by the system team.
-	if strings.HasPrefix(req.Name, "superserve/") && teamID != h.systemTeamID() {
+	// `/` is reserved for platform-curated templates (superserve/...).
+	if strings.Contains(req.Name, "/") && teamID != h.systemTeamID() {
 		respondErrorMsg(c, "bad_request",
-			"names starting with 'superserve/' are reserved",
+			"names cannot contain '/' (reserved for platform-curated templates)",
 			http.StatusBadRequest)
 		return
 	}
@@ -581,6 +581,37 @@ func (h *Handlers) GetTemplate(c *gin.Context) {
 		return
 	}
 
+	c.JSON(http.StatusOK, toTemplateResponse(tpl))
+}
+
+// GetTemplateByName resolves a template by its name (caller's team or
+// system team). Wildcard route so names containing `/` (system templates
+// like `superserve/python-3.11`) work without URL-encoding.
+func (h *Handlers) GetTemplateByName(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	// gin's *catch-all captures with a leading `/`; strip it.
+	name := strings.TrimPrefix(c.Param("name"), "/")
+	if name == "" {
+		respondErrorMsg(c, "bad_request", "name is required", http.StatusBadRequest)
+		return
+	}
+	tpl, err := h.DB.GetTemplateByName(c.Request.Context(), db.GetTemplateByNameParams{
+		Name:     name,
+		TeamID:   teamID,
+		TeamID_2: h.systemTeamID(),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB GetTemplateByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
 	c.JSON(http.StatusOK, toTemplateResponse(tpl))
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -48,6 +48,7 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 		// the POST /templates/:id/builds endpoint just enqueues a row.
 		api.GET("/templates", h.ListTemplates)
 		api.POST("/templates", h.CreateTemplate)
+		api.GET("/templates/names/*name", h.GetTemplateByName)
 		api.GET("/templates/:template_id", h.GetTemplate)
 		api.DELETE("/templates/:template_id", h.DeleteTemplate)
 		api.GET("/templates/:template_id/builds", h.ListTemplateBuilds)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1432,13 +1432,14 @@ func TestIntegration_CreateTemplate_NameCharSet(t *testing.T) {
 	}{
 		{"foo", true, "lowercase ok"},
 		{"my-python-env", true, "hyphens ok"},
-		{"a/b/c", true, "slashes ok"},
 		{"foo.bar", true, "dot ok"},
 		{"f", true, "single char ok"},
 		{"Foo", false, "capitals rejected"},
 		{"foo bar", false, "space rejected"},
 		{"-foo", false, "leading hyphen rejected"},
 		{"foo-", false, "trailing hyphen rejected"},
+		{"a/b/c", false, "slash rejected (customer)"},
+		{"acme/foo", false, "slash rejected (customer)"},
 		{"/foo", false, "leading slash rejected"},
 		{"foo/", false, "trailing slash rejected"},
 		{"foo!", false, "punctuation rejected"},
@@ -1482,5 +1483,52 @@ func TestIntegration_CreateTemplate_DuplicateLiveNameReturns409(t *testing.T) {
 	w := do(r, "POST", "/templates", apiKey, body)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestIntegration_GetTemplateByName_OwnAndSystem covers the by-name lookup:
+// caller's team templates resolve, system templates resolve (slash names
+// handled by wildcard route), and unknown names 404.
+func TestIntegration_GetTemplateByName_OwnAndSystem(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	// Seed the caller's own template.
+	const ownName = "my-thing"
+	own, err := testQueries.CreateTemplate(ctx, db.CreateTemplateParams{
+		TeamID:    teamID,
+		Name:      ownName,
+		BuildSpec: []byte(`{"from":"debian:12-slim","steps":[]}`),
+		Vcpu:      1, MemoryMib: 1024, DiskMib: 4096,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Own template by name → 200, returns the seeded row.
+	w := do(r, "GET", "/templates/names/"+ownName, apiKey, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("own by-name: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	resp := mustJSON(t, w)
+	if resp["id"] != own.ID.String() {
+		t.Errorf("own by-name id mismatch: got %v want %s", resp["id"], own.ID)
+	}
+
+	// System template by name (wildcard route handles the slash).
+	w = do(r, "GET", "/templates/names/superserve/base", apiKey, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("system by-name: expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	resp = mustJSON(t, w)
+	if resp["name"] != "superserve/base" {
+		t.Errorf("system by-name name mismatch: got %v want superserve/base", resp["name"])
+	}
+
+	// Unknown name → 404.
+	w = do(r, "GET", "/templates/names/nope-not-here", apiKey, "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown by-name: expected 404, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Two related changes that close the namespace squat hole and give SDKs a clean name lookup path.

**1. Forbid `/` in customer template names.** Today the regex allows it but we only blocked the `superserve/` prefix specifically. A customer could still create `system/foo`, `e2b/bar`, etc. — names that *look* platform-curated. Now `/` is rejected for all non-system teams.

**2. Add `GET /templates/names/{name}`.** Dedicated lookup endpoint for resolving a template by name to a single object (200/404), mirroring `GET /templates/{template_id}` but keyed on name. Wildcard route handles the slash in system template names (`superserve/python-3.11`).

## Notes

- Customer-created templates: flat names only (no `/`). All existing customer templates are flat anyway, so no migration needed.
- System templates: keep their `superserve/...` namespacing.
- OpenAPI `pattern` on the create-template `name` field tightened to drop `/` (matches what customers can submit).