### PR TITLE
secrets [3/6]: MITM enforcement daemon

### DIFF
--- a/cmd/secretsproxy/main.go
+++ b/cmd/secretsproxy/main.go
@@ -1,0 +1,368 @@
+// Command secretsproxy runs the in-host MITM enforcement daemon.
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	yaml "go.yaml.in/yaml/v3"
+
+	dbq "github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/egresspolicy"
+	"github.com/superserve-ai/sandbox/internal/secretsproxy"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal().Err(err).Msg("secretsproxy exited with error")
+	}
+}
+
+func run() error {
+	zerolog.TimeFieldFormat = time.RFC3339
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
+		With().Str("svc", "secretsproxy").Logger()
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	rootCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	ca, err := secretsproxy.NewCA(cfg.CACertPath, cfg.CAKeyPath, cfg.CertCacheSize)
+	if err != nil {
+		return fmt.Errorf("init CA: %w", err)
+	}
+	log.Info().
+		Str("ca_cert", cfg.CACertPath).
+		Str("ca_key", cfg.CAKeyPath).
+		Msg("CA initialized")
+
+	jwksFetcher := secretsproxy.NewHTTPJWKSFetcher(cfg.ControlPlaneURL, cfg.DaemonAuthToken)
+	verifier, err := secretsproxy.NewVerifier(rootCtx, jwksFetcher)
+	if err != nil {
+		return fmt.Errorf("init JWKS: %w", err)
+	}
+	resolver := secretsproxy.NewJWTResolver(verifier)
+	log.Info().Str("control_plane", cfg.ControlPlaneURL).Msg("JWKS loaded from control plane")
+
+	httpVault := secretsproxy.NewHTTPVaultClient(cfg.ControlPlaneURL, cfg.DaemonAuthToken)
+	cachedVault := secretsproxy.NewCachedVault(httpVault, secretsproxy.VaultCacheOptions{
+		TTL:      cfg.VaultCacheTTL,
+		IdleTTL:  cfg.VaultCacheIdleTTL,
+		Capacity: cfg.VaultCacheCapacity,
+	})
+
+	httpRules := secretsproxy.NewHTTPRulesClient(cfg.ControlPlaneURL, cfg.DaemonAuthToken)
+	cachedRules := secretsproxy.NewCachedRules(httpRules, secretsproxy.RulesCacheOptions{})
+
+	revoker := secretsproxy.NewRevoker()
+	revoked, err := secretsproxy.FetchRevokedSandboxes(rootCtx, cfg.ControlPlaneURL, cfg.DaemonAuthToken)
+	if err != nil {
+		return fmt.Errorf("bootstrap revocations: %w", err)
+	}
+	revoker.Bootstrap(revoked)
+	log.Info().Int("revoked_sandboxes", len(revoked)).Msg("revocations loaded from control plane")
+
+	auditSink, dbCleanup, err := buildAuditSink(rootCtx, cfg)
+	if err != nil {
+		return fmt.Errorf("init audit sink: %w", err)
+	}
+	defer func() {
+		if dbCleanup != nil {
+			dbCleanup()
+		}
+	}()
+
+	blockedPorts, err := loadBlockedPorts(cfg.BlocklistConfigPath)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not load blocked egress ports; port policy disabled")
+	}
+
+	dnsResolver := buildPolicyResolver(cfg.UpstreamResolverAddr)
+	proxy := secretsproxy.NewProxy(cfg.ProxyAddr, secretsproxy.Options{
+		CA:                  ca,
+		Resolver:            resolver,
+		Vault:               cachedVault,
+		Rules:               cachedRules,
+		Audit:               auditSink,
+		Revoker:             revoker,
+		SandboxFacingHost:   cfg.SandboxFacingHost,
+		MaxRequestBodyBytes: cfg.MaxRequestBodyBytes,
+		UpstreamTransport:   buildUpstreamTransport(dnsResolver),
+		BlockedPorts:        blockedPorts,
+		BlockInternalAddrs:  true,
+		DNSResolver:         dnsResolver,
+	})
+	if cfg.UpstreamResolverAddr != "" {
+		log.Info().Str("resolver", cfg.UpstreamResolverAddr).Msg("upstream name resolution routed through policy resolver")
+	}
+	if len(blockedPorts) > 0 {
+		log.Info().Int("count", len(blockedPorts)).Msg("egress port policy loaded")
+	}
+	proxyErrCh := make(chan error, 1)
+	go func() { proxyErrCh <- proxy.ListenAndServe() }()
+	log.Info().Str("addr", cfg.ProxyAddr).Msg("proxy listener started")
+
+	control := secretsproxy.NewControlServer(cfg.ControlSocketPath, cachedVault, cachedRules, revoker)
+	controlErrCh := make(chan error, 1)
+	go func() { controlErrCh <- control.ListenAndServe() }()
+	log.Info().Str("socket", cfg.ControlSocketPath).Msg("control RPC listener started")
+
+	select {
+	case <-rootCtx.Done():
+		log.Info().Msg("shutdown signal received")
+	case err := <-proxyErrCh:
+		if !isClosedServer(err) {
+			log.Error().Err(err).Msg("proxy listener exited unexpectedly")
+		}
+	case err := <-controlErrCh:
+		if !isClosedServer(err) {
+			log.Error().Err(err).Msg("control listener exited unexpectedly")
+		}
+	}
+
+	// Graceful shutdown — bound so a wedged peer can't hold us forever.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = proxy.Shutdown(shutdownCtx)
+	_ = control.Shutdown(shutdownCtx)
+	_ = auditSink.Shutdown(shutdownCtx)
+
+	if dropped := droppedCount(auditSink); dropped > 0 {
+		log.Warn().Int64("dropped", dropped).Msg("audit events dropped at shutdown")
+	}
+	return nil
+}
+
+func isClosedServer(err error) bool {
+	if err == nil {
+		return true
+	}
+	return err == http.ErrServerClosed
+}
+
+// droppedCount returns the SQLAuditSink dropped counter, or 0 for other sinks.
+func droppedCount(sink secretsproxy.AuditSink) int64 {
+	if s, ok := sink.(*secretsproxy.SQLAuditSink); ok {
+		return s.Dropped()
+	}
+	return 0
+}
+
+// loadBlockedPorts reads blocked_egress_ports from the operator egress-blocklist
+// YAML. An empty path yields no blocked ports.
+func loadBlockedPorts(path string) ([]int, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read blocklist config: %w", err)
+	}
+	var doc struct {
+		BlockedEgressPorts []int `yaml:"blocked_egress_ports"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse blocklist config %s: %w", path, err)
+	}
+	return doc.BlockedEgressPorts, nil
+}
+
+// buildPolicyResolver returns a resolver that sends queries to resolverAddr so
+// resolution follows the same egress policy as guest traffic. A nil result
+// (resolverAddr unset) means the default resolver.
+func buildPolicyResolver(resolverAddr string) *net.Resolver {
+	if resolverAddr == "" {
+		return nil
+	}
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 5 * time.Second}
+			return d.DialContext(ctx, network, resolverAddr)
+		},
+	}
+}
+
+// buildUpstreamTransport builds the upstream transport, resolving through res
+// and applying the internal-IP guard on every dial.
+func buildUpstreamTransport(res *net.Resolver) *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   denyInternalDial,
+		Resolver:  res,
+	}
+	return &http.Transport{
+		DialContext:           dialer.DialContext,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ForceAttemptHTTP2:     false,
+	}
+}
+
+// denyInternalDial rejects dials to internal ranges. Running on the resolved
+// address, it catches IP-literal targets and hostnames that resolve internally.
+func denyInternalDial(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	if ip := net.ParseIP(host); ip != nil && egresspolicy.IsIPDenied(ip) {
+		return fmt.Errorf("blocked: internal address %s", ip)
+	}
+	return nil
+}
+
+type config struct {
+	ProxyAddr         string
+	ControlSocketPath string
+	CACertPath        string
+	CAKeyPath         string
+	CertCacheSize     int
+
+	ControlPlaneURL    string
+	DaemonAuthToken    string
+	VaultCacheTTL      time.Duration
+	VaultCacheIdleTTL  time.Duration
+	VaultCacheCapacity int
+
+	DatabaseURL string
+
+	AuditBufferSize int
+	AuditBatchSize  int
+	AuditFlushEvery time.Duration
+
+	SandboxFacingHost   string
+	MaxRequestBodyBytes int64
+
+	// UpstreamResolverAddr, when set, routes upstream name resolution through
+	// this DNS server (host:port) so dials follow the same egress policy as
+	// guest traffic.
+	UpstreamResolverAddr string
+
+	// BlocklistConfigPath points at the operator egress-blocklist YAML. Its
+	// blocked_egress_ports are refused at CONNECT, matching the host firewall.
+	BlocklistConfigPath string
+}
+
+func loadConfig() (*config, error) {
+	c := &config{
+		ProxyAddr:            envOr("SECRETSPROXY_LISTEN", "0.0.0.0:9443"),
+		ControlSocketPath:    envOr("SECRETSPROXY_SOCKET", "/run/secretsproxy/control.sock"),
+		CACertPath:           envOr("SECRETSPROXY_CA_CERT", "/var/lib/secretsproxy/ca.crt"),
+		CAKeyPath:            envOr("SECRETSPROXY_CA_KEY", "/var/lib/secretsproxy/ca.key"),
+		CertCacheSize:        1024,
+		ControlPlaneURL:      strings.TrimRight(envOr("CONTROL_PLANE_URL", ""), "/"),
+		DaemonAuthToken:      os.Getenv("DAEMON_AUTH_TOKEN"),
+		VaultCacheTTL:        parseDur(os.Getenv("VAULT_CACHE_TTL"), 60*time.Second),
+		VaultCacheIdleTTL:    parseDur(os.Getenv("VAULT_CACHE_IDLE_TTL"), 10*time.Minute),
+		VaultCacheCapacity:   int(parseInt64Bytes(os.Getenv("VAULT_CACHE_CAPACITY"), 1024)),
+		DatabaseURL:          os.Getenv("DATABASE_URL"),
+		AuditBufferSize:      4096,
+		AuditBatchSize:       64,
+		AuditFlushEvery:      250 * time.Millisecond,
+		MaxRequestBodyBytes:  parseInt64Bytes(os.Getenv("SECRETSPROXY_MAX_BODY_BYTES"), 256*1024*1024),
+		UpstreamResolverAddr: strings.TrimSpace(os.Getenv("SECRETSPROXY_DNS_RESOLVER")),
+		BlocklistConfigPath:  strings.TrimSpace(os.Getenv("SECRETSPROXY_BLOCKLIST_CONFIG")),
+	}
+	flag.StringVar(&c.ProxyAddr, "listen", c.ProxyAddr, "proxy listener address (host:port)")
+	flag.StringVar(&c.ControlSocketPath, "socket", c.ControlSocketPath, "control RPC unix socket path")
+	flag.Parse()
+
+	if c.ControlPlaneURL == "" {
+		return nil, fmt.Errorf("CONTROL_PLANE_URL is required")
+	}
+	if c.DaemonAuthToken == "" {
+		return nil, fmt.Errorf("DAEMON_AUTH_TOKEN is required")
+	}
+	if addr := os.Getenv("SECRETSPROXY_SANDBOX_ADDR"); addr != "" {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("SECRETSPROXY_SANDBOX_ADDR %q: %w", addr, err)
+		}
+		c.SandboxFacingHost = host
+	}
+	if c.UpstreamResolverAddr != "" {
+		if _, _, err := net.SplitHostPort(c.UpstreamResolverAddr); err != nil {
+			return nil, fmt.Errorf("SECRETSPROXY_DNS_RESOLVER %q: %w", c.UpstreamResolverAddr, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(c.CACertPath), 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir CA dir: %w", err)
+	}
+	return c, nil
+}
+
+func envOr(k, fallback string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseDur(raw string, fallback time.Duration) time.Duration {
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return d
+}
+
+func parseInt64Bytes(raw string, fallback int64) int64 {
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n <= 0 {
+		return fallback
+	}
+	return n
+}
+
+// buildAuditSink returns the SQL sink; missing DATABASE_URL fails closed unless SECRETSPROXY_AUDIT_DISABLED=true.
+func buildAuditSink(ctx context.Context, cfg *config) (secretsproxy.AuditSink, func(), error) {
+	if cfg.DatabaseURL == "" {
+		if os.Getenv("SECRETSPROXY_AUDIT_DISABLED") == "true" {
+			log.Warn().Msg("SECRETSPROXY_AUDIT_DISABLED=true; audit events will be discarded")
+			return secretsproxy.NewNopAuditSink(), nil, nil
+		}
+		return nil, nil, fmt.Errorf("DATABASE_URL is required; set SECRETSPROXY_AUDIT_DISABLED=true to run without audit")
+	}
+	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("connect to audit DB: %w", err)
+	}
+	queries := dbq.New(pool)
+	sink := secretsproxy.NewSQLAuditSink(queries, secretsproxy.SQLAuditSinkOptions{
+		BufferSize:    cfg.AuditBufferSize,
+		BatchSize:     cfg.AuditBatchSize,
+		FlushInterval: cfg.AuditFlushEvery,
+	})
+	cleanup := func() { pool.Close() }
+	log.Info().Msg("audit sink: SQL")
+	return sink, cleanup, nil
+}

--- a/cmd/secretsproxy/main_test.go
+++ b/cmd/secretsproxy/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildUpstreamTransport(t *testing.T) {
+	// DialContext is always set so the internal-IP guard applies, whether or
+	// not a policy resolver is configured.
+	if got := buildUpstreamTransport(nil); got.DialContext == nil {
+		t.Error("DialContext should be set for the internal-IP guard without a resolver")
+	}
+	if got := buildUpstreamTransport(buildPolicyResolver("127.0.0.1:19053")); got.DialContext == nil {
+		t.Error("DialContext should be set with a resolver")
+	}
+}
+
+func TestDenyInternalDial(t *testing.T) {
+	cases := []struct {
+		addr      string
+		wantBlock bool
+	}{
+		{"10.0.0.1:443", true},
+		{"169.254.169.254:443", true},
+		{"192.168.0.5:8080", true},
+		{"8.8.8.8:443", false},
+		{"1.1.1.1:80", false},
+	}
+	for _, c := range cases {
+		err := denyInternalDial("tcp", c.addr, nil)
+		if (err != nil) != c.wantBlock {
+			t.Errorf("denyInternalDial(%q) err=%v, wantBlock=%v", c.addr, err, c.wantBlock)
+		}
+	}
+}
+
+func TestLoadBlockedPorts(t *testing.T) {
+	// No path configured: no ports, no error.
+	if ports, err := loadBlockedPorts(""); err != nil || ports != nil {
+		t.Errorf("empty path: ports=%v err=%v", ports, err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blocklist.yaml")
+	if err := os.WriteFile(path, []byte("blocked_egress_ports:\n  - 3333\n  - 4444\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ports, err := loadBlockedPorts(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ports) != 2 || ports[0] != 3333 || ports[1] != 4444 {
+		t.Errorf("got %v, want [3333 4444]", ports)
+	}
+}

--- a/deploy/superserve-secretsproxy.service
+++ b/deploy/superserve-secretsproxy.service
@@ -1,0 +1,52 @@
+[Unit]
+Description=Superserve Secrets Proxy Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/secretsproxy
+EnvironmentFile=/etc/sandbox/secretsproxy.env
+
+# /var/lib/secretsproxy persists the CA cert+key across restarts.
+# Regenerating breaks every sandbox that trusts the previous CA.
+StateDirectory=secretsproxy
+StateDirectoryMode=0700
+# /run/secretsproxy is owned by the dynamic user; the control socket lives here.
+RuntimeDirectory=secretsproxy
+RuntimeDirectoryMode=0700
+
+# Drop root — the daemon holds the CA private key and KMS-derived
+# credentials. systemd chowns StateDirectory and RuntimeDirectory on each start.
+DynamicUser=yes
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectClock=true
+ProtectHostname=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+
+KillMode=process
+Restart=always
+RestartSec=2
+LimitNOFILE=65536
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=secretsproxy
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/secretsproxy/audit.go
+++ b/internal/secretsproxy/audit.go
@@ -1,0 +1,224 @@
+package secretsproxy
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// AuditEvent is one row in the proxy_audit table.
+type AuditEvent struct {
+	TeamID    string
+	SandboxID string
+	SecretID  string // empty for passthrough (no credential used)
+
+	Method string
+	Host   string
+	Path   string
+
+	// Status is the status returned to the sandbox; UpstreamStatus is set only
+	// when the request was forwarded.
+	Status         int32
+	UpstreamStatus *int32
+	LatencyMs      int32
+	// ErrorCode is the short proxy-reason on rejection.
+	ErrorCode string
+}
+
+// AuditSink receives AuditEvents from the proxy.
+type AuditSink interface {
+	Emit(ev AuditEvent)
+	// Shutdown drains buffered events, bounded by ctx.
+	Shutdown(ctx context.Context) error
+}
+
+// nopAuditSink discards events.
+type nopAuditSink struct{}
+
+// NewNopAuditSink returns an AuditSink that discards every event.
+func NewNopAuditSink() AuditSink { return nopAuditSink{} }
+
+func (nopAuditSink) Emit(AuditEvent)                {}
+func (nopAuditSink) Shutdown(context.Context) error { return nil }
+
+// SQLAuditSink writes batched AuditEvents to proxy_audit. Drops on a full
+// buffer instead of back-pressuring the request path.
+type SQLAuditSink struct {
+	queries *db.Queries
+
+	bufSize   int
+	batchSize int
+	flushTick time.Duration
+
+	ch       chan AuditEvent
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+	stop     chan struct{}
+
+	dropMu  sync.Mutex
+	dropped int64
+}
+
+// SQLAuditSinkOptions tunes the sink. Zero values fall back to defaults
+// (BufferSize 4096, BatchSize 64, FlushInterval 250ms).
+type SQLAuditSinkOptions struct {
+	BufferSize    int
+	BatchSize     int
+	FlushInterval time.Duration
+}
+
+// NewSQLAuditSink starts the background writer.
+func NewSQLAuditSink(queries *db.Queries, opts SQLAuditSinkOptions) *SQLAuditSink {
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = 4096
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 64
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = 250 * time.Millisecond
+	}
+	s := &SQLAuditSink{
+		queries:   queries,
+		bufSize:   opts.BufferSize,
+		batchSize: opts.BatchSize,
+		flushTick: opts.FlushInterval,
+		ch:        make(chan AuditEvent, opts.BufferSize),
+		stop:      make(chan struct{}),
+	}
+	s.wg.Add(1)
+	go s.run()
+	return s
+}
+
+// Emit is non-blocking; drops on a full buffer (tracked by Dropped).
+func (s *SQLAuditSink) Emit(ev AuditEvent) {
+	select {
+	case s.ch <- ev:
+	default:
+		s.dropMu.Lock()
+		s.dropped++
+		s.dropMu.Unlock()
+	}
+}
+
+// Dropped returns the cumulative number of events dropped due to a full buffer.
+func (s *SQLAuditSink) Dropped() int64 {
+	s.dropMu.Lock()
+	defer s.dropMu.Unlock()
+	return s.dropped
+}
+
+// Shutdown stops the writer and drains the buffer, bounded by ctx.
+func (s *SQLAuditSink) Shutdown(ctx context.Context) error {
+	s.stopOnce.Do(func() { close(s.stop) })
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// run drains the channel into batched inserts on size or time triggers.
+func (s *SQLAuditSink) run() {
+	defer s.wg.Done()
+	batch := make([]AuditEvent, 0, s.batchSize)
+	ticker := time.NewTicker(s.flushTick)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		s.writeBatch(batch)
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case ev := <-s.ch:
+			batch = append(batch, ev)
+			if len(batch) >= s.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-s.stop:
+			// Drain queued events before exiting.
+			for {
+				select {
+				case ev := <-s.ch:
+					batch = append(batch, ev)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+func (s *SQLAuditSink) writeBatch(batch []AuditEvent) {
+	// Fire-and-forget: per-row failures are logged and skipped.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, ev := range batch {
+		params, perr := auditEventToParams(ev)
+		if perr != nil {
+			log.Warn().Err(perr).Msg("secretsproxy: drop audit event with malformed ids")
+			continue
+		}
+		if err := s.queries.InsertProxyAudit(ctx, params); err != nil {
+			log.Warn().Err(err).Msg("secretsproxy: InsertProxyAudit failed")
+		}
+	}
+}
+
+func auditEventToParams(ev AuditEvent) (db.InsertProxyAuditParams, error) {
+	teamID, err := uuid.Parse(ev.TeamID)
+	if err != nil {
+		return db.InsertProxyAuditParams{}, err
+	}
+	sandboxID, err := uuid.Parse(ev.SandboxID)
+	if err != nil {
+		return db.InsertProxyAuditParams{}, err
+	}
+	var secretID pgtype.UUID
+	if ev.SecretID != "" {
+		parsed, err := uuid.Parse(ev.SecretID)
+		if err != nil {
+			return db.InsertProxyAuditParams{}, err
+		}
+		secretID = pgtype.UUID{Bytes: parsed, Valid: true}
+	}
+	var errorCode *string
+	if ev.ErrorCode != "" {
+		c := ev.ErrorCode
+		errorCode = &c
+	}
+	latency := ev.LatencyMs
+	return db.InsertProxyAuditParams{
+		TeamID:         teamID,
+		SandboxID:      sandboxID,
+		SecretID:       secretID,
+		Method:         ev.Method,
+		Host:           ev.Host,
+		Path:           ev.Path,
+		Status:         ev.Status,
+		UpstreamStatus: ev.UpstreamStatus,
+		LatencyMs:      &latency,
+		ErrorCode:      errorCode,
+	}, nil
+}

--- a/internal/secretsproxy/ca.go
+++ b/internal/secretsproxy/ca.go
@@ -1,0 +1,272 @@
+// Package secretsproxy is the in-host MITM enforcement daemon: it terminates
+// TLS, applies the allowlist + credential-injection pipeline, and forwards upstream.
+package secretsproxy
+
+import (
+	"container/list"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// CA mints leaf certificates on demand for each intercepted hostname.
+type CA struct {
+	rootCert *x509.Certificate
+	rootKey  *ecdsa.PrivateKey
+	rootPEM  []byte
+	cache    *leafCache
+}
+
+const (
+	leafLifetime = 72 * time.Hour
+	rootLifetime = 10 * 365 * 24 * time.Hour
+)
+
+// NewCA loads the CA from disk or generates a new one and persists the key with mode 0600.
+func NewCA(caCertPath, caKeyPath string, cacheSize int) (*CA, error) {
+	certPEM, errCert := os.ReadFile(caCertPath)
+	keyPEM, errKey := os.ReadFile(caKeyPath)
+
+	switch {
+	case errCert == nil && errKey == nil:
+		return loadCA(certPEM, keyPEM, cacheSize)
+	case errors.Is(errCert, os.ErrNotExist) && errors.Is(errKey, os.ErrNotExist):
+		return generateAndPersistCA(caCertPath, caKeyPath, cacheSize)
+	default:
+		// One file present, one missing → fail loud rather than orphan trust.
+		if errCert != nil {
+			return nil, fmt.Errorf("read CA cert: %w", errCert)
+		}
+		return nil, fmt.Errorf("read CA key: %w", errKey)
+	}
+}
+
+func loadCA(certPEM, keyPEM []byte, cacheSize int) (*CA, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("CA cert PEM is missing or wrong type")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA cert: %w", err)
+	}
+
+	kblock, _ := pem.Decode(keyPEM)
+	if kblock == nil || kblock.Type != "EC PRIVATE KEY" {
+		return nil, errors.New("CA key PEM is missing or wrong type (want EC PRIVATE KEY)")
+	}
+	key, err := x509.ParseECPrivateKey(kblock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA key: %w", err)
+	}
+	return &CA{
+		rootCert: cert,
+		rootKey:  key,
+		rootPEM:  certPEM,
+		cache:    newLeafCache(cacheSize),
+	}, nil
+}
+
+// GenerateCA mints a fresh ECDSA P-256 self-signed CA and returns the PEM pair.
+func GenerateCA() (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Superserve Sandbox Proxy CA",
+			Organization: []string{"Superserve"},
+		},
+		NotBefore:             time.Now().Add(-5 * time.Minute),
+		NotAfter:              time.Now().Add(rootLifetime),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("self-sign CA: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal CA key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+func generateAndPersistCA(caCertPath, caKeyPath string, cacheSize int) (*CA, error) {
+	certPEM, keyPEM, err := GenerateCA()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(caCertPath), 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir CA cert dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(caKeyPath), 0o700); err != nil {
+		return nil, fmt.Errorf("mkdir CA key dir: %w", err)
+	}
+	if err := os.WriteFile(caCertPath, certPEM, 0o644); err != nil {
+		return nil, fmt.Errorf("write CA cert: %w", err)
+	}
+	if err := os.WriteFile(caKeyPath, keyPEM, 0o600); err != nil {
+		return nil, fmt.Errorf("write CA key: %w", err)
+	}
+	return loadCA(certPEM, keyPEM, cacheSize)
+}
+
+// RootPEM returns the CA certificate in PEM form.
+func (ca *CA) RootPEM() []byte { return ca.rootPEM }
+
+// MintLeaf returns a TLS leaf cert for sni, generating + caching on miss. Concurrency-safe.
+func (ca *CA) MintLeaf(sni string) (*tls.Certificate, error) {
+	if err := validateSNI(sni); err != nil {
+		return nil, err
+	}
+	if c, ok := ca.cache.get(sni); ok {
+		return c, nil
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate leaf key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: sni},
+		NotBefore:    time.Now().Add(-5 * time.Minute),
+		NotAfter:     time.Now().Add(leafLifetime),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(sni); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{sni}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.rootCert, &leafKey.PublicKey, ca.rootKey)
+	if err != nil {
+		return nil, fmt.Errorf("sign leaf for %s: %w", sni, err)
+	}
+
+	cert := &tls.Certificate{
+		Certificate: [][]byte{der, ca.rootCert.Raw},
+		PrivateKey:  leafKey,
+	}
+	ca.cache.set(sni, cert)
+	return cert, nil
+}
+
+// validateSNI bounds the LRU-cache attack surface: cap at the DNS-name max
+// (253 bytes), reject control chars, allow IP literals through.
+func validateSNI(sni string) error {
+	if sni == "" {
+		return fmt.Errorf("sni: empty")
+	}
+	if len(sni) > 253 {
+		return fmt.Errorf("sni: %d bytes exceeds DNS-name max of 253", len(sni))
+	}
+	if net.ParseIP(sni) != nil {
+		return nil
+	}
+	for i := 0; i < len(sni); i++ {
+		c := sni[i]
+		if c < 0x20 || c == 0x7f {
+			return fmt.Errorf("sni: control character at byte %d", i)
+		}
+	}
+	return nil
+}
+
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	n, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, fmt.Errorf("rand serial: %w", err)
+	}
+	return n, nil
+}
+
+// leafCache is a fixed-size LRU keyed by SNI hostname.
+type leafCache struct {
+	mu       sync.Mutex
+	capacity int
+	items    map[string]*list.Element
+	order    *list.List
+}
+
+type leafCacheEntry struct {
+	sni  string
+	cert *tls.Certificate
+}
+
+func newLeafCache(capacity int) *leafCache {
+	if capacity <= 0 {
+		capacity = 1024
+	}
+	return &leafCache{
+		capacity: capacity,
+		items:    make(map[string]*list.Element, capacity),
+		order:    list.New(),
+	}
+}
+
+func (c *leafCache) get(sni string) (*tls.Certificate, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[sni]
+	if !ok {
+		return nil, false
+	}
+	c.order.MoveToFront(el)
+	return el.Value.(*leafCacheEntry).cert, true
+}
+
+func (c *leafCache) set(sni string, cert *tls.Certificate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[sni]; ok {
+		el.Value.(*leafCacheEntry).cert = cert
+		c.order.MoveToFront(el)
+		return
+	}
+	el := c.order.PushFront(&leafCacheEntry{sni: sni, cert: cert})
+	c.items[sni] = el
+	if c.order.Len() > c.capacity {
+		oldest := c.order.Back()
+		if oldest != nil {
+			c.order.Remove(oldest)
+			delete(c.items, oldest.Value.(*leafCacheEntry).sni)
+		}
+	}
+}
+
+func (c *leafCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/internal/secretsproxy/ca_test.go
+++ b/internal/secretsproxy/ca_test.go
@@ -1,0 +1,283 @@
+package secretsproxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestNewCAGeneratesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+
+	ca, err := NewCA(certPath, keyPath, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ca.RootPEM() == nil || !strings.Contains(string(ca.RootPEM()), "BEGIN CERTIFICATE") {
+		t.Fatal("RootPEM did not return a PEM block")
+	}
+
+	// Files should exist with the expected modes.
+	certInfo, err := os.Stat(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if certInfo.Mode().Perm() != 0o644 {
+		t.Errorf("cert file mode = %o, want 0644", certInfo.Mode().Perm())
+	}
+	keyInfo, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keyInfo.Mode().Perm() != 0o600 {
+		t.Errorf("key file mode = %o, want 0600", keyInfo.Mode().Perm())
+	}
+}
+
+func TestNewCAReloadsExistingMaterial(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+
+	first, err := NewCA(certPath, keyPath, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPEM := string(first.RootPEM())
+
+	// Second invocation must reuse the on-disk material — restart safety.
+	second, err := NewCA(certPath, keyPath, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second.RootPEM()) != firstPEM {
+		t.Errorf("CA was regenerated on reload; sandboxes that trust the old CA would break")
+	}
+}
+
+func TestNewCAFailsLoudOnMixedPresence(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+
+	// Bootstrap to get real material.
+	if _, err := NewCA(certPath, keyPath, 16); err != nil {
+		t.Fatal(err)
+	}
+	// Delete the key but leave the cert.
+	if err := os.Remove(keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewCA(certPath, keyPath, 16); err == nil {
+		t.Fatal("expected error on mixed cert-present / key-missing state — silent regen would orphan sandboxes")
+	}
+}
+
+func TestMintLeafProducesValidServerCert(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := ca.MintLeaf("api.openai.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leaf.Certificate) < 2 {
+		t.Fatal("leaf should chain to the CA (2+ DER blocks)")
+	}
+
+	// Parse the leaf and verify CN/DNS SAN.
+	parsed, err := x509.ParseCertificate(leaf.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Subject.CommonName != "api.openai.com" {
+		t.Errorf("CN = %q, want api.openai.com", parsed.Subject.CommonName)
+	}
+	dnsFound := false
+	for _, n := range parsed.DNSNames {
+		if n == "api.openai.com" {
+			dnsFound = true
+		}
+	}
+	if !dnsFound {
+		t.Errorf("DNS SAN missing api.openai.com, got %v", parsed.DNSNames)
+	}
+
+	// And the leaf must verify against the CA we minted from.
+	roots := x509.NewCertPool()
+	rootParsed, err := x509.ParseCertificate(leaf.Certificate[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots.AddCert(rootParsed)
+	if _, err := parsed.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		DNSName:   "api.openai.com",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("leaf failed CA verify: %v", err)
+	}
+}
+
+func TestMintLeafForIPLiteral(t *testing.T) {
+	// IP literals must be encoded as IP SAN, not DNS SAN.
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := ca.MintLeaf("127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := x509.ParseCertificate(leaf.Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.DNSNames) != 0 {
+		t.Errorf("DNS SAN should be empty for IP literal, got %v", parsed.DNSNames)
+	}
+	if len(parsed.IPAddresses) != 1 || !parsed.IPAddresses[0].Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("IP SAN want [127.0.0.1], got %v", parsed.IPAddresses)
+	}
+}
+
+func TestMintLeafCachesHits(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf1, err := ca.MintLeaf("api.openai.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf2, err := ca.MintLeaf("api.openai.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Same pointer — second call hit the cache rather than re-minting.
+	if leaf1 != leaf2 {
+		t.Errorf("expected cache hit to return same cert; got distinct pointers (cache miss)")
+	}
+	if ca.cache.len() != 1 {
+		t.Errorf("cache should have 1 entry after two requests for same SNI, got %d", ca.cache.len())
+	}
+}
+
+func TestMintLeafConcurrentSafe(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hosts := []string{
+		"api.openai.com", "api.anthropic.com", "api.github.com",
+		"api.stripe.com", "slack.com", "api.linear.app",
+	}
+	var wg sync.WaitGroup
+	errCh := make(chan error, 256)
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			host := hosts[n%len(hosts)]
+			if _, err := ca.MintLeaf(host); err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent MintLeaf: %v", err)
+	}
+	if ca.cache.len() != len(hosts) {
+		t.Errorf("expected cache to hold %d distinct hosts, got %d", len(hosts), ca.cache.len())
+	}
+}
+
+func TestLeafCacheEvictsLRU(t *testing.T) {
+	c := newLeafCache(2)
+	c.set("a", &tls.Certificate{})
+	c.set("b", &tls.Certificate{})
+	c.set("c", &tls.Certificate{}) // evicts a
+
+	if _, ok := c.get("a"); ok {
+		t.Errorf("a should have been evicted as LRU")
+	}
+	if _, ok := c.get("b"); !ok {
+		t.Errorf("b should still be cached")
+	}
+	if _, ok := c.get("c"); !ok {
+		t.Errorf("c should still be cached")
+	}
+}
+
+func TestLeafCachePromotesOnGet(t *testing.T) {
+	c := newLeafCache(2)
+	c.set("a", &tls.Certificate{})
+	c.set("b", &tls.Certificate{})
+	// Touch a so it's no longer the LRU; b should evict next.
+	if _, ok := c.get("a"); !ok {
+		t.Fatal("a missing before LRU promotion")
+	}
+	c.set("c", &tls.Certificate{}) // should evict b, not a
+	if _, ok := c.get("a"); !ok {
+		t.Errorf("a was unexpectedly evicted after being touched")
+	}
+	if _, ok := c.get("b"); ok {
+		t.Errorf("b should have been evicted as the new LRU")
+	}
+}
+
+func TestLeafCacheZeroCapacityDefaults(t *testing.T) {
+	// A 0 capacity would otherwise immediately evict every entry; we
+	// expect a sensible default so callers can pass 0 safely.
+	c := newLeafCache(0)
+	c.set("a", &tls.Certificate{})
+	if _, ok := c.get("a"); !ok {
+		t.Errorf("zero-capacity cache should have fallen back to a default")
+	}
+}
+
+func TestMintLeafRejectsAttackerControlledSNI(t *testing.T) {
+	// Overlong or control-character SNIs must be rejected before they touch
+	// the LRU cache, so an attacker can't grind it with many unique inputs.
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		sni  string
+	}{
+		{"empty", ""},
+		{"too long", strings.Repeat("a.", 200)},                         // 400 bytes
+		{"control character", "evil.example.com\x00.actual.example.com"}, // null injection
+		{"newline", "host\nhost2"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := ca.MintLeaf(c.sni); err == nil {
+				t.Errorf("MintLeaf(%q) should have rejected, got nil error", c.sni)
+			}
+		})
+	}
+
+	// Sanity: a normal hostname still works.
+	if _, err := ca.MintLeaf("api.example.com"); err != nil {
+		t.Errorf("MintLeaf for normal host failed: %v", err)
+	}
+}

--- a/internal/secretsproxy/connect.go
+++ b/internal/secretsproxy/connect.go
@@ -1,0 +1,347 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/egresspolicy"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
+)
+
+// hop-by-hop headers per RFC 7230 plus proxy-auth headers; none of these
+// are forwarded to the upstream.
+var hopByHop = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Proxy-Connection":    true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+// handleConnect terminates a CONNECT tunnel, runs the MITM TLS handshake
+// on the client side, and forwards each inner request to the captured upstream.
+// A panic in any per-tunnel stage is reported to Sentry and contained so the
+// daemon keeps serving other sandboxes.
+func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	defer sentrylog.Recover("secretsproxy.handleConnect")
+	target := r.Host
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		http.Error(w, "CONNECT target must be host:port", http.StatusBadRequest)
+		return
+	}
+
+	jwtString, err := ParseProxyAuthJWT(r)
+	if err != nil {
+		writeProxyAuthChallenge(w)
+		return
+	}
+
+	scope, err := p.resolver.Authenticate(r.Context(), remoteHost(r.RemoteAddr), jwtString)
+	if err != nil {
+		p.logger.Warn("proxy auth rejected",
+			"remote", r.RemoteAddr, "host", host, "err", err.Error())
+		writeProxyAuthChallenge(w)
+		return
+	}
+
+	if p.revoker != nil && p.revoker.IsSandboxRevoked(scope.SandboxID) {
+		p.logger.Warn("sandbox revoked", "sandbox", scope.SandboxID, "host", host)
+		http.Error(w, "sandbox revoked", http.StatusForbidden)
+		return
+	}
+
+	if p.isBlockedPort(port) {
+		p.logger.Warn("blocked egress port", "sandbox", scope.SandboxID, "host", host, "port", port)
+		http.Error(w, "destination port blocked by policy", http.StatusForbidden)
+		return
+	}
+
+	// IP-literal targets in an internal range are rejected here; hostnames that
+	// resolve to an internal IP are caught by the upstream dialer.
+	if p.blockInternalAddrs {
+		if ip := net.ParseIP(host); ip != nil && egresspolicy.IsIPDenied(ip) {
+			p.logger.Warn("blocked internal address", "sandbox", scope.SandboxID, "host", host)
+			http.Error(w, "destination address blocked by policy", http.StatusForbidden)
+			return
+		}
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "internal proxy error", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hj.Hijack()
+	if err != nil {
+		p.logger.Warn("hijack failed", "err", err.Error())
+		http.Error(w, "internal proxy error", http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		_ = clientConn.Close()
+		return
+	}
+
+	// Leaf cert SAN binds to the CONNECT target, not the inner-handshake SNI.
+	innerTLSConf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			sni := hello.ServerName
+			if sni == "" {
+				sni = host
+			}
+			return p.ca.MintLeaf(sni)
+		},
+	}
+	tlsConn := tls.Server(clientConn, innerTLSConf)
+	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
+	if err := tlsConn.Handshake(); err != nil {
+		p.logger.Warn("mitm TLS handshake failed",
+			"host", host,
+			"sandbox", scope.SandboxID,
+			"err", err.Error())
+		_ = tlsConn.Close()
+		return
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+
+	listener := newOneShotListener(tlsConn)
+	srv := &http.Server{
+		Handler:           p.forwardHandler(target, host, scope),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      5 * time.Minute,
+		IdleTimeout:       2 * time.Minute,
+		ConnState: func(c net.Conn, state http.ConnState) {
+			if state == http.StateHijacked || state == http.StateClosed {
+				_ = listener.Close()
+			}
+		},
+	}
+	_ = srv.Serve(listener)
+}
+
+// writeProxyAuthChallenge writes a 407 with a Proxy-Authenticate header.
+func writeProxyAuthChallenge(w http.ResponseWriter) {
+	w.Header().Set("Proxy-Authenticate", `Basic realm="superserve-proxy"`)
+	http.Error(w, "Proxy-Authorization required", http.StatusProxyAuthRequired)
+}
+
+// oneShotListener wraps a single net.Conn so http.Server.Serve can drive it.
+type oneShotListener struct {
+	conn   net.Conn
+	yield  chan net.Conn
+	closed chan struct{}
+}
+
+func newOneShotListener(c net.Conn) *oneShotListener {
+	l := &oneShotListener{
+		conn:   c,
+		yield:  make(chan net.Conn, 1),
+		closed: make(chan struct{}),
+	}
+	l.yield <- c
+	return l
+}
+
+var errOneShotListenerClosed = errors.New("secretsproxy: one-shot listener closed")
+
+func (l *oneShotListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.yield:
+		return c, nil
+	case <-l.closed:
+		return nil, errOneShotListenerClosed
+	}
+}
+
+func (l *oneShotListener) Close() error {
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	return nil
+}
+
+func (l *oneShotListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// forwardHandler returns the per-tunnel http.Handler: pipeline + forward + audit.
+func (p *Proxy) forwardHandler(target, host string, scope *Scope) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture before outReq mutation / body consumption.
+		method := r.Method
+		path := r.URL.Path
+		start := time.Now()
+
+		baseEvent := AuditEvent{
+			SandboxID: scope.SandboxID,
+			TeamID:    scope.TeamID,
+			Method:    method,
+			Host:      host,
+			Path:      path,
+		}
+		// finalize emits one audit row per swapped secret. With no swap,
+		// a single row is emitted with secret_id="" so the request is recorded.
+		finalize := func(status int, upstreamStatus *int32, secretIDs []string, reason string) {
+			latency := int32(time.Since(start).Milliseconds())
+			if len(secretIDs) == 0 {
+				ev := baseEvent
+				ev.Status = int32(status)
+				ev.UpstreamStatus = upstreamStatus
+				ev.ErrorCode = reason
+				ev.LatencyMs = latency
+				p.audit.Emit(ev)
+				return
+			}
+			for _, sid := range secretIDs {
+				ev := baseEvent
+				ev.Status = int32(status)
+				ev.UpstreamStatus = upstreamStatus
+				ev.SecretID = sid
+				ev.ErrorCode = reason
+				ev.LatencyMs = latency
+				p.audit.Emit(ev)
+			}
+		}
+
+		// Rebuild against the captured host so a Host-header rewrite cannot redirect mid-stream.
+		upstreamURL := *r.URL
+		upstreamURL.Scheme = "https"
+		upstreamURL.Host = target
+
+		ctx, cancel := context.WithCancel(r.Context())
+		defer cancel()
+
+		bodyReader := http.MaxBytesReader(w, r.Body, p.maxRequestBodyBytes)
+		outReq, err := http.NewRequestWithContext(ctx, r.Method, upstreamURL.String(), bodyReader)
+		if err != nil {
+			p.logger.Warn("build upstream request failed",
+				"host", host, "sandbox", scope.SandboxID, "err", err.Error())
+			writeBrokerError(w, http.StatusBadGateway, "build_request", "could not build upstream request")
+			finalize(http.StatusBadGateway, nil, nil, "build_request")
+			return
+		}
+		copyForwardableHeaders(r.Header, outReq.Header)
+		outReq.Host = host
+
+		// Pipeline runs when both Vault and a non-empty Scope are wired; otherwise pass through.
+		var matchedSecretIDs []string
+		if scope != nil && p.vault != nil {
+			rules, ok := p.fetchEgressRules(ctx, scope.SandboxID)
+			if !ok {
+				// Cold cache + control plane unreachable: fail the request
+				// closed and loud rather than enforce no policy.
+				writeBrokerError(w, http.StatusServiceUnavailable, "policy_unavailable", "egress policy temporarily unavailable")
+				finalize(http.StatusServiceUnavailable, nil, nil, "policy_unavailable")
+				return
+			}
+			// Resolve the upstream only when CIDR rules need an IP to match.
+			var upstreamIP net.IP
+			if egresspolicy.HasCIDR(rules.Allow) || egresspolicy.HasCIDR(rules.Deny) {
+				upstreamIP = p.resolveUpstreamIP(ctx, host)
+			}
+			out, ierr := injectRequest(ctx, scope, p.vault, outReq, host, upstreamIP, rules)
+			if ierr != nil {
+				p.logger.Warn("inject pipeline failed",
+					"host", host, "sandbox", scope.SandboxID, "err", ierr.Error())
+				writeBrokerError(w, http.StatusBadGateway, "inject_error", "request rejected by sandbox proxy")
+				finalize(http.StatusBadGateway, nil, out.MatchedSecretIDs, "inject_error")
+				return
+			}
+			matchedSecretIDs = out.MatchedSecretIDs
+			switch out.Action {
+			case denyAction:
+				writeBrokerError(w, http.StatusForbidden, out.Reason, "host or credential blocked by sandbox policy")
+				finalize(http.StatusForbidden, nil, matchedSecretIDs, out.Reason)
+				return
+			case revokedAction:
+				writeBrokerError(w, http.StatusServiceUnavailable, out.Reason, "credential revoked")
+				finalize(http.StatusServiceUnavailable, nil, matchedSecretIDs, out.Reason)
+				return
+			}
+		}
+
+		resp, err := p.upstream.RoundTrip(outReq)
+		if err != nil {
+			// Body-size overflow surfaces here as RoundTrip returning a
+			// MaxBytesError wrapped by the transport; distinguish it from
+			// genuine unreachable upstream so the agent sees the right code.
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				msg := fmt.Sprintf("request body exceeds %d bytes", p.maxRequestBodyBytes)
+				writeBrokerError(w, http.StatusRequestEntityTooLarge, "body_too_large", msg)
+				finalize(http.StatusRequestEntityTooLarge, nil, matchedSecretIDs, "body_too_large")
+				return
+			}
+			p.logger.Warn("upstream RoundTrip failed",
+				"host", host, "sandbox", scope.SandboxID, "err", err.Error())
+			writeBrokerError(w, http.StatusBadGateway, "upstream_unreachable", "upstream unreachable")
+			finalize(http.StatusBadGateway, nil, matchedSecretIDs, "upstream_unreachable")
+			return
+		}
+		defer resp.Body.Close()
+
+		copyForwardableHeaders(resp.Header, w.Header())
+		w.WriteHeader(resp.StatusCode)
+		// Flush per chunk so SSE / streaming responses reach the client promptly.
+		flusher, _ := w.(http.Flusher)
+		streamWithFlush(w, resp.Body, flusher)
+
+		upstreamStatus := int32(resp.StatusCode)
+		finalize(resp.StatusCode, &upstreamStatus, matchedSecretIDs, "")
+	})
+}
+
+// writeBrokerError emits a structured proxy-layer rejection with X-Superserve-Proxy-Error.
+func writeBrokerError(w http.ResponseWriter, status int, reason, msg string) {
+	w.Header().Set("X-Superserve-Proxy-Error", "true")
+	w.Header().Set("X-Superserve-Proxy-Reason", reason)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(msg))
+}
+
+// copyForwardableHeaders copies headers skipping hop-by-hop ones.
+func copyForwardableHeaders(src, dst http.Header) {
+	for k, vv := range src {
+		if hopByHop[http.CanonicalHeaderKey(k)] {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// streamWithFlush copies src → dst, flushing after each read for SSE / chunked transfers.
+func streamWithFlush(dst io.Writer, src io.Reader, flusher http.Flusher) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := src.Read(buf)
+		if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/internal/secretsproxy/control.go
+++ b/internal/secretsproxy/control.go
@@ -1,0 +1,137 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// ControlServer is the daemon-internal HTTP API served over a 0600 unix socket.
+type ControlServer struct {
+	cachedVault *cachedVault
+	cachedRules *cachedRules
+	revoker     *Revoker
+
+	httpServer  *http.Server
+	socketPath  string
+	isListening atomic.Bool
+}
+
+// NewControlServer builds the server. Nil cachedVault, cachedRules, or revoker
+// turn the corresponding endpoints into no-ops.
+func NewControlServer(socketPath string, cv *cachedVault, cr *cachedRules, r *Revoker) *ControlServer {
+	c := &ControlServer{
+		cachedVault: cv,
+		cachedRules: cr,
+		revoker:     r,
+		socketPath:  socketPath,
+	}
+	c.httpServer = &http.Server{
+		Handler:           c.handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return c
+}
+
+// IsListening reports whether the control socket is bound.
+func (c *ControlServer) IsListening() bool { return c.isListening.Load() }
+
+// ListenAndServe binds the unix socket (overwriting any existing one) and serves.
+func (c *ControlServer) ListenAndServe() error {
+	if err := os.MkdirAll(filepath.Dir(c.socketPath), 0o700); err != nil {
+		return err
+	}
+	if err := os.Remove(c.socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	l, err := net.Listen("unix", c.socketPath)
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(c.socketPath, 0o600); err != nil {
+		_ = l.Close()
+		return err
+	}
+	return c.Serve(l)
+}
+
+// Serve accepts on the provided listener.
+func (c *ControlServer) Serve(l net.Listener) error {
+	c.isListening.Store(true)
+	defer c.isListening.Store(false)
+	return c.httpServer.Serve(l)
+}
+
+// Shutdown stops the server; safe to call multiple times.
+func (c *ControlServer) Shutdown(ctx context.Context) error {
+	return c.httpServer.Shutdown(ctx)
+}
+
+func (c *ControlServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", c.handleHealth)
+	mux.HandleFunc("/v1/secrets/", c.handleSecretAction)
+	mux.HandleFunc("/v1/sandboxes/", c.handleSandboxAction)
+	return mux
+}
+
+func (c *ControlServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+func (c *ControlServer) handleSecretAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/secrets/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[1] != "invalidate" || parts[0] == "" {
+		http.Error(w, "expected /v1/secrets/{id}/invalidate", http.StatusNotFound)
+		return
+	}
+	id := parts[0]
+	if c.cachedVault != nil {
+		c.cachedVault.Invalidate(id)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (c *ControlServer) handleSandboxAction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/sandboxes/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		http.Error(w, "expected /v1/sandboxes/{id}/{revoke|rules}", http.StatusNotFound)
+		return
+	}
+	switch parts[1] {
+	case "revoke":
+		if c.revoker != nil {
+			c.revoker.RevokeSandbox(parts[0])
+		}
+	case "rules":
+		if c.cachedRules != nil {
+			c.cachedRules.Invalidate(parts[0])        // drop stale (PATCH)
+			c.cachedRules.Warm(r.Context(), parts[0]) // pre-fetch fresh (prime / re-warm)
+		}
+	default:
+		http.Error(w, "expected /v1/sandboxes/{id}/{revoke|rules}", http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/secretsproxy/control_test.go
+++ b/internal/secretsproxy/control_test.go
@@ -1,0 +1,217 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// startControlServerOnSocket binds the control server to a temp unix socket.
+func startControlServerOnSocket(t *testing.T, cv *cachedVault, cr *cachedRules) (*http.Client, *ControlServer, *Revoker) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "control.sock")
+	rev := NewRevoker()
+	cs := NewControlServer(sockPath, cv, cr, rev)
+
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = cs.Serve(l) }()
+	t.Cleanup(func() { _ = cs.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if cs.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !cs.IsListening() {
+		t.Fatal("control server not listening")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+	return client, cs, rev
+}
+
+func TestControlInvalidateDropsCacheEntry(t *testing.T) {
+	clock := newFakeClock()
+	upstream := &stubVault{values: map[string]string{"s": "v1"}}
+	cv := newCachedVaultWithClock(upstream, time.Hour, clock)
+	client, _, _ := startControlServerOnSocket(t, cv, nil)
+
+	// Warm the cache.
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "s")
+	upstream.values["s"] = "v2"
+
+	// Hit the invalidate endpoint over the control socket.
+	req, _ := http.NewRequest(http.MethodPost, "http://unix/v1/secrets/s/invalidate", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("invalidate: want 200, got %d", resp.StatusCode)
+	}
+
+	v, _ := cv.FetchCredential(context.Background(), "team-1", "s")
+	if v != "v2" {
+		t.Errorf("invalidate should have forced a refetch, got %q", v)
+	}
+}
+
+func TestControlInvalidateIsNoOpWithoutVault(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "http://unix/v1/secrets/sec-1/invalidate", nil)
+	resp, _ := client.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("invalidate without cache: want 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestControlInvalidateRejectsMalformedPath(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+	req, _ := http.NewRequest(http.MethodPost, "http://unix/v1/secrets/bare", nil)
+	resp, _ := client.Do(req)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("bare /v1/secrets/<id>: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestControlInvalidateRejectsGET(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+	resp, _ := client.Get("http://unix/v1/secrets/s/invalidate")
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET should be 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestControlSandboxRevoke(t *testing.T) {
+	client, _, rev := startControlServerOnSocket(t, nil, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, "http://unix/v1/sandboxes/sb-1/revoke", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke: want 200, got %d", resp.StatusCode)
+	}
+	if !rev.IsSandboxRevoked("sb-1") {
+		t.Fatal("revoker should reflect the revoke call")
+	}
+}
+
+func TestControlInvalidateSandboxRules(t *testing.T) {
+	upstream := &stubRules{rules: EgressRules{Allow: []string{"a.com"}}}
+	cr := NewCachedRules(upstream, RulesCacheOptions{TTL: time.Hour})
+	client, _, _ := startControlServerOnSocket(t, nil, cr)
+
+	_, _ = cr.FetchRules(context.Background(), "sb-1") // warm
+
+	req, _ := http.NewRequest(http.MethodPost, "http://unix/v1/sandboxes/sb-1/rules", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rules invalidate: want 200, got %d", resp.StatusCode)
+	}
+
+	_, _ = cr.FetchRules(context.Background(), "sb-1") // must re-fetch
+	if upstream.calls != 2 {
+		t.Errorf("invalidate should force a refetch; calls=%d", upstream.calls)
+	}
+}
+
+func TestControlSandboxRevokeRejectsMalformedPath(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+
+	for _, path := range []string{"/v1/sandboxes/", "/v1/sandboxes/sb-1", "/v1/sandboxes/sb-1/destroy"} {
+		req, _ := http.NewRequest(http.MethodPost, "http://unix"+path, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("%s: want 404, got %d", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestControlSandboxRevokeRejectsGET(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+	resp, err := client.Get("http://unix/v1/sandboxes/sb-1/revoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("want 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestControlHealth(t *testing.T) {
+	client, _, _ := startControlServerOnSocket(t, nil, nil)
+	resp, err := client.Get("http://unix/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("health: want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK bool `json:"ok"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if !body.OK {
+		t.Errorf("health.ok should be true")
+	}
+}
+
+func TestControlSocketIsModeRestricted(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctl.sock")
+	cs := NewControlServer(sockPath, nil, nil, nil)
+	go func() { _ = cs.ListenAndServe() }()
+	t.Cleanup(func() { _ = cs.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if cs.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !cs.IsListening() {
+		t.Fatal("control server not listening via ListenAndServe")
+	}
+
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		t.Errorf("socket mode = %o, want 0600", mode)
+	}
+}
+
+func TestControlShutdownBeforeServeIsSafe(t *testing.T) {
+	// httpServer is constructed in NewControlServer, so Shutdown can be
+	// called before Serve without racing on a nil pointer.
+	c := NewControlServer("/dev/null/not-a-socket", nil, nil, nil)
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Errorf("Shutdown before Serve should be a no-op, got %v", err)
+	}
+}

--- a/internal/secretsproxy/e2e_jwt_test.go
+++ b/internal/secretsproxy/e2e_jwt_test.go
@@ -1,0 +1,307 @@
+package secretsproxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// jwksHTTP serves a single Ed25519 public key under /internal/jwks. Stands in
+// for the control plane in tests that need a real JWKS-backed verifier.
+func jwksHTTP(t *testing.T, kid string, pub ed25519.PublicKey) *httptest.Server {
+	t.Helper()
+	body, _ := json.Marshal(JWKSResponse{Keys: []JWKSKey{{
+		Kid: kid,
+		Kty: "OKP",
+		Crv: "Ed25519",
+		X:   base64.RawURLEncoding.EncodeToString(pub),
+	}}})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// JWKSResponse / JWKSKey mirror what the control plane's /internal/jwks emits.
+// Mirrored locally so the test doesn't import the api package.
+type JWKSResponse struct {
+	Keys []JWKSKey `json:"keys"`
+}
+type JWKSKey struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+}
+
+// e2eDaemon brings up a full proxy stack (CA, JWKS-backed Verifier, JWTResolver,
+// vault, audit) — exactly what the production daemon does, minus the unix
+// control socket. Tests assert that requests carrying a JWT signed by jwksKey
+// succeed against the running upstream.
+type e2eDaemon struct {
+	proxyAddr string
+	ca        *CA
+	audit     *recordingAudit
+}
+
+func startE2EDaemon(t *testing.T, jwksURL string, vault VaultClient, upstreamCert *x509.Certificate) *e2eDaemon {
+	t.Helper()
+
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fetcher := NewHTTPJWKSFetcher(jwksURL, "test-tok")
+	verifier, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	resolver := NewJWTResolver(verifier)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(upstreamCert)
+	upstreamTr := &http.Transport{
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool},
+	}
+
+	audit := &recordingAudit{}
+	p := NewProxy("127.0.0.1:0", Options{
+		CA:                ca,
+		Resolver:          resolver,
+		Vault:             vault,
+		Audit:             audit,
+		UpstreamTransport: upstreamTr,
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = p.Serve(l) }()
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if p.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !p.IsListening() {
+		t.Fatal("proxy never came up")
+	}
+
+	return &e2eDaemon{proxyAddr: l.Addr().String(), ca: ca, audit: audit}
+}
+
+// makeRequestThroughProxy opens a CONNECT tunnel with the supplied JWT, does
+// the inner TLS handshake against the proxy's MITM leaf, sends a GET, and
+// returns the parsed response. Caller closes resp.Body.
+func makeRequestThroughProxy(t *testing.T, d *e2eDaemon, upstreamHostPort, jwtString string, headers map[string]string) *http.Response {
+	t.Helper()
+
+	conn := dialProxy(t, d.proxyAddr, d.ca)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	status, ok := sendConnect(t, conn, upstreamHostPort, jwtString)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(d.ca.RootPEM())
+	host, _, _ := net.SplitHostPort(upstreamHostPort)
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: host,
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+
+	reqLine := fmt.Sprintf("GET /resource HTTP/1.1\r\nHost: %s\r\n", upstreamHostPort)
+	for k, v := range headers {
+		reqLine += fmt.Sprintf("%s: %s\r\n", k, v)
+	}
+	reqLine += "\r\n"
+	if _, err := tlsClient.Write([]byte(reqLine)); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tlsClient), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return resp
+}
+
+// TestE2E_JWTPathInjectsCredentialEndToEnd builds the full daemon stack against
+// a fake JWKS-serving control plane, mints a JWT signed by the control plane's
+// key, sends a request through the proxy, and verifies the upstream sees the
+// real credential (proving the inject pipeline runs end-to-end through the
+// JWT verification + resolver path).
+func TestE2E_JWTPathInjectsCredentialEndToEnd(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake control plane: serves JWKS.
+	jwksSrv := jwksHTTP(t, "v1", pub)
+
+	// Fake upstream: echoes back the Authorization header it observed.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Auth", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	vault := &stubVault{teamID: "team-e2e", values: map[string]string{"sec-anthropic": "sk-ant-REAL"}}
+
+	d := startE2EDaemon(t, jwksSrv.URL, vault, upstream.Certificate())
+
+	// Mint a JWT that authorizes 127.0.0.1 (loopback) with one binding.
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-e2e",
+		SourceIP: "127.0.0.1",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: "proxy-anth-e2e",
+			SecretID:   "sec-anthropic",
+			EnvKey:     "ANTHROPIC_API_KEY",
+			Hosts:      []string{"127.0.0.1"},
+			AuthType:   "bearer",
+			AuthConfig: map[string]any{},
+		}},
+	}, time.Now())
+
+	resp := makeRequestThroughProxy(t, d, upstreamURL.Host, tok, map[string]string{
+		"Authorization": "Bearer proxy-anth-e2e",
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Upstream-Auth"); got != "Bearer sk-ant-REAL" {
+		t.Errorf("upstream Authorization: want %q, got %q", "Bearer sk-ant-REAL", got)
+	}
+	if len(d.audit.snapshot()) != 1 {
+		t.Errorf("want exactly 1 audit event, got %d", len(d.audit.snapshot()))
+	}
+}
+
+// TestE2E_DaemonRestartDoesNotInvalidateJWT proves the headline property: a
+// JWT minted before the daemon restarted still works against a freshly-started
+// daemon (with empty in-memory state). This is the property that pause/resume
+// and operational daemon restarts rely on.
+func TestE2E_DaemonRestartDoesNotInvalidateJWT(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jwksSrv := jwksHTTP(t, "v1", pub)
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Auth", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	vault := &stubVault{teamID: "team-restart", values: map[string]string{"sec-1": "real-secret-value"}}
+
+	// First daemon: agent's JWT is minted while this daemon is up.
+	d1 := startE2EDaemon(t, jwksSrv.URL, vault, upstream.Certificate())
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-restart",
+		SourceIP: "127.0.0.1",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: "proxy-x",
+			SecretID:   "sec-1",
+			EnvKey:     "SOME_KEY",
+			Hosts:      []string{"127.0.0.1"},
+			AuthType:   "bearer",
+			AuthConfig: map[string]any{},
+		}},
+	}, time.Now())
+
+	resp1 := makeRequestThroughProxy(t, d1, upstreamURL.Host, tok, map[string]string{
+		"Authorization": "Bearer proxy-x",
+	})
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("first daemon: want 200, got %d", resp1.StatusCode)
+	}
+	if got := resp1.Header.Get("X-Upstream-Auth"); got != "Bearer real-secret-value" {
+		t.Fatalf("first daemon: upstream Authorization mismatch: %q", got)
+	}
+
+	// "Restart" the daemon: stand up a brand-new daemon (new Verifier with
+	// freshly-fetched JWKS, new in-memory anything). Reuse the same JWT —
+	// it must still authenticate and inject correctly.
+	d2 := startE2EDaemon(t, jwksSrv.URL, vault, upstream.Certificate())
+
+	resp2 := makeRequestThroughProxy(t, d2, upstreamURL.Host, tok, map[string]string{
+		"Authorization": "Bearer proxy-x",
+	})
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("post-restart daemon: want 200, got %d", resp2.StatusCode)
+	}
+	if got := resp2.Header.Get("X-Upstream-Auth"); got != "Bearer real-secret-value" {
+		t.Errorf("post-restart daemon: upstream Authorization mismatch: %q", got)
+	}
+}
+
+// TestE2E_SourceIPMismatchIsRejected pins the two-factor scoping: a JWT
+// claiming source_ip=X is rejected when the request lands from a different IP.
+// The proxy hears CONNECTs over loopback (127.0.0.1), so a JWT claiming
+// 10.99.99.99 must fail.
+func TestE2E_SourceIPMismatchIsRejected(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jwksSrv := jwksHTTP(t, "v1", pub)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	d := startE2EDaemon(t, jwksSrv.URL, &stubVault{}, upstream.Certificate())
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-x",
+		SourceIP: "10.99.99.99", // does NOT match 127.0.0.1
+	}, time.Now())
+
+	conn := dialProxy(t, d.proxyAddr, d.ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, upstreamURL.Host, tok)
+	if ok {
+		t.Fatalf("CONNECT should have failed for source-IP mismatch; got %q", status)
+	}
+	if status == "" {
+		t.Error("empty status line on rejection")
+	}
+}

--- a/internal/secretsproxy/inject.go
+++ b/internal/secretsproxy/inject.go
@@ -1,0 +1,320 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/superserve-ai/sandbox/internal/egresspolicy"
+)
+
+// InjectOutcome describes what the proxy decided for one request.
+type InjectOutcome struct {
+	// Action is "allow", "deny", or "revoked".
+	Action string
+	// Reason is a short machine-readable code for rejection responses.
+	Reason string
+	// MatchedSecretIDs lists every secret swapped for this request, or — on
+	// deny/revoked — the binding that triggered the rejection. Empty = passthrough.
+	MatchedSecretIDs []string
+}
+
+const (
+	allowAction   = "allow"
+	denyAction    = "deny"
+	revokedAction = "revoked"
+)
+
+// injectRequest applies the egress + credential-injection pipeline to an
+// outbound request, mutating headers in place under a strip-then-set invariant.
+// If the request carries proxy tokens for multiple bindings, each is swapped
+// independently — every binding's credential reaches its intended slot.
+func injectRequest(
+	ctx context.Context,
+	scope *Scope,
+	vault VaultClient,
+	req *http.Request,
+	upstreamHost string,
+	upstreamIP net.IP,
+	rules EgressRules,
+) (InjectOutcome, error) {
+	if allowed, reason := hostAllowedByEgress(upstreamHost, upstreamIP, rules); !allowed {
+		return InjectOutcome{Action: denyAction, Reason: reason}, nil
+	}
+
+	matches := findAllMatchingBindings(req, scope)
+	if len(matches) == 0 {
+		return InjectOutcome{Action: allowAction}, nil
+	}
+
+	// Phase 1: resolve every match before mutating headers, so a failure
+	// surfaces cleanly without leaving the request half-swapped.
+	type resolvedSwap struct {
+		secretID   string
+		authType   string
+		authConfig map[string]any
+		value      string
+	}
+	swaps := make([]resolvedSwap, 0, len(matches))
+	for _, binding := range matches {
+		if !hostMatchesCredential(upstreamHost, binding.Hosts) {
+			return InjectOutcome{
+				Action:           denyAction,
+				Reason:           "credential_host_mismatch",
+				MatchedSecretIDs: []string{binding.SecretID},
+			}, nil
+		}
+		authType, authConfig, ok := dispatchAuthShape(binding, upstreamHost)
+		if !ok {
+			return InjectOutcome{
+				Action:           denyAction,
+				Reason:           "credential_host_mismatch",
+				MatchedSecretIDs: []string{binding.SecretID},
+			}, nil
+		}
+		value, err := vault.FetchCredential(ctx, scope.TeamID, binding.SecretID)
+		if err != nil {
+			if errors.Is(err, ErrCredentialRevoked) {
+				return InjectOutcome{
+					Action:           revokedAction,
+					Reason:           "credential_revoked",
+					MatchedSecretIDs: []string{binding.SecretID},
+				}, nil
+			}
+			return InjectOutcome{}, err
+		}
+		swaps = append(swaps, resolvedSwap{
+			secretID:   binding.SecretID,
+			authType:   authType,
+			authConfig: authConfig,
+			value:      value,
+		})
+	}
+
+	// Phase 2: apply every swap.
+	matched := make([]string, 0, len(swaps))
+	for _, s := range swaps {
+		if err := applyInjectionShape(req, s.authType, s.authConfig, s.value); err != nil {
+			return InjectOutcome{}, fmt.Errorf("apply injection: %w", err)
+		}
+		matched = append(matched, s.secretID)
+	}
+
+	return InjectOutcome{
+		Action:           allowAction,
+		MatchedSecretIDs: matched,
+	}, nil
+}
+
+// dispatchAuthShape returns the (authType, authConfig) the writer should use
+// for upstreamHost. For multi-rule bindings, it picks the first rule whose
+// host list includes upstreamHost; ok=false if none match (binding allowlist
+// reaches the host but no rule covers it — fail closed). For legacy single-rule
+// bindings, it returns the binding's top-level shape directly.
+func dispatchAuthShape(b Binding, upstreamHost string) (string, map[string]any, bool) {
+	if len(b.Rules) == 0 {
+		return b.AuthType, b.AuthConfig, true
+	}
+	for _, r := range b.Rules {
+		if hostMatchesCredential(upstreamHost, r.Hosts) {
+			return r.AuthType, r.AuthConfig, true
+		}
+	}
+	return "", nil, false
+}
+
+// hostAllowedByEgress evaluates the fetched egress policy; upstreamIP is used
+// for CIDR rules.
+func hostAllowedByEgress(host string, upstreamIP net.IP, rules EgressRules) (bool, string) {
+	return egresspolicy.EvalEgress(host, upstreamIP, rules.Allow, rules.Deny, rules.UnmatchedHostPolicy)
+}
+
+// hostMatchesCredential checks host against the credential's allowed list using
+// strict single-label wildcards, so a credential can't be routed to an
+// unintended deep subdomain. An empty list fails closed.
+func hostMatchesCredential(host string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, p := range allowed {
+		if egresspolicy.MatchHostStrict(host, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// findAllMatchingBindings returns every binding whose proxy token appears in
+// the request. Multi-rule bindings are scanned against every rule's shape.
+// Output is sorted by SecretID for deterministic ordering across runs.
+func findAllMatchingBindings(req *http.Request, scope *Scope) []Binding {
+	var out []Binding
+	for proxyToken, binding := range scope.Bindings {
+		if len(binding.Rules) > 0 {
+			for _, r := range binding.Rules {
+				if shapeHasToken(req, r.AuthType, r.AuthConfig, proxyToken) {
+					out = append(out, binding)
+					break
+				}
+			}
+			continue
+		}
+		if shapeHasToken(req, binding.AuthType, binding.AuthConfig, proxyToken) {
+			out = append(out, binding)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SecretID < out[j].SecretID })
+	return out
+}
+
+// shapeHasToken reports whether req carries proxyToken in the (authType, cfg)
+// shape. Shared by the legacy single-rule scan and the multi-rule scan.
+func shapeHasToken(req *http.Request, authType string, cfg map[string]any, proxyToken string) bool {
+	switch authType {
+	case "bearer":
+		got := req.Header.Get("Authorization")
+		return strings.EqualFold(got, "Bearer "+proxyToken)
+	case "basic":
+		_, pw, ok := decodeBasicAuth(req.Header.Get("Authorization"))
+		if !ok {
+			return false
+		}
+		return subtle.ConstantTimeCompare([]byte(pw), []byte(proxyToken)) == 1
+	case "api-key":
+		name, _ := stringFromAuthConfig(cfg, "header")
+		if name == "" {
+			name = "Authorization"
+		}
+		prefix, _ := stringFromAuthConfig(cfg, "prefix")
+		got := req.Header.Get(name)
+		return got == prefix+proxyToken
+	case "custom":
+		headers, _ := mapStringFromAuthConfig(cfg, "headers")
+		for name, tmpl := range headers {
+			expected := strings.ReplaceAll(tmpl, "{{ value }}", proxyToken)
+			if req.Header.Get(name) == expected {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// applyInjectionShape strips auth-owned headers and sets them to the real value(s).
+// The strip is unconditional so a client-set value can never be preserved.
+// For basic, a configured username overrides preserve-inbound so the writer
+// can pin a required username regardless of what the client sent.
+func applyInjectionShape(req *http.Request, authType string, cfg map[string]any, real string) error {
+	switch authType {
+	case "bearer":
+		req.Header.Del("Authorization")
+		req.Header.Set("Authorization", "Bearer "+real)
+		return nil
+	case "basic":
+		user, _ := stringFromAuthConfig(cfg, "username")
+		if user == "" {
+			// Preserve the inbound username; fall back to "x" for empty-user inputs.
+			inbound, _, ok := decodeBasicAuth(req.Header.Get("Authorization"))
+			if ok && inbound != "" {
+				user = inbound
+			} else {
+				user = "x"
+			}
+		}
+		req.Header.Del("Authorization")
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(user+":"+real)))
+		return nil
+	case "api-key":
+		name, _ := stringFromAuthConfig(cfg, "header")
+		if name == "" {
+			name = "Authorization"
+		}
+		prefix, _ := stringFromAuthConfig(cfg, "prefix")
+		req.Header.Del(name)
+		req.Header.Set(name, prefix+real)
+		return nil
+	case "custom":
+		headers, _ := mapStringFromAuthConfig(cfg, "headers")
+		for name := range headers {
+			req.Header.Del(name)
+		}
+		for name, tmpl := range headers {
+			rendered := strings.ReplaceAll(tmpl, "{{ value }}", real)
+			if strings.ContainsAny(rendered, "\r\n") {
+				return fmt.Errorf("custom auth: header %q resolved to a value with CR/LF (injection guard)", name)
+			}
+			req.Header.Set(name, rendered)
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown auth_type %q", authType)
+}
+
+// decodeBasicAuth parses `Basic <base64(user:password)>`; ok=false on any malformed input.
+func decodeBasicAuth(header string) (user, password string, ok bool) {
+	if !strings.HasPrefix(header, "Basic ") {
+		return "", "", false
+	}
+	raw := strings.TrimSpace(header[len("Basic "):])
+	if raw == "" {
+		return "", "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		if d2, err2 := base64.RawURLEncoding.DecodeString(raw); err2 == nil {
+			decoded = d2
+		} else {
+			return "", "", false
+		}
+	}
+	creds := string(decoded)
+	idx := strings.IndexByte(creds, ':')
+	if idx < 0 {
+		return "", "", false
+	}
+	return creds[:idx], creds[idx+1:], true
+}
+
+func stringFromAuthConfig(cfg map[string]any, key string) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	v, ok := cfg[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func mapStringFromAuthConfig(cfg map[string]any, key string) (map[string]string, bool) {
+	if cfg == nil {
+		return nil, false
+	}
+	v, ok := cfg[key]
+	if !ok {
+		return nil, false
+	}
+	// JSON unmarshal yields map[string]any; convert.
+	asAny, ok := v.(map[string]any)
+	if !ok {
+		if asStr, ok := v.(map[string]string); ok {
+			return asStr, true
+		}
+		return nil, false
+	}
+	out := make(map[string]string, len(asAny))
+	for k, vv := range asAny {
+		if s, ok := vv.(string); ok {
+			out[k] = s
+		}
+	}
+	return out, true
+}

--- a/internal/secretsproxy/inject_test.go
+++ b/internal/secretsproxy/inject_test.go
@@ -1,0 +1,866 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stubVault returns canned values keyed by secret id. Caller's teamID must
+// equal stubVault.teamID (empty defaults to "team-1") or fetch is revoked.
+type stubVault struct {
+	teamID string
+	values map[string]string
+	err    error
+	calls  int
+}
+
+func (s *stubVault) FetchCredential(_ context.Context, teamID, secretID string) (string, error) {
+	s.calls++
+	if s.err != nil {
+		return "", s.err
+	}
+	want := s.teamID
+	if want == "" {
+		want = "team-1"
+	}
+	if teamID != want {
+		return "", ErrCredentialRevoked
+	}
+	v, ok := s.values[secretID]
+	if !ok {
+		return "", ErrCredentialRevoked
+	}
+	return v, nil
+}
+
+func newReq(method, host string, headers map[string]string) *http.Request {
+	r, _ := http.NewRequest(method, "https://"+host+"/v1/things", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func sandboxWithBindings(bindings map[string]Binding) *Scope {
+	if bindings == nil {
+		bindings = map[string]Binding{}
+	}
+	return &Scope{
+		SandboxID: "sb-1",
+		TeamID:    "team-1",
+		SourceIP:  "10.0.0.1",
+		Bindings:  bindings,
+	}
+}
+
+func TestHostAllowedByEgress(t *testing.T) {
+	rules := func(allow, deny []string, policy string) EgressRules {
+		return EgressRules{Allow: allow, Deny: deny, UnmatchedHostPolicy: policy}
+	}
+	t.Run("passthrough default when no rules", func(t *testing.T) {
+		if ok, _ := hostAllowedByEgress("api.openai.com", nil, rules(nil, nil, "passthrough")); !ok {
+			t.Error("want allow on empty rules + passthrough policy")
+		}
+	})
+	t.Run("deny policy + no rules blocks all", func(t *testing.T) {
+		ok, reason := hostAllowedByEgress("api.openai.com", nil, rules(nil, nil, "deny"))
+		if ok {
+			t.Error("want deny under default-deny policy")
+		}
+		if reason != "unmatched_host_denied" {
+			t.Errorf("reason = %q, want unmatched_host_denied", reason)
+		}
+	})
+	t.Run("allow short-circuits before deny", func(t *testing.T) {
+		if ok, _ := hostAllowedByEgress("api.openai.com", nil, rules([]string{"api.openai.com"}, []string{"0.0.0.0/0"}, "passthrough")); !ok {
+			t.Error("allow match should win even with a broad deny configured")
+		}
+	})
+	t.Run("non-allow falls through to implicit-deny", func(t *testing.T) {
+		ok, reason := hostAllowedByEgress("evil.com", nil, rules([]string{"api.openai.com"}, nil, "passthrough"))
+		if ok {
+			t.Error("want implicit-deny when allow list non-empty and no match")
+		}
+		if reason != "host_not_allowed" {
+			t.Errorf("reason = %q, want host_not_allowed", reason)
+		}
+	})
+	t.Run("wildcard host matches", func(t *testing.T) {
+		if ok, _ := hostAllowedByEgress("api.openai.com", nil, rules([]string{"*.openai.com"}, nil, "passthrough")); !ok {
+			t.Error("wildcard should match subdomain")
+		}
+		if ok, _ := hostAllowedByEgress("other.com", nil, rules([]string{"*.openai.com"}, nil, "passthrough")); ok {
+			t.Error("wildcard should not match unrelated host")
+		}
+	})
+}
+
+func TestBearerInjectionEndToEnd(t *testing.T) {
+	binding := Binding{
+		SecretID:   "sec-anthropic",
+		EnvKey:     "ANTHROPIC_API_KEY",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.anthropic.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-tok-anth": binding})
+	vault := &stubVault{values: map[string]string{"sec-anthropic": "sk-ant-REAL-KEY"}}
+
+	req := newReq("POST", "api.anthropic.com", map[string]string{
+		"Authorization": "Bearer proxy-tok-anth",
+		"User-Agent":    "agent/1.0",
+	})
+
+	out, err := injectRequest(context.Background(), st, vault, req, "api.anthropic.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	if len(out.MatchedSecretIDs) != 1 || out.MatchedSecretIDs[0] != "sec-anthropic" {
+		t.Errorf("secret_id not captured for audit: %+v", out)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer sk-ant-REAL-KEY" {
+		t.Errorf("Authorization not swapped: got %q", got)
+	}
+	if req.Header.Get("User-Agent") != "agent/1.0" {
+		t.Errorf("unrelated headers should pass through")
+	}
+}
+
+func TestBasicInjectionMatchesPasswordAndPreservesUser(t *testing.T) {
+	// Daemon matches on the password portion only and preserves the user.
+	binding := Binding{
+		SecretID:   "sec-jira",
+		AuthType:   "basic",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"yoursite.atlassian.net"},
+	}
+	proxyToken := "ssrv_proxy_jira_aaa"
+	st := sandboxWithBindings(map[string]Binding{proxyToken: binding})
+	vault := &stubVault{values: map[string]string{"sec-jira": "real-jira-pat"}}
+
+	clientAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user@example.com:"+proxyToken))
+	req := newReq("GET", "yoursite.atlassian.net", map[string]string{
+		"Authorization": clientAuth,
+	})
+
+	out, err := injectRequest(context.Background(), st, vault, req, "yoursite.atlassian.net", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user@example.com:real-jira-pat"))
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("basic injection mangled headers: want %q, got %q", want, got)
+	}
+}
+
+func TestBasicMatchRejectsWrongPassword(t *testing.T) {
+	binding := Binding{
+		SecretID: "sec-jira", AuthType: "basic",
+		AuthConfig: map[string]any{}, Hosts: []string{"api.example.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"correct-tok": binding})
+	vault := &stubVault{values: map[string]string{"sec-jira": "x"}}
+
+	// Different password must not match.
+	wrong := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:other-tok"))
+	req := newReq("GET", "api.example.com", map[string]string{"Authorization": wrong})
+
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Errorf("want allow (passthrough — no matching binding), got %+v", out)
+	}
+	if got := req.Header.Get("Authorization"); got != wrong {
+		t.Errorf("passthrough should not mutate Authorization, got %q", got)
+	}
+}
+
+func TestBasicInjectionFallsBackToXUserWhenAgentSendsNoUser(t *testing.T) {
+	// Empty-user input substitutes "x" so the upstream doesn't reject the request.
+	binding := Binding{
+		SecretID: "sec-x", AuthType: "basic",
+		AuthConfig: map[string]any{}, Hosts: []string{"api.example.com"},
+	}
+	tok := "proxy-aaa"
+	st := sandboxWithBindings(map[string]Binding{tok: binding})
+	vault := &stubVault{values: map[string]string{"sec-x": "real-pw"}}
+
+	emptyUser := "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+tok))
+	req := newReq("GET", "api.example.com", map[string]string{"Authorization": emptyUser})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil || out.Action != "allow" {
+		t.Fatalf("want allow, got %+v err=%v", out, err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("x:real-pw"))
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("basic empty-user fallback: want %q, got %q", want, got)
+	}
+}
+
+func TestDecodeBasicAuthEdgeCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		ok     bool
+		user   string
+		pw     string
+	}{
+		{"not basic", "Bearer xyz", false, "", ""},
+		{"empty after Basic", "Basic ", false, "", ""},
+		{"malformed base64", "Basic !@#$", false, "", ""},
+		{"no colon", "Basic " + base64.StdEncoding.EncodeToString([]byte("nocolon")), false, "", ""},
+		{"happy", "Basic " + base64.StdEncoding.EncodeToString([]byte("u:p")), true, "u", "p"},
+		{"colon in password", "Basic " + base64.StdEncoding.EncodeToString([]byte("u:p:more")), true, "u", "p:more"},
+		{"raw-url base64", "Basic " + base64.RawURLEncoding.EncodeToString([]byte("u:p")), true, "u", "p"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, p, ok := decodeBasicAuth(tc.header)
+			if ok != tc.ok || u != tc.user || p != tc.pw {
+				t.Errorf("want (%q,%q,%v), got (%q,%q,%v)", tc.user, tc.pw, tc.ok, u, p, ok)
+			}
+		})
+	}
+}
+
+func TestAPIKeyInjectionUsesConfiguredHeader(t *testing.T) {
+	binding := Binding{
+		SecretID:   "sec-anthropic",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "x-api-key"},
+		Hosts:      []string{"api.anthropic.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"sk-ant-proxy-aaa": binding})
+	vault := &stubVault{values: map[string]string{"sec-anthropic": "sk-ant-REAL"}}
+
+	req := newReq("POST", "api.anthropic.com", map[string]string{
+		"x-api-key": "sk-ant-proxy-aaa",
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.anthropic.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	if got := req.Header.Get("x-api-key"); got != "sk-ant-REAL" {
+		t.Errorf("api-key swap: want sk-ant-REAL, got %q", got)
+	}
+}
+
+func TestAPIKeyInjectionWithPrefix(t *testing.T) {
+	binding := Binding{
+		SecretID:   "sec-x",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "Authorization", "prefix": "ApiKey "},
+		Hosts:      []string{"api.example.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"prox-tok": binding})
+	vault := &stubVault{values: map[string]string{"sec-x": "REAL"}}
+
+	req := newReq("GET", "api.example.com", map[string]string{"Authorization": "ApiKey prox-tok"})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	if got := req.Header.Get("Authorization"); got != "ApiKey REAL" {
+		t.Errorf("api-key prefix swap: want %q, got %q", "ApiKey REAL", got)
+	}
+}
+
+func TestCustomInjectionSetsMultipleHeaders(t *testing.T) {
+	binding := Binding{
+		SecretID: "sec-acme",
+		AuthType: "custom",
+		AuthConfig: map[string]any{
+			"headers": map[string]string{
+				"X-Api-Key":   "Bearer {{ value }}",
+				"X-Tenant-Id": "static-tenant-123",
+			},
+		},
+		Hosts: []string{"api.acme.internal"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-acme": binding})
+	vault := &stubVault{values: map[string]string{"sec-acme": "REAL-ACME"}}
+
+	req := newReq("POST", "api.acme.internal", map[string]string{
+		"X-Api-Key": "Bearer proxy-acme",
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.acme.internal", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	if got := req.Header.Get("X-Api-Key"); got != "Bearer REAL-ACME" {
+		t.Errorf("X-Api-Key not swapped: %q", got)
+	}
+	if got := req.Header.Get("X-Tenant-Id"); got != "static-tenant-123" {
+		t.Errorf("static header not set: %q", got)
+	}
+}
+
+func TestStripThenSetStripsClientPlantedHeader(t *testing.T) {
+	// A second Authorization value planted by the client must be stripped.
+	binding := Binding{
+		SecretID:   "sec-openai",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.openai.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-openai-aaa": binding})
+	vault := &stubVault{values: map[string]string{"sec-openai": "sk-REAL"}}
+
+	req := newReq("POST", "api.openai.com", map[string]string{
+		"Authorization": "Bearer proxy-openai-aaa",
+	})
+	req.Header.Add("Authorization", "Bearer planted-evil-key")
+
+	out, err := injectRequest(context.Background(), st, vault, req, "api.openai.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Fatalf("want allow, got %+v", out)
+	}
+	values := req.Header.Values("Authorization")
+	if len(values) != 1 {
+		t.Fatalf("want exactly one Authorization value after strip-then-set, got %d (%v)", len(values), values)
+	}
+	if values[0] != "Bearer sk-REAL" {
+		t.Errorf("Authorization value: want %q, got %q", "Bearer sk-REAL", values[0])
+	}
+}
+
+func TestCustomTemplateRejectsCRLFInResolvedValue(t *testing.T) {
+	// CRLF in the resolved value must fail rather than smuggle a header line.
+	binding := Binding{
+		SecretID:   "sec-bad",
+		AuthType:   "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-Token": "Bearer {{ value }}"}},
+		Hosts:      []string{"api.bad.example"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-bad": binding})
+	vault := &stubVault{values: map[string]string{"sec-bad": "innocent\r\nX-Evil: planted"}}
+
+	req := newReq("GET", "api.bad.example", map[string]string{"X-Token": "Bearer proxy-bad"})
+	_, err := injectRequest(context.Background(), st, vault, req, "api.bad.example", nil, EgressRules{})
+	if err == nil {
+		t.Fatal("want CRLF-guard error")
+	}
+}
+
+func TestNoMatchingBindingFallsThroughToPassthrough(t *testing.T) {
+	st := sandboxWithBindings(nil) // no bindings
+	vault := &stubVault{}
+
+	req := newReq("GET", "api.openai.com", map[string]string{
+		"Authorization": "Bearer client-managed-key",
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.openai.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "allow" {
+		t.Errorf("want allow on passthrough, got %+v", out)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer client-managed-key" {
+		t.Errorf("passthrough should not mutate Authorization, got %q", got)
+	}
+}
+
+func TestCredentialHostMismatchDenied(t *testing.T) {
+	binding := Binding{
+		SecretID:   "sec-openai",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.openai.com"}, // only openai
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-openai-aaa": binding})
+	vault := &stubVault{values: map[string]string{"sec-openai": "sk-REAL"}}
+
+	req := newReq("POST", "evil.example.com", map[string]string{
+		"Authorization": "Bearer proxy-openai-aaa",
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "evil.example.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "deny" {
+		t.Errorf("want deny on credential/host mismatch, got %+v", out)
+	}
+	if out.Reason != "credential_host_mismatch" {
+		t.Errorf("reason = %q, want credential_host_mismatch", out.Reason)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer proxy-openai-aaa" {
+		t.Errorf("Authorization should be untouched on deny, got %q", got)
+	}
+}
+
+func TestRevokedCredentialSurfacesAsRevoked(t *testing.T) {
+	binding := Binding{
+		SecretID:   "sec-revoked",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.example.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{"proxy-tok": binding})
+	vault := &stubVault{err: ErrCredentialRevoked}
+
+	req := newReq("GET", "api.example.com", map[string]string{"Authorization": "Bearer proxy-tok"})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "revoked" {
+		t.Errorf("want revoked action, got %+v", out)
+	}
+	if len(out.MatchedSecretIDs) != 1 || out.MatchedSecretIDs[0] != "sec-revoked" {
+		t.Errorf("want secret id in outcome, got %+v", out)
+	}
+}
+
+// fakeClock returns a deterministic time.Time; Advance crosses TTL boundaries without sleep.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1_000_000, 0)} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+func newCachedVaultWithClock(upstream VaultClient, ttl time.Duration, clock *fakeClock) *cachedVault {
+	cv := NewCachedVault(upstream, VaultCacheOptions{
+		TTL:      ttl,
+		IdleTTL:  time.Hour,
+		Capacity: 256,
+	})
+	cv.now = clock.Now
+	return cv
+}
+
+// TestCachedVaultIsTeamScoped: same secretID under a different teamID must not hit the cache.
+func TestCachedVaultIsTeamScoped(t *testing.T) {
+	upstream := &stubVault{teamID: "team-A", values: map[string]string{"s": "secret-A"}}
+	cv := newCachedVaultWithClock(upstream, time.Hour, newFakeClock())
+
+	// Prime cache as team-A.
+	v, err := cv.FetchCredential(context.Background(), "team-A", "s")
+	if err != nil || v != "secret-A" {
+		t.Fatalf("team-A fetch: v=%q err=%v", v, err)
+	}
+
+	// Same secretID from team-B must NOT hit the team-A entry.
+	_, err = cv.FetchCredential(context.Background(), "team-B", "s")
+	if !errors.Is(err, ErrCredentialRevoked) {
+		t.Fatalf("team-B fetch must be revoked, got err=%v", err)
+	}
+}
+
+func TestCachedVaultServesFromCache(t *testing.T) {
+	upstream := &stubVault{values: map[string]string{"s": "v1"}}
+	cv := newCachedVaultWithClock(upstream, 10*time.Second, newFakeClock())
+
+	v, err := cv.FetchCredential(context.Background(), "team-1", "s")
+	if err != nil || v != "v1" {
+		t.Fatalf("first fetch: v=%q err=%v", v, err)
+	}
+	// Mutate the upstream — the cache should still return the original.
+	upstream.values["s"] = "v2"
+	v, err = cv.FetchCredential(context.Background(), "team-1", "s")
+	if err != nil || v != "v1" {
+		t.Fatalf("cached fetch: v=%q err=%v", v, err)
+	}
+}
+
+func TestCachedVaultRefreshesAfterTTL(t *testing.T) {
+	clock := newFakeClock()
+	upstream := &stubVault{values: map[string]string{"s": "v1"}}
+	cv := newCachedVaultWithClock(upstream, 10*time.Second, clock)
+
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "s")
+	upstream.values["s"] = "v2"
+	clock.advance(11 * time.Second) // past TTL
+	v, err := cv.FetchCredential(context.Background(), "team-1", "s")
+	if err != nil || v != "v2" {
+		t.Errorf("after TTL: want v2, got v=%q err=%v", v, err)
+	}
+}
+
+func TestCachedVaultInvalidate(t *testing.T) {
+	clock := newFakeClock()
+	upstream := &stubVault{values: map[string]string{"s": "v1"}}
+	cv := newCachedVaultWithClock(upstream, time.Hour, clock)
+
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "s")
+	upstream.values["s"] = "v2"
+	cv.Invalidate("s") // forces a refetch on next access regardless of TTL
+	v, _ := cv.FetchCredential(context.Background(), "team-1", "s")
+	if v != "v2" {
+		t.Errorf("Invalidate should force refetch, got %q", v)
+	}
+}
+
+func TestCachedVaultPropagatesError(t *testing.T) {
+	cv := newCachedVaultWithClock(&stubVault{err: errors.New("boom")}, time.Second, newFakeClock())
+	_, err := cv.FetchCredential(context.Background(), "team-1", "s")
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("want boom error, got %v", err)
+	}
+}
+
+// githubPerHostBinding mirrors what the JWT resolver builds for a github
+// provider-shortcut secret.
+func githubPerHostBinding(secretID string) Binding {
+	return Binding{
+		SecretID: secretID,
+		EnvKey:   "GITHUB_TOKEN",
+		Hosts:    []string{"api.github.com", "github.com"},
+		Rules: []BindingRule{
+			{Hosts: []string{"api.github.com"}, AuthType: "bearer"},
+			{Hosts: []string{"github.com"}, AuthType: "basic", AuthConfig: map[string]any{"username": "x-access-token"}},
+		},
+	}
+}
+
+func TestPerHostDispatchPicksBearerForRESTHost(t *testing.T) {
+	// api.github.com → Bearer rule wins, swap into Authorization header verbatim.
+	proxyTok := "ghp_proxy_token_aaaa"
+	st := sandboxWithBindings(map[string]Binding{proxyTok: githubPerHostBinding("sec-gh")})
+	vault := &stubVault{values: map[string]string{"sec-gh": "github_pat_REAL"}}
+
+	req := newReq("GET", "api.github.com", map[string]string{
+		"Authorization": "Bearer " + proxyTok,
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.github.com", nil, EgressRules{})
+	if err != nil || out.Action != "allow" {
+		t.Fatalf("want allow, got %+v err=%v", out, err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer github_pat_REAL" {
+		t.Errorf("Bearer rule should swap header verbatim, got %q", got)
+	}
+}
+
+func TestPerHostDispatchPicksBasicForGitHost(t *testing.T) {
+	// github.com → Basic rule wins, with username forced to x-access-token
+	// regardless of what the client sent.
+	proxyTok := "ghp_proxy_token_bbbb"
+	st := sandboxWithBindings(map[string]Binding{proxyTok: githubPerHostBinding("sec-gh")})
+	vault := &stubVault{values: map[string]string{"sec-gh": "github_pat_REAL"}}
+
+	// git over HTTPS sends username=x-access-token and password=<PAT>.
+	inbound := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:"+proxyTok))
+	req := newReq("GET", "github.com", map[string]string{"Authorization": inbound})
+
+	out, err := injectRequest(context.Background(), st, vault, req, "github.com", nil, EgressRules{})
+	if err != nil || out.Action != "allow" {
+		t.Fatalf("want allow, got %+v err=%v", out, err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:github_pat_REAL"))
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("Basic rule with username override: want %q, got %q", want, got)
+	}
+}
+
+func TestPerHostBasicUsernameOverridesInbound(t *testing.T) {
+	// Even if the agent sent a different Basic username, the rule's username
+	// is authoritative — prevents an agent from picking a wrong username that
+	// the upstream silently rejects.
+	binding := Binding{
+		SecretID: "sec-x", Hosts: []string{"git.example.com"},
+		Rules: []BindingRule{
+			{Hosts: []string{"git.example.com"}, AuthType: "basic", AuthConfig: map[string]any{"username": "forced-user"}},
+		},
+	}
+	tok := "proxy-xyz"
+	st := sandboxWithBindings(map[string]Binding{tok: binding})
+	vault := &stubVault{values: map[string]string{"sec-x": "REAL"}}
+
+	inbound := "Basic " + base64.StdEncoding.EncodeToString([]byte("agent-picked:"+tok))
+	req := newReq("GET", "git.example.com", map[string]string{"Authorization": inbound})
+	out, err := injectRequest(context.Background(), st, vault, req, "git.example.com", nil, EgressRules{})
+	if err != nil || out.Action != "allow" {
+		t.Fatalf("want allow, got %+v err=%v", out, err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("forced-user:REAL"))
+	if got := req.Header.Get("Authorization"); got != want {
+		t.Errorf("rule username should override inbound: want %q got %q", want, got)
+	}
+}
+
+func TestPerHostNoMatchingRuleDeniesAsHostMismatch(t *testing.T) {
+	// Binding's allowlist reaches the host (so the egress check passes), but
+	// none of the per-host rules cover it — fail closed.
+	binding := Binding{
+		SecretID: "sec-x",
+		// allowlist explicitly includes both hosts so egress passes the first
+		// hostMatchesCredential check; per-host rules are stricter.
+		Hosts: []string{"api.github.com", "github.com", "raw.githubusercontent.com"},
+		Rules: []BindingRule{
+			{Hosts: []string{"api.github.com"}, AuthType: "bearer"},
+			{Hosts: []string{"github.com"}, AuthType: "basic", AuthConfig: map[string]any{"username": "x-access-token"}},
+		},
+	}
+	tok := "ghp_proxy_token_cccc"
+	st := sandboxWithBindings(map[string]Binding{tok: binding})
+	vault := &stubVault{values: map[string]string{"sec-x": "REAL"}}
+
+	req := newReq("GET", "raw.githubusercontent.com", map[string]string{
+		"Authorization": "Bearer " + tok,
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "raw.githubusercontent.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "deny" || out.Reason != "credential_host_mismatch" {
+		t.Errorf("want credential_host_mismatch, got %+v", out)
+	}
+	// Strip-then-set invariant: a denied request still has its original header.
+	if got := req.Header.Get("Authorization"); got != "Bearer "+tok {
+		t.Errorf("denied request should not have its header swapped, got %q", got)
+	}
+}
+
+func TestPerHostScannerMatchesBasicShapeOnRuleBindings(t *testing.T) {
+	// A binding with no top-level AuthType (multi-rule) must still match
+	// requests in any of the rule shapes.
+	binding := githubPerHostBinding("sec-gh")
+	binding.AuthType = "" // multi-rule bindings carry no top-level type
+	tok := "ghp_proxy_token_dddd"
+	st := sandboxWithBindings(map[string]Binding{tok: binding})
+	vault := &stubVault{values: map[string]string{"sec-gh": "github_pat_REAL"}}
+
+	bearReq := newReq("GET", "api.github.com", map[string]string{"Authorization": "Bearer " + tok})
+	if out, _ := injectRequest(context.Background(), st, vault, bearReq, "api.github.com", nil, EgressRules{}); out.Action != "allow" {
+		t.Errorf("bearer-shaped request must match bearer rule, got %+v", out)
+	}
+
+	basicHdr := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:"+tok))
+	basicReq := newReq("GET", "github.com", map[string]string{"Authorization": basicHdr})
+	if out, _ := injectRequest(context.Background(), st, vault, basicReq, "github.com", nil, EgressRules{}); out.Action != "allow" {
+		t.Errorf("basic-shaped request must match basic rule, got %+v", out)
+	}
+}
+
+func TestDispatchAuthShapeLegacySingleRule(t *testing.T) {
+	// Legacy single-rule bindings (no Rules) keep working unchanged.
+	b := Binding{AuthType: "bearer", AuthConfig: nil, Hosts: []string{"api.example.com"}}
+	authType, cfg, ok := dispatchAuthShape(b, "api.example.com")
+	if !ok || authType != "bearer" || cfg != nil {
+		t.Errorf("legacy dispatch: got (%q, %v, %v), want (bearer, nil, true)", authType, cfg, ok)
+	}
+}
+
+func TestMultiBindingSwapsAllMatchedHeaders(t *testing.T) {
+	// When a request carries proxy tokens for multiple bindings, every one
+	// of them must be swapped — not just the first match.
+	bA := Binding{
+		SecretID: "sec-A", AuthType: "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-Header-A": "{{ value }}"}},
+		Hosts:      []string{"api.example.com"},
+	}
+	bB := Binding{
+		SecretID: "sec-B", AuthType: "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-Header-B": "{{ value }}"}},
+		Hosts:      []string{"api.example.com"},
+	}
+	tokA := "proxy-tok-A"
+	tokB := "proxy-tok-B"
+	st := sandboxWithBindings(map[string]Binding{tokA: bA, tokB: bB})
+	vault := &stubVault{values: map[string]string{
+		"sec-A": "REAL-VALUE-A",
+		"sec-B": "REAL-VALUE-B",
+	}}
+
+	req := newReq("GET", "api.example.com", map[string]string{
+		"X-Header-A": tokA,
+		"X-Header-B": tokB,
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil || out.Action != "allow" {
+		t.Fatalf("want allow, got %+v err=%v", out, err)
+	}
+	if got := req.Header.Get("X-Header-A"); got != "REAL-VALUE-A" {
+		t.Errorf("X-Header-A: want REAL-VALUE-A, got %q", got)
+	}
+	if got := req.Header.Get("X-Header-B"); got != "REAL-VALUE-B" {
+		t.Errorf("X-Header-B: want REAL-VALUE-B, got %q (binding B's swap was skipped)", got)
+	}
+	if len(out.MatchedSecretIDs) != 2 {
+		t.Errorf("want 2 matched secret IDs for audit, got %v", out.MatchedSecretIDs)
+	}
+}
+
+func TestMultiBindingDeterministicOrder(t *testing.T) {
+	// Outcome ordering must be deterministic across runs even though
+	// scope.Bindings is a Go map (which iterates in randomized order).
+	bA := Binding{SecretID: "sec-A", AuthType: "bearer", Hosts: []string{"api.example.com"}}
+	bB := Binding{SecretID: "sec-B", AuthType: "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-B": "{{ value }}"}},
+		Hosts:      []string{"api.example.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{
+		"proxy-A": bA, "proxy-B": bB,
+	})
+	vault := &stubVault{values: map[string]string{"sec-A": "RA", "sec-B": "RB"}}
+
+	for i := 0; i < 20; i++ {
+		req := newReq("GET", "api.example.com", map[string]string{
+			"Authorization": "Bearer proxy-A",
+			"X-B":           "proxy-B",
+		})
+		out, _ := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+		if len(out.MatchedSecretIDs) != 2 ||
+			out.MatchedSecretIDs[0] != "sec-A" || out.MatchedSecretIDs[1] != "sec-B" {
+			t.Fatalf("iteration %d: matched IDs not sorted: %v", i, out.MatchedSecretIDs)
+		}
+	}
+}
+
+func TestMultiBindingRevocationAbortsRequest(t *testing.T) {
+	// If any matched binding is revoked, the whole request must abort —
+	// no partial swap leaving one header with a real value and another with
+	// a (now meaningless) proxy token.
+	bA := Binding{
+		SecretID: "sec-OK", AuthType: "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-A": "{{ value }}"}},
+		Hosts:      []string{"api.example.com"},
+	}
+	bB := Binding{
+		SecretID: "sec-REVOKED", AuthType: "custom",
+		AuthConfig: map[string]any{"headers": map[string]string{"X-B": "{{ value }}"}},
+		Hosts:      []string{"api.example.com"},
+	}
+	st := sandboxWithBindings(map[string]Binding{
+		"proxy-A": bA, "proxy-B": bB,
+	})
+	// stubVault returns the OK value for sec-OK; sec-REVOKED isn't in the map.
+	vault := &stubVault{values: map[string]string{"sec-OK": "REAL-OK"}}
+
+	req := newReq("GET", "api.example.com", map[string]string{
+		"X-A": "proxy-A",
+		"X-B": "proxy-B",
+	})
+	out, err := injectRequest(context.Background(), st, vault, req, "api.example.com", nil, EgressRules{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Action != "revoked" {
+		t.Errorf("want revoked action, got %+v", out)
+	}
+	// X-A must not have been swapped — resolution failed before any apply.
+	if got := req.Header.Get("X-A"); got != "proxy-A" {
+		t.Errorf("X-A should be untouched on revocation; got %q", got)
+	}
+	if got := req.Header.Get("X-B"); got != "proxy-B" {
+		t.Errorf("X-B should be untouched on revocation; got %q", got)
+	}
+}
+
+func TestCachedVaultEvictsLRUWhenCapacityReached(t *testing.T) {
+	// Cache must bound its size: once capacity is reached, the least
+	// recently used entry is evicted on insert. Without this, the cache
+	// grows unbounded for sandboxes with many short-lived secrets.
+	clock := &fakeClock{t: time.Now()}
+	upstream := &stubVault{values: map[string]string{"a": "A", "b": "B", "c": "C"}}
+	cv := NewCachedVault(upstream, VaultCacheOptions{
+		TTL:      time.Hour,
+		IdleTTL:  time.Hour,
+		Capacity: 2,
+	})
+	cv.now = clock.Now
+
+	for _, sid := range []string{"a", "b", "c"} {
+		if _, err := cv.FetchCredential(context.Background(), "team-1", sid); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if cv.order.Len() != 2 {
+		t.Errorf("cache len = %d, want 2 (capacity bound)", cv.order.Len())
+	}
+	// "a" was the oldest insert; should be evicted.
+	if _, ok := cv.entries[cacheKey{teamID: "team-1", secretID: "a"}]; ok {
+		t.Error("expected oldest entry 'a' to be evicted")
+	}
+	if _, ok := cv.entries[cacheKey{teamID: "team-1", secretID: "c"}]; !ok {
+		t.Error("newest entry 'c' must be present")
+	}
+}
+
+func TestCachedVaultLRUOrderPromotedOnHit(t *testing.T) {
+	// A cache hit must move the entry to the front of the LRU list,
+	// otherwise frequently-accessed entries get evicted prematurely.
+	clock := &fakeClock{t: time.Now()}
+	upstream := &stubVault{values: map[string]string{"a": "A", "b": "B", "c": "C"}}
+	cv := NewCachedVault(upstream, VaultCacheOptions{
+		TTL: time.Hour, IdleTTL: time.Hour, Capacity: 2,
+	})
+	cv.now = clock.Now
+
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "a")
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "b")
+	// Touch "a" — must move it to front.
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "a")
+	// Insert "c" — now "b" should be the LRU victim, not "a".
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "c")
+
+	if _, ok := cv.entries[cacheKey{teamID: "team-1", secretID: "a"}]; !ok {
+		t.Error("touched 'a' was prematurely evicted")
+	}
+	if _, ok := cv.entries[cacheKey{teamID: "team-1", secretID: "b"}]; ok {
+		t.Error("'b' should have been LRU-evicted in favor of touched 'a'")
+	}
+}
+
+func TestCachedVaultIdleTTLEvictsStaleEntry(t *testing.T) {
+	// An entry that hasn't been accessed in IdleTTL is dropped on the next
+	// access attempt and re-fetched, bounding memory for never-revisited
+	// entries even when capacity isn't reached.
+	clock := &fakeClock{t: time.Now()}
+	upstream := &stubVault{values: map[string]string{"a": "A"}}
+	cv := NewCachedVault(upstream, VaultCacheOptions{
+		TTL: time.Hour, IdleTTL: 5 * time.Minute, Capacity: 1024,
+	})
+	cv.now = clock.Now
+
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "a")
+	if upstream.calls != 1 {
+		t.Fatalf("upstream calls after first fetch: got %d, want 1", upstream.calls)
+	}
+
+	// Advance past idle TTL with no access.
+	clock.advance(6 * time.Minute)
+	_, _ = cv.FetchCredential(context.Background(), "team-1", "a")
+	if upstream.calls != 2 {
+		t.Errorf("idle-evicted entry should trigger a re-fetch, got %d upstream calls", upstream.calls)
+	}
+}

--- a/internal/secretsproxy/jwt.go
+++ b/internal/secretsproxy/jwt.go
@@ -1,0 +1,301 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// backgroundRefreshTimeout caps an async JWKS fetch — long enough for a slow
+// control plane, short enough that a stuck fetcher doesn't hold a goroutine.
+const backgroundRefreshTimeout = 30 * time.Second
+
+// secretsJWTIssuer is the iss claim the daemon requires; matches the control
+// plane's `api.SecretsJWTIssuer`.
+const secretsJWTIssuer = "superserve-controlplane"
+
+// JWTBindingClaim mirrors `api.SecretsBindingClaim` over the JWT wire shape.
+// When Rules is present, AuthType/AuthConfig are unused; the daemon dispatches
+// by upstream host using the rule list.
+type JWTBindingClaim struct {
+	ProxyToken string         `json:"p"`
+	SecretID   string         `json:"s"`
+	EnvKey     string         `json:"e"`
+	Hosts      []string       `json:"h"`
+	AuthType   string         `json:"t,omitempty"`
+	AuthConfig map[string]any `json:"c,omitempty"`
+	Rules      []JWTRuleClaim `json:"rules,omitempty"`
+}
+
+// JWTRuleClaim is one (hosts → auth shape) entry inside JWTBindingClaim.Rules.
+type JWTRuleClaim struct {
+	Hosts    []string          `json:"h"`
+	AuthType string            `json:"t"`
+	Username string            `json:"u,omitempty"`
+	Header   string            `json:"hd,omitempty"`
+	Prefix   string            `json:"pf,omitempty"`
+	Headers  map[string]string `json:"hs,omitempty"`
+}
+
+// JWTClaims is the parsed JWT payload. Egress rules are not carried here — the
+// proxy fetches them live so a PATCH applies without re-minting.
+type JWTClaims struct {
+	TeamID   string            `json:"team_id"`
+	SourceIP string            `json:"source_ip"`
+	Bindings []JWTBindingClaim `json:"bindings,omitempty"`
+
+	jwt.RegisteredClaims
+}
+
+// JWT verification errors. Discrete sentinel values so callers can branch on
+// reason (typically all map to 407 on the wire).
+var (
+	ErrJWTMissing          = errors.New("secretsproxy: jwt missing")
+	ErrJWTMalformed        = errors.New("secretsproxy: jwt malformed")
+	ErrJWTBadSignature     = errors.New("secretsproxy: jwt signature failed")
+	ErrJWTExpired          = errors.New("secretsproxy: jwt expired")
+	ErrJWTWrongIssuer      = errors.New("secretsproxy: jwt wrong issuer")
+	ErrJWTUnknownKid       = errors.New("secretsproxy: jwt unknown kid")
+	ErrJWTSourceIPMismatch = errors.New("secretsproxy: jwt source_ip does not match remote address")
+	ErrJWTMissingClaim     = errors.New("secretsproxy: jwt missing required claim")
+)
+
+// JWKSFetcher loads the set of trusted verification keys. The production
+// implementation hits the control plane's /internal/jwks endpoint; tests
+// inject a stub that returns canned keys.
+type JWKSFetcher interface {
+	Fetch(ctx context.Context) (map[string]ed25519.PublicKey, error)
+}
+
+// Verifier parses and verifies secrets JWTs against keys fetched from a
+// JWKSFetcher. Concurrency-safe; the key map is replaced atomically on refresh.
+type Verifier struct {
+	fetcher JWKSFetcher
+
+	mu            sync.RWMutex
+	keys          map[string]ed25519.PublicKey
+	lastFetch     time.Time
+	missCooldown  time.Duration // bounds how often a kid miss can trigger a refresh
+	lastMissFetch time.Time
+	refreshing    bool // true while a background JWKS fetch is in flight
+	clock         func() time.Time
+
+	// backgroundRefreshes increments after each background refresh attempt
+	// (success or failure). Tests observe completion via this counter.
+	backgroundRefreshes atomic.Uint64
+}
+
+// NewVerifier builds a Verifier and performs the initial JWKS load. Returns
+// an error if the initial load fails — the daemon should refuse to start in
+// that state rather than accept any JWT silently.
+func NewVerifier(ctx context.Context, fetcher JWKSFetcher) (*Verifier, error) {
+	v := &Verifier{
+		fetcher:      fetcher,
+		missCooldown: 60 * time.Second,
+		clock:        time.Now,
+	}
+	if err := v.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("initial JWKS load: %w", err)
+	}
+	return v, nil
+}
+
+// Refresh re-fetches the JWKS and atomically replaces the cached keys.
+func (v *Verifier) Refresh(ctx context.Context) error { return v.refresh(ctx) }
+
+func (v *Verifier) refresh(ctx context.Context) error {
+	keys, err := v.fetcher.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	v.mu.Lock()
+	v.keys = keys
+	v.lastFetch = v.clock()
+	v.mu.Unlock()
+	return nil
+}
+
+// Verify parses jwtString, verifies signature + standard claims, and checks
+// that the source_ip claim matches expectedSourceIP. On unknown kid, the
+// verifier attempts one cached refresh (debounced) before failing.
+func (v *Verifier) Verify(ctx context.Context, jwtString, expectedSourceIP string) (*JWTClaims, error) {
+	if jwtString == "" {
+		return nil, ErrJWTMissing
+	}
+
+	claims := &JWTClaims{}
+	token, err := jwt.ParseWithClaims(jwtString, claims, v.keyfunc(ctx),
+		jwt.WithValidMethods([]string{jwt.SigningMethodEdDSA.Alg()}),
+		jwt.WithIssuer(secretsJWTIssuer),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, mapJWTError(err)
+	}
+	if !token.Valid {
+		return nil, ErrJWTBadSignature
+	}
+
+	if claims.TeamID == "" || claims.SourceIP == "" || claims.Subject == "" {
+		return nil, ErrJWTMissingClaim
+	}
+	if claims.SourceIP != expectedSourceIP {
+		return nil, ErrJWTSourceIPMismatch
+	}
+	return claims, nil
+}
+
+// keyfunc returns the per-Parse callback the JWT library uses to look up a
+// public key by kid. On unknown kid, kicks off an async JWKS refresh and
+// fails the current request — JWKS fetch latency never blocks the request
+// path; the next request after refresh completes will succeed.
+func (v *Verifier) keyfunc(_ context.Context) jwt.Keyfunc {
+	return func(token *jwt.Token) (any, error) {
+		kid, _ := token.Header["kid"].(string)
+		if kid == "" {
+			return nil, ErrJWTMalformed
+		}
+		if key, ok := v.lookup(kid); ok {
+			return key, nil
+		}
+		v.maybeRefreshAsync()
+		return nil, ErrJWTUnknownKid
+	}
+}
+
+// maybeRefreshAsync kicks off a JWKS refresh in a background goroutine if
+// (a) the miss cooldown has elapsed and (b) no refresh is already in flight.
+// Detached from the request context so the refresh isn't cancelled when the
+// request returns.
+func (v *Verifier) maybeRefreshAsync() {
+	v.mu.Lock()
+	now := v.clock()
+	if v.refreshing || now.Sub(v.lastMissFetch) < v.missCooldown {
+		v.mu.Unlock()
+		return
+	}
+	v.refreshing = true
+	v.lastMissFetch = now
+	v.mu.Unlock()
+
+	go func() {
+		defer func() {
+			v.mu.Lock()
+			v.refreshing = false
+			v.mu.Unlock()
+			v.backgroundRefreshes.Add(1)
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), backgroundRefreshTimeout)
+		defer cancel()
+		_ = v.refresh(ctx)
+	}()
+}
+
+func (v *Verifier) lookup(kid string) (ed25519.PublicKey, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	key, ok := v.keys[kid]
+	return key, ok
+}
+
+// mapJWTError converts library errors to our sentinels so callers can branch
+// uniformly. Anything we don't recognize maps to ErrJWTBadSignature.
+func mapJWTError(err error) error {
+	switch {
+	case errors.Is(err, jwt.ErrTokenExpired):
+		return ErrJWTExpired
+	case errors.Is(err, jwt.ErrTokenInvalidIssuer):
+		return ErrJWTWrongIssuer
+	case errors.Is(err, ErrJWTUnknownKid):
+		return ErrJWTUnknownKid
+	case errors.Is(err, ErrJWTMalformed):
+		return ErrJWTMalformed
+	case errors.Is(err, jwt.ErrTokenMalformed):
+		return ErrJWTMalformed
+	default:
+		return ErrJWTBadSignature
+	}
+}
+
+// HTTPJWKSFetcher reads the JWKS from the control plane's /internal/jwks
+// endpoint. Authenticates with the daemon's shared token (same as the vault
+// decrypt path).
+type HTTPJWKSFetcher struct {
+	baseURL    string
+	authToken  string
+	httpClient *http.Client
+}
+
+// NewHTTPJWKSFetcher builds a fetcher targeting {baseURL}/internal/jwks.
+func NewHTTPJWKSFetcher(baseURL, authToken string) *HTTPJWKSFetcher {
+	return &HTTPJWKSFetcher{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		authToken:  authToken,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// jwksResponse mirrors the wire shape of /internal/jwks. Only Ed25519 keys
+// (kty=OKP, crv=Ed25519) are accepted; other entries are skipped.
+type jwksResponse struct {
+	Keys []struct {
+		Kid string `json:"kid"`
+		Kty string `json:"kty"`
+		Crv string `json:"crv"`
+		X   string `json:"x"`
+	} `json:"keys"`
+}
+
+// Fetch implements JWKSFetcher.
+func (f *HTTPJWKSFetcher) Fetch(ctx context.Context) (map[string]ed25519.PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.baseURL+"/internal/jwks", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build jwks request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+f.authToken)
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("jwks request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("control plane rejected daemon auth on JWKS fetch (%d): check DAEMON_AUTH_TOKEN matches control plane INTERNAL_API_TOKEN", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("control plane returned %d on JWKS fetch: %s", resp.StatusCode, string(raw))
+	}
+	var body jwksResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode jwks: %w", err)
+	}
+	out := make(map[string]ed25519.PublicKey, len(body.Keys))
+	for _, k := range body.Keys {
+		if k.Kty != "OKP" || k.Crv != "Ed25519" || k.Kid == "" {
+			continue
+		}
+		raw, err := base64.RawURLEncoding.DecodeString(k.X)
+		if err != nil {
+			continue
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			continue
+		}
+		out[k.Kid] = ed25519.PublicKey(raw)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no usable Ed25519 keys in JWKS response")
+	}
+	return out, nil
+}

--- a/internal/secretsproxy/jwt_resolver.go
+++ b/internal/secretsproxy/jwt_resolver.go
@@ -1,0 +1,80 @@
+package secretsproxy
+
+import "context"
+
+// ruleAuthConfig flattens a JWTRuleClaim's typed fields into the same
+// map[string]any shape the injector already consumes for single-rule bindings,
+// so the writers in inject.go can stay shape-agnostic.
+func ruleAuthConfig(r JWTRuleClaim) map[string]any {
+	switch r.AuthType {
+	case "basic":
+		if r.Username == "" {
+			return nil
+		}
+		return map[string]any{"username": r.Username}
+	case "api-key":
+		cfg := map[string]any{"header": r.Header}
+		if r.Prefix != "" {
+			cfg["prefix"] = r.Prefix
+		}
+		return cfg
+	case "custom":
+		if len(r.Headers) == 0 {
+			return nil
+		}
+		headers := make(map[string]any, len(r.Headers))
+		for k, v := range r.Headers {
+			headers[k] = v
+		}
+		return map[string]any{"headers": headers}
+	}
+	return nil
+}
+
+// JWTResolver authenticates a CONNECT by verifying the JWT against the
+// JWKS-backed Verifier and translating the claims into a Scope.
+type JWTResolver struct {
+	verifier *Verifier
+}
+
+// NewJWTResolver returns a Resolver that authenticates each CONNECT via the
+// supplied Verifier (which itself owns the JWKS cache and refresh policy).
+func NewJWTResolver(v *Verifier) *JWTResolver {
+	return &JWTResolver{verifier: v}
+}
+
+// Authenticate implements Resolver. Any verification failure surfaces as
+// ErrUnknownSandbox so callers can map every rejection uniformly to 407.
+func (r *JWTResolver) Authenticate(ctx context.Context, sourceIP, jwt string) (*Scope, error) {
+	claims, err := r.verifier.Verify(ctx, jwt, sourceIP)
+	if err != nil {
+		return nil, err
+	}
+	bindings := make(map[string]Binding, len(claims.Bindings))
+	for _, b := range claims.Bindings {
+		binding := Binding{
+			SecretID:   b.SecretID,
+			EnvKey:     b.EnvKey,
+			AuthType:   b.AuthType,
+			AuthConfig: b.AuthConfig,
+			Hosts:      b.Hosts,
+		}
+		if len(b.Rules) > 0 {
+			binding.Rules = make([]BindingRule, 0, len(b.Rules))
+			for _, r := range b.Rules {
+				binding.Rules = append(binding.Rules, BindingRule{
+					Hosts:      r.Hosts,
+					AuthType:   r.AuthType,
+					AuthConfig: ruleAuthConfig(r),
+				})
+			}
+		}
+		bindings[b.ProxyToken] = binding
+	}
+	return &Scope{
+		SandboxID: claims.Subject,
+		TeamID:    claims.TeamID,
+		SourceIP:  claims.SourceIP,
+		Bindings:  bindings,
+	}, nil
+}

--- a/internal/secretsproxy/jwt_test.go
+++ b/internal/secretsproxy/jwt_test.go
@@ -1,0 +1,502 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// stubFetcher is a JWKSFetcher driven by a function so tests can swap behavior
+// (initial load, refresh-on-miss, rotation) without coordinating channels.
+type stubFetcher struct {
+	mu    sync.Mutex
+	fn    func() (map[string]ed25519.PublicKey, error)
+	calls int
+}
+
+func (f *stubFetcher) Fetch(ctx context.Context) (map[string]ed25519.PublicKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.fn()
+}
+
+func (f *stubFetcher) setFn(fn func() (map[string]ed25519.PublicKey, error)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fn = fn
+}
+
+func (f *stubFetcher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// signForTest builds a JWT with the supplied private key and kid. Mirrors what
+// the control plane's SecretsSigner would emit; redeclared here so the daemon
+// tests don't import the api package.
+func signForTest(t *testing.T, priv ed25519.PrivateKey, kid string, claims JWTClaims, now time.Time) string {
+	t.Helper()
+	if claims.Issuer == "" {
+		claims.Issuer = secretsJWTIssuer
+	}
+	if claims.IssuedAt == nil {
+		claims.IssuedAt = jwt.NewNumericDate(now)
+	}
+	if claims.ExpiresAt == nil {
+		claims.ExpiresAt = jwt.NewNumericDate(now.Add(time.Hour))
+	}
+	if claims.Subject == "" {
+		claims.Subject = "sandbox-1"
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, &claims)
+	token.Header["kid"] = kid
+	s, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func newKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub, priv
+}
+
+func TestVerifier_HappyPath(t *testing.T) {
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: "sk-ant-api03-aaaa",
+			SecretID:   "secret-1",
+			EnvKey:     "ANTHROPIC_API_KEY",
+			Hosts:      []string{"api.anthropic.com"},
+			AuthType:   "api-key",
+			AuthConfig: map[string]any{"header": "x-api-key"},
+		}},
+	}, time.Now())
+
+	claims, err := v.Verify(context.Background(), tok, "10.0.0.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.TeamID != "team-1" {
+		t.Errorf("TeamID: %q", claims.TeamID)
+	}
+	if claims.Subject != "sandbox-1" {
+		t.Errorf("Subject: %q", claims.Subject)
+	}
+	if len(claims.Bindings) != 1 || claims.Bindings[0].SecretID != "secret-1" {
+		t.Errorf("bindings drift: %+v", claims.Bindings)
+	}
+}
+
+func TestVerifier_RejectsBadSignature(t *testing.T) {
+	pub, _ := newKeypair(t)       // trusted public key
+	_, otherPriv := newKeypair(t) // attacker's private key, never trusted
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+
+	tok := signForTest(t, otherPriv, "v1", JWTClaims{
+		TeamID: "team-1", SourceIP: "10.0.0.5",
+	}, time.Now())
+
+	_, err := v.Verify(context.Background(), tok, "10.0.0.5")
+	if !errors.Is(err, ErrJWTBadSignature) {
+		t.Errorf("want ErrJWTBadSignature, got %v", err)
+	}
+}
+
+func TestVerifier_RejectsExpired(t *testing.T) {
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+	}, time.Now())
+
+	_, err := v.Verify(context.Background(), tok, "10.0.0.5")
+	if !errors.Is(err, ErrJWTExpired) {
+		t.Errorf("want ErrJWTExpired, got %v", err)
+	}
+}
+
+func TestVerifier_RejectsWrongIssuer(t *testing.T) {
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID: "team-1", SourceIP: "10.0.0.5",
+		RegisteredClaims: jwt.RegisteredClaims{Issuer: "imposter"},
+	}, time.Now())
+
+	_, err := v.Verify(context.Background(), tok, "10.0.0.5")
+	if !errors.Is(err, ErrJWTWrongIssuer) {
+		t.Errorf("want ErrJWTWrongIssuer, got %v", err)
+	}
+}
+
+func TestVerifier_RejectsSourceIPMismatch(t *testing.T) {
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID: "team-1", SourceIP: "10.0.0.5",
+	}, time.Now())
+
+	_, err := v.Verify(context.Background(), tok, "10.0.0.99")
+	if !errors.Is(err, ErrJWTSourceIPMismatch) {
+		t.Errorf("want ErrJWTSourceIPMismatch, got %v", err)
+	}
+}
+
+func TestVerifier_RejectsMissingRequiredClaims(t *testing.T) {
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+
+	cases := []struct {
+		name   string
+		claims JWTClaims
+	}{
+		{"no team_id", JWTClaims{SourceIP: "10.0.0.5"}},
+		{"no source_ip", JWTClaims{TeamID: "team-1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok := signForTest(t, priv, "v1", tc.claims, time.Now())
+			_, err := v.Verify(context.Background(), tok, "10.0.0.5")
+			if !errors.Is(err, ErrJWTMissingClaim) && !errors.Is(err, ErrJWTSourceIPMismatch) {
+				// Missing source_ip slips through claim parse with empty string
+				// and trips the source-IP check; the test accepts either.
+				t.Errorf("want claim or source-ip rejection, got %v", err)
+			}
+		})
+	}
+}
+
+func TestVerifier_RejectsEmptyJWT(t *testing.T) {
+	pub, _ := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+	if _, err := v.Verify(context.Background(), "", "10.0.0.5"); !errors.Is(err, ErrJWTMissing) {
+		t.Errorf("want ErrJWTMissing, got %v", err)
+	}
+}
+
+func TestVerifier_RejectsMalformed(t *testing.T) {
+	pub, _ := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, _ := NewVerifier(context.Background(), fetcher)
+	if _, err := v.Verify(context.Background(), "not.a.jwt", "10.0.0.5"); !errors.Is(err, ErrJWTMalformed) {
+		t.Errorf("want ErrJWTMalformed, got %v", err)
+	}
+}
+
+func TestVerifier_UnknownKidTriggersAsyncRefresh(t *testing.T) {
+	// Unknown kid kicks off a background refresh: the request that triggered
+	// the miss fails with ErrJWTUnknownKid (JWKS fetch never blocks the
+	// request path), but the next request after the refresh completes succeeds.
+	pub1, priv1 := newKeypair(t)
+	pub2, priv2 := newKeypair(t)
+
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub1}, nil
+	}}
+	v, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = priv1
+
+	// Simulate rotation.
+	fetcher.setFn(func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub1, "v2": pub2}, nil
+	})
+	tokV2 := signForTest(t, priv2, "v2", JWTClaims{TeamID: "t", SourceIP: "1.1.1.1"}, time.Now())
+
+	// First attempt fails — refresh kicks off in the background.
+	prevRefreshes := v.backgroundRefreshes.Load()
+	if _, err := v.Verify(context.Background(), tokV2, "1.1.1.1"); !errors.Is(err, ErrJWTUnknownKid) {
+		t.Fatalf("first miss must fail fast with ErrJWTUnknownKid, got %v", err)
+	}
+	waitForBackgroundRefresh(t, v, prevRefreshes)
+
+	// Second attempt — keys are now refreshed.
+	claims, err := v.Verify(context.Background(), tokV2, "1.1.1.1")
+	if err != nil {
+		t.Fatalf("after background refresh, expected success, got %v", err)
+	}
+	if claims.TeamID != "t" {
+		t.Errorf("claims TeamID drift: %q", claims.TeamID)
+	}
+	if fetcher.callCount() != 2 {
+		t.Errorf("expected exactly 2 fetches (initial + one background refresh), got %d", fetcher.callCount())
+	}
+}
+
+// waitForBackgroundRefresh polls until at least one background refresh has
+// completed since prev. Avoids time.Sleep dependence in tests.
+func waitForBackgroundRefresh(t *testing.T, v *Verifier, prev uint64) {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		if v.backgroundRefreshes.Load() > prev {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("background refresh never completed")
+}
+
+func TestVerifier_UnknownKidRefreshDebounced(t *testing.T) {
+	pub, _ := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a v2 token that will trigger the miss path. Use a fresh key so it
+	// would also fail signature, but we're asserting on fetch-call count.
+	_, otherPriv := newKeypair(t)
+	tok := signForTest(t, otherPriv, "v2", JWTClaims{TeamID: "t", SourceIP: "1.1.1.1"}, time.Now())
+
+	// First miss kicks off an async refresh; subsequent misses within
+	// the cooldown must NOT trigger more fetches.
+	prevRefreshes := v.backgroundRefreshes.Load()
+	for i := 0; i < 5; i++ {
+		_, _ = v.Verify(context.Background(), tok, "1.1.1.1")
+	}
+	waitForBackgroundRefresh(t, v, prevRefreshes)
+	// 1 initial + 1 miss-refresh = 2 total.
+	if fetcher.callCount() != 2 {
+		t.Errorf("expected 2 fetches with cooldown, got %d", fetcher.callCount())
+	}
+}
+
+func TestVerifier_InitialFetchFailureRefusesToStart(t *testing.T) {
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return nil, errors.New("control plane unreachable")
+	}}
+	if _, err := NewVerifier(context.Background(), fetcher); err == nil {
+		t.Fatal("expected error from initial JWKS load failure")
+	}
+}
+
+func TestHTTPJWKSFetcher_ParsesValidResponse(t *testing.T) {
+	pub, _ := newKeypair(t)
+	body := `{"keys":[{"kid":"v1","kty":"OKP","crv":"Ed25519","x":"` +
+		base64.RawURLEncoding.EncodeToString(pub) + `"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-tok" {
+			http.Error(w, "bad auth", http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path != "/internal/jwks" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	f := NewHTTPJWKSFetcher(srv.URL, "test-tok")
+	keys, err := f.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 || !pub.Equal(keys["v1"]) {
+		t.Errorf("keys mismatch: %+v", keys)
+	}
+}
+
+func TestHTTPJWKSFetcher_SurfacesAuthFailure(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "nope", code)
+			}))
+			defer srv.Close()
+			f := NewHTTPJWKSFetcher(srv.URL, "wrong")
+			_, err := f.Fetch(context.Background())
+			if err == nil || !strings.Contains(err.Error(), "DAEMON_AUTH_TOKEN") {
+				t.Errorf("want auth-failure error mentioning DAEMON_AUTH_TOKEN, got %v", err)
+			}
+		})
+	}
+}
+
+func TestHTTPJWKSFetcher_RejectsEmptyKeys(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	defer srv.Close()
+	f := NewHTTPJWKSFetcher(srv.URL, "tok")
+	if _, err := f.Fetch(context.Background()); err == nil {
+		t.Fatal("expected error on empty JWKS")
+	}
+}
+
+func TestHTTPJWKSFetcher_SkipsNonEd25519Keys(t *testing.T) {
+	pub, _ := newKeypair(t)
+	body := `{"keys":[
+		{"kid":"rsa","kty":"RSA","x":"ignored"},
+		{"kid":"v1","kty":"OKP","crv":"Ed25519","x":"` + base64.RawURLEncoding.EncodeToString(pub) + `"}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	f := NewHTTPJWKSFetcher(srv.URL, "tok")
+	keys, err := f.Fetch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := keys["rsa"]; ok {
+		t.Error("RSA key should have been skipped")
+	}
+	if _, ok := keys["v1"]; !ok {
+		t.Error("Ed25519 key should be present")
+	}
+}
+
+func TestVerifier_PerHostRulesRoundTrip(t *testing.T) {
+	// A JWT minted with multi-rule bindings must survive parse and produce
+	// the matching Rule list on the verified claims.
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: "ghp_proxy_aaa",
+			SecretID:   "sec-gh",
+			EnvKey:     "GITHUB_TOKEN",
+			Hosts:      []string{"api.github.com", "github.com"},
+			Rules: []JWTRuleClaim{
+				{Hosts: []string{"api.github.com"}, AuthType: "bearer"},
+				{Hosts: []string{"github.com"}, AuthType: "basic", Username: "x-access-token"},
+			},
+		}},
+	}, time.Now())
+
+	claims, err := v.Verify(context.Background(), tok, "10.0.0.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claims.Bindings) != 1 {
+		t.Fatalf("bindings count: %d", len(claims.Bindings))
+	}
+	b := claims.Bindings[0]
+	if len(b.Rules) != 2 {
+		t.Fatalf("rules count: %d", len(b.Rules))
+	}
+	if b.Rules[0].AuthType != "bearer" || b.Rules[0].Hosts[0] != "api.github.com" {
+		t.Errorf("rule 0 drift: %+v", b.Rules[0])
+	}
+	if b.Rules[1].AuthType != "basic" || b.Rules[1].Username != "x-access-token" {
+		t.Errorf("rule 1 drift: %+v", b.Rules[1])
+	}
+}
+
+func TestJWTResolver_PerHostRulesPopulateBindingRules(t *testing.T) {
+	// Resolver must translate JWTRuleClaim → BindingRule with the right
+	// AuthConfig shape so the inject pipeline finds the username.
+	pub, priv := newKeypair(t)
+	fetcher := &stubFetcher{fn: func() (map[string]ed25519.PublicKey, error) {
+		return map[string]ed25519.PublicKey{"v1": pub}, nil
+	}}
+	v, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewJWTResolver(v)
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: "ghp_proxy_bbb",
+			SecretID:   "sec-gh",
+			EnvKey:     "GITHUB_TOKEN",
+			Hosts:      []string{"api.github.com", "github.com"},
+			Rules: []JWTRuleClaim{
+				{Hosts: []string{"api.github.com"}, AuthType: "bearer"},
+				{Hosts: []string{"github.com"}, AuthType: "basic", Username: "x-access-token"},
+			},
+		}},
+	}, time.Now())
+
+	scope, err := resolver.Authenticate(context.Background(), "10.0.0.5", tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, ok := scope.Bindings["ghp_proxy_bbb"]
+	if !ok {
+		t.Fatal("binding not present in scope")
+	}
+	if len(b.Rules) != 2 {
+		t.Fatalf("rules count: %d", len(b.Rules))
+	}
+	// Basic rule's username must round-trip into AuthConfig where the writer reads it.
+	got, _ := stringFromAuthConfig(b.Rules[1].AuthConfig, "username")
+	if got != "x-access-token" {
+		t.Errorf("basic rule username lost: cfg=%v", b.Rules[1].AuthConfig)
+	}
+}

--- a/internal/secretsproxy/log_cleanliness_test.go
+++ b/internal/secretsproxy/log_cleanliness_test.go
@@ -1,0 +1,152 @@
+package secretsproxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLogsDoNotLeakCredentialValues exercises the full proxy stack with real
+// credentials and a captured slog output. It then scans every log line for
+// the cleartext credential, JWT, and proxy token — none should appear.
+//
+// This is a regression check: any future change that accidentally adds the
+// credential value to a log line (e.g., via err.Error() that wraps an HTTP
+// request dump) will be caught here.
+func TestLogsDoNotLeakCredentialValues(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jwksSrv := jwksHTTP(t, "v1", pub)
+
+	const (
+		realCredentialValue = "sk-ant-VERY-SECRET-CREDENTIAL-VALUE"
+		proxyTokenInEnv     = "proxy-tok-DO-NOT-LEAK"
+	)
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(upstream.Close)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	// Capture all slog output produced by the proxy.
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fetcher := NewHTTPJWKSFetcher(jwksSrv.URL, "test-tok")
+	verifier, err := NewVerifier(context.Background(), fetcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewJWTResolver(verifier)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(upstream.Certificate())
+	upstreamTr := &http.Transport{
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool},
+	}
+	vault := &stubVault{values: map[string]string{"sec-1": realCredentialValue}}
+
+	p := NewProxy("127.0.0.1:0", Options{
+		CA:                ca,
+		Resolver:          resolver,
+		Vault:             vault,
+		Audit:             &recordingAudit{},
+		Logger:            logger,
+		UpstreamTransport: upstreamTr,
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = p.Serve(l) }()
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+	for i := 0; i < 50; i++ {
+		if p.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !p.IsListening() {
+		t.Fatal("proxy never came up")
+	}
+
+	tok := signForTest(t, priv, "v1", JWTClaims{
+		TeamID:   "team-1",
+		SourceIP: "127.0.0.1",
+		Bindings: []JWTBindingClaim{{
+			ProxyToken: proxyTokenInEnv,
+			SecretID:   "sec-1",
+			EnvKey:     "ANTHROPIC_API_KEY",
+			Hosts:      []string{"127.0.0.1"},
+			AuthType:   "bearer",
+			AuthConfig: map[string]any{},
+		}},
+	}, time.Now())
+
+	// Drive a happy-path request through the proxy.
+	conn := dialProxy(t, l.Addr().String(), ca)
+	defer conn.Close()
+	status, ok := sendConnect(t, conn, upstreamURL.Host, tok)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+	pool2 := x509.NewCertPool()
+	pool2.AppendCertsFromPEM(ca.RootPEM())
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: "127.0.0.1",
+		RootCAs:    pool2,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatal(err)
+	}
+	req := "GET /x HTTP/1.1\r\nHost: " + upstreamURL.Host + "\r\nAuthorization: Bearer " + proxyTokenInEnv + "\r\n\r\n"
+	if _, err := tlsClient.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tlsClient), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	// Also exercise the reject path; that's where errors with sensitive
+	// substrings could most plausibly leak.
+	badConn := dialProxy(t, l.Addr().String(), ca)
+	defer badConn.Close()
+	_, _ = sendConnect(t, badConn, upstreamURL.Host, "this-is-not-a-valid-jwt")
+
+	logs := logBuf.String()
+	forbidden := []string{realCredentialValue, tok, proxyTokenInEnv}
+	for _, secret := range forbidden {
+		if strings.Contains(logs, secret) {
+			t.Errorf("log output contains forbidden substring: %q\nfull logs:\n%s", secret, logs)
+		}
+	}
+}
+

--- a/internal/secretsproxy/proxy.go
+++ b/internal/secretsproxy/proxy.go
@@ -1,0 +1,284 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// Resolver authenticates a proxy connection from its source IP and bearer JWT.
+type Resolver interface {
+	Authenticate(ctx context.Context, sourceIP, jwt string) (*Scope, error)
+}
+
+// Scope is the per-connection authorization context built from a verified JWT.
+// Egress rules are not carried here — they are fetched live per request so a
+// PATCH takes effect without re-minting the JWT.
+type Scope struct {
+	SandboxID string
+	TeamID    string
+	SourceIP  string
+	// Bindings is the proxy_token → Binding map the inject pipeline uses to
+	// match outbound requests against the sandbox's configured credentials.
+	Bindings map[string]Binding
+}
+
+// Binding is one (proxy_token → credential) pair carried in the JWT. When
+// Rules is non-empty, AuthType/AuthConfig are unused at egress; the inject
+// pipeline picks a rule by upstream host. Hosts stays as the binding-wide
+// allowlist regardless.
+type Binding struct {
+	SecretID   string
+	EnvKey     string
+	AuthType   string         // bearer | basic | api-key | custom
+	AuthConfig map[string]any // type-specific config
+	Hosts      []string       // upstream hosts this credential applies to
+	Rules      []BindingRule  // per-host rules, dispatched at egress
+}
+
+// BindingRule is one (hosts → auth shape) entry inside Binding.Rules.
+type BindingRule struct {
+	Hosts      []string
+	AuthType   string
+	AuthConfig map[string]any
+}
+
+// ErrUnknownSandbox is returned for any rejection of the proxy CONNECT (bad
+// signature, expired JWT, source-IP mismatch, etc.). The dispatcher maps all
+// of these to a 407.
+var ErrUnknownSandbox = errors.New("secretsproxy: connection rejected")
+
+// Proxy is the MITM HTTPS ingress.
+type Proxy struct {
+	addr     string
+	ca       *CA
+	resolver Resolver
+	logger   *slog.Logger
+
+	vault               VaultClient
+	rules               RulesClient
+	audit               AuditSink
+	revoker             *Revoker
+	httpServer          *http.Server
+	tlsConfig           *tls.Config
+	upstream            *http.Transport
+	isListening         atomic.Bool
+	sandboxFacingHost   string
+	maxRequestBodyBytes int64
+	blockedPorts        map[int]bool
+	blockInternalAddrs  bool
+	dnsResolver         *net.Resolver
+}
+
+// Options carries Proxy dependencies. Nil Logger, Vault, Audit, and UpstreamTransport
+// fall back to safe defaults (discard logger, passthrough, no-op sink, strict TLS transport).
+type Options struct {
+	CA                *CA
+	Resolver          Resolver
+	Vault             VaultClient
+	Rules             RulesClient
+	Audit             AuditSink
+	Revoker           *Revoker
+	Logger            *slog.Logger
+	UpstreamTransport *http.Transport
+
+	// IP sandboxes connect to. SNI fallback for clients that omit it (e.g. curl to an IP).
+	SandboxFacingHost string
+
+	// MaxRequestBodyBytes caps each forwarded request body. Zero falls back
+	// to defaultMaxRequestBodyBytes.
+	MaxRequestBodyBytes int64
+
+	// BlockedPorts lists egress ports the proxy refuses to tunnel to,
+	// matching the operator's host-firewall port policy.
+	BlockedPorts []int
+
+	// BlockInternalAddrs rejects CONNECTs to internal-range IP literals.
+	BlockInternalAddrs bool
+
+	// DNSResolver resolves upstream hosts for CIDR egress rules. Nil uses the
+	// default resolver.
+	DNSResolver *net.Resolver
+}
+
+const defaultMaxRequestBodyBytes int64 = 256 * 1024 * 1024
+
+// NewProxy constructs the proxy bound to addr.
+func NewProxy(addr string, opts Options) *Proxy {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+
+	upstream := opts.UpstreamTransport
+	if upstream == nil {
+		upstream = &http.Transport{
+			TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ForceAttemptHTTP2:     false,
+		}
+	}
+	audit := opts.Audit
+	if audit == nil {
+		audit = NewNopAuditSink()
+	}
+	maxBody := opts.MaxRequestBodyBytes
+	if maxBody <= 0 {
+		maxBody = defaultMaxRequestBodyBytes
+	}
+	var blockedPorts map[int]bool
+	if len(opts.BlockedPorts) > 0 {
+		blockedPorts = make(map[int]bool, len(opts.BlockedPorts))
+		for _, port := range opts.BlockedPorts {
+			blockedPorts[port] = true
+		}
+	}
+	p := &Proxy{
+		addr:                addr,
+		ca:                  opts.CA,
+		resolver:            opts.Resolver,
+		vault:               opts.Vault,
+		rules:               opts.Rules,
+		audit:               audit,
+		revoker:             opts.Revoker,
+		logger:              logger,
+		upstream:            upstream,
+		sandboxFacingHost:   opts.SandboxFacingHost,
+		maxRequestBodyBytes: maxBody,
+		blockedPorts:        blockedPorts,
+		blockInternalAddrs:  opts.BlockInternalAddrs,
+		dnsResolver:         opts.DNSResolver,
+	}
+
+	p.tlsConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			sni := hello.ServerName
+			if sni == "" {
+				sni = p.sandboxFacingHost
+			}
+			if sni == "" {
+				host, _, err := net.SplitHostPort(hello.Conn.LocalAddr().String())
+				if err != nil || host == "" {
+					host = "127.0.0.1"
+				}
+				sni = host
+			}
+			return p.ca.MintLeaf(sni)
+		},
+	}
+
+	p.httpServer = &http.Server{
+		Addr:              addr,
+		Handler:           http.HandlerFunc(p.dispatch),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return p
+}
+
+// Addr returns the configured listener address.
+func (p *Proxy) Addr() string { return p.addr }
+
+// RootPEM returns the CA cert in PEM form for installation into client trust stores.
+func (p *Proxy) RootPEM() []byte { return p.ca.RootPEM() }
+
+// IsListening reports whether the listener is bound and accepting connections.
+func (p *Proxy) IsListening() bool { return p.isListening.Load() }
+
+// ListenAndServe binds and serves. Blocks until Shutdown is called.
+func (p *Proxy) ListenAndServe() error {
+	l, err := net.Listen("tcp", p.addr)
+	if err != nil {
+		return err
+	}
+	return p.Serve(l)
+}
+
+// Serve accepts on the provided listener, wrapping it in TLS so the
+// Proxy-Authorization header is encrypted on the wire.
+func (p *Proxy) Serve(l net.Listener) error {
+	p.isListening.Store(true)
+	defer p.isListening.Store(false)
+	return p.httpServer.Serve(tls.NewListener(l, p.tlsConfig))
+}
+
+// Shutdown stops the listener gracefully.
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	p.upstream.CloseIdleConnections()
+	return p.httpServer.Shutdown(ctx)
+}
+
+func (p *Proxy) dispatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.handleConnect(w, r)
+		return
+	}
+	http.Error(w,
+		"this endpoint is an HTTPS forward proxy; only CONNECT is supported",
+		http.StatusBadRequest)
+}
+
+// isBlockedPort reports whether portStr is an operator-blocked egress port.
+// An unparseable port is treated as not blocked; the dial fails downstream.
+func (p *Proxy) isBlockedPort(portStr string) bool {
+	if len(p.blockedPorts) == 0 {
+		return false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return false
+	}
+	return p.blockedPorts[port]
+}
+
+// fetchEgressRules returns the sandbox's current egress rules. ok is false only
+// when there is no policy source at all (cold cache + control plane unreachable),
+// so the caller can fail the request closed instead of enforcing nothing. A nil
+// rules client (passthrough/test mode) yields empty rules and ok=true.
+func (p *Proxy) fetchEgressRules(ctx context.Context, sandboxID string) (EgressRules, bool) {
+	if p.rules == nil {
+		return EgressRules{}, true
+	}
+	r, err := p.rules.FetchRules(ctx, sandboxID)
+	if err != nil {
+		p.logger.Warn("fetch egress rules failed", "sandbox", sandboxID, "err", err.Error())
+		return EgressRules{}, false
+	}
+	return r, true
+}
+
+// resolveUpstreamIP resolves host to a single IP for CIDR rule evaluation. An
+// IP-literal host is returned as-is; a resolution failure returns nil, which
+// never matches a CIDR rule.
+func (p *Proxy) resolveUpstreamIP(ctx context.Context, host string) net.IP {
+	if ip := net.ParseIP(host); ip != nil {
+		return ip
+	}
+	r := p.dnsResolver
+	if r == nil {
+		r = net.DefaultResolver
+	}
+	ips, err := r.LookupIP(ctx, "ip", host)
+	if err != nil || len(ips) == 0 {
+		return nil
+	}
+	return ips[0]
+}
+
+// remoteHost extracts the host portion (no port) from r.RemoteAddr.
+func remoteHost(remoteAddr string) string {
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}

--- a/internal/secretsproxy/proxy_test.go
+++ b/internal/secretsproxy/proxy_test.go
@@ -1,0 +1,755 @@
+package secretsproxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stubResolver accepts a fixed JWT string. Tests use this to exercise the
+// proxy without standing up a full Verifier + JWKS.
+type stubResolver struct {
+	wantJWT  string
+	scopeOut *Scope
+	calls    int
+}
+
+func (s *stubResolver) Authenticate(_ context.Context, _ string, jwt string) (*Scope, error) {
+	s.calls++
+	if jwt == s.wantJWT {
+		return s.scopeOut, nil
+	}
+	return nil, ErrUnknownSandbox
+}
+
+// setupProxy stands up a Proxy bound to a random port plus an httptest HTTPS upstream.
+// opt overrides apply on top of the default Options (CA, Resolver, transport, revoker).
+func setupProxy(t *testing.T, resolver Resolver, opts ...func(*Options)) (proxyAddr string, upstream *httptest.Server, ca *CA, revoker *Revoker) {
+	t.Helper()
+
+	upstream = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Saw-Path", r.URL.Path)
+		w.Header().Set("X-Upstream-Saw-Method", r.Method)
+		w.Header().Set("X-Upstream-Auth", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, "hello from upstream\n")
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	var err error
+	ca, err = NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Permissive transport for the test: trust the httptest server's cert.
+	upstreamCert := upstream.Certificate()
+	upstreamPool := x509.NewCertPool()
+	upstreamPool.AddCert(upstreamCert)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    upstreamPool,
+		},
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Second,
+	}
+
+	revoker = NewRevoker()
+	pOpts := Options{
+		CA:                ca,
+		Resolver:          resolver,
+		UpstreamTransport: tr,
+		Revoker:           revoker,
+	}
+	for _, fn := range opts {
+		fn(&pOpts)
+	}
+	p := NewProxy("127.0.0.1:0", pOpts)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyAddr = l.Addr().String()
+
+	go func() { _ = p.Serve(l) }()
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if p.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !p.IsListening() {
+		t.Fatal("proxy never reported listening")
+	}
+	return proxyAddr, upstream, ca, revoker
+}
+
+// dialProxy opens a TLS connection to the proxy ingress.
+func dialProxy(t *testing.T, proxyAddr string, ca *CA) net.Conn {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca.RootPEM()) {
+		t.Fatal("failed to add CA to pool")
+	}
+	conf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+		ServerName: "127.0.0.1",
+	}
+	conn, err := tls.Dial("tcp", proxyAddr, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+// sendConnect writes a CONNECT request and reads the proxy's response line.
+// The auth header carries Basic base64("sb:<jwt>") — user portion is fixed,
+// JWT is the password.
+func sendConnect(t *testing.T, conn net.Conn, target, jwtString string) (statusLine string, ok bool) {
+	t.Helper()
+	auth := base64.StdEncoding.EncodeToString([]byte("sb:" + jwtString))
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: Basic %s\r\n\r\n", target, target, auth)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(conn)
+	statusLine, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	statusLine = strings.TrimRight(statusLine, "\r\n")
+	// Drain headers so the conn is at the inner TLS handshake boundary.
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+	return statusLine, strings.HasPrefix(statusLine, "HTTP/1.1 200")
+}
+
+func TestProxyConnectAndForward(t *testing.T) {
+	const testJWT = "test-jwt-string"
+	resolver := &stubResolver{wantJWT: testJWT, scopeOut: &Scope{SandboxID: "sandbox-1", TeamID: "team-1"}}
+	proxyAddr, upstream, ca, _ := setupProxy(t, resolver)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	target := upstreamURL.Host
+	status, ok := sendConnect(t, conn, target, testJWT)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+
+	// Inner TLS handshake; trust the proxy CA that signed the leaf.
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.RootPEM())
+	upstreamHost, _, _ := net.SplitHostPort(target)
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: upstreamHost,
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+
+	// Send a regular HTTP/1.1 request through the tunnel.
+	req := fmt.Sprintf("GET /test-path HTTP/1.1\r\nHost: %s\r\nAuthorization: Bearer sk-proxy-aaa\r\n\r\n", target)
+	if _, err := tlsClient.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(tlsClient)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Upstream-Saw-Path"); got != "/test-path" {
+		t.Errorf("upstream path: want /test-path, got %q", got)
+	}
+	if got := resp.Header.Get("X-Upstream-Saw-Method"); got != "GET" {
+		t.Errorf("upstream method: want GET, got %q", got)
+	}
+	if got := resp.Header.Get("X-Upstream-Auth"); got != "Bearer sk-proxy-aaa" {
+		t.Errorf("passthrough (no inject pipeline) should forward Authorization unchanged, got %q", got)
+	}
+	if !strings.Contains(string(body), "hello from upstream") {
+		t.Errorf("body: want upstream payload, got %q", string(body))
+	}
+	if resolver.calls != 1 {
+		t.Errorf("Resolver.Authenticate called %d times, want 1", resolver.calls)
+	}
+}
+
+func TestProxyRejectsMissingProxyAuth(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "x", scopeOut: &Scope{}}
+	proxyAddr, upstream, ca, _ := setupProxy(t, resolver)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", upstreamURL.Host, upstreamURL.Host)
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(conn)
+	statusLine, _ := br.ReadString('\n')
+	if !strings.Contains(statusLine, "407") {
+		t.Errorf("want 407 Proxy Authentication Required, got %q", strings.TrimSpace(statusLine))
+	}
+	if resolver.calls != 0 {
+		t.Errorf("Resolver should not be reached for missing auth header, got %d calls", resolver.calls)
+	}
+}
+
+func TestProxyRejectsUnknownSandbox(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "good-jwt", scopeOut: &Scope{SandboxID: "sandbox-1", TeamID: "team-1"}}
+	proxyAddr, upstream, ca, _ := setupProxy(t, resolver)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, upstreamURL.Host, "wrong-jwt")
+	if ok {
+		t.Fatalf("CONNECT should have failed for unknown sandbox; got %q", status)
+	}
+	if !strings.Contains(status, "407") {
+		t.Errorf("want 407 on unknown sandbox, got %q", status)
+	}
+	if resolver.calls != 1 {
+		t.Errorf("Resolver.Authenticate calls: want 1, got %d", resolver.calls)
+	}
+}
+
+func TestProxyRejectsRevokedSandbox(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "good-jwt", scopeOut: &Scope{SandboxID: "sandbox-1", TeamID: "team-1"}}
+	proxyAddr, upstream, ca, revoker := setupProxy(t, resolver)
+	upstreamURL, _ := url.Parse(upstream.URL)
+	revoker.RevokeSandbox("sandbox-1")
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, upstreamURL.Host, "good-jwt")
+	if ok {
+		t.Fatalf("CONNECT must fail when sandbox is revoked; got %q", status)
+	}
+	if !strings.Contains(status, "403") {
+		t.Errorf("want 403 on revoked sandbox, got %q", status)
+	}
+}
+
+func TestProxyRejectsBlockedPort(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "good-jwt", scopeOut: &Scope{SandboxID: "sandbox-1", TeamID: "team-1"}}
+	proxyAddr, _, ca, _ := setupProxy(t, resolver, func(o *Options) {
+		o.BlockedPorts = []int{4444}
+	})
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, "example.com:4444", "good-jwt")
+	if ok {
+		t.Fatalf("CONNECT to a blocked port must fail; got %q", status)
+	}
+	if !strings.Contains(status, "403") {
+		t.Errorf("want 403 on blocked port, got %q", status)
+	}
+}
+
+func TestProxyRejectsInternalAddress(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "good-jwt", scopeOut: &Scope{SandboxID: "sandbox-1", TeamID: "team-1"}}
+	proxyAddr, _, ca, _ := setupProxy(t, resolver, func(o *Options) {
+		o.BlockInternalAddrs = true
+	})
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, "169.254.169.254:443", "good-jwt")
+	if ok {
+		t.Fatalf("CONNECT to an internal IP must fail; got %q", status)
+	}
+	if !strings.Contains(status, "403") {
+		t.Errorf("want 403 on internal address, got %q", status)
+	}
+}
+
+func TestIsBlockedPort(t *testing.T) {
+	p := NewProxy("127.0.0.1:0", Options{BlockedPorts: []int{4444, 3333}})
+	cases := []struct {
+		port string
+		want bool
+	}{
+		{"4444", true},
+		{"3333", true},
+		{"443", false},
+		{"notaport", false}, // unparseable → not blocked
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := p.isBlockedPort(c.port); got != c.want {
+			t.Errorf("isBlockedPort(%q) = %v, want %v", c.port, got, c.want)
+		}
+	}
+	if NewProxy("127.0.0.1:0", Options{}).isBlockedPort("4444") {
+		t.Error("no blocked ports configured: 4444 should not be blocked")
+	}
+}
+
+func TestProxyRejectsNonConnectInV1(t *testing.T) {
+	resolver := &stubResolver{wantJWT: "x", scopeOut: &Scope{}}
+	proxyAddr, _, ca, _ := setupProxy(t, resolver)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	// Absolute-form forward-proxy request; daemon only supports CONNECT.
+	req := "GET http://api.example.com/ HTTP/1.1\r\nHost: api.example.com\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(conn)
+	statusLine, _ := br.ReadString('\n')
+	if !strings.Contains(statusLine, "400") {
+		t.Errorf("want 400 on non-CONNECT, got %q", strings.TrimSpace(statusLine))
+	}
+}
+
+func TestCopyForwardableHeadersStripsHopByHop(t *testing.T) {
+	src := http.Header{
+		"Content-Type":        {"application/json"},
+		"Connection":          {"close"},
+		"Keep-Alive":          {"timeout=5"},
+		"Proxy-Authorization": {"Basic xxxx"},
+		"Authorization":       {"Bearer real-key"},
+		"X-Trace-Id":          {"abc"},
+	}
+	dst := http.Header{}
+	copyForwardableHeaders(src, dst)
+
+	if dst.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type not forwarded")
+	}
+	if dst.Get("Authorization") != "Bearer real-key" {
+		t.Errorf("Authorization should be forwarded by copyForwardableHeaders")
+	}
+	if dst.Get("X-Trace-Id") != "abc" {
+		t.Errorf("X-Trace-Id not forwarded")
+	}
+	for _, h := range []string{"Connection", "Keep-Alive", "Proxy-Authorization"} {
+		if dst.Get(h) != "" {
+			t.Errorf("hop-by-hop header %s should have been stripped", h)
+		}
+	}
+}
+
+// recordingAudit captures every event the proxy emits.
+type recordingAudit struct {
+	mu     sync.Mutex
+	events []AuditEvent
+}
+
+func (r *recordingAudit) Emit(ev AuditEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, ev)
+}
+func (r *recordingAudit) Shutdown(_ context.Context) error { return nil }
+func (r *recordingAudit) snapshot() []AuditEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]AuditEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// setupProxyWithInject stands up a Proxy whose resolver returns the supplied
+// scope verbatim on any JWT match. The injected scope drives the egress +
+// inject pipeline as if a verified JWT had carried those claims.
+func setupProxyWithInject(t *testing.T, scope *Scope, vault VaultClient) (proxyAddr string, upstream *httptest.Server, ca *CA, audit *recordingAudit, jwt string) {
+	t.Helper()
+
+	upstream = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream-Auth", r.Header.Get("Authorization"))
+		w.Header().Set("X-Upstream-ApiKey", r.Header.Get("x-api-key"))
+		_, _ = io.WriteString(w, "ok\n")
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	var err error
+	ca, err = NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(upstream.Certificate())
+	tr := &http.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool}}
+
+	jwt = "test-jwt-for-" + scope.SandboxID
+	audit = &recordingAudit{}
+	p := NewProxy("127.0.0.1:0", Options{
+		CA:                ca,
+		Resolver:          &stubResolver{wantJWT: jwt, scopeOut: scope},
+		Vault:             vault,
+		Audit:             audit,
+		UpstreamTransport: tr,
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyAddr = l.Addr().String()
+	go func() { _ = p.Serve(l) }()
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if p.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !p.IsListening() {
+		t.Fatal("proxy not listening")
+	}
+	return proxyAddr, upstream, ca, audit, jwt
+}
+
+func TestProxyInjectsBearerEndToEnd(t *testing.T) {
+	scope := &Scope{
+		SandboxID: "sb-1",
+		TeamID:    "team-1",
+		SourceIP:  "127.0.0.1",
+		Bindings: map[string]Binding{
+			"proxy-anth-aaa": {
+				SecretID:   "sec-anthropic",
+				EnvKey:     "ANTHROPIC_API_KEY",
+				AuthType:   "bearer",
+				AuthConfig: map[string]any{},
+				Hosts:      []string{"127.0.0.1"}, // httptest binds 127.0.0.1
+			},
+		},
+	}
+	vault := &stubVault{values: map[string]string{"sec-anthropic": "sk-ant-REAL"}}
+
+	proxyAddr, upstream, ca, audit, jwt := setupProxyWithInject(t, scope, vault)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	status, ok := sendConnect(t, conn, upstreamURL.Host, jwt)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.RootPEM())
+	upstreamHost, _, _ := net.SplitHostPort(upstreamURL.Host)
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: upstreamHost,
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+
+	req := fmt.Sprintf(
+		"GET /v1/messages HTTP/1.1\r\nHost: %s\r\nAuthorization: Bearer proxy-anth-aaa\r\n\r\n",
+		upstreamURL.Host,
+	)
+	if _, err := tlsClient.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tlsClient), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Upstream-Auth"); got != "Bearer sk-ant-REAL" {
+		t.Errorf("upstream received %q, want %q", got, "Bearer sk-ant-REAL")
+	}
+
+	events := audit.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit: want 1 event, got %d (%+v)", len(events), events)
+	}
+	got := events[0]
+	if got.Status != http.StatusOK {
+		t.Errorf("audit.Status: want 200, got %d", got.Status)
+	}
+	if got.UpstreamStatus == nil || *got.UpstreamStatus != http.StatusOK {
+		t.Errorf("audit.UpstreamStatus: want *200, got %v", got.UpstreamStatus)
+	}
+	if got.SecretID != "sec-anthropic" {
+		t.Errorf("audit.SecretID: want sec-anthropic, got %q", got.SecretID)
+	}
+	if got.SandboxID != "sb-1" || got.TeamID != "team-1" {
+		t.Errorf("audit identity drift: %+v", got)
+	}
+	if got.Method != "GET" || got.Host == "" || got.Path != "/v1/messages" {
+		t.Errorf("audit request-shape drift: %+v", got)
+	}
+	if got.ErrorCode != "" {
+		t.Errorf("audit.ErrorCode on success should be empty, got %q", got.ErrorCode)
+	}
+}
+
+func TestProxyDeniesHostNotInCredentialAllowlist(t *testing.T) {
+	scope := &Scope{
+		SandboxID: "sb-1",
+		TeamID:    "team-1",
+		SourceIP:  "127.0.0.1",
+		Bindings: map[string]Binding{
+			"proxy-openai-aaa": {
+				SecretID:   "sec-openai",
+				AuthType:   "bearer",
+				AuthConfig: map[string]any{},
+				Hosts:      []string{"api.openai.com"},
+			},
+		},
+	}
+	vault := &stubVault{values: map[string]string{"sec-openai": "sk-REAL"}}
+
+	proxyAddr, upstream, ca, audit, jwt := setupProxyWithInject(t, scope, vault)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+	status, ok := sendConnect(t, conn, upstreamURL.Host, jwt)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.RootPEM())
+	upstreamHost, _, _ := net.SplitHostPort(upstreamURL.Host)
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: upstreamHost, RootCAs: pool, MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+
+	req := fmt.Sprintf("GET / HTTP/1.1\r\nHost: %s\r\nAuthorization: Bearer proxy-openai-aaa\r\n\r\n", upstreamURL.Host)
+	_, _ = tlsClient.Write([]byte(req))
+	resp, err := http.ReadResponse(bufio.NewReader(tlsClient), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status: want 403, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Superserve-Proxy-Error"); got != "true" {
+		t.Errorf("X-Superserve-Proxy-Error header missing, got %q", got)
+	}
+	if reason := resp.Header.Get("X-Superserve-Proxy-Reason"); reason != "credential_host_mismatch" {
+		t.Errorf("reason: want credential_host_mismatch, got %q", reason)
+	}
+
+	events := audit.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("audit: want 1 deny event, got %d (%+v)", len(events), events)
+	}
+	ev := events[0]
+	if ev.Status != http.StatusForbidden {
+		t.Errorf("audit.Status: want 403, got %d", ev.Status)
+	}
+	if ev.UpstreamStatus != nil {
+		t.Errorf("audit.UpstreamStatus: want nil on deny, got %v", *ev.UpstreamStatus)
+	}
+	if ev.ErrorCode != "credential_host_mismatch" {
+		t.Errorf("audit.ErrorCode: want credential_host_mismatch, got %q", ev.ErrorCode)
+	}
+	if ev.SecretID != "sec-openai" {
+		t.Errorf("audit.SecretID: want sec-openai on credential-host-mismatch, got %q", ev.SecretID)
+	}
+}
+
+func TestOneShotListener(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	l := newOneShotListener(serverConn)
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != serverConn {
+		t.Errorf("first Accept should yield the wrapped conn")
+	}
+	// Second Accept blocks until Close.
+	done := make(chan error, 1)
+	go func() {
+		_, err := l.Accept()
+		done <- err
+	}()
+	select {
+	case <-done:
+		t.Fatal("second Accept returned before Close")
+	case <-time.After(50 * time.Millisecond):
+	}
+	_ = l.Close()
+	select {
+	case err := <-done:
+		if !errors.Is(err, errOneShotListenerClosed) {
+			t.Errorf("want errOneShotListenerClosed, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Accept did not return after Close")
+	}
+	// Double-close should be safe.
+	_ = l.Close()
+}
+
+// TestProxyTLS_SANFallbacks: when SNI is empty, the leaf cert SAN must
+// match SandboxFacingHost.
+func TestProxyTLS_SANFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewProxy("127.0.0.1:0", Options{
+		CA:                ca,
+		Resolver:          &stubResolver{},
+		SandboxFacingHost: "192.0.2.1",
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = p.Serve(l) }()
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	for i := 0; i < 50; i++ {
+		if p.IsListening() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.RootPEM())
+
+	conn, err := tls.Dial("tcp", l.Addr().String(), &tls.Config{
+		RootCAs:            pool,
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	leaf := conn.ConnectionState().PeerCertificates[0]
+	wantIP := net.ParseIP("192.0.2.1")
+	found := false
+	for _, ip := range leaf.IPAddresses {
+		if ip.Equal(wantIP) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("leaf SAN missing %s; got DNS=%v IP=%v", wantIP, leaf.DNSNames, leaf.IPAddresses)
+	}
+}
+
+func TestProxyRejectsOversizedBodyWith413(t *testing.T) {
+	// A body larger than MaxRequestBodyBytes must surface as 413 Payload
+	// Too Large with a body_too_large reason so the agent can handle it.
+	const testJWT = "test-jwt-body"
+	const limit = 1024
+	resolver := &stubResolver{wantJWT: testJWT, scopeOut: &Scope{SandboxID: "sb-body", TeamID: "team-1"}}
+	proxyAddr, upstream, ca, _ := setupProxy(t, resolver,
+		func(o *Options) { o.MaxRequestBodyBytes = limit },
+	)
+	upstreamURL, _ := url.Parse(upstream.URL)
+
+	conn := dialProxy(t, proxyAddr, ca)
+	defer conn.Close()
+
+	target := upstreamURL.Host
+	status, ok := sendConnect(t, conn, target, testJWT)
+	if !ok {
+		t.Fatalf("CONNECT failed: %q", status)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(ca.RootPEM())
+	upstreamHost, _, _ := net.SplitHostPort(target)
+	tlsClient := tls.Client(conn, &tls.Config{
+		ServerName: upstreamHost, RootCAs: pool, MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+
+	// Send a body comfortably larger than the limit.
+	body := strings.Repeat("X", limit*4)
+	req := fmt.Sprintf(
+		"POST /large HTTP/1.1\r\nHost: %s\r\nContent-Length: %d\r\n\r\n%s",
+		target, len(body), body,
+	)
+	if _, err := tlsClient.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+	br := bufio.NewReader(tlsClient)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status: want 413, got %d", resp.StatusCode)
+	}
+	if reason := resp.Header.Get("X-Superserve-Proxy-Reason"); reason != "body_too_large" {
+		t.Errorf("proxy reason: want body_too_large, got %q", reason)
+	}
+	if flag := resp.Header.Get("X-Superserve-Proxy-Error"); flag != "true" {
+		t.Errorf("proxy error flag missing, got %q", flag)
+	}
+}

--- a/internal/secretsproxy/proxyauth.go
+++ b/internal/secretsproxy/proxyauth.go
@@ -1,0 +1,48 @@
+package secretsproxy
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+var (
+	ErrMissingProxyAuth   = errors.New("missing Proxy-Authorization header")
+	ErrMalformedProxyAuth = errors.New("Proxy-Authorization malformed (want 'Basic <base64(user:jwt)>')")
+)
+
+// ParseProxyAuthJWT extracts the JWT from r's Proxy-Authorization header.
+// The header carries `Basic base64(<user>:<jwt>)`; user is informational
+// (typically "sb") and ignored — the JWT in the password position is what
+// the daemon verifies.
+func ParseProxyAuthJWT(r *http.Request) (string, error) {
+	raw := r.Header.Get("Proxy-Authorization")
+	if raw == "" {
+		return "", ErrMissingProxyAuth
+	}
+
+	const scheme = "Basic "
+	if !strings.HasPrefix(raw, scheme) {
+		return "", ErrMalformedProxyAuth
+	}
+	encoded := strings.TrimSpace(raw[len(scheme):])
+	if encoded == "" {
+		return "", ErrMalformedProxyAuth
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		decoded, err = base64.RawStdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", ErrMalformedProxyAuth
+		}
+	}
+
+	creds := string(decoded)
+	colon := strings.IndexByte(creds, ':')
+	if colon < 0 || colon == len(creds)-1 {
+		return "", ErrMalformedProxyAuth
+	}
+	return creds[colon+1:], nil
+}

--- a/internal/secretsproxy/proxyauth_test.go
+++ b/internal/secretsproxy/proxyauth_test.go
@@ -1,0 +1,90 @@
+package secretsproxy
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func makeProxyAuthReq(headerValue string) *http.Request {
+	r, _ := http.NewRequest(http.MethodConnect, "https://api.openai.com:443/", nil)
+	if headerValue != "" {
+		r.Header.Set("Proxy-Authorization", headerValue)
+	}
+	return r
+}
+
+func TestParseProxyAuthJWT(t *testing.T) {
+	const jwtBody = "eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiJzYi0xIn0.SIGNATURE"
+
+	tests := []struct {
+		name    string
+		header  string
+		wantErr error
+		wantJWT string
+	}{
+		{
+			name:    "missing header",
+			header:  "",
+			wantErr: ErrMissingProxyAuth,
+		},
+		{
+			name:    "wrong scheme",
+			header:  "Bearer abc",
+			wantErr: ErrMalformedProxyAuth,
+		},
+		{
+			name:    "empty credentials",
+			header:  "Basic ",
+			wantErr: ErrMalformedProxyAuth,
+		},
+		{
+			name:    "not base64",
+			header:  "Basic !!!notbase64!!!",
+			wantErr: ErrMalformedProxyAuth,
+		},
+		{
+			name:    "no colon",
+			header:  "Basic " + base64.StdEncoding.EncodeToString([]byte("justjwt")),
+			wantErr: ErrMalformedProxyAuth,
+		},
+		{
+			name:    "trailing colon (empty JWT)",
+			header:  "Basic " + base64.StdEncoding.EncodeToString([]byte("sb:")),
+			wantErr: ErrMalformedProxyAuth,
+		},
+		{
+			name:    "happy path (sb:jwt)",
+			header:  "Basic " + base64.StdEncoding.EncodeToString([]byte("sb:"+jwtBody)),
+			wantJWT: jwtBody,
+		},
+		{
+			name:    "empty user portion accepted (':jwt')",
+			header:  "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+jwtBody)),
+			wantJWT: jwtBody,
+		},
+		{
+			name:    "raw-std-encoding (no padding) accepted",
+			header:  "Basic " + base64.RawStdEncoding.EncodeToString([]byte("u:"+jwtBody)),
+			wantJWT: jwtBody,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotJWT, err := ParseProxyAuthJWT(makeProxyAuthReq(tc.header))
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err: want %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotJWT != tc.wantJWT {
+				t.Errorf("jwt: want %q, got %q", tc.wantJWT, gotJWT)
+			}
+		})
+	}
+}

--- a/internal/secretsproxy/revoker.go
+++ b/internal/secretsproxy/revoker.go
@@ -1,0 +1,39 @@
+package secretsproxy
+
+import "sync"
+
+// Revoker tracks sandbox IDs the control plane has revoked.
+type Revoker struct {
+	mu        sync.RWMutex
+	sandboxes map[string]struct{}
+}
+
+func NewRevoker() *Revoker {
+	return &Revoker{sandboxes: map[string]struct{}{}}
+}
+
+// RevokeSandbox adds sandboxID to the revoked set. Idempotent.
+func (r *Revoker) RevokeSandbox(sandboxID string) {
+	r.mu.Lock()
+	r.sandboxes[sandboxID] = struct{}{}
+	r.mu.Unlock()
+}
+
+// IsSandboxRevoked reports whether sandboxID was revoked.
+func (r *Revoker) IsSandboxRevoked(sandboxID string) bool {
+	r.mu.RLock()
+	_, ok := r.sandboxes[sandboxID]
+	r.mu.RUnlock()
+	return ok
+}
+
+// Bootstrap replaces the revoked set with the supplied IDs. Used at startup.
+func (r *Revoker) Bootstrap(sandboxIDs []string) {
+	next := make(map[string]struct{}, len(sandboxIDs))
+	for _, id := range sandboxIDs {
+		next[id] = struct{}{}
+	}
+	r.mu.Lock()
+	r.sandboxes = next
+	r.mu.Unlock()
+}

--- a/internal/secretsproxy/revoker_http.go
+++ b/internal/secretsproxy/revoker_http.go
@@ -1,0 +1,39 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type revokedSandboxesResponse struct {
+	Sandboxes []string `json:"sandboxes"`
+}
+
+// FetchRevokedSandboxes pulls active sandbox revocations from the control plane.
+func FetchRevokedSandboxes(ctx context.Context, baseURL, authToken string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/internal/sandbox_revocations", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch revocations: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("control plane returned %d: %s", resp.StatusCode, string(raw))
+	}
+	var out revokedSandboxesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode revocations response: %w", err)
+	}
+	return out.Sandboxes, nil
+}

--- a/internal/secretsproxy/revoker_test.go
+++ b/internal/secretsproxy/revoker_test.go
@@ -1,0 +1,80 @@
+package secretsproxy
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRevoker_EmptyReportsNotRevoked(t *testing.T) {
+	r := NewRevoker()
+	if r.IsSandboxRevoked("sb-1") {
+		t.Fatal("empty revoker must not report sandbox revoked")
+	}
+}
+
+func TestRevoker_RevokeThenCheck(t *testing.T) {
+	r := NewRevoker()
+	r.RevokeSandbox("sb-1")
+	if !r.IsSandboxRevoked("sb-1") {
+		t.Fatal("revoked sandbox must report revoked")
+	}
+	if r.IsSandboxRevoked("sb-2") {
+		t.Fatal("non-revoked sandbox must report not revoked")
+	}
+}
+
+func TestRevoker_RevokeIsIdempotent(t *testing.T) {
+	r := NewRevoker()
+	r.RevokeSandbox("sb-1")
+	r.RevokeSandbox("sb-1")
+	if !r.IsSandboxRevoked("sb-1") {
+		t.Fatal("double-revoke must not flip state")
+	}
+}
+
+func TestRevoker_BootstrapReplacesSet(t *testing.T) {
+	r := NewRevoker()
+	r.RevokeSandbox("stale")
+	r.Bootstrap([]string{"sb-1", "sb-2"})
+
+	if r.IsSandboxRevoked("stale") {
+		t.Fatal("Bootstrap must replace, not merge — stale entry should be gone")
+	}
+	if !r.IsSandboxRevoked("sb-1") || !r.IsSandboxRevoked("sb-2") {
+		t.Fatal("bootstrapped entries must be revoked")
+	}
+}
+
+func TestRevoker_ConcurrentReadWrite(t *testing.T) {
+	// Run under -race to verify the RWMutex is sufficient.
+	r := NewRevoker()
+	const n = 1000
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(id int) {
+			defer wg.Done()
+			r.RevokeSandbox(idString(id))
+		}(i)
+		go func(id int) {
+			defer wg.Done()
+			_ = r.IsSandboxRevoked(idString(id))
+		}(i)
+	}
+	wg.Wait()
+}
+
+func idString(i int) string {
+	const digits = "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	n := len(b)
+	for i > 0 {
+		n--
+		b[n] = digits[i%10]
+		i /= 10
+	}
+	return string(b[n:])
+}

--- a/internal/secretsproxy/rules.go
+++ b/internal/secretsproxy/rules.go
@@ -1,0 +1,158 @@
+package secretsproxy
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+)
+
+// EgressRules is a sandbox's egress allow/deny policy, fetched live rather than
+// carried in the JWT so a PATCH takes effect without re-minting.
+type EgressRules struct {
+	Allow               []string
+	Deny                []string
+	UnmatchedHostPolicy string
+}
+
+// RulesClient resolves a sandbox's current egress rules.
+type RulesClient interface {
+	FetchRules(ctx context.Context, sandboxID string) (EgressRules, error)
+}
+
+// RulesCacheOptions configures cachedRules. Zero values fall back to defaults.
+type RulesCacheOptions struct {
+	TTL      time.Duration // freshness before re-fetch (default 30s)
+	IdleTTL  time.Duration // evict entries idle this long (default 10m)
+	Capacity int           // LRU bound (default 1024)
+}
+
+// cachedRules wraps a RulesClient with an LRU + TTL cache. On a fetch error it
+// serves the last-known-good value if one is cached, so a control-plane blip
+// never silently drops policy; only a cold cache + fetch failure returns an
+// error (the caller then fails the request closed, never open).
+type cachedRules struct {
+	upstream RulesClient
+	ttl      time.Duration
+	idleTTL  time.Duration
+	capacity int
+	now      func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]*list.Element
+	order   *list.List
+}
+
+type rulesEntry struct {
+	sandboxID string
+	rules     EgressRules
+	expires   time.Time
+	lastUsed  time.Time
+}
+
+// NewCachedRules wraps client with an LRU + TTL cache.
+func NewCachedRules(client RulesClient, opts RulesCacheOptions) *cachedRules {
+	if opts.TTL <= 0 {
+		opts.TTL = 30 * time.Second
+	}
+	if opts.IdleTTL <= 0 {
+		opts.IdleTTL = 10 * time.Minute
+	}
+	if opts.Capacity <= 0 {
+		opts.Capacity = 1024
+	}
+	return &cachedRules{
+		upstream: client,
+		ttl:      opts.TTL,
+		idleTTL:  opts.IdleTTL,
+		capacity: opts.Capacity,
+		now:      time.Now,
+		entries:  make(map[string]*list.Element, opts.Capacity),
+		order:    list.New(),
+	}
+}
+
+// FetchRules returns fresh cached rules, re-fetches when stale, and serves the
+// last-known-good value if the re-fetch fails.
+func (c *cachedRules) FetchRules(ctx context.Context, sandboxID string) (EgressRules, error) {
+	now := c.now()
+
+	c.mu.Lock()
+	if el, ok := c.entries[sandboxID]; ok {
+		e := el.Value.(*rulesEntry)
+		switch {
+		case now.Sub(e.lastUsed) >= c.idleTTL:
+			c.removeRules(el) // idle: drop, no longer worth keeping
+		case now.Before(e.expires):
+			e.lastUsed = now
+			c.order.MoveToFront(el)
+			r := e.rules
+			c.mu.Unlock()
+			return r, nil
+		}
+		// else: expired but not idle — keep it for last-known-good below.
+	}
+	c.mu.Unlock()
+
+	r, err := c.upstream.FetchRules(ctx, sandboxID)
+	if err != nil {
+		c.mu.Lock()
+		if el, ok := c.entries[sandboxID]; ok {
+			e := el.Value.(*rulesEntry)
+			e.lastUsed = now
+			c.order.MoveToFront(el)
+			stale := e.rules
+			c.mu.Unlock()
+			return stale, nil // last-known-good; caller logs the underlying error
+		}
+		c.mu.Unlock()
+		return EgressRules{}, err // cold cache + fetch failure
+	}
+
+	c.mu.Lock()
+	now = c.now()
+	if el, ok := c.entries[sandboxID]; ok {
+		e := el.Value.(*rulesEntry)
+		e.rules = r
+		e.expires = now.Add(c.ttl)
+		e.lastUsed = now
+		c.order.MoveToFront(el)
+	} else {
+		el := c.order.PushFront(&rulesEntry{
+			sandboxID: sandboxID,
+			rules:     r,
+			expires:   now.Add(c.ttl),
+			lastUsed:  now,
+		})
+		c.entries[sandboxID] = el
+		for c.order.Len() > c.capacity {
+			c.removeRules(c.order.Back())
+		}
+	}
+	c.mu.Unlock()
+	return r, nil
+}
+
+// Invalidate drops the cached entry for sandboxID so the next request re-fetches.
+func (c *cachedRules) Invalidate(sandboxID string) {
+	c.mu.Lock()
+	if el, ok := c.entries[sandboxID]; ok {
+		c.removeRules(el)
+	}
+	c.mu.Unlock()
+}
+
+// Warm fetches and caches the rules for sandboxID so a later request hits a warm
+// cache. Used to prime at create and re-warm after a PATCH, so the first proxied
+// request never needs a live fetch (which would fail if the control plane were
+// briefly unreachable). Best-effort — a fetch failure leaves the cache cold.
+func (c *cachedRules) Warm(ctx context.Context, sandboxID string) {
+	_, _ = c.FetchRules(ctx, sandboxID)
+}
+
+// removeRules removes an element from both the map and the list. Caller holds c.mu.
+func (c *cachedRules) removeRules(el *list.Element) {
+	e := el.Value.(*rulesEntry)
+	delete(c.entries, e.sandboxID)
+	c.order.Remove(el)
+}

--- a/internal/secretsproxy/rules_http.go
+++ b/internal/secretsproxy/rules_http.go
@@ -1,0 +1,70 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// HTTPRulesClient fetches a sandbox's egress rules from the control plane.
+type HTTPRulesClient struct {
+	baseURL    string
+	authToken  string
+	httpClient *http.Client
+}
+
+// NewHTTPRulesClient builds a client that GETs {baseURL}/internal/sandboxes/{id}/egress_rules with Bearer auth.
+func NewHTTPRulesClient(baseURL, authToken string) *HTTPRulesClient {
+	return &HTTPRulesClient{
+		baseURL:   baseURL,
+		authToken: authToken,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type egressRulesResponse struct {
+	Allow               []string `json:"allow"`
+	Deny                []string `json:"deny"`
+	UnmatchedHostPolicy string   `json:"unmatched_host_policy"`
+}
+
+// FetchRules resolves sandboxID to its current egress rules. A 404 (sandbox
+// gone) yields empty rules so the dispatcher treats it as no policy rather than
+// erroring; transient 5xx are surfaced so the cache serves last-known-good.
+func (c *HTTPRulesClient) FetchRules(ctx context.Context, sandboxID string) (EgressRules, error) {
+	u := c.baseURL + "/internal/sandboxes/" + url.PathEscape(sandboxID) + "/egress_rules"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return EgressRules{}, fmt.Errorf("build egress_rules request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return EgressRules{}, fmt.Errorf("egress_rules request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return EgressRules{}, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return EgressRules{}, fmt.Errorf("control plane rejected daemon auth (%d)", resp.StatusCode)
+	default:
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return EgressRules{}, fmt.Errorf("control plane returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var rr egressRulesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rr); err != nil {
+		return EgressRules{}, fmt.Errorf("decode egress_rules response: %w", err)
+	}
+	return EgressRules{Allow: rr.Allow, Deny: rr.Deny, UnmatchedHostPolicy: rr.UnmatchedHostPolicy}, nil
+}

--- a/internal/secretsproxy/rules_test.go
+++ b/internal/secretsproxy/rules_test.go
@@ -1,0 +1,93 @@
+package secretsproxy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubRules struct {
+	rules EgressRules
+	err   error
+	calls int
+}
+
+func (s *stubRules) FetchRules(_ context.Context, _ string) (EgressRules, error) {
+	s.calls++
+	if s.err != nil {
+		return EgressRules{}, s.err
+	}
+	return s.rules, nil
+}
+
+func TestCachedRules_FreshHitAvoidsRefetch(t *testing.T) {
+	up := &stubRules{rules: EgressRules{Allow: []string{"a.com"}}}
+	c := NewCachedRules(up, RulesCacheOptions{TTL: time.Minute})
+	for i := 0; i < 3; i++ {
+		if r, err := c.FetchRules(context.Background(), "sb-1"); err != nil || len(r.Allow) != 1 {
+			t.Fatalf("fetch %d: %v %+v", i, err, r)
+		}
+	}
+	if up.calls != 1 {
+		t.Errorf("want 1 upstream call (cached), got %d", up.calls)
+	}
+}
+
+func TestCachedRules_LastKnownGoodOnError(t *testing.T) {
+	up := &stubRules{rules: EgressRules{Deny: []string{"bad.com"}}}
+	now := time.Now()
+	c := NewCachedRules(up, RulesCacheOptions{TTL: time.Second})
+	c.now = func() time.Time { return now }
+
+	if _, err := c.FetchRules(context.Background(), "sb-1"); err != nil {
+		t.Fatal(err)
+	}
+	// Expire the entry and make the control plane fail.
+	now = now.Add(2 * time.Second)
+	up.err = errors.New("control plane down")
+
+	r, err := c.FetchRules(context.Background(), "sb-1")
+	if err != nil {
+		t.Fatalf("should serve last-known-good, got err %v", err)
+	}
+	if len(r.Deny) != 1 || r.Deny[0] != "bad.com" {
+		t.Errorf("last-known-good not served: %+v", r)
+	}
+}
+
+func TestCachedRules_ColdCacheErrorPropagates(t *testing.T) {
+	up := &stubRules{err: errors.New("down")}
+	c := NewCachedRules(up, RulesCacheOptions{})
+	if _, err := c.FetchRules(context.Background(), "sb-1"); err == nil {
+		t.Error("cold cache + fetch error must return an error so the caller fails closed")
+	}
+}
+
+func TestCachedRules_WarmPopulatesCache(t *testing.T) {
+	up := &stubRules{rules: EgressRules{Allow: []string{"a.com"}}}
+	c := NewCachedRules(up, RulesCacheOptions{TTL: time.Minute})
+
+	c.Warm(context.Background(), "sb-1")
+	if up.calls != 1 {
+		t.Fatalf("Warm should fetch once; calls=%d", up.calls)
+	}
+	// A subsequent request is now a cache hit — no live fetch needed.
+	if _, err := c.FetchRules(context.Background(), "sb-1"); err != nil {
+		t.Fatal(err)
+	}
+	if up.calls != 1 {
+		t.Errorf("Warm should have populated the cache; calls=%d", up.calls)
+	}
+}
+
+func TestCachedRules_InvalidateForcesRefetch(t *testing.T) {
+	up := &stubRules{rules: EgressRules{Allow: []string{"a.com"}}}
+	c := NewCachedRules(up, RulesCacheOptions{TTL: time.Minute})
+	_, _ = c.FetchRules(context.Background(), "sb-1")
+	c.Invalidate("sb-1")
+	_, _ = c.FetchRules(context.Background(), "sb-1")
+	if up.calls != 2 {
+		t.Errorf("invalidate should force a refetch; calls=%d", up.calls)
+	}
+}

--- a/internal/secretsproxy/userinfo_spike_test.go
+++ b/internal/secretsproxy/userinfo_spike_test.go
@@ -1,0 +1,123 @@
+package secretsproxy
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLongUserinfoRoundTripsThroughHTTPTransport verifies that a ~10 KB
+// opaque token in HTTPS_PROXY userinfo survives Go's http.Transport round-trip
+// into a CONNECT request the daemon can parse. The JWT at our 32-binding cap
+// is ~10 KB; this pins the transport-layer assumption that bound.
+func TestLongUserinfoRoundTripsThroughHTTPTransport(t *testing.T) {
+	// Pick a size that exceeds the worst-case JWT for our binding cap.
+	rawTokenBytes := make([]byte, 8*1024)
+	if _, err := rand.Read(rawTokenBytes); err != nil {
+		t.Fatal(err)
+	}
+	longToken := base64.RawURLEncoding.EncodeToString(rawTokenBytes) // ~10.9 KB
+
+	// Minimal proxy: accept the CONNECT, parse Proxy-Authorization, echo
+	// the decoded userinfo back on a single-line response, then close.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	type seen struct {
+		user, pass string
+		err        error
+	}
+	seenCh := make(chan seen, 1)
+
+	go func() {
+		conn, err := l.Accept()
+		if err != nil {
+			seenCh <- seen{err: err}
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+		req, err := http.ReadRequest(bufio.NewReader(conn))
+		if err != nil {
+			seenCh <- seen{err: err}
+			return
+		}
+		if req.Method != http.MethodConnect {
+			seenCh <- seen{err: nil, user: "method=" + req.Method}
+			return
+		}
+
+		header := req.Header.Get("Proxy-Authorization")
+		const prefix = "Basic "
+		if !strings.HasPrefix(header, prefix) {
+			seenCh <- seen{err: nil, user: "missing-basic"}
+			return
+		}
+		decoded, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(header[len(prefix):]))
+		if derr != nil {
+			seenCh <- seen{err: derr}
+			return
+		}
+		creds := string(decoded)
+		idx := strings.IndexByte(creds, ':')
+		if idx < 0 {
+			seenCh <- seen{err: nil, user: "no-colon"}
+			return
+		}
+		seenCh <- seen{user: creds[:idx], pass: creds[idx+1:]}
+
+		// Reject the tunnel (we only care about the CONNECT itself).
+		_, _ = conn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n"))
+	}()
+
+	proxyURL := &url.URL{
+		Scheme: "http",
+		User:   url.UserPassword("sb", longToken),
+		Host:   l.Addr().String(),
+	}
+
+	tr := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+	}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	// Any HTTPS URL will do; we'll get a CONNECT to that host:port. The
+	// upstream is never actually reached because our fake proxy closes.
+	_, err = client.Get("https://example.invalid/")
+	if err == nil {
+		t.Fatal("expected upstream connect to fail (fake proxy doesn't tunnel)")
+	}
+
+	select {
+	case got := <-seenCh:
+		if got.err != nil {
+			t.Fatalf("proxy read error: %v", got.err)
+		}
+		if got.user != "sb" {
+			t.Errorf("user portion: got %q, want %q", got.user, "sb")
+		}
+		if got.pass != longToken {
+			t.Errorf("password portion length: got %d, want %d (first 32: got %q want %q)",
+				len(got.pass), len(longToken), safePrefix(got.pass, 32), safePrefix(longToken, 32))
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("proxy goroutine never returned")
+	}
+}
+
+func safePrefix(s string, n int) string {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/secretsproxy/vault.go
+++ b/internal/secretsproxy/vault.go
@@ -1,0 +1,146 @@
+package secretsproxy
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// VaultClient fetches credential values for the daemon.
+type VaultClient interface {
+	FetchCredential(ctx context.Context, teamID, secretID string) (string, error)
+}
+
+// ErrCredentialRevoked indicates the secret has been soft-deleted or is no longer valid.
+var ErrCredentialRevoked = errors.New("secretsproxy: credential revoked or not found")
+
+// VaultCacheOptions configures cachedVault. Zero values fall back to defaults.
+type VaultCacheOptions struct {
+	// TTL is how long a cached value is treated as fresh before re-fetching
+	// from the upstream. Defaults to 60s.
+	TTL time.Duration
+	// IdleTTL evicts entries that haven't been accessed in this long, even
+	// when the cache isn't full. Defaults to 10m.
+	IdleTTL time.Duration
+	// Capacity bounds the cache size. LRU evicts the least-recently-used
+	// entry once the bound is reached. Defaults to 1024.
+	Capacity int
+}
+
+// cachedVault wraps a VaultClient with an LRU cache plus freshness and idle TTLs.
+type cachedVault struct {
+	upstream VaultClient
+	ttl      time.Duration
+	idleTTL  time.Duration
+	capacity int
+	now      func() time.Time
+
+	mu      sync.Mutex
+	entries map[cacheKey]*list.Element
+	order   *list.List
+}
+
+type cacheKey struct {
+	teamID   string
+	secretID string
+}
+
+type cachedEntry struct {
+	key      cacheKey
+	value    string
+	expires  time.Time // freshness deadline — past this, refetch
+	lastUsed time.Time // for idle-TTL eviction
+}
+
+// NewCachedVault wraps client with an LRU + TTL cache.
+func NewCachedVault(client VaultClient, opts VaultCacheOptions) *cachedVault {
+	if opts.TTL <= 0 {
+		opts.TTL = 60 * time.Second
+	}
+	if opts.IdleTTL <= 0 {
+		opts.IdleTTL = 10 * time.Minute
+	}
+	if opts.Capacity <= 0 {
+		opts.Capacity = 1024
+	}
+	return &cachedVault{
+		upstream: client,
+		ttl:      opts.TTL,
+		idleTTL:  opts.IdleTTL,
+		capacity: opts.Capacity,
+		now:      time.Now,
+		entries:  make(map[cacheKey]*list.Element, opts.Capacity),
+		order:    list.New(),
+	}
+}
+
+// FetchCredential returns the cached value when fresh and not idle-evicted,
+// otherwise hits the upstream. On insert, evicts LRU tail if over capacity.
+func (c *cachedVault) FetchCredential(ctx context.Context, teamID, secretID string) (string, error) {
+	key := cacheKey{teamID: teamID, secretID: secretID}
+	now := c.now()
+
+	c.mu.Lock()
+	if el, ok := c.entries[key]; ok {
+		e := el.Value.(*cachedEntry)
+		if now.Before(e.expires) && now.Sub(e.lastUsed) < c.idleTTL {
+			e.lastUsed = now
+			c.order.MoveToFront(el)
+			c.mu.Unlock()
+			return e.value, nil
+		}
+		c.removeElement(el)
+	}
+	c.mu.Unlock()
+
+	v, err := c.upstream.FetchCredential(ctx, teamID, secretID)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.Lock()
+	now = c.now()
+	if el, ok := c.entries[key]; ok {
+		// A concurrent caller raced us to insert; refresh the existing entry
+		// in place instead of duplicating.
+		e := el.Value.(*cachedEntry)
+		e.value = v
+		e.expires = now.Add(c.ttl)
+		e.lastUsed = now
+		c.order.MoveToFront(el)
+	} else {
+		el := c.order.PushFront(&cachedEntry{
+			key:      key,
+			value:    v,
+			expires:  now.Add(c.ttl),
+			lastUsed: now,
+		})
+		c.entries[key] = el
+		for c.order.Len() > c.capacity {
+			c.removeElement(c.order.Back())
+		}
+	}
+	c.mu.Unlock()
+	return v, nil
+}
+
+// Invalidate drops every cached entry for secretID across all teams.
+func (c *cachedVault) Invalidate(secretID string) {
+	c.mu.Lock()
+	for k, el := range c.entries {
+		if k.secretID == secretID {
+			c.removeElement(el)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// removeElement removes an LRU element from both the map and the list. The
+// caller must hold c.mu.
+func (c *cachedVault) removeElement(el *list.Element) {
+	e := el.Value.(*cachedEntry)
+	delete(c.entries, e.key)
+	c.order.Remove(el)
+}

--- a/internal/secretsproxy/vault_http.go
+++ b/internal/secretsproxy/vault_http.go
@@ -1,0 +1,109 @@
+package secretsproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// HTTPVaultClient fetches credential values from the control plane's decrypt endpoint.
+type HTTPVaultClient struct {
+	baseURL    string
+	authToken  string
+	httpClient *http.Client
+}
+
+// NewHTTPVaultClient builds a client that POSTs to {baseURL}/internal/secrets/decrypt with Bearer auth.
+func NewHTTPVaultClient(baseURL, authToken string) *HTTPVaultClient {
+	return &HTTPVaultClient{
+		baseURL:   baseURL,
+		authToken: authToken,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type decryptRequest struct {
+	TeamID   string `json:"team_id"`
+	SecretID string `json:"secret_id"`
+}
+
+type decryptResponse struct {
+	Value string `json:"value"`
+}
+
+// FetchCredential resolves (teamID, secretID) to cleartext; 404/410 → ErrCredentialRevoked.
+// Retries once on transient upstream errors (502/503/504) so a single control-plane
+// hiccup doesn't fail a user request.
+func (c *HTTPVaultClient) FetchCredential(ctx context.Context, teamID, secretID string) (string, error) {
+	body, err := json.Marshal(decryptRequest{TeamID: teamID, SecretID: secretID})
+	if err != nil {
+		return "", fmt.Errorf("marshal decrypt request: %w", err)
+	}
+
+	resp, err := c.doDecryptWithRetry(ctx, body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound, http.StatusGone:
+		return "", ErrCredentialRevoked
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "", fmt.Errorf("control plane rejected daemon auth (%d): check DAEMON_AUTH_TOKEN matches control plane INTERNAL_API_TOKEN", resp.StatusCode)
+	default:
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("control plane returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var dr decryptResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return "", fmt.Errorf("decode decrypt response: %w", err)
+	}
+	if dr.Value == "" {
+		// Empty plaintext is pathological but legal — map to revoked so the
+		// request path returns 503 rather than a confusing internal error.
+		return "", ErrCredentialRevoked
+	}
+	return dr.Value, nil
+}
+
+// doDecryptWithRetry posts to /internal/secrets/decrypt with one retry on
+// 502/503/504. Body is reset per attempt; ctx cancellation aborts both.
+func (c *HTTPVaultClient) doDecryptWithRetry(ctx context.Context, body []byte) (*http.Response, error) {
+	const attempts = 2
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			c.baseURL+"/internal/secrets/decrypt", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("build decrypt request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("decrypt request: %w", err)
+			if ctx.Err() != nil {
+				return nil, lastErr
+			}
+			continue
+		}
+		if resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
+			resp.StatusCode == http.StatusGatewayTimeout {
+			lastErr = fmt.Errorf("control plane returned %d", resp.StatusCode)
+			resp.Body.Close()
+			continue
+		}
+		return resp, nil
+	}
+	return nil, lastErr
+}

--- a/internal/secretsproxy/vault_http_test.go
+++ b/internal/secretsproxy/vault_http_test.go
@@ -1,0 +1,145 @@
+package secretsproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPVaultClientHappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/secrets/decrypt" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer daemon-tok" {
+			t.Errorf("missing or wrong daemon auth: %q", r.Header.Get("Authorization"))
+		}
+		var req decryptRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.SecretID != "sec-1" {
+			t.Errorf("secret_id: want sec-1, got %q", req.SecretID)
+		}
+		if req.TeamID != "team-1" {
+			t.Errorf("team_id: want team-1, got %q", req.TeamID)
+		}
+		_ = json.NewEncoder(w).Encode(decryptResponse{Value: "sk-real"})
+	}))
+	defer srv.Close()
+
+	c := NewHTTPVaultClient(srv.URL, "daemon-tok")
+	v, err := c.FetchCredential(context.Background(), "team-1", "sec-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "sk-real" {
+		t.Errorf("value: want sk-real, got %q", v)
+	}
+}
+
+func TestHTTPVaultClientMaps404ToRevoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPVaultClient(srv.URL, "daemon-tok")
+	_, err := c.FetchCredential(context.Background(), "team-1", "sec-revoked")
+	if !errors.Is(err, ErrCredentialRevoked) {
+		t.Errorf("want ErrCredentialRevoked, got %v", err)
+	}
+}
+
+func TestHTTPVaultClientSurfacesAuthFailure(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "bad daemon token", code)
+			}))
+			defer srv.Close()
+			c := NewHTTPVaultClient(srv.URL, "wrong")
+			_, err := c.FetchCredential(context.Background(), "team-1", "sec-1")
+			if err == nil {
+				t.Fatal("want auth error")
+			}
+			if !strings.Contains(err.Error(), "DAEMON_AUTH_TOKEN") {
+				t.Errorf("error should name DAEMON_AUTH_TOKEN for operator clarity, got %v", err)
+			}
+		})
+	}
+}
+
+func TestHTTPVaultClientSurfacesGenericFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer srv.Close()
+	c := NewHTTPVaultClient(srv.URL, "tok")
+	_, err := c.FetchCredential(context.Background(), "team-1", "sec-1")
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Errorf("want 500 in error, got %v", err)
+	}
+}
+
+func TestHTTPVaultClientEmptyValueMapsToRevoked(t *testing.T) {
+	// Empty plaintext is treated as a revoked credential so the request
+	// path returns the same 503 as any other unusable secret.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(decryptResponse{Value: ""})
+	}))
+	defer srv.Close()
+	c := NewHTTPVaultClient(srv.URL, "tok")
+	_, err := c.FetchCredential(context.Background(), "team-1", "sec-1")
+	if !errors.Is(err, ErrCredentialRevoked) {
+		t.Errorf("want ErrCredentialRevoked, got %v", err)
+	}
+}
+
+func TestHTTPVaultClientRetriesOnTransient5xx(t *testing.T) {
+	// One brief upstream hiccup must not fail the request — the client
+	// retries 502/503/504 once before giving up.
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(decryptResponse{Value: "real-value"})
+	}))
+	defer srv.Close()
+	c := NewHTTPVaultClient(srv.URL, "tok")
+	val, err := c.FetchCredential(context.Background(), "team-1", "sec-1")
+	if err != nil {
+		t.Fatalf("retry should have succeeded, got %v", err)
+	}
+	if val != "real-value" {
+		t.Errorf("value mismatch: got %q", val)
+	}
+	if calls != 2 {
+		t.Errorf("want 2 calls (one fail, one success), got %d", calls)
+	}
+}
+
+func TestHTTPVaultClientStopsAfterOneRetry(t *testing.T) {
+	// Persistent upstream failure shouldn't loop forever — give up after
+	// one retry and surface the last error.
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	c := NewHTTPVaultClient(srv.URL, "tok")
+	if _, err := c.FetchCredential(context.Background(), "team-1", "sec-1"); err == nil {
+		t.Errorf("want error on persistent 502, got nil")
+	}
+	if calls != 2 {
+		t.Errorf("want exactly 2 attempts, got %d", calls)
+	}
+}

--- a/scripts/gen-secretsproxy-ca/main.go
+++ b/scripts/gen-secretsproxy-ca/main.go
@@ -1,0 +1,44 @@
+// Command gen-secretsproxy-ca writes a fresh CA cert (0644) + key (0600)
+// to the paths given by -cert and -key.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/superserve-ai/sandbox/internal/secretsproxy"
+)
+
+func main() {
+	certPath := flag.String("cert", "", "output path for the PEM certificate (required)")
+	keyPath := flag.String("key", "", "output path for the PEM private key (required)")
+	flag.Parse()
+	if *certPath == "" || *keyPath == "" {
+		fmt.Fprintln(os.Stderr, "both -cert and -key are required")
+		os.Exit(2)
+	}
+	certPEM, keyPEM, err := secretsproxy.GenerateCA()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "generate CA:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*certPath, certPEM, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "write cert:", err)
+		os.Exit(1)
+	}
+	// Force final mode regardless of umask — a restrictive umask can
+	// otherwise leave the key unreadable by the daemon at runtime.
+	if err := os.Chmod(*certPath, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "chmod cert:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*keyPath, keyPEM, 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, "write key:", err)
+		os.Exit(1)
+	}
+	if err := os.Chmod(*keyPath, 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, "chmod key:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
**Stack 3 of 6.** Base: `amit/secrets-2-crypto-proto`.

The secrets-proxy daemon: JWT-scoped credential injection, vault client, egress-rule enforcement, per-sandbox revocation, control socket, CA tooling, systemd unit. Self-contained binary — not invoked until stack 6.

Largest layer (the daemon is one cohesive subsystem). Review/merge after [2/6].