### PR TITLE
reaper: anchor sandbox timeout window on current active session so resume re-arms it

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -309,23 +309,35 @@ JOIN team t ON s.team_id = t.id
 WHERE s.id = $1 AND s.destroyed_at IS NULL;
 
 -- name: ClaimExpiredSandboxes :many
--- Atomically claims active sandboxes whose hard timeout has elapsed and marks
+-- Atomically claims active sandboxes whose timeout window has elapsed and marks
 -- them as 'pausing'. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas
 -- skip rows already being processed, so multi-replica Cloud Run deployments
 -- do not double-process the same sandbox.
 --
+-- The timeout window is measured from the start of the current active session
+-- (the open sandbox_active_interval row, which is re-opened on every resume),
+-- not from created_at. So each resume re-arms the full timeout_seconds window:
+-- a sandbox resumed after pausing gets a fresh window instead of being claimed
+-- again immediately on a deadline that already elapsed.
+--
 -- Only 'active' sandboxes are claimed — paused sandboxes are already stopped,
 -- and transient states (starting, pausing) are skipped to avoid racing with
 -- in-progress operations. The 60-second grace window prevents reaping a sandbox
--- that was just created with a very short timeout before it finishes starting up.
+-- that was just resumed (or created) with a very short timeout before it settles.
 WITH expired AS (
   SELECT id, team_id, name, snapshot_id, host_id
   FROM sandbox
   WHERE destroyed_at IS NULL
     AND timeout_seconds IS NOT NULL
     AND status = 'active'
-    AND created_at + (timeout_seconds || ' seconds')::interval < now()
-    AND created_at < now() - interval '60 seconds'
+    AND (
+      SELECT max(sai.started_at) FROM sandbox_active_interval sai
+      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
+    ) + (timeout_seconds || ' seconds')::interval < now()
+    AND (
+      SELECT max(sai.started_at) FROM sandbox_active_interval sai
+      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
+    ) < now() - interval '60 seconds'
   ORDER BY created_at ASC
   LIMIT $1
   FOR UPDATE SKIP LOCKED

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -309,38 +309,39 @@ JOIN team t ON s.team_id = t.id
 WHERE s.id = $1 AND s.destroyed_at IS NULL;
 
 -- name: ClaimExpiredSandboxes :many
--- Atomically claims active sandboxes whose timeout window has elapsed and marks
--- them as 'pausing'. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas
--- skip rows already being processed, so multi-replica Cloud Run deployments
--- do not double-process the same sandbox.
+-- Atomically claims active sandboxes past their timeout and marks them 'pausing'.
+-- FOR UPDATE OF s SKIP LOCKED lets concurrent reaper replicas skip in-flight rows.
 --
--- The timeout window is measured from the start of the current active session
--- (the open sandbox_active_interval row, which is re-opened on every resume),
--- not from created_at. So each resume re-arms the full timeout_seconds window:
--- a sandbox resumed after pausing gets a fresh window instead of being claimed
--- again immediately on a deadline that already elapsed.
+-- timeout_seconds bounds an active session, not total lifetime, so the window is
+-- anchored on the current session start (the open sandbox_active_interval row,
+-- reopened on resume) — each resume re-arms it. Anchoring on created_at would
+-- instead keep a sandbox that ever exceeded its timeout permanently eligible.
 --
--- Only 'active' sandboxes are claimed — paused sandboxes are already stopped,
--- and transient states (starting, pausing) are skipped to avoid racing with
--- in-progress operations. The 60-second grace window prevents reaping a sandbox
--- that was just resumed (or created) with a very short timeout before it settles.
-WITH expired AS (
-  SELECT id, team_id, name, snapshot_id, host_id
-  FROM sandbox
-  WHERE destroyed_at IS NULL
-    AND timeout_seconds IS NOT NULL
-    AND status = 'active'
-    AND (
-      SELECT max(sai.started_at) FROM sandbox_active_interval sai
-      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
-    ) + (timeout_seconds || ' seconds')::interval < now()
-    AND (
-      SELECT max(sai.started_at) FROM sandbox_active_interval sai
-      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
-    ) < now() - interval '60 seconds'
-  ORDER BY created_at ASC
+-- COALESCE falls back to created_at when interval bookkeeping (best-effort) leaves
+-- an active sandbox with no open interval; otherwise the NULL comparison would
+-- silently exempt it from the timeout.
+--
+-- Only 'active' rows are eligible; the 60s grace floor spares freshly started or
+-- resumed sandboxes with very short timeouts.
+WITH open_sessions AS (
+  -- Current session start per sandbox: the open interval, computed once.
+  SELECT sandbox_id, max(started_at) AS session_start
+  FROM sandbox_active_interval
+  WHERE ended_at IS NULL
+  GROUP BY sandbox_id
+),
+expired AS (
+  SELECT s.id, s.team_id, s.name, s.snapshot_id, s.host_id
+  FROM sandbox s
+  LEFT JOIN open_sessions os ON os.sandbox_id = s.id
+  WHERE s.destroyed_at IS NULL
+    AND s.timeout_seconds IS NOT NULL
+    AND s.status = 'active'
+    AND COALESCE(os.session_start, s.created_at) + (s.timeout_seconds || ' seconds')::interval < now()
+    AND COALESCE(os.session_start, s.created_at) < now() - interval '60 seconds'
+  ORDER BY s.created_at ASC
   LIMIT $1
-  FOR UPDATE SKIP LOCKED
+  FOR UPDATE OF s SKIP LOCKED
 ),
 paused AS (
   UPDATE sandbox

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -231,8 +231,14 @@ WITH expired AS (
   WHERE destroyed_at IS NULL
     AND timeout_seconds IS NOT NULL
     AND status = 'active'
-    AND created_at + (timeout_seconds || ' seconds')::interval < now()
-    AND created_at < now() - interval '60 seconds'
+    AND (
+      SELECT max(sai.started_at) FROM sandbox_active_interval sai
+      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
+    ) + (timeout_seconds || ' seconds')::interval < now()
+    AND (
+      SELECT max(sai.started_at) FROM sandbox_active_interval sai
+      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
+    ) < now() - interval '60 seconds'
   ORDER BY created_at ASC
   LIMIT $1
   FOR UPDATE SKIP LOCKED
@@ -276,15 +282,21 @@ type ClaimExpiredSandboxesRow struct {
 	HostID     string      `json:"host_id"`
 }
 
-// Atomically claims active sandboxes whose hard timeout has elapsed and marks
+// Atomically claims active sandboxes whose timeout window has elapsed and marks
 // them as 'pausing'. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas
 // skip rows already being processed, so multi-replica Cloud Run deployments
 // do not double-process the same sandbox.
 //
+// The timeout window is measured from the start of the current active session
+// (the open sandbox_active_interval row, which is re-opened on every resume),
+// not from created_at. So each resume re-arms the full timeout_seconds window:
+// a sandbox resumed after pausing gets a fresh window instead of being claimed
+// again immediately on a deadline that already elapsed.
+//
 // Only 'active' sandboxes are claimed — paused sandboxes are already stopped,
 // and transient states (starting, pausing) are skipped to avoid racing with
 // in-progress operations. The 60-second grace window prevents reaping a sandbox
-// that was just created with a very short timeout before it finishes starting up.
+// that was just resumed (or created) with a very short timeout before it settles.
 func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]ClaimExpiredSandboxesRow, error) {
 	rows, err := q.db.Query(ctx, claimExpiredSandboxes, limit)
 	if err != nil {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -225,23 +225,25 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 }
 
 const claimExpiredSandboxes = `-- name: ClaimExpiredSandboxes :many
-WITH expired AS (
-  SELECT id, team_id, name, snapshot_id, host_id
-  FROM sandbox
-  WHERE destroyed_at IS NULL
-    AND timeout_seconds IS NOT NULL
-    AND status = 'active'
-    AND (
-      SELECT max(sai.started_at) FROM sandbox_active_interval sai
-      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
-    ) + (timeout_seconds || ' seconds')::interval < now()
-    AND (
-      SELECT max(sai.started_at) FROM sandbox_active_interval sai
-      WHERE sai.sandbox_id = sandbox.id AND sai.ended_at IS NULL
-    ) < now() - interval '60 seconds'
-  ORDER BY created_at ASC
+WITH open_sessions AS (
+  -- Current session start per sandbox: the open interval, computed once.
+  SELECT sandbox_id, max(started_at) AS session_start
+  FROM sandbox_active_interval
+  WHERE ended_at IS NULL
+  GROUP BY sandbox_id
+),
+expired AS (
+  SELECT s.id, s.team_id, s.name, s.snapshot_id, s.host_id
+  FROM sandbox s
+  LEFT JOIN open_sessions os ON os.sandbox_id = s.id
+  WHERE s.destroyed_at IS NULL
+    AND s.timeout_seconds IS NOT NULL
+    AND s.status = 'active'
+    AND COALESCE(os.session_start, s.created_at) + (s.timeout_seconds || ' seconds')::interval < now()
+    AND COALESCE(os.session_start, s.created_at) < now() - interval '60 seconds'
+  ORDER BY s.created_at ASC
   LIMIT $1
-  FOR UPDATE SKIP LOCKED
+  FOR UPDATE OF s SKIP LOCKED
 ),
 paused AS (
   UPDATE sandbox
@@ -282,21 +284,20 @@ type ClaimExpiredSandboxesRow struct {
 	HostID     string      `json:"host_id"`
 }
 
-// Atomically claims active sandboxes whose timeout window has elapsed and marks
-// them as 'pausing'. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas
-// skip rows already being processed, so multi-replica Cloud Run deployments
-// do not double-process the same sandbox.
+// Atomically claims active sandboxes past their timeout and marks them 'pausing'.
+// FOR UPDATE OF s SKIP LOCKED lets concurrent reaper replicas skip in-flight rows.
 //
-// The timeout window is measured from the start of the current active session
-// (the open sandbox_active_interval row, which is re-opened on every resume),
-// not from created_at. So each resume re-arms the full timeout_seconds window:
-// a sandbox resumed after pausing gets a fresh window instead of being claimed
-// again immediately on a deadline that already elapsed.
+// timeout_seconds bounds an active session, not total lifetime, so the window is
+// anchored on the current session start (the open sandbox_active_interval row,
+// reopened on resume) — each resume re-arms it. Anchoring on created_at would
+// instead keep a sandbox that ever exceeded its timeout permanently eligible.
 //
-// Only 'active' sandboxes are claimed — paused sandboxes are already stopped,
-// and transient states (starting, pausing) are skipped to avoid racing with
-// in-progress operations. The 60-second grace window prevents reaping a sandbox
-// that was just resumed (or created) with a very short timeout before it settles.
+// COALESCE falls back to created_at when interval bookkeeping (best-effort) leaves
+// an active sandbox with no open interval; otherwise the NULL comparison would
+// silently exempt it from the timeout.
+//
+// Only 'active' rows are eligible; the 60s grace floor spares freshly started or
+// resumed sandboxes with very short timeouts.
 func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]ClaimExpiredSandboxesRow, error) {
 	rows, err := q.db.Query(ctx, claimExpiredSandboxes, limit)
 	if err != nil {


### PR DESCRIPTION
## Problem

`timeout_seconds` (the opt-in auto-pause cap) is measured from `created_at`. Once a sandbox lives past its timeout, `created_at + timeout_seconds` is permanently in the past — so **every resume is immediately re-eligible for the reaper**, which re-pauses it within one poll cycle (≤30s). The result: a sandbox that has outlived its timeout can never stay running — resuming it (e.g. opening a terminal) drops the connection ~20s later, repeatedly.

This hits interactive/terminal users whose sandboxes are resumed after the timeout has elapsed.

## Fix

Anchor the timeout window on the **start of the current active session** instead of `created_at`:

```sql
-- before:  created_at + timeout_seconds < now()
-- after:   max(open sandbox_active_interval.started_at) + timeout_seconds < now()
```

The resume path (`ActivateSandbox`) already opens a fresh `sandbox_active_interval` row with `started_at = now()` on every resume, so each resume now re-arms the full `timeout_seconds` window. The 60s grace floor is moved to the same anchor. No migration — reuses existing data.

## Why it's safe

Both pause paths atomically close the open interval (`BeginPause`, `ClaimExpiredSandboxes`), and resume opens a fresh one — so `max(open started_at)` is the last activation time:

- Pause → interval closed (`ended_at` set).
- Resume → fresh interval (`started_at = now()`); `ActivateSandbox`'s `ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING` only matters if a stale open interval exists, which the atomic closes prevent.