### PR TITLE
network: instrument pool.Claim phases and hostFW.AddVM lock-wait

### DIFF
--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/rs/zerolog"
@@ -28,7 +29,8 @@ type hostFirewallAPI interface {
 // Rules persist in the kernel across vmd restarts — leaked rules from
 // prior lifetimes match dead veths and are harmless.
 type HostFirewall struct {
-	mu sync.Mutex
+	mu  sync.Mutex
+	log zerolog.Logger
 
 	ipt       *iptables.IPTables
 	hostIface string
@@ -63,6 +65,7 @@ func NewHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log z
 		httpProxyPort: httpProxyPort,
 		tlsProxyPort:  tlsProxyPort,
 		vmRules:       make(map[string][]vmRule),
+		log:           log,
 	}
 
 	// Static MSS clamp: applies to all forwarded TCP SYN packets going
@@ -83,8 +86,17 @@ func NewHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log z
 
 // AddVM adds FORWARD + MASQUERADE rules for a VM's veth interface.
 func (hfw *HostFirewall) AddVM(vmID, vethName, hostCIDR string) error {
+	tEntry := time.Now()
 	hfw.mu.Lock()
 	defer hfw.mu.Unlock()
+	tLockAcquired := time.Now()
+	defer func() {
+		hfw.log.Info().
+			Str("vm_id", vmID).
+			Int64("hfw_lock_wait_ms", tLockAcquired.Sub(tEntry).Milliseconds()).
+			Int64("hfw_apply_ms", time.Since(tLockAcquired).Milliseconds()).
+			Msg("hostFW: AddVM complete")
+	}()
 
 	rules := []vmRule{}
 	// Drop UDP/443 so QUIC can't bypass the TCP-only REDIRECT + SNI

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -94,6 +95,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 // Validates each slot's kernel netns is still present; phantoms are
 // discarded and their idx returned to the allocator via cleanup.
 func (p *Pool) Claim(vmID string) *VMNetInfo {
+	tEntry := time.Now()
 	for {
 		var slot *preallocSlot
 
@@ -108,6 +110,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 				return nil
 			}
 		}
+		tPopped := time.Now()
 
 		// Race: ns can vanish between this check and AddVM; fc startup catches it.
 		if !nsExists(slot.info.Namespace) {
@@ -119,6 +122,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			p.cleanup(slot)
 			continue
 		}
+		tNsChecked := time.Now()
 
 		// Add host-level firewall rules (requires vmID).
 		hostCIDR := slot.info.HostIP + "/32"
@@ -127,11 +131,21 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			p.cleanup(slot)
 			return nil
 		}
+		tHostFwDone := time.Now()
 
 		p.mgr.mu.Lock()
 		p.mgr.devices[vmID] = slot.info
 		p.mgr.mu.Unlock()
+		tDone := time.Now()
 
+		p.log.Info().
+			Str("vm_id", vmID).
+			Int64("claim_pop_ms", tPopped.Sub(tEntry).Milliseconds()).
+			Int64("claim_nscheck_ms", tNsChecked.Sub(tPopped).Milliseconds()).
+			Int64("claim_hostfw_ms", tHostFwDone.Sub(tNsChecked).Milliseconds()).
+			Int64("claim_devmap_ms", tDone.Sub(tHostFwDone).Milliseconds()).
+			Int64("claim_total_ms", tDone.Sub(tEntry).Milliseconds()).
+			Msg("pool: claim complete")
 		return slot.info
 	}
 }


### PR DESCRIPTION
Adds per-phase timing inside pool.Claim (pop, ns-check, hostFW, devmap) and splits hostFW.AddVM into lock-wait vs apply. Confirms whether the 2.3s p50 in SetupVM is in hostFW.AddVM's global mutex.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->