### PR TITLE
limits: lower default per-team caps to 10 sandboxes and 5 templates

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -234,15 +234,19 @@ func run() error {
 	return nil
 }
 
-// reconcileSystemTeamQuota lifts the system team's max_sandboxes above any
-// realistic cap so the sandbox_quota_on_insert trigger never rejects it.
+// reconcileSystemTeamQuota lifts the system team's max_sandboxes and
+// max_templates so the quota trigger and template-count check never block it.
 func reconcileSystemTeamQuota(ctx context.Context, pool *pgxpool.Pool, systemTeamID string) {
 	if systemTeamID == "" {
 		return
 	}
 	tag, err := pool.Exec(ctx,
-		`UPDATE team SET max_sandboxes = $1
-		 WHERE id = $2 AND (max_sandboxes IS NULL OR max_sandboxes < $1)`,
+		`UPDATE team
+		 SET max_sandboxes = $1,
+		     max_templates = $1
+		 WHERE id = $2
+		   AND (max_sandboxes IS NULL OR max_sandboxes < $1
+		     OR max_templates IS NULL OR max_templates < $1)`,
 		math.MaxInt32, systemTeamID,
 	)
 	if err != nil {

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -103,7 +103,7 @@ const (
 	defaultMaxVcpu      = 2
 	defaultMaxMemoryMib = 2048
 	defaultMaxDiskMib   = 8192
-	defaultMaxTemplates = 50
+	defaultMaxTemplates = 5
 
 	defaultVcpu     = 1
 	defaultMemoryMi = 1024

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -103,7 +103,7 @@ const (
 	defaultMaxVcpu      = 2
 	defaultMaxMemoryMib = 2048
 	defaultMaxDiskMib   = 8192
-	defaultMaxTemplates = 5
+	defaultMaxTemplates = 10
 
 	defaultVcpu     = 1
 	defaultMemoryMi = 1024

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -13,14 +13,14 @@ func ptrInt32(v int32) *int32 { return &v }
 func TestComputeQuotaAlerts(t *testing.T) {
 	atThreshold := uuid.New()  // sandboxes 80/100 = 80% -> alert
 	below := uuid.New()        // sandboxes 79/100 = 79% -> no
-	tmplDefault := uuid.New()  // templates 40/50 via default 50 = 80% -> alert
+	tmplDefault := uuid.New()  // templates 4/5 via default 5 = 80% -> alert
 	tmplOverride := uuid.New() // templates 10/200 (override) = 5% -> no
 	zeroLimit := uuid.New()    // max 0 -> must not alert or panic
 
 	rows := []db.ListTeamQuotaUsageRow{
 		{ID: atThreshold, Name: "at", ActiveSandboxCount: 80, MaxSandboxes: 100},
 		{ID: below, Name: "below", ActiveSandboxCount: 79, MaxSandboxes: 100, TemplateCount: 1},
-		{ID: tmplDefault, Name: "tdefault", MaxSandboxes: 100, TemplateCount: 40}, // MaxTemplates nil -> default
+		{ID: tmplDefault, Name: "tdefault", MaxSandboxes: 100, TemplateCount: 4}, // MaxTemplates nil -> default
 		{ID: tmplOverride, Name: "toverride", MaxSandboxes: 100, MaxTemplates: ptrInt32(200), TemplateCount: 10},
 		{ID: zeroLimit, Name: "zero", ActiveSandboxCount: 5, MaxSandboxes: 0},
 	}

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -13,14 +13,14 @@ func ptrInt32(v int32) *int32 { return &v }
 func TestComputeQuotaAlerts(t *testing.T) {
 	atThreshold := uuid.New()  // sandboxes 80/100 = 80% -> alert
 	below := uuid.New()        // sandboxes 79/100 = 79% -> no
-	tmplDefault := uuid.New()  // templates 4/5 via default 5 = 80% -> alert
+	tmplDefault := uuid.New()  // templates 8/10 via default 10 = 80% -> alert
 	tmplOverride := uuid.New() // templates 10/200 (override) = 5% -> no
 	zeroLimit := uuid.New()    // max 0 -> must not alert or panic
 
 	rows := []db.ListTeamQuotaUsageRow{
 		{ID: atThreshold, Name: "at", ActiveSandboxCount: 80, MaxSandboxes: 100},
 		{ID: below, Name: "below", ActiveSandboxCount: 79, MaxSandboxes: 100, TemplateCount: 1},
-		{ID: tmplDefault, Name: "tdefault", MaxSandboxes: 100, TemplateCount: 4}, // MaxTemplates nil -> default
+		{ID: tmplDefault, Name: "tdefault", MaxSandboxes: 100, TemplateCount: 8}, // MaxTemplates nil -> default
 		{ID: tmplOverride, Name: "toverride", MaxSandboxes: 100, MaxTemplates: ptrInt32(200), TemplateCount: 10},
 		{ID: zeroLimit, Name: "zero", ActiveSandboxCount: 5, MaxSandboxes: 0},
 	}

--- a/supabase/migrations/20260612000001_lower_default_limits.sql
+++ b/supabase/migrations/20260612000001_lower_default_limits.sql
@@ -1,6 +1,3 @@
--- Lower per-team caps. max_sandboxes default 100 -> 10. Existing teams on
--- the old default are reduced; explicit overrides are preserved.
--- max_templates lives in code (defaultMaxTemplates, also dropped to 5).
--- Per-team exemptions, if any, are applied out-of-band after this runs.
+-- max_sandboxes default 100 -> 10. Templates default in code.
 ALTER TABLE team ALTER COLUMN max_sandboxes SET DEFAULT 10;
 UPDATE team SET max_sandboxes = 10 WHERE max_sandboxes = 100;

--- a/supabase/migrations/20260612000001_lower_default_limits.sql
+++ b/supabase/migrations/20260612000001_lower_default_limits.sql
@@ -1,3 +1,3 @@
--- max_sandboxes default 100 -> 10. Templates default in code.
-ALTER TABLE team ALTER COLUMN max_sandboxes SET DEFAULT 10;
-UPDATE team SET max_sandboxes = 10 WHERE max_sandboxes = 100;
+-- max_sandboxes default 100 -> 20; bumps rows still on the old default. Templates default in code.
+ALTER TABLE team ALTER COLUMN max_sandboxes SET DEFAULT 20;
+UPDATE team SET max_sandboxes = 20 WHERE max_sandboxes = 100;

--- a/supabase/migrations/20260612000001_lower_default_limits.sql
+++ b/supabase/migrations/20260612000001_lower_default_limits.sql
@@ -1,0 +1,6 @@
+-- Lower per-team caps. max_sandboxes default 100 -> 10. Existing teams on
+-- the old default are reduced; explicit overrides are preserved.
+-- max_templates lives in code (defaultMaxTemplates, also dropped to 5).
+-- Per-team exemptions, if any, are applied out-of-band after this runs.
+ALTER TABLE team ALTER COLUMN max_sandboxes SET DEFAULT 10;
+UPDATE team SET max_sandboxes = 10 WHERE max_sandboxes = 100;


### PR DESCRIPTION
Drops the per-team defaults from 100 sandboxes / 50 templates to 10 / 5 to shrink the abuse blast radius. Existing teams on the old default are reduced; explicit overrides are preserved. The system team's quotas are reconciled at controlplane start. Any per-team exemptions are applied out-of-band after this lands.