### PR TITLE
uffd: eliminate fd-reuse race via os.File + SyscallConn().Control()

### DIFF
--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -238,6 +238,23 @@ func (h *Handler) closeFd() {
 	}
 }
 
+// withFd runs fn with the UFFD fd held alive via SyscallConn().Control().
+// Returns false if the file is gone.
+func (h *Handler) withFd(fn func(fd uintptr)) bool {
+	f := h.file.Load()
+	if f == nil {
+		return false
+	}
+	sc, err := f.SyscallConn()
+	if err != nil {
+		return false
+	}
+	if err := sc.Control(fn); err != nil {
+		return false
+	}
+	return true
+}
+
 func (h *Handler) acceptAndReceive(ctx context.Context) error {
 	// SetDeadline is the only way to make AcceptUnix interruptible; the
 	// watchdog below sets it to the past on ctx cancel.
@@ -369,20 +386,11 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 		if err := gctx.Err(); err != nil {
 			return g.Wait()
 		}
-		f := h.file.Load()
-		if f == nil {
-			return g.Wait()
-		}
-		sc, err := f.SyscallConn()
-		if err != nil {
-			return g.Wait()
-		}
-
 		var n int
 		var readErr error
 		var pollErr error
 		var revents int16
-		ctrlErr := sc.Control(func(fd uintptr) {
+		if !h.withFd(func(fd uintptr) {
 			pollFds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
 			_, pollErr = unix.Poll(pollFds, pollTimeoutMs)
 			if pollErr != nil {
@@ -392,10 +400,7 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 			if revents&unix.POLLIN != 0 {
 				n, readErr = h.readFn(int(fd), msgBuf[:])
 			}
-		})
-		if ctrlErr != nil {
-			// File closed between Load and Control (or during Control's
-			// incref). Treat as clean exit.
+		}) {
 			return g.Wait()
 		}
 		if pollErr != nil {
@@ -482,19 +487,10 @@ func (h *Handler) servePagefault(g *errgroup.Group, faultAddr, pageSize uint64) 
 			return fmt.Errorf("source page lookup: %w", err)
 		}
 
-		f := h.file.Load()
-		if f == nil {
-			return nil
-		}
-		sc, err := f.SyscallConn()
-		if err != nil {
-			return nil
-		}
 		var copyErr error
-		ctrlErr := sc.Control(func(fd uintptr) {
+		if !h.withFd(func(fd uintptr) {
 			_, copyErr = ioctlCopy(fd, pageAddr, srcPtr, pageSize, 0)
-		})
-		if ctrlErr != nil {
+		}) {
 			return nil
 		}
 		if copyErr != nil {
@@ -528,19 +524,10 @@ func (h *Handler) handleRemove(start, end uint64) {
 		return
 	}
 	length := end - start
-	f := h.file.Load()
-	if f == nil {
-		return
-	}
-	sc, scErr := f.SyscallConn()
-	if scErr != nil {
-		return
-	}
 	var err error
-	ctrlErr := sc.Control(func(fd uintptr) {
+	if !h.withFd(func(fd uintptr) {
 		err = ioctlZeropage(fd, start, length)
-	})
-	if ctrlErr != nil {
+	}) {
 		return
 	}
 	if err != nil {

--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -24,9 +24,6 @@ import (
 // worker.
 const defaultFaultWorkers = 256
 
-// uffdClosed is the sentinel value of Handler.uffdFd before the fd is
-// received and after it has been closed.
-const uffdClosed = ^uintptr(0)
 
 // GuestRegionMapping is the JSON Firecracker sends over the UDS alongside
 // the userfaultfd fd. Field tags must match
@@ -87,11 +84,12 @@ type Handler struct {
 	source   *Source
 	listener *net.UnixListener
 
-	// fdMu (RLock per ioctl, Lock around close) prevents an ioctl from
-	// racing with close + kernel fd-reuse. uffdFd is atomic so the
-	// lock-free serveLoop read is sound under Go's memory model.
-	fdMu   sync.RWMutex
-	uffdFd atomic.Uintptr // uffdClosed when not held
+	// file owns the UFFD fd. All syscalls go through SyscallConn().Control(),
+	// which holds an internal refcount during the callback. file.Close()
+	// blocks until in-flight Control callbacks return, so the kernel-side
+	// fd cannot be reused by another open while any handler op is still
+	// touching it.
+	file atomic.Pointer[os.File]
 
 	mappings []GuestRegionMapping
 	pageSize uint64
@@ -118,7 +116,6 @@ func New(cfg Config) *Handler {
 		handshakeDone: make(chan error, 1),
 		readFn:        unix.Read,
 	}
-	h.uffdFd.Store(uffdClosed)
 	return h
 }
 
@@ -233,19 +230,12 @@ func (h *Handler) Close() error {
 	return firstErr
 }
 
-// closeFd closes the userfaultfd under the write lock so no in-flight
-// ioctl can be operating on the fd when the kernel frees the slot
-// (preventing fd-number reuse from redirecting a worker's ioctl to an
-// unrelated open). Idempotent.
+// closeFd drops the UFFD file. file.Close() blocks until in-flight
+// SyscallConn callbacks return. Idempotent via atomic swap.
 func (h *Handler) closeFd() {
-	h.fdMu.Lock()
-	defer h.fdMu.Unlock()
-	fd := h.uffdFd.Load()
-	if fd == uffdClosed {
-		return
+	if f := h.file.Swap(nil); f != nil {
+		_ = f.Close()
 	}
-	_ = unix.Close(int(fd))
-	h.uffdFd.Store(uffdClosed)
 }
 
 func (h *Handler) acceptAndReceive(ctx context.Context) error {
@@ -313,11 +303,8 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 		return errors.New("no UFFD fd received in SCM_RIGHTS")
 	}
 
-	// Firecracker creates UFFD with O_NONBLOCK; clear it so unix.Read
-	// blocks (cancellation closes the fd → EBADF wakes the read).
-	if flags, err := unix.FcntlInt(uintptr(uffdFd), unix.F_GETFL, 0); err == nil {
-		_, _ = unix.FcntlInt(uintptr(uffdFd), unix.F_SETFL, flags&^unix.O_NONBLOCK)
-	}
+	// Keep the fd non-blocking (firecracker's default). serveLoop drives
+	// readiness with poll() inside a SyscallConn callback.
 
 	var mappings []GuestRegionMapping
 	if err := json.Unmarshal(body[:n], &mappings); err != nil {
@@ -337,7 +324,12 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 		return fmt.Errorf("invalid page size in mappings: %+v", mappings[0])
 	}
 
-	h.uffdFd.Store(uintptr(uffdFd))
+	file := os.NewFile(uintptr(uffdFd), fmt.Sprintf("uffd-%d", uffdFd))
+	if file == nil {
+		_ = unix.Close(uffdFd)
+		return fmt.Errorf("os.NewFile returned nil for fd %d", uffdFd)
+	}
+	h.file.Store(file)
 	h.mappings = mappings
 	h.pageSize = pageSize
 
@@ -351,12 +343,18 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 	return nil
 }
 
+// pollTimeoutMs bounds how long each poll waits before the loop checks
+// ctx. It's the maximum cancellation latency for serveLoop; real events
+// wake poll immediately, so this knob doesn't affect throughput.
+const pollTimeoutMs = 100
+
 func (h *Handler) serveLoop(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(h.cfg.FaultWorkers)
 
-	// Closing the UFFD fd is the only way to wake a blocking read on it,
-	// so bridge context cancellation to a close here.
+	// Bridge context cancellation to closeFd. file.Close() blocks until
+	// in-flight Control callbacks return; the short poll timeout below
+	// caps that wait to pollTimeoutMs.
 	go func() {
 		<-gctx.Done()
 		h.closeFd()
@@ -367,29 +365,71 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 		if err := gctx.Err(); err != nil {
 			return g.Wait()
 		}
-		fd := h.uffdFd.Load()
-		if fd == uffdClosed {
+		f := h.file.Load()
+		if f == nil {
 			return g.Wait()
 		}
-		n, err := h.readFn(int(fd), msgBuf[:])
+		sc, err := f.SyscallConn()
 		if err != nil {
-			if errors.Is(err, syscall.EINTR) {
+			return g.Wait()
+		}
+
+		var n int
+		var readErr error
+		var pollErr error
+		var revents int16
+		ctrlErr := sc.Control(func(fd uintptr) {
+			pollFds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+			_, pollErr = unix.Poll(pollFds, pollTimeoutMs)
+			if pollErr != nil {
+				return
+			}
+			revents = pollFds[0].Revents
+			if revents&unix.POLLIN != 0 {
+				n, readErr = h.readFn(int(fd), msgBuf[:])
+			}
+		})
+		if ctrlErr != nil {
+			// File closed between Load and Control (or during Control's
+			// incref). Treat as clean exit.
+			return g.Wait()
+		}
+		if pollErr != nil {
+			if errors.Is(pollErr, syscall.EINTR) {
 				continue
 			}
-			// EBADF: cancellation goroutine closed the fd. EINVAL: kernel
-			// returned "invalid argument", typically because Firecracker
-			// exited and unmapped its VMAs before we drained the queue.
-			// Both mean "nothing more to read here" — exit cleanly.
-			if errors.Is(err, syscall.EBADF) || errors.Is(err, syscall.EINVAL) {
-				if errors.Is(err, syscall.EINVAL) {
+			return fmt.Errorf("poll uffd: %w", pollErr)
+		}
+		if revents&unix.POLLIN == 0 {
+			// POLLHUP/POLLNVAL or just a timeout — re-check ctx and the
+			// file pointer at the top of the loop. POLLERR doesn't exit
+			// here because UFFD can signal it transiently post-handshake.
+			if revents&(unix.POLLHUP|unix.POLLNVAL) != 0 {
+				return g.Wait()
+			}
+			continue
+		}
+		if readErr != nil {
+			if errors.Is(readErr, syscall.EINTR) {
+				continue
+			}
+			// EBADF means the fd is gone; EINVAL means firecracker
+			// unmapped its VMAs. Either is a clean exit.
+			if errors.Is(readErr, syscall.EBADF) || errors.Is(readErr, syscall.EINVAL) {
+				if errors.Is(readErr, syscall.EINVAL) {
 					h.log.Debug().Msg("uffd serveLoop exiting cleanly on EINVAL — firecracker likely unmapped VMAs")
 				}
 				return g.Wait()
 			}
-			return fmt.Errorf("read uffd_msg: %w", err)
+			// EAGAIN despite POLLIN — defensive, retry.
+			if errors.Is(readErr, syscall.EAGAIN) || errors.Is(readErr, syscall.EWOULDBLOCK) {
+				h.stats.EagainRetries.Add(1)
+				continue
+			}
+			return fmt.Errorf("read uffd_msg: %w", readErr)
 		}
 		if n == 0 {
-			return g.Wait() // Firecracker exited.
+			return g.Wait()
 		}
 		if n < int(unsafe.Sizeof(uffdMsg{})) {
 			h.log.Warn().Int("bytes", n).Msg("short uffd_msg read; skipping")
@@ -438,14 +478,21 @@ func (h *Handler) servePagefault(g *errgroup.Group, faultAddr, pageSize uint64) 
 			return fmt.Errorf("source page lookup: %w", err)
 		}
 
-		h.fdMu.RLock()
-		fd := h.uffdFd.Load()
-		if fd == uffdClosed {
-			h.fdMu.RUnlock()
+		f := h.file.Load()
+		if f == nil {
 			return nil
 		}
-		_, copyErr := ioctlCopy(fd, pageAddr, srcPtr, pageSize, 0)
-		h.fdMu.RUnlock()
+		sc, err := f.SyscallConn()
+		if err != nil {
+			return nil
+		}
+		var copyErr error
+		ctrlErr := sc.Control(func(fd uintptr) {
+			_, copyErr = ioctlCopy(fd, pageAddr, srcPtr, pageSize, 0)
+		})
+		if ctrlErr != nil {
+			return nil
+		}
 		if copyErr != nil {
 			// EEXIST: another fault on the same page raced ahead of us;
 			// it's already mapped. Benign.
@@ -477,14 +524,21 @@ func (h *Handler) handleRemove(start, end uint64) {
 		return
 	}
 	length := end - start
-	h.fdMu.RLock()
-	fd := h.uffdFd.Load()
-	if fd == uffdClosed {
-		h.fdMu.RUnlock()
+	f := h.file.Load()
+	if f == nil {
 		return
 	}
-	err := ioctlZeropage(fd, start, length)
-	h.fdMu.RUnlock()
+	sc, scErr := f.SyscallConn()
+	if scErr != nil {
+		return
+	}
+	var err error
+	ctrlErr := sc.Control(func(fd uintptr) {
+		err = ioctlZeropage(fd, start, length)
+	})
+	if ctrlErr != nil {
+		return
+	}
 	if err != nil {
 		// EAGAIN: another REMOVE event is queued ahead of us — the next
 		// REMOVE will cover this range, so skipping the zero is correct.

--- a/internal/vm/uffd/handler.go
+++ b/internal/vm/uffd/handler.go
@@ -329,7 +329,10 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 		_ = unix.Close(uffdFd)
 		return fmt.Errorf("os.NewFile returned nil for fd %d", uffdFd)
 	}
-	h.file.Store(file)
+	// Defensive: if a prior file is somehow still installed, close it.
+	if old := h.file.Swap(file); old != nil {
+		_ = old.Close()
+	}
 	h.mappings = mappings
 	h.pageSize = pageSize
 
@@ -344,8 +347,9 @@ func (h *Handler) acceptAndReceive(ctx context.Context) error {
 }
 
 // pollTimeoutMs bounds how long each poll waits before the loop checks
-// ctx. It's the maximum cancellation latency for serveLoop; real events
-// wake poll immediately, so this knob doesn't affect throughput.
+// ctx, and also bounds how long closeFd may block on the in-flight
+// Control callback. Real events wake poll immediately, so this knob
+// doesn't affect throughput.
 const pollTimeoutMs = 100
 
 func (h *Handler) serveLoop(ctx context.Context) error {
@@ -401,11 +405,11 @@ func (h *Handler) serveLoop(ctx context.Context) error {
 			return fmt.Errorf("poll uffd: %w", pollErr)
 		}
 		if revents&unix.POLLIN == 0 {
-			// POLLHUP/POLLNVAL or just a timeout — re-check ctx and the
-			// file pointer at the top of the loop. POLLERR doesn't exit
-			// here because UFFD can signal it transiently post-handshake.
 			if revents&(unix.POLLHUP|unix.POLLNVAL) != 0 {
 				return g.Wait()
+			}
+			if revents&unix.POLLERR != 0 {
+				h.log.Debug().Int16("revents", revents).Msg("uffd poll returned POLLERR without POLLIN")
 			}
 			continue
 		}

--- a/internal/vm/uffd/handler_test.go
+++ b/internal/vm/uffd/handler_test.go
@@ -164,8 +164,33 @@ func TestHandler_WaitHandshake_CtxCancel(t *testing.T) {
 // drain the queue) makes serveLoop return nil rather than propagate an
 // error to the caller.
 func TestServeLoop_EINVALReturnsCleanly(t *testing.T) {
-	// Pipe stand-in for the uffd fd — closeFd (triggered when serveLoop
-	// returns and cancels gctx) will close it, so it must be real.
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer wPipe.Close()
+	// Prime the pipe so poll signals readable; readFn returns EINVAL.
+	if _, err := wPipe.Write([]byte{0}); err != nil {
+		t.Fatalf("prime pipe: %v", err)
+	}
+
+	h := New(Config{
+		FaultWorkers: 1,
+		Logger:       zerolog.Nop(),
+	})
+	h.file.Store(rPipe)
+	h.readFn = func(fd int, p []byte) (int, error) {
+		return 0, syscall.EINVAL
+	}
+
+	if err := h.serveLoop(context.Background()); err != nil {
+		t.Errorf("serveLoop returned %v, want nil on EINVAL", err)
+	}
+}
+
+// TestServeLoop_CtxCancelExitsPromptly verifies cancellation latency is
+// bounded by the poll timeout (~pollTimeoutMs).
+func TestServeLoop_CtxCancelExitsPromptly(t *testing.T) {
 	rPipe, wPipe, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -176,12 +201,55 @@ func TestServeLoop_EINVALReturnsCleanly(t *testing.T) {
 		FaultWorkers: 1,
 		Logger:       zerolog.Nop(),
 	})
-	h.uffdFd.Store(uintptr(rPipe.Fd()))
-	h.readFn = func(fd int, p []byte) (int, error) {
-		return 0, syscall.EINVAL
-	}
+	h.file.Store(rPipe)
 
-	if err := h.serveLoop(context.Background()); err != nil {
-		t.Errorf("serveLoop returned %v, want nil on EINVAL", err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if err := h.serveLoop(ctx); err != nil {
+		t.Errorf("serveLoop returned %v, want nil on cancel", err)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("serveLoop took %v to exit on cancel; want < 500ms", elapsed)
+	}
+}
+
+// TestCloseFd_WaitsForInFlightControl verifies that closeFd blocks until
+// any in-flight SyscallConn().Control callback returns.
+func TestCloseFd_WaitsForInFlightControl(t *testing.T) {
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer wPipe.Close()
+
+	h := New(Config{Logger: zerolog.Nop()})
+	h.file.Store(rPipe)
+
+	// Hold a Control callback open for 200ms.
+	sc, err := rPipe.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		_ = sc.Control(func(_ uintptr) {
+			time.Sleep(200 * time.Millisecond)
+			close(released)
+		})
+	}()
+	time.Sleep(20 * time.Millisecond) // ensure Control is in flight
+
+	// closeFd must wait for the Control callback to finish.
+	start := time.Now()
+	h.closeFd()
+	elapsed := time.Since(start)
+	select {
+	case <-released:
+	default:
+		t.Errorf("closeFd returned before Control callback released")
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("closeFd took %v; expected to wait for in-flight Control (~200ms)", elapsed)
 	}
 }

--- a/internal/vm/uffd/handler_test.go
+++ b/internal/vm/uffd/handler_test.go
@@ -226,19 +226,20 @@ func TestCloseFd_WaitsForInFlightControl(t *testing.T) {
 	h := New(Config{Logger: zerolog.Nop()})
 	h.file.Store(rPipe)
 
-	// Hold a Control callback open for 200ms.
 	sc, err := rPipe.SyscallConn()
 	if err != nil {
 		t.Fatalf("SyscallConn: %v", err)
 	}
+	inFlight := make(chan struct{})
 	released := make(chan struct{})
 	go func() {
 		_ = sc.Control(func(_ uintptr) {
+			close(inFlight)
 			time.Sleep(200 * time.Millisecond)
 			close(released)
 		})
 	}()
-	time.Sleep(20 * time.Millisecond) // ensure Control is in flight
+	<-inFlight // proven in-flight, not assumed
 
 	// closeFd must wait for the Control callback to finish.
 	start := time.Now()
@@ -249,7 +250,7 @@ func TestCloseFd_WaitsForInFlightControl(t *testing.T) {
 	default:
 		t.Errorf("closeFd returned before Control callback released")
 	}
-	if elapsed < 150*time.Millisecond {
+	if elapsed < 100*time.Millisecond {
 		t.Errorf("closeFd took %v; expected to wait for in-flight Control (~200ms)", elapsed)
 	}
 }

--- a/internal/vm/uffd/prefetch.go
+++ b/internal/vm/uffd/prefetch.go
@@ -27,7 +27,7 @@ func (h *Handler) runPrefetch(ctx context.Context) {
 		h.log.Warn().Msg("prefetch: no page size, skipping")
 		return
 	}
-	if h.uffdFd.Load() == uffdClosed {
+	if h.file.Load() == nil {
 		return
 	}
 
@@ -65,14 +65,21 @@ func (h *Handler) prefetchOne(offset, pageSize uint64) (stop bool, err error) {
 		return false, perr
 	}
 
-	h.fdMu.RLock()
-	fd := h.uffdFd.Load()
-	if fd == uffdClosed {
-		h.fdMu.RUnlock()
+	f := h.file.Load()
+	if f == nil {
 		return true, nil
 	}
-	_, copyErr := ioctlCopy(fd, dst, srcPtr, pageSize, 0)
-	h.fdMu.RUnlock()
+	sc, err := f.SyscallConn()
+	if err != nil {
+		return true, nil
+	}
+	var copyErr error
+	ctrlErr := sc.Control(func(fd uintptr) {
+		_, copyErr = ioctlCopy(fd, dst, srcPtr, pageSize, 0)
+	})
+	if ctrlErr != nil {
+		return true, nil
+	}
 	if copyErr != nil {
 		if errors.Is(copyErr, syscall.EEXIST) {
 			h.stats.PrefetchSkipped.Add(1)

--- a/internal/vm/uffd/prefetch.go
+++ b/internal/vm/uffd/prefetch.go
@@ -65,19 +65,10 @@ func (h *Handler) prefetchOne(offset, pageSize uint64) (stop bool, err error) {
 		return false, perr
 	}
 
-	f := h.file.Load()
-	if f == nil {
-		return true, nil
-	}
-	sc, err := f.SyscallConn()
-	if err != nil {
-		return true, nil
-	}
 	var copyErr error
-	ctrlErr := sc.Control(func(fd uintptr) {
+	if !h.withFd(func(fd uintptr) {
 		_, copyErr = ioctlCopy(fd, dst, srcPtr, pageSize, 0)
-	})
-	if ctrlErr != nil {
+	}) {
 		return true, nil
 	}
 	if copyErr != nil {


### PR DESCRIPTION
Wraps the UFFD fd in os.File so close blocks until in-flight syscalls release the refcount. Eliminates the cross-VM event leakage we observed in prod (fault address matching another VM's mapping range when fd numbers got reused between handshake and read).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->