### PR TITLE
templates: add openclaw and hermes system templates

### DIFF
--- a/superserve_templates/superserve-hermes.json
+++ b/superserve_templates/superserve-hermes.json
@@ -7,7 +7,7 @@
     "from": "ubuntu:24.04",
     "steps": [
       {
-        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
+        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux xz-utils && rm -rf /var/lib/apt/lists/*"
       },
       {
         "run": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"

--- a/superserve_templates/superserve-hermes.json
+++ b/superserve_templates/superserve-hermes.json
@@ -10,7 +10,7 @@
         "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux xz-utils && rm -rf /var/lib/apt/lists/*"
       },
       {
-        "run": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+        "run": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.5.16/scripts/install.sh | bash"
       }
     ]
   }

--- a/superserve_templates/superserve-hermes.json
+++ b/superserve_templates/superserve-hermes.json
@@ -1,0 +1,17 @@
+{
+  "name": "superserve/hermes",
+  "vcpu": 2,
+  "memory_mib": 2048,
+  "disk_mib": 8192,
+  "build_spec": {
+    "from": "ubuntu:24.04",
+    "steps": [
+      {
+        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
+      },
+      {
+        "run": "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+      }
+    ]
+  }
+}

--- a/superserve_templates/superserve-openclaw.json
+++ b/superserve_templates/superserve-openclaw.json
@@ -1,0 +1,17 @@
+{
+  "name": "superserve/openclaw",
+  "vcpu": 2,
+  "memory_mib": 2048,
+  "disk_mib": 8192,
+  "build_spec": {
+    "from": "ubuntu:24.04",
+    "steps": [
+      {
+        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
+      },
+      {
+        "run": "curl -fsSL https://openclaw.ai/install.sh | bash"
+      }
+    ]
+  }
+}

--- a/superserve_templates/superserve-openclaw.json
+++ b/superserve_templates/superserve-openclaw.json
@@ -7,7 +7,7 @@
     "from": "ubuntu:24.04",
     "steps": [
       {
-        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux xz-utils && rm -rf /var/lib/apt/lists/*"
+        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
       },
       {
         "run": "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard --version 2026.5.18"

--- a/superserve_templates/superserve-openclaw.json
+++ b/superserve_templates/superserve-openclaw.json
@@ -10,7 +10,7 @@
         "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
       },
       {
-        "run": "curl -fsSL https://openclaw.ai/install.sh | bash"
+        "run": "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard"
       }
     ]
   }

--- a/superserve_templates/superserve-openclaw.json
+++ b/superserve_templates/superserve-openclaw.json
@@ -7,10 +7,10 @@
     "from": "ubuntu:24.04",
     "steps": [
       {
-        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux && rm -rf /var/lib/apt/lists/*"
+        "run": "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates tmux xz-utils && rm -rf /var/lib/apt/lists/*"
       },
       {
-        "run": "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard"
+        "run": "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard --version 2026.5.18"
       }
     ]
   }


### PR DESCRIPTION
Adds two curated system templates: `superserve/openclaw` and `superserve/hermes`. Both Ubuntu 24.04 + tmux + upstream curl|bash installer, sized at 2 vCPU / 2 GiB / 8 GiB to match `claude-code`.

Seed workflow will build them on staging then prod; spec-hash idempotency leaves the existing six untouched.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->