### PR TITLE
uffd: treat EAGAIN as transient, log mappings on out-of-range fault

### DIFF
--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -66,15 +66,16 @@ type Config struct {
 }
 
 type Stats struct {
-	FaultsServed     atomic.Uint64
-	BytesServed      atomic.Uint64
-	CopyErrors       atomic.Uint64
-	UnknownEvents    atomic.Uint64
-	RemoveEvents     atomic.Uint64
-	EagainRetries    atomic.Uint64
-	Eexist           atomic.Uint64
-	PrefetchedPages  atomic.Uint64
-	PrefetchSkipped  atomic.Uint64 // EEXIST during prefetch (page already faulted by guest)
+	FaultsServed       atomic.Uint64
+	BytesServed        atomic.Uint64
+	CopyErrors         atomic.Uint64
+	UnknownEvents      atomic.Uint64
+	RemoveEvents       atomic.Uint64
+	IoctlEagainRetries atomic.Uint64 // UFFDIO_COPY/ZEROPAGE returned EAGAIN; kernel will redeliver
+	ReadEagainRetries  atomic.Uint64 // serveLoop's read returned EAGAIN despite poll signalling readable
+	Eexist             atomic.Uint64
+	PrefetchedPages    atomic.Uint64
+	PrefetchSkipped    atomic.Uint64 // EEXIST during prefetch (page already faulted by guest)
 }
 
 // Handler binds a UDS, receives a userfaultfd fd from Firecracker, then
@@ -354,7 +355,7 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(h.cfg.FaultWorkers)
 
-	// Closing the UFFD fd is the only way to wake a blocking read on it,
+	// Closing the UFFD fd is the way to wake a blocking poll on it,
 	// so bridge context cancellation to a close here.
 	go func() {
 		<-gctx.Done()
@@ -362,6 +363,8 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 	}()
 
 	var msgBuf [32]byte
+	pollFds := []unix.PollFd{{Events: unix.POLLIN}}
+	const pollTimeoutMs = 100
 	for {
 		if err := gctx.Err(); err != nil {
 			return g.Wait()
@@ -369,6 +372,29 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 		fd := h.uffdFd.Load()
 		if fd == uffdClosed {
 			return g.Wait()
+		}
+		pollFds[0].Fd = int32(fd)
+		pollFds[0].Revents = 0
+		nReady, pollErr := unix.Poll(pollFds, pollTimeoutMs)
+		if pollErr != nil {
+			if errors.Is(pollErr, syscall.EINTR) {
+				continue
+			}
+			if errors.Is(pollErr, syscall.EBADF) {
+				return g.Wait()
+			}
+			return fmt.Errorf("poll uffd: %w", pollErr)
+		}
+		if nReady == 0 {
+			continue
+		}
+		revents := pollFds[0].Revents
+		if revents&(unix.POLLHUP|unix.POLLERR|unix.POLLNVAL) != 0 {
+			h.log.Debug().Int16("revents", revents).Msg("uffd serveLoop exiting on poll revents")
+			return g.Wait()
+		}
+		if revents&unix.POLLIN == 0 {
+			continue
 		}
 		n, err := h.readFn(int(fd), msgBuf[:])
 		if err != nil {
@@ -385,15 +411,10 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 				}
 				return g.Wait()
 			}
-			// EAGAIN: fd is non-blocking — back off briefly and retry.
-			// A real message, EBADF, or EINVAL will arrive soon.
+			// EAGAIN despite a positive poll(POLLIN) signal — should not
+			// happen, but loop back rather than crash the handler.
 			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
-				h.stats.EagainRetries.Add(1)
-				select {
-				case <-gctx.Done():
-					return g.Wait()
-				case <-time.After(time.Millisecond):
-				}
+				h.stats.ReadEagainRetries.Add(1)
 				continue
 			}
 			return fmt.Errorf("read uffd_msg: %w", err)
@@ -467,7 +488,7 @@ func (h *Handler) servePagefault(g *errgroup.Group, faultAddr, pageSize uint64) 
 			// all ioctls return EAGAIN until it's drained. The kernel
 			// re-fires the fault after we handle the REMOVE.
 			if errors.Is(copyErr, syscall.EAGAIN) {
-				h.stats.EagainRetries.Add(1)
+				h.stats.IoctlEagainRetries.Add(1)
 				return nil
 			}
 			h.stats.CopyErrors.Add(1)
@@ -499,7 +520,7 @@ func (h *Handler) handleRemove(start, end uint64) {
 		// EAGAIN: another REMOVE event is queued ahead of us — the next
 		// REMOVE will cover this range, so skipping the zero is correct.
 		if errors.Is(err, syscall.EAGAIN) {
-			h.stats.EagainRetries.Add(1)
+			h.stats.IoctlEagainRetries.Add(1)
 			return
 		}
 		h.log.Warn().Err(err).Uint64("start", start).Uint64("end", end).Msg("UFFDIO_ZEROPAGE failed")

--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -364,6 +364,8 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 
 	var msgBuf [32]byte
 	pollFds := []unix.PollFd{{Events: unix.POLLIN}}
+	// pollTimeoutMs caps cancellation latency. Tightening it doesn't help
+	// throughput — real events wake poll immediately.
 	const pollTimeoutMs = 100
 	for {
 		if err := gctx.Err(); err != nil {

--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -385,6 +385,17 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 				}
 				return g.Wait()
 			}
+			// EAGAIN: fd is non-blocking — back off briefly and retry.
+			// A real message, EBADF, or EINVAL will arrive soon.
+			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+				h.stats.EagainRetries.Add(1)
+				select {
+				case <-gctx.Done():
+					return g.Wait()
+				case <-time.After(time.Millisecond):
+				}
+				continue
+			}
 			return fmt.Errorf("read uffd_msg: %w", err)
 		}
 		if n == 0 {
@@ -418,7 +429,12 @@ func (h *Handler) servePagefault(g *errgroup.Group, faultAddr, pageSize uint64) 
 
 		region := h.findRegion(pageAddr)
 		if region == nil {
-			h.log.Error().Uint64("addr", faultAddr).Msg("page fault address outside all regions; killing handler")
+			h.log.Error().
+				Str("fault_addr", fmt.Sprintf("%#x", faultAddr)).
+				Str("page_addr", fmt.Sprintf("%#x", pageAddr)).
+				Uint64("page_size", pageSize).
+				Interface("mappings", h.mappings).
+				Msg("page fault address outside all regions; killing handler")
 			return fmt.Errorf("address %#x outside guest regions", faultAddr)
 		}
 

--- a/internal/vm/uffd/handler_test.go
+++ b/internal/vm/uffd/handler_test.go
@@ -247,7 +247,28 @@ func TestServeLoop_CtxCancelExitsPromptly(t *testing.T) {
 	if err := h.serveLoop(ctx); err != nil {
 		t.Errorf("serveLoop returned %v, want nil on cancel", err)
 	}
-	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
-		t.Errorf("serveLoop took %v to exit on cancel; want < 500ms", elapsed)
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Errorf("serveLoop took %v to exit on cancel; want < 250ms", elapsed)
+	}
+}
+
+// TestServeLoop_POLLHUPExitsCleanly verifies that POLLHUP from poll
+// (the write end of the fd was closed) makes serveLoop return nil.
+func TestServeLoop_POLLHUPExitsCleanly(t *testing.T) {
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	// Close write end so poll(rPipe) returns POLLHUP.
+	wPipe.Close()
+
+	h := New(Config{
+		FaultWorkers: 1,
+		Logger:       zerolog.Nop(),
+	})
+	h.uffdFd.Store(uintptr(rPipe.Fd()))
+
+	if err := h.serveLoop(context.Background()); err != nil {
+		t.Errorf("serveLoop returned %v, want nil on POLLHUP", err)
 	}
 }

--- a/internal/vm/uffd/handler_test.go
+++ b/internal/vm/uffd/handler_test.go
@@ -172,6 +172,11 @@ func TestServeLoop_EINVALReturnsCleanly(t *testing.T) {
 	}
 	defer wPipe.Close()
 
+	// Prime the pipe so poll signals readable; readFn returns EINVAL.
+	if _, err := wPipe.Write([]byte{0}); err != nil {
+		t.Fatalf("prime pipe: %v", err)
+	}
+
 	h := New(Config{
 		FaultWorkers: 1,
 		Logger:       zerolog.Nop(),
@@ -183,5 +188,66 @@ func TestServeLoop_EINVALReturnsCleanly(t *testing.T) {
 
 	if err := h.serveLoop(context.Background()); err != nil {
 		t.Errorf("serveLoop returned %v, want nil on EINVAL", err)
+	}
+}
+
+// TestServeLoop_EAGAINIncrementsCounterAndContinues verifies the EAGAIN
+// safety net in the read path: counter increments, loop continues.
+func TestServeLoop_EAGAINIncrementsCounterAndContinues(t *testing.T) {
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer wPipe.Close()
+	if _, err := wPipe.Write([]byte{0}); err != nil {
+		t.Fatalf("prime pipe: %v", err)
+	}
+
+	h := New(Config{
+		FaultWorkers: 1,
+		Logger:       zerolog.Nop(),
+	})
+	h.uffdFd.Store(uintptr(rPipe.Fd()))
+
+	var calls int
+	h.readFn = func(fd int, p []byte) (int, error) {
+		calls++
+		if calls == 1 {
+			return 0, syscall.EAGAIN
+		}
+		return 0, syscall.EINVAL
+	}
+
+	if err := h.serveLoop(context.Background()); err != nil {
+		t.Errorf("serveLoop returned %v, want nil", err)
+	}
+	if got := h.stats.ReadEagainRetries.Load(); got != 1 {
+		t.Errorf("ReadEagainRetries = %d, want 1", got)
+	}
+}
+
+// TestServeLoop_CtxCancelExitsPromptly verifies that gctx cancellation
+// makes serveLoop exit within the poll timeout, not after a real event.
+func TestServeLoop_CtxCancelExitsPromptly(t *testing.T) {
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer wPipe.Close()
+
+	h := New(Config{
+		FaultWorkers: 1,
+		Logger:       zerolog.Nop(),
+	})
+	h.uffdFd.Store(uintptr(rPipe.Fd()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if err := h.serveLoop(ctx); err != nil {
+		t.Errorf("serveLoop returned %v, want nil on cancel", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("serveLoop took %v to exit on cancel; want < 500ms", elapsed)
 	}
 }


### PR DESCRIPTION
Two UFFD handler reliability fixes observed during the burst benchmark.

**poll()-based serveLoop.** Firecracker creates the UFFD fd as non-blocking; vmd tries to clear `O_NONBLOCK` post-handshake but silently ignores fcntl errors. When the clear doesn't take effect, `unix.Read` returns EAGAIN, which the old serveLoop treated as fatal — the handler died, the guest hung on its next page fault. Switching to `poll(POLLIN, 100ms) → read` makes the read independent of the fd's blocking mode and gives a clean cancellation path via the 100ms timeout. EAGAIN remains as a defensive safety net (counter + continue).

**Diagnostics on out-of-range fault.** The "page fault address outside all regions" error currently logs only the fault address. Without knowing what mappings were loaded at handshake, we can't tell whether the kernel sent a fault outside the registered range, our `findRegion` math is wrong, or mappings are corrupted. Now logs the full mappings list, the page-aligned fault address, and the page size on this error path.

**Observability split.** `EagainRetries` is split into `IoctlEagainRetries` (UFFDIO_COPY/ZEROPAGE EAGAIN — benign kernel queue drain) and `ReadEagainRetries` (read-path EAGAIN despite positive poll — should be zero in normal operation).