### PR TITLE
vm,boxd: timeout actually kills child tree + response carries through

### DIFF
--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -396,10 +396,23 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 	}
 
 	isPTY := msg.GetPty() != nil
-	if isPTY {
-		return s.startPTY(ctx, cmd, msg, stream, &timedOut)
+	if !isPTY {
+		// Kill the whole pgid on timeout — killing the shell alone leaves
+		// orphaned children (e.g. `sleep` under `sh -c`) running.
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.Setpgid = true
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		cmd.WaitDelay = time.Second
+		return s.startPipes(ctx, cmd, stream, &timedOut)
 	}
-	return s.startPipes(ctx, cmd, stream, &timedOut)
+	return s.startPTY(ctx, cmd, msg, stream, &timedOut)
 }
 
 // timeoutExitCode matches GNU coreutils `timeout(1)`.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1077,7 +1077,8 @@ func (m *Manager) ExecCommand(ctx context.Context, vmID, command string, timeout
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	// +15s grace so boxd's End event isn't raced by ctx cancel at `timeout`.
+	ctx, cancel := context.WithTimeout(ctx, timeout+15*time.Second)
 	defer cancel()
 
 	result, err := httpExec(ctx, vmIP, command, timeout, opts)
@@ -1110,7 +1111,8 @@ func (m *Manager) ExecCommandStream(ctx context.Context, vmID, command string, t
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	// +15s grace, same reason as ExecCommand.
+	ctx, cancel := context.WithTimeout(ctx, timeout+15*time.Second)
 	defer cancel()
 
 	if err := httpExecStream(ctx, vmIP, command, timeout, opts, onChunk); err != nil {


### PR DESCRIPTION
## Issue

`POST /sandboxes/:id/exec` with `timeout_s` still returns HTTP 500 `internal_error` when the timeout fires, instead of 200 with `exit_code: 124`. PR #50 fixed the controlplane and (partly) boxd; two more layers were missed.

## Fixes

**1. `internal/vm/manager.go` — vmd stream ctx grace.** `ExecCommand` was wrapping the ctx with exactly `timeout`, so the stream cancelled at the same instant boxd killed the child — racing (and losing to) boxd's `End` event. Extend the stream ctx with `+15s` grace (same value the controlplane already uses). Boxd still kills the child at the user-supplied `timeout`; only the stream gets the extra time to deliver the response. Applied to both `ExecCommand` and `ExecCommandStream`.

**2. `cmd/boxd/main.go` — kill the whole process group.** Boxd's timeout was sending SIGKILL only to the shell (`sh -c "sleep 10"`), leaving the actual `sleep` child orphaned to init. The pipe FDs stayed open, boxd's pipe-reader goroutines blocked, and the End event was delayed until the orphaned child died naturally. Now boxd starts the child in its own pgid and signals the whole group on timeout, so child trees actually die when expected.

## Result

`sleep 10` with `timeout_s=2` now returns **HTTP 200 + exit_code 124 in ~2s** instead of 500 in 2s (pre-fix-1) or 200+124 in 10s (with fix-1 only).