### PR TITLE
secrets [5/6]: per-sandbox network flow capture

### DIFF
--- a/internal/network/denied.go
+++ b/internal/network/denied.go
@@ -1,47 +1,14 @@
 package network
 
-import "net"
+import (
+	"net"
 
-// DeniedCIDRs are private/internal IP ranges that sandboxes must never reach.
-// These are always blocked regardless of user configuration.
-//
-// The IPv4 entries are loaded into the nftables predefined deny set inside
-// each sandbox namespace. The IPv6 entries are NOT loaded into nftables
-// (our sets are IPv4-only; all v6 egress is dropped wholesale by a separate
-// nfproto ipv6 drop rule) — they are kept here for the TCP egress proxy's
-// DNS rebinding check, which verifies that a domain does not resolve to a
-// link-local or loopback address before dialing upstream.
-var DeniedCIDRs = []string{
-	"10.0.0.0/8",
-	"127.0.0.0/8",
-	"169.254.0.0/16",
-	"172.16.0.0/12",
-	"192.168.0.0/16",
-	// IPv6 — used only by IsIPDenied (DNS rebinding check), not by nftables sets.
-	"::1/128",
-	"fc00::/7",
-	"fe80::/10",
-}
+	"github.com/superserve-ai/sandbox/internal/egresspolicy"
+)
 
-// parsedDeniedNets is the parsed form of DeniedCIDRs for quick IP lookups.
-var parsedDeniedNets []*net.IPNet
+// DeniedCIDRs and IsIPDenied are defined in egresspolicy so both proxies share
+// one source; re-exported here to keep the network package's callers unchanged.
+var DeniedCIDRs = egresspolicy.DeniedCIDRs
 
-func init() {
-	for _, cidr := range DeniedCIDRs {
-		_, ipNet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			panic("invalid denied CIDR: " + cidr)
-		}
-		parsedDeniedNets = append(parsedDeniedNets, ipNet)
-	}
-}
-
-// IsIPDenied checks if an IP falls within any of the always-denied ranges.
-func IsIPDenied(ip net.IP) bool {
-	for _, ipNet := range parsedDeniedNets {
-		if ipNet.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
+// IsIPDenied reports whether an IP falls within any always-denied range.
+func IsIPDenied(ip net.IP) bool { return egresspolicy.IsIPDenied(ip) }

--- a/internal/network/flowaudit.go
+++ b/internal/network/flowaudit.go
@@ -1,0 +1,277 @@
+package network
+
+import (
+	"context"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// FlowEvent is one egress connection observed by the proxy. team_id is resolved
+// by the writer from SandboxID, so the hot path never needs team context.
+type FlowEvent struct {
+	SandboxID  string // sandbox UUID (the proxy's host-IP → sandbox mapping)
+	Protocol   string // 'http' | 'tls' | 'other'
+	Host       string // SNI / Host header; empty for raw connections
+	DstIP      string
+	DstPort    int32
+	Verdict    string // 'allowed' | 'blocked' | 'failed'
+	MatchRule  string
+	BytesSent  int64
+	BytesRecv  int64
+	DurationMs int32
+}
+
+// FlowSink receives FlowEvents from the egress proxy.
+type FlowSink interface {
+	Emit(ev FlowEvent)
+	Shutdown(ctx context.Context) error
+}
+
+// nopFlowSink discards events. Used when no DB is configured so the proxy's
+// data path is identical to having no logging at all.
+type nopFlowSink struct{}
+
+// NewNopFlowSink returns a FlowSink that discards every event.
+func NewNopFlowSink() FlowSink { return nopFlowSink{} }
+
+func (nopFlowSink) Emit(FlowEvent)                 {}
+func (nopFlowSink) Shutdown(context.Context) error { return nil }
+
+// SQLFlowSink writes batched FlowEvents to net_flow. Drops on a full buffer
+// instead of back-pressuring the connection path.
+type SQLFlowSink struct {
+	queries *db.Queries
+
+	batchSize int
+	flushTick time.Duration
+
+	ch       chan FlowEvent
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+	stop     chan struct{}
+
+	dropMu  sync.Mutex
+	dropped int64
+
+	// resolveTeam looks up a sandbox's team; defaults to the DB query.
+	resolveTeam func(context.Context, uuid.UUID) (uuid.UUID, error)
+
+	// teams caches sandbox_id → team_id so each insert doesn't re-query.
+	teamMu sync.Mutex
+	teams  map[uuid.UUID]uuid.UUID
+}
+
+// SQLFlowSinkOptions tunes the sink. Zero values fall back to defaults
+// (BufferSize 8192, BatchSize 128, FlushInterval 500ms).
+type SQLFlowSinkOptions struct {
+	BufferSize    int
+	BatchSize     int
+	FlushInterval time.Duration
+}
+
+// NewSQLFlowSink starts the background writer.
+func NewSQLFlowSink(queries *db.Queries, opts SQLFlowSinkOptions) *SQLFlowSink {
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = 8192
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 128
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = 500 * time.Millisecond
+	}
+	s := &SQLFlowSink{
+		queries:   queries,
+		batchSize: opts.BatchSize,
+		flushTick: opts.FlushInterval,
+		ch:        make(chan FlowEvent, opts.BufferSize),
+		stop:      make(chan struct{}),
+		teams:     make(map[uuid.UUID]uuid.UUID),
+	}
+	if queries != nil {
+		s.resolveTeam = queries.GetSandboxTeamID
+	}
+	s.wg.Add(1)
+	go s.run()
+	return s
+}
+
+// Emit is non-blocking; drops on a full buffer (tracked by Dropped).
+func (s *SQLFlowSink) Emit(ev FlowEvent) {
+	select {
+	case s.ch <- ev:
+	default:
+		s.dropMu.Lock()
+		s.dropped++
+		s.dropMu.Unlock()
+	}
+}
+
+// Dropped returns the cumulative number of events dropped due to a full buffer.
+func (s *SQLFlowSink) Dropped() int64 {
+	s.dropMu.Lock()
+	defer s.dropMu.Unlock()
+	return s.dropped
+}
+
+// Shutdown stops the writer and drains the buffer, bounded by ctx.
+func (s *SQLFlowSink) Shutdown(ctx context.Context) error {
+	s.stopOnce.Do(func() { close(s.stop) })
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *SQLFlowSink) run() {
+	defer s.wg.Done()
+	batch := make([]FlowEvent, 0, s.batchSize)
+	ticker := time.NewTicker(s.flushTick)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		s.writeBatch(batch)
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case ev := <-s.ch:
+			batch = append(batch, ev)
+			if len(batch) >= s.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-s.stop:
+			for {
+				select {
+				case ev := <-s.ch:
+					batch = append(batch, ev)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+func (s *SQLFlowSink) writeBatch(batch []FlowEvent) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, ev := range batch {
+		params, ok := s.eventToParams(ctx, ev)
+		if !ok {
+			continue
+		}
+		if err := s.queries.InsertNetFlow(ctx, params); err != nil {
+			log.Warn().Err(err).Msg("network: InsertNetFlow failed")
+		}
+	}
+}
+
+// maxTeamCache bounds the sandbox→team map so it can't grow without limit
+// over the host's lifetime. At the cap, an arbitrary entry is evicted; a
+// re-lookup just re-populates it.
+const maxTeamCache = 4096
+
+// teamFor resolves and caches the team for a sandbox. Returns false when the
+// sandbox can't be resolved (e.g. already destroyed) — the event is dropped
+// rather than written without a team.
+func (s *SQLFlowSink) teamFor(ctx context.Context, sandboxID uuid.UUID) (uuid.UUID, bool) {
+	s.teamMu.Lock()
+	if t, ok := s.teams[sandboxID]; ok {
+		s.teamMu.Unlock()
+		return t, true
+	}
+	s.teamMu.Unlock()
+
+	if s.resolveTeam == nil {
+		return uuid.UUID{}, false
+	}
+	team, err := s.resolveTeam(ctx, sandboxID)
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	s.teamMu.Lock()
+	if len(s.teams) >= maxTeamCache {
+		for k := range s.teams {
+			delete(s.teams, k)
+			break
+		}
+	}
+	s.teams[sandboxID] = team
+	s.teamMu.Unlock()
+	return team, true
+}
+
+func (s *SQLFlowSink) eventToParams(ctx context.Context, ev FlowEvent) (db.InsertNetFlowParams, bool) {
+	sandboxID, err := uuid.Parse(ev.SandboxID)
+	if err != nil {
+		return db.InsertNetFlowParams{}, false
+	}
+	teamID, ok := s.teamFor(ctx, sandboxID)
+	if !ok {
+		return db.InsertNetFlowParams{}, false
+	}
+	return flowParams(ev, sandboxID, teamID)
+}
+
+// flowParams builds insert params from an event and its resolved ids.
+func flowParams(ev FlowEvent, sandboxID, teamID uuid.UUID) (db.InsertNetFlowParams, bool) {
+	dstIP, err := netip.ParseAddr(ev.DstIP)
+	if err != nil {
+		return db.InsertNetFlowParams{}, false
+	}
+	var host *string
+	if ev.Host != "" {
+		h := ev.Host
+		host = &h
+	}
+	var matchRule *string
+	if ev.MatchRule != "" {
+		m := ev.MatchRule
+		matchRule = &m
+	}
+	var bytesSent, bytesRecv *int64
+	if ev.BytesSent > 0 {
+		bytesSent = &ev.BytesSent
+	}
+	if ev.BytesRecv > 0 {
+		bytesRecv = &ev.BytesRecv
+	}
+	var durationMs *int32
+	if ev.DurationMs > 0 {
+		durationMs = &ev.DurationMs
+	}
+	return db.InsertNetFlowParams{
+		TeamID:     teamID,
+		SandboxID:  sandboxID,
+		Protocol:   ev.Protocol,
+		Host:       host,
+		DstIp:      dstIP,
+		DstPort:    ev.DstPort,
+		Verdict:    ev.Verdict,
+		MatchRule:  matchRule,
+		BytesSent:  bytesSent,
+		BytesRecv:  bytesRecv,
+		DurationMs: durationMs,
+	}, true
+}

--- a/internal/network/flowaudit_test.go
+++ b/internal/network/flowaudit_test.go
@@ -1,0 +1,199 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// tcpPair returns a connected pair of TCP loopback conns: the dialer side and
+// the accepted side. Real TCP (not net.Pipe) so relay's CloseWrite half-close
+// works and writes are buffered rather than synchronous.
+func tcpPair(t *testing.T) (dial, accept net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	type res struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- res{c, err}
+	}()
+	dial, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	r := <-ch
+	if r.err != nil {
+		t.Fatalf("accept: %v", r.err)
+	}
+	return dial, r.c
+}
+
+func TestRelayCountsBytesBothDirections(t *testing.T) {
+	sandboxClient, a := tcpPair(t) // a is relay's sandbox side
+	b, upstream := tcpPair(t)      // b is relay's upstream side
+
+	var up, down int64
+	done := make(chan struct{})
+	go func() {
+		up, down = relay(a, b)
+		close(done)
+	}()
+
+	// Upstream reads the request, replies, then closes (EOF to relay's b→a).
+	go func() {
+		buf := make([]byte, 5)
+		io.ReadFull(upstream, buf)
+		upstream.Write([]byte("world-reply"))
+		upstream.Close()
+	}()
+
+	// Sandbox sends 5 bytes, half-closes (EOF to relay's a→b), reads the reply.
+	sandboxClient.Write([]byte("hello"))
+	sandboxClient.(*net.TCPConn).CloseWrite()
+	io.ReadAll(sandboxClient)
+	sandboxClient.Close()
+
+	<-done
+	if up != 5 {
+		t.Errorf("bytes sandbox→upstream = %d, want 5", up)
+	}
+	if down != 11 {
+		t.Errorf("bytes upstream→sandbox = %d, want 11", down)
+	}
+}
+
+func TestFlowParams(t *testing.T) {
+	sb := uuid.New()
+	team := uuid.New()
+
+	t.Run("full event maps every field", func(t *testing.T) {
+		ev := FlowEvent{
+			Protocol: "tls", Host: "api.example.com", DstIP: "1.2.3.4",
+			DstPort: 443, Verdict: "allowed", MatchRule: "domain",
+			BytesSent: 100, BytesRecv: 200, DurationMs: 12,
+		}
+		p, ok := flowParams(ev, sb, team)
+		if !ok {
+			t.Fatal("flowParams returned !ok for valid event")
+		}
+		if p.TeamID != team || p.SandboxID != sb || p.Protocol != "tls" ||
+			p.DstPort != 443 || p.Verdict != "allowed" {
+			t.Errorf("scalar fields mismatch: %+v", p)
+		}
+		if p.Host == nil || *p.Host != "api.example.com" {
+			t.Errorf("host = %v, want api.example.com", p.Host)
+		}
+		if p.DstIp.String() != "1.2.3.4" {
+			t.Errorf("dst_ip = %s, want 1.2.3.4", p.DstIp)
+		}
+		if p.BytesSent == nil || *p.BytesSent != 100 || p.DurationMs == nil || *p.DurationMs != 12 {
+			t.Errorf("byte/duration pointers wrong: %+v", p)
+		}
+	})
+
+	t.Run("empty host and zero metrics become nil", func(t *testing.T) {
+		ev := FlowEvent{Protocol: "other", DstIP: "10.0.0.1", DstPort: 22, Verdict: "blocked"}
+		p, ok := flowParams(ev, sb, team)
+		if !ok {
+			t.Fatal("!ok for valid blocked event")
+		}
+		if p.Host != nil || p.MatchRule != nil || p.BytesSent != nil ||
+			p.BytesRecv != nil || p.DurationMs != nil {
+			t.Errorf("expected nil optionals, got %+v", p)
+		}
+	})
+
+	t.Run("bad dst ip rejected", func(t *testing.T) {
+		ev := FlowEvent{Protocol: "tls", DstIP: "not-an-ip", DstPort: 443, Verdict: "allowed"}
+		if _, ok := flowParams(ev, sb, team); ok {
+			t.Error("expected !ok for malformed dst ip")
+		}
+	})
+}
+
+func TestTeamCacheResolvesAndBounds(t *testing.T) {
+	var calls int64
+	known := uuid.New()
+	team := uuid.New()
+	s := &SQLFlowSink{
+		teams: make(map[uuid.UUID]uuid.UUID),
+		resolveTeam: func(_ context.Context, id uuid.UUID) (uuid.UUID, error) {
+			atomic.AddInt64(&calls, 1)
+			if id == known {
+				return team, nil
+			}
+			return uuid.UUID{}, errors.New("not found")
+		},
+	}
+
+	// First lookup hits the resolver; second is cached.
+	if got, ok := s.teamFor(context.Background(), known); !ok || got != team {
+		t.Fatalf("teamFor(known) = %v, %v", got, ok)
+	}
+	if _, ok := s.teamFor(context.Background(), known); !ok {
+		t.Fatal("second teamFor(known) should hit cache")
+	}
+	if n := atomic.LoadInt64(&calls); n != 1 {
+		t.Errorf("resolver called %d times, want 1 (second should be cached)", n)
+	}
+
+	// Unresolvable sandbox is dropped (not cached).
+	if _, ok := s.teamFor(context.Background(), uuid.New()); ok {
+		t.Error("teamFor for unknown sandbox should return !ok")
+	}
+
+	// Cache stays bounded at maxTeamCache.
+	s.resolveTeam = func(_ context.Context, id uuid.UUID) (uuid.UUID, error) {
+		return uuid.New(), nil
+	}
+	for i := 0; i < maxTeamCache*2; i++ {
+		s.teamFor(context.Background(), uuid.New())
+	}
+	s.teamMu.Lock()
+	n := len(s.teams)
+	s.teamMu.Unlock()
+	if n > maxTeamCache {
+		t.Errorf("team cache size = %d, exceeds bound %d", n, maxTeamCache)
+	}
+}
+
+func TestNopFlowSink(t *testing.T) {
+	sink := NewNopFlowSink()
+	// Must not panic or block.
+	sink.Emit(FlowEvent{SandboxID: "x"})
+	if err := sink.Shutdown(context.Background()); err != nil {
+		t.Errorf("nop Shutdown returned %v", err)
+	}
+}
+
+func TestSQLFlowSinkEmitNonBlockingDrops(t *testing.T) {
+	// A sink whose buffer is full must drop rather than block the caller.
+	s := &SQLFlowSink{ch: make(chan FlowEvent, 1)}
+	s.ch <- FlowEvent{} // fill the single slot
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.Emit(FlowEvent{}) // would block if Emit weren't non-blocking
+	}()
+	wg.Wait() // returns only because Emit dropped instead of blocking
+
+	if s.Dropped() != 1 {
+		t.Errorf("Dropped = %d, want 1", s.Dropped())
+	}
+}

--- a/internal/network/hostfw.go
+++ b/internal/network/hostfw.go
@@ -34,9 +34,10 @@ const dnsRedirectChain = "SANDBOX_DNS_REDIRECT"
 // through the host: UDP/443 DROP (kills QUIC bypass of the SNI allowlist),
 // operator-configured egress port DROPs, MSS clamp, FORWARD ACCEPT between
 // veth+ and the host iface, MASQUERADE for vmIPRange to the host iface,
-// REDIRECT HTTP/HTTPS from veth+ to the egress proxy, and an optional
-// REDIRECT of all guest DNS to an operator-run resolver. All operations are
-// idempotent.
+// REDIRECT HTTP/HTTPS from veth+ to the egress proxy, an optional REDIRECT
+// of all guest DNS to an operator-run resolver, and (when secretsProxyPort > 0)
+// REDIRECT secretsProxyDst:secretsProxyPort to the local secretsproxy daemon.
+// All operations are idempotent.
 //
 // blockedPorts come from the operator blocklist config — only ports 80/443
 // are redirected through the egress proxy, so anything else a VM dials goes
@@ -51,7 +52,7 @@ const dnsRedirectChain = "SANDBOX_DNS_REDIRECT"
 // (SANDBOX_EGRESS_PORTS, SANDBOX_DNS_REDIRECT): only the vmd daemon
 // reconciles them. Auxiliary managers pass false so a concurrent template
 // build does not flush the daemon's rules.
-func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort, dnsRedirectPort uint16, blockedPorts []uint16, manageOwnedChains bool, log zerolog.Logger) error {
+func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort, dnsRedirectPort uint16, secretsProxyDst string, secretsProxyPort uint16, blockedPorts []uint16, manageOwnedChains bool, log zerolog.Logger) error {
 	_, ipnet, err := net.ParseCIDR(vmIPRange)
 	if err != nil {
 		return fmt.Errorf("vmIPRange %s invalid: %w", vmIPRange, err)
@@ -168,13 +169,26 @@ func installHostFirewall(hostIface string, httpProxyPort, tlsProxyPort, dnsRedir
 		rules = append(rules, rule{"nat", "PREROUTING",
 			[]string{"-i", "veth+", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", tlsProxyPort)}})
 	}
+	if secretsProxyPort > 0 {
+		if ip := net.ParseIP(secretsProxyDst); ip == nil || ip.To4() == nil {
+			return fmt.Errorf("invalid secretsProxyDst %q (must be IPv4)", secretsProxyDst)
+		}
+		// -d narrows the match so we don't intercept unrelated dport-9443 traffic.
+		rules = append(rules, rule{"nat", "PREROUTING",
+			[]string{"-i", "veth+", "-p", "tcp", "-d", secretsProxyDst, "--dport", fmt.Sprintf("%d", secretsProxyPort),
+				"-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", secretsProxyPort)}})
+	}
 	for _, r := range rules {
 		if err := ipt.AppendUnique(r.table, r.chain, r.args...); err != nil {
 			return fmt.Errorf("add %s/%s rule: %w", r.table, r.chain, err)
 		}
 	}
 
-	log.Info().Str("host_iface", hostIface).Msg("host firewall ready (static prefix rules)")
+	log.Info().
+		Str("host_iface", hostIface).
+		Str("secrets_proxy_dst", secretsProxyDst).
+		Uint16("secrets_proxy_port", secretsProxyPort).
+		Msg("host firewall ready (static prefix rules)")
 	return nil
 }
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -54,11 +54,11 @@ type Config struct {
 
 // VMNetInfo holds the network resources for a single VM.
 type VMNetInfo struct {
-	Namespace  string    // Network namespace name.
-	TAPDevice  string    // TAP device inside namespace (always "tap0").
-	VMIP       string    // VM's internal IP (always VMInternalIP).
-	GatewayIP  string    // Gateway inside namespace (always VMGatewayIP).
-	HostIP     string    // Host-side IP to reach this VM.
+	Namespace  string // Network namespace name.
+	TAPDevice  string // TAP device inside namespace (always "tap0").
+	VMIP       string // VM's internal IP (always VMInternalIP).
+	GatewayIP  string // Gateway inside namespace (always VMGatewayIP).
+	HostIP     string // Host-side IP to reach this VM.
 	MACAddress string
 	Firewall   *Firewall // nftables firewall for this VM (inside namespace).
 }
@@ -95,6 +95,10 @@ type Manager struct {
 	tlsProxyPort   uint16
 	otherProxyPort uint16
 
+	// Sandbox-facing address for the secretsproxy daemon. Zero port disables the REDIRECT.
+	secretsProxyDst  string
+	secretsProxyPort uint16
+
 	// blockedEgressPorts are dropped in the host FORWARD chain for all
 	// sandbox traffic. Sourced from the operator blocklist config.
 	blockedEgressPorts []uint16
@@ -109,6 +113,14 @@ type Manager struct {
 	// auxiliary managers (template-builder) must not flush the chain or
 	// they would wipe the daemon's port drops on every build.
 	ownsEgressPortChain bool
+}
+
+// registerEgress attributes a VM's flows so logging covers every sandbox,
+// not only those with explicit egress rules.
+func (m *Manager) registerEgress(vmID string, info *VMNetInfo) {
+	if m.egressProxy != nil && info != nil {
+		m.egressProxy.RegisterSandbox(info.HostIP, vmID)
+	}
 }
 
 // SetEgressProxy attaches the TCP egress proxy so the manager can remove
@@ -132,6 +144,15 @@ func WithStartSlot(idx int) ManagerOption {
 // egress domain filtering).
 func WithHTTPProxyPort(port uint16) ManagerOption {
 	return func(m *Manager) { m.httpProxyPort = port }
+}
+
+// WithSecretsProxyAddr sets the sandbox-facing address for the secretsproxy
+// daemon. Port 0 disables the REDIRECT.
+func WithSecretsProxyAddr(host string, port uint16) ManagerOption {
+	return func(m *Manager) {
+		m.secretsProxyDst = host
+		m.secretsProxyPort = port
+	}
 }
 
 // WithBlockedEgressPorts sets destination ports dropped in the host FORWARD
@@ -177,7 +198,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		opt(mgr)
 	}
 
-	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
+	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.secretsProxyDst, mgr.secretsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
 
@@ -218,6 +239,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 	// Try the pre-allocated pool first; fall back to on-demand setup.
 	if m.pool != nil {
 		if info := m.pool.Claim(vmID); info != nil {
+			m.registerEgress(vmID, info)
 			return info, nil
 		}
 		m.log.Info().Str("vm_id", vmID).Msg("network pool empty, falling back to on-demand setup")
@@ -237,6 +259,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 	m.mu.Lock()
 	m.devices[vmID] = info
 	m.mu.Unlock()
+	m.registerEgress(vmID, info)
 
 	m.log.Info().
 		Str("vm_id", vmID).
@@ -340,11 +363,11 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	if err := nsExecGo(nsName, func() error {
 		var fwErr error
 		fw, fwErr = NewFirewall(FirewallConfig{
-			TAPInterface:   TAPName,
-			VethPeer:       vpeerName,
-			VMIP:           VMInternalIP,
-			HostIP:         hostIP,
-			GatewayIP:      VMGatewayIP,
+			TAPInterface: TAPName,
+			VethPeer:     vpeerName,
+			VMIP:         VMInternalIP,
+			HostIP:       hostIP,
+			GatewayIP:    VMGatewayIP,
 		})
 		return fwErr
 	}); err != nil {
@@ -477,7 +500,7 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
 	}
-	m.devices[vmID] = &VMNetInfo{
+	info := &VMNetInfo{
 		Namespace:  namespace,
 		TAPDevice:  TAPName,
 		VMIP:       VMInternalIP,
@@ -486,7 +509,9 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		MACAddress: macAddress,
 		Firewall:   fw, // nil if AttachFirewall failed; CleanupVM tolerates it
 	}
+	m.devices[vmID] = info
 	m.mu.Unlock()
+	m.registerEgress(vmID, info)
 
 	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
 	return nil
@@ -551,6 +576,7 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	}
 	m.devices[vmID] = info
 	m.mu.Unlock()
+	m.registerEgress(vmID, info)
 
 	return info, nil
 }

--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -15,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
 
+	"github.com/superserve-ai/sandbox/internal/egresspolicy"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
@@ -40,6 +42,12 @@ type EgressProxy struct {
 	// maxConnsPerSandbox is the per-sandbox connection limit. -1 = unlimited.
 	maxConnsPerSandbox int
 
+	// flowSink records one event per connection. Never nil — defaults to a nop
+	// sink so the data path is unaffected when logging is not configured.
+	// Guarded by sinkMu so it can be installed after Start.
+	sinkMu   sync.RWMutex
+	flowSink FlowSink
+
 	// blocklist is the global egress denylist (nil = disabled). Checked
 	// before per-sandbox rules; a blocklist hit cannot be overridden by a
 	// sandbox's own allow rules.
@@ -55,6 +63,8 @@ type EgressRules struct {
 	AllowedCIDRs   []string
 	DeniedCIDRs    []string
 	AllowedDomains []string
+	// SandboxID attributes flow-log rows. Empty disables logging for the sandbox.
+	SandboxID string
 }
 
 func NewEgressProxy(httpPort, tlsPort, otherPort uint16, maxConns int, log zerolog.Logger) *EgressProxy {
@@ -65,7 +75,39 @@ func NewEgressProxy(httpPort, tlsPort, otherPort uint16, maxConns int, log zerol
 		log:                log.With().Str("component", "egress-proxy").Logger(),
 		limiter:            NewConnectionLimiter(),
 		maxConnsPerSandbox: maxConns,
+		flowSink:           NewNopFlowSink(),
 		rules:              make(map[string]*EgressRules),
+	}
+}
+
+// SetFlowSink installs the connection-flow logging sink. Safe to call after Start.
+func (p *EgressProxy) SetFlowSink(sink FlowSink) {
+	if sink == nil {
+		return
+	}
+	p.sinkMu.Lock()
+	p.flowSink = sink
+	p.sinkMu.Unlock()
+}
+
+func (p *EgressProxy) getFlowSink() FlowSink {
+	p.sinkMu.RLock()
+	defer p.sinkMu.RUnlock()
+	return p.flowSink
+}
+
+// RegisterSandbox associates a sandbox ID with a host IP for flow attribution,
+// preserving any allow/deny rules already set for that IP. Idempotent.
+func (p *EgressProxy) RegisterSandbox(hostIP, sandboxID string) {
+	if hostIP == "" || sandboxID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if r, ok := p.rules[hostIP]; ok {
+		r.SandboxID = sandboxID
+	} else {
+		p.rules[hostIP] = &EgressRules{SandboxID: sandboxID}
 	}
 }
 
@@ -155,24 +197,24 @@ func (p *EgressProxy) listen(ctx context.Context, port uint16, handler func(cont
 
 // handleHTTP handles port 80 traffic — reads the HTTP Host header for domain filtering.
 func (p *EgressProxy) handleHTTP(ctx context.Context, conn net.Conn) {
-	p.handleConn(ctx, conn, func(peeked []byte) string {
+	p.handleConn(ctx, conn, "http", func(peeked []byte) string {
 		return extractHTTPHost(peeked)
 	})
 }
 
 // handleTLS handles port 443 traffic — reads the TLS ClientHello SNI for domain filtering.
 func (p *EgressProxy) handleTLS(ctx context.Context, conn net.Conn) {
-	p.handleConn(ctx, conn, func(peeked []byte) string {
+	p.handleConn(ctx, conn, "tls", func(peeked []byte) string {
 		return extractSNI(peeked)
 	})
 }
 
 // handleOther handles all other TCP traffic — CIDR-only, no protocol inspection.
 func (p *EgressProxy) handleOther(ctx context.Context, conn net.Conn) {
-	p.handleConn(ctx, conn, nil)
+	p.handleConn(ctx, conn, "other", nil)
 }
 
-func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHostname func([]byte) string) {
+func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol string, extractHostname func([]byte) string) {
 	defer conn.Close()
 
 	// Get original destination before REDIRECT.
@@ -229,6 +271,21 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 		peekedData = buf
 	}
 
+	// Identify the sandbox up front so every block path (global blocklist,
+	// per-sandbox rule, dial-time) can attribute a flow-log row.
+	rules := p.getRules(srcHost)
+	var sandboxID string
+	if rules != nil {
+		sandboxID = rules.SandboxID
+	}
+	flow := FlowEvent{
+		SandboxID: sandboxID,
+		Protocol:  protocol,
+		Host:      hostname,
+		DstIP:     dstIP.String(),
+		DstPort:   int32(dstPort),
+	}
+
 	// Global blocklist first — a hit here cannot be overridden by the
 	// sandbox's own allow rules.
 	if p.blocklist != nil {
@@ -239,13 +296,19 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 				Str("hostname", hostname).
 				Str("match", dim).
 				Msg("egress blocked by global blocklist")
+			if sandboxID != "" {
+				flow.Verdict = "blocked"
+				flow.MatchRule = "blocklist"
+				p.getFlowSink().Emit(flow)
+			}
 			return
 		}
 	}
 
 	// Check egress rules.
-	rules := p.getRules(srcHost)
 	allowed, matchType := p.isAllowed(rules, hostname, dstIP)
+	flow.MatchRule = matchType
+
 	if !allowed {
 		p.log.Info().
 			Str("src", srcHost).
@@ -253,6 +316,10 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 			Str("hostname", hostname).
 			Str("match", matchType).
 			Msg("egress blocked")
+		if sandboxID != "" {
+			flow.Verdict = "blocked"
+			p.getFlowSink().Emit(flow)
+		}
 		return
 	}
 
@@ -265,7 +332,11 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 		upstreamAddr = net.JoinHostPort(dstIP.String(), fmt.Sprintf("%d", dstPort))
 	}
 
-	// Dial upstream with DNS rebinding protection.
+	// Dial upstream with DNS rebinding protection. The flags distinguish a
+	// policy block (internal-IP guard or blocklist, caught once the hostname
+	// resolves) from a plain dial failure, for logging. Atomic because Control
+	// may run on parallel dial goroutines for dual-stack hosts.
+	var ipDenied, dialBlocklisted atomic.Bool
 	dialer := &net.Dialer{
 		Timeout: upstreamDialTimeout,
 		Control: func(network, address string, c syscall.RawConn) error {
@@ -275,10 +346,12 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 			}
 			resolved := net.ParseIP(host)
 			if resolved != nil && IsIPDenied(resolved) {
+				ipDenied.Store(true)
 				return fmt.Errorf("blocked: hostname resolved to internal IP %s", resolved)
 			}
 			if resolved != nil && p.blocklist != nil {
 				if blocked, _ := p.blocklist.Blocked("", resolved); blocked {
+					dialBlocklisted.Store(true)
 					return fmt.Errorf("blocked: hostname resolved to blocklisted IP %s", resolved)
 				}
 			}
@@ -289,19 +362,47 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, extractHost
 	upstream, err := dialer.DialContext(ctx, "tcp", upstreamAddr)
 	if err != nil {
 		p.log.Debug().Err(err).Str("upstream", upstreamAddr).Msg("dial failed")
+		if sandboxID != "" {
+			// A resolved-IP rejection is a policy block; anything else failed
+			// to connect.
+			switch {
+			case dialBlocklisted.Load():
+				flow.Verdict = "blocked"
+				flow.MatchRule = "blocklist"
+			case ipDenied.Load():
+				flow.Verdict = "blocked"
+				flow.MatchRule = "internal-ip"
+			default:
+				flow.Verdict = "failed"
+			}
+			p.getFlowSink().Emit(flow)
+		}
 		return
 	}
 	defer upstream.Close()
 
 	// If we peeked data, write it to upstream first.
+	sent := int64(len(peekedData))
 	if len(peekedData) > 0 {
 		if _, err := upstream.Write(peekedData); err != nil {
+			if sandboxID != "" {
+				flow.Verdict = "failed"
+				p.getFlowSink().Emit(flow)
+			}
 			return
 		}
 	}
 
 	// Bidirectional proxy.
-	relay(conn, upstream)
+	start := time.Now()
+	up, down := relay(conn, upstream)
+	if sandboxID != "" {
+		flow.Verdict = "allowed"
+		flow.BytesSent = sent + up
+		flow.BytesRecv = down
+		flow.DurationMs = int32(time.Since(start).Milliseconds())
+		p.getFlowSink().Emit(flow)
+	}
 }
 
 // isAllowed uses an "allow wins" model: a match in allow_out short-circuits
@@ -354,39 +455,26 @@ func (p *EgressProxy) isAllowed(rules *EgressRules, hostname string, dstIP net.I
 // A bare "*" is NOT supported — it's too easy to misuse and would silently
 // bypass all deny rules. Use explicit CIDR allow rules for "match all".
 func matchDomain(hostname, pattern string) bool {
-	if pattern == "" {
-		return false
-	}
-	if pattern == "*" {
-		return false // bare wildcard is intentionally rejected
-	}
-	if strings.EqualFold(pattern, hostname) {
-		return true
-	}
-	if strings.HasPrefix(pattern, "*.") {
-		suffix := pattern[1:]
-		if strings.HasSuffix(strings.ToLower(hostname), strings.ToLower(suffix)) {
-			return true
-		}
-	}
-	return false
+	return egresspolicy.MatchHost(hostname, pattern)
 }
 
-// relay copies data bidirectionally between two connections.
-func relay(a, b net.Conn) {
+// relay proxies bytes in both directions and returns the totals: aToB is bytes
+// sent from the sandbox (a) to the upstream (b), bToA the reverse.
+func relay(a, b net.Conn) (aToB, bToA int64) {
 	done := make(chan struct{})
 	go func() {
-		io.Copy(b, a)
+		aToB, _ = io.Copy(b, a)
 		if tc, ok := b.(*net.TCPConn); ok {
 			tc.CloseWrite()
 		}
 		close(done)
 	}()
-	io.Copy(a, b)
+	bToA, _ = io.Copy(a, b)
 	if tc, ok := a.(*net.TCPConn); ok {
 		tc.CloseWrite()
 	}
 	<-done
+	return aToB, bToA
 }
 
 // ---------------------------------------------------------------------------
@@ -444,12 +532,12 @@ func (r *sniReader) Read(b []byte) (int, error) {
 }
 
 func (r *sniReader) Write(b []byte) (int, error)        { return len(b), nil }
-func (r *sniReader) Close() error                        { return nil }
-func (r *sniReader) LocalAddr() net.Addr                 { return &net.TCPAddr{} }
-func (r *sniReader) RemoteAddr() net.Addr                { return &net.TCPAddr{} }
-func (r *sniReader) SetDeadline(t time.Time) error       { return nil }
-func (r *sniReader) SetReadDeadline(t time.Time) error   { return nil }
-func (r *sniReader) SetWriteDeadline(t time.Time) error  { return nil }
+func (r *sniReader) Close() error                       { return nil }
+func (r *sniReader) LocalAddr() net.Addr                { return &net.TCPAddr{} }
+func (r *sniReader) RemoteAddr() net.Addr               { return &net.TCPAddr{} }
+func (r *sniReader) SetDeadline(t time.Time) error      { return nil }
+func (r *sniReader) SetReadDeadline(t time.Time) error  { return nil }
+func (r *sniReader) SetWriteDeadline(t time.Time) error { return nil }
 
 // ---------------------------------------------------------------------------
 // SO_ORIGINAL_DST — retrieve original destination before REDIRECT

--- a/internal/network/proxy_test.go
+++ b/internal/network/proxy_test.go
@@ -265,7 +265,7 @@ func TestMatchDomain(t *testing.T) {
 		{"API.OPENAI.COM", "api.openai.com", true},
 		{"api.openai.com", "API.OPENAI.COM", true},
 		{"api.openai.com", "*.openai.com", true},
-		{"deep.api.openai.com", "*.openai.com", true},
+		{"deep.api.openai.com", "*.openai.com", true}, // egress wildcard matches any depth
 		{"openai.com", "*.openai.com", false},
 		{"api.openai.com", "*.example.com", false},
 		{"anything.com", "*", false},


### PR DESCRIPTION
**Stack 5 of 6.** Base: `amit/secrets-4-controlplane-api`.

net_flow capture in the egress proxy: connection-level allow/blocked/failed logging feeding the unified network-log endpoint from [4/6].

Review/merge after [4/6].