### PR TITLE
uffd: log mappings on handshake complete

### DIFF
--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -345,6 +345,7 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 		Int("regions", len(mappings)).
 		Uint64("page_size", pageSize).
 		Int("uffd_fd", uffdFd).
+		Interface("mappings", mappings).
 		Msg("uffd handshake complete")
 
 	return nil


### PR DESCRIPTION
Diagnostic. Lets us cross-correlate a failure's fault address against every live VM's registered range — needed to confirm/refute the fd-reuse hypothesis.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->