### PR TITLE
analytics: backend usage tracking to PostHog

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	grpcstatus "google.golang.org/grpc/status"
 
+	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/api"
 	"github.com/superserve-ai/sandbox/internal/config"
 	dbq "github.com/superserve-ai/sandbox/internal/db"
@@ -110,6 +111,14 @@ func run() error {
 	handlers := api.NewHandlers(vmdClient, queries, cfg)
 	handlers.Pool = dbPool
 
+	// Product-usage analytics — no-op when POSTHOG_KEY is unset.
+	analyticsClient, err := analytics.New(os.Getenv("POSTHOG_KEY"), os.Getenv("POSTHOG_HOST"), log.Logger)
+	if err != nil {
+		log.Fatal().Err(err).Msg("init analytics")
+	}
+	defer analyticsClient.Close()
+	handlers.Analytics = analyticsClient
+
 	// Host registry: resolves host_id → VMDClient via DB lookup + gRPC dial.
 	// Interceptors below fire onDead on codes.Unavailable so the registry
 	// drops stale cached clients.
@@ -154,7 +163,7 @@ func run() error {
 		supervisor.DefaultBuildSupervisorConfig(cfg.DefaultHostID),
 		queries,
 		buildResolver,
-	).Start(ctx)
+	).WithAnalytics(analyticsClient).Start(ctx)
 
 	// Launch the host health detector. Marks active hosts as unhealthy
 	// when their VMD heartbeat goes stale (>2 min). The scheduler
@@ -284,13 +293,15 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 // instance from the snapshot files, bypassing any in-memory state. Used as
 // a fallback when ResumeInstance returns NotFound (e.g. after VMD lost its
 // map to a crash but the snapshot files are still on disk).
-func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir string, envVars map[string]string) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (string, uint32, uint32, error) {
 	resp, err := c.client.RestoreSnapshot(ctx, &vmdpb.RestoreSnapshotRequest{
 		VmId:         vmID,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
 		BasePath:     basePath,
 		DeltaDir:     deltaDir,
+		TeamId:       teamID,
+		OwnerId:      ownerID,
 		EnvVars:      envVars,
 	})
 	if err != nil {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/auth"
 	"github.com/superserve-ai/sandbox/internal/proxy"
 )
@@ -40,6 +41,14 @@ func main() {
 	resolver := proxy.NewVMDResolver(vmdAddr)
 	proxyHandler := proxy.NewHandler(domain, resolver, log)
 	proxyHandler.StartSweeper(ctx)
+
+	// Product-usage analytics for exec/files — no-op when POSTHOG_KEY is unset.
+	analyticsClient, err := analytics.New(os.Getenv("POSTHOG_KEY"), os.Getenv("POSTHOG_HOST"), log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("init analytics")
+	}
+	defer analyticsClient.Close()
+	proxyHandler.WithAnalytics(analyticsClient)
 
 	// Data-plane auth — the HMAC seed is shared with the control plane.
 	// Both sides derive per-sandbox access tokens as HMAC-SHA256(seed, sandboxID).

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/nftables v0.3.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
+	github.com/posthog/posthog-go v1.14.0
 	github.com/rs/zerolog v1.34.0
 	github.com/vishvananda/netns v0.0.5
 	go.etcd.io/bbolt v1.4.3
@@ -67,6 +68,7 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/google/nftables v0.3.0 h1:bkyZ0cbpVeMHXOrtlFc8ISmfVqq5gPJukoYieyVmITg
 github.com/google/nftables v0.3.0/go.mod h1:BCp9FsrbF1Fn/Yu6CLUc9GGZFw/+hsxfluNXXmxBfRM=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -164,6 +166,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posthog/posthog-go v1.14.0 h1:pN0+v7kvKkykRQDf6E0KNYJvKqhJ+VzQGlfxYHfZMhs=
+github.com/posthog/posthog-go v1.14.0/go.mod h1:xsVOW9YImilUcazwPNEq4PJDqEZf2KeCS758zXjwkPg=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -1,0 +1,140 @@
+// Package analytics emits product-usage events to PostHog from the control
+// plane and the data-plane proxy, attributed to the user behind the request
+// (matching the console's distinct_id) and grouped by team. Capture is
+// non-blocking and a no-op when PostHog is unconfigured.
+package analytics
+
+import (
+	"time"
+
+	"github.com/posthog/posthog-go"
+	"github.com/rs/zerolog"
+)
+
+// closeTimeout bounds how long Close waits for the worker to drain, so a wedged
+// PostHog can never hold up process shutdown.
+const closeTimeout = 2 * time.Second
+
+// bufferSize bounds the in-flight event queue. When full (PostHog slow/down),
+// Capture drops events rather than blocking the caller.
+const bufferSize = 1024
+
+// Client wraps the PostHog client. The zero value (and a Client from New with
+// an empty key) is a safe no-op.
+type Client struct {
+	ph     posthog.Client
+	log    zerolog.Logger
+	events chan event
+	quit   chan struct{}
+	done   chan struct{}
+}
+
+type event struct {
+	actorID string
+	teamID  string
+	name    string
+	props   map[string]any
+}
+
+// New returns a Client. When apiKey is empty, Capture is a no-op. host may be
+// empty to use PostHog's default endpoint.
+func New(apiKey, host string, log zerolog.Logger) (*Client, error) {
+	if apiKey == "" {
+		log.Info().Msg("analytics: PostHog not configured; usage events disabled")
+		return &Client{log: log}, nil
+	}
+	cfg := posthog.Config{}
+	if host != "" {
+		cfg.Endpoint = host
+	}
+	ph, err := posthog.NewWithConfig(apiKey, cfg)
+	if err != nil {
+		return nil, err
+	}
+	c := &Client{
+		ph:     ph,
+		log:    log,
+		events: make(chan event, bufferSize),
+		quit:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	go c.worker()
+	return c, nil
+}
+
+// worker drains the buffer into PostHog until Close signals quit, then flushes
+// what's buffered and exits. events is never closed, so Capture can't panic on
+// a shutdown race; a slow Enqueue backs up only this worker, never a request.
+func (c *Client) worker() {
+	defer close(c.done)
+	for {
+		select {
+		case ev := <-c.events:
+			c.enqueue(ev)
+		case <-c.quit:
+			for {
+				select {
+				case ev := <-c.events:
+					c.enqueue(ev)
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+func (c *Client) enqueue(ev event) {
+	p := posthog.NewProperties()
+	for k, v := range ev.props {
+		p.Set(k, v)
+	}
+	var groups posthog.Groups
+	if ev.teamID != "" {
+		groups = posthog.NewGroups().Set("team", ev.teamID)
+	}
+	if err := c.ph.Enqueue(posthog.Capture{
+		DistinctId: distinctID(ev.actorID, ev.teamID),
+		Event:      ev.name,
+		Properties: p,
+		Groups:     groups,
+	}); err != nil {
+		c.log.Debug().Err(err).Str("event", ev.name).Msg("analytics: enqueue failed")
+	}
+}
+
+// Capture records an event attributed to actorID (the Supabase user id,
+// matching the console's distinct_id) and team; an empty actorID falls back to
+// a team-scoped id. Non-blocking: drops on a full buffer, no-op when unset.
+func (c *Client) Capture(actorID, teamID, name string, props map[string]any) {
+	if c == nil || c.events == nil {
+		return
+	}
+	select {
+	case c.events <- event{actorID: actorID, teamID: teamID, name: name, props: props}:
+	default:
+		// Buffer full (PostHog slow/down) — drop to protect the hot path.
+	}
+}
+
+// Close stops the worker (after flushing buffered events) and closes the
+// underlying client. Safe to call once; not safe for concurrent calls.
+func (c *Client) Close() {
+	if c == nil || c.events == nil {
+		return
+	}
+	close(c.quit)
+	select {
+	case <-c.done:
+	case <-time.After(closeTimeout):
+	}
+	_ = c.ph.Close()
+}
+
+// distinctID returns the actor when known, else a team-scoped id.
+func distinctID(actorID, teamID string) string {
+	if actorID != "" {
+		return actorID
+	}
+	return "team:" + teamID
+}

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -1,0 +1,67 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestDistinctID(t *testing.T) {
+	tests := []struct {
+		name, actor, team, want string
+	}{
+		{"actor known -> person", "user-123", "team-9", "user-123"},
+		{"no actor -> team-scoped", "", "team-9", "team:team-9"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := distinctID(tc.actor, tc.team); got != tc.want {
+				t.Errorf("distinctID(%q,%q) = %q, want %q", tc.actor, tc.team, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCaptureNoopWhenUnconfigured(t *testing.T) {
+	c, err := New("", "", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Must not panic or error when PostHog is unconfigured.
+	c.Capture("user-1", "team-1", "sandbox_created", map[string]any{"id": "abc"})
+	c.Close()
+
+	// A nil receiver is also a safe no-op.
+	var nilClient *Client
+	nilClient.Capture("u", "t", "evt", nil)
+}
+
+func TestCaptureNonBlockingAndCloseBounded(t *testing.T) {
+	// Bogus endpoint exercises the worker + bounded Close path without network.
+	c, err := New("phc_test", "http://127.0.0.1:1", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 5000; i++ {
+			c.Capture("user-1", "team-1", "command_run", map[string]any{"i": i})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Capture blocked under load (buffer drop not working)")
+	}
+
+	closed := make(chan struct{})
+	go func() { c.Close(); close(closed) }()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within bound")
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 
+	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/auth"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
@@ -65,6 +66,23 @@ type Handlers struct {
 	Config    *config.Config
 	Hosts     HostRegistry // when set, routes VMD calls via host_id
 	Scheduler Scheduler    // when set, picks host on create
+	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
+}
+
+// capture emits a usage event attributed to the API key's owner and team.
+func (h *Handlers) capture(c *gin.Context, event string, props map[string]any) {
+	if h.Analytics == nil {
+		return
+	}
+	var actor string
+	if a := actorIDFromContext(c); a != nil {
+		actor = a.String()
+	}
+	var team string
+	if t, err := teamIDFromContext(c); err == nil {
+		team = t.String()
+	}
+	h.Analytics.Capture(actor, team, event, props)
 }
 
 // NewHandlers creates a new Handlers instance.
@@ -392,7 +410,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
 			// because resume is supposed to preserve whatever envs the sandbox
 			// already has baked into the snapshot — not inject new ones.
-			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", nil)
+			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
 				revertToPaused()
@@ -468,6 +486,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 
 	// ActivateSandbox's CTE atomically opened the sandbox_active_interval row.
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
+	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
 	return true
 }
 
@@ -571,6 +590,14 @@ func actorIDFromContext(c *gin.Context) *uuid.UUID {
 		return nil
 	}
 	return &id
+}
+
+// ownerIDFromContext returns the actor's UUID as a string, or "" when unknown.
+func ownerIDFromContext(c *gin.Context) string {
+	if a := actorIDFromContext(c); a != nil {
+		return a.String()
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------------------
@@ -706,6 +733,7 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 
 	// DestroySandbox's CTE atomically closed the open sandbox_active_interval row.
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "deleted", "success", &sandbox.Name, nil, nil)
+	h.capture(c, "sandbox_deleted", map[string]any{"sandbox_id": sandboxID.String()})
 
 	c.Status(http.StatusNoContent)
 }
@@ -1258,7 +1286,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// on top of the template's baked defaults by vmd (boxd resumes with
 	// template context, then the restore RPC posts these on top).
 	tVmdStart := time.Now()
-	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, req.EnvVars)
+	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
 	tVmdEnd := time.Now()
 
 	// Wait for the parallel INSERT to complete — its result determines
@@ -1428,6 +1456,10 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	}
 	// ActivateSandbox's CTE atomically opened the sandbox_active_interval row.
 	h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorID, "sandbox", "started", "success", &sandbox.Name, nil, createdMeta)
+	h.capture(c, "sandbox_created", map[string]any{
+		"sandbox_id":  sandbox.ID.String(),
+		"template_id": fromTemplateID,
+	})
 
 	sandbox.Status = db.SandboxStatusActive
 	resp := h.sandboxToResponseWithToken(sandbox)
@@ -1596,6 +1628,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 	// Interval was already closed at BeginPause; FinalizePause is the
 	// end of the VMD pause work, not the moment the sandbox left active.
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "paused", "success", &sandbox.Name, nil, nil)
+	h.capture(c, "sandbox_paused", map[string]any{"sandbox_id": sandboxID.String()})
 
 	c.Status(http.StatusNoContent)
 }
@@ -1814,6 +1847,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		}
 
 		h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorIDFromContext(c), "network", "updated", "success", &sandbox.Name, nil, networkConfig)
+		h.capture(c, "sandbox_network_updated", map[string]any{"sandbox_id": sandboxID.String()})
 	}
 
 	if body.Metadata != nil {

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -527,6 +527,10 @@ func (h *Handlers) CreateTemplate(c *gin.Context) {
 	h.logTemplateActivity(c.Request.Context(), row.ID, teamID, actorID, "template", "created", "success", nil)
 	h.logTemplateActivity(c.Request.Context(), row.ID, teamID, actorID, "template", "build_started", "success",
 		buildMetadata(row.BuildID))
+	h.capture(c, "template_build_started", map[string]any{
+		"template_id": row.ID.String(),
+		"build_id":    row.BuildID.String(),
+	})
 }
 
 func buildMetadata(buildID uuid.UUID) []byte {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -57,7 +57,7 @@ func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath 
 	}
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
 	if s.restoreFn != nil {
 		ip, err := s.restoreFn(ctx, id, snapshotPath, memPath)
 		return ip, 1, 1024, err

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -169,7 +169,7 @@ func (s *stubVMD) PauseInstance(_ context.Context, _, _ string) (string, string,
 func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (s *stubVMD) ExecCommand(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -60,6 +60,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		fail.write(w)
 		return
 	}
+	h.captureUsage(instanceID, "command_run", info)
 
 	transport := h.transports.get(instanceID, info)
 	target := &url.URL{

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -126,6 +126,7 @@ func (h *Handler) serveExecWS(w http.ResponseWriter, r *http.Request, instanceID
 		fail.write(w)
 		return
 	}
+	h.captureUsage(instanceID, "command_run", info)
 
 	acceptOpts := &websocket.AcceptOptions{
 		// Any origin: the token is the control. Auth isn't ambient (the token

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -167,6 +167,11 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 		fail.write(w)
 		return
 	}
+	fileEvent := "file_read" // only GET/POST reach here; POST is a write
+	if r.Method == http.MethodPost {
+		fileEvent = "file_write"
+	}
+	h.captureUsage(instanceID, fileEvent, info)
 
 	// From here on it's just a transparent reverse proxy to boxd.
 	// Reuse the lifecycle-keyed transport cache for the same reasons

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/analytics"
 )
 
 // Timeout constants.
@@ -78,6 +80,9 @@ type Handler struct {
 	// allowedOrigins is the set of browser origins allowed for CORS on
 	// data-plane endpoints (/files). Shared with the terminal origin check.
 	allowedOrigins []string
+
+	// analytics emits data-plane usage events; set via WithAnalytics, nil no-ops.
+	analytics *analytics.Client
 }
 
 // originAllowed checks whether the given Origin header matches one of the
@@ -118,6 +123,20 @@ func NewHandler(domain string, resolver Resolver, log zerolog.Logger) *Handler {
 		log:          log,
 	}
 	return h
+}
+
+// WithAnalytics enables data-plane usage events (exec/files).
+func (h *Handler) WithAnalytics(a *analytics.Client) *Handler {
+	h.analytics = a
+	return h
+}
+
+// captureUsage emits a data-plane usage event attributed to the sandbox owner.
+func (h *Handler) captureUsage(instanceID, event string, info InstanceInfo) {
+	if h.analytics == nil {
+		return
+	}
+	h.analytics.Capture(info.OwnerID, info.TeamID, event, map[string]any{"sandbox_id": instanceID})
 }
 
 // StartSweeper launches a background goroutine that periodically closes

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -22,6 +22,8 @@ type InstanceInfo struct {
 	VMIP      string
 	Status    string
 	StartedAt int64 // Unix nanoseconds; changes on restart — used as transport lifecycle key
+	TeamID    string // owning team, for usage attribution
+	OwnerID   string // creating user, for usage attribution; empty when unknown
 }
 
 // lifecycleKey returns a string stable for the lifetime of one VM boot.
@@ -113,6 +115,8 @@ type vmdResponse struct {
 	VMIP      string `json:"vm_ip"`
 	Status    string `json:"status"`
 	StartedAt int64  `json:"started_at"`
+	TeamID    string `json:"team_id"`
+	OwnerID   string `json:"owner_id"`
 }
 
 func (r *VMDResolver) fetch(ctx context.Context, instanceID string) (InstanceInfo, error) {
@@ -141,7 +145,7 @@ func (r *VMDResolver) fetch(ctx context.Context, instanceID string) (InstanceInf
 		return InstanceInfo{}, fmt.Errorf("resolver: decode response: %w", err)
 	}
 
-	info := InstanceInfo{VMIP: raw.VMIP, Status: raw.Status, StartedAt: raw.StartedAt}
+	info := InstanceInfo{VMIP: raw.VMIP, Status: raw.Status, StartedAt: raw.StartedAt, TeamID: raw.TeamID, OwnerID: raw.OwnerID}
 	r.store(instanceID, info, nil, r.ttl)
 	return info, nil
 }

--- a/internal/proxy/terminal.go
+++ b/internal/proxy/terminal.go
@@ -193,6 +193,7 @@ func (h *Handler) serveTerminal(w http.ResponseWriter, r *http.Request, instance
 		fail.write(w)
 		return
 	}
+	h.captureUsage(instanceID, "terminal_opened", info)
 
 	// From here on, errors go back through the WebSocket (if the upgrade
 	// succeeds) because we've committed to streaming.

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/builder"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
@@ -98,10 +99,11 @@ type Resolver func(ctx context.Context, hostID string) (vmdclient.Client, error)
 // state lives in the DB. Safe to instantiate once at controlplane boot and
 // Start() with the process-lifetime context.
 type BuildSupervisor struct {
-	cfg     BuildSupervisorConfig
-	q       *db.Queries
-	resolve Resolver
-	log     zerolog.Logger
+	cfg       BuildSupervisorConfig
+	q         *db.Queries
+	resolve   Resolver
+	log       zerolog.Logger
+	analytics *analytics.Client // when set, emits build-outcome events; nil is a no-op
 }
 
 // NewBuildSupervisor constructs a supervisor.
@@ -112,6 +114,12 @@ func NewBuildSupervisor(cfg BuildSupervisorConfig, q *db.Queries, resolve Resolv
 		resolve: resolve,
 		log:     log.With().Str("component", "build_supervisor").Logger(),
 	}
+}
+
+// WithAnalytics enables build-outcome events (succeeded/failed).
+func (s *BuildSupervisor) WithAnalytics(a *analytics.Client) *BuildSupervisor {
+	s.analytics = a
+	return s
 }
 
 // Start launches the ticker goroutine. Exits cleanly when ctx is cancelled.
@@ -500,6 +508,18 @@ func (s *BuildSupervisor) logBuildCompleted(ctx context.Context, row db.Template
 		Metadata:     metaJSON,
 	}); err != nil {
 		s.log.Error().Err(err).Str("build_id", row.ID.String()).Msg("activity log build_completed")
+	}
+
+	if s.analytics != nil {
+		event := "template_build_succeeded"
+		if status != "success" {
+			event = "template_build_failed"
+		}
+		// The build row carries no creator, so attribution is team-scoped.
+		s.analytics.Capture("", row.TeamID.String(), event, map[string]any{
+			"template_id": row.TemplateID.String(),
+			"build_id":    row.ID.String(),
+		})
 	}
 }
 

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -104,7 +104,7 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 		}
 	}
 
-	inst, err := a.mgr.RestoreVMSnapshot(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), vmCfg, netCfg)
+	inst, err := a.mgr.RestoreVMSnapshot(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), vmCfg, netCfg, req.GetTeamId(), req.GetOwnerId())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vm/local_http.go
+++ b/internal/vm/local_http.go
@@ -80,6 +80,8 @@ type instanceResponse struct {
 	VMIP      string `json:"vm_ip"`
 	Status    string `json:"status"`
 	StartedAt int64  `json:"started_at"` // Unix nanoseconds — proxy lifecycle key
+	TeamID    string `json:"team_id,omitempty"`
+	OwnerID   string `json:"owner_id,omitempty"`
 }
 
 // handleInstance handles GET /instances/{instanceID}.
@@ -106,6 +108,8 @@ func (s *LocalHTTPServer) handleInstance(w http.ResponseWriter, r *http.Request)
 		VMIP:      info.VMIP,
 		Status:    info.Status.String(),
 		StartedAt: info.CreatedAt.UnixNano(),
+		TeamID:    info.TeamID,
+		OwnerID:   info.OwnerID,
 	}); err != nil {
 		s.log.Error().Err(err).Str("instance", instanceID).Msg("failed to encode instance response")
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -95,6 +95,8 @@ type VMInstance struct {
 	MemFilePath  string
 	CreatedAt    time.Time
 	Metadata     map[string]string
+	TeamID       string // owning team; carried for data-plane usage attribution
+	OwnerID      string // creating user; empty when unknown
 
 	mu sync.RWMutex
 }
@@ -775,9 +777,9 @@ func (m *Manager) assertUnderVMSnapshotDir(vmID, p string) error {
 
 // RestoreVMSnapshot boots a VM from a previously captured snapshot.
 func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, memPath string,
-	resourceLimits VMConfig, netCfg *network.Config,
+	resourceLimits VMConfig, netCfg *network.Config, teamID, ownerID string,
 ) (*VMInstance, error) {
-	return m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, "")
+	return m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, teamID, ownerID, "")
 }
 
 // restoreVMSnapshot is the implementation. recordToPath is empty for normal
@@ -785,7 +787,7 @@ func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 // recording, in which case the in-firecracker UFFD handler writes each served
 // page offset to that file on VM shutdown.
 func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, memPath string,
-	resourceLimits VMConfig, netCfg *network.Config, recordToPath string,
+	resourceLimits VMConfig, netCfg *network.Config, teamID, ownerID, recordToPath string,
 ) (*VMInstance, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	tEntry := time.Now()
@@ -823,6 +825,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Config:       resourceLimits,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
+		TeamID:       teamID,
+		OwnerID:      ownerID,
 	}
 	m.vms[vmID] = inst
 	m.mu.Unlock()
@@ -1297,6 +1301,8 @@ type InstanceInfo struct {
 	VMIP      string
 	Status    VMStatus
 	CreatedAt time.Time
+	TeamID    string
+	OwnerID   string
 }
 
 // LookupInstance returns the address, status, and creation time of a VM.
@@ -1315,6 +1321,8 @@ func (m *Manager) LookupInstance(vmID string) (InstanceInfo, bool) {
 		VMIP:      inst.IP,
 		Status:    inst.Status,
 		CreatedAt: inst.CreatedAt,
+		TeamID:    inst.TeamID,
+		OwnerID:   inst.OwnerID,
 	}
 	inst.mu.RUnlock()
 	return info, true
@@ -1469,7 +1477,7 @@ func (m *Manager) RecordAccessPattern(ctx context.Context, vmID, snapshotPath, m
 		return nil
 	}
 
-	inst, err := m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, outputPath)
+	inst, err := m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, "", "", outputPath)
 	if err != nil {
 		return fmt.Errorf("restore for recording: %w", err)
 	}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -43,6 +43,9 @@ type VMRecord struct {
 	// persisted — it's only relevant at create-from-template; a resumed
 	// sandbox reuses its existing overlay file in place.
 	BasePath string `json:"base_path,omitempty"`
+	// Persisted so usage attribution survives a vmd restart.
+	TeamID  string `json:"team_id,omitempty"`
+	OwnerID string `json:"owner_id,omitempty"`
 }
 
 // StateStore wraps a BoltDB database for VM state persistence.
@@ -162,6 +165,8 @@ func toRecord(inst *VMInstance) VMRecord {
 		VCPU:         inst.Config.VCPU,
 		MemoryMiB:    inst.Config.MemoryMiB,
 		BasePath:     inst.Config.BasePath,
+		TeamID:       inst.TeamID,
+		OwnerID:      inst.OwnerID,
 	}
 }
 
@@ -183,6 +188,8 @@ func toInstance(rec VMRecord) *VMInstance {
 		MemFilePath:  rec.MemFilePath,
 		CreatedAt:    rec.CreatedAt,
 		Metadata:     rec.Metadata,
+		TeamID:       rec.TeamID,
+		OwnerID:      rec.OwnerID,
 		Config: VMConfig{
 			VCPU:      rec.VCPU,
 			MemoryMiB: rec.MemoryMiB,

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -16,7 +16,7 @@ type Client interface {
 	// ResumeInstance fails with NotFound (e.g. after a VMD crash lost the
 	// in-memory map but the snapshot files are still on disk). basePath +
 	// deltaDir are populated for overlay-mode templates, empty for legacy.
-	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
 	// DeleteSnapshot removes the on-disk vmstate + memory files for a
 	// previous snapshot. Idempotent: missing files return nil. Used by the
 	// control plane to garbage-collect the previous snapshot after a new

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -299,6 +299,10 @@ message RestoreSnapshotRequest {
   // empty, the per-VM overlay starts empty (used for pause/resume of a
   // single sandbox, where the overlay file is already populated).
   string delta_dir = 9;
+  // Owning team and creating user, carried so the data-plane proxy can
+  // attribute exec/file activity without a database. Both may be empty.
+  string team_id = 10;
+  string owner_id = 11;
 }
 
 message RestoreSnapshotResponse {

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -1598,7 +1598,11 @@ type RestoreSnapshotRequest struct {
 	// Directory containing rootfs.delta for fast clone-from-template. When
 	// empty, the per-VM overlay starts empty (used for pause/resume of a
 	// single sandbox, where the overlay file is already populated).
-	DeltaDir      string `protobuf:"bytes,9,opt,name=delta_dir,json=deltaDir,proto3" json:"delta_dir,omitempty"`
+	DeltaDir string `protobuf:"bytes,9,opt,name=delta_dir,json=deltaDir,proto3" json:"delta_dir,omitempty"`
+	// Owning team and creating user, carried so the data-plane proxy can
+	// attribute exec/file activity without a database. Both may be empty.
+	TeamId        string `protobuf:"bytes,10,opt,name=team_id,json=teamId,proto3" json:"team_id,omitempty"`
+	OwnerId       string `protobuf:"bytes,11,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1685,6 +1689,20 @@ func (x *RestoreSnapshotRequest) GetBasePath() string {
 func (x *RestoreSnapshotRequest) GetDeltaDir() string {
 	if x != nil {
 		return x.DeltaDir
+	}
+	return ""
+}
+
+func (x *RestoreSnapshotRequest) GetTeamId() string {
+	if x != nil {
+		return x.TeamId
+	}
+	return ""
+}
+
+func (x *RestoreSnapshotRequest) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
 	}
 	return ""
 }
@@ -2850,7 +2868,7 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12&\n" +
-	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xe8\x03\n" +
+	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\x9c\x04\n" +
 	"\x16RestoreSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
@@ -2859,7 +2877,10 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x0enetwork_config\x18\x06 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\x12Q\n" +
 	"\benv_vars\x18\a \x03(\v26.superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntryR\aenvVars\x12\x1b\n" +
 	"\tbase_path\x18\b \x01(\tR\bbasePath\x12\x1b\n" +
-	"\tdelta_dir\x18\t \x01(\tR\bdeltaDir\x1a:\n" +
+	"\tdelta_dir\x18\t \x01(\tR\bdeltaDir\x12\x17\n" +
+	"\ateam_id\x18\n" +
+	" \x01(\tR\x06teamId\x12\x19\n" +
+	"\bowner_id\x18\v \x01(\tR\aownerId\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x04\x10\x05R\foverlay_path\"\xcc\x01\n" +


### PR DESCRIPTION
Emits product-usage events to PostHog from the backend, attributed to the user behind the request (same `distinct_id` the console uses) and grouped by team — so SDK/API usage unifies with console activity under one PostHog person.

## Events
- **Control plane** (person + team): `sandbox_created`, `sandbox_resumed`, `sandbox_paused`, `sandbox_deleted`, `sandbox_network_updated`, `template_build_started`
- **Data plane / proxy** (sandbox owner + team): `command_run` (`/exec`, `/exec/stream`, `/exec/connect`), `file_read`, `file_write`, `terminal_opened`
- **Build supervisor** (team): `template_build_succeeded`, `template_build_failed`

## How
- New `internal/analytics` package: non-blocking (drop-on-full buffer + background worker), shutdown-bounded, no-op when `POSTHOG_KEY` is unset.
- The proxy has no DB and only knows the sandbox ID, so `team_id`/`owner_id` are plumbed via the `RestoreSnapshot` RPC → vmd (in-memory + BoltDB, survives restart) → `/instances` → resolver cache. Owner/team ride along in the already-cached lookup, so the exec/files hot path adds only a field read + a non-blocking enqueue.

## Notes
- No-op until `POSTHOG_KEY` is set in the control plane (Cloud Run) and proxy (host) envs — point both at the same PostHog project as the console.
- Build outcomes are team-attributed (the build row has no creator); everything else is person-level.
- All additive/backward-compatible: proto fields default empty, BoltDB record degrades gracefully, no migration.