### PR TITLE
sandbox: a failed resume must never brick a sandbox

### DIFF
--- a/db/queries/sandbox_active_intervals.sql
+++ b/db/queries/sandbox_active_intervals.sql
@@ -1,12 +1,11 @@
 -- name: OpenSandboxActiveInterval :exec
 -- Opens an interval row when a sandbox transitions into 'active' (created or
--- resumed). The partial unique index sandbox_active_interval(sandbox_id) WHERE
--- ended_at IS NULL guarantees at most one open row per sandbox at any time;
--- in the unlikely event a prior open row was left dangling, the caller should
--- treat the unique-violation as recoverable (sandbox is already considered
--- running) rather than a hard error.
+-- resumed). A dangling open row from a prior transition is recoverable, so
+-- ON CONFLICT makes this a no-op rather than a unique-violation the caller
+-- would have to special-case.
 INSERT INTO sandbox_active_interval (sandbox_id, team_id, actor_id, started_at)
-VALUES ($1, $2, $3, now());
+VALUES ($1, $2, $3, now())
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING;
 
 -- name: CloseSandboxActiveInterval :exec
 -- Closes the currently-open interval for a sandbox. The WHERE ended_at IS NULL
@@ -31,3 +30,21 @@ FROM sandbox_active_interval
 WHERE sandbox_id = $1 AND ended_at IS NOT NULL
 ORDER BY ended_at DESC
 LIMIT 1;
+
+-- name: CloseOrphanedActiveIntervals :execrows
+-- Defense-in-depth sweep: close interval rows left open while their sandbox is
+-- no longer active (a transition whose close didn't land). Left alone they
+-- count the sandbox active in WAU forever. end_reason mirrors the terminal
+-- state; the settle window avoids racing a transiently non-active sandbox.
+UPDATE sandbox_active_interval sai
+SET ended_at = now(),
+    end_reason = CASE s.status
+        WHEN 'failed'  THEN 'failed'
+        WHEN 'deleted' THEN 'deleted'
+        ELSE 'paused'
+    END
+FROM sandbox s
+WHERE sai.sandbox_id = s.id
+  AND sai.ended_at IS NULL
+  AND s.status IN ('paused', 'failed', 'deleted')
+  AND s.updated_at < now() - interval '5 minutes';

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -77,6 +77,7 @@ WHERE id = $1 AND team_id = $5 AND destroyed_at IS NULL;
 --
 -- A leftover open interval must not fail the activation, so ON CONFLICT keeps
 -- the existing open row — an orphaned interval can never block a resumed VM.
+-- (Creation has no prior interval; this reuse only ever applies on resume.)
 WITH activated AS (
   UPDATE sandbox
   SET status = 'active',

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -74,6 +74,9 @@ WHERE id = $1 AND team_id = $5 AND destroyed_at IS NULL;
 -- sandbox observable as active has a matching open interval — otherwise a
 -- crash/timeout between the two writes would leave the sandbox active with
 -- no interval, undercounting WAU until the next state transition.
+--
+-- A leftover open interval must not fail the activation, so ON CONFLICT keeps
+-- the existing open row — an orphaned interval can never block a resumed VM.
 WITH activated AS (
   UPDATE sandbox
   SET status = 'active',
@@ -86,7 +89,8 @@ WITH activated AS (
 )
 INSERT INTO sandbox_active_interval (sandbox_id, team_id, actor_id, started_at)
 SELECT a.id, a.team_id, $6, now()
-FROM activated a;
+FROM activated a
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING;
 
 -- name: SetSandboxSnapshot :exec
 UPDATE sandbox

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -457,8 +457,8 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// resumable 'paused' state. Prefer leak over loss.
 	pauseAndRevert := func() {
 		pctx, pcancel := context.WithTimeout(revertCtx, vmdTimeout)
-		defer pcancel()
 		snapPath, memPath, perr := vmd.PauseInstance(pctx, sandboxID.String(), "")
+		pcancel()
 		if perr != nil {
 			// VM unreachable — nothing to preserve; mark failed rather than
 			// wedge in 'resuming' (the CTE also closes any open interval).
@@ -466,13 +466,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID)
 			return
 		}
-		// Overlay preserved; flip resuming → paused via the normal pause finalize.
-		if _, ferr := h.DB.FinalizePause(pctx, db.FinalizePauseParams{
+		// Fresh deadline so a slow snapshot above can't starve the DB write.
+		// Overlay preserved; flip resuming → paused via FinalizePause.
+		fctx, fcancel := context.WithTimeout(revertCtx, vmdTimeout)
+		defer fcancel()
+		if _, ferr := h.DB.FinalizePause(fctx, db.FinalizePauseParams{
 			ID:        sandboxID,
 			TeamID:    teamID,
 			Path:      snapPath,
 			MemPath:   &memPath,
-			SizeBytes: 0,
+			SizeBytes: 0, // snapshot size isn't tracked for pauses (matches PauseSandbox)
 			Trigger:   "resume_revert",
 		}); ferr != nil {
 			// VM is safely paused; only bookkeeping failed. Best-effort status

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -451,20 +451,42 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	destroyAndRevert := func() {
-		dctx, dcancel := context.WithTimeout(revertCtx, vmdTimeout)
-		defer dcancel()
-		if err := vmd.DestroyInstance(dctx, sandboxID.String(), true); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("destroy VM after resume failure failed")
+	// Once the VM is up, a failed finalize step must NOT destroy it —
+	// DestroyInstance deletes the overlay (the sandbox's disk). Re-pause
+	// instead: snapshotting preserves the overlay and returns it to a clean,
+	// resumable 'paused' state. Prefer leak over loss.
+	pauseAndRevert := func() {
+		pctx, pcancel := context.WithTimeout(revertCtx, vmdTimeout)
+		defer pcancel()
+		snapPath, memPath, perr := vmd.PauseInstance(pctx, sandboxID.String(), "")
+		if perr != nil {
+			// VM unreachable — nothing to preserve; mark failed rather than
+			// wedge in 'resuming' (the CTE also closes any open interval).
+			log.Error().Err(perr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: PauseInstance failed, marking sandbox failed")
+			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID)
+			return
 		}
-		revertToPaused()
+		// Overlay preserved; flip resuming → paused via the normal pause finalize.
+		if _, ferr := h.DB.FinalizePause(pctx, db.FinalizePauseParams{
+			ID:        sandboxID,
+			TeamID:    teamID,
+			Path:      snapPath,
+			MemPath:   &memPath,
+			SizeBytes: 0,
+			Trigger:   "resume_revert",
+		}); ferr != nil {
+			// VM is safely paused; only bookkeeping failed. Best-effort status
+			// flip — the reconciler is the backstop.
+			log.Error().Err(ferr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: FinalizePause failed, best-effort revert to paused")
+			revertToPaused()
+		}
 	}
 
 	// Apply egress rules before committing to 'active' so "active ⇒ rules
 	// applied" holds by construction.
 	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
-		destroyAndRevert()
+		pauseAndRevert()
 		respondError(c, ErrInternal)
 		return false
 	}
@@ -478,7 +500,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		ActorID:   actorUUID(actorIDFromContext(c)),
 	}); err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
-		destroyAndRevert()
+		pauseAndRevert()
 		respondError(c, ErrInternal)
 		return false
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -215,6 +215,15 @@ func errorRow(err error) *mockRow {
 	return &mockRow{scanFn: func(...any) error { return err }}
 }
 
+// uuidRow returns a mockRow for a query that RETURNs a single uuid (e.g.
+// FinalizePause's snapshot_id).
+func uuidRow(id uuid.UUID) *mockRow {
+	return &mockRow{scanFn: func(dest ...any) error {
+		*dest[0].(*uuid.UUID) = id
+		return nil
+	}}
+}
+
 // activityRow returns a mockRow for CreateActivity's Scan (14 fields).
 func activityRow() *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
@@ -743,7 +752,9 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 
 // Network-reapply failure after VMD resume must destroy the VM, revert DB to
 // paused, and never flip status to active.
-func TestResumeSandbox_NetworkReapplyFailure_DestroysAndReverts(t *testing.T) {
+// A resume that gets the VM up but then fails to reapply egress rules must
+// re-pause the VM (preserving the overlay), never destroy it.
+func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	snapshotID := uuid.New()
@@ -754,7 +765,7 @@ func TestResumeSandbox_NetworkReapplyFailure_DestroysAndReverts(t *testing.T) {
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
 	}
 
-	var destroyCalled, updateNetworkCalled int32
+	var destroyCalled, pauseCalled, updateNetworkCalled, finalizeCalled, activateCalled int32
 	vmd := &stubVMD{
 		resumeFn: func(context.Context, string, string, string) (string, error) {
 			return "10.0.0.5", nil
@@ -763,31 +774,34 @@ func TestResumeSandbox_NetworkReapplyFailure_DestroysAndReverts(t *testing.T) {
 			atomic.AddInt32(&destroyCalled, 1)
 			return nil
 		},
+		pauseFn: func(context.Context, string, string) (string, string, error) {
+			atomic.AddInt32(&pauseCalled, 1)
+			return "/snapshots/test/vmstate.snap", "/snapshots/test/mem.snap", nil
+		},
 		updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
 			atomic.AddInt32(&updateNetworkCalled, 1)
 			return fmt.Errorf("nftables push failed")
 		},
 	}
 
-	var activateCalled, revertCalled int32
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
-			case strings.Contains(sql, "FROM sandbox"):
-				return sandboxRow(sb)
+			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
+				atomic.AddInt32(&finalizeCalled, 1)
+				return uuidRow(snapshotID)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
 			}
 			return activityRow()
 		},
 		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
 			if strings.Contains(sql, "'active'") {
 				atomic.AddInt32(&activateCalled, 1)
-			}
-			if strings.Contains(sql, "SET status = 'paused'") {
-				atomic.AddInt32(&revertCalled, 1)
 			}
 			return pgconn.NewCommandTag("UPDATE 1"), nil
 		},
@@ -803,19 +817,24 @@ func TestResumeSandbox_NetworkReapplyFailure_DestroysAndReverts(t *testing.T) {
 	if got := atomic.LoadInt32(&updateNetworkCalled); got != 1 {
 		t.Errorf("reapplyNetworkConfig calls = %d, want 1", got)
 	}
-	if got := atomic.LoadInt32(&destroyCalled); got != 1 {
-		t.Errorf("DestroyInstance calls = %d, want 1 (on failure)", got)
+	// Must never destroy a resumed VM — that deletes the overlay.
+	if got := atomic.LoadInt32(&destroyCalled); got != 0 {
+		t.Errorf("DestroyInstance calls = %d, want 0 (must not destroy a resumed VM)", got)
+	}
+	if got := atomic.LoadInt32(&pauseCalled); got != 1 {
+		t.Errorf("PauseInstance calls = %d, want 1 (re-pause preserves overlay)", got)
+	}
+	if got := atomic.LoadInt32(&finalizeCalled); got != 1 {
+		t.Errorf("FinalizePause calls = %d, want 1 (revert to paused)", got)
 	}
 	if got := atomic.LoadInt32(&activateCalled); got != 0 {
 		t.Errorf("ActivateSandbox calls = %d, want 0 (network failed before commit)", got)
 	}
-	if got := atomic.LoadInt32(&revertCalled); got != 1 {
-		t.Errorf("RevertResumeToPaused calls = %d, want 1", got)
-	}
 }
 
-// DB activate failure after network reapply must also destroy the VM + revert.
-func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
+// A DB activate failure after the VM is up must re-pause (preserve the
+// overlay), never destroy — the path that previously bricked a sandbox.
+func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	snapshotID := uuid.New()
@@ -825,7 +844,7 @@ func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
 	}
 
-	var destroyCalled int32
+	var destroyCalled, pauseCalled, finalizeCalled int32
 	vmd := &stubVMD{
 		resumeFn: func(context.Context, string, string, string) (string, error) {
 			return "10.0.0.5", nil
@@ -834,27 +853,30 @@ func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
 			atomic.AddInt32(&destroyCalled, 1)
 			return nil
 		},
+		pauseFn: func(context.Context, string, string) (string, string, error) {
+			atomic.AddInt32(&pauseCalled, 1)
+			return "/snapshots/test/vmstate.snap", "/snapshots/test/mem.snap", nil
+		},
 	}
 
-	var revertCalled int32
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
-			case strings.Contains(sql, "FROM sandbox"):
-				return sandboxRow(sb)
+			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
+				atomic.AddInt32(&finalizeCalled, 1)
+				return uuidRow(snapshotID)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
 			}
 			return activityRow()
 		},
 		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
 			if strings.Contains(sql, "'active'") {
 				return pgconn.CommandTag{}, fmt.Errorf("db connection lost")
-			}
-			if strings.Contains(sql, "SET status = 'paused'") {
-				atomic.AddInt32(&revertCalled, 1)
 			}
 			return pgconn.NewCommandTag("UPDATE 1"), nil
 		},
@@ -867,11 +889,14 @@ func TestResumeSandbox_ActivateFailure_DestroysAndReverts(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
 	}
-	if got := atomic.LoadInt32(&destroyCalled); got != 1 {
-		t.Errorf("DestroyInstance calls = %d, want 1", got)
+	if got := atomic.LoadInt32(&destroyCalled); got != 0 {
+		t.Errorf("DestroyInstance calls = %d, want 0 (must not destroy a resumed VM)", got)
 	}
-	if got := atomic.LoadInt32(&revertCalled); got != 1 {
-		t.Errorf("RevertResumeToPaused calls = %d, want 1", got)
+	if got := atomic.LoadInt32(&pauseCalled); got != 1 {
+		t.Errorf("PauseInstance calls = %d, want 1 (re-pause preserves overlay)", got)
+	}
+	if got := atomic.LoadInt32(&finalizeCalled); got != 1 {
+		t.Errorf("FinalizePause calls = %d, want 1 (revert to paused)", got)
 	}
 }
 

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -70,9 +70,14 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
 
+	runTick := func() {
+		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
+		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
+	}
+
 	// Run once immediately so a control plane restart does not delay
 	// cleanup by up to `interval` seconds.
-	sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
+	runTick()
 
 	for {
 		select {
@@ -80,8 +85,23 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 			log.Info().Msg("timeout reaper exiting")
 			return
 		case <-ticker.C:
-			sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
+			runTick()
 		}
+	}
+}
+
+// sweepOrphanedIntervals closes intervals left open on no-longer-active
+// sandboxes — defense-in-depth for WAU accuracy, off the request path.
+func (h *Handlers) sweepOrphanedIntervals(ctx context.Context) {
+	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	n, err := h.DB.CloseOrphanedActiveIntervals(qctx)
+	if err != nil {
+		log.Error().Err(err).Msg("reaper: CloseOrphanedActiveIntervals failed")
+		return
+	}
+	if n > 0 {
+		log.Warn().Int64("closed", n).Msg("reaper: closed orphaned active intervals")
 	}
 }
 

--- a/internal/db/sandbox_active_intervals.sql.go
+++ b/internal/db/sandbox_active_intervals.sql.go
@@ -12,6 +12,33 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const closeOrphanedActiveIntervals = `-- name: CloseOrphanedActiveIntervals :execrows
+UPDATE sandbox_active_interval sai
+SET ended_at = now(),
+    end_reason = CASE s.status
+        WHEN 'failed'  THEN 'failed'
+        WHEN 'deleted' THEN 'deleted'
+        ELSE 'paused'
+    END
+FROM sandbox s
+WHERE sai.sandbox_id = s.id
+  AND sai.ended_at IS NULL
+  AND s.status IN ('paused', 'failed', 'deleted')
+  AND s.updated_at < now() - interval '5 minutes'
+`
+
+// Defense-in-depth sweep: close interval rows left open while their sandbox is
+// no longer active (a transition whose close didn't land). Left alone they
+// count the sandbox active in WAU forever. end_reason mirrors the terminal
+// state; the settle window avoids racing a transiently non-active sandbox.
+func (q *Queries) CloseOrphanedActiveIntervals(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, closeOrphanedActiveIntervals)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const closeSandboxActiveInterval = `-- name: CloseSandboxActiveInterval :exec
 UPDATE sandbox_active_interval
 SET ended_at = now(),
@@ -58,6 +85,7 @@ func (q *Queries) GetMostRecentClosedSandboxIntervalActor(ctx context.Context, s
 const openSandboxActiveInterval = `-- name: OpenSandboxActiveInterval :exec
 INSERT INTO sandbox_active_interval (sandbox_id, team_id, actor_id, started_at)
 VALUES ($1, $2, $3, now())
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING
 `
 
 type OpenSandboxActiveIntervalParams struct {
@@ -67,11 +95,9 @@ type OpenSandboxActiveIntervalParams struct {
 }
 
 // Opens an interval row when a sandbox transitions into 'active' (created or
-// resumed). The partial unique index sandbox_active_interval(sandbox_id) WHERE
-// ended_at IS NULL guarantees at most one open row per sandbox at any time;
-// in the unlikely event a prior open row was left dangling, the caller should
-// treat the unique-violation as recoverable (sandbox is already considered
-// running) rather than a hard error.
+// resumed). A dangling open row from a prior transition is recoverable, so
+// ON CONFLICT makes this a no-op rather than a unique-violation the caller
+// would have to special-case.
 func (q *Queries) OpenSandboxActiveInterval(ctx context.Context, arg OpenSandboxActiveIntervalParams) error {
 	_, err := q.db.Exec(ctx, openSandboxActiveInterval, arg.SandboxID, arg.TeamID, arg.ActorID)
 	return err

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -28,6 +28,7 @@ WITH activated AS (
 INSERT INTO sandbox_active_interval (sandbox_id, team_id, actor_id, started_at)
 SELECT a.id, a.team_id, $6, now()
 FROM activated a
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING
 `
 
 type ActivateSandboxParams struct {
@@ -44,6 +45,9 @@ type ActivateSandboxParams struct {
 // sandbox observable as active has a matching open interval — otherwise a
 // crash/timeout between the two writes would leave the sandbox active with
 // no interval, undercounting WAU until the next state transition.
+//
+// A leftover open interval must not fail the activation, so ON CONFLICT keeps
+// the existing open row — an orphaned interval can never block a resumed VM.
 func (q *Queries) ActivateSandbox(ctx context.Context, arg ActivateSandboxParams) error {
 	_, err := q.db.Exec(ctx, activateSandbox,
 		arg.ID,

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -48,6 +48,7 @@ type ActivateSandboxParams struct {
 //
 // A leftover open interval must not fail the activation, so ON CONFLICT keeps
 // the existing open row — an orphaned interval can never block a resumed VM.
+// (Creation has no prior interval; this reuse only ever applies on resume.)
 func (q *Queries) ActivateSandbox(ctx context.Context, arg ActivateSandboxParams) error {
 	_, err := q.db.Exec(ctx, activateSandbox,
 		arg.ID,

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -624,6 +624,116 @@ func TestIntegration_ResumeSandbox_ActiveConflict(t *testing.T) {
 	}
 }
 
+func countOpenIntervals(t *testing.T, ctx context.Context, sandboxID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(ctx,
+		`SELECT count(*) FROM sandbox_active_interval WHERE sandbox_id = $1 AND ended_at IS NULL`,
+		sandboxID).Scan(&n); err != nil {
+		t.Fatalf("count open intervals: %v", err)
+	}
+	return n
+}
+
+// A stale OPEN interval (a prior transition that failed to close it) must not
+// break resume: before ON CONFLICT it collided and the handler tore the VM
+// down. Now the open row is reused and resume succeeds.
+func TestIntegration_ResumeSandbox_StaleOpenInterval(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"stale-box"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	sandboxID, _ := uuid.Parse(sid)
+
+	if pw := do(r, "POST", "/sandboxes/"+sid+"/pause", apiKey, ""); pw.Code != http.StatusNoContent {
+		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
+	}
+
+	// Simulate the orphan: open a second interval while the sandbox is paused,
+	// leaving its row dangling exactly as a missed close would.
+	if err := testQueries.OpenSandboxActiveInterval(ctx, db.OpenSandboxActiveIntervalParams{
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+	}); err != nil {
+		t.Fatalf("seed stale interval: %v", err)
+	}
+	if open := countOpenIntervals(t, ctx, sandboxID); open != 1 {
+		t.Fatalf("setup: open intervals = %d, want 1", open)
+	}
+
+	rw := do(r, "POST", "/sandboxes/"+sid+"/resume", apiKey, "")
+	if rw.Code != http.StatusOK {
+		t.Fatalf("resume with stale interval: expected 200, got %d: %s", rw.Code, rw.Body.String())
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != db.SandboxStatusActive {
+		t.Errorf("DB status = %q, want active", sb.Status)
+	}
+	// ON CONFLICT DO NOTHING reuses the existing open row — no duplicate.
+	if open := countOpenIntervals(t, ctx, sandboxID); open != 1 {
+		t.Errorf("open intervals after resume = %d, want 1", open)
+	}
+}
+
+// The reaper's orphan sweep closes intervals left open while their sandbox is
+// no longer active, but only once the settle window has passed.
+func TestIntegration_CloseOrphanedActiveIntervals(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"orphan-box"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	sandboxID, _ := uuid.Parse(sid)
+
+	if pw := do(r, "POST", "/sandboxes/"+sid+"/pause", apiKey, ""); pw.Code != http.StatusNoContent {
+		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
+	}
+	if err := testQueries.OpenSandboxActiveInterval(ctx, db.OpenSandboxActiveIntervalParams{
+		SandboxID: sandboxID,
+		TeamID:    teamID,
+	}); err != nil {
+		t.Fatalf("seed stale interval: %v", err)
+	}
+
+	// Within the settle window → sweep must leave the fresh transition alone.
+	if _, err := testQueries.CloseOrphanedActiveIntervals(ctx); err != nil {
+		t.Fatalf("sweep (fresh): %v", err)
+	}
+	if open := countOpenIntervals(t, ctx, sandboxID); open != 1 {
+		t.Errorf("within settle window: open = %d, want 1 (untouched)", open)
+	}
+
+	// Backdate past the settle window → sweep now closes the orphan.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE sandbox SET updated_at = now() - interval '10 minutes' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+	n, err := testQueries.CloseOrphanedActiveIntervals(ctx)
+	if err != nil {
+		t.Fatalf("sweep (settled): %v", err)
+	}
+	if n < 1 {
+		t.Errorf("sweep closed %d rows, want >= 1", n)
+	}
+	if open := countOpenIntervals(t, ctx, sandboxID); open != 0 {
+		t.Errorf("after settle window: open = %d, want 0 (closed)", open)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DELETE /sandboxes/:id
 // ---------------------------------------------------------------------------

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -635,6 +635,26 @@ func countOpenIntervals(t *testing.T, ctx context.Context, sandboxID uuid.UUID) 
 	return n
 }
 
+// waitForSandboxStatus polls until the sandbox reaches want (or fails), rather
+// than sleeping a fixed interval that goes flaky under load.
+func waitForSandboxStatus(t *testing.T, ctx context.Context, id, teamID uuid.UUID, want db.SandboxStatus) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: id, TeamID: teamID})
+		if err != nil {
+			t.Fatalf("get sandbox: %v", err)
+		}
+		if sb.Status == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sandbox status = %q, want %q (timed out)", sb.Status, want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // A stale OPEN interval (a prior transition that failed to close it) must not
 // break resume: before ON CONFLICT it collided and the handler tore the VM
 // down. Now the open row is reused and resume succeeds.
@@ -671,14 +691,7 @@ func TestIntegration_ResumeSandbox_StaleOpenInterval(t *testing.T) {
 		t.Fatalf("resume with stale interval: expected 200, got %d: %s", rw.Code, rw.Body.String())
 	}
 
-	time.Sleep(50 * time.Millisecond)
-	sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
-	if err != nil {
-		t.Fatalf("get sandbox: %v", err)
-	}
-	if sb.Status != db.SandboxStatusActive {
-		t.Errorf("DB status = %q, want active", sb.Status)
-	}
+	waitForSandboxStatus(t, ctx, sandboxID, teamID, db.SandboxStatusActive)
 	// ON CONFLICT DO NOTHING reuses the existing open row — no duplicate.
 	if open := countOpenIntervals(t, ctx, sandboxID); open != 1 {
 		t.Errorf("open intervals after resume = %d, want 1", open)
@@ -731,6 +744,52 @@ func TestIntegration_CloseOrphanedActiveIntervals(t *testing.T) {
 	}
 	if open := countOpenIntervals(t, ctx, sandboxID); open != 0 {
 		t.Errorf("after settle window: open = %d, want 0 (closed)", open)
+	}
+}
+
+// pauseAndRevert calls FinalizePause from 'resuming', not 'pausing'. Confirm on
+// real Postgres that it has no source-status precondition: it flips to paused.
+func TestIntegration_FinalizePause_FromResuming(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"finalize-resuming"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	sandboxID, _ := uuid.Parse(sid)
+	// Pause first for a deterministic state, then force 'resuming' directly.
+	if pw := do(r, "POST", "/sandboxes/"+sid+"/pause", apiKey, ""); pw.Code != http.StatusNoContent {
+		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
+	}
+	if _, err := testPool.Exec(ctx,
+		`UPDATE sandbox SET status = 'resuming' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatalf("force resuming: %v", err)
+	}
+
+	mem := "/snapshots/" + sid + "/mem.snap"
+	snapID, err := testQueries.FinalizePause(ctx, db.FinalizePauseParams{
+		ID:      sandboxID,
+		TeamID:  teamID,
+		Path:    "/snapshots/" + sid + "/vmstate.snap",
+		MemPath: &mem,
+		Trigger: "resume_revert",
+	})
+	if err != nil {
+		t.Fatalf("FinalizePause from resuming failed (status precondition?): %v", err)
+	}
+	if snapID == uuid.Nil {
+		t.Fatal("FinalizePause returned nil snapshot id")
+	}
+
+	sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+	if err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if sb.Status != db.SandboxStatusPaused {
+		t.Errorf("status after FinalizePause = %q, want paused", sb.Status)
 	}
 }
 


### PR DESCRIPTION
## What happened

A paused sandbox (`73517ad8…`) was permanently bricked by a *resume*. Root cause, traced end-to-end through control-plane logs, the vmd host, and the DB:

1. Resume restored the VM successfully.
2. `ActivateSandbox`'s `sandbox_active_interval` insert collided with a **stale open interval** (a prior transition left one dangling) → `idx_sai_one_open_per_sandbox` unique violation.
3. The handler's error path called `DestroyInstance(force=true)` → `cleanupRunDir` → `os.RemoveAll(rundir)`, which **deleted the per-VM `overlay.ext4`** — the writable disk.
4. The sandbox stayed `paused` in the DB but its disk was gone, so it 500'd on every resume forever, with nothing flagging it.

In short: a *bookkeeping* insert failing caused the handler to *force-destroy a healthy resumed VM* and lose its data.

## The fix — three independent layers (any one stops it)

**1. Idempotent interval opens.** `ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING` on both open sites (`ActivateSandbox` CTE + `OpenSandboxActiveInterval`). A stale interval can no longer fail a resume — this just makes the code obey the contract already documented on `OpenSandboxActiveInterval`.

**2. Non-destructive resume compensation.** Once the VM is up, a finalize failure (egress rules **or** DB activate) now re-pauses via `PauseInstance`→`FinalizePause` — preserving the overlay — instead of `DestroyInstance`. Verified against vmd internals that *no* `pauseAndRevert` path reaches `cleanupRunDir`: VM-in-map → re-pause; snapshot fails → `handleVMError` (no rundir delete) → mark failed; VM gone → mark failed. The worst case is a `failed` sandbox with its disk intact — never data loss. *Prefer leak over loss.*

**3. Orphan-interval sweep.** The reaper tick closes intervals left open on settled non-active sandboxes (5-min settle window, `end_reason` mirrors terminal state). Kills the precondition and WAU skew; off the request path.

## Latency

Hot paths (create / resume / pause) are unaffected. `ON CONFLICT` is the same index probe that already runs; create's `ActivateSandbox` is async; the sweep is a background tick. Only a *failed* resume's 500 is slightly delayed (snapshot vs. kill), bounded by `vmdTimeout`.

## Tests

- Rewrote the two resume-failure unit tests to assert **pause-not-destroy** (`DestroyInstance` calls = 0).
- New integration tests (real Postgres): resume **succeeds** with a pre-seeded stale interval (reproduces the incident), and the sweep closes a backdated orphan while sparing fresh transitions.

## Possible future work (not needed now)

Layers 1–2 make this brick impossible, so there is no immediate follow-up. *Only if* we ever actually observe overlays going missing through some other path (out-of-band cleanup, disk faults) is it worth surfacing unrecoverable sandboxes instead of silent 500s — mark `failed` on a permanent restore error, an alert-first reconciler overlay check, and the reconciler's first tests. Not worth building speculatively: auto-`failed` from a filesystem heuristic risks mass-failing healthy sandboxes, so it should land only when there's a real signal.