### PR TITLE
builder: rewrite apt sources to nova.clouds Ubuntu mirror

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -82,7 +82,7 @@ func (b *inProcessBuilder) BuildRootfs(ctx context.Context, spec BuildSpec, dest
 	}
 	logger.Info().Str("digest", digest).Msg("image flattened")
 
-	boxdBytes, err := injectGuestAgent(scratch, b.cfg.BoxdBinaryPath)
+	boxdBytes, err := injectGuestAgent(scratch, b.cfg.BoxdBinaryPath, &logger)
 	if err != nil {
 		return BuildRootfsResult{}, fmt.Errorf("inject boxd: %w", err)
 	}

--- a/internal/builder/inject.go
+++ b/internal/builder/inject.go
@@ -120,8 +120,12 @@ func injectGuestAgent(rootfsDir, boxdBinaryPath string, logger *zerolog.Logger) 
 		return 0, fmt.Errorf("write /etc/resolv.conf: %w", err)
 	}
 
-	// Public Canonical apt mirrors silently drop GCE egress; rewrite to the
-	// in-region GCE mirror so apt-get inside the build VM doesn't hang.
+	// Public Canonical apt mirrors are intermittently throttled / unreachable
+	// during the May 2026 archive outages, which produces partial .deb
+	// downloads and dpkg failures inside build VMs. Rewrite to
+	// nova.clouds.archive.ubuntu.com (Canonical's cloud-targeted mirror,
+	// which has a separate sync path and has stayed reachable through the
+	// event) so apt-get works.
 	if err := rewriteAptSources(rootfsDir, logger); err != nil {
 		return 0, fmt.Errorf("rewrite apt sources: %w", err)
 	}
@@ -129,13 +133,14 @@ func injectGuestAgent(rootfsDir, boxdBinaryPath string, logger *zerolog.Logger) 
 	return binSize, nil
 }
 
-// TODO(multi-region): make this a builder config field if we ever run
-// build VMs outside us-central1.
-const gceUbuntuMirrorHost = "us-central1.gce.archive.ubuntu.com"
+// Replacement mirror for canonicalUbuntuMirrors. nova.clouds is Canonical's
+// cloud-targeted mirror; it has a separate upstream sync path from the public
+// archive and was the only Ubuntu mirror to stay at 100% uptime through the
+// May 2026 archive.ubuntu.com / security.ubuntu.com outages.
+const ubuntuMirrorHost = "nova.clouds.archive.ubuntu.com"
 
-// Ubuntu-only. deb.debian.org is currently unaffected by the same outage;
-// if it ever needs equivalent handling, the GCE Debian path is via
-// mirror.gcr.io, not gce.archive.ubuntu.com.
+// Ubuntu-only. deb.debian.org is on a separate mirror network and currently
+// unaffected.
 var canonicalUbuntuMirrors = []string{
 	"archive.ubuntu.com",
 	"security.ubuntu.com",
@@ -143,16 +148,17 @@ var canonicalUbuntuMirrors = []string{
 
 const aptRewriteHeader = `# Rewritten by Superserve template builder.
 # Public Canonical mirrors (archive.ubuntu.com / security.ubuntu.com) are
-# rate-limited from GCE egress and frequently unreachable; the regional
-# mirror at us-central1.gce.archive.ubuntu.com serves the same archive
-# contents and is reachable in <50 ms. See:
-#   https://discuss.google.dev/t/gce-ubuntu-mirror-slowness/102707
+# intermittently throttled and serve partial responses during the ongoing
+# archive outages, which surfaces as dpkg errors on truncated .deb files.
+# nova.clouds.archive.ubuntu.com is Canonical's cloud-targeted mirror and
+# serves the same archive contents over a separate, healthy sync path.
 `
 
-// rewriteAptSources rewrites http:// references to canonicalUbuntuMirrors in
-// /etc/apt/sources.list and /etc/apt/sources.list.d/{*.list,*.sources} to
-// point at the GCE regional mirror. No-op when /etc/apt is absent or when no
-// file references a canonical hostname.
+// rewriteAptSources rewrites http:// and https:// references to
+// canonicalUbuntuMirrors in /etc/apt/sources.list and
+// /etc/apt/sources.list.d/{*.list,*.sources} to point at ubuntuMirrorHost.
+// No-op when /etc/apt is absent or when no file references a canonical
+// hostname.
 func rewriteAptSources(rootfsDir string, logger *zerolog.Logger) error {
 	aptDir := filepath.Join(rootfsDir, "etc/apt")
 	if _, err := os.Stat(aptDir); err != nil {
@@ -182,9 +188,9 @@ func rewriteAptSources(rootfsDir string, logger *zerolog.Logger) error {
 	}
 	if len(rewritten) > 0 && logger != nil {
 		logger.Info().
-			Str("mirror", gceUbuntuMirrorHost).
+			Str("mirror", ubuntuMirrorHost).
 			Strs("files", rewritten).
-			Msg("rewrote apt sources to GCE regional mirror")
+			Msg("rewrote apt sources to alternate Ubuntu mirror")
 	}
 	return nil
 }
@@ -229,9 +235,10 @@ func rewriteAptFile(path string) (bool, error) {
 	}
 	contents := string(data)
 
-	// The GCE mirror is HTTP-only, so https:// references get downgraded.
-	// apt verifies package signatures via Signed-By: independent of transport,
-	// so HTTP is fine for authenticity.
+	// We rewrite over both schemes and emit http:// — apt verifies package
+	// signatures via Signed-By: independent of transport, so HTTP is fine for
+	// authenticity, and HTTP-only matches the default Ubuntu sources.list
+	// convention.
 	schemes := []string{"http://", "https://"}
 
 	needsRewrite := false
@@ -253,7 +260,7 @@ func rewriteAptFile(path string) (bool, error) {
 	rewritten := contents
 	for _, host := range canonicalUbuntuMirrors {
 		for _, scheme := range schemes {
-			rewritten = strings.ReplaceAll(rewritten, scheme+host, "http://"+gceUbuntuMirrorHost)
+			rewritten = strings.ReplaceAll(rewritten, scheme+host, "http://"+ubuntuMirrorHost)
 		}
 	}
 

--- a/internal/builder/inject.go
+++ b/internal/builder/inject.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 // tiniBinary is a static linux/amd64 build of tini v0.19.0 — a minimal
@@ -117,7 +120,135 @@ func injectGuestAgent(rootfsDir, boxdBinaryPath string) (int64, error) {
 		return 0, fmt.Errorf("write /etc/resolv.conf: %w", err)
 	}
 
+	// Public Canonical apt mirrors silently drop GCE egress; rewrite to the
+	// in-region GCE mirror so apt-get inside the build VM doesn't hang.
+	if err := rewriteAptSources(rootfsDir); err != nil {
+		return 0, fmt.Errorf("rewrite apt sources: %w", err)
+	}
+
 	return binSize, nil
+}
+
+const gceUbuntuMirrorHost = "us-central1.gce.archive.ubuntu.com"
+
+var canonicalUbuntuMirrors = []string{
+	"archive.ubuntu.com",
+	"security.ubuntu.com",
+}
+
+const aptRewriteHeader = `# Rewritten by Superserve template builder.
+# Public Canonical mirrors (archive.ubuntu.com / security.ubuntu.com) are
+# rate-limited from GCE egress and frequently unreachable; the regional
+# mirror at us-central1.gce.archive.ubuntu.com serves the same archive
+# contents and is reachable in <50 ms. See:
+#   https://discuss.google.dev/t/gce-ubuntu-mirror-slowness/102707
+`
+
+// rewriteAptSources rewrites http:// references to canonicalUbuntuMirrors in
+// /etc/apt/sources.list and /etc/apt/sources.list.d/{*.list,*.sources} to
+// point at the GCE regional mirror. No-op when /etc/apt is absent or when no
+// file references a canonical hostname.
+func rewriteAptSources(rootfsDir string) error {
+	aptDir := filepath.Join(rootfsDir, "etc/apt")
+	if _, err := os.Stat(aptDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", aptDir, err)
+	}
+
+	files, err := findAptSourceFiles(aptDir)
+	if err != nil {
+		return fmt.Errorf("scan apt source files: %w", err)
+	}
+	var rewritten []string
+	for _, path := range files {
+		changed, err := rewriteAptFile(path)
+		if err != nil {
+			return fmt.Errorf("rewrite %s: %w", path, err)
+		}
+		if changed {
+			if rel, relErr := filepath.Rel(rootfsDir, path); relErr == nil {
+				rewritten = append(rewritten, "/"+rel)
+			} else {
+				rewritten = append(rewritten, path)
+			}
+		}
+	}
+	if len(rewritten) > 0 {
+		log.Info().
+			Str("component", "builder").
+			Str("mirror", gceUbuntuMirrorHost).
+			Strs("files", rewritten).
+			Msg("rewrote apt sources to GCE regional mirror")
+	}
+	return nil
+}
+
+func findAptSourceFiles(aptDir string) ([]string, error) {
+	var files []string
+
+	mainList := filepath.Join(aptDir, "sources.list")
+	if _, err := os.Stat(mainList); err == nil {
+		files = append(files, mainList)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	listDir := filepath.Join(aptDir, "sources.list.d")
+	entries, err := os.ReadDir(listDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return files, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".list") || strings.HasSuffix(name, ".sources") {
+			files = append(files, filepath.Join(listDir, name))
+		}
+	}
+	return files, nil
+}
+
+// rewriteAptFile rewrites one apt sources file in place. Returns changed=true
+// only when the file matched a canonical hostname and was overwritten.
+// Idempotent: re-running on an already-rewritten file is a no-op.
+func rewriteAptFile(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	contents := string(data)
+
+	needsRewrite := false
+	for _, host := range canonicalUbuntuMirrors {
+		if strings.Contains(contents, "http://"+host) {
+			needsRewrite = true
+			break
+		}
+	}
+	if !needsRewrite {
+		return false, nil
+	}
+
+	rewritten := contents
+	for _, host := range canonicalUbuntuMirrors {
+		rewritten = strings.ReplaceAll(rewritten, "http://"+host, "http://"+gceUbuntuMirrorHost)
+	}
+
+	if !strings.HasPrefix(rewritten, aptRewriteHeader) {
+		rewritten = aptRewriteHeader + rewritten
+	}
+
+	if err := os.WriteFile(path, []byte(rewritten), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // resolvConf is the minimal DNS config baked into every template rootfs.

--- a/internal/builder/inject.go
+++ b/internal/builder/inject.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 // tiniBinary is a static linux/amd64 build of tini v0.19.0 — a minimal
@@ -51,7 +51,7 @@ var seedentropyBinary []byte
 //   /sbin/init                 (0755)  — shell wrapper that execs tini
 //
 // Returns the byte count of the boxd binary copied, for observability.
-func injectGuestAgent(rootfsDir, boxdBinaryPath string) (int64, error) {
+func injectGuestAgent(rootfsDir, boxdBinaryPath string, logger *zerolog.Logger) (int64, error) {
 	if boxdBinaryPath == "" {
 		return 0, fmt.Errorf("boxd binary path is empty")
 	}
@@ -122,15 +122,20 @@ func injectGuestAgent(rootfsDir, boxdBinaryPath string) (int64, error) {
 
 	// Public Canonical apt mirrors silently drop GCE egress; rewrite to the
 	// in-region GCE mirror so apt-get inside the build VM doesn't hang.
-	if err := rewriteAptSources(rootfsDir); err != nil {
+	if err := rewriteAptSources(rootfsDir, logger); err != nil {
 		return 0, fmt.Errorf("rewrite apt sources: %w", err)
 	}
 
 	return binSize, nil
 }
 
+// TODO(multi-region): make this a builder config field if we ever run
+// build VMs outside us-central1.
 const gceUbuntuMirrorHost = "us-central1.gce.archive.ubuntu.com"
 
+// Ubuntu-only. deb.debian.org is currently unaffected by the same outage;
+// if it ever needs equivalent handling, the GCE Debian path is via
+// mirror.gcr.io, not gce.archive.ubuntu.com.
 var canonicalUbuntuMirrors = []string{
 	"archive.ubuntu.com",
 	"security.ubuntu.com",
@@ -148,7 +153,7 @@ const aptRewriteHeader = `# Rewritten by Superserve template builder.
 // /etc/apt/sources.list and /etc/apt/sources.list.d/{*.list,*.sources} to
 // point at the GCE regional mirror. No-op when /etc/apt is absent or when no
 // file references a canonical hostname.
-func rewriteAptSources(rootfsDir string) error {
+func rewriteAptSources(rootfsDir string, logger *zerolog.Logger) error {
 	aptDir := filepath.Join(rootfsDir, "etc/apt")
 	if _, err := os.Stat(aptDir); err != nil {
 		if os.IsNotExist(err) {
@@ -175,9 +180,8 @@ func rewriteAptSources(rootfsDir string) error {
 			}
 		}
 	}
-	if len(rewritten) > 0 {
-		log.Info().
-			Str("component", "builder").
+	if len(rewritten) > 0 && logger != nil {
+		logger.Info().
 			Str("mirror", gceUbuntuMirrorHost).
 			Strs("files", rewritten).
 			Msg("rewrote apt sources to GCE regional mirror")
@@ -225,10 +229,20 @@ func rewriteAptFile(path string) (bool, error) {
 	}
 	contents := string(data)
 
+	// The GCE mirror is HTTP-only, so https:// references get downgraded.
+	// apt verifies package signatures via Signed-By: independent of transport,
+	// so HTTP is fine for authenticity.
+	schemes := []string{"http://", "https://"}
+
 	needsRewrite := false
 	for _, host := range canonicalUbuntuMirrors {
-		if strings.Contains(contents, "http://"+host) {
-			needsRewrite = true
+		for _, scheme := range schemes {
+			if strings.Contains(contents, scheme+host) {
+				needsRewrite = true
+				break
+			}
+		}
+		if needsRewrite {
 			break
 		}
 	}
@@ -238,7 +252,9 @@ func rewriteAptFile(path string) (bool, error) {
 
 	rewritten := contents
 	for _, host := range canonicalUbuntuMirrors {
-		rewritten = strings.ReplaceAll(rewritten, "http://"+host, "http://"+gceUbuntuMirrorHost)
+		for _, scheme := range schemes {
+			rewritten = strings.ReplaceAll(rewritten, scheme+host, "http://"+gceUbuntuMirrorHost)
+		}
 	}
 
 	if !strings.HasPrefix(rewritten, aptRewriteHeader) {

--- a/internal/builder/inject_test.go
+++ b/internal/builder/inject_test.go
@@ -1,0 +1,130 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRewriteAptSources covers the apt-source rewrite path: hosts in the
+// canonical Ubuntu list get redirected to the GCE regional mirror, unrelated
+// URLs and HTTPS sources stay put, files without canonical references aren't
+// touched, the rewrite is idempotent, and the function is a no-op on
+// non-Ubuntu rootfs trees.
+func TestRewriteAptSources(t *testing.T) {
+	t.Run("rewrites archive and security hosts in classic sources.list", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "etc/apt/sources.list"), ""+
+			"deb http://archive.ubuntu.com/ubuntu noble main\n"+
+			"deb http://security.ubuntu.com/ubuntu noble-security main\n")
+
+		if err := rewriteAptSources(root); err != nil {
+			t.Fatalf("rewriteAptSources: %v", err)
+		}
+
+		got := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		if !strings.HasPrefix(got, aptRewriteHeader) {
+			t.Errorf("expected file to begin with rewrite header; got:\n%s", got)
+		}
+		// Match on protocol+host so we don't false-positive on the GCE
+		// mirror's own hostname (which contains "archive.ubuntu.com" as
+		// a substring).
+		body := strings.TrimPrefix(got, aptRewriteHeader)
+		for _, stale := range []string{"http://archive.ubuntu.com", "http://security.ubuntu.com"} {
+			if strings.Contains(body, stale) {
+				t.Errorf("stale URL %q still present after rewrite:\n%s", stale, body)
+			}
+		}
+		if strings.Count(body, gceUbuntuMirrorHost) != 2 {
+			t.Errorf("expected GCE mirror hostname in 2 deb lines, got %d:\n%s",
+				strings.Count(body, gceUbuntuMirrorHost), body)
+		}
+	})
+
+	t.Run("rewrites deb822 .sources file in sources.list.d", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"), ""+
+			"Types: deb deb-src\n"+
+			"URIs: http://archive.ubuntu.com/ubuntu/\n"+
+			"Suites: noble noble-updates\n"+
+			"Components: main universe\n")
+
+		if err := rewriteAptSources(root); err != nil {
+			t.Fatalf("rewriteAptSources: %v", err)
+		}
+
+		got := readFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"))
+		if !strings.Contains(got, "URIs: http://"+gceUbuntuMirrorHost+"/ubuntu/") {
+			t.Errorf("URIs line not rewritten:\n%s", got)
+		}
+	})
+
+	t.Run("leaves unrelated PPA and HTTPS sources untouched", func(t *testing.T) {
+		root := t.TempDir()
+		original := "" +
+			"deb http://ppa.launchpad.net/some/ppa/ubuntu noble main\n" +
+			"deb https://archive.ubuntu.com/ubuntu noble main\n" + // HTTPS — not rewritten
+			"deb http://my.private.mirror/ubuntu noble main\n"
+		writeFile(t, filepath.Join(root, "etc/apt/sources.list"), original)
+
+		if err := rewriteAptSources(root); err != nil {
+			t.Fatalf("rewriteAptSources: %v", err)
+		}
+
+		got := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		if got != original {
+			t.Errorf("expected file untouched (no http canonical refs), got:\n%s", got)
+		}
+	})
+
+	t.Run("idempotent — rewriting twice does not double-prepend the header", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "etc/apt/sources.list"),
+			"deb http://archive.ubuntu.com/ubuntu noble main\n")
+
+		if err := rewriteAptSources(root); err != nil {
+			t.Fatalf("first rewrite: %v", err)
+		}
+		first := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+
+		if err := rewriteAptSources(root); err != nil {
+			t.Fatalf("second rewrite: %v", err)
+		}
+		second := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+
+		if first != second {
+			t.Errorf("rewrite is not idempotent.\nfirst:\n%s\nsecond:\n%s", first, second)
+		}
+	})
+
+	t.Run("no-op when /etc/apt is absent", func(t *testing.T) {
+		root := t.TempDir() // empty
+		if err := rewriteAptSources(root); err != nil {
+			t.Errorf("expected nil error for missing /etc/apt, got: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/internal/builder/inject_test.go
+++ b/internal/builder/inject_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 // TestRewriteAptSources covers the apt-source rewrite path: canonical hosts
-// get redirected to the GCE regional mirror over both http:// and https://
-// (downgraded to http://), unrelated URLs are left alone, the rewrite is
+// get redirected to the replacement mirror over both http:// and https://
+// (emitted as http://), unrelated URLs are left alone, the rewrite is
 // idempotent, and the function is a no-op on non-Ubuntu rootfs trees.
 func TestRewriteAptSources(t *testing.T) {
 	t.Run("rewrites archive and security hosts in classic sources.list", func(t *testing.T) {
@@ -26,18 +26,18 @@ func TestRewriteAptSources(t *testing.T) {
 		if !strings.HasPrefix(got, aptRewriteHeader) {
 			t.Errorf("expected file to begin with rewrite header; got:\n%s", got)
 		}
-		// Match on protocol+host so we don't false-positive on the GCE
-		// mirror's own hostname (which contains "archive.ubuntu.com" as
-		// a substring).
+		// Match on protocol+host so we don't false-positive on the
+		// replacement mirror's own hostname (which contains
+		// "archive.ubuntu.com" as a substring).
 		body := strings.TrimPrefix(got, aptRewriteHeader)
 		for _, stale := range []string{"http://archive.ubuntu.com", "http://security.ubuntu.com"} {
 			if strings.Contains(body, stale) {
 				t.Errorf("stale URL %q still present after rewrite:\n%s", stale, body)
 			}
 		}
-		if strings.Count(body, gceUbuntuMirrorHost) != 2 {
-			t.Errorf("expected GCE mirror hostname in 2 deb lines, got %d:\n%s",
-				strings.Count(body, gceUbuntuMirrorHost), body)
+		if strings.Count(body, ubuntuMirrorHost) != 2 {
+			t.Errorf("expected replacement mirror hostname in 2 deb lines, got %d:\n%s",
+				strings.Count(body, ubuntuMirrorHost), body)
 		}
 	})
 
@@ -54,7 +54,7 @@ func TestRewriteAptSources(t *testing.T) {
 		}
 
 		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"))
-		if !strings.Contains(got, "URIs: http://"+gceUbuntuMirrorHost+"/ubuntu/") {
+		if !strings.Contains(got, "URIs: http://"+ubuntuMirrorHost+"/ubuntu/") {
 			t.Errorf("URIs line not rewritten:\n%s", got)
 		}
 	})
@@ -77,7 +77,7 @@ func TestRewriteAptSources(t *testing.T) {
 		}
 	})
 
-	t.Run("rewrites https:// canonical sources to http:// GCE mirror", func(t *testing.T) {
+	t.Run("rewrites https:// canonical sources to http:// replacement mirror", func(t *testing.T) {
 		root := t.TempDir()
 		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"),
 			"deb https://archive.ubuntu.com/ubuntu noble main\n"+
@@ -97,9 +97,9 @@ func TestRewriteAptSources(t *testing.T) {
 				t.Errorf("stale URL %q still present after rewrite:\n%s", stale, body)
 			}
 		}
-		if strings.Count(body, "http://"+gceUbuntuMirrorHost) != 2 {
+		if strings.Count(body, "http://"+ubuntuMirrorHost) != 2 {
 			t.Errorf("expected http://%s twice in body (HTTPS downgraded), got %d:\n%s",
-				gceUbuntuMirrorHost, strings.Count(body, "http://"+gceUbuntuMirrorHost), body)
+				ubuntuMirrorHost, strings.Count(body, "http://"+ubuntuMirrorHost), body)
 		}
 	})
 

--- a/internal/builder/inject_test.go
+++ b/internal/builder/inject_test.go
@@ -7,23 +7,22 @@ import (
 	"testing"
 )
 
-// TestRewriteAptSources covers the apt-source rewrite path: hosts in the
-// canonical Ubuntu list get redirected to the GCE regional mirror, unrelated
-// URLs and HTTPS sources stay put, files without canonical references aren't
-// touched, the rewrite is idempotent, and the function is a no-op on
-// non-Ubuntu rootfs trees.
+// TestRewriteAptSources covers the apt-source rewrite path: canonical hosts
+// get redirected to the GCE regional mirror over both http:// and https://
+// (downgraded to http://), unrelated URLs are left alone, the rewrite is
+// idempotent, and the function is a no-op on non-Ubuntu rootfs trees.
 func TestRewriteAptSources(t *testing.T) {
 	t.Run("rewrites archive and security hosts in classic sources.list", func(t *testing.T) {
 		root := t.TempDir()
-		writeFile(t, filepath.Join(root, "etc/apt/sources.list"), ""+
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"), ""+
 			"deb http://archive.ubuntu.com/ubuntu noble main\n"+
 			"deb http://security.ubuntu.com/ubuntu noble-security main\n")
 
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Fatalf("rewriteAptSources: %v", err)
 		}
 
-		got := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
 		if !strings.HasPrefix(got, aptRewriteHeader) {
 			t.Errorf("expected file to begin with rewrite header; got:\n%s", got)
 		}
@@ -44,54 +43,106 @@ func TestRewriteAptSources(t *testing.T) {
 
 	t.Run("rewrites deb822 .sources file in sources.list.d", func(t *testing.T) {
 		root := t.TempDir()
-		writeFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"), ""+
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"), ""+
 			"Types: deb deb-src\n"+
 			"URIs: http://archive.ubuntu.com/ubuntu/\n"+
 			"Suites: noble noble-updates\n"+
 			"Components: main universe\n")
 
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Fatalf("rewriteAptSources: %v", err)
 		}
 
-		got := readFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"))
+		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list.d/ubuntu.sources"))
 		if !strings.Contains(got, "URIs: http://"+gceUbuntuMirrorHost+"/ubuntu/") {
 			t.Errorf("URIs line not rewritten:\n%s", got)
 		}
 	})
 
-	t.Run("leaves unrelated PPA and HTTPS sources untouched", func(t *testing.T) {
+	t.Run("leaves PPA and customer-private mirrors untouched", func(t *testing.T) {
 		root := t.TempDir()
 		original := "" +
 			"deb http://ppa.launchpad.net/some/ppa/ubuntu noble main\n" +
-			"deb https://archive.ubuntu.com/ubuntu noble main\n" + // HTTPS — not rewritten
-			"deb http://my.private.mirror/ubuntu noble main\n"
-		writeFile(t, filepath.Join(root, "etc/apt/sources.list"), original)
+			"deb http://my.private.mirror/ubuntu noble main\n" +
+			"deb https://my.private.mirror/ubuntu noble main\n"
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"), original)
 
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Fatalf("rewriteAptSources: %v", err)
 		}
 
-		got := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
 		if got != original {
-			t.Errorf("expected file untouched (no http canonical refs), got:\n%s", got)
+			t.Errorf("expected file untouched (no canonical refs), got:\n%s", got)
+		}
+	})
+
+	t.Run("rewrites https:// canonical sources to http:// GCE mirror", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"),
+			"deb https://archive.ubuntu.com/ubuntu noble main\n"+
+				"deb https://security.ubuntu.com/ubuntu noble-security main\n")
+
+		if err := rewriteAptSources(root, nil); err != nil {
+			t.Fatalf("rewriteAptSources: %v", err)
+		}
+
+		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		body := strings.TrimPrefix(got, aptRewriteHeader)
+		for _, stale := range []string{
+			"https://archive.ubuntu.com", "https://security.ubuntu.com",
+			"http://archive.ubuntu.com", "http://security.ubuntu.com",
+		} {
+			if strings.Contains(body, stale) {
+				t.Errorf("stale URL %q still present after rewrite:\n%s", stale, body)
+			}
+		}
+		if strings.Count(body, "http://"+gceUbuntuMirrorHost) != 2 {
+			t.Errorf("expected http://%s twice in body (HTTPS downgraded), got %d:\n%s",
+				gceUbuntuMirrorHost, strings.Count(body, "http://"+gceUbuntuMirrorHost), body)
+		}
+	})
+
+	t.Run("rewrites canonical lines and leaves non-canonical lines alone in one file", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"),
+			"deb http://archive.ubuntu.com/ubuntu noble main\n"+
+				"deb http://ppa.launchpad.net/some/ppa/ubuntu noble main\n"+
+				"deb http://security.ubuntu.com/ubuntu noble-security main\n"+
+				"deb http://my.private.mirror/ubuntu noble main\n")
+
+		if err := rewriteAptSources(root, nil); err != nil {
+			t.Fatalf("rewriteAptSources: %v", err)
+		}
+
+		got := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		body := strings.TrimPrefix(got, aptRewriteHeader)
+		for _, stale := range []string{"http://archive.ubuntu.com", "http://security.ubuntu.com"} {
+			if strings.Contains(body, stale) {
+				t.Errorf("canonical %q still present after rewrite:\n%s", stale, body)
+			}
+		}
+		for _, kept := range []string{"http://ppa.launchpad.net/some/ppa/ubuntu", "http://my.private.mirror/ubuntu"} {
+			if !strings.Contains(body, kept) {
+				t.Errorf("non-canonical %q was dropped or rewritten:\n%s", kept, body)
+			}
 		}
 	})
 
 	t.Run("idempotent — rewriting twice does not double-prepend the header", func(t *testing.T) {
 		root := t.TempDir()
-		writeFile(t, filepath.Join(root, "etc/apt/sources.list"),
+		writeTestFile(t, filepath.Join(root, "etc/apt/sources.list"),
 			"deb http://archive.ubuntu.com/ubuntu noble main\n")
 
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Fatalf("first rewrite: %v", err)
 		}
-		first := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		first := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
 
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Fatalf("second rewrite: %v", err)
 		}
-		second := readFile(t, filepath.Join(root, "etc/apt/sources.list"))
+		second := readTestFile(t, filepath.Join(root, "etc/apt/sources.list"))
 
 		if first != second {
 			t.Errorf("rewrite is not idempotent.\nfirst:\n%s\nsecond:\n%s", first, second)
@@ -100,7 +151,7 @@ func TestRewriteAptSources(t *testing.T) {
 
 	t.Run("no-op when /etc/apt is absent", func(t *testing.T) {
 		root := t.TempDir() // empty
-		if err := rewriteAptSources(root); err != nil {
+		if err := rewriteAptSources(root, nil); err != nil {
 			t.Errorf("expected nil error for missing /etc/apt, got: %v", err)
 		}
 	})
@@ -110,7 +161,7 @@ func TestRewriteAptSources(t *testing.T) {
 // helpers
 // ---------------------------------------------------------------------------
 
-func writeFile(t *testing.T, path, contents string) {
+func writeTestFile(t *testing.T, path, contents string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
@@ -120,7 +171,7 @@ func writeFile(t *testing.T, path, contents string) {
 	}
 }
 
-func readFile(t *testing.T, path string) string {
+func readTestFile(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
Canonical's archive.ubuntu.com / security.ubuntu.com are intermittently
throttled during the ongoing DDoS and serve partial responses, which
surfaces as dpkg errors on truncated .deb files inside template builds.

Rewrite apt sources at rootfs-build time to nova.clouds.archive.ubuntu.com
— Canonical's cloud-targeted mirror. It has a separate upstream sync path
from the public archive and was the only Ubuntu mirror at 100% uptime
through the May 2026 outages.

Validated end-to-end on staging: rebuilds the previously-failing custom
template (`ubuntu:24.04` → `apt-get install ca-certificates curl gpg` →
`curl install.sh | sh`) in 52s vs prior 10-min timeout. `mesa mount`
inside the resulting sandbox works (FUSE + repo dir visible).