### PR TITLE
network: allow_out wins over deny_out so default-deny + allowlist works

### DIFF
--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -272,37 +272,16 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 	relay(conn, upstream)
 }
 
-// isAllowed checks if egress is allowed based on domain and CIDR rules.
-// Returns (allowed, matchType).
-//
-// Priority order is fail-safe: deny is always checked BEFORE allow, so a
-// user who writes {"allow_out": ["*.example.com"], "deny_out": ["0.0.0.0/0"]}
-// cannot accidentally bypass the deny rule via a matching allowlist entry.
-//
-//  1. No rules configured → allow (default)
-//  2. Destination matches any deny CIDR → deny
-//  3. Destination matches any allow domain → allow
-//  4. Destination matches any allow CIDR → allow
-//  5. Allow list is non-empty but nothing matched → deny (implicit deny)
-//  6. Allow list is empty → allow (deny list only)
+// isAllowed uses an "allow wins" model: a match in allow_out short-circuits
+// before deny_out, so {"allow_out": ["api.openai.com"], "deny_out": ["0.0.0.0/0"]}
+// allows the named host and blocks everything else. A broad allow therefore
+// shadows a more specific deny — narrow the allow list rather than relying on
+// overlapping denies.
 func (p *EgressProxy) isAllowed(rules *EgressRules, hostname string, dstIP net.IP) (bool, string) {
 	if rules == nil {
 		return true, "default"
 	}
 
-	// Priority 1: deny CIDRs — evaluated first so they cannot be bypassed
-	// by a matching allow entry.
-	for _, cidr := range rules.DeniedCIDRs {
-		_, ipNet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			continue
-		}
-		if ipNet.Contains(dstIP) {
-			return false, "cidr"
-		}
-	}
-
-	// Priority 2: allow domains.
 	if hostname != "" {
 		for _, domain := range rules.AllowedDomains {
 			if matchDomain(hostname, domain) {
@@ -311,7 +290,6 @@ func (p *EgressProxy) isAllowed(rules *EgressRules, hostname string, dstIP net.I
 		}
 	}
 
-	// Priority 2: allow CIDRs.
 	for _, cidr := range rules.AllowedCIDRs {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -322,14 +300,20 @@ func (p *EgressProxy) isAllowed(rules *EgressRules, hostname string, dstIP net.I
 		}
 	}
 
-	// Allow list was non-empty but nothing matched → implicit deny.
-	// This makes {"allow_out": ["api.openai.com"]} work as users expect
-	// (only the listed domain is allowed, everything else blocked).
+	for _, cidr := range rules.DeniedCIDRs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(dstIP) {
+			return false, "cidr"
+		}
+	}
+
 	if len(rules.AllowedDomains) > 0 || len(rules.AllowedCIDRs) > 0 {
 		return false, "implicit-deny"
 	}
 
-	// Only a deny list was configured and nothing matched → allow.
 	return true, "default"
 }
 

--- a/internal/network/proxy_test.go
+++ b/internal/network/proxy_test.go
@@ -1,0 +1,280 @@
+package network
+
+import (
+	"net"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestIsAllowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       *EgressRules
+		hostname    string
+		dstIP       string
+		wantAllowed bool
+		wantMatch   string
+	}{
+		{
+			name:        "nil rules → allow",
+			rules:       nil,
+			hostname:    "api.openai.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "default",
+		},
+		{
+			name:        "empty rules → allow",
+			rules:       &EgressRules{},
+			hostname:    "anything.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "default",
+		},
+		{
+			name: "allow domain only, hostname matches → allow",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+			},
+			hostname:    "api.openai.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "domain",
+		},
+		{
+			name: "allow domain only, hostname mismatch → implicit deny",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+			},
+			hostname:    "evil.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "implicit-deny",
+		},
+		{
+			name: "allow CIDR only, IP matches → allow",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"8.8.8.0/24"},
+			},
+			hostname:    "",
+			dstIP:       "8.8.8.8",
+			wantAllowed: true,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "allow CIDR only, IP outside → implicit deny",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"8.8.8.0/24"},
+			},
+			hostname:    "",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "implicit-deny",
+		},
+		{
+			name: "deny CIDR only, IP matches → deny",
+			rules: &EgressRules{
+				DeniedCIDRs: []string{"1.2.3.0/24"},
+			},
+			hostname:    "",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "deny CIDR only, IP outside → default allow",
+			rules: &EgressRules{
+				DeniedCIDRs: []string{"1.2.3.0/24"},
+			},
+			hostname:    "",
+			dstIP:       "8.8.8.8",
+			wantAllowed: true,
+			wantMatch:   "default",
+		},
+		{
+			// Regression: previously returned (false, "cidr") because the
+			// 0.0.0.0/0 deny was evaluated before the domain allow.
+			name: "deny all + allow domain, hostname matches → allow",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "api.openai.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "domain",
+		},
+		{
+			name: "deny all + allow domain, hostname mismatch → deny",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "evil.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "deny all + allow CIDR, IP matches → allow",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"8.8.8.0/24"},
+				DeniedCIDRs:  []string{"0.0.0.0/0"},
+			},
+			hostname:    "",
+			dstIP:       "8.8.8.8",
+			wantAllowed: true,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "deny all + allow CIDR, IP outside → deny",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"8.8.8.0/24"},
+				DeniedCIDRs:  []string{"0.0.0.0/0"},
+			},
+			hostname:    "",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "wildcard allow domain matches subdomain",
+			rules: &EgressRules{
+				AllowedDomains: []string{"*.openai.com"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "api.openai.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "domain",
+		},
+		{
+			name: "wildcard allow domain does not match unrelated host",
+			rules: &EgressRules{
+				AllowedDomains: []string{"*.openai.com"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "evil.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "bare wildcard '*' is rejected (no domain match)",
+			rules: &EgressRules{
+				AllowedDomains: []string{"*"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "anything.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "broad allow CIDR shadows specific deny CIDR",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"10.0.0.0/8"},
+				DeniedCIDRs:  []string{"10.1.1.1/32"},
+			},
+			hostname:    "",
+			dstIP:       "10.1.1.1",
+			wantAllowed: true,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "domain allow shadows deny CIDR that would otherwise match",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+				DeniedCIDRs:    []string{"1.2.3.0/24"},
+			},
+			hostname:    "api.openai.com",
+			dstIP:       "1.2.3.4",
+			wantAllowed: true,
+			wantMatch:   "domain",
+		},
+		{
+			name: "no hostname, allow domain present, allow CIDR matches → allow",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+				AllowedCIDRs:   []string{"8.8.8.0/24"},
+				DeniedCIDRs:    []string{"0.0.0.0/0"},
+			},
+			hostname:    "",
+			dstIP:       "8.8.8.8",
+			wantAllowed: true,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "no hostname, only allow domain configured, IP not in any allow → implicit deny",
+			rules: &EgressRules{
+				AllowedDomains: []string{"api.openai.com"},
+			},
+			hostname:    "",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "implicit-deny",
+		},
+		{
+			name: "malformed allow CIDR is skipped, valid one still matches",
+			rules: &EgressRules{
+				AllowedCIDRs: []string{"not-a-cidr", "8.8.8.0/24"},
+				DeniedCIDRs:  []string{"0.0.0.0/0"},
+			},
+			hostname:    "",
+			dstIP:       "8.8.8.8",
+			wantAllowed: true,
+			wantMatch:   "cidr",
+		},
+		{
+			name: "malformed deny CIDR is skipped, evaluation continues",
+			rules: &EgressRules{
+				DeniedCIDRs: []string{"not-a-cidr", "1.2.3.0/24"},
+			},
+			hostname:    "",
+			dstIP:       "1.2.3.4",
+			wantAllowed: false,
+			wantMatch:   "cidr",
+		},
+	}
+
+	p := NewEgressProxy(0, 0, 0, 0, zerolog.Nop())
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.dstIP)
+			if ip == nil {
+				t.Fatalf("invalid test IP %q", tc.dstIP)
+			}
+			gotAllowed, gotMatch := p.isAllowed(tc.rules, tc.hostname, ip)
+			if gotAllowed != tc.wantAllowed || gotMatch != tc.wantMatch {
+				t.Errorf("isAllowed(hostname=%q, ip=%s) = (%v, %q), want (%v, %q)",
+					tc.hostname, tc.dstIP, gotAllowed, gotMatch, tc.wantAllowed, tc.wantMatch)
+			}
+		})
+	}
+}
+
+func TestMatchDomain(t *testing.T) {
+	tests := []struct {
+		hostname string
+		pattern  string
+		want     bool
+	}{
+		{"api.openai.com", "api.openai.com", true},
+		{"API.OPENAI.COM", "api.openai.com", true},
+		{"api.openai.com", "API.OPENAI.COM", true},
+		{"api.openai.com", "*.openai.com", true},
+		{"deep.api.openai.com", "*.openai.com", true},
+		{"openai.com", "*.openai.com", false},
+		{"api.openai.com", "*.example.com", false},
+		{"anything.com", "*", false},
+		{"anything.com", "", false},
+	}
+	for _, tc := range tests {
+		got := matchDomain(tc.hostname, tc.pattern)
+		if got != tc.want {
+			t.Errorf("matchDomain(%q, %q) = %v, want %v", tc.hostname, tc.pattern, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the case where `{"allow_out": ["api.openai.com"], "deny_out": ["0.0.0.0/0"]}` blocks `api.openai.com` because the `0.0.0.0/0` deny is evaluated before the domain allow.

Switches `isAllowed` to an "allow wins" model: allow_out short-circuits before deny_out. Adds a table test in `proxy_test.go` (didn't exist) covering the regression row plus the broader matrix.

Tradeoff: a broad allow shadows a more specific deny. Documented in the docstring.