### PR TITLE
Race condition fix

### DIFF
--- a/internal/billing/rollup.go
+++ b/internal/billing/rollup.go
@@ -43,6 +43,13 @@ type HourlyRollupConfig struct {
 	Workers               int
 }
 
+type teamBackfillBatch struct {
+	TeamID     uuid.UUID
+	FromHour   time.Time
+	ToHour     time.Time
+	HourStarts []time.Time
+}
+
 type rollupJob struct {
 	ID           uuid.UUID
 	TeamID       uuid.UUID
@@ -302,85 +309,229 @@ func enqueueBackfill(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupCo
 		return 0, nil
 	}
 
-	hours, err := nextBackfillHours(ctx, pool, backfillStart, rollingStart, cfg.BackfillBatchHours)
+	batches, err := nextTeamBackfillBatches(ctx, pool, backfillStart, rollingStart, cfg.BackfillBatchHours, cfg.BatchSize)
 	if err != nil {
 		return 0, err
 	}
-	if len(hours) == 0 {
+	if len(batches) == 0 {
 		return 0, nil
 	}
 
 	total := int64(0)
-	for _, hourStart := range hours {
-		enqueued, err := enqueueHour(ctx, pool, hourStart, hourStart.Add(time.Hour), false)
+	for _, batch := range batches {
+		batchTotal := int64(0)
+		for _, hourStart := range batch.HourStarts {
+			enqueued, err := enqueueTeamHour(ctx, pool, batch.TeamID, hourStart, hourStart.Add(time.Hour), false)
+			if err != nil {
+				return total, err
+			}
+			batchTotal += enqueued
+		}
+		total += batchTotal
+
+		enabled, err := teamFeatureEnabled(ctx, pool, batch.TeamID, "billing_hourly_rollups")
 		if err != nil {
 			return total, err
 		}
-		total += enqueued
-	}
+		if !enabled {
+			log.Info().
+				Str("team_id", batch.TeamID.String()).
+				Time("from_hour", batch.FromHour).
+				Time("to_hour", batch.ToHour).
+				Msg("billing hourly rollup backfill cursor not advanced because team flag is disabled")
+			continue
+		}
 
-	if err := advanceBackfillCursor(ctx, pool, hours[0], hours[len(hours)-1].Add(time.Hour)); err != nil {
-		log.Warn().
-			Err(err).
-			Int64("jobs_enqueued", total).
-			Time("from_hour", hours[0]).
-			Time("to_hour", hours[len(hours)-1].Add(time.Hour)).
-			Msg("advance billing rollup backfill cursor failed after enqueue")
-		return total, err
+		if err := advanceTeamBackfillCursor(ctx, pool, batch.TeamID, batch.FromHour, batch.ToHour); err != nil {
+			log.Warn().
+				Err(err).
+				Str("team_id", batch.TeamID.String()).
+				Int64("jobs_enqueued", batchTotal).
+				Time("from_hour", batch.FromHour).
+				Time("to_hour", batch.ToHour).
+				Msg("advance billing rollup team backfill cursor failed after enqueue")
+			return total, err
+		}
 	}
 	return total, nil
 }
 
-func nextBackfillHours(ctx context.Context, pool *pgxpool.Pool, startHour, endHour time.Time, batchHours int) ([]time.Time, error) {
+func enqueueTeamHour(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, hourStart, hourEnd time.Time, refreshCompleted bool) (int64, error) {
 	const query = `
-INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
-VALUES ('hourly', $1)
-ON CONFLICT (name) DO UPDATE
-SET next_hour_start = CASE
-        WHEN billing_rollup_backfill_state.next_hour_start < $1 THEN $1
-        ELSE billing_rollup_backfill_state.next_hour_start
+INSERT INTO billing_rollup_job (team_id, hour_start, hour_end, status, next_attempt_at)
+SELECT $1, $2, $3, 'pending', now()
+WHERE feature_enabled('billing_hourly_rollups', $1)
+  AND EXISTS (
+      SELECT 1
+      FROM sandbox_compute_billing_interval i
+      WHERE i.team_id = $1
+        AND i.started_at < $3
+        AND $2 < LEAST(now(), $3)
+        AND COALESCE(i.ended_at, LEAST(now(), $3)) > $2
+
+      UNION
+
+      SELECT 1
+      FROM sandbox_storage_interval i
+      WHERE i.team_id = $1
+        AND i.started_at < $3
+        AND $2 < LEAST(now(), $3)
+        AND COALESCE(i.ended_at, LEAST(now(), $3)) > $2
+  )
+ON CONFLICT (team_id, hour_start) DO UPDATE
+SET hour_end = EXCLUDED.hour_end,
+    status = 'pending',
+    locked_by = NULL,
+    locked_until = NULL,
+    last_error = CASE
+        WHEN billing_rollup_job.status = 'pending'
+         AND billing_rollup_job.next_attempt_at > now()
+            THEN billing_rollup_job.last_error
+        ELSE NULL
     END,
-    updated_at = CASE
-        WHEN billing_rollup_backfill_state.next_hour_start < $1 THEN now()
-        ELSE billing_rollup_backfill_state.updated_at
-    END
-RETURNING next_hour_start`
+    next_attempt_at = CASE
+        WHEN billing_rollup_job.status = 'pending'
+         AND billing_rollup_job.next_attempt_at > now()
+            THEN billing_rollup_job.next_attempt_at
+        ELSE now()
+    END,
+    attempt_count = CASE
+        WHEN billing_rollup_job.status = 'completed' THEN 0
+        ELSE billing_rollup_job.attempt_count
+    END,
+    completed_at = NULL,
+    updated_at = now()
+WHERE billing_rollup_job.status = 'pending'
+   OR (
+       $4::boolean
+       AND billing_rollup_job.status = 'completed'
+       AND (
+           billing_rollup_job.hour_end > now()
+           OR billing_rollup_job.completed_at < now() - interval '1 hour'
+       )
+   )`
 
-	var cursor time.Time
-	if err := pool.QueryRow(ctx, query, startHour).Scan(&cursor); err != nil {
-		return nil, err
-	}
-
-	if !cursor.Before(endHour) {
-		return nil, nil
-	}
-	batchEnd := cursor.Add(time.Duration(batchHours) * time.Hour)
-	if batchEnd.After(endHour) {
-		batchEnd = endHour
-	}
-
-	hours := make([]time.Time, 0, int(batchEnd.Sub(cursor)/time.Hour))
-	for hour := cursor; hour.Before(batchEnd); hour = hour.Add(time.Hour) {
-		hours = append(hours, hour)
-	}
-	return hours, nil
+	tag, err := pool.Exec(ctx, query, teamID, hourStart, hourEnd, refreshCompleted)
+	return tag.RowsAffected(), err
 }
 
-func advanceBackfillCursor(ctx context.Context, pool *pgxpool.Pool, fromHour, toHour time.Time) error {
+func nextTeamBackfillBatches(ctx context.Context, pool *pgxpool.Pool, startHour, endHour time.Time, batchHours int, teamLimit int) ([]teamBackfillBatch, error) {
+	if teamLimit <= 0 {
+		teamLimit = defaultHourlyRollupBatchSize
+	}
+
+	const query = `
+WITH interval_teams AS (
+    SELECT DISTINCT team_id
+    FROM (
+        SELECT i.team_id
+        FROM sandbox_compute_billing_interval i
+        WHERE i.started_at < $2
+          AND $1 < LEAST(now(), $2)
+          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+
+        UNION
+
+        SELECT i.team_id
+        FROM sandbox_storage_interval i
+        WHERE i.started_at < $2
+          AND $1 < LEAST(now(), $2)
+          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+    ) billing_teams
+    WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
+),
+eligible_team_cursors AS (
+    SELECT
+        interval_teams.team_id,
+        COALESCE(state.next_hour_start, $1) AS next_hour_start
+    FROM interval_teams
+    LEFT JOIN billing_rollup_team_backfill_state state
+      ON state.team_id = interval_teams.team_id
+    WHERE COALESCE(state.next_hour_start, $1) < $2
+),
+candidate_teams AS (
+    SELECT team_id, next_hour_start
+    FROM eligible_team_cursors
+    ORDER BY next_hour_start, team_id
+    LIMIT $3
+),
+upserted AS (
+    INSERT INTO billing_rollup_team_backfill_state (team_id, next_hour_start)
+    SELECT team_id, next_hour_start
+    FROM candidate_teams
+    ON CONFLICT (team_id) DO UPDATE
+    SET next_hour_start = CASE
+            WHEN billing_rollup_team_backfill_state.next_hour_start < $1 THEN $1
+            ELSE billing_rollup_team_backfill_state.next_hour_start
+        END,
+        updated_at = CASE
+            WHEN billing_rollup_team_backfill_state.next_hour_start < $1 THEN now()
+            ELSE billing_rollup_team_backfill_state.updated_at
+        END
+    RETURNING team_id, next_hour_start
+)
+SELECT team_id, next_hour_start
+FROM upserted
+ORDER BY next_hour_start, team_id`
+
+	rows, err := pool.Query(ctx, query, startHour, endHour, teamLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	batches := make([]teamBackfillBatch, 0, teamLimit)
+	for rows.Next() {
+		var batch teamBackfillBatch
+		if err := rows.Scan(&batch.TeamID, &batch.FromHour); err != nil {
+			return nil, err
+		}
+		batch.ToHour = batch.FromHour.Add(time.Duration(batchHours) * time.Hour)
+		if batch.ToHour.After(endHour) {
+			batch.ToHour = endHour
+		}
+		for hour := batch.FromHour; hour.Before(batch.ToHour); hour = hour.Add(time.Hour) {
+			batch.HourStarts = append(batch.HourStarts, hour)
+		}
+		batches = append(batches, batch)
+	}
+	return batches, rows.Err()
+}
+
+func advanceTeamBackfillCursor(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, fromHour, toHour time.Time) error {
 	tag, err := pool.Exec(ctx, `
-UPDATE billing_rollup_backfill_state
-SET next_hour_start = $2,
+UPDATE billing_rollup_team_backfill_state
+SET next_hour_start = $3,
     updated_at = now()
-WHERE name = 'hourly'
-  AND next_hour_start = $1
-`, fromHour, toHour)
+WHERE team_id = $1
+  AND next_hour_start >= $2
+  AND next_hour_start <= $3
+`, teamID, fromHour, toHour)
 	if err != nil {
 		return err
 	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("billing rollup backfill cursor changed before advance from %s to %s", fromHour, toHour)
+	if tag.RowsAffected() > 0 {
+		return nil
 	}
-	return nil
+
+	var current time.Time
+	if err := pool.QueryRow(ctx, `
+SELECT next_hour_start
+FROM billing_rollup_team_backfill_state
+WHERE team_id = $1
+`, teamID).Scan(&current); err != nil {
+		return err
+	}
+	if !current.Before(toHour) {
+		return nil
+	}
+	return fmt.Errorf("billing rollup team backfill cursor moved backward before advance for team %s from %s to %s; current cursor is %s", teamID, fromHour, toHour, current)
+}
+
+func teamFeatureEnabled(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, key string) (bool, error) {
+	var enabled bool
+	err := pool.QueryRow(ctx, `SELECT feature_enabled($1, $2)`, key, teamID).Scan(&enabled)
+	return enabled, err
 }
 
 func claimJobs(ctx context.Context, pool *pgxpool.Pool, cfg HourlyRollupConfig, workerID string, lockedUntil time.Time) ([]rollupJob, error) {

--- a/internal/billing/rollup_integration_exports.go
+++ b/internal/billing/rollup_integration_exports.go
@@ -49,8 +49,8 @@ func EnqueueBackfillForTest(ctx context.Context, pool *pgxpool.Pool, cfg HourlyR
 	return enqueueBackfill(ctx, pool, cfg, now)
 }
 
-func NextBackfillHoursForTest(ctx context.Context, pool *pgxpool.Pool, startHour time.Time, endHour time.Time, batchHours int) ([]time.Time, error) {
-	return nextBackfillHours(ctx, pool, startHour, endHour, batchHours)
+func AdvanceTeamBackfillCursorForTest(ctx context.Context, pool *pgxpool.Pool, teamID uuid.UUID, fromHour time.Time, toHour time.Time) error {
+	return advanceTeamBackfillCursor(ctx, pool, teamID, fromHour, toHour)
 }
 
 func ProcessJobsForTest(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, cfg HourlyRollupConfig, workerID string) {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -239,6 +239,12 @@ type BillingRollupSchedulerLease struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 }
 
+type BillingRollupTeamBackfillState struct {
+	TeamID        uuid.UUID `json:"team_id"`
+	NextHourStart time.Time `json:"next_hour_start"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
 type DeviceCode struct {
 	ID         uuid.UUID   `json:"id"`
 	DeviceCode string      `json:"device_code"`

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1431,43 +1431,6 @@ func TestIntegration_BillingRollupSchedulerPreservesPendingRetryBackoff(t *testi
 	}
 }
 
-func TestIntegration_BillingRollupBackfillDoesNotRestartAfterCatchUp(t *testing.T) {
-	ctx := context.Background()
-	resetBillingRollupBackfillState(t, ctx)
-	now := time.Now().UTC().Truncate(time.Hour)
-	rollingStart := now.Add(-23 * time.Hour)
-	backfillStart := now.Add(-72 * time.Hour)
-
-	if _, err := testPool.Exec(ctx, `
-		INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
-		VALUES ('hourly', $1)
-		ON CONFLICT (name) DO UPDATE
-		SET next_hour_start = EXCLUDED.next_hour_start
-	`, rollingStart); err != nil {
-		t.Fatalf("seed caught-up backfill cursor: %v", err)
-	}
-
-	hours, err := billing.NextBackfillHoursForTest(ctx, testPool, backfillStart, rollingStart, 24)
-	if err != nil {
-		t.Fatalf("read next backfill hours: %v", err)
-	}
-	if len(hours) != 0 {
-		t.Fatalf("backfill hours = %d, want 0 after catch-up", len(hours))
-	}
-
-	var cursor time.Time
-	if err := testPool.QueryRow(ctx, `
-		SELECT next_hour_start
-		FROM billing_rollup_backfill_state
-		WHERE name = 'hourly'
-	`).Scan(&cursor); err != nil {
-		t.Fatalf("read backfill cursor: %v", err)
-	}
-	if !cursor.Equal(rollingStart) {
-		t.Fatalf("cursor = %s, want preserved at %s", cursor, rollingStart)
-	}
-}
-
 func TestIntegration_BillingRollupBackfillCursorAdvancesAfterEnqueue(t *testing.T) {
 	ctx := context.Background()
 	resetBillingRollupBackfillState(t, ctx)
@@ -1483,22 +1446,15 @@ func TestIntegration_BillingRollupBackfillCursorAdvancesAfterEnqueue(t *testing.
 		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
 	}
 	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
-	if _, err := testPool.Exec(ctx, `
-		UPDATE sandbox_compute_billing_interval
-		SET started_at = $2, ended_at = $3, end_reason = 'paused',
-		    vcpu_count = 1, memory_mib = 1024
-		WHERE sandbox_id = $1 AND ended_at IS NULL
-	`, sandboxID, backfillStart.Add(5*time.Second), backfillStart.Add(30*time.Second)); err != nil {
-		t.Fatalf("set compute interval: %v", err)
-	}
+	seedComputeBillingInterval(t, ctx, sandboxID, teamID, backfillStart.Add(5*time.Second), backfillStart.Add(30*time.Second))
 
 	if _, err := testPool.Exec(ctx, `
-		INSERT INTO billing_rollup_backfill_state (name, next_hour_start)
-		VALUES ('hourly', $1)
-		ON CONFLICT (name) DO UPDATE
+		INSERT INTO billing_rollup_team_backfill_state (team_id, next_hour_start)
+		VALUES ($1, $2)
+		ON CONFLICT (team_id) DO UPDATE
 		SET next_hour_start = EXCLUDED.next_hour_start
-	`, backfillStart); err != nil {
-		t.Fatalf("seed backfill cursor: %v", err)
+	`, teamID, backfillStart); err != nil {
+		t.Fatalf("seed team backfill cursor: %v", err)
 	}
 
 	enqueued, err := billing.EnqueueBackfillForTest(ctx, testPool, billing.HourlyRollupConfig{
@@ -1516,13 +1472,132 @@ func TestIntegration_BillingRollupBackfillCursorAdvancesAfterEnqueue(t *testing.
 	var cursor time.Time
 	if err := testPool.QueryRow(ctx, `
 		SELECT next_hour_start
-		FROM billing_rollup_backfill_state
-		WHERE name = 'hourly'
-	`).Scan(&cursor); err != nil {
-		t.Fatalf("read backfill cursor: %v", err)
+		FROM billing_rollup_team_backfill_state
+		WHERE team_id = $1
+	`, teamID).Scan(&cursor); err != nil {
+		t.Fatalf("read team backfill cursor: %v", err)
 	}
 	if !cursor.Equal(firstHourEnd) {
 		t.Fatalf("cursor = %s, want advanced to %s after successful enqueue", cursor, firstHourEnd)
+	}
+}
+
+func TestIntegration_BillingRollupTeamBackfillCursorAdvanceToleratesConcurrentAdvance(t *testing.T) {
+	ctx := context.Background()
+	resetBillingRollupBackfillState(t, ctx)
+	teamID, _ := seedTeamAndKey(t)
+	fromHour := time.Now().UTC().Truncate(time.Hour).Add(-48 * time.Hour)
+	toHour := fromHour.Add(24 * time.Hour)
+	concurrentCursor := fromHour.Add(time.Hour)
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO billing_rollup_team_backfill_state (team_id, next_hour_start)
+		VALUES ($1, $2)
+	`, teamID, concurrentCursor); err != nil {
+		t.Fatalf("seed concurrent team backfill cursor: %v", err)
+	}
+	if err := billing.AdvanceTeamBackfillCursorForTest(ctx, testPool, teamID, fromHour, toHour); err != nil {
+		t.Fatalf("advance team cursor after concurrent progress: %v", err)
+	}
+
+	var cursor time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT next_hour_start
+		FROM billing_rollup_team_backfill_state
+		WHERE team_id = $1
+	`, teamID).Scan(&cursor); err != nil {
+		t.Fatalf("read team backfill cursor: %v", err)
+	}
+	if !cursor.Equal(toHour) {
+		t.Fatalf("cursor = %s, want advanced to %s", cursor, toHour)
+	}
+	if err := billing.AdvanceTeamBackfillCursorForTest(ctx, testPool, teamID, fromHour, toHour); err != nil {
+		t.Fatalf("advance team cursor should be idempotent once already advanced: %v", err)
+	}
+}
+
+func TestIntegration_BillingRollupBackfillDoesNotAdvanceDisabledTeamCursor(t *testing.T) {
+	ctx := context.Background()
+	resetBillingRollupBackfillState(t, ctx)
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+	now := time.Now().UTC().Truncate(time.Hour)
+	oldHourStart := now.Add(-48 * time.Hour)
+	oldHourEnd := oldHourStart.Add(time.Hour)
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES
+			($1, 'billing_metrics_write', true),
+			($1, 'billing_hourly_rollups', false)
+		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
+	`, teamID); err != nil {
+		t.Fatalf("configure billing feature flags: %v", err)
+	}
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"rollup-backfill-disabled-team"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+	seedComputeBillingInterval(t, ctx, sandboxID, teamID, oldHourStart.Add(5*time.Second), oldHourStart.Add(30*time.Second))
+
+	if _, err := billing.EnqueueBackfillForTest(ctx, testPool, billing.HourlyRollupConfig{
+		LookbackHours:         24,
+		BackfillLookbackHours: 72,
+		BackfillBatchHours:    72,
+	}, now); err != nil {
+		t.Fatalf("enqueue disabled backfill: %v", err)
+	}
+
+	var disabledTeamJobs int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM billing_rollup_job
+		WHERE team_id = $1
+	`, teamID).Scan(&disabledTeamJobs); err != nil {
+		t.Fatalf("count disabled team backfill jobs: %v", err)
+	}
+	if disabledTeamJobs != 0 {
+		t.Fatalf("disabled team backfill jobs = %d, want 0", disabledTeamJobs)
+	}
+
+	var cursorRows int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM billing_rollup_team_backfill_state
+		WHERE team_id = $1
+	`, teamID).Scan(&cursorRows); err != nil {
+		t.Fatalf("count disabled team backfill cursor rows: %v", err)
+	}
+	if cursorRows != 0 {
+		t.Fatalf("disabled team backfill cursor rows = %d, want 0", cursorRows)
+	}
+
+	enableBillingHourlyRollups(t, ctx, teamID)
+	enqueued, err := billing.EnqueueBackfillForTest(ctx, testPool, billing.HourlyRollupConfig{
+		LookbackHours:         24,
+		BackfillLookbackHours: 72,
+		BackfillBatchHours:    72,
+	}, now)
+	if err != nil {
+		t.Fatalf("enqueue enabled backfill: %v", err)
+	}
+	if enqueued == 0 {
+		t.Fatal("expected newly enabled team to enqueue historical backfill job")
+	}
+
+	var jobs int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM billing_rollup_job
+		WHERE team_id = $1
+		  AND hour_start = $2
+		  AND hour_end = $3
+	`, teamID, oldHourStart, oldHourEnd).Scan(&jobs); err != nil {
+		t.Fatalf("count newly enabled team backfill jobs: %v", err)
+	}
+	if jobs != 1 {
+		t.Fatalf("newly enabled team backfill jobs = %d, want 1", jobs)
 	}
 }
 
@@ -1590,16 +1665,39 @@ func resetBillingRollupBackfillState(t *testing.T, ctx context.Context) {
 	if _, err := testPool.Exec(ctx, `DELETE FROM billing_rollup_backfill_state WHERE name = 'hourly'`); err != nil {
 		t.Fatalf("reset billing rollup backfill state: %v", err)
 	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM billing_rollup_team_backfill_state`); err != nil {
+		t.Fatalf("reset billing rollup team backfill state: %v", err)
+	}
+}
+
+func seedComputeBillingInterval(t *testing.T, ctx context.Context, sandboxID uuid.UUID, teamID uuid.UUID, startedAt time.Time, endedAt time.Time) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		DELETE FROM sandbox_compute_billing_interval
+		WHERE sandbox_id = $1
+	`, sandboxID); err != nil {
+		t.Fatalf("clear compute billing intervals: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_compute_billing_interval (
+			sandbox_id, team_id, vcpu_count, memory_mib, started_at, ended_at, end_reason
+		)
+		VALUES ($1, $2, 1, 1024, $3, $4, 'paused')
+	`, sandboxID, teamID, startedAt, endedAt); err != nil {
+		t.Fatalf("insert compute billing interval: %v", err)
+	}
 }
 
 func enableBillingHourlyRollups(t *testing.T, ctx context.Context, teamID uuid.UUID) {
 	t.Helper()
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO team_feature_flag (team_id, key, enabled)
-		VALUES ($1, 'billing_hourly_rollups', true)
+		VALUES
+			($1, 'billing_metrics_write', true),
+			($1, 'billing_hourly_rollups', true)
 		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
 	`, teamID); err != nil {
-		t.Fatalf("enable billing_hourly_rollups: %v", err)
+		t.Fatalf("enable billing rollup feature flags: %v", err)
 	}
 }
 
@@ -2112,24 +2210,25 @@ func TestIntegration_ActivityLog_PauseRecorded(t *testing.T) {
 		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
 	}
 
-	time.Sleep(100 * time.Millisecond)
-	activities, err := testQueries.ListActivityBySandbox(ctx, db.ListActivityBySandboxParams{
-		SandboxID: pgtype.UUID{Bytes: sandboxID, Valid: true},
-		Limit:     20,
-	})
-	if err != nil {
-		t.Fatalf("list activities: %v", err)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		activities, err := testQueries.ListActivityBySandbox(ctx, db.ListActivityBySandboxParams{
+			SandboxID: pgtype.UUID{Bytes: sandboxID, Valid: true},
+			Limit:     20,
+		})
+		if err != nil {
+			t.Fatalf("list activities: %v", err)
+		}
+
+		for _, a := range activities {
+			if a.Category == "sandbox" && a.Action == "paused" {
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
 	}
 
-	var found bool
-	for _, a := range activities {
-		if a.Category == "sandbox" && a.Action == "paused" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("no 'sandbox/paused' activity record after pause")
-	}
+	t.Error("no 'sandbox/paused' activity record after pause")
 }
 
 func TestIntegration_ActivityLog_ActorAttributedToKeyCreator(t *testing.T) {

--- a/supabase/migrations/20260618000003_billing_rollup_team_backfill_state.sql
+++ b/supabase/migrations/20260618000003_billing_rollup_team_backfill_state.sql
@@ -1,0 +1,54 @@
+-- Tenant-aware hourly billing backfill cursor.
+--
+-- The original backfill cursor was global. That could skip historical hours
+-- for teams whose billing_hourly_rollups flag was disabled while the global
+-- cursor passed over their intervals. Per-team cursors let newly enabled teams
+-- catch up from the configured backfill start without rewinding other tenants.
+
+CREATE TABLE billing_rollup_team_backfill_state (
+    team_id          uuid PRIMARY KEY REFERENCES team(id) ON DELETE CASCADE,
+    next_hour_start  timestamptz NOT NULL,
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_billing_rollup_team_backfill_next_hour
+    ON billing_rollup_team_backfill_state(next_hour_start, team_id);
+
+-- This is internal scheduler state. RLS is enabled and no policies are created
+-- intentionally: anon/authenticated roles get no direct access, while the
+-- control plane scheduler uses the service role to read and advance cursors.
+ALTER TABLE public.billing_rollup_team_backfill_state ENABLE ROW LEVEL SECURITY;
+
+
+-- Bootstrap tenants known to have been covered by the old global cursor so
+-- deploying this migration does not rewind them to the full backfill lookback.
+-- Teams with explicit team-level billing_hourly_rollups overrides are left
+-- unseeded because team_feature_flag only stores current state: a currently
+-- enabled override may have been disabled while the old global cursor advanced.
+-- Those teams initialize from the configured backfill start when the scheduler
+-- next sees them enabled, preserving catch-up for skipped hours.
+WITH global_cursor AS (
+    SELECT next_hour_start
+    FROM billing_rollup_backfill_state
+    WHERE name = 'hourly'
+),
+candidate_teams AS (
+    SELECT DISTINCT team_id
+    FROM (
+        SELECT team_id FROM sandbox_compute_billing_interval
+        UNION
+        SELECT team_id FROM sandbox_storage_interval
+    ) billing_teams
+    WHERE feature_enabled('billing_hourly_rollups', billing_teams.team_id)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM team_feature_flag tff
+          WHERE tff.team_id = billing_teams.team_id
+            AND tff.key = 'billing_hourly_rollups'
+      )
+)
+INSERT INTO billing_rollup_team_backfill_state (team_id, next_hour_start)
+SELECT candidate_teams.team_id, global_cursor.next_hour_start
+FROM candidate_teams
+CROSS JOIN global_cursor
+ON CONFLICT (team_id) DO NOTHING;


### PR DESCRIPTION
Fixes hourly billing rollup backfill to use tenant-scoped cursors so disabled teams are not skipped and concurrent scheduler workers can safely make progress without cursor races.