### PR TITLE
network: reattach firewall state on vmd restart

### DIFF
--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -193,8 +193,39 @@ func NewFirewall(cfg FirewallConfig) (*Firewall, error) {
 	return fw, nil
 }
 
-// Close tears down the nftables connection. The kernel automatically
-// removes the table and all rules when the lasting connection closes.
+// AttachFirewall binds a Firewall handle to nftables state already in
+// the kernel for this namespace (e.g., from a prior vmd lifetime). Must
+// be called from within the target namespace. Unlike NewFirewall it
+// does NOT install rules — struct refs are bound to existing kernel
+// objects by Name+Table, so ReplaceUserRules operates on them in place.
+func AttachFirewall(cfg FirewallConfig) (*Firewall, error) {
+	conn, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		return nil, fmt.Errorf("new nftables conn: %w", err)
+	}
+	table := &nftables.Table{Name: tableName, Family: nftables.TableFamilyINet}
+	return &Firewall{
+		conn:               conn,
+		table:              table,
+		filterChain:        &nftables.Chain{Name: "preroute_filter", Table: table},
+		natChain:           &nftables.Chain{Name: "preroute_nat", Table: table},
+		postChain:          &nftables.Chain{Name: "postroute_nat", Table: table},
+		fwdChain:           &nftables.Chain{Name: "forward_mangle", Table: table},
+		predefinedDenySet:  &nftables.Set{Table: table, Name: "predefined_deny", KeyType: nftables.TypeIPAddr, Interval: true},
+		predefinedAllowSet: &nftables.Set{Table: table, Name: "predefined_allow", KeyType: nftables.TypeIPAddr, Interval: true},
+		userDenySet:        &nftables.Set{Table: table, Name: "user_deny", KeyType: nftables.TypeIPAddr, Interval: true},
+		userAllowSet:       &nftables.Set{Table: table, Name: "user_allow", KeyType: nftables.TypeIPAddr, Interval: true},
+		tapIface:           cfg.TAPInterface,
+		vethPeer:           cfg.VethPeer,
+		vmIP:               cfg.VMIP,
+		hostIP:             cfg.HostIP,
+		gatewayIP:          cfg.GatewayIP,
+	}, nil
+}
+
+// Close tears down the nftables connection. Kernel-level table and
+// rules persist across the close — they're owned by the kernel, not
+// by this netlink handle. AttachFirewall can re-bind to them later.
 func (fw *Firewall) Close() error {
 	if fw.conn == nil {
 		return nil

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -40,11 +40,10 @@ type vmRule struct {
 	prepend bool // insert at top of chain instead of appending
 }
 
-// NewHostFirewall initializes the host firewall. On first call it adds
-// a static MSS clamp rule. On restart, existing per-VM rules from the
-// previous process are already in the kernel (iptables rules persist)
-// and will be cleaned up when RemoveVM is called — or leaked harmlessly
-// if the VM was already destroyed.
+// NewHostFirewall initializes the host firewall. Adds a static MSS clamp
+// rule (idempotent via AppendUnique). Per-VM rules from prior lifetimes
+// remain in the kernel; ReattachAll re-invokes AddVM for each surviving
+// VM to repopulate the in-memory tracking map (AddVM is idempotent).
 func NewHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) (*HostFirewall, error) {
 	ipt, err := iptables.New()
 	if err != nil {
@@ -157,20 +156,13 @@ func (hfw *HostFirewall) RemoveVM(vmID string) error {
 	return firstErr
 }
 
-// Close removes all VM rules we've tracked during this vmd lifetime.
-// Rules from prior lifetimes (if any) are left in the kernel — they
-// match veths/IPs that no longer exist and are effectively dead.
+// Close drops the in-memory tracking map. Kernel-level iptables rules
+// remain — they're kernel state, not process state. The next vmd
+// lifetime rebuilds the map via ReattachAll → AddVM (idempotent).
 func (hfw *HostFirewall) Close() error {
 	hfw.mu.Lock()
 	defer hfw.mu.Unlock()
-
-	for vmID, rules := range hfw.vmRules {
-		for _, r := range rules {
-			_ = hfw.ipt.DeleteIfExists(r.table, r.chain, r.args...)
-		}
-		delete(hfw.vmRules, vmID)
-	}
-
+	hfw.vmRules = make(map[string][]vmRule)
 	return nil
 }
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -389,15 +389,13 @@ func (m *Manager) CleanupVM(vmID string) {
 		m.egressProxy.RemoveRules(info.HostIP)
 	}
 
-	// Try to recycle the slot into the pool instead of tearing it down.
-	// The namespace, veth, TAP, and base nftables stay configured —
-	// only the vmID-specific host firewall and egress rules were removed
-	// above. The next Claim re-adds them for the new vmID.
-	if m.pool != nil {
-		// Reset user-defined firewall rules to defaults before recycling.
-		if info.Firewall != nil {
-			_ = info.Firewall.ReplaceUserRules(nil, nil)
-		}
+	// Recycle the slot into the pool — namespace, veth, TAP, and base
+	// nftables stay configured; the next Claim re-adds vmID-specific
+	// rules. Skipped when info.Firewall is nil (reattached VM whose
+	// in-ns handle couldn't be rebound) — pooling would let the next
+	// Claim silently lose per-VM egress filtering.
+	if m.pool != nil && info.Firewall != nil {
+		_ = info.Firewall.ReplaceUserRules(nil, nil)
 		m.pool.Return(&preallocSlot{idx: idx, info: info, vethName: vethName})
 		return
 	}
@@ -424,6 +422,84 @@ func (m *Manager) CleanupVM(vmID string) {
 	_ = run(ctx, "ip", "netns", "del", info.Namespace)
 
 	m.log.Info().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("network namespace cleaned up")
+}
+
+// ReattachVM rebinds vmd's view of an already-running VM's network state
+// at startup. After this call: the slot is marked in-use (no SetupVM
+// collisions), devices[vmID] is populated (CleanupVM can tear it down),
+// host-level firewall rules are present + tracked, and the in-namespace
+// nftables Firewall handle is reattached so the customer's subsequent
+// UpdateFirewallRules calls apply to the existing kernel state.
+func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
+	idx, ok := slotFromNamespace(namespace)
+	if !ok {
+		return fmt.Errorf("reattach %s: cannot parse slot from namespace %q", vmID, namespace)
+	}
+	vethName := fmt.Sprintf("veth-%d", idx)
+	hostCIDR := fmt.Sprintf("%s/32", hostIP)
+
+	// Rebind in-namespace nftables handle. Non-fatal on failure: kernel
+	// rules already enforce traffic; only future updates would be lost.
+	fwCfg := FirewallConfig{
+		TAPInterface: TAPName,
+		VethPeer:     "eth0",
+		VMIP:         VMInternalIP,
+		HostIP:       hostIP,
+		GatewayIP:    VMGatewayIP,
+	}
+	var fw *Firewall
+	if err := nsExecGo(namespace, func() error {
+		f, err := AttachFirewall(fwCfg)
+		if err != nil {
+			return err
+		}
+		fw = f
+		return nil
+	}); err != nil {
+		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
+	}
+
+	m.mu.Lock()
+	// Bump nextSlot past this idx so new VMs don't collide. Gap slots
+	// below nextSlot are wasted until bitmap allocation lands.
+	if idx >= m.nextSlot {
+		m.nextSlot = idx + 1
+	}
+	m.devices[vmID] = &VMNetInfo{
+		Namespace:  namespace,
+		TAPDevice:  TAPName,
+		VMIP:       VMInternalIP,
+		GatewayIP:  VMGatewayIP,
+		HostIP:     hostIP,
+		MACAddress: macAddress,
+		Firewall:   fw, // nil if AttachFirewall failed; CleanupVM tolerates it
+	}
+	m.mu.Unlock()
+
+	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
+		return fmt.Errorf("reattach %s: restore host firewall: %w", vmID, err)
+	}
+	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
+	return nil
+}
+
+// slotFromNamespace parses "ns-N" → N (digits only). Returns (0, false)
+// on malformed input. Strict: trailing non-digit characters are rejected
+// to avoid silently mapping "ns-2-something" to slot 2.
+func slotFromNamespace(namespace string) (int, bool) {
+	const prefix = "ns-"
+	if len(namespace) <= len(prefix) || namespace[:len(prefix)] != prefix {
+		return 0, false
+	}
+	digits := namespace[len(prefix):]
+	idx := 0
+	for _, c := range digits {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		idx = idx*10 + int(c-'0')
+	}
+	return idx, true
 }
 
 // SweepOrphanNamespaces removes host namespaces and veth interfaces

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -1,0 +1,33 @@
+package network
+
+import "testing"
+
+func TestSlotFromNamespace(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantIdx   int
+		wantOK    bool
+	}{
+		{"ns-0", 0, true},
+		{"ns-1", 1, true},
+		{"ns-17", 17, true},
+		{"ns-9999", 9999, true},
+		{"", 0, false},
+		{"ns-", 0, false},
+		{"ns", 0, false},
+		{"foo-1", 0, false},
+		{"ns-abc", 0, false},
+		{"ns-1foo", 0, false},
+		{"ns-2-extra", 0, false},
+		{"ns--1", 0, false},
+		{"ns-0x10", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			idx, ok := slotFromNamespace(tc.in)
+			if ok != tc.wantOK || idx != tc.wantIdx {
+				t.Errorf("slotFromNamespace(%q) = (%d, %v), want (%d, %v)", tc.in, idx, ok, tc.wantIdx, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1090,6 +1090,15 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		m.vms[rec.ID] = inst
 		m.mu.Unlock()
 
+		// Restore network manager state for this VM: slot tracking,
+		// devices map, host firewall rules (re-installed via idempotent
+		// AddVM in case the kernel rules were lost).
+		if inst.Namespace != "" && inst.IP != "" {
+			if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+				log.Error().Err(err).Msg("reattach: restore network state failed")
+			}
+		}
+
 		m.persistState(inst)
 		log.Info().Int("pid", inst.PID).Str("ip", inst.IP).Msg("reattached to running VM")
 		reattached++


### PR DESCRIPTION
HostFirewall.Close was deleting per-VM iptables rules from the kernel on shutdown, and ReattachAll wasn't restoring them — every vmd restart silently broke outbound NAT for existing customer sandboxes (DNS, HTTPS, everything). The in-namespace nftables handle wasn't reattached either, so customers couldn't update their egress allowlists post-restart. This fixes both.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->