### PR TITLE
network: config-driven egress blocklist for proxy and host firewall

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -250,8 +250,24 @@ func main() {
 
 	lc := newLifecycle(log)
 
+	// ---- Egress blocklist (optional) ----
+	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
+	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
+	// blocklist.
+	var blocklist *network.Blocklist
+	var netMgrOpts []network.ManagerOption
+	if path := os.Getenv("VMD_EGRESS_BLOCKLIST_CONFIG"); path != "" {
+		blCfg, err := network.LoadBlocklistConfig(path)
+		if err != nil {
+			log.Fatal().Err(err).Str("path", path).Msg("failed to load egress blocklist config")
+		}
+		blocklist = network.NewBlocklist(blCfg, log)
+		netMgrOpts = append(netMgrOpts, network.WithBlockedEgressPorts(blCfg.BlockedEgressPorts))
+		log.Info().Str("path", path).Int("feeds", len(blCfg.DomainFeeds)).Int("blocked_ports", len(blCfg.BlockedEgressPorts)).Msg("egress blocklist configured")
+	}
+
 	// ---- Network manager + host firewall ----
-	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log)
+	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
@@ -295,6 +311,10 @@ func main() {
 	)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
+	if blocklist != nil {
+		egressProxy.SetBlocklist(blocklist)
+		lc.start("egress blocklist", func() error { return blocklist.Start(ctx) })
+	}
 	lc.start("egress proxy", func() error { return egressProxy.Start(ctx) })
 
 	// ---- BoltDB state store ----

--- a/deploy/egress-blocklist.example.yaml
+++ b/deploy/egress-blocklist.example.yaml
@@ -1,0 +1,33 @@
+# Example egress blocklist config for vmd.
+#
+# Point VMD_EGRESS_BLOCKLIST_CONFIG at a file with this schema. The real
+# config is deployment-specific — do not commit actual feed URLs or block
+# entries to the repository. This example uses placeholder values only.
+#
+# Entries from all sources are merged into one denylist enforced by the
+# egress proxy (domains via SNI/Host, plus destination IPs) and the host
+# firewall (ports). The denylist takes precedence over per-sandbox allow
+# rules. Feed fetch failures keep the last good list; the merged list is
+# persisted to state_path so restarts are seeded before the first fetch.
+
+# Plain-text feeds: one entry per line, '#' comments. Entries may be
+# domains, IPs, IP:port pairs, or CIDRs. URLs or local file paths.
+domain_feeds:
+  - https://threat-intel.example.com/bad-domains.txt
+  - /etc/sandbox/extra-blocked.txt
+
+# Pinned entries, always blocked regardless of feed contents.
+custom_domains:
+  - blocked.example.com
+custom_cidrs:
+  - 192.0.2.0/24
+
+# Destination ports dropped (TCP and UDP) for all sandbox traffic.
+blocked_egress_ports: [12345]
+
+# How often feeds are re-fetched. Go duration syntax. Default 6h.
+refresh_interval: 6h
+
+# Where the last good merged list is persisted. Defaults to
+# "blocklist.state" next to this config file.
+state_path: /var/lib/sandbox/blocklist.state

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -1,0 +1,403 @@
+package network
+
+// blocklist.go implements a global egress denylist for the egress proxy and
+// host firewall. Which feeds are fetched, which domains/CIDRs are pinned,
+// and which ports are dropped all come from an operator-supplied config
+// file; nothing is built in.
+//
+// Enforcement points:
+//   - EgressProxy checks Blocked() on every HTTP/TLS connection (SNI/Host
+//     plus original destination IP) before per-sandbox rules.
+//   - installHostFirewall drops BlockedEgressPorts in the FORWARD chain for
+//     traffic that is not redirected through the proxy.
+//
+// The list is a denylist, so the failure mode is "no extra blocking", never
+// "block everything": a fetch error keeps the last good snapshot, and the
+// last good snapshot is persisted to StatePath so a vmd restart does not
+// come up empty while the first fetch is in flight.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	// defaultBlocklistRefresh is used when refresh_interval is unset.
+	defaultBlocklistRefresh = 6 * time.Hour
+
+	// maxFeedBytes caps a single feed download so a hijacked or
+	// misconfigured feed URL cannot exhaust memory.
+	maxFeedBytes = 16 << 20 // 16 MiB
+
+	feedFetchTimeout = 60 * time.Second
+)
+
+// BlocklistConfig is the schema of the operator-supplied config file
+// (VMD_EGRESS_BLOCKLIST_CONFIG). All fields are optional.
+type BlocklistConfig struct {
+	// DomainFeeds are URLs (http/https) or local file paths to plain-text
+	// feeds: one entry per line, '#' starts a comment. Entries may be
+	// domains, IPs, IP:port pairs, or CIDRs.
+	DomainFeeds []string `yaml:"domain_feeds"`
+
+	// CustomDomains and CustomCIDRs are pinned entries that are always
+	// blocked regardless of feed contents.
+	CustomDomains []string `yaml:"custom_domains"`
+	CustomCIDRs   []string `yaml:"custom_cidrs"`
+
+	// BlockedEgressPorts are dropped in the host FORWARD chain for all
+	// sandbox traffic (both TCP and UDP).
+	BlockedEgressPorts []uint16 `yaml:"blocked_egress_ports"`
+
+	// RefreshInterval is a Go duration string ("6h", "30m"). Default 6h.
+	RefreshInterval string `yaml:"refresh_interval"`
+
+	// StatePath is where the last good merged list is persisted. Default:
+	// "<config dir>/blocklist.state".
+	StatePath string `yaml:"state_path"`
+}
+
+// LoadBlocklistConfig reads and validates the YAML config at path.
+func LoadBlocklistConfig(path string) (*BlocklistConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read blocklist config: %w", err)
+	}
+	var cfg BlocklistConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parse blocklist config %s: %w", path, err)
+	}
+	if cfg.RefreshInterval != "" {
+		if _, err := time.ParseDuration(cfg.RefreshInterval); err != nil {
+			return nil, fmt.Errorf("invalid refresh_interval %q: %w", cfg.RefreshInterval, err)
+		}
+	}
+	for _, c := range cfg.CustomCIDRs {
+		if _, err := parseCIDROrIP(c); err != nil {
+			return nil, fmt.Errorf("invalid custom_cidrs entry %q: %w", c, err)
+		}
+	}
+	if cfg.StatePath == "" {
+		cfg.StatePath = filepath.Join(filepath.Dir(path), "blocklist.state")
+	}
+	return &cfg, nil
+}
+
+func (c *BlocklistConfig) refreshInterval() time.Duration {
+	if c.RefreshInterval == "" {
+		return defaultBlocklistRefresh
+	}
+	d, err := time.ParseDuration(c.RefreshInterval)
+	if err != nil {
+		return defaultBlocklistRefresh
+	}
+	return d
+}
+
+// blocklistSnapshot is an immutable merged view of all sources. Swapped
+// atomically on refresh so lookups never take a lock.
+type blocklistSnapshot struct {
+	domains map[string]struct{}
+	nets    []netip.Prefix
+}
+
+// Blocklist holds the current snapshot and refreshes it from the configured
+// feeds. Lookup methods are safe for concurrent use.
+type Blocklist struct {
+	cfg  *BlocklistConfig
+	log  zerolog.Logger
+	cur  atomic.Pointer[blocklistSnapshot]
+	http *http.Client
+}
+
+// NewBlocklist builds a Blocklist seeded from the pinned config entries and
+// the persisted state file (if present). Feeds are first fetched in Start.
+func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
+	b := &Blocklist{
+		cfg:  cfg,
+		log:  log.With().Str("component", "egress-blocklist").Logger(),
+		http: &http.Client{Timeout: feedFetchTimeout},
+	}
+
+	seed := newSnapshotBuilder()
+	seed.addConfigEntries(cfg)
+	if raw, err := os.ReadFile(cfg.StatePath); err == nil {
+		n := seed.addFeedText(string(raw))
+		b.log.Info().Int("entries", n).Str("path", cfg.StatePath).Msg("seeded blocklist from persisted state")
+	}
+	b.cur.Store(seed.snapshot())
+	return b
+}
+
+// Start fetches all feeds immediately, then refreshes on the configured
+// interval. Blocks until ctx is cancelled.
+func (b *Blocklist) Start(ctx context.Context) error {
+	b.refresh(ctx)
+	ticker := time.NewTicker(b.cfg.refreshInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			b.refresh(ctx)
+		}
+	}
+}
+
+// Blocked reports whether a connection identified by hostname (may be empty)
+// and destination IP hits the blocklist. The second return value names the
+// matching dimension ("domain" or "ip") for logging.
+func (b *Blocklist) Blocked(hostname string, dstIP net.IP) (bool, string) {
+	snap := b.cur.Load()
+	if snap == nil {
+		return false, ""
+	}
+	if hostname != "" && snap.blockedDomain(hostname) {
+		return true, "domain"
+	}
+	if dstIP != nil {
+		if addr, ok := netip.AddrFromSlice(dstIP.To4()); ok {
+			for _, p := range snap.nets {
+				if p.Contains(addr) {
+					return true, "ip"
+				}
+			}
+		}
+	}
+	return false, ""
+}
+
+// blockedDomain walks parent labels so a blocked "example.com" also blocks
+// "pool.example.com".
+func (s *blocklistSnapshot) blockedDomain(hostname string) bool {
+	h := strings.ToLower(strings.TrimSuffix(hostname, "."))
+	for h != "" {
+		if _, ok := s.domains[h]; ok {
+			return true
+		}
+		_, parent, ok := strings.Cut(h, ".")
+		if !ok {
+			break
+		}
+		h = parent
+	}
+	return false
+}
+
+// refresh fetches every feed and atomically swaps in the merged snapshot.
+// A feed that fails to fetch is logged and skipped; if ALL feeds fail the
+// previous snapshot is kept so transient outages never shrink coverage.
+func (b *Blocklist) refresh(ctx context.Context) {
+	builder := newSnapshotBuilder()
+	builder.addConfigEntries(b.cfg)
+
+	fetched, failed := 0, 0
+	var stateText strings.Builder
+	for _, src := range b.cfg.DomainFeeds {
+		text, err := b.fetchFeed(ctx, src)
+		if err != nil {
+			failed++
+			b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed")
+			continue
+		}
+		fetched++
+		builder.addFeedText(text)
+		stateText.WriteString(text)
+		stateText.WriteString("\n")
+	}
+
+	if fetched == 0 && len(b.cfg.DomainFeeds) > 0 {
+		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("all blocklist feeds failed; keeping previous snapshot")
+		return
+	}
+
+	snap := builder.snapshot()
+	b.cur.Store(snap)
+	b.log.Info().
+		Int("domains", len(snap.domains)).
+		Int("cidrs", len(snap.nets)).
+		Int("feeds_ok", fetched).
+		Int("feeds_failed", failed).
+		Msg("blocklist refreshed")
+
+	if fetched > 0 {
+		if err := writeFileAtomic(b.cfg.StatePath, []byte(stateText.String())); err != nil {
+			b.log.Warn().Err(err).Str("path", b.cfg.StatePath).Msg("failed to persist blocklist state")
+		}
+	}
+}
+
+func (b *Blocklist) fetchFeed(ctx context.Context, src string) (string, error) {
+	if !strings.HasPrefix(src, "http://") && !strings.HasPrefix(src, "https://") {
+		raw, err := os.ReadFile(src)
+		if err != nil {
+			return "", err
+		}
+		return string(raw), nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedBytes))
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot building / feed parsing
+// ---------------------------------------------------------------------------
+
+type snapshotBuilder struct {
+	domains map[string]struct{}
+	nets    map[netip.Prefix]struct{}
+}
+
+func newSnapshotBuilder() *snapshotBuilder {
+	return &snapshotBuilder{
+		domains: make(map[string]struct{}),
+		nets:    make(map[netip.Prefix]struct{}),
+	}
+}
+
+func (sb *snapshotBuilder) addConfigEntries(cfg *BlocklistConfig) {
+	for _, d := range cfg.CustomDomains {
+		if d = normalizeDomain(d); d != "" {
+			sb.domains[d] = struct{}{}
+		}
+	}
+	for _, c := range cfg.CustomCIDRs {
+		if p, err := parseCIDROrIP(c); err == nil {
+			sb.nets[p] = struct{}{}
+		}
+	}
+}
+
+// addFeedText parses feed lines into the builder and returns the number of
+// entries accepted. Unparseable lines are skipped — feeds aggregated from
+// threat intel commonly mix formats and annotations.
+func (sb *snapshotBuilder) addFeedText(text string) int {
+	added := 0
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// CIDR (1.2.3.0/24)
+		if strings.Contains(line, "/") {
+			if p, err := netip.ParsePrefix(line); err == nil && p.Addr().Is4() {
+				sb.nets[p.Masked()] = struct{}{}
+				added++
+			}
+			continue
+		}
+
+		// IP:port (1.2.3.4:8080) — port is irrelevant for a destination
+		// denylist; block the IP outright.
+		if host, _, err := net.SplitHostPort(line); err == nil {
+			line = host
+		}
+
+		// Bare IP (1.2.3.4)
+		if addr, err := netip.ParseAddr(line); err == nil {
+			if addr.Is4() {
+				sb.nets[netip.PrefixFrom(addr, 32)] = struct{}{}
+				added++
+			}
+			continue
+		}
+
+		// Domain
+		if d := normalizeDomain(line); d != "" {
+			sb.domains[d] = struct{}{}
+			added++
+		}
+	}
+	return added
+}
+
+func (sb *snapshotBuilder) snapshot() *blocklistSnapshot {
+	nets := make([]netip.Prefix, 0, len(sb.nets))
+	for p := range sb.nets {
+		nets = append(nets, p)
+	}
+	return &blocklistSnapshot{domains: sb.domains, nets: nets}
+}
+
+// normalizeDomain lowercases and validates a domain-ish entry. Returns ""
+// for entries that cannot be a DNS name (so junk feed lines are dropped
+// instead of polluting the set).
+func normalizeDomain(d string) string {
+	d = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(d, ".")))
+	d = strings.TrimPrefix(d, "*.")
+	if d == "" || !strings.Contains(d, ".") || len(d) > 253 {
+		return ""
+	}
+	for _, r := range d {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.', r == '_':
+		default:
+			return ""
+		}
+	}
+	return d
+}
+
+// parseCIDROrIP accepts both "1.2.3.0/24" and bare "1.2.3.4" config entries.
+func parseCIDROrIP(s string) (netip.Prefix, error) {
+	if strings.Contains(s, "/") {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return p.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -1,0 +1,198 @@
+package network
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestAddFeedText(t *testing.T) {
+	sb := newSnapshotBuilder()
+	n := sb.addFeedText(`
+# comment line
+pool.example.com
+EVIL.Example.ORG.   # trailing comment
+1.2.3.4
+5.6.7.8:8081
+10.20.0.0/16
+not a valid entry !!
+singlelabel
+2001:db8::1
+`)
+	if n != 5 {
+		t.Errorf("addFeedText accepted %d entries, want 5", n)
+	}
+
+	snap := sb.snapshot()
+	for _, d := range []string{"pool.example.com", "evil.example.org"} {
+		if _, ok := snap.domains[d]; !ok {
+			t.Errorf("domain %q missing from snapshot", d)
+		}
+	}
+	if _, ok := snap.domains["singlelabel"]; ok {
+		t.Error("dotless entry should have been rejected")
+	}
+	if len(snap.nets) != 3 {
+		t.Errorf("got %d nets, want 3 (two /32s and one /16)", len(snap.nets))
+	}
+}
+
+func TestBlockedDomainWalksParents(t *testing.T) {
+	sb := newSnapshotBuilder()
+	sb.addFeedText("blocked.test\n")
+	snap := sb.snapshot()
+
+	for host, want := range map[string]bool{
+		"blocked.test":        true,
+		"pool.blocked.test":   true,
+		"a.pool.blocked.test": true,
+		"POOL.BLOCKED.TEST":   true,
+		"notblocked.test":     false,
+		"blocked.test.evil":   false,
+		"other.test":          false,
+	} {
+		if got := snap.blockedDomain(host); got != want {
+			t.Errorf("blockedDomain(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestBlocklistBlocked(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("pool.example.com\n9.9.9.0/24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &BlocklistConfig{
+		DomainFeeds:   []string{feed},
+		CustomDomains: []string{"pinned.example.net"},
+		CustomCIDRs:   []string{"1.2.3.4"},
+		StatePath:     filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+
+	tests := []struct {
+		hostname string
+		ip       string
+		want     bool
+		wantDim  string
+	}{
+		{"pool.example.com", "8.8.8.8", true, "domain"},
+		{"deep.pool.example.com", "8.8.8.8", true, "domain"},
+		{"pinned.example.net", "8.8.8.8", true, "domain"},
+		{"", "9.9.9.42", true, "ip"},
+		{"", "1.2.3.4", true, "ip"},
+		{"fine.example.com", "8.8.8.8", false, ""},
+		{"", "8.8.8.8", false, ""},
+	}
+	for _, tc := range tests {
+		got, dim := b.Blocked(tc.hostname, net.ParseIP(tc.ip))
+		if got != tc.want || dim != tc.wantDim {
+			t.Errorf("Blocked(%q, %s) = (%v, %q), want (%v, %q)",
+				tc.hostname, tc.ip, got, dim, tc.want, tc.wantDim)
+		}
+	}
+
+	// State file should have been persisted for cold-start seeding.
+	if _, err := os.Stat(cfg.StatePath); err != nil {
+		t.Errorf("state file not persisted: %v", err)
+	}
+
+	// A fresh Blocklist seeded only from state (feed gone) still blocks.
+	os.Remove(feed)
+	b2 := NewBlocklist(cfg, zerolog.Nop())
+	if got, _ := b2.Blocked("pool.example.com", nil); !got {
+		t.Error("state-seeded blocklist should block pool.example.com before first refresh")
+	}
+}
+
+func TestRefreshKeepsLastGoodOnTotalFailure(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("pool.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{feed},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("pool.example.com", nil); !got {
+		t.Fatal("expected pool.example.com blocked after first refresh")
+	}
+
+	// Feed disappears — refresh must keep the previous snapshot.
+	os.Remove(feed)
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("pool.example.com", nil); !got {
+		t.Error("snapshot was lost after total feed failure")
+	}
+}
+
+func TestLoadBlocklistConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bl.yaml")
+	if err := os.WriteFile(path, []byte(`
+domain_feeds:
+  - https://example.com/feed.txt
+custom_domains:
+  - bad.example.com
+custom_cidrs:
+  - 1.2.3.0/24
+blocked_egress_ports: [12345, 23456]
+refresh_interval: 30m
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadBlocklistConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.BlockedEgressPorts) != 2 || cfg.BlockedEgressPorts[0] != 12345 {
+		t.Errorf("blocked_egress_ports = %v, want [12345 23456]", cfg.BlockedEgressPorts)
+	}
+	if cfg.refreshInterval().Minutes() != 30 {
+		t.Errorf("refresh interval = %v, want 30m", cfg.refreshInterval())
+	}
+	if cfg.StatePath != filepath.Join(dir, "blocklist.state") {
+		t.Errorf("default state path = %q", cfg.StatePath)
+	}
+
+	// Invalid duration and invalid CIDR must be rejected at load time.
+	for name, content := range map[string]string{
+		"bad duration": "refresh_interval: nonsense\n",
+		"bad cidr":     "custom_cidrs: [not-a-cidr]\n",
+	} {
+		p := filepath.Join(dir, "bad.yaml")
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadBlocklistConfig(p); err == nil {
+			t.Errorf("%s: expected load error, got nil", name)
+		}
+	}
+}
+
+func TestProxyBlocklistPrecedesSandboxAllow(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &BlocklistConfig{
+		CustomDomains: []string{"pool.example.com"},
+		StatePath:     filepath.Join(dir, "state"),
+	}
+	p := NewEgressProxy(0, 0, 0, 0, zerolog.Nop())
+	p.SetBlocklist(NewBlocklist(cfg, zerolog.Nop()))
+
+	// The sandbox explicitly allows the domain — the global blocklist must
+	// still win. handleConn checks the blocklist before isAllowed, so here
+	// we verify the lookup the proxy performs.
+	if blocked, dim := p.blocklist.Blocked("pool.example.com", net.ParseIP("8.8.8.8")); !blocked || dim != "domain" {
+		t.Errorf("Blocked() = (%v, %q), want (true, domain)", blocked, dim)
+	}
+}

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -21,10 +21,15 @@ const vmIPRange = "10.11.0.0/16"
 
 // installHostFirewall installs the static rules that route all VM traffic
 // through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
-// MSS clamp, FORWARD ACCEPT between veth+ and the host iface, MASQUERADE
-// for vmIPRange to the host iface, and REDIRECT HTTP/HTTPS from veth+ to
-// the egress proxy. All operations are idempotent.
-func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) error {
+// operator-configured egress port DROPs, MSS clamp, FORWARD ACCEPT between
+// veth+ and the host iface, MASQUERADE for vmIPRange to the host iface, and
+// REDIRECT HTTP/HTTPS from veth+ to the egress proxy. All operations are
+// idempotent.
+//
+// blockedPorts come from the operator blocklist config — only ports 80/443
+// are redirected through the egress proxy, so anything else a VM dials goes
+// straight through FORWARD and must be dropped here.
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, blockedPorts []uint16, log zerolog.Logger) error {
 	_, ipnet, err := net.ParseCIDR(vmIPRange)
 	if err != nil {
 		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
@@ -38,16 +43,27 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, l
 		return fmt.Errorf("init iptables: %w", err)
 	}
 
-	// UDP/443 DROP must precede the veth+ ACCEPT below so QUIC traffic
+	// DROP rules must precede the veth+ ACCEPT below so matching traffic
 	// is dropped before the broad ACCEPT terminates the chain walk.
-	udpDrop := []string{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"}
-	exists, err := ipt.Exists("filter", "FORWARD", udpDrop...)
-	if err != nil {
-		return fmt.Errorf("check veth+ UDP/443 DROP: %w", err)
+	// UDP/443 kills the QUIC bypass of the SNI allowlist; blockedPorts are
+	// the operator-configured egress port denylist.
+	drops := [][]string{
+		{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"},
 	}
-	if !exists {
-		if err := ipt.Insert("filter", "FORWARD", 1, udpDrop...); err != nil {
-			return fmt.Errorf("insert veth+ UDP/443 DROP: %w", err)
+	for _, port := range blockedPorts {
+		for _, proto := range []string{"tcp", "udp"} {
+			drops = append(drops, []string{"-i", "veth+", "-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"})
+		}
+	}
+	for _, drop := range drops {
+		exists, err := ipt.Exists("filter", "FORWARD", drop...)
+		if err != nil {
+			return fmt.Errorf("check veth+ DROP %v: %w", drop, err)
+		}
+		if !exists {
+			if err := ipt.Insert("filter", "FORWARD", 1, drop...); err != nil {
+				return fmt.Errorf("insert veth+ DROP %v: %w", drop, err)
+			}
 		}
 	}
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -94,6 +94,10 @@ type Manager struct {
 	httpProxyPort  uint16
 	tlsProxyPort   uint16
 	otherProxyPort uint16
+
+	// blockedEgressPorts are dropped in the host FORWARD chain for all
+	// sandbox traffic. Sourced from the operator blocklist config.
+	blockedEgressPorts []uint16
 }
 
 // SetEgressProxy attaches the TCP egress proxy so the manager can remove
@@ -119,6 +123,13 @@ func WithHTTPProxyPort(port uint16) ManagerOption {
 	return func(m *Manager) { m.httpProxyPort = port }
 }
 
+// WithBlockedEgressPorts sets destination ports dropped in the host FORWARD
+// chain for all sandbox traffic (TCP and UDP). Ports come from the operator
+// blocklist config.
+func WithBlockedEgressPorts(ports []uint16) ManagerOption {
+	return func(m *Manager) { m.blockedEgressPorts = ports }
+}
+
 func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, opts ...ManagerOption) (*Manager, error) {
 	if err := enableIPForward(ctx); err != nil {
 		return nil, err
@@ -137,7 +148,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, log.With().Str("component", "host_fw").Logger()); err != nil {
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.blockedEgressPorts, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
 

--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -40,6 +40,11 @@ type EgressProxy struct {
 	// maxConnsPerSandbox is the per-sandbox connection limit. -1 = unlimited.
 	maxConnsPerSandbox int
 
+	// blocklist is the global egress denylist (nil = disabled). Checked
+	// before per-sandbox rules; a blocklist hit cannot be overridden by a
+	// sandbox's own allow rules.
+	blocklist *Blocklist
+
 	// sandboxRules maps sandbox host IPs to their egress config.
 	mu    sync.RWMutex
 	rules map[string]*EgressRules // key = sandbox host IP
@@ -62,6 +67,12 @@ func NewEgressProxy(httpPort, tlsPort, otherPort uint16, maxConns int, log zerol
 		maxConnsPerSandbox: maxConns,
 		rules:              make(map[string]*EgressRules),
 	}
+}
+
+// SetBlocklist attaches the global egress denylist. Must be called before
+// Start; the blocklist's own snapshot swapping handles later updates.
+func (p *EgressProxy) SetBlocklist(b *Blocklist) {
+	p.blocklist = b
 }
 
 // SetRules updates the egress rules for a sandbox identified by its host IP.
@@ -218,6 +229,20 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 		peekedData = buf
 	}
 
+	// Global blocklist first — a hit here cannot be overridden by the
+	// sandbox's own allow rules.
+	if p.blocklist != nil {
+		if blocked, dim := p.blocklist.Blocked(hostname, dstIP); blocked {
+			p.log.Warn().
+				Str("src", srcHost).
+				Str("dst", dstIP.String()).
+				Str("hostname", hostname).
+				Str("match", dim).
+				Msg("egress blocked by global blocklist")
+			return
+		}
+	}
+
 	// Check egress rules.
 	rules := p.getRules(srcHost)
 	allowed, matchType := p.isAllowed(rules, hostname, dstIP)
@@ -251,6 +276,11 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 			resolved := net.ParseIP(host)
 			if resolved != nil && IsIPDenied(resolved) {
 				return fmt.Errorf("blocked: hostname resolved to internal IP %s", resolved)
+			}
+			if resolved != nil && p.blocklist != nil {
+				if blocked, _ := p.blocklist.Blocked("", resolved); blocked {
+					return fmt.Errorf("blocked: hostname resolved to blocklisted IP %s", resolved)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
## What

Adds an optional, config-driven egress denylist for sandbox traffic, enforced at two points:

- **Egress proxy** (`internal/network/proxy.go`): connections are checked against the denylist (Host header / SNI plus the original destination IP) before per-sandbox rules are evaluated. Hostnames that re-resolve to a denylisted IP are also rejected at dial time.
- **Host firewall** (`internal/network/hostfw.go`): configured destination ports are dropped (TCP and UDP) at the top of the FORWARD chain for all `veth+` traffic. Only ports 80/443 are redirected through the egress proxy, so other ports are enforced here.

## Configuration

All list contents (feeds, pinned domains/CIDRs, ports) come from an operator-supplied file pointed at by `VMD_EGRESS_BLOCKLIST_CONFIG` — see `deploy/egress-blocklist.example.yaml` for the schema. When the env var is unset the feature is disabled and there is no behavior change.

- Feeds are plain-text (one entry per line, `#` comments): domains, IPs, `IP:port` pairs, or CIDRs.
- Refreshed on a configurable interval with lock-free atomic snapshot swaps.
- A failed refresh keeps the last good snapshot; the merged list is persisted to disk so restarts are seeded before the first fetch.
- Domain matching walks parent labels (`a.b.example.com` matches a listed `example.com`).

## Testing

- New tests in `internal/network/blocklist_test.go`: feed parsing (incl. `IP:port` and CIDR forms), parent-label matching, denylist-precedes-sandbox-allow, last-good-on-feed-failure, config validation, and state-file seeding.
- `GOOS=linux go build ./...` and `go vet` clean; the network package is Linux-only (nftables) so the full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)