### PR TITLE
secrets [4/6]: control-plane API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -449,10 +449,290 @@ paths:
       responses:
         "101":
           description: Switching Protocols — the WebSocket is established.
+
+  /secrets:
+    post:
+      operationId: createSecret
+      tags: [Secrets]
+      summary: Create a secret
+      description: |
+        Stores a credential under the caller's team. The plaintext is
+        envelope-encrypted at rest and is never returned by any API.
+        At sandbox-create time, bind the secret to an environment-variable
+        name via the `secrets` map on `POST /sandboxes`; the agent sees a
+        proxy token in env and the in-host enforcement daemon swaps it for
+        the real value at egress.
+
+        Use `provider` for built-in shortcuts (e.g. `anthropic`, `openai`,
+        `github`, `stripe`) which auto-fill the auth scheme and allowed
+        upstream hosts. Use `auth` + `hosts` for a custom integration.
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSecretRequest"
+      responses:
+        "201":
+          description: Secret created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecretResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    get:
+      operationId: listSecrets
+      tags: [Secrets]
+      summary: List secrets for the calling team
+      description: |
+        Returns metadata for all secrets owned by the team. Cleartext values
+        are never returned.
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Secret metadata list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SecretResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /secrets/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Secret name as set at creation.
+    get:
+      operationId: getSecret
+      tags: [Secrets]
+      summary: Get a secret's metadata
+      description: Returns metadata only — the cleartext value is never returned.
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Secret metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecretResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      operationId: updateSecretValue
+      tags: [Secrets]
+      summary: Rotate a secret's value
+      description: |
+        Replaces the stored ciphertext with a freshly-encrypted copy of the
+        new value. All sandboxes bound to this secret continue to work; in-host
+        caches are invalidated so the next egress uses the new value.
+      security:
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSecretRequest"
+      responses:
+        "200":
+          description: Secret updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SecretResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      operationId: deleteSecret
+      tags: [Secrets]
+      summary: Revoke a secret
+      description: |
+        Soft-deletes the secret: the proxy daemon refuses to serve it and
+        new sandbox bindings fail. Existing audit-history queries still
+        resolve the row. The same name can be re-used by creating a new secret.
+      security:
+        - apiKey: []
+      responses:
+        "204":
+          description: Secret revoked
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /sandboxes/{sandbox_id}/network:
+    parameters:
+      - $ref: "#/components/parameters/SandboxId"
+    get:
+      operationId: listSandboxNetwork
+      tags: [Sandboxes]
+      summary: List a sandbox's egress activity
+      description: |
+        The unified per-sandbox network log: every outbound connection the
+        sandbox made, merged into one time-ordered stream, most recent first.
+        Each row has a `kind` — `connection` (host, bytes, allow/deny verdict)
+        or `request` (HTTP method, path, status, and the secret used, when a
+        credential was injected). Fields not relevant to a row's kind are
+        omitted.
+
+        Filter by time window (`since`/`before`) and `verdict`. Paginate by
+        passing the response's `next_cursor` as `before` while `has_more` is
+        true. A `verdict` filter returns only `connection` rows, since request
+        rows carry no verdict.
+      security:
+        - apiKey: []
+      parameters:
+        - $ref: "#/components/parameters/AuditLimit"
+        - name: before
+          in: query
+          description: Return rows strictly older than this RFC3339 timestamp. Also the pagination cursor.
+          schema:
+            type: string
+            format: date-time
+        - name: since
+          in: query
+          description: Return rows at or newer than this RFC3339 timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: verdict
+          in: query
+          description: Filter to connection rows with this verdict. Excludes request rows.
+          schema:
+            type: string
+            enum: [allowed, blocked, failed]
+      responses:
+        "200":
+          description: A page of network events (most recent first)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NetworkEventPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /secrets/{name}/audit:
+    parameters:
+      - $ref: "#/components/parameters/SecretName"
+    get:
+      operationId: listSecretAudit
+      tags: [Secrets]
+      summary: List proxy egress events that used this credential
+      description: |
+        Returns proxy_audit events for every outbound request that the
+        in-host enforcement daemon swapped with this credential, across
+        every sandbox it was bound to. Each row includes the originating
+        sandbox name (null when that sandbox has since been deleted).
+      security:
+        - apiKey: []
+      parameters:
+        - $ref: "#/components/parameters/AuditLimit"
+        - $ref: "#/components/parameters/AuditBefore"
+        - $ref: "#/components/parameters/AuditStatusFilter"
+      responses:
+        "200":
+          description: Audit events (most recent first)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProxyAuditEvent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /secrets/{name}/sandboxes:
+    parameters:
+      - $ref: "#/components/parameters/SecretName"
+    get:
+      operationId: listSecretSandboxes
+      tags: [Secrets]
+      summary: List sandboxes currently bound to this credential
+      description: >
+        Returns the active (non-destroyed) sandboxes that have this credential
+        bound, with the env-var name each binding uses. Useful before rotation
+        or deletion ("which sandboxes will be affected?").
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Bound sandboxes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SandboxSecretBinding"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /providers:
+    get:
+      operationId: listProviders
+      tags: [Secrets]
+      summary: List the built-in provider shortcut catalog
+      description: >
+        Returns the providers customers can pass as `provider` on
+        `POST /secrets`. Backend-of-record so the console picker stays
+        in sync as the catalog grows.
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Provider catalog
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderShortcut"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /files:
     servers:
@@ -856,6 +1136,42 @@ components:
         format: uuid
       description: The unique identifier of the template build.
 
+    SecretName:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Secret name as set at creation.
+
+    AuditLimit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+
+    AuditBefore:
+      name: before
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int64
+      description: Return events with `id` strictly less than this cursor.
+
+    AuditStatusFilter:
+      name: status
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [2xx, 3xx, 4xx, 5xx, errors]
+      description: Narrow by HTTP status class; `errors` includes 4xx and 5xx.
+
   schemas:
     CreateSandboxRequest:
       type: object
@@ -929,6 +1245,19 @@ components:
             run_id: 7f3c-21
         network:
           $ref: "#/components/schemas/NetworkConfig"
+        secrets:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Bind team-stored credentials to environment variables inside the
+            sandbox. Keys are env-var names; values are secret names from
+            `POST /secrets`. The agent never sees the real value: it sees a
+            proxy token in env, and the in-host enforcement daemon swaps the
+            token for the real credential at egress.
+          example:
+            ANTHROPIC_API_KEY: anthropic-prod
+            GITHUB_TOKEN: ghp-readonly
 
     SandboxListItem:
       description: Sandbox shape returned by list endpoints.
@@ -982,7 +1311,7 @@ components:
             owner: agent-7
 
     SandboxResponse:
-      description: Single-sandbox shape — `SandboxListItem` plus `access_token`.
+      description: Single-sandbox shape — `SandboxListItem` plus `access_token` and bound secrets.
       allOf:
         - $ref: "#/components/schemas/SandboxListItem"
         - type: object
@@ -993,6 +1322,24 @@ components:
                 Per-sandbox access token for data-plane operations (file
                 upload/download, terminal). Pass as the `X-Access-Token`
                 header.
+            secrets:
+              type: array
+              description: >
+                Credentials bound to this sandbox. Each entry maps an env-var
+                name visible to the agent to the secret name it resolves to.
+                `revoked=true` when the underlying secret has been soft-deleted
+                (the env var still holds the now-useless proxy token).
+              items:
+                type: object
+                required: [env_key, secret_name]
+                properties:
+                  env_key:
+                    type: string
+                  secret_name:
+                    type: string
+                  revoked:
+                    type: boolean
+                    default: false
 
     ResumeResponse:
       type: object
@@ -1388,6 +1735,357 @@ components:
       example:
         path: /home/user/out.txt
         size: 1024
+
+    CreateSecretRequest:
+      type: object
+      required: [name, value]
+      properties:
+        name:
+          type: string
+          maxLength: 128
+          pattern: "^[A-Za-z_][A-Za-z0-9_-]*$"
+          description: >
+            Identifier used to reference the secret later (e.g. in the
+            `secrets` map on `POST /sandboxes`).
+        value:
+          type: string
+          maxLength: 8192
+          description: Cleartext credential. Encrypted at rest; never returned.
+        provider:
+          type: string
+          description: >
+            Built-in provider shortcut (e.g. `anthropic`, `openai`, `github`,
+            `stripe`). When set, auto-fills auth scheme and allowed upstream
+            hosts. Mutually exclusive with `auth` and `hosts`. `github`
+            emits a `per_host` config so the same PAT works for both
+            api.github.com REST (`Bearer`) and github.com git over HTTPS
+            (`Basic` with `x-access-token`).
+        auth:
+          $ref: "#/components/schemas/SecretAuthConfig"
+        hosts:
+          type: array
+          items:
+            type: string
+          maxItems: 16
+          description: >
+            Upstream allow list. Required when `auth` is set. Each entry is a
+            hostname or single-level wildcard (e.g. `api.example.com`,
+            `*.example.com`).
+
+    UpdateSecretRequest:
+      type: object
+      required: [value]
+      properties:
+        value:
+          type: string
+          maxLength: 8192
+          description: New cleartext value to encrypt and store.
+
+    SecretAuthConfig:
+      description: |
+        Egress auth shape. Use the single-rule form (`type` + type-specific
+        fields) for credentials that authenticate the same way on every host.
+        Use `per_host` when the same credential needs different auth schemes
+        on different hosts of the same provider — for example one host
+        accepts `Bearer` while another accepts `Basic` with a fixed username.
+        Single-rule and `per_host` are mutually exclusive.
+      oneOf:
+        - $ref: "#/components/schemas/SecretAuthConfigSingleRule"
+        - $ref: "#/components/schemas/SecretAuthConfigPerHost"
+
+    SecretAuthConfigSingleRule:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [bearer, basic, api-key, custom]
+          description: |
+            Egress auth scheme:
+            - `bearer`: `Authorization: Bearer <value>`
+            - `basic`: `Authorization: Basic <base64(username:value)>`
+            - `api-key`: custom header (set `header`, optionally `prefix`)
+            - `custom`: caller-defined `headers` map
+        header:
+          type: string
+          description: Header name (required for `api-key`).
+        prefix:
+          type: string
+          description: Optional value prefix (used by `api-key`).
+        username:
+          type: string
+          description: >
+            Optional username for `basic`. When set, this username is used
+            verbatim in the outbound Basic header (overrides any username sent
+            by the client). When empty, the inbound username is preserved, or
+            `x` is used if absent.
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          maxProperties: 8
+          description: Header-name → value template (required for `custom`).
+
+    SecretAuthConfigPerHost:
+      type: object
+      required: [per_host]
+      properties:
+        per_host:
+          type: array
+          minItems: 1
+          maxItems: 16
+          items:
+            $ref: "#/components/schemas/SecretPerHostRule"
+          description: >
+            Per-host rule list. The daemon picks the first rule whose `hosts`
+            match the upstream host at egress. Every host referenced here must
+            also appear in the top-level `hosts` allowlist. Rules may not
+            overlap (a host belongs to at most one rule).
+
+    SecretPerHostRule:
+      type: object
+      required: [hosts, type]
+      properties:
+        hosts:
+          type: array
+          minItems: 1
+          maxItems: 16
+          items:
+            type: string
+          description: >
+            Hosts this rule authenticates. Exact hostnames or single-level
+            wildcards (`*.example.com`).
+        type:
+          type: string
+          enum: [bearer, basic, api-key, custom]
+        header:
+          type: string
+          description: Header name (required for `api-key`).
+        prefix:
+          type: string
+          description: Optional value prefix (used by `api-key`).
+        username:
+          type: string
+          description: Username slot for `basic`. Used verbatim in the outbound `Basic <base64(username:value)>` header.
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          maxProperties: 8
+          description: Header-name → value template (required for `custom`).
+
+    SecretResponse:
+      type: object
+      required: [id, name, auth_type, auth_config, hosts, created_at, updated_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        auth_type:
+          type: string
+          enum: [bearer, basic, api-key, custom, per_host]
+          description: >
+            `per_host` indicates a multi-rule secret; the resolved rules are
+            in `auth_config.per_host`.
+        auth_config:
+          type: object
+          additionalProperties: true
+          description: Resolved auth scheme details (no cleartext value).
+        provider_shortcut:
+          type: string
+          nullable: true
+          description: Provider shortcut used at creation, if any.
+        hosts:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp of the most recent egress that used this secret.
+
+    ProxyAuditEvent:
+      type: object
+      required: [id, ts, sandbox_id, method, host, path, status]
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Monotonic event id — also the pagination cursor.
+        ts:
+          type: string
+          format: date-time
+        sandbox_id:
+          type: string
+          format: uuid
+        sandbox_name:
+          type: string
+          nullable: true
+          description: >
+            Originating sandbox's name at query time. Only populated by
+            cross-sandbox views such as `GET /secrets/{name}/audit`. Null
+            when the sandbox has since been deleted.
+        secret_id:
+          type: string
+          format: uuid
+          description: Secret involved in this request, if any.
+        method:
+          type: string
+        host:
+          type: string
+          description: Upstream host targeted by the request.
+        path:
+          type: string
+        status:
+          type: integer
+          format: int32
+          description: Status the proxy returned to the sandbox.
+        upstream_status:
+          type: integer
+          format: int32
+          nullable: true
+          description: Status returned by the upstream (absent if the proxy short-circuited).
+        latency_ms:
+          type: integer
+          format: int32
+          nullable: true
+        error_code:
+          type: string
+          nullable: true
+          description: Stable error tag when the proxy denied or failed the request.
+
+    NetworkEventPage:
+      type: object
+      required: [data, next_cursor, has_more]
+      description: A page of network events with pagination metadata.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/NetworkEvent"
+        next_cursor:
+          type: string
+          format: date-time
+          nullable: true
+          description: Pass as `before` to fetch the next page. Null when has_more is false.
+        has_more:
+          type: boolean
+          description: Whether more rows exist beyond this page.
+
+    NetworkEvent:
+      type: object
+      required: [kind, id, ts]
+      description: |
+        One row in the unified network log. `kind` selects which fields are
+        present: connection rows carry dst_ip/verdict/bytes, request rows carry
+        method/path/status/secret_id. Unused fields are omitted.
+      properties:
+        kind:
+          type: string
+          enum: [connection, request]
+        id:
+          type: integer
+          format: int64
+        ts:
+          type: string
+          format: date-time
+        host:
+          type: string
+          description: Destination host (SNI / HTTP Host).
+        dst_ip:
+          type: string
+          description: Connection rows only.
+        dst_port:
+          type: integer
+          format: int32
+        verdict:
+          type: string
+          enum: [allowed, blocked, failed]
+          description: Connection rows only.
+        match_rule:
+          type: string
+          description: Connection rows — which rule decided (domain, cidr, internal-ip, …).
+        bytes_sent:
+          type: integer
+          format: int64
+        bytes_recv:
+          type: integer
+          format: int64
+        method:
+          type: string
+          description: Request rows only.
+        path:
+          type: string
+        status:
+          type: integer
+          format: int32
+          description: Request rows — HTTP status returned to the sandbox.
+        upstream_status:
+          type: integer
+          format: int32
+        latency_ms:
+          type: integer
+          format: int32
+        secret_id:
+          type: string
+          format: uuid
+          description: Request rows — the secret injected, if any.
+        error_code:
+          type: string
+
+    SandboxSecretBinding:
+      type: object
+      required: [sandbox_id, sandbox_name, env_key, status]
+      properties:
+        sandbox_id:
+          type: string
+          format: uuid
+        sandbox_name:
+          type: string
+        env_key:
+          type: string
+          description: Env-var name the secret resolves to inside the sandbox.
+        status:
+          type: string
+          enum: [active, paused, resuming, failed]
+
+    ProviderShortcut:
+      type: object
+      required: [name, display, auth_type, hosts, token_shape]
+      description: >
+        One entry of the built-in provider catalog. The console renders pickers
+        from this list so a new shortcut added on the backend appears without
+        a frontend redeploy.
+      properties:
+        name:
+          type: string
+          description: Stable identifier used as `provider` on `POST /secrets`.
+        display:
+          type: string
+          description: Human-readable label.
+        auth_type:
+          type: string
+          enum: [bearer, basic, api-key, custom, per_host]
+        auth_config:
+          type: object
+          additionalProperties: true
+          description: Resolved auth shape; same JSON shape as `SecretResponse.auth_config`.
+        hosts:
+          type: array
+          items:
+            type: string
+        token_shape:
+          type: string
+          description: Prefix-shaped sample of the proxy token issued for this provider (e.g. `sk-ant-api03-...`).
 
     Error:
       type: object

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/getsentry/sentry-go"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
@@ -25,10 +26,11 @@ import (
 	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/api"
 	"github.com/superserve-ai/sandbox/internal/config"
-	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	dbq "github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/hostreg"
 	"github.com/superserve-ai/sandbox/internal/scheduler"
+	"github.com/superserve-ai/sandbox/internal/secrets"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/supervisor"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
@@ -131,6 +133,32 @@ func run() error {
 	}
 	defer analyticsClient.Close()
 	handlers.Analytics = analyticsClient
+
+	// /secrets endpoints require KMS_KEY_RESOURCE; otherwise they remain disabled.
+	if cfg.KMSKeyResource != "" {
+		kmsClient, kerr := kms.NewKeyManagementClient(ctx)
+		if kerr != nil {
+			log.Warn().Err(kerr).Msg("KMS init failed; /secrets endpoints disabled")
+		} else {
+			handlers.Encryptor = secrets.NewKMSEncryptor(kmsClient, cfg.KMSKeyResource)
+			log.Info().Str("kek", cfg.KMSKeyResource).Msg("KMS encryptor wired for /secrets")
+		}
+	} else {
+		log.Info().Msg("KMS_KEY_RESOURCE empty; /secrets endpoints disabled")
+	}
+
+	// Sandbox JWT signer requires SECRETS_SIGNING_KEY; empty disables minting.
+	if cfg.SecretsSigningKey != "" {
+		signer, serr := api.NewSecretsSigner(cfg.SecretsSigningKey, cfg.SecretsSigningKeyID)
+		if serr != nil {
+			log.Warn().Err(serr).Msg("SECRETS_SIGNING_KEY init failed; JWT signing disabled")
+		} else {
+			handlers.Signer = signer
+			log.Info().Str("kid", cfg.SecretsSigningKeyID).Msg("JWT signer wired for /internal/jwks and sandbox secrets")
+		}
+	} else {
+		log.Info().Msg("SECRETS_SIGNING_KEY empty; JWT signing disabled (sandboxes with `secrets:` will fail)")
+	}
 
 	// Host registry: resolves host_id → VMDClient via DB lookup + gRPC dial.
 	// Interceptors below fire onDead on codes.Unavailable so the registry
@@ -292,12 +320,11 @@ func (c *grpcVMDClient) PauseInstance(ctx context.Context, vmID, snapshotDir str
 	return resp.SnapshotPath, resp.MemFilePath, nil
 }
 
-func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string, envVars map[string]string) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string) (string, uint32, uint32, error) {
 	resp, err := c.client.ResumeVM(ctx, &vmdpb.ResumeVMRequest{
 		VmId:         vmID,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
-		EnvVars:      envVars,
 	})
 	if err != nil {
 		return "", 0, 0, fmt.Errorf("gRPC ResumeVM: %w", err)
@@ -311,9 +338,9 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 }
 
 // RestoreSnapshot is the stateless restore path — VMD creates a fresh VM
-// instance from the snapshot files, bypassing any in-memory state. Used as
-// a fallback when ResumeInstance returns NotFound (e.g. after VMD lost its
-// map to a crash but the snapshot files are still on disk).
+// instance from the snapshot files, bypassing any in-memory state. For
+// sandboxes with secrets the caller passes envVars=nil and pushes env via
+// InjectSandboxEnv after minting a JWT against the returned source IP.
 func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (string, uint32, uint32, error) {
 	resp, err := c.client.RestoreSnapshot(ctx, &vmdpb.RestoreSnapshotRequest{
 		VmId:         vmID,
@@ -334,6 +361,18 @@ func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath,
 		mem = rl.GetMemoryMib()
 	}
 	return resp.IpAddress, vcpu, mem, nil
+}
+
+func (c *grpcVMDClient) InjectSandboxEnv(ctx context.Context, vmID string, envVars map[string]string, secretsJWT string) error {
+	_, err := c.client.InjectSandboxEnv(ctx, &vmdpb.InjectSandboxEnvRequest{
+		VmId:       vmID,
+		EnvVars:    envVars,
+		SecretsJwt: secretsJWT,
+	})
+	if err != nil {
+		return fmt.Errorf("gRPC InjectSandboxEnv: %w", err)
+	}
+	return nil
 }
 
 // DeleteSnapshot removes the on-disk snapshot artifacts for a previous pause.
@@ -460,6 +499,30 @@ func (c *grpcVMDClient) UpdateSandboxNetwork(ctx context.Context, vmID string, a
 	})
 	if err != nil {
 		return fmt.Errorf("gRPC UpdateSandboxNetwork: %w", err)
+	}
+	return nil
+}
+
+func (c *grpcVMDClient) InvalidateSecret(ctx context.Context, secretID string) error {
+	_, err := c.client.InvalidateSecret(ctx, &vmdpb.InvalidateSecretRequest{SecretId: secretID})
+	if err != nil {
+		return fmt.Errorf("gRPC InvalidateSecret: %w", err)
+	}
+	return nil
+}
+
+func (c *grpcVMDClient) RevokeSandbox(ctx context.Context, sandboxID string) error {
+	_, err := c.client.RevokeSandbox(ctx, &vmdpb.RevokeSandboxRequest{SandboxId: sandboxID})
+	if err != nil {
+		return fmt.Errorf("gRPC RevokeSandbox: %w", err)
+	}
+	return nil
+}
+
+func (c *grpcVMDClient) InvalidateSandboxRules(ctx context.Context, sandboxID string) error {
+	_, err := c.client.InvalidateSandboxRules(ctx, &vmdpb.InvalidateSandboxRulesRequest{SandboxId: sandboxID})
+	if err != nil {
+		return fmt.Errorf("gRPC InvalidateSandboxRules: %w", err)
 	}
 	return nil
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/auth"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/secrets"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
@@ -65,9 +66,11 @@ type Handlers struct {
 	DB        *db.Queries
 	Pool      *pgxpool.Pool // required by paths that need their own transaction (e.g. build-concurrency admission)
 	Config    *config.Config
-	Hosts     HostRegistry // when set, routes VMD calls via host_id
-	Scheduler Scheduler    // when set, picks host on create
+	Hosts     HostRegistry      // when set, routes VMD calls via host_id
+	Scheduler Scheduler         // when set, picks host on create
 	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
+	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
+	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
 }
 
 // capture emits a usage event attributed to the API key's owner and team.
@@ -146,6 +149,32 @@ func (h *Handlers) logSandboxActivity(reqCtx context.Context, sandboxID, teamID 
 		})
 		if err != nil {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msgf("async %s/%s activity log failed", category, action)
+		}
+	}()
+}
+
+// logSecretActivity writes a secret-scoped activity record. secretName is a
+// denormalized snapshot stored at write time so the row stays readable even
+// after the underlying secret is hard-deleted.
+func (h *Handlers) logSecretActivity(reqCtx context.Context, secretID, teamID uuid.UUID, actorID *uuid.UUID, action, status, secretName string, metadata []byte) {
+	asyncCtx := context.WithoutCancel(reqCtx)
+	go func() {
+		defer sentrylog.Recover("secret-activity-log")
+		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
+		defer cancel()
+		_, err := h.DB.CreateActivity(ctx, db.CreateActivityParams{
+			SecretID:     pgtype.UUID{Bytes: secretID, Valid: true},
+			SecretName:   &secretName,
+			ResourceType: "secret",
+			TeamID:       teamID,
+			ActorID:      actorUUID(actorID),
+			Category:     "secret",
+			Action:       action,
+			Status:       &status,
+			Metadata:     metadata,
+		})
+		if err != nil {
+			log.Error().Err(err).Str("secret_id", secretID.String()).Msgf("async secret/%s activity log failed", action)
 		}
 	}()
 }
@@ -405,7 +434,9 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 
 	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 	defer vmdCancel()
-	ipAddress, actualVcpu, actualMemMiB, err := vmd.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath, nil)
+	// Resume is a no-op for secrets: the agent's HTTPS_PROXY (with its JWT) and
+	// per-binding proxy tokens are in the snapshot.
+	ipAddress, actualVcpu, actualMemMiB, err := vmd.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath)
 	if err != nil {
 		if isVMDNotFound(err) {
 			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).
@@ -535,6 +566,26 @@ type persistedEgressConfig struct {
 		DeniedCIDRs    []string `json:"denied_cidrs"`
 		AllowedDomains []string `json:"allowed_domains"`
 	} `json:"egress"`
+}
+
+// egressConfigJSON splits the request's egress entries into CIDRs and domains
+// and marshals the network_config jsonb shape persisted on the sandbox row.
+func egressConfigJSON(network *networkConfigRequest) (allowedCIDRs, allowedDomains []string, raw []byte) {
+	for _, entry := range network.AllowOut {
+		if isIPOrCIDR(entry) {
+			allowedCIDRs = append(allowedCIDRs, entry)
+		} else {
+			allowedDomains = append(allowedDomains, entry)
+		}
+	}
+	raw, _ = json.Marshal(map[string]any{
+		"egress": map[string]any{
+			"allowed_cidrs":   allowedCIDRs,
+			"denied_cidrs":    network.DenyOut,
+			"allowed_domains": allowedDomains,
+		},
+	})
+	return allowedCIDRs, allowedDomains, raw
 }
 
 // reapplyNetworkConfig reads the sandbox's persisted egress config and pushes
@@ -750,6 +801,21 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
+	// Record the revocation so daemons can refuse the JWT, and fan out the
+	// notification to the host. Detach from the request context so a client
+	// disconnect mid-DELETE doesn't strand a destroyed sandbox without its
+	// revocation row. Bootstrap-on-restart still recovers if fanout fails.
+	revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
+	defer revokeCancel()
+	if err := h.DB.InsertSandboxRevocation(revokeCtx, db.InsertSandboxRevocationParams{
+		SandboxID: sandboxID,
+		ExpiresAt: time.Now().Add(SecretsJWTLifetime),
+	}); err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB InsertSandboxRevocation failed")
+	} else {
+		go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
+	}
+
 	// Best-effort cleanup of pause snapshots. Failures are logged but
 	// don't fail the delete — manual cleanup may be required if vmd was
 	// unreachable.
@@ -891,20 +957,34 @@ type createSandboxRequest struct {
 	// they live in boxd's memory for the sandbox's lifetime and survive
 	// pause/resume via snapshot.
 	EnvVars map[string]string `json:"env_vars,omitempty"`
+
+	// Secrets binds team-stored credentials to env-var names; the agent sees a
+	// per-binding proxy token, swapped for the real value at egress.
+	Secrets map[string]string `json:"secrets,omitempty"`
 }
 
 type sandboxResponse struct {
-	ID             uuid.UUID             `json:"id"`
-	Name           string                `json:"name"`
-	Status         string                `json:"status"`
-	VcpuCount      int32                 `json:"vcpu_count"`
-	MemoryMib      int32                 `json:"memory_mib"`
-	AccessToken    string                `json:"access_token,omitempty"`
-	SnapshotID     *uuid.UUID            `json:"snapshot_id,omitempty"`
-	CreatedAt      time.Time             `json:"created_at"`
-	TimeoutSeconds *int32                `json:"timeout_seconds,omitempty"`
-	Network        *networkConfigRequest `json:"network,omitempty"`
-	Metadata       map[string]string     `json:"metadata"`
+	ID             uuid.UUID              `json:"id"`
+	Name           string                 `json:"name"`
+	Status         string                 `json:"status"`
+	VcpuCount      int32                  `json:"vcpu_count"`
+	MemoryMib      int32                  `json:"memory_mib"`
+	AccessToken    string                 `json:"access_token,omitempty"`
+	SnapshotID     *uuid.UUID             `json:"snapshot_id,omitempty"`
+	CreatedAt      time.Time              `json:"created_at"`
+	TimeoutSeconds *int32                 `json:"timeout_seconds,omitempty"`
+	Network        *networkConfigRequest  `json:"network,omitempty"`
+	Metadata       map[string]string      `json:"metadata"`
+	Secrets        []sandboxSecretBinding `json:"secrets,omitempty"`
+}
+
+// sandboxSecretBinding mirrors one (env_key → secret) binding on a sandbox.
+// `revoked` is true when the underlying secret has been soft-deleted —
+// the binding row stays but the daemon refuses to swap on use.
+type sandboxSecretBinding struct {
+	EnvKey     string `json:"env_key"`
+	SecretName string `json:"secret_name"`
+	Revoked    bool   `json:"revoked,omitempty"`
 }
 
 func (h *Handlers) sandboxToResponse(s db.Sandbox) sandboxResponse {
@@ -1085,7 +1165,32 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, h.sandboxToResponseWithToken(sandbox))
+	resp := h.sandboxToResponseWithToken(sandbox)
+	resp.Secrets = h.fetchSandboxSecretBindings(c.Request.Context(), sandboxID)
+	c.JSON(http.StatusOK, resp)
+}
+
+// fetchSandboxSecretBindings is a best-effort read of the sandbox's secret
+// bindings for the detail response. A DB failure is logged but doesn't fail
+// the request — the sandbox shape is still useful without the bindings list.
+func (h *Handlers) fetchSandboxSecretBindings(ctx context.Context, sandboxID uuid.UUID) []sandboxSecretBinding {
+	rows, err := h.DB.ListSandboxSecretBindings(ctx, sandboxID)
+	if err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ListSandboxSecretBindings failed")
+		return nil
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]sandboxSecretBinding, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, sandboxSecretBinding{
+			EnvKey:     r.EnvKey,
+			SecretName: r.SecretName,
+			Revoked:    r.SecretRevoked,
+		})
+	}
+	return out
 }
 
 func (h *Handlers) CreateSandbox(c *gin.Context) {
@@ -1136,6 +1241,19 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
 	}
+	if err := validateSecretsRefs(req.Secrets); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	// env_vars and secrets share the env-var namespace; 400 on collision.
+	for k := range req.Secrets {
+		if _, dup := req.EnvVars[k]; dup {
+			respondErrorMsg(c, "bad_request",
+				fmt.Sprintf("env-var key %q appears in both env_vars and secrets; pick one", k),
+				http.StatusBadRequest)
+			return
+		}
+	}
 	// Marshal once into the canonical jsonb shape. Empty / nil maps are
 	// stored as the empty object so the column is never NULL.
 	metadataJSON, err := json.Marshal(req.Metadata)
@@ -1152,6 +1270,13 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 
 	teamID, err := teamIDFromContext(c)
 	if err != nil {
+		return
+	}
+
+	// Resolve secret references before spinning up the VM so a typo 400s cleanly.
+	secretBindings, secretMeta, appErr := h.resolveSecretBindingsForCreate(c.Request.Context(), teamID, req.Secrets)
+	if appErr != nil {
+		respondError(c, appErr)
 		return
 	}
 
@@ -1306,13 +1431,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 	defer vmdCancel()
 
-	// RestoreSnapshot (not ResumeInstance) for the from_template path:
-	// ResumeInstance assumes the VM already exists in vmd's in-memory map
-	// (the pause→resume contract), which is fine for a paused sandbox but
-	// not for a fresh one we're creating now. Restore takes snapshot paths
-	// and boots a new VM from them statelessly. Caller env vars are merged
-	// on top of the template's baked defaults by vmd (boxd resumes with
-	// template context, then the restore RPC posts these on top).
+	envVarsToShip := mergeEnvVarsWithSecrets(req.EnvVars, secretMeta)
+
+	// Phase 1: RestoreSnapshot boots the VM with the caller's env vars and
+	// returns its source IP. For sandboxes with secrets, a follow-up
+	// InjectSandboxEnv pushes the env again together with the JWT minted
+	// against the now-known source IP.
 	tVmdStart := time.Now()
 	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
 	tVmdEnd := time.Now()
@@ -1384,11 +1508,63 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	}
 
-	// Past this point the VM is running. Detach from cancellation so a
-	// client disconnect cannot lose the state transition, but preserve
-	// the trace/span context so post-VMD writes stay in the request trace.
+	// Phase 2: with the source IP known, mint the per-sandbox secrets JWT
+	// (when secrets are configured) and push env vars to the running boxd.
+	// If injection fails, tear the VM down and mark the row failed — a
+	// sandbox that boots without its env vars is unusable.
 	postCtx, postCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
 	defer postCancel()
+
+	// Persist egress rules before injecting the env, so the secrets proxy's live
+	// rule fetch sees them before the agent can issue a proxied request. The
+	// nftables push happens later (it needs the booted VM); the DB write does not.
+	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
+		_, _, networkConfig := egressConfigJSON(req.Network)
+		if err := h.DB.UpdateSandboxNetworkConfig(postCtx, db.UpdateSandboxNetworkConfigParams{
+			ID:            sandbox.ID,
+			NetworkConfig: networkConfig,
+			TeamID:        teamID,
+		}); err != nil {
+			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("persist network_config before env inject failed")
+		}
+	}
+
+	var secretsJWT string
+	if len(secretMeta) > 0 {
+		jwt, jerr := h.mintSecretsJWT(sandboxID.String(), teamID.String(), ipAddress, secretMeta)
+		if jerr != nil {
+			log.Error().Err(jerr).Str("sandbox_id", sandboxID.String()).Msg("mint secrets JWT")
+			h.failSandboxAfterBoot(postCtx, sandbox.ID, teamID, sandboxID.String())
+			respondError(c, ErrInternal)
+			return
+		}
+		secretsJWT = jwt
+	}
+	if injErr := vmd.InjectSandboxEnv(postCtx, sandboxID.String(), envVarsToShip, secretsJWT); injErr != nil {
+		// A vmd without this RPC already applied these env vars during
+		// RestoreSnapshot; tolerate its absence only when no JWT needs this path.
+		if secretsJWT == "" && isVMDUnimplemented(injErr) {
+			log.Warn().Str("sandbox_id", sandboxID.String()).Msg("vmd lacks InjectSandboxEnv; env applied during restore")
+		} else {
+			log.Error().Err(injErr).Str("sandbox_id", sandboxID.String()).Msg("VMD InjectSandboxEnv failed")
+			h.failSandboxAfterBoot(postCtx, sandbox.ID, teamID, sandboxID.String())
+			respondError(c, ErrInternal)
+			return
+		}
+	}
+
+	// Prime the secrets proxy's egress-rules cache so the agent's first proxied
+	// request hits a warm cache (covers a control-plane blip right after create).
+	// Best-effort; the on-demand fetch + TTL is the fallback.
+	if len(secretMeta) > 0 {
+		go func() {
+			pctx, pcancel := context.WithTimeout(context.Background(), vmdTimeout)
+			defer pcancel()
+			if err := vmd.InvalidateSandboxRules(pctx, sandboxID.String()); err != nil {
+				log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("prime egress rules cache failed (fetch fallback)")
+			}
+		}()
+	}
 
 	// Single atomic transition: starting → active with real resources
 	// and IP. VMD's response is the source of truth for vcpu/memory
@@ -1441,35 +1617,32 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		}
 	}()
 
+	if len(secretBindings) > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range secretBindings {
+				secretBindings[i].SandboxID = sandbox.ID
+				if err := h.DB.AddSandboxSecret(postCtx, secretBindings[i]); err != nil {
+					log.Error().Err(err).
+						Str("sandbox_id", sandbox.ID.String()).
+						Str("env_key", secretBindings[i].EnvKey).
+						Msg("DB AddSandboxSecret failed")
+				}
+			}
+		}()
+	}
+
 	if hasNetworkRules {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			var allowedCIDRs, allowedDomains []string
-			for _, entry := range req.Network.AllowOut {
-				if isIPOrCIDR(entry) {
-					allowedCIDRs = append(allowedCIDRs, entry)
-				} else {
-					allowedDomains = append(allowedDomains, entry)
-				}
-			}
-
+			// network_config was persisted above (before env injection); this
+			// only pushes the nftables rules, which need the booted VM.
+			allowedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
 			if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, req.Network.DenyOut, allowedDomains); err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("failed to apply network rules at creation")
-				return
 			}
-			networkConfig, _ := json.Marshal(map[string]any{
-				"egress": map[string]any{
-					"allowed_cidrs":   allowedCIDRs,
-					"denied_cidrs":    req.Network.DenyOut,
-					"allowed_domains": allowedDomains,
-				},
-			})
-			_ = h.DB.UpdateSandboxNetworkConfig(postCtx, db.UpdateSandboxNetworkConfigParams{
-				ID:            sandbox.ID,
-				NetworkConfig: networkConfig,
-				TeamID:        teamID,
-			})
 		}()
 	}
 	wg.Wait()
@@ -1876,6 +2049,18 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 
 		h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorIDFromContext(c), "network", "updated", "success", &sandbox.Name, nil, networkConfig)
 		h.capture(c, "sandbox_network_updated", map[string]any{"sandbox_id": sandboxID.String()})
+
+		// Push the egress-rules invalidation so the secrets proxy re-fetches the
+		// new rules immediately; the daemon's cache TTL is the fallback if this
+		// best-effort push fails. Detached context — the gin.Context is recycled
+		// once the handler returns.
+		go func() {
+			ictx, icancel := context.WithTimeout(context.Background(), vmdTimeout)
+			defer icancel()
+			if err := vmd.InvalidateSandboxRules(ictx, sandboxID.String()); err != nil {
+				log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("PATCH: invalidate sandbox rules failed (TTL fallback)")
+			}
+		}()
 	}
 
 	if body.Metadata != nil {

--- a/internal/api/handlers_network.go
+++ b/internal/api/handlers_network.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// networkEvent is one row in the unified per-sandbox egress log. kind says
+// whether it came from the connection log (net_flow) or the request log
+// (proxy_audit); fields not applicable to a kind are omitted.
+type networkEvent struct {
+	Kind string `json:"kind"` // "connection" | "request"
+	ID   int64  `json:"id"`
+	Ts   string `json:"ts"`
+	Host string `json:"host,omitempty"`
+
+	// connection (net_flow)
+	DstIP     string  `json:"dst_ip,omitempty"`
+	DstPort   *int32  `json:"dst_port,omitempty"`
+	Verdict   string  `json:"verdict,omitempty"`
+	MatchRule *string `json:"match_rule,omitempty"`
+	BytesSent *int64  `json:"bytes_sent,omitempty"`
+	BytesRecv *int64  `json:"bytes_recv,omitempty"`
+
+	// request (proxy_audit)
+	Method         string  `json:"method,omitempty"`
+	Path           string  `json:"path,omitempty"`
+	Status         *int32  `json:"status,omitempty"`
+	UpstreamStatus *int32  `json:"upstream_status,omitempty"`
+	LatencyMs      *int32  `json:"latency_ms,omitempty"`
+	SecretID       *string `json:"secret_id,omitempty"`
+	ErrorCode      *string `json:"error_code,omitempty"`
+
+	ts time.Time // unexported, for the merge sort
+}
+
+// networkResponse wraps the event page with cursor metadata so clients can
+// paginate without inferring the cursor from the rows themselves.
+type networkResponse struct {
+	Data       []networkEvent `json:"data"`
+	NextCursor *string        `json:"next_cursor"`
+	HasMore    bool           `json:"has_more"`
+}
+
+// GetSandboxNetwork returns the unified per-sandbox egress log: connection rows
+// (net_flow) and request rows (proxy_audit) merged into one time-ordered
+// stream, most recent first. Supports an optional time window (since/before)
+// and verdict filter; before is also the pagination cursor. The response wraps
+// the rows with next_cursor and has_more.
+func (h *Handlers) GetSandboxNetwork(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	sandboxID, err := parseSandboxID(c)
+	if err != nil {
+		return
+	}
+
+	if _, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+		ID: sandboxID, TeamID: teamID,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondError(c, ErrSandboxNotFound)
+			return
+		}
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	limit, err := parseAuditLimit(c.Query("limit"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	before, err := parseNetworkTime(c.Query("before"), "before")
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	since, err := parseNetworkTime(c.Query("since"), "since")
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	verdict, err := parseNetworkVerdict(c.Query("verdict"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := c.Request.Context()
+	// Fetch a full page from each source; merging then trimming to `limit`
+	// yields the correct newest-first window across both.
+	flows, err := h.DB.ListNetFlowEvents(ctx, db.ListNetFlowEventsParams{
+		SandboxID: sandboxID, Before: before, Since: since, Verdict: verdict, RowLimit: limit,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ListNetFlowEvents failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	// Request rows carry no verdict, so a verdict filter restricts the result
+	// to connection rows.
+	var requests []db.ProxyAudit
+	if verdict == nil {
+		requests, err = h.DB.ListProxyAuditEvents(ctx, db.ListProxyAuditEventsParams{
+			SandboxID: sandboxID, Before: before, Since: since, RowLimit: limit,
+		})
+		if err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ListProxyAuditEvents failed")
+			respondError(c, ErrInternal)
+			return
+		}
+	}
+
+	merged := make([]networkEvent, 0, len(flows)+len(requests))
+	for _, f := range flows {
+		merged = append(merged, flowToEvent(f))
+	}
+	for _, r := range requests {
+		merged = append(merged, requestToEvent(r))
+	}
+	sort.Slice(merged, func(i, j int) bool { return merged[i].ts.After(merged[j].ts) })
+
+	// More rows remain if either source filled its page, or the merge held more
+	// than one page's worth (the trimmed remainder is also "more").
+	hasMore := len(flows) == int(limit) || len(requests) == int(limit) || len(merged) > int(limit)
+	if len(merged) > int(limit) {
+		merged = merged[:limit]
+	}
+	var nextCursor *string
+	if hasMore && len(merged) > 0 {
+		cursor := merged[len(merged)-1].Ts
+		nextCursor = &cursor
+	}
+	c.JSON(http.StatusOK, networkResponse{Data: merged, NextCursor: nextCursor, HasMore: hasMore})
+}
+
+func flowToEvent(f db.NetFlow) networkEvent {
+	ev := networkEvent{
+		Kind:      "connection",
+		ID:        f.ID,
+		Ts:        f.Ts.UTC().Format(time.RFC3339Nano),
+		ts:        f.Ts,
+		DstIP:     f.DstIp.String(),
+		DstPort:   &f.DstPort,
+		Verdict:   f.Verdict,
+		MatchRule: f.MatchRule,
+		BytesSent: f.BytesSent,
+		BytesRecv: f.BytesRecv,
+	}
+	if f.Host != nil {
+		ev.Host = *f.Host
+	}
+	return ev
+}
+
+func requestToEvent(r db.ProxyAudit) networkEvent {
+	ev := networkEvent{
+		Kind:           "request",
+		ID:             r.ID,
+		Ts:             r.Ts.UTC().Format(time.RFC3339Nano),
+		ts:             r.Ts,
+		Host:           r.Host,
+		Method:         r.Method,
+		Path:           r.Path,
+		Status:         &r.Status,
+		UpstreamStatus: r.UpstreamStatus,
+		LatencyMs:      r.LatencyMs,
+		ErrorCode:      r.ErrorCode,
+	}
+	if r.SecretID.Valid {
+		s := uuid.UUID(r.SecretID.Bytes).String()
+		ev.SecretID = &s
+	}
+	return ev
+}
+
+// parseNetworkTime parses an RFC3339 time-window param (before/since), including
+// the sub-second cursor emitted as next_cursor. Empty leaves the bound unset.
+func parseNetworkTime(raw, param string) (pgtype.Timestamptz, error) {
+	if raw == "" {
+		return pgtype.Timestamptz{}, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return pgtype.Timestamptz{}, fmt.Errorf("%s must be an RFC3339 timestamp", param)
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}, nil
+}
+
+// parseNetworkVerdict validates the optional ?verdict= filter. Empty = no
+// filter (nil); a verdict restricts results to connection rows.
+func parseNetworkVerdict(raw string) (*string, error) {
+	switch raw {
+	case "":
+		return nil, nil
+	case "allowed", "blocked", "failed":
+		return &raw, nil
+	default:
+		return nil, errors.New("verdict must be one of allowed, blocked, failed")
+	}
+}

--- a/internal/api/handlers_network_test.go
+++ b/internal/api/handlers_network_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+func TestFlowToEvent(t *testing.T) {
+	host := "api.example.com"
+	rule := "domain"
+	var sent, recv int64 = 100, 200
+	f := db.NetFlow{
+		ID: 7, Ts: time.Unix(1000, 0).UTC(),
+		Host: &host, DstIp: netip.MustParseAddr("1.2.3.4"), DstPort: 443,
+		Verdict: "allowed", MatchRule: &rule, BytesSent: &sent, BytesRecv: &recv,
+	}
+	ev := flowToEvent(f)
+
+	if ev.Kind != "connection" || ev.ID != 7 || ev.Host != "api.example.com" ||
+		ev.DstIP != "1.2.3.4" || ev.Verdict != "allowed" {
+		t.Errorf("connection fields wrong: %+v", ev)
+	}
+	if ev.DstPort == nil || *ev.DstPort != 443 || ev.BytesSent == nil || *ev.BytesSent != 100 {
+		t.Errorf("ports/bytes wrong: %+v", ev)
+	}
+	// Request-only fields must stay empty.
+	if ev.Method != "" || ev.Status != nil || ev.SecretID != nil {
+		t.Errorf("request fields leaked onto a connection: %+v", ev)
+	}
+}
+
+func TestRequestToEvent(t *testing.T) {
+	secret := uuid.New()
+	var upstream, latency int32 = 200, 42
+	r := db.ProxyAudit{
+		ID: 9, Ts: time.Unix(2000, 0).UTC(),
+		SecretID: pgtype.UUID{Bytes: secret, Valid: true},
+		Method:   "POST", Host: "api.anthropic.com", Path: "/v1/messages",
+		Status: 200, UpstreamStatus: &upstream, LatencyMs: &latency,
+	}
+	ev := requestToEvent(r)
+
+	if ev.Kind != "request" || ev.ID != 9 || ev.Method != "POST" ||
+		ev.Host != "api.anthropic.com" || ev.Path != "/v1/messages" {
+		t.Errorf("request fields wrong: %+v", ev)
+	}
+	if ev.Status == nil || *ev.Status != 200 {
+		t.Errorf("status wrong: %+v", ev)
+	}
+	if ev.SecretID == nil || *ev.SecretID != secret.String() {
+		t.Errorf("secret_id = %v, want %s", ev.SecretID, secret)
+	}
+	// Connection-only fields must stay empty.
+	if ev.DstIP != "" || ev.Verdict != "" || ev.DstPort != nil {
+		t.Errorf("connection fields leaked onto a request: %+v", ev)
+	}
+}
+
+func TestRequestToEventNullSecret(t *testing.T) {
+	ev := requestToEvent(db.ProxyAudit{ID: 1, Ts: time.Unix(1, 0), Status: 200})
+	if ev.SecretID != nil {
+		t.Errorf("secret_id should be nil when not set, got %v", *ev.SecretID)
+	}
+}
+
+func TestParseNetworkTime(t *testing.T) {
+	if got, err := parseNetworkTime("", "before"); err != nil || got.Valid {
+		t.Errorf("empty should be (invalid, nil), got (%v, %v)", got, err)
+	}
+	if got, err := parseNetworkTime("2026-06-09T12:00:00Z", "since"); err != nil || !got.Valid {
+		t.Errorf("valid RFC3339 should parse, got (%v, %v)", got, err)
+	}
+	// The next_cursor is sub-second; it must round-trip back through before/since.
+	sub := "2026-06-09T12:00:00.123456789Z"
+	if got, err := parseNetworkTime(sub, "before"); err != nil || !got.Valid || got.Time.Nanosecond() != 123456789 {
+		t.Errorf("sub-second cursor should parse with nanos, got (%v, %v)", got, err)
+	}
+	if _, err := parseNetworkTime("not-a-time", "since"); err == nil {
+		t.Error("garbage timestamp should error")
+	}
+}
+
+func TestParseNetworkVerdict(t *testing.T) {
+	if got, err := parseNetworkVerdict(""); err != nil || got != nil {
+		t.Errorf("empty should be (nil, nil), got (%v, %v)", got, err)
+	}
+	for _, v := range []string{"allowed", "blocked", "failed"} {
+		if got, err := parseNetworkVerdict(v); err != nil || got == nil || *got != v {
+			t.Errorf("%q should parse, got (%v, %v)", v, got, err)
+		}
+	}
+	if _, err := parseNetworkVerdict("bogus"); err == nil {
+		t.Error("invalid verdict should error")
+	}
+}

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -1,0 +1,1496 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/publicsuffix"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/secrets"
+)
+
+// tokenSpec describes how to mint a fresh proxy token for one provider.
+// Shape must match the upstream key format so SDK validators accept it.
+type tokenSpec struct {
+	Prefix   string
+	BodyLen  int
+	Alphabet string // "alnum" or "b64url"
+}
+
+// providerShortcut is a pre-baked credential template (auth config + hosts + token spec).
+type providerShortcut struct {
+	Display    string // human-readable label shown in console pickers
+	AuthType   string
+	AuthConfig map[string]any
+	Hosts      []string
+	Token      tokenSpec
+}
+
+var providerShortcuts = map[string]providerShortcut{
+	"anthropic": {
+		Display:    "Anthropic",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "x-api-key"},
+		Hosts:      []string{"api.anthropic.com"},
+		Token:      tokenSpec{Prefix: "sk-ant-api03-", BodyLen: 48, Alphabet: "alnum"},
+	},
+	"openai": {
+		Display:    "OpenAI",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.openai.com"},
+		Token:      tokenSpec{Prefix: "sk-proj-", BodyLen: 64, Alphabet: "alnum"},
+	},
+	"github": {
+		// REST uses Bearer; git over HTTPS uses Basic with x-access-token.
+		Display:  "GitHub",
+		AuthType: authTypePerHost,
+		AuthConfig: map[string]any{
+			"per_host": []map[string]any{
+				{"hosts": []string{"api.github.com"}, "type": "bearer"},
+				{"hosts": []string{"github.com"}, "type": "basic", "username": "x-access-token"},
+			},
+		},
+		Hosts: []string{"api.github.com", "github.com"},
+		Token: tokenSpec{Prefix: "ghp_", BodyLen: 36, Alphabet: "alnum"},
+	},
+	"stripe": {
+		Display:    "Stripe",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.stripe.com"},
+		// sk_test_ rather than sk_live_ so scanners don't flag the token as live payment data.
+		Token: tokenSpec{Prefix: "sk_test_", BodyLen: 24, Alphabet: "alnum"},
+	},
+	"slack": {
+		Display:    "Slack",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"slack.com"},
+		Token:      tokenSpec{Prefix: "xoxb-", BodyLen: 43, Alphabet: "b64url"},
+	},
+	"linear": {
+		Display:    "Linear",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "Authorization"},
+		Hosts:      []string{"api.linear.app"},
+		Token:      tokenSpec{Prefix: "lin_api_", BodyLen: 32, Alphabet: "alnum"},
+	},
+	"xai": {
+		Display:    "xAI",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.x.ai"},
+		Token:      tokenSpec{Prefix: "xai-", BodyLen: 80, Alphabet: "alnum"},
+	},
+	"gemini": {
+		// Native API takes the key in the x-goog-api-key header.
+		Display:    "Google Gemini",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "x-goog-api-key"},
+		Hosts:      []string{"generativelanguage.googleapis.com"},
+		Token:      tokenSpec{Prefix: "AIza", BodyLen: 35, Alphabet: "b64url"},
+	},
+	"perplexity": {
+		Display:    "Perplexity",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.perplexity.ai"},
+		Token:      tokenSpec{Prefix: "pplx-", BodyLen: 48, Alphabet: "alnum"},
+	},
+	"exa": {
+		Display:    "Exa",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "x-api-key"},
+		Hosts:      []string{"api.exa.ai"},
+		// Exa keys have no documented prefix; mint a prefixless body.
+		Token: tokenSpec{BodyLen: 32, Alphabet: "alnum"},
+	},
+	"firecrawl": {
+		Display:    "Firecrawl",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.firecrawl.dev"},
+		Token:      tokenSpec{Prefix: "fc-", BodyLen: 36, Alphabet: "alnum"},
+	},
+	"gitlab": {
+		Display:    "GitLab",
+		AuthType:   "api-key",
+		AuthConfig: map[string]any{"header": "PRIVATE-TOKEN"},
+		Hosts:      []string{"gitlab.com"},
+		Token:      tokenSpec{Prefix: "glpat-", BodyLen: 20, Alphabet: "alnum"},
+	},
+	"vercel": {
+		Display:    "Vercel",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.vercel.com"},
+		Token:      tokenSpec{Prefix: "vcp_", BodyLen: 24, Alphabet: "alnum"},
+	},
+	"cloudflare": {
+		Display:    "Cloudflare",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.cloudflare.com"},
+		// Cloudflare API tokens are a 40-char alphanumeric string with no prefix.
+		Token: tokenSpec{BodyLen: 40, Alphabet: "alnum"},
+	},
+	"asana": {
+		Display:    "Asana",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"app.asana.com"},
+		// Asana tokens are opaque with no stable prefix.
+		Token: tokenSpec{BodyLen: 32, Alphabet: "alnum"},
+	},
+	"sentry": {
+		Display:    "Sentry",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"sentry.io"},
+		Token:      tokenSpec{Prefix: "sntrys_", BodyLen: 32, Alphabet: "alnum"},
+	},
+	"resend": {
+		Display:    "Resend",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.resend.com"},
+		Token:      tokenSpec{Prefix: "re_", BodyLen: 24, Alphabet: "alnum"},
+	},
+	"notion": {
+		Display:    "Notion",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"api.notion.com"},
+		Token:      tokenSpec{Prefix: "ntn_", BodyLen: 43, Alphabet: "alnum"},
+	},
+	"openrouter": {
+		Display:    "OpenRouter",
+		AuthType:   "bearer",
+		AuthConfig: map[string]any{},
+		Hosts:      []string{"openrouter.ai"},
+		Token:      tokenSpec{Prefix: "sk-or-v1-", BodyLen: 64, Alphabet: "alnum"},
+	},
+}
+
+// defaultTokenSpec mints tokens for explicit-auth credentials (no provider shortcut).
+var defaultTokenSpec = tokenSpec{Prefix: "ssrv_proxy_", BodyLen: 43, Alphabet: "b64url"}
+
+func knownProviders() []string {
+	out := make([]string, 0, len(providerShortcuts))
+	for k := range providerShortcuts {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// authConfigRequest is the typed auth block (bearer | basic | api-key | custom).
+// For type=basic, value is the password; the user portion is preserved at egress.
+// When PerHost is set, Type and the type-specific fields must be empty; each
+// rule in PerHost carries its own shape.
+type authConfigRequest struct {
+	Type     string            `json:"type,omitempty"`
+	Header   string            `json:"header,omitempty"`   // api-key only
+	Prefix   string            `json:"prefix,omitempty"`   // api-key only
+	Username string            `json:"username,omitempty"` // basic only — overrides preserve-inbound
+	Headers  map[string]string `json:"headers,omitempty"`  // custom only
+	PerHost  []perHostRule     `json:"per_host,omitempty"` // multi-rule, dispatched by upstream host
+}
+
+// perHostRule is one (hosts → auth shape) entry inside authConfigRequest.PerHost.
+type perHostRule struct {
+	Hosts    []string          `json:"hosts"`
+	Type     string            `json:"type"`
+	Header   string            `json:"header,omitempty"`
+	Prefix   string            `json:"prefix,omitempty"`
+	Username string            `json:"username,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+}
+
+type createSecretRequest struct {
+	Name     string             `json:"name"`
+	Value    string             `json:"value"`
+	Provider string             `json:"provider,omitempty"` // shortcut name (mutually exclusive with auth+hosts)
+	Auth     *authConfigRequest `json:"auth,omitempty"`     // explicit auth config (with hosts)
+	Hosts    []string           `json:"hosts,omitempty"`    // upstream allow list when auth is explicit
+}
+
+type updateSecretRequest struct {
+	Value string `json:"value"`
+}
+
+type secretResponse struct {
+	ID               uuid.UUID      `json:"id"`
+	Name             string         `json:"name"`
+	AuthType         string         `json:"auth_type"`
+	AuthConfig       map[string]any `json:"auth_config"`
+	ProviderShortcut *string        `json:"provider_shortcut,omitempty"`
+	Hosts            []string       `json:"hosts"`
+	CreatedAt        string         `json:"created_at"`
+	UpdatedAt        string         `json:"updated_at"`
+	LastUsedAt       *string        `json:"last_used_at,omitempty"`
+}
+
+func toSecretResponse(s db.Secret) secretResponse {
+	resp := secretResponse{
+		ID:               s.ID,
+		Name:             s.Name,
+		AuthType:         s.AuthType,
+		ProviderShortcut: s.ProviderShortcut,
+		Hosts:            s.Hosts,
+		CreatedAt:        s.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:        s.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	cfg := map[string]any{}
+	if len(s.AuthConfig) > 0 {
+		_ = json.Unmarshal(s.AuthConfig, &cfg)
+	}
+	resp.AuthConfig = cfg
+	if s.LastUsedAt.Valid {
+		t := s.LastUsedAt.Time.UTC().Format(time.RFC3339)
+		resp.LastUsedAt = &t
+	}
+	return resp
+}
+
+const (
+	maxSecretNameLen  = 128
+	maxSecretValueLen = 8 * 1024
+	maxHostsPerSecret = 16
+	maxCustomHeaders  = 8
+)
+
+// secretNameRE: leading letter/underscore, then alphanumerics / '_' / '-'.
+var secretNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// hostRE accepts a bare hostname or one-level wildcard (no ports, paths, schemes).
+var hostRE = regexp.MustCompile(`^(\*\.)?[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$`)
+
+// headerNameRE matches RFC 7230 token-class characters.
+var headerNameRE = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+
+func validateSecretName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if len(name) > maxSecretNameLen {
+		return fmt.Errorf("name exceeds %d characters", maxSecretNameLen)
+	}
+	if !secretNameRE.MatchString(name) {
+		return errors.New("name must start with a letter or underscore and contain only letters, digits, '_', '-'")
+	}
+	return nil
+}
+
+func validateSecretValue(value string) error {
+	if value == "" {
+		return errors.New("value is required")
+	}
+	if len(value) > maxSecretValueLen {
+		return fmt.Errorf("value exceeds %d bytes", maxSecretValueLen)
+	}
+	return nil
+}
+
+func validateHosts(hosts []string) error {
+	if len(hosts) == 0 {
+		return errors.New("hosts is required (at least one upstream)")
+	}
+	if len(hosts) > maxHostsPerSecret {
+		return fmt.Errorf("hosts has %d entries, max is %d", len(hosts), maxHostsPerSecret)
+	}
+	for i, h := range hosts {
+		h = strings.TrimSpace(h)
+		if !hostRE.MatchString(h) {
+			return fmt.Errorf("hosts[%d]: %q is not a valid hostname", i, h)
+		}
+		if err := rejectOverbroadWildcard(h); err != nil {
+			return fmt.Errorf("hosts[%d]: %w", i, err)
+		}
+		hosts[i] = h
+	}
+	return nil
+}
+
+// rejectOverbroadWildcard refuses wildcards rooted at a public suffix
+// (`*.com`, `*.co.uk`). Private TLDs (.local, .test) aren't on Mozilla's
+// PSL and so are allowed through.
+func rejectOverbroadWildcard(host string) error {
+	if !strings.HasPrefix(host, "*.") {
+		return nil
+	}
+	base := strings.ToLower(host[2:])
+	suffix, _ := publicsuffix.PublicSuffix(base)
+	if base == suffix {
+		return fmt.Errorf("wildcard %q is too broad — %q is a public suffix; narrow to a specific subdomain", host, base)
+	}
+	return nil
+}
+
+func validateAuthConfig(auth *authConfigRequest) error {
+	if auth == nil {
+		return errors.New("auth is required when provider is not set")
+	}
+	if len(auth.PerHost) > 0 {
+		if auth.Type != "" || auth.Header != "" || auth.Prefix != "" || auth.Username != "" || len(auth.Headers) > 0 {
+			return errors.New("auth.per_host is mutually exclusive with auth.type and the type-specific fields")
+		}
+		return nil // per-host rules validated separately against the hosts allowlist
+	}
+	if auth.Type == "" {
+		return errors.New("auth.type or auth.per_host is required")
+	}
+	return validateAuthShape(auth.Type, auth.Header, auth.Prefix, auth.Username, auth.Headers, "auth")
+}
+
+// validateAuthShape validates one (type, fields) combo. fieldPath is the JSON
+// pointer prefix used in error messages (e.g. "auth" or "auth.per_host[0]").
+func validateAuthShape(authType, header, prefix, username string, headers map[string]string, fieldPath string) error {
+	switch authType {
+	case "bearer":
+		if header != "" || prefix != "" || username != "" || len(headers) > 0 {
+			return fmt.Errorf("%s.type=%q does not accept header/prefix/username/headers", fieldPath, authType)
+		}
+	case "basic":
+		if header != "" || prefix != "" || len(headers) > 0 {
+			return fmt.Errorf("%s.type=%q does not accept header/prefix/headers", fieldPath, authType)
+		}
+		if username != "" && strings.ContainsAny(username, ":\r\n") {
+			return fmt.Errorf("%s.username may not contain ':' or CR/LF", fieldPath)
+		}
+	case "api-key":
+		if header == "" {
+			return fmt.Errorf("%s.header is required for type=api-key", fieldPath)
+		}
+		if !headerNameRE.MatchString(header) {
+			return fmt.Errorf("%s.header %q is not a valid header name", fieldPath, header)
+		}
+		if len(headers) > 0 {
+			return fmt.Errorf("%s.headers is not allowed for type=api-key", fieldPath)
+		}
+		if username != "" {
+			return fmt.Errorf("%s.username is not allowed for type=api-key", fieldPath)
+		}
+	case "custom":
+		if len(headers) == 0 {
+			return fmt.Errorf("%s.headers is required for type=custom", fieldPath)
+		}
+		if len(headers) > maxCustomHeaders {
+			return fmt.Errorf("%s.headers has %d entries, max is %d", fieldPath, len(headers), maxCustomHeaders)
+		}
+		for name, tmpl := range headers {
+			if !headerNameRE.MatchString(name) {
+				return fmt.Errorf("%s.headers: %q is not a valid header name", fieldPath, name)
+			}
+			if !strings.Contains(tmpl, "{{ value }}") {
+				return fmt.Errorf("%s.headers[%s]: template must reference {{ value }} so the credential is actually injected", fieldPath, name)
+			}
+		}
+		if header != "" || prefix != "" || username != "" {
+			return fmt.Errorf("%s.type=custom does not accept header/prefix/username; use headers map", fieldPath)
+		}
+	case "":
+		return fmt.Errorf("%s.type is required", fieldPath)
+	default:
+		return fmt.Errorf("%s.type %q is not supported (got: bearer, basic, api-key, custom)", fieldPath, authType)
+	}
+	return nil
+}
+
+// validatePerHostRules checks that every rule's hosts are reachable from
+// the top-level allowlist (wildcard-aware), that no two rules' hosts overlap,
+// and that each rule's auth fields validate against its declared type.
+func validatePerHostRules(rules []perHostRule, allowedHosts []string) error {
+	if len(rules) == 0 {
+		return errors.New("auth.per_host must contain at least one rule")
+	}
+	if len(rules) > maxHostsPerSecret {
+		return fmt.Errorf("auth.per_host has %d rules, max is %d", len(rules), maxHostsPerSecret)
+	}
+	type seenHost struct {
+		ruleIdx int
+		host    string
+	}
+	var seen []seenHost
+	for i := range rules {
+		r := &rules[i]
+		if err := validateHosts(r.Hosts); err != nil {
+			return fmt.Errorf("auth.per_host[%d]: %w", i, err)
+		}
+		for _, h := range r.Hosts {
+			if !hostReachable(h, allowedHosts) {
+				return fmt.Errorf("auth.per_host[%d].hosts: %q is not reachable from the top-level hosts allowlist", i, h)
+			}
+			for _, prev := range seen {
+				if patternsOverlap(h, prev.host) {
+					return fmt.Errorf("auth.per_host[%d].hosts: %q overlaps with auth.per_host[%d].hosts %q", i, h, prev.ruleIdx, prev.host)
+				}
+			}
+			seen = append(seen, seenHost{i, h})
+		}
+		if err := validateAuthShape(r.Type, r.Header, r.Prefix, r.Username, r.Headers, fmt.Sprintf("auth.per_host[%d]", i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// hostReachable reports whether at least one pattern in allowedHosts matches
+// every host that h could refer to. Mirrors the daemon's matchHost semantics
+// so validation and runtime agree on what "reachable" means.
+func hostReachable(h string, allowedHosts []string) bool {
+	for _, p := range allowedHosts {
+		if patternCovers(p, h) {
+			return true
+		}
+	}
+	return false
+}
+
+// patternCovers returns true if every host matched by inner is also matched
+// by outer. Both args may be exact hosts or `*.suffix` wildcards.
+func patternCovers(outer, inner string) bool {
+	outer = strings.ToLower(strings.TrimSpace(outer))
+	inner = strings.ToLower(strings.TrimSpace(inner))
+	if outer == inner {
+		return true
+	}
+	outerWild := strings.HasPrefix(outer, "*.")
+	innerWild := strings.HasPrefix(inner, "*.")
+	if !outerWild {
+		// An exact outer can only cover an identical exact inner (handled above).
+		return false
+	}
+	outerSuffix := outer[1:] // ".X"
+	outerBare := outer[2:]   // "X"
+	if !innerWild {
+		// Wildcard *.X covers exact host h iff h ends in ".X" and h != "X".
+		return strings.HasSuffix(inner, outerSuffix) && inner != outerBare
+	}
+	// Wildcard *.X covers wildcard *.Y iff Y ends in .X (so every host matched
+	// by *.Y also has the .X suffix). The bare-domain exclusion is preserved
+	// at runtime by matchHost on each individual host.
+	return strings.HasSuffix(inner[1:], outerSuffix)
+}
+
+// patternsOverlap returns true if a and b share at least one host they both
+// match. Used at create time to reject ambiguous per-host rules.
+func patternsOverlap(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+	if a == b {
+		return true
+	}
+	aWild := strings.HasPrefix(a, "*.")
+	bWild := strings.HasPrefix(b, "*.")
+	switch {
+	case !aWild && !bWild:
+		return false
+	case aWild && !bWild:
+		suf, bare := a[1:], a[2:]
+		return strings.HasSuffix(b, suf) && b != bare
+	case !aWild && bWild:
+		suf, bare := b[1:], b[2:]
+		return strings.HasSuffix(a, suf) && a != bare
+	default:
+		// Two wildcards *.X and *.Y overlap iff one suffix-contains the other:
+		// every host *.foo.example.com matches is also matched by *.example.com.
+		aSuf, bSuf := a[1:], b[1:]
+		return strings.HasSuffix(aSuf, bSuf) || strings.HasSuffix(bSuf, aSuf)
+	}
+}
+
+// resolveAuth flattens the request into (auth_type, auth_config, hosts, provider_shortcut).
+// Mutually exclusive: provider XOR (auth + hosts).
+func resolveAuth(req createSecretRequest) (authType string, authConfig []byte, hosts []string, shortcut *string, err error) {
+	hasProvider := req.Provider != ""
+	hasExplicit := req.Auth != nil || len(req.Hosts) > 0
+
+	if hasProvider && hasExplicit {
+		err = errors.New("provider is mutually exclusive with auth/hosts; pick one")
+		return
+	}
+	if !hasProvider && !hasExplicit {
+		err = fmt.Errorf("must specify either provider (one of: %s) or auth + hosts", strings.Join(knownProviders(), ", "))
+		return
+	}
+
+	if hasProvider {
+		p, ok := providerShortcuts[req.Provider]
+		if !ok {
+			err = fmt.Errorf("provider %q is not supported (got: %s)", req.Provider, strings.Join(knownProviders(), ", "))
+			return
+		}
+		authType = p.AuthType
+		authConfig, err = json.Marshal(p.AuthConfig)
+		if err != nil {
+			return
+		}
+		hosts = append([]string(nil), p.Hosts...)
+		s := req.Provider
+		shortcut = &s
+		return
+	}
+
+	if err = validateAuthConfig(req.Auth); err != nil {
+		return
+	}
+	if err = validateHosts(req.Hosts); err != nil {
+		return
+	}
+	if len(req.Auth.PerHost) > 0 {
+		if err = validatePerHostRules(req.Auth.PerHost, req.Hosts); err != nil {
+			return
+		}
+		authType = authTypePerHost
+		authConfig, err = marshalPerHostConfig(req.Auth.PerHost)
+		hosts = req.Hosts
+		return
+	}
+	authType = req.Auth.Type
+	cfg := map[string]any{}
+	switch authType {
+	case "api-key":
+		cfg["header"] = req.Auth.Header
+		if req.Auth.Prefix != "" {
+			cfg["prefix"] = req.Auth.Prefix
+		}
+	case "basic":
+		if req.Auth.Username != "" {
+			cfg["username"] = req.Auth.Username
+		}
+	case "custom":
+		cfg["headers"] = req.Auth.Headers
+	}
+	authConfig, err = json.Marshal(cfg)
+	hosts = req.Hosts
+	return
+}
+
+// authTypePerHost is the auth_type sentinel for multi-rule secrets. The
+// daemon dispatches by upstream host using the rules embedded in auth_config.
+const authTypePerHost = "per_host"
+
+// marshalPerHostConfig serializes the rule list into auth_config jsonb shape.
+func marshalPerHostConfig(rules []perHostRule) ([]byte, error) {
+	out := make([]map[string]any, 0, len(rules))
+	for _, r := range rules {
+		entry := map[string]any{
+			"hosts": r.Hosts,
+			"type":  r.Type,
+		}
+		switch r.Type {
+		case "basic":
+			if r.Username != "" {
+				entry["username"] = r.Username
+			}
+		case "api-key":
+			entry["header"] = r.Header
+			if r.Prefix != "" {
+				entry["prefix"] = r.Prefix
+			}
+		case "custom":
+			entry["headers"] = r.Headers
+		}
+		out = append(out, entry)
+	}
+	return json.Marshal(map[string]any{"per_host": out})
+}
+
+func (h *Handlers) requireEncryptor(c *gin.Context) bool {
+	if h.Encryptor == nil {
+		log.Error().Msg("/secrets called but no Encryptor configured")
+		respondError(c, ErrInternal)
+		return false
+	}
+	return true
+}
+
+func (h *Handlers) CreateSecret(c *gin.Context) {
+	if !h.requireEncryptor(c) {
+		return
+	}
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+
+	var req createSecretRequest
+	if err := bindJSONStrict(c, &req); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.Provider = strings.TrimSpace(req.Provider)
+
+	if err := validateSecretName(req.Name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateSecretValue(req.Value); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	authType, authConfig, hosts, shortcut, err := resolveAuth(req)
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	enc, err := h.Encryptor.Encrypt(c.Request.Context(), []byte(req.Value))
+	if err != nil {
+		log.Error().Err(err).Str("name", req.Name).Msg("KMS encrypt failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	row, err := h.DB.CreateSecret(c.Request.Context(), db.CreateSecretParams{
+		TeamID:           teamID,
+		Name:             req.Name,
+		AuthType:         authType,
+		AuthConfig:       authConfig,
+		ProviderShortcut: shortcut,
+		Hosts:            hosts,
+		Ciphertext:       enc.Ciphertext,
+		EncryptedDek:     enc.EncryptedDEK,
+		KekID:            enc.KEKID,
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			respondErrorMsg(c, "conflict",
+				fmt.Sprintf("a secret named %q already exists", req.Name),
+				http.StatusConflict)
+			return
+		}
+		log.Error().Err(err).Str("name", req.Name).Msg("DB CreateSecret failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	meta, _ := json.Marshal(map[string]any{
+		"auth_type":         authType,
+		"provider_shortcut": shortcut,
+		"hosts":             hosts,
+	})
+	h.logSecretActivity(c.Request.Context(), row.ID, teamID, actorIDFromContext(c), "created", "success", row.Name, meta)
+
+	c.JSON(http.StatusCreated, toSecretResponse(row))
+}
+
+func (h *Handlers) ListSecrets(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	rows, err := h.DB.ListSecretsForTeam(c.Request.Context(), teamID)
+	if err != nil {
+		log.Error().Err(err).Msg("DB ListSecretsForTeam failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	out := make([]secretResponse, len(rows))
+	for i, row := range rows {
+		out[i] = toSecretResponse(row)
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (h *Handlers) GetSecret(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	name := c.Param("name")
+	if err := validateSecretName(name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	row, err := h.DB.GetSecretByName(c.Request.Context(), db.GetSecretByNameParams{
+		TeamID: teamID, Name: name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Secret not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	c.JSON(http.StatusOK, toSecretResponse(row))
+}
+
+func (h *Handlers) PatchSecret(c *gin.Context) {
+	if !h.requireEncryptor(c) {
+		return
+	}
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	name := c.Param("name")
+	if err := validateSecretName(name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var req updateSecretRequest
+	if err := bindJSONStrict(c, &req); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateSecretValue(req.Value); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	existing, err := h.DB.GetSecretByName(c.Request.Context(), db.GetSecretByNameParams{
+		TeamID: teamID, Name: name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Secret not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	enc, err := h.Encryptor.Encrypt(c.Request.Context(), []byte(req.Value))
+	if err != nil {
+		log.Error().Err(err).Str("name", name).Msg("KMS encrypt failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	updated, err := h.DB.UpdateSecretValue(c.Request.Context(), db.UpdateSecretValueParams{
+		ID:           existing.ID,
+		TeamID:       teamID,
+		Ciphertext:   enc.Ciphertext,
+		EncryptedDek: enc.EncryptedDEK,
+		KekID:        enc.KEKID,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("name", name).Msg("DB UpdateSecretValue failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	// Best-effort cache fanout; the daemon TTL is the fallback.
+	go h.fanoutInvalidate(context.Background(), updated.ID)
+
+	h.logSecretActivity(c.Request.Context(), updated.ID, teamID, actorIDFromContext(c), "rotated", "success", updated.Name, nil)
+
+	c.JSON(http.StatusOK, toSecretResponse(updated))
+}
+
+func (h *Handlers) DeleteSecret(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	name := c.Param("name")
+	if err := validateSecretName(name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	row, err := h.DB.SoftDeleteSecretByName(c.Request.Context(), db.SoftDeleteSecretByNameParams{
+		TeamID: teamID, Name: name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Secret not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB SoftDeleteSecretByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	// Best-effort cache fanout; the daemon TTL is the fallback.
+	go h.fanoutInvalidate(context.Background(), row.ID)
+
+	h.logSecretActivity(c.Request.Context(), row.ID, teamID, actorIDFromContext(c), "deleted", "success", row.Name, nil)
+
+	c.Status(http.StatusNoContent)
+}
+
+// fanoutInvalidate calls InvalidateSecret on every host that has a sandbox
+// bound to secretID. Best-effort; failures are logged.
+func (h *Handlers) fanoutInvalidate(ctx context.Context, secretID uuid.UUID) {
+	if h.Hosts == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := h.DB.ListSandboxesForSecret(ctx, secretID)
+	if err != nil {
+		log.Warn().Err(err).Str("secret_id", secretID.String()).Msg("fanout: list sandboxes for secret")
+		return
+	}
+	hosts := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		if r.HostID != "" {
+			hosts[r.HostID] = struct{}{}
+		}
+	}
+	if len(hosts) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for hostID := range hosts {
+		wg.Add(1)
+		go func(hostID string) {
+			defer wg.Done()
+			client, herr := h.Hosts.ClientFor(ctx, hostID)
+			if herr != nil {
+				log.Warn().Err(herr).Str("host_id", hostID).Msg("fanout: resolve host client")
+				return
+			}
+			if err := client.InvalidateSecret(ctx, secretID.String()); err != nil {
+				log.Warn().Err(err).Str("host_id", hostID).Str("secret_id", secretID.String()).Msg("fanout: InvalidateSecret failed")
+			}
+		}(hostID)
+	}
+	wg.Wait()
+}
+
+// ListSandboxRevocations returns the active sandbox-revocation set for daemon bootstrap.
+func (h *Handlers) ListSandboxRevocations(c *gin.Context) {
+	rows, err := h.DB.ListActiveSandboxRevocations(c.Request.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("DB ListActiveSandboxRevocations failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	out := make([]string, 0, len(rows))
+	for _, id := range rows {
+		out = append(out, id.String())
+	}
+	c.JSON(http.StatusOK, gin.H{"sandboxes": out})
+}
+
+// GetSandboxEgressRules serves a sandbox's current egress rules to the secrets
+// proxy, which fetches them live rather than reading stale values from the JWT.
+// Internal endpoint (daemon-authed), so it is not team-scoped.
+func (h *Handlers) GetSandboxEgressRules(c *gin.Context) {
+	sandboxID, err := uuid.Parse(c.Param("sandbox_id"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", "invalid sandbox id", http.StatusBadRequest)
+		return
+	}
+	row, err := h.DB.GetSandboxEgressContext(c.Request.Context(), sandboxID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxEgressContext failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	var cfg persistedEgressConfig
+	if len(row.NetworkConfig) > 0 {
+		if uerr := json.Unmarshal(row.NetworkConfig, &cfg); uerr != nil {
+			log.Warn().Err(uerr).Str("sandbox_id", sandboxID.String()).Msg("parse network_config for egress rules")
+		}
+	}
+	allow := append(append([]string{}, cfg.Egress.AllowedCIDRs...), cfg.Egress.AllowedDomains...)
+	c.JSON(http.StatusOK, gin.H{
+		"allow":                 allow,
+		"deny":                  cfg.Egress.DeniedCIDRs,
+		"unmatched_host_policy": row.UnmatchedHostPolicy,
+	})
+}
+
+// fanoutSandboxRevoke calls RevokeSandbox on the daemon at hostID. Best-effort;
+// the daemon picks it up via bootstrap on next restart if this call fails.
+func (h *Handlers) fanoutSandboxRevoke(ctx context.Context, sandboxID uuid.UUID, hostID string) {
+	if h.Hosts == nil || hostID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	client, err := h.Hosts.ClientFor(ctx, hostID)
+	if err != nil {
+		log.Warn().Err(err).Str("host_id", hostID).Msg("fanout revoke: resolve host client")
+		return
+	}
+	if err := client.RevokeSandbox(ctx, sandboxID.String()); err != nil {
+		log.Warn().Err(err).Str("host_id", hostID).Str("sandbox_id", sandboxID.String()).Msg("fanout revoke: RevokeSandbox failed")
+	}
+}
+
+type decryptSecretRequest struct {
+	TeamID   string `json:"team_id"`
+	SecretID string `json:"secret_id"`
+}
+
+type decryptSecretResponse struct {
+	Value string `json:"value"`
+}
+
+// DecryptSecret handles POST /internal/secrets/decrypt for the in-host daemon.
+// Authenticated via INTERNAL_API_TOKEN; 404 for missing, soft-deleted, or cross-team.
+func (h *Handlers) DecryptSecret(c *gin.Context) {
+	if !h.requireEncryptor(c) {
+		return
+	}
+	var req decryptSecretRequest
+	if err := bindJSONStrict(c, &req); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	secretID, err := uuid.Parse(req.SecretID)
+	if err != nil {
+		respondErrorMsg(c, "bad_request", "secret_id is not a valid UUID", http.StatusBadRequest)
+		return
+	}
+	teamID, err := uuid.Parse(req.TeamID)
+	if err != nil {
+		respondErrorMsg(c, "bad_request", "team_id is not a valid UUID", http.StatusBadRequest)
+		return
+	}
+
+	row, err := h.DB.GetSecretByIDForDecrypt(c.Request.Context(), db.GetSecretByIDForDecryptParams{
+		ID: secretID, TeamID: teamID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "secret not found or revoked", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("secret_id", secretID.String()).Msg("DB GetSecretByIDForDecrypt in DecryptSecret")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	plaintext, err := h.Encryptor.Decrypt(c.Request.Context(), secrets.Encrypted{
+		Ciphertext:   row.Ciphertext,
+		EncryptedDEK: row.EncryptedDek,
+		KEKID:        row.KekID,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("secret_id", secretID.String()).Msg("KMS decrypt in DecryptSecret")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	// Best-effort last-used stamp.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = h.DB.TouchSecretLastUsed(ctx, secretID)
+	}()
+
+	c.JSON(http.StatusOK, decryptSecretResponse{Value: string(plaintext)})
+}
+
+var envKeyRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateSecretsRefs validates the `secrets` map on POST /sandboxes.
+func validateSecretsRefs(refs map[string]string) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	if len(refs) > envVarsMaxKeys {
+		return fmt.Errorf("secrets has %d entries, max is %d", len(refs), envVarsMaxKeys)
+	}
+	for envKey, name := range refs {
+		if !envKeyRE.MatchString(envKey) {
+			return fmt.Errorf("secrets key %q is not a valid env-var name", envKey)
+		}
+		if err := validateSecretName(name); err != nil {
+			return fmt.Errorf("secrets[%s]: %w", envKey, err)
+		}
+	}
+	return nil
+}
+
+// resolveSecretBindingsForCreate returns sandbox_secret rows and the daemon-shipped
+// metadata for the referenced secrets; cleartext stays in the vault.
+func (h *Handlers) resolveSecretBindingsForCreate(
+	ctx context.Context,
+	teamID uuid.UUID,
+	refs map[string]string,
+) (bindings []db.AddSandboxSecretParams, meta []SecretBindingMeta, appErr *AppError) {
+	if len(refs) == 0 {
+		return nil, nil, nil
+	}
+	bindings = make([]db.AddSandboxSecretParams, 0, len(refs))
+	meta = make([]SecretBindingMeta, 0, len(refs))
+
+	for envKey, name := range refs {
+		row, err := h.DB.GetSecretByName(ctx, db.GetSecretByNameParams{
+			TeamID: teamID, Name: name,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, nil, NewAppError("secret_not_found",
+					fmt.Sprintf("secrets[%s] references %q, which does not exist for this team", envKey, name),
+					http.StatusBadRequest)
+			}
+			log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName during sandbox create")
+			return nil, nil, ErrInternal
+		}
+		bindings = append(bindings, db.AddSandboxSecretParams{
+			SecretID: row.ID,
+			EnvKey:   envKey,
+		})
+		token, terr := mintProxyToken(row.ProviderShortcut)
+		if terr != nil {
+			log.Error().Err(terr).Msg("mintProxyToken during sandbox create")
+			return nil, nil, ErrInternal
+		}
+		meta = append(meta, SecretBindingMeta{
+			SecretID:         row.ID,
+			EnvKey:           envKey,
+			AuthType:         row.AuthType,
+			AuthConfig:       row.AuthConfig,
+			ProviderShortcut: row.ProviderShortcut,
+			Hosts:            row.Hosts,
+			ProxyToken:       token,
+		})
+	}
+	return bindings, meta, nil
+}
+
+// mintSecretsJWT builds the per-sandbox secrets JWT. Returns the signed JWT
+// string. The sandbox's veth source IP binds the token; egress rules are not
+// carried here — the proxy fetches them live from GetSandboxEgressRules.
+func (h *Handlers) mintSecretsJWT(sandboxID, teamID, sourceIP string, meta []SecretBindingMeta) (string, error) {
+	if h.Signer == nil {
+		return "", fmt.Errorf("secrets signer not configured")
+	}
+	claims := SecretsClaims{
+		TeamID:   teamID,
+		SourceIP: sourceIP,
+	}
+	claims.Bindings = make([]SecretsBindingClaim, 0, len(meta))
+	for _, m := range meta {
+		var authCfg map[string]any
+		if len(m.AuthConfig) > 0 {
+			if err := json.Unmarshal(m.AuthConfig, &authCfg); err != nil {
+				return "", fmt.Errorf("decode auth_config for env_key=%q: %w", m.EnvKey, err)
+			}
+		}
+		binding := SecretsBindingClaim{
+			ProxyToken: m.ProxyToken,
+			SecretID:   m.SecretID.String(),
+			EnvKey:     m.EnvKey,
+			Hosts:      m.Hosts,
+		}
+		if m.AuthType == authTypePerHost {
+			rules, rerr := perHostRulesFromConfig(authCfg)
+			if rerr != nil {
+				return "", fmt.Errorf("decode per_host rules for env_key=%q: %w", m.EnvKey, rerr)
+			}
+			binding.Rules = rules
+		} else {
+			binding.AuthType = m.AuthType
+			binding.AuthConfig = authCfg
+		}
+		claims.Bindings = append(claims.Bindings, binding)
+	}
+	return h.Signer.Sign(sandboxID, claims)
+}
+
+// perHostRulesFromConfig converts the jsonb per_host blob into JWT rule claims.
+func perHostRulesFromConfig(cfg map[string]any) ([]SecretsBindingRuleClaim, error) {
+	raw, ok := cfg["per_host"]
+	if !ok {
+		return nil, errors.New("auth_config missing per_host entry")
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, errors.New("auth_config.per_host is not a list")
+	}
+	out := make([]SecretsBindingRuleClaim, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("per_host[%d] is not an object", i)
+		}
+		rule := SecretsBindingRuleClaim{}
+		if h, ok := m["hosts"].([]any); ok {
+			rule.Hosts = make([]string, 0, len(h))
+			for _, hv := range h {
+				if s, ok := hv.(string); ok {
+					rule.Hosts = append(rule.Hosts, s)
+				}
+			}
+		}
+		rule.AuthType, _ = m["type"].(string)
+		if v, ok := m["username"].(string); ok {
+			rule.Username = v
+		}
+		if v, ok := m["header"].(string); ok {
+			rule.Header = v
+		}
+		if v, ok := m["prefix"].(string); ok {
+			rule.Prefix = v
+		}
+		if hs, ok := m["headers"].(map[string]any); ok {
+			rule.Headers = make(map[string]string, len(hs))
+			for k, v := range hs {
+				if s, ok := v.(string); ok {
+					rule.Headers[k] = s
+				}
+			}
+		}
+		out = append(out, rule)
+	}
+	return out, nil
+}
+
+// mergeEnvVarsWithSecrets overlays per-binding proxy tokens onto envVars,
+// returning a fresh map. Callers must have ensured the keys don't collide.
+func mergeEnvVarsWithSecrets(envVars map[string]string, meta []SecretBindingMeta) map[string]string {
+	if len(meta) == 0 {
+		return envVars
+	}
+	out := make(map[string]string, len(envVars)+len(meta))
+	for k, v := range envVars {
+		out[k] = v
+	}
+	for _, m := range meta {
+		out[m.EnvKey] = m.ProxyToken
+	}
+	return out
+}
+
+// SecretBindingMeta is the per-binding info shipped to the daemon and injected
+// as the agent's env-var value. Carries no cleartext.
+type SecretBindingMeta struct {
+	SecretID         uuid.UUID
+	EnvKey           string
+	AuthType         string
+	AuthConfig       []byte
+	ProviderShortcut *string
+	Hosts            []string
+	ProxyToken       string
+}
+
+// mintProxyToken returns a fresh per-binding token shaped to match the upstream key format.
+func mintProxyToken(providerShortcut *string) (string, error) {
+	spec := defaultTokenSpec
+	if providerShortcut != nil {
+		if sc, ok := providerShortcuts[*providerShortcut]; ok && sc.Token.BodyLen > 0 {
+			spec = sc.Token
+		}
+	}
+	body, err := mintTokenBody(spec.BodyLen, spec.Alphabet)
+	if err != nil {
+		return "", err
+	}
+	return spec.Prefix + body, nil
+}
+
+const alnumAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+// mintTokenBody returns n characters drawn from the named alphabet ("alnum" or "b64url").
+func mintTokenBody(n int, alphabet string) (string, error) {
+	if n <= 0 {
+		return "", fmt.Errorf("invalid body length %d", n)
+	}
+	switch alphabet {
+	case "alnum":
+		return randomFromAlnum(n)
+	case "b64url":
+		raw := make([]byte, (n*6+7)/8)
+		if _, err := rand.Read(raw); err != nil {
+			return "", fmt.Errorf("rand: %w", err)
+		}
+		s := base64.RawURLEncoding.EncodeToString(raw)
+		return s[:n], nil
+	default:
+		return "", fmt.Errorf("unsupported alphabet %q", alphabet)
+	}
+}
+
+// randomFromAlnum samples n bytes from alnumAlphabet with rejection sampling for uniformity.
+func randomFromAlnum(n int) (string, error) {
+	const aLen = byte(len(alnumAlphabet))
+	cutoff := byte(256 - (256 % int(aLen)))
+
+	out := make([]byte, n)
+	buf := make([]byte, n*2)
+	bufIdx := len(buf)
+	for i := 0; i < n; {
+		if bufIdx >= len(buf) {
+			if _, err := rand.Read(buf); err != nil {
+				return "", fmt.Errorf("rand: %w", err)
+			}
+			bufIdx = 0
+		}
+		b := buf[bufIdx]
+		bufIdx++
+		if b >= cutoff {
+			continue
+		}
+		out[i] = alnumAlphabet[int(b)%int(aLen)]
+		i++
+	}
+	return string(out), nil
+}
+
+const (
+	auditDefaultLimit = 100
+	auditMaxLimit     = 1000
+)
+
+type proxyAuditResponse struct {
+	ID             int64   `json:"id"`
+	Ts             string  `json:"ts"`
+	SandboxID      string  `json:"sandbox_id"`
+	SandboxName    *string `json:"sandbox_name,omitempty"` // populated for cross-sandbox views; null for deleted sandboxes
+	SecretID       string  `json:"secret_id,omitempty"`
+	Method         string  `json:"method"`
+	Host           string  `json:"host"`
+	Path           string  `json:"path"`
+	Status         int32   `json:"status"`
+	UpstreamStatus *int32  `json:"upstream_status,omitempty"`
+	LatencyMs      *int32  `json:"latency_ms,omitempty"`
+	ErrorCode      *string `json:"error_code,omitempty"`
+}
+
+// toAuditResponseFromSecret renders a row from ListAuditForSecret. SandboxName
+// is nil when the sandbox referenced in the audit row has been deleted.
+func toAuditResponseFromSecret(r db.ListAuditForSecretRow) proxyAuditResponse {
+	resp := proxyAuditResponse{
+		ID:             r.ID,
+		Ts:             r.Ts.UTC().Format(time.RFC3339Nano),
+		SandboxID:      r.SandboxID.String(),
+		SandboxName:    r.SandboxName,
+		Method:         r.Method,
+		Host:           r.Host,
+		Path:           r.Path,
+		Status:         r.Status,
+		UpstreamStatus: r.UpstreamStatus,
+		LatencyMs:      r.LatencyMs,
+		ErrorCode:      r.ErrorCode,
+	}
+	if r.SecretID.Valid {
+		resp.SecretID = uuid.UUID(r.SecretID.Bytes).String()
+	}
+	return resp
+}
+
+// GetSecretAudit returns the per-secret audit log: every egress request that
+// used this credential across every sandbox it was bound to.
+func (h *Handlers) GetSecretAudit(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	name := c.Param("name")
+	if err := validateSecretName(name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	secret, err := h.DB.GetSecretByName(c.Request.Context(), db.GetSecretByNameParams{
+		TeamID: teamID, Name: name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Secret not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	limit, err := parseAuditLimit(c.Query("limit"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	before, err := parseAuditBefore(c.Query("before"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	minStatus, maxStatus, err := parseStatusFilter(c.Query("status"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	rows, err := h.DB.ListAuditForSecret(c.Request.Context(), db.ListAuditForSecretParams{
+		SecretID: pgtype.UUID{Bytes: secret.ID, Valid: true},
+		TeamID:   teamID,
+		Column3:  before,
+		Column4:  minStatus,
+		Column5:  maxStatus,
+		Limit:    limit,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("name", name).Msg("DB ListAuditForSecret failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	out := make([]proxyAuditResponse, len(rows))
+	for i, r := range rows {
+		out[i] = toAuditResponseFromSecret(r)
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// sandboxBoundResponse is one row of "sandboxes bound to this secret".
+type sandboxBoundResponse struct {
+	SandboxID   string `json:"sandbox_id"`
+	SandboxName string `json:"sandbox_name"`
+	EnvKey      string `json:"env_key"`
+	Status      string `json:"status"`
+}
+
+// GetSecretSandboxes returns the active sandboxes that have this secret
+// bound, with the env-var name each binding uses.
+func (h *Handlers) GetSecretSandboxes(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	name := c.Param("name")
+	if err := validateSecretName(name); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	secret, err := h.DB.GetSecretByName(c.Request.Context(), db.GetSecretByNameParams{
+		TeamID: teamID, Name: name,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			respondErrorMsg(c, "not_found", "Secret not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	rows, err := h.DB.ListSandboxesBoundToSecret(c.Request.Context(), db.ListSandboxesBoundToSecretParams{
+		SecretID: secret.ID,
+		TeamID:   teamID,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("name", name).Msg("DB ListSandboxesBoundToSecret failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	out := make([]sandboxBoundResponse, len(rows))
+	for i, r := range rows {
+		out[i] = sandboxBoundResponse{
+			SandboxID:   r.ID.String(),
+			SandboxName: r.Name,
+			EnvKey:      r.EnvKey,
+			Status:      string(r.Status),
+		}
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// parseStatusFilter accepts "", "2xx", "3xx", "4xx", "5xx", or "errors"
+// (errors = anything ≥ 400). Returns (min, max) inclusive bounds. "" means
+// no filter (0, 9999 — the sentinel the sqlc query expects).
+func parseStatusFilter(raw string) (int32, int32, error) {
+	switch raw {
+	case "":
+		return 0, 9999, nil
+	case "2xx":
+		return 200, 299, nil
+	case "3xx":
+		return 300, 399, nil
+	case "4xx":
+		return 400, 499, nil
+	case "5xx":
+		return 500, 599, nil
+	case "errors":
+		return 400, 9999, nil
+	default:
+		return 0, 0, fmt.Errorf("status must be one of: 2xx, 3xx, 4xx, 5xx, errors")
+	}
+}
+
+func parseAuditLimit(raw string) (int32, error) {
+	if raw == "" {
+		return auditDefaultLimit, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 1 {
+		return 0, fmt.Errorf("limit must be a positive integer")
+	}
+	if v > auditMaxLimit {
+		return 0, fmt.Errorf("limit must be <= %d", auditMaxLimit)
+	}
+	return int32(v), nil
+}
+
+func parseAuditBefore(raw string) (int64, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v < 0 {
+		return 0, fmt.Errorf("before must be a non-negative integer")
+	}
+	return v, nil
+}
+
+// providerResponse is one entry of the provider catalog returned by
+// GET /providers. Backend-of-record so consumers stay in sync with the
+// in-memory providerShortcuts map.
+type providerResponse struct {
+	Name       string         `json:"name"`
+	Display    string         `json:"display"`
+	AuthType   string         `json:"auth_type"`
+	AuthConfig map[string]any `json:"auth_config"`
+	Hosts      []string       `json:"hosts"`
+	TokenShape string         `json:"token_shape"` // prefix + body-len hint for UX ("sk-ant-api03-...")
+}
+
+// ListProviders returns the built-in provider catalog in canonical order so
+// the console always picks the same default. No team-scope check — the
+// catalog is identical across teams.
+func (h *Handlers) ListProviders(c *gin.Context) {
+	out := make([]providerResponse, 0, len(providerShortcuts))
+	for _, name := range knownProviders() {
+		p := providerShortcuts[name]
+		out = append(out, providerResponse{
+			Name:       name,
+			Display:    p.Display,
+			AuthType:   p.AuthType,
+			AuthConfig: p.AuthConfig,
+			Hosts:      append([]string(nil), p.Hosts...),
+			TokenShape: p.Token.Prefix + "...",
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/internal/api/handlers_secret_test.go
+++ b/internal/api/handlers_secret_test.go
@@ -1,0 +1,896 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestValidateSecretName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"empty", "", "required"},
+		{"whitespace only", "   ", "required"},
+		{"valid simple", "anthropic-prod", ""},
+		{"valid underscore start", "_internal", ""},
+		{"valid alphanumeric mix", "Stripe_Key2", ""},
+		{"starts with digit", "1anthropic", "must start with"},
+		{"starts with hyphen", "-anthropic", "must start with"},
+		{"contains space", "anthropic prod", "must start with"},
+		{"contains slash", "anthropic/prod", "must start with"},
+		{"too long", strings.Repeat("a", maxSecretNameLen+1), "exceeds"},
+		{"max length boundary", strings.Repeat("a", maxSecretNameLen), ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSecretName(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateSecretValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"empty rejected", "", "required"},
+		{"single byte allowed", "x", ""},
+		{"realistic key allowed", "sk-ant-api03-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", ""},
+		{"exceeds cap", strings.Repeat("a", maxSecretValueLen+1), "exceeds"},
+		{"max length boundary", strings.Repeat("a", maxSecretValueLen), ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSecretValue(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantErr string
+	}{
+		{"empty rejected", []string{}, "required"},
+		{"nil rejected", nil, "required"},
+		{"single hostname", []string{"api.openai.com"}, ""},
+		{"multiple", []string{"api.github.com", "github.com"}, ""},
+		{"wildcard subdomain", []string{"*.github.com"}, ""},
+		{"too many", repeatHost("api.example.com", maxHostsPerSecret+1), "max is"},
+		{"invalid: path included", []string{"api.openai.com/v1"}, "is not a valid hostname"},
+		{"invalid: scheme prefix", []string{"https://api.openai.com"}, "is not a valid hostname"},
+		{"invalid: port suffix", []string{"api.openai.com:443"}, "is not a valid hostname"},
+		{"invalid: bare TLD", []string{"localhost"}, "is not a valid hostname"},
+		{"invalid: empty string", []string{""}, "is not a valid hostname"},
+		{"invalid: bare wildcard", []string{"*"}, "is not a valid hostname"},
+		{"invalid: nested wildcard", []string{"*.*.example.com"}, "is not a valid hostname"},
+		{"whitespace trimmed", []string{"  api.openai.com  "}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Defensive copy: validateHosts mutates in place (whitespace trim).
+			input := append([]string(nil), tc.input...)
+			err := validateHosts(input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func repeatHost(host string, n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = host
+	}
+	return out
+}
+
+func TestValidateAuthConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *authConfigRequest
+		wantErr string
+	}{
+		{"nil rejected", nil, "required"},
+		{"empty type", &authConfigRequest{}, "auth.type or auth.per_host is required"},
+		{"unsupported type", &authConfigRequest{Type: "oauth"}, "not supported"},
+
+		// bearer
+		{"bearer ok", &authConfigRequest{Type: "bearer"}, ""},
+		{"bearer rejects header", &authConfigRequest{Type: "bearer", Header: "x-foo"}, "does not accept"},
+		{"bearer rejects prefix", &authConfigRequest{Type: "bearer", Prefix: "X "}, "does not accept"},
+		{"bearer rejects headers map", &authConfigRequest{Type: "bearer", Headers: map[string]string{"a": "{{ value }}"}}, "does not accept"},
+
+		// basic
+		{"basic ok", &authConfigRequest{Type: "basic"}, ""},
+		{"basic rejects header", &authConfigRequest{Type: "basic", Header: "x-foo"}, "does not accept"},
+
+		// api-key
+		{"api-key needs header", &authConfigRequest{Type: "api-key"}, "header is required"},
+		{"api-key ok minimal", &authConfigRequest{Type: "api-key", Header: "x-api-key"}, ""},
+		{"api-key ok with prefix", &authConfigRequest{Type: "api-key", Header: "Authorization", Prefix: "ApiKey "}, ""},
+		{"api-key invalid header chars", &authConfigRequest{Type: "api-key", Header: "x api key"}, "is not a valid header name"},
+		{"api-key rejects headers map", &authConfigRequest{Type: "api-key", Header: "x-api-key", Headers: map[string]string{"a": "{{ value }}"}}, "not allowed"},
+
+		// custom
+		{"custom needs headers", &authConfigRequest{Type: "custom"}, "headers is required"},
+		{"custom ok", &authConfigRequest{Type: "custom", Headers: map[string]string{"X-Api-Key": "Bearer {{ value }}"}}, ""},
+		{"custom rejects header field", &authConfigRequest{Type: "custom", Header: "x-foo", Headers: map[string]string{"X-A": "{{ value }}"}}, "does not accept"},
+		{"custom rejects template without {{ value }}", &authConfigRequest{Type: "custom", Headers: map[string]string{"X-Api-Key": "static"}}, "must reference {{ value }}"},
+		{"custom rejects bad header name", &authConfigRequest{Type: "custom", Headers: map[string]string{"X Api Key": "{{ value }}"}}, "is not a valid header name"},
+		{"custom too many headers",
+			&authConfigRequest{Type: "custom", Headers: repeatHeaderMap("h%d", "v {{ value }}", maxCustomHeaders+1)},
+			"max is"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAuthConfig(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func repeatHeaderMap(keyFmt, val string, n int) map[string]string {
+	out := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		out[strings.ReplaceAll(keyFmt, "%d", itoa(i))] = val
+	}
+	return out
+}
+
+func itoa(n int) string {
+	// avoid strconv to keep this helper self-contained
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+func TestResolveAuth(t *testing.T) {
+	t.Run("provider shortcut populates auth_type, config, hosts", func(t *testing.T) {
+		req := createSecretRequest{Name: "anthropic-prod", Value: "v", Provider: "anthropic"}
+		authType, cfgJSON, hosts, shortcut, err := resolveAuth(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if authType != "api-key" {
+			t.Errorf("want api-key, got %q", authType)
+		}
+		var cfg map[string]any
+		if jErr := json.Unmarshal(cfgJSON, &cfg); jErr != nil {
+			t.Fatal(jErr)
+		}
+		if cfg["header"] != "x-api-key" {
+			t.Errorf("want header=x-api-key, got %v", cfg["header"])
+		}
+		if len(hosts) != 1 || hosts[0] != "api.anthropic.com" {
+			t.Errorf("want hosts=[api.anthropic.com], got %v", hosts)
+		}
+		if shortcut == nil || *shortcut != "anthropic" {
+			t.Errorf("want shortcut=anthropic, got %v", shortcut)
+		}
+	})
+
+	t.Run("provider shortcut: github carries both hosts", func(t *testing.T) {
+		req := createSecretRequest{Name: "gh-prod", Value: "v", Provider: "github"}
+		_, _, hosts, _, err := resolveAuth(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(hosts)
+		want := []string{"api.github.com", "github.com"}
+		if len(hosts) != 2 || hosts[0] != want[0] || hosts[1] != want[1] {
+			t.Errorf("want %v, got %v", want, hosts)
+		}
+	})
+
+	t.Run("explicit auth config wins", func(t *testing.T) {
+		req := createSecretRequest{
+			Name:  "linear-prod",
+			Value: "v",
+			Auth:  &authConfigRequest{Type: "api-key", Header: "Authorization"},
+			Hosts: []string{"api.linear.app"},
+		}
+		authType, cfgJSON, hosts, shortcut, err := resolveAuth(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if authType != "api-key" {
+			t.Errorf("want api-key, got %q", authType)
+		}
+		var cfg map[string]any
+		_ = json.Unmarshal(cfgJSON, &cfg)
+		if cfg["header"] != "Authorization" {
+			t.Errorf("want Authorization, got %v", cfg["header"])
+		}
+		if len(hosts) != 1 || hosts[0] != "api.linear.app" {
+			t.Errorf("want hosts=[api.linear.app], got %v", hosts)
+		}
+		if shortcut != nil {
+			t.Errorf("want nil shortcut on explicit auth, got %v", shortcut)
+		}
+	})
+
+	t.Run("bearer explicit emits empty config (no extra knobs)", func(t *testing.T) {
+		req := createSecretRequest{
+			Name:  "stripe-prod",
+			Value: "v",
+			Auth:  &authConfigRequest{Type: "bearer"},
+			Hosts: []string{"api.stripe.com"},
+		}
+		_, cfgJSON, _, _, err := resolveAuth(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(cfgJSON) != "{}" {
+			t.Errorf("want empty cfg {}, got %s", string(cfgJSON))
+		}
+	})
+
+	t.Run("custom auth emits headers map in config", func(t *testing.T) {
+		req := createSecretRequest{
+			Name:  "internal-prod",
+			Value: "v",
+			Auth:  &authConfigRequest{Type: "custom", Headers: map[string]string{"X-Api-Key": "Bearer {{ value }}"}},
+			Hosts: []string{"api.internal"},
+		}
+		_, cfgJSON, _, _, err := resolveAuth(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var cfg map[string]any
+		_ = json.Unmarshal(cfgJSON, &cfg)
+		headers, ok := cfg["headers"].(map[string]any)
+		if !ok || headers["X-Api-Key"] != "Bearer {{ value }}" {
+			t.Errorf("want headers map preserved, got %v", cfg)
+		}
+	})
+
+	t.Run("mutual exclusion: provider + auth rejected", func(t *testing.T) {
+		req := createSecretRequest{
+			Name:     "x",
+			Value:    "v",
+			Provider: "anthropic",
+			Auth:     &authConfigRequest{Type: "bearer"},
+		}
+		_, _, _, _, err := resolveAuth(req)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("want mutually exclusive error, got %v", err)
+		}
+	})
+
+	t.Run("mutual exclusion: provider + hosts rejected", func(t *testing.T) {
+		req := createSecretRequest{
+			Name:     "x",
+			Value:    "v",
+			Provider: "anthropic",
+			Hosts:    []string{"api.anthropic.com"},
+		}
+		_, _, _, _, err := resolveAuth(req)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("want mutually exclusive error, got %v", err)
+		}
+	})
+
+	t.Run("neither provider nor auth rejected", func(t *testing.T) {
+		req := createSecretRequest{Name: "x", Value: "v"}
+		_, _, _, _, err := resolveAuth(req)
+		if err == nil || !strings.Contains(err.Error(), "must specify") {
+			t.Errorf("want must-specify error, got %v", err)
+		}
+	})
+
+	t.Run("unknown provider lists known ones", func(t *testing.T) {
+		req := createSecretRequest{Name: "x", Value: "v", Provider: "datadog"}
+		_, _, _, _, err := resolveAuth(req)
+		if err == nil {
+			t.Fatal("want error")
+		}
+		msg := err.Error()
+		for _, p := range knownProviders() {
+			if !strings.Contains(msg, p) {
+				t.Errorf("error should mention %q, got %q", p, msg)
+			}
+		}
+	})
+}
+
+func TestValidateSecretsRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr string
+	}{
+		{"empty allowed", nil, ""},
+		{"single binding", map[string]string{"ANTHROPIC_API_KEY": "anthropic-prod"}, ""},
+		{"too many bindings",
+			repeatStrMap("KEY%d", "name", envVarsMaxKeys+1),
+			"max is"},
+		{"invalid env var key (digit start)", map[string]string{"1KEY": "anthropic-prod"}, "is not a valid env-var name"},
+		{"invalid env var key (hyphen)", map[string]string{"MY-KEY": "anthropic-prod"}, "is not a valid env-var name"},
+		{"valid env var key with underscore", map[string]string{"_KEY": "anthropic-prod"}, ""},
+		{"invalid secret name", map[string]string{"KEY": "1invalid"}, "must start with"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSecretsRefs(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func repeatStrMap(keyFmt, val string, n int) map[string]string {
+	out := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		out[strings.ReplaceAll(keyFmt, "%d", itoa(i))] = val
+	}
+	return out
+}
+
+func TestProviderShortcutsAllValid(t *testing.T) {
+	for name, sc := range providerShortcuts {
+		t.Run(name, func(t *testing.T) {
+			if sc.AuthType == "" {
+				t.Fatal("AuthType empty")
+			}
+			if len(sc.Hosts) == 0 {
+				t.Fatal("Hosts empty")
+			}
+			hosts := append([]string(nil), sc.Hosts...)
+			if err := validateHosts(hosts); err != nil {
+				t.Fatalf("Hosts fail validation: %v", err)
+			}
+			req := createSecretRequest{Name: "x", Value: "v", Provider: name}
+			authType, _, gotHosts, shortcut, err := resolveAuth(req)
+			if err != nil {
+				t.Fatalf("resolveAuth: %v", err)
+			}
+			if authType != sc.AuthType {
+				t.Errorf("auth_type drift: want %q got %q", sc.AuthType, authType)
+			}
+			if len(gotHosts) != len(sc.Hosts) {
+				t.Errorf("hosts drift: want %v got %v", sc.Hosts, gotHosts)
+			}
+			if shortcut == nil || *shortcut != name {
+				t.Errorf("shortcut name drift: want %q got %v", name, shortcut)
+			}
+		})
+	}
+}
+
+func TestMintProxyTokenMatchesProviderSpec(t *testing.T) {
+	alnumRE := regexp.MustCompile(`^[A-Za-z0-9]+$`)
+	b64urlRE := regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+	for name, sc := range providerShortcuts {
+		t.Run(name, func(t *testing.T) {
+			n := name
+			tok, err := mintProxyToken(&n)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(tok, sc.Token.Prefix) {
+				t.Errorf("token %q missing prefix %q", tok, sc.Token.Prefix)
+			}
+			body := strings.TrimPrefix(tok, sc.Token.Prefix)
+			if len(body) != sc.Token.BodyLen {
+				t.Errorf("body length: want %d, got %d (%q)", sc.Token.BodyLen, len(body), body)
+			}
+			switch sc.Token.Alphabet {
+			case "alnum":
+				if !alnumRE.MatchString(body) {
+					t.Errorf("alnum body must be [A-Za-z0-9]+, got %q", body)
+				}
+			case "b64url":
+				if !b64urlRE.MatchString(body) {
+					t.Errorf("b64url body must be [A-Za-z0-9_-]+, got %q", body)
+				}
+			default:
+				t.Errorf("unknown alphabet %q in catalog", sc.Token.Alphabet)
+			}
+		})
+	}
+}
+
+// TestMintProxyTokenPassesUpstreamStrictRegex pins minted tokens to upstream key formats.
+func TestMintProxyTokenPassesUpstreamStrictRegex(t *testing.T) {
+	cases := []struct {
+		provider string
+		regex    string
+	}{
+		{"github", `^ghp_[a-zA-Z0-9]{36}$`},
+		{"anthropic", `^sk-ant-api03-[A-Za-z0-9]{48}$`},
+		{"stripe", `^sk_test_[A-Za-z0-9]+$`},
+		{"linear", `^lin_api_[A-Za-z0-9]+$`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			re := regexp.MustCompile(tc.regex)
+			p := tc.provider
+			tok, err := mintProxyToken(&p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !re.MatchString(tok) {
+				t.Errorf("minted token %q does not match upstream regex %s", tok, tc.regex)
+			}
+		})
+	}
+}
+
+func TestMintProxyTokenFallsBackToDefaultSpec(t *testing.T) {
+	tok, err := mintProxyToken(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(tok, defaultTokenSpec.Prefix) {
+		t.Errorf("token %q missing default prefix %q", tok, defaultTokenSpec.Prefix)
+	}
+	body := strings.TrimPrefix(tok, defaultTokenSpec.Prefix)
+	if len(body) != defaultTokenSpec.BodyLen {
+		t.Errorf("default body length: want %d, got %d", defaultTokenSpec.BodyLen, len(body))
+	}
+}
+
+func TestMintProxyTokenUniqueness(t *testing.T) {
+	name := "anthropic"
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		tok, err := mintProxyToken(&name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, dup := seen[tok]; dup {
+			t.Fatalf("duplicate token after %d mints — CSPRNG broken", i)
+		}
+		seen[tok] = struct{}{}
+	}
+}
+
+func TestRandomFromAlnumDistribution(t *testing.T) {
+	// Every alphabet character should appear in a 10k sample.
+	const samples = 10000
+	s, err := randomFromAlnum(samples)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[byte]int, 62)
+	for i := 0; i < len(s); i++ {
+		seen[s[i]]++
+	}
+	if len(seen) != 62 {
+		t.Errorf("expected all 62 alnum characters across %d samples, got %d distinct", samples, len(seen))
+	}
+}
+
+func TestMergeEnvVarsWithSecrets(t *testing.T) {
+	envVars := map[string]string{"MODE": "prod", "PORT": "8080"}
+	meta := []SecretBindingMeta{
+		{EnvKey: "ANTHROPIC_API_KEY", ProxyToken: "sk-ant-proxy-aaa"},
+		{EnvKey: "GITHUB_TOKEN", ProxyToken: "ghp_proxy_bbb"},
+	}
+	out := mergeEnvVarsWithSecrets(envVars, meta)
+
+	if out["MODE"] != "prod" {
+		t.Errorf("env_var overlay should preserve customer values, got %v", out)
+	}
+	if out["ANTHROPIC_API_KEY"] != "sk-ant-proxy-aaa" {
+		t.Errorf("proxy token missing: %v", out)
+	}
+	if out["GITHUB_TOKEN"] != "ghp_proxy_bbb" {
+		t.Errorf("proxy token missing: %v", out)
+	}
+	if _, ok := envVars["ANTHROPIC_API_KEY"]; ok {
+		t.Error("input map was mutated; need a fresh map")
+	}
+}
+
+func TestMergeEnvVarsWithSecretsNoBindingsIsCheap(t *testing.T) {
+	envVars := map[string]string{"MODE": "prod"}
+	out := mergeEnvVarsWithSecrets(envVars, nil)
+	if out["MODE"] != "prod" {
+		t.Errorf("env_vars passthrough broken")
+	}
+}
+
+func TestKnownProvidersStable(t *testing.T) {
+	want := []string{"anthropic", "asana", "cloudflare", "exa", "firecrawl", "gemini", "github", "gitlab", "linear", "notion", "openai", "openrouter", "perplexity", "resend", "sentry", "slack", "stripe", "vercel", "xai"}
+	got := knownProviders()
+	if len(got) != len(want) {
+		t.Fatalf("provider count drift: want %d (%v), got %d (%v)", len(want), want, len(got), got)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Errorf("provider list drift at [%d]: want %q, got %q (full got=%v)", i, p, got[i], got)
+		}
+	}
+}
+
+func TestValidatePerHostRulesRejectsOverlap(t *testing.T) {
+	rules := []perHostRule{
+		{Hosts: []string{"api.github.com"}, Type: "bearer"},
+		{Hosts: []string{"api.github.com"}, Type: "basic"},
+	}
+	err := validatePerHostRules(rules, []string{"api.github.com"})
+	if err == nil || !strings.Contains(err.Error(), "overlaps") {
+		t.Errorf("want overlap error, got %v", err)
+	}
+}
+
+func TestValidatePerHostRulesRejectsHostOutsideAllowlist(t *testing.T) {
+	rules := []perHostRule{
+		{Hosts: []string{"github.com"}, Type: "basic", Username: "x-access-token"},
+	}
+	err := validatePerHostRules(rules, []string{"api.github.com"})
+	if err == nil || !strings.Contains(err.Error(), "not reachable") {
+		t.Errorf("want reachability error, got %v", err)
+	}
+}
+
+func TestValidatePerHostRulesRejectsWildcardExactOverlap(t *testing.T) {
+	// "*.example.com" and "api.example.com" both match api.example.com — ambiguous.
+	rules := []perHostRule{
+		{Hosts: []string{"*.example.com"}, Type: "bearer"},
+		{Hosts: []string{"api.example.com"}, Type: "basic"},
+	}
+	err := validatePerHostRules(rules, []string{"*.example.com", "api.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "overlaps") {
+		t.Errorf("want overlap error, got %v", err)
+	}
+}
+
+func TestValidatePerHostRulesRejectsNestedWildcardOverlap(t *testing.T) {
+	// "*.example.com" covers everything "*.foo.example.com" covers — overlap.
+	rules := []perHostRule{
+		{Hosts: []string{"*.example.com"}, Type: "bearer"},
+		{Hosts: []string{"*.foo.example.com"}, Type: "basic"},
+	}
+	err := validatePerHostRules(rules, []string{"*.example.com", "*.foo.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "overlaps") {
+		t.Errorf("want overlap error, got %v", err)
+	}
+}
+
+func TestValidatePerHostRulesAllowsWildcardCoverageOfExactRuleHost(t *testing.T) {
+	// Top-level "*.example.com" should make "api.example.com" reachable.
+	rules := []perHostRule{
+		{Hosts: []string{"api.example.com"}, Type: "bearer"},
+	}
+	err := validatePerHostRules(rules, []string{"*.example.com"})
+	if err != nil {
+		t.Errorf("wildcard allowlist should cover exact rule host: %v", err)
+	}
+}
+
+func TestValidatePerHostRulesAllowsNonOverlappingWildcards(t *testing.T) {
+	// Two wildcards on disjoint domains must not be flagged as overlapping.
+	rules := []perHostRule{
+		{Hosts: []string{"*.example.com"}, Type: "bearer"},
+		{Hosts: []string{"*.other.com"}, Type: "basic"},
+	}
+	err := validatePerHostRules(rules, []string{"*.example.com", "*.other.com"})
+	if err != nil {
+		t.Errorf("disjoint wildcards must not overlap: %v", err)
+	}
+}
+
+func TestPatternCovers(t *testing.T) {
+	cases := []struct {
+		outer, inner string
+		want         bool
+	}{
+		{"api.example.com", "api.example.com", true},
+		{"api.example.com", "other.example.com", false},
+		{"*.example.com", "api.example.com", true},
+		{"*.example.com", "example.com", false}, // wildcard excludes bare
+		{"*.example.com", "api.foo.example.com", true},
+		{"*.example.com", "*.foo.example.com", true},
+		{"*.foo.example.com", "*.example.com", false}, // narrow doesn't cover wide
+		{"*.com", "*.example.com", true},
+		{"api.example.com", "*.example.com", false}, // exact doesn't cover wildcard
+	}
+	for _, c := range cases {
+		if got := patternCovers(c.outer, c.inner); got != c.want {
+			t.Errorf("patternCovers(%q, %q) = %v, want %v", c.outer, c.inner, got, c.want)
+		}
+	}
+}
+
+func TestPatternsOverlap(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"api.example.com", "api.example.com", true},
+		{"api.example.com", "other.example.com", false},
+		{"*.example.com", "api.example.com", true},
+		{"*.example.com", "example.com", false},
+		{"*.example.com", "*.example.com", true},
+		{"*.example.com", "*.foo.example.com", true}, // narrower nested inside wider
+		{"*.example.com", "*.other.com", false},
+		{"*.com", "*.example.com", true},
+	}
+	for _, c := range cases {
+		if got := patternsOverlap(c.a, c.b); got != c.want {
+			t.Errorf("patternsOverlap(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestValidatePerHostRulesPropagatesPerTypeValidation(t *testing.T) {
+	rules := []perHostRule{
+		{Hosts: []string{"api.example.com"}, Type: "api-key"}, // missing header
+	}
+	err := validatePerHostRules(rules, []string{"api.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "header is required") {
+		t.Errorf("want missing-header error, got %v", err)
+	}
+}
+
+func TestValidateAuthConfigRejectsMixingLegacyAndPerHost(t *testing.T) {
+	auth := &authConfigRequest{
+		Type:    "bearer",
+		PerHost: []perHostRule{{Hosts: []string{"api.example.com"}, Type: "bearer"}},
+	}
+	err := validateAuthConfig(auth)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("want mutual-exclusion error, got %v", err)
+	}
+}
+
+func TestResolveAuthEmitsPerHostShape(t *testing.T) {
+	// Explicit per-host secret → auth_type=per_host, auth_config carries the rules.
+	req := createSecretRequest{
+		Name: "gh", Value: "github_pat_xxx",
+		Auth: &authConfigRequest{
+			PerHost: []perHostRule{
+				{Hosts: []string{"api.github.com"}, Type: "bearer"},
+				{Hosts: []string{"github.com"}, Type: "basic", Username: "x-access-token"},
+			},
+		},
+		Hosts: []string{"api.github.com", "github.com"},
+	}
+	authType, authConfig, hosts, shortcut, err := resolveAuth(req)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	if authType != authTypePerHost {
+		t.Errorf("auth_type: want per_host, got %q", authType)
+	}
+	if shortcut != nil {
+		t.Errorf("shortcut should be nil for explicit auth")
+	}
+	if len(hosts) != 2 {
+		t.Errorf("hosts: want 2, got %v", hosts)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(authConfig, &cfg); err != nil {
+		t.Fatalf("auth_config JSON: %v", err)
+	}
+	list, ok := cfg["per_host"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("per_host shape drift: %v", cfg)
+	}
+}
+
+func TestGitHubProviderShortcutEmitsPerHost(t *testing.T) {
+	// github now emits per-host config so a single PAT covers both api.github.com
+	// (Bearer) and github.com (Basic with x-access-token).
+	req := createSecretRequest{Name: "gh", Value: "github_pat_xxx", Provider: "github"}
+	authType, authConfig, _, shortcut, err := resolveAuth(req)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	if authType != authTypePerHost {
+		t.Errorf("github should emit per_host auth_type, got %q", authType)
+	}
+	if shortcut == nil || *shortcut != "github" {
+		t.Errorf("shortcut metadata lost: %v", shortcut)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(authConfig, &cfg); err != nil {
+		t.Fatalf("auth_config JSON: %v", err)
+	}
+	list, _ := cfg["per_host"].([]any)
+	if len(list) != 2 {
+		t.Fatalf("github should have 2 rules, got %d", len(list))
+	}
+	// Verify rule 0 is bearer for api.github.com.
+	r0 := list[0].(map[string]any)
+	if r0["type"] != "bearer" {
+		t.Errorf("rule 0 type: %v", r0["type"])
+	}
+	// Verify rule 1 is basic with x-access-token username for github.com.
+	r1 := list[1].(map[string]any)
+	if r1["type"] != "basic" || r1["username"] != "x-access-token" {
+		t.Errorf("rule 1 shape: %v", r1)
+	}
+}
+
+func TestPerHostRulesFromConfig(t *testing.T) {
+	// Round-trip a per_host jsonb config through the JWT-claim translator.
+	cfg := map[string]any{
+		"per_host": []any{
+			map[string]any{
+				"hosts": []any{"api.github.com"},
+				"type":  "bearer",
+			},
+			map[string]any{
+				"hosts":    []any{"github.com"},
+				"type":     "basic",
+				"username": "x-access-token",
+			},
+		},
+	}
+	rules, err := perHostRulesFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("perHostRulesFromConfig: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("rule count: %d", len(rules))
+	}
+	if rules[0].AuthType != "bearer" || rules[0].Hosts[0] != "api.github.com" {
+		t.Errorf("rule 0 drift: %+v", rules[0])
+	}
+	if rules[1].AuthType != "basic" || rules[1].Username != "x-access-token" {
+		t.Errorf("rule 1 drift: %+v", rules[1])
+	}
+}
+
+func TestRejectOverbroadWildcardOnPublicSuffix(t *testing.T) {
+	cases := []struct {
+		host      string
+		wantError bool
+	}{
+		{"api.example.com", false},
+		{"*.example.com", false},
+		{"*.example.co.uk", false},
+		{"*.bbc.co.uk", false},
+		{"*.com", true},            // public suffix
+		{"*.co.uk", true},          // multi-label public suffix
+		{"*.io", true},             // public suffix
+		{"*.us", true},             // public suffix
+		{"*.example.local", false}, // private TLD not in PSL
+	}
+	for _, c := range cases {
+		t.Run(c.host, func(t *testing.T) {
+			err := rejectOverbroadWildcard(c.host)
+			if (err != nil) != c.wantError {
+				t.Errorf("rejectOverbroadWildcard(%q) = %v, wantError=%v", c.host, err, c.wantError)
+			}
+		})
+	}
+}
+
+func TestParseStatusFilter(t *testing.T) {
+	cases := []struct {
+		in            string
+		wantMin       int32
+		wantMax       int32
+		wantErrSubstr string
+	}{
+		{"", 0, 9999, ""},
+		{"2xx", 200, 299, ""},
+		{"3xx", 300, 399, ""},
+		{"4xx", 400, 499, ""},
+		{"5xx", 500, 599, ""},
+		{"errors", 400, 9999, ""},
+		{"bogus", 0, 0, "status must be one of"},
+		{"200", 0, 0, "status must be one of"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			min, max, err := parseStatusFilter(c.in)
+			if c.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				if min != c.wantMin || max != c.wantMax {
+					t.Errorf("got (%d, %d), want (%d, %d)", min, max, c.wantMin, c.wantMax)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), c.wantErrSubstr) {
+				t.Errorf("want err containing %q, got %v", c.wantErrSubstr, err)
+			}
+		})
+	}
+}
+
+func TestListProvidersReturnsCatalog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handlers{}
+	r := gin.New()
+	r.GET("/providers", h.ListProviders)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/providers", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status: %d", w.Code)
+	}
+	var got []providerResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(providerShortcuts) {
+		t.Fatalf("provider count: got %d, want %d", len(got), len(providerShortcuts))
+	}
+	wantNames := knownProviders()
+	for i, p := range got {
+		if p.Name != wantNames[i] {
+			t.Errorf("order drift at [%d]: got %q want %q", i, p.Name, wantNames[i])
+		}
+		if p.Display == "" {
+			t.Errorf("display empty for %q", p.Name)
+		}
+		if p.TokenShape == "" {
+			t.Errorf("token_shape empty for %q", p.Name)
+		}
+	}
+}
+
+func TestProviderShortcutsHaveDisplayNames(t *testing.T) {
+	for name, p := range providerShortcuts {
+		if p.Display == "" {
+			t.Errorf("provider %q missing Display field", name)
+		}
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -18,15 +18,13 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
-
-// ---------------------------------------------------------------------------
-// Mock VMDClient
-// ---------------------------------------------------------------------------
 
 type stubVMD struct {
 	destroyFn        func(ctx context.Context, id string, force bool) error
@@ -36,6 +34,7 @@ type stubVMD struct {
 	deleteSnapshotFn func(ctx context.Context, id, snapshotPath, memPath string) error
 	execFn           func(ctx context.Context, id, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (string, string, int32, error)
 	updateNetworkFn  func(ctx context.Context, id string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
+	injectEnvFn      func(ctx context.Context, id string, envVars map[string]string, secretsJWT string) error
 }
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
@@ -50,7 +49,7 @@ func (s *stubVMD) PauseInstance(ctx context.Context, id, snapshotDir string) (st
 	}
 	return "/snapshots/vmstate.snap", "/snapshots/mem.snap", nil
 }
-func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string, envVars map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string) (string, uint32, uint32, error) {
 	if s.resumeFn != nil {
 		ip, err := s.resumeFn(ctx, id, snapshotPath, memPath)
 		return ip, 1, 1024, err
@@ -90,6 +89,15 @@ func (s *stubVMD) UpdateSandboxNetwork(ctx context.Context, id string, allowed, 
 	}
 	return nil
 }
+func (s *stubVMD) InvalidateSecret(_ context.Context, _ string) error       { return nil }
+func (s *stubVMD) RevokeSandbox(_ context.Context, _ string) error          { return nil }
+func (s *stubVMD) InvalidateSandboxRules(_ context.Context, _ string) error { return nil }
+func (s *stubVMD) InjectSandboxEnv(ctx context.Context, id string, envVars map[string]string, secretsJWT string) error {
+	if s.injectEnvFn != nil {
+		return s.injectEnvFn(ctx, id, envVars, secretsJWT)
+	}
+	return nil
+}
 
 // Template build methods — no-op stubs. Handler tests don't exercise
 // the build pipeline; supervisor integration tests are the right place
@@ -106,10 +114,6 @@ func (s *stubVMD) StreamBuildLogs(_ context.Context, _ string, _ func(vmdclient.
 	return nil
 }
 
-// ---------------------------------------------------------------------------
-// Mock DBTX — drives db.Queries without a real database
-// ---------------------------------------------------------------------------
-
 type mockRow struct {
 	scanFn func(dest ...any) error
 }
@@ -119,6 +123,8 @@ func (r *mockRow) Scan(dest ...any) error { return r.scanFn(dest...) }
 type mockDBTX struct {
 	queryRowFn func(ctx context.Context, sql string, args ...any) pgx.Row
 	execFn     func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	// queryFn is optional; nil falls back to an empty rows iterator.
+	queryFn func(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
 
 func (m *mockDBTX) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
@@ -129,13 +135,25 @@ func (m *mockDBTX) Exec(ctx context.Context, sql string, args ...any) (pgconn.Co
 	return m.execFn(ctx, sql, args...)
 }
 
-func (m *mockDBTX) Query(context.Context, string, ...any) (pgx.Rows, error) {
-	return nil, fmt.Errorf("Query not expected")
+func (m *mockDBTX) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	if m.queryFn != nil {
+		return m.queryFn(ctx, sql, args...)
+	}
+	return emptyRows{}, nil
 }
 
-// ---------------------------------------------------------------------------
-// Row helpers
-// ---------------------------------------------------------------------------
+// emptyRows is a no-row pgx.Rows implementation.
+type emptyRows struct{}
+
+func (emptyRows) Close()                                       {}
+func (emptyRows) Err() error                                   { return nil }
+func (emptyRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (emptyRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (emptyRows) Next() bool                                   { return false }
+func (emptyRows) Scan(...any) error                            { return fmt.Errorf("emptyRows.Scan") }
+func (emptyRows) Values() ([]any, error)                       { return nil, nil }
+func (emptyRows) RawValues() [][]byte                          { return nil }
+func (emptyRows) Conn() *pgx.Conn                              { return nil }
 
 // sandboxRow returns a mockRow that populates a Sandbox from GetSandbox's Scan
 // call (16 destination pointers matching the column order in sqlc-generated
@@ -245,10 +263,6 @@ func activityRow() *mockRow {
 	}}
 }
 
-// ---------------------------------------------------------------------------
-// Router / request helpers
-// ---------------------------------------------------------------------------
-
 func setupTestRouter(h *Handlers, teamID string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -290,10 +304,6 @@ func errorCode(body map[string]any) string {
 	code, _ := errObj["code"].(string)
 	return code
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 func TestDeleteSandbox_Success(t *testing.T) {
 	sandboxID := uuid.New()
@@ -483,10 +493,6 @@ func TestDeleteSandbox_ActivityLogFailure_StillReturns204(t *testing.T) {
 		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
 	}
 }
-
-// ---------------------------------------------------------------------------
-// ResumeSandbox tests
-// ---------------------------------------------------------------------------
 
 // snapshotRow returns a mockRow that populates a Snapshot from GetSnapshot's
 // Scan call (9 destination pointers matching the column order).
@@ -900,13 +906,6 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// ActivateSandbox tests — idempotent "make this sandbox usable" endpoint.
-// Reuses loadActiveOrResumeSandbox under the hood; the tests focus on the
-// edge case ResumeSandbox doesn't cover (already-active sandbox returns 200
-// with a token, no VMD call).
-// ---------------------------------------------------------------------------
-
 func TestActivateSandbox_AlreadyActive_200WithSandboxResponse(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
@@ -1133,10 +1132,6 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
 	}
 }
-
-// ---------------------------------------------------------------------------
-// ExecSandbox tests
-// ---------------------------------------------------------------------------
 
 func TestExecSandbox_Success(t *testing.T) {
 	sandboxID := uuid.New()
@@ -1496,10 +1491,6 @@ func TestExecSandbox_MissingTeamID(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// CreateSandbox tests
-// ---------------------------------------------------------------------------
-
 func createSandboxReq(body string) *http.Request {
 	return httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body))
 }
@@ -1554,6 +1545,97 @@ func TestCreateSandbox_Success(t *testing.T) {
 	}
 	if v := body["memory_mib"].(float64); v == 0 {
 		t.Error("memory_mib is 0 — VMD's reported value was not propagated to the response")
+	}
+}
+
+func TestCreateSandbox_InjectEnvUnimplementedTolerated(t *testing.T) {
+	teamID := uuid.New()
+	sandboxID := uuid.New()
+
+	// A vmd that predates InjectSandboxEnv returns Unimplemented. With no
+	// secrets bound, the env vars were already applied during RestoreSnapshot,
+	// so creation should still succeed.
+	vmd := &stubVMD{
+		injectEnvFn: func(context.Context, string, map[string]string, string) error {
+			return status.Error(codes.Unimplemented, "unknown method InjectSandboxEnv")
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				return sandboxRow(db.Sandbox{
+					ID: sandboxID, TeamID: teamID, Name: "sb",
+					Status: db.SandboxStatusStarting, VcpuCount: 1, MemoryMib: 256,
+					CreatedAt: time.Now(),
+				})
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+	if body := parseJSON(t, w); body["status"] != "active" {
+		t.Errorf("status = %q, want active", body["status"])
+	}
+}
+
+func TestCreateSandbox_InjectEnvErrorFails(t *testing.T) {
+	teamID := uuid.New()
+	sandboxID := uuid.New()
+
+	// A real injection failure (not Unimplemented) has no fallback: the VM is
+	// torn down and the request fails.
+	var destroyed bool
+	vmd := &stubVMD{
+		injectEnvFn: func(context.Context, string, map[string]string, string) error {
+			return status.Error(codes.Internal, "post-init failed")
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed = true
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				return sandboxRow(db.Sandbox{
+					ID: sandboxID, TeamID: teamID, Name: "sb",
+					Status: db.SandboxStatusStarting, VcpuCount: 1, MemoryMib: 256,
+				})
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !destroyed {
+		t.Error("VM was not torn down after injection failure")
 	}
 }
 
@@ -1675,10 +1757,6 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// PauseSandbox tests
-// ---------------------------------------------------------------------------
 
 func pauseRequest(sandboxID string) *http.Request {
 	return httptest.NewRequest(http.MethodPost, "/sandboxes/"+sandboxID+"/pause", nil)
@@ -1891,10 +1969,6 @@ func TestTeamIDFromContext_InvalidUUID(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// validateMetadata tests
-// ---------------------------------------------------------------------------
-
 func TestValidateMetadata(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1983,10 +2057,6 @@ func makeMetadata(n int, keyPrefix, val string) map[string]string {
 	return out
 }
 
-// ---------------------------------------------------------------------------
-// parseMetadataFilter tests
-// ---------------------------------------------------------------------------
-
 func TestParseMetadataFilter(t *testing.T) {
 	t.Run("no filters", func(t *testing.T) {
 		got, err := parseMetadataFilter(map[string][]string{"page": {"1"}})
@@ -2035,10 +2105,6 @@ func TestParseMetadataFilter(t *testing.T) {
 		}
 	})
 }
-
-// ---------------------------------------------------------------------------
-// CreateSandbox metadata tests
-// ---------------------------------------------------------------------------
 
 func TestCreateSandbox_WithMetadata(t *testing.T) {
 	teamID := uuid.New()

--- a/internal/api/jwt.go
+++ b/internal/api/jwt.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rs/zerolog/log"
+)
+
+// SecretsJWTIssuer is the fixed `iss` claim on every secrets JWT.
+const SecretsJWTIssuer = "superserve-controlplane"
+
+// SecretsJWTLifetime is the safety-net upper bound on a leaked JWT's blast
+// radius. Revocation on sandbox destroy is the primary kill switch.
+const SecretsJWTLifetime = 90 * 24 * time.Hour
+
+// SecretsBindingsCap bounds the number of bindings allowed per sandbox so the
+// resulting JWT stays within practical HTTPS_PROXY userinfo lengths
+// (~10 KB worst case at this cap, comfortably under mainstream HTTP-client
+// URL limits).
+const SecretsBindingsCap = 32
+
+// SecretsBindingClaim is the per-binding entry in the JWT's `bindings` array.
+// Field tags use short names to keep the JWT compact in HTTPS_PROXY userinfo.
+// When Rules is non-empty it overrides AuthType/AuthConfig; the daemon dispatches
+// by upstream host. Hosts remains the binding-wide allowlist.
+type SecretsBindingClaim struct {
+	ProxyToken string                    `json:"p"`
+	SecretID   string                    `json:"s"`
+	EnvKey     string                    `json:"e"`
+	Hosts      []string                  `json:"h"`
+	AuthType   string                    `json:"t,omitempty"`
+	AuthConfig map[string]any            `json:"c,omitempty"`
+	Rules      []SecretsBindingRuleClaim `json:"rules,omitempty"`
+}
+
+// SecretsBindingRuleClaim is one (hosts → auth shape) entry inside Rules.
+// Flat fields keep the JWT compact; the daemon dispatches on Hosts.
+type SecretsBindingRuleClaim struct {
+	Hosts    []string          `json:"h"`
+	AuthType string            `json:"t"`
+	Username string            `json:"u,omitempty"`  // basic only
+	Header   string            `json:"hd,omitempty"` // api-key only
+	Prefix   string            `json:"pf,omitempty"` // api-key only
+	Headers  map[string]string `json:"hs,omitempty"` // custom only
+}
+
+// SecretsClaims is the JWT payload.
+type SecretsClaims struct {
+	TeamID   string                `json:"team_id"`
+	SourceIP string                `json:"source_ip"`
+	Bindings []SecretsBindingClaim `json:"bindings,omitempty"`
+
+	jwt.RegisteredClaims
+}
+
+// SecretsSigner mints signed JWTs for the secrets feature.
+type SecretsSigner struct {
+	priv ed25519.PrivateKey
+	kid  string
+}
+
+// NewSecretsSigner builds a signer from a base64-encoded 32-byte Ed25519 seed.
+// Accepts both standard and URL-safe base64, with or without padding.
+func NewSecretsSigner(seedBase64, kid string) (*SecretsSigner, error) {
+	if kid == "" {
+		return nil, errors.New("secrets signing key id is required")
+	}
+	seedBase64 = stripWhitespace(seedBase64)
+	seed, err := decodeBase64Permissive(seedBase64)
+	if err != nil {
+		return nil, fmt.Errorf("decode signing key: %w", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("signing key seed has %d bytes, want %d", len(seed), ed25519.SeedSize)
+	}
+	return &SecretsSigner{
+		priv: ed25519.NewKeyFromSeed(seed),
+		kid:  kid,
+	}, nil
+}
+
+// Sign returns a serialized JWT with the supplied claims. iss, iat, exp are
+// filled in automatically; the caller supplies sandbox-specific fields.
+func (s *SecretsSigner) Sign(sandboxID string, claims SecretsClaims) (string, error) {
+	return s.sign(sandboxID, claims, time.Now())
+}
+
+// sign is the testable form; production callers use Sign which passes time.Now.
+func (s *SecretsSigner) sign(sandboxID string, claims SecretsClaims, now time.Time) (string, error) {
+	if sandboxID == "" {
+		return "", errors.New("sandbox id is required")
+	}
+	if claims.TeamID == "" {
+		return "", errors.New("team id is required")
+	}
+	if claims.SourceIP == "" {
+		return "", errors.New("source ip is required")
+	}
+	if len(claims.Bindings) > SecretsBindingsCap {
+		return "", fmt.Errorf("bindings count %d exceeds cap of %d", len(claims.Bindings), SecretsBindingsCap)
+	}
+	claims.RegisteredClaims = jwt.RegisteredClaims{
+		Issuer:    SecretsJWTIssuer,
+		Subject:   sandboxID,
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(SecretsJWTLifetime)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, &claims)
+	token.Header["kid"] = s.kid
+	return token.SignedString(s.priv)
+}
+
+// PublicKey returns the Ed25519 verification public key.
+func (s *SecretsSigner) PublicKey() ed25519.PublicKey {
+	return s.priv.Public().(ed25519.PublicKey)
+}
+
+// KeyID returns the kid that this signer puts on minted JWTs.
+func (s *SecretsSigner) KeyID() string { return s.kid }
+
+// JWKS returns the JSON Web Key Set the daemon polls. Single-key today;
+// multi-key during rotation windows is a config change (one more entry).
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK is one entry in the JWKS. We only emit Ed25519 keys (kty=OKP, crv=Ed25519).
+type JWK struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+}
+
+// JWKS returns the single-key JWKS for the daemon to fetch.
+func (s *SecretsSigner) JWKS() JWKS {
+	return JWKS{Keys: []JWK{{
+		Kid: s.kid,
+		Kty: "OKP",
+		Crv: "Ed25519",
+		X:   base64.RawURLEncoding.EncodeToString(s.PublicKey()),
+	}}}
+}
+
+func decodeBase64Permissive(s string) ([]byte, error) {
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil {
+			return b, nil
+		}
+	}
+	return nil, errors.New("not valid base64")
+}
+
+// JWKS handles GET /internal/jwks. Authenticated by InternalAuth middleware.
+// Returns 503 if no Signer is configured so a misconfigured deploy fails loud.
+func (h *Handlers) JWKS(c *gin.Context) {
+	if h.Signer == nil {
+		log.Error().Msg("/internal/jwks called but no Signer configured")
+		respondErrorMsg(c, "service_unavailable", "secrets signer not configured", http.StatusServiceUnavailable)
+		return
+	}
+	c.JSON(http.StatusOK, h.Signer.JWKS())
+}
+
+func stripWhitespace(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+			continue
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}

--- a/internal/api/jwt_test.go
+++ b/internal/api/jwt_test.go
@@ -1,0 +1,437 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// newTestSigner builds a signer with a fresh random keypair and the given kid.
+func newTestSigner(t *testing.T, kid string) *SecretsSigner {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed := priv.Seed()
+	s, err := NewSecretsSigner(base64.StdEncoding.EncodeToString(seed), kid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestSecretsSigner_SignAndVerifyRoundTrip(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+
+	claims := SecretsClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		Bindings: []SecretsBindingClaim{{
+			ProxyToken: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789012345678901",
+			SecretID:   "secret-uuid-1",
+			EnvKey:     "ANTHROPIC_API_KEY",
+			Hosts:      []string{"api.anthropic.com"},
+			AuthType:   "api-key",
+			AuthConfig: map[string]any{"header": "x-api-key"},
+		}},
+	}
+
+	tok, err := signer.Sign("sandbox-1", claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok == "" {
+		t.Fatal("empty token")
+	}
+
+	// Round-trip parse using the same library and the signer's public key.
+	parsed, err := jwt.ParseWithClaims(tok, &SecretsClaims{}, func(t *jwt.Token) (any, error) {
+		if t.Method.Alg() != jwt.SigningMethodEdDSA.Alg() {
+			t.Method = jwt.SigningMethodEdDSA
+		}
+		return signer.PublicKey(), nil
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !parsed.Valid {
+		t.Fatal("token not valid")
+	}
+	got := parsed.Claims.(*SecretsClaims)
+	if got.TeamID != "team-1" {
+		t.Errorf("TeamID drift: %q", got.TeamID)
+	}
+	if got.SourceIP != "10.0.0.5" {
+		t.Errorf("SourceIP drift: %q", got.SourceIP)
+	}
+	if got.Issuer != SecretsJWTIssuer {
+		t.Errorf("iss: got %q, want %q", got.Issuer, SecretsJWTIssuer)
+	}
+	if got.Subject != "sandbox-1" {
+		t.Errorf("sub: got %q", got.Subject)
+	}
+	if len(got.Bindings) != 1 || got.Bindings[0].SecretID != "secret-uuid-1" {
+		t.Errorf("bindings drift: %+v", got.Bindings)
+	}
+}
+
+func TestSecretsSigner_RejectsTamperedToken(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+	tok, err := signer.Sign("sandbox-1", SecretsClaims{
+		TeamID: "team-1", SourceIP: "10.0.0.5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Flip a byte in the payload (middle segment).
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT segments, got %d", len(parts))
+	}
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	payload[0] ^= 0xff
+	tampered := parts[0] + "." + base64.RawURLEncoding.EncodeToString(payload) + "." + parts[2]
+
+	_, err = jwt.ParseWithClaims(tampered, &SecretsClaims{}, func(*jwt.Token) (any, error) {
+		return signer.PublicKey(), nil
+	})
+	if err == nil {
+		t.Fatal("tampered token unexpectedly accepted")
+	}
+}
+
+func TestSecretsSigner_SignSetsKidAndAlg(t *testing.T) {
+	signer := newTestSigner(t, "v7")
+	tok, err := signer.Sign("sandbox-1", SecretsClaims{TeamID: "t", SourceIP: "10.0.0.1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headerB64 := strings.SplitN(tok, ".", 2)[0]
+	headerBytes, err := base64.RawURLEncoding.DecodeString(headerB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		t.Fatal(err)
+	}
+	if header["kid"] != "v7" {
+		t.Errorf("kid: got %v, want v7", header["kid"])
+	}
+	if header["alg"] != "EdDSA" {
+		t.Errorf("alg: got %v, want EdDSA", header["alg"])
+	}
+	if header["typ"] != "JWT" {
+		t.Errorf("typ: got %v, want JWT", header["typ"])
+	}
+}
+
+func TestSecretsSigner_ExpiryHorizon(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tok, err := signer.sign("sandbox-1", SecretsClaims{
+		TeamID: "team-1", SourceIP: "10.0.0.5",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := jwt.ParseWithClaims(tok, &SecretsClaims{}, func(*jwt.Token) (any, error) {
+		return signer.PublicKey(), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := parsed.Claims.(*SecretsClaims)
+	wantExp := now.Add(SecretsJWTLifetime)
+	if !got.ExpiresAt.Time.Equal(wantExp) {
+		t.Errorf("exp: got %v, want %v", got.ExpiresAt.Time, wantExp)
+	}
+	if !got.IssuedAt.Time.Equal(now) {
+		t.Errorf("iat: got %v, want %v", got.IssuedAt.Time, now)
+	}
+}
+
+func TestSecretsSigner_RejectsMissingRequiredFields(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+	cases := []struct {
+		name      string
+		sandboxID string
+		claims    SecretsClaims
+	}{
+		{"missing sandbox id", "", SecretsClaims{TeamID: "t", SourceIP: "1.1.1.1"}},
+		{"missing team id", "sandbox-1", SecretsClaims{SourceIP: "1.1.1.1"}},
+		{"missing source ip", "sandbox-1", SecretsClaims{TeamID: "t"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := signer.Sign(tc.sandboxID, tc.claims); err == nil {
+				t.Error("want error, got nil")
+			}
+		})
+	}
+}
+
+func TestNewSecretsSigner_RejectsBadKey(t *testing.T) {
+	cases := []struct {
+		name string
+		seed string
+		kid  string
+	}{
+		{"empty kid", base64.StdEncoding.EncodeToString(make([]byte, ed25519.SeedSize)), ""},
+		{"bad base64", "not-base64-!@#", "v1"},
+		{"wrong seed size", base64.StdEncoding.EncodeToString(make([]byte, 16)), "v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewSecretsSigner(tc.seed, tc.kid); err == nil {
+				t.Error("want error, got nil")
+			}
+		})
+	}
+}
+
+func TestNewSecretsSigner_AcceptsBase64Variants(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatal(err)
+	}
+	encs := map[string]string{
+		"std":     base64.StdEncoding.EncodeToString(seed),
+		"raw-std": base64.RawStdEncoding.EncodeToString(seed),
+		"url":     base64.URLEncoding.EncodeToString(seed),
+		"raw-url": base64.RawURLEncoding.EncodeToString(seed),
+	}
+	for name, encoded := range encs {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewSecretsSigner(encoded, "v1"); err != nil {
+				t.Errorf("variant %s: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestJWKSHandler_ReturnsKeysWithAuth(t *testing.T) {
+	t.Setenv("INTERNAL_API_TOKEN", "test-internal-tok")
+	signer := newTestSigner(t, "v1")
+	h := &Handlers{Signer: signer}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/internal/jwks", InternalAuth(), h.JWKS)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/jwks", nil)
+	req.Header.Set("Authorization", "Bearer test-internal-tok")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var body JWKS
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(body.Keys) != 1 || body.Keys[0].Kid != "v1" || body.Keys[0].Crv != "Ed25519" {
+		t.Errorf("jwks drift: %+v", body)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(body.Keys[0].X)
+	if err != nil {
+		t.Fatalf("x not base64url: %v", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		t.Errorf("public key bytes: got %d, want %d", len(decoded), ed25519.PublicKeySize)
+	}
+}
+
+func TestJWKSHandler_RejectsMissingAuth(t *testing.T) {
+	t.Setenv("INTERNAL_API_TOKEN", "test-tok")
+	h := &Handlers{Signer: newTestSigner(t, "v1")}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/internal/jwks", InternalAuth(), h.JWKS)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/jwks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", w.Code)
+	}
+}
+
+func TestJWKSHandler_503WhenSignerNotConfigured(t *testing.T) {
+	t.Setenv("INTERNAL_API_TOKEN", "test-tok")
+	h := &Handlers{Signer: nil}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/internal/jwks", InternalAuth(), h.JWKS)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/jwks", nil)
+	req.Header.Set("Authorization", "Bearer test-tok")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestSecretsSigner_JWKS(t *testing.T) {
+	signer := newTestSigner(t, "v3")
+	jwks := signer.JWKS()
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("want 1 key, got %d", len(jwks.Keys))
+	}
+	k := jwks.Keys[0]
+	if k.Kid != "v3" {
+		t.Errorf("kid: %q", k.Kid)
+	}
+	if k.Kty != "OKP" {
+		t.Errorf("kty: %q", k.Kty)
+	}
+	if k.Crv != "Ed25519" {
+		t.Errorf("crv: %q", k.Crv)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(k.X)
+	if err != nil {
+		t.Fatalf("x not base64url: %v", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		t.Errorf("public key bytes: got %d, want %d", len(decoded), ed25519.PublicKeySize)
+	}
+}
+
+func TestSecretsSigner_JWTSizeAtCap(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+
+	// SecretsBindingsCap bindings — the documented worst case.
+	bindings := make([]SecretsBindingClaim, SecretsBindingsCap)
+	for i := range bindings {
+		bindings[i] = SecretsBindingClaim{
+			ProxyToken: "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			SecretID:   "11111111-2222-3333-4444-555555555555",
+			EnvKey:     "ANTHROPIC_API_KEY_XX",
+			Hosts:      []string{"api.anthropic.com"},
+			AuthType:   "api-key",
+			AuthConfig: map[string]any{"header": "x-api-key"},
+		}
+	}
+	tok, err := signer.Sign("sandbox-1", SecretsClaims{
+		TeamID:   "11111111-2222-3333-4444-555555555555",
+		SourceIP: "10.0.0.5",
+		Bindings: bindings,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mainstream HTTP clients accept URLs up to 16 KB without issue;
+	// fail the test if we approach 12 KB so a future claim-bloat regression
+	// is caught early.
+	if len(tok) > 12*1024 {
+		t.Errorf("JWT at binding cap is %d bytes; alarm threshold is 12 KB", len(tok))
+	}
+	t.Logf("JWT size at %d bindings: %d bytes", SecretsBindingsCap, len(tok))
+}
+
+func TestSecretsSigner_RejectsTooManyBindings(t *testing.T) {
+	signer := newTestSigner(t, "v1")
+	bindings := make([]SecretsBindingClaim, SecretsBindingsCap+1)
+	for i := range bindings {
+		bindings[i] = SecretsBindingClaim{
+			ProxyToken: "x", SecretID: "y", AuthType: "bearer",
+		}
+	}
+	_, err := signer.Sign("sandbox-1", SecretsClaims{
+		TeamID: "t", SourceIP: "1.1.1.1", Bindings: bindings,
+	})
+	if err == nil {
+		t.Fatal("want error for exceeding bindings cap, got nil")
+	}
+}
+
+func TestSecretsSigner_PerHostRulesSurviveSignAndParse(t *testing.T) {
+	// Round-trip a multi-rule binding through sign + parse, confirming the
+	// wire-format Rules field carries through and the legacy t+c fields are
+	// omitted when omitempty applies.
+	signer := newTestSigner(t, "v1")
+	claims := SecretsClaims{
+		TeamID:   "team-1",
+		SourceIP: "10.0.0.5",
+		Bindings: []SecretsBindingClaim{{
+			ProxyToken: "ghp_proxy_aaaa",
+			SecretID:   "secret-gh-1",
+			EnvKey:     "GITHUB_TOKEN",
+			Hosts:      []string{"api.github.com", "github.com"},
+			Rules: []SecretsBindingRuleClaim{
+				{Hosts: []string{"api.github.com"}, AuthType: "bearer"},
+				{Hosts: []string{"github.com"}, AuthType: "basic", Username: "x-access-token"},
+			},
+		}},
+	}
+	tok, err := signer.Sign("sandbox-1", claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Parse back and check Rules survive.
+	parsed, err := jwt.ParseWithClaims(tok, &SecretsClaims{}, func(*jwt.Token) (any, error) {
+		return signer.PublicKey(), nil
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := parsed.Claims.(*SecretsClaims)
+	if len(got.Bindings) != 1 {
+		t.Fatalf("bindings count: %d", len(got.Bindings))
+	}
+	b := got.Bindings[0]
+	if b.AuthType != "" {
+		t.Errorf("legacy AuthType should be empty for per_host binding, got %q", b.AuthType)
+	}
+	if len(b.Rules) != 2 {
+		t.Fatalf("rules count: %d", len(b.Rules))
+	}
+	if b.Rules[0].AuthType != "bearer" || b.Rules[0].Hosts[0] != "api.github.com" {
+		t.Errorf("rule 0 drift: %+v", b.Rules[0])
+	}
+	if b.Rules[1].AuthType != "basic" || b.Rules[1].Username != "x-access-token" {
+		t.Errorf("rule 1 drift: %+v", b.Rules[1])
+	}
+	// Decode the JWT body and assert that the legacy `t` field is absent for
+	// the multi-rule binding (omitempty had to fire).
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatal("malformed jwt")
+	}
+	body, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	rawBindings := raw["bindings"].([]any)
+	rawBinding := rawBindings[0].(map[string]any)
+	if _, hasT := rawBinding["t"]; hasT {
+		t.Errorf("legacy t field should be omitted from per_host binding, body=%v", rawBinding)
+	}
+	if _, hasC := rawBinding["c"]; hasC {
+		t.Errorf("legacy c field should be omitted from per_host binding, body=%v", rawBinding)
+	}
+	if _, hasRules := rawBinding["rules"]; !hasRules {
+		t.Errorf("rules field missing from JWT body: %v", rawBinding)
+	}
+}

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -73,6 +73,7 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 	runTick := func() {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
 		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
+		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
 	}
 
 	// Run once immediately so a control plane restart does not delay
@@ -102,6 +103,20 @@ func (h *Handlers) sweepOrphanedIntervals(ctx context.Context) {
 	}
 	if n > 0 {
 		log.Warn().Int64("closed", n).Msg("reaper: closed orphaned active intervals")
+	}
+}
+
+// cleanupExpiredRevocations deletes sandbox_revocation rows past their TTL.
+func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
+	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	n, err := h.DB.DeleteExpiredSandboxRevocations(queryCtx)
+	if err != nil {
+		log.Warn().Err(err).Msg("reaper: cleanup revocations failed")
+		return
+	}
+	if n > 0 {
+		log.Info().Int64("reaped", n).Msg("reaper: deleted expired sandbox revocations")
 	}
 }
 
@@ -241,7 +256,9 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	}
 
 	vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
-	_, _, _, err := vmd.ResumeInstance(vmdCtx, sbx.ID.String(), snapshotPath, memPath, nil)
+	// Reaper rollback resume: brings the VM back up after a pause-DB-write
+	// failure, before the customer ever sees the transition.
+	_, _, _, err := vmd.ResumeInstance(vmdCtx, sbx.ID.String(), snapshotPath, memPath)
 	vmdCancel()
 	if err != nil {
 		rl.Error().Err(err).Msg("reaper: rollback resume failed")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 
-	"github.com/gin-gonic/gin"
 	sentrygin "github.com/getsentry/sentry-go/gin"
+	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -58,6 +58,18 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 		api.GET("/templates/:template_id/builds/:build_id", h.GetTemplateBuild)
 		api.DELETE("/templates/:template_id/builds/:build_id", h.CancelTemplateBuild)
 		api.GET("/templates/:template_id/builds/:build_id/logs", h.StreamTemplateBuildLogs)
+
+		api.POST("/secrets", h.CreateSecret)
+		api.GET("/secrets", h.ListSecrets)
+		api.GET("/secrets/:name", h.GetSecret)
+		api.PATCH("/secrets/:name", h.PatchSecret)
+		api.DELETE("/secrets/:name", h.DeleteSecret)
+		api.GET("/secrets/:name/audit", h.GetSecretAudit)
+		api.GET("/secrets/:name/sandboxes", h.GetSecretSandboxes)
+
+		api.GET("/providers", h.ListProviders)
+
+		api.GET("/sandboxes/:sandbox_id/network", h.GetSandboxNetwork)
 	}
 
 	r.GET("/health", h.Health)
@@ -71,6 +83,10 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 	internal.Use(InternalAuth())
 	{
 		internal.POST("/hosts/:host_id/heartbeat", h.HostHeartbeat)
+		internal.POST("/secrets/decrypt", h.DecryptSecret)
+		internal.GET("/jwks", h.JWKS)
+		internal.GET("/sandbox_revocations", h.ListSandboxRevocations)
+		internal.GET("/sandboxes/:sandbox_id/egress_rules", h.GetSandboxEgressRules)
 	}
 
 	return r

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -71,6 +71,15 @@ func isVMDInvalidArgument(err error) bool {
 	return status.Code(err) == codes.InvalidArgument
 }
 
+// isVMDUnimplemented reports whether vmd lacks the called RPC (gRPC
+// Unimplemented) — e.g. a host that predates InjectSandboxEnv.
+func isVMDUnimplemented(err error) bool {
+	if err == nil {
+		return false
+	}
+	return status.Code(err) == codes.Unimplemented
+}
+
 // vmdErrorMessage returns the gRPC message from a vmd error, stripping
 // gRPC/transport framing so the string is safe to surface to API callers.
 func vmdErrorMessage(err error) string {
@@ -99,4 +108,21 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async mark-failed write failed")
 		}
 	}()
+}
+
+// failSandboxAfterBoot destroys a running VM and marks the sandbox row as failed.
+// Used by CreateSandbox when a post-restore step (env injection, JWT mint)
+// fails — the VM is already running but unusable, so we tear it down and
+// surface the failure to the customer.
+func (h *Handlers) failSandboxAfterBoot(ctx context.Context, sandboxID, teamID uuid.UUID, instanceID string) {
+	if err := h.VMD.DestroyInstance(ctx, instanceID, true); err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("destroy after failed boot")
+	}
+	if err := h.DB.UpdateSandboxStatus(ctx, db.UpdateSandboxStatusParams{
+		ID:     sandboxID,
+		Status: db.SandboxStatusFailed,
+		TeamID: teamID,
+	}); err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("mark-failed after destroy")
+	}
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -31,10 +31,6 @@ import (
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
-// ---------------------------------------------------------------------------
-// Test infrastructure
-// ---------------------------------------------------------------------------
-
 var (
 	testPool         *pgxpool.Pool
 	testQueries      *db.Queries
@@ -166,11 +162,14 @@ func (s *stubVMD) DestroyInstance(_ context.Context, _ string, _ bool) error { r
 func (s *stubVMD) PauseInstance(_ context.Context, _, _ string) (string, string, error) {
 	return "/snapshots/disk.snap", "/snapshots/mem.snap", nil
 }
-func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
+}
+func (s *stubVMD) InjectSandboxEnv(_ context.Context, _ string, _ map[string]string, _ string) error {
+	return nil
 }
 func (s *stubVMD) ExecCommand(_ context.Context, _, _ string, _ []string, _ map[string]string, _ string, _ uint32) (string, string, int32, error) {
 	return "hello\n", "", 0, nil
@@ -183,7 +182,10 @@ func (s *stubVMD) ExecCommandStream(_ context.Context, _, _ string, _ []string, 
 func (s *stubVMD) UpdateSandboxNetwork(_ context.Context, _ string, _, _, _ []string) error {
 	return nil
 }
-func (s *stubVMD) DeleteSnapshot(_ context.Context, _, _, _ string) error { return nil }
+func (s *stubVMD) InvalidateSecret(_ context.Context, _ string) error        { return nil }
+func (s *stubVMD) RevokeSandbox(_ context.Context, _ string) error           { return nil }
+func (s *stubVMD) InvalidateSandboxRules(_ context.Context, _ string) error  { return nil }
+func (s *stubVMD) DeleteSnapshot(_ context.Context, _, _, _ string) error    { return nil }
 func (s *stubVMD) DeleteTemplateArtifacts(_ context.Context, _ string) error { return nil }
 func (s *stubVMD) DeleteBuildArtifacts(_ context.Context, _, _ string) error { return nil }
 func (s *stubVMD) ListBuildArtifacts(_ context.Context) ([]vmdclient.BuildArtifactEntry, error) {
@@ -280,7 +282,6 @@ func newRouter(t *testing.T) *gin.Engine {
 	return api.SetupRouter(t.Context(), h, testPool)
 }
 
-
 func do(r *gin.Engine, method, path, apiKey, body string) *httptest.ResponseRecorder {
 	var bodyReader io.Reader
 	if body != "" {
@@ -315,10 +316,6 @@ func mustJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{}
 	}
 	return m
 }
-
-// ---------------------------------------------------------------------------
-// Auth
-// ---------------------------------------------------------------------------
 
 func TestIntegration_Auth_HealthNoKeyRequired(t *testing.T) {
 	w := do(newRouter(t), "GET", "/health", "", "")
@@ -361,10 +358,6 @@ func TestIntegration_Auth_RevokedKey(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// POST /sandboxes
-// ---------------------------------------------------------------------------
-
 func TestIntegration_CreateSandbox_Success(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
@@ -399,10 +392,6 @@ func TestIntegration_CreateSandbox_Success(t *testing.T) {
 		t.Errorf("memory_mib = %d, want 1024", sb.MemoryMib)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// GET /sandboxes and GET /sandboxes/:id
-// ---------------------------------------------------------------------------
 
 func TestIntegration_ListSandboxes(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
@@ -505,10 +494,6 @@ func TestIntegration_CreateSandbox_ValidationError(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// POST /sandboxes/:id/pause
-// ---------------------------------------------------------------------------
-
 func TestIntegration_PauseSandbox_Success(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
@@ -568,10 +553,6 @@ func TestIntegration_PauseSandbox_AlreadyPaused(t *testing.T) {
 		t.Fatalf("expected 409 on double-pause, got %d: %s", w.Code, w.Body.String())
 	}
 }
-
-// ---------------------------------------------------------------------------
-// POST /sandboxes/:id/resume
-// ---------------------------------------------------------------------------
 
 func TestIntegration_ResumeSandbox_Success(t *testing.T) {
 	ctx := context.Background()
@@ -828,10 +809,6 @@ func TestIntegration_DeleteSandbox_NotFound(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// POST /sandboxes/:id/exec
-// ---------------------------------------------------------------------------
-
 func TestIntegration_ExecSandbox_Success(t *testing.T) {
 	ctx := context.Background()
 	_, apiKey := seedTeamAndKey(t)
@@ -967,10 +944,6 @@ func TestIntegration_ExecSandboxStream_PausedAutoResume(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Team isolation
-// ---------------------------------------------------------------------------
-
 func TestIntegration_TeamIsolation_Delete(t *testing.T) {
 	_, apiKeyA := seedTeamAndKey(t)
 	_, apiKeyB := seedTeamAndKey(t)
@@ -1012,10 +985,6 @@ func TestIntegration_TeamIsolation_Exec(t *testing.T) {
 		t.Fatalf("expected 404 (team isolation on exec), got %d: %s", ew.Code, ew.Body.String())
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Activity logging
-// ---------------------------------------------------------------------------
 
 func TestIntegration_ActivityLog_DeleteRecorded(t *testing.T) {
 	ctx := context.Background()
@@ -1169,10 +1138,6 @@ func TestIntegration_ActivityLog_ActorNullWhenKeyHasNoCreator(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Concurrent sandbox creation via API
-// ---------------------------------------------------------------------------
-
 func TestIntegration_ConcurrentCreate(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)
@@ -1216,10 +1181,6 @@ func TestIntegration_ConcurrentCreate(t *testing.T) {
 		}
 	}
 }
-
-// ---------------------------------------------------------------------------
-// PATCH /sandboxes/:id
-// ---------------------------------------------------------------------------
 
 func TestIntegration_PatchSandbox_Network_Success(t *testing.T) {
 	teamID, apiKey := seedTeamAndKey(t)
@@ -1337,10 +1298,6 @@ func TestIntegration_PatchSandbox_UnknownField(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// POST /sandboxes with network config
-// ---------------------------------------------------------------------------
-
 func TestIntegration_CreateSandbox_WithNetworkConfig(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)
@@ -1355,10 +1312,6 @@ func TestIntegration_CreateSandbox_WithNetworkConfig(t *testing.T) {
 		t.Errorf("expected status=active, got %v", body["status"])
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Security headers
-// ---------------------------------------------------------------------------
 
 func TestIntegration_SecurityHeaders(t *testing.T) {
 	r := newRouter(t)
@@ -1377,10 +1330,6 @@ func TestIntegration_SecurityHeaders(t *testing.T) {
 		t.Error("missing Strict-Transport-Security")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Sandbox metadata
-// ---------------------------------------------------------------------------
 
 func TestIntegration_CreateSandbox_WithMetadata(t *testing.T) {
 	ctx := context.Background()
@@ -1618,10 +1567,6 @@ func TestIntegration_ListSandboxes_FilterRejectsAdversarial(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Rate limiting
-// ---------------------------------------------------------------------------
-
 func TestIntegration_RateLimit_Headers(t *testing.T) {
 	r := newRouter(t)
 
@@ -1636,10 +1581,6 @@ func TestIntegration_RateLimit_Headers(t *testing.T) {
 		t.Error("missing RateLimit-Remaining header")
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Templates
-// ---------------------------------------------------------------------------
 
 // TestIntegration_CreateTemplate_NameReusableAfterDelete verifies the partial
 // unique index on (team_id, name) WHERE deleted_at IS NULL: once a template

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -3,7 +3,9 @@
 // internal/hostreg can reference it without circular imports.
 package vmdclient
 
-import "context"
+import (
+	"context"
+)
 
 // Client defines the subset of the VM daemon gRPC interface used by the
 // control plane. Implementations: grpcVMDClient in cmd/controlplane,
@@ -11,12 +13,18 @@ import "context"
 type Client interface {
 	DestroyInstance(ctx context.Context, instanceID string, force bool) error
 	PauseInstance(ctx context.Context, instanceID, snapshotDir string) (snapshotPath, memPath string, err error)
-	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	// ResumeInstance restores a paused VM.
+	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
 	// RestoreSnapshot is the stateless restore path used as a fallback when
 	// ResumeInstance fails with NotFound (e.g. after a VMD crash lost the
 	// in-memory map but the snapshot files are still on disk). basePath +
 	// deltaDir are populated for overlay-mode templates, empty for legacy.
+	// For sandboxes with secrets the caller passes envVars=nil here and uses
+	// InjectSandboxEnv below once the source IP is known and a JWT is minted.
 	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	// InjectSandboxEnv pushes env vars and the optional secrets JWT into a
+	// running sandbox's boxd. Idempotent.
+	InjectSandboxEnv(ctx context.Context, instanceID string, envVars map[string]string, secretsJWT string) error
 	// DeleteSnapshot removes the on-disk vmstate + memory files for a
 	// previous snapshot. Idempotent: missing files return nil. Used by the
 	// control plane to garbage-collect the previous snapshot after a new
@@ -33,6 +41,21 @@ type Client interface {
 	ExecCommand(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32) (stdout, stderr string, exitCode int32, err error)
 	ExecCommandStream(ctx context.Context, instanceID, command string, args []string, env map[string]string, workingDir string, timeoutS uint32, onChunk func(stdout, stderr []byte, exitCode int32, finished bool)) error
 	UpdateSandboxNetwork(ctx context.Context, instanceID string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
+
+	// InvalidateSecret asks vmd's local secretsproxy daemon to drop the
+	// cached cleartext for secretID. Used by the control plane to push
+	// a rotation or revocation faster than the daemon's vault-cache TTL.
+	// Idempotent on the daemon side.
+	InvalidateSecret(ctx context.Context, secretID string) error
+
+	// RevokeSandbox tells the local secretsproxy daemon that sandboxID's
+	// JWT must no longer authorize requests. Idempotent.
+	RevokeSandbox(ctx context.Context, sandboxID string) error
+
+	// InvalidateSandboxRules asks the local secretsproxy daemon to drop its
+	// cached egress rules for sandboxID, so the next request re-fetches them.
+	// Used by the control plane after a network PATCH. Idempotent.
+	InvalidateSandboxRules(ctx context.Context, sandboxID string) error
 
 	// BuildTemplate kicks off an async template build on this vmd host.
 	// Returns the opaque build VM id; poll GetBuildStatus with it until a


### PR DESCRIPTION
**Stack 4 of 6.** Base: `amit/secrets-3-daemon`.

Control-plane API: credential CRUD, provider catalog, binding to sandboxes, per-sandbox JWT minting, the live egress-rules endpoint, the unified network-log endpoint, OpenAPI, and the vmdclient interface. Endpoints exist but the daemon is not wired to vmd yet.

Review/merge after [3/6].