### PR TITLE
secrets [6/6]: wire enforcement and flow capture into vmd

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -33,6 +33,7 @@ on:
       - 'internal/db/**'
       - 'internal/hostreg/**'
       - 'internal/scheduler/**'
+      - 'internal/secrets/**'
       - 'internal/supervisor/**'
       - 'internal/vmdclient/**'
       - 'proto/**'

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -22,11 +22,14 @@ on:
       - 'cmd/vmd/**'
       - 'cmd/boxd/**'
       - 'cmd/template-builder/**'
+      - 'cmd/secretsproxy/**'
       - 'internal/vm/**'
       - 'internal/network/**'
       - 'internal/builder/**'
       - 'internal/db/**'
+      - 'internal/secretsproxy/**'
       - 'deploy/superserve-vmd.service'
+      - 'deploy/superserve-secretsproxy.service'
       - 'deploy/firecracker@.service'
       - 'deploy/firecracker-netns@.service'
       - 'deploy/sandboxes.slice'
@@ -50,15 +53,14 @@ jobs:
           cache: true
 
       - name: Build binaries
-        # Always build all three. Hash-compare on the host decides whether
-        # to install boxd + rebuild the rootfs, so a no-op is cheap at rest.
-        # The previous HEAD~1..HEAD diff check missed boxd changes that
-        # landed in any commit other than the last one on a push.
+        # Always build all four. Hash-compare on the host decides whether
+        # to install boxd / secretsproxy, so a no-op is cheap at rest.
         run: |
           mkdir -p bin
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/vmd ./cmd/vmd
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/boxd ./cmd/boxd
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/template-builder ./cmd/template-builder
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/secretsproxy ./cmd/secretsproxy
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -98,12 +100,13 @@ jobs:
           cache: true
 
       - name: Build binaries
-        # Always build all three; hash-compare on the host decides install.
+        # Always build all four; hash-compare on the host decides install.
         run: |
           mkdir -p bin
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/vmd ./cmd/vmd
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/boxd ./cmd/boxd
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/template-builder ./cmd/template-builder
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -trimpath -o bin/secretsproxy ./cmd/secretsproxy
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -52,7 +52,9 @@ BUNDLE_FILES = [
     "bin/vmd",
     "bin/boxd",
     "bin/template-builder",
+    "bin/secretsproxy",
     "deploy/superserve-vmd.service",
+    "deploy/superserve-secretsproxy.service",
     "deploy/firecracker@.service",
     "deploy/firecracker-netns@.service",
     "deploy/sandboxes.slice",
@@ -181,6 +183,19 @@ def main() -> int:
                 echo "boxd unchanged ($CUR_HASH) — skipping install + rootfs rebuild"
             fi
 
+            # secretsproxy daemon: hash-compare for idempotent install.
+            NEW_SP_HASH=$(sha256sum {extract_dir}/bin/secretsproxy | awk '{{print $1}}')
+            CUR_SP_HASH=$(sha256sum {install_dir}/secretsproxy 2>/dev/null | awk '{{print $1}}' || echo none)
+            if [ "$NEW_SP_HASH" != "$CUR_SP_HASH" ]; then
+                echo "secretsproxy changed ($CUR_SP_HASH -> $NEW_SP_HASH) — installing"
+                sudo install -m 0755 {extract_dir}/bin/secretsproxy {install_dir}/secretsproxy
+            else
+                echo "secretsproxy unchanged ($CUR_SP_HASH) — skipping binary install"
+            fi
+            sudo install -m 0644 {extract_dir}/deploy/superserve-secretsproxy.service /etc/systemd/system/superserve-secretsproxy.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --quiet superserve-secretsproxy.service
+
             sudo rm -rf {extract_dir}
             rm -f {bundle_remote}
 
@@ -191,6 +206,16 @@ def main() -> int:
                 echo 'SENTRY_DSN={sentry_dsn}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
+            # Upsert SECRETSPROXY_SOCKET on both env files. The daemon writes
+            # its control socket into RuntimeDirectory=/run/secretsproxy under
+            # DynamicUser; vmd connects to the same path.
+            for env_file in /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env; do
+                if [ -f "$env_file" ]; then
+                    sudo sed -i '/^SECRETSPROXY_SOCKET=/d' "$env_file"
+                    echo 'SECRETSPROXY_SOCKET=/run/secretsproxy/control.sock' | sudo tee -a "$env_file" > /dev/null
+                fi
+            done
+
             sudo systemctl restart {service}
             sleep 3
             sudo systemctl is-active --quiet {service} || (
@@ -199,6 +224,21 @@ def main() -> int:
                 sudo journalctl -u {service} --no-pager -n 40 >&2 || true
                 exit 1
             )
+
+            # Restart secretsproxy; tolerate missing env file on hosts not
+            # yet provisioned (is-active check below is gated on the file).
+            sudo systemctl restart superserve-secretsproxy.service || true
+            if [ -f /etc/sandbox/secretsproxy.env ]; then
+                sleep 2
+                sudo systemctl is-active --quiet superserve-secretsproxy.service || (
+                    echo "ERROR: superserve-secretsproxy failed to become active after restart" >&2
+                    sudo systemctl status --no-pager superserve-secretsproxy.service >&2 || true
+                    sudo journalctl -u superserve-secretsproxy.service --no-pager -n 40 >&2 || true
+                    exit 1
+                )
+            else
+                echo "/etc/sandbox/secretsproxy.env not present; daemon not started (provision env file to enable)"
+            fi
         """)
 
         r = subprocess.run(

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -195,6 +195,7 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 	b, err := builder.NewBuilder(builder.Config{
 		BoxdBinaryPath:           cfg.boxdBin,
 		MaxUncompressedSizeBytes: int64(cfg.diskMiB) * 1024 * 1024,
+		ProxyCACertPath:          os.Getenv("SECRETSPROXY_CA_CERT"),
 	})
 	if err != nil {
 		return fmt.Errorf("create builder: %w", err)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -53,6 +53,18 @@ type Config struct {
 	// the heartbeat goroutine to POST liveness. Optional — if unset,
 	// heartbeat is disabled.
 	ControlPlaneURL string
+
+	// SecretsProxySocket is the local secretsproxy daemon's control-RPC unix-socket path.
+	// When empty, broker registration is skipped.
+	SecretsProxySocket string
+
+	// SecretsProxySandboxAddr is the host:port the sandbox writes into HTTPS_PROXY
+	// to reach the local secretsproxy daemon. When empty, no proxy env var is injected.
+	SecretsProxySandboxAddr string
+
+	// Parsed form of SecretsProxySandboxAddr; wires the host firewall REDIRECT.
+	SecretsProxySandboxDst  string
+	SecretsProxySandboxPort uint16
 }
 
 func loadConfig() (Config, error) {
@@ -62,19 +74,21 @@ func loadConfig() (Config, error) {
 	}
 
 	cfg := Config{
-		FirecrackerBin: envOrDefault("FIRECRACKER_BIN", "/usr/local/bin/firecracker"),
-		JailerBin:      envOrDefault("JAILER_BIN", "/usr/bin/jailer"),
-		KernelPath:     requireEnv("KERNEL_PATH"),
-		BaseRootfsPath: requireEnv("BASE_ROOTFS_PATH"),
-		SnapshotDir:    envOrDefault("SNAPSHOT_DIR", "/var/lib/sandbox/snapshots"),
-		RunDir:         envOrDefault("RUN_DIR", "/var/lib/sandbox/rundir"),
-		GRPCPort:       port,
-		HostInterface:      envOrDefault("HOST_INTERFACE", "eth0"),
-		TemplateBuilderBin: envOrDefault("TEMPLATE_BUILDER_BIN", "/usr/local/bin/template-builder"),
-		BoxdBinaryPath:     envOrDefault("BOXD_BINARY_PATH", "/usr/local/bin/boxd"),
-		HostID:          envOrDefault("HOST_ID", "default"),
-		DatabaseURL:     os.Getenv("DATABASE_URL"),
-		ControlPlaneURL: os.Getenv("CONTROL_PLANE_URL"),
+		FirecrackerBin:          envOrDefault("FIRECRACKER_BIN", "/usr/local/bin/firecracker"),
+		JailerBin:               envOrDefault("JAILER_BIN", "/usr/bin/jailer"),
+		KernelPath:              requireEnv("KERNEL_PATH"),
+		BaseRootfsPath:          requireEnv("BASE_ROOTFS_PATH"),
+		SnapshotDir:             envOrDefault("SNAPSHOT_DIR", "/var/lib/sandbox/snapshots"),
+		RunDir:                  envOrDefault("RUN_DIR", "/var/lib/sandbox/rundir"),
+		GRPCPort:                port,
+		HostInterface:           envOrDefault("HOST_INTERFACE", "eth0"),
+		TemplateBuilderBin:      envOrDefault("TEMPLATE_BUILDER_BIN", "/usr/local/bin/template-builder"),
+		BoxdBinaryPath:          envOrDefault("BOXD_BINARY_PATH", "/usr/local/bin/boxd"),
+		HostID:                  envOrDefault("HOST_ID", "default"),
+		DatabaseURL:             os.Getenv("DATABASE_URL"),
+		ControlPlaneURL:         os.Getenv("CONTROL_PLANE_URL"),
+		SecretsProxySocket:      os.Getenv("SECRETSPROXY_SOCKET"),
+		SecretsProxySandboxAddr: os.Getenv("SECRETSPROXY_SANDBOX_ADDR"),
 	}
 
 	if cfg.KernelPath == "" {
@@ -84,7 +98,33 @@ func loadConfig() (Config, error) {
 		return Config{}, fmt.Errorf("BASE_ROOTFS_PATH environment variable is required")
 	}
 
+	if cfg.SecretsProxySandboxAddr != "" {
+		host, port, err := parseSecretsProxyAddr(cfg.SecretsProxySandboxAddr)
+		if err != nil {
+			return Config{}, fmt.Errorf("SECRETSPROXY_SANDBOX_ADDR %q: %w", cfg.SecretsProxySandboxAddr, err)
+		}
+		cfg.SecretsProxySandboxDst = host
+		cfg.SecretsProxySandboxPort = port
+	}
+
 	return cfg, nil
+}
+
+// parseSecretsProxyAddr parses host:port; host must be an IPv4 literal because
+// the nat REDIRECT rule it feeds can't resolve DNS.
+func parseSecretsProxyAddr(addr string) (string, uint16, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+	if ip := net.ParseIP(host); ip == nil || ip.To4() == nil {
+		return "", 0, fmt.Errorf("host %q must be an IPv4 literal", host)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil || port == 0 {
+		return "", 0, fmt.Errorf("port %q must be 1-65535", portStr)
+	}
+	return host, uint16(port), nil
 }
 
 func envOrDefault(key, fallback string) string {
@@ -292,6 +332,8 @@ func main() {
 	}
 
 	// ---- Network manager + host firewall ----
+	netMgrOpts = append(netMgrOpts,
+		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
@@ -403,6 +445,15 @@ func main() {
 			return nil
 		})
 		log.Info().Msg("reconciler DB connection ready")
+
+		// Per-connection egress logging. Drops on a full buffer rather than
+		// back-pressuring the proxy's data path.
+		flowSink := network.NewSQLFlowSink(reconcilerDB, network.SQLFlowSinkOptions{})
+		egressProxy.SetFlowSink(flowSink)
+		lc.addCloser("net_flow sink", func(closeCtx context.Context) error {
+			return flowSink.Shutdown(closeCtx)
+		})
+		log.Info().Msg("egress flow logging enabled")
 	} else {
 		log.Warn().Msg("DATABASE_URL unset — reconciler will run in BoltDB↔systemd-only mode")
 	}
@@ -459,7 +510,15 @@ func main() {
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(64 << 20), // 64 MiB
 	)
-	vmdpb.RegisterVMDaemonServer(grpcServer, vm.NewGRPCAdapter(mgr))
+	adapter := vm.NewGRPCAdapter(mgr).
+		WithSecretsBroker(cfg.SecretsProxySocket, cfg.SecretsProxySandboxAddr)
+	vmdpb.RegisterVMDaemonServer(grpcServer, adapter)
+	if cfg.SecretsProxySocket != "" {
+		log.Info().
+			Str("socket", cfg.SecretsProxySocket).
+			Str("sandbox_addr", cfg.SecretsProxySandboxAddr).
+			Msg("secretsproxy daemon integration enabled")
+	}
 	lc.start("grpc server", func() error {
 		log.Info().Int("port", cfg.GRPCPort).Msg("gRPC server listening")
 		if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func TestParseSecretsProxyAddr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		input    string
+		wantHost string
+		wantPort uint16
+		wantErr  bool
+	}{
+		{name: "valid ipv4 + port", input: "192.0.2.1:9443", wantHost: "192.0.2.1", wantPort: 9443},
+		{name: "missing port", input: "192.0.2.1", wantErr: true},
+		{name: "hostname rejected", input: "proxy.local:9443", wantErr: true},
+		{name: "ipv6 rejected", input: "[::1]:9443", wantErr: true},
+		{name: "port zero rejected", input: "192.0.2.1:0", wantErr: true},
+		{name: "port too large", input: "192.0.2.1:70000", wantErr: true},
+		{name: "non-numeric port", input: "192.0.2.1:abc", wantErr: true},
+		{name: "empty host", input: ":9443", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, err := parseSecretsProxyAddr(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got host=%q port=%d", host, port)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if host != tc.wantHost || port != tc.wantPort {
+				t.Fatalf("got (%q, %d), want (%q, %d)", host, port, tc.wantHost, tc.wantPort)
+			}
+		})
+	}
+}

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -88,6 +88,10 @@ func (b *inProcessBuilder) BuildRootfs(ctx context.Context, spec BuildSpec, dest
 	}
 	logger.Info().Int64("boxd_bytes", boxdBytes).Msg("boxd injected")
 
+	if err := injectProxyCA(scratch, b.cfg.ProxyCACertPath, &logger); err != nil {
+		return BuildRootfsResult{}, fmt.Errorf("inject proxy CA: %w", err)
+	}
+
 	if err := makeExt4(ctx, scratch, destPath, sizeMiB); err != nil {
 		return BuildRootfsResult{}, fmt.Errorf("make ext4: %w", err)
 	}

--- a/internal/builder/inject.go
+++ b/internal/builder/inject.go
@@ -154,6 +154,50 @@ const aptRewriteHeader = `# Rewritten by Superserve template builder.
 # serves the same archive contents over a separate, healthy sync path.
 `
 
+// injectProxyCA writes the secretsproxy CA into the rootfs trust store.
+// No-op when caCertPath is empty.
+func injectProxyCA(rootfsDir, caCertPath string, logger *zerolog.Logger) error {
+	if caCertPath == "" {
+		return nil
+	}
+	cert, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return fmt.Errorf("read proxy CA: %w", err)
+	}
+
+	additionalDir := filepath.Join(rootfsDir, "usr/local/share/ca-certificates")
+	if err := os.MkdirAll(additionalDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", additionalDir, err)
+	}
+	additionalCert := filepath.Join(additionalDir, "superserve-proxy.crt")
+	if err := os.WriteFile(additionalCert, cert, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", additionalCert, err)
+	}
+
+	// Append to the bundle so tools trust the cert without running update-ca-certificates.
+	bundlePath := filepath.Join(rootfsDir, "etc/ssl/certs/ca-certificates.crt")
+	bf, err := os.OpenFile(bundlePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if logger != nil {
+				logger.Warn().Str("bundle", bundlePath).Msg("system trust bundle absent; proxy CA installed only to /usr/local/share/ca-certificates")
+			}
+			return nil
+		}
+		return fmt.Errorf("open %s: %w", bundlePath, err)
+	}
+	defer bf.Close()
+	// Defensive newline so an existing bundle without a trailing newline
+	// doesn't run the appended cert's BEGIN line into the previous line.
+	if _, err := bf.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("append separator to %s: %w", bundlePath, err)
+	}
+	if _, err := bf.Write(cert); err != nil {
+		return fmt.Errorf("append to %s: %w", bundlePath, err)
+	}
+	return nil
+}
+
 // rewriteAptSources rewrites http:// and https:// references to
 // canonicalUbuntuMirrors in /etc/apt/sources.list and
 // /etc/apt/sources.list.d/{*.list,*.sources} to point at ubuntuMirrorHost.

--- a/internal/builder/inject_test.go
+++ b/internal/builder/inject_test.go
@@ -7,6 +7,80 @@ import (
 	"testing"
 )
 
+func TestInjectProxyCA(t *testing.T) {
+	t.Parallel()
+	const certPEM = "-----BEGIN CERTIFICATE-----\nTESTCERT\n-----END CERTIFICATE-----\n"
+
+	writeCertFile := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "ca.crt")
+		if err := os.WriteFile(path, []byte(certPEM), 0o644); err != nil {
+			t.Fatalf("seed cert: %v", err)
+		}
+		return path
+	}
+
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		rootfs := t.TempDir()
+		if err := injectProxyCA(rootfs, "", nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(rootfs, "usr/local/share/ca-certificates/superserve-proxy.crt")); !os.IsNotExist(err) {
+			t.Fatalf("cert should not have been written when path is empty: %v", err)
+		}
+	})
+
+	t.Run("writes additional cert and appends to existing bundle", func(t *testing.T) {
+		rootfs := t.TempDir()
+		bundleDir := filepath.Join(rootfs, "etc/ssl/certs")
+		if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+			t.Fatalf("mkdir bundle: %v", err)
+		}
+		bundlePath := filepath.Join(bundleDir, "ca-certificates.crt")
+		existing := "-----BEGIN CERTIFICATE-----\nEXISTING\n-----END CERTIFICATE-----\n"
+		if err := os.WriteFile(bundlePath, []byte(existing), 0o644); err != nil {
+			t.Fatalf("seed bundle: %v", err)
+		}
+
+		if err := injectProxyCA(rootfs, writeCertFile(t), nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(rootfs, "usr/local/share/ca-certificates/superserve-proxy.crt"))
+		if err != nil || string(got) != certPEM {
+			t.Fatalf("additional cert: %v, %q", err, got)
+		}
+		bundle, err := os.ReadFile(bundlePath)
+		if err != nil {
+			t.Fatalf("read bundle: %v", err)
+		}
+		if !strings.HasPrefix(string(bundle), existing) || !strings.HasSuffix(string(bundle), certPEM) {
+			t.Fatalf("bundle did not preserve existing + append cert; got: %q", bundle)
+		}
+	})
+
+	t.Run("missing bundle still writes the additional cert", func(t *testing.T) {
+		rootfs := t.TempDir()
+		if err := injectProxyCA(rootfs, writeCertFile(t), nil); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(rootfs, "usr/local/share/ca-certificates/superserve-proxy.crt")); err != nil {
+			t.Fatalf("additional cert missing: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(rootfs, "etc/ssl/certs/ca-certificates.crt")); !os.IsNotExist(err) {
+			t.Fatalf("bundle should remain absent: %v", err)
+		}
+	})
+
+	t.Run("source path missing returns an error", func(t *testing.T) {
+		err := injectProxyCA(t.TempDir(), "/no/such/cert", nil)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}
+
 // TestRewriteAptSources covers the apt-source rewrite path: canonical hosts
 // get redirected to the replacement mirror over both http:// and https://
 // (emitted as http://), unrelated URLs are left alone, the rewrite is

--- a/internal/builder/types.go
+++ b/internal/builder/types.go
@@ -84,6 +84,9 @@ type Config struct {
 	// MaxUncompressedSizeBytes is a safety cap on the flattened filesystem
 	// before mkfs.ext4 runs. 0 means "no cap".
 	MaxUncompressedSizeBytes int64
+
+	// Path to the secretsproxy CA cert. Empty disables CA install.
+	ProxyCACertPath string
 }
 
 // ApplyDefaults fills in zero-valued fields with sensible defaults.

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -16,12 +16,22 @@ import (
 // GRPCAdapter wraps a Manager to implement vmdpb.VMDaemonServer.
 type GRPCAdapter struct {
 	vmdpb.UnimplementedVMDaemonServer
-	mgr *Manager
+	mgr             *Manager
+	secrets         *SecretsBrokerClient
+	sandboxProxyURL string // SECRETSPROXY_SANDBOX_ADDR — empty disables HTTPS_PROXY injection
 }
 
 // NewGRPCAdapter creates a new adapter that bridges the proto interface to the Manager.
 func NewGRPCAdapter(mgr *Manager) *GRPCAdapter {
-	return &GRPCAdapter{mgr: mgr}
+	return &GRPCAdapter{mgr: mgr, secrets: NewSecretsBrokerClient("")}
+}
+
+// WithSecretsBroker enables the secretsproxy integration; empty socketPath disables it.
+// sandboxProxyURL is the host:port the sandbox writes into HTTPS_PROXY.
+func (a *GRPCAdapter) WithSecretsBroker(socketPath, sandboxProxyURL string) *GRPCAdapter {
+	a.secrets = NewSecretsBrokerClient(socketPath)
+	a.sandboxProxyURL = sandboxProxyURL
+	return a
 }
 
 func (a *GRPCAdapter) DestroyVM(ctx context.Context, req *vmdpb.DestroyVMRequest) (*vmdpb.DestroyVMResponse, error) {
@@ -41,7 +51,7 @@ func (a *GRPCAdapter) PauseVM(ctx context.Context, req *vmdpb.PauseVMRequest) (*
 		return nil, err
 	}
 	return &vmdpb.PauseVMResponse{
-		VmId:        req.GetVmId(),
+		VmId:         req.GetVmId(),
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
 	}, nil
@@ -53,6 +63,8 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 		return nil, err
 	}
 
+	// Resume is a no-op for secrets: the agent's HTTPS_PROXY (with its JWT) and
+	// per-binding proxy tokens are in the snapshot and don't need re-injection.
 	if err := postBoxdInit(ctx, inst.IP, req.GetEnvVars(), vmHostname(inst.ID)); err != nil {
 		return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", err)
 	}
@@ -109,14 +121,8 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 		return nil, err
 	}
 
-	// Apply caller env vars and the per-sandbox hostname.
-	if initErr := postBoxdInit(ctx, inst.IP, req.GetEnvVars(), vmHostname(inst.ID)); initErr != nil {
-		// Tear the VM down — a sandbox whose env vars weren't applied
-		// would silently serve stale/missing secrets to the user.
-		_ = a.mgr.DestroyVM(ctx, inst.ID, true)
-		return nil, status.Errorf(codes.Internal, "post-restore init failed: %v", initErr)
-	}
-
+	// Env vars are pushed in a separate InjectSandboxEnv call so the control
+	// plane can mint a JWT against the now-known source IP before injection.
 	return &vmdpb.RestoreSnapshotResponse{
 		VmId:       inst.ID,
 		SocketPath: inst.SocketPath,
@@ -127,6 +133,32 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 			MemoryMib: inst.Config.MemoryMiB,
 		},
 	}, nil
+}
+
+// InjectSandboxEnv pushes env vars and the sandbox's hostname into the running
+// boxd. When secrets_jwt is non-empty vmd builds the HTTPS_PROXY URL from its
+// configured daemon address and adds it to env_vars before sending.
+func (a *GRPCAdapter) InjectSandboxEnv(ctx context.Context, req *vmdpb.InjectSandboxEnvRequest) (*vmdpb.InjectSandboxEnvResponse, error) {
+	vmID := req.GetVmId()
+	if vmID == "" {
+		return nil, status.Error(codes.InvalidArgument, "vm_id is required")
+	}
+	inst, err := a.mgr.GetVMInfo(ctx, vmID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "vm %s: %v", vmID, err)
+	}
+	envVars := req.GetEnvVars()
+	jwt := req.GetSecretsJwt()
+	if err := RequireProxyForJWT(jwt, a.sandboxProxyURL); err != nil {
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+	if jwt != "" {
+		envVars = InjectHTTPSProxyEnvWithJWT(envVars, a.sandboxProxyURL, jwt)
+	}
+	if err := postBoxdInit(ctx, inst.IP, envVars, vmHostname(vmID)); err != nil {
+		return nil, status.Errorf(codes.Internal, "post-init failed: %v", err)
+	}
+	return &vmdpb.InjectSandboxEnvResponse{VmId: vmID}, nil
 }
 
 // DeleteSnapshot unlinks the vmstate + memory files for a previous snapshot.
@@ -297,11 +329,47 @@ func (a *GRPCAdapter) UpdateSandboxNetwork(ctx context.Context, req *vmdpb.Updat
 				AllowedCIDRs:   egress.GetAllowedCidrs(),
 				DeniedCIDRs:    egress.GetDeniedCidrs(),
 				AllowedDomains: egress.GetAllowedDomains(),
+				SandboxID:      vmID,
 			})
 		}
 	}
 
 	return &vmdpb.UpdateSandboxNetworkResponse{VmId: vmID}, nil
+}
+
+// InvalidateSecret forwards the invalidate call to the local secretsproxy daemon.
+// Returns OK when the daemon is disabled on this host.
+func (a *GRPCAdapter) InvalidateSecret(ctx context.Context, req *vmdpb.InvalidateSecretRequest) (*vmdpb.InvalidateSecretResponse, error) {
+	if req.GetSecretId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "secret_id is required")
+	}
+	if err := a.secrets.InvalidateSecret(ctx, req.GetSecretId()); err != nil {
+		return nil, status.Errorf(codes.Internal, "secretsproxy invalidate: %v", err)
+	}
+	return &vmdpb.InvalidateSecretResponse{}, nil
+}
+
+// RevokeSandbox forwards the revoke to the local secretsproxy daemon.
+func (a *GRPCAdapter) RevokeSandbox(ctx context.Context, req *vmdpb.RevokeSandboxRequest) (*vmdpb.RevokeSandboxResponse, error) {
+	if req.GetSandboxId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+	if err := a.secrets.RevokeSandbox(ctx, req.GetSandboxId()); err != nil {
+		return nil, status.Errorf(codes.Internal, "secretsproxy revoke: %v", err)
+	}
+	return &vmdpb.RevokeSandboxResponse{}, nil
+}
+
+// InvalidateSandboxRules forwards the egress-rules invalidation to the local
+// secretsproxy daemon. Returns OK when the daemon is disabled on this host.
+func (a *GRPCAdapter) InvalidateSandboxRules(ctx context.Context, req *vmdpb.InvalidateSandboxRulesRequest) (*vmdpb.InvalidateSandboxRulesResponse, error) {
+	if req.GetSandboxId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+	if err := a.secrets.InvalidateSandboxRules(ctx, req.GetSandboxId()); err != nil {
+		return nil, status.Errorf(codes.Internal, "secretsproxy invalidate rules: %v", err)
+	}
+	return &vmdpb.InvalidateSandboxRulesResponse{}, nil
 }
 
 func (a *GRPCAdapter) BuildTemplate(ctx context.Context, req *vmdpb.BuildTemplateRequest) (*vmdpb.BuildTemplateResponse, error) {

--- a/internal/vm/secretsproxy.go
+++ b/internal/vm/secretsproxy.go
@@ -1,0 +1,148 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+// SecretsBrokerClient is vmd's unix-socket client for the local secretsproxy
+// daemon. With the JWT-scoped daemon design the only remaining server-side
+// operation is cache invalidation; sandbox registration is implicit in the
+// per-request JWT and needs no out-of-band setup. Empty socketPath disables
+// every method (silent no-op).
+type SecretsBrokerClient struct {
+	socketPath string
+	httpClient *http.Client
+}
+
+// NewSecretsBrokerClient builds a client; empty socketPath disables every call.
+func NewSecretsBrokerClient(socketPath string) *SecretsBrokerClient {
+	c := &SecretsBrokerClient{socketPath: socketPath}
+	if socketPath != "" {
+		c.httpClient = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return (&net.Dialer{Timeout: 2 * time.Second}).DialContext(ctx, "unix", socketPath)
+				},
+			},
+			Timeout: 5 * time.Second,
+		}
+	}
+	return c
+}
+
+// Enabled reports whether the client will actually talk to the daemon.
+func (c *SecretsBrokerClient) Enabled() bool { return c.socketPath != "" }
+
+// ErrDaemonRefused is returned when the daemon rejects a call with a 4xx.
+var ErrDaemonRefused = errors.New("secretsproxy daemon rejected call")
+
+// InvalidateSecret tells the daemon to drop any cached cleartext for secretID. Idempotent.
+func (c *SecretsBrokerClient) InvalidateSecret(ctx context.Context, secretID string) error {
+	if !c.Enabled() {
+		return nil
+	}
+	url := "http://unix/v1/secrets/" + secretID + "/invalidate"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon invalidate: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("%w: status %d: %s", ErrDaemonRefused, resp.StatusCode, string(raw))
+	}
+	return nil
+}
+
+// RevokeSandbox tells the daemon that sandboxID's JWT must no longer authorize requests. Idempotent.
+func (c *SecretsBrokerClient) RevokeSandbox(ctx context.Context, sandboxID string) error {
+	if !c.Enabled() {
+		return nil
+	}
+	url := "http://unix/v1/sandboxes/" + sandboxID + "/revoke"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon revoke: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("%w: status %d: %s", ErrDaemonRefused, resp.StatusCode, string(raw))
+	}
+	return nil
+}
+
+// InvalidateSandboxRules tells the daemon to drop cached egress rules for sandboxID. Idempotent.
+func (c *SecretsBrokerClient) InvalidateSandboxRules(ctx context.Context, sandboxID string) error {
+	if !c.Enabled() {
+		return nil
+	}
+	url := "http://unix/v1/sandboxes/" + sandboxID + "/rules"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon invalidate rules: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("%w: status %d: %s", ErrDaemonRefused, resp.StatusCode, string(raw))
+	}
+	return nil
+}
+
+// RequireProxyForJWT errors when a JWT is present but no proxy is configured.
+func RequireProxyForJWT(jwt, proxyURL string) error {
+	if jwt != "" && proxyURL == "" {
+		return errors.New("sandbox has secrets but SECRETSPROXY_SANDBOX_ADDR is unset on vmd")
+	}
+	return nil
+}
+
+// Trust-store paths. Must match what injectProxyCA writes into the rootfs.
+const (
+	systemTrustBundle = "/etc/ssl/certs/ca-certificates.crt"
+	systemTrustDir    = "/etc/ssl/certs"
+	proxyCAOnlyCert   = "/usr/local/share/ca-certificates/superserve-proxy.crt"
+)
+
+// InjectHTTPSProxyEnvWithJWT returns a copy of envVars with HTTPS_PROXY and the
+// CA-trust env vars set so the sandbox routes HTTPS egress through the daemon
+// and trusts its MITM cert. No-op when sandboxAddr or jwt is empty.
+//
+// HTTP_PROXY is intentionally omitted: the daemon is CONNECT-only and never
+// injects secrets into cleartext HTTP, so plain-HTTP egress flows direct.
+func InjectHTTPSProxyEnvWithJWT(envVars map[string]string, sandboxAddr, jwt string) map[string]string {
+	if sandboxAddr == "" || jwt == "" {
+		return envVars
+	}
+	proxyURL := fmt.Sprintf("https://sb:%s@%s", jwt, sandboxAddr)
+	out := make(map[string]string, len(envVars)+6)
+	for k, v := range envVars {
+		out[k] = v
+	}
+	out["HTTPS_PROXY"] = proxyURL
+	out["SSL_CERT_FILE"] = systemTrustBundle
+	out["SSL_CERT_DIR"] = systemTrustDir
+	out["CURL_CA_BUNDLE"] = systemTrustBundle
+	out["REQUESTS_CA_BUNDLE"] = systemTrustBundle
+	out["NODE_EXTRA_CA_CERTS"] = proxyCAOnlyCert
+	return out
+}

--- a/internal/vm/secretsproxy_test.go
+++ b/internal/vm/secretsproxy_test.go
@@ -1,0 +1,195 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordingDaemon stands up a unix-socket HTTP server that records every
+// invalidate request so the test can assert vmd posted the right shape.
+type recordingDaemon struct {
+	t           *testing.T
+	socketPath  string
+	stopped     chan struct{}
+	invalidated []string
+
+	failNext int
+}
+
+func newRecordingDaemon(t *testing.T) *recordingDaemon {
+	t.Helper()
+	dir := t.TempDir()
+	d := &recordingDaemon{
+		t:          t,
+		socketPath: filepath.Join(dir, "daemon.sock"),
+		stopped:    make(chan struct{}),
+	}
+
+	l, err := net.Listen("unix", d.socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/secrets/", func(w http.ResponseWriter, r *http.Request) {
+		if d.failNext != 0 {
+			w.WriteHeader(d.failNext)
+			d.failNext = 0
+			return
+		}
+		rest := strings.TrimPrefix(r.URL.Path, "/v1/secrets/")
+		parts := strings.SplitN(rest, "/", 2)
+		if len(parts) != 2 || parts[1] != "invalidate" || parts[0] == "" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		d.invalidated = append(d.invalidated, parts[0])
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 2 * time.Second}
+	go func() {
+		_ = srv.Serve(l)
+		close(d.stopped)
+	}()
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+	return d
+}
+
+func TestSecretsBrokerClient_InvalidateSecret(t *testing.T) {
+	d := newRecordingDaemon(t)
+	c := NewSecretsBrokerClient(d.socketPath)
+
+	if err := c.InvalidateSecret(context.Background(), "sec-1"); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	if len(d.invalidated) != 1 || d.invalidated[0] != "sec-1" {
+		t.Errorf("recorded invalidations drift: %+v", d.invalidated)
+	}
+}
+
+func TestSecretsBrokerClient_InvalidateSecret_DisabledNoOp(t *testing.T) {
+	c := NewSecretsBrokerClient("") // empty socketPath disables every call
+	if c.Enabled() {
+		t.Fatal("client with empty socketPath should report Enabled=false")
+	}
+	if err := c.InvalidateSecret(context.Background(), "sec-1"); err != nil {
+		t.Errorf("disabled client should silently succeed, got %v", err)
+	}
+}
+
+func TestSecretsBrokerClient_InvalidateSecret_SurfaceErrors(t *testing.T) {
+	d := newRecordingDaemon(t)
+	c := NewSecretsBrokerClient(d.socketPath)
+
+	d.failNext = http.StatusInternalServerError
+	err := c.InvalidateSecret(context.Background(), "sec-1")
+	if err == nil || !errors.Is(err, ErrDaemonRefused) {
+		t.Errorf("want ErrDaemonRefused on 500, got %v", err)
+	}
+}
+
+func TestInjectHTTPSProxyEnvWithJWT(t *testing.T) {
+	trustKeys := []string{"SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS"}
+
+	cases := []struct {
+		name        string
+		sandboxAddr string
+		jwt         string
+		wantProxy   string
+	}{
+		{"happy path", "192.0.2.1:9443", "the.jwt.body", "https://sb:the.jwt.body@192.0.2.1:9443"},
+		{"empty addr returns input", "", "x", ""},
+		{"empty jwt returns input", "192.0.2.1:9443", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := map[string]string{"MODE": "prod"}
+			out := InjectHTTPSProxyEnvWithJWT(in, tc.sandboxAddr, tc.jwt)
+			if out["MODE"] != "prod" {
+				t.Errorf("existing keys must be preserved")
+			}
+			if tc.wantProxy == "" {
+				if _, ok := out["HTTPS_PROXY"]; ok {
+					t.Errorf("HTTPS_PROXY should not be set when addr or jwt is empty")
+				}
+				for _, k := range trustKeys {
+					if _, ok := out[k]; ok {
+						t.Errorf("%s should not be set when proxy injection is skipped", k)
+					}
+				}
+				return
+			}
+			if got := out["HTTPS_PROXY"]; got != tc.wantProxy {
+				t.Errorf("HTTPS_PROXY: want %q, got %q", tc.wantProxy, got)
+			}
+			// HTTP_PROXY must not be set — plain-HTTP egress stays direct.
+			if _, ok := out["HTTP_PROXY"]; ok {
+				t.Errorf("HTTP_PROXY should not be set")
+			}
+			for _, k := range trustKeys {
+				if out[k] == "" {
+					t.Errorf("%s should be set alongside HTTPS_PROXY", k)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectHTTPSProxyEnvWithJWT_OverridesCustomerTrustVars(t *testing.T) {
+	in := map[string]string{
+		"SSL_CERT_FILE":       "/customer/path",
+		"REQUESTS_CA_BUNDLE":  "/customer/path",
+		"NODE_EXTRA_CA_CERTS": "/customer/path",
+	}
+	out := InjectHTTPSProxyEnvWithJWT(in, "192.0.2.1:9443", "abc")
+	if out["SSL_CERT_FILE"] == "/customer/path" {
+		t.Error("our SSL_CERT_FILE must override the customer's so TLS trusts the daemon CA")
+	}
+	if out["REQUESTS_CA_BUNDLE"] == "/customer/path" {
+		t.Error("our REQUESTS_CA_BUNDLE must override the customer's")
+	}
+	if out["NODE_EXTRA_CA_CERTS"] == "/customer/path" {
+		t.Error("our NODE_EXTRA_CA_CERTS must override the customer's")
+	}
+}
+
+func TestInjectHTTPSProxyEnvWithJWT_DoesNotMutateInput(t *testing.T) {
+	in := map[string]string{"MODE": "prod"}
+	_ = InjectHTTPSProxyEnvWithJWT(in, "10.0.0.3:9443", "abc")
+	if _, ok := in["HTTPS_PROXY"]; ok {
+		t.Errorf("input map was mutated")
+	}
+}
+
+func TestRequireProxyForJWT(t *testing.T) {
+	cases := []struct {
+		name     string
+		jwt      string
+		proxyURL string
+		wantErr  bool
+	}{
+		{"no JWT, no proxy", "", "", false},
+		{"no JWT, proxy set", "", "192.0.2.1:9443", false},
+		{"JWT set, proxy set", "tok", "192.0.2.1:9443", false},
+		{"JWT set, proxy missing must error", "tok", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireProxyForJWT(tc.jwt, tc.proxyURL)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// json import retained for future test additions that exercise the wire shape.
+var _ = json.Marshal


### PR DESCRIPTION
**Stack 6 of 6 — activation.** Base: `amit/secrets-5-network-log`.

Wires the daemon and flow sink into vmd (RPC adapter, network manager, builder, deploy workflows). **This is where the feature turns on.** Merge last.

After this merges, the stack tip equals the staging-verified branch (the original #84 diff). Supersedes #84.