### PR TITLE
supervisor: stop pinning superseded ready builds in reconciler

### DIFF
--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -216,6 +216,9 @@ WHERE id = $1 AND status IN ('pending', 'building', 'snapshotting');
 -- the snapshot paths populated. Mirrors the FinalizePause CTE pattern in
 -- sandboxes.sql: one roundtrip, no torn states. Returns the template row
 -- so the caller can log the outcome.
+--
+-- INVARIANT: status='ready' and template.base_path must become visible
+-- together — the reconciler GCs build dirs not referenced by base_path.
 WITH build_done AS (
   UPDATE template_build
   SET status = 'ready',

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -52,16 +52,17 @@ WHERE id = $1 AND team_id = $2 AND deleted_at IS NULL;
 SELECT base_path FROM template
 WHERE id = $1 AND deleted_at IS NULL;
 
--- name: ListLiveTemplateBuilds :many
--- Reconciler input: in-flight or ready builds. Their on-disk artifacts
--- must be preserved; in-flight may still be writing.
+-- name: ListInFlightBuilds :many
+-- Reconciler input: builds whose artifact dirs may still be actively
+-- written. Completed builds (status='ready') are pinned by
+-- template.base_path / sandbox.base_path instead.
 SELECT template_id, id AS build_id
 FROM template_build
-WHERE status IN ('pending', 'building', 'snapshotting', 'ready');
+WHERE status IN ('pending', 'building', 'snapshotting');
 
 -- name: ListAllTemplateBasePaths :many
--- Reconciler input: current base_path per template. Belt-and-suspenders
--- with ListLiveTemplateBuilds in case a row flipped between queries.
+-- Reconciler input: authoritative pointer to each template's current build.
+-- FinalizeBuild updates this atomically with the status flip to 'ready'.
 SELECT id, base_path FROM template
 WHERE deleted_at IS NULL AND base_path IS NOT NULL;
 

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -682,8 +682,8 @@ type ListAllTemplateBasePathsRow struct {
 	BasePath *string   `json:"base_path"`
 }
 
-// Reconciler input: current base_path per template. Belt-and-suspenders
-// with ListLiveTemplateBuilds in case a row flipped between queries.
+// Reconciler input: authoritative pointer to each template's current build.
+// FinalizeBuild updates this atomically with the status flip to 'ready'.
 func (q *Queries) ListAllTemplateBasePaths(ctx context.Context) ([]ListAllTemplateBasePathsRow, error) {
 	rows, err := q.db.Query(ctx, listAllTemplateBasePaths)
 	if err != nil {
@@ -751,28 +751,29 @@ func (q *Queries) ListBuildsForTemplate(ctx context.Context, arg ListBuildsForTe
 	return items, nil
 }
 
-const listLiveTemplateBuilds = `-- name: ListLiveTemplateBuilds :many
+const listInFlightBuilds = `-- name: ListInFlightBuilds :many
 SELECT template_id, id AS build_id
 FROM template_build
-WHERE status IN ('pending', 'building', 'snapshotting', 'ready')
+WHERE status IN ('pending', 'building', 'snapshotting')
 `
 
-type ListLiveTemplateBuildsRow struct {
+type ListInFlightBuildsRow struct {
 	TemplateID uuid.UUID `json:"template_id"`
 	BuildID    uuid.UUID `json:"build_id"`
 }
 
-// Reconciler input: in-flight or ready builds. Their on-disk artifacts
-// must be preserved; in-flight may still be writing.
-func (q *Queries) ListLiveTemplateBuilds(ctx context.Context) ([]ListLiveTemplateBuildsRow, error) {
-	rows, err := q.db.Query(ctx, listLiveTemplateBuilds)
+// Reconciler input: builds whose artifact dirs may still be actively
+// written. Completed builds (status='ready') are pinned by
+// template.base_path / sandbox.base_path instead.
+func (q *Queries) ListInFlightBuilds(ctx context.Context) ([]ListInFlightBuildsRow, error) {
+	rows, err := q.db.Query(ctx, listInFlightBuilds)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListLiveTemplateBuildsRow{}
+	items := []ListInFlightBuildsRow{}
 	for rows.Next() {
-		var i ListLiveTemplateBuildsRow
+		var i ListInFlightBuildsRow
 		if err := rows.Scan(&i.TemplateID, &i.BuildID); err != nil {
 			return nil, err
 		}

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -384,6 +384,9 @@ type FinalizeBuildParams struct {
 // the snapshot paths populated. Mirrors the FinalizePause CTE pattern in
 // sandboxes.sql: one roundtrip, no torn states. Returns the template row
 // so the caller can log the outcome.
+//
+// INVARIANT: status='ready' and template.base_path must become visible
+// together — the reconciler GCs build dirs not referenced by base_path.
 func (q *Queries) FinalizeBuild(ctx context.Context, arg FinalizeBuildParams) (Template, error) {
 	row := q.db.QueryRow(ctx, finalizeBuild,
 		arg.ID,

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -522,6 +522,10 @@ func (s *BuildSupervisor) reconcileLoop(ctx context.Context) {
 	}
 }
 
+// maxDeletesPerReconcile bounds per-tick deletion I/O so a backlog of
+// orphans is spread across ticks; the remainder is picked up next tick.
+const maxDeletesPerReconcile = 50
+
 // reconcileOrphanBuilds diffs vmd's disk against the DB live set; the
 // snapshot-time guard prevents racing with builds started mid-run.
 func (s *BuildSupervisor) reconcileOrphanBuilds(ctx context.Context) {
@@ -544,26 +548,43 @@ func (s *BuildSupervisor) reconcileOrphanBuilds(ctx context.Context) {
 	}
 
 	toDelete := reconcileDecision(onDisk, live, snapshotTime)
+	attempted := 0
 	deleted := 0
 	for _, e := range toDelete {
+		if attempted >= maxDeletesPerReconcile {
+			break
+		}
+		attempted++
 		if err := vmd.DeleteBuildArtifacts(ctx, e.TemplateID, e.BuildID); err != nil {
 			s.log.Warn().Err(err).Str("template_id", e.TemplateID).Str("build_id", e.BuildID).Msg("reconcile: DeleteBuildArtifacts")
 			continue
 		}
+		s.log.Info().
+			Str("template_id", e.TemplateID).
+			Str("build_id", e.BuildID).
+			Time("mtime", time.Unix(e.MTimeUnix, 0)).
+			Msg("reconcile: gc orphan build dir")
 		deleted++
 	}
-	s.log.Debug().Int("on_disk", len(onDisk)).Int("live", len(live)).Int("deleted", deleted).Msg("orphan reconcile complete")
+	s.log.Info().
+		Int("on_disk", len(onDisk)).
+		Int("live", len(live)).
+		Int("attempted", attempted).
+		Int("deleted", deleted).
+		Int("deferred", len(toDelete)-attempted).
+		Msg("orphan reconcile complete")
 }
 
-// collectLiveBuildKeys returns "<templateID>/<buildID>" keys for every
-// build that must be preserved: in-flight, ready, or pinned by a sandbox
-// or template.base_path.
+// collectLiveBuildKeys returns "<templateID>/<buildID>" keys for build
+// dirs that must be preserved: in-flight + each template's current
+// base_path + sandbox pins to prior builds. status='ready' is not a
+// signal here — see ListInFlightBuilds.
 func (s *BuildSupervisor) collectLiveBuildKeys(ctx context.Context) (map[string]struct{}, error) {
 	live := map[string]struct{}{}
 
-	builds, err := s.q.ListLiveTemplateBuilds(ctx)
+	builds, err := s.q.ListInFlightBuilds(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("ListLiveTemplateBuilds: %w", err)
+		return nil, fmt.Errorf("ListInFlightBuilds: %w", err)
 	}
 	for _, b := range builds {
 		// On-disk subdir name is "build-<template_build_uuid>" (set by the

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -65,6 +65,10 @@ type BuildSupervisorConfig struct {
 	// ReconcileInterval is the period for the orphan-builds reconciler.
 	// 0 disables it (used by tests).
 	ReconcileInterval time.Duration
+
+	// MaxDeletesPerReconcile bounds per-tick deletion I/O; the remainder
+	// is picked up next tick. 0 means unbounded (used by tests).
+	MaxDeletesPerReconcile int
 }
 
 // DefaultBuildSupervisorConfig returns sensible defaults.
@@ -78,6 +82,7 @@ func DefaultBuildSupervisorConfig(hostID string) BuildSupervisorConfig {
 		BuildTimeout:              30 * time.Minute,
 		ReapBatchSize:             20,
 		ReconcileInterval:         5 * time.Minute,
+		MaxDeletesPerReconcile:    50,
 	}
 }
 
@@ -522,10 +527,6 @@ func (s *BuildSupervisor) reconcileLoop(ctx context.Context) {
 	}
 }
 
-// maxDeletesPerReconcile bounds per-tick deletion I/O so a backlog of
-// orphans is spread across ticks; the remainder is picked up next tick.
-const maxDeletesPerReconcile = 50
-
 // reconcileOrphanBuilds diffs vmd's disk against the DB live set; the
 // snapshot-time guard prevents racing with builds started mid-run.
 func (s *BuildSupervisor) reconcileOrphanBuilds(ctx context.Context) {
@@ -548,24 +549,7 @@ func (s *BuildSupervisor) reconcileOrphanBuilds(ctx context.Context) {
 	}
 
 	toDelete := reconcileDecision(onDisk, live, snapshotTime)
-	attempted := 0
-	deleted := 0
-	for _, e := range toDelete {
-		if attempted >= maxDeletesPerReconcile {
-			break
-		}
-		attempted++
-		if err := vmd.DeleteBuildArtifacts(ctx, e.TemplateID, e.BuildID); err != nil {
-			s.log.Warn().Err(err).Str("template_id", e.TemplateID).Str("build_id", e.BuildID).Msg("reconcile: DeleteBuildArtifacts")
-			continue
-		}
-		s.log.Info().
-			Str("template_id", e.TemplateID).
-			Str("build_id", e.BuildID).
-			Time("mtime", time.Unix(e.MTimeUnix, 0)).
-			Msg("reconcile: gc orphan build dir")
-		deleted++
-	}
+	attempted, deleted := applyDeletions(ctx, s.log, vmd, toDelete, s.cfg.MaxDeletesPerReconcile)
 	s.log.Info().
 		Int("on_disk", len(onDisk)).
 		Int("live", len(live)).
@@ -573,6 +557,33 @@ func (s *BuildSupervisor) reconcileOrphanBuilds(ctx context.Context) {
 		Int("deleted", deleted).
 		Int("deferred", len(toDelete)-attempted).
 		Msg("orphan reconcile complete")
+}
+
+// buildArtifactDeleter is the subset of vmdclient.Client applyDeletions needs.
+type buildArtifactDeleter interface {
+	DeleteBuildArtifacts(ctx context.Context, templateID, buildID string) error
+}
+
+// applyDeletions issues delete calls up to budget (0 == unbounded).
+// Failed deletes consume budget so a stuck dir can't dominate throughput.
+func applyDeletions(ctx context.Context, log zerolog.Logger, vmd buildArtifactDeleter, toDelete []vmdclient.BuildArtifactEntry, budget int) (attempted, deleted int) {
+	for _, e := range toDelete {
+		if budget > 0 && attempted >= budget {
+			break
+		}
+		attempted++
+		if err := vmd.DeleteBuildArtifacts(ctx, e.TemplateID, e.BuildID); err != nil {
+			log.Warn().Err(err).Str("template_id", e.TemplateID).Str("build_id", e.BuildID).Msg("reconcile: DeleteBuildArtifacts")
+			continue
+		}
+		log.Debug().
+			Str("template_id", e.TemplateID).
+			Str("build_id", e.BuildID).
+			Time("mtime", time.Unix(e.MTimeUnix, 0)).
+			Msg("reconcile: gc orphan build dir")
+		deleted++
+	}
+	return attempted, deleted
 }
 
 // collectLiveBuildKeys returns "<templateID>/<buildID>" keys for build

--- a/internal/supervisor/build_supervisor_test.go
+++ b/internal/supervisor/build_supervisor_test.go
@@ -56,6 +56,16 @@ func TestReconcileDecision(t *testing.T) {
 			live:      []string{tplA + "/" + bldX},
 			wantDelta: []string{tplA + "/" + bldY},
 		},
+		{
+			name: "superseded ready build reclaimed",
+			onDisk: []vmdclient.BuildArtifactEntry{
+				{TemplateID: tplA, BuildID: bldX, MTimeUnix: old}, // current
+				{TemplateID: tplA, BuildID: bldY, MTimeUnix: old}, // superseded
+				{TemplateID: tplA, BuildID: bldZ, MTimeUnix: old}, // older
+			},
+			live:      []string{tplA + "/" + bldX},
+			wantDelta: []string{tplA + "/" + bldY, tplA + "/" + bldZ},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/supervisor/build_supervisor_test.go
+++ b/internal/supervisor/build_supervisor_test.go
@@ -1,8 +1,14 @@
 package supervisor
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
@@ -86,6 +92,73 @@ func TestReconcileDecision(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeDeleter struct {
+	calls  []string
+	failOn map[string]bool
+}
+
+func (f *fakeDeleter) DeleteBuildArtifacts(_ context.Context, tplID, buildID string) error {
+	key := tplID + "/" + buildID
+	f.calls = append(f.calls, key)
+	if f.failOn[key] {
+		return errors.New("simulated")
+	}
+	return nil
+}
+
+func TestApplyDeletions(t *testing.T) {
+	mkEntries := func(n int) []vmdclient.BuildArtifactEntry {
+		out := make([]vmdclient.BuildArtifactEntry, n)
+		for i := range out {
+			out[i] = vmdclient.BuildArtifactEntry{
+				TemplateID: "tpl",
+				BuildID:    fmt.Sprintf("build-%03d", i),
+			}
+		}
+		return out
+	}
+	log := zerolog.New(io.Discard)
+
+	t.Run("caps at budget", func(t *testing.T) {
+		f := &fakeDeleter{}
+		attempted, deleted := applyDeletions(context.Background(), log, f, mkEntries(60), 50)
+		if attempted != 50 || deleted != 50 || len(f.calls) != 50 {
+			t.Errorf("attempted=%d deleted=%d calls=%d, want 50/50/50", attempted, deleted, len(f.calls))
+		}
+	})
+
+	t.Run("under budget processes all", func(t *testing.T) {
+		f := &fakeDeleter{}
+		attempted, deleted := applyDeletions(context.Background(), log, f, mkEntries(7), 50)
+		if attempted != 7 || deleted != 7 {
+			t.Errorf("attempted=%d deleted=%d, want 7/7", attempted, deleted)
+		}
+	})
+
+	t.Run("zero budget is unbounded", func(t *testing.T) {
+		f := &fakeDeleter{}
+		attempted, deleted := applyDeletions(context.Background(), log, f, mkEntries(120), 0)
+		if attempted != 120 || deleted != 120 {
+			t.Errorf("attempted=%d deleted=%d, want 120/120", attempted, deleted)
+		}
+	})
+
+	t.Run("failures count against budget", func(t *testing.T) {
+		f := &fakeDeleter{failOn: map[string]bool{
+			"tpl/build-000": true,
+			"tpl/build-001": true,
+			"tpl/build-002": true,
+		}}
+		attempted, deleted := applyDeletions(context.Background(), log, f, mkEntries(60), 50)
+		if attempted != 50 {
+			t.Errorf("attempted=%d, want 50 (failures still consume budget)", attempted)
+		}
+		if deleted != 47 {
+			t.Errorf("deleted=%d, want 47", deleted)
+		}
+	})
 }
 
 func TestBuildKeyFromPath(t *testing.T) {


### PR DESCRIPTION
The reconciler's live set included every `template_build` row at `status='ready'`, so every historical successful build pinned its on-disk dir forever. Each template rebuild left another dir behind that the GC could never reclaim.

Narrow `ListInFlightBuilds` (renamed from `ListLiveTemplateBuilds`) to in-flight statuses only. Liveness for completed builds comes from `template.base_path` (current) and `sandbox.base_path` (sandbox pins to prior builds), which the reconciler already collects.

Also adds a per-tick deletion budget (50) so the first reconcile after deploy doesn't spike I/O when clearing a long-accumulated backlog, plus INFO logs per GC'd dir for forensics.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->