### PR TITLE
deploy: remove sandboxes.slice CPUQuota — was throttling all sandboxes to 0.9 CPU total

### DIFF
--- a/deploy/sandboxes.slice
+++ b/deploy/sandboxes.slice
@@ -7,7 +7,10 @@ CPUAccounting=yes
 MemoryAccounting=yes
 IOAccounting=yes
 
-# Safety ceiling: sandboxes cannot consume the entire host.
-# Per-sandbox limits are set via drop-in files on each unit.
+# Memory ceiling: percentage is of total host RAM (correct semantics).
 MemoryMax=95%
-CPUQuota=90%
+
+# No CPUQuota: systemd interprets N% as N% of ONE CPU, not the host. A
+# prior CPUQuota=90% capped all sandboxes to 0.9 CPU total, serializing
+# burst creates. CPU fairness left to the kernel scheduler; per-VM vCPU
+# counts are enforced by Firecracker.


### PR DESCRIPTION
systemd interprets `CPUQuota=90%` as 90% of one CPU, not 90% of the host — so on a 192-core box the entire sandboxes.slice was throttled to 0.9 CPU total, serializing burst creates.