### PR TITLE
template-builder: flatten via snapshot-editor instead of in-process Go

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -41,13 +41,14 @@ func main() {
 	snapshotDir := flag.String("snapshot-dir", "", "base path for snapshot output")
 	kernelPath := flag.String("kernel", "", "path to vmlinux")
 	fcBin := flag.String("firecracker", "", "path to firecracker binary")
+	snapshotEditorBin := flag.String("snapshot-editor", "", "path to snapshot-editor binary")
 	boxdBin := flag.String("boxd", "", "path to boxd binary")
 	hostIface := flag.String("host-interface", "ens4", "host network interface")
 	slotIndex := flag.Int("slot-index", 200, "network slot index (must not collide with vmd)")
 	timeout := flag.Duration("timeout", 15*time.Minute, "build timeout")
 	flag.Parse()
 
-	if *templateID == "" || *specJSON == "" || *runDir == "" || *snapshotDir == "" || *kernelPath == "" || *fcBin == "" || *boxdBin == "" {
+	if *templateID == "" || *specJSON == "" || *runDir == "" || *snapshotDir == "" || *kernelPath == "" || *fcBin == "" || *snapshotEditorBin == "" || *boxdBin == "" {
 		flag.Usage()
 		os.Exit(2)
 	}
@@ -77,9 +78,10 @@ func main() {
 		diskMiB:    uint32(*disk),
 		runDir:     *runDir,
 		snapshotDir: *snapshotDir,
-		kernelPath: *kernelPath,
-		fcBin:      *fcBin,
-		boxdBin:    *boxdBin,
+		kernelPath:        *kernelPath,
+		fcBin:             *fcBin,
+		snapshotEditorBin: *snapshotEditorBin,
+		boxdBin:           *boxdBin,
 		hostIface:  *hostIface,
 		slotIndex:  *slotIndex,
 	})
@@ -160,19 +162,20 @@ func classifyBuildError(err error) (code, userMsg string) {
 }
 
 type buildConfig struct {
-	templateID  string
-	buildID     string
-	spec        builder.BuildSpec
-	vcpu        uint32
-	memoryMiB   uint32
-	diskMiB     uint32
-	runDir      string
-	snapshotDir string
-	kernelPath  string
-	fcBin       string
-	boxdBin     string
-	hostIface   string
-	slotIndex   int
+	templateID        string
+	buildID           string
+	spec              builder.BuildSpec
+	vcpu              uint32
+	memoryMiB         uint32
+	diskMiB           uint32
+	runDir            string
+	snapshotDir       string
+	kernelPath        string
+	fcBin             string
+	snapshotEditorBin string
+	boxdBin           string
+	hostIface         string
+	slotIndex         int
 }
 
 func runBuild(ctx context.Context, cfg buildConfig) error {
@@ -293,6 +296,17 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 		return fmt.Errorf("snapshot: %w", err)
 	}
 	emitInternal("system", "snapshot captured")
+
+	// Bake delta into base + zero side-car so per-sandbox restores skip apply_delta.
+	flattenCmd := exec.CommandContext(ctx, cfg.snapshotEditorBin, "flatten", "run",
+		"--base-path", basePath,
+		"--delta-path", deltaPath,
+		"--sidecar-path", snapPath+".overlay",
+	)
+	if out, err := flattenCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("snapshot-editor flatten: %w (%s)", err, out)
+	}
+	emitInternal("system", "delta flattened into base")
 
 	// Flush host page cache for each artifact so a sandbox cp'ing them
 	// later doesn't see sparse holes from still-dirty pages.

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -35,6 +35,7 @@ type Config struct {
 	GRPCPort           int
 	HostInterface      string
 	TemplateBuilderBin string
+	SnapshotEditorBin  string
 	BoxdBinaryPath     string
 
 	// HostID identifies this bare-metal host in the `host` table. Used by
@@ -69,6 +70,7 @@ func loadConfig() (Config, error) {
 		GRPCPort:       port,
 		HostInterface:      envOrDefault("HOST_INTERFACE", "eth0"),
 		TemplateBuilderBin: envOrDefault("TEMPLATE_BUILDER_BIN", "/usr/local/bin/template-builder"),
+		SnapshotEditorBin:  envOrDefault("SNAPSHOT_EDITOR_BIN", "/usr/local/bin/snapshot-editor"),
 		BoxdBinaryPath:     envOrDefault("BOXD_BINARY_PATH", "/usr/local/bin/boxd"),
 		HostID:          envOrDefault("HOST_ID", "default"),
 		DatabaseURL:     os.Getenv("DATABASE_URL"),
@@ -260,6 +262,7 @@ func main() {
 		SnapshotDir:           cfg.SnapshotDir,
 		RunDir:                cfg.RunDir,
 		TemplateBuilderBin:    cfg.TemplateBuilderBin,
+		SnapshotEditorBin:     cfg.SnapshotEditorBin,
 		BoxdBinaryPath:        cfg.BoxdBinaryPath,
 		HostInterface:         cfg.HostInterface,
 		MaxConcurrentRestores: maxRestores,

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -126,6 +126,7 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 		"--snapshot-dir", m.cfg.SnapshotDir,
 		"--kernel", m.cfg.KernelPath,
 		"--firecracker", m.cfg.FirecrackerBin,
+		"--snapshot-editor", m.cfg.SnapshotEditorBin,
 		"--boxd", m.cfg.BoxdBinaryPath,
 		"--host-interface", m.cfg.HostInterface,
 		"--slot-index", fmt.Sprint(slotIndex),

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -123,6 +123,7 @@ type ManagerConfig struct {
 	SnapshotDir        string
 	RunDir             string
 	TemplateBuilderBin string // Path to template-builder binary.
+	SnapshotEditorBin  string // Path to snapshot-editor binary (passed to template-builder).
 	BoxdBinaryPath     string // Path to boxd binary (passed to template-builder).
 	HostInterface      string // Host network interface (e.g. "ens4").
 	// MaxConcurrentRestores caps parallel RestoreVMSnapshot operations to


### PR DESCRIPTION
## Summary

Switches the template-builder flatten step from the in-process Go implementation (closed PR #60) to shelling out to firecracker's new `snapshot-editor flatten` subcommand (superserve-ai/firecracker#10).

The Go impl needed to mirror firecracker's CRC64 polynomial and bitcode side-car format from Go — that asymmetry caused the CRC saga and left the side-car bitmap stale (silent-corruption trap if any future restore caller omitted `delta_dir`). The Rust subcommand uses firecracker's own types end-to-end, so byte-for-byte compatibility is guaranteed and the side-car is zeroed correctly.

**Plumbing:** new `SNAPSHOT_EDITOR_BIN` env var (defaults to `/usr/local/bin/snapshot-editor`) flows vmd → ManagerConfig → template-builder exec. Single new flag `--snapshot-editor` on template-builder.

**Deploy order:** the new `snapshot-editor` binary needs to be on hosts before this lands. Build/deploy firecracker (PR #10) first.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->