### PR TITLE
api: test that openapi.yaml stays in sync with registered routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/vishvananda/netns v0.0.5
 	go.etcd.io/bbolt v1.4.3
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.43.0
@@ -96,7 +97,6 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// dataPlaneSpecPaths are documented in the spec but served by boxd, not the
+// control-plane router, so they have no route here.
+var dataPlaneSpecPaths = map[string]bool{
+	"/files": true,
+}
+
+// TestOpenAPISpecMatchesRoutes fails if a registered route is missing from
+// api/openapi.yaml, or a documented operation has no route — keeping the two
+// in sync. Mismatches are reported as exact "METHOD /path".
+func TestOpenAPISpecMatchesRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// An empty Handlers suffices to enumerate routes; the handlers are never called.
+	router := SetupRouter(ctx, &Handlers{}, nil)
+
+	routeOps := map[string]bool{}
+	for _, ri := range router.Routes() {
+		// Internal infra endpoints are intentionally undocumented.
+		if strings.HasPrefix(ri.Path, "/internal/") {
+			continue
+		}
+		routeOps[ri.Method+" "+ginPathToOpenAPI(ri.Path)] = true
+	}
+
+	specOps := loadSpecOps(t)
+
+	// Every control-plane route must be documented.
+	for op := range routeOps {
+		if !specOps[op] {
+			t.Errorf("route %q is registered but missing from api/openapi.yaml — add it to the spec", op)
+		}
+	}
+
+	// Every documented operation must have a route, except data-plane paths.
+	for op := range specOps {
+		path := strings.SplitN(op, " ", 2)[1]
+		if dataPlaneSpecPaths[path] {
+			continue
+		}
+		if !routeOps[op] {
+			t.Errorf("operation %q is in api/openapi.yaml but has no control-plane route — remove it from the spec or implement it", op)
+		}
+	}
+}
+
+// loadSpecOps parses api/openapi.yaml and returns its operations as "METHOD /path".
+func loadSpecOps(t *testing.T) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	// Only the HTTP-method keys are operations (skip parameters/servers/etc.).
+	var doc struct {
+		Paths map[string]map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+
+	httpMethods := map[string]bool{
+		"GET": true, "POST": true, "PUT": true, "PATCH": true,
+		"DELETE": true, "HEAD": true, "OPTIONS": true,
+	}
+	ops := map[string]bool{}
+	for path, item := range doc.Paths {
+		for key := range item {
+			if m := strings.ToUpper(key); httpMethods[m] {
+				ops[m+" "+path] = true
+			}
+		}
+	}
+	return ops
+}
+
+// ginPathToOpenAPI rewrites gin's ":param" segments into OpenAPI's "{param}" form.
+func ginPathToOpenAPI(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		if strings.HasPrefix(s, ":") {
+			segs[i] = "{" + s[1:] + "}"
+		}
+	}
+	return strings.Join(segs, "/")
+}


### PR DESCRIPTION
Adds an automated check so the OpenAPI spec and the control-plane routes can't drift apart silently — the gap that let documented and undocumented endpoints diverge.

## What it does
A Go test enumerates the registered gin routes and cross-checks them against `api/openapi.yaml` in both directions:
- A registered route with no spec entry fails the test (undocumented endpoint).
- A documented operation with no route fails the test (stale spec entry).

Failures report the exact `METHOD /path`, so the fix is obvious.

## Notes
- `/internal/*` (VMD heartbeat) is excluded — intentionally undocumented.
- `/files` is exempt — it's served by boxd, not the control-plane router.
- Runs in the existing `go test ./...` CI step; no workflow change.