### PR TITLE
proxy: add full-duplex /exec/ws WebSocket endpoint with stdin support

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -412,6 +412,43 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /exec/ws:
+    servers:
+      - url: https://sandbox.superserve.ai
+        description: Shared host — send the sandbox ID in `X-Superserve-Sandbox-Id`.
+      - url: https://boxd-{sandbox_id}.sandbox.superserve.ai
+        description: Per-sandbox host.
+        variables:
+          sandbox_id:
+            default: ""
+            description: The sandbox ID.
+    get:
+      operationId: execWebSocket
+      tags: [Exec]
+      summary: Run a command over a WebSocket
+      description: |
+        Runs a command over a WebSocket, streaming output back and accepting
+        stdin over one connection.
+
+        Connect with two `Sec-WebSocket-Protocol` values: `superserve.exec.v1`
+        and `token.<access-token>`.
+
+        - First frame (text): an `ExecRequest` JSON object. Omitting `timeout_s`
+          runs with no per-command timeout.
+        - Client frames: a binary frame is stdin; a text frame is JSON control —
+          `{"type":"stdin","data":"..."}`, `{"type":"stdin_close"}`, or
+          `{"type":"signal","name":"SIGINT"}`.
+        - Server frames (text): `ExecStreamEvent` JSON — `{"stdout":"..."}`,
+          `{"stderr":"..."}`, then `{"exit_code":N,"finished":true}`. Closes on
+          exit.
+      responses:
+        "101":
+          description: Switching Protocols — the WebSocket is established.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /files:
     servers:
       - url: https://sandbox.superserve.ai

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -412,7 +412,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
-  /exec/ws:
+  /exec/connect:
     servers:
       - url: https://sandbox.superserve.ai
         description: Shared host — send the sandbox ID in `X-Superserve-Sandbox-Id`.
@@ -423,7 +423,7 @@ paths:
             default: ""
             description: The sandbox ID.
     get:
-      operationId: execWebSocket
+      operationId: execConnect
       tags: [Exec]
       summary: Run a command over a WebSocket
       description: |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -433,15 +433,19 @@ paths:
         Connect with two `Sec-WebSocket-Protocol` values: `superserve.exec.v1`
         and `token.<access-token>`.
 
+        I/O rides binary frames prefixed with a one-byte channel, so output is
+        byte-exact; lifecycle and control ride text JSON frames.
+
         - First frame (text): an `ExecRequest` JSON object. Omitting `timeout_s`
           runs with no per-command timeout.
-        - Client frames: a binary frame is stdin; a text frame is JSON control —
-          `{"type":"stdin","data":"..."}`, `{"type":"stdin_close"}`, or
-          `{"type":"signal","name":"SIGINT"}`. Frames are capped at 64 KiB, so
-          chunk larger stdin.
-        - Server frames (text): `ExecStreamEvent` JSON — `{"stdout":"..."}`,
-          `{"stderr":"..."}`, then `{"exit_code":N,"finished":true}`. Closes on
-          exit.
+        - Client frames: a binary frame is stdin, prefixed with channel `0x00`
+          (`[0x00][bytes]`); a text frame is JSON control —
+          `{"type":"stdin_close"}` or `{"type":"signal","name":"SIGINT"}`.
+          Frames are capped at 64 KiB, so chunk larger stdin.
+        - Server frames: a binary frame is output, prefixed with its channel
+          (`0x01` stdout, `0x02` stderr); a text frame is JSON lifecycle —
+          `{"exit_code":N,"finished":true}`, or `{"error":"...","code":"..."}`.
+          Closes on exit.
       responses:
         "101":
           description: Switching Protocols — the WebSocket is established.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -437,7 +437,8 @@ paths:
           runs with no per-command timeout.
         - Client frames: a binary frame is stdin; a text frame is JSON control —
           `{"type":"stdin","data":"..."}`, `{"type":"stdin_close"}`, or
-          `{"type":"signal","name":"SIGINT"}`.
+          `{"type":"signal","name":"SIGINT"}`. Frames are capped at 64 KiB, so
+          chunk larger stdin.
         - Server frames (text): `ExecStreamEvent` JSON — `{"stdout":"..."}`,
           `{"stderr":"..."}`, then `{"exit_code":N,"finished":true}`. Closes on
           exit.

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -115,7 +115,7 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		return nil
 	}
 
-	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
+	if err := s.runProcess(r.Context(), req.toStartRequest(), emit, false); err != nil {
 		writeRunError(w, err)
 		return
 	}
@@ -213,7 +213,7 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 		return nil
 	}
 
-	if err := s.runProcess(r.Context(), req.toStartRequest(), emit); err != nil {
+	if err := s.runProcess(r.Context(), req.toStartRequest(), emit, false); err != nil {
 		errEvent, _ := json.Marshal(map[string]any{
 			"error":    err.Error(),
 			"code":     runErrorCode(err),

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -525,8 +525,7 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eve
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
-	// stdin pipe lets SendInput feed the process. cmd.Wait closes it once
-	// the process exits, so we don't close it on the read path.
+	// stdin pipe lets SendInput feed the process; cmd.Wait closes it on exit.
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, err)
@@ -641,8 +640,7 @@ func (s *processService) SendInput(ctx context.Context, req *connect.Request[pb.
 	}
 	proc := val.(*runningProcess)
 
-	// PTY mode: input goes to the terminal master. EOF has no meaning here
-	// (the client sends Ctrl-D as a data byte), so it's ignored.
+	// PTY mode: input goes to the terminal master; EOF is ignored.
 	if proc.tty != nil {
 		if _, err := proc.tty.Write(req.Msg.GetData()); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -331,10 +331,11 @@ func resolveUser(name string) (*user.User, *syscall.Credential, error) {
 type eventEmitter func(*pb.ProcessEvent) error
 
 func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
-	return s.runProcess(ctx, req.Msg, stream.Send)
+	// Interactive: gets a stdin pipe for SendInput (one-shot /exec passes false).
+	return s.runProcess(ctx, req.Msg, stream.Send, true)
 }
 
-func (s *processService) runProcess(ctx context.Context, msg *pb.StartRequest, emit eventEmitter) error {
+func (s *processService) runProcess(ctx context.Context, msg *pb.StartRequest, emit eventEmitter, wantStdin bool) error {
 	cmdName := msg.GetCmd()
 	if cmdName == "" {
 		cmdName = defaultShell
@@ -420,7 +421,7 @@ func (s *processService) runProcess(ctx context.Context, msg *pb.StartRequest, e
 			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		}
 		cmd.WaitDelay = time.Second
-		return s.startPipes(ctx, cmd, emit, &timedOut)
+		return s.startPipes(ctx, cmd, emit, &timedOut, wantStdin)
 	}
 	return s.startPTY(ctx, cmd, msg, emit, &timedOut)
 }
@@ -515,7 +516,7 @@ func (s *processService) startPTY(ctx context.Context, cmd *exec.Cmd, msg *pb.St
 	})
 }
 
-func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eventEmitter, timedOut *atomic.Bool) error {
+func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eventEmitter, timedOut *atomic.Bool, wantStdin bool) error {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, err)
@@ -525,10 +526,15 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eve
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
-	// stdin pipe lets SendInput feed the process; cmd.Wait closes it on exit.
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
+	// Only open a stdin pipe when the caller can feed it (the streaming RPC).
+	// Otherwise leave cmd.Stdin nil so the child reads /dev/null and sees EOF
+	// immediately, instead of blocking on a pipe nobody will close.
+	var stdin io.WriteCloser
+	if wantStdin {
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			return connect.NewError(connect.CodeInternal, err)
+		}
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -180,8 +180,9 @@ func setHostname(name string) error {
 // ---------------------------------------------------------------------------
 
 type runningProcess struct {
-	cmd *exec.Cmd
-	tty *os.File // nil for non-PTY processes.
+	cmd   *exec.Cmd
+	tty   *os.File       // nil for non-PTY processes.
+	stdin io.WriteCloser // stdin pipe for non-PTY processes; nil in PTY mode.
 }
 
 // sandboxContext holds the sandbox-level state that persists across exec
@@ -524,12 +525,19 @@ func (s *processService) startPipes(ctx context.Context, cmd *exec.Cmd, emit eve
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
+	// stdin pipe lets SendInput feed the process. cmd.Wait closes it once
+	// the process exits, so we don't close it on the read path.
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+
 	if err := cmd.Start(); err != nil {
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
 	pid := uint32(cmd.Process.Pid)
-	s.processes.Store(pid, &runningProcess{cmd: cmd})
+	s.processes.Store(pid, &runningProcess{cmd: cmd, stdin: stdin})
 	defer s.processes.Delete(pid)
 
 	if err := emit(&pb.ProcessEvent{
@@ -633,9 +641,27 @@ func (s *processService) SendInput(ctx context.Context, req *connect.Request[pb.
 	}
 	proc := val.(*runningProcess)
 
+	// PTY mode: input goes to the terminal master. EOF has no meaning here
+	// (the client sends Ctrl-D as a data byte), so it's ignored.
 	if proc.tty != nil {
 		if _, err := proc.tty.Write(req.Msg.GetData()); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		return connect.NewResponse(&pb.SendInputResponse{}), nil
+	}
+
+	// Non-PTY: write to the process's stdin pipe, then optionally close it
+	// to signal EOF.
+	if proc.stdin != nil {
+		if data := req.Msg.GetData(); len(data) > 0 {
+			if _, err := proc.stdin.Write(data); err != nil {
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+		}
+		if req.Msg.GetEof() {
+			if err := proc.stdin.Close(); err != nil {
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
 		}
 	}
 

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -331,8 +331,8 @@ func resolveUser(name string) (*user.User, *syscall.Credential, error) {
 type eventEmitter func(*pb.ProcessEvent) error
 
 func (s *processService) Start(ctx context.Context, req *connect.Request[pb.StartRequest], stream *connect.ServerStream[pb.ProcessEvent]) error {
-	// Interactive: gets a stdin pipe for SendInput (one-shot /exec passes false).
-	return s.runProcess(ctx, req.Msg, stream.Send, true)
+	// Only the interactive bridge sets stdin; build steps and execs leave it off.
+	return s.runProcess(ctx, req.Msg, stream.Send, req.Msg.GetStdin())
 }
 
 func (s *processService) runProcess(ctx context.Context, msg *pb.StartRequest, emit eventEmitter, wantStdin bool) error {

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -703,7 +703,14 @@ func (s *processService) Signal(ctx context.Context, req *connect.Request[pb.Sig
 	}
 
 	sig := syscall.Signal(req.Msg.GetSignal())
-	if err := proc.cmd.Process.Signal(sig); err != nil {
+	// Non-PTY commands are their own process group (Setpgid), so signal the
+	// group — otherwise a child like `sleep` under `sh -c` survives. PTY keeps
+	// direct delivery.
+	if proc.tty == nil {
+		if err := syscall.Kill(-proc.cmd.Process.Pid, sig); err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	} else if err := proc.cmd.Process.Signal(sig); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 

--- a/cmd/boxd/stdin_test.go
+++ b/cmd/boxd/stdin_test.go
@@ -38,7 +38,7 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		// `cat` echoes stdin to stdout. Cwd must exist or fork/exec fails.
-		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat", Cwd: "/tmp"}, emit)
+		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat", Cwd: "/tmp"}, emit, true)
 	}()
 
 	var pid uint32
@@ -76,6 +76,28 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 	}
 }
 
+// TestRunProcess_NoStdinExitsOnEOF guards that a non-interactive exec
+// (wantStdin=false) leaves stdin at /dev/null, so a stdin-reading command like
+// `cat` sees EOF and exits instead of blocking until the timeout.
+func TestRunProcess_NoStdinExitsOnEOF(t *testing.T) {
+	s := newProcessService()
+	done := make(chan error, 1)
+	go func() {
+		done <- s.runProcess(context.Background(), &pb.StartRequest{
+			Cmd: "cat", Cwd: "/tmp",
+		}, func(*pb.ProcessEvent) error { return nil }, false)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runProcess: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("cat blocked on stdin; expected immediate EOF with wantStdin=false")
+	}
+}
+
 // TestSignal_TerminatesShellCommand guards that Signal terminates a non-PTY
 // shell-wrapped command.
 func TestSignal_TerminatesShellCommand(t *testing.T) {
@@ -91,7 +113,7 @@ func TestSignal_TerminatesShellCommand(t *testing.T) {
 	go func() {
 		done <- s.runProcess(context.Background(), &pb.StartRequest{
 			Cmd: "/bin/sh", Args: []string{"-c", "sleep 30"}, Cwd: "/tmp",
-		}, emit)
+		}, emit, false)
 	}()
 
 	var pid uint32

--- a/cmd/boxd/stdin_test.go
+++ b/cmd/boxd/stdin_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
+)
+
+// TestSendInput_NonPTYStdin verifies that SendInput feeds a non-PTY process's
+// stdin and that Eof closes it, letting a stdin-consuming command (cat) echo
+// the input back and exit. This covers the wiring added for /exec/ws.
+func TestSendInput_NonPTYStdin(t *testing.T) {
+	s := newProcessService()
+
+	var (
+		mu     sync.Mutex
+		stdout []byte
+	)
+	pidCh := make(chan uint32, 1)
+	emit := func(ev *pb.ProcessEvent) error {
+		switch x := ev.Event.(type) {
+		case *pb.ProcessEvent_Start:
+			pidCh <- x.Start.GetPid()
+		case *pb.ProcessEvent_Data:
+			if o := x.Data.GetStdout(); len(o) > 0 {
+				mu.Lock()
+				stdout = append(stdout, o...)
+				mu.Unlock()
+			}
+		}
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		// `cat` with no args reads stdin until EOF and echoes it to stdout.
+		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat"}, emit)
+	}()
+
+	var pid uint32
+	select {
+	case pid = <-pidCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for StartEvent")
+	}
+
+	// Write to stdin and signal EOF in one call — cat should echo and exit.
+	if _, err := s.SendInput(context.Background(), connect.NewRequest(&pb.SendInputRequest{
+		Pid:  pid,
+		Data: []byte("hello stdin\n"),
+		Eof:  true,
+	})); err != nil {
+		t.Fatalf("SendInput: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runProcess: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit after stdin EOF")
+	}
+
+	mu.Lock()
+	got := string(stdout)
+	mu.Unlock()
+	if got != "hello stdin\n" {
+		t.Errorf("stdout = %q, want %q", got, "hello stdin\n")
+	}
+}

--- a/cmd/boxd/stdin_test.go
+++ b/cmd/boxd/stdin_test.go
@@ -38,12 +38,16 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		// `cat` with no args reads stdin until EOF and echoes it to stdout.
-		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat"}, emit)
+		// Cwd must exist or fork/exec fails (it defaults to a home dir that
+		// isn't present in the test environment).
+		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat", Cwd: "/tmp"}, emit)
 	}()
 
 	var pid uint32
 	select {
 	case pid = <-pidCh:
+	case err := <-done:
+		t.Fatalf("runProcess returned before StartEvent: %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for StartEvent")
 	}

--- a/cmd/boxd/stdin_test.go
+++ b/cmd/boxd/stdin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -75,5 +76,47 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 	mu.Unlock()
 	if got != "hello stdin\n" {
 		t.Errorf("stdout = %q, want %q", got, "hello stdin\n")
+	}
+}
+
+// TestSignal_TerminatesShellCommand guards that Signal terminates a non-PTY
+// shell-wrapped command. Delivery to a forked child (vs the shell leader) is
+// covered by the staging e2e check.
+func TestSignal_TerminatesShellCommand(t *testing.T) {
+	s := newProcessService()
+	pidCh := make(chan uint32, 1)
+	emit := func(ev *pb.ProcessEvent) error {
+		if st := ev.GetStart(); st != nil {
+			pidCh <- st.GetPid()
+		}
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- s.runProcess(context.Background(), &pb.StartRequest{
+			Cmd: "/bin/sh", Args: []string{"-c", "sleep 30"}, Cwd: "/tmp",
+		}, emit)
+	}()
+
+	var pid uint32
+	select {
+	case pid = <-pidCh:
+	case err := <-done:
+		t.Fatalf("runProcess returned before StartEvent: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for StartEvent")
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	if _, err := s.Signal(context.Background(), connect.NewRequest(&pb.SignalRequest{
+		Pid: pid, Signal: int32(syscall.SIGTERM),
+	})); err != nil {
+		t.Fatalf("Signal: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SIGTERM did not terminate the command")
 	}
 }

--- a/cmd/boxd/stdin_test.go
+++ b/cmd/boxd/stdin_test.go
@@ -11,9 +11,8 @@ import (
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
-// TestSendInput_NonPTYStdin verifies that SendInput feeds a non-PTY process's
-// stdin and that Eof closes it, letting a stdin-consuming command (cat) echo
-// the input back and exit. This covers the wiring added for /exec/ws.
+// TestSendInput_NonPTYStdin verifies SendInput feeds a non-PTY process's stdin
+// and that Eof closes it — cat echoes the input back and exits.
 func TestSendInput_NonPTYStdin(t *testing.T) {
 	s := newProcessService()
 
@@ -38,9 +37,7 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		// `cat` with no args reads stdin until EOF and echoes it to stdout.
-		// Cwd must exist or fork/exec fails (it defaults to a home dir that
-		// isn't present in the test environment).
+		// `cat` echoes stdin to stdout. Cwd must exist or fork/exec fails.
 		done <- s.runProcess(context.Background(), &pb.StartRequest{Cmd: "cat", Cwd: "/tmp"}, emit)
 	}()
 
@@ -80,8 +77,7 @@ func TestSendInput_NonPTYStdin(t *testing.T) {
 }
 
 // TestSignal_TerminatesShellCommand guards that Signal terminates a non-PTY
-// shell-wrapped command. Delivery to a forked child (vs the shell leader) is
-// covered by the staging e2e check.
+// shell-wrapped command.
 func TestSignal_TerminatesShellCommand(t *testing.T) {
 	s := newProcessService()
 	pidCh := make(chan uint32, 1)

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -69,19 +69,19 @@ func main() {
 	}()
 
 	err := runBuild(ctx, buildConfig{
-		templateID: *templateID,
-		buildID:    *buildID,
-		spec:       spec,
-		vcpu:       uint32(*vcpu),
-		memoryMiB:  uint32(*memory),
-		diskMiB:    uint32(*disk),
-		runDir:     *runDir,
+		templateID:  *templateID,
+		buildID:     *buildID,
+		spec:        spec,
+		vcpu:        uint32(*vcpu),
+		memoryMiB:   uint32(*memory),
+		diskMiB:     uint32(*disk),
+		runDir:      *runDir,
 		snapshotDir: *snapshotDir,
-		kernelPath: *kernelPath,
-		fcBin:      *fcBin,
-		boxdBin:    *boxdBin,
-		hostIface:  *hostIface,
-		slotIndex:  *slotIndex,
+		kernelPath:  *kernelPath,
+		fcBin:       *fcBin,
+		boxdBin:     *boxdBin,
+		hostIface:   *hostIface,
+		slotIndex:   *slotIndex,
 	})
 	if err != nil {
 		// Emit a user-visible error (stable code + user-friendly message)
@@ -559,6 +559,8 @@ func executeBuildSteps(ctx context.Context, vmIP string, spec builder.BuildSpec)
 			"TERM":  "xterm",
 			"LANG":  "C.UTF-8",
 			"SHELL": "/bin/sh",
+			// Builds are non-interactive; keep apt/debconf from prompting.
+			"DEBIAN_FRONTEND": "noninteractive",
 		},
 	}
 

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -14,7 +14,8 @@ import (
 // dataPlaneSpecPaths are documented in the spec but served by boxd, not the
 // control-plane router, so they have no route here.
 var dataPlaneSpecPaths = map[string]bool{
-	"/files": true,
+	"/files":   true,
+	"/exec/ws": true,
 }
 
 // TestOpenAPISpecMatchesRoutes fails if a registered route is missing from

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -14,8 +14,8 @@ import (
 // dataPlaneSpecPaths are documented in the spec but served by boxd, not the
 // control-plane router, so they have no route here.
 var dataPlaneSpecPaths = map[string]bool{
-	"/files":   true,
-	"/exec/ws": true,
+	"/files":        true,
+	"/exec/connect": true,
 }
 
 // TestOpenAPISpecMatchesRoutes fails if a registered route is missing from

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -36,6 +36,11 @@ const (
 // output, so a quiet-but-running command isn't cut. A var so tests can shorten it.
 var execPingInterval = 30 * time.Second
 
+// firstFrameWait bounds how long we wait for the client's start frame before
+// giving up, so a connection that upgrades but never sends one can't pin a
+// goroutine.
+const firstFrameWait = 10 * time.Second
+
 // execWSStart is the first (text) frame: the command to run. Mirrors the
 // /exec request body so one payload shape works across all transports.
 type execWSStart struct {
@@ -154,9 +159,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	defer cancel()
 
 	// The first frame must be a JSON start message naming the command.
-	// Bound the wait so a client that connects but never sends one doesn't
-	// pin a goroutine.
-	readCtx, readCancel := context.WithTimeout(bridgeCtx, writeWait)
+	readCtx, readCancel := context.WithTimeout(bridgeCtx, firstFrameWait)
 	typ, raw, err := ws.Read(readCtx)
 	readCancel()
 	if err != nil {
@@ -208,8 +211,11 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	// Liveness: ping the client; a missed pong (within writeWait) tears down.
 	// Decoupled from output, so a quiet-but-running command isn't cut. Ping is
 	// safe alongside the writer and needs the read pump below to receive pongs.
+	// Read the interval once here (not in the goroutine) so tests can override
+	// the package var without racing the bridge's goroutines.
+	pingInterval := execPingInterval
 	go func() {
-		ticker := time.NewTicker(execPingInterval)
+		ticker := time.NewTicker(pingInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -304,6 +310,11 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 				return
 			}
 
+			// SendInput is synchronous and preserves stdin order. If the
+			// process stops draining stdin its pipe fills and SendInput
+			// blocks, parking this pump and delaying any control frame (e.g. a
+			// signal) queued behind it. Acceptable: interactive stdin is small
+			// and drained promptly — same trade-off as the terminal bridge.
 			switch typ {
 			case websocket.MessageBinary:
 				if _, err := procClient.SendInput(bridgeCtx, connect.NewRequest(&pb.SendInputRequest{

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -1,0 +1,391 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog"
+
+	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
+	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
+)
+
+const (
+	// execWSPath is the full-duplex WebSocket counterpart to /exec/stream:
+	// stdout/stderr/exit frames downstream, stdin upstream, over one socket.
+	execWSPath = "/exec/ws"
+
+	// execProtocol is echoed on upgrade. Bump the version if the frame format
+	// changes so old clients fail loudly.
+	execProtocol = "superserve.exec.v1"
+
+	// execMaxSessionDuration is the hard session ceiling; reaching it kills the
+	// running command. Longer than the terminal's — agent runs are longer-lived.
+	execMaxSessionDuration = 12 * time.Hour
+)
+
+// execPingInterval is how often the bridge pings the client; a missed pong
+// (within writeWait) tears the session down. Liveness is thus decoupled from
+// output, so a quiet-but-running command isn't cut. A var so tests can shorten it.
+var execPingInterval = 30 * time.Second
+
+// execWSStart is the first (text) frame: the command to run. Mirrors the
+// /exec request body so one payload shape works across all transports.
+type execWSStart struct {
+	Command    string            `json:"command"`
+	Args       []string          `json:"args,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	WorkingDir string            `json:"working_dir,omitempty"`
+	TimeoutS   int               `json:"timeout_s,omitempty"`
+}
+
+// execWSControl is a post-start client text frame. Binary frames are raw
+// stdin; text frames are JSON control, discriminated by Type.
+type execWSControl struct {
+	Type string `json:"type"`           // "stdin" | "stdin_close" | "signal"
+	Data string `json:"data,omitempty"` // stdin payload when Type == "stdin"
+	Name string `json:"name,omitempty"` // signal name when Type == "signal"
+}
+
+// execWSEvent is a server→client text frame, matching the SSE exec event
+// shape so clients parse both transports the same way.
+type execWSEvent struct {
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	ExitCode *int32 `json:"exit_code,omitempty"`
+	Finished bool   `json:"finished,omitempty"`
+	Error    string `json:"error,omitempty"`
+	Code     string `json:"code,omitempty"`
+}
+
+// toStartRequest builds the boxd StartRequest. No args → run as a shell string
+// (/bin/sh -c); args → run raw, matching the /exec contract.
+//
+// An absent timeout means no per-command timeout (unlike /exec's 30s default):
+// the long-lived session is bounded by the ping and max-session cap instead.
+func (s *execWSStart) toStartRequest() *pb.StartRequest {
+	var timeoutMs uint32
+	if s.TimeoutS > 0 {
+		timeoutMs = uint32(s.TimeoutS) * 1000
+	}
+	cmd, args := s.Command, s.Args
+	if len(args) == 0 {
+		cmd = "/bin/sh"
+		args = []string{"-c", s.Command}
+	}
+	return &pb.StartRequest{
+		Cmd:       cmd,
+		Args:      args,
+		Envs:      s.Env,
+		Cwd:       s.WorkingDir,
+		TimeoutMs: timeoutMs,
+	}
+}
+
+// serveExecWS handles GET /exec/ws on the boxd host label. It upgrades the
+// connection to a WebSocket and bridges full-duplex to boxd
+// ProcessService.Start in non-PTY mode.
+//
+// Pre-upgrade errors are returned as HTTP responses; post-upgrade errors go
+// back as WebSocket close frames.
+func (h *Handler) serveExecWS(w http.ResponseWriter, r *http.Request, instanceID string) {
+	// Token-gated like /exec and /files — no Origin allowlist, since customer
+	// apps run on their own domains.
+	if !h.execEnabled {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Token rides in Sec-WebSocket-Protocol, never the URL. Scrub any query
+	// and discourage Referer leakage, matching the terminal bridge.
+	r.URL.RawQuery = ""
+	w.Header().Set("Referrer-Policy", "no-referrer")
+
+	token := extractTerminalToken(r)
+	if token == "" {
+		http.Error(w, "missing token (pass as Sec-WebSocket-Protocol: token.<value>)", http.StatusUnauthorized)
+		return
+	}
+
+	info, fail := h.authorizeSandboxRequest(r.Context(), token, instanceID)
+	if fail != nil {
+		h.log.Warn().Str("sandbox_id", instanceID).Int("status", fail.Status).Msg("exec/ws: auth failed")
+		fail.write(w)
+		return
+	}
+
+	acceptOpts := &websocket.AcceptOptions{
+		// Any origin: the token is the control. Auth isn't ambient (the token
+		// is set explicitly, not auto-attached), so there's no cross-site
+		// WS-hijacking vector to gate against.
+		InsecureSkipVerify: true,
+		Subprotocols:       []string{execProtocol},
+		CompressionMode:    websocket.CompressionDisabled,
+	}
+
+	ws, err := websocket.Accept(w, r, acceptOpts)
+	if err != nil {
+		h.log.Warn().Err(err).Msg("exec/ws: WS upgrade failed")
+		return
+	}
+	ws.SetReadLimit(maxReadBytes)
+
+	transport := h.transports.get(instanceID, info)
+	httpClient := &http.Client{Transport: transport}
+	baseURL := fmt.Sprintf("http://%s:%d", info.VMIP, boxdPort)
+	procClient := boxdpbconnect.NewProcessServiceClient(httpClient, baseURL)
+
+	h.bridgeExecWS(r.Context(), ws, procClient, instanceID)
+}
+
+// bridgeExecWS pumps frames between the WebSocket and boxd until either side
+// closes. It owns the WS handle and closes it on the way out.
+func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClient boxdpbconnect.ProcessServiceClient, instanceID string) {
+	l := h.log.With().Str("sandbox_id", instanceID).Logger()
+
+	bridgeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// The first frame must be a JSON start message naming the command.
+	// Bound the wait so a client that connects but never sends one doesn't
+	// pin a goroutine.
+	readCtx, readCancel := context.WithTimeout(bridgeCtx, writeWait)
+	typ, raw, err := ws.Read(readCtx)
+	readCancel()
+	if err != nil {
+		_ = ws.Close(websocket.StatusPolicyViolation, "expected start message")
+		return
+	}
+	if typ != websocket.MessageText {
+		_ = ws.Close(websocket.StatusUnsupportedData, "start message must be text JSON")
+		return
+	}
+	var start execWSStart
+	if err := json.Unmarshal(raw, &start); err != nil || start.Command == "" {
+		_ = ws.Close(websocket.StatusPolicyViolation, "invalid start message (command required)")
+		return
+	}
+
+	stream, err := procClient.Start(bridgeCtx, connect.NewRequest(start.toStartRequest()))
+	if err != nil {
+		l.Error().Err(err).Msg("exec/ws: boxd Start failed")
+		_ = ws.Close(websocket.StatusInternalError, "failed to start command")
+		return
+	}
+
+	// First event must be StartEvent — it carries the PID needed for
+	// SendInput / Signal.
+	if !stream.Receive() {
+		serr := stream.Err()
+		l.Error().Err(serr).Msg("exec/ws: stream empty on start")
+		if serr != nil {
+			msg, code := clientExecError(serr)
+			_ = writeExecEvent(bridgeCtx, ws, &execWSEvent{Error: msg, Code: code, Finished: true})
+		}
+		_ = ws.Close(websocket.StatusInternalError, "command did not start")
+		return
+	}
+	startEvent := stream.Msg().GetStart()
+	if startEvent == nil {
+		l.Error().Msg("exec/ws: first event was not StartEvent")
+		_ = ws.Close(websocket.StatusInternalError, "unexpected event")
+		return
+	}
+	pid := startEvent.GetPid()
+	l.Info().Uint32("pid", pid).Msg("exec/ws: bridge established")
+
+	// Hard session ceiling, independent of activity.
+	sessionDeadline := time.NewTimer(execMaxSessionDuration)
+	defer sessionDeadline.Stop()
+
+	// Liveness: ping the client; a missed pong (within writeWait) tears down.
+	// Decoupled from output, so a quiet-but-running command isn't cut. Ping is
+	// safe alongside the writer and needs the read pump below to receive pongs.
+	go func() {
+		ticker := time.NewTicker(execPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-bridgeCtx.Done():
+				return
+			case <-sessionDeadline.C:
+				l.Info().Dur("max", execMaxSessionDuration).Msg("exec/ws: max session reached, closing")
+				cancel()
+				return
+			case <-ticker.C:
+				pingCtx, pingCancel := context.WithTimeout(bridgeCtx, writeWait)
+				err := ws.Ping(pingCtx)
+				pingCancel()
+				if err != nil {
+					if !errors.Is(err, context.Canceled) {
+						l.Debug().Err(err).Msg("exec/ws: ping failed, tearing down")
+					}
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// ------- boxd → client -------
+	// Translate ProcessEvents into JSON event frames. End closes the WS.
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for stream.Receive() {
+			msg := stream.Msg()
+			var ev execWSEvent
+			send := false
+			if d := msg.GetData(); d != nil {
+				if out := d.GetStdout(); len(out) > 0 {
+					ev.Stdout = string(out)
+					send = true
+				} else if out := d.GetStderr(); len(out) > 0 {
+					ev.Stderr = string(out)
+					send = true
+				}
+			}
+			if e := msg.GetEnd(); e != nil {
+				code := e.GetExitCode()
+				ev.ExitCode = &code
+				ev.Finished = true
+				send = true
+			}
+			if !send {
+				continue
+			}
+			if err := writeExecEvent(bridgeCtx, ws, &ev); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					l.Debug().Err(err).Msg("exec/ws: WS write failed")
+				}
+				return
+			}
+			if ev.Finished {
+				_ = ws.Close(websocket.StatusNormalClosure, "command exited")
+				return
+			}
+		}
+		if err := stream.Err(); err != nil && !errors.Is(err, context.Canceled) {
+			l.Warn().Err(err).Msg("exec/ws: boxd stream error")
+			msg, code := clientExecError(err)
+			_ = writeExecEvent(bridgeCtx, ws, &execWSEvent{
+				Error:    msg,
+				Code:     code,
+				Finished: true,
+			})
+			_ = ws.Close(websocket.StatusInternalError, "command error")
+		}
+	}()
+
+	// ------- client → boxd -------
+	// Binary frames are raw stdin; text frames are JSON control messages.
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for {
+			typ, data, err := ws.Read(bridgeCtx)
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					closeErr := websocket.CloseStatus(err)
+					if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
+						l.Debug().Err(err).Msg("exec/ws: WS read ended")
+					}
+				}
+				return
+			}
+
+			switch typ {
+			case websocket.MessageBinary:
+				if _, err := procClient.SendInput(bridgeCtx, connect.NewRequest(&pb.SendInputRequest{
+					Pid:  pid,
+					Data: data,
+				})); err != nil {
+					l.Warn().Err(err).Msg("exec/ws: SendInput failed")
+				}
+			case websocket.MessageText:
+				h.handleExecControl(bridgeCtx, procClient, pid, data, l)
+			}
+		}
+	}()
+
+	wg.Wait()
+	_ = ws.Close(websocket.StatusNormalClosure, "bridge closed")
+}
+
+// handleExecControl dispatches a text control frame to the right boxd RPC.
+// Unknown types are logged and dropped so a newer client can't tear down the
+// session.
+func (h *Handler) handleExecControl(ctx context.Context, client boxdpbconnect.ProcessServiceClient, pid uint32, data []byte, l zerolog.Logger) {
+	var msg execWSControl
+	if err := json.Unmarshal(data, &msg); err != nil {
+		l.Warn().Err(err).Msg("exec/ws: bad control JSON")
+		return
+	}
+
+	switch msg.Type {
+	case "stdin":
+		if _, err := client.SendInput(ctx, connect.NewRequest(&pb.SendInputRequest{
+			Pid:  pid,
+			Data: []byte(msg.Data),
+		})); err != nil {
+			l.Warn().Err(err).Msg("exec/ws: stdin SendInput failed")
+		}
+
+	case "stdin_close":
+		if _, err := client.SendInput(ctx, connect.NewRequest(&pb.SendInputRequest{
+			Pid: pid,
+			Eof: true,
+		})); err != nil {
+			l.Warn().Err(err).Msg("exec/ws: stdin_close failed")
+		}
+
+	case "signal":
+		signum, ok := signalNameToNumber(msg.Name)
+		if !ok {
+			l.Warn().Str("name", msg.Name).Msg("exec/ws: unknown signal name")
+			return
+		}
+		if _, err := client.Signal(ctx, connect.NewRequest(&pb.SignalRequest{
+			Pid:    pid,
+			Signal: signum,
+		})); err != nil {
+			l.Warn().Err(err).Msg("exec/ws: Signal failed")
+		}
+
+	default:
+		l.Debug().Str("type", msg.Type).Msg("exec/ws: unknown control type")
+	}
+}
+
+// clientExecError maps a boxd stream error to a safe client-facing message.
+// Invalid-argument errors carry boxd's own validation text (safe to surface);
+// anything else is generic, so connection details never reach the client.
+func clientExecError(err error) (message, code string) {
+	var ce *connect.Error
+	if errors.As(err, &ce) && ce.Code() == connect.CodeInvalidArgument {
+		return ce.Message(), "bad_request"
+	}
+	return "the command failed to run", "exec_failed"
+}
+
+// writeExecEvent marshals an event and writes it as a single text frame,
+// bounded by writeWait so a slow client can't block the bridge forever.
+func writeExecEvent(ctx context.Context, ws *websocket.Conn, ev *execWSEvent) error {
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+	wctx, cancel := context.WithTimeout(ctx, writeWait)
+	defer cancel()
+	return ws.Write(wctx, websocket.MessageText, raw)
+}

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -29,6 +29,12 @@ const (
 	// execMaxSessionDuration is the hard session ceiling; reaching it kills the
 	// running command. Longer than the terminal's — agent runs are longer-lived.
 	execMaxSessionDuration = 12 * time.Hour
+
+	// I/O rides binary frames tagged with a one-byte channel, so output stays
+	// byte-exact rather than being forced through a UTF-8 string.
+	execChStdin  = 0x00
+	execChStdout = 0x01
+	execChStderr = 0x02
 )
 
 // execPingInterval is how often the bridge pings the client; a missed pong
@@ -51,19 +57,16 @@ type execWSStart struct {
 	TimeoutS   int               `json:"timeout_s,omitempty"`
 }
 
-// execWSControl is a post-start client text frame. Binary frames are raw
-// stdin; text frames are JSON control, discriminated by Type.
+// execWSControl is a post-start client text frame. Binary frames carry I/O
+// (channel 0 = stdin); text frames are JSON control, discriminated by Type.
 type execWSControl struct {
-	Type string `json:"type"`           // "stdin" | "stdin_close" | "signal"
-	Data string `json:"data,omitempty"` // stdin payload when Type == "stdin"
+	Type string `json:"type"`           // "stdin_close" | "signal"
 	Name string `json:"name,omitempty"` // signal name when Type == "signal"
 }
 
-// execWSEvent is a server→client text frame, matching the SSE exec event
-// shape so clients parse both transports the same way.
+// execWSEvent is a server→client text frame for lifecycle and errors. Output
+// itself rides binary frames, not this struct.
 type execWSEvent struct {
-	Stdout   string `json:"stdout,omitempty"`
-	Stderr   string `json:"stderr,omitempty"`
 	ExitCode *int32 `json:"exit_code,omitempty"`
 	Finished bool   `json:"finished,omitempty"`
 	Error    string `json:"error,omitempty"`
@@ -239,39 +242,40 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	wg.Add(2)
 
 	// ------- boxd → client -------
-	// Translate ProcessEvents into JSON event frames. End closes the WS.
+	// stdout/stderr go out as channel-tagged binary frames; the End event is a
+	// text lifecycle frame that closes the WS.
 	go func() {
 		defer wg.Done()
 		defer cancel()
 		for stream.Receive() {
 			msg := stream.Msg()
-			var ev execWSEvent
-			send := false
 			if d := msg.GetData(); d != nil {
 				if out := d.GetStdout(); len(out) > 0 {
-					ev.Stdout = string(out)
-					send = true
-				} else if out := d.GetStderr(); len(out) > 0 {
-					ev.Stderr = string(out)
-					send = true
+					if err := writeExecData(bridgeCtx, ws, execChStdout, out); err != nil {
+						if !errors.Is(err, context.Canceled) {
+							l.Debug().Err(err).Msg("exec/ws: WS write failed")
+						}
+						return
+					}
 				}
+				if out := d.GetStderr(); len(out) > 0 {
+					if err := writeExecData(bridgeCtx, ws, execChStderr, out); err != nil {
+						if !errors.Is(err, context.Canceled) {
+							l.Debug().Err(err).Msg("exec/ws: WS write failed")
+						}
+						return
+					}
+				}
+				continue
 			}
 			if e := msg.GetEnd(); e != nil {
 				code := e.GetExitCode()
-				ev.ExitCode = &code
-				ev.Finished = true
-				send = true
-			}
-			if !send {
-				continue
-			}
-			if err := writeExecEvent(bridgeCtx, ws, &ev); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					l.Debug().Err(err).Msg("exec/ws: WS write failed")
+				if err := writeExecEvent(bridgeCtx, ws, &execWSEvent{ExitCode: &code, Finished: true}); err != nil {
+					if !errors.Is(err, context.Canceled) {
+						l.Debug().Err(err).Msg("exec/ws: WS write failed")
+					}
+					return
 				}
-				return
-			}
-			if ev.Finished {
 				_ = ws.Close(websocket.StatusNormalClosure, "command exited")
 				return
 			}
@@ -289,7 +293,8 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	}()
 
 	// ------- client → boxd -------
-	// Binary frames are raw stdin; text frames are JSON control messages.
+	// Binary frames are channel-tagged I/O (channel 0 = stdin); text frames are
+	// JSON control messages.
 	go func() {
 		defer wg.Done()
 		defer cancel()
@@ -310,9 +315,12 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 			// frames (e.g. a signal). Acceptable for interactive stdin.
 			switch typ {
 			case websocket.MessageBinary:
+				if len(data) == 0 || data[0] != execChStdin {
+					continue // empty or unknown channel
+				}
 				if _, err := procClient.SendInput(bridgeCtx, connect.NewRequest(&pb.SendInputRequest{
 					Pid:  pid,
-					Data: data,
+					Data: data[1:],
 				})); err != nil {
 					l.Warn().Err(err).Msg("exec/ws: SendInput failed")
 				}
@@ -337,14 +345,6 @@ func (h *Handler) handleExecControl(ctx context.Context, client boxdpbconnect.Pr
 	}
 
 	switch msg.Type {
-	case "stdin":
-		if _, err := client.SendInput(ctx, connect.NewRequest(&pb.SendInputRequest{
-			Pid:  pid,
-			Data: []byte(msg.Data),
-		})); err != nil {
-			l.Warn().Err(err).Msg("exec/ws: stdin SendInput failed")
-		}
-
 	case "stdin_close":
 		if _, err := client.SendInput(ctx, connect.NewRequest(&pb.SendInputRequest{
 			Pid: pid,
@@ -382,8 +382,8 @@ func clientExecError(err error) (message, code string) {
 	return "the command failed to run", "exec_failed"
 }
 
-// writeExecEvent marshals an event and writes it as a single text frame,
-// bounded by writeWait so a slow client can't block the bridge forever.
+// writeExecEvent marshals a lifecycle event and writes it as a single text
+// frame, bounded by writeWait so a slow client can't block the bridge forever.
 func writeExecEvent(ctx context.Context, ws *websocket.Conn, ev *execWSEvent) error {
 	raw, err := json.Marshal(ev)
 	if err != nil {
@@ -392,4 +392,15 @@ func writeExecEvent(ctx context.Context, ws *websocket.Conn, ev *execWSEvent) er
 	wctx, cancel := context.WithTimeout(ctx, writeWait)
 	defer cancel()
 	return ws.Write(wctx, websocket.MessageText, raw)
+}
+
+// writeExecData writes one output chunk as a binary frame prefixed with its
+// channel byte, keeping bytes exact end to end.
+func writeExecData(ctx context.Context, ws *websocket.Conn, channel byte, data []byte) error {
+	frame := make([]byte, 1+len(data))
+	frame[0] = channel
+	copy(frame[1:], data)
+	wctx, cancel := context.WithTimeout(ctx, writeWait)
+	defer cancel()
+	return ws.Write(wctx, websocket.MessageBinary, frame)
 }

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -94,12 +94,9 @@ func (s *execWSStart) toStartRequest() *pb.StartRequest {
 	}
 }
 
-// serveExecWS handles GET /exec/ws on the boxd host label. It upgrades the
-// connection to a WebSocket and bridges full-duplex to boxd
-// ProcessService.Start in non-PTY mode.
-//
-// Pre-upgrade errors are returned as HTTP responses; post-upgrade errors go
-// back as WebSocket close frames.
+// serveExecWS upgrades GET /exec/ws to a WebSocket and bridges it full-duplex
+// to boxd ProcessService.Start (non-PTY). Pre-upgrade errors are HTTP
+// responses; after upgrade they're WebSocket close frames.
 func (h *Handler) serveExecWS(w http.ResponseWriter, r *http.Request, instanceID string) {
 	// Token-gated like /exec and /files — no Origin allowlist, since customer
 	// apps run on their own domains.
@@ -208,11 +205,9 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	sessionDeadline := time.NewTimer(execMaxSessionDuration)
 	defer sessionDeadline.Stop()
 
-	// Liveness: ping the client; a missed pong (within writeWait) tears down.
-	// Decoupled from output, so a quiet-but-running command isn't cut. Ping is
-	// safe alongside the writer and needs the read pump below to receive pongs.
-	// Read the interval once here (not in the goroutine) so tests can override
-	// the package var without racing the bridge's goroutines.
+	// Liveness: ping the client; a missed pong (within writeWait) tears down,
+	// so a quiet-but-running command isn't cut. Read the interval into a local
+	// (not in the goroutine) so tests can override the var without a race.
 	pingInterval := execPingInterval
 	go func() {
 		ticker := time.NewTicker(pingInterval)
@@ -310,11 +305,9 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 				return
 			}
 
-			// SendInput is synchronous and preserves stdin order. If the
-			// process stops draining stdin its pipe fills and SendInput
-			// blocks, parking this pump and delaying any control frame (e.g. a
-			// signal) queued behind it. Acceptable: interactive stdin is small
-			// and drained promptly — same trade-off as the terminal bridge.
+			// SendInput is synchronous (preserves stdin order). If the process
+			// stops draining stdin, SendInput blocks and delays later control
+			// frames (e.g. a signal). Acceptable for interactive stdin.
 			switch typ {
 			case websocket.MessageBinary:
 				if _, err := procClient.SendInput(bridgeCtx, connect.NewRequest(&pb.SendInputRequest{

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -94,6 +94,7 @@ func (s *execWSStart) toStartRequest() *pb.StartRequest {
 		Envs:      s.Env,
 		Cwd:       s.WorkingDir,
 		TimeoutMs: timeoutMs,
+		Stdin:     true, // interactive
 	}
 }
 

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	// execWSPath is the full-duplex WebSocket counterpart to /exec/stream:
+	// execConnectPath is the full-duplex counterpart to /exec/stream:
 	// stdout/stderr/exit frames downstream, stdin upstream, over one socket.
-	execWSPath = "/exec/ws"
+	execConnectPath = "/exec/connect"
 
 	// execProtocol is echoed on upgrade. Bump the version if the frame format
 	// changes so old clients fail loudly.
@@ -97,7 +97,7 @@ func (s *execWSStart) toStartRequest() *pb.StartRequest {
 	}
 }
 
-// serveExecWS upgrades GET /exec/ws to a WebSocket and bridges it full-duplex
+// serveExecWS upgrades GET /exec/connect to a WebSocket and bridges it full-duplex
 // to boxd ProcessService.Start (non-PTY). Pre-upgrade errors are HTTP
 // responses; after upgrade they're WebSocket close frames.
 func (h *Handler) serveExecWS(w http.ResponseWriter, r *http.Request, instanceID string) {

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -1,0 +1,429 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/rs/zerolog"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"github.com/superserve-ai/sandbox/internal/auth"
+	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
+	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
+)
+
+// pushStdout / pushStderr enqueue non-PTY data events — these become JSON
+// text frames on the exec/ws client side. (pushStart/pushEnd/inputs/signals
+// live on fakeProcessService in terminal_test.go.)
+func (f *fakeProcessService) pushStdout(data []byte) {
+	f.events <- &pb.ProcessEvent{Event: &pb.ProcessEvent_Data{
+		Data: &pb.DataEvent{Output: &pb.DataEvent_Stdout{Stdout: data}},
+	}}
+}
+
+func (f *fakeProcessService) pushStderr(data []byte) {
+	f.events <- &pb.ProcessEvent{Event: &pb.ProcessEvent_Data{
+		Data: &pb.DataEvent{Output: &pb.DataEvent_Stderr{Stderr: data}},
+	}}
+}
+
+type execWSTestEnv struct {
+	t        *testing.T
+	fake     *fakeProcessService
+	clientWS *websocket.Conn
+}
+
+func newExecWSTestEnv(t *testing.T) *execWSTestEnv {
+	t.Helper()
+	fake := newFakeProcessService()
+
+	path, handler := boxdpbconnect.NewProcessServiceHandler(fake)
+	boxdMux := http.NewServeMux()
+	boxdMux.Handle(path, handler)
+	boxdSrv := httptest.NewUnstartedServer(h2c.NewHandler(boxdMux, &http2.Server{}))
+	boxdSrv.EnableHTTP2 = true
+	boxdSrv.Start()
+
+	procClient := boxdpbconnect.NewProcessServiceClient(boxdSrv.Client(), boxdSrv.URL)
+
+	h := &Handler{transports: newTransportCache(), log: zerolog.Nop()}
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+			CompressionMode:    websocket.CompressionDisabled,
+		})
+		if err != nil {
+			t.Errorf("ws accept: %v", err)
+			return
+		}
+		h.bridgeExecWS(r.Context(), ws, procClient, "sbx-test")
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(proxySrv.URL, "http")
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer dialCancel()
+	clientWS, _, err := websocket.Dial(dialCtx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = clientWS.Close(websocket.StatusNormalClosure, "cleanup")
+		proxySrv.Close()
+		boxdSrv.Close()
+	})
+	return &execWSTestEnv{t: t, fake: fake, clientWS: clientWS}
+}
+
+// sendStart pushes the StartEvent (so the bridge captures the PID) and writes
+// the JSON start frame that names the command.
+func (e *execWSTestEnv) sendStart(pid uint32, command string) {
+	e.t.Helper()
+	e.fake.pushStart(pid)
+	cmd, _ := json.Marshal(command)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := e.clientWS.Write(ctx, websocket.MessageText, []byte(`{"command":`+string(cmd)+`}`)); err != nil {
+		e.t.Fatalf("send start: %v", err)
+	}
+	// Give the bridge a moment to consume the start frame + StartEvent and
+	// enter the pump loop before the test drives traffic.
+	time.Sleep(100 * time.Millisecond)
+}
+
+func (e *execWSTestEnv) readEvent(ctx context.Context) execWSEvent {
+	e.t.Helper()
+	typ, data, err := e.clientWS.Read(ctx)
+	if err != nil {
+		e.t.Fatalf("client read: %v", err)
+	}
+	if typ != websocket.MessageText {
+		e.t.Fatalf("frame type = %v, want Text", typ)
+	}
+	var ev execWSEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		e.t.Fatalf("unmarshal event: %v (raw %q)", err, data)
+	}
+	return ev
+}
+
+func TestExecWS_StdoutForwarded(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "echo hi")
+	env.fake.pushStdout([]byte("hello\n"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ev := env.readEvent(ctx)
+	if ev.Stdout != "hello\n" {
+		t.Errorf("stdout = %q, want %q", ev.Stdout, "hello\n")
+	}
+	if ev.Stderr != "" || ev.Finished {
+		t.Errorf("unexpected fields on stdout event: %+v", ev)
+	}
+}
+
+func TestExecWS_StderrForwarded(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "ls /nope")
+	env.fake.pushStderr([]byte("no such file\n"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ev := env.readEvent(ctx)
+	if ev.Stderr != "no such file\n" {
+		t.Errorf("stderr = %q, want %q", ev.Stderr, "no such file\n")
+	}
+}
+
+func TestExecWS_EndClosesWithExitCode(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "false")
+	env.fake.pushEnd(3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ev := env.readEvent(ctx)
+	if ev.ExitCode == nil || *ev.ExitCode != 3 {
+		t.Fatalf("exit_code = %v, want 3", ev.ExitCode)
+	}
+	if !ev.Finished {
+		t.Errorf("finished = false, want true")
+	}
+	// The bridge should close the WS right after the final event.
+	if _, _, err := env.clientWS.Read(ctx); websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+		t.Errorf("close status = %d, want NormalClosure", websocket.CloseStatus(err))
+	}
+}
+
+func TestExecWS_BinaryFrameIsStdin(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "cat")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := env.clientWS.Write(ctx, websocket.MessageBinary, []byte("piped input")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	select {
+	case got := <-env.fake.inputs:
+		if string(got.Data) != "piped input" {
+			t.Errorf("SendInput.Data = %q, want %q", got.Data, "piped input")
+		}
+		if got.Pid != 7 {
+			t.Errorf("SendInput.Pid = %d, want 7", got.Pid)
+		}
+		if got.Eof {
+			t.Errorf("Eof = true, want false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for SendInput")
+	}
+}
+
+func TestExecWS_StdinControlAndClose(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "cat")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// {type:"stdin"} writes to stdin without EOF.
+	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"type":"stdin","data":"hi there"}`)); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	got := <-env.fake.inputs
+	if string(got.Data) != "hi there" || got.Eof {
+		t.Errorf("stdin control = %+v, want data=%q eof=false", got, "hi there")
+	}
+
+	// {type:"stdin_close"} sends EOF.
+	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"type":"stdin_close"}`)); err != nil {
+		t.Fatalf("write stdin_close: %v", err)
+	}
+	gotClose := <-env.fake.inputs
+	if !gotClose.Eof {
+		t.Errorf("stdin_close Eof = false, want true")
+	}
+}
+
+func TestExecWS_SignalForwarded(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "sleep 100")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"type":"signal","name":"SIGTERM"}`)); err != nil {
+		t.Fatalf("write signal: %v", err)
+	}
+
+	select {
+	case got := <-env.fake.signals:
+		if got.Signal != 15 { // SIGTERM
+			t.Errorf("Signal = %d, want 15 (SIGTERM)", got.Signal)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Signal")
+	}
+}
+
+// TestServeExecWS_ForeignOriginAccepted goes through the full serveExecWS
+// handler and verifies that a connection from an origin NOT in the terminal
+// allowlist is still accepted — exec/ws is gated by the access token, not by
+// Origin, so customer apps on their own domains can connect.
+func TestServeExecWS_ForeignOriginAccepted(t *testing.T) {
+	fake := newFakeProcessService()
+	path, handler := boxdpbconnect.NewProcessServiceHandler(fake)
+	boxdMux := http.NewServeMux()
+	boxdMux.Handle(path, handler)
+	boxdSrv := httptest.NewUnstartedServer(h2c.NewHandler(boxdMux, &http2.Server{}))
+	boxdSrv.EnableHTTP2 = true
+	boxdSrv.Start()
+	defer boxdSrv.Close()
+
+	seedKey := []byte("test-seed-key-that-is-at-least-32-bytes-long!!")
+	sandboxID := "sbx-execws-origin"
+	domain := "sandbox.test"
+
+	upURL, _ := url.Parse(boxdSrv.URL)
+	resolver := &stubResolver{
+		info: InstanceInfo{
+			VMIP:      upURL.Hostname(),
+			Status:    "running",
+			StartedAt: time.Now().UnixNano(),
+		},
+	}
+
+	h := NewHandler(domain, resolver, zerolog.Nop())
+	// Deliberately restrict the terminal allowlist to a console origin —
+	// exec/ws must ignore it and accept a different (customer) origin.
+	h.WithAuth(seedKey).WithExec().WithTerminal([]string{"https://console.example.com"})
+
+	upHost := upURL.Host
+	h.transports = &transportCache{items: map[string]*transportEntry{}}
+	h.transports.items[sandboxID] = &transportEntry{
+		lifecycleKey: resolver.info.lifecycleKey(),
+		transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, upHost)
+			},
+			DisableKeepAlives: true,
+		},
+		lastUsed: time.Now(),
+	}
+
+	host := "boxd-" + sandboxID + "." + domain
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Host = host
+		h.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	token := auth.ComputeAccessToken(seedKey, sandboxID)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/exec/ws"
+
+	fake.pushStart(99)
+	fake.pushStdout([]byte("from a foreign origin\n"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader:   http.Header{"Origin": []string{"https://customer.example.com"}},
+		Subprotocols: []string{execProtocol, "token." + token},
+	})
+	if err != nil {
+		t.Fatalf("exec/ws dial from a foreign origin should succeed, got: %v", err)
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "done")
+
+	if err := ws.Write(ctx, websocket.MessageText, []byte(`{"command":"echo hi"}`)); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+	typ, data, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if typ != websocket.MessageText {
+		t.Fatalf("frame type = %v, want Text", typ)
+	}
+	var ev execWSEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Stdout != "from a foreign origin\n" {
+		t.Errorf("stdout = %q, want %q", ev.Stdout, "from a foreign origin\n")
+	}
+}
+
+func TestExecWS_PingKeepsLiveSessionAlive(t *testing.T) {
+	old := execPingInterval
+	execPingInterval = 50 * time.Millisecond
+	t.Cleanup(func() { execPingInterval = old })
+
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "long-running")
+
+	// Emit output only after several ping cycles have elapsed. The client is
+	// blocked in Read below (so it auto-pongs), so the session must survive
+	// the pings and still deliver the output.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		env.fake.pushStdout([]byte("still here\n"))
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ev := env.readEvent(ctx)
+	if ev.Stdout != "still here\n" {
+		t.Errorf("stdout = %q, want %q (session should survive pings)", ev.Stdout, "still here\n")
+	}
+}
+
+// TestExecWS_StreamErrorIsGenericized verifies that a boxd/connection error
+// (which can contain internal addresses) is NOT surfaced verbatim to the
+// client — only a generic message is sent.
+func TestExecWS_StreamErrorIsGenericized(t *testing.T) {
+	fake := newFakeProcessService()
+	fake.startErr = errors.New("dial tcp 10.0.0.5:49983: connection refused")
+
+	path, handler := boxdpbconnect.NewProcessServiceHandler(fake)
+	boxdMux := http.NewServeMux()
+	boxdMux.Handle(path, handler)
+	boxdSrv := httptest.NewUnstartedServer(h2c.NewHandler(boxdMux, &http2.Server{}))
+	boxdSrv.EnableHTTP2 = true
+	boxdSrv.Start()
+	defer boxdSrv.Close()
+
+	procClient := boxdpbconnect.NewProcessServiceClient(boxdSrv.Client(), boxdSrv.URL)
+	h := &Handler{transports: newTransportCache(), log: zerolog.Nop()}
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+			CompressionMode:    websocket.CompressionDisabled,
+		})
+		if err != nil {
+			return
+		}
+		h.bridgeExecWS(r.Context(), ws, procClient, "sbx")
+	}))
+	defer proxySrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(proxySrv.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "done")
+
+	if err := ws.Write(ctx, websocket.MessageText, []byte(`{"command":"echo hi"}`)); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+
+	typ, data, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if typ != websocket.MessageText {
+		t.Fatalf("frame type = %v, want Text error event", typ)
+	}
+	var ev execWSEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if strings.Contains(ev.Error, "10.0.0.5") || strings.Contains(ev.Error, "49983") {
+		t.Errorf("internal address leaked to client: %q", ev.Error)
+	}
+	if ev.Error != "the command failed to run" {
+		t.Errorf("error = %q, want generic message", ev.Error)
+	}
+}
+
+func TestExecWS_InvalidStartClosesWS(t *testing.T) {
+	env := newExecWSTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Empty command must be rejected before any process starts.
+	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"command":""}`)); err != nil {
+		t.Fatalf("write start: %v", err)
+	}
+
+	if _, _, err := env.clientWS.Read(ctx); websocket.CloseStatus(err) != websocket.StatusPolicyViolation {
+		t.Errorf("close status = %d, want PolicyViolation", websocket.CloseStatus(err))
+	}
+}

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -96,8 +96,8 @@ func (e *execWSTestEnv) sendStart(pid uint32, command string) {
 	if err := e.clientWS.Write(ctx, websocket.MessageText, []byte(`{"command":`+string(cmd)+`}`)); err != nil {
 		e.t.Fatalf("send start: %v", err)
 	}
-	// Give the bridge a moment to consume the start frame + StartEvent and
-	// enter the pump loop before the test drives traffic.
+	// Let the bridge consume the start frame + StartEvent and enter the pump
+	// loop before the test drives traffic.
 	time.Sleep(100 * time.Millisecond)
 }
 

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -324,7 +324,7 @@ func TestServeExecWS_ForeignOriginAccepted(t *testing.T) {
 	defer srv.Close()
 
 	token := auth.ComputeAccessToken(seedKey, sandboxID)
-	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/exec/ws"
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/exec/connect"
 
 	fake.pushStart(99)
 	fake.pushStdout([]byte("from a foreign origin\n"))

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -135,6 +135,14 @@ func (e *execWSTestEnv) readData(ctx context.Context) (byte, []byte) {
 	return data[0], data[1:]
 }
 
+// TestExecWSStart_RequestsStdin guards that the WS bridge requests an
+// interactive stdin pipe (build steps and one-shot execs don't).
+func TestExecWSStart_RequestsStdin(t *testing.T) {
+	if got := (&execWSStart{Command: "cat"}).toStartRequest().GetStdin(); !got {
+		t.Errorf("toStartRequest().Stdin = false, want true (interactive)")
+	}
+}
+
 func TestExecWS_StdoutForwarded(t *testing.T) {
 	env := newExecWSTestEnv(t)
 	env.sendStart(7, "echo hi")

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -22,9 +23,9 @@ import (
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
 )
 
-// pushStdout / pushStderr enqueue non-PTY data events — these become JSON
-// text frames on the exec/ws client side. (pushStart/pushEnd/inputs/signals
-// live on fakeProcessService in terminal_test.go.)
+// pushStdout / pushStderr enqueue non-PTY data events — these become
+// channel-tagged binary frames on the exec/ws client side. (pushStart/pushEnd/
+// inputs/signals live on fakeProcessService in terminal_test.go.)
 func (f *fakeProcessService) pushStdout(data []byte) {
 	f.events <- &pb.ProcessEvent{Event: &pb.ProcessEvent_Data{
 		Data: &pb.DataEvent{Output: &pb.DataEvent_Stdout{Stdout: data}},
@@ -117,6 +118,23 @@ func (e *execWSTestEnv) readEvent(ctx context.Context) execWSEvent {
 	return ev
 }
 
+// readData reads one binary output frame and returns its channel byte and
+// payload. Fails if the next frame isn't binary.
+func (e *execWSTestEnv) readData(ctx context.Context) (byte, []byte) {
+	e.t.Helper()
+	typ, data, err := e.clientWS.Read(ctx)
+	if err != nil {
+		e.t.Fatalf("client read: %v", err)
+	}
+	if typ != websocket.MessageBinary {
+		e.t.Fatalf("frame type = %v, want Binary", typ)
+	}
+	if len(data) == 0 {
+		e.t.Fatalf("binary frame missing channel byte")
+	}
+	return data[0], data[1:]
+}
+
 func TestExecWS_StdoutForwarded(t *testing.T) {
 	env := newExecWSTestEnv(t)
 	env.sendStart(7, "echo hi")
@@ -124,12 +142,31 @@ func TestExecWS_StdoutForwarded(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	ev := env.readEvent(ctx)
-	if ev.Stdout != "hello\n" {
-		t.Errorf("stdout = %q, want %q", ev.Stdout, "hello\n")
+	ch, payload := env.readData(ctx)
+	if ch != execChStdout {
+		t.Errorf("channel = %d, want %d (stdout)", ch, execChStdout)
 	}
-	if ev.Stderr != "" || ev.Finished {
-		t.Errorf("unexpected fields on stdout event: %+v", ev)
+	if string(payload) != "hello\n" {
+		t.Errorf("stdout = %q, want %q", payload, "hello\n")
+	}
+}
+
+// TestExecWS_BinaryStdoutIsByteExact guards the whole point of the binary
+// framing: non-UTF-8 output survives the round trip unmangled.
+func TestExecWS_BinaryStdoutIsByteExact(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "cat image.png")
+	raw := []byte{0x00, 0xff, 0xfe, 0x80, 0x01}
+	env.fake.pushStdout(raw)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ch, payload := env.readData(ctx)
+	if ch != execChStdout {
+		t.Errorf("channel = %d, want %d (stdout)", ch, execChStdout)
+	}
+	if !bytes.Equal(payload, raw) {
+		t.Errorf("stdout = %v, want %v (binary must be byte-exact)", payload, raw)
 	}
 }
 
@@ -140,9 +177,12 @@ func TestExecWS_StderrForwarded(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	ev := env.readEvent(ctx)
-	if ev.Stderr != "no such file\n" {
-		t.Errorf("stderr = %q, want %q", ev.Stderr, "no such file\n")
+	ch, payload := env.readData(ctx)
+	if ch != execChStderr {
+		t.Errorf("channel = %d, want %d (stderr)", ch, execChStderr)
+	}
+	if string(payload) != "no such file\n" {
+		t.Errorf("stderr = %q, want %q", payload, "no such file\n")
 	}
 }
 
@@ -172,7 +212,8 @@ func TestExecWS_BinaryFrameIsStdin(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := env.clientWS.Write(ctx, websocket.MessageBinary, []byte("piped input")); err != nil {
+	// Stdin rides channel 0; the payload follows the channel byte.
+	if err := env.clientWS.Write(ctx, websocket.MessageBinary, append([]byte{execChStdin}, "piped input"...)); err != nil {
 		t.Fatalf("client write: %v", err)
 	}
 
@@ -192,21 +233,12 @@ func TestExecWS_BinaryFrameIsStdin(t *testing.T) {
 	}
 }
 
-func TestExecWS_StdinControlAndClose(t *testing.T) {
+func TestExecWS_StdinClose(t *testing.T) {
 	env := newExecWSTestEnv(t)
 	env.sendStart(7, "cat")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-
-	// {type:"stdin"} writes to stdin without EOF.
-	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"type":"stdin","data":"hi there"}`)); err != nil {
-		t.Fatalf("write stdin: %v", err)
-	}
-	got := <-env.fake.inputs
-	if string(got.Data) != "hi there" || got.Eof {
-		t.Errorf("stdin control = %+v, want data=%q eof=false", got, "hi there")
-	}
 
 	// {type:"stdin_close"} sends EOF.
 	if err := env.clientWS.Write(ctx, websocket.MessageText, []byte(`{"type":"stdin_close"}`)); err != nil {
@@ -316,15 +348,14 @@ func TestServeExecWS_ForeignOriginAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if typ != websocket.MessageText {
-		t.Fatalf("frame type = %v, want Text", typ)
+	if typ != websocket.MessageBinary {
+		t.Fatalf("frame type = %v, want Binary", typ)
 	}
-	var ev execWSEvent
-	if err := json.Unmarshal(data, &ev); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if len(data) == 0 || data[0] != execChStdout {
+		t.Fatalf("frame channel = %v, want stdout", data)
 	}
-	if ev.Stdout != "from a foreign origin\n" {
-		t.Errorf("stdout = %q, want %q", ev.Stdout, "from a foreign origin\n")
+	if string(data[1:]) != "from a foreign origin\n" {
+		t.Errorf("stdout = %q, want %q", data[1:], "from a foreign origin\n")
 	}
 }
 
@@ -346,9 +377,9 @@ func TestExecWS_PingKeepsLiveSessionAlive(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	ev := env.readEvent(ctx)
-	if ev.Stdout != "still here\n" {
-		t.Errorf("stdout = %q, want %q (session should survive pings)", ev.Stdout, "still here\n")
+	ch, payload := env.readData(ctx)
+	if ch != execChStdout || string(payload) != "still here\n" {
+		t.Errorf("got channel %d %q, want stdout %q (session should survive pings)", ch, payload, "still here\n")
 	}
 }
 

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -77,6 +77,8 @@ func (h *Handler) serveBoxdPort(w http.ResponseWriter, r *http.Request, instance
 		h.serveExec(w, r, instanceID)
 	case execStreamPath:
 		h.serveExecStream(w, r, instanceID)
+	case execWSPath:
+		h.serveExecWS(w, r, instanceID)
 	default:
 		http.NotFound(w, r)
 	}

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -77,7 +77,7 @@ func (h *Handler) serveBoxdPort(w http.ResponseWriter, r *http.Request, instance
 		h.serveExec(w, r, instanceID)
 	case execStreamPath:
 		h.serveExecStream(w, r, instanceID)
-	case execWSPath:
+	case execConnectPath:
 		h.serveExecWS(w, r, instanceID)
 	default:
 		http.NotFound(w, r)
@@ -123,7 +123,6 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 	if r.Method == http.MethodPost {
 		r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
 	}
-
 
 	// Path traversal rejection. boxd's own safePath runs filepath.Clean,
 	// which silently resolves `..` segments instead of refusing them —
@@ -223,4 +222,3 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 	}
 	rp.ServeHTTP(w, r)
 }
-

--- a/proto/boxd.proto
+++ b/proto/boxd.proto
@@ -33,6 +33,9 @@ message StartRequest {
   // User to run the command as. Empty falls back to boxd's default user
   // (set by the template or root).
   string user = 7;
+  // If true, attach a stdin pipe (interactive, for SendInput). False leaves
+  // stdin at /dev/null/EOF so non-interactive tools (apt/debconf) don't hang.
+  bool stdin = 8;
 }
 
 message PtyConfig {

--- a/proto/boxd.proto
+++ b/proto/boxd.proto
@@ -77,6 +77,9 @@ message KeepAlive {}
 message SendInputRequest {
   uint32 pid = 1;
   bytes data = 2;
+  // When true, close the process's stdin after writing data, signalling EOF.
+  // Applies to non-PTY processes; ignored in PTY mode.
+  bool eof = 3;
 }
 
 message SendInputResponse {}

--- a/proto/boxdpb/boxd.pb.go
+++ b/proto/boxdpb/boxd.pb.go
@@ -572,9 +572,12 @@ func (*KeepAlive) Descriptor() ([]byte, []int) {
 }
 
 type SendInputRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Pid           uint32                 `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
-	Data          []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Pid   uint32                 `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
+	Data  []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+	// When true, close the process's stdin after writing data, signalling EOF.
+	// Applies to non-PTY processes; ignored in PTY mode.
+	Eof           bool `protobuf:"varint,3,opt,name=eof,proto3" json:"eof,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -621,6 +624,13 @@ func (x *SendInputRequest) GetData() []byte {
 		return x.Data
 	}
 	return nil
+}
+
+func (x *SendInputRequest) GetEof() bool {
+	if x != nil {
+		return x.Eof
+	}
+	return false
 }
 
 type SendInputResponse struct {
@@ -1392,10 +1402,11 @@ const file_proto_boxd_proto_rawDesc = "" +
 	"\x06exited\x18\x02 \x01(\bR\x06exited\x12\x16\n" +
 	"\x06status\x18\x03 \x01(\tR\x06status\x12\x14\n" +
 	"\x05error\x18\x04 \x01(\tR\x05error\"\v\n" +
-	"\tKeepAlive\"8\n" +
+	"\tKeepAlive\"J\n" +
 	"\x10SendInputRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\rR\x03pid\x12\x12\n" +
-	"\x04data\x18\x02 \x01(\fR\x04data\"\x13\n" +
+	"\x04data\x18\x02 \x01(\fR\x04data\x12\x10\n" +
+	"\x03eof\x18\x03 \x01(\bR\x03eof\"\x13\n" +
 	"\x11SendInputResponse\"W\n" +
 	"\rResizeRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\rR\x03pid\x124\n" +

--- a/proto/boxdpb/boxd.pb.go
+++ b/proto/boxdpb/boxd.pb.go
@@ -31,7 +31,11 @@ type StartRequest struct {
 	TimeoutMs uint32                 `protobuf:"varint,6,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"` // 0 = no timeout.
 	// User to run the command as. Empty falls back to boxd's default user
 	// (set by the template or root).
-	User          string `protobuf:"bytes,7,opt,name=user,proto3" json:"user,omitempty"`
+	User string `protobuf:"bytes,7,opt,name=user,proto3" json:"user,omitempty"`
+	// Attach a stdin pipe so SendInput can feed the process (interactive).
+	// False leaves stdin at /dev/null (immediate EOF), so non-interactive
+	// tooling like apt/debconf doesn't block on a prompt.
+	Stdin         bool `protobuf:"varint,8,opt,name=stdin,proto3" json:"stdin,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -113,6 +117,13 @@ func (x *StartRequest) GetUser() string {
 		return x.User
 	}
 	return ""
+}
+
+func (x *StartRequest) GetStdin() bool {
+	if x != nil {
+		return x.Stdin
+	}
+	return false
 }
 
 type PtyConfig struct {
@@ -1365,7 +1376,7 @@ var File_proto_boxd_proto protoreflect.FileDescriptor
 
 const file_proto_boxd_proto_rawDesc = "" +
 	"\n" +
-	"\x10proto/boxd.proto\x12\x12superserve.boxd.v1\"\xa3\x02\n" +
+	"\x10proto/boxd.proto\x12\x12superserve.boxd.v1\"\xb9\x02\n" +
 	"\fStartRequest\x12\x10\n" +
 	"\x03cmd\x18\x01 \x01(\tR\x03cmd\x12\x12\n" +
 	"\x04args\x18\x02 \x03(\tR\x04args\x12>\n" +
@@ -1374,7 +1385,8 @@ const file_proto_boxd_proto_rawDesc = "" +
 	"\x03pty\x18\x05 \x01(\v2\x1d.superserve.boxd.v1.PtyConfigR\x03pty\x12\x1d\n" +
 	"\n" +
 	"timeout_ms\x18\x06 \x01(\rR\ttimeoutMs\x12\x12\n" +
-	"\x04user\x18\a \x01(\tR\x04user\x1a7\n" +
+	"\x04user\x18\a \x01(\tR\x04user\x12\x14\n" +
+	"\x05stdin\x18\b \x01(\bR\x05stdin\x1a7\n" +
 	"\tEnvsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"A\n" +


### PR DESCRIPTION
Adds a WebSocket exec endpoint so clients can run a command and stream its output back over a single connection, with stdin support — the full-duplex counterpart to the SSE `/exec/stream`.

## Changes
- **boxd**: wire stdin for non-PTY processes — `SendInputRequest.eof`, an stdin pipe on the process, and `SendInput` writing to it / closing on EOF. (Previously a no-op for non-PTY.)
- **proxy**: new `/exec/ws` bridge — upgrades the connection and bridges to `ProcessService.Start` in non-PTY mode. Structured `stdout`/`stderr`/`exit` JSON frames downstream; binary stdin + text control (`stdin`/`stdin_close`/`signal`) upstream. Added to the boxd-port allowlist.
- **spec**: `/exec/ws` documented in `api/openapi.yaml`.