### PR TITLE
vmd: reclaim paused-sandbox network slot on delete after restart

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -461,6 +461,33 @@ func (m *Manager) CleanupVM(vmID string) {
 	m.log.Info().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("network namespace cleaned up")
 }
 
+// CleanupVMOrNamespace tears down a VM's network slot. When the VM is tracked
+// in devices it delegates to CleanupVM (which may recycle the slot to the
+// pool). When it is not tracked — e.g. a reattached VM whose network state was
+// never restored into devices — it reclaims the slot directly from the
+// namespace so the ns/veth/slot isn't leaked until the next restart sweep.
+// A no-op when the namespace is empty, malformed, or already gone.
+func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
+	m.mu.Lock()
+	_, tracked := m.devices[vmID]
+	m.mu.Unlock()
+	if tracked {
+		m.CleanupVM(vmID)
+		return
+	}
+
+	idx, ok := slotFromNamespace(fallbackNamespace)
+	if !ok || !nsExists(fallbackNamespace) {
+		return
+	}
+	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
+	m.mu.Lock()
+	m.freeSlots = append(m.freeSlots, idx)
+	m.mu.Unlock()
+	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
+		Msg("reclaimed network slot for untracked VM")
+}
+
 // ReattachVM rebinds vmd's view of an already-running VM's network state
 // at startup. After this call: the slot is marked in-use (no SetupVM
 // collisions), devices[vmID] is populated (CleanupVM can tear it down),

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -38,9 +38,9 @@ func newTestManager() *Manager {
 
 func TestSlotFromNamespace(t *testing.T) {
 	cases := []struct {
-		in        string
-		wantIdx   int
-		wantOK    bool
+		in      string
+		wantIdx int
+		wantOK  bool
 	}{
 		{"ns-0", 0, true},
 		{"ns-1", 1, true},
@@ -195,5 +195,51 @@ func TestEnsureVMSlot_InvalidNamespace(t *testing.T) {
 	_, err := m.EnsureVMSlot(context.Background(), "vm-x", "garbage", "10.11.0.3", "")
 	if err == nil {
 		t.Fatalf("expected error for invalid namespace, got nil")
+	}
+}
+
+func TestCleanupVMOrNamespace_TrackedDelegates(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	m.devices["vm-t"] = &VMNetInfo{Namespace: "ns-2", HostIP: "10.11.0.2"}
+
+	m.CleanupVMOrNamespace("vm-t", "")
+
+	if _, ok := m.devices["vm-t"]; ok {
+		t.Error("tracked VM should have been removed from devices via CleanupVM")
+	}
+}
+
+func TestCleanupVMOrNamespace_EmptyAndInvalidNamespaceNoop(t *testing.T) {
+	withTestNetnsDir(t)
+	for _, ns := range []string{"", "garbage"} {
+		m := newTestManager()
+		m.CleanupVMOrNamespace("vm-u", ns)
+		if len(m.freeSlots) != 0 {
+			t.Errorf("ns=%q: freeSlots = %v, want [] (no reclaim)", ns, m.freeSlots)
+		}
+	}
+}
+
+func TestCleanupVMOrNamespace_MissingNamespaceNoop(t *testing.T) {
+	withTestNetnsDir(t) // ns-5 intentionally not touched → nsExists is false
+	m := newTestManager()
+
+	m.CleanupVMOrNamespace("vm-u", "ns-5")
+
+	if len(m.freeSlots) != 0 {
+		t.Errorf("freeSlots = %v, want [] (namespace gone, nothing to reclaim)", m.freeSlots)
+	}
+}
+
+func TestCleanupVMOrNamespace_ReclaimsUntrackedSlot(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-5")
+	m := newTestManager()
+
+	m.CleanupVMOrNamespace("vm-u", "ns-5")
+
+	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
+		t.Errorf("freeSlots = %v, want [5] (slot reclaimed)", m.freeSlots)
 	}
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -512,7 +512,14 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 		}
 	}
 
-	m.netMgr.CleanupVM(vmID)
+	// Reclaim the network slot even if the VM isn't tracked in the devices
+	// map (e.g. a paused VM reattached without network state) — pass the
+	// known namespace so the slot isn't leaked.
+	ns := ""
+	if instErr == nil {
+		ns = inst.Namespace
+	}
+	m.netMgr.CleanupVMOrNamespace(vmID, ns)
 
 	// Fall back to vmID when the instance is absent (RunDirID == vmID anyway).
 	rundirKey := vmID
@@ -1077,6 +1084,14 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 			m.mu.Lock()
 			m.vms[rec.ID] = inst
 			m.mu.Unlock()
+			// Repopulate the network slot like running VMs do, so a paused
+			// sandbox deleted before its next resume can reclaim its slot.
+			// Resume's EnsureVMSlot is idempotent, so this is safe.
+			if inst.Namespace != "" && inst.IP != "" {
+				if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+					log.Error().Err(err).Msg("reattach: restore paused VM network state failed")
+				}
+			}
 			log.Info().Msg("reattached paused VM")
 			reattached++
 			continue


### PR DESCRIPTION
Paused VMs were reattached to the in-memory VM map on restart but skipped `netMgr.ReattachVM`, so `devices[vmID]` stayed empty and `CleanupVM` no-op'd on delete — leaking the ns/veth/slot until the next restart sweep.

- **Root cause:** reattach network state for paused VMs too (mirrors the running-VM path; resume's `EnsureVMSlot` is idempotent, so it's a safe no-op on resume).
- **Backstop:** `DestroyVM` reclaims the slot by namespace even when a VM isn't tracked in `devices`, so the slot is freed at delete time rather than waiting for a restart.

Slot accounting matches `pool.cleanup` (delete ns + return idx to `freeSlots`); `nsExists` guards on every allocator prevent reuse collisions.