### PR TITLE
vmd: rebuild missing netns on resume, validate pool slots, allocator consults kernel

### DIFF
--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -10,6 +10,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// hostFirewallAPI is the Manager's view of *HostFirewall, stubbed by tests.
+type hostFirewallAPI interface {
+	AddVM(vmID, vethName, hostCIDR string) error
+	RemoveVM(vmID string) error
+	Close() error
+}
+
 // HostFirewall manages host-level iptables rules for VM internet access.
 // Appends per-VM rules to the kernel's built-in chains:
 //   - filter/FORWARD: allow traffic between each VM's veth and the host interface

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -85,7 +85,7 @@ type Manager struct {
 	nextSlot  int   // next new slot (used when freeSlots is empty)
 
 	// Host-level nftables firewall (FORWARD + MASQUERADE + MSS clamping).
-	hostFW *HostFirewall
+	hostFW hostFirewallAPI
 
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -447,9 +447,7 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
 	}
 
-	// Do the fallible step before recording success: a future retry would
-	// see m.devices[vmID] populated and short-circuit, never re-attempting
-	// the firewall.
+	// AddVM before devices insert — a retry can't re-attempt it once devices is set.
 	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
 		return fmt.Errorf("reattach %s: restore host firewall: %w", vmID, err)
 	}
@@ -503,6 +501,9 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		if err != nil {
 			return nil, fmt.Errorf("ensure %s: rebuild slot %d: %w", vmID, idx, err)
 		}
+		if macAddress != "" && built.MACAddress != macAddress {
+			m.log.Warn().Str("vm_id", vmID).Str("expected", macAddress).Str("got", built.MACAddress).Msg("rebuilt MAC differs from stored — deterministic mapping may have drifted")
+		}
 		info = built
 		vethName = builtVeth
 	} else {
@@ -518,10 +519,7 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		vethName = fmt.Sprintf("veth-%d", idx)
 	}
 
-	// Do the fallible step before recording success: if AddVM fails and
-	// we'd already set m.devices[vmID], the next retry would short-circuit
-	// on the fast path (hasDevice && nsExists) and never re-attempt the
-	// firewall — leaving the VM running with no host rules.
+	// AddVM before devices insert — a retry short-circuits on the fast path otherwise.
 	hostCIDR := fmt.Sprintf("%s/32", hostIP)
 	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
 		return nil, fmt.Errorf("ensure %s: restore host firewall: %w", vmID, err)
@@ -530,6 +528,12 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	m.mu.Lock()
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
+	}
+	for i, s := range m.freeSlots {
+		if s == idx {
+			m.freeSlots = append(m.freeSlots[:i], m.freeSlots[i+1:]...)
+			break
+		}
 	}
 	m.devices[vmID] = info
 	m.mu.Unlock()
@@ -592,10 +596,10 @@ func (m *Manager) claimSlotIndex() (int, error) {
 // still in the ns first so slot recycling can't collide with a
 // vmd-crash-orphaned firecracker still holding veth/TAP peers.
 func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
-	entries, err := os.ReadDir("/run/netns")
+	entries, err := os.ReadDir(netnsDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			m.log.Warn().Err(err).Msg("sweep: list /run/netns failed")
+			m.log.Warn().Err(err).Msg("sweep: list netns dir failed")
 		}
 		return 0
 	}
@@ -648,7 +652,7 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 // killProcessesInNs SIGKILLs every process whose net namespace matches
 // /run/netns/<name>. Returns the number of pids signalled.
 func killProcessesInNs(name string) int {
-	nsPath := "/run/netns/" + name
+	nsPath := netnsDir + "/" + name
 	nsStat, err := os.Stat(nsPath)
 	if err != nil {
 		return 0
@@ -714,8 +718,11 @@ func (m *Manager) UpdateFirewallRules(vmID string, allowedCIDRs, deniedCIDRs []s
 // Helpers
 // ---------------------------------------------------------------------------
 
+// netnsDir is overridden by tests.
+var netnsDir = "/run/netns"
+
 func nsExists(nsName string) bool {
-	_, err := os.Stat("/run/netns/" + nsName)
+	_, err := os.Stat(netnsDir + "/" + nsName)
 	return err == nil
 }
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -447,6 +447,13 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
 	}
 
+	// Do the fallible step before recording success: a future retry would
+	// see m.devices[vmID] populated and short-circuit, never re-attempting
+	// the firewall.
+	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
+		return fmt.Errorf("reattach %s: restore host firewall: %w", vmID, err)
+	}
+
 	m.mu.Lock()
 	// Bump nextSlot past this idx so new VMs don't collide. Gap slots
 	// below nextSlot are wasted until bitmap allocation lands.
@@ -464,9 +471,6 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	}
 	m.mu.Unlock()
 
-	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
-		return fmt.Errorf("reattach %s: restore host firewall: %w", vmID, err)
-	}
 	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
 	return nil
 }
@@ -514,17 +518,21 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		vethName = fmt.Sprintf("veth-%d", idx)
 	}
 
+	// Do the fallible step before recording success: if AddVM fails and
+	// we'd already set m.devices[vmID], the next retry would short-circuit
+	// on the fast path (hasDevice && nsExists) and never re-attempt the
+	// firewall — leaving the VM running with no host rules.
+	hostCIDR := fmt.Sprintf("%s/32", hostIP)
+	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
+		return nil, fmt.Errorf("ensure %s: restore host firewall: %w", vmID, err)
+	}
+
 	m.mu.Lock()
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
 	}
 	m.devices[vmID] = info
 	m.mu.Unlock()
-
-	hostCIDR := fmt.Sprintf("%s/32", hostIP)
-	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
-		return nil, fmt.Errorf("ensure %s: restore host firewall: %w", vmID, err)
-	}
 
 	return info, nil
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -488,14 +488,16 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	m.mu.Lock()
 	existing, hasDevice := m.devices[vmID]
 	m.mu.Unlock()
-	if hasDevice && nsExists(namespace) {
-		return existing, nil
-	}
 
 	var info *VMNetInfo
 	var vethName string
 
-	if !nsExists(namespace) {
+	switch {
+	case hasDevice && nsExists(namespace):
+		// Preserve Firewall handle for future UpdateFirewallRules; AddVM below is idempotent.
+		info = existing
+		vethName = fmt.Sprintf("veth-%d", idx)
+	case !nsExists(namespace):
 		m.log.Warn().Str("vm_id", vmID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
 		built, builtVeth, err := m.setupSlot(ctx, idx)
 		if err != nil {
@@ -506,7 +508,7 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		}
 		info = built
 		vethName = builtVeth
-	} else {
+	default:
 		// Firewall handle stays nil; UpdateFirewallRules creates a fresh one.
 		info = &VMNetInfo{
 			Namespace:  namespace,

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -499,6 +499,9 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		vethName = fmt.Sprintf("veth-%d", idx)
 	case !nsExists(namespace):
 		m.log.Warn().Str("vm_id", vmID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
+		// ip netns delete only tears down the inside-ns side; the host-side
+		// veth-N can survive and collide with setupSlot's fresh veth creation.
+		m.cleanupFull(namespace, fmt.Sprintf("veth-%d", idx))
 		built, builtVeth, err := m.setupSlot(ctx, idx)
 		if err != nil {
 			return nil, fmt.Errorf("ensure %s: rebuild slot %d: %w", vmID, idx, err)

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -190,26 +190,14 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		m.log.Debug().Str("vm_id", vmID).Msg("network pool empty, falling back to on-demand setup")
 	}
 
-	m.mu.Lock()
-	var idx int
-	if len(m.freeSlots) > 0 {
-		idx = m.freeSlots[len(m.freeSlots)-1]
-		m.freeSlots = m.freeSlots[:len(m.freeSlots)-1]
-	} else {
-		if m.nextSlot > MaxSlots {
-			m.mu.Unlock()
-			return nil, ErrNoSlots
-		}
-		idx = m.nextSlot
-		m.nextSlot++
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		return nil, err
 	}
-	m.mu.Unlock()
 
 	info, vethName, err := m.setupSlot(ctx, idx)
 	if err != nil {
-		m.mu.Lock()
-		m.freeSlots = append(m.freeSlots, idx)
-		m.mu.Unlock()
+		// idx stays consumed — reusing a colliding idx would loop.
 		return nil, err
 	}
 
@@ -483,6 +471,64 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
+// EnsureVMSlot guarantees the kernel network state for vmID is present and
+// tracked. Idempotent.
+//
+// IP and MAC are deterministic from the slot index parsed out of namespace,
+// so a rebuild preserves the VM's network identity. Per-customer egress
+// rules are NOT restored here; the caller reapplies them.
+func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, macAddress string) (*VMNetInfo, error) {
+	idx, ok := slotFromNamespace(namespace)
+	if !ok {
+		return nil, fmt.Errorf("ensure %s: cannot parse slot from namespace %q", vmID, namespace)
+	}
+
+	m.mu.Lock()
+	existing, hasDevice := m.devices[vmID]
+	m.mu.Unlock()
+	if hasDevice && nsExists(namespace) {
+		return existing, nil
+	}
+
+	var info *VMNetInfo
+	var vethName string
+
+	if !nsExists(namespace) {
+		m.log.Warn().Str("vm_id", vmID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
+		built, builtVeth, err := m.setupSlot(ctx, idx)
+		if err != nil {
+			return nil, fmt.Errorf("ensure %s: rebuild slot %d: %w", vmID, idx, err)
+		}
+		info = built
+		vethName = builtVeth
+	} else {
+		// Firewall handle stays nil; UpdateFirewallRules creates a fresh one.
+		info = &VMNetInfo{
+			Namespace:  namespace,
+			TAPDevice:  TAPName,
+			VMIP:       VMInternalIP,
+			GatewayIP:  VMGatewayIP,
+			HostIP:     hostIP,
+			MACAddress: macAddress,
+		}
+		vethName = fmt.Sprintf("veth-%d", idx)
+	}
+
+	m.mu.Lock()
+	if idx >= m.nextSlot {
+		m.nextSlot = idx + 1
+	}
+	m.devices[vmID] = info
+	m.mu.Unlock()
+
+	hostCIDR := fmt.Sprintf("%s/32", hostIP)
+	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
+		return nil, fmt.Errorf("ensure %s: restore host firewall: %w", vmID, err)
+	}
+
+	return info, nil
+}
+
 // slotFromNamespace parses "ns-N" → N (digits only). Returns (0, false)
 // on malformed input. Strict: trailing non-digit characters are rejected
 // to avoid silently mapping "ns-2-something" to slot 2.
@@ -500,6 +546,37 @@ func slotFromNamespace(namespace string) (int, bool) {
 		idx = idx*10 + int(c-'0')
 	}
 	return idx, true
+}
+
+// claimSlotIndex picks a slot idx free in both freeSlots and the kernel.
+// Skips indices whose netns already exists (paused VM from a past lifetime,
+// etc.). Race window after the nsExists check remains; callers must still
+// handle setupSlot returning "already exists".
+func (m *Manager) claimSlotIndex() (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for {
+		var idx int
+		if len(m.freeSlots) > 0 {
+			idx = m.freeSlots[len(m.freeSlots)-1]
+			m.freeSlots = m.freeSlots[:len(m.freeSlots)-1]
+		} else {
+			if m.nextSlot > MaxSlots {
+				return 0, ErrNoSlots
+			}
+			idx = m.nextSlot
+			m.nextSlot++
+		}
+
+		if nsExists(fmt.Sprintf("ns-%d", idx)) {
+			// Discard; returning idx to freeSlots would loop on next call.
+			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — kernel ns already exists")
+			continue
+		}
+
+		return idx, nil
+	}
 }
 
 // SweepOrphanNamespaces removes host namespaces and veth interfaces

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -150,22 +150,6 @@ func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
 	}
 }
 
-func TestEnsureVMSlot_FastPathReturnsExisting(t *testing.T) {
-	dir := withTestNetnsDir(t)
-	touchNS(t, dir, "ns-3")
-	m := newTestManager()
-	existing := &VMNetInfo{Namespace: "ns-3", HostIP: "10.11.0.3"}
-	m.devices["vm-x"] = existing
-
-	got, err := m.EnsureVMSlot(context.Background(), "vm-x", "ns-3", "10.11.0.3", "")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if got != existing {
-		t.Errorf("expected fast-path to return the existing entry pointer")
-	}
-}
-
 func TestEnsureVMSlot_InvalidNamespace(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -123,7 +123,7 @@ func TestClaimSlotIndex_SkipsPhantomFromNextSlot(t *testing.T) {
 
 func TestClaimSlotIndex_SkipsPhantomFromFreeSlots(t *testing.T) {
 	dir := withTestNetnsDir(t)
-	touchNS(t, dir, "ns-5") // 5 is a phantom in kernel
+	touchNS(t, dir, "ns-7") // 7 is top-of-stack (LIFO), phantom in kernel
 	m := newTestManager()
 	m.freeSlots = []int{5, 7}
 
@@ -131,8 +131,8 @@ func TestClaimSlotIndex_SkipsPhantomFromFreeSlots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if idx != 7 {
-		t.Errorf("idx = %d, want 7 (5 skipped as phantom)", idx)
+	if idx != 5 {
+		t.Errorf("idx = %d, want 5 (7 skipped as phantom, fell back to 5)", idx)
 	}
 	if len(m.freeSlots) != 0 {
 		t.Errorf("freeSlots = %v, want [] (both popped)", m.freeSlots)

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -37,6 +37,35 @@ func newTestManager() *Manager {
 	}
 }
 
+// stubHostFW records AddVM/RemoveVM calls so tests can assert on them.
+type stubHostFW struct {
+	added   []string // "vmID|veth|cidr"
+	removed []string
+	addErr  error
+}
+
+func (s *stubHostFW) AddVM(vmID, vethName, hostCIDR string) error {
+	if s.addErr != nil {
+		return s.addErr
+	}
+	s.added = append(s.added, vmID+"|"+vethName+"|"+hostCIDR)
+	return nil
+}
+
+func (s *stubHostFW) RemoveVM(vmID string) error {
+	s.removed = append(s.removed, vmID)
+	return nil
+}
+
+func (s *stubHostFW) Close() error { return nil }
+
+func newTestManagerWithStubFW() (*Manager, *stubHostFW) {
+	fw := &stubHostFW{}
+	m := newTestManager()
+	m.hostFW = fw
+	return m, fw
+}
+
 func TestSlotFromNamespace(t *testing.T) {
 	cases := []struct {
 		in        string
@@ -147,6 +176,66 @@ func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
 	_, err := m.claimSlotIndex()
 	if !errors.Is(err, ErrNoSlots) {
 		t.Errorf("err = %v, want ErrNoSlots", err)
+	}
+}
+
+func TestEnsureVMSlot_HealthyVMReplaysFirewall(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-3")
+	m, fw := newTestManagerWithStubFW()
+	existing := &VMNetInfo{Namespace: "ns-3", HostIP: "10.11.0.3"}
+	m.devices["vm-x"] = existing
+
+	got, err := m.EnsureVMSlot(context.Background(), "vm-x", "ns-3", "10.11.0.3", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != existing {
+		t.Errorf("expected same VMNetInfo pointer back (Firewall handle preserved)")
+	}
+	if len(fw.added) != 1 || fw.added[0] != "vm-x|veth-3|10.11.0.3/32" {
+		t.Errorf("AddVM calls = %v, want one call with veth-3 + 10.11.0.3/32", fw.added)
+	}
+}
+
+func TestEnsureVMSlot_ReconstructWhenDeviceMapEmpty(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	m, fw := newTestManagerWithStubFW()
+
+	got, err := m.EnsureVMSlot(context.Background(), "vm-y", "ns-7", "10.11.0.7", "AA:FC:00:00:00:07")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Namespace != "ns-7" || got.HostIP != "10.11.0.7" || got.MACAddress != "AA:FC:00:00:00:07" {
+		t.Errorf("reconstructed info wrong: %+v", got)
+	}
+	if got.Firewall != nil {
+		t.Errorf("Firewall handle should be nil; UpdateFirewallRules creates a fresh one")
+	}
+	if m.devices["vm-y"] != got {
+		t.Errorf("vm-y not registered in devices map after reconstruct")
+	}
+	if m.nextSlot < 8 {
+		t.Errorf("nextSlot = %d, want >= 8 (advanced past idx 7)", m.nextSlot)
+	}
+	if len(fw.added) != 1 || fw.added[0] != "vm-y|veth-7|10.11.0.7/32" {
+		t.Errorf("AddVM calls = %v, want one call with veth-7", fw.added)
+	}
+}
+
+func TestEnsureVMSlot_AddVMFailureSkipsDeviceInsert(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-4")
+	m, fw := newTestManagerWithStubFW()
+	fw.addErr = errors.New("simulated iptables failure")
+
+	_, err := m.EnsureVMSlot(context.Background(), "vm-z", "ns-4", "10.11.0.4", "")
+	if err == nil {
+		t.Fatal("expected error from AddVM failure")
+	}
+	if _, present := m.devices["vm-z"]; present {
+		t.Errorf("devices map should not contain vm-z after AddVM failure (retry must re-attempt)")
 	}
 }
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -1,6 +1,41 @@
 package network
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func withTestNetnsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old := netnsDir
+	netnsDir = dir
+	t.Cleanup(func() { netnsDir = old })
+	return dir
+}
+
+func touchNS(t *testing.T, dir, name string) {
+	t.Helper()
+	f, err := os.Create(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("create fake netns %s: %v", name, err)
+	}
+	_ = f.Close()
+}
+
+// hostFW is nil — tests must not exercise paths that touch it.
+func newTestManager() *Manager {
+	return &Manager{
+		log:      zerolog.Nop(),
+		devices:  make(map[string]*VMNetInfo),
+		nextSlot: 1,
+	}
+}
 
 func TestSlotFromNamespace(t *testing.T) {
 	cases := []struct {
@@ -29,5 +64,114 @@ func TestSlotFromNamespace(t *testing.T) {
 				t.Errorf("slotFromNamespace(%q) = (%d, %v), want (%d, %v)", tc.in, idx, ok, tc.wantIdx, tc.wantOK)
 			}
 		})
+	}
+}
+
+func TestClaimSlotIndex_FreshNextSlot(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if idx != 1 {
+		t.Errorf("idx = %d, want 1", idx)
+	}
+	if m.nextSlot != 2 {
+		t.Errorf("nextSlot = %d, want 2", m.nextSlot)
+	}
+}
+
+func TestClaimSlotIndex_PrefersFreeSlotsLIFO(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	m.freeSlots = []int{5, 7}
+
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if idx != 7 {
+		t.Errorf("idx = %d, want 7 (LIFO pop)", idx)
+	}
+	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
+		t.Errorf("freeSlots = %v, want [5]", m.freeSlots)
+	}
+	if m.nextSlot != 1 {
+		t.Errorf("nextSlot bumped to %d when popping from freeSlots", m.nextSlot)
+	}
+}
+
+func TestClaimSlotIndex_SkipsPhantomFromNextSlot(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	touchNS(t, dir, "ns-2")
+	m := newTestManager()
+
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if idx != 3 {
+		t.Errorf("idx = %d, want 3 (1 and 2 are phantoms)", idx)
+	}
+	if m.nextSlot != 4 {
+		t.Errorf("nextSlot = %d, want 4 (advanced past phantoms)", m.nextSlot)
+	}
+}
+
+func TestClaimSlotIndex_SkipsPhantomFromFreeSlots(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-5") // 5 is a phantom in kernel
+	m := newTestManager()
+	m.freeSlots = []int{5, 7}
+
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if idx != 7 {
+		t.Errorf("idx = %d, want 7 (5 skipped as phantom)", idx)
+	}
+	if len(m.freeSlots) != 0 {
+		t.Errorf("freeSlots = %v, want [] (both popped)", m.freeSlots)
+	}
+}
+
+func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	m.nextSlot = MaxSlots + 1
+
+	_, err := m.claimSlotIndex()
+	if !errors.Is(err, ErrNoSlots) {
+		t.Errorf("err = %v, want ErrNoSlots", err)
+	}
+}
+
+func TestEnsureVMSlot_FastPathReturnsExisting(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-3")
+	m := newTestManager()
+	existing := &VMNetInfo{Namespace: "ns-3", HostIP: "10.11.0.3"}
+	m.devices["vm-x"] = existing
+
+	got, err := m.EnsureVMSlot(context.Background(), "vm-x", "ns-3", "10.11.0.3", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != existing {
+		t.Errorf("expected fast-path to return the existing entry pointer")
+	}
+}
+
+func TestEnsureVMSlot_InvalidNamespace(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	_, err := m.EnsureVMSlot(context.Background(), "vm-x", "garbage", "10.11.0.3", "")
+	if err == nil {
+		t.Fatalf("expected error for invalid namespace, got nil")
 	}
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -87,34 +87,49 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 // Prefers recycled slots (zero setup cost) over fresh ones (one nftables
 // call). Returns nil if both pools are empty — caller falls back to
 // on-demand SetupVM.
+//
+// Validates each slot's kernel netns is still present; phantoms are
+// discarded and their idx returned to the allocator via cleanup.
 func (p *Pool) Claim(vmID string) *VMNetInfo {
-	var slot *preallocSlot
+	for {
+		var slot *preallocSlot
 
-	// Prefer recycled slots — they already have host firewall rules
-	// from the previous owner, which get replaced below.
-	select {
-	case slot = <-p.recycled:
-	default:
+		// Prefer recycled slots — they already have host firewall rules
+		// from the previous owner, which get replaced below.
 		select {
-		case slot = <-p.fresh:
+		case slot = <-p.recycled:
 		default:
+			select {
+			case slot = <-p.fresh:
+			default:
+				return nil
+			}
+		}
+
+		if !nsExists(slot.info.Namespace) {
+			p.log.Warn().
+				Str("vm_id", vmID).
+				Str("namespace", slot.info.Namespace).
+				Int("slot", slot.idx).
+				Msg("pool: discarded phantom slot (kernel netns missing)")
+			p.cleanup(slot)
+			continue
+		}
+
+		// Add host-level firewall rules (requires vmID).
+		hostCIDR := slot.info.HostIP + "/32"
+		if err := p.mgr.hostFW.AddVM(vmID, slot.vethName, hostCIDR); err != nil {
+			p.log.Error().Err(err).Str("vm_id", vmID).Msg("claim: AddVM firewall failed")
+			p.cleanup(slot)
 			return nil
 		}
+
+		p.mgr.mu.Lock()
+		p.mgr.devices[vmID] = slot.info
+		p.mgr.mu.Unlock()
+
+		return slot.info
 	}
-
-	// Add host-level firewall rules (requires vmID).
-	hostCIDR := slot.info.HostIP + "/32"
-	if err := p.mgr.hostFW.AddVM(vmID, slot.vethName, hostCIDR); err != nil {
-		p.log.Error().Err(err).Str("vm_id", vmID).Msg("claim: AddVM firewall failed")
-		p.cleanup(slot)
-		return nil
-	}
-
-	p.mgr.mu.Lock()
-	p.mgr.devices[vmID] = slot.info
-	p.mgr.mu.Unlock()
-
-	return slot.info
 }
 
 // Return puts a slot back into the recycled pool after a sandbox is
@@ -204,30 +219,16 @@ func (p *Pool) mustAllocate(ctx context.Context) *preallocSlot {
 }
 
 func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
-	// Grab a slot index from the manager's free list.
-	p.mgr.mu.Lock()
-	var idx int
-	if len(p.mgr.freeSlots) > 0 {
-		idx = p.mgr.freeSlots[len(p.mgr.freeSlots)-1]
-		p.mgr.freeSlots = p.mgr.freeSlots[:len(p.mgr.freeSlots)-1]
-	} else {
-		if p.mgr.nextSlot > MaxSlots {
-			p.mgr.mu.Unlock()
-			return nil, ErrNoSlots
-		}
-		idx = p.mgr.nextSlot
-		p.mgr.nextSlot++
+	idx, err := p.mgr.claimSlotIndex()
+	if err != nil {
+		return nil, err
 	}
-	p.mgr.mu.Unlock()
 
 	// Run the full network setup (namespace, veth, TAP, nftables).
 	// This is the expensive part we're moving off the hot path.
 	info, vethName, err := p.mgr.setupSlot(ctx, idx)
 	if err != nil {
-		// Don't return the index to freeSlots — the namespace may be in
-		// use by a running sandbox from a previous VMD lifetime. Returning
-		// it would cause an infinite retry loop. The index is consumed;
-		// the next allocate will use nextSlot or a different free index.
+		// idx stays consumed — reusing a colliding idx would loop.
 		return nil, err
 	}
 

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -106,6 +106,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			}
 		}
 
+		// Race: ns can vanish between this check and AddVM; fc startup catches it.
 		if !nsExists(slot.info.Namespace) {
 			p.log.Warn().
 				Str("vm_id", vmID).

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1,0 +1,53 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestPoolClaim_DiscardsPhantomReturnsNil(t *testing.T) {
+	withTestNetnsDir(t) // no fake ns-1 → ns-1 looks gone from kernel
+	m := newTestManager()
+
+	p := &Pool{
+		mgr:      m,
+		log:      zerolog.Nop(),
+		newSize:  4,
+		fresh:    make(chan *preallocSlot, 4),
+		recycled: make(chan *preallocSlot, 4),
+		stopCh:   make(chan struct{}),
+	}
+
+	p.fresh <- &preallocSlot{
+		idx:      1,
+		info:     &VMNetInfo{Namespace: "ns-1", HostIP: "10.11.0.1"},
+		vethName: "veth-1",
+	}
+
+	got := p.Claim("vm-x")
+	if got != nil {
+		t.Fatalf("expected nil (only phantom available), got %+v", got)
+	}
+	if len(m.freeSlots) != 1 || m.freeSlots[0] != 1 {
+		t.Errorf("freeSlots = %v, want [1] (phantom idx returned)", m.freeSlots)
+	}
+}
+
+func TestPoolClaim_EmptyChannelsReturnsNil(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	p := &Pool{
+		mgr:      m,
+		log:      zerolog.Nop(),
+		newSize:  4,
+		fresh:    make(chan *preallocSlot, 4),
+		recycled: make(chan *preallocSlot, 4),
+		stopCh:   make(chan struct{}),
+	}
+
+	if got := p.Claim("vm-x"); got != nil {
+		t.Errorf("expected nil from empty pool, got %+v", got)
+	}
+}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -626,6 +626,12 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	vmDir := filepath.Join(m.cfg.RunDir, rundirKey)
 	socketPath := filepath.Join(vmDir, "firecracker.sock")
 
+	if inst.Namespace != "" {
+		if _, err := m.netMgr.EnsureVMSlot(ctx, vmID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+			return nil, fmt.Errorf("ensure network slot for resume: %w", err)
+		}
+	}
+
 	pid, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("start firecracker for restore: %w", err)


### PR DESCRIPTION
Three network reliability fixes hardening vmd against missing-ns / poisoned-pool / colliding-slot edge cases.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->