### PR TITLE
vmd: raise default network slot pool to 128 (was 32)

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -30,6 +30,22 @@ import (
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
+// vmdRetryServiceConfig retries vmd RPCs on UNAVAILABLE. Retry only
+// fires before the server sends a response, so create RPCs can't
+// double-execute.
+const vmdRetryServiceConfig = `{
+  "methodConfig": [{
+    "name": [{"service": "superserve.vmd.v1.VMDaemon"}],
+    "retryPolicy": {
+      "maxAttempts": 5,
+      "initialBackoff": "0.2s",
+      "maxBackoff": "2s",
+      "backoffMultiplier": 2.0,
+      "retryableStatusCodes": ["UNAVAILABLE"]
+    }
+  }]
+}`
+
 func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
@@ -68,6 +84,7 @@ func run() error {
 	// Connect to VMD via gRPC.
 	grpcConn, err := grpc.NewClient(cfg.VMDAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(vmdRetryServiceConfig),
 	)
 	if err != nil {
 		return fmt.Errorf("dial VMD gRPC: %w", err)
@@ -88,6 +105,7 @@ func run() error {
 	dialVMD := func(addr string, onDead func()) (vmdclient.Client, error) {
 		conn, err := grpc.NewClient(addr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithDefaultServiceConfig(vmdRetryServiceConfig),
 			grpc.WithUnaryInterceptor(deadHostUnaryInterceptor(onDead)),
 			grpc.WithStreamInterceptor(deadHostStreamInterceptor(onDead)),
 		)

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -30,9 +30,9 @@ import (
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
-// vmdRetryServiceConfig retries vmd RPCs on UNAVAILABLE. Retry only
-// fires before the server sends a response, so create RPCs can't
-// double-execute.
+// vmdRetryServiceConfig retries on UNAVAILABLE only — gRPC guarantees
+// such requests never reached the server, so create RPCs can't
+// double-execute. Other codes lack this guarantee.
 const vmdRetryServiceConfig = `{
   "methodConfig": [{
     "name": [{"service": "superserve.vmd.v1.VMDaemon"}],
@@ -103,6 +103,7 @@ func run() error {
 	// Interceptors below fire onDead on codes.Unavailable so the registry
 	// drops stale cached clients.
 	dialVMD := func(addr string, onDead func()) (vmdclient.Client, error) {
+		// Retry runs inside the invoker; the dead-host interceptor sees the post-retry outcome only.
 		conn, err := grpc.NewClient(addr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithDefaultServiceConfig(vmdRetryServiceConfig),

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -306,9 +306,12 @@ func main() {
 	}
 
 	// ---- Pre-allocate network slots ----
-	// Keeps a handful of ready-to-use network namespaces so sandbox creation
+	// Keeps a buffer of ready-to-use network namespaces so sandbox creation
 	// grabs one in microseconds instead of running ~11 shell commands.
-	netPool := netMgr.StartPool(ctx, network.PoolConfig{})
+	netPoolNew, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_NEW_SIZE", "128"))
+	netPool := netMgr.StartPool(ctx, network.PoolConfig{
+		NewSize: netPoolNew,
+	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 
 	// ---- Optional DB connection for the reconciler ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -307,7 +307,7 @@ func main() {
 
 	// ---- Pre-allocate network slots ----
 	// Keeps a buffer of ready-to-use network namespaces so sandbox creation
-	// grabs one in microseconds instead of running ~18 shell commands.
+	// claims one off the hot path instead of building it inline.
 	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "128"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
 		NewSize: netPoolFresh,

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -307,10 +307,10 @@ func main() {
 
 	// ---- Pre-allocate network slots ----
 	// Keeps a buffer of ready-to-use network namespaces so sandbox creation
-	// grabs one in microseconds instead of running ~11 shell commands.
-	netPoolNew, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_NEW_SIZE", "128"))
+	// grabs one in microseconds instead of running ~18 shell commands.
+	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "128"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
-		NewSize: netPoolNew,
+		NewSize: netPoolFresh,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -187,7 +187,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		if info := m.pool.Claim(vmID); info != nil {
 			return info, nil
 		}
-		m.log.Debug().Str("vm_id", vmID).Msg("network pool empty, falling back to on-demand setup")
+		m.log.Info().Str("vm_id", vmID).Msg("network pool empty, falling back to on-demand setup")
 	}
 
 	idx, err := m.claimSlotIndex()

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -182,7 +182,7 @@ func (m *Manager) SetProxyPorts(http, tls, other uint16) {
 // The host reaches the VM at hostIP:<port>. NAT inside the namespace
 // translates to 169.254.0.21:<port>. No guest IP reconfig needed.
 func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNetInfo, error) {
-	// Try the pre-allocated pool first (microseconds instead of ~10-30ms).
+	// Try the pre-allocated pool first; fall back to on-demand setup.
 	if m.pool != nil {
 		if info := m.pool.Claim(vmID); info != nil {
 			return info, nil

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -20,8 +20,8 @@ type PoolConfig struct {
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
-// firewall rules so that SetupVM can claim a ready slot in microseconds
-// instead of running ~11 shell commands on the hot path (~10-30ms).
+// firewall rules so that SetupVM can claim a ready slot off the hot path
+// instead of building one inline.
 //
 // The pool is optional — if not started, SetupVM falls back to on-demand
 // setup (the original behavior). Call StartPool after NewManager to enable.

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -66,15 +66,18 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	}
 
 	// Fill initial batch synchronously so the pool is warm on first create.
+	// Transient slot failures don't abort — the refill loop catches up.
+	filled := 0
 	for i := 0; i < newSize; i++ {
 		slot, err := p.allocate(ctx)
 		if err != nil {
-			p.log.Error().Err(err).Int("filled", i).Msg("initial pool fill incomplete")
-			break
+			p.log.Warn().Err(err).Int("attempt", i+1).Msg("initial pool slot failed; continuing")
+			continue
 		}
 		p.fresh <- slot
+		filled++
 	}
-	p.log.Info().Int("fresh", len(p.fresh)).Int("recycle_cap", recycleSize).Msg("network pool ready")
+	p.log.Info().Int("fresh", filled).Int("target", newSize).Int("recycle_cap", recycleSize).Msg("network pool ready")
 
 	p.wg.Add(1)
 	go p.refillLoop(ctx)


### PR DESCRIPTION
The pre-allocated network slot pool defaults to 32. Sandbox creation calls that find the pool empty fall back to on-demand `setupSlot`, which serializes on kernel mutexes (`net_ns_mutex`, nftables transaction lock). Under a 100-burst, 68 of 100 sandboxes hit the on-demand path and take 5-10s each just for network setup.

Raise the default to 128 to cover the expected burst with margin, and expose `VMD_NET_POOL_FRESH_SIZE` for ops tuning.

Also adds gRPC retry on UNAVAILABLE to the controlplane→vmd client so the wider boot window (sequential pool fill ~4s vs ~1s before) doesn't surface as spurious sandbox-create failures during deploys. Retry only fires on UNAVAILABLE (gRPC's "request never reached the server" guarantee), so create RPCs can't double-execute.

Init pool fill now continues past per-slot failures instead of aborting on the first one.