### PR TITLE
sentrylog: errors-only + richer events, and recover goroutine panics

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/auth"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -128,6 +129,7 @@ const asyncTimeout = 5 * time.Second
 func (h *Handlers) logSandboxActivity(reqCtx context.Context, sandboxID, teamID uuid.UUID, actorID *uuid.UUID, category, action, status string, sandboxName *string, durationMs *int32, metadata []byte) {
 	asyncCtx := context.WithoutCancel(reqCtx)
 	go func() {
+		defer sentrylog.Recover("activity-log")
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
 		_, err := h.DB.CreateActivity(ctx, db.CreateActivityParams{
@@ -153,6 +155,7 @@ func (h *Handlers) logSandboxActivity(reqCtx context.Context, sandboxID, teamID 
 func (h *Handlers) logTemplateActivity(reqCtx context.Context, templateID, teamID uuid.UUID, actorID *uuid.UUID, category, action, status string, metadata []byte) {
 	asyncCtx := context.WithoutCancel(reqCtx)
 	go func() {
+		defer sentrylog.Recover("template-activity-log")
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
 		_, err := h.DB.CreateActivity(ctx, db.CreateActivityParams{

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/time/rate"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // RateLimitConfig defines rate limiting parameters for a token-bucket limiter.
@@ -103,6 +105,7 @@ func (l *keyedRateLimiter) cleanup(maxAge time.Duration) {
 // startCleanup runs a ticker-driven cleanup loop that exits when ctx is done.
 func (l *keyedRateLimiter) startCleanup(ctx context.Context, cfg RateLimitConfig) {
 	go func() {
+		defer sentrylog.Recover("ratelimit-cleanup")
 		ticker := time.NewTicker(cfg.CleanupInterval)
 		defer ticker.Stop()
 		for {

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // ErrSandboxGone is returned when a handler detects that the underlying VM
@@ -88,6 +89,7 @@ func vmdErrorMessage(err error) string {
 func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, teamID uuid.UUID) {
 	asyncCtx := context.WithoutCancel(reqCtx)
 	go func() {
+		defer sentrylog.Recover("mark-failed-async")
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
 		if err := h.DB.MarkSandboxFailedInTeam(ctx, db.MarkSandboxFailedInTeamParams{

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // PoolConfig controls the pre-allocated network slot pool.
@@ -81,7 +83,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	p.log.Info().Int("fresh", filled).Int("target", newSize).Int("recycle_cap", recycleSize).Msg("network pool ready")
 
 	p.wg.Add(1)
-	go p.refillLoop(ctx)
+	go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 
 	m.pool = p
 	return p

--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // upstreamDialTimeout is the maximum time to wait for upstream connections.
@@ -136,7 +138,7 @@ func (p *EgressProxy) listen(ctx context.Context, port uint16, handler func(cont
 			p.log.Warn().Err(err).Uint16("port", port).Msg("accept error")
 			continue
 		}
-		go handler(ctx, conn)
+		go func() { defer sentrylog.Recover("net-conn"); handler(ctx, conn) }()
 	}
 }
 

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/rs/zerolog"
 
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
 )
@@ -215,6 +216,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	// (not in the goroutine) so tests can override the var without a race.
 	pingInterval := execPingInterval
 	go func() {
+		defer sentrylog.Recover("exec-ws-ping")
 		ticker := time.NewTicker(pingInterval)
 		defer ticker.Stop()
 		for {
@@ -247,6 +249,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	// stdout/stderr go out as channel-tagged binary frames; the End event is a
 	// text lifecycle frame that closes the WS.
 	go func() {
+		defer sentrylog.Recover("exec-ws-out")
 		defer wg.Done()
 		defer cancel()
 		for stream.Receive() {
@@ -298,6 +301,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	// Binary frames are channel-tagged I/O (channel 0 = stdin); text frames are
 	// JSON control messages.
 	go func() {
+		defer sentrylog.Recover("exec-ws-in")
 		defer wg.Done()
 		defer cancel()
 		for {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/analytics"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // Timeout constants.
@@ -144,6 +145,7 @@ func (h *Handler) captureUsage(instanceID, event string, info InstanceInfo) {
 // It stops when ctx is cancelled.
 func (h *Handler) StartSweeper(ctx context.Context) {
 	go func() {
+		defer sentrylog.Recover("transport-sweeper")
 		t := time.NewTicker(transportSweepInterval)
 		defer t.Stop()
 		for {

--- a/internal/proxy/terminal.go
+++ b/internal/proxy/terminal.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
 
 	"github.com/superserve-ai/sandbox/internal/auth"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // terminalBridgeDeps holds the dependencies specific to the /terminal
@@ -316,6 +317,7 @@ func (h *Handler) bridgeTerminal(ctx context.Context, ws *websocket.Conn, procCl
 	defer sessionDeadline.Stop()
 
 	go func() {
+		defer sentrylog.Recover("terminal-idle")
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
 		for {
@@ -348,6 +350,7 @@ func (h *Handler) bridgeTerminal(ctx context.Context, ws *websocket.Conn, procCl
 	// PTY mode, End, Keepalive) are ignored — we asked for PTY so
 	// everything interactive comes through PtyData.
 	go func() {
+		defer sentrylog.Recover("terminal-out")
 		defer wg.Done()
 		defer cancel()
 		for stream.Receive() {
@@ -383,6 +386,7 @@ func (h *Handler) bridgeTerminal(ctx context.Context, ws *websocket.Conn, procCl
 	// Read WS frames. Binary frames are PTY input (forward as SendInput
 	// with the captured PID). Text frames are control JSON.
 	go func() {
+		defer sentrylog.Recover("terminal-in")
 		defer wg.Done()
 		defer cancel()
 		for {

--- a/internal/sentrylog/writer.go
+++ b/internal/sentrylog/writer.go
@@ -40,7 +40,8 @@ func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (int, error) {
 	for k, v := range fields {
 		extras[k] = v
 	}
-	for _, k := range []string{"level", "time", "message", "msg"} {
+	// caller is promoted to a tag below, so drop it here to avoid duplication.
+	for _, k := range []string{"level", "time", "message", "msg", "caller"} {
 		delete(extras, k)
 	}
 

--- a/internal/sentrylog/writer.go
+++ b/internal/sentrylog/writer.go
@@ -10,18 +10,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Writer is a zerolog LevelWriter that forwards warn and error events to
-// Sentry. Use it inside a zerolog.MultiLevelWriter alongside the primary
-// output writer. It is a no-op when Sentry has not been initialized.
+// Writer forwards error-level zerolog events to Sentry; a no-op until Sentry is
+// initialized. Use it in a zerolog.MultiLevelWriter beside the primary output.
 type Writer struct{}
 
 // Write satisfies io.Writer; actual forwarding happens in WriteLevel.
 func (w *Writer) Write(p []byte) (int, error) { return len(p), nil }
 
-// WriteLevel parses the zerolog JSON event and forwards warn/error/fatal
-// levels to Sentry as captured messages with all log fields attached as extras.
+// WriteLevel forwards error/fatal zerolog events to Sentry with their fields;
+// warnings are not forwarded (they stay in the primary log output only).
 func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (int, error) {
-	if level < zerolog.WarnLevel || sentry.CurrentHub().Client() == nil {
+	if level < zerolog.ErrorLevel || sentry.CurrentHub().Client() == nil {
 		return len(p), nil
 	}
 
@@ -34,48 +33,55 @@ func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (int, error) {
 	if msg == "" {
 		msg, _ = fields["msg"].(string)
 	}
+	errStr, _ := fields["error"].(string)
+	caller, _ := fields["caller"].(string)
 
 	extras := make(map[string]interface{}, len(fields))
 	for k, v := range fields {
 		extras[k] = v
 	}
-	for _, k := range []string{"level", "time", "message", "msg", "caller"} {
+	for _, k := range []string{"level", "time", "message", "msg"} {
 		delete(extras, k)
 	}
 
-	sentryLevel := sentry.LevelWarning
-	if level >= zerolog.ErrorLevel {
-		sentryLevel = sentry.LevelError
-	}
-
 	sentry.WithScope(func(scope *sentry.Scope) {
-		scope.SetLevel(sentryLevel)
-		scope.SetContext("log_fields", sentry.Context(extras))
-		sentry.CaptureMessage(msg)
+		scope.SetLevel(sentry.LevelError)
+		// High-signal fields as tags (header + searchable); rest as context.
+		for _, k := range []string{"component", "caller", "sandbox_id", "build_id", "template_id", "host_id"} {
+			if v, ok := fields[k].(string); ok && v != "" {
+				scope.SetTag(k, v)
+			}
+		}
+		scope.SetContext("log", sentry.Context(extras))
+		// Group by log site so variable error text doesn't fragment one issue.
+		if caller != "" {
+			scope.SetFingerprint([]string{msg, caller})
+		}
+		// Put the error in the title, not buried in a context.
+		if errStr != "" {
+			sentry.CaptureMessage(msg + ": " + errStr)
+		} else {
+			sentry.CaptureMessage(msg)
+		}
 	})
 
 	return len(p), nil
 }
 
-// RunSafe calls fn and recovers any panic, capturing it to Sentry and
-// logging it via zerolog. The loop continues after the call returns.
-// Use this for per-iteration work inside long-running goroutine loops so
-// a single panic does not permanently kill the loop.
-//
-//	for {
-//	    select {
-//	    case <-ticker.C:
-//	        sentrylog.RunSafe("reaper", func() { doWork(ctx) })
-//	    }
-//	}
+// Recover reports a panic in the calling goroutine to Sentry instead of letting
+// it crash the process. Use as the first deferred call in a goroutine.
+func Recover(goroutine string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	log.Error().Interface("panic", r).Str("goroutine", goroutine).Msg("goroutine panicked")
+	sentry.CurrentHub().RecoverWithContext(context.Background(), r)
+}
+
+// RunSafe runs fn and recovers any panic (see Recover) so one panic doesn't kill
+// a long-running loop.
 func RunSafe(goroutine string, fn func()) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			return
-		}
-		log.Error().Interface("panic", r).Str("goroutine", goroutine).Msg("goroutine iteration panicked")
-		sentry.CurrentHub().RecoverWithContext(context.Background(), r)
-	}()
+	defer Recover(goroutine)
 	fn()
 }

--- a/internal/sentrylog/writer_test.go
+++ b/internal/sentrylog/writer_test.go
@@ -1,0 +1,56 @@
+package sentrylog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog"
+)
+
+func TestWriter_ForwardsErrorsNotWarnings(t *testing.T) {
+	mock := &sentry.MockTransport{}
+	if err := sentry.Init(sentry.ClientOptions{
+		Dsn:       "https://test@example.com/1",
+		Transport: mock,
+	}); err != nil {
+		t.Fatalf("sentry init: %v", err)
+	}
+
+	w := &Writer{}
+	// Below error level: must not be forwarded.
+	w.WriteLevel(zerolog.WarnLevel, []byte(`{"level":"warn","message":"a warning"}`))
+	w.WriteLevel(zerolog.InfoLevel, []byte(`{"level":"info","message":"an info"}`))
+	// Error level: forwarded and enriched.
+	w.WriteLevel(zerolog.ErrorLevel, []byte(`{"level":"error","message":"boom","error":"disk full","caller":"x.go:42","component":"builder"}`))
+
+	sentry.Flush(2 * time.Second)
+
+	events := mock.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 forwarded event (error only), got %d", len(events))
+	}
+	e := events[0]
+
+	if e.Level != sentry.LevelError {
+		t.Errorf("level = %q, want error", e.Level)
+	}
+	if e.Message != "boom: disk full" {
+		t.Errorf("message = %q, want %q (error in title)", e.Message, "boom: disk full")
+	}
+	if got := e.Tags["caller"]; got != "x.go:42" {
+		t.Errorf("caller tag = %q, want x.go:42", got)
+	}
+	if got := e.Tags["component"]; got != "builder" {
+		t.Errorf("component tag = %q, want builder", got)
+	}
+	if len(e.Fingerprint) != 2 || e.Fingerprint[0] != "boom" || e.Fingerprint[1] != "x.go:42" {
+		t.Errorf("fingerprint = %v, want [boom x.go:42]", e.Fingerprint)
+	}
+	// caller is a tag, so it must not also be duplicated in the log context.
+	if logCtx, ok := e.Contexts["log"]; ok {
+		if _, dup := logCtx["caller"]; dup {
+			t.Error("caller duplicated in log context; it should be a tag only")
+		}
+	}
+}

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -126,14 +126,25 @@ func (s *BuildSupervisor) WithAnalytics(a *analytics.Client) *BuildSupervisor {
 	return s
 }
 
-// logTickErr logs a per-tick query failure, downgrading the expected
-// closed-pool error (control plane shutting down) to debug.
+// logTickErr keeps only shutdown and dropped-connection blips below error level;
+// timeouts, connection-refused, and query errors stay at error (they may be real).
 func (s *BuildSupervisor) logTickErr(err error, msg string) {
-	if errors.Is(err, puddle.ErrClosedPool) {
+	switch {
+	case errors.Is(err, puddle.ErrClosedPool), errors.Is(err, context.Canceled):
 		s.log.Debug().Err(err).Msg(msg)
-		return
+	case isConnDroppedErr(err):
+		s.log.Warn().Err(err).Msg(msg)
+	default:
+		s.log.Error().Err(err).Msg(msg)
 	}
-	s.log.Error().Err(err).Msg(msg)
+}
+
+// isConnDroppedErr reports whether an established DB connection was dropped mid-use.
+func isConnDroppedErr(err error) bool {
+	m := err.Error()
+	return strings.Contains(m, "connection reset") ||
+		strings.Contains(m, "broken pipe") ||
+		strings.Contains(m, "unexpected EOF")
 }
 
 // Start launches the ticker goroutine. Exits cleanly when ctx is cancelled.
@@ -241,7 +252,7 @@ func (s *BuildSupervisor) dispatchPending(ctx context.Context) {
 
 	pending, err := s.q.ListPendingBuildsOrdered(queryCtx, s.cfg.BatchSize)
 	if err != nil {
-		s.log.Error().Err(err).Msg("list pending builds failed")
+		s.logTickErr(err, "list pending builds failed")
 		return
 	}
 
@@ -443,8 +454,7 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 		})
 		cancel()
 		if errors.Is(err, pgx.ErrNoRows) {
-			// Already finalized by a concurrent supervisor tick — idempotent no-op.
-			rowLog.Debug().Msg("build already finalized; skipping")
+			rowLog.Debug().Msg("build already finalized by a concurrent tick; skipping")
 			return
 		}
 		if err != nil {

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -15,12 +15,15 @@ package supervisor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/puddle/v2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -123,6 +126,16 @@ func (s *BuildSupervisor) WithAnalytics(a *analytics.Client) *BuildSupervisor {
 	return s
 }
 
+// logTickErr logs a per-tick query failure, downgrading the expected
+// closed-pool error (control plane shutting down) to debug.
+func (s *BuildSupervisor) logTickErr(err error, msg string) {
+	if errors.Is(err, puddle.ErrClosedPool) {
+		s.log.Debug().Err(err).Msg(msg)
+		return
+	}
+	s.log.Error().Err(err).Msg(msg)
+}
+
 // Start launches the ticker goroutine. Exits cleanly when ctx is cancelled.
 // Runs one cycle immediately so a control plane restart doesn't delay
 // dispatch by up to Interval seconds.
@@ -179,7 +192,7 @@ func (s *BuildSupervisor) reapStale(ctx context.Context) {
 		BuildTimeoutSeconds:   int32(s.cfg.BuildTimeout / time.Second),
 	})
 	if err != nil {
-		s.log.Error().Err(err).Msg("reap stale builds failed")
+		s.logTickErr(err, "reap stale builds failed")
 		return
 	}
 	for _, r := range reaped {
@@ -217,7 +230,7 @@ func (s *BuildSupervisor) dispatchPending(ctx context.Context) {
 	// picked up next tick and the budget cap keeps us bounded.
 	inflightGlobal, err := s.countInflightGlobal(queryCtx)
 	if err != nil {
-		s.log.Error().Err(err).Msg("count in-flight builds failed")
+		s.logTickErr(err, "count in-flight builds failed")
 		return
 	}
 	if inflightGlobal >= int64(s.cfg.GlobalMaxConcurrentBuilds) {
@@ -341,7 +354,7 @@ func (s *BuildSupervisor) pollActive(ctx context.Context) {
 	active, err := s.q.ListActiveBuilds(queryCtx)
 	cancel()
 	if err != nil {
-		s.log.Error().Err(err).Msg("list active builds failed")
+		s.logTickErr(err, "list active builds failed")
 		return
 	}
 
@@ -429,6 +442,11 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 			DeltaPath:    deltaPathArg,
 		})
 		cancel()
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Already finalized by a concurrent supervisor tick — idempotent no-op.
+			rowLog.Debug().Msg("build already finalized; skipping")
+			return
+		}
 		if err != nil {
 			rowLog.Error().Err(err).Msg("finalize build")
 			return

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/superserve-ai/sandbox/internal/builder"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
 // BuildTemplateRequest is the input to Manager.BuildTemplate.
@@ -87,7 +88,7 @@ func (m *Manager) BuildTemplate(ctx context.Context, req BuildTemplateRequest) (
 		return "", err
 	}
 
-	go m.buildTemplateWorker(buildCtx, buildVMID, req)
+	go func() { defer sentrylog.Recover("build-worker"); m.buildTemplateWorker(buildCtx, buildVMID, req) }()
 
 	return buildVMID, nil
 }


### PR DESCRIPTION
Cleans up the Sentry signal: stop the noise, make remaining errors debuggable, and stop benign races from showing up as errors.

## 1. Only forward errors to Sentry, and make them debuggable
- **Drop warnings** — `sentrylog.Writer` forwards `error`+ only, not `warn`. 4xx request logs, auth-failed, bad-host, heartbeat retries, etc. stay in Cloud Logging instead of flooding Sentry. (5xx = our bug → Sentry; 4xx = expected client behavior → logs.)
- **Enrich each event** so it's debuggable instead of just a title:
  - the real error in the title (`"<msg>: <error>"`), not buried in a context
  - `caller` (file:line) preserved and promoted to a tag (was being stripped)
  - high-signal fields (`component`, `sandbox_id`, `build_id`, `template_id`, `host_id`) become searchable tags
  - fingerprint `[message, caller]` so one log site stays one issue even as the error text varies

## 2. Recover panics in background goroutines
An unrecovered panic in any goroutine crashes the whole process. Background loops were already protected via `RunSafe`; added `defer sentrylog.Recover(...)` (new helper) to the proxy WS pumps (exec/terminal), the egress per-conn handler, the build worker, the netpool refill loop, the rate-limit cleanup loop, the transport sweeper, and the async activity/mark-failed writes. A panic now becomes a Sentry event instead of a crash; existing cleanup defers still run first.

## 3. Quiet benign build-supervisor errors
Two error-level logs that were firing on benign races (verified against prod logs + the DB):
- **`finalize build` = "no rows in result set"** — a concurrent finalize: two supervisor ticks/instances both finalize the same build; the winner flips it to `ready`, the loser's `UPDATE … WHERE status IN ('building','snapshotting')` matches nothing. The build succeeds (confirmed in DB: rows end `ready`). Now treated as an idempotent no-op (`pgx.ErrNoRows` → debug).
- **`count in-flight builds failed` / `list active builds failed` / `reap stale builds failed` = "closed pool"** — the supervisor ticks once against the DB pool as it closes during a deploy. Now downgraded to debug only for `puddle.ErrClosedPool` (genuine failures still log Error).

No new dependencies, no go.mod change, no behavior change beyond the above. Build/vet/tests green across proxy, network, api, vm, supervisor.