### PR TITLE
vmd: auto-collect failed firecracker units

### DIFF
--- a/deploy/firecracker@.service
+++ b/deploy/firecracker@.service
@@ -2,6 +2,7 @@
 Description=Firecracker VM %i
 After=network-online.target
 StopWhenUnneeded=no
+CollectMode=inactive-or-failed
 
 [Service]
 Type=simple


### PR DESCRIPTION
Adds `CollectMode=inactive-or-failed` to the firecracker unit template so systemd garbage-collects each unit when it stops. Prevents systemd registry buildup that slows down `systemctl start` over time.