### PR TITLE
uffd: log mappings + page-aligned addr on out-of-range fault

### DIFF
--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -418,7 +418,12 @@ func (h *Handler) servePagefault(g *errgroup.Group, faultAddr, pageSize uint64) 
 
 		region := h.findRegion(pageAddr)
 		if region == nil {
-			h.log.Error().Uint64("addr", faultAddr).Msg("page fault address outside all regions; killing handler")
+			h.log.Error().
+				Str("fault_addr", fmt.Sprintf("%#x", faultAddr)).
+				Str("page_addr", fmt.Sprintf("%#x", pageAddr)).
+				Uint64("page_size", pageSize).
+				Interface("mappings", h.mappings).
+				Msg("page fault address outside all regions; killing handler")
 			return fmt.Errorf("address %#x outside guest regions", faultAddr)
 		}
 


### PR DESCRIPTION
When a UFFD fault hits no registered region, log the mappings + page-aligned address so the next occurrence is diagnosable.

(Diagnostic-only piece of PR #67, separated from the poll() refactor reverted in #68.)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->