### PR TITLE
network: config-driven egress blocklist for proxy and host firewall

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -255,7 +255,10 @@ func main() {
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
 	// blocklist.
 	var blocklist *network.Blocklist
-	var netMgrOpts []network.ManagerOption
+	// vmd is the daemon, so it owns and reconciles the shared egress port
+	// chain even when no ports are configured (so disabling the feature
+	// clears stale drops). template-builder must not pass this.
+	netMgrOpts := []network.ManagerOption{network.WithEgressPortChainOwner()}
 	if path := os.Getenv("VMD_EGRESS_BLOCKLIST_CONFIG"); path != "" {
 		blCfg, err := network.LoadBlocklistConfig(path)
 		if err != nil {
@@ -328,6 +331,11 @@ func main() {
 			log.Fatal().Err(err).Msg("failed to install host egress block table")
 		}
 		blocklist.SetCIDRSink(hostBlock.UpdateCIDRs)
+		// Seed the host drop set from the state-seeded snapshot now, before
+		// the first feed fetch (which may block up to feedFetchTimeout per
+		// feed). Otherwise seeded CIDRs go unenforced on non-proxied ports
+		// during the startup window.
+		hostBlock.UpdateCIDRs(blocklist.CIDRs())
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blocklist.Start(ctx) })
 	}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -313,6 +313,14 @@ func main() {
 	netMgr.SetEgressProxy(egressProxy)
 	if blocklist != nil {
 		egressProxy.SetBlocklist(blocklist)
+		// Mirror IP/CIDR entries into a host-level nftables drop set so they
+		// are enforced on every port, not just the proxied web ports.
+		hostBlock, err := network.NewHostEgressBlock(log)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to install host egress block table")
+		}
+		blocklist.SetCIDRSink(hostBlock.UpdateCIDRs)
+		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blocklist.Start(ctx) })
 	}
 	lc.start("egress proxy", func() error { return egressProxy.Start(ctx) })

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -264,6 +264,14 @@ func main() {
 		blocklist = network.NewBlocklist(blCfg, log)
 		netMgrOpts = append(netMgrOpts, network.WithBlockedEgressPorts(blCfg.BlockedEgressPorts))
 		log.Info().Str("path", path).Int("feeds", len(blCfg.DomainFeeds)).Int("blocked_ports", len(blCfg.BlockedEgressPorts)).Msg("egress blocklist configured")
+	} else {
+		// Feature disabled — drop any host egress-block table a previous run
+		// installed so its CIDR drops stop affecting sandbox egress. The
+		// per-VM port-drop chain self-heals: installHostFirewall always runs
+		// and ClearChain empties it when no ports are configured.
+		if err := network.RemoveHostEgressBlock(); err != nil {
+			log.Debug().Err(err).Msg("removing stale host egress block table")
+		}
 	}
 
 	// ---- Network manager + host firewall ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -250,8 +250,24 @@ func main() {
 
 	lc := newLifecycle(log)
 
+	// ---- Egress blocklist (optional) ----
+	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
+	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
+	// blocklist.
+	var blocklist *network.Blocklist
+	var netMgrOpts []network.ManagerOption
+	if path := os.Getenv("VMD_EGRESS_BLOCKLIST_CONFIG"); path != "" {
+		blCfg, err := network.LoadBlocklistConfig(path)
+		if err != nil {
+			log.Fatal().Err(err).Str("path", path).Msg("failed to load egress blocklist config")
+		}
+		blocklist = network.NewBlocklist(blCfg, log)
+		netMgrOpts = append(netMgrOpts, network.WithBlockedEgressPorts(blCfg.BlockedEgressPorts))
+		log.Info().Str("path", path).Int("feeds", len(blCfg.DomainFeeds)).Int("blocked_ports", len(blCfg.BlockedEgressPorts)).Msg("egress blocklist configured")
+	}
+
 	// ---- Network manager + host firewall ----
-	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log)
+	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
@@ -295,6 +311,10 @@ func main() {
 	)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
+	if blocklist != nil {
+		egressProxy.SetBlocklist(blocklist)
+		lc.start("egress blocklist", func() error { return blocklist.Start(ctx) })
+	}
 	lc.start("egress proxy", func() error { return egressProxy.Start(ctx) })
 
 	// ---- BoltDB state store ----

--- a/deploy/egress-blocklist.example.yaml
+++ b/deploy/egress-blocklist.example.yaml
@@ -4,11 +4,14 @@
 # config is deployment-specific — do not commit actual feed URLs or block
 # entries to the repository. This example uses placeholder values only.
 #
-# Entries from all sources are merged into one denylist enforced by the
-# egress proxy (domains via SNI/Host, plus destination IPs) and the host
-# firewall (ports). The denylist takes precedence over per-sandbox allow
-# rules. Feed fetch failures keep the last good list; the merged list is
-# persisted to state_path so restarts are seeded before the first fetch.
+# Entries from all sources are merged into one denylist. Enforcement:
+#   - Domains: matched on proxied HTTP/TLS via Host header / SNI.
+#   - IPs/CIDRs: matched on proxied web traffic AND dropped at the host
+#     firewall on every port and protocol.
+#   - Ports: dropped at the host firewall for all sandbox traffic.
+# The denylist takes precedence over per-sandbox allow rules. A failed feed
+# fetch falls back to that feed's last good copy; the merged list is persisted
+# to state_path so restarts are seeded before the first fetch.
 
 # Plain-text feeds: one entry per line, '#' comments. Entries may be
 # domains, IPs, IP:port pairs, or CIDRs. URLs or local file paths.

--- a/deploy/egress-blocklist.example.yaml
+++ b/deploy/egress-blocklist.example.yaml
@@ -1,0 +1,33 @@
+# Example egress blocklist config for vmd.
+#
+# Point VMD_EGRESS_BLOCKLIST_CONFIG at a file with this schema. The real
+# config is deployment-specific — do not commit actual feed URLs or block
+# entries to the repository. This example uses placeholder values only.
+#
+# Entries from all sources are merged into one denylist enforced by the
+# egress proxy (domains via SNI/Host, plus destination IPs) and the host
+# firewall (ports). The denylist takes precedence over per-sandbox allow
+# rules. Feed fetch failures keep the last good list; the merged list is
+# persisted to state_path so restarts are seeded before the first fetch.
+
+# Plain-text feeds: one entry per line, '#' comments. Entries may be
+# domains, IPs, IP:port pairs, or CIDRs. URLs or local file paths.
+domain_feeds:
+  - https://threat-intel.example.com/bad-domains.txt
+  - /etc/sandbox/extra-blocked.txt
+
+# Pinned entries, always blocked regardless of feed contents.
+custom_domains:
+  - blocked.example.com
+custom_cidrs:
+  - 192.0.2.0/24
+
+# Destination ports dropped (TCP and UDP) for all sandbox traffic.
+blocked_egress_ports: [12345]
+
+# How often feeds are re-fetched. Go duration syntax. Default 6h.
+refresh_interval: 6h
+
+# Where the last good merged list is persisted. Defaults to
+# "blocklist.state" next to this config file.
+state_path: /var/lib/sandbox/blocklist.state

--- a/deploy/egress-blocklist.example.yaml
+++ b/deploy/egress-blocklist.example.yaml
@@ -25,7 +25,10 @@ custom_domains:
 custom_cidrs:
   - 192.0.2.0/24
 
-# Destination ports dropped (TCP and UDP) for all sandbox traffic.
+# Destination ports dropped (TCP and UDP) for all sandbox traffic. Ports 80
+# and 443 are rejected here — they are REDIRECTed to the egress proxy before
+# the drop would apply, so web traffic is governed by the domain blocklist
+# and the proxy, not by port drops.
 blocked_egress_ports: [12345]
 
 # How often feeds are re-fetched. Go duration syntax. Default 6h.

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -121,15 +121,25 @@ type Blocklist struct {
 	log  zerolog.Logger
 	cur  atomic.Pointer[blocklistSnapshot]
 	http *http.Client
+
+	// feedCache holds the last successfully fetched text per feed URL so a
+	// transient failure of one feed does not drop that feed's entries from
+	// the merged snapshot. Only touched from the single refresh goroutine.
+	feedCache map[string]string
+
+	// sink, if set, receives the snapshot's CIDRs after every refresh so
+	// downstream enforcers (e.g. the host firewall) can mirror them.
+	sink func([]string)
 }
 
 // NewBlocklist builds a Blocklist seeded from the pinned config entries and
 // the persisted state file (if present). Feeds are first fetched in Start.
 func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
 	b := &Blocklist{
-		cfg:  cfg,
-		log:  log.With().Str("component", "egress-blocklist").Logger(),
-		http: &http.Client{Timeout: feedFetchTimeout},
+		cfg:       cfg,
+		log:       log.With().Str("component", "egress-blocklist").Logger(),
+		http:      &http.Client{Timeout: feedFetchTimeout},
+		feedCache: make(map[string]string),
 	}
 
 	seed := newSnapshotBuilder()
@@ -140,6 +150,27 @@ func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
 	}
 	b.cur.Store(seed.snapshot())
 	return b
+}
+
+// SetCIDRSink registers a callback invoked with the snapshot's CIDR list
+// after each refresh (and on the initial refresh in Start). Used to mirror
+// IP/CIDR entries into the host firewall so they are enforced on every port,
+// not only the proxied HTTP/TLS ports. Must be set before Start.
+func (b *Blocklist) SetCIDRSink(fn func([]string)) {
+	b.sink = fn
+}
+
+// CIDRs returns the current snapshot's blocked prefixes as strings.
+func (b *Blocklist) CIDRs() []string {
+	snap := b.cur.Load()
+	if snap == nil {
+		return nil
+	}
+	out := make([]string, 0, len(snap.nets))
+	for _, p := range snap.nets {
+		out = append(out, p.String())
+	}
+	return out
 }
 
 // Start fetches all feeds immediately, then refreshes on the configured
@@ -199,29 +230,41 @@ func (s *blocklistSnapshot) blockedDomain(hostname string) bool {
 }
 
 // refresh fetches every feed and atomically swaps in the merged snapshot.
-// A feed that fails to fetch is logged and skipped; if ALL feeds fail the
-// previous snapshot is kept so transient outages never shrink coverage.
+//
+// A feed that fails to fetch falls back to its last successfully fetched
+// text (feedCache) so one transient failure cannot drop that feed's entries
+// while others succeed. A feed that has never succeeded contributes nothing.
+// If no feed yields any text (fresh or cached) the previous snapshot is kept
+// so transient outages never shrink coverage.
 func (b *Blocklist) refresh(ctx context.Context) {
 	builder := newSnapshotBuilder()
 	builder.addConfigEntries(b.cfg)
 
-	fetched, failed := 0, 0
+	fetched, cached, failed := 0, 0, 0
 	var stateText strings.Builder
 	for _, src := range b.cfg.DomainFeeds {
 		text, err := b.fetchFeed(ctx, src)
 		if err != nil {
-			failed++
-			b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed")
-			continue
+			prev, ok := b.feedCache[src]
+			if !ok {
+				failed++
+				b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed (no cached copy)")
+				continue
+			}
+			cached++
+			text = prev
+			b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed; using cached copy")
+		} else {
+			fetched++
+			b.feedCache[src] = text
 		}
-		fetched++
 		builder.addFeedText(text)
 		stateText.WriteString(text)
 		stateText.WriteString("\n")
 	}
 
-	if fetched == 0 && len(b.cfg.DomainFeeds) > 0 {
-		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("all blocklist feeds failed; keeping previous snapshot")
+	if fetched == 0 && cached == 0 && len(b.cfg.DomainFeeds) > 0 {
+		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("no blocklist feed data (fresh or cached); keeping previous snapshot")
 		return
 	}
 
@@ -231,9 +274,16 @@ func (b *Blocklist) refresh(ctx context.Context) {
 		Int("domains", len(snap.domains)).
 		Int("cidrs", len(snap.nets)).
 		Int("feeds_ok", fetched).
+		Int("feeds_cached", cached).
 		Int("feeds_failed", failed).
 		Msg("blocklist refreshed")
 
+	if b.sink != nil {
+		b.sink(b.CIDRs())
+	}
+
+	// Persist only freshly fetched data — a refresh served entirely from
+	// cache adds nothing new, and the state file already holds it.
 	if fetched > 0 {
 		if err := writeFileAtomic(b.cfg.StatePath, []byte(stateText.String())); err != nil {
 			b.log.Warn().Err(err).Str("path", b.cfg.StatePath).Msg("failed to persist blocklist state")

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -131,6 +131,10 @@ type Blocklist struct {
 	cur  atomic.Pointer[blocklistSnapshot]
 	http *http.Client
 
+	// maxBytes caps a single HTTP feed download. Defaults to maxFeedBytes;
+	// overridable in tests.
+	maxBytes int64
+
 	// feedCache holds the last successfully fetched text per feed URL so a
 	// transient failure of one feed does not drop that feed's entries from
 	// the merged snapshot. Only touched from the single refresh goroutine.
@@ -149,6 +153,7 @@ func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
 		log:       log.With().Str("component", "egress-blocklist").Logger(),
 		http:      &http.Client{Timeout: feedFetchTimeout},
 		feedCache: make(map[string]string),
+		maxBytes:  maxFeedBytes,
 	}
 
 	seed := newSnapshotBuilder()
@@ -333,9 +338,16 @@ func (b *Blocklist) fetchFeed(ctx context.Context, src string) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("status %d", resp.StatusCode)
 	}
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedBytes))
+	// Read one byte past the cap so truncation is detectable. A silently
+	// truncated feed would otherwise count as a successful fetch, overwrite
+	// the cache, and persist a partial state — dropping every entry past the
+	// cutoff. Fail instead, so refresh() falls back to the last-good copy.
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, b.maxBytes+1))
 	if err != nil {
 		return "", err
+	}
+	if int64(len(raw)) > b.maxBytes {
+		return "", fmt.Errorf("feed exceeds %d byte cap", b.maxBytes)
 	}
 	return string(raw), nil
 }

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -1,0 +1,403 @@
+package network
+
+// blocklist.go implements a global egress denylist for the egress proxy and
+// host firewall. Which feeds are fetched, which domains/CIDRs are pinned,
+// and which ports are dropped all come from an operator-supplied config
+// file; nothing is built in.
+//
+// Enforcement points:
+//   - EgressProxy checks Blocked() on every HTTP/TLS connection (SNI/Host
+//     plus original destination IP) before per-sandbox rules.
+//   - installHostFirewall drops BlockedEgressPorts in the FORWARD chain for
+//     traffic that is not redirected through the proxy.
+//
+// The list is a denylist, so the failure mode is "no extra blocking", never
+// "block everything": a fetch error keeps the last good snapshot, and the
+// last good snapshot is persisted to StatePath so a vmd restart does not
+// come up empty while the first fetch is in flight.
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	// defaultBlocklistRefresh is used when refresh_interval is unset.
+	defaultBlocklistRefresh = 6 * time.Hour
+
+	// maxFeedBytes caps a single feed download so a hijacked or
+	// misconfigured feed URL cannot exhaust memory.
+	maxFeedBytes = 16 << 20 // 16 MiB
+
+	feedFetchTimeout = 60 * time.Second
+)
+
+// BlocklistConfig is the schema of the operator-supplied config file
+// (VMD_EGRESS_BLOCKLIST_CONFIG). All fields are optional.
+type BlocklistConfig struct {
+	// DomainFeeds are URLs (http/https) or local file paths to plain-text
+	// feeds: one entry per line, '#' starts a comment. Entries may be
+	// domains, IPs, IP:port pairs, or CIDRs.
+	DomainFeeds []string `yaml:"domain_feeds"`
+
+	// CustomDomains and CustomCIDRs are pinned entries that are always
+	// blocked regardless of feed contents.
+	CustomDomains []string `yaml:"custom_domains"`
+	CustomCIDRs   []string `yaml:"custom_cidrs"`
+
+	// BlockedEgressPorts are dropped in the host FORWARD chain for all
+	// sandbox traffic (both TCP and UDP).
+	BlockedEgressPorts []uint16 `yaml:"blocked_egress_ports"`
+
+	// RefreshInterval is a Go duration string ("6h", "30m"). Default 6h.
+	RefreshInterval string `yaml:"refresh_interval"`
+
+	// StatePath is where the last good merged list is persisted. Default:
+	// "<config dir>/blocklist.state".
+	StatePath string `yaml:"state_path"`
+}
+
+// LoadBlocklistConfig reads and validates the YAML config at path.
+func LoadBlocklistConfig(path string) (*BlocklistConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read blocklist config: %w", err)
+	}
+	var cfg BlocklistConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parse blocklist config %s: %w", path, err)
+	}
+	if cfg.RefreshInterval != "" {
+		if _, err := time.ParseDuration(cfg.RefreshInterval); err != nil {
+			return nil, fmt.Errorf("invalid refresh_interval %q: %w", cfg.RefreshInterval, err)
+		}
+	}
+	for _, c := range cfg.CustomCIDRs {
+		if _, err := parseCIDROrIP(c); err != nil {
+			return nil, fmt.Errorf("invalid custom_cidrs entry %q: %w", c, err)
+		}
+	}
+	if cfg.StatePath == "" {
+		cfg.StatePath = filepath.Join(filepath.Dir(path), "blocklist.state")
+	}
+	return &cfg, nil
+}
+
+func (c *BlocklistConfig) refreshInterval() time.Duration {
+	if c.RefreshInterval == "" {
+		return defaultBlocklistRefresh
+	}
+	d, err := time.ParseDuration(c.RefreshInterval)
+	if err != nil {
+		return defaultBlocklistRefresh
+	}
+	return d
+}
+
+// blocklistSnapshot is an immutable merged view of all sources. Swapped
+// atomically on refresh so lookups never take a lock.
+type blocklistSnapshot struct {
+	domains map[string]struct{}
+	nets    []netip.Prefix
+}
+
+// Blocklist holds the current snapshot and refreshes it from the configured
+// feeds. Lookup methods are safe for concurrent use.
+type Blocklist struct {
+	cfg  *BlocklistConfig
+	log  zerolog.Logger
+	cur  atomic.Pointer[blocklistSnapshot]
+	http *http.Client
+}
+
+// NewBlocklist builds a Blocklist seeded from the pinned config entries and
+// the persisted state file (if present). Feeds are first fetched in Start.
+func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
+	b := &Blocklist{
+		cfg:  cfg,
+		log:  log.With().Str("component", "egress-blocklist").Logger(),
+		http: &http.Client{Timeout: feedFetchTimeout},
+	}
+
+	seed := newSnapshotBuilder()
+	seed.addConfigEntries(cfg)
+	if raw, err := os.ReadFile(cfg.StatePath); err == nil {
+		n := seed.addFeedText(string(raw))
+		b.log.Info().Int("entries", n).Str("path", cfg.StatePath).Msg("seeded blocklist from persisted state")
+	}
+	b.cur.Store(seed.snapshot())
+	return b
+}
+
+// Start fetches all feeds immediately, then refreshes on the configured
+// interval. Blocks until ctx is cancelled.
+func (b *Blocklist) Start(ctx context.Context) error {
+	b.refresh(ctx)
+	ticker := time.NewTicker(b.cfg.refreshInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			b.refresh(ctx)
+		}
+	}
+}
+
+// Blocked reports whether a connection identified by hostname (may be empty)
+// and destination IP hits the blocklist. The second return value names the
+// matching dimension ("domain" or "ip") for logging.
+func (b *Blocklist) Blocked(hostname string, dstIP net.IP) (bool, string) {
+	snap := b.cur.Load()
+	if snap == nil {
+		return false, ""
+	}
+	if hostname != "" && snap.blockedDomain(hostname) {
+		return true, "domain"
+	}
+	if dstIP != nil {
+		if addr, ok := netip.AddrFromSlice(dstIP.To4()); ok {
+			for _, p := range snap.nets {
+				if p.Contains(addr) {
+					return true, "ip"
+				}
+			}
+		}
+	}
+	return false, ""
+}
+
+// blockedDomain walks parent labels so a blocked "example.com" also blocks
+// "pool.example.com".
+func (s *blocklistSnapshot) blockedDomain(hostname string) bool {
+	h := strings.ToLower(strings.TrimSuffix(hostname, "."))
+	for h != "" {
+		if _, ok := s.domains[h]; ok {
+			return true
+		}
+		_, parent, ok := strings.Cut(h, ".")
+		if !ok {
+			break
+		}
+		h = parent
+	}
+	return false
+}
+
+// refresh fetches every feed and atomically swaps in the merged snapshot.
+// A feed that fails to fetch is logged and skipped; if ALL feeds fail the
+// previous snapshot is kept so transient outages never shrink coverage.
+func (b *Blocklist) refresh(ctx context.Context) {
+	builder := newSnapshotBuilder()
+	builder.addConfigEntries(b.cfg)
+
+	fetched, failed := 0, 0
+	var stateText strings.Builder
+	for _, src := range b.cfg.DomainFeeds {
+		text, err := b.fetchFeed(ctx, src)
+		if err != nil {
+			failed++
+			b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed")
+			continue
+		}
+		fetched++
+		builder.addFeedText(text)
+		stateText.WriteString(text)
+		stateText.WriteString("\n")
+	}
+
+	if fetched == 0 && len(b.cfg.DomainFeeds) > 0 {
+		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("all blocklist feeds failed; keeping previous snapshot")
+		return
+	}
+
+	snap := builder.snapshot()
+	b.cur.Store(snap)
+	b.log.Info().
+		Int("domains", len(snap.domains)).
+		Int("cidrs", len(snap.nets)).
+		Int("feeds_ok", fetched).
+		Int("feeds_failed", failed).
+		Msg("blocklist refreshed")
+
+	if fetched > 0 {
+		if err := writeFileAtomic(b.cfg.StatePath, []byte(stateText.String())); err != nil {
+			b.log.Warn().Err(err).Str("path", b.cfg.StatePath).Msg("failed to persist blocklist state")
+		}
+	}
+}
+
+func (b *Blocklist) fetchFeed(ctx context.Context, src string) (string, error) {
+	if !strings.HasPrefix(src, "http://") && !strings.HasPrefix(src, "https://") {
+		raw, err := os.ReadFile(src)
+		if err != nil {
+			return "", err
+		}
+		return string(raw), nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedBytes))
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot building / feed parsing
+// ---------------------------------------------------------------------------
+
+type snapshotBuilder struct {
+	domains map[string]struct{}
+	nets    map[netip.Prefix]struct{}
+}
+
+func newSnapshotBuilder() *snapshotBuilder {
+	return &snapshotBuilder{
+		domains: make(map[string]struct{}),
+		nets:    make(map[netip.Prefix]struct{}),
+	}
+}
+
+func (sb *snapshotBuilder) addConfigEntries(cfg *BlocklistConfig) {
+	for _, d := range cfg.CustomDomains {
+		if d = normalizeDomain(d); d != "" {
+			sb.domains[d] = struct{}{}
+		}
+	}
+	for _, c := range cfg.CustomCIDRs {
+		if p, err := parseCIDROrIP(c); err == nil {
+			sb.nets[p] = struct{}{}
+		}
+	}
+}
+
+// addFeedText parses feed lines into the builder and returns the number of
+// entries accepted. Unparseable lines are skipped — feeds aggregated from
+// threat intel commonly mix formats and annotations.
+func (sb *snapshotBuilder) addFeedText(text string) int {
+	added := 0
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// CIDR (1.2.3.0/24)
+		if strings.Contains(line, "/") {
+			if p, err := netip.ParsePrefix(line); err == nil && p.Addr().Is4() {
+				sb.nets[p.Masked()] = struct{}{}
+				added++
+			}
+			continue
+		}
+
+		// IP:port (1.2.3.4:8080) — port is irrelevant for a destination
+		// denylist; block the IP outright.
+		if host, _, err := net.SplitHostPort(line); err == nil {
+			line = host
+		}
+
+		// Bare IP (1.2.3.4)
+		if addr, err := netip.ParseAddr(line); err == nil {
+			if addr.Is4() {
+				sb.nets[netip.PrefixFrom(addr, 32)] = struct{}{}
+				added++
+			}
+			continue
+		}
+
+		// Domain
+		if d := normalizeDomain(line); d != "" {
+			sb.domains[d] = struct{}{}
+			added++
+		}
+	}
+	return added
+}
+
+func (sb *snapshotBuilder) snapshot() *blocklistSnapshot {
+	nets := make([]netip.Prefix, 0, len(sb.nets))
+	for p := range sb.nets {
+		nets = append(nets, p)
+	}
+	return &blocklistSnapshot{domains: sb.domains, nets: nets}
+}
+
+// normalizeDomain lowercases and validates a domain-ish entry. Returns ""
+// for entries that cannot be a DNS name (so junk feed lines are dropped
+// instead of polluting the set).
+func normalizeDomain(d string) string {
+	d = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(d, ".")))
+	d = strings.TrimPrefix(d, "*.")
+	if d == "" || !strings.Contains(d, ".") || len(d) > 253 {
+		return ""
+	}
+	for _, r := range d {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '.', r == '_':
+		default:
+			return ""
+		}
+	}
+	return d
+}
+
+// parseCIDROrIP accepts both "1.2.3.0/24" and bare "1.2.3.4" config entries.
+func parseCIDROrIP(s string) (netip.Prefix, error) {
+	if strings.Contains(s, "/") {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return p.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -265,6 +265,12 @@ func (b *Blocklist) refresh(ctx context.Context) {
 
 	if fetched == 0 && cached == 0 && len(b.cfg.DomainFeeds) > 0 {
 		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("no blocklist feed data (fresh or cached); keeping previous snapshot")
+		// Still push the current (e.g. state-seeded) CIDRs to the sink: on a
+		// cold start with all feeds down, the host drop set would otherwise
+		// stay empty and leave seeded IPs reachable on non-proxied ports.
+		if b.sink != nil {
+			b.sink(b.CIDRs())
+		}
 		return
 	}
 

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -241,10 +241,12 @@ func (b *Blocklist) refresh(ctx context.Context) {
 	builder.addConfigEntries(b.cfg)
 
 	fetched, cached, failed := 0, 0, 0
+	degraded := false
 	var stateText strings.Builder
 	for _, src := range b.cfg.DomainFeeds {
 		text, err := b.fetchFeed(ctx, src)
 		if err != nil {
+			degraded = true
 			prev, ok := b.feedCache[src]
 			if !ok {
 				failed++
@@ -263,15 +265,16 @@ func (b *Blocklist) refresh(ctx context.Context) {
 		stateText.WriteString("\n")
 	}
 
-	if fetched == 0 && cached == 0 && len(b.cfg.DomainFeeds) > 0 {
-		b.log.Warn().Int("feeds", len(b.cfg.DomainFeeds)).Msg("no blocklist feed data (fresh or cached); keeping previous snapshot")
-		// Still push the current (e.g. state-seeded) CIDRs to the sink: on a
-		// cold start with all feeds down, the host drop set would otherwise
-		// stay empty and leave seeded IPs reachable on non-proxied ports.
-		if b.sink != nil {
-			b.sink(b.CIDRs())
+	// Fail-safe: a failed or missing feed must never shrink coverage. Union
+	// the previous snapshot so entries sourced only from an unavailable feed
+	// survive — including entries seeded from the state file at startup, for
+	// which there is no per-feed cache to fall back on. A later fully
+	// successful refresh rebuilds without this union, so legitimate removals
+	// still take effect once every feed is reachable again.
+	if degraded {
+		if prev := b.cur.Load(); prev != nil {
+			builder.addSnapshot(prev)
 		}
-		return
 	}
 
 	snap := builder.snapshot()
@@ -284,13 +287,16 @@ func (b *Blocklist) refresh(ctx context.Context) {
 		Int("feeds_failed", failed).
 		Msg("blocklist refreshed")
 
+	// Mirror CIDRs to the host firewall on every refresh, degraded ones
+	// included, so the host drop set always matches the active snapshot.
 	if b.sink != nil {
 		b.sink(b.CIDRs())
 	}
 
-	// Persist only freshly fetched data — a refresh served entirely from
-	// cache adds nothing new, and the state file already holds it.
-	if fetched > 0 {
+	// Persist only a fully successful fetch so the on-disk state always
+	// represents a complete snapshot for cold-start seeding — never the
+	// shrunken text of a degraded round.
+	if !degraded && fetched > 0 {
 		if err := writeFileAtomic(b.cfg.StatePath, []byte(stateText.String())); err != nil {
 			b.log.Warn().Err(err).Str("path", b.cfg.StatePath).Msg("failed to persist blocklist state")
 		}
@@ -338,6 +344,17 @@ func newSnapshotBuilder() *snapshotBuilder {
 	return &snapshotBuilder{
 		domains: make(map[string]struct{}),
 		nets:    make(map[netip.Prefix]struct{}),
+	}
+}
+
+// addSnapshot merges an existing snapshot's entries into the builder. Used to
+// retain previous coverage across a degraded refresh.
+func (sb *snapshotBuilder) addSnapshot(s *blocklistSnapshot) {
+	for d := range s.domains {
+		sb.domains[d] = struct{}{}
+	}
+	for _, p := range s.nets {
+		sb.nets[p] = struct{}{}
 	}
 }
 

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -159,7 +159,10 @@ func NewBlocklist(cfg *BlocklistConfig, log zerolog.Logger) *Blocklist {
 	seed := newSnapshotBuilder()
 	seed.addConfigEntries(cfg)
 	if raw, err := os.ReadFile(cfg.StatePath); err == nil {
-		n := seed.addFeedText(string(raw))
+		n, perr := seed.addFeedText(string(raw))
+		if perr != nil {
+			b.log.Warn().Err(perr).Str("path", cfg.StatePath).Msg("persisted state parse incomplete")
+		}
 		b.log.Info().Int("entries", n).Str("path", cfg.StatePath).Msg("seeded blocklist from persisted state")
 	}
 	b.cur.Store(seed.snapshot())
@@ -259,6 +262,7 @@ func (b *Blocklist) refresh(ctx context.Context) {
 	var stateText strings.Builder
 	for _, src := range b.cfg.DomainFeeds {
 		text, err := b.fetchFeed(ctx, src)
+		fromCache := false
 		if err != nil {
 			degraded = true
 			prev, ok := b.feedCache[src]
@@ -267,14 +271,29 @@ func (b *Blocklist) refresh(ctx context.Context) {
 				b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed (no cached copy)")
 				continue
 			}
-			cached++
 			text = prev
+			fromCache = true
 			b.log.Warn().Err(err).Str("feed", src).Msg("blocklist feed fetch failed; using cached copy")
+		}
+
+		// Parse in isolation so a malformed feed (e.g. a line longer than the
+		// scanner buffer, which stops Scan mid-stream) is treated as a failed
+		// feed rather than silently contributing a truncated set.
+		fb := newSnapshotBuilder()
+		if _, perr := fb.addFeedText(text); perr != nil {
+			degraded = true
+			failed++
+			b.log.Warn().Err(perr).Str("feed", src).Msg("blocklist feed parse failed; skipping feed")
+			continue
+		}
+
+		if fromCache {
+			cached++
 		} else {
 			fetched++
 			b.feedCache[src] = text
 		}
-		builder.addFeedText(text)
+		builder.addSnapshot(fb.snapshot())
 		stateText.WriteString(text)
 		stateText.WriteString("\n")
 	}
@@ -394,8 +413,10 @@ func (sb *snapshotBuilder) addConfigEntries(cfg *BlocklistConfig) {
 
 // addFeedText parses feed lines into the builder and returns the number of
 // entries accepted. Unparseable lines are skipped — feeds aggregated from
-// threat intel commonly mix formats and annotations.
-func (sb *snapshotBuilder) addFeedText(text string) int {
+// threat intel commonly mix formats and annotations. A non-nil error means
+// the scan stopped early (e.g. a line exceeding the buffer), so the parse is
+// incomplete and the caller must not treat the result as authoritative.
+func (sb *snapshotBuilder) addFeedText(text string) (int, error) {
 	added := 0
 	scanner := bufio.NewScanner(strings.NewReader(text))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
@@ -439,7 +460,7 @@ func (sb *snapshotBuilder) addFeedText(text string) int {
 			added++
 		}
 	}
-	return added
+	return added, scanner.Err()
 }
 
 func (sb *snapshotBuilder) snapshot() *blocklistSnapshot {

--- a/internal/network/blocklist.go
+++ b/internal/network/blocklist.go
@@ -90,6 +90,15 @@ func LoadBlocklistConfig(path string) (*BlocklistConfig, error) {
 			return nil, fmt.Errorf("invalid custom_cidrs entry %q: %w", c, err)
 		}
 	}
+	for _, p := range cfg.BlockedEgressPorts {
+		// 80/443 are REDIRECTed to the egress proxy in PREROUTING, which runs
+		// before the FORWARD drop, so a port drop here would be a silent
+		// no-op. Web traffic is governed by the domain blocklist and the
+		// proxy path instead. Reject rather than silently ignore.
+		if p == 80 || p == 443 {
+			return nil, fmt.Errorf("blocked_egress_ports must not contain %d: web ports are enforced via the egress proxy and domain rules, not port drops", p)
+		}
+	}
 	if cfg.StatePath == "" {
 		cfg.StatePath = filepath.Join(filepath.Dir(path), "blocklist.state")
 	}

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -295,10 +295,13 @@ refresh_interval: 30m
 		t.Errorf("default state path = %q", cfg.StatePath)
 	}
 
-	// Invalid duration and invalid CIDR must be rejected at load time.
+	// Invalid duration, invalid CIDR, and un-droppable web ports must all be
+	// rejected at load time.
 	for name, content := range map[string]string{
 		"bad duration": "refresh_interval: nonsense\n",
 		"bad cidr":     "custom_cidrs: [not-a-cidr]\n",
+		"web port 80":  "blocked_egress_ports: [80]\n",
+		"web port 443": "blocked_egress_ports: [443, 3333]\n",
 	} {
 		p := filepath.Join(dir, "bad.yaml")
 		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -2,6 +2,8 @@ package network
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -262,6 +264,47 @@ func TestCIDRSinkFiresWhenAllFeedsDownWithSeededState(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != "198.51.100.0/24" {
 		t.Errorf("sink CIDRs = %v, want [198.51.100.0/24] from seeded state", got)
+	}
+}
+
+func TestOversizedFeedFailsAndKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+
+	// Server whose body length depends on a switch, so we can serve a small
+	// good body first, then an oversized one.
+	oversized := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if oversized {
+			w.Write([]byte("a.example.com\nb.example.com\nc.example.com\n")) // > cap below
+		} else {
+			w.Write([]byte("a.example.com\n"))
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{srv.URL},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.maxBytes = 20 // tiny cap for the test
+
+	b.refresh(t.Context()) // small body, succeeds
+	if got, _ := b.Blocked("a.example.com", nil); !got {
+		t.Fatal("expected a.example.com blocked after first refresh")
+	}
+
+	// Now the feed exceeds the cap: the fetch must fail, not silently
+	// truncate, so the last-good snapshot is retained.
+	oversized = true
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("a.example.com", nil); !got {
+		t.Error("last-good entry lost after oversized feed; truncation was treated as success")
+	}
+
+	// State file must not have been overwritten with truncated content.
+	if raw, err := os.ReadFile(cfg.StatePath); err == nil && len(raw) > 20 {
+		t.Errorf("state file holds %d bytes; oversized feed should not have persisted", len(raw))
 	}
 }
 

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -135,6 +135,67 @@ func TestRefreshKeepsLastGoodOnTotalFailure(t *testing.T) {
 	}
 }
 
+func TestRefreshKeepsFailedFeedFromCache(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.txt")
+	flaky := filepath.Join(dir, "flaky.txt")
+	if err := os.WriteFile(good, []byte("stable.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flaky, []byte("flaky-only.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{good, flaky},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+
+	// One feed fails this round; the other still succeeds. The failed feed's
+	// entries must survive from cache rather than vanishing.
+	os.Remove(flaky)
+	b.refresh(t.Context())
+
+	if got, _ := b.Blocked("flaky-only.example.com", nil); !got {
+		t.Error("entry from transiently-failed feed was dropped; expected cache fallback")
+	}
+	if got, _ := b.Blocked("stable.example.com", nil); !got {
+		t.Error("entry from healthy feed missing after partial-failure refresh")
+	}
+}
+
+func TestCIDRSinkInvokedOnRefresh(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("10.20.30.0/24\nblocked.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{feed},
+		CustomCIDRs: []string{"203.0.113.7"},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+
+	var got []string
+	b.SetCIDRSink(func(c []string) { got = c })
+	b.refresh(t.Context())
+
+	// Sink should receive only CIDRs (not domains): the feed /24 and the
+	// pinned /32.
+	if len(got) != 2 {
+		t.Fatalf("sink got %v, want 2 CIDRs", got)
+	}
+	found := map[string]bool{}
+	for _, c := range got {
+		found[c] = true
+	}
+	if !found["10.20.30.0/24"] || !found["203.0.113.7/32"] {
+		t.Errorf("sink CIDRs = %v, missing expected entries", got)
+	}
+}
+
 func TestLoadBlocklistConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bl.yaml")

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAddFeedText(t *testing.T) {
 	sb := newSnapshotBuilder()
-	n := sb.addFeedText(`
+	n, err := sb.addFeedText(`
 # comment line
 pool.example.com
 EVIL.Example.ORG.   # trailing comment
@@ -25,6 +25,9 @@ not a valid entry !!
 singlelabel
 2001:db8::1
 `)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if n != 5 {
 		t.Errorf("addFeedText accepted %d entries, want 5", n)
 	}
@@ -264,6 +267,43 @@ func TestCIDRSinkFiresWhenAllFeedsDownWithSeededState(t *testing.T) {
 	}
 	if len(got) != 1 || got[0] != "198.51.100.0/24" {
 		t.Errorf("sink CIDRs = %v, want [198.51.100.0/24] from seeded state", got)
+	}
+}
+
+func TestAddFeedTextRejectsOverlongLine(t *testing.T) {
+	sb := newSnapshotBuilder()
+	// A single line larger than the scanner's 1 MiB buffer stops Scan early.
+	overlong := strings.Repeat("a", 2<<20)
+	_, err := sb.addFeedText("good.example.com\n" + overlong + "\n")
+	if err == nil {
+		t.Fatal("expected a scanner error for an over-long line, got nil")
+	}
+}
+
+func TestFeedParseErrorKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("keep.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{feed},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("keep.example.com", nil); !got {
+		t.Fatal("expected keep.example.com blocked after first refresh")
+	}
+
+	// Feed mutates to contain an over-long line: the parse must fail and the
+	// last-good snapshot must be retained, not replaced by a truncated set.
+	if err := os.WriteFile(feed, []byte(strings.Repeat("a", 2<<20)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("keep.example.com", nil); !got {
+		t.Error("last-good entry lost after a feed parse error")
 	}
 }
 

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -1,0 +1,198 @@
+package network
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestAddFeedText(t *testing.T) {
+	sb := newSnapshotBuilder()
+	n := sb.addFeedText(`
+# comment line
+pool.example.com
+EVIL.Example.ORG.   # trailing comment
+1.2.3.4
+5.6.7.8:8081
+10.20.0.0/16
+not a valid entry !!
+singlelabel
+2001:db8::1
+`)
+	if n != 5 {
+		t.Errorf("addFeedText accepted %d entries, want 5", n)
+	}
+
+	snap := sb.snapshot()
+	for _, d := range []string{"pool.example.com", "evil.example.org"} {
+		if _, ok := snap.domains[d]; !ok {
+			t.Errorf("domain %q missing from snapshot", d)
+		}
+	}
+	if _, ok := snap.domains["singlelabel"]; ok {
+		t.Error("dotless entry should have been rejected")
+	}
+	if len(snap.nets) != 3 {
+		t.Errorf("got %d nets, want 3 (two /32s and one /16)", len(snap.nets))
+	}
+}
+
+func TestBlockedDomainWalksParents(t *testing.T) {
+	sb := newSnapshotBuilder()
+	sb.addFeedText("blocked.test\n")
+	snap := sb.snapshot()
+
+	for host, want := range map[string]bool{
+		"blocked.test":        true,
+		"pool.blocked.test":   true,
+		"a.pool.blocked.test": true,
+		"POOL.BLOCKED.TEST":   true,
+		"notblocked.test":     false,
+		"blocked.test.evil":   false,
+		"other.test":          false,
+	} {
+		if got := snap.blockedDomain(host); got != want {
+			t.Errorf("blockedDomain(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestBlocklistBlocked(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("pool.example.com\n9.9.9.0/24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &BlocklistConfig{
+		DomainFeeds:   []string{feed},
+		CustomDomains: []string{"pinned.example.net"},
+		CustomCIDRs:   []string{"1.2.3.4"},
+		StatePath:     filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+
+	tests := []struct {
+		hostname string
+		ip       string
+		want     bool
+		wantDim  string
+	}{
+		{"pool.example.com", "8.8.8.8", true, "domain"},
+		{"deep.pool.example.com", "8.8.8.8", true, "domain"},
+		{"pinned.example.net", "8.8.8.8", true, "domain"},
+		{"", "9.9.9.42", true, "ip"},
+		{"", "1.2.3.4", true, "ip"},
+		{"fine.example.com", "8.8.8.8", false, ""},
+		{"", "8.8.8.8", false, ""},
+	}
+	for _, tc := range tests {
+		got, dim := b.Blocked(tc.hostname, net.ParseIP(tc.ip))
+		if got != tc.want || dim != tc.wantDim {
+			t.Errorf("Blocked(%q, %s) = (%v, %q), want (%v, %q)",
+				tc.hostname, tc.ip, got, dim, tc.want, tc.wantDim)
+		}
+	}
+
+	// State file should have been persisted for cold-start seeding.
+	if _, err := os.Stat(cfg.StatePath); err != nil {
+		t.Errorf("state file not persisted: %v", err)
+	}
+
+	// A fresh Blocklist seeded only from state (feed gone) still blocks.
+	os.Remove(feed)
+	b2 := NewBlocklist(cfg, zerolog.Nop())
+	if got, _ := b2.Blocked("pool.example.com", nil); !got {
+		t.Error("state-seeded blocklist should block pool.example.com before first refresh")
+	}
+}
+
+func TestRefreshKeepsLastGoodOnTotalFailure(t *testing.T) {
+	dir := t.TempDir()
+	feed := filepath.Join(dir, "feed.txt")
+	if err := os.WriteFile(feed, []byte("pool.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{feed},
+		StatePath:   filepath.Join(dir, "state"),
+	}
+	b := NewBlocklist(cfg, zerolog.Nop())
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("pool.example.com", nil); !got {
+		t.Fatal("expected pool.example.com blocked after first refresh")
+	}
+
+	// Feed disappears — refresh must keep the previous snapshot.
+	os.Remove(feed)
+	b.refresh(t.Context())
+	if got, _ := b.Blocked("pool.example.com", nil); !got {
+		t.Error("snapshot was lost after total feed failure")
+	}
+}
+
+func TestLoadBlocklistConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bl.yaml")
+	if err := os.WriteFile(path, []byte(`
+domain_feeds:
+  - https://example.com/feed.txt
+custom_domains:
+  - bad.example.com
+custom_cidrs:
+  - 1.2.3.0/24
+blocked_egress_ports: [12345, 23456]
+refresh_interval: 30m
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadBlocklistConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.BlockedEgressPorts) != 2 || cfg.BlockedEgressPorts[0] != 12345 {
+		t.Errorf("blocked_egress_ports = %v, want [12345 23456]", cfg.BlockedEgressPorts)
+	}
+	if cfg.refreshInterval().Minutes() != 30 {
+		t.Errorf("refresh interval = %v, want 30m", cfg.refreshInterval())
+	}
+	if cfg.StatePath != filepath.Join(dir, "blocklist.state") {
+		t.Errorf("default state path = %q", cfg.StatePath)
+	}
+
+	// Invalid duration and invalid CIDR must be rejected at load time.
+	for name, content := range map[string]string{
+		"bad duration": "refresh_interval: nonsense\n",
+		"bad cidr":     "custom_cidrs: [not-a-cidr]\n",
+	} {
+		p := filepath.Join(dir, "bad.yaml")
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadBlocklistConfig(p); err == nil {
+			t.Errorf("%s: expected load error, got nil", name)
+		}
+	}
+}
+
+func TestProxyBlocklistPrecedesSandboxAllow(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &BlocklistConfig{
+		CustomDomains: []string{"pool.example.com"},
+		StatePath:     filepath.Join(dir, "state"),
+	}
+	p := NewEgressProxy(0, 0, 0, 0, zerolog.Nop())
+	p.SetBlocklist(NewBlocklist(cfg, zerolog.Nop()))
+
+	// The sandbox explicitly allows the domain — the global blocklist must
+	// still win. handleConn checks the blocklist before isAllowed, so here
+	// we verify the lookup the proxy performs.
+	if blocked, dim := p.blocklist.Blocked("pool.example.com", net.ParseIP("8.8.8.8")); !blocked || dim != "domain" {
+		t.Errorf("Blocked() = (%v, %q), want (true, domain)", blocked, dim)
+	}
+}

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -196,6 +196,33 @@ func TestCIDRSinkInvokedOnRefresh(t *testing.T) {
 	}
 }
 
+func TestCIDRSinkFiresWhenAllFeedsDownWithSeededState(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state")
+	// Pre-seed a state file with a CIDR, simulating a prior good fetch.
+	if err := os.WriteFile(statePath, []byte("198.51.100.0/24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{filepath.Join(dir, "missing-feed.txt")}, // never resolves
+		StatePath:   statePath,
+	}
+	b := NewBlocklist(cfg, zerolog.Nop()) // seeds snapshot from state
+
+	var got []string
+	sinkCalled := false
+	b.SetCIDRSink(func(c []string) { sinkCalled = true; got = c })
+
+	b.refresh(t.Context()) // feed fails, no cache → early return path
+
+	if !sinkCalled {
+		t.Fatal("sink not invoked on total feed outage; host drop set would stay empty")
+	}
+	if len(got) != 1 || got[0] != "198.51.100.0/24" {
+		t.Errorf("sink CIDRs = %v, want [198.51.100.0/24] from seeded state", got)
+	}
+}
+
 func TestLoadBlocklistConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bl.yaml")

--- a/internal/network/blocklist_test.go
+++ b/internal/network/blocklist_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -193,6 +194,47 @@ func TestCIDRSinkInvokedOnRefresh(t *testing.T) {
 	}
 	if !found["10.20.30.0/24"] || !found["203.0.113.7/32"] {
 		t.Errorf("sink CIDRs = %v, missing expected entries", got)
+	}
+}
+
+func TestRefreshPreservesSeededStateOnPartialFirstFailure(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state")
+	// State from a prior good run holds entries from BOTH feeds (the on-disk
+	// state is a merged blob, not attributable to a specific feed).
+	if err := os.WriteFile(statePath, []byte("from-good.example.com\nfrom-flaky.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "good.txt")
+	if err := os.WriteFile(good, []byte("from-good.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	flaky := filepath.Join(dir, "flaky.txt") // missing → fails, and no cache yet
+	cfg := &BlocklistConfig{
+		DomainFeeds: []string{good, flaky},
+		StatePath:   statePath,
+	}
+	b := NewBlocklist(cfg, zerolog.Nop()) // seeds cur from state; feedCache empty
+
+	b.refresh(t.Context()) // good succeeds, flaky fails on the very first refresh
+
+	// The flaky feed's entry existed only in seeded state (no per-feed cache),
+	// so it must be retained via the previous-snapshot union, not dropped.
+	if got, _ := b.Blocked("from-flaky.example.com", nil); !got {
+		t.Error("state-seeded entry from a feed that failed on first refresh was dropped")
+	}
+	if got, _ := b.Blocked("from-good.example.com", nil); !got {
+		t.Error("entry from the healthy feed missing")
+	}
+
+	// A round that fails must not overwrite the on-disk state with a shrunken
+	// snapshot, so a subsequent cold start still seeds the full set.
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "from-flaky.example.com") {
+		t.Error("degraded refresh overwrote state file, losing the failed feed's entries")
 	}
 }
 

--- a/internal/network/egressblock.go
+++ b/internal/network/egressblock.go
@@ -26,6 +26,22 @@ import (
 
 const hostEgressBlockTable = "sandbox-egress-block"
 
+// RemoveHostEgressBlock deletes the vmd-owned drop table if it exists. Call
+// at startup when the blocklist feature is disabled so a table installed by a
+// previous run stops dropping sandbox egress. Best-effort: a missing table is
+// not an error.
+func RemoveHostEgressBlock() error {
+	conn, err := nftables.New()
+	if err != nil {
+		return fmt.Errorf("new nftables conn: %w", err)
+	}
+	conn.DelTable(&nftables.Table{Family: nftables.TableFamilyINet, Name: hostEgressBlockTable})
+	if err := conn.Flush(); err != nil {
+		return nil // table absent (or already gone) — nothing to clean up
+	}
+	return nil
+}
+
 // HostEgressBlock manages the host nftables table that drops traffic to
 // blocklisted IPv4 prefixes. Safe for use from a single refresh goroutine.
 type HostEgressBlock struct {
@@ -83,6 +99,11 @@ func NewHostEgressBlock(log zerolog.Logger) (*HostEgressBlock, error) {
 	// (in vmIPRange), so unrelated forwarded traffic on a cohabitated host
 	// (Docker, kube, VPN) is left untouched. Guarded by nfproto ipv4 since
 	// this is an inet table.
+	//
+	// This saddr match depends on the in-namespace SNAT in firewall.go
+	// (installNATRules). If that SNAT moves to the host, sandbox packets
+	// would carry the VM IP here instead and this match would silently fail
+	// to scope — keep the two in sync.
 	conn.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,

--- a/internal/network/egressblock.go
+++ b/internal/network/egressblock.go
@@ -16,6 +16,7 @@ package network
 
 import (
 	"fmt"
+	"net/netip"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
@@ -75,13 +76,19 @@ func NewHostEgressBlock(log zerolog.Logger) (*HostEgressBlock, error) {
 		Policy:   &policy,
 	})
 
-	// ip daddr @blocked_v4 drop — guarded by nfproto ipv4 since this is an
-	// inet table (IPv6 sandbox egress is already dropped upstream).
+	// ip saddr <vmIPRange> ip daddr @blocked_v4 drop.
+	//
+	// The source match scopes the drop to sandbox egress: by the time a VM's
+	// packet reaches the host FORWARD hook it has been SNAT'd to its hostIP
+	// (in vmIPRange), so unrelated forwarded traffic on a cohabitated host
+	// (Docker, kube, VPN) is left untouched. Guarded by nfproto ipv4 since
+	// this is an inet table.
 	conn.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
 		Exprs: flatten(
 			nfprotoIPv4(),
+			ipv4SrcInPrefix(vmIPRange),
 			ipv4DstLookup(set),
 			verdictDrop(),
 		),
@@ -139,4 +146,28 @@ func nfprotoIPv4() []expr.Any {
 		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
 		&expr.Cmp{Register: 1, Op: expr.CmpOpEq, Data: []byte{unix.NFPROTO_IPV4}},
 	}
+}
+
+// ipv4SrcInPrefix matches packets whose IPv4 source address falls inside the
+// given CIDR. Panics if cidr is not a valid IPv4 prefix — callers pass a
+// compile-time constant (vmIPRange).
+func ipv4SrcInPrefix(cidr string) []expr.Any {
+	p := netip.MustParsePrefix(cidr)
+	network := p.Masked().Addr().As4()
+	mask := prefixMask4(p.Bits())
+	return []expr.Any{
+		// Load IPv4 src addr (offset 12 in network header, 4 bytes).
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 12, Len: 4},
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: mask[:], Xor: []byte{0, 0, 0, 0}},
+		&expr.Cmp{Register: 1, Op: expr.CmpOpEq, Data: network[:]},
+	}
+}
+
+// prefixMask4 returns the 4-byte network mask for an IPv4 prefix length.
+func prefixMask4(bits int) [4]byte {
+	var m uint32
+	if bits > 0 {
+		m = ^uint32(0) << uint(32-bits)
+	}
+	return [4]byte{byte(m >> 24), byte(m >> 16), byte(m >> 8), byte(m)}
 }

--- a/internal/network/egressblock.go
+++ b/internal/network/egressblock.go
@@ -1,0 +1,142 @@
+package network
+
+// egressblock.go enforces the blocklist's IP/CIDR entries at the host level.
+//
+// The egress proxy only sees traffic on the proxied web ports (80/443 are the
+// only ports REDIRECTed to it), so a Blocked() IP check there does not cover
+// a sandbox dialing a blocklisted address on some other port. This installs a
+// host nftables table whose FORWARD chain drops any forwarded packet destined
+// for a blocklisted IPv4 prefix, on every port and protocol. The set is
+// refreshed from the blocklist on each fetch.
+//
+// The table is independent of the iptables FORWARD rules in hostfw.go: it only
+// ever DROPs, so a misordering relative to those rules can at worst fail to
+// block (the status quo) — it can never accept traffic the host would
+// otherwise drop, nor break egress.
+
+import (
+	"fmt"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"github.com/rs/zerolog"
+	"golang.org/x/sys/unix"
+)
+
+const hostEgressBlockTable = "sandbox-egress-block"
+
+// HostEgressBlock manages the host nftables table that drops traffic to
+// blocklisted IPv4 prefixes. Safe for use from a single refresh goroutine.
+type HostEgressBlock struct {
+	conn  *nftables.Conn
+	table *nftables.Table
+	set   *nftables.Set
+	log   zerolog.Logger
+}
+
+// NewHostEgressBlock creates (or recreates) the host drop table in the current
+// (root) network namespace. Any pre-existing table of the same name is removed
+// first so a vmd restart never stacks duplicate rules.
+func NewHostEgressBlock(log zerolog.Logger) (*HostEgressBlock, error) {
+	// Best-effort clean slate: delete a stale table from a prior lifetime.
+	if c, err := nftables.New(); err == nil {
+		c.DelTable(&nftables.Table{Family: nftables.TableFamilyINet, Name: hostEgressBlockTable})
+		_ = c.Flush() // ignore: table may not exist
+	}
+
+	conn, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		return nil, fmt.Errorf("new nftables conn: %w", err)
+	}
+
+	table := conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   hostEgressBlockTable,
+	})
+
+	set := &nftables.Set{
+		Table:    table,
+		Name:     "blocked_v4",
+		KeyType:  nftables.TypeIPAddr,
+		Interval: true,
+	}
+	if err := conn.AddSet(set, nil); err != nil {
+		conn.CloseLasting()
+		return nil, fmt.Errorf("add blocked_v4 set: %w", err)
+	}
+
+	policy := nftables.ChainPolicyAccept
+	chain := conn.AddChain(&nftables.Chain{
+		Name:     "forward_block",
+		Table:    table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookForward,
+		Priority: nftables.ChainPriorityRef(-10),
+		Policy:   &policy,
+	})
+
+	// ip daddr @blocked_v4 drop — guarded by nfproto ipv4 since this is an
+	// inet table (IPv6 sandbox egress is already dropped upstream).
+	conn.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: flatten(
+			nfprotoIPv4(),
+			ipv4DstLookup(set),
+			verdictDrop(),
+		),
+	})
+
+	if err := conn.Flush(); err != nil {
+		conn.CloseLasting()
+		return nil, fmt.Errorf("install host egress block table: %w", err)
+	}
+
+	return &HostEgressBlock{
+		conn:  conn,
+		table: table,
+		set:   set,
+		log:   log.With().Str("component", "host-egress-block").Logger(),
+	}, nil
+}
+
+// UpdateCIDRs replaces the drop set with the given IPv4 prefixes. Non-IPv4
+// entries are skipped (cidrsToElements handles that). Intended as the
+// Blocklist CIDR sink.
+func (h *HostEgressBlock) UpdateCIDRs(cidrs []string) {
+	elems, err := cidrsToElements(cidrs)
+	if err != nil {
+		h.log.Warn().Err(err).Msg("failed to parse blocklist CIDRs; keeping previous host drop set")
+		return
+	}
+	h.conn.FlushSet(h.set)
+	if len(elems) > 0 {
+		if err := h.conn.SetAddElements(h.set, elems); err != nil {
+			h.log.Warn().Err(err).Msg("failed to stage host drop set update")
+			return
+		}
+	}
+	if err := h.conn.Flush(); err != nil {
+		h.log.Warn().Err(err).Msg("failed to apply host drop set update")
+		return
+	}
+	h.log.Info().Int("cidrs", len(elems)/2).Msg("host egress block set updated")
+}
+
+// Close releases the netlink handle. The kernel table persists.
+func (h *HostEgressBlock) Close() error {
+	if h.conn == nil {
+		return nil
+	}
+	err := h.conn.CloseLasting()
+	h.conn = nil
+	return err
+}
+
+// nfprotoIPv4 matches packets whose network-layer protocol is IPv4.
+func nfprotoIPv4() []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
+		&expr.Cmp{Register: 1, Op: expr.CmpOpEq, Data: []byte{unix.NFPROTO_IPV4}},
+	}
+}

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"net/netip"
+	"sort"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
@@ -695,7 +696,7 @@ func cidrsToElements(cidrs []string) ([]nftables.SetElement, error) {
 		}
 	}
 
-	var elems []nftables.SetElement
+	var prefixes []netip.Prefix
 	for _, cidr := range cidrs {
 		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
@@ -704,7 +705,19 @@ func cidrsToElements(cidrs []string) ([]nftables.SetElement, error) {
 		if !prefix.Addr().Is4() {
 			continue
 		}
-		s4 := prefix.Masked().Addr().As4()
+		prefixes = append(prefixes, prefix.Masked())
+	}
+
+	// Coalesce before emitting: nftables interval sets reject overlapping
+	// elements, and aggregated feeds routinely contain a prefix alongside
+	// one it already covers (e.g. 203.0.113.0/24 and 203.0.113.7/32). A
+	// single rejected element fails the whole flush, so without this the
+	// host drop set would silently stay empty.
+	prefixes = coalescePrefixes(prefixes)
+
+	var elems []nftables.SetElement
+	for _, prefix := range prefixes {
+		s4 := prefix.Addr().As4()
 		e4 := prefixEnd(prefix)
 		elems = append(elems,
 			nftables.SetElement{Key: s4[:]},
@@ -712,6 +725,35 @@ func cidrsToElements(cidrs []string) ([]nftables.SetElement, error) {
 		)
 	}
 	return elems, nil
+}
+
+// coalescePrefixes drops any prefix fully contained within another, plus exact
+// duplicates. Two CIDR prefixes are always either disjoint or nested, so
+// removing contained prefixes eliminates every overlap nftables would reject.
+// Input prefixes must already be masked.
+func coalescePrefixes(prefixes []netip.Prefix) []netip.Prefix {
+	// Broader blocks (shorter prefix length) first, so a covering prefix is
+	// always seen before the entries it covers.
+	sort.Slice(prefixes, func(i, j int) bool {
+		if prefixes[i].Bits() != prefixes[j].Bits() {
+			return prefixes[i].Bits() < prefixes[j].Bits()
+		}
+		return prefixes[i].Addr().Less(prefixes[j].Addr())
+	})
+	var kept []netip.Prefix
+	for _, p := range prefixes {
+		covered := false
+		for _, k := range kept {
+			if k.Bits() <= p.Bits() && k.Contains(p.Addr()) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			kept = append(kept, p)
+		}
+	}
+	return kept
 }
 
 // prefixEnd returns the first address past the prefix range as a 4-byte IPv4.

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -352,6 +352,14 @@ func (fw *Firewall) installNATRules() {
 	hostIP := mustParseAddr(fw.hostIP)
 
 	// POSTROUTING: SNAT outbound from VM IP → host IP.
+	//
+	// INVARIANT: this SNAT happens inside the namespace, so sandbox egress
+	// already appears sourced from hostIP (within vmIPRange) by the time it
+	// reaches the host FORWARD hook. The host egress-block drop relies on
+	// that to scope itself with `ip saddr vmIPRange` (see
+	// internal/network/egressblock.go). If SNAT ever moves to the host,
+	// packets would still carry the VM IP at FORWARD and that drop would
+	// silently stop matching — update both sites together.
 	fw.conn.AddRule(&nftables.Rule{
 		Table: fw.table,
 		Chain: fw.postChain,

--- a/internal/network/firewall_test.go
+++ b/internal/network/firewall_test.go
@@ -1,0 +1,76 @@
+package network
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestCoalescePrefixes(t *testing.T) {
+	parse := func(ss ...string) []netip.Prefix {
+		var out []netip.Prefix
+		for _, s := range ss {
+			out = append(out, netip.MustParsePrefix(s).Masked())
+		}
+		return out
+	}
+	key := func(ps []netip.Prefix) map[string]bool {
+		m := map[string]bool{}
+		for _, p := range ps {
+			m[p.String()] = true
+		}
+		return m
+	}
+
+	tests := []struct {
+		name string
+		in   []netip.Prefix
+		want []string
+	}{
+		{
+			name: "drops prefix covered by a broader one",
+			in:   parse("203.0.113.0/24", "203.0.113.7/32"),
+			want: []string{"203.0.113.0/24"},
+		},
+		{
+			name: "drops exact duplicates",
+			in:   parse("198.51.100.0/24", "198.51.100.0/24"),
+			want: []string{"198.51.100.0/24"},
+		},
+		{
+			name: "keeps disjoint prefixes",
+			in:   parse("10.0.0.0/8", "192.168.0.0/16"),
+			want: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name: "collapses several nested under one",
+			in:   parse("172.16.0.0/12", "172.16.1.0/24", "172.16.1.5/32", "8.8.8.8/32"),
+			want: []string{"172.16.0.0/12", "8.8.8.8/32"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := key(coalescePrefixes(tc.in))
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for _, w := range tc.want {
+				if !got[w] {
+					t.Errorf("missing %s in %v", w, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCidrsToElementsCoalesces(t *testing.T) {
+	// Overlapping input must not produce overlapping interval elements
+	// (which nftables would reject). /24 + contained /32 → just the /24 pair.
+	elems, err := cidrsToElements([]string{"203.0.113.0/24", "203.0.113.7/32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 2 {
+		t.Errorf("got %d set elements, want 2 (one start/end pair)", len(elems))
+	}
+}

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -21,10 +21,15 @@ const vmIPRange = "10.11.0.0/16"
 
 // installHostFirewall installs the static rules that route all VM traffic
 // through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
-// MSS clamp, FORWARD ACCEPT between veth+ and the host iface, MASQUERADE
-// for vmIPRange to the host iface, and REDIRECT HTTP/HTTPS from veth+ to
-// the egress proxy. All operations are idempotent.
-func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, log zerolog.Logger) error {
+// operator-configured egress port DROPs, MSS clamp, FORWARD ACCEPT between
+// veth+ and the host iface, MASQUERADE for vmIPRange to the host iface, and
+// REDIRECT HTTP/HTTPS from veth+ to the egress proxy. All operations are
+// idempotent.
+//
+// blockedPorts come from the operator blocklist config — only ports 80/443
+// are redirected through the egress proxy, so anything else a VM dials goes
+// straight through FORWARD and must be dropped here.
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, blockedPorts []uint16, log zerolog.Logger) error {
 	_, ipnet, err := net.ParseCIDR(vmIPRange)
 	if err != nil {
 		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
@@ -38,16 +43,27 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, l
 		return fmt.Errorf("init iptables: %w", err)
 	}
 
-	// UDP/443 DROP must precede the veth+ ACCEPT below so QUIC traffic
+	// DROP rules must precede the veth+ ACCEPT below so matching traffic
 	// is dropped before the broad ACCEPT terminates the chain walk.
-	udpDrop := []string{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"}
-	exists, err := ipt.Exists("filter", "FORWARD", udpDrop...)
-	if err != nil {
-		return fmt.Errorf("check veth+ UDP/443 DROP: %w", err)
+	// UDP/443 kills the QUIC bypass of the SNI allowlist; blockedPorts are
+	// the operator-configured egress port denylist.
+	drops := [][]string{
+		{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"},
 	}
-	if !exists {
-		if err := ipt.Insert("filter", "FORWARD", 1, udpDrop...); err != nil {
-			return fmt.Errorf("insert veth+ UDP/443 DROP: %w", err)
+	for _, port := range blockedPorts {
+		for _, proto := range []string{"tcp", "udp"} {
+			drops = append(drops, []string{"-i", "veth+", "-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"})
+		}
+	}
+	for _, drop := range drops {
+		exists, err := ipt.Exists("filter", "FORWARD", drop...)
+		if err != nil {
+			return fmt.Errorf("check veth+ DROP %v: %w", drop, err)
+		}
+		if !exists {
+			if err := ipt.Insert("filter", "FORWARD", 1, drop...); err != nil {
+				return fmt.Errorf("insert veth+ DROP %v: %w", drop, err)
+			}
 		}
 	}
 

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -19,6 +19,11 @@ import (
 // vmIPRange must contain every host IP that hostIPForSlot can return.
 const vmIPRange = "10.11.0.0/16"
 
+// portDropChain is the vmd-owned filter chain holding the operator-configured
+// egress port drops. Kept separate from FORWARD so it can be flushed and
+// rebuilt on each start, reconciling away ports removed from config.
+const portDropChain = "SANDBOX_EGRESS_PORTS"
+
 // installHostFirewall installs the static rules that route all VM traffic
 // through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
 // operator-configured egress port DROPs, MSS clamp, FORWARD ACCEPT between
@@ -43,27 +48,44 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, b
 		return fmt.Errorf("init iptables: %w", err)
 	}
 
-	// DROP rules must precede the veth+ ACCEPT below so matching traffic
-	// is dropped before the broad ACCEPT terminates the chain walk.
-	// UDP/443 kills the QUIC bypass of the SNI allowlist; blockedPorts are
-	// the operator-configured egress port denylist.
-	drops := [][]string{
-		{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"},
+	// UDP/443 DROP must precede the veth+ ACCEPT below so QUIC traffic
+	// (which would bypass the SNI allowlist) is dropped before the broad
+	// ACCEPT terminates the chain walk. This rule is static.
+	udpDrop := []string{"-i", "veth+", "-p", "udp", "--dport", "443", "-j", "DROP"}
+	exists, err := ipt.Exists("filter", "FORWARD", udpDrop...)
+	if err != nil {
+		return fmt.Errorf("check veth+ UDP/443 DROP: %w", err)
+	}
+	if !exists {
+		if err := ipt.Insert("filter", "FORWARD", 1, udpDrop...); err != nil {
+			return fmt.Errorf("insert veth+ UDP/443 DROP: %w", err)
+		}
+	}
+
+	// Operator-configured egress port drops live in a vmd-owned chain so the
+	// live ruleset stays in sync with config. ClearChain creates-or-flushes,
+	// so a port removed from blockedPorts since the last start is dropped
+	// from the chain instead of lingering in FORWARD forever. The chain is
+	// entered via a single jump for veth+ traffic, placed before the ACCEPT.
+	if err := ipt.ClearChain("filter", portDropChain); err != nil {
+		return fmt.Errorf("reset %s chain: %w", portDropChain, err)
 	}
 	for _, port := range blockedPorts {
 		for _, proto := range []string{"tcp", "udp"} {
-			drops = append(drops, []string{"-i", "veth+", "-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"})
+			if err := ipt.AppendUnique("filter", portDropChain,
+				"-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"); err != nil {
+				return fmt.Errorf("add %s/%d DROP to %s: %w", proto, port, portDropChain, err)
+			}
 		}
 	}
-	for _, drop := range drops {
-		exists, err := ipt.Exists("filter", "FORWARD", drop...)
-		if err != nil {
-			return fmt.Errorf("check veth+ DROP %v: %w", drop, err)
-		}
-		if !exists {
-			if err := ipt.Insert("filter", "FORWARD", 1, drop...); err != nil {
-				return fmt.Errorf("insert veth+ DROP %v: %w", drop, err)
-			}
+	portJump := []string{"-i", "veth+", "-j", portDropChain}
+	exists, err = ipt.Exists("filter", "FORWARD", portJump...)
+	if err != nil {
+		return fmt.Errorf("check %s jump: %w", portDropChain, err)
+	}
+	if !exists {
+		if err := ipt.Insert("filter", "FORWARD", 1, portJump...); err != nil {
+			return fmt.Errorf("insert %s jump: %w", portDropChain, err)
 		}
 	}
 

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -34,7 +34,11 @@ const portDropChain = "SANDBOX_EGRESS_PORTS"
 // blockedPorts come from the operator blocklist config — only ports 80/443
 // are redirected through the egress proxy, so anything else a VM dials goes
 // straight through FORWARD and must be dropped here.
-func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, blockedPorts []uint16, log zerolog.Logger) error {
+//
+// manageEgressPortChain gates ownership of the shared SANDBOX_EGRESS_PORTS
+// chain: only the vmd daemon reconciles it. Auxiliary managers pass false so
+// a concurrent template build does not flush the daemon's port drops.
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, blockedPorts []uint16, manageEgressPortChain bool, log zerolog.Logger) error {
 	_, ipnet, err := net.ParseCIDR(vmIPRange)
 	if err != nil {
 		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
@@ -67,25 +71,31 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, b
 	// so a port removed from blockedPorts since the last start is dropped
 	// from the chain instead of lingering in FORWARD forever. The chain is
 	// entered via a single jump for veth+ traffic, placed before the ACCEPT.
-	if err := ipt.ClearChain("filter", portDropChain); err != nil {
-		return fmt.Errorf("reset %s chain: %w", portDropChain, err)
-	}
-	for _, port := range blockedPorts {
-		for _, proto := range []string{"tcp", "udp"} {
-			if err := ipt.AppendUnique("filter", portDropChain,
-				"-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"); err != nil {
-				return fmt.Errorf("add %s/%d DROP to %s: %w", proto, port, portDropChain, err)
+	//
+	// Only the chain owner (vmd) touches it. An auxiliary manager flushing
+	// the shared chain would wipe the daemon's port drops for the duration
+	// of, e.g., a template build.
+	if manageEgressPortChain {
+		if err := ipt.ClearChain("filter", portDropChain); err != nil {
+			return fmt.Errorf("reset %s chain: %w", portDropChain, err)
+		}
+		for _, port := range blockedPorts {
+			for _, proto := range []string{"tcp", "udp"} {
+				if err := ipt.AppendUnique("filter", portDropChain,
+					"-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"); err != nil {
+					return fmt.Errorf("add %s/%d DROP to %s: %w", proto, port, portDropChain, err)
+				}
 			}
 		}
-	}
-	portJump := []string{"-i", "veth+", "-j", portDropChain}
-	exists, err = ipt.Exists("filter", "FORWARD", portJump...)
-	if err != nil {
-		return fmt.Errorf("check %s jump: %w", portDropChain, err)
-	}
-	if !exists {
-		if err := ipt.Insert("filter", "FORWARD", 1, portJump...); err != nil {
-			return fmt.Errorf("insert %s jump: %w", portDropChain, err)
+		portJump := []string{"-i", "veth+", "-j", portDropChain}
+		exists, err = ipt.Exists("filter", "FORWARD", portJump...)
+		if err != nil {
+			return fmt.Errorf("check %s jump: %w", portDropChain, err)
+		}
+		if !exists {
+			if err := ipt.Insert("filter", "FORWARD", 1, portJump...); err != nil {
+				return fmt.Errorf("insert %s jump: %w", portDropChain, err)
+			}
 		}
 	}
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -98,6 +98,12 @@ type Manager struct {
 	// blockedEgressPorts are dropped in the host FORWARD chain for all
 	// sandbox traffic. Sourced from the operator blocklist config.
 	blockedEgressPorts []uint16
+
+	// ownsEgressPortChain marks this manager as the sole owner of the
+	// shared SANDBOX_EGRESS_PORTS chain. Only the vmd daemon sets it;
+	// auxiliary managers (template-builder) must not flush the chain or
+	// they would wipe the daemon's port drops on every build.
+	ownsEgressPortChain bool
 }
 
 // SetEgressProxy attaches the TCP egress proxy so the manager can remove
@@ -130,6 +136,15 @@ func WithBlockedEgressPorts(ports []uint16) ManagerOption {
 	return func(m *Manager) { m.blockedEgressPorts = ports }
 }
 
+// WithEgressPortChainOwner marks this manager as the owner of the shared
+// SANDBOX_EGRESS_PORTS chain, so it reconciles (flushes and rebuilds) that
+// chain on startup. Set this only for the vmd daemon — auxiliary managers
+// (e.g. template-builder) must leave the chain alone so concurrent builds
+// don't wipe the daemon's port drops.
+func WithEgressPortChainOwner() ManagerOption {
+	return func(m *Manager) { m.ownsEgressPortChain = true }
+}
+
 func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, opts ...ManagerOption) (*Manager, error) {
 	if err := enableIPForward(ctx); err != nil {
 		return nil, err
@@ -148,7 +163,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.blockedEgressPorts, log.With().Str("component", "host_fw").Logger()); err != nil {
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -94,6 +94,10 @@ type Manager struct {
 	httpProxyPort  uint16
 	tlsProxyPort   uint16
 	otherProxyPort uint16
+
+	// blockedEgressPorts are dropped in the host FORWARD chain for all
+	// sandbox traffic. Sourced from the operator blocklist config.
+	blockedEgressPorts []uint16
 }
 
 // SetEgressProxy attaches the TCP egress proxy so the manager can remove
@@ -119,6 +123,13 @@ func WithHTTPProxyPort(port uint16) ManagerOption {
 	return func(m *Manager) { m.httpProxyPort = port }
 }
 
+// WithBlockedEgressPorts sets destination ports dropped in the host FORWARD
+// chain for all sandbox traffic (TCP and UDP). Ports come from the operator
+// blocklist config.
+func WithBlockedEgressPorts(ports []uint16) ManagerOption {
+	return func(m *Manager) { m.blockedEgressPorts = ports }
+}
+
 func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, opts ...ManagerOption) (*Manager, error) {
 	if err := enableIPForward(ctx); err != nil {
 		return nil, err
@@ -137,7 +148,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, log.With().Str("component", "host_fw").Logger()); err != nil {
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.blockedEgressPorts, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
 

--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -40,6 +40,11 @@ type EgressProxy struct {
 	// maxConnsPerSandbox is the per-sandbox connection limit. -1 = unlimited.
 	maxConnsPerSandbox int
 
+	// blocklist is the global egress denylist (nil = disabled). Checked
+	// before per-sandbox rules; a blocklist hit cannot be overridden by a
+	// sandbox's own allow rules.
+	blocklist *Blocklist
+
 	// sandboxRules maps sandbox host IPs to their egress config.
 	mu    sync.RWMutex
 	rules map[string]*EgressRules // key = sandbox host IP
@@ -62,6 +67,12 @@ func NewEgressProxy(httpPort, tlsPort, otherPort uint16, maxConns int, log zerol
 		maxConnsPerSandbox: maxConns,
 		rules:              make(map[string]*EgressRules),
 	}
+}
+
+// SetBlocklist attaches the global egress denylist. Must be called before
+// Start; the blocklist's own snapshot swapping handles later updates.
+func (p *EgressProxy) SetBlocklist(b *Blocklist) {
+	p.blocklist = b
 }
 
 // SetRules updates the egress rules for a sandbox identified by its host IP.
@@ -218,6 +229,20 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 		peekedData = buf
 	}
 
+	// Global blocklist first — a hit here cannot be overridden by the
+	// sandbox's own allow rules.
+	if p.blocklist != nil {
+		if blocked, dim := p.blocklist.Blocked(hostname, dstIP); blocked {
+			p.log.Warn().
+				Str("src", srcHost).
+				Str("dst", dstIP.String()).
+				Str("hostname", hostname).
+				Str("match", dim).
+				Msg("egress blocked by global blocklist")
+			return
+		}
+	}
+
 	// Check egress rules.
 	rules := p.getRules(srcHost)
 	allowed, matchType := p.isAllowed(rules, hostname, dstIP)
@@ -251,6 +276,11 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 			resolved := net.ParseIP(host)
 			if resolved != nil && IsIPDenied(resolved) {
 				return fmt.Errorf("blocked: hostname resolved to internal IP %s", resolved)
+			}
+			if resolved != nil && p.blocklist != nil {
+				if blocked, _ := p.blocklist.Blocked("", resolved); blocked {
+					return fmt.Errorf("blocked: hostname resolved to blocklisted IP %s", resolved)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
## What

Adds an optional, config-driven egress denylist for sandbox traffic, enforced at two points:

- **Egress proxy** (`internal/network/proxy.go`): connections are checked against the denylist (Host header / SNI plus the original destination IP) before per-sandbox rules are evaluated. Hostnames that re-resolve to a denylisted IP are also rejected at dial time.
- **Host firewall** (`internal/network/hostfw.go`): configured destination ports are dropped (TCP and UDP) at the top of the FORWARD chain for all `veth+` traffic. Only ports 80/443 are redirected through the egress proxy, so other ports are enforced here.

## Configuration

All list contents (feeds, pinned domains/CIDRs, ports) come from an operator-supplied file pointed at by `VMD_EGRESS_BLOCKLIST_CONFIG` — see `deploy/egress-blocklist.example.yaml` for the schema. When the env var is unset the feature is disabled and there is no behavior change.

- Feeds are plain-text (one entry per line, `#` comments): domains, IPs, `IP:port` pairs, or CIDRs.
- Refreshed on a configurable interval with lock-free atomic snapshot swaps.
- A failed refresh keeps the last good snapshot; the merged list is persisted to disk so restarts are seeded before the first fetch.
- Domain matching walks parent labels (`a.b.example.com` matches a listed `example.com`).

## Testing

- New tests in `internal/network/blocklist_test.go`: feed parsing (incl. `IP:port` and CIDR forms), parent-label matching, denylist-precedes-sandbox-allow, last-good-on-feed-failure, config validation, and state-file seeding.
- `GOOS=linux go build ./...` and `go vet` clean; the network package is Linux-only (nftables) so the full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)