### PR TITLE
controlplane: instrument CreateSandbox phases, make DB pool size configurable

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -68,8 +69,18 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Connect to PostgreSQL.
-	dbPool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	// Connect to PostgreSQL. DB_MAX_CONNS overrides the pool size; unset
+	// uses the pgxpool default of max(4, NumCPU).
+	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("parse database url: %w", err)
+	}
+	if v := os.Getenv("DB_MAX_CONNS"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			poolCfg.MaxConns = int32(n)
+		}
+	}
+	dbPool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return fmt.Errorf("connect to database: %w", err)
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -953,6 +953,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 }
 
 func (h *Handlers) CreateSandbox(c *gin.Context) {
+	tStart := time.Now()
 	var req createSandboxRequest
 	if err := bindJSONStrict(c, &req); err != nil {
 		respondErrorMsg(c, "bad_request", "Request body is not valid JSON or contains unknown fields.", http.StatusBadRequest)
@@ -1038,8 +1039,10 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// authoritative shape.
 	var templateVcpu, templateMemMiB uint32
 	var fromTemplateName, fromTemplateID string
+	var tLookupDone time.Time
 	if req.FromTemplate != nil {
 		tpl, err := h.lookupTemplateForCreate(c, teamID, *req.FromTemplate)
+		tLookupDone = time.Now()
 		if err != nil {
 			return // error already responded
 		}
@@ -1151,9 +1154,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			DeltaPath:      nil,
 		})
 	}
+	var tInsertStart, tInsertEnd time.Time
 	go func() {
+		tInsertStart = time.Now()
 		// Quota is enforced by the sandbox_quota_on_insert trigger.
 		sb, err := runInsert(h.DB)
+		tInsertEnd = time.Now()
 		insertCh <- insertResult{sandbox: sb, err: err}
 	}()
 
@@ -1171,11 +1177,14 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// and boots a new VM from them statelessly. Caller env vars are merged
 	// on top of the template's baked defaults by vmd (boxd resumes with
 	// template context, then the restore RPC posts these on top).
+	tVmdStart := time.Now()
 	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, req.EnvVars)
+	tVmdEnd := time.Now()
 
 	// Wait for the parallel INSERT to complete — its result determines
 	// how we handle a VMD failure (mark row failed vs. nothing to mark).
 	insertRes := <-insertCh
+	tInsertReceive := time.Now()
 	sandbox := insertRes.sandbox
 	dbErr := insertRes.err
 
@@ -1323,6 +1332,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		}()
 	}
 	wg.Wait()
+	tPostDone := time.Now()
 
 	var createdMeta []byte
 	if fromTemplateName != "" {
@@ -1338,6 +1348,15 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
 		resp.Network = req.Network
 	}
+	log.Info().
+		Str("sandbox_id", sandbox.ID.String()).
+		Int64("lookup_ms", tLookupDone.Sub(tStart).Milliseconds()).
+		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
+		Int64("insert_ms", tInsertEnd.Sub(tInsertStart).Milliseconds()).
+		Int64("insert_wait_after_vmd_ms", tInsertReceive.Sub(tVmdEnd).Milliseconds()).
+		Int64("post_ms", tPostDone.Sub(tInsertReceive).Milliseconds()).
+		Int64("total_ms", tPostDone.Sub(tStart).Milliseconds()).
+		Msg("CreateSandbox phases")
 	c.JSON(http.StatusCreated, resp)
 }
 


### PR DESCRIPTION
Adds per-phase timing logs to CreateSandbox (lookup, vmd, insert, post) so we can see which step dominates the 2.4s burst latency. Also exposes DB_MAX_CONNS env var (default unchanged) for A/B testing pool-exhaustion as a candidate bottleneck.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->