### PR TITLE
api: publish only the production server in the OpenAPI spec

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,12 +44,8 @@ info:
     name: Proprietary
 
 servers:
-  - url: https://api-staging.superserve.ai
-    description: Staging
   - url: https://api.superserve.ai
     description: Production
-  - url: http://localhost:8080
-    description: Local development
 
 paths:
   /health:


### PR DESCRIPTION
The public API reference (docs.superserve.ai) was defaulting to the staging URL because `servers:` listed staging first. Keep only the production server (`https://api.superserve.ai`) so the rendered examples and the server default point at prod. Spec metadata only — no route or behavior change; route-sync test green.