### PR TITLE
quota: enable RLS on quota_alert_state

### DIFF
--- a/supabase/migrations/20260607000001_quota_alert_state_rls.sql
+++ b/supabase/migrations/20260607000001_quota_alert_state_rls.sql
@@ -1,0 +1,3 @@
+-- Internal table (only the quota watcher touches it): RLS on, no policies, so
+-- the anon/authenticated roles get no access. Idempotent if already enabled.
+ALTER TABLE public.quota_alert_state ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
The `quota_alert_state` table (added in #97) was created without RLS — every other table in the schema enables it (`enable_rls_all_tables`, and e.g. `sandbox_active_interval` does too). RLS was enabled manually in the Supabase UI on the live DB to close the gap; this brings the **repo migration in sync** so a fresh DB (or any environment not touched by hand) gets it too.

- Idempotent `ENABLE ROW LEVEL SECURITY` — a no-op where it was already enabled out of band.
- No policies, matching the convention for control-plane-internal tables: only the quota watcher touches it via the privileged service connection, so the `anon`/`authenticated` API roles correctly get no access.