### PR TITLE
vmd: detect-only disk-orphan reconciler pass

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -463,6 +463,7 @@ func main() {
 	reconcilerCfg := vm.DefaultReconcilerConfig()
 	reconcilerCfg.HostID = cfg.HostID
 	reconcilerCfg.DB = reconcilerDB
+	reconcilerCfg.DiskScanEnabled = envOrDefault("VMD_DISK_SCAN", "true") != "false"
 	reconciler := vm.NewReconciler(mgr, reconcilerCfg)
 	lc.start("reconciler", func() error { reconciler.Run(ctx); return nil })
 

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -158,6 +158,16 @@ FROM sandbox s
 LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL;
 
+-- name: ListRecentlyDestroyedSandboxIDsByHost :many
+-- Used by the VMD disk reconciler so a sandbox destroyed within the grace
+-- window — whose on-disk cleanup may still be in flight — is kept out of the
+-- orphan set rather than raced.
+SELECT id
+FROM sandbox
+WHERE host_id = sqlc.arg(host_id)
+  AND destroyed_at IS NOT NULL
+  AND destroyed_at > sqlc.arg(destroyed_after);
+
 -- name: MarkSandboxFailed :exec
 -- Used by the reconciler to mark a sandbox failed when VMD detects it is
 -- actually gone. No team_id filter — the reconciler runs with host scope,

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -705,6 +705,42 @@ func (q *Queries) ListPinnedBuildPaths(ctx context.Context) ([]*string, error) {
 	return items, nil
 }
 
+const listRecentlyDestroyedSandboxIDsByHost = `-- name: ListRecentlyDestroyedSandboxIDsByHost :many
+SELECT id
+FROM sandbox
+WHERE host_id = $1
+  AND destroyed_at IS NOT NULL
+  AND destroyed_at > $2
+`
+
+type ListRecentlyDestroyedSandboxIDsByHostParams struct {
+	HostID         string             `json:"host_id"`
+	DestroyedAfter pgtype.Timestamptz `json:"destroyed_after"`
+}
+
+// Used by the VMD disk reconciler so a sandbox destroyed within the grace
+// window — whose on-disk cleanup may still be in flight — is kept out of the
+// orphan set rather than raced.
+func (q *Queries) ListRecentlyDestroyedSandboxIDsByHost(ctx context.Context, arg ListRecentlyDestroyedSandboxIDsByHostParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listRecentlyDestroyedSandboxIDsByHost, arg.HostID, arg.DestroyedAfter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []uuid.UUID{}
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
 SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, snap.path AS snapshot_path
 FROM sandbox s

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -429,11 +429,8 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	}
 
 	// Keep-set: live rows plus rows destroyed within the grace window.
-	keep := make(map[string]struct{}, len(dbSandboxes))
-	for id := range dbSandboxes {
-		keep[id] = struct{}{}
-	}
 	cutoff := snapshotTime.Add(-r.cfg.DiskGracePeriod)
+	keep := liveKeepSet(dbSandboxes, cutoff)
 	qctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
 	recent, err := r.cfg.DB.ListRecentlyDestroyedSandboxIDsByHost(qctx, db.ListRecentlyDestroyedSandboxIDsByHostParams{
 		HostID:         r.cfg.HostID,
@@ -478,6 +475,21 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		Int64("orphan_bytes", bytes).
 		Strs("sample", sample).
 		Msg("disk scan (detect-only): orphan per-sandbox dirs would be reclaimed")
+}
+
+// liveKeepSet returns the sandbox IDs whose on-disk dirs must be kept: every
+// host row except terminally-failed ones whose failure settled before cutoff
+// (those can never be resumed, so their dirs are reclaimable). Pure: no DB or
+// filesystem access.
+func liveKeepSet(rows map[string]db.ListSandboxesByHostRow, cutoff time.Time) map[string]struct{} {
+	keep := make(map[string]struct{}, len(rows))
+	for id, row := range rows {
+		if row.Sandbox.Status == db.SandboxStatusFailed && row.Sandbox.UpdatedAt.Before(cutoff) {
+			continue
+		}
+		keep[id] = struct{}{}
+	}
+	return keep
 }
 
 // selectOrphanDirs returns the sandbox UUIDs whose on-disk dirs have no live or

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -155,8 +155,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		return
 	}
 
-	// Captured before any DB read so a dir created after the keep-set query
-	// (mtime > snapshotTime) is never treated as an orphan.
+	// Pass timestamp; the disk scan derives its grace cutoff from it (rows
+	// destroyed within, and dirs touched within, DiskGracePeriod are kept).
 	snapshotTime := time.Now()
 
 	// Source B: active systemd units.
@@ -451,7 +451,7 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 			Msg("disk scan: empty keep-set — reporting all on-disk dirs as orphans (verify before enabling reclamation)")
 	}
 
-	orphans := selectOrphanDirs(onDisk, keep, snapshotTime)
+	orphans := selectOrphanDirs(onDisk, keep, cutoff)
 	if len(orphans) == 0 {
 		log.Info().Int("on_disk", len(onDisk)).Msg("disk scan: no orphan dirs")
 		return
@@ -491,15 +491,17 @@ func liveKeepSet(rows map[string]db.ListSandboxesByHostRow, cutoff time.Time) ma
 }
 
 // selectOrphanDirs returns the sandbox UUIDs whose on-disk dirs have no live or
-// within-grace row and whose newest mtime predates this pass's snapshot. Pure:
-// no DB or filesystem access.
-func selectOrphanDirs(onDisk map[string]sandboxDirInfo, keep map[string]struct{}, snapshotTime time.Time) []string {
+// within-grace row AND whose newest mtime is older than cutoff. The mtime age
+// grace keeps an in-flight create — whose rundir exists before its DB INSERT
+// commits, so it has no visible row yet — from being flagged as an orphan.
+// Pure: no DB or filesystem access.
+func selectOrphanDirs(onDisk map[string]sandboxDirInfo, keep map[string]struct{}, cutoff time.Time) []string {
 	var orphans []string
 	for id, info := range onDisk {
 		if _, live := keep[id]; live {
 			continue
 		}
-		if info.mtime.After(snapshotTime) {
+		if info.mtime.After(cutoff) {
 			continue
 		}
 		orphans = append(orphans, id)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -445,10 +445,13 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		keep[id.String()] = struct{}{}
 	}
 
+	// An empty keep-set is suspicious — a query bug would also produce it — but
+	// a drained or all-failed host is a legitimate all-orphan case, and
+	// detect-only reporting is harmless. Flag it loudly and still report; the
+	// empty-set guard that aborts belongs on the reclamation step, not here.
 	if len(keep) == 0 {
-		log.Error().Int("on_disk", len(onDisk)).
-			Msg("disk scan: empty keep-set with dirs present — aborting pass (guard)")
-		return
+		log.Warn().Int("on_disk", len(onDisk)).
+			Msg("disk scan: empty keep-set — reporting all on-disk dirs as orphans (verify before enabling reclamation)")
 	}
 
 	orphans := selectOrphanDirs(onDisk, keep, snapshotTime)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -410,9 +410,8 @@ type sandboxDirInfo struct {
 }
 
 // detectDiskOrphans implements Drift 6 in detect-only mode: it logs the
-// per-sandbox dirs it would reclaim and deletes nothing. Fail-closed — without
-// a DB keep-set it does nothing — and it aborts when the keep-set is empty
-// against a non-empty disk, which is almost always a query bug.
+// per-sandbox dirs it would reclaim and deletes nothing. Fail-closed: without
+// a DB keep-set it does nothing.
 func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Time, dbSandboxes map[string]db.ListSandboxesByHostRow) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_scan").Logger()
 
@@ -445,10 +444,8 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		keep[id.String()] = struct{}{}
 	}
 
-	// An empty keep-set is suspicious — a query bug would also produce it — but
-	// a drained or all-failed host is a legitimate all-orphan case, and
-	// detect-only reporting is harmless. Flag it loudly and still report; the
-	// empty-set guard that aborts belongs on the reclamation step, not here.
+	// A drained or all-failed host legitimately has an empty keep-set; report it
+	// (detect-only is harmless). The hard abort-guard belongs on reclamation.
 	if len(keep) == 0 {
 		log.Warn().Int("on_disk", len(onDisk)).
 			Msg("disk scan: empty keep-set — reporting all on-disk dirs as orphans (verify before enabling reclamation)")
@@ -480,10 +477,8 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		Msg("disk scan (detect-only): orphan per-sandbox dirs would be reclaimed")
 }
 
-// liveKeepSet returns the sandbox IDs whose on-disk dirs must be kept: every
-// host row except terminally-failed ones whose failure settled before cutoff
-// (those can never be resumed, so their dirs are reclaimable). Pure: no DB or
-// filesystem access.
+// liveKeepSet returns the sandbox IDs to keep: every host row except
+// terminally-failed ones settled before cutoff (those can't be resumed). Pure.
 func liveKeepSet(rows map[string]db.ListSandboxesByHostRow, cutoff time.Time) map[string]struct{} {
 	keep := make(map[string]struct{}, len(rows))
 	for id, row := range rows {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -427,12 +428,7 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		return
 	}
 
-	// Keep-set: live rows, rows destroyed within the grace window, and any VM
-	// with an active systemd unit (a running VM whose DB row is momentarily
-	// missing — Drift 3 grace, rate limit, or a failed stop — must not be
-	// flagged).
 	cutoff := snapshotTime.Add(-r.cfg.DiskGracePeriod)
-	keep := liveKeepSet(dbSandboxes, cutoff)
 	qctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
 	recent, err := r.cfg.DB.ListRecentlyDestroyedSandboxIDsByHost(qctx, db.ListRecentlyDestroyedSandboxIDsByHostParams{
 		HostID:         r.cfg.HostID,
@@ -443,12 +439,7 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		log.Error().Err(err).Msg("disk scan: recently-destroyed query failed — skipping (fail-closed)")
 		return
 	}
-	for _, id := range recent {
-		keep[id.String()] = struct{}{}
-	}
-	for id := range active {
-		keep[id] = struct{}{}
-	}
+	keep := diskKeepSet(dbSandboxes, recent, active, cutoff)
 
 	// A drained or all-failed host legitimately has an empty keep-set; report it
 	// (detect-only is harmless). The hard abort-guard belongs on reclamation.
@@ -483,14 +474,25 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		Msg("disk scan (detect-only): orphan per-sandbox dirs would be reclaimed")
 }
 
-// liveKeepSet returns the sandbox IDs to keep: every host row except
-// terminally-failed ones settled before cutoff (those can't be resumed). Pure.
-func liveKeepSet(rows map[string]db.ListSandboxesByHostRow, cutoff time.Time) map[string]struct{} {
-	keep := make(map[string]struct{}, len(rows))
-	for id, row := range rows {
+// diskKeepSet is every sandbox UUID whose on-disk dirs must NOT be reclaimed —
+// the union of all signals a dir may be in use: non-destroyed DB rows (minus
+// failures settled before cutoff), rows destroyed within grace, and active
+// systemd units (a running VM whose row is momentarily gone). BoltDB-only UUIDs
+// are excluded on purpose: no row AND no unit means a dead VM (Drift 5's job),
+// so its dir is reclaimable. In-flight creates are caught by the caller's mtime
+// grace, not here. Pure.
+func diskKeepSet(dbSandboxes map[string]db.ListSandboxesByHostRow, recent []uuid.UUID, active map[string]bool, cutoff time.Time) map[string]struct{} {
+	keep := make(map[string]struct{}, len(dbSandboxes)+len(recent)+len(active))
+	for id, row := range dbSandboxes {
 		if row.Sandbox.Status == db.SandboxStatusFailed && row.Sandbox.UpdatedAt.Before(cutoff) {
 			continue
 		}
+		keep[id] = struct{}{}
+	}
+	for _, id := range recent {
+		keep[id.String()] = struct{}{}
+	}
+	for id := range active {
 		keep[id] = struct{}{}
 	}
 	return keep
@@ -566,8 +568,15 @@ func dirSize(ctx context.Context, paths []string) int64 {
 			if err != nil || d.IsDir() {
 				return nil
 			}
-			if fi, e := d.Info(); e == nil {
-				total += fi.Size()
+			fi, e := d.Info()
+			if e != nil {
+				return nil
+			}
+			// Count allocated blocks (du-style), not apparent length: overlay
+			// images are sparse (createOverlay truncates to the base size), so
+			// fi.Size() would massively overstate the disk a delete frees.
+			if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+				total += st.Blocks * 512 // st_blocks is in 512-byte units
 			}
 			return nil
 		})

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -398,7 +398,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		every = 1
 	}
 	if r.cfg.DiskScanEnabled && r.passCount%uint64(every) == 0 {
-		r.detectDiskOrphans(ctx, snapshotTime, dbSandboxes)
+		r.detectDiskOrphans(ctx, snapshotTime, dbSandboxes, active)
 	}
 }
 
@@ -412,7 +412,7 @@ type sandboxDirInfo struct {
 // detectDiskOrphans implements Drift 6 in detect-only mode: it logs the
 // per-sandbox dirs it would reclaim and deletes nothing. Fail-closed: without
 // a DB keep-set it does nothing.
-func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Time, dbSandboxes map[string]db.ListSandboxesByHostRow) {
+func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Time, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_scan").Logger()
 
 	if r.cfg.DB == nil || r.cfg.HostID == "" || dbSandboxes == nil {
@@ -427,7 +427,10 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		return
 	}
 
-	// Keep-set: live rows plus rows destroyed within the grace window.
+	// Keep-set: live rows, rows destroyed within the grace window, and any VM
+	// with an active systemd unit (a running VM whose DB row is momentarily
+	// missing — Drift 3 grace, rate limit, or a failed stop — must not be
+	// flagged).
 	cutoff := snapshotTime.Add(-r.cfg.DiskGracePeriod)
 	keep := liveKeepSet(dbSandboxes, cutoff)
 	qctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
@@ -442,6 +445,9 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	}
 	for _, id := range recent {
 		keep[id.String()] = struct{}{}
+	}
+	for id := range active {
+		keep[id] = struct{}{}
 	}
 
 	// A drained or all-failed host legitimately has an empty keep-set; report it

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -40,6 +41,17 @@ type ReconcilerConfig struct {
 	// detection (BoltDB ↔ systemd ↔ DB) and writes audit log entries.
 	// When nil, it only compares BoltDB and systemd.
 	DB *db.Queries
+	// DiskScanEnabled turns on the detect-only disk-orphan pass: it scans
+	// RunDir/SnapshotDir for per-sandbox dirs with no live row and logs what
+	// it would reclaim. It never deletes.
+	DiskScanEnabled bool
+	// DiskGracePeriod keeps a sandbox's dirs out of the orphan set for this
+	// long after destroyed_at, so an in-flight in-band delete isn't raced.
+	DiskGracePeriod time.Duration
+	// DiskScanEvery runs the disk pass once every Nth reconcile tick so a
+	// filesystem walk doesn't ride the fast liveness loop. Values < 1 mean
+	// every tick.
+	DiskScanEvery int
 }
 
 // DefaultReconcilerConfig returns sensible defaults from the design doc.
@@ -48,6 +60,9 @@ func DefaultReconcilerConfig() ReconcilerConfig {
 		Interval:           30 * time.Second,
 		GracePeriod:        60 * time.Second,
 		MaxAutoFailPerHour: 5,
+		DiskScanEnabled:    true,
+		DiskGracePeriod:    24 * time.Hour,
+		DiskScanEvery:      4,
 	}
 }
 
@@ -72,6 +87,10 @@ type Reconciler struct {
 	mu          sync.Mutex
 	driftSeen   map[string]time.Time
 	autoFailLog []time.Time // timestamps of recent auto-fail actions
+
+	// passCount counts completed reconcile passes, used to run the disk
+	// scan on a slower sub-cadence. Only touched from the single Run loop.
+	passCount uint64
 }
 
 // NewReconciler creates a reconciler bound to a Manager.
@@ -135,6 +154,10 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		log.Debug().Msg("no state store — skipping run")
 		return
 	}
+
+	// Captured before any DB read so a dir created after the keep-set query
+	// (mtime > snapshotTime) is never treated as an orphan.
+	snapshotTime := time.Now()
 
 	// Source B: active systemd units.
 	ids, err := listActiveFirecrackerUnits(ctx)
@@ -366,6 +389,172 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			r.clearDrift("bolt-orphan:" + id)
 		}
 	}
+
+	// Drift 6 (detect-only): per-sandbox dirs on disk with no live row. Runs
+	// on a slower sub-cadence so the filesystem walk doesn't ride every tick.
+	r.passCount++
+	every := r.cfg.DiskScanEvery
+	if every < 1 {
+		every = 1
+	}
+	if r.cfg.DiskScanEnabled && r.passCount%uint64(every) == 0 {
+		r.detectDiskOrphans(ctx, snapshotTime, dbSandboxes)
+	}
+}
+
+// sandboxDirInfo is one sandbox's on-disk footprint: every dir found for its
+// UUID and the newest mtime across them.
+type sandboxDirInfo struct {
+	mtime time.Time
+	paths []string
+}
+
+// detectDiskOrphans implements Drift 6 in detect-only mode: it logs the
+// per-sandbox dirs it would reclaim and deletes nothing. Fail-closed — without
+// a DB keep-set it does nothing — and it aborts when the keep-set is empty
+// against a non-empty disk, which is almost always a query bug.
+func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Time, dbSandboxes map[string]db.ListSandboxesByHostRow) {
+	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_scan").Logger()
+
+	if r.cfg.DB == nil || r.cfg.HostID == "" || dbSandboxes == nil {
+		log.Debug().Msg("disk scan skipped — no DB keep-set (fail-closed)")
+		return
+	}
+
+	// Source D: per-sandbox dirs. A name that parses as a UUID excludes the
+	// template mount target, the build tree, and build-* VMs by construction.
+	onDisk := scanSandboxDirs(r.mgr.cfg.RunDir, r.mgr.cfg.SnapshotDir)
+	if len(onDisk) == 0 {
+		return
+	}
+
+	// Keep-set: live rows plus rows destroyed within the grace window.
+	keep := make(map[string]struct{}, len(dbSandboxes))
+	for id := range dbSandboxes {
+		keep[id] = struct{}{}
+	}
+	cutoff := snapshotTime.Add(-r.cfg.DiskGracePeriod)
+	qctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
+	recent, err := r.cfg.DB.ListRecentlyDestroyedSandboxIDsByHost(qctx, db.ListRecentlyDestroyedSandboxIDsByHostParams{
+		HostID:         r.cfg.HostID,
+		DestroyedAfter: pgtype.Timestamptz{Time: cutoff, Valid: true},
+	})
+	cancel()
+	if err != nil {
+		log.Error().Err(err).Msg("disk scan: recently-destroyed query failed — skipping (fail-closed)")
+		return
+	}
+	for _, id := range recent {
+		keep[id.String()] = struct{}{}
+	}
+
+	if len(keep) == 0 {
+		log.Error().Int("on_disk", len(onDisk)).
+			Msg("disk scan: empty keep-set with dirs present — aborting pass (guard)")
+		return
+	}
+
+	orphans := selectOrphanDirs(onDisk, keep, snapshotTime)
+	if len(orphans) == 0 {
+		log.Info().Int("on_disk", len(onDisk)).Msg("disk scan: no orphan dirs")
+		return
+	}
+
+	var dirCount int
+	var bytes int64
+	for _, id := range orphans {
+		info := onDisk[id]
+		dirCount += len(info.paths)
+		bytes += dirSize(ctx, info.paths)
+	}
+
+	sample := orphans
+	if len(sample) > 20 {
+		sample = sample[:20]
+	}
+	log.Warn().
+		Int("orphan_sandboxes", len(orphans)).
+		Int("orphan_dirs", dirCount).
+		Int64("orphan_bytes", bytes).
+		Strs("sample", sample).
+		Msg("disk scan (detect-only): orphan per-sandbox dirs would be reclaimed")
+}
+
+// selectOrphanDirs returns the sandbox UUIDs whose on-disk dirs have no live or
+// within-grace row and whose newest mtime predates this pass's snapshot. Pure:
+// no DB or filesystem access.
+func selectOrphanDirs(onDisk map[string]sandboxDirInfo, keep map[string]struct{}, snapshotTime time.Time) []string {
+	var orphans []string
+	for id, info := range onDisk {
+		if _, live := keep[id]; live {
+			continue
+		}
+		if info.mtime.After(snapshotTime) {
+			continue
+		}
+		orphans = append(orphans, id)
+	}
+	return orphans
+}
+
+// scanSandboxDirs enumerates direct children of each root whose name parses as
+// a UUID — the per-sandbox dirs. Non-UUID entries (template, templates,
+// build-*) and unreadable roots/entries are skipped. A sandbox's dirs across
+// roots are merged, keeping the newest mtime.
+func scanSandboxDirs(roots ...string) map[string]sandboxDirInfo {
+	out := make(map[string]sandboxDirInfo)
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			id, err := uuid.Parse(e.Name())
+			if err != nil {
+				continue
+			}
+			fi, err := e.Info()
+			if err != nil {
+				continue
+			}
+			key := id.String()
+			cur := out[key]
+			cur.paths = append(cur.paths, filepath.Join(root, e.Name()))
+			if fi.ModTime().After(cur.mtime) {
+				cur.mtime = fi.ModTime()
+			}
+			out[key] = cur
+		}
+	}
+	return out
+}
+
+// dirSize sums the size of every regular file under the given paths. Errors are
+// swallowed so one unreadable entry can't abort the measurement, and the walk
+// stops early if ctx is cancelled so the pass stays within its deadline.
+func dirSize(ctx context.Context, paths []string) int64 {
+	var total int64
+	for _, p := range paths {
+		_ = filepath.WalkDir(p, func(_ string, d os.DirEntry, err error) error {
+			if ctx.Err() != nil {
+				return filepath.SkipAll
+			}
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if fi, e := d.Info(); e == nil {
+				total += fi.Size()
+			}
+			return nil
+		})
+	}
+	return total
 }
 
 // isAlive returns true when the VM's systemd unit is currently active.

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -60,18 +60,18 @@ func TestScanSandboxDirs_UUIDOnly_MergesRoots(t *testing.T) {
 // selectOrphanDirs keeps live and grace-window sandboxes, drops orphans, and
 // ignores dirs newer than the pass snapshot.
 func TestSelectOrphanDirs(t *testing.T) {
-	snapshotTime := time.Unix(1_000_000, 0)
-	old := snapshotTime.Add(-time.Hour)
-	fresh := snapshotTime.Add(time.Hour)
+	cutoff := time.Unix(1_000_000, 0)
+	old := cutoff.Add(-time.Hour)
+	fresh := cutoff.Add(time.Hour)
 
 	onDisk := map[string]sandboxDirInfo{
-		uuidA: {mtime: old},   // not in keep, old → orphan
+		uuidA: {mtime: old},   // not in keep, older than cutoff → orphan
 		uuidB: {mtime: old},   // in keep → kept
-		uuidC: {mtime: fresh}, // not in keep but newer than snapshot → kept
+		uuidC: {mtime: fresh}, // not in keep but within grace (in-flight create) → kept
 	}
 	keep := map[string]struct{}{uuidB: {}}
 
-	got := selectOrphanDirs(onDisk, keep, snapshotTime)
+	got := selectOrphanDirs(onDisk, keep, cutoff)
 	if len(got) != 1 || got[0] != uuidA {
 		t.Fatalf("want [%s], got %v", uuidA, got)
 	}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1,0 +1,101 @@
+package vm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	uuidA = "11111111-1111-1111-1111-111111111111"
+	uuidB = "22222222-2222-2222-2222-222222222222"
+	uuidC = "33333333-3333-3333-3333-333333333333"
+)
+
+// scanSandboxDirs enumerates only UUID-named dirs and merges a sandbox's dirs
+// across roots, so template/templates/build-* and stray files are ignored.
+func TestScanSandboxDirs_UUIDOnly_MergesRoots(t *testing.T) {
+	runDir := t.TempDir()
+	snapDir := t.TempDir()
+
+	for _, name := range []string{uuidA, uuidB, templateDirName, TemplatesDirName, "build-xyz"} {
+		if err := os.MkdirAll(filepath.Join(runDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "stray.file"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+	// uuidA also under snapshots (merge), plus a snapshots-only uuidC.
+	for _, name := range []string{uuidA, uuidC} {
+		if err := os.MkdirAll(filepath.Join(snapDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir snap %s: %v", name, err)
+		}
+	}
+
+	got := scanSandboxDirs(runDir, snapDir)
+
+	if len(got) != 3 {
+		t.Fatalf("want 3 sandbox dirs, got %d: %v", len(got), keysOf(got))
+	}
+	for _, id := range []string{uuidA, uuidB, uuidC} {
+		if _, ok := got[id]; !ok {
+			t.Errorf("missing %s", id)
+		}
+	}
+	if n := len(got[uuidA].paths); n != 2 {
+		t.Errorf("uuidA should span both roots (2 paths), got %d", n)
+	}
+	for _, reserved := range []string{templateDirName, TemplatesDirName, "build-xyz", "stray.file"} {
+		if _, ok := got[reserved]; ok {
+			t.Errorf("reserved/non-uuid entry %q was enumerated", reserved)
+		}
+	}
+}
+
+// selectOrphanDirs keeps live and grace-window sandboxes, drops orphans, and
+// ignores dirs newer than the pass snapshot.
+func TestSelectOrphanDirs(t *testing.T) {
+	snapshotTime := time.Unix(1_000_000, 0)
+	old := snapshotTime.Add(-time.Hour)
+	fresh := snapshotTime.Add(time.Hour)
+
+	onDisk := map[string]sandboxDirInfo{
+		uuidA: {mtime: old},   // not in keep, old → orphan
+		uuidB: {mtime: old},   // in keep → kept
+		uuidC: {mtime: fresh}, // not in keep but newer than snapshot → kept
+	}
+	keep := map[string]struct{}{uuidB: {}}
+
+	got := selectOrphanDirs(onDisk, keep, snapshotTime)
+	if len(got) != 1 || got[0] != uuidA {
+		t.Fatalf("want [%s], got %v", uuidA, got)
+	}
+}
+
+func TestDirSize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b"), make([]byte, 23), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := dirSize(context.Background(), []string{dir}); got != 123 {
+		t.Errorf("dirSize = %d, want 123", got)
+	}
+}
+
+func keysOf(m map[string]sandboxDirInfo) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/superserve-ai/sandbox/internal/db"
 )
 
@@ -77,46 +79,65 @@ func TestSelectOrphanDirs(t *testing.T) {
 	}
 }
 
+// dirSize counts allocated blocks (du-style), not apparent length, so a sparse
+// overlay's huge logical size isn't reported as reclaimable.
 func TestDirSize(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "a"), make([]byte, 100), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "real"), make([]byte, 8192), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	sub := filepath.Join(dir, "sub")
-	if err := os.MkdirAll(sub, 0o755); err != nil {
+	// Apparent size 1 GiB, but Truncate allocates no blocks → sparse.
+	f, err := os.Create(filepath.Join(dir, "sparse.ext4"))
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(sub, "b"), make([]byte, 23), 0o600); err != nil {
+	if err := f.Truncate(1 << 30); err != nil {
 		t.Fatal(err)
 	}
-	if got := dirSize(context.Background(), []string{dir}); got != 123 {
-		t.Errorf("dirSize = %d, want 123", got)
+	f.Close()
+
+	got := dirSize(context.Background(), []string{dir})
+	if got == 0 {
+		t.Error("dirSize = 0; the real file's allocated blocks should be counted")
+	}
+	if got >= 1<<30 {
+		t.Errorf("dirSize = %d; want << 1 GiB (sparse apparent size must not be counted)", got)
 	}
 }
 
-// liveKeepSet keeps every status except failures that settled before the
-// cutoff; recently-failed rows stay (grace) so an in-flight cleanup isn't raced.
-func TestLiveKeepSet_ExcludesSettledFailed(t *testing.T) {
+// diskKeepSet is the complete reclaim guard: it must keep a dir live via ANY
+// source — DB row, recently-destroyed grace, or an active unit — and exclude
+// only genuinely-dead ones (settled-failed, and UUIDs in no source at all).
+func TestDiskKeepSet(t *testing.T) {
 	cutoff := time.Unix(1_000_000, 0)
 	row := func(s db.SandboxStatus, updated time.Time) db.ListSandboxesByHostRow {
 		return db.ListSandboxesByHostRow{Sandbox: db.Sandbox{Status: s, UpdatedAt: updated}}
 	}
-	rows := map[string]db.ListSandboxesByHostRow{
-		"active":     row(db.SandboxStatusActive, cutoff.Add(-time.Hour)),
-		"paused":     row(db.SandboxStatusPaused, cutoff.Add(-time.Hour)),
-		"failed-old": row(db.SandboxStatusFailed, cutoff.Add(-time.Hour)), // settled → reclaimable
-		"failed-new": row(db.SandboxStatusFailed, cutoff.Add(time.Hour)),  // within grace → kept
+	const (
+		recentID = "44444444-4444-4444-4444-444444444444" // recently destroyed → kept
+		activeID = "55555555-5555-5555-5555-555555555555" // running unit, no row → kept
+		orphanID = "66666666-6666-6666-6666-666666666666" // in no source → reclaimable
+	)
+	dbSandboxes := map[string]db.ListSandboxesByHostRow{
+		uuidA: row(db.SandboxStatusActive, cutoff.Add(-time.Hour)), // live → kept
+		uuidB: row(db.SandboxStatusPaused, cutoff.Add(-time.Hour)), // live → kept
+		uuidC: row(db.SandboxStatusFailed, cutoff.Add(-time.Hour)), // settled-failed → excluded
+		"new": row(db.SandboxStatusFailed, cutoff.Add(time.Hour)),  // within grace → kept
 	}
+	recent := []uuid.UUID{uuid.MustParse(recentID)}
+	active := map[string]bool{activeID: true}
 
-	keep := liveKeepSet(rows, cutoff)
+	keep := diskKeepSet(dbSandboxes, recent, active, cutoff)
 
-	for _, id := range []string{"active", "paused", "failed-new"} {
+	for _, id := range []string{uuidA, uuidB, "new", recentID, activeID} {
 		if _, ok := keep[id]; !ok {
 			t.Errorf("%s should be in keep-set", id)
 		}
 	}
-	if _, ok := keep["failed-old"]; ok {
-		t.Error("settled-failed sandbox should be excluded from keep-set")
+	for _, id := range []string{uuidC, orphanID} {
+		if _, ok := keep[id]; ok {
+			t.Errorf("%s should NOT be in keep-set (reclaimable)", id)
+		}
 	}
 }
 

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/superserve-ai/sandbox/internal/db"
 )
 
 const (
@@ -89,6 +91,32 @@ func TestDirSize(t *testing.T) {
 	}
 	if got := dirSize(context.Background(), []string{dir}); got != 123 {
 		t.Errorf("dirSize = %d, want 123", got)
+	}
+}
+
+// liveKeepSet keeps every status except failures that settled before the
+// cutoff; recently-failed rows stay (grace) so an in-flight cleanup isn't raced.
+func TestLiveKeepSet_ExcludesSettledFailed(t *testing.T) {
+	cutoff := time.Unix(1_000_000, 0)
+	row := func(s db.SandboxStatus, updated time.Time) db.ListSandboxesByHostRow {
+		return db.ListSandboxesByHostRow{Sandbox: db.Sandbox{Status: s, UpdatedAt: updated}}
+	}
+	rows := map[string]db.ListSandboxesByHostRow{
+		"active":     row(db.SandboxStatusActive, cutoff.Add(-time.Hour)),
+		"paused":     row(db.SandboxStatusPaused, cutoff.Add(-time.Hour)),
+		"failed-old": row(db.SandboxStatusFailed, cutoff.Add(-time.Hour)), // settled → reclaimable
+		"failed-new": row(db.SandboxStatusFailed, cutoff.Add(time.Hour)),  // within grace → kept
+	}
+
+	keep := liveKeepSet(rows, cutoff)
+
+	for _, id := range []string{"active", "paused", "failed-new"} {
+		if _, ok := keep[id]; !ok {
+			t.Errorf("%s should be in keep-set", id)
+		}
+	}
+	if _, ok := keep["failed-old"]; ok {
+		t.Error("settled-failed sandbox should be excluded from keep-set")
 	}
 }
 

--- a/supabase/migrations/20260620000001_sandbox_host_destroyed_index.sql
+++ b/supabase/migrations/20260620000001_sandbox_host_destroyed_index.sql
@@ -1,0 +1,9 @@
+-- Supports the VMD disk reconciler's recently-destroyed lookup
+-- (ListRecentlyDestroyedSandboxIDsByHost):
+--   host_id = $1 AND destroyed_at IS NOT NULL AND destroyed_at > $2.
+-- The existing idx_sandbox_host is partial on destroyed_at IS NULL and does
+-- not cover destroyed rows, so without this the lookup scans the deleted
+-- portion of sandbox every pass on hosts with accumulated history.
+CREATE INDEX IF NOT EXISTS idx_sandbox_host_destroyed
+ON sandbox (host_id, destroyed_at)
+WHERE destroyed_at IS NOT NULL;


### PR DESCRIPTION
Adds a filesystem source to the vm reconciler that detects per-sandbox run/snapshot dirs with no live (or within-grace) sandbox row and logs what it would reclaim — bytes + sample. Deletes nothing; reclamation is a follow-up once the numbers are validated.

Keep-set = live host rows (minus terminally-failed sandboxes whose failure has settled past the grace window) + rows destroyed within grace. An all-orphan host (drained / only settled-failed) is reported, not suppressed — the hard empty-keep-set abort belongs on the future reclamation step, not on detect-only.

Safety: fail-closed without a DB keep-set (no-op), snapshot-time-before-DB-read mtime grace, UUID-only enumeration (excludes template/templates/build-*), deadline-bounded walk, slower sub-cadence. Kill-switch via `VMD_DISK_SCAN=false`.

Also adds a partial index `(host_id, destroyed_at) WHERE destroyed_at IS NOT NULL` for the destroyed-row lookup the scan runs each pass.