### PR TITLE
network: collapse hostFW to static prefix rules

### DIFF
--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"sync"
-	"time"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/rs/zerolog"
@@ -18,172 +16,80 @@ type hostFirewallAPI interface {
 	Close() error
 }
 
-// HostFirewall manages host-level iptables rules for VM internet access.
-// Appends per-VM rules to the kernel's built-in chains:
-//   - filter/FORWARD: allow traffic between each VM's veth and the host interface
-//   - nat/POSTROUTING: MASQUERADE outbound traffic from each VM's host IP
-//   - nat/PREROUTING: REDIRECT HTTP to the egress proxy for domain filtering
-//   - filter/FORWARD: MSS clamping on forwarded TCP SYN packets
-//
-// Uses coreos/go-iptables (append to built-in chains, no custom table).
-// Rules persist in the kernel across vmd restarts — leaked rules from
-// prior lifetimes match dead veths and are harmless.
-type HostFirewall struct {
-	mu  sync.Mutex
-	log zerolog.Logger
+// vmIPRange must match Manager's host-IP allocation scheme.
+const vmIPRange = "10.11.0.0/16"
 
-	ipt       *iptables.IPTables
-	hostIface string
+// HostFirewall installs static iptables rules covering all VMs via the
+// veth+ interface prefix and vmIPRange subnet: FORWARD ACCEPT, MSS clamp,
+// POSTROUTING MASQUERADE, PREROUTING REDIRECT to the egress proxy, and a
+// UDP/443 DROP so QUIC can't bypass the SNI allowlist. Idempotent.
+type HostFirewall struct{}
 
-	httpProxyPort uint16 // egress proxy HTTP inspection port
-	tlsProxyPort  uint16 // egress proxy TLS/SNI inspection port
-
-	// Per-VM rule specs for cleanup.
-	vmRules map[string][]vmRule
-}
-
-type vmRule struct {
-	table   string
-	chain   string
-	args    []string
-	prepend bool // insert at top of chain instead of appending
-}
-
-// NewHostFirewall initializes the host firewall. Adds a static MSS clamp
-// rule (idempotent via AppendUnique). Per-VM rules from prior lifetimes
-// remain in the kernel; ReattachAll re-invokes AddVM for each surviving
-// VM to repopulate the in-memory tracking map (AddVM is idempotent).
+// NewHostFirewall installs the rules. Idempotent.
 func NewHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) (*HostFirewall, error) {
 	ipt, err := iptables.New()
 	if err != nil {
 		return nil, fmt.Errorf("init iptables: %w", err)
 	}
+	if err := installRules(ipt, hostIface, httpProxyPort, tlsProxyPort); err != nil {
+		return nil, err
+	}
+	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (static prefix rules)")
+	return &HostFirewall{}, nil
+}
 
-	hfw := &HostFirewall{
-		ipt:           ipt,
-		hostIface:     hostIface,
-		httpProxyPort: httpProxyPort,
-		tlsProxyPort:  tlsProxyPort,
-		vmRules:       make(map[string][]vmRule),
-		log:           log,
+func installRules(ipt *iptables.IPTables, hostIface string, httpProxyPort, tlsProxyPort uint16) error {
+	// UDP/443 DROP at position 1 so QUIC is dropped before the broad
+	// veth+ ACCEPT below terminates the chain walk.
+	udpDrop := []string{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"}
+	exists, err := ipt.Exists("filter", "FORWARD", udpDrop...)
+	if err != nil {
+		return fmt.Errorf("check veth+ UDP/443 DROP: %w", err)
+	}
+	if !exists {
+		if err := ipt.Insert("filter", "FORWARD", 1, udpDrop...); err != nil {
+			return fmt.Errorf("insert veth+ UDP/443 DROP: %w", err)
+		}
 	}
 
-	// Static MSS clamp: applies to all forwarded TCP SYN packets going
-	// out via the host interface. Idempotent — AppendUnique is a no-op
-	// if the rule already exists from a prior vmd lifetime.
-	mssArgs := []string{
+	if err := ipt.AppendUnique("filter", "FORWARD",
 		"-o", hostIface,
 		"-p", "tcp", "--tcp-flags", "SYN,RST", "SYN",
 		"-j", "TCPMSS", "--clamp-mss-to-pmtu",
-	}
-	if err := ipt.AppendUnique("filter", "FORWARD", mssArgs...); err != nil {
-		return nil, fmt.Errorf("add MSS clamp rule: %w", err)
-	}
-
-	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (iptables)")
-	return hfw, nil
-}
-
-// AddVM adds FORWARD + MASQUERADE rules for a VM's veth interface.
-func (hfw *HostFirewall) AddVM(vmID, vethName, hostCIDR string) error {
-	tEntry := time.Now()
-	hfw.mu.Lock()
-	defer hfw.mu.Unlock()
-	tLockAcquired := time.Now()
-	defer func() {
-		hfw.log.Info().
-			Str("vm_id", vmID).
-			Int64("hfw_lock_wait_ms", tLockAcquired.Sub(tEntry).Milliseconds()).
-			Int64("hfw_apply_ms", time.Since(tLockAcquired).Milliseconds()).
-			Msg("hostFW: AddVM complete")
-	}()
-
-	rules := []vmRule{}
-	// Drop UDP/443 so QUIC can't bypass the TCP-only REDIRECT + SNI
-	// allowlist. Must be inserted above the per-veth ACCEPT below.
-	if hfw.tlsProxyPort > 0 {
-		rules = append(rules, vmRule{
-			table: "filter", chain: "FORWARD",
-			args:    []string{"-i", vethName, "-p", "udp", "--dport", "443", "-j", "DROP"},
-			prepend: true,
-		})
-	}
-	rules = append(rules,
-		// FORWARD: veth → host interface (outbound)
-		vmRule{table: "filter", chain: "FORWARD", args: []string{"-i", vethName, "-o", hfw.hostIface, "-j", "ACCEPT"}},
-		// FORWARD: host interface → veth (inbound/response)
-		vmRule{table: "filter", chain: "FORWARD", args: []string{"-i", hfw.hostIface, "-o", vethName, "-j", "ACCEPT"}},
-		// POSTROUTING: MASQUERADE outbound from this VM's host IP
-		vmRule{table: "nat", chain: "POSTROUTING", args: []string{"-s", hostCIDR, "-o", hfw.hostIface, "-j", "MASQUERADE"}},
-	)
-	if hfw.httpProxyPort > 0 {
-		rules = append(rules, vmRule{
-			table: "nat", chain: "PREROUTING",
-			args: []string{"-i", vethName, "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", hfw.httpProxyPort)},
-		})
-	}
-	if hfw.tlsProxyPort > 0 {
-		rules = append(rules, vmRule{
-			table: "nat", chain: "PREROUTING",
-			args: []string{"-i", vethName, "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", hfw.tlsProxyPort)},
-		})
+	); err != nil {
+		return fmt.Errorf("add MSS clamp: %w", err)
 	}
 
+	type rule struct {
+		table, chain string
+		args         []string
+	}
+	rules := []rule{
+		{"filter", "FORWARD", []string{"-i", "veth+", "-o", hostIface, "-j", "ACCEPT"}},
+		{"filter", "FORWARD", []string{"-i", hostIface, "-o", "veth+", "-j", "ACCEPT"}},
+		{"nat", "POSTROUTING", []string{"-s", vmIPRange, "-o", hostIface, "-j", "MASQUERADE"}},
+	}
+	if httpProxyPort > 0 {
+		rules = append(rules, rule{"nat", "PREROUTING",
+			[]string{"-i", "veth+", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", httpProxyPort)}})
+	}
+	if tlsProxyPort > 0 {
+		rules = append(rules, rule{"nat", "PREROUTING",
+			[]string{"-i", "veth+", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", tlsProxyPort)}})
+	}
 	for _, r := range rules {
-		if r.prepend {
-			// Exists-check keeps Insert idempotent across vmd restarts.
-			exists, err := hfw.ipt.Exists(r.table, r.chain, r.args...)
-			if err != nil {
-				return fmt.Errorf("check %s/%s rule for %s: %w", r.table, r.chain, vmID, err)
-			}
-			if !exists {
-				if err := hfw.ipt.Insert(r.table, r.chain, 1, r.args...); err != nil {
-					return fmt.Errorf("insert %s/%s rule for %s: %w", r.table, r.chain, vmID, err)
-				}
-			}
-			continue
-		}
-		if err := hfw.ipt.AppendUnique(r.table, r.chain, r.args...); err != nil {
-			return fmt.Errorf("add %s/%s rule for %s: %w", r.table, r.chain, vmID, err)
+		if err := ipt.AppendUnique(r.table, r.chain, r.args...); err != nil {
+			return fmt.Errorf("add %s/%s rule: %w", r.table, r.chain, err)
 		}
 	}
-
-	hfw.vmRules[vmID] = rules
 	return nil
 }
 
-// RemoveVM removes all host-level rules for a VM. Errors are logged
-// but don't prevent cleanup of remaining rules — a leaked iptables
-// rule is harmless (matches a veth/IP that no longer exists).
-func (hfw *HostFirewall) RemoveVM(vmID string) error {
-	hfw.mu.Lock()
-	defer hfw.mu.Unlock()
+// Per-VM hooks are no-ops — the static rules above cover every veth.
 
-	rules, ok := hfw.vmRules[vmID]
-	if !ok {
-		return nil
-	}
-
-	var firstErr error
-	for _, r := range rules {
-		if err := hfw.ipt.DeleteIfExists(r.table, r.chain, r.args...); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("delete %s/%s rule for %s: %w", r.table, r.chain, vmID, err)
-		}
-	}
-
-	delete(hfw.vmRules, vmID)
-	return firstErr
-}
-
-// Close drops the in-memory tracking map. Kernel-level iptables rules
-// remain — they're kernel state, not process state. The next vmd
-// lifetime rebuilds the map via ReattachAll → AddVM (idempotent).
-func (hfw *HostFirewall) Close() error {
-	hfw.mu.Lock()
-	defer hfw.mu.Unlock()
-	hfw.vmRules = make(map[string][]vmRule)
-	return nil
-}
+func (hfw *HostFirewall) AddVM(vmID, vethName, hostCIDR string) error { return nil }
+func (hfw *HostFirewall) RemoveVM(vmID string) error                  { return nil }
+func (hfw *HostFirewall) Close() error                                { return nil }
 
 // enableIPForward enables IPv4 forwarding. Called once during Manager init.
 func enableIPForward(ctx context.Context) error {

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -1,46 +1,45 @@
 package network
 
+// hostfw.go installs the host-level iptables rules that route VM traffic.
+// Rules match by interface-prefix (veth+) and subnet (vmIPRange) and assume
+// vmd owns the host's filter/FORWARD, nat/PREROUTING, and nat/POSTROUTING
+// chains. On a cohabitated host (Docker, kubelet, ...) veth+ would catch
+// foreign interfaces; rules would need to move into vmd-owned custom chains.
+
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/rs/zerolog"
 )
 
-// hostFirewallAPI is the Manager's view of *HostFirewall, stubbed by tests.
-type hostFirewallAPI interface {
-	AddVM(vmID, vethName, hostCIDR string) error
-	RemoveVM(vmID string) error
-	Close() error
-}
-
-// vmIPRange must match Manager's host-IP allocation scheme.
+// vmIPRange must contain every host IP that hostIPForSlot can return.
 const vmIPRange = "10.11.0.0/16"
 
-// HostFirewall installs static iptables rules covering all VMs via the
-// veth+ interface prefix and vmIPRange subnet: FORWARD ACCEPT, MSS clamp,
-// POSTROUTING MASQUERADE, PREROUTING REDIRECT to the egress proxy, and a
-// UDP/443 DROP so QUIC can't bypass the SNI allowlist. Idempotent.
-type HostFirewall struct{}
+// installHostFirewall installs the static rules that route all VM traffic
+// through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
+// MSS clamp, FORWARD ACCEPT between veth+ and the host iface, MASQUERADE
+// for vmIPRange to the host iface, and REDIRECT HTTP/HTTPS from veth+ to
+// the egress proxy. All operations are idempotent.
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) error {
+	_, ipnet, err := net.ParseCIDR(vmIPRange)
+	if err != nil {
+		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
+	}
+	if !ipnet.Contains(net.ParseIP(hostIPForSlot(0))) || !ipnet.Contains(net.ParseIP(hostIPForSlot(MaxSlots-1))) {
+		return fmt.Errorf("vmIPRange %s does not cover the full slot allocation range", vmIPRange)
+	}
 
-// NewHostFirewall installs the rules. Idempotent.
-func NewHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) (*HostFirewall, error) {
 	ipt, err := iptables.New()
 	if err != nil {
-		return nil, fmt.Errorf("init iptables: %w", err)
+		return fmt.Errorf("init iptables: %w", err)
 	}
-	if err := installRules(ipt, hostIface, httpProxyPort, tlsProxyPort); err != nil {
-		return nil, err
-	}
-	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (static prefix rules)")
-	return &HostFirewall{}, nil
-}
 
-func installRules(ipt *iptables.IPTables, hostIface string, httpProxyPort, tlsProxyPort uint16) error {
-	// UDP/443 DROP at position 1 so QUIC is dropped before the broad
-	// veth+ ACCEPT below terminates the chain walk.
+	// UDP/443 DROP must precede the veth+ ACCEPT below so QUIC traffic
+	// is dropped before the broad ACCEPT terminates the chain walk.
 	udpDrop := []string{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"}
 	exists, err := ipt.Exists("filter", "FORWARD", udpDrop...)
 	if err != nil {
@@ -82,14 +81,10 @@ func installRules(ipt *iptables.IPTables, hostIface string, httpProxyPort, tlsPr
 			return fmt.Errorf("add %s/%s rule: %w", r.table, r.chain, err)
 		}
 	}
+
+	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (static prefix rules)")
 	return nil
 }
-
-// Per-VM hooks are no-ops — the static rules above cover every veth.
-
-func (hfw *HostFirewall) AddVM(vmID, vethName, hostCIDR string) error { return nil }
-func (hfw *HostFirewall) RemoveVM(vmID string) error                  { return nil }
-func (hfw *HostFirewall) Close() error                                { return nil }
 
 // enableIPForward enables IPv4 forwarding. Called once during Manager init.
 func enableIPForward(ctx context.Context) error {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -84,9 +84,6 @@ type Manager struct {
 	freeSlots []int // recycled slot indices
 	nextSlot  int   // next new slot (used when freeSlots is empty)
 
-	// Host-level nftables firewall (FORWARD + MASQUERADE + MSS clamping).
-	hostFW hostFirewallAPI
-
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
 
@@ -140,20 +137,16 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	hostFW, err := NewHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, log.With().Str("component", "host_fw").Logger())
-	if err != nil {
-		return nil, fmt.Errorf("init host firewall: %w", err)
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, log.With().Str("component", "host_fw").Logger()); err != nil {
+		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
-	mgr.hostFW = hostFW
 
 	return mgr, nil
 }
 
-// Close tears down the host firewall. Should be called on VMD shutdown.
+// Close is retained for caller symmetry. Host iptables rules persist in the
+// kernel across vmd restarts; the next installHostFirewall reinstalls them.
 func (m *Manager) Close() error {
-	if m.hostFW != nil {
-		return m.hostFW.Close()
-	}
 	return nil
 }
 
@@ -195,17 +188,10 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		return nil, err
 	}
 
-	info, vethName, err := m.setupSlot(ctx, idx)
+	info, _, err := m.setupSlot(ctx, idx)
 	if err != nil {
 		// idx stays consumed — reusing a colliding idx would loop.
 		return nil, err
-	}
-
-	// Host-level nftables rules require the vmID.
-	hostCIDR := fmt.Sprintf("%s/32", info.HostIP)
-	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
-		m.cleanupFull(info.Namespace, vethName)
-		return nil, fmt.Errorf("add host firewall rules: %w", err)
 	}
 
 	m.mu.Lock()
@@ -221,12 +207,17 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 	return info, nil
 }
 
+// hostIPForSlot returns the host-side IP for a given slot index. The full
+// range across all valid idx values must stay within hostfw.go's vmIPRange.
+func hostIPForSlot(idx int) string {
+	return fmt.Sprintf("10.11.%d.%d", idx/256, idx%256)
+}
+
 // setupSlot runs the expensive network setup (namespace, veth, TAP,
 // nftables, routing) for a single slot index. Used by both SetupVM
-// (on-demand) and Pool (pre-allocation). Does NOT add host-level
-// firewall rules — that requires a vmID and is done by the caller.
+// (on-demand) and Pool (pre-allocation).
 func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
-	hostIP := fmt.Sprintf("10.11.%d.%d", idx/256, idx%256)
+	hostIP := hostIPForSlot(idx)
 	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
 	vethIP := fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256)
 	nsName := fmt.Sprintf("ns-%d", idx)
@@ -367,11 +358,6 @@ func (m *Manager) CleanupVM(vmID string) {
 	fmt.Sscanf(info.Namespace, "ns-%d", &idx)
 	vethName := fmt.Sprintf("veth-%d", idx)
 
-	// Remove host-level nftables rules (vmID-specific).
-	if err := m.hostFW.RemoveVM(vmID); err != nil {
-		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("error removing host firewall rules")
-	}
-
 	// Remove per-sandbox egress proxy rules.
 	if m.egressProxy != nil {
 		m.egressProxy.RemoveRules(info.HostIP)
@@ -415,16 +401,14 @@ func (m *Manager) CleanupVM(vmID string) {
 // ReattachVM rebinds vmd's view of an already-running VM's network state
 // at startup. After this call: the slot is marked in-use (no SetupVM
 // collisions), devices[vmID] is populated (CleanupVM can tear it down),
-// host-level firewall rules are present + tracked, and the in-namespace
-// nftables Firewall handle is reattached so the customer's subsequent
-// UpdateFirewallRules calls apply to the existing kernel state.
+// and the in-namespace nftables Firewall handle is reattached so the
+// customer's subsequent UpdateFirewallRules calls apply to the existing
+// kernel state.
 func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	idx, ok := slotFromNamespace(namespace)
 	if !ok {
 		return fmt.Errorf("reattach %s: cannot parse slot from namespace %q", vmID, namespace)
 	}
-	vethName := fmt.Sprintf("veth-%d", idx)
-	hostCIDR := fmt.Sprintf("%s/32", hostIP)
 
 	// Rebind in-namespace nftables handle. Non-fatal on failure: kernel
 	// rules already enforce traffic; only future updates would be lost.
@@ -445,11 +429,6 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		return nil
 	}); err != nil {
 		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
-	}
-
-	// AddVM before devices insert — a retry can't re-attempt it once devices is set.
-	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
-		return fmt.Errorf("reattach %s: restore host firewall: %w", vmID, err)
 	}
 
 	m.mu.Lock()
@@ -490,19 +469,17 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	m.mu.Unlock()
 
 	var info *VMNetInfo
-	var vethName string
 
 	switch {
 	case hasDevice && nsExists(namespace):
-		// Preserve Firewall handle for future UpdateFirewallRules; AddVM below is idempotent.
+		// Preserve Firewall handle for future UpdateFirewallRules.
 		info = existing
-		vethName = fmt.Sprintf("veth-%d", idx)
 	case !nsExists(namespace):
 		m.log.Warn().Str("vm_id", vmID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
 		// ip netns delete only tears down the inside-ns side; the host-side
 		// veth-N can survive and collide with setupSlot's fresh veth creation.
 		m.cleanupFull(namespace, fmt.Sprintf("veth-%d", idx))
-		built, builtVeth, err := m.setupSlot(ctx, idx)
+		built, _, err := m.setupSlot(ctx, idx)
 		if err != nil {
 			return nil, fmt.Errorf("ensure %s: rebuild slot %d: %w", vmID, idx, err)
 		}
@@ -510,7 +487,6 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 			m.log.Warn().Str("vm_id", vmID).Str("expected", macAddress).Str("got", built.MACAddress).Msg("rebuilt MAC differs from stored — deterministic mapping may have drifted")
 		}
 		info = built
-		vethName = builtVeth
 	default:
 		// Firewall handle stays nil; UpdateFirewallRules creates a fresh one.
 		info = &VMNetInfo{
@@ -521,13 +497,6 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 			HostIP:     hostIP,
 			MACAddress: macAddress,
 		}
-		vethName = fmt.Sprintf("veth-%d", idx)
-	}
-
-	// AddVM before devices insert — a retry short-circuits on the fast path otherwise.
-	hostCIDR := fmt.Sprintf("%s/32", hostIP)
-	if err := m.hostFW.AddVM(vmID, vethName, hostCIDR); err != nil {
-		return nil, fmt.Errorf("ensure %s: restore host firewall: %w", vmID, err)
 	}
 
 	m.mu.Lock()

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -28,42 +28,12 @@ func touchNS(t *testing.T, dir, name string) {
 	_ = f.Close()
 }
 
-// hostFW is nil — tests must not exercise paths that touch it.
 func newTestManager() *Manager {
 	return &Manager{
 		log:      zerolog.Nop(),
 		devices:  make(map[string]*VMNetInfo),
 		nextSlot: 1,
 	}
-}
-
-// stubHostFW records AddVM/RemoveVM calls so tests can assert on them.
-type stubHostFW struct {
-	added   []string // "vmID|veth|cidr"
-	removed []string
-	addErr  error
-}
-
-func (s *stubHostFW) AddVM(vmID, vethName, hostCIDR string) error {
-	if s.addErr != nil {
-		return s.addErr
-	}
-	s.added = append(s.added, vmID+"|"+vethName+"|"+hostCIDR)
-	return nil
-}
-
-func (s *stubHostFW) RemoveVM(vmID string) error {
-	s.removed = append(s.removed, vmID)
-	return nil
-}
-
-func (s *stubHostFW) Close() error { return nil }
-
-func newTestManagerWithStubFW() (*Manager, *stubHostFW) {
-	fw := &stubHostFW{}
-	m := newTestManager()
-	m.hostFW = fw
-	return m, fw
 }
 
 func TestSlotFromNamespace(t *testing.T) {
@@ -182,7 +152,7 @@ func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
 func TestEnsureVMSlot_HealthyVMReplaysFirewall(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-3")
-	m, fw := newTestManagerWithStubFW()
+	m := newTestManager()
 	existing := &VMNetInfo{Namespace: "ns-3", HostIP: "10.11.0.3"}
 	m.devices["vm-x"] = existing
 
@@ -193,15 +163,12 @@ func TestEnsureVMSlot_HealthyVMReplaysFirewall(t *testing.T) {
 	if got != existing {
 		t.Errorf("expected same VMNetInfo pointer back (Firewall handle preserved)")
 	}
-	if len(fw.added) != 1 || fw.added[0] != "vm-x|veth-3|10.11.0.3/32" {
-		t.Errorf("AddVM calls = %v, want one call with veth-3 + 10.11.0.3/32", fw.added)
-	}
 }
 
 func TestEnsureVMSlot_ReconstructWhenDeviceMapEmpty(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-7")
-	m, fw := newTestManagerWithStubFW()
+	m := newTestManager()
 
 	got, err := m.EnsureVMSlot(context.Background(), "vm-y", "ns-7", "10.11.0.7", "AA:FC:00:00:00:07")
 	if err != nil {
@@ -218,24 +185,6 @@ func TestEnsureVMSlot_ReconstructWhenDeviceMapEmpty(t *testing.T) {
 	}
 	if m.nextSlot < 8 {
 		t.Errorf("nextSlot = %d, want >= 8 (advanced past idx 7)", m.nextSlot)
-	}
-	if len(fw.added) != 1 || fw.added[0] != "vm-y|veth-7|10.11.0.7/32" {
-		t.Errorf("AddVM calls = %v, want one call with veth-7", fw.added)
-	}
-}
-
-func TestEnsureVMSlot_AddVMFailureSkipsDeviceInsert(t *testing.T) {
-	dir := withTestNetnsDir(t)
-	touchNS(t, dir, "ns-4")
-	m, fw := newTestManagerWithStubFW()
-	fw.addErr = errors.New("simulated iptables failure")
-
-	_, err := m.EnsureVMSlot(context.Background(), "vm-z", "ns-4", "10.11.0.4", "")
-	if err == nil {
-		t.Fatal("expected error from AddVM failure")
-	}
-	if _, present := m.devices["vm-z"]; present {
-		t.Errorf("devices map should not contain vm-z after AddVM failure (retry must re-attempt)")
 	}
 }
 

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -99,8 +99,6 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 	for {
 		var slot *preallocSlot
 
-		// Prefer recycled slots — they already have host firewall rules
-		// from the previous owner, which get replaced below.
 		select {
 		case slot = <-p.recycled:
 		default:
@@ -112,7 +110,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 		}
 		tPopped := time.Now()
 
-		// Race: ns can vanish between this check and AddVM; fc startup catches it.
+		// Race: ns can vanish between this check and devmap insert; fc startup catches it.
 		if !nsExists(slot.info.Namespace) {
 			p.log.Warn().
 				Str("vm_id", vmID).
@@ -124,15 +122,6 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 		}
 		tNsChecked := time.Now()
 
-		// Add host-level firewall rules (requires vmID).
-		hostCIDR := slot.info.HostIP + "/32"
-		if err := p.mgr.hostFW.AddVM(vmID, slot.vethName, hostCIDR); err != nil {
-			p.log.Error().Err(err).Str("vm_id", vmID).Msg("claim: AddVM firewall failed")
-			p.cleanup(slot)
-			return nil
-		}
-		tHostFwDone := time.Now()
-
 		p.mgr.mu.Lock()
 		p.mgr.devices[vmID] = slot.info
 		p.mgr.mu.Unlock()
@@ -142,8 +131,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			Str("vm_id", vmID).
 			Int64("claim_pop_ms", tPopped.Sub(tEntry).Milliseconds()).
 			Int64("claim_nscheck_ms", tNsChecked.Sub(tPopped).Milliseconds()).
-			Int64("claim_hostfw_ms", tHostFwDone.Sub(tNsChecked).Milliseconds()).
-			Int64("claim_devmap_ms", tDone.Sub(tHostFwDone).Milliseconds()).
+			Int64("claim_devmap_ms", tDone.Sub(tNsChecked).Milliseconds()).
 			Int64("claim_total_ms", tDone.Sub(tEntry).Milliseconds()).
 			Msg("pool: claim complete")
 		return slot.info


### PR DESCRIPTION
Replaces per-VM iptables installation in `HostFirewall.AddVM` with static `veth+` / `10.11.0.0/16` prefix rules installed once at startup. AddVM/RemoveVM/Close become no-ops, eliminating the global mutex that serialized 100 concurrent sandbox creates and was the root cause of the burst-TTI gap (p50 lock wait 1.7s in PR #74 instrumentation). Validated on staging across single-sandbox, multi-sandbox, AllowOut/DenyOut, pause/resume, and template-build scenarios.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/superserve-ai/sandbox/pull/75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->