### PR TITLE
uffd: treat EINVAL on uffd_msg read as clean shutdown

### DIFF
--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -103,6 +103,9 @@ type Handler struct {
 	prefetchWg sync.WaitGroup
 
 	closed atomic.Bool
+
+	// readFn defaults to unix.Read; tests override to inject error paths.
+	readFn func(fd int, p []byte) (n int, err error)
 }
 
 func New(cfg Config) *Handler {
@@ -113,6 +116,7 @@ func New(cfg Config) *Handler {
 		cfg:           cfg,
 		log:           cfg.Logger.With().Str("component", "uffd").Logger(),
 		handshakeDone: make(chan error, 1),
+		readFn:        unix.Read,
 	}
 	h.uffdFd.Store(uffdClosed)
 	return h
@@ -366,7 +370,7 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 		if fd == uffdClosed {
 			return g.Wait()
 		}
-		n, err := unix.Read(int(fd), msgBuf[:])
+		n, err := h.readFn(int(fd), msgBuf[:])
 		if err != nil {
 			if errors.Is(err, syscall.EINTR) {
 				continue
@@ -376,6 +380,9 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 			// exited and unmapped its VMAs before we drained the queue.
 			// Both mean "nothing more to read here" — exit cleanly.
 			if errors.Is(err, syscall.EBADF) || errors.Is(err, syscall.EINVAL) {
+				if errors.Is(err, syscall.EINVAL) {
+					h.log.Debug().Msg("uffd serveLoop exiting cleanly on EINVAL — firecracker likely unmapped VMAs")
+				}
 				return g.Wait()
 			}
 			return fmt.Errorf("read uffd_msg: %w", err)

--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -371,8 +371,11 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 			if errors.Is(err, syscall.EINTR) {
 				continue
 			}
-			// EBADF: cancellation goroutine closed the fd. Exit cleanly.
-			if errors.Is(err, syscall.EBADF) {
+			// EBADF: cancellation goroutine closed the fd. EINVAL: kernel
+			// returned "invalid argument", typically because Firecracker
+			// exited and unmapped its VMAs before we drained the queue.
+			// Both mean "nothing more to read here" — exit cleanly.
+			if errors.Is(err, syscall.EBADF) || errors.Is(err, syscall.EINVAL) {
 				return g.Wait()
 			}
 			return fmt.Errorf("read uffd_msg: %w", err)

--- a/internal/vm/uffd/handler_test.go
+++ b/internal/vm/uffd/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 	"unsafe"
@@ -154,5 +156,32 @@ func TestHandler_WaitHandshake_CtxCancel(t *testing.T) {
 	}
 	if time.Since(start) > 100*time.Millisecond {
 		t.Errorf("cancel didn't propagate promptly: %v", time.Since(start))
+	}
+}
+
+// TestServeLoop_EINVALReturnsCleanly verifies that EINVAL from the read of
+// the uffd fd (which happens when firecracker unmaps its VMAs before we
+// drain the queue) makes serveLoop return nil rather than propagate an
+// error to the caller.
+func TestServeLoop_EINVALReturnsCleanly(t *testing.T) {
+	// Pipe stand-in for the uffd fd — closeFd (triggered when serveLoop
+	// returns and cancels gctx) will close it, so it must be real.
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer wPipe.Close()
+
+	h := New(Config{
+		FaultWorkers: 1,
+		Logger:       zerolog.Nop(),
+	})
+	h.uffdFd.Store(uintptr(rPipe.Fd()))
+	h.readFn = func(fd int, p []byte) (int, error) {
+		return 0, syscall.EINVAL
+	}
+
+	if err := h.serveLoop(context.Background()); err != nil {
+		t.Errorf("serveLoop returned %v, want nil on EINVAL", err)
 	}
 }


### PR DESCRIPTION
Observed during burst-benchmark teardown: when Firecracker exits and unmaps its VMAs before we drain the userfaultfd queue, our `unix.Read(uffdFd)` returns EINVAL. The serveLoop currently logs this as `uffd handler exited with error` even though the VM is already being destroyed — benign race, misleading log. Treats EINVAL the same as EBADF (clean exit).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->