### PR TITLE
data-plane: direct exec on per-sandbox boxd

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -62,6 +62,7 @@ jobs:
           SHA: ${{ github.sha }}
           SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_STAGING }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_STAGING }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_STAGING }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_STAGING }}
         run: |
           python3 .github/workflows/scripts/deploy-proxy.py
@@ -106,6 +107,7 @@ jobs:
           SHA: ${{ github.sha }}
           SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
         run: |
           python3 .github/workflows/scripts/deploy-proxy.py

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -7,6 +7,7 @@ Env vars:
   VMD_LABEL                  required — gcloud instances list label filter
   VMD_INSTALL_DIR            required — bin install dir on the host
   SHA                        required — commit SHA (only first 8 chars used)
+  PROXY_DOMAIN               required — host suffix the proxy serves (e.g. sandbox.superserve.ai)
   SANDBOX_ACCESS_TOKEN_SEED  optional — hex, >=32 bytes (>=64 hex chars)
   PROXY_ALLOWED_ORIGINS      optional — comma-separated origin patterns
   REQUIRE_DATA_PLANE         optional — "", "0", or "1"
@@ -26,6 +27,13 @@ def main() -> int:
     install_dir = os.environ.get("VMD_INSTALL_DIR", "/usr/local/bin")
     sha = os.environ["SHA"][:8]
 
+    proxy_domain = os.environ.get("PROXY_DOMAIN", "")
+    if not proxy_domain:
+        print("ERROR: PROXY_DOMAIN is required", file=sys.stderr)
+        return 1
+    if not re.fullmatch(r"[A-Za-z0-9.\-]+", proxy_domain):
+        print("ERROR: PROXY_DOMAIN contains disallowed characters", file=sys.stderr)
+        return 1
     access_seed = os.environ.get("SANDBOX_ACCESS_TOKEN_SEED", "")
     if access_seed and not re.fullmatch(r"[0-9a-fA-F]{64,}", access_seed):
         print("ERROR: SANDBOX_ACCESS_TOKEN_SEED must be hex-encoded, >= 32 bytes (64 hex chars)", file=sys.stderr)
@@ -91,14 +99,13 @@ def main() -> int:
             sudo systemctl enable proxy
 
             sudo mkdir -p /etc/sandbox
-            if [ -n "{access_seed}" ]; then
-                sudo tee /etc/sandbox/proxy.env > /dev/null <<PROXYENV
+            sudo tee /etc/sandbox/proxy.env > /dev/null <<PROXYENV
+            PROXY_DOMAIN={proxy_domain}
             SANDBOX_ACCESS_TOKEN_SEED={access_seed}
             PROXY_ALLOWED_ORIGINS={terminal_origins}
             REQUIRE_DATA_PLANE={require_data_plane}
             PROXYENV
-                sudo chmod 0600 /etc/sandbox/proxy.env
-            fi
+            sudo chmod 0600 /etc/sandbox/proxy.env
 
             sudo systemctl restart proxy
             sleep 3

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -293,6 +293,48 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /sandboxes/{sandbox_id}/activate:
+    parameters:
+      - $ref: "#/components/parameters/SandboxId"
+
+    post:
+      operationId: activateSandbox
+      tags: [Sandboxes]
+      summary: Ensure the sandbox is active and return a fresh access token
+      description: |
+        Idempotent "make this sandbox usable" endpoint, intended as the
+        single round-trip the SDK makes before doing operations directly
+        against the per-sandbox data plane.
+
+        - If the sandbox is `active`: returns the current sandbox payload
+          including a fresh access token, no state change.
+        - If the sandbox is `paused`: resumes it (same code path as
+          `/resume`), then returns the sandbox payload with the new token.
+        - If the sandbox is in any other state (`pausing`, `resuming`,
+          `failed`, `creating`): returns 409 — caller should retry once
+          the state settles.
+        - If the sandbox does not exist or belongs to another team: 404.
+
+        Unlike `/resume`, this endpoint is idempotent: calling it on an
+        already-active sandbox is a no-op that returns the current token.
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Sandbox is now active; payload includes access token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
 
   /sandboxes/{sandbox_id}/exec:
     parameters:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -311,7 +311,7 @@ paths:
         - If the sandbox is `paused`: resumes it (same code path as
           `/resume`), then returns the sandbox payload with the new token.
         - If the sandbox is in any other state (`pausing`, `resuming`,
-          `failed`, `creating`): returns 409 — caller should retry once
+          `failed`, `starting`): returns 409 — caller should retry once
           the state settles.
         - If the sandbox does not exist or belongs to another team: 404.
 
@@ -890,7 +890,12 @@ components:
 
     ExecStreamEvent:
       type: object
-      description: A single SSE event payload emitted by the exec/stream endpoint.
+      description: |
+        A single SSE event payload emitted by the exec/stream endpoint.
+        `stdout`/`stderr` are JSON strings — see `ExecResult` for the UTF-8
+        caveat on binary output. The stream also emits SSE comment frames
+        (`: keepalive\n\n`) every 15s to keep proxies from closing idle
+        connections; parsers MUST ignore lines that don't start with `data: `.
       properties:
         timestamp:
           type: string
@@ -939,6 +944,10 @@ components:
 
     ExecResult:
       type: object
+      description: |
+        `stdout` and `stderr` are JSON strings, which require valid UTF-8.
+        Non-UTF-8 bytes are replaced with U+FFFD. To capture binary output,
+        redirect it to a file in the sandbox and download via the files API.
       properties:
         stdout:
           type: string

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -12,10 +12,8 @@ import (
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
-// writeRunError maps a runProcess() error onto an HTTP response code +
-// JSON body. CodeInvalidArgument (command not in PATH, invalid user)
-// becomes 400 to match the controlplane's behavior; everything else is
-// 500.
+// CodeInvalidArgument → 400 (command not in PATH, invalid user);
+// everything else → 500.
 func writeRunError(w http.ResponseWriter, err error) {
 	var ce *connect.Error
 	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
@@ -25,9 +23,6 @@ func writeRunError(w http.ResponseWriter, err error) {
 	http.Error(w, "internal error", http.StatusInternalServerError)
 }
 
-// runErrorCode names the SSE error event code for a runProcess() error.
-// Matches the controlplane streaming.go convention (bad_request /
-// exec_failed) so SDK error parsing is identical across transports.
 func runErrorCode(err error) string {
 	var ce *connect.Error
 	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
@@ -36,8 +31,8 @@ func runErrorCode(err error) string {
 	return "exec_failed"
 }
 
-// HTTP /exec request shape, mirrors the controlplane sandboxExecRequest
-// shape (handlers.go) so the SDK can target either with the same body.
+// execRequest shape mirrors the controlplane exec body so the SDK can
+// target either with the same payload.
 type execRequest struct {
 	Command    string            `json:"command"`
 	Args       []string          `json:"args,omitempty"`
@@ -46,17 +41,12 @@ type execRequest struct {
 	TimeoutS   int               `json:"timeout_s,omitempty"`
 }
 
-// HTTP /exec response shape, mirrors the controlplane ExecSandbox
-// response (handlers.go:1597).
 type execResponse struct {
 	Stdout   string `json:"stdout"`
 	Stderr   string `json:"stderr"`
 	ExitCode int32  `json:"exit_code"`
 }
 
-// toStartRequest maps the HTTP-friendly shape onto the gRPC StartRequest.
-// Empty timeout becomes 30s (matches controlplane default in handlers.go
-// and streaming.go).
 func (r *execRequest) toStartRequest() *pb.StartRequest {
 	timeoutMs := uint32(r.TimeoutS) * 1000
 	if timeoutMs == 0 {
@@ -71,10 +61,8 @@ func (r *execRequest) toStartRequest() *pb.StartRequest {
 	}
 }
 
-// handleExec is the synchronous data-plane exec endpoint. Reads a JSON
-// body, runs the command to completion in-VM, and returns
-// {stdout, stderr, exit_code}. Same response shape as the controlplane's
-// POST /sandboxes/{id}/exec so SDK error/parsing code paths are shared.
+// handleExec runs the command to completion and returns the result in
+// one JSON body.
 func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
@@ -109,8 +97,6 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 			case *pb.DataEvent_Stderr:
 				stderr = append(stderr, out.Stderr...)
 			case *pb.DataEvent_PtyData:
-				// Synchronous /exec never sets pty; if a future caller does,
-				// route pty output to stdout so it's not silently lost.
 				stdout = append(stdout, out.PtyData...)
 			}
 		case *pb.ProcessEvent_End:
@@ -120,9 +106,6 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
-		// Same fail-loud surface as the gRPC handler: ConnectError carries
-		// a code we map to HTTP status. CodeInvalidArgument (e.g. command
-		// not in PATH) → 400 to match controlplane behavior.
 		writeRunError(w, err)
 		return
 	}
@@ -135,10 +118,7 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleExecStream is the SSE data-plane exec endpoint. Same input
-// shape as handleExec; emits incremental {timestamp, stdout?, stderr?,
-// exit_code?, finished?} events matching the controlplane's
-// POST /sandboxes/{id}/exec/stream shape (streaming.go).
+// handleExecStream streams stdout/stderr/end events as SSE.
 func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
@@ -168,10 +148,8 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
-	// Single writer to satisfy emit's documented single-consumer
-	// contract — runProcess multiplexes stdout/stderr already, so all
-	// emit calls happen serially from the goroutine that drains the
-	// internal channel.
+	// runProcess multiplexes stdout/stderr internally, so emit is called
+	// from a single goroutine — safe to write to w without locking.
 	emit := func(ev *pb.ProcessEvent) error {
 		payload := map[string]any{
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
@@ -190,9 +168,6 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 			payload["exit_code"] = x.End.ExitCode
 			payload["finished"] = true
 		case *pb.ProcessEvent_Start:
-			// Start events are internal-only; clients only care about
-			// data + end. Suppress to keep the SSE wire compact and
-			// match the controlplane's externally-observed shape.
 			return nil
 		}
 
@@ -208,8 +183,7 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
-		// Headers are already committed — surface the failure as a coded
-		// error event so the client can distinguish it from a normal exit.
+		// Headers are already committed — surface as a coded SSE event.
 		errEvent, _ := json.Marshal(map[string]any{
 			"error":    err.Error(),
 			"code":     runErrorCode(err),

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
+)
+
+// writeRunError maps a runProcess() error onto an HTTP response code +
+// JSON body. CodeInvalidArgument (command not in PATH, invalid user)
+// becomes 400 to match the controlplane's behavior; everything else is
+// 500.
+func writeRunError(w http.ResponseWriter, err error) {
+	var ce *connect.Error
+	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
+		http.Error(w, ce.Message(), http.StatusBadRequest)
+		return
+	}
+	http.Error(w, "internal error", http.StatusInternalServerError)
+}
+
+// runErrorCode names the SSE error event code for a runProcess() error.
+// Matches the controlplane streaming.go convention (bad_request /
+// exec_failed) so SDK error parsing is identical across transports.
+func runErrorCode(err error) string {
+	var ce *connect.Error
+	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
+		return "bad_request"
+	}
+	return "exec_failed"
+}
+
+// HTTP /exec request shape, mirrors the controlplane sandboxExecRequest
+// shape (handlers.go) so the SDK can target either with the same body.
+type execRequest struct {
+	Command    string            `json:"command"`
+	Args       []string          `json:"args,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	WorkingDir string            `json:"working_dir,omitempty"`
+	TimeoutS   int               `json:"timeout_s,omitempty"`
+}
+
+// HTTP /exec response shape, mirrors the controlplane ExecSandbox
+// response (handlers.go:1597).
+type execResponse struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int32  `json:"exit_code"`
+}
+
+// toStartRequest maps the HTTP-friendly shape onto the gRPC StartRequest.
+// Empty timeout becomes 30s (matches controlplane default in handlers.go
+// and streaming.go).
+func (r *execRequest) toStartRequest() *pb.StartRequest {
+	timeoutMs := uint32(r.TimeoutS) * 1000
+	if timeoutMs == 0 {
+		timeoutMs = 30 * 1000
+	}
+	return &pb.StartRequest{
+		Cmd:       r.Command,
+		Args:      r.Args,
+		Envs:      r.Env,
+		Cwd:       r.WorkingDir,
+		TimeoutMs: timeoutMs,
+	}
+}
+
+// handleExec is the synchronous data-plane exec endpoint. Reads a JSON
+// body, runs the command to completion in-VM, and returns
+// {stdout, stderr, exit_code}. Same response shape as the controlplane's
+// POST /sandboxes/{id}/exec so SDK error/parsing code paths are shared.
+func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req execRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Command == "" {
+		http.Error(w, "command is required", http.StatusBadRequest)
+		return
+	}
+
+	var (
+		mu       sync.Mutex
+		stdout   []byte
+		stderr   []byte
+		exitCode int32
+	)
+	emit := func(ev *pb.ProcessEvent) error {
+		mu.Lock()
+		defer mu.Unlock()
+		switch x := ev.Event.(type) {
+		case *pb.ProcessEvent_Data:
+			switch out := x.Data.Output.(type) {
+			case *pb.DataEvent_Stdout:
+				stdout = append(stdout, out.Stdout...)
+			case *pb.DataEvent_Stderr:
+				stderr = append(stderr, out.Stderr...)
+			case *pb.DataEvent_PtyData:
+				// Synchronous /exec never sets pty; if a future caller does,
+				// route pty output to stdout so it's not silently lost.
+				stdout = append(stdout, out.PtyData...)
+			}
+		case *pb.ProcessEvent_End:
+			exitCode = x.End.ExitCode
+		}
+		return nil
+	}
+
+	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
+		// Same fail-loud surface as the gRPC handler: ConnectError carries
+		// a code we map to HTTP status. CodeInvalidArgument (e.g. command
+		// not in PATH) → 400 to match controlplane behavior.
+		writeRunError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(execResponse{
+		Stdout:   string(stdout),
+		Stderr:   string(stderr),
+		ExitCode: exitCode,
+	})
+}
+
+// handleExecStream is the SSE data-plane exec endpoint. Same input
+// shape as handleExec; emits incremental {timestamp, stdout?, stderr?,
+// exit_code?, finished?} events matching the controlplane's
+// POST /sandboxes/{id}/exec/stream shape (streaming.go).
+func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req execRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Command == "" {
+		http.Error(w, "command is required", http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	// Single writer to satisfy emit's documented single-consumer
+	// contract — runProcess multiplexes stdout/stderr already, so all
+	// emit calls happen serially from the goroutine that drains the
+	// internal channel.
+	emit := func(ev *pb.ProcessEvent) error {
+		payload := map[string]any{
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		switch x := ev.Event.(type) {
+		case *pb.ProcessEvent_Data:
+			switch out := x.Data.Output.(type) {
+			case *pb.DataEvent_Stdout:
+				payload["stdout"] = string(out.Stdout)
+			case *pb.DataEvent_Stderr:
+				payload["stderr"] = string(out.Stderr)
+			case *pb.DataEvent_PtyData:
+				payload["stdout"] = string(out.PtyData)
+			}
+		case *pb.ProcessEvent_End:
+			payload["exit_code"] = x.End.ExitCode
+			payload["finished"] = true
+		case *pb.ProcessEvent_Start:
+			// Start events are internal-only; clients only care about
+			// data + end. Suppress to keep the SSE wire compact and
+			// match the controlplane's externally-observed shape.
+			return nil
+		}
+
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", raw); err != nil {
+			return err
+		}
+		flusher.Flush()
+		return nil
+	}
+
+	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
+		// Headers are already committed — surface the failure as a coded
+		// error event so the client can distinguish it from a normal exit.
+		errEvent, _ := json.Marshal(map[string]any{
+			"error":    err.Error(),
+			"code":     runErrorCode(err),
+			"finished": true,
+		})
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", errEvent)
+		flusher.Flush()
+	}
+}

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,15 +13,17 @@ import (
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
-// CodeInvalidArgument → 400 (command not in PATH, invalid user);
-// everything else → 500.
+// var, not const, so tests can shorten it.
+var sseKeepaliveInterval = 15 * time.Second
+
+// CodeInvalidArgument → 400, everything else → 500.
 func writeRunError(w http.ResponseWriter, err error) {
 	var ce *connect.Error
 	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
 		http.Error(w, ce.Message(), http.StatusBadRequest)
 		return
 	}
-	http.Error(w, "internal error", http.StatusInternalServerError)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 
 func runErrorCode(err error) string {
@@ -148,8 +151,27 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
-	// runProcess multiplexes stdout/stderr internally, so emit is called
-	// from a single goroutine — safe to write to w without locking.
+	// emit and the keepalive ticker both write to w; serialize them.
+	var writeMu sync.Mutex
+
+	keepaliveCtx, stopKeepalive := context.WithCancel(r.Context())
+	defer stopKeepalive()
+	go func() {
+		ticker := time.NewTicker(sseKeepaliveInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-keepaliveCtx.Done():
+				return
+			case <-ticker.C:
+				writeMu.Lock()
+				_, _ = fmt.Fprint(w, ": keepalive\n\n")
+				flusher.Flush()
+				writeMu.Unlock()
+			}
+		}
+	}()
+
 	emit := func(ev *pb.ProcessEvent) error {
 		payload := map[string]any{
 			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
@@ -175,6 +197,8 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 		if err != nil {
 			return err
 		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
 		if _, err := fmt.Fprintf(w, "data: %s\n\n", raw); err != nil {
 			return err
 		}
@@ -183,13 +207,14 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
-		// Headers are already committed — surface as a coded SSE event.
 		errEvent, _ := json.Marshal(map[string]any{
 			"error":    err.Error(),
 			"code":     runErrorCode(err),
 			"finished": true,
 		})
+		writeMu.Lock()
 		_, _ = fmt.Fprintf(w, "data: %s\n\n", errEvent)
 		flusher.Flush()
+		writeMu.Unlock()
 	}
 }

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -20,7 +20,7 @@ func newProcessService() *processService {
 
 func TestHandleExec_Success(t *testing.T) {
 	s := newProcessService()
-	body := `{"command":"/bin/sh","args":["-c","printf hi; printf err 1>&2; exit 0"]}`
+	body := `{"command":"/bin/sh","args":["-c","printf hi; printf err 1>&2; exit 0"],"working_dir":"/tmp"}`
 	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
@@ -46,7 +46,7 @@ func TestHandleExec_Success(t *testing.T) {
 
 func TestHandleExec_NonzeroExit(t *testing.T) {
 	s := newProcessService()
-	body := `{"command":"/bin/sh","args":["-c","exit 7"]}`
+	body := `{"command":"/bin/sh","args":["-c","exit 7"],"working_dir":"/tmp"}`
 	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
 	w := httptest.NewRecorder()
 
@@ -135,7 +135,7 @@ func parseSSEEvents(t *testing.T, body []byte) []map[string]any {
 
 func TestHandleExecStream_Success(t *testing.T) {
 	s := newProcessService()
-	body := `{"command":"/bin/sh","args":["-c","printf one; printf two; exit 0"]}`
+	body := `{"command":"/bin/sh","args":["-c","printf one; printf two; exit 0"],"working_dir":"/tmp"}`
 	req := httptest.NewRequest(http.MethodPost, "/exec/stream", strings.NewReader(body))
 	w := httptest.NewRecorder()
 

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func newProcessService() *processService {
@@ -188,6 +189,48 @@ func TestHandleExecStream_WrongMethod(t *testing.T) {
 
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+// Keepalive frame appears + emit still works; under -race, also catches
+// any future regression that drops writeMu.
+func TestHandleExecStream_KeepaliveFiresAndDoesNotRaceWithEmit(t *testing.T) {
+	prev := sseKeepaliveInterval
+	sseKeepaliveInterval = 20 * time.Millisecond
+	t.Cleanup(func() { sseKeepaliveInterval = prev })
+
+	s := newProcessService()
+	body := `{"command":"/bin/sh","args":["-c","printf one; sleep 0.1; printf two; exit 0"],"working_dir":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec/stream", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExecStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	raw := w.Body.String()
+	if !strings.Contains(raw, ": keepalive") {
+		t.Errorf("no keepalive comment frame in body; got: %q", raw)
+	}
+
+	events := parseSSEEvents(t, w.Body.Bytes())
+	var stdout strings.Builder
+	var sawFinished bool
+	for _, ev := range events {
+		if v, ok := ev["stdout"].(string); ok {
+			stdout.WriteString(v)
+		}
+		if f, ok := ev["finished"].(bool); ok && f {
+			sawFinished = true
+		}
+	}
+	if stdout.String() != "onetwo" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "onetwo")
+	}
+	if !sawFinished {
+		t.Error("never saw finished=true event")
 	}
 }
 

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newProcessService() *processService {
+	return &processService{
+		processes: &sync.Map{},
+		ctx:       &sandboxContext{},
+	}
+}
+
+func TestHandleExec_Success(t *testing.T) {
+	s := newProcessService()
+	body := `{"command":"/bin/sh","args":["-c","printf hi; printf err 1>&2; exit 0"]}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp execResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v; body: %s", err, w.Body.String())
+	}
+	if resp.Stdout != "hi" {
+		t.Errorf("stdout = %q, want %q", resp.Stdout, "hi")
+	}
+	if resp.Stderr != "err" {
+		t.Errorf("stderr = %q, want %q", resp.Stderr, "err")
+	}
+	if resp.ExitCode != 0 {
+		t.Errorf("exit_code = %d, want 0", resp.ExitCode)
+	}
+}
+
+func TestHandleExec_NonzeroExit(t *testing.T) {
+	s := newProcessService()
+	body := `{"command":"/bin/sh","args":["-c","exit 7"]}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (non-zero exit is NOT an HTTP error)", w.Code, http.StatusOK)
+	}
+	var resp execResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.ExitCode != 7 {
+		t.Errorf("exit_code = %d, want 7", resp.ExitCode)
+	}
+}
+
+func TestHandleExec_BadJSON(t *testing.T) {
+	s := newProcessService()
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{not json`))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleExec_MissingCommand(t *testing.T) {
+	s := newProcessService()
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleExec_WrongMethod(t *testing.T) {
+	s := newProcessService()
+	req := httptest.NewRequest(http.MethodGet, "/exec", nil)
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleExec_CommandNotFound_400(t *testing.T) {
+	s := newProcessService()
+	body := `{"command":"this-binary-does-not-exist-anywhere"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (resolve error → 400)", w.Code, http.StatusBadRequest)
+	}
+}
+
+// parseSSEEvents extracts each `data: {...}\n\n` block from an SSE
+// response body and decodes the JSON payload.
+func parseSSEEvents(t *testing.T, body []byte) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			t.Fatalf("decode SSE payload %q: %v", payload, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func TestHandleExecStream_Success(t *testing.T) {
+	s := newProcessService()
+	body := `{"command":"/bin/sh","args":["-c","printf one; printf two; exit 0"]}`
+	req := httptest.NewRequest(http.MethodPost, "/exec/stream", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExecStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	events := parseSSEEvents(t, w.Body.Bytes())
+	if len(events) < 2 {
+		t.Fatalf("expected ≥2 events (data + end); got %d: %v", len(events), events)
+	}
+
+	// Concatenate all stdout chunks; SSE may emit them in 1+ events.
+	var stdout strings.Builder
+	var sawFinished bool
+	var exitCode float64
+	for _, ev := range events {
+		if v, ok := ev["stdout"].(string); ok {
+			stdout.WriteString(v)
+		}
+		if f, ok := ev["finished"].(bool); ok && f {
+			sawFinished = true
+			if c, ok := ev["exit_code"].(float64); ok {
+				exitCode = c
+			}
+		}
+	}
+	if stdout.String() != "onetwo" {
+		t.Errorf("aggregated stdout = %q, want %q", stdout.String(), "onetwo")
+	}
+	if !sawFinished {
+		t.Error("never saw finished=true event")
+	}
+	if exitCode != 0 {
+		t.Errorf("exit_code = %v, want 0", exitCode)
+	}
+}
+
+func TestHandleExecStream_WrongMethod(t *testing.T) {
+	s := newProcessService()
+	req := httptest.NewRequest(http.MethodGet, "/exec/stream", nil)
+	w := httptest.NewRecorder()
+
+	s.handleExecStream(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleExecStream_BadCommand_EmitsErrorEvent(t *testing.T) {
+	s := newProcessService()
+	body := `{"command":"this-binary-does-not-exist-anywhere"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec/stream", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExecStream(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (headers commit before runProcess fails)", w.Code)
+	}
+	events := parseSSEEvents(t, w.Body.Bytes())
+	if len(events) == 0 {
+		t.Fatal("no events emitted")
+	}
+	last := events[len(events)-1]
+	if last["code"] != "bad_request" {
+		t.Errorf("last event code = %q, want bad_request", last["code"])
+	}
+	if last["finished"] != true {
+		t.Errorf("last event finished = %v, want true", last["finished"])
+	}
+}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -324,10 +324,8 @@ func resolveUser(name string) (*user.User, *syscall.Credential, error) {
 	return u, &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
 }
 
-// eventEmitter is the abstraction over "where do this process's events
-// go?" — set to stream.Send for the gRPC Start handler, or to a
-// JSON-accumulator/SSE-writer for the HTTP /exec and /exec/stream
-// handlers. Same execution logic, three transports.
+// eventEmitter abstracts the event sink so runProcess can serve the
+// gRPC Start handler, HTTP /exec, and /exec/stream from one path.
 type eventEmitter func(*pb.ProcessEvent) error
 
 func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
@@ -539,12 +537,10 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eve
 		return err
 	}
 
-	// Fan stdout + stderr through a multiplex so a single consumer owns
-	// emit. connect-go's ServerStream (one of emit's concrete targets)
-	// is not safe for concurrent use — direct Send from both readers
-	// races the HTTP/1.1 chunked writer and produces malformed frames
-	// ("bare LF", "invalid byte in chunk length") observed under load.
-	// The HTTP emitters have similar single-writer requirements.
+	// Fan stdout + stderr through a multiplex so emit is invoked from a
+	// single goroutine. ServerStream is not safe for concurrent Send
+	// (manifests as "bare LF" / "invalid byte in chunk length" under
+	// load), and the HTTP emitters share the same single-writer need.
 	mux := NewMultiplexedChannel[*pb.ProcessEvent](256)
 	consumer, _ := mux.Fork()
 

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -324,8 +324,9 @@ func resolveUser(name string) (*user.User, *syscall.Credential, error) {
 	return u, &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
 }
 
-// eventEmitter abstracts the event sink so runProcess can serve the
-// gRPC Start handler, HTTP /exec, and /exec/stream from one path.
+// eventEmitter is runProcess's sink — shared by gRPC Start, /exec, and
+// /exec/stream. Contract: invoked from a single goroutine. Fanning out
+// would corrupt the response on both HTTP endpoints.
 type eventEmitter func(*pb.ProcessEvent) error
 
 func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -87,10 +87,12 @@ func main() {
 	mux.Handle(boxdpbconnect.NewProcessServiceHandler(procService))
 	mux.Handle(boxdpbconnect.NewFilesystemServiceHandler(&filesystemService{}))
 
-	// Raw HTTP endpoints (file content transfer + health + init).
+	// Raw HTTP endpoints (file content transfer + health + init + exec).
 	mux.HandleFunc("/files", handleFiles)
 	mux.HandleFunc("/init", handleInit(ctx))
 	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/exec", procService.handleExec)
+	mux.HandleFunc("/exec/stream", procService.handleExecStream)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", httpPort)
 	log.Printf("boxd listening on %s (Connect RPC + HTTP)", addr)
@@ -322,9 +324,17 @@ func resolveUser(name string) (*user.User, *syscall.Credential, error) {
 	return u, &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
 }
 
-func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
-	msg := req.Msg
+// eventEmitter is the abstraction over "where do this process's events
+// go?" — set to stream.Send for the gRPC Start handler, or to a
+// JSON-accumulator/SSE-writer for the HTTP /exec and /exec/stream
+// handlers. Same execution logic, three transports.
+type eventEmitter func(*pb.ProcessEvent) error
 
+func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
+	return s.runProcess(ctx, req.Msg, stream.Send)
+}
+
+func (s *processService) runProcess(ctx context.Context, msg *pb.StartRequest, emit eventEmitter) error {
 	cmdName := msg.GetCmd()
 	if cmdName == "" {
 		cmdName = defaultShell
@@ -410,9 +420,9 @@ func (s *processService) Start(ctx context.Context, req *connect.Request[pb.Star
 			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
 		cmd.WaitDelay = time.Second
-		return s.startPipes(ctx, cmd, stream, &timedOut)
+		return s.startPipes(ctx, cmd, emit, &timedOut)
 	}
-	return s.startPTY(ctx, cmd, msg, stream, &timedOut)
+	return s.startPTY(ctx, cmd, msg, emit, &timedOut)
 }
 
 // timeoutExitCode matches GNU coreutils `timeout(1)`.
@@ -438,7 +448,7 @@ func finalExitCode(ps *os.ProcessState, timedOut bool) int32 {
 	return 137
 }
 
-func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.StartRequest, stream *connect.ServerStream[pb.ProcessEvent], timedOut *atomic.Bool) error {
+func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.StartRequest, emit eventEmitter, timedOut *atomic.Bool) error {
 	cols := uint16(msg.GetPty().GetSize().GetCols())
 	rows := uint16(msg.GetPty().GetSize().GetRows())
 	if cols == 0 {
@@ -461,7 +471,7 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	defer s.processes.Delete(pid)
 
 	// Send start event.
-	if err := stream.Send(&pb.ProcessEvent{
+	if err := emit(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_Start{Start: &pb.StartEvent{Pid: pid}},
 	}); err != nil {
 		return err
@@ -477,7 +487,7 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 			if n > 0 {
 				data := make([]byte, n)
 				copy(data, buf[:n])
-				_ = stream.Send(&pb.ProcessEvent{
+				_ = emit(&pb.ProcessEvent{
 					Event: &pb.ProcessEvent_Data{Data: &pb.DataEvent{
 						Output: &pb.DataEvent_PtyData{PtyData: data},
 					}},
@@ -496,7 +506,7 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	if cmd.ProcessState != nil {
 		status = cmd.ProcessState.String()
 	}
-	return stream.Send(&pb.ProcessEvent{
+	return emit(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
 			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),
@@ -505,7 +515,7 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	})
 }
 
-func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *connect.ServerStream[pb.ProcessEvent], timedOut *atomic.Bool) error {
+func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eventEmitter, timedOut *atomic.Bool) error {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, err)
@@ -523,17 +533,18 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 	s.processes.Store(pid, &runningProcess{cmd: cmd})
 	defer s.processes.Delete(pid)
 
-	if err := stream.Send(&pb.ProcessEvent{
+	if err := emit(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_Start{Start: &pb.StartEvent{Pid: pid}},
 	}); err != nil {
 		return err
 	}
 
 	// Fan stdout + stderr through a multiplex so a single consumer owns
-	// stream.Send. connect-go's ServerStream is not safe for concurrent
-	// use — direct Send from both readers races the HTTP/1.1 chunked
-	// writer and produces malformed frames ("bare LF", "invalid byte in
-	// chunk length") observed under load.
+	// emit. connect-go's ServerStream (one of emit's concrete targets)
+	// is not safe for concurrent use — direct Send from both readers
+	// races the HTTP/1.1 chunked writer and produces malformed frames
+	// ("bare LF", "invalid byte in chunk length") observed under load.
+	// The HTTP emitters have similar single-writer requirements.
 	mux := NewMultiplexedChannel[*pb.ProcessEvent](256)
 	consumer, _ := mux.Fork()
 
@@ -544,7 +555,7 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 			if firstErr != nil {
 				continue // keep draining so the mux can close cleanly
 			}
-			if err := stream.Send(ev); err != nil {
+			if err := emit(ev); err != nil {
 				firstErr = err
 			}
 		}
@@ -608,7 +619,7 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, stream *
 	if cmd.ProcessState != nil {
 		status = cmd.ProcessState.String()
 	}
-	return stream.Send(&pb.ProcessEvent{
+	return emit(&pb.ProcessEvent{
 		Event: &pb.ProcessEvent_End{End: &pb.EndEvent{
 			ExitCode: finalExitCode(cmd.ProcessState, timedOut.Load()),
 			Exited:   cmd.ProcessState != nil && cmd.ProcessState.Exited(),

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -64,6 +64,8 @@ func main() {
 		proxyHandler.WithAuth(seed)
 		proxyHandler.WithFiles()
 		log.Info().Msg("files endpoint enabled")
+		proxyHandler.WithExec()
+		log.Info().Msg("exec endpoint enabled")
 
 		if originsEnv != "" {
 			origins := splitCSV(originsEnv)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -508,6 +508,23 @@ func actorIDFromContext(c *gin.Context) *uuid.UUID {
 // Sandbox lifecycle
 // ---------------------------------------------------------------------------
 
+// ActivateSandbox is the idempotent "make this sandbox usable" endpoint.
+// Resumes a paused sandbox, returns the current state + access token on
+// already-active sandboxes. The SDK calls this once per session before
+// hitting the data plane directly, so the data plane never has to know
+// about lifecycle state.
+//
+// Returns the full sandbox payload with access_token. Errors mirror
+// loadActiveOrResumeSandbox: 404 if missing, 409 for non-paused/non-active
+// states (e.g. pausing, resuming, failed).
+func (h *Handlers) ActivateSandbox(c *gin.Context) {
+	sandbox := h.loadActiveOrResumeSandbox(c)
+	if sandbox == nil {
+		return
+	}
+	c.JSON(http.StatusOK, h.sandboxToResponseWithToken(*sandbox))
+}
+
 func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -508,15 +508,9 @@ func actorIDFromContext(c *gin.Context) *uuid.UUID {
 // Sandbox lifecycle
 // ---------------------------------------------------------------------------
 
-// ActivateSandbox is the idempotent "make this sandbox usable" endpoint.
-// Resumes a paused sandbox, returns the current state + access token on
-// already-active sandboxes. The SDK calls this once per session before
-// hitting the data plane directly, so the data plane never has to know
-// about lifecycle state.
-//
-// Returns the full sandbox payload with access_token. Errors mirror
-// loadActiveOrResumeSandbox: 404 if missing, 409 for non-paused/non-active
-// states (e.g. pausing, resuming, failed).
+// ActivateSandbox returns the sandbox payload + a fresh access token,
+// transparently resuming the VM if it was paused. Idempotent on active
+// sandboxes. Transitional states (pausing, resuming, failed) → 409.
 func (h *Handlers) ActivateSandbox(c *gin.Context) {
 	sandbox := h.loadActiveOrResumeSandbox(c)
 	if sandbox == nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -996,20 +996,30 @@ func TestActivateSandbox_NotFound(t *testing.T) {
 	}
 }
 
-func TestActivateSandbox_FailedState_409(t *testing.T) {
-	sandboxID := uuid.New()
-	teamID := uuid.New()
-	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Status: db.SandboxStatusFailed}
-
-	mock := &mockDBTX{
-		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+func TestActivateSandbox_NonResumableStates_409(t *testing.T) {
+	cases := []db.SandboxStatus{
+		db.SandboxStatusFailed,
+		db.SandboxStatusPausing,
+		db.SandboxStatusResuming,
+		db.SandboxStatusStarting,
 	}
-	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
-	w := httptest.NewRecorder()
-	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+	for _, status := range cases {
+		t.Run(string(status), func(t *testing.T) {
+			sandboxID := uuid.New()
+			teamID := uuid.New()
+			sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Status: status}
 
-	if w.Code != http.StatusConflict {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+			mock := &mockDBTX{
+				queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+			}
+			h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+			w := httptest.NewRecorder()
+			setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+			if w.Code != http.StatusConflict {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+			}
+		})
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
@@ -250,6 +251,7 @@ func setupTestRouter(h *Handlers, teamID string) *gin.Engine {
 	})
 	r.POST("/sandboxes", h.CreateSandbox)
 	r.POST("/sandboxes/:sandbox_id/resume", h.ResumeSandbox)
+	r.POST("/sandboxes/:sandbox_id/activate", h.ActivateSandbox)
 	r.POST("/sandboxes/:sandbox_id/pause", h.PauseSandbox)
 	r.DELETE("/sandboxes/:sandbox_id", h.DeleteSandbox)
 	r.POST("/sandboxes/:sandbox_id/exec", h.ExecSandbox)
@@ -511,6 +513,10 @@ func boolRow(value bool) *mockRow {
 
 func resumeRequest(sandboxID string) *http.Request {
 	return httptest.NewRequest(http.MethodPost, "/sandboxes/"+sandboxID+"/resume", nil)
+}
+
+func activateRequest(sandboxID string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/sandboxes/"+sandboxID+"/activate", nil)
 }
 
 func pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID uuid.UUID) db.Sandbox {
@@ -866,6 +872,155 @@ func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&revertCalled); got != 1 {
 		t.Errorf("RevertResumeToPaused calls = %d, want 1", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ActivateSandbox tests — idempotent "make this sandbox usable" endpoint.
+// Reuses loadActiveOrResumeSandbox under the hood; the tests focus on the
+// edge case ResumeSandbox doesn't cover (already-active sandbox returns 200
+// with a token, no VMD call).
+// ---------------------------------------------------------------------------
+
+func TestActivateSandbox_AlreadyActive_200WithSandboxResponse(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{
+		ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive,
+		VcpuCount: 2, MemoryMib: 1024,
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+	}
+	vmd := &stubVMD{}
+
+	h := &Handlers{
+		VMD:    vmd,
+		DB:     db.New(mock),
+		Config: &config.Config{SandboxAccessTokenSeed: []byte("test-seed-for-hmac-32-bytes-min!!")},
+	}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := parseJSON(t, w)
+	if body["status"] != "active" {
+		t.Errorf("status = %q, want active", body["status"])
+	}
+	if body["id"] != sandboxID.String() {
+		t.Errorf("id = %q, want %q", body["id"], sandboxID)
+	}
+	if _, ok := body["access_token"].(string); !ok {
+		t.Error("expected access_token in response when SandboxAccessTokenSeed is set")
+	}
+	if body["vcpu_count"].(float64) != 2 {
+		t.Errorf("vcpu_count = %v, want 2", body["vcpu_count"])
+	}
+}
+
+func TestActivateSandbox_PausedResumesAndReturns200(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", SizeBytes: 1024, Trigger: "pause",
+	}
+
+	var resumeCalled bool
+	vmd := &stubVMD{
+		destroyFn: func(context.Context, string, bool) error { return nil },
+		resumeFn: func(_ context.Context, id, _, _ string) (string, error) {
+			resumeCalled = true
+			return "10.0.0.5", nil
+		},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{
+		VMD:    vmd,
+		DB:     db.New(mock),
+		Config: &config.Config{SandboxAccessTokenSeed: []byte("test-seed-for-hmac-32-bytes-min!!")},
+	}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !resumeCalled {
+		t.Error("VMD.ResumeInstance was not called for paused sandbox")
+	}
+	body := parseJSON(t, w)
+	if body["status"] != "active" {
+		t.Errorf("status = %q, want active", body["status"])
+	}
+	if _, ok := body["access_token"].(string); !ok {
+		t.Error("expected access_token in response")
+	}
+}
+
+func TestActivateSandbox_NotFound(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return notFoundRow() },
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestActivateSandbox_FailedState_409(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Status: db.SandboxStatusFailed}
+
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestActivateSandbox_InvalidUUID(t *testing.T) {
+	teamID := uuid.New()
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(&mockDBTX{})}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest("not-a-uuid"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -35,6 +35,7 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 		api.GET("/sandboxes", h.ListSandboxes)
 		api.GET("/sandboxes/:sandbox_id", h.GetSandboxByID)
 		api.POST("/sandboxes/:sandbox_id/resume", h.ResumeSandbox)
+		api.POST("/sandboxes/:sandbox_id/activate", h.ActivateSandbox)
 		api.POST("/sandboxes/:sandbox_id/pause", h.PauseSandbox)
 		api.DELETE("/sandboxes/:sandbox_id", h.DeleteSandbox)
 		api.PATCH("/sandboxes/:sandbox_id", h.PatchSandbox)

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -1,0 +1,123 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+const (
+	// execPath is the synchronous data-plane exec endpoint on the boxd
+	// host label: POST → run command to completion → JSON response.
+	// Shape matches the controlplane's /sandboxes/{id}/exec.
+	execPath = "/exec"
+
+	// execStreamPath is the SSE data-plane exec endpoint on the boxd
+	// host label: POST → stream stdout/stderr/end events as SSE.
+	// Shape matches the controlplane's /sandboxes/{id}/exec/stream.
+	execStreamPath = "/exec/stream"
+)
+
+// WithExec enables the /exec and /exec/stream HTTP reverse proxy on
+// boxdPort. Requires WithAuth to have been called first. Off by default
+// — the SDK keeps using the controlplane /sandboxes/{id}/exec path
+// until both proxy and SDK have been upgraded.
+func (h *Handler) WithExec() *Handler {
+	if h.seedKey == nil {
+		panic("proxy: WithExec requires WithAuth to be called first")
+	}
+	h.execEnabled = true
+	return h
+}
+
+// serveExec handles POST /exec on the boxd host label. Auth + scrub +
+// reverse-proxy to boxd's HTTP /exec handler. Mirror of serveFiles
+// without the path-traversal check (no path query param here) and
+// without CORS (data-plane exec is not browser-facing today).
+func (h *Handler) serveExec(w http.ResponseWriter, r *http.Request, instanceID string) {
+	if !h.execEnabled {
+		// Started without WithExec — don't leak that the feature exists.
+		http.NotFound(w, r)
+		return
+	}
+	h.serveExecCommon(w, r, instanceID, false)
+}
+
+// serveExecStream handles POST /exec/stream on the boxd host label. Same
+// shape as serveExec but configures the reverse proxy for SSE: forces
+// flushing on every write so events aren't buffered en route, and never
+// retries on error mid-stream (headers have committed once the upstream
+// starts writing).
+func (h *Handler) serveExecStream(w http.ResponseWriter, r *http.Request, instanceID string) {
+	if !h.execEnabled {
+		http.NotFound(w, r)
+		return
+	}
+	h.serveExecCommon(w, r, instanceID, true)
+}
+
+func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instanceID string, streaming bool) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	token := r.Header.Get(accessTokenHeader)
+	if token == "" {
+		http.Error(w, "missing X-Access-Token header", http.StatusUnauthorized)
+		return
+	}
+	r.Header.Del(accessTokenHeader)
+	w.Header().Set("Referrer-Policy", "no-referrer")
+
+	info, fail := h.authorizeSandboxRequest(r.Context(), token, instanceID)
+	if fail != nil {
+		h.log.Warn().Str("sandbox_id", instanceID).Int("status", fail.Status).Msg("exec: auth failed")
+		fail.write(w)
+		return
+	}
+
+	transport := h.transports.get(instanceID, info)
+	target := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s:%d", info.VMIP, boxdPort),
+	}
+
+	rp := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = r.Host
+			// Same header scrub as serveFiles: drop forwarded-* + caller-
+			// supplied real-IP headers so boxd or any future middleware
+			// can't be fooled about who initiated the request.
+			req.Header["X-Forwarded-For"] = nil
+			for _, hdr := range []string{
+				"X-Forwarded-Host",
+				"X-Forwarded-Proto",
+				"X-Real-Ip",
+				"Forwarded",
+			} {
+				req.Header.Del(hdr)
+			}
+		},
+		Transport: transport,
+		// FlushInterval -1 streams every chunk as it arrives. Required for
+		// /exec/stream so SSE events reach the client without buffering;
+		// harmless for synchronous /exec where the body is small.
+		FlushInterval: -1,
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
+			h.log.Error().Err(proxyErr).
+				Str("instance", instanceID).
+				Str("target", target.Host).
+				Bool("streaming", streaming).
+				Msg("exec: upstream error")
+			h.resolver.Invalidate(instanceID)
+			rw.Header().Set("Retry-After", "2")
+			http.Error(rw, "sandbox unreachable", http.StatusBadGateway)
+		},
+	}
+	rp.ServeHTTP(w, r)
+}

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -8,21 +8,12 @@ import (
 )
 
 const (
-	// execPath is the synchronous data-plane exec endpoint on the boxd
-	// host label: POST → run command to completion → JSON response.
-	// Shape matches the controlplane's /sandboxes/{id}/exec.
-	execPath = "/exec"
-
-	// execStreamPath is the SSE data-plane exec endpoint on the boxd
-	// host label: POST → stream stdout/stderr/end events as SSE.
-	// Shape matches the controlplane's /sandboxes/{id}/exec/stream.
+	execPath       = "/exec"
 	execStreamPath = "/exec/stream"
 )
 
-// WithExec enables the /exec and /exec/stream HTTP reverse proxy on
-// boxdPort. Requires WithAuth to have been called first. Off by default
-// — the SDK keeps using the controlplane /sandboxes/{id}/exec path
-// until both proxy and SDK have been upgraded.
+// WithExec enables /exec and /exec/stream on the boxd host label.
+// Requires WithAuth.
 func (h *Handler) WithExec() *Handler {
 	if h.seedKey == nil {
 		panic("proxy: WithExec requires WithAuth to be called first")
@@ -31,24 +22,14 @@ func (h *Handler) WithExec() *Handler {
 	return h
 }
 
-// serveExec handles POST /exec on the boxd host label. Auth + scrub +
-// reverse-proxy to boxd's HTTP /exec handler. Mirror of serveFiles
-// without the path-traversal check (no path query param here) and
-// without CORS (data-plane exec is not browser-facing today).
 func (h *Handler) serveExec(w http.ResponseWriter, r *http.Request, instanceID string) {
 	if !h.execEnabled {
-		// Started without WithExec — don't leak that the feature exists.
 		http.NotFound(w, r)
 		return
 	}
 	h.serveExecCommon(w, r, instanceID, false)
 }
 
-// serveExecStream handles POST /exec/stream on the boxd host label. Same
-// shape as serveExec but configures the reverse proxy for SSE: forces
-// flushing on every write so events aren't buffered en route, and never
-// retries on error mid-stream (headers have committed once the upstream
-// starts writing).
 func (h *Handler) serveExecStream(w http.ResponseWriter, r *http.Request, instanceID string) {
 	if !h.execEnabled {
 		http.NotFound(w, r)
@@ -90,9 +71,6 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
 			req.Host = r.Host
-			// Same header scrub as serveFiles: drop forwarded-* + caller-
-			// supplied real-IP headers so boxd or any future middleware
-			// can't be fooled about who initiated the request.
 			req.Header["X-Forwarded-For"] = nil
 			for _, hdr := range []string{
 				"X-Forwarded-Host",
@@ -104,9 +82,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 			}
 		},
 		Transport: transport,
-		// FlushInterval -1 streams every chunk as it arrives. Required for
-		// /exec/stream so SSE events reach the client without buffering;
-		// harmless for synchronous /exec where the body is small.
+		// -1: stream each chunk as it arrives — required for SSE.
 		FlushInterval: -1,
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
 			h.log.Error().Err(proxyErr).

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -1,0 +1,205 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// newExecTestEnv mirrors newFilesTestEnv but wires WithExec instead of
+// WithFiles, so the /exec and /exec/stream paths reach the upstream and
+// /files paths 404 in this harness. Keeps test isolation: a misconfigured
+// allowlist regression in either feature is caught by its own tests.
+func newExecTestEnv(t *testing.T) *filesTestEnv {
+	t.Helper()
+
+	seedKey := []byte("test-seed-key-that-is-at-least-32-bytes-long!!")
+
+	env := &filesTestEnv{
+		t:         t,
+		seedKey:   seedKey,
+		sandboxID: "sbx-" + strings.Repeat("e", 8),
+		domain:    "sandbox.test",
+	}
+
+	env.upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		env.upstreamMu.Lock()
+		env.lastReq = capturedRequest{
+			method:   r.Method,
+			path:     r.URL.Path,
+			host:     r.Host,
+			hasToken: r.Header.Get("X-Access-Token") != "",
+			fwdFor:   r.Header.Get("X-Forwarded-For"),
+			received: true,
+		}
+		env.upstreamMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"stdout":"","stderr":"","exit_code":0}`))
+	}))
+	t.Cleanup(env.upstream.Close)
+
+	upURL, _ := url.Parse(env.upstream.URL)
+	env.resolver = &stubResolver{
+		info: InstanceInfo{
+			VMIP:      upURL.Hostname(),
+			Status:    "running",
+			StartedAt: time.Now().UnixNano(),
+		},
+	}
+
+	env.handler = NewHandler(env.domain, env.resolver, zerolog.Nop())
+	env.handler.WithAuth(seedKey).WithExec()
+
+	// Redirect transport at the per-sandbox cache so the boxd-internal
+	// VMIP:boxdPort dial lands on the httptest upstream instead.
+	upHost := upURL.Host
+	env.handler.transports = &transportCache{items: map[string]*transportEntry{}}
+	redirTransport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, upHost)
+		},
+		DisableKeepAlives: true,
+	}
+	env.handler.transports.items[env.sandboxID] = &transportEntry{
+		lifecycleKey: env.resolver.info.lifecycleKey(),
+		transport:    redirTransport,
+		lastUsed:     time.Now(),
+	}
+
+	return env
+}
+
+func (e *filesTestEnv) buildExecRequest(path, token, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "http://unused"+path, strings.NewReader(body))
+	req.Host = "boxd-" + e.sandboxID + "." + e.domain
+	if token != "" {
+		req.Header.Set("X-Access-Token", token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestExec_ValidToken_ForwardsToUpstream(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := env.buildExecRequest("/exec", env.validToken(), `{"command":"echo"}`)
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	env.upstreamMu.Lock()
+	defer env.upstreamMu.Unlock()
+	if !env.lastReq.received {
+		t.Fatal("upstream did not receive the request")
+	}
+	if env.lastReq.method != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", env.lastReq.method)
+	}
+	if env.lastReq.path != "/exec" {
+		t.Errorf("upstream path = %q, want /exec", env.lastReq.path)
+	}
+	if env.lastReq.hasToken {
+		t.Error("X-Access-Token was forwarded to upstream — should be scrubbed")
+	}
+}
+
+func TestExecStream_ValidToken_ForwardsToUpstream(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := env.buildExecRequest("/exec/stream", env.validToken(), `{"command":"echo"}`)
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	env.upstreamMu.Lock()
+	defer env.upstreamMu.Unlock()
+	if !env.lastReq.received || env.lastReq.path != "/exec/stream" {
+		t.Errorf("upstream path = %q, want /exec/stream", env.lastReq.path)
+	}
+}
+
+func TestExec_MissingToken_401(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := env.buildExecRequest("/exec", "", `{"command":"echo"}`)
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	env.upstreamMu.Lock()
+	defer env.upstreamMu.Unlock()
+	if env.lastReq.received {
+		t.Error("upstream was contacted despite missing token")
+	}
+}
+
+func TestExec_BadToken_401(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := env.buildExecRequest("/exec", "not-a-valid-token", `{"command":"echo"}`)
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestExec_WrongMethod_405(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := httptest.NewRequest(http.MethodGet, "http://unused/exec", nil)
+	req.Host = "boxd-" + env.sandboxID + "." + env.domain
+	req.Header.Set("X-Access-Token", env.validToken())
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+// When the proxy is started without WithExec, the path 404s — same
+// invisible-feature treatment as /files and /terminal.
+func TestExec_NotEnabled_404(t *testing.T) {
+	seedKey := []byte("test-seed-key-that-is-at-least-32-bytes-long!!")
+	domain := "sandbox.test"
+	sandboxID := "sbx-" + strings.Repeat("z", 8)
+
+	h := NewHandler(domain, &stubResolver{info: InstanceInfo{VMIP: "127.0.0.1", Status: "running"}}, zerolog.Nop())
+	h.WithAuth(seedKey) // WithExec deliberately not called
+
+	req := httptest.NewRequest(http.MethodPost, "http://unused/exec", strings.NewReader(`{"command":"echo"}`))
+	req.Host = "boxd-" + sandboxID + "." + domain
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (feature should not leak)", w.Code)
+	}
+}
+
+func TestExec_WithoutWithAuth_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when WithExec called before WithAuth")
+		}
+	}()
+	h := NewHandler("sandbox.test", &stubResolver{}, zerolog.Nop())
+	h.WithExec()
+}

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -73,6 +73,10 @@ func (h *Handler) serveBoxdPort(w http.ResponseWriter, r *http.Request, instance
 			return
 		}
 		h.serveTerminal(w, r, instanceID)
+	case execPath:
+		h.serveExec(w, r, instanceID)
+	case execStreamPath:
+		h.serveExecStream(w, r, instanceID)
 	default:
 		http.NotFound(w, r)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -71,6 +71,10 @@ type Handler struct {
 	// filesEnabled controls whether /files on boxdPort is served.
 	filesEnabled bool
 
+	// execEnabled controls whether /exec and /exec/stream on boxdPort are
+	// served. Set via WithExec; default off.
+	execEnabled bool
+
 	// allowedOrigins is the set of browser origins allowed for CORS on
 	// data-plane endpoints (/files). Shared with the terminal origin check.
 	allowedOrigins []string


### PR DESCRIPTION
Adds idempotent `POST /sandboxes/:id/activate` on controlplane, `POST /exec` + `/exec/stream` on boxd, and proxy `WithExec()` allowlist. SDK migration is a follow-up in the superserve repo.

Also migrated proxy from L4 SSL Proxy LB to L7 HTTPS LB. The L4 LB lacked HTTP-level connection pooling, adding ~140 ms tail latency to 20-50 % of requests to every data-plane endpoint (`/files`, `/terminal`, `/exec`) due to TCP pool churn. The L7 LB's HTTP-aware pool multiplexes requests over warm backend connections, eliminating the churn — which means this PR's data-plane latency win is consistent rather than bimodal.