### PR TITLE
secretsproxy: fix flaky audit-event test race and macOS socket path overflow

### DIFF
--- a/internal/secretsproxy/control_test.go
+++ b/internal/secretsproxy/control_test.go
@@ -11,10 +11,23 @@ import (
 	"time"
 )
 
+// shortSocketPath returns a socket path under the macOS sun_path limit (104
+// bytes). t.TempDir() embeds the test name and can overflow it, failing
+// net.Listen; a short MkdirTemp dir stays under the limit on every OS.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ssp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, name)
+}
+
 // startControlServerOnSocket binds the control server to a temp unix socket.
 func startControlServerOnSocket(t *testing.T, cv *cachedVault, cr *cachedRules) (*http.Client, *ControlServer, *Revoker) {
 	t.Helper()
-	sockPath := filepath.Join(t.TempDir(), "control.sock")
+	sockPath := shortSocketPath(t, "control.sock")
 	rev := NewRevoker()
 	cs := NewControlServer(sockPath, cv, cr, rev)
 
@@ -182,7 +195,7 @@ func TestControlHealth(t *testing.T) {
 }
 
 func TestControlSocketIsModeRestricted(t *testing.T) {
-	sockPath := filepath.Join(t.TempDir(), "ctl.sock")
+	sockPath := shortSocketPath(t, "ctl.sock")
 	cs := NewControlServer(sockPath, nil, nil, nil)
 	go func() { _ = cs.ListenAndServe() }()
 	t.Cleanup(func() { _ = cs.Shutdown(context.Background()) })

--- a/internal/secretsproxy/e2e_jwt_test.go
+++ b/internal/secretsproxy/e2e_jwt_test.go
@@ -203,8 +203,8 @@ func TestE2E_JWTPathInjectsCredentialEndToEnd(t *testing.T) {
 	if got := resp.Header.Get("X-Upstream-Auth"); got != "Bearer sk-ant-REAL" {
 		t.Errorf("upstream Authorization: want %q, got %q", "Bearer sk-ant-REAL", got)
 	}
-	if len(d.audit.snapshot()) != 1 {
-		t.Errorf("want exactly 1 audit event, got %d", len(d.audit.snapshot()))
+	if events := d.audit.waitForEvents(t, 1); len(events) != 1 {
+		t.Errorf("want exactly 1 audit event, got %d", len(events))
 	}
 }
 

--- a/internal/secretsproxy/proxy_test.go
+++ b/internal/secretsproxy/proxy_test.go
@@ -376,21 +376,60 @@ func TestCopyForwardableHeadersStripsHopByHop(t *testing.T) {
 	}
 }
 
-// recordingAudit captures every event the proxy emits.
+// recordingAudit captures every event the proxy emits. The zero value is ready
+// to use; cond is created lazily so &recordingAudit{} stays valid.
 type recordingAudit struct {
 	mu     sync.Mutex
+	cond   *sync.Cond
 	events []AuditEvent
+}
+
+// condLocked returns the broadcast condition, creating it on first use. Caller holds mu.
+func (r *recordingAudit) condLocked() *sync.Cond {
+	if r.cond == nil {
+		r.cond = sync.NewCond(&r.mu)
+	}
+	return r.cond
 }
 
 func (r *recordingAudit) Emit(ev AuditEvent) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.events = append(r.events, ev)
+	r.condLocked().Broadcast()
 }
 func (r *recordingAudit) Shutdown(_ context.Context) error { return nil }
 func (r *recordingAudit) snapshot() []AuditEvent {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	out := make([]AuditEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// waitForEvents blocks until at least n events are emitted or the timeout
+// elapses, then snapshots. The proxy emits the audit row after forwarding the
+// response, which can land just after the client's headers-only ReadResponse
+// returns — so a single snapshot races the emit. The watchdog wakes the waiter
+// on timeout, leaving a missing event to fail the caller's assertion.
+func (r *recordingAudit) waitForEvents(t *testing.T, n int) []AuditEvent {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cond := r.condLocked()
+
+	timedOut := false
+	timer := time.AfterFunc(2*time.Second, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		timedOut = true
+		cond.Broadcast()
+	})
+	defer timer.Stop()
+
+	for len(r.events) < n && !timedOut {
+		cond.Wait()
+	}
 	out := make([]AuditEvent, len(r.events))
 	copy(out, r.events)
 	return out
@@ -508,7 +547,7 @@ func TestProxyInjectsBearerEndToEnd(t *testing.T) {
 		t.Errorf("upstream received %q, want %q", got, "Bearer sk-ant-REAL")
 	}
 
-	events := audit.snapshot()
+	events := audit.waitForEvents(t, 1)
 	if len(events) != 1 {
 		t.Fatalf("audit: want 1 event, got %d (%+v)", len(events), events)
 	}
@@ -586,7 +625,7 @@ func TestProxyDeniesHostNotInCredentialAllowlist(t *testing.T) {
 		t.Errorf("reason: want credential_host_mismatch, got %q", reason)
 	}
 
-	events := audit.snapshot()
+	events := audit.waitForEvents(t, 1)
 	if len(events) != 1 {
 		t.Fatalf("audit: want 1 deny event, got %d (%+v)", len(events), events)
 	}


### PR DESCRIPTION
Fixes intermittent CI failures (`want 1 audit event, got 0`). Tests snapshotted the in-process audit recorder right after `http.ReadResponse` (headers only), racing the proxy's emit which lands after the response is forwarded. Replaced with a `sync.Cond`-based wait. Also fixed control-socket tests that broke on macOS (`t.TempDir()` overflows the 104-byte sun_path limit). Verified 100× under -race.