### PR TITLE
vm: systemctl start --no-block + phase instrumentation

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1620,8 +1620,9 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	tStartUnitDone := time.Now()
 
 	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
+		status := unitFailureSummary(ctx, systemdUnitName(vmID))
 		_ = stopUnit(ctx, systemdUnitName(vmID))
-		return 0, fmt.Errorf("wait for socket: %w", err)
+		return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
 	}
 	tSocketReady := time.Now()
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1613,16 +1613,23 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 		return 0, fmt.Errorf("write start script: %w", err)
 	}
 
-	// Start the systemd unit.
+	tStartUnit := time.Now()
 	if err := startUnit(ctx, systemdUnitName(vmID)); err != nil {
 		return 0, fmt.Errorf("start systemd unit: %w", err)
 	}
+	tStartUnitDone := time.Now()
 
-	// Wait for the Firecracker API socket.
 	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
 		_ = stopUnit(ctx, systemdUnitName(vmID))
 		return 0, fmt.Errorf("wait for socket: %w", err)
 	}
+	tSocketReady := time.Now()
+
+	m.log.Info().
+		Str("vm_id", vmID).
+		Int64("start_unit_ms", tStartUnitDone.Sub(tStartUnit).Milliseconds()).
+		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds()).
+		Msg("fc startup phases")
 
 	// Read the PID asynchronously so the create path isn't slowed down
 	// by the ~15ms dbus roundtrip. The PID is populated in the instance

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -14,14 +14,32 @@ func systemdUnitName(vmID string) string {
 }
 
 // startUnit starts a systemd unit. Idempotent — starting an already-running
-// unit is a no-op.
+// unit is a no-op. Returns after the start job is queued; readiness is
+// signalled by the unit's own side effect (e.g., API socket appearing).
 func startUnit(ctx context.Context, unit string) error {
-	cmd := exec.CommandContext(ctx, "systemctl", "start", unit)
+	cmd := exec.CommandContext(ctx, "systemctl", "start", "--no-block", unit)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("systemctl start %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+// unitFailureSummary returns a one-line summary of a unit's
+// Result/SubState for embedding in error messages. Best-effort —
+// returns "unknown" on any error.
+func unitFailureSummary(ctx context.Context, unit string) string {
+	cmd := exec.CommandContext(ctx, "systemctl", "show", "--property=Result,SubState", "--value", unit)
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	s := strings.TrimSpace(string(out))
+	s = strings.ReplaceAll(s, "\n", " ")
+	if s == "" {
+		return "unknown"
+	}
+	return s
 }
 
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped


### PR DESCRIPTION
Adds finer-grained timing for sandbox create startup and switches `systemctl start` to `--no-block` since waitForSocket is already the readiness signal.