### PR TITLE
boxd,api: exec timeout returns exit 124 instead of HTTP 500

### DIFF
--- a/cmd/boxd/exit_test.go
+++ b/cmd/boxd/exit_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFinalExitCode_Normal(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 7")
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-nil err for non-zero exit")
+	}
+	got := finalExitCode(cmd.ProcessState, false)
+	if got != 7 {
+		t.Errorf("finalExitCode = %d, want 7", got)
+	}
+}
+
+func TestFinalExitCode_TimedOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/sleep", "5")
+	_ = cmd.Run()
+	got := finalExitCode(cmd.ProcessState, true)
+	if got != timeoutExitCode {
+		t.Errorf("finalExitCode (timed out) = %d, want %d", got, timeoutExitCode)
+	}
+}
+
+func TestFinalExitCode_SignalKilled(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "5")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	_ = cmd.Wait()
+	got := finalExitCode(cmd.ProcessState, false)
+	if got != 137 {
+		t.Errorf("finalExitCode (SIGKILL) = %d, want 137", got)
+	}
+}
+
+func TestFinalExitCode_NilProcessState(t *testing.T) {
+	if got := finalExitCode(nil, false); got != 0 {
+		t.Errorf("finalExitCode(nil, false) = %d, want 0", got)
+	}
+	if got := finalExitCode(nil, true); got != timeoutExitCode {
+		t.Errorf("finalExitCode(nil, true) = %d, want %d", got, timeoutExitCode)
+	}
+}
+
+func TestStartTimeout_AtomicFlag(t *testing.T) {
+	cmdCtx, cmdCancel := context.WithCancel(context.Background())
+	defer cmdCancel()
+	var timedOut atomic.Bool
+
+	timer := time.AfterFunc(50*time.Millisecond, func() {
+		timedOut.Store(true)
+		cmdCancel()
+	})
+	defer timer.Stop()
+
+	cmd := exec.CommandContext(cmdCtx, "/bin/sleep", "5")
+	start := time.Now()
+	_ = cmd.Run()
+	elapsed := time.Since(start)
+
+	if !timedOut.Load() {
+		t.Error("timedOut flag was not set; timer didn't fire")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("cmd took %v; expected to be killed within ~50ms", elapsed)
+	}
+	got := finalExitCode(cmd.ProcessState, timedOut.Load())
+	if got != timeoutExitCode {
+		t.Errorf("finalExitCode = %d, want %d", got, timeoutExitCode)
+	}
+}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -356,11 +357,18 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 		}
 	}
 
-	timeout := time.Duration(msg.GetTimeoutMs()) * time.Millisecond
-	var cancel context.CancelFunc
-	if timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
+	// cmdCtx must be separate from the stream context so the timeout kills
+	// only the child process — the stream stays alive to deliver the End
+	// event with the timeout exit code.
+	cmdCtx, cmdCancel := context.WithCancel(ctx)
+	defer cmdCancel()
+	var timedOut atomic.Bool
+	if timeoutMs := msg.GetTimeoutMs(); timeoutMs > 0 {
+		timer := time.AfterFunc(time.Duration(timeoutMs)*time.Millisecond, func() {
+			timedOut.Store(true)
+			cmdCancel()
+		})
+		defer timer.Stop()
 	}
 
 	// Resolve bare command names against the CHILD's PATH, not boxd's own.
@@ -380,7 +388,7 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 		resolvedCmd = p
 	}
 
-	cmd := exec.CommandContext(ctx, resolvedCmd, args...)
+	cmd := exec.CommandContext(cmdCtx, resolvedCmd, args...)
 	cmd.Dir = cwd
 	cmd.Env = childEnv
 	if cred != nil {
@@ -389,12 +397,35 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 
 	isPTY := msg.GetPty() != nil
 	if isPTY {
-		return s.startPTY(ctx, cmd, msg, stream)
+		return s.startPTY(ctx, cmd, msg, stream, &timedOut)
 	}
-	return s.startPipes(ctx, cmd, stream)
+	return s.startPipes(ctx, cmd, stream, &timedOut)
 }
 
-func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.StartRequest, stream *connect.ServerStream[pb.ProcessEvent]) error {
+// timeoutExitCode matches GNU coreutils `timeout(1)`.
+const timeoutExitCode int32 = 124
+
+// finalExitCode maps a finished cmd's state into the exit code the caller
+// sees: 124 on timeout, 128+signal on signal-kill (default 137 for SIGKILL
+// when WaitStatus is unavailable), pass-through otherwise.
+func finalExitCode(ps *os.ProcessState, timedOut bool) int32 {
+	if timedOut {
+		return timeoutExitCode
+	}
+	if ps == nil {
+		return 0
+	}
+	code := int32(ps.ExitCode())
+	if code != -1 {
+		return code
+	}
+	if status, ok := ps.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return int32(128 + status.Signal())
+	}
+	return 137
+}
+
+func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.StartRequest, stream *connect.ServerStream[pb.ProcessEvent], timedOut *atomic.Bool) error {
 	cols := uint16(msg.GetPty().GetSize().GetCols())
 	rows := uint16(msg.GetPty().GetSize().GetRows())
 	if cols == 0 {
@@ -446,32 +477,18 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	}()
 
 	<-done
-	waitErr := cmd.Wait()
-
-	exitCode := int32(0)
-	errMsg := ""
-	if cmd.ProcessState != nil {
-		exitCode = int32(cmd.ProcessState.ExitCode())
-		// Signal-killed processes report ExitCode -1. Map to 128+signal convention.
-		if exitCode == -1 && waitErr != nil {
-			exitCode = 137 // default to SIGKILL
-			if status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok && status.Signaled() {
-				exitCode = int32(128 + status.Signal())
-			}
-		}
-	}
+	_ = cmd.Wait()
 
 	return stream.Send(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
-			ExitCode: exitCode,
+			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),
 			Status:   cmd.ProcessState.String(),
-			Error:    errMsg,
 		}},
 	})
 }
 
-func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *connect.ServerStream[pb.ProcessEvent]) error {
+func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *connect.ServerStream[pb.ProcessEvent], timedOut *atomic.Bool) error {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, err)
@@ -561,7 +578,7 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 	}()
 
 	wg.Wait()
-	cmd.Wait()
+	_ = cmd.Wait()
 
 	// Flush data events to the stream before sending End. Closing the
 	// mux drains it, closes the consumer channel, and unblocks sendDone.
@@ -570,14 +587,9 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 		return sendErr
 	}
 
-	exitCode := int32(0)
-	if cmd.ProcessState != nil {
-		exitCode = int32(cmd.ProcessState.ExitCode())
-	}
-
 	return stream.Send(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
-			ExitCode: exitCode,
+			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),
 			Status:   cmd.ProcessState.String(),
 		}},

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -479,11 +479,15 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	<-done
 	_ = cmd.Wait()
 
+	status := ""
+	if cmd.ProcessState != nil {
+		status = cmd.ProcessState.String()
+	}
 	return stream.Send(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
 			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),
-			Status:   cmd.ProcessState.String(),
+			Status:   status,
 		}},
 	})
 }
@@ -587,11 +591,15 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 		return sendErr
 	}
 
+	status := ""
+	if cmd.ProcessState != nil {
+		status = cmd.ProcessState.String()
+	}
 	return stream.Send(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
 			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),
-			Status:   cmd.ProcessState.String(),
+			Status:   status,
 		}},
 	})
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1461,8 +1461,14 @@ func (h *Handlers) ExecSandbox(c *gin.Context) {
 	}
 
 	// Cap the request goroutine if boxd ever wedges past its own timeout.
-	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(),
-		time.Duration(req.TimeoutS+15)*time.Second)
+	// Only apply when a timeout is actually set; otherwise commands with no
+	// timeout would be killed after 15 s.
+	vmdCtx := c.Request.Context()
+	vmdCancel := context.CancelFunc(func() {})
+	if req.TimeoutS > 0 {
+		vmdCtx, vmdCancel = context.WithTimeout(c.Request.Context(),
+			time.Duration(req.TimeoutS+15)*time.Second)
+	}
 	defer vmdCancel()
 
 	start := time.Now()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1460,8 +1460,13 @@ func (h *Handlers) ExecSandbox(c *gin.Context) {
 		return
 	}
 
+	// Cap the request goroutine if boxd ever wedges past its own timeout.
+	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(),
+		time.Duration(req.TimeoutS+15)*time.Second)
+	defer vmdCancel()
+
 	start := time.Now()
-	stdout, stderr, exitCode, err := vmd.ExecCommand(c.Request.Context(), sandbox.ID.String(),
+	stdout, stderr, exitCode, err := vmd.ExecCommand(vmdCtx, sandbox.ID.String(),
 		req.Command, req.Args, req.Env, req.WorkingDir, uint32(req.TimeoutS))
 	durationMs := int32(time.Since(start).Milliseconds())
 	if err != nil {


### PR DESCRIPTION
## Problem

`POST /sandboxes/:id/exec` with `timeout_s` returns HTTP 500 when the timeout fires, instead of a normal `200 { exit_code: 124 }`.

Root cause: boxd's `Start` RPC wrapped one context with the timeout and used it for both the child process and the streaming response. When the timer fired, the child got killed and the stream context got cancelled simultaneously — leaving boxd unable to send the End event, which propagated as an RPC error and got mapped to 500.

## Fix

- **boxd** (`cmd/boxd/main.go`): decouple cmd ctx from stream ctx. Use `time.AfterFunc` + an `atomic.Bool` to kill only the child on timeout; stream stays alive to send the End event with exit 124.
- **boxd**: extract `finalExitCode(ps, timedOut)` to unify exit-code mapping. As a bonus, `startPipes` now maps signal-killed processes to 128+signal, matching `startPTY`.
- **controlplane** (`internal/api/handlers.go`): add a `TimeoutS + 15s` backstop on the gRPC call so a wedged boxd can't hang the request goroutine forever.