### PR TITLE
vmd: clean up rundir on DestroyVM even when the VM is absent from memory

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -462,11 +462,10 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	log.Info().Bool("force", force).Msg("destroying VM")
 
-	// vmID names the rundir/snapshot dir and the systemd unit. Reject non-leaf
-	// values up front: cleanup runs even without an in-memory instance, so an
-	// empty or "../"-bearing id would let os.RemoveAll escape RunDir.
-	if !isLeafName(vmID) {
-		return status.Error(codes.InvalidArgument, "vm_id must be a non-empty path-safe identifier")
+	// Cleanup runs even without an in-memory instance, so a malformed or reserved
+	// vmID could escape RunDir or wipe a shared dir.
+	if !isLeafName(vmID) || isReservedRunDirName(vmID) {
+		return status.Error(codes.InvalidArgument, "vm_id must be a valid per-VM identifier")
 	}
 
 	// A paused or post-restart VM may be absent from m.vms. Don't early-return on
@@ -1379,8 +1378,8 @@ func (m *Manager) createOverlay(dirName, basePath string) (string, error) {
 }
 
 func (m *Manager) cleanupRunDir(dirName string) {
-	if !isLeafName(dirName) {
-		m.log.Error().Str("dir", dirName).Msg("refusing to remove unsafe rundir name")
+	if !isLeafName(dirName) || isReservedRunDirName(dirName) {
+		m.log.Error().Str("dir", dirName).Msg("refusing to remove unsafe or reserved rundir name")
 		return
 	}
 	vmDir := filepath.Join(m.cfg.RunDir, dirName)
@@ -1394,6 +1393,12 @@ func (m *Manager) cleanupRunDir(dirName string) {
 // cannot escape that directory via filepath.Join + os.RemoveAll.
 func isLeafName(s string) bool {
 	return s != "" && s != "." && s != ".." && !strings.ContainsAny(s, `/\`)
+}
+
+// isReservedRunDirName reports whether name is a shared dir under RunDir
+// (template mount target, build tree) rather than a per-VM dir.
+func isReservedRunDirName(name string) bool {
+	return name == templateDirName || name == TemplatesDirName || strings.HasPrefix(name, "build-")
 }
 
 // stopUnitDuringRestoreError stops the per-VM systemd unit when a restore

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1398,7 +1398,7 @@ func isLeafName(s string) bool {
 // isReservedRunDirName reports whether name is a shared dir under RunDir
 // (template mount target, build tree) rather than a per-VM dir.
 func isReservedRunDirName(name string) bool {
-	return name == templateDirName || name == TemplatesDirName || strings.HasPrefix(name, "build-")
+	return name == templateDirName || name == TemplatesDirName
 }
 
 // stopUnitDuringRestoreError stops the per-VM systemd unit when a restore

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -462,6 +462,13 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	log.Info().Bool("force", force).Msg("destroying VM")
 
+	// vmID names the rundir/snapshot dir and the systemd unit. Reject non-leaf
+	// values up front: cleanup runs even without an in-memory instance, so an
+	// empty or "../"-bearing id would let os.RemoveAll escape RunDir.
+	if !isLeafName(vmID) {
+		return status.Error(codes.InvalidArgument, "vm_id must be a non-empty path-safe identifier")
+	}
+
 	// A paused or post-restart VM may be absent from m.vms. Don't early-return on
 	// that: unit stop and rundir removal are derivable from vmID and must run, or
 	// destroying a paused sandbox leaks its rundir. Process/socket teardown needs
@@ -1372,10 +1379,21 @@ func (m *Manager) createOverlay(dirName, basePath string) (string, error) {
 }
 
 func (m *Manager) cleanupRunDir(dirName string) {
+	if !isLeafName(dirName) {
+		m.log.Error().Str("dir", dirName).Msg("refusing to remove unsafe rundir name")
+		return
+	}
 	vmDir := filepath.Join(m.cfg.RunDir, dirName)
 	if err := os.RemoveAll(vmDir); err != nil {
 		m.log.Warn().Err(err).Str("dir", dirName).Msg("failed to remove rundir")
 	}
+}
+
+// isLeafName reports whether s is safe as a single path element under a managed
+// directory — non-empty, not "."/"..", and free of separators — so callers
+// cannot escape that directory via filepath.Join + os.RemoveAll.
+func isLeafName(s string) bool {
+	return s != "" && s != "." && s != ".." && !strings.ContainsAny(s, `/\`)
 }
 
 // stopUnitDuringRestoreError stops the per-VM systemd unit when a restore

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -459,13 +459,14 @@ func (m *Manager) coldBootFromRootfs(ctx context.Context, vmID, rootfsPath strin
 
 // DestroyVM terminates a VM and cleans up all its resources.
 func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error {
-	inst, err := m.getInstance(vmID)
-	if err != nil {
-		return err
-	}
-
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	log.Info().Bool("force", force).Msg("destroying VM")
+
+	// A paused or post-restart VM may be absent from m.vms. Don't early-return on
+	// that: unit stop and rundir removal are derivable from vmID and must run, or
+	// destroying a paused sandbox leaks its rundir. Process/socket teardown needs
+	// the instance, so it's gated below. Destroy is idempotent.
+	inst, instErr := m.getInstance(vmID)
 
 	// Stop the systemd unit if one exists — this is the path for sandbox
 	// VMs launched via startFirecrackerViaSystemd.
@@ -482,31 +483,34 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	// Next VM that claims the slot fails with EBUSY ("Open tap device failed:
 	// Resource busy"). See internal/network/manager.go:344 for the pool
 	// return path that assumes the previous owner is dead.
-	inst.mu.RLock()
-	pid := inst.PID
-	inst.mu.RUnlock()
-	if pid > 0 {
-		if proc, err := os.FindProcess(pid); err == nil {
-			// SIGKILL is safe here: we're tearing down, no graceful shutdown
-			// is expected. For systemd-managed VMs this is a no-op because
-			// stopUnit already killed the process.
-			_ = proc.Signal(syscall.SIGKILL)
-			// Give the kernel a moment to actually release fds before we
-			// hand the namespace + TAP back to the pool. 100ms is enough
-			// in practice — Linux process teardown is fast once all fds
-			// are dropped.
-			waitForPIDExit(pid, 500*time.Millisecond)
+	if instErr == nil {
+		inst.mu.RLock()
+		pid := inst.PID
+		sockPath := inst.SocketPath
+		inst.mu.RUnlock()
+		if pid > 0 {
+			if proc, err := os.FindProcess(pid); err == nil {
+				// SIGKILL is safe here: we're tearing down, no graceful shutdown
+				// is expected. For systemd-managed VMs this is a no-op because
+				// stopUnit already killed the process.
+				_ = proc.Signal(syscall.SIGKILL)
+				// Give the kernel a moment to actually release fds before we
+				// hand the namespace + TAP back to the pool. 100ms is enough
+				// in practice — Linux process teardown is fast once all fds
+				// are dropped.
+				waitForPIDExit(pid, 500*time.Millisecond)
+			}
 		}
-	}
-
-	if inst.SocketPath != "" {
-		_ = os.Remove(inst.SocketPath)
+		if sockPath != "" {
+			_ = os.Remove(sockPath)
+		}
 	}
 
 	m.netMgr.CleanupVM(vmID)
 
+	// Fall back to vmID when the instance is absent (RunDirID == vmID anyway).
 	rundirKey := vmID
-	if inst.RunDirID != "" {
+	if instErr == nil && inst.RunDirID != "" {
 		rundirKey = inst.RunDirID
 	}
 	m.cleanupRunDir(rundirKey)

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/network"
 )
@@ -345,6 +347,34 @@ func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
 	}
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		t.Fatalf("rundir %s still present after DestroyVM — leaked", dir)
+	}
+}
+
+// TestDestroyVM_UnsafeVMID_Rejected: a non-path-safe vmID must be rejected
+// before any cleanup runs, so os.RemoveAll can't escape RunDir.
+func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
+	runDir := t.TempDir()
+	sentinel := filepath.Join(runDir, "keep")
+	if err := os.MkdirAll(sentinel, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	mgr := &Manager{
+		cfg:    ManagerConfig{RunDir: runDir},
+		netMgr: &network.Manager{},
+		log:    zerolog.Nop(),
+	}
+
+	for _, vmID := range []string{"", ".", "..", "../escape", "a/b"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := mgr.DestroyVM(ctx, vmID, true)
+		cancel()
+		if status.Code(err) != codes.InvalidArgument {
+			t.Errorf("DestroyVM(%q): want InvalidArgument, got %v", vmID, err)
+		}
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("RunDir contents removed by an unsafe vmID: %v", err)
 	}
 }
 

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -354,7 +354,7 @@ func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
 // rejected before cleanup, so it can't escape RunDir or wipe shared dirs.
 func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 	runDir := t.TempDir()
-	shared := []string{"keep", templateDirName, TemplatesDirName, "build-tmpl1"}
+	shared := []string{"keep", templateDirName, TemplatesDirName}
 	for _, name := range shared {
 		if err := os.MkdirAll(filepath.Join(runDir, name), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", name, err)
@@ -367,7 +367,7 @@ func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 		log:    zerolog.Nop(),
 	}
 
-	rejected := []string{"", ".", "..", "../escape", "a/b", templateDirName, TemplatesDirName, "build-tmpl1"}
+	rejected := []string{"", ".", "..", "../escape", "a/b", templateDirName, TemplatesDirName}
 	for _, vmID := range rejected {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		err := mgr.DestroyVM(ctx, vmID, true)
@@ -379,6 +379,16 @@ func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 	for _, name := range shared {
 		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
 			t.Fatalf("shared dir %q removed by a rejected vmID: %v", name, err)
+		}
+	}
+
+	// Per-VM build/recording ids must remain cleanable, not reserved.
+	for _, vmID := range []string{"build-tmpl1", "build-record-tmpl1"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := mgr.DestroyVM(ctx, vmID, true)
+		cancel()
+		if err != nil {
+			t.Errorf("DestroyVM(%q): want nil, got %v", vmID, err)
 		}
 	}
 }

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/network"
 )
 
 // TestPlanRestore pins the restore-decision behavior across the four input
@@ -312,6 +314,37 @@ func TestDeleteSnapshotFiles_BothEmpty_Rejected(t *testing.T) {
 	mgr := &Manager{cfg: ManagerConfig{SnapshotDir: t.TempDir()}}
 	if err := mgr.DeleteSnapshotFiles("vm-abc", "", ""); err == nil {
 		t.Error("expected rejection when both paths are empty")
+	}
+}
+
+// TestDestroyVM_AbsentInstance_CleansRundir: destroying a VM that's absent from
+// m.vms (e.g. a paused sandbox) must still remove its rundir, not leak it.
+func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
+	runDir := t.TempDir()
+	vmID := "11111111-1111-1111-1111-111111111111"
+	dir := filepath.Join(runDir, vmID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "overlay.ext4"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// nil vms → getInstance NotFound (the absent path); zero-value netMgr and
+	// nil state make CleanupVM/deleteState no-ops for an unknown vmID.
+	mgr := &Manager{
+		cfg:    ManagerConfig{RunDir: runDir},
+		netMgr: &network.Manager{},
+		log:    zerolog.Nop(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := mgr.DestroyVM(ctx, vmID, true); err != nil {
+		t.Fatalf("DestroyVM: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("rundir %s still present after DestroyVM — leaked", dir)
 	}
 }
 

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -350,13 +350,15 @@ func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
 	}
 }
 
-// TestDestroyVM_UnsafeVMID_Rejected: a non-path-safe vmID must be rejected
-// before any cleanup runs, so os.RemoveAll can't escape RunDir.
+// TestDestroyVM_UnsafeVMID_Rejected: a non-path-safe or reserved vmID is
+// rejected before cleanup, so it can't escape RunDir or wipe shared dirs.
 func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 	runDir := t.TempDir()
-	sentinel := filepath.Join(runDir, "keep")
-	if err := os.MkdirAll(sentinel, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	shared := []string{"keep", templateDirName, TemplatesDirName, "build-tmpl1"}
+	for _, name := range shared {
+		if err := os.MkdirAll(filepath.Join(runDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
 	}
 
 	mgr := &Manager{
@@ -365,7 +367,8 @@ func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 		log:    zerolog.Nop(),
 	}
 
-	for _, vmID := range []string{"", ".", "..", "../escape", "a/b"} {
+	rejected := []string{"", ".", "..", "../escape", "a/b", templateDirName, TemplatesDirName, "build-tmpl1"}
+	for _, vmID := range rejected {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		err := mgr.DestroyVM(ctx, vmID, true)
 		cancel()
@@ -373,8 +376,10 @@ func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 			t.Errorf("DestroyVM(%q): want InvalidArgument, got %v", vmID, err)
 		}
 	}
-	if _, err := os.Stat(sentinel); err != nil {
-		t.Fatalf("RunDir contents removed by an unsafe vmID: %v", err)
+	for _, name := range shared {
+		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
+			t.Fatalf("shared dir %q removed by a rejected vmID: %v", name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
`DestroyVM` early-returned when the VM wasn't in the in-memory map, so deleting a paused sandbox (always absent from the map) skipped `cleanupRunDir` and leaked its rundir. Now the unit-stop + rundir removal run unconditionally (derivable from vmID); process/socket teardown stays gated on the instance being present.