### PR TITLE
api: replace per-team advisory lock with counter+trigger quota enforcement

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -61,6 +62,8 @@ func run() error {
 		return fmt.Errorf("ping database: %w", err)
 	}
 	log.Info().Msg("connected to database")
+
+	reconcileSystemTeamQuota(ctx, dbPool, cfg.SystemTeamID)
 
 	// Connect to VMD via gRPC.
 	grpcConn, err := grpc.NewClient(cfg.VMDAddress,
@@ -169,6 +172,26 @@ func run() error {
 
 	log.Info().Msg("controlplane stopped")
 	return nil
+}
+
+// reconcileSystemTeamQuota lifts the system team's max_sandboxes above any
+// realistic cap so the sandbox_quota_on_insert trigger never rejects it.
+func reconcileSystemTeamQuota(ctx context.Context, pool *pgxpool.Pool, systemTeamID string) {
+	if systemTeamID == "" {
+		return
+	}
+	tag, err := pool.Exec(ctx,
+		`UPDATE team SET max_sandboxes = $1
+		 WHERE id = $2 AND (max_sandboxes IS NULL OR max_sandboxes < $1)`,
+		math.MaxInt32, systemTeamID,
+	)
+	if err != nil {
+		log.Warn().Err(err).Str("system_team_id", systemTeamID).
+			Msg("reconcile system team quota failed — system team may be capped at default")
+		return
+	}
+	log.Info().Str("system_team_id", systemTeamID).Int64("rows", tag.RowsAffected()).
+		Msg("system team quota reconciled")
 }
 
 // ---------------------------------------------------------------------------

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -42,12 +42,6 @@ WHERE base_path = $1 AND destroyed_at IS NULL;
 SELECT DISTINCT base_path FROM sandbox
 WHERE base_path IS NOT NULL AND destroyed_at IS NULL;
 
--- name: CountActiveSandboxesForTeam :one
--- Active = consumes host resources. Excludes failed (VM is gone) and
--- destroyed (row is dead). Includes starting/active/pausing/paused/resuming.
-SELECT COUNT(*)::bigint FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL AND status != 'failed';
-
 -- name: ListSandboxesByTeam :many
 SELECT * FROM sandbox
 WHERE team_id = $1 AND destroyed_at IS NULL

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
@@ -28,16 +29,25 @@ import (
 // VMDClient is the interface for talking to a VM daemon.
 type VMDClient = vmdclient.Client
 
-// sandboxQuotaError is the sentinel returned from CreateSandbox's INSERT
-// goroutine when the per-team count cap is reached. Carries the cap so
-// the handler can include it in the user-facing error.
-type sandboxQuotaError struct{ limit int64 }
+// SQLSTATE raised by the sandbox_quota_on_insert trigger.
+const sandboxQuotaErrCode = "SS001"
 
-func (e sandboxQuotaError) Error() string {
-	return fmt.Sprintf("sandbox quota exceeded (limit=%d)", e.limit)
+func isSandboxQuotaErr(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == sandboxQuotaErrCode
 }
 
-func errSandboxQuotaExceeded(limit int64) error { return sandboxQuotaError{limit: limit} }
+// respondQuotaExceeded best-effort fetches the team's cap for the message;
+// falls back to defaultMaxSandboxes if GetTeam errs.
+func (h *Handlers) respondQuotaExceeded(c *gin.Context, teamID uuid.UUID) {
+	limit := int64(defaultMaxSandboxes)
+	if team, err := h.DB.GetTeam(c.Request.Context(), teamID); err == nil && team.MaxSandboxes != nil {
+		limit = int64(*team.MaxSandboxes)
+	}
+	respondErrorMsg(c, "too_many_sandboxes",
+		fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", limit),
+		http.StatusTooManyRequests)
+}
 
 // Scheduler selects a host for new sandboxes.
 type Scheduler interface {
@@ -1144,56 +1154,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		})
 	}
 	go func() {
-		// Test path: when no Pool is wired (unit tests with a mock DBTX),
-		// skip the count check and just do the INSERT.
-		if h.Pool == nil {
-			sb, err := runInsert(h.DB)
-			insertCh <- insertResult{sandbox: sb, err: err}
-			return
-		}
-
-		// Wrap count + insert in a tx with the per-team advisory lock so
-		// concurrent submits can't both pass at limit-1.
-		tx, err := h.Pool.BeginTx(insertCtx, pgx.TxOptions{})
-		if err != nil {
-			insertCh <- insertResult{err: err}
-			return
-		}
-		defer tx.Rollback(insertCtx)
-
-		if _, err := tx.Exec(insertCtx, "SELECT pg_advisory_xact_lock(hashtext($1))", teamID.String()); err != nil {
-			insertCh <- insertResult{err: err}
-			return
-		}
-		q := h.DB.WithTx(tx)
-
-		// Per-team sandbox count cap. System team is exempt.
-		if teamID != h.systemTeamID() {
-			team, err := q.GetTeam(insertCtx, teamID)
-			if err != nil {
-				insertCh <- insertResult{err: err}
-				return
-			}
-			count, err := q.CountActiveSandboxesForTeam(insertCtx, teamID)
-			if err != nil {
-				insertCh <- insertResult{err: err}
-				return
-			}
-			effMaxSandboxes := int64(defaultMaxSandboxes)
-			if team.MaxSandboxes != nil {
-				effMaxSandboxes = int64(*team.MaxSandboxes)
-			}
-			if count >= effMaxSandboxes {
-				insertCh <- insertResult{err: errSandboxQuotaExceeded(effMaxSandboxes)}
-				return
-			}
-		}
-
-		sb, insertErr := runInsert(q)
-		if insertErr == nil {
-			insertErr = tx.Commit(insertCtx)
-		}
-		insertCh <- insertResult{sandbox: sb, err: insertErr}
+		// Quota is enforced by the sandbox_quota_on_insert trigger.
+		sb, err := runInsert(h.DB)
+		insertCh <- insertResult{sandbox: sb, err: err}
 	}()
 
 	// Boot the VM synchronously — the client gets a response only after
@@ -1221,9 +1184,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// 0 rows from CreateSandboxFromTemplate = template deleted mid-create.
 	templateRace := templateID.Valid && errors.Is(dbErr, pgx.ErrNoRows)
 
-	// Per-team sandbox count cap; surfaced from the goroutine via sentinel.
-	var quotaErr sandboxQuotaError
-	quotaExceeded := errors.As(dbErr, &quotaErr)
+	// Per-team sandbox count cap; raised by sandbox_quota_on_insert trigger.
+	quotaExceeded := isSandboxQuotaErr(dbErr)
 
 	switch {
 	case dbErr != nil && vmdErr != nil:
@@ -1234,9 +1196,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			return
 		}
 		if quotaExceeded {
-			respondErrorMsg(c, "too_many_sandboxes",
-				fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", quotaErr.limit),
-				http.StatusTooManyRequests)
+			h.respondQuotaExceeded(c, teamID)
 			return
 		}
 		respondError(c, ErrInternal)
@@ -1254,9 +1214,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			return
 		}
 		if quotaExceeded {
-			respondErrorMsg(c, "too_many_sandboxes",
-				fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", quotaErr.limit),
-				http.StatusTooManyRequests)
+			h.respondQuotaExceeded(c, teamID)
 			return
 		}
 		respondError(c, ErrInternal)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -38,15 +38,13 @@ func isSandboxQuotaErr(err error) bool {
 }
 
 // respondQuotaExceeded best-effort fetches the team's cap for the message;
-// falls back to defaultMaxSandboxes if GetTeam errs.
+// falls back to a generic phrasing if GetTeam errs.
 func (h *Handlers) respondQuotaExceeded(c *gin.Context, teamID uuid.UUID) {
-	limit := int64(defaultMaxSandboxes)
-	if team, err := h.DB.GetTeam(c.Request.Context(), teamID); err == nil && team.MaxSandboxes != nil {
-		limit = int64(*team.MaxSandboxes)
+	msg := "team has reached its sandbox limit; delete some or contact support@superserve.ai for higher"
+	if team, err := h.DB.GetTeam(c.Request.Context(), teamID); err == nil {
+		msg = fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", team.MaxSandboxes)
 	}
-	respondErrorMsg(c, "too_many_sandboxes",
-		fmt.Sprintf("team has reached the limit of %d sandboxes; delete some or contact support@superserve.ai for higher", limit),
-		http.StatusTooManyRequests)
+	respondErrorMsg(c, "too_many_sandboxes", msg, http.StatusTooManyRequests)
 }
 
 // Scheduler selects a host for new sandboxes.

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -102,7 +102,6 @@ const (
 	defaultMaxMemoryMib = 2048
 	defaultMaxDiskMib   = 8192
 	defaultMaxTemplates = 10
-	defaultMaxSandboxes = 50
 
 	defaultVcpu     = 1
 	defaultMemoryMi = 1024

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1399,6 +1399,53 @@ func TestCreateSandbox_MissingTeamID(t *testing.T) {
 	}
 }
 
+func TestCreateSandbox_QuotaExceeded(t *testing.T) {
+	teamID := uuid.New()
+	vmd := &stubVMD{}
+
+	// SS001 is what the sandbox_quota_on_insert trigger raises on over-quota.
+	var destroyCalled bool
+	vmd.destroyFn = func(_ context.Context, _ string, _ bool) error {
+		destroyCalled = true
+		return nil
+	}
+
+	quotaErr := &pgconn.PgError{Code: "SS001", Message: "sandbox quota exceeded"}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				return errorRow(quotaErr)
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			// GetTeam lookup in respondQuotaExceeded falls back to the
+			// code default when this errs.
+			return notFoundRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"x"}`))
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusTooManyRequests, w.Body.String())
+	}
+	body := parseJSON(t, w)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj["code"] != "too_many_sandboxes" {
+		t.Errorf("error code = %v, want too_many_sandboxes", errObj["code"])
+	}
+	if !destroyCalled {
+		t.Error("orphan VM was not destroyed after quota rejection")
+	}
+}
+
 func TestCreateSandbox_VMDError(t *testing.T) {
 	teamID := uuid.New()
 	sandboxID := uuid.New()

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -283,7 +283,7 @@ type Team struct {
 	MaxTemplateMemoryMib *int32    `json:"max_template_memory_mib"`
 	MaxTemplateDiskMib   *int32    `json:"max_template_disk_mib"`
 	MaxTemplates         *int32    `json:"max_templates"`
-	MaxSandboxes         *int32    `json:"max_sandboxes"`
+	MaxSandboxes         int32     `json:"max_sandboxes"`
 	ActiveSandboxCount   int32     `json:"active_sandbox_count"`
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -284,6 +284,7 @@ type Team struct {
 	MaxTemplateDiskMib   *int32    `json:"max_template_disk_mib"`
 	MaxTemplates         *int32    `json:"max_templates"`
 	MaxSandboxes         *int32    `json:"max_sandboxes"`
+	ActiveSandboxCount   int32     `json:"active_sandbox_count"`
 }
 
 type TeamMember struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -212,20 +212,6 @@ func (q *Queries) CountActiveSandboxesAtBasePath(ctx context.Context, basePath *
 	return column_1, err
 }
 
-const countActiveSandboxesForTeam = `-- name: CountActiveSandboxesForTeam :one
-SELECT COUNT(*)::bigint FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL AND status != 'failed'
-`
-
-// Active = consumes host resources. Excludes failed (VM is gone) and
-// destroyed (row is dead). Includes starting/active/pausing/paused/resuming.
-func (q *Queries) CountActiveSandboxesForTeam(ctx context.Context, teamID uuid.UUID) (int64, error) {
-	row := q.db.QueryRow(ctx, countActiveSandboxesForTeam, teamID)
-	var column_1 int64
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const createSandbox = `-- name: CreateSandbox :one
 INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)

--- a/internal/db/teams.sql.go
+++ b/internal/db/teams.sql.go
@@ -14,7 +14,7 @@ import (
 const createTeam = `-- name: CreateTeam :one
 INSERT INTO team (name)
 VALUES ($1)
-RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count
 `
 
 func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
@@ -31,6 +31,7 @@ func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
 		&i.MaxTemplateDiskMib,
 		&i.MaxTemplates,
 		&i.MaxSandboxes,
+		&i.ActiveSandboxCount,
 	)
 	return i, err
 }
@@ -46,7 +47,7 @@ func (q *Queries) DeleteTeam(ctx context.Context, id uuid.UUID) error {
 }
 
 const getTeam = `-- name: GetTeam :one
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count FROM team
 WHERE id = $1
 `
 
@@ -64,6 +65,7 @@ func (q *Queries) GetTeam(ctx context.Context, id uuid.UUID) (Team, error) {
 		&i.MaxTemplateDiskMib,
 		&i.MaxTemplates,
 		&i.MaxSandboxes,
+		&i.ActiveSandboxCount,
 	)
 	return i, err
 }
@@ -81,7 +83,7 @@ func (q *Queries) GetTeamBuildConcurrency(ctx context.Context, id uuid.UUID) (in
 }
 
 const getTeamByName = `-- name: GetTeamByName :one
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count FROM team
 WHERE name = $1
 `
 
@@ -99,12 +101,13 @@ func (q *Queries) GetTeamByName(ctx context.Context, name string) (Team, error) 
 		&i.MaxTemplateDiskMib,
 		&i.MaxTemplates,
 		&i.MaxSandboxes,
+		&i.ActiveSandboxCount,
 	)
 	return i, err
 }
 
 const listTeams = `-- name: ListTeams :many
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count FROM team
 ORDER BY created_at DESC
 `
 
@@ -128,6 +131,7 @@ func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 			&i.MaxTemplateDiskMib,
 			&i.MaxTemplates,
 			&i.MaxSandboxes,
+			&i.ActiveSandboxCount,
 		); err != nil {
 			return nil, err
 		}
@@ -143,7 +147,7 @@ const updateTeamName = `-- name: UpdateTeamName :one
 UPDATE team
 SET name = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count
 `
 
 type UpdateTeamNameParams struct {
@@ -165,6 +169,7 @@ func (q *Queries) UpdateTeamName(ctx context.Context, arg UpdateTeamNameParams) 
 		&i.MaxTemplateDiskMib,
 		&i.MaxTemplates,
 		&i.MaxSandboxes,
+		&i.ActiveSandboxCount,
 	)
 	return i, err
 }

--- a/supabase/migrations/20260513000001_sandbox_quota_counter.sql
+++ b/supabase/migrations/20260513000001_sandbox_quota_counter.sql
@@ -2,6 +2,10 @@
 -- destroyed_at is null and status != 'failed'`. Triggers maintain it
 -- in sync; the INSERT trigger raises SQLSTATE 'SS001' on quota exceed.
 
+-- Hold EXCLUSIVE on sandbox so concurrent INSERTs can't land between
+-- the backfill SELECT and the trigger creation. Reads stay allowed.
+LOCK TABLE sandbox IN EXCLUSIVE MODE;
+
 ALTER TABLE team
   ADD COLUMN active_sandbox_count integer NOT NULL DEFAULT 0;
 

--- a/supabase/migrations/20260513000001_sandbox_quota_counter.sql
+++ b/supabase/migrations/20260513000001_sandbox_quota_counter.sql
@@ -2,6 +2,10 @@
 -- destroyed_at is null and status != 'failed'`. Triggers maintain it
 -- in sync; the INSERT trigger raises SQLSTATE 'SS001' on quota exceed.
 
+-- Wrap as a single tx so LOCK TABLE works under `supabase db push`
+-- (it runs statements autocommit otherwise).
+BEGIN;
+
 -- Hold EXCLUSIVE on sandbox so concurrent INSERTs can't land between
 -- the backfill SELECT and the trigger creation. Reads stay allowed.
 LOCK TABLE sandbox IN EXCLUSIVE MODE;
@@ -109,3 +113,5 @@ CREATE TRIGGER trg_sandbox_quota_on_delete
   AFTER DELETE ON sandbox
   FOR EACH ROW
   EXECUTE FUNCTION sandbox_quota_on_delete();
+
+COMMIT;

--- a/supabase/migrations/20260513000001_sandbox_quota_counter.sql
+++ b/supabase/migrations/20260513000001_sandbox_quota_counter.sql
@@ -1,0 +1,107 @@
+-- team.active_sandbox_count mirrors `count(*) from sandbox where
+-- destroyed_at is null and status != 'failed'`. Triggers maintain it
+-- in sync; the INSERT trigger raises SQLSTATE 'SS001' on quota exceed.
+
+ALTER TABLE team
+  ADD COLUMN active_sandbox_count integer NOT NULL DEFAULT 0;
+
+-- Backfill from existing data. Table is small in prod; one statement is fine.
+UPDATE team t
+SET active_sandbox_count = sub.cnt
+FROM (
+  SELECT team_id, COUNT(*)::int AS cnt
+  FROM sandbox
+  WHERE destroyed_at IS NULL AND status != 'failed'
+  GROUP BY team_id
+) sub
+WHERE t.id = sub.team_id;
+
+-- System team gets a sentinel max so the trigger's uniform check is a
+-- no-op for it. UUID matches SYSTEM_TEAM_ID env in the controlplane.
+UPDATE team
+SET max_sandboxes = 2147483647
+WHERE id = '258e290e-d30d-4d2a-b751-07da118248c0'
+  AND (max_sandboxes IS NULL OR max_sandboxes < 1000);
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_insert() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  new_count integer;
+  effective_max integer;
+BEGIN
+  IF NEW.destroyed_at IS NOT NULL OR NEW.status = 'failed' THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE team
+  SET active_sandbox_count = active_sandbox_count + 1
+  WHERE id = NEW.team_id
+  RETURNING active_sandbox_count, COALESCE(max_sandboxes, 50)
+  INTO new_count, effective_max;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'team % does not exist', NEW.team_id;
+  END IF;
+
+  IF new_count > effective_max THEN
+    RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
+      USING ERRCODE = 'SS001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_quota_on_insert
+  BEFORE INSERT ON sandbox
+  FOR EACH ROW
+  EXECUTE FUNCTION sandbox_quota_on_insert();
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  was_active boolean;
+  is_active boolean;
+BEGIN
+  was_active := (OLD.destroyed_at IS NULL AND OLD.status != 'failed');
+  is_active := (NEW.destroyed_at IS NULL AND NEW.status != 'failed');
+
+  IF was_active AND NOT is_active THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = NEW.team_id;
+  ELSIF NOT was_active AND is_active THEN
+    UPDATE team
+    SET active_sandbox_count = active_sandbox_count + 1
+    WHERE id = NEW.team_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_quota_on_update
+  AFTER UPDATE ON sandbox
+  FOR EACH ROW
+  WHEN (OLD.destroyed_at IS DISTINCT FROM NEW.destroyed_at OR OLD.status IS DISTINCT FROM NEW.status)
+  EXECUTE FUNCTION sandbox_quota_on_update();
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_delete() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.destroyed_at IS NULL AND OLD.status != 'failed' THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = OLD.team_id;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_quota_on_delete
+  AFTER DELETE ON sandbox
+  FOR EACH ROW
+  EXECUTE FUNCTION sandbox_quota_on_delete();

--- a/supabase/migrations/20260513000001_sandbox_quota_counter.sql
+++ b/supabase/migrations/20260513000001_sandbox_quota_counter.sql
@@ -20,12 +20,12 @@ FROM (
 ) sub
 WHERE t.id = sub.team_id;
 
--- System team gets a sentinel max so the trigger's uniform check is a
--- no-op for it. UUID matches SYSTEM_TEAM_ID env in the controlplane.
-UPDATE team
-SET max_sandboxes = 2147483647
-WHERE id = '258e290e-d30d-4d2a-b751-07da118248c0'
-  AND (max_sandboxes IS NULL OR max_sandboxes < 1000);
+-- Make max_sandboxes the single source of truth (was COALESCEd in two places).
+UPDATE team SET max_sandboxes = 50 WHERE max_sandboxes IS NULL;
+ALTER TABLE team ALTER COLUMN max_sandboxes SET DEFAULT 50;
+ALTER TABLE team ALTER COLUMN max_sandboxes SET NOT NULL;
+
+-- System team's quota exemption is reconciled by the controlplane on startup.
 
 CREATE OR REPLACE FUNCTION sandbox_quota_on_insert() RETURNS trigger
     LANGUAGE plpgsql
@@ -41,7 +41,7 @@ BEGIN
   UPDATE team
   SET active_sandbox_count = active_sandbox_count + 1
   WHERE id = NEW.team_id
-  RETURNING active_sandbox_count, COALESCE(max_sandboxes, 50)
+  RETURNING active_sandbox_count, max_sandboxes
   INTO new_count, effective_max;
 
   IF NOT FOUND THEN


### PR DESCRIPTION
## Summary
- `pg_advisory_xact_lock(hashtext(teamID))` in `CreateSandbox` serialized every same-team insert through 5 round-trips inside the lock, collapsing burst latency to ~13s p50 for 100 concurrent same-team creates (measured against prod).
- Replaced with a `team.active_sandbox_count` column maintained by INSERT/UPDATE/DELETE triggers; the INSERT trigger raises SQLSTATE `SS001` on quota exceed and the handler maps that to a 429. Lock hold per insert drops from ~50ms → ~5ms, estimated burst p50 1-2s.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->