### PR TITLE
proxy: route by X-Superserve-Sandbox-Id header on shared host

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34,10 +34,14 @@ info:
 
     `/exec`, `/exec/stream`, and `/files` are served on a separate host. Authenticate
     with the per-sandbox `X-Access-Token` returned by create / resume / activate.
-    Either of these host forms reaches the same endpoints:
+    Two host forms reach the same endpoints:
 
-    - `https://sandbox.superserve.ai/...` with `X-Superserve-Sandbox-Id: <sandbox_id>`
-    - `https://boxd-{sandbox_id}.sandbox.superserve.ai/...` (no routing header needed)
+    - `https://sandbox.superserve.ai/...` with `X-Superserve-Sandbox-Id: <sandbox_id>` —
+      preferred for server-side SDK clients; collapses all sandbox traffic onto a single
+      HTTP origin so the client's connection pool can be reused.
+    - `https://boxd-{sandbox_id}.sandbox.superserve.ai/...` — required for browsers
+      (avoids the CORS preflight that the routing header would otherwise trigger) and
+      convenient for ad-hoc curl. No routing header needed.
   contact:
     name: Superserve Team
   license:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,6 +29,15 @@ info:
     and build-essential pre-installed). Callers can override with any template
     name (e.g. `superserve/python-3.11`, `superserve/node-22`) or a team-owned template UUID
     via the `from_template` field on `POST /sandboxes`.
+
+    ## Data-plane endpoints
+
+    `/exec`, `/exec/stream`, and `/files` are served on a separate host. Authenticate
+    with the per-sandbox `X-Access-Token` returned by create / resume / activate.
+    Either of these host forms reaches the same endpoints:
+
+    - `https://sandbox.superserve.ai/...` with `X-Superserve-Sandbox-Id: <sandbox_id>`
+    - `https://boxd-{sandbox_id}.sandbox.superserve.ai/...` (no routing header needed)
   contact:
     name: Superserve Team
   license:

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -51,6 +51,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		return
 	}
 	r.Header.Del(accessTokenHeader)
+	r.Header.Del(headerSandboxID)
 	w.Header().Set("Referrer-Policy", "no-referrer")
 
 	info, fail := h.authorizeSandboxRequest(r.Context(), token, instanceID)

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -203,3 +203,30 @@ func TestExec_WithoutWithAuth_Panics(t *testing.T) {
 	h := NewHandler("sandbox.test", &stubResolver{}, zerolog.Nop())
 	h.WithExec()
 }
+
+func TestExec_SharedHost_ForwardsToUpstream(t *testing.T) {
+	env := newExecTestEnv(t)
+	req := httptest.NewRequest(http.MethodPost, "http://unused/exec", strings.NewReader(`{"command":"echo"}`))
+	req.Host = env.domain
+	req.Header.Set(headerSandboxID, env.sandboxID)
+	req.Header.Set("X-Access-Token", env.validToken())
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	env.upstreamMu.Lock()
+	defer env.upstreamMu.Unlock()
+	if !env.lastReq.received {
+		t.Fatal("upstream did not receive the request")
+	}
+	if env.lastReq.path != "/exec" {
+		t.Errorf("upstream path = %q, want /exec", env.lastReq.path)
+	}
+	if env.lastReq.hasToken {
+		t.Error("X-Access-Token was forwarded to upstream — should be scrubbed")
+	}
+}

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -32,12 +32,13 @@ func newExecTestEnv(t *testing.T) *filesTestEnv {
 	env.upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		env.upstreamMu.Lock()
 		env.lastReq = capturedRequest{
-			method:   r.Method,
-			path:     r.URL.Path,
-			host:     r.Host,
-			hasToken: r.Header.Get("X-Access-Token") != "",
-			fwdFor:   r.Header.Get("X-Forwarded-For"),
-			received: true,
+			method:             r.Method,
+			path:               r.URL.Path,
+			host:               r.Host,
+			hasToken:           r.Header.Get("X-Access-Token") != "",
+			hasSandboxIDHeader: r.Header.Get(headerSandboxID) != "",
+			fwdFor:             r.Header.Get("X-Forwarded-For"),
+			received:           true,
 		}
 		env.upstreamMu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
@@ -228,5 +229,8 @@ func TestExec_SharedHost_ForwardsToUpstream(t *testing.T) {
 	}
 	if env.lastReq.hasToken {
 		t.Error("X-Access-Token was forwarded to upstream — should be scrubbed")
+	}
+	if env.lastReq.hasSandboxIDHeader {
+		t.Error("X-Superserve-Sandbox-Id was forwarded to upstream — should be scrubbed")
 	}
 }

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -156,6 +156,7 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 
 	// Scrub the token before forwarding to boxd.
 	r.Header.Del(accessTokenHeader)
+	r.Header.Del(headerSandboxID)
 
 	w.Header().Set("Referrer-Policy", "no-referrer")
 

--- a/internal/proxy/files_test.go
+++ b/internal/proxy/files_test.go
@@ -364,3 +364,27 @@ func TestFiles_DisabledReturns404(t *testing.T) {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
 }
+
+func TestFiles_SharedHost_ForwardsToUpstream(t *testing.T) {
+	env := newFilesTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodPost, "http://unused/files?path=/f.txt", strings.NewReader("content"))
+	req.Host = env.domain
+	req.Header.Set(headerSandboxID, env.sandboxID)
+	req.Header.Set("X-Access-Token", env.validToken())
+	w := httptest.NewRecorder()
+
+	env.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	env.upstreamMu.Lock()
+	defer env.upstreamMu.Unlock()
+	if !env.lastReq.received {
+		t.Fatal("upstream did not receive the request")
+	}
+	if env.lastReq.path != "/files" {
+		t.Errorf("upstream path = %q, want /files", env.lastReq.path)
+	}
+}

--- a/internal/proxy/files_test.go
+++ b/internal/proxy/files_test.go
@@ -54,14 +54,15 @@ type filesTestEnv struct {
 }
 
 type capturedRequest struct {
-	method      string
-	path        string
-	rawQuery    string
-	host        string
-	hasToken    bool
-	fwdFor      string
-	body        string
-	received    bool
+	method             string
+	path               string
+	rawQuery           string
+	host               string
+	hasToken           bool
+	hasSandboxIDHeader bool
+	fwdFor             string
+	body               string
+	received           bool
 }
 
 func newFilesTestEnv(t *testing.T) *filesTestEnv {
@@ -80,14 +81,15 @@ func newFilesTestEnv(t *testing.T) *filesTestEnv {
 		bodyBytes, _ := io.ReadAll(r.Body)
 		env.upstreamMu.Lock()
 		env.lastReq = capturedRequest{
-			method:   r.Method,
-			path:     r.URL.Path,
-			rawQuery: r.URL.RawQuery,
-			host:     r.Host,
-			hasToken: r.Header.Get("X-Access-Token") != "",
-			fwdFor:   r.Header.Get("X-Forwarded-For"),
-			body:     string(bodyBytes),
-			received: true,
+			method:             r.Method,
+			path:               r.URL.Path,
+			rawQuery:           r.URL.RawQuery,
+			host:               r.Host,
+			hasToken:           r.Header.Get("X-Access-Token") != "",
+			hasSandboxIDHeader: r.Header.Get(headerSandboxID) != "",
+			fwdFor:             r.Header.Get("X-Forwarded-For"),
+			body:               string(bodyBytes),
+			received:           true,
 		}
 		env.upstreamMu.Unlock()
 
@@ -386,5 +388,8 @@ func TestFiles_SharedHost_ForwardsToUpstream(t *testing.T) {
 	}
 	if env.lastReq.path != "/files" {
 		t.Errorf("upstream path = %q, want /files", env.lastReq.path)
+	}
+	if env.lastReq.hasSandboxIDHeader {
+		t.Error("X-Superserve-Sandbox-Id was forwarded to upstream — should be scrubbed")
 	}
 }

--- a/internal/proxy/host.go
+++ b/internal/proxy/host.go
@@ -15,7 +15,7 @@ var validInstanceID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
 
 const headerSandboxID = "X-Superserve-Sandbox-Id"
 
-// Parse resolves the target sandbox + port from an incoming request.
+// ParseRequest resolves the target sandbox + port from an incoming request.
 // Two routing modes:
 //
 //   - Shared-host: Host equals the configured domain and the
@@ -24,7 +24,7 @@ const headerSandboxID = "X-Superserve-Sandbox-Id"
 //   - Subdomain: Host is "{label}-{id}.{domain}", same as ParseHost.
 //
 // A subdomain-form Host is never overridden by a routing header.
-func Parse(host string, headers http.Header, domain string) (port int, instanceID string, err error) {
+func ParseRequest(host string, headers http.Header, domain string) (port int, instanceID string, err error) {
 	if isSharedHost(host, domain) {
 		id := headers.Get(headerSandboxID)
 		if id == "" {

--- a/internal/proxy/host.go
+++ b/internal/proxy/host.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -11,6 +12,40 @@ import (
 // validInstanceID restricts instance IDs to alphanumeric + hyphen, max 64 chars.
 // Prevents path traversal (%2f, ..) from reaching the VMD resolver URL.
 var validInstanceID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,63}$`)
+
+const headerSandboxID = "X-Superserve-Sandbox-Id"
+
+// Parse resolves the target sandbox + port from an incoming request.
+// Two routing modes:
+//
+//   - Shared-host: Host equals the configured domain and the
+//     X-Superserve-Sandbox-Id header carries the ID. Always boxdPort.
+//
+//   - Subdomain: Host is "{label}-{id}.{domain}", same as ParseHost.
+//
+// A subdomain-form Host is never overridden by a routing header.
+func Parse(host string, headers http.Header, domain string) (port int, instanceID string, err error) {
+	if isSharedHost(host, domain) {
+		id := headers.Get(headerSandboxID)
+		if id == "" {
+			return 0, "", fmt.Errorf("proxy: shared host %q requires %s header", host, headerSandboxID)
+		}
+		if !validInstanceID.MatchString(id) {
+			return 0, "", fmt.Errorf("proxy: invalid sandbox ID in %s header", headerSandboxID)
+		}
+		return boxdPort, id, nil
+	}
+	return ParseHost(host, domain)
+}
+
+// isSharedHost reports whether host (with any :port stripped) equals the configured domain.
+func isSharedHost(host, domain string) bool {
+	hostname, _, err := net.SplitHostPort(host)
+	if err != nil {
+		hostname = host
+	}
+	return hostname == domain
+}
 
 // boxdHostLabel is the reserved left-most label that addresses boxd's
 // own HTTP endpoint on the edge proxy. We deliberately do NOT let

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -133,5 +134,125 @@ func TestParseHost(t *testing.T) {
 				t.Errorf("instanceID: got %q, want %q", instanceID, tt.wantInstanceID)
 			}
 		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	const sandboxID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"
+
+	tests := []struct {
+		name           string
+		host           string
+		headerID       string
+		wantPort       int
+		wantInstanceID string
+		wantErr        bool
+	}{
+		// Shared-host routes via header.
+		{
+			name:           "shared-host with header",
+			host:           testDomain,
+			headerID:       sandboxID,
+			wantPort:       boxdPort,
+			wantInstanceID: sandboxID,
+		},
+		{
+			name:           "shared-host with :443 suffix",
+			host:           testDomain + ":443",
+			headerID:       sandboxID,
+			wantPort:       boxdPort,
+			wantInstanceID: sandboxID,
+		},
+		{
+			name:    "shared-host missing header",
+			host:    testDomain,
+			wantErr: true,
+		},
+		{
+			name:     "shared-host with path traversal in header",
+			host:     testDomain,
+			headerID: "../etc",
+			wantErr:  true,
+		},
+		{
+			name:     "shared-host with underscore in header",
+			host:     testDomain,
+			headerID: "abc_def",
+			wantErr:  true,
+		},
+		{
+			name:     "shared-host with empty header value",
+			host:     testDomain,
+			headerID: "",
+			wantErr:  true,
+		},
+
+		// Subdomain path unchanged.
+		{
+			name:           "subdomain still routes",
+			host:           "boxd-" + sandboxID + "." + testDomain,
+			wantPort:       boxdPort,
+			wantInstanceID: sandboxID,
+		},
+		{
+			name:           "subdomain on user app port",
+			host:           "3000-mybox." + testDomain,
+			wantPort:       3000,
+			wantInstanceID: "mybox",
+		},
+		{
+			name:           "subdomain header ignored when not on shared host",
+			host:           "boxd-" + sandboxID + "." + testDomain,
+			headerID:       "different-sandbox",
+			wantPort:       boxdPort,
+			wantInstanceID: sandboxID,
+		},
+		{
+			name:    "off-domain host with header",
+			host:    "sandbox.attacker.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := http.Header{}
+			if tt.headerID != "" {
+				headers.Set(headerSandboxID, tt.headerID)
+			}
+			port, instanceID, err := Parse(tt.host, headers, testDomain)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got port=%d instanceID=%q", port, instanceID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tt.wantPort {
+				t.Errorf("port: got %d, want %d", port, tt.wantPort)
+			}
+			if instanceID != tt.wantInstanceID {
+				t.Errorf("instanceID: got %q, want %q", instanceID, tt.wantInstanceID)
+			}
+		})
+	}
+}
+
+// On a subdomain Host, the routing header is ignored — the subdomain wins.
+func TestParse_HeaderRoutingRequiresSharedHost(t *testing.T) {
+	const targetID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"
+	const attackerID = "deadbeef"
+
+	headers := http.Header{}
+	headers.Set(headerSandboxID, attackerID)
+
+	_, gotID, err := Parse("boxd-"+targetID+"."+testDomain, headers, testDomain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotID != targetID {
+		t.Errorf("header overrode subdomain routing: got id %q, want %q", gotID, targetID)
 	}
 }

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -137,7 +137,7 @@ func TestParseHost(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
+func TestParseRequest(t *testing.T) {
 	const sandboxID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"
 
 	tests := []struct {
@@ -214,7 +214,7 @@ func TestParse(t *testing.T) {
 			if tt.headerID != "" {
 				headers.Set(headerSandboxID, tt.headerID)
 			}
-			port, instanceID, err := Parse(tt.host, headers, testDomain)
+			port, instanceID, err := ParseRequest(tt.host, headers, testDomain)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got port=%d instanceID=%q", port, instanceID)
@@ -235,14 +235,14 @@ func TestParse(t *testing.T) {
 }
 
 // On a subdomain Host, the routing header is ignored — the subdomain wins.
-func TestParse_HeaderRoutingRequiresSharedHost(t *testing.T) {
+func TestParseRequest_HeaderRoutingRequiresSharedHost(t *testing.T) {
 	const targetID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"
 	const attackerID = "deadbeef"
 
 	headers := http.Header{}
 	headers.Set(headerSandboxID, attackerID)
 
-	_, gotID, err := Parse("boxd-"+targetID+"."+testDomain, headers, testDomain)
+	_, gotID, err := ParseRequest("boxd-"+targetID+"."+testDomain, headers, testDomain)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -180,12 +180,6 @@ func TestParse(t *testing.T) {
 			headerID: "abc_def",
 			wantErr:  true,
 		},
-		{
-			name:     "shared-host with empty header value",
-			host:     testDomain,
-			headerID: "",
-			wantErr:  true,
-		},
 
 		// Subdomain path unchanged.
 		{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -140,7 +140,7 @@ func (h *Handler) StartSweeper(ctx context.Context) {
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	port, instanceID, err := Parse(r.Host, r.Header, h.domain)
+	port, instanceID, err := ParseRequest(r.Host, r.Header, h.domain)
 	if err != nil {
 		h.log.Warn().Err(err).Str("host", r.Host).Msg("bad host")
 		http.Error(w, "invalid sandbox URL", http.StatusBadRequest)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -140,7 +140,7 @@ func (h *Handler) StartSweeper(ctx context.Context) {
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	port, instanceID, err := ParseHost(r.Host, h.domain)
+	port, instanceID, err := Parse(r.Host, r.Header, h.domain)
 	if err != nil {
 		h.log.Warn().Err(err).Str("host", r.Host).Msg("bad host")
 		http.Error(w, "invalid sandbox URL", http.StatusBadRequest)


### PR DESCRIPTION
## Summary
Adds a second routing mode to the data-plane proxy: requests to `sandbox.superserve.ai` carrying an `X-Superserve-Sandbox-Id` header dispatch to the same boxd endpoints (`/exec`, `/exec/stream`, `/files`) as the existing per-sandbox subdomain. The subdomain path (`boxd-{id}.sandbox.superserve.ai`) is unchanged and remains the fallback for browsers and curl.

Why: SDK clients hitting 100 unique subdomains pay 100 cold TLS handshakes per burst because HTTP clients key connection pools by origin. A shared host collapses that to one origin and one pool.

Code is dormant in prod until DNS + LB host rule for `sandbox.superserve.ai` are added (separate GCP change). Zero behavior change for existing traffic.