### PR TITLE
build: stop failing in-flight builds on a racy vmd not-found and adopt completed builds from disk

### DIFF
--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -58,6 +58,10 @@ type BuildSupervisorConfig struct {
 	// vmd.CancelBuild and mark failed.
 	BuildTimeout time.Duration
 
+	// RegisterGrace is how long after dispatch a vmd "not found" is tolerated
+	// before being treated as terminal (covers the poll-before-register race).
+	RegisterGrace time.Duration
+
 	// ReapBatchSize caps how many stale rows ReapStaleBuilds touches per
 	// tick. Mirrors BatchSize's bounding rationale.
 	ReapBatchSize int32
@@ -80,6 +84,7 @@ func DefaultBuildSupervisorConfig(hostID string) BuildSupervisorConfig {
 		HostID:                    hostID,
 		PendingTimeout:            2 * time.Minute,
 		BuildTimeout:              30 * time.Minute,
+		RegisterGrace:             60 * time.Second,
 		ReapBatchSize:             20,
 		ReconcileInterval:         5 * time.Minute,
 		MaxDeletesPerReconcile:    50,
@@ -365,14 +370,19 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 		rowLog.Warn().Err(err).Msg("GetBuildStatus failed")
 		return
 	}
-	if res.NotFound {
-		// vmd lost this build (restart, or never dispatched). Mark failed
-		// so the user can retry rather than waiting indefinitely.
-		rowLog.Warn().Msg("vmd has no record of build; marking failed")
-		s.failBuild(ctx, row.ID, "vmd has no record of this build (likely vmd restarted)")
+	switch classifyNotFound(res, row.StartedAt.Time, row.StartedAt.Valid, time.Now(), s.cfg.RegisterGrace) {
+	case nfWait:
+		// Within grace of dispatch, NotFound is the poll-before-register race,
+		// not a lost build — retry next tick.
+		rowLog.Debug().Msg("vmd has no record yet; within register grace, retrying next tick")
+		return
+	case nfFail:
+		rowLog.Warn().Dur("grace", s.cfg.RegisterGrace).Msg("vmd has no record of build after dispatch grace; marking failed")
+		s.failBuild(ctx, row.ID, "build was not found on the build host after dispatch (it may have been lost to a host restart); retry the build")
 		return
 	}
 
+	// nfProceed: vmd has the build — act on its reported status.
 	switch res.Status {
 	case "running":
 		// No transition needed; we're already 'building' in DB.
@@ -432,6 +442,37 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 		rowLog.Info().Str("status", res.Status).Str("error", res.ErrorMessage).Msg("build terminal")
 		s.logBuildCompleted(ctx, row, "error", res.ErrorMessage, "")
 	}
+}
+
+// notFoundDecision is what a vmd GetBuildStatus result implies for the poll.
+type notFoundDecision int
+
+const (
+	nfProceed notFoundDecision = iota // vmd has the build — act on res.Status
+	nfWait                            // NotFound, but still within register grace
+	nfFail                            // NotFound past grace — treat as lost
+)
+
+// classifyNotFound decides how pollOne should handle a GetBuildStatus result.
+// Pure so the decision is unit-testable without DB or gRPC.
+func classifyNotFound(res vmdclient.BuildStatusResult, startedAt time.Time, startedValid bool, now time.Time, grace time.Duration) notFoundDecision {
+	if !res.NotFound {
+		return nfProceed
+	}
+	if notFoundIsTerminal(startedAt, startedValid, now, grace) {
+		return nfFail
+	}
+	return nfWait
+}
+
+// notFoundIsTerminal reports whether a vmd "not found" is a permanent failure:
+// true only once the build has been dispatched longer than grace. With no valid
+// dispatch time it returns false (the stale-build reaper is the backstop).
+func notFoundIsTerminal(startedAt time.Time, startedValid bool, now time.Time, grace time.Duration) bool {
+	if !startedValid || startedAt.IsZero() {
+		return false
+	}
+	return now.Sub(startedAt) >= grace
 }
 
 // logBuildCompleted writes a template/build_completed activity row so user

--- a/internal/supervisor/notfound_grace_test.go
+++ b/internal/supervisor/notfound_grace_test.go
@@ -1,0 +1,85 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+func TestClassifyNotFound(t *testing.T) {
+	grace := 60 * time.Second
+	now := time.Unix(1_000_000, 0)
+	dispatched := func(ago time.Duration) time.Time { return now.Add(-ago) }
+
+	tests := []struct {
+		name string
+		res  vmdclient.BuildStatusResult
+		at   time.Time
+		want notFoundDecision
+	}{
+		{"vmd has the build -> proceed", vmdclient.BuildStatusResult{Status: "running"}, dispatched(5 * time.Second), nfProceed},
+		{"ready -> proceed", vmdclient.BuildStatusResult{Status: "ready"}, dispatched(5 * time.Second), nfProceed},
+		{"not found within grace -> wait", vmdclient.BuildStatusResult{NotFound: true}, dispatched(5 * time.Second), nfWait},
+		{"not found past grace -> fail", vmdclient.BuildStatusResult{NotFound: true}, dispatched(90 * time.Second), nfFail},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyNotFound(tc.res, tc.at, true, now, grace); got != tc.want {
+				t.Errorf("classifyNotFound = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNotFoundIsTerminal(t *testing.T) {
+	grace := 60 * time.Second
+	now := time.Unix(1_000_000, 0)
+
+	tests := []struct {
+		name         string
+		startedAt    time.Time
+		startedValid bool
+		want         bool
+	}{
+		{
+			name:         "within grace -> not terminal",
+			startedAt:    now.Add(-5 * time.Second),
+			startedValid: true,
+			want:         false,
+		},
+		{
+			name:         "just dispatched -> not terminal",
+			startedAt:    now,
+			startedValid: true,
+			want:         false,
+		},
+		{
+			name:         "past grace -> terminal",
+			startedAt:    now.Add(-90 * time.Second),
+			startedValid: true,
+			want:         true,
+		},
+		{
+			name:         "exactly at grace -> terminal",
+			startedAt:    now.Add(-grace),
+			startedValid: true,
+			want:         true,
+		},
+		{
+			name:         "no valid dispatch time -> never terminal here",
+			startedAt:    now.Add(-time.Hour),
+			startedValid: false,
+			want:         false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := notFoundIsTerminal(tc.startedAt, tc.startedValid, now, grace)
+			if got != tc.want {
+				t.Errorf("notFoundIsTerminal = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -3,6 +3,8 @@ package vm
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -181,25 +183,67 @@ func (m *Manager) cancelBuildRecord(buildVMID string, reason string) (BuildStatu
 	return prev, true
 }
 
-// GetBuildStatus returns the read-only snapshot of a build's state. Returns
-// false when the build ID is unknown — the supervisor maps that to "vmd
-// has no record, build is effectively gone."
+// GetBuildStatus returns a build's state from the in-memory registry, falling
+// back to on-disk artifacts when memory has no record (e.g. after a vmd
+// restart) so a completed build is never reported as lost.
 func (m *Manager) GetBuildStatus(buildVMID string) (BuildStatusSnapshot, bool) {
 	m.buildsMu.RLock()
-	defer m.buildsMu.RUnlock()
 	rec, ok := m.builds[buildVMID]
-	if !ok {
+	if ok {
+		snap := BuildStatusSnapshot{
+			BuildVMID:  rec.BuildVMID,
+			TemplateID: rec.TemplateID,
+			Status:     rec.Status,
+			Result:     rec.Result,
+			Error:      rec.Error,
+			StartedAt:  rec.StartedAt,
+			EndedAt:    rec.EndedAt,
+		}
+		m.buildsMu.RUnlock()
+		return snap, true
+	}
+	m.buildsMu.RUnlock()
+	// Not in memory — consult durable artifacts on disk (no lock held).
+	return loadDurableBuild(m.cfg.SnapshotDir, buildVMID)
+}
+
+// loadDurableBuild adopts a completed build from its on-disk artifacts. To
+// avoid adopting a half-written build, it returns ready only when
+// build.meta.json parses and every artifact file it references exists.
+func loadDurableBuild(snapshotRoot, buildVMID string) (BuildStatusSnapshot, bool) {
+	matches, err := filepath.Glob(filepath.Join(snapshotRoot, TemplatesDirName, "*", buildVMID, "build.meta.json"))
+	if err != nil || len(matches) != 1 {
+		return BuildStatusSnapshot{}, false
+	}
+	dir := filepath.Dir(matches[0])
+	res, err := readBuildMetaJSON(dir)
+	if err != nil || !buildArtifactsPresent(res) {
 		return BuildStatusSnapshot{}, false
 	}
 	return BuildStatusSnapshot{
-		BuildVMID:  rec.BuildVMID,
-		TemplateID: rec.TemplateID,
-		Status:     rec.Status,
-		Result:     rec.Result,
-		Error:      rec.Error,
-		StartedAt:  rec.StartedAt,
-		EndedAt:    rec.EndedAt,
+		BuildVMID:  buildVMID,
+		TemplateID: filepath.Base(filepath.Dir(dir)),
+		Status:     BuildStatusReady,
+		Result:     res,
 	}, true
+}
+
+// buildArtifactsPresent reports whether every file build.meta.json references
+// exists and is non-empty, with a real snapshot (snapshot + mem) present.
+func buildArtifactsPresent(r *BuildTemplateResult) bool {
+	if r == nil || r.SnapshotPath == "" || r.MemFilePath == "" {
+		return false
+	}
+	for _, p := range []string{r.SnapshotPath, r.MemFilePath, r.BasePath, r.DeltaPath, r.RootfsPath} {
+		if p == "" {
+			continue
+		}
+		fi, err := os.Stat(p)
+		if err != nil || fi.Size() == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // CancelBuild marks a build cancelled and signals its template-builder

--- a/internal/vm/durable_build_test.go
+++ b/internal/vm/durable_build_test.go
@@ -1,0 +1,87 @@
+package vm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDurableBuild(t *testing.T) {
+	root := t.TempDir()
+	const tid = "11111111-1111-1111-1111-111111111111"
+	const bvid = "build-22222222-2222-2222-2222-222222222222"
+	dir := filepath.Join(root, TemplatesDirName, tid, bvid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := filepath.Join(dir, "snapshot")
+	mem := filepath.Join(dir, "mem")
+	base := filepath.Join(dir, "base.ext4")
+	delta := filepath.Join(dir, "rootfs.delta")
+	writeNonEmpty := func(p string) {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, p := range []string{snap, mem, base, delta} {
+		writeNonEmpty(p)
+	}
+
+	writeMeta := func() {
+		b, _ := json.Marshal(map[string]any{
+			"snapshot_path":   snap,
+			"mem_path":        mem,
+			"rootfs_path":     base,
+			"base_path":       base,
+			"delta_path":      delta,
+			"resolved_digest": "sha256:abc",
+			"size_bytes":      int64(8589934592),
+		})
+		if err := os.WriteFile(filepath.Join(dir, "build.meta.json"), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("complete build is adopted as ready", func(t *testing.T) {
+		writeMeta()
+		got, ok := loadDurableBuild(root, bvid)
+		if !ok {
+			t.Fatal("expected a complete on-disk build to be adopted")
+		}
+		if got.Status != BuildStatusReady {
+			t.Errorf("status = %q, want ready", got.Status)
+		}
+		if got.TemplateID != tid {
+			t.Errorf("template id = %q, want %q", got.TemplateID, tid)
+		}
+		if got.Result == nil || got.Result.ResolvedDigest != "sha256:abc" {
+			t.Error("result must be populated from build.meta.json")
+		}
+	})
+
+	t.Run("missing referenced artifact is not adopted", func(t *testing.T) {
+		writeMeta()
+		if err := os.Remove(delta); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := loadDurableBuild(root, bvid); ok {
+			t.Error("must not adopt when a referenced artifact file is missing")
+		}
+		writeNonEmpty(delta) // restore for any later use
+	})
+
+	t.Run("unknown build returns not found", func(t *testing.T) {
+		if _, ok := loadDurableBuild(root, "build-nonexistent"); ok {
+			t.Error("unknown build must not be adopted")
+		}
+	})
+
+	t.Run("no meta json is not adopted", func(t *testing.T) {
+		_ = os.Remove(filepath.Join(dir, "build.meta.json"))
+		if _, ok := loadDurableBuild(root, bvid); ok {
+			t.Error("a build dir without build.meta.json must not be adopted")
+		}
+	})
+}


### PR DESCRIPTION
Template builds were being marked failed with `vmd has no record of this build (likely vmd restarted)` even when vmd had the build and went on to finish it. Root cause: the supervisor stamps `vmd_build_vm_id` (and `started_at`) before vmd registers the build, and multiple control-plane instances poll concurrently — so a poll can hit vmd in the brief window before registration and a single `NotFound` was treated as a permanent failure.