### PR TITLE
adding a rollup job

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/api"
+	"github.com/superserve-ai/sandbox/internal/billing"
 	"github.com/superserve-ai/sandbox/internal/config"
 	dbq "github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/hostreg"
@@ -210,6 +211,14 @@ func run() error {
 	// when their VMD heartbeat goes stale (>2 min). The scheduler
 	// excludes unhealthy hosts from placement.
 	go api.StartHostDetector(ctx, queries)
+
+	// Billing dashboard rollups are provisional and recomputable from raw
+	// interval rows. Team-level feature flags decide which tenants roll up.
+	if billing.HourlyRollupDisabledFromEnv() {
+		log.Info().Msg("billing hourly rollup worker disabled (BILLING_HOURLY_ROLLUP_DISABLED set)")
+	} else {
+		billing.StartHourlyRollupService(ctx, dbPool, queries, billing.DefaultHourlyRollupConfig())
+	}
 
 	// Quota watcher: alerts (Slack) when a team crosses 80% of a resource limit.
 	// Only runs when a webhook is configured.

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -152,29 +152,6 @@ UNION ALL
 SELECT * FROM immutable_existing
 LIMIT 1;
 
--- name: ListTeamsForHourlyBillingRollup :many
--- Teams with raw billing intervals overlapping an hour. The feature flag keeps
--- rollout tenant-scoped while avoiding scans over teams with no recent usage.
-SELECT DISTINCT team_id
-FROM (
-    SELECT i.team_id
-    FROM sandbox_compute_billing_interval i
-    WHERE i.started_at < sqlc.arg(hour_end)
-      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
-      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
-
-    UNION
-
-    SELECT i.team_id
-    FROM sandbox_storage_interval i
-    WHERE i.started_at < sqlc.arg(hour_end)
-      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
-      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
-) billing_teams
-WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
-ORDER BY team_id;
-
-
 -- name: UpsertTeamBillingUsageHour :one
 WITH compute AS (
     SELECT

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -152,6 +152,29 @@ UNION ALL
 SELECT * FROM immutable_existing
 LIMIT 1;
 
+-- name: ListTeamsForHourlyBillingRollup :many
+-- Teams with raw billing intervals overlapping an hour. The feature flag keeps
+-- rollout tenant-scoped while avoiding scans over teams with no recent usage.
+SELECT DISTINCT team_id
+FROM (
+    SELECT i.team_id
+    FROM sandbox_compute_billing_interval i
+    WHERE i.started_at < sqlc.arg(hour_end)
+      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
+      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
+
+    UNION
+
+    SELECT i.team_id
+    FROM sandbox_storage_interval i
+    WHERE i.started_at < sqlc.arg(hour_end)
+      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
+      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
+) billing_teams
+WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
+ORDER BY team_id;
+
+
 -- name: UpsertTeamBillingUsageHour :one
 WITH compute AS (
     SELECT
@@ -402,4 +425,153 @@ VALUES (sqlc.arg(team_id), sqlc.arg(key), sqlc.arg(enabled))
 ON CONFLICT (team_id, key) DO UPDATE
 SET enabled = EXCLUDED.enabled,
     updated_at = now()
+RETURNING *;
+
+-- name: ListActivePricingRates :many
+WITH ranked_rates AS (
+    SELECT
+        r.plan_key,
+        p.name AS plan_name,
+        p.currency,
+        r.resource,
+        r.unit,
+        r.price_usd,
+        r.effective_from,
+        row_number() OVER (
+            PARTITION BY r.resource, r.unit
+            ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC
+        ) AS rate_rank
+    FROM pricing_rate r
+    JOIN pricing_plan p ON p.key = r.plan_key
+    WHERE r.plan_key = sqlc.arg(plan_key)
+      AND p.active
+      AND r.effective_from <= now()
+      AND (r.effective_to IS NULL OR r.effective_to > now())
+)
+SELECT
+    plan_key,
+    plan_name,
+    currency,
+    resource,
+    unit,
+    price_usd,
+    effective_from
+FROM ranked_rates
+WHERE rate_rank = 1
+ORDER BY resource, unit;
+
+-- name: ListPricingRatesForPlanAt :many
+WITH ranked_rates AS (
+    SELECT
+        r.plan_key,
+        p.name AS plan_name,
+        p.currency,
+        r.resource,
+        r.unit,
+        r.price_usd,
+        r.effective_from,
+        row_number() OVER (
+            PARTITION BY r.resource, r.unit
+            ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC
+        ) AS rate_rank
+    FROM pricing_rate r
+    JOIN pricing_plan p ON p.key = r.plan_key
+    WHERE r.plan_key = sqlc.arg(plan_key)
+      AND p.active
+      AND r.effective_from <= sqlc.arg(effective_at)::timestamptz
+      AND (r.effective_to IS NULL OR r.effective_to > sqlc.arg(effective_at)::timestamptz)
+)
+SELECT
+    plan_key,
+    plan_name,
+    currency,
+    resource,
+    unit,
+    price_usd,
+    effective_from
+FROM ranked_rates
+WHERE rate_rank = 1
+ORDER BY resource, unit;
+
+-- name: GetTeamActivePricingPlan :one
+SELECT COALESCE((
+    SELECT tpp.plan_key
+    FROM team_pricing_plan tpp
+    JOIN pricing_plan p ON p.key = tpp.plan_key
+    WHERE tpp.team_id = sqlc.arg(team_id)
+      AND p.active
+      AND tpp.effective_from <= now()
+      AND (tpp.effective_to IS NULL OR tpp.effective_to > now())
+    ORDER BY tpp.effective_from DESC
+    LIMIT 1
+), 'payg')::text AS plan_key;
+
+-- name: AssignTeamPricingPlan :one
+INSERT INTO team_pricing_plan (team_id, plan_key, effective_from, effective_to, assigned_by)
+VALUES (
+    sqlc.arg(team_id),
+    sqlc.arg(plan_key),
+    sqlc.arg(effective_from),
+    sqlc.narg(effective_to),
+    sqlc.narg(assigned_by)
+)
+RETURNING *;
+
+-- name: GrantTeamCredit :one
+INSERT INTO team_credit_grant (
+    team_id, amount_usd, remaining_usd, reason, expires_at, created_by
+)
+VALUES (
+    sqlc.arg(team_id),
+    sqlc.arg(amount_usd),
+    sqlc.arg(amount_usd),
+    sqlc.narg(reason),
+    sqlc.narg(expires_at),
+    sqlc.narg(created_by)
+)
+RETURNING *;
+
+-- name: GetTeamCreditBalance :one
+SELECT COALESCE(SUM(remaining_usd), 0)::numeric AS balance_usd
+FROM team_credit_grant
+WHERE team_id = sqlc.arg(team_id)
+  AND remaining_usd > 0
+  AND (expires_at IS NULL OR expires_at > now());
+
+-- name: ListTeamCreditGrants :many
+SELECT *
+FROM team_credit_grant
+WHERE team_id = sqlc.arg(team_id)
+ORDER BY created_at DESC;
+
+-- name: ApplyTeamCreditGrant :one
+UPDATE team_credit_grant
+SET remaining_usd = remaining_usd - sqlc.arg(amount_usd),
+    updated_at = now()
+WHERE id = sqlc.arg(grant_id)
+  AND team_id = sqlc.arg(team_id)
+  AND sqlc.arg(amount_usd) > 0
+  AND remaining_usd >= sqlc.arg(amount_usd)
+  AND (expires_at IS NULL OR expires_at > now())
+RETURNING *;
+
+-- name: RecordTeamCreditLedgerEntry :one
+INSERT INTO team_credit_ledger (
+    team_id,
+    grant_id,
+    billing_period_start,
+    billing_period_end,
+    amount_usd,
+    reason,
+    created_by
+)
+VALUES (
+    sqlc.arg(team_id),
+    sqlc.narg(grant_id),
+    sqlc.narg(billing_period_start),
+    sqlc.narg(billing_period_end),
+    sqlc.arg(amount_usd),
+    sqlc.arg(reason),
+    sqlc.narg(created_by)
+)
 RETURNING *;

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -454,7 +454,6 @@ WITH ranked_rates AS (
     FROM pricing_rate r
     JOIN pricing_plan p ON p.key = r.plan_key
     WHERE r.plan_key = sqlc.arg(plan_key)
-      AND p.active
       AND r.effective_from <= sqlc.arg(effective_at)::timestamptz
       AND (r.effective_to IS NULL OR r.effective_to > sqlc.arg(effective_at)::timestamptz)
 )

--- a/internal/billing/rollup.go
+++ b/internal/billing/rollup.go
@@ -1,0 +1,547 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+const (
+	defaultHourlyRollupSchedulerInterval     = 5 * time.Minute
+	defaultHourlyRollupWorkerPoll            = 10 * time.Second
+	defaultHourlyRollupLookbackHours         = 24
+	defaultHourlyRollupBackfillLookbackHours = 90 * 24
+	defaultHourlyRollupBackfillBatchHours    = 24
+	defaultHourlyRollupLeaseDuration         = 2 * time.Minute
+	defaultHourlyRollupLockDuration          = 5 * time.Minute
+	defaultHourlyRollupBatchSize             = 100
+	defaultHourlyRollupMaxAttempts           = 5
+	defaultHourlyRollupWorkers               = 1
+)
+
+type HourlyRollupConfig struct {
+	SchedulerInterval     time.Duration
+	WorkerPoll            time.Duration
+	LookbackHours         int
+	BackfillLookbackHours int
+	BackfillBatchHours    int
+	LeaseDuration         time.Duration
+	LockDuration          time.Duration
+	BatchSize             int
+	MaxAttempts           int
+	Workers               int
+}
+
+type rollupJob struct {
+	ID           uuid.UUID
+	TeamID       uuid.UUID
+	HourStart    time.Time
+	HourEnd      time.Time
+	AttemptCount int
+}
+
+func DefaultHourlyRollupConfig() HourlyRollupConfig {
+	return HourlyRollupConfig{
+		SchedulerInterval:     durationFromEnv("BILLING_HOURLY_ROLLUP_INTERVAL", defaultHourlyRollupSchedulerInterval),
+		WorkerPoll:            durationFromEnv("BILLING_HOURLY_ROLLUP_WORKER_POLL", defaultHourlyRollupWorkerPoll),
+		LookbackHours:         intFromEnv("BILLING_HOURLY_ROLLUP_LOOKBACK_HOURS", defaultHourlyRollupLookbackHours),
+		BackfillLookbackHours: intFromEnv("BILLING_HOURLY_ROLLUP_BACKFILL_LOOKBACK_HOURS", defaultHourlyRollupBackfillLookbackHours),
+		BackfillBatchHours:    intFromEnv("BILLING_HOURLY_ROLLUP_BACKFILL_BATCH_HOURS", defaultHourlyRollupBackfillBatchHours),
+		LeaseDuration:         durationFromEnv("BILLING_HOURLY_ROLLUP_LEASE_DURATION", defaultHourlyRollupLeaseDuration),
+		LockDuration:          durationFromEnv("BILLING_HOURLY_ROLLUP_LOCK_DURATION", defaultHourlyRollupLockDuration),
+		BatchSize:             intFromEnv("BILLING_HOURLY_ROLLUP_BATCH_SIZE", defaultHourlyRollupBatchSize),
+		MaxAttempts:           intFromEnv("BILLING_HOURLY_ROLLUP_MAX_ATTEMPTS", defaultHourlyRollupMaxAttempts),
+		Workers:               intFromEnv("BILLING_HOURLY_ROLLUP_WORKERS", defaultHourlyRollupWorkers),
+	}
+}
+
+func HourlyRollupDisabledFromEnv() bool {
+	return os.Getenv("BILLING_HOURLY_ROLLUP_DISABLED") == "1" ||
+		os.Getenv("BILLING_HOURLY_ROLLUP_DISABLED") == "true"
+}
+
+func StartHourlyRollupService(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig) {
+	cfg = normalizeConfig(cfg)
+	workerID := workerID()
+
+	log.Info().
+		Str("worker_id", workerID).
+		Dur("scheduler_interval", cfg.SchedulerInterval).
+		Dur("worker_poll", cfg.WorkerPoll).
+		Int("lookback_hours", cfg.LookbackHours).
+		Int("backfill_lookback_hours", cfg.BackfillLookbackHours).
+		Int("backfill_batch_hours", cfg.BackfillBatchHours).
+		Int("workers", cfg.Workers).
+		Int("batch_size", cfg.BatchSize).
+		Msg("billing hourly rollup service starting")
+
+	go runScheduler(ctx, pool, cfg, workerID)
+	for i := 0; i < cfg.Workers; i++ {
+		go runWorker(ctx, pool, q, cfg, fmt.Sprintf("%s-%d", workerID, i))
+	}
+}
+
+func runScheduler(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, workerID string) {
+	runSchedulerTick(ctx, pool, cfg, workerID)
+
+	ticker := time.NewTicker(cfg.SchedulerInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Str("worker_id", workerID).Msg("billing hourly rollup scheduler stopped")
+			return
+		case <-ticker.C:
+			runSchedulerTick(ctx, pool, cfg, workerID)
+		}
+	}
+}
+
+func runSchedulerTick(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, workerID string) {
+	claimed, err := claimSchedulerLease(ctx, pool, workerID, time.Now().UTC().Add(cfg.LeaseDuration))
+	if err != nil {
+		log.Warn().Err(err).Str("worker_id", workerID).Msg("claim billing rollup scheduler lease failed")
+		return
+	}
+	if !claimed {
+		return
+	}
+
+	total := int64(0)
+	now := time.Now().UTC()
+	for _, hourStart := range rollupHours(now, cfg.LookbackHours) {
+		enqueued, err := enqueueHour(ctx, pool, hourStart, hourStart.Add(time.Hour), true)
+		if err != nil {
+			log.Error().Err(err).Time("hour_start", hourStart).Msg("enqueue billing hourly rollup jobs failed")
+			continue
+		}
+		total += enqueued
+	}
+
+	backfillTotal, err := enqueueBackfill(ctx, pool, cfg, now)
+	if err != nil {
+		log.Error().Err(err).Msg("enqueue billing hourly rollup backfill jobs failed")
+	} else {
+		total += backfillTotal
+	}
+
+	log.Info().
+		Str("worker_id", workerID).
+		Int64("jobs_enqueued_or_refreshed", total).
+		Int64("backfill_jobs_enqueued", backfillTotal).
+		Int("lookback_hours", cfg.LookbackHours).
+		Int("backfill_lookback_hours", cfg.BackfillLookbackHours).
+		Msg("billing hourly rollup scheduler tick completed")
+}
+
+func runWorker(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig, workerID string) {
+	processJobs(ctx, pool, q, cfg, workerID)
+
+	ticker := time.NewTicker(cfg.WorkerPoll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Str("worker_id", workerID).Msg("billing hourly rollup worker stopped")
+			return
+		case <-ticker.C:
+			processJobs(ctx, pool, q, cfg, workerID)
+		}
+	}
+}
+
+func processJobs(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig, workerID string) {
+	jobs, err := claimJobs(ctx, pool, cfg, workerID, time.Now().UTC().Add(cfg.LockDuration))
+	if err != nil {
+		log.Warn().Err(err).Str("worker_id", workerID).Msg("claim billing hourly rollup jobs failed")
+		return
+	}
+	if len(jobs) == 0 {
+		return
+	}
+
+	for _, job := range jobs {
+		if err := processJob(ctx, pool, q, cfg, workerID, job); err != nil {
+			log.Warn().
+				Err(err).
+				Str("worker_id", workerID).
+				Str("job_id", job.ID.String()).
+				Str("team_id", job.TeamID.String()).
+				Time("hour_start", job.HourStart).
+				Msg("billing hourly rollup job failed")
+		}
+	}
+}
+
+func processJob(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig, workerID string, job rollupJob) error {
+	_, err := q.UpsertTeamBillingUsageHour(ctx, db.UpsertTeamBillingUsageHourParams{
+		TeamID:    job.TeamID,
+		HourStart: timestamptz(job.HourStart),
+		HourEnd:   timestamptz(job.HourEnd),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The team flag may have been disabled after the scheduler enqueued the job.
+		err = nil
+	}
+	if err != nil {
+		nextAttemptAt := time.Now().UTC().Add(backoff(job.AttemptCount))
+		if failErr := failJob(ctx, pool, job.ID, workerID, cfg.MaxAttempts, nextAttemptAt, err.Error()); failErr != nil {
+			return errors.Join(err, failErr)
+		}
+		return err
+	}
+
+	if err := completeJob(ctx, pool, job.ID, workerID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func claimSchedulerLease(ctx context.Context, pool *pgxpool.Pool, workerID string, lockedUntil time.Time) (bool, error) {
+	const query = `
+INSERT INTO billing_rollup_scheduler_lease (name, locked_by, locked_until)
+VALUES ('hourly', $1, $2)
+ON CONFLICT (name) DO UPDATE
+SET locked_by = EXCLUDED.locked_by,
+    locked_until = EXCLUDED.locked_until,
+    updated_at = now()
+WHERE billing_rollup_scheduler_lease.locked_until <= now()
+   OR billing_rollup_scheduler_lease.locked_by = EXCLUDED.locked_by
+RETURNING true`
+
+	var claimed bool
+	err := pool.QueryRow(ctx, query, workerID, lockedUntil).Scan(&claimed)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	return claimed, err
+}
+
+func enqueueHour(ctx context.Context, pool *pgxpool.Pool, hourStart, hourEnd time.Time, refreshCompleted bool) (int64, error) {
+	const query = `
+WITH candidate_teams AS (
+    SELECT DISTINCT team_id
+    FROM (
+        SELECT i.team_id
+        FROM sandbox_compute_billing_interval i
+        WHERE i.started_at < $2
+          AND $1 < LEAST(now(), $2)
+          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+
+        UNION
+
+        SELECT i.team_id
+        FROM sandbox_storage_interval i
+        WHERE i.started_at < $2
+          AND $1 < LEAST(now(), $2)
+          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+    ) billing_teams
+    WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
+)
+INSERT INTO billing_rollup_job (team_id, hour_start, hour_end, status, next_attempt_at)
+SELECT team_id, $1, $2, 'pending', now()
+FROM candidate_teams
+ON CONFLICT (team_id, hour_start) DO UPDATE
+SET hour_end = EXCLUDED.hour_end,
+    status = 'pending',
+    locked_by = NULL,
+    locked_until = NULL,
+    last_error = CASE
+        WHEN billing_rollup_job.status = 'pending'
+         AND billing_rollup_job.next_attempt_at > now()
+            THEN billing_rollup_job.last_error
+        ELSE NULL
+    END,
+    next_attempt_at = CASE
+        WHEN billing_rollup_job.status = 'pending'
+         AND billing_rollup_job.next_attempt_at > now()
+            THEN billing_rollup_job.next_attempt_at
+        ELSE now()
+    END,
+    attempt_count = CASE
+        WHEN billing_rollup_job.status = 'completed' THEN 0
+        ELSE billing_rollup_job.attempt_count
+    END,
+    completed_at = NULL,
+    updated_at = now()
+WHERE billing_rollup_job.status = 'pending'
+   OR ($3::boolean AND billing_rollup_job.status = 'completed')`
+
+	tag, err := pool.Exec(ctx, query, hourStart, hourEnd, refreshCompleted)
+	return tag.RowsAffected(), err
+}
+
+func enqueueBackfill(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, now time.Time) (int64, error) {
+	if cfg.BackfillLookbackHours <= cfg.LookbackHours || cfg.BackfillBatchHours <= 0 {
+		return 0, nil
+	}
+
+	rollingStart := now.UTC().Truncate(time.Hour).Add(-time.Duration(cfg.LookbackHours-1) * time.Hour)
+	backfillStart := now.UTC().Truncate(time.Hour).Add(-time.Duration(cfg.BackfillLookbackHours) * time.Hour)
+	if !backfillStart.Before(rollingStart) {
+		return 0, nil
+	}
+
+	hours, err := nextBackfillHours(ctx, pool, backfillStart, rollingStart, cfg.BackfillBatchHours)
+	if err != nil {
+		return 0, err
+	}
+	if len(hours) == 0 {
+		return 0, nil
+	}
+
+	total := int64(0)
+	for _, hourStart := range hours {
+		enqueued, err := enqueueHour(ctx, pool, hourStart, hourStart.Add(time.Hour), false)
+		if err != nil {
+			return total, err
+		}
+		total += enqueued
+	}
+
+	if err := advanceBackfillCursor(ctx, pool, hours[0], hours[len(hours)-1].Add(time.Hour)); err != nil {
+		return total, err
+	}
+	return total, nil
+}
+
+func nextBackfillHours(ctx context.Context, pool *pgxpool.Pool, startHour, endHour time.Time, batchHours int) ([]time.Time, error) {
+	const query = `
+INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
+VALUES ('hourly', $1)
+ON CONFLICT (name) DO UPDATE
+SET next_hour_start = CASE
+        WHEN billing_rollup_backfill_state.next_hour_start < $1 THEN $1
+        ELSE billing_rollup_backfill_state.next_hour_start
+    END,
+    updated_at = CASE
+        WHEN billing_rollup_backfill_state.next_hour_start < $1 THEN now()
+        ELSE billing_rollup_backfill_state.updated_at
+    END
+RETURNING next_hour_start`
+
+	var cursor time.Time
+	if err := pool.QueryRow(ctx, query, startHour).Scan(&cursor); err != nil {
+		return nil, err
+	}
+
+	if !cursor.Before(endHour) {
+		return nil, nil
+	}
+	batchEnd := cursor.Add(time.Duration(batchHours) * time.Hour)
+	if batchEnd.After(endHour) {
+		batchEnd = endHour
+	}
+
+	hours := make([]time.Time, 0, int(batchEnd.Sub(cursor)/time.Hour))
+	for hour := cursor; hour.Before(batchEnd); hour = hour.Add(time.Hour) {
+		hours = append(hours, hour)
+	}
+	return hours, nil
+}
+
+func advanceBackfillCursor(ctx context.Context, pool *pgxpool.Pool, fromHour, toHour time.Time) error {
+	tag, err := pool.Exec(ctx, `
+UPDATE billing_rollup_backfill_state
+SET next_hour_start = $2,
+    updated_at = now()
+WHERE name = 'hourly'
+  AND next_hour_start = $1
+`, fromHour, toHour)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("billing rollup backfill cursor changed before advance from %s to %s", fromHour, toHour)
+	}
+	return nil
+}
+
+func claimJobs(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, workerID string, lockedUntil time.Time) ([]rollupJob, error) {
+	const query = `
+WITH candidate AS (
+    SELECT id
+    FROM billing_rollup_job
+    WHERE (
+          (
+              status IN ('pending', 'failed')
+              AND next_attempt_at <= now()
+              AND attempt_count < $1
+          )
+          OR (
+              status = 'running'
+              AND locked_until <= now()
+          )
+      )
+    ORDER BY hour_start ASC, updated_at ASC
+    LIMIT $2
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE billing_rollup_job j
+SET status = 'running',
+    attempt_count = CASE
+        WHEN j.status = 'running' AND j.locked_until <= now() THEN j.attempt_count
+        ELSE j.attempt_count + 1
+    END,
+    locked_by = $3,
+    locked_until = $4,
+    updated_at = now()
+FROM candidate
+WHERE j.id = candidate.id
+RETURNING j.id, j.team_id, j.hour_start, j.hour_end, j.attempt_count`
+
+	rows, err := pool.Query(ctx, query, cfg.MaxAttempts, cfg.BatchSize, workerID, lockedUntil)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	jobs := make([]rollupJob, 0, cfg.BatchSize)
+	for rows.Next() {
+		var job rollupJob
+		if err := rows.Scan(&job.ID, &job.TeamID, &job.HourStart, &job.HourEnd, &job.AttemptCount); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func completeJob(ctx context.Context, pool *pgxpool.Pool, jobID uuid.UUID, workerID string) error {
+	const query = `
+UPDATE billing_rollup_job
+SET status = 'completed',
+    locked_by = NULL,
+    locked_until = NULL,
+    last_error = NULL,
+    completed_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND locked_by = $2`
+
+	_, err := pool.Exec(ctx, query, jobID, workerID)
+	return err
+}
+
+func failJob(ctx context.Context, pool *pgxpool.Pool, jobID uuid.UUID, workerID string, maxAttempts int, nextAttemptAt time.Time, message string) error {
+	const query = `
+UPDATE billing_rollup_job
+SET status = CASE WHEN attempt_count >= $3 THEN 'failed' ELSE 'pending' END,
+    locked_by = NULL,
+    locked_until = NULL,
+    next_attempt_at = $4,
+    last_error = left($5, 2000),
+    updated_at = now()
+WHERE id = $1
+  AND locked_by = $2`
+
+	_, err := pool.Exec(ctx, query, jobID, workerID, maxAttempts, nextAttemptAt, message)
+	return err
+}
+
+func rollupHours(now time.Time, lookbackHours int) []time.Time {
+	currentHour := now.UTC().Truncate(time.Hour)
+	startHour := currentHour.Add(-time.Duration(lookbackHours-1) * time.Hour)
+
+	hours := make([]time.Time, 0, lookbackHours)
+	for hour := startHour; !hour.After(currentHour); hour = hour.Add(time.Hour) {
+		hours = append(hours, hour)
+	}
+	return hours
+}
+
+func normalizeConfig(cfg HourlyRollupConfig) HourlyRollupConfig {
+	if cfg.SchedulerInterval <= 0 {
+		cfg.SchedulerInterval = defaultHourlyRollupSchedulerInterval
+	}
+	if cfg.WorkerPoll <= 0 {
+		cfg.WorkerPoll = defaultHourlyRollupWorkerPoll
+	}
+	if cfg.LookbackHours <= 0 {
+		cfg.LookbackHours = defaultHourlyRollupLookbackHours
+	}
+	if cfg.BackfillLookbackHours < 0 {
+		cfg.BackfillLookbackHours = defaultHourlyRollupBackfillLookbackHours
+	}
+	if cfg.BackfillBatchHours < 0 {
+		cfg.BackfillBatchHours = defaultHourlyRollupBackfillBatchHours
+	}
+	if cfg.LeaseDuration <= 0 {
+		cfg.LeaseDuration = defaultHourlyRollupLeaseDuration
+	}
+	if cfg.LockDuration <= 0 {
+		cfg.LockDuration = defaultHourlyRollupLockDuration
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultHourlyRollupBatchSize
+	}
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = defaultHourlyRollupMaxAttempts
+	}
+	if cfg.Workers < 0 {
+		cfg.Workers = defaultHourlyRollupWorkers
+	}
+	return cfg
+}
+
+func timestamptz(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t.UTC(), Valid: true}
+}
+
+func backoff(attemptCount int) time.Duration {
+	if attemptCount <= 0 {
+		return 30 * time.Second
+	}
+	delay := time.Duration(attemptCount*attemptCount) * 30 * time.Second
+	if delay > time.Hour {
+		return time.Hour
+	}
+	return delay
+}
+
+func workerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown-host"
+	}
+	return fmt.Sprintf("%s-%d", host, os.Getpid())
+}
+
+func durationFromEnv(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		log.Warn().Str("key", key).Str("value", raw).Msg("invalid duration env; using default")
+		return fallback
+	}
+	return parsed
+}
+
+func intFromEnv(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		log.Warn().Str("key", key).Str("value", raw).Msg("invalid integer env; using default")
+		return fallback
+	}
+	return parsed
+}

--- a/internal/billing/rollup.go
+++ b/internal/billing/rollup.go
@@ -278,7 +278,14 @@ SET hour_end = EXCLUDED.hour_end,
     completed_at = NULL,
     updated_at = now()
 WHERE billing_rollup_job.status = 'pending'
-   OR ($3::boolean AND billing_rollup_job.status = 'completed')`
+   OR (
+       $3::boolean
+       AND billing_rollup_job.status = 'completed'
+       AND (
+           billing_rollup_job.hour_end > now()
+           OR billing_rollup_job.completed_at < now() - interval '1 hour'
+       )
+   )`
 
 	tag, err := pool.Exec(ctx, query, hourStart, hourEnd, refreshCompleted)
 	return tag.RowsAffected(), err
@@ -313,6 +320,12 @@ func enqueueBackfill(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupCo
 	}
 
 	if err := advanceBackfillCursor(ctx, pool, hours[0], hours[len(hours)-1].Add(time.Hour)); err != nil {
+		log.Warn().
+			Err(err).
+			Int64("jobs_enqueued", total).
+			Time("from_hour", hours[0]).
+			Time("to_hour", hours[len(hours)-1].Add(time.Hour)).
+			Msg("advance billing rollup backfill cursor failed after enqueue")
 		return total, err
 	}
 	return total, nil
@@ -491,7 +504,7 @@ func normalizeConfig(cfg HourlyRollupConfig) HourlyRollupConfig {
 	if cfg.MaxAttempts <= 0 {
 		cfg.MaxAttempts = defaultHourlyRollupMaxAttempts
 	}
-	if cfg.Workers < 0 {
+	if cfg.Workers <= 0 {
 		cfg.Workers = defaultHourlyRollupWorkers
 	}
 	return cfg

--- a/internal/billing/rollup_integration_exports.go
+++ b/internal/billing/rollup_integration_exports.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package billing
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+type RollupJobForTest struct {
+	ID           uuid.UUID
+	TeamID       uuid.UUID
+	HourStart    time.Time
+	HourEnd      time.Time
+	AttemptCount int
+}
+
+func ClaimJobsForTest(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, workerID string) ([]RollupJobForTest, error) {
+	cfg = normalizeConfig(cfg)
+	jobs, err := claimJobs(ctx, pool, cfg, workerID, time.Now().UTC().Add(cfg.LockDuration))
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]RollupJobForTest, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, RollupJobForTest{
+			ID:           job.ID,
+			TeamID:       job.TeamID,
+			HourStart:    job.HourStart,
+			HourEnd:      job.HourEnd,
+			AttemptCount: job.AttemptCount,
+		})
+	}
+	return out, nil
+}
+
+func EnqueueHourForTest(ctx context.Context, pool *pgxpool.Pool, hourStart time.Time, hourEnd time.Time) (int64, error) {
+	return enqueueHour(ctx, pool, hourStart, hourEnd, true)
+}
+
+func EnqueueBackfillForTest(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, now time.Time) (int64, error) {
+	cfg = normalizeConfig(cfg)
+	return enqueueBackfill(ctx, pool, cfg, now)
+}
+
+func NextBackfillHoursForTest(ctx context.Context, pool *pgxpool.Pool, startHour time.Time, endHour time.Time, batchHours int) ([]time.Time, error) {
+	return nextBackfillHours(ctx, pool, startHour, endHour, batchHours)
+}
+
+func ProcessJobsForTest(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig, workerID string) {
+	cfg = normalizeConfig(cfg)
+	processJobs(ctx, pool, q, cfg, workerID)
+}

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -718,54 +718,6 @@ func (q *Queries) ListTeamCreditGrants(ctx context.Context, teamID uuid.UUID) ([
 	return items, nil
 }
 
-const listTeamsForHourlyBillingRollup = `-- name: ListTeamsForHourlyBillingRollup :many
-SELECT DISTINCT team_id
-FROM (
-    SELECT i.team_id
-    FROM sandbox_compute_billing_interval i
-    WHERE i.started_at < $1
-      AND $2 < LEAST(now(), $1)
-      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
-
-    UNION
-
-    SELECT i.team_id
-    FROM sandbox_storage_interval i
-    WHERE i.started_at < $1
-      AND $2 < LEAST(now(), $1)
-      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
-) billing_teams
-WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
-ORDER BY team_id
-`
-
-type ListTeamsForHourlyBillingRollupParams struct {
-	HourEnd   time.Time   `json:"hour_end"`
-	HourStart interface{} `json:"hour_start"`
-}
-
-// Teams with raw billing intervals overlapping an hour. The feature flag keeps
-// rollout tenant-scoped while avoiding scans over teams with no recent usage.
-func (q *Queries) ListTeamsForHourlyBillingRollup(ctx context.Context, arg ListTeamsForHourlyBillingRollupParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, listTeamsForHourlyBillingRollup, arg.HourEnd, arg.HourStart)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []uuid.UUID{}
-	for rows.Next() {
-		var team_id uuid.UUID
-		if err := rows.Scan(&team_id); err != nil {
-			return nil, err
-		}
-		items = append(items, team_id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listUnresolvedBillingPeriodAnomalies = `-- name: ListUnresolvedBillingPeriodAnomalies :many
 SELECT id, team_id, period_start, period_end, severity, kind, sandbox_id, details, detected_at, resolved_at, resolved_by
 FROM billing_period_anomaly

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -13,6 +13,42 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const applyTeamCreditGrant = `-- name: ApplyTeamCreditGrant :one
+UPDATE team_credit_grant
+SET remaining_usd = remaining_usd - $1,
+    updated_at = now()
+WHERE id = $2
+  AND team_id = $3
+  AND $1 > 0
+  AND remaining_usd >= $1
+  AND (expires_at IS NULL OR expires_at > now())
+RETURNING id, team_id, amount_usd, remaining_usd, currency, reason, expires_at, created_by, created_at, updated_at
+`
+
+type ApplyTeamCreditGrantParams struct {
+	AmountUsd pgtype.Numeric `json:"amount_usd"`
+	GrantID   uuid.UUID      `json:"grant_id"`
+	TeamID    uuid.UUID      `json:"team_id"`
+}
+
+func (q *Queries) ApplyTeamCreditGrant(ctx context.Context, arg ApplyTeamCreditGrantParams) (TeamCreditGrant, error) {
+	row := q.db.QueryRow(ctx, applyTeamCreditGrant, arg.AmountUsd, arg.GrantID, arg.TeamID)
+	var i TeamCreditGrant
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.AmountUsd,
+		&i.RemainingUsd,
+		&i.Currency,
+		&i.Reason,
+		&i.ExpiresAt,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const approveTeamBillingPeriod = `-- name: ApproveTeamBillingPeriod :one
 UPDATE team_billing_period
 SET status = 'approved',
@@ -66,6 +102,46 @@ func (q *Queries) ApproveTeamBillingPeriod(ctx context.Context, arg ApproveTeamB
 		&i.FinalizedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const assignTeamPricingPlan = `-- name: AssignTeamPricingPlan :one
+INSERT INTO team_pricing_plan (team_id, plan_key, effective_from, effective_to, assigned_by)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5
+)
+RETURNING team_id, plan_key, effective_from, effective_to, assigned_by, created_at
+`
+
+type AssignTeamPricingPlanParams struct {
+	TeamID        uuid.UUID          `json:"team_id"`
+	PlanKey       string             `json:"plan_key"`
+	EffectiveFrom time.Time          `json:"effective_from"`
+	EffectiveTo   pgtype.Timestamptz `json:"effective_to"`
+	AssignedBy    pgtype.UUID        `json:"assigned_by"`
+}
+
+func (q *Queries) AssignTeamPricingPlan(ctx context.Context, arg AssignTeamPricingPlanParams) (TeamPricingPlan, error) {
+	row := q.db.QueryRow(ctx, assignTeamPricingPlan,
+		arg.TeamID,
+		arg.PlanKey,
+		arg.EffectiveFrom,
+		arg.EffectiveTo,
+		arg.AssignedBy,
+	)
+	var i TeamPricingPlan
+	err := row.Scan(
+		&i.TeamID,
+		&i.PlanKey,
+		&i.EffectiveFrom,
+		&i.EffectiveTo,
+		&i.AssignedBy,
+		&i.CreatedAt,
 	)
 	return i, err
 }
@@ -238,6 +314,27 @@ func (q *Queries) FinalizeTeamBillingPeriod(ctx context.Context, arg FinalizeTea
 	return i, err
 }
 
+const getTeamActivePricingPlan = `-- name: GetTeamActivePricingPlan :one
+SELECT COALESCE((
+    SELECT tpp.plan_key
+    FROM team_pricing_plan tpp
+    JOIN pricing_plan p ON p.key = tpp.plan_key
+    WHERE tpp.team_id = $1
+      AND p.active
+      AND tpp.effective_from <= now()
+      AND (tpp.effective_to IS NULL OR tpp.effective_to > now())
+    ORDER BY tpp.effective_from DESC
+    LIMIT 1
+), 'payg')::text AS plan_key
+`
+
+func (q *Queries) GetTeamActivePricingPlan(ctx context.Context, teamID uuid.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, getTeamActivePricingPlan, teamID)
+	var plan_key string
+	err := row.Scan(&plan_key)
+	return plan_key, err
+}
+
 const getTeamBillingUsage = `-- name: GetTeamBillingUsage :one
 WITH compute AS (
     SELECT
@@ -312,6 +409,68 @@ func (q *Queries) GetTeamBillingUsage(ctx context.Context, arg GetTeamBillingUsa
 	return i, err
 }
 
+const getTeamCreditBalance = `-- name: GetTeamCreditBalance :one
+SELECT COALESCE(SUM(remaining_usd), 0)::numeric AS balance_usd
+FROM team_credit_grant
+WHERE team_id = $1
+  AND remaining_usd > 0
+  AND (expires_at IS NULL OR expires_at > now())
+`
+
+func (q *Queries) GetTeamCreditBalance(ctx context.Context, teamID uuid.UUID) (pgtype.Numeric, error) {
+	row := q.db.QueryRow(ctx, getTeamCreditBalance, teamID)
+	var balance_usd pgtype.Numeric
+	err := row.Scan(&balance_usd)
+	return balance_usd, err
+}
+
+const grantTeamCredit = `-- name: GrantTeamCredit :one
+INSERT INTO team_credit_grant (
+    team_id, amount_usd, remaining_usd, reason, expires_at, created_by
+)
+VALUES (
+    $1,
+    $2,
+    $2,
+    $3,
+    $4,
+    $5
+)
+RETURNING id, team_id, amount_usd, remaining_usd, currency, reason, expires_at, created_by, created_at, updated_at
+`
+
+type GrantTeamCreditParams struct {
+	TeamID    uuid.UUID          `json:"team_id"`
+	AmountUsd pgtype.Numeric     `json:"amount_usd"`
+	Reason    *string            `json:"reason"`
+	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	CreatedBy pgtype.UUID        `json:"created_by"`
+}
+
+func (q *Queries) GrantTeamCredit(ctx context.Context, arg GrantTeamCreditParams) (TeamCreditGrant, error) {
+	row := q.db.QueryRow(ctx, grantTeamCredit,
+		arg.TeamID,
+		arg.AmountUsd,
+		arg.Reason,
+		arg.ExpiresAt,
+		arg.CreatedBy,
+	)
+	var i TeamCreditGrant
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.AmountUsd,
+		&i.RemainingUsd,
+		&i.Currency,
+		&i.Reason,
+		&i.ExpiresAt,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const isFeatureEnabledForTeam = `-- name: IsFeatureEnabledForTeam :one
 SELECT feature_enabled($1, $2)::boolean AS enabled
 `
@@ -326,6 +485,155 @@ func (q *Queries) IsFeatureEnabledForTeam(ctx context.Context, arg IsFeatureEnab
 	var enabled bool
 	err := row.Scan(&enabled)
 	return enabled, err
+}
+
+const listActivePricingRates = `-- name: ListActivePricingRates :many
+WITH ranked_rates AS (
+    SELECT
+        r.plan_key,
+        p.name AS plan_name,
+        p.currency,
+        r.resource,
+        r.unit,
+        r.price_usd,
+        r.effective_from,
+        row_number() OVER (
+            PARTITION BY r.resource, r.unit
+            ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC
+        ) AS rate_rank
+    FROM pricing_rate r
+    JOIN pricing_plan p ON p.key = r.plan_key
+    WHERE r.plan_key = $1
+      AND p.active
+      AND r.effective_from <= now()
+      AND (r.effective_to IS NULL OR r.effective_to > now())
+)
+SELECT
+    plan_key,
+    plan_name,
+    currency,
+    resource,
+    unit,
+    price_usd,
+    effective_from
+FROM ranked_rates
+WHERE rate_rank = 1
+ORDER BY resource, unit
+`
+
+type ListActivePricingRatesRow struct {
+	PlanKey       string         `json:"plan_key"`
+	PlanName      string         `json:"plan_name"`
+	Currency      string         `json:"currency"`
+	Resource      string         `json:"resource"`
+	Unit          string         `json:"unit"`
+	PriceUsd      pgtype.Numeric `json:"price_usd"`
+	EffectiveFrom time.Time      `json:"effective_from"`
+}
+
+func (q *Queries) ListActivePricingRates(ctx context.Context, planKey string) ([]ListActivePricingRatesRow, error) {
+	rows, err := q.db.Query(ctx, listActivePricingRates, planKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListActivePricingRatesRow{}
+	for rows.Next() {
+		var i ListActivePricingRatesRow
+		if err := rows.Scan(
+			&i.PlanKey,
+			&i.PlanName,
+			&i.Currency,
+			&i.Resource,
+			&i.Unit,
+			&i.PriceUsd,
+			&i.EffectiveFrom,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPricingRatesForPlanAt = `-- name: ListPricingRatesForPlanAt :many
+WITH ranked_rates AS (
+    SELECT
+        r.plan_key,
+        p.name AS plan_name,
+        p.currency,
+        r.resource,
+        r.unit,
+        r.price_usd,
+        r.effective_from,
+        row_number() OVER (
+            PARTITION BY r.resource, r.unit
+            ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC
+        ) AS rate_rank
+    FROM pricing_rate r
+    JOIN pricing_plan p ON p.key = r.plan_key
+    WHERE r.plan_key = $1
+      AND p.active
+      AND r.effective_from <= $2::timestamptz
+      AND (r.effective_to IS NULL OR r.effective_to > $2::timestamptz)
+)
+SELECT
+    plan_key,
+    plan_name,
+    currency,
+    resource,
+    unit,
+    price_usd,
+    effective_from
+FROM ranked_rates
+WHERE rate_rank = 1
+ORDER BY resource, unit
+`
+
+type ListPricingRatesForPlanAtParams struct {
+	PlanKey     string    `json:"plan_key"`
+	EffectiveAt time.Time `json:"effective_at"`
+}
+
+type ListPricingRatesForPlanAtRow struct {
+	PlanKey       string         `json:"plan_key"`
+	PlanName      string         `json:"plan_name"`
+	Currency      string         `json:"currency"`
+	Resource      string         `json:"resource"`
+	Unit          string         `json:"unit"`
+	PriceUsd      pgtype.Numeric `json:"price_usd"`
+	EffectiveFrom time.Time      `json:"effective_from"`
+}
+
+func (q *Queries) ListPricingRatesForPlanAt(ctx context.Context, arg ListPricingRatesForPlanAtParams) ([]ListPricingRatesForPlanAtRow, error) {
+	rows, err := q.db.Query(ctx, listPricingRatesForPlanAt, arg.PlanKey, arg.EffectiveAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPricingRatesForPlanAtRow{}
+	for rows.Next() {
+		var i ListPricingRatesForPlanAtRow
+		if err := rows.Scan(
+			&i.PlanKey,
+			&i.PlanName,
+			&i.Currency,
+			&i.Resource,
+			&i.Unit,
+			&i.PriceUsd,
+			&i.EffectiveFrom,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listTeamBillingUsageHourly = `-- name: ListTeamBillingUsageHourly :many
@@ -365,6 +673,92 @@ func (q *Queries) ListTeamBillingUsageHourly(ctx context.Context, arg ListTeamBi
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTeamCreditGrants = `-- name: ListTeamCreditGrants :many
+SELECT id, team_id, amount_usd, remaining_usd, currency, reason, expires_at, created_by, created_at, updated_at
+FROM team_credit_grant
+WHERE team_id = $1
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListTeamCreditGrants(ctx context.Context, teamID uuid.UUID) ([]TeamCreditGrant, error) {
+	rows, err := q.db.Query(ctx, listTeamCreditGrants, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []TeamCreditGrant{}
+	for rows.Next() {
+		var i TeamCreditGrant
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.AmountUsd,
+			&i.RemainingUsd,
+			&i.Currency,
+			&i.Reason,
+			&i.ExpiresAt,
+			&i.CreatedBy,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTeamsForHourlyBillingRollup = `-- name: ListTeamsForHourlyBillingRollup :many
+SELECT DISTINCT team_id
+FROM (
+    SELECT i.team_id
+    FROM sandbox_compute_billing_interval i
+    WHERE i.started_at < $1
+      AND $2 < LEAST(now(), $1)
+      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
+
+    UNION
+
+    SELECT i.team_id
+    FROM sandbox_storage_interval i
+    WHERE i.started_at < $1
+      AND $2 < LEAST(now(), $1)
+      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
+) billing_teams
+WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
+ORDER BY team_id
+`
+
+type ListTeamsForHourlyBillingRollupParams struct {
+	HourEnd   time.Time   `json:"hour_end"`
+	HourStart interface{} `json:"hour_start"`
+}
+
+// Teams with raw billing intervals overlapping an hour. The feature flag keeps
+// rollout tenant-scoped while avoiding scans over teams with no recent usage.
+func (q *Queries) ListTeamsForHourlyBillingRollup(ctx context.Context, arg ListTeamsForHourlyBillingRollupParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listTeamsForHourlyBillingRollup, arg.HourEnd, arg.HourStart)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []uuid.UUID{}
+	for rows.Next() {
+		var team_id uuid.UUID
+		if err := rows.Scan(&team_id); err != nil {
+			return nil, err
+		}
+		items = append(items, team_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -502,6 +896,63 @@ func (q *Queries) MarkTeamBillingPeriodExported(ctx context.Context, arg MarkTea
 		&i.FinalizedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const recordTeamCreditLedgerEntry = `-- name: RecordTeamCreditLedgerEntry :one
+INSERT INTO team_credit_ledger (
+    team_id,
+    grant_id,
+    billing_period_start,
+    billing_period_end,
+    amount_usd,
+    reason,
+    created_by
+)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7
+)
+RETURNING id, team_id, grant_id, billing_period_start, billing_period_end, amount_usd, reason, created_by, created_at
+`
+
+type RecordTeamCreditLedgerEntryParams struct {
+	TeamID             uuid.UUID          `json:"team_id"`
+	GrantID            pgtype.UUID        `json:"grant_id"`
+	BillingPeriodStart pgtype.Timestamptz `json:"billing_period_start"`
+	BillingPeriodEnd   pgtype.Timestamptz `json:"billing_period_end"`
+	AmountUsd          pgtype.Numeric     `json:"amount_usd"`
+	Reason             string             `json:"reason"`
+	CreatedBy          pgtype.UUID        `json:"created_by"`
+}
+
+func (q *Queries) RecordTeamCreditLedgerEntry(ctx context.Context, arg RecordTeamCreditLedgerEntryParams) (TeamCreditLedger, error) {
+	row := q.db.QueryRow(ctx, recordTeamCreditLedgerEntry,
+		arg.TeamID,
+		arg.GrantID,
+		arg.BillingPeriodStart,
+		arg.BillingPeriodEnd,
+		arg.AmountUsd,
+		arg.Reason,
+		arg.CreatedBy,
+	)
+	var i TeamCreditLedger
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.GrantID,
+		&i.BillingPeriodStart,
+		&i.BillingPeriodEnd,
+		&i.AmountUsd,
+		&i.Reason,
+		&i.CreatedBy,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -576,7 +576,6 @@ WITH ranked_rates AS (
     FROM pricing_rate r
     JOIN pricing_plan p ON p.key = r.plan_key
     WHERE r.plan_key = $1
-      AND p.active
       AND r.effective_from <= $2::timestamptz
       AND (r.effective_to IS NULL OR r.effective_to > $2::timestamptz)
 )

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -210,6 +210,35 @@ type BillingPeriodAnomaly struct {
 	ResolvedBy  pgtype.UUID        `json:"resolved_by"`
 }
 
+type BillingRollupBackfillState struct {
+	Name          string    `json:"name"`
+	NextHourStart time.Time `json:"next_hour_start"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type BillingRollupJob struct {
+	ID            uuid.UUID          `json:"id"`
+	TeamID        uuid.UUID          `json:"team_id"`
+	HourStart     time.Time          `json:"hour_start"`
+	HourEnd       time.Time          `json:"hour_end"`
+	Status        string             `json:"status"`
+	AttemptCount  int32              `json:"attempt_count"`
+	NextAttemptAt time.Time          `json:"next_attempt_at"`
+	LockedBy      *string            `json:"locked_by"`
+	LockedUntil   pgtype.Timestamptz `json:"locked_until"`
+	LastError     *string            `json:"last_error"`
+	EnqueuedAt    time.Time          `json:"enqueued_at"`
+	CompletedAt   pgtype.Timestamptz `json:"completed_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
+}
+
+type BillingRollupSchedulerLease struct {
+	Name        string    `json:"name"`
+	LockedBy    string    `json:"locked_by"`
+	LockedUntil time.Time `json:"locked_until"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
 type DeviceCode struct {
 	ID         uuid.UUID   `json:"id"`
 	DeviceCode string      `json:"device_code"`
@@ -264,6 +293,26 @@ type NetFlow struct {
 	BytesSent  *int64     `json:"bytes_sent"`
 	BytesRecv  *int64     `json:"bytes_recv"`
 	DurationMs *int32     `json:"duration_ms"`
+}
+
+type PricingPlan struct {
+	Key       string    `json:"key"`
+	Name      string    `json:"name"`
+	Currency  string    `json:"currency"`
+	Active    bool      `json:"active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type PricingRate struct {
+	ID            uuid.UUID          `json:"id"`
+	PlanKey       string             `json:"plan_key"`
+	Resource      string             `json:"resource"`
+	Unit          string             `json:"unit"`
+	PriceUsd      pgtype.Numeric     `json:"price_usd"`
+	EffectiveFrom time.Time          `json:"effective_from"`
+	EffectiveTo   pgtype.Timestamptz `json:"effective_to"`
+	CreatedAt     time.Time          `json:"created_at"`
 }
 
 type Profile struct {
@@ -462,6 +511,31 @@ type TeamBillingUsageHourly struct {
 	UpdatedAt         time.Time      `json:"updated_at"`
 }
 
+type TeamCreditGrant struct {
+	ID           uuid.UUID          `json:"id"`
+	TeamID       uuid.UUID          `json:"team_id"`
+	AmountUsd    pgtype.Numeric     `json:"amount_usd"`
+	RemainingUsd pgtype.Numeric     `json:"remaining_usd"`
+	Currency     string             `json:"currency"`
+	Reason       *string            `json:"reason"`
+	ExpiresAt    pgtype.Timestamptz `json:"expires_at"`
+	CreatedBy    pgtype.UUID        `json:"created_by"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
+}
+
+type TeamCreditLedger struct {
+	ID                 uuid.UUID          `json:"id"`
+	TeamID             uuid.UUID          `json:"team_id"`
+	GrantID            pgtype.UUID        `json:"grant_id"`
+	BillingPeriodStart pgtype.Timestamptz `json:"billing_period_start"`
+	BillingPeriodEnd   pgtype.Timestamptz `json:"billing_period_end"`
+	AmountUsd          pgtype.Numeric     `json:"amount_usd"`
+	Reason             string             `json:"reason"`
+	CreatedBy          pgtype.UUID        `json:"created_by"`
+	CreatedAt          time.Time          `json:"created_at"`
+}
+
 type TeamFeatureFlag struct {
 	TeamID    uuid.UUID `json:"team_id"`
 	Key       string    `json:"key"`
@@ -475,6 +549,15 @@ type TeamMember struct {
 	ProfileID uuid.UUID `json:"profile_id"`
 	Role      string    `json:"role"`
 	JoinedAt  time.Time `json:"joined_at"`
+}
+
+type TeamPricingPlan struct {
+	TeamID        uuid.UUID          `json:"team_id"`
+	PlanKey       string             `json:"plan_key"`
+	EffectiveFrom time.Time          `json:"effective_from"`
+	EffectiveTo   pgtype.Timestamptz `json:"effective_to"`
+	AssignedBy    pgtype.UUID        `json:"assigned_by"`
+	CreatedAt     time.Time          `json:"created_at"`
 }
 
 type Template struct {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -813,6 +813,34 @@ func TestIntegration_PricingRatesForPlanAtUseRequestedTime(t *testing.T) {
 	}
 }
 
+func TestIntegration_PricingRatesForPlanAtIncludesInactivePlan(t *testing.T) {
+	ctx := context.Background()
+	planKey := "inactive-historical-plan-" + uuid.New().String()
+	now := time.Now().UTC()
+
+	insertPricingPlanForTest(t, ctx, planKey, false)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+		VALUES
+			($1, 'vcpu', 'second', 0.000011, $2),
+			($1, 'memory_gib', 'second', 0.0000045, $2),
+			($1, 'storage_gib', 'second', 0.00000003, $2)
+	`, planKey, now.Add(-time.Hour)); err != nil {
+		t.Fatalf("insert inactive historical pricing rates: %v", err)
+	}
+
+	rates, err := testQueries.ListPricingRatesForPlanAt(ctx, db.ListPricingRatesForPlanAtParams{
+		PlanKey:     planKey,
+		EffectiveAt: now,
+	})
+	if err != nil {
+		t.Fatalf("list pricing rates for inactive plan: %v", err)
+	}
+	if len(rates) != 3 {
+		t.Fatalf("rates length = %d, want 3 for historical inactive plan", len(rates))
+	}
+}
+
 func TestIntegration_InactiveTeamPricingPlanFallsBackToPayg(t *testing.T) {
 	ctx := context.Background()
 	teamID, _ := seedTeamAndKey(t)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -738,15 +738,28 @@ func TestIntegration_PricingRatesUseNewestEffectiveVersion(t *testing.T) {
 	if len(rates) != 3 {
 		t.Fatalf("rates length = %d, want 3", len(rates))
 	}
+	wantPrices := map[string]float64{
+		"vcpu":        0.000022,
+		"memory_gib":  0.0000045,
+		"storage_gib": 0.00000003,
+	}
+	seen := map[string]bool{}
 	for _, rate := range rates {
-		if rate.Resource == "vcpu" {
-			if got := numericFloat64(t, rate.PriceUsd); got != 0.000022 {
-				t.Fatalf("vcpu price = %v, want newest effective price", got)
-			}
-			return
+		want, ok := wantPrices[rate.Resource]
+		if !ok {
+			t.Errorf("unexpected pricing resource %q", rate.Resource)
+			continue
+		}
+		seen[rate.Resource] = true
+		if got := numericFloat64(t, rate.PriceUsd); got != want {
+			t.Errorf("%s price = %v, want %v", rate.Resource, got, want)
 		}
 	}
-	t.Fatal("missing vcpu pricing rate")
+	for resource := range wantPrices {
+		if !seen[resource] {
+			t.Errorf("missing pricing rate for %s", resource)
+		}
+	}
 }
 
 func TestIntegration_PricingRatesForPlanAtUseRequestedTime(t *testing.T) {
@@ -776,15 +789,28 @@ func TestIntegration_PricingRatesForPlanAtUseRequestedTime(t *testing.T) {
 	if len(rates) != 3 {
 		t.Fatalf("rates length = %d, want 3", len(rates))
 	}
+	wantPrices := map[string]float64{
+		"vcpu":        0.000011,
+		"memory_gib":  0.0000045,
+		"storage_gib": 0.00000003,
+	}
+	seen := map[string]bool{}
 	for _, rate := range rates {
-		if rate.Resource == "vcpu" {
-			if got := numericFloat64(t, rate.PriceUsd); got != 0.000011 {
-				t.Fatalf("vcpu price = %v, want price effective at requested time", got)
-			}
-			return
+		want, ok := wantPrices[rate.Resource]
+		if !ok {
+			t.Errorf("unexpected pricing resource %q", rate.Resource)
+			continue
+		}
+		seen[rate.Resource] = true
+		if got := numericFloat64(t, rate.PriceUsd); got != want {
+			t.Errorf("%s price = %v, want %v", rate.Resource, got, want)
 		}
 	}
-	t.Fatal("missing vcpu pricing rate")
+	for resource := range wantPrices {
+		if !seen[resource] {
+			t.Errorf("missing pricing rate for %s", resource)
+		}
+	}
 }
 
 func TestIntegration_InactiveTeamPricingPlanFallsBackToPayg(t *testing.T) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/superserve-ai/sandbox/internal/api"
+	"github.com/superserve-ai/sandbox/internal/billing"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
@@ -713,6 +714,111 @@ func TestIntegration_BillingMetricsWriteFeatureFlag(t *testing.T) {
 	}
 }
 
+func TestIntegration_PricingRatesUseNewestEffectiveVersion(t *testing.T) {
+	ctx := context.Background()
+	planKey := "test-plan-" + uuid.New().String()
+	now := time.Now().UTC()
+
+	insertPricingPlanForTest(t, ctx, planKey, true)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+		VALUES
+			($1, 'vcpu', 'second', 0.000011, $2),
+			($1, 'vcpu', 'second', 0.000022, $3),
+			($1, 'memory_gib', 'second', 0.0000045, $2),
+			($1, 'storage_gib', 'second', 0.00000003, $2)
+	`, planKey, now.Add(-2*time.Hour), now.Add(-time.Hour)); err != nil {
+		t.Fatalf("insert pricing rates: %v", err)
+	}
+
+	rates, err := testQueries.ListActivePricingRates(ctx, planKey)
+	if err != nil {
+		t.Fatalf("list active pricing rates: %v", err)
+	}
+	if len(rates) != 3 {
+		t.Fatalf("rates length = %d, want 3", len(rates))
+	}
+	for _, rate := range rates {
+		if rate.Resource == "vcpu" {
+			if got := numericFloat64(t, rate.PriceUsd); got != 0.000022 {
+				t.Fatalf("vcpu price = %v, want newest effective price", got)
+			}
+			return
+		}
+	}
+	t.Fatal("missing vcpu pricing rate")
+}
+
+func TestIntegration_PricingRatesForPlanAtUseRequestedTime(t *testing.T) {
+	ctx := context.Background()
+	planKey := "test-plan-" + uuid.New().String()
+	now := time.Now().UTC()
+
+	insertPricingPlanForTest(t, ctx, planKey, true)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+		VALUES
+			($1, 'vcpu', 'second', 0.000011, $2),
+			($1, 'vcpu', 'second', 0.000022, $3),
+			($1, 'memory_gib', 'second', 0.0000045, $2),
+			($1, 'storage_gib', 'second', 0.00000003, $2)
+	`, planKey, now.Add(-2*time.Hour), now.Add(time.Hour)); err != nil {
+		t.Fatalf("insert pricing rates: %v", err)
+	}
+
+	rates, err := testQueries.ListPricingRatesForPlanAt(ctx, db.ListPricingRatesForPlanAtParams{
+		PlanKey:     planKey,
+		EffectiveAt: now,
+	})
+	if err != nil {
+		t.Fatalf("list pricing rates for time: %v", err)
+	}
+	if len(rates) != 3 {
+		t.Fatalf("rates length = %d, want 3", len(rates))
+	}
+	for _, rate := range rates {
+		if rate.Resource == "vcpu" {
+			if got := numericFloat64(t, rate.PriceUsd); got != 0.000011 {
+				t.Fatalf("vcpu price = %v, want price effective at requested time", got)
+			}
+			return
+		}
+	}
+	t.Fatal("missing vcpu pricing rate")
+}
+
+func TestIntegration_InactiveTeamPricingPlanFallsBackToPayg(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+	planKey := "inactive-plan-" + uuid.New().String()
+
+	insertPricingPlanForTest(t, ctx, planKey, false)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_pricing_plan (team_id, plan_key, effective_from)
+		VALUES ($1, $2, now() - interval '1 hour')
+	`, teamID, planKey); err != nil {
+		t.Fatalf("assign inactive pricing plan: %v", err)
+	}
+
+	resolved, err := testQueries.GetTeamActivePricingPlan(ctx, teamID)
+	if err != nil {
+		t.Fatalf("get team active pricing plan: %v", err)
+	}
+	if resolved != "payg" {
+		t.Fatalf("pricing plan = %q, want payg fallback", resolved)
+	}
+}
+
+func insertPricingPlanForTest(t *testing.T, ctx context.Context, planKey string, active bool) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_plan (key, name, currency, active)
+		VALUES ($1, 'Integration test pricing', 'USD', $2)
+	`, planKey, active); err != nil {
+		t.Fatalf("insert pricing plan: %v", err)
+	}
+}
+
 func TestIntegration_BillingPeriodRollupFuturePeriodIsZero(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
@@ -1092,6 +1198,421 @@ func TestIntegration_GetTeamBillingUsage(t *testing.T) {
 	}
 	if got := numericFloat64(t, rollup.StorageMibSeconds); got != 245_760 {
 		t.Fatalf("rollup storage MiB seconds = %v, want 245760", got)
+	}
+}
+
+func TestIntegration_BillingRollupWorkersProcessDistinctJobs(t *testing.T) {
+	ctx := context.Background()
+	teamA, _ := seedTeamAndKey(t)
+	teamB, _ := seedTeamAndKey(t)
+	hourStart := time.Now().UTC().Truncate(time.Hour).Add(-time.Hour)
+	hourEnd := hourStart.Add(time.Hour)
+
+	enableBillingHourlyRollups(t, ctx, teamA)
+	enableBillingHourlyRollups(t, ctx, teamB)
+	insertBillingRollupJob(t, ctx, teamA, hourStart, hourEnd, "pending", "", time.Time{}, 0)
+	insertBillingRollupJob(t, ctx, teamB, hourStart, hourEnd, "pending", "", time.Time{}, 0)
+
+	cfg := billing.HourlyRollupConfig{
+		BatchSize:    1,
+		MaxAttempts:  5,
+		LockDuration: time.Minute,
+	}
+	billing.ProcessJobsForTest(ctx, testPool, testQueries, cfg, "rollup-worker-a")
+	billing.ProcessJobsForTest(ctx, testPool, testQueries, cfg, "rollup-worker-b")
+
+	var completed int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM billing_rollup_job
+		WHERE team_id IN ($1, $2)
+		  AND hour_start = $3
+		  AND status = 'completed'
+	`, teamA, teamB, hourStart).Scan(&completed); err != nil {
+		t.Fatalf("count completed rollup jobs: %v", err)
+	}
+	if completed != 2 {
+		t.Fatalf("completed rollup jobs = %d, want 2", completed)
+	}
+
+	var hourlyRows int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM team_billing_usage_hourly
+		WHERE team_id IN ($1, $2)
+		  AND hour_start = $3
+	`, teamA, teamB, hourStart).Scan(&hourlyRows); err != nil {
+		t.Fatalf("count hourly usage rows: %v", err)
+	}
+	if hourlyRows != 2 {
+		t.Fatalf("hourly usage rows = %d, want 2", hourlyRows)
+	}
+}
+
+func TestIntegration_BillingRollupStaleLockIsClaimable(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+	hourStart := time.Now().UTC().Truncate(time.Hour).Add(-2 * time.Hour)
+	hourEnd := hourStart.Add(time.Hour)
+	staleLockedUntil := time.Now().UTC().Add(-time.Minute)
+
+	enableBillingHourlyRollups(t, ctx, teamID)
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"stale-rollup-reclaim"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_compute_billing_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'paused',
+		    vcpu_count = 1, memory_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, hourStart.Add(5*time.Second), hourStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set compute interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_storage_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'deleted',
+		    disk_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, hourStart.Add(5*time.Second), hourStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set storage interval: %v", err)
+	}
+
+	jobID := insertBillingRollupJob(t, ctx, teamID, hourStart, hourEnd, "running", "stale-worker", staleLockedUntil, 5)
+	if _, err := billing.EnqueueHourForTest(ctx, testPool, hourStart, hourEnd); err != nil {
+		t.Fatalf("enqueue hour with stale running job: %v", err)
+	}
+
+	cfg := billing.HourlyRollupConfig{
+		BatchSize:    1,
+		MaxAttempts:  5,
+		LockDuration: time.Minute,
+	}
+	jobs, err := billing.ClaimJobsForTest(ctx, testPool, cfg, "replacement-worker")
+	if err != nil {
+		t.Fatalf("claim stale rollup job: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("claimed jobs = %d, want 1", len(jobs))
+	}
+	if jobs[0].ID != jobID {
+		t.Fatalf("claimed job id = %s, want %s", jobs[0].ID, jobID)
+	}
+
+	var status, lockedBy string
+	var attemptCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, locked_by, attempt_count
+		FROM billing_rollup_job
+		WHERE id = $1
+	`, jobID).Scan(&status, &lockedBy, &attemptCount); err != nil {
+		t.Fatalf("read claimed stale job: %v", err)
+	}
+	if status != "running" {
+		t.Fatalf("status = %q, want running", status)
+	}
+	if lockedBy != "replacement-worker" {
+		t.Fatalf("locked_by = %q, want replacement-worker", lockedBy)
+	}
+	if attemptCount != 5 {
+		t.Fatalf("attempt_count = %d, want 5", attemptCount)
+	}
+}
+
+func TestIntegration_BillingRollupSchedulerPreservesPendingRetryBackoff(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+	hourStart := time.Now().UTC().Truncate(time.Hour).Add(-2 * time.Hour)
+	hourEnd := hourStart.Add(time.Hour)
+	nextAttemptAt := time.Now().UTC().Add(30 * time.Minute)
+
+	enableBillingHourlyRollups(t, ctx, teamID)
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"rollup-preserve-backoff"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_compute_billing_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'paused',
+		    vcpu_count = 1, memory_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, hourStart.Add(5*time.Second), hourStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set compute interval: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO billing_rollup_job (
+			team_id, hour_start, hour_end, status, attempt_count, next_attempt_at, last_error
+		)
+		VALUES ($1, $2, $3, 'pending', 2, $4, 'temporary failure')
+	`, teamID, hourStart, hourEnd, nextAttemptAt); err != nil {
+		t.Fatalf("insert pending retry job: %v", err)
+	}
+	if _, err := billing.EnqueueHourForTest(ctx, testPool, hourStart, hourEnd); err != nil {
+		t.Fatalf("enqueue hour with pending retry job: %v", err)
+	}
+
+	var gotNextAttemptAt time.Time
+	var gotLastError string
+	var gotAttemptCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT next_attempt_at, last_error, attempt_count
+		FROM billing_rollup_job
+		WHERE team_id = $1 AND hour_start = $2
+	`, teamID, hourStart).Scan(&gotNextAttemptAt, &gotLastError, &gotAttemptCount); err != nil {
+		t.Fatalf("read pending retry job: %v", err)
+	}
+	if gotNextAttemptAt.Before(nextAttemptAt.Add(-time.Second)) {
+		t.Fatalf("next_attempt_at = %s, want preserved near %s", gotNextAttemptAt, nextAttemptAt)
+	}
+	if gotLastError != "temporary failure" {
+		t.Fatalf("last_error = %q, want preserved", gotLastError)
+	}
+	if gotAttemptCount != 2 {
+		t.Fatalf("attempt_count = %d, want 2", gotAttemptCount)
+	}
+}
+
+func TestIntegration_BillingRollupBackfillDoesNotRestartAfterCatchUp(t *testing.T) {
+	ctx := context.Background()
+	resetBillingRollupBackfillState(t, ctx)
+	now := time.Now().UTC().Truncate(time.Hour)
+	rollingStart := now.Add(-23 * time.Hour)
+	backfillStart := now.Add(-72 * time.Hour)
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
+		VALUES ('hourly', $1)
+		ON CONFLICT (name) DO UPDATE
+		SET next_hour_start = EXCLUDED.next_hour_start
+	`, rollingStart); err != nil {
+		t.Fatalf("seed caught-up backfill cursor: %v", err)
+	}
+
+	hours, err := billing.NextBackfillHoursForTest(ctx, testPool, backfillStart, rollingStart, 24)
+	if err != nil {
+		t.Fatalf("read next backfill hours: %v", err)
+	}
+	if len(hours) != 0 {
+		t.Fatalf("backfill hours = %d, want 0 after catch-up", len(hours))
+	}
+
+	var cursor time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT next_hour_start
+		FROM billing_rollup_backfill_state
+		WHERE name = 'hourly'
+	`).Scan(&cursor); err != nil {
+		t.Fatalf("read backfill cursor: %v", err)
+	}
+	if !cursor.Equal(rollingStart) {
+		t.Fatalf("cursor = %s, want preserved at %s", cursor, rollingStart)
+	}
+}
+
+func TestIntegration_BillingRollupBackfillCursorAdvancesAfterEnqueue(t *testing.T) {
+	ctx := context.Background()
+	resetBillingRollupBackfillState(t, ctx)
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+	now := time.Now().UTC().Truncate(time.Hour)
+	backfillStart := now.Add(-48 * time.Hour)
+	firstHourEnd := backfillStart.Add(time.Hour)
+
+	enableBillingHourlyRollups(t, ctx, teamID)
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"rollup-backfill-cursor"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_compute_billing_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'paused',
+		    vcpu_count = 1, memory_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, backfillStart.Add(5*time.Second), backfillStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set compute interval: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
+		VALUES ('hourly', $1)
+		ON CONFLICT (name) DO UPDATE
+		SET next_hour_start = EXCLUDED.next_hour_start
+	`, backfillStart); err != nil {
+		t.Fatalf("seed backfill cursor: %v", err)
+	}
+
+	enqueued, err := billing.EnqueueBackfillForTest(ctx, testPool, billing.HourlyRollupConfig{
+		LookbackHours:         24,
+		BackfillLookbackHours: 72,
+		BackfillBatchHours:    1,
+	}, now)
+	if err != nil {
+		t.Fatalf("enqueue backfill: %v", err)
+	}
+	if enqueued == 0 {
+		t.Fatal("expected backfill to enqueue at least one job")
+	}
+
+	var cursor time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT next_hour_start
+		FROM billing_rollup_backfill_state
+		WHERE name = 'hourly'
+	`).Scan(&cursor); err != nil {
+		t.Fatalf("read backfill cursor: %v", err)
+	}
+	if !cursor.Equal(firstHourEnd) {
+		t.Fatalf("cursor = %s, want advanced to %s after successful enqueue", cursor, firstHourEnd)
+	}
+}
+
+func TestIntegration_BillingRollupBackfillEnqueuesBeforeRollingWindow(t *testing.T) {
+	ctx := context.Background()
+	resetBillingRollupBackfillState(t, ctx)
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+	now := time.Now().UTC().Truncate(time.Hour)
+	oldHourStart := now.Add(-48 * time.Hour)
+	oldHourEnd := oldHourStart.Add(time.Hour)
+
+	enableBillingHourlyRollups(t, ctx, teamID)
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"rollup-backfill-old-hour"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_compute_billing_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'paused',
+		    vcpu_count = 1, memory_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, oldHourStart.Add(5*time.Second), oldHourStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set compute interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_storage_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'deleted',
+		    disk_mib = 1024
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, oldHourStart.Add(5*time.Second), oldHourStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set storage interval: %v", err)
+	}
+
+	enqueued, err := billing.EnqueueBackfillForTest(ctx, testPool, billing.HourlyRollupConfig{
+		LookbackHours:         24,
+		BackfillLookbackHours: 72,
+		BackfillBatchHours:    72,
+	}, now)
+	if err != nil {
+		t.Fatalf("enqueue backfill: %v", err)
+	}
+	if enqueued == 0 {
+		t.Fatal("expected backfill to enqueue at least one old rollup job")
+	}
+
+	var jobs int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM billing_rollup_job
+		WHERE team_id = $1
+		  AND hour_start = $2
+		  AND hour_end = $3
+	`, teamID, oldHourStart, oldHourEnd).Scan(&jobs); err != nil {
+		t.Fatalf("count backfilled jobs: %v", err)
+	}
+	if jobs != 1 {
+		t.Fatalf("backfilled jobs = %d, want 1", jobs)
+	}
+}
+
+func resetBillingRollupBackfillState(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `DELETE FROM billing_rollup_backfill_state WHERE name = 'hourly'`); err != nil {
+		t.Fatalf("reset billing rollup backfill state: %v", err)
+	}
+}
+
+func enableBillingHourlyRollups(t *testing.T, ctx context.Context, teamID uuid.UUID) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'billing_hourly_rollups', true)
+		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
+	`, teamID); err != nil {
+		t.Fatalf("enable billing_hourly_rollups: %v", err)
+	}
+}
+
+func insertBillingRollupJob(
+	t *testing.T,
+	ctx context.Context,
+	teamID uuid.UUID,
+	hourStart time.Time,
+	hourEnd time.Time,
+	status string,
+	lockedBy string,
+	lockedUntil time.Time,
+	attemptCount int,
+) uuid.UUID {
+	t.Helper()
+
+	var jobID uuid.UUID
+	if status == "running" {
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO billing_rollup_job (
+				team_id, hour_start, hour_end, status, attempt_count,
+				locked_by, locked_until, next_attempt_at
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, now() - interval '1 minute')
+			RETURNING id
+		`, teamID, hourStart, hourEnd, status, attemptCount, lockedBy, lockedUntil).Scan(&jobID); err != nil {
+			t.Fatalf("insert running billing rollup job: %v", err)
+		}
+		return jobID
+	}
+
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO billing_rollup_job (
+			team_id, hour_start, hour_end, status, attempt_count, next_attempt_at
+		)
+		VALUES ($1, $2, $3, $4, $5, now() - interval '1 minute')
+		RETURNING id
+	`, teamID, hourStart, hourEnd, status, attemptCount).Scan(&jobID); err != nil {
+		t.Fatalf("insert billing rollup job: %v", err)
+	}
+	return jobID
+}
+
+func TestIntegration_TeamCreditLedgerRejectsCrossTeamGrant(t *testing.T) {
+	ctx := context.Background()
+	grantTeamID, _ := seedTeamAndKey(t)
+	ledgerTeamID, _ := seedTeamAndKey(t)
+
+	var grantID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO team_credit_grant (
+			team_id, amount_usd, remaining_usd, reason
+		)
+		VALUES ($1, 10.00, 10.00, 'test grant')
+		RETURNING id
+	`, grantTeamID).Scan(&grantID); err != nil {
+		t.Fatalf("insert credit grant: %v", err)
+	}
+
+	_, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_ledger (
+			team_id, grant_id, amount_usd, reason
+		)
+		VALUES ($1, $2, -1.00, 'cross-team attribution should fail')
+	`, ledgerTeamID, grantID)
+	if err == nil {
+		t.Fatal("expected cross-team credit ledger grant reference to fail")
 	}
 }
 

--- a/supabase/migrations/20260617000003_billing_pricing_credits.sql
+++ b/supabase/migrations/20260617000003_billing_pricing_credits.sql
@@ -1,0 +1,137 @@
+-- PAYG pricing and billing credits.
+--
+-- Pricing is versioned and read-only to tenants. Credits are modeled as a
+-- balance/grant ledger, not as a separate pricing tier, so teams can remain on
+-- PAYG while promotional or support credits are applied at invoice time.
+
+CREATE TABLE pricing_plan (
+    key          text PRIMARY KEY,
+    name         text NOT NULL,
+    currency     text NOT NULL DEFAULT 'USD',
+    active       boolean NOT NULL DEFAULT true,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT pricing_plan_key_nonempty CHECK (key <> ''),
+    CONSTRAINT pricing_plan_currency_valid CHECK (currency ~ '^[A-Z]{3}$')
+);
+
+CREATE TABLE pricing_rate (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_key        text NOT NULL REFERENCES pricing_plan(key),
+    resource        text NOT NULL,
+    unit            text NOT NULL,
+    price_usd       numeric(20, 12) NOT NULL,
+    effective_from  timestamptz NOT NULL DEFAULT now(),
+    effective_to    timestamptz,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT pricing_rate_resource_valid
+        CHECK (resource IN ('vcpu', 'memory_gib', 'storage_gib')),
+    CONSTRAINT pricing_rate_unit_valid
+        CHECK (unit = 'second'),
+    CONSTRAINT pricing_rate_price_non_negative CHECK (price_usd >= 0),
+    CONSTRAINT pricing_rate_period_valid
+        CHECK (effective_to IS NULL OR effective_to > effective_from),
+    CONSTRAINT pricing_rate_unique_version
+        UNIQUE (plan_key, resource, unit, effective_from)
+);
+
+CREATE INDEX idx_pricing_rate_active
+    ON pricing_rate(plan_key, resource, unit, effective_from DESC)
+    WHERE effective_to IS NULL;
+
+CREATE TABLE team_pricing_plan (
+    team_id         uuid NOT NULL REFERENCES team(id),
+    plan_key        text NOT NULL REFERENCES pricing_plan(key),
+    effective_from  timestamptz NOT NULL DEFAULT now(),
+    effective_to    timestamptz,
+    assigned_by     uuid REFERENCES profile(id),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (team_id, effective_from),
+    CONSTRAINT team_pricing_plan_period_valid
+        CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+
+CREATE INDEX idx_team_pricing_plan_active
+    ON team_pricing_plan(team_id, effective_from DESC)
+    WHERE effective_to IS NULL;
+
+CREATE TABLE team_credit_grant (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id        uuid NOT NULL REFERENCES team(id),
+    amount_usd     numeric(20, 6) NOT NULL,
+    remaining_usd  numeric(20, 6) NOT NULL,
+    currency       text NOT NULL DEFAULT 'USD',
+    reason         text,
+    expires_at     timestamptz,
+    created_by     uuid REFERENCES profile(id),
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT team_credit_grant_amount_positive CHECK (amount_usd > 0),
+    CONSTRAINT team_credit_grant_remaining_valid
+        CHECK (remaining_usd >= 0 AND remaining_usd <= amount_usd),
+    CONSTRAINT team_credit_grant_currency_valid CHECK (currency = 'USD'),
+    CONSTRAINT team_credit_grant_id_team_unique UNIQUE (id, team_id)
+);
+
+CREATE INDEX idx_team_credit_grant_active
+    ON team_credit_grant(team_id, expires_at)
+    WHERE remaining_usd > 0;
+
+CREATE TABLE team_credit_ledger (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id              uuid NOT NULL REFERENCES team(id),
+    grant_id             uuid,
+    billing_period_start timestamptz,
+    billing_period_end   timestamptz,
+    amount_usd           numeric(20, 6) NOT NULL,
+    reason               text NOT NULL,
+    created_by           uuid REFERENCES profile(id),
+    created_at           timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT team_credit_ledger_amount_nonzero CHECK (amount_usd <> 0),
+    CONSTRAINT team_credit_ledger_reason_nonempty CHECK (reason <> ''),
+    CONSTRAINT team_credit_ledger_period_valid CHECK (
+        (billing_period_start IS NULL AND billing_period_end IS NULL)
+        OR (billing_period_start IS NOT NULL
+            AND billing_period_end IS NOT NULL
+            AND billing_period_end > billing_period_start)
+    ),
+    CONSTRAINT team_credit_ledger_grant_team_fk
+        FOREIGN KEY (grant_id, team_id)
+        REFERENCES team_credit_grant(id, team_id)
+);
+
+CREATE INDEX idx_team_credit_ledger_team_created
+    ON team_credit_ledger(team_id, created_at DESC);
+
+-- Internal billing/pricing tables: RLS on, no tenant policies. Customer access
+-- must go through backend/service-role APIs so tenants cannot grant credits,
+-- mutate pricing, or read another team's billing state directly.
+ALTER TABLE public.pricing_plan ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pricing_rate ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.team_pricing_plan ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.team_credit_grant ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.team_credit_ledger ENABLE ROW LEVEL SECURITY;
+
+INSERT INTO pricing_plan (key, name, currency, active)
+VALUES ('payg', 'Pay-as-you-go', 'USD', true)
+ON CONFLICT (key) DO UPDATE
+SET name = EXCLUDED.name,
+    currency = EXCLUDED.currency,
+    active = EXCLUDED.active,
+    updated_at = now();
+
+-- Source of truth for the current public rates:
+-- https://www.superserve.ai/pricing/
+INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+VALUES
+    ('payg', 'vcpu', 'second', 0.000014000000, '2026-06-17 00:00:00+00'::timestamptz),
+    ('payg', 'memory_gib', 'second', 0.000004500000, '2026-06-17 00:00:00+00'::timestamptz),
+    ('payg', 'storage_gib', 'second', 0.000000030000, '2026-06-17 00:00:00+00'::timestamptz)
+ON CONFLICT (plan_key, resource, unit, effective_from) DO UPDATE
+SET price_usd = EXCLUDED.price_usd,
+    effective_to = EXCLUDED.effective_to;

--- a/supabase/migrations/20260617000003_billing_pricing_credits.sql
+++ b/supabase/migrations/20260617000003_billing_pricing_credits.sql
@@ -38,8 +38,7 @@ CREATE TABLE pricing_rate (
 );
 
 CREATE INDEX idx_pricing_rate_active
-    ON pricing_rate(plan_key, resource, unit, effective_from DESC)
-    WHERE effective_to IS NULL;
+    ON pricing_rate(plan_key, resource, unit, effective_from DESC);
 
 CREATE TABLE team_pricing_plan (
     team_id         uuid NOT NULL REFERENCES team(id),

--- a/supabase/migrations/20260617000004_billing_rollup_jobs.sql
+++ b/supabase/migrations/20260617000004_billing_rollup_jobs.sql
@@ -1,0 +1,88 @@
+-- Durable hourly billing rollup work queue.
+--
+-- The hourly usage table is recomputable from raw interval rows. This queue
+-- makes catch-up durable and horizontally scalable: one scheduler enqueues
+-- team-hour jobs, and any number of workers can claim jobs with SKIP LOCKED.
+
+CREATE TABLE billing_rollup_scheduler_lease (
+    name          text PRIMARY KEY,
+    locked_by     text NOT NULL,
+    locked_until  timestamptz NOT NULL,
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT billing_rollup_scheduler_lease_name_nonempty CHECK (name <> ''),
+    CONSTRAINT billing_rollup_scheduler_lease_locked_by_nonempty CHECK (locked_by <> '')
+);
+
+CREATE TABLE billing_rollup_backfill_state (
+    name             text PRIMARY KEY,
+    next_hour_start  timestamptz NOT NULL,
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT billing_rollup_backfill_state_name_nonempty CHECK (name <> '')
+);
+
+CREATE TABLE billing_rollup_job (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id        uuid NOT NULL REFERENCES team(id),
+    hour_start     timestamptz NOT NULL,
+    hour_end       timestamptz NOT NULL,
+    status         text NOT NULL DEFAULT 'pending',
+    attempt_count  int NOT NULL DEFAULT 0,
+    next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    locked_by      text,
+    locked_until   timestamptz,
+    last_error     text,
+    enqueued_at    timestamptz NOT NULL DEFAULT now(),
+    completed_at   timestamptz,
+    updated_at     timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT billing_rollup_job_unique_team_hour UNIQUE (team_id, hour_start),
+    CONSTRAINT billing_rollup_job_hour_valid CHECK (hour_end = hour_start + interval '1 hour'),
+    CONSTRAINT billing_rollup_job_status_valid
+        CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+    CONSTRAINT billing_rollup_job_attempt_count_non_negative CHECK (attempt_count >= 0),
+    CONSTRAINT billing_rollup_job_lock_fields CHECK (
+        (status = 'running' AND locked_by IS NOT NULL AND locked_until IS NOT NULL)
+        OR (status <> 'running' AND locked_by IS NULL AND locked_until IS NULL)
+    ),
+    CONSTRAINT billing_rollup_job_completed_fields CHECK (
+        (status = 'completed' AND completed_at IS NOT NULL)
+        OR (status <> 'completed')
+    )
+);
+
+CREATE INDEX idx_billing_rollup_job_claim
+    ON billing_rollup_job(status, next_attempt_at, hour_start, updated_at)
+    WHERE status IN ('pending', 'failed', 'running');
+
+CREATE INDEX idx_billing_rollup_job_team_hour
+    ON billing_rollup_job(team_id, hour_start DESC);
+
+CREATE INDEX idx_billing_rollup_job_lag
+    ON billing_rollup_job(hour_start)
+    WHERE status IN ('pending', 'failed');
+
+-- The scheduler discovers candidate teams by hour without a team_id predicate.
+-- These time-first indexes avoid full interval-table scans on every tick.
+CREATE INDEX idx_scbi_started_team_rollup
+    ON sandbox_compute_billing_interval(started_at, team_id);
+CREATE INDEX idx_scbi_open_started_team_rollup
+    ON sandbox_compute_billing_interval(started_at, team_id)
+    WHERE ended_at IS NULL;
+CREATE INDEX idx_scbi_ended_team_rollup
+    ON sandbox_compute_billing_interval(ended_at, team_id)
+    WHERE ended_at IS NOT NULL;
+
+CREATE INDEX idx_ssi_started_team_rollup
+    ON sandbox_storage_interval(started_at, team_id);
+CREATE INDEX idx_ssi_open_started_team_rollup
+    ON sandbox_storage_interval(started_at, team_id)
+    WHERE ended_at IS NULL;
+CREATE INDEX idx_ssi_ended_team_rollup
+    ON sandbox_storage_interval(ended_at, team_id)
+    WHERE ended_at IS NOT NULL;
+
+ALTER TABLE public.billing_rollup_scheduler_lease ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.billing_rollup_backfill_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.billing_rollup_job ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Adds durable hourly billing rollups with a scalable worker queue, backfill support, retry handling, and tenant-scoped billing usage aggregation. Also introduces PAYG pricing and credit tables so billing calculations can use versioned pricing data and customer credits safely.
https://linear.app/superserve/issue/SS-55