### PR TITLE
observability: add Sentry to proxy and vmd bare-metal services

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
             --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --update-env-vars SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
             --region ${{ vars.GCP_REGION }} \
             --project ${{ vars.GCP_PROJECT }}
 

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -109,5 +109,6 @@ jobs:
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
           PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python3 .github/workflows/scripts/deploy-proxy.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -76,7 +76,6 @@ jobs:
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py
 
@@ -122,5 +121,6 @@ jobs:
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -76,6 +76,7 @@ jobs:
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py
 

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -11,6 +11,7 @@ Env vars:
   SANDBOX_ACCESS_TOKEN_SEED  optional — hex, >=32 bytes (>=64 hex chars)
   PROXY_ALLOWED_ORIGINS      optional — comma-separated origin patterns
   REQUIRE_DATA_PLANE         optional — "", "0", or "1"
+  SENTRY_DSN                 optional — Sentry DSN URL for error reporting
 """
 
 import os
@@ -45,6 +46,10 @@ def main() -> int:
     require_data_plane = os.environ.get("REQUIRE_DATA_PLANE", "")
     if require_data_plane not in ("", "0", "1"):
         print('ERROR: REQUIRE_DATA_PLANE must be empty, "0", or "1"', file=sys.stderr)
+        return 1
+    sentry_dsn = os.environ.get("SENTRY_DSN", "")
+    if sentry_dsn and not re.fullmatch(r"https://[A-Za-z0-9@./:_\-]+", sentry_dsn):
+        print("ERROR: SENTRY_DSN must be a https:// URL or empty", file=sys.stderr)
         return 1
 
     result = subprocess.run(
@@ -104,6 +109,7 @@ def main() -> int:
             SANDBOX_ACCESS_TOKEN_SEED={access_seed}
             PROXY_ALLOWED_ORIGINS={terminal_origins}
             REQUIRE_DATA_PLANE={require_data_plane}
+            SENTRY_DSN={sentry_dsn}
             PROXYENV
             sudo chmod 0600 /etc/sandbox/proxy.env
 

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -66,6 +66,7 @@ def main() -> int:
     service = os.environ.get("VMD_SERVICE", "superserve-vmd")
     install_dir = os.environ.get("VMD_INSTALL_DIR", "/usr/local/bin")
     sha = os.environ["SHA"][:8]
+    sentry_dsn = os.environ.get("SENTRY_DSN", "")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -182,6 +183,10 @@ def main() -> int:
 
             sudo rm -rf {extract_dir}
             rm -f {bundle_remote}
+
+            # Upsert SENTRY_DSN in the vmd env file without touching other vars.
+            sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
+            echo 'SENTRY_DSN={sentry_dsn}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
 
             sudo systemctl restart {service}
             sleep 3

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -185,8 +185,11 @@ def main() -> int:
             rm -f {bundle_remote}
 
             # Upsert SENTRY_DSN in the vmd env file without touching other vars.
-            sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
-            echo 'SENTRY_DSN={sentry_dsn}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            # Only update when a non-empty value is provided; skip silently otherwise.
+            if [ -n '{sentry_dsn}' ]; then
+                sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
+                echo 'SENTRY_DSN={sentry_dsn}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            fi
 
             sudo systemctl restart {service}
             sleep 3

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -10,18 +10,29 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/auth"
 	"github.com/superserve-ai/sandbox/internal/proxy"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	log := zerolog.New(os.Stdout).With().
+	multi := zerolog.MultiLevelWriter(os.Stdout, &sentrylog.Writer{})
+	log := zerolog.New(multi).With().
 		Timestamp().
 		Str("service", "proxy").
 		Logger()
+
+	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
+		if err := sentry.Init(sentry.ClientOptions{Dsn: dsn, EnableLogs: true}); err != nil {
+			log.Warn().Err(err).Msg("sentry.Init failed")
+		} else {
+			defer sentry.Flush(2 * time.Second)
+		}
+	}
 
 	addr := envOrDefault("PROXY_ADDR", ":5007")
 	redirectAddr := envOrDefault("PROXY_REDIRECT_ADDR", ":5008")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -14,12 +14,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 
 	dbq "github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/network"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/vm"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
@@ -203,10 +205,19 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 func main() {
 	// Structured logging with zerolog — unix timestamp, caller info enabled.
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	log := zerolog.New(os.Stdout).With().
+	multi := zerolog.MultiLevelWriter(os.Stdout, &sentrylog.Writer{})
+	log := zerolog.New(multi).With().
 		Timestamp().
 		Str("service", "vmd").
 		Logger()
+
+	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
+		if err := sentry.Init(sentry.ClientOptions{Dsn: dsn, EnableLogs: true}); err != nil {
+			log.Warn().Err(err).Msg("sentry.Init failed")
+		} else {
+			defer sentry.Flush(2 * time.Second)
+		}
+	}
 
 	cfg, err := loadConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary

Extends the Sentry integration (landed in #91) to the proxy and vmd processes running on bare-metal GCP instances.

- Adds `sentrylog.Writer` to zerolog in both `cmd/proxy` and `cmd/vmd` — warn/error logs are forwarded to Sentry automatically
- Sentry is initialized from `SENTRY_DSN` at startup; no-op when unset (staging deploys are unaffected)
- `deploy-proxy.py` writes `SENTRY_DSN` into `/etc/sandbox/proxy.env` on each production deploy
- `deploy-vmd.py` upserts `SENTRY_DSN` into the existing `/etc/sandbox/vmd.env` without touching host-specific vars like `KERNEL_PATH` or `BASE_ROOTFS_PATH`
- Both deploy workflows pass `SENTRY_DSN` from the `production` environment secret

## Test plan

- [ ] Merge and trigger a production deploy — verify `SENTRY_DSN` appears in `/etc/sandbox/proxy.env` and `/etc/sandbox/vmd.env` on a host
- [ ] Confirm proxy/vmd warn/error logs show up in the Sentry dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)