### PR TITLE
vmd,template-builder: per-VM rootfs at the magic path so sandboxes don't share a backing file

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -177,9 +177,9 @@ type buildConfig struct {
 
 func runBuild(ctx context.Context, cfg buildConfig) error {
 	buildVMID := "build-" + cfg.templateID
-	rootfsDir := filepath.Join(cfg.runDir, "templates", cfg.templateID)
+	rootfsDir := filepath.Join(cfg.runDir, vm.TemplatesDirName, cfg.templateID)
 	rootfsPath := filepath.Join(rootfsDir, "rootfs.ext4")
-	snapDir := filepath.Join(cfg.snapshotDir, "templates", cfg.templateID)
+	snapDir := filepath.Join(cfg.snapshotDir, vm.TemplatesDirName, cfg.templateID)
 
 	if err := os.MkdirAll(rootfsDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir rootfs dir: %w", err)
@@ -336,6 +336,11 @@ func startFirecracker(ctx context.Context, fcBin, socketPath string, cfg vm.Fire
 		templateDir, perVMRootfs, rootfsLink, fcBin, socketPath, cfg.VMID,
 	)
 	cmd := exec.Command("ip", "netns", "exec", netNS, "unshare", "-m", "--", "sh", "-c", script)
+	// Surface shell errors from the mount/symlink prelude — without this,
+	// a failure before exec'ing firecracker shows up as an opaque
+	// wait-for-socket timeout. Inherits up to vmd's journald via the
+	// outer template-builder subprocess.
+	cmd.Stderr = os.Stderr
 	// Pdeathsig: kernel kills firecracker if we die for any reason
 	// (including SIGKILL), so orphans can't hold TAP/netns.
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -225,11 +225,13 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 	}
 	_ = os.Remove(socketPath)
 
+	// Bake the magic path into the snapshot so vmd's per-VM symlink
+	// actually intercepts it on restore.
 	fcCfg := vm.FirecrackerConfig{
 		SocketPath: socketPath,
 		KernelPath: cfg.kernelPath,
 		KernelArgs: "console=ttyS0 reboot=k panic=1 pci=off quiet loglevel=0 random.trust_cpu=on",
-		RootfsPath: perVMRootfs,
+		RootfsPath: vm.TemplateMagicRootfsPath(cfg.runDir),
 		VCPUCount:  int(cfg.vcpu),
 		MemSizeMiB: int(cfg.memoryMiB),
 		TAPDevice:  network.TAPName,
@@ -239,7 +241,7 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 		GatewayIP:  network.VMGatewayIP,
 	}
 
-	pid, err := startFirecracker(ctx, cfg.fcBin, socketPath, fcCfg, netInfo.Namespace)
+	pid, err := startFirecracker(ctx, cfg.fcBin, socketPath, fcCfg, netInfo.Namespace, cfg.runDir, perVMRootfs)
 	if err != nil {
 		return fmt.Errorf("start firecracker: %w", err)
 	}
@@ -324,9 +326,16 @@ func setupNetwork(ctx context.Context, hostIface string, slotIndex int, vmID str
 // Firecracker launch
 // ---------------------------------------------------------------------------
 
-func startFirecracker(ctx context.Context, fcBin, socketPath string, cfg vm.FirecrackerConfig, netNS string) (int, error) {
-	cmd := exec.Command("ip", "netns", "exec", netNS,
-		fcBin, "--api-sock", socketPath, "--id", cfg.VMID)
+func startFirecracker(ctx context.Context, fcBin, socketPath string, cfg vm.FirecrackerConfig, netNS, runDir, perVMRootfs string) (int, error) {
+	// Mirror vmd's restore-side trick at build time so the snapshot
+	// references the same magic path on both sides.
+	templateDir := vm.TemplateMagicDir(runDir)
+	rootfsLink := vm.TemplateMagicRootfsPath(runDir)
+	script := fmt.Sprintf(
+		"mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q && exec %q --api-sock %q --id %q",
+		templateDir, perVMRootfs, rootfsLink, fcBin, socketPath, cfg.VMID,
+	)
+	cmd := exec.Command("ip", "netns", "exec", netNS, "unshare", "-m", "--", "sh", "-c", script)
 	// Pdeathsig: kernel kills firecracker if we die for any reason
 	// (including SIGKILL), so orphans can't hold TAP/netns.
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -154,7 +154,7 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	// the source of truth; no in-memory registration needed because the
 	// sandbox create path reads snapshot paths from the control plane DB
 	// and calls RestoreSnapshot with those paths directly.
-	snapshotDir := filepath.Join(m.cfg.SnapshotDir, "templates", req.TemplateID)
+	snapshotDir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, req.TemplateID)
 	result, err := readBuildMetaJSON(snapshotDir)
 	if err != nil {
 		return nil, fmt.Errorf("read build meta: %w", err)

--- a/internal/vm/build_cleanup.go
+++ b/internal/vm/build_cleanup.go
@@ -30,7 +30,7 @@ import (
 // directories are logged but don't abort the sweep — one bad dir shouldn't
 // block vmd startup.
 func (m *Manager) CleanupOrphanBuilds() int {
-	snapshotsRoot := filepath.Join(m.cfg.SnapshotDir, "templates")
+	snapshotsRoot := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
 	entries, err := os.ReadDir(snapshotsRoot)
 	if err != nil {
 		// Directory doesn't exist → no orphans to clean. First-time vmd
@@ -72,7 +72,7 @@ func (m *Manager) CleanupOrphanBuilds() int {
 
 		// Remove the corresponding rundir (rootfs.ext4). A future user-build
 		// for the same template_id will re-create it.
-		rundir := filepath.Join(m.cfg.RunDir, "templates", templateID)
+		rundir := filepath.Join(m.cfg.RunDir, TemplatesDirName, templateID)
 		if err := os.RemoveAll(rundir); err != nil {
 			m.log.Warn().Err(err).Str("dir", rundir).Msg("remove orphan rundir")
 		}
@@ -99,8 +99,8 @@ func (m *Manager) DeleteTemplateArtifacts(templateID string) error {
 	if templateID == "" {
 		return fmt.Errorf("template_id is required")
 	}
-	snapshotDir := filepath.Join(m.cfg.SnapshotDir, "templates", templateID)
-	rundir := filepath.Join(m.cfg.RunDir, "templates", templateID)
+	snapshotDir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID)
+	rundir := filepath.Join(m.cfg.RunDir, TemplatesDirName, templateID)
 	if err := os.RemoveAll(snapshotDir); err != nil {
 		return fmt.Errorf("remove %s: %w", snapshotDir, err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -180,6 +180,32 @@ func (m *Manager) templateRunDir() string {
 	return filepath.Join(m.cfg.RunDir, templateDirName)
 }
 
+// TemplateMagicDir is the per-process tmpfs mountpoint both build and
+// restore use; divergence here re-introduces the shared-rootfs bug.
+func TemplateMagicDir(runDir string) string {
+	return filepath.Join(runDir, templateDirName)
+}
+
+// TemplateMagicRootfsPath is the `path_on_host` baked into every snapshot.
+func TemplateMagicRootfsPath(runDir string) string {
+	return filepath.Join(TemplateMagicDir(runDir), "rootfs.ext4")
+}
+
+// templateRootfsForSnapshot maps .../templates/<id>/<file>.snap →
+// <runDir>/templates/<id>/rootfs.ext4. Lets vmd find the template's rootfs
+// without needing controlplane to pass it.
+func templateRootfsForSnapshot(runDir, snapshotPath string) (string, error) {
+	parent := filepath.Dir(snapshotPath)            // .../templates/<templateID>
+	templateID := filepath.Base(parent)             // <templateID>
+	if filepath.Base(filepath.Dir(parent)) != "templates" {
+		return "", fmt.Errorf("snapshot path %q does not look like .../templates/<id>/<file>", snapshotPath)
+	}
+	if templateID == "" || templateID == "." || templateID == string(filepath.Separator) {
+		return "", fmt.Errorf("snapshot path %q has an empty template id segment", snapshotPath)
+	}
+	return filepath.Join(runDir, "templates", templateID, "rootfs.ext4"), nil
+}
+
 // ---------------------------------------------------------------------------
 // Cold boot — only used by the template build pipeline
 // ---------------------------------------------------------------------------
@@ -646,13 +672,21 @@ func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	m.mu.Unlock()
 
 	if diskPath == "" {
+		// Per-VM copy must come from the template's rootfs so disk content
+		// matches the snapshot's memory state; BaseRootfsPath is a fallback
+		// for non-template paths.
+		src, srcErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
+		if srcErr != nil {
+			log.Warn().Err(srcErr).Str("snapshot_path", snapshotPath).Msg("falling back to BaseRootfsPath")
+			src = m.cfg.BaseRootfsPath
+		}
 		var err error
-		diskPath, err = m.copyRootfs(ctx, vmID, m.cfg.BaseRootfsPath)
+		diskPath, err = m.copyRootfs(ctx, vmID, src)
 		if err != nil {
 			m.setStatus(vmID, StatusError)
 			return nil, fmt.Errorf("copy rootfs for restore: %w", err)
 		}
-		log.Debug().Str("disk_path", diskPath).Msg("created rootfs copy for restored VM")
+		log.Debug().Str("disk_path", diskPath).Str("src", src).Msg("created rootfs copy for restored VM")
 	}
 
 	var tapDevice, macAddr, hostIP, nsName string

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -32,6 +32,10 @@ import (
 // — so every Firecracker process sees its own files at the same fixed path.
 const templateDirName = "template"
 
+// TemplatesDirName is the layout directory under RunDir / SnapshotDir that
+// holds per-template artifacts (rootfs at build time, snapshot files).
+const TemplatesDirName = "templates"
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -191,19 +195,49 @@ func TemplateMagicRootfsPath(runDir string) string {
 	return filepath.Join(TemplateMagicDir(runDir), "rootfs.ext4")
 }
 
+// resolveRestoreDisk picks the disk file for a restored VM when the caller
+// didn't supply one. Two legitimate cases:
+//
+//   - Template restore (snapshot path looks like .../templates/<id>/...) —
+//     copy the template's rootfs to a fresh per-VM file.
+//   - Sandbox resume after vmd cold restart — the per-VM rootfs already
+//     exists at <runDir>/<vmID>/rootfs.ext4 from when the sandbox was first
+//     created; reuse it.
+//
+// Anything else is an error: silently falling back to BaseRootfsPath would
+// put the wrong disk under the snapshot's memory view.
+func (m *Manager) resolveRestoreDisk(ctx context.Context, vmID, snapshotPath string) (string, error) {
+	if src, srcErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath); srcErr == nil {
+		dst, err := m.copyRootfs(ctx, vmID, src)
+		if err != nil {
+			return "", fmt.Errorf("copy rootfs for restore: %w", err)
+		}
+		return dst, nil
+	} else {
+		existing := filepath.Join(m.cfg.RunDir, vmID, "rootfs.ext4")
+		if _, statErr := os.Stat(existing); statErr != nil {
+			return "", fmt.Errorf(
+				"resolve rootfs for vm %s: snapshot %q is not a template snapshot (%v) and per-VM rootfs %q is missing (%v)",
+				vmID, snapshotPath, srcErr, existing, statErr,
+			)
+		}
+		return existing, nil
+	}
+}
+
 // templateRootfsForSnapshot maps .../templates/<id>/<file>.snap →
 // <runDir>/templates/<id>/rootfs.ext4. Lets vmd find the template's rootfs
 // without needing controlplane to pass it.
 func templateRootfsForSnapshot(runDir, snapshotPath string) (string, error) {
 	parent := filepath.Dir(snapshotPath)            // .../templates/<templateID>
 	templateID := filepath.Base(parent)             // <templateID>
-	if filepath.Base(filepath.Dir(parent)) != "templates" {
+	if filepath.Base(filepath.Dir(parent)) != TemplatesDirName {
 		return "", fmt.Errorf("snapshot path %q does not look like .../templates/<id>/<file>", snapshotPath)
 	}
 	if templateID == "" || templateID == "." || templateID == string(filepath.Separator) {
 		return "", fmt.Errorf("snapshot path %q has an empty template id segment", snapshotPath)
 	}
-	return filepath.Join(runDir, "templates", templateID, "rootfs.ext4"), nil
+	return filepath.Join(runDir, TemplatesDirName, templateID, "rootfs.ext4"), nil
 }
 
 // ---------------------------------------------------------------------------
@@ -672,21 +706,12 @@ func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	m.mu.Unlock()
 
 	if diskPath == "" {
-		// Per-VM copy must come from the template's rootfs so disk content
-		// matches the snapshot's memory state; BaseRootfsPath is a fallback
-		// for non-template paths.
-		src, srcErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
-		if srcErr != nil {
-			log.Warn().Err(srcErr).Str("snapshot_path", snapshotPath).Msg("falling back to BaseRootfsPath")
-			src = m.cfg.BaseRootfsPath
-		}
 		var err error
-		diskPath, err = m.copyRootfs(ctx, vmID, src)
+		diskPath, err = m.resolveRestoreDisk(ctx, vmID, snapshotPath)
 		if err != nil {
 			m.setStatus(vmID, StatusError)
-			return nil, fmt.Errorf("copy rootfs for restore: %w", err)
+			return nil, err
 		}
-		log.Debug().Str("disk_path", diskPath).Str("src", src).Msg("created rootfs copy for restored VM")
 	}
 
 	var tapDevice, macAddr, hostIP, nsName string

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,57 @@ func TestTemplateMagicDir_MatchesTemplateRunDir(t *testing.T) {
 	}
 	if got, want := TemplateMagicRootfsPath(cfg.RunDir), filepath.Join(mgr.templateRunDir(), "rootfs.ext4"); got != want {
 		t.Errorf("TemplateMagicRootfsPath = %q, want %q", got, want)
+	}
+}
+
+func TestTemplateRootfsForSnapshot_RejectsNonTemplatePaths(t *testing.T) {
+	// Caller must error out, not silently fall back to BaseRootfsPath.
+	for _, p := range []string{"", ".", "/", "/var/lib/sandbox/snapshots/foo"} {
+		if _, err := templateRootfsForSnapshot("/var/lib/sandbox/rundir", p); err == nil {
+			t.Errorf("expected error for non-template snapshot path %q", p)
+		}
+	}
+}
+
+// TestResolveRestoreDisk_NonTemplate_NoExistingRootfs_Errors is the
+// integration-shaped test the PR review asked for: drive the actual disk
+// resolution path with a non-template snapshot AND no per-VM rootfs on
+// disk, and assert it errors instead of silently using BaseRootfsPath.
+func TestResolveRestoreDisk_NonTemplate_NoExistingRootfs_Errors(t *testing.T) {
+	runDir := t.TempDir()
+	mgr := &Manager{cfg: ManagerConfig{
+		RunDir:          runDir,
+		BaseRootfsPath:  "/should/not/be/used.ext4",
+	}}
+
+	_, err := mgr.resolveRestoreDisk(context.Background(), "vm-abc", "/snapshots/not-a-template/vmstate.snap")
+	if err == nil {
+		t.Fatalf("expected error for non-template snapshot with no per-VM rootfs; got nil")
+	}
+}
+
+// TestResolveRestoreDisk_SandboxResume_UsesExistingPerVMRootfs covers the
+// vmd-cold-restart path: snapshot path isn't a template path, but the
+// per-VM rootfs already exists from when the sandbox was first created.
+// Resolution should reuse that file (no copy, no error).
+func TestResolveRestoreDisk_SandboxResume_UsesExistingPerVMRootfs(t *testing.T) {
+	runDir := t.TempDir()
+	vmID := "vm-abc"
+	existing := filepath.Join(runDir, vmID, "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(existing), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(existing, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	mgr := &Manager{cfg: ManagerConfig{RunDir: runDir}}
+	got, err := mgr.resolveRestoreDisk(context.Background(), vmID, "/snapshots/sb-1/snap-1/vmstate.snap")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != existing {
+		t.Errorf("got %q, want %q", got, existing)
 	}
 }
 

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -17,6 +17,70 @@ func TestTemplateRunDir(t *testing.T) {
 	}
 }
 
+func TestTemplateMagicDir_MatchesTemplateRunDir(t *testing.T) {
+	// The exported helper used by cmd/template-builder must agree with vmd's
+	// internal templateRunDir — divergence here silently re-introduces the
+	// shared-rootfs bug because the build side and restore side would target
+	// different paths.
+	cfg := ManagerConfig{RunDir: "/var/lib/sandbox/rundir"}
+	mgr := &Manager{cfg: cfg}
+
+	if got, want := TemplateMagicDir(cfg.RunDir), mgr.templateRunDir(); got != want {
+		t.Errorf("TemplateMagicDir = %q, templateRunDir = %q — must match", got, want)
+	}
+	if got, want := TemplateMagicRootfsPath(cfg.RunDir), filepath.Join(mgr.templateRunDir(), "rootfs.ext4"); got != want {
+		t.Errorf("TemplateMagicRootfsPath = %q, want %q", got, want)
+	}
+}
+
+func TestTemplateRootfsForSnapshot(t *testing.T) {
+	runDir := "/var/lib/sandbox/rundir"
+	cases := []struct {
+		name     string
+		snapPath string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "well-formed template snapshot path",
+			snapPath: "/var/lib/sandbox/snapshots/templates/abcd-1234/vmstate.snap",
+			want:     "/var/lib/sandbox/rundir/templates/abcd-1234/rootfs.ext4",
+		},
+		{
+			name:     "mem.snap also resolves to the same template",
+			snapPath: "/var/lib/sandbox/snapshots/templates/abcd-1234/mem.snap",
+			want:     "/var/lib/sandbox/rundir/templates/abcd-1234/rootfs.ext4",
+		},
+		{
+			name:     "non-template snapshot path is rejected (re-pause / sandbox snapshots)",
+			snapPath: "/var/lib/sandbox/snapshots/sandbox-1/snap-123/vmstate.snap",
+			wantErr:  true,
+		},
+		{
+			name:     "missing templates segment is rejected",
+			snapPath: "/var/lib/sandbox/snapshots/abcd-1234/vmstate.snap",
+			wantErr:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := templateRootfsForSnapshot(runDir, tc.snapPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got %q", tc.snapPath, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTemplateDirNameIsFixed(t *testing.T) {
 	if templateDirName != "template" {
 		t.Errorf("templateDirName = %q, want %q", templateDirName, "template")


### PR DESCRIPTION
Every sandbox from the same template was opening the same `rootfs.ext4` file on the host: the snapshot baked the build-VM's path while vmd's per-VM mount-namespace symlink targeted a different path that was never actually used. Concurrent writes corrupted each other and surfaced as ext4 "Structure needs cleaning" / dpkg failures.

Fix: both sides now use the same magic path so vmd's mount-namespace symlink actually intercepts, and the per-VM rootfs is copied from the template's rootfs (not the global base).

## Validated end-to-end on staging

- **Per-VM isolation**: lsof on staging vmd while two concurrent sandboxes from `superserve/base` are running — each Firecracker has its own `/var/lib/sandbox/rundir/<vm_id>/rootfs.ext4` (no shared inode).
- **Original failure gone**: ran the exact snippet that previously hit `dpkg: ... 'AdduserCommon.pm': Structure needs cleaning` against staging — Mesa installer completes cleanly end-to-end.
- **Concurrent stress**: 5 sandboxes from the same template, parallel `apt-get install` of `gpg` / `jq` / `adduser` (the package that broke before) — 0 ext4 errors, 0 dpkg errors, all exit 0.
- **Custom-template path**: built a custom template with the Mesa docs' build_spec, spun 5 concurrent sandboxes from it, parallel apt-installs — all clean. Same lsof check confirmed each had its own rootfs file.

Rollout: deploy → force-rebuild templates.