### PR TITLE
template-builder: classify mkfs disk-overflow failures as image_too_large

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -105,8 +105,9 @@ func classifyBuildError(err error) (code, userMsg string) {
 	// Specific-cause cases must come before the broad "build rootfs" / "pull "
 	// match below, which would otherwise swallow them as registry failures.
 
-	case strings.Contains(raw, "flattened image exceeds"):
-		return "image_too_large", "image is too large for the requested disk_mib; increase disk_mib"
+	case strings.Contains(raw, "flattened image exceeds"),
+		strings.Contains(raw, "while populating file system"):
+		return "image_too_large", "image is too large for the requested disk; increase disk_mib or use a smaller base image"
 
 	case strings.Contains(raw, "parse image reference"):
 		return "bad_reference", "image reference is malformed; check the format like 'python:3.11' or 'ghcr.io/org/image:tag'"

--- a/cmd/template-builder/main_test.go
+++ b/cmd/template-builder/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestClassifyBuildError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      string
+		wantCode string
+	}{
+		{
+			name:     "image larger than the whole disk (extraction cap)",
+			err:      "build rootfs: flattened image exceeds 1073741824 bytes",
+			wantCode: "image_too_large",
+		},
+		{
+			name:     "image fits raw disk but not usable space (mkfs populate overflow)",
+			err:      `make ext4: mkfs.ext4: exit status 1: mkfs.ext4: Could not allocate block in ext2 filesystem while populating file system`,
+			wantCode: "image_too_large",
+		},
+		{
+			name:     "inode exhaustion during populate",
+			err:      "make ext4: mkfs.ext4: exit status 1: Could not allocate inode in ext2 filesystem while populating file system",
+			wantCode: "image_too_large",
+		},
+		{
+			name:     "an unrelated mkfs failure is NOT image_too_large",
+			err:      "make ext4: mkfs.ext4: exit status 1: mke2fs: invalid blocks count - destPath",
+			wantCode: "build_failed",
+		},
+		{
+			name:     "registry pull failure still classified as pull",
+			err:      "build rootfs: pull python:3.12: manifest unknown",
+			wantCode: "image_pull_failed",
+		},
+		{
+			name:     "unknown error falls back to build_failed",
+			err:      "something totally unexpected happened",
+			wantCode: "build_failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			code, msg := classifyBuildError(errors.New(tc.err))
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
+			}
+			if strings.TrimSpace(msg) == "" {
+				t.Error("user message must not be empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
When an image fits the raw `disk_mib` but not the usable ext4 space (or exhausts inodes), `mkfs.ext4 -d` fails in the populate phase and was misreported as the generic `build_failed`. Now classified as `image_too_large` with an actionable message — same root cause as the existing "image larger than disk" case, now reported consistently.