### PR TITLE
network: optional transparent DNS redirection for sandbox guests

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -277,6 +277,20 @@ func main() {
 		}
 	}
 
+	// ---- Guest DNS redirect (optional) ----
+	// VMD_DNS_REDIRECT_PORT routes all sandbox DNS (TCP+UDP/53) to a
+	// resolver the operator runs on that host port, regardless of the
+	// nameservers configured inside the guest. Unset = guest DNS goes
+	// out unmodified.
+	if v := os.Getenv("VMD_DNS_REDIRECT_PORT"); v != "" {
+		port, err := strconv.ParseUint(v, 10, 16)
+		if err != nil || port == 0 {
+			log.Fatal().Str("value", v).Msg("VMD_DNS_REDIRECT_PORT must be a port number (1-65535)")
+		}
+		netMgrOpts = append(netMgrOpts, network.WithDNSRedirectPort(uint16(port)))
+		log.Info().Uint64("port", port).Msg("guest DNS redirect enabled")
+	}
+
 	// ---- Network manager + host firewall ----
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -24,21 +24,34 @@ const vmIPRange = "10.11.0.0/16"
 // rebuilt on each start, reconciling away ports removed from config.
 const portDropChain = "SANDBOX_EGRESS_PORTS"
 
+// dnsRedirectChain is the vmd-owned nat chain holding the optional guest DNS
+// redirect. Same reconcile pattern as portDropChain: flushed and rebuilt on
+// each start, so changing or unsetting the resolver port never leaves a stale
+// REDIRECT behind.
+const dnsRedirectChain = "SANDBOX_DNS_REDIRECT"
+
 // installHostFirewall installs the static rules that route all VM traffic
 // through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
 // operator-configured egress port DROPs, MSS clamp, FORWARD ACCEPT between
-// veth+ and the host iface, MASQUERADE for vmIPRange to the host iface, and
-// REDIRECT HTTP/HTTPS from veth+ to the egress proxy. All operations are
+// veth+ and the host iface, MASQUERADE for vmIPRange to the host iface,
+// REDIRECT HTTP/HTTPS from veth+ to the egress proxy, and an optional
+// REDIRECT of all guest DNS to an operator-run resolver. All operations are
 // idempotent.
 //
 // blockedPorts come from the operator blocklist config — only ports 80/443
 // are redirected through the egress proxy, so anything else a VM dials goes
 // straight through FORWARD and must be dropped here.
 //
-// manageEgressPortChain gates ownership of the shared SANDBOX_EGRESS_PORTS
-// chain: only the vmd daemon reconciles it. Auxiliary managers pass false so
-// a concurrent template build does not flush the daemon's port drops.
-func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, blockedPorts []uint16, manageEgressPortChain bool, log zerolog.Logger) error {
+// dnsRedirectPort, when non-zero, redirects all VM DNS (TCP and UDP dport
+// 53) to that port on the host, where the operator runs a resolver. The
+// redirect is transparent: it applies no matter which nameserver the guest
+// image has configured.
+//
+// manageOwnedChains gates ownership of the shared vmd-owned chains
+// (SANDBOX_EGRESS_PORTS, SANDBOX_DNS_REDIRECT): only the vmd daemon
+// reconciles them. Auxiliary managers pass false so a concurrent template
+// build does not flush the daemon's rules.
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort, dnsRedirectPort uint16, blockedPorts []uint16, manageOwnedChains bool, log zerolog.Logger) error {
 	_, ipnet, err := net.ParseCIDR(vmIPRange)
 	if err != nil {
 		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
@@ -75,11 +88,19 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, b
 	// Only the chain owner (vmd) touches it. An auxiliary manager flushing
 	// the shared chain would wipe the daemon's port drops for the duration
 	// of, e.g., a template build.
-	if manageEgressPortChain {
+	if manageOwnedChains {
 		if err := ipt.ClearChain("filter", portDropChain); err != nil {
 			return fmt.Errorf("reset %s chain: %w", portDropChain, err)
 		}
-		for _, port := range blockedPorts {
+		dropPorts := blockedPorts
+		if dnsRedirectPort > 0 {
+			// The DNS redirect below only captures plain DNS on port 53.
+			// Encrypted DNS on its dedicated port (DoT/DoQ, 853) would
+			// silently sidestep the operator's resolver, so it is dropped
+			// whenever the redirect is active.
+			dropPorts = append(append([]uint16(nil), blockedPorts...), 853)
+		}
+		for _, port := range dropPorts {
 			for _, proto := range []string{"tcp", "udp"} {
 				if err := ipt.AppendUnique("filter", portDropChain,
 					"-p", proto, "--dport", fmt.Sprintf("%d", port), "-j", "DROP"); err != nil {
@@ -95,6 +116,29 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, b
 		if !exists {
 			if err := ipt.Insert("filter", "FORWARD", 1, portJump...); err != nil {
 				return fmt.Errorf("insert %s jump: %w", portDropChain, err)
+			}
+		}
+
+		// Guest DNS redirect, in its own vmd-owned nat chain. The jump is
+		// installed unconditionally; with the feature off the chain is
+		// empty and the jump is a no-op, which is also what reconciles
+		// away a redirect removed from config.
+		if err := ipt.ClearChain("nat", dnsRedirectChain); err != nil {
+			return fmt.Errorf("reset %s chain: %w", dnsRedirectChain, err)
+		}
+		for _, args := range dnsRedirectRules(dnsRedirectPort) {
+			if err := ipt.AppendUnique("nat", dnsRedirectChain, args...); err != nil {
+				return fmt.Errorf("add DNS redirect to %s: %w", dnsRedirectChain, err)
+			}
+		}
+		dnsJump := []string{"-i", "veth+", "-j", dnsRedirectChain}
+		exists, err = ipt.Exists("nat", "PREROUTING", dnsJump...)
+		if err != nil {
+			return fmt.Errorf("check %s jump: %w", dnsRedirectChain, err)
+		}
+		if !exists {
+			if err := ipt.Insert("nat", "PREROUTING", 1, dnsJump...); err != nil {
+				return fmt.Errorf("insert %s jump: %w", dnsRedirectChain, err)
 			}
 		}
 	}
@@ -132,6 +176,24 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort uint16, b
 
 	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (static prefix rules)")
 	return nil
+}
+
+// dnsRedirectRules returns the nat rules for the guest DNS redirect: all TCP
+// and UDP traffic destined to port 53 — whatever resolver address the guest
+// has configured — is redirected to the operator's resolver port on the
+// host. Returns nil when the feature is disabled (port 0).
+func dnsRedirectRules(port uint16) [][]string {
+	if port == 0 {
+		return nil
+	}
+	var rules [][]string
+	for _, proto := range []string{"udp", "tcp"} {
+		rules = append(rules, []string{
+			"-p", proto, "--dport", "53",
+			"-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", port),
+		})
+	}
+	return rules
 }
 
 // enableIPForward enables IPv4 forwarding. Called once during Manager init.

--- a/internal/network/hostfw_test.go
+++ b/internal/network/hostfw_test.go
@@ -1,0 +1,20 @@
+package network
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDNSRedirectRules(t *testing.T) {
+	if got := dnsRedirectRules(0); got != nil {
+		t.Fatalf("port 0 must disable the redirect, got %v", got)
+	}
+
+	want := [][]string{
+		{"-p", "udp", "--dport", "53", "-j", "REDIRECT", "--to-port", "19053"},
+		{"-p", "tcp", "--dport", "53", "-j", "REDIRECT", "--to-port", "19053"},
+	}
+	if got := dnsRedirectRules(19053); !reflect.DeepEqual(got, want) {
+		t.Fatalf("dnsRedirectRules(19053) = %v, want %v", got, want)
+	}
+}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -99,6 +99,11 @@ type Manager struct {
 	// sandbox traffic. Sourced from the operator blocklist config.
 	blockedEgressPorts []uint16
 
+	// dnsRedirectPort, when non-zero, transparently redirects all sandbox
+	// DNS (TCP and UDP dport 53) to this host port, where the operator
+	// runs a resolver. Zero leaves guest DNS untouched.
+	dnsRedirectPort uint16
+
 	// ownsEgressPortChain marks this manager as the sole owner of the
 	// shared SANDBOX_EGRESS_PORTS chain. Only the vmd daemon sets it;
 	// auxiliary managers (template-builder) must not flush the chain or
@@ -136,6 +141,15 @@ func WithBlockedEgressPorts(ports []uint16) ManagerOption {
 	return func(m *Manager) { m.blockedEgressPorts = ports }
 }
 
+// WithDNSRedirectPort redirects all sandbox DNS traffic (TCP and UDP port
+// 53) to the given port on the host, regardless of which nameserver the
+// guest has configured. The operator is responsible for running a resolver
+// on that port; with the redirect active, encrypted-DNS bypass on port 853
+// (DoT/DoQ) is dropped. Pass 0 (default) to leave guest DNS untouched.
+func WithDNSRedirectPort(port uint16) ManagerOption {
+	return func(m *Manager) { m.dnsRedirectPort = port }
+}
+
 // WithEgressPortChainOwner marks this manager as the owner of the shared
 // SANDBOX_EGRESS_PORTS chain, so it reconciles (flushes and rebuilds) that
 // chain on startup. Set this only for the vmd daemon — auxiliary managers
@@ -163,7 +177,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
 


### PR DESCRIPTION
Adds an opt-in, config-driven way to route all sandbox DNS through an operator-run resolver.

When `VMD_DNS_REDIRECT_PORT` is set, the host firewall transparently redirects all guest DNS (TCP and UDP port 53, whichever nameserver the guest image has configured) to that port on the host, where the operator runs a resolver of their choice — e.g. unbound or bind, for caching, internal zones, or whatever resolution policy the deployment needs. Because encrypted DNS on its dedicated port would sidestep the configured resolver, TCP/UDP 853 (DoT/DoQ) is dropped while the redirect is active.

Implementation follows the existing patterns in `internal/network`:

- The redirect lives in a vmd-owned nat chain (`SANDBOX_DNS_REDIRECT`) that is flushed and rebuilt on each start, so changing or unsetting the port reconciles cleanly — same pattern as `SANDBOX_EGRESS_PORTS`.
- Same `REDIRECT` mechanism as the existing 80/443 egress-proxy interception; conntrack handles reply un-NAT, so the guest sees answers from whatever resolver address it queried.
- New `WithDNSRedirectPort` manager option. Only the daemon (chain owner) reconciles the chain, so concurrent template builds can't wipe it.
- Applies host-side to all `veth+` traffic, so it covers running VMs immediately — no template rebuild required.

With the env var unset there is no behavior change, and the owned chain is cleared on startup so a previously installed redirect is removed.

Operator note: the resolver must listen on the redirect port reachable via the host-side veth addresses (simplest: `0.0.0.0:<port>`) and accept queries from the sandbox source range (`10.11.0.0/16`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)