### PR TITLE
vm: preallocate per-slot mount namespace to skip start.sh setup work

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -321,7 +321,8 @@ func main() {
 	// claims one off the hot path instead of building it inline.
 	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "128"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
-		NewSize: netPoolFresh,
+		NewSize:                netPoolFresh,
+		MountNsTmpfsMountPoint: filepath.Join(cfg.RunDir, "template"),
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -61,6 +61,9 @@ type VMNetInfo struct {
 	HostIP     string    // Host-side IP to reach this VM.
 	MACAddress string
 	Firewall   *Firewall // nftables firewall for this VM (inside namespace).
+	// MountNsBindPath is non-empty when the slot has a preallocated
+	// mount namespace; empty selects the legacy `unshare -m` start.sh path.
+	MountNsBindPath string
 }
 
 // ---------------------------------------------------------------------------
@@ -363,14 +366,26 @@ func (m *Manager) CleanupVM(vmID string) {
 		m.egressProxy.RemoveRules(info.HostIP)
 	}
 
-	// Recycle the slot into the pool — namespace, veth, TAP, and base
-	// nftables stay configured; the next Claim re-adds vmID-specific
-	// rules. Skipped when info.Firewall is nil (reattached VM whose
-	// in-ns handle couldn't be rebound) — pooling would let the next
-	// Claim silently lose per-VM egress filtering.
+	if info.MountNsBindPath != "" && m.pool != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		UnbindSandboxFromSlot(ctx, info.MountNsBindPath, m.pool.tmpfsMountPoint, sandboxLinkNames)
+		cancel()
+	}
+
+	// Recycle the slot into the pool. Skipped when info.Firewall is nil
+	// (reattached VM whose in-ns handle couldn't be rebound) — pooling
+	// would let the next Claim silently lose per-VM egress filtering.
 	if m.pool != nil && info.Firewall != nil {
 		_ = info.Firewall.ReplaceUserRules(nil, nil)
-		m.pool.Return(&preallocSlot{idx: idx, info: info, vethName: vethName})
+		slot := &preallocSlot{idx: idx, info: info, vethName: vethName}
+		if info.MountNsBindPath != "" {
+			slot.mountNs = &slotMountNs{
+				BindPath:        info.MountNsBindPath,
+				TmpfsMountPoint: m.pool.tmpfsMountPoint,
+			}
+		}
+		info.MountNsBindPath = ""
+		m.pool.Return(slot)
 		return
 	}
 
@@ -395,7 +410,24 @@ func (m *Manager) CleanupVM(vmID string) {
 	_ = run(ctx, "ip", "link", "del", vethName)
 	_ = run(ctx, "ip", "netns", "del", info.Namespace)
 
+	// Release the mount-ns bind here too — recycle path was skipped,
+	// so without this the bind leaks until the next vmd boot.
+	if info.MountNsBindPath != "" {
+		_ = run(ctx, "umount", info.MountNsBindPath)
+		_ = os.Remove(info.MountNsBindPath)
+	}
+
 	m.log.Info().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("network namespace cleaned up")
+}
+
+// SetMountNsBindPath is used by reattach to record a restored bind so
+// the slot keeps its prepared-namespace fast path. No-op if vmID isn't tracked.
+func (m *Manager) SetMountNsBindPath(vmID, bindPath string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if info, ok := m.devices[vmID]; ok {
+		info.MountNsBindPath = bindPath
+	}
 }
 
 // ReattachVM rebinds vmd's view of an already-running VM's network state
@@ -513,6 +545,11 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	m.mu.Unlock()
 
 	return info, nil
+}
+
+// SlotFromNamespace is the exported form of slotFromNamespace.
+func SlotFromNamespace(namespace string) (int, bool) {
+	return slotFromNamespace(namespace)
 }
 
 // slotFromNamespace parses "ns-N" → N (digits only). Returns (0, false)

--- a/internal/network/mountns.go
+++ b/internal/network/mountns.go
@@ -1,0 +1,185 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const mountNsBindRoot = "/run/sandbox/ns"
+
+// sandboxLinkNames is the exhaustive set unbound at recycle time. Missing
+// names are no-ops; update when a new template layout adds a link name.
+var sandboxLinkNames = []string{"base.ext4", "overlay.ext4", "rootfs.ext4"}
+
+type slotMountNs struct {
+	BindPath string
+	// TmpfsMountPoint MUST match firecracker's snapshot `path_on_host` so
+	// per-VM symlinks placed inside the tmpfs become visible to fc at the
+	// path it expects.
+	TmpfsMountPoint string
+}
+
+// prepareSlotMountNamespace creates a persistent mount namespace via
+// `unshare --mount=<bind>` — the bind keeps the namespace alive after
+// unshare exits. tmpfsMountPoint is the same path for every slot; each
+// slot's namespace is isolated.
+func prepareSlotMountNamespace(ctx context.Context, idx int, tmpfsMountPoint string) (*slotMountNs, error) {
+	if tmpfsMountPoint == "" {
+		return nil, fmt.Errorf("tmpfsMountPoint is required")
+	}
+	if err := os.MkdirAll(mountNsBindRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir bind root: %w", err)
+	}
+	if err := os.MkdirAll(tmpfsMountPoint, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir tmpfs mount point: %w", err)
+	}
+
+	bindPath := filepath.Join(mountNsBindRoot, fmt.Sprintf("mnt-%d", idx))
+	if err := writeEmptyFile(bindPath); err != nil {
+		return nil, fmt.Errorf("create bind target: %w", err)
+	}
+
+	setupScript := fmt.Sprintf(
+		"mount --make-rprivate / && mount -t tmpfs tmpfs %q",
+		tmpfsMountPoint,
+	)
+	if err := run(ctx, "unshare", "--mount="+bindPath, "--", "sh", "-c", setupScript); err != nil {
+		_ = os.Remove(bindPath)
+		return nil, fmt.Errorf("unshare: %w", err)
+	}
+
+	return &slotMountNs{BindPath: bindPath, TmpfsMountPoint: tmpfsMountPoint}, nil
+}
+
+func releaseSlotMountNamespace(ctx context.Context, mns *slotMountNs) error {
+	if mns == nil || mns.BindPath == "" {
+		return nil
+	}
+	_ = run(ctx, "umount", mns.BindPath)
+	_ = os.Remove(mns.BindPath)
+	return nil
+}
+
+// ClearStaleSlotBindMounts removes leftover bind mounts from a previous
+// vmd lifetime. Running sandboxes are unaffected: fc holds its own
+// /proc/<pid>/ns/mnt reference, so unmounting the bind doesn't free
+// the namespace. Mount points that survived to this point are
+// preserved (just restored by RestoreSlotMountNsBind during reattach).
+func ClearStaleSlotBindMounts(ctx context.Context) error {
+	entries, err := os.ReadDir(mountNsBindRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", mountNsBindRoot, err)
+	}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "mnt-") {
+			continue
+		}
+		path := filepath.Join(mountNsBindRoot, e.Name())
+		if isMountPoint(path) {
+			continue
+		}
+		_ = run(ctx, "umount", path)
+		_ = os.Remove(path)
+	}
+	return nil
+}
+
+// RestoreSlotMountNsBind rebinds /proc/<pid>/ns/mnt → slot bind path
+// during vmd-restart reattach so the slot keeps its prepared-namespace
+// handle. Caller stores the returned path on VMNetInfo.MountNsBindPath.
+func RestoreSlotMountNsBind(ctx context.Context, idx, pid int) (string, error) {
+	if pid <= 0 {
+		return "", fmt.Errorf("invalid pid %d", pid)
+	}
+	// PID-reuse defense: refuse to bind if /proc/<pid> isn't fc. Without
+	// this, a stale BoltDB PID could point at an unrelated process whose
+	// namespace we'd then expose to the next sandbox.
+	if !isFirecrackerPID(pid) {
+		return "", fmt.Errorf("pid %d is not a firecracker process", pid)
+	}
+	if err := os.MkdirAll(mountNsBindRoot, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir bind root: %w", err)
+	}
+	bindPath := filepath.Join(mountNsBindRoot, fmt.Sprintf("mnt-%d", idx))
+	if err := writeEmptyFile(bindPath); err != nil {
+		return "", fmt.Errorf("create bind target: %w", err)
+	}
+	// Drop any prior bind so we don't stack mount layers across restarts.
+	if isMountPoint(bindPath) {
+		_ = run(ctx, "umount", bindPath)
+	}
+	src := fmt.Sprintf("/proc/%d/ns/mnt", pid)
+	if err := run(ctx, "mount", "--bind", src, bindPath); err != nil {
+		_ = os.Remove(bindPath)
+		return "", fmt.Errorf("bind %s -> %s: %w", src, bindPath, err)
+	}
+	return bindPath, nil
+}
+
+func isFirecrackerPID(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "firecracker"
+}
+
+// isMountPoint via st_dev comparison — avoids depending on the
+// `mountpoint` binary, whose absence would silently misclassify a
+// live bind as not-a-mount and let ClearStaleSlotBindMounts tear it down.
+func isMountPoint(path string) bool {
+	var st1, st2 syscall.Stat_t
+	if err := syscall.Lstat(path, &st1); err != nil {
+		return false
+	}
+	if err := syscall.Lstat(filepath.Dir(path), &st2); err != nil {
+		return false
+	}
+	return st1.Dev != st2.Dev
+}
+
+// BindSandboxIntoSlot creates per-VM symlinks inside the slot's tmpfs.
+// Idempotent — re-bind after a transient failure is safe.
+func BindSandboxIntoSlot(ctx context.Context, bindPath, tmpfsMountPoint string, links [][2]string) error {
+	if bindPath == "" {
+		return fmt.Errorf("bindPath required")
+	}
+	for _, l := range links {
+		target, name := l[0], l[1]
+		if target == "" || name == "" {
+			return fmt.Errorf("bind link target and name required (got target=%q name=%q)", target, name)
+		}
+		linkPath := filepath.Join(tmpfsMountPoint, name)
+		script := fmt.Sprintf("rm -f %q && ln -s %q %q", linkPath, target, linkPath)
+		if err := run(ctx, "nsenter", "--mount="+bindPath, "--", "sh", "-c", script); err != nil {
+			return fmt.Errorf("bind link %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// UnbindSandboxFromSlot is best-effort: missing links are no-ops.
+func UnbindSandboxFromSlot(ctx context.Context, bindPath, tmpfsMountPoint string, linkNames []string) {
+	if bindPath == "" {
+		return
+	}
+	for _, name := range linkNames {
+		linkPath := filepath.Join(tmpfsMountPoint, name)
+		_ = run(ctx, "nsenter", "--mount="+bindPath, "--", "rm", "-f", linkPath)
+	}
+}
+
+func writeEmptyFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/internal/network/mountns_test.go
+++ b/internal/network/mountns_test.go
@@ -1,0 +1,63 @@
+package network
+
+import "testing"
+
+// Tests here cover the pure-functional bits of mountns.go (paths, link
+// list, error guards). Tests that actually mount, unshare, or nsenter
+// require root on Linux and live in integration tests (mountns_integ_test.go).
+
+func TestSandboxLinkNames_StableSet(t *testing.T) {
+	// CleanupVM unbinds the set unconditionally. Adding a new link layout
+	// means updating this list; this test enforces the contract.
+	want := []string{"base.ext4", "overlay.ext4", "rootfs.ext4"}
+	if len(sandboxLinkNames) != len(want) {
+		t.Fatalf("sandboxLinkNames len=%d, want %d", len(sandboxLinkNames), len(want))
+	}
+	for i, n := range want {
+		if sandboxLinkNames[i] != n {
+			t.Errorf("sandboxLinkNames[%d] = %q, want %q", i, sandboxLinkNames[i], n)
+		}
+	}
+}
+
+func TestPrepareSlotMountNamespace_RequiresMountPoint(t *testing.T) {
+	if _, err := prepareSlotMountNamespace(nil, 0, ""); err == nil {
+		t.Fatal("expected error when tmpfsMountPoint is empty")
+	}
+}
+
+func TestBindSandboxIntoSlot_RequiresBindPath(t *testing.T) {
+	err := BindSandboxIntoSlot(nil, "", "/tmp", [][2]string{{"/src", "name"}})
+	if err == nil {
+		t.Fatal("expected error when bindPath is empty")
+	}
+}
+
+func TestBindSandboxIntoSlot_RejectsEmptyLinkFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		links [][2]string
+	}{
+		{"empty target", [][2]string{{"", "name"}}},
+		{"empty name", [][2]string{{"/src", ""}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := BindSandboxIntoSlot(nil, "/run/sandbox/ns/mnt-0", "/tmp", tc.links)
+			if err == nil {
+				t.Fatal("expected error for malformed link")
+			}
+		})
+	}
+}
+
+func TestReleaseSlotMountNamespace_NilSafe(t *testing.T) {
+	if err := releaseSlotMountNamespace(nil, nil); err != nil {
+		t.Errorf("releaseSlotMountNamespace(nil) = %v, want nil", err)
+	}
+}
+
+func TestUnbindSandboxFromSlot_EmptyBindPathIsNoOp(t *testing.T) {
+	// Should not panic, should not call out to nsenter.
+	UnbindSandboxFromSlot(nil, "", "/tmp", []string{"x.ext4"})
+}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -20,6 +21,10 @@ type PoolConfig struct {
 	// setup (namespace, veth, TAP, nftables are already configured).
 	// Default: 100.
 	RecycleSize int
+	// MountNsTmpfsMountPoint MUST match firecracker's snapshot
+	// `path_on_host`. Empty disables mount-ns prealloc (start.sh
+	// then takes the legacy `unshare -m` path).
+	MountNsTmpfsMountPoint string
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
@@ -29,22 +34,24 @@ type PoolConfig struct {
 // The pool is optional — if not started, SetupVM falls back to on-demand
 // setup (the original behavior). Call StartPool after NewManager to enable.
 type Pool struct {
-	mgr      *Manager
-	log      zerolog.Logger
-	newSize  int
-	fresh    chan *preallocSlot // pre-allocated from scratch
-	recycled chan *preallocSlot // returned from destroyed sandboxes
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
+	mgr             *Manager
+	log             zerolog.Logger
+	newSize         int
+	tmpfsMountPoint string
+	fresh           chan *preallocSlot // pre-allocated from scratch
+	recycled        chan *preallocSlot // returned from destroyed sandboxes
+	stopCh          chan struct{}
+	wg              sync.WaitGroup
 }
 
 // preallocSlot holds a fully configured network namespace ready to be
-// assigned to a VM.
+// assigned to a VM. mountNs is nil when prealloc is disabled (start.sh
+// then falls back to `unshare -m`).
 type preallocSlot struct {
-	idx  int
-	info *VMNetInfo
-	// vethName is needed for cleanup if the slot is never claimed.
+	idx      int
+	info     *VMNetInfo
 	vethName string
+	mountNs  *slotMountNs
 }
 
 // StartPool creates and starts the network slot pool. Blocks until the
@@ -60,12 +67,18 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	}
 
 	p := &Pool{
-		mgr:      m,
-		log:      m.log.With().Str("component", "net_pool").Logger(),
-		newSize:  newSize,
-		fresh:    make(chan *preallocSlot, newSize),
-		recycled: make(chan *preallocSlot, recycleSize),
-		stopCh:   make(chan struct{}),
+		mgr:             m,
+		log:             m.log.With().Str("component", "net_pool").Logger(),
+		newSize:         newSize,
+		tmpfsMountPoint: cfg.MountNsTmpfsMountPoint,
+		fresh:           make(chan *preallocSlot, newSize),
+		recycled:        make(chan *preallocSlot, recycleSize),
+		stopCh:          make(chan struct{}),
+	}
+	if p.tmpfsMountPoint != "" {
+		if err := ClearStaleSlotBindMounts(ctx); err != nil {
+			p.log.Warn().Err(err).Msg("clearing stale slot bind mounts failed; continuing")
+		}
 	}
 
 	// Fill initial batch synchronously so the pool is warm on first create.
@@ -123,6 +136,10 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			continue
 		}
 		tNsChecked := time.Now()
+
+		if slot.mountNs != nil {
+			slot.info.MountNsBindPath = slot.mountNs.BindPath
+		}
 
 		p.mgr.mu.Lock()
 		p.mgr.devices[vmID] = slot.info
@@ -240,12 +257,28 @@ func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
 		return nil, err
 	}
 
-	return &preallocSlot{idx: idx, info: info, vethName: vethName}, nil
+	slot := &preallocSlot{idx: idx, info: info, vethName: vethName}
+
+	if p.tmpfsMountPoint != "" {
+		mns, err := prepareSlotMountNamespace(ctx, idx, p.tmpfsMountPoint)
+		if err != nil {
+			// idx stays consumed (matches setupSlot's invariant) so a
+			// persistent prep failure can't loop on the same broken idx.
+			p.mgr.cleanupFull(info.Namespace, vethName)
+			return nil, fmt.Errorf("prepare mount ns: %w", err)
+		}
+		slot.mountNs = mns
+	}
+
+	return slot, nil
 }
 
 func (p *Pool) cleanup(slot *preallocSlot) {
 	if slot == nil || slot.info == nil {
 		return
+	}
+	if slot.mountNs != nil {
+		_ = releaseSlotMountNamespace(context.Background(), slot.mountNs)
 	}
 	nsName := slot.info.Namespace
 	p.mgr.cleanupFull(nsName, slot.vethName)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1114,6 +1114,19 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		if inst.Namespace != "" && inst.IP != "" {
 			if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
 				log.Error().Err(err).Msg("reattach: restore network state failed")
+			} else if rec.PID > 0 {
+				// Restore the slot's mount-ns bind so the next sandbox
+				// lifecycle keeps the fast nsenter path.
+				if idx, ok := network.SlotFromNamespace(inst.Namespace); ok {
+					rctx, rcancel := context.WithTimeout(ctx, 5*time.Second)
+					bindPath, rerr := network.RestoreSlotMountNsBind(rctx, idx, rec.PID)
+					rcancel()
+					if rerr != nil {
+						log.Warn().Err(rerr).Int("slot", idx).Msg("reattach: mount-ns bind restore failed; slot will fall back to legacy on next claim")
+					} else {
+						m.netMgr.SetMountNsBindPath(rec.ID, bindPath)
+					}
+				}
 			}
 		}
 
@@ -1592,8 +1605,7 @@ func (m *Manager) startFirecrackerColdBoot(ctx context.Context, vmID, socketPath
 
 // startFirecrackerViaSystemd writes the start script and launches Firecracker
 // as a standalone systemd unit. The VM survives VMD restarts because systemd
-// owns the process, not VMD. Non-empty basePath switches the start script to
-// the dual-symlink overlay layout.
+// owns the process, not VMD.
 func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPath, perVMRootfs, basePath, netNS string) (int, error) {
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
 		return 0, fmt.Errorf("mkdir socket dir: %w", err)
@@ -1602,21 +1614,37 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 
 	templateDir := m.templateRunDir()
 
-	var setupCmds string
-	if basePath != "" {
-		baseLink := filepath.Join(templateDir, "base.ext4")
-		overlayLink := filepath.Join(templateDir, "overlay.ext4")
-		setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q && ln -s %q %q",
-			templateDir, basePath, baseLink, perVMRootfs, overlayLink)
+	netInfo := m.netMgr.GetVMNetInfo(vmID)
+	mountNsBindPath := ""
+	if netInfo != nil {
+		mountNsBindPath = netInfo.MountNsBindPath
+	}
+
+	var scriptContent string
+	if mountNsBindPath != "" {
+		if err := m.bindSandboxLinks(ctx, mountNsBindPath, templateDir, perVMRootfs, basePath); err != nil {
+			return 0, fmt.Errorf("bind sandbox links into slot: %w", err)
+		}
+		scriptContent = fmt.Sprintf("#!/bin/sh\nexec ip netns exec %s nsenter --mount=%s -- %s --api-sock %s --id %s\n",
+			netNS, shellQuote(mountNsBindPath), shellQuote(m.cfg.FirecrackerBin), shellQuote(socketPath), shellQuote(vmID))
 	} else {
-		rootfsLink := filepath.Join(templateDir, "rootfs.ext4")
-		setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q",
-			templateDir, perVMRootfs, rootfsLink)
+		var setupCmds string
+		if basePath != "" {
+			baseLink := filepath.Join(templateDir, "base.ext4")
+			overlayLink := filepath.Join(templateDir, "overlay.ext4")
+			setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q && ln -s %q %q",
+				templateDir, basePath, baseLink, perVMRootfs, overlayLink)
+		} else {
+			rootfsLink := filepath.Join(templateDir, "rootfs.ext4")
+			setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q",
+				templateDir, perVMRootfs, rootfsLink)
+		}
+		// %q (Go double-quoted) is safe inside `sh -c '...'` for our controlled paths.
+		scriptContent = fmt.Sprintf("#!/bin/sh\nexec ip netns exec %s unshare -m -- sh -c '%s && exec %q --api-sock %q --id %q'\n",
+			netNS, setupCmds, m.cfg.FirecrackerBin, socketPath, vmID)
 	}
 
 	scriptPath := filepath.Join(filepath.Dir(socketPath), "start.sh")
-	scriptContent := fmt.Sprintf("#!/bin/sh\nexec ip netns exec %s unshare -m -- sh -c '%s && exec %q --api-sock %q --id %q'\n",
-		netNS, setupCmds, m.cfg.FirecrackerBin, socketPath, vmID)
 	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0o755); err != nil {
 		return 0, fmt.Errorf("write start script: %w", err)
 	}
@@ -1634,10 +1662,15 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	}
 	tSocketReady := time.Now()
 
+	mountNsMode := "prealloc"
+	if mountNsBindPath == "" {
+		mountNsMode = "legacy"
+	}
 	m.log.Info().
 		Str("vm_id", vmID).
 		Int64("start_unit_ms", tStartUnitDone.Sub(tStartUnit).Milliseconds()).
 		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds()).
+		Str("mount_ns_mode", mountNsMode).
 		Msg("fc startup phases")
 
 	// Read the PID asynchronously so the create path isn't slowed down
@@ -1646,6 +1679,30 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	go m.resolveAndSetPID(vmID)
 
 	return 0, nil
+}
+
+// bindSandboxLinks creates the per-VM template symlinks inside the slot's
+// mount namespace. Layout matches the legacy branch: dual-link
+// (base+overlay) when basePath is non-empty, single-link (rootfs) otherwise.
+func (m *Manager) bindSandboxLinks(ctx context.Context, bindPath, tmpfsMountPoint, perVMRootfs, basePath string) error {
+	var links [][2]string
+	if basePath != "" {
+		links = [][2]string{
+			{basePath, "base.ext4"},
+			{perVMRootfs, "overlay.ext4"},
+		}
+	} else {
+		links = [][2]string{
+			{perVMRootfs, "rootfs.ext4"},
+		}
+	}
+	return network.BindSandboxIntoSlot(ctx, bindPath, tmpfsMountPoint, links)
+}
+
+// shellQuote single-quotes s for safe inclusion in /bin/sh exec lines.
+// Embedded single quotes are escaped as '\''.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (m *Manager) resolveAndSetPID(vmID string) {


### PR DESCRIPTION
Pre-creates a per-slot mount namespace + tmpfs at network-slot allocation time so `start.sh` no longer does `unshare -m` / `mount tmpfs` / `ln -s` on the sandbox-create hot path. The hot path becomes `nsenter --mount=<slot>` + exec firecracker. Pool-exhausted creates fall back to the existing legacy path.