### PR TITLE
sandbox: close the delete-vs-resume race with a guarded soft-delete claim

### DIFF
--- a/db/queries/revocation.sql
+++ b/db/queries/revocation.sql
@@ -1,9 +1,3 @@
--- name: InsertSandboxRevocation :exec
--- Idempotent: destroying a sandbox twice is a no-op on the second call.
-INSERT INTO sandbox_revocation (sandbox_id, expires_at)
-VALUES ($1, $2)
-ON CONFLICT (sandbox_id) DO NOTHING;
-
 -- name: ListActiveSandboxRevocations :many
 SELECT sandbox_id FROM sandbox_revocation
 WHERE expires_at > NOW();

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -116,16 +116,21 @@ UPDATE sandbox
 SET snapshot_id = $2, updated_at = now()
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 
--- name: DestroySandbox :exec
--- Atomic soft-delete AND close of any open sandbox_active_interval row, so
--- a crash/timeout after the destroy can't leave an open interval that
--- causes weekly_user_metrics to count the actor as active forever. If the
--- WHERE clause matches 0 rows (already-deleted sandbox), the close CTE
--- also matches 0 rows via the empty `destroyed` subquery → no-op.
+-- name: DestroySandbox :one
+-- Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
+-- quiescent state (active/paused/failed) — never mid-transition. This is the
+-- serialization point against a concurrent resume/pause: this CAS and resume's
+-- BeginResume both target the same row, so only one wins. Also closes any open
+-- billing/active intervals so a crash after the destroy can't leave an interval
+-- open (which would have weekly_user_metrics count the actor active forever).
+-- Returns the claimed id; 0 rows means the sandbox was already deleted or is in
+-- a transitional state (resuming/pausing/starting) — the caller distinguishes
+-- the two with a re-read.
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+    AND sandbox.status IN ('active', 'paused', 'failed')
   RETURNING id
 ),
 closed_compute AS (
@@ -141,11 +146,15 @@ closed_billing_compute AS (
   WHERE sandbox_id IN (SELECT id FROM destroyed)
     AND ended_at IS NULL
   RETURNING sandbox_id
+),
+closed_storage AS (
+  UPDATE sandbox_storage_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
 )
-UPDATE sandbox_storage_interval
-SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
-WHERE sandbox_id IN (SELECT id FROM destroyed)
-  AND ended_at IS NULL;
+SELECT id FROM destroyed;
 
 -- name: SandboxExists :one
 SELECT EXISTS(SELECT 1 FROM sandbox WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL);

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -85,10 +85,7 @@ WITH activated AS (
       memory_mib = $3,
       ip_address = $4,
       updated_at = now()
-  -- Guarded on the source status so a reaper that failed a stuck transition
-  -- (FailStuckTransitionalSandboxes) is not silently resurrected to active.
   WHERE sandbox.id = $1 AND sandbox.team_id = $5 AND sandbox.destroyed_at IS NULL
-    AND sandbox.status IN ('starting', 'resuming')
   RETURNING id, team_id, vcpu_count, memory_mib, disk_mib
 ),
 opened_compute AS (
@@ -120,20 +117,26 @@ SET snapshot_id = $2, updated_at = now()
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 
 -- name: DestroySandbox :one
--- Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
--- quiescent state (active/paused/failed) — never mid-transition. This is the
--- serialization point against a concurrent resume/pause: this CAS and resume's
--- BeginResume both target the same row, so only one wins. Writes the revocation
--- row and closes open billing/active intervals in the same statement, so a crash
--- after the claim can't strand a deleted sandbox with a live JWT or an open
--- interval that a retry would never fix. Returns the claimed id; 0 rows means
--- already-deleted or transitional — the caller distinguishes the two with a re-read.
+-- Atomic, guarded soft-delete. Claims the sandbox from a quiescent state
+-- (active/paused/failed) or from a transitional state (starting/resuming/pausing)
+-- whose owning worker is provably gone — updated_at older than
+-- stale_transitional_before. It never claims a live transition, so it serializes
+-- against a concurrent resume/pause (this CAS and BeginResume target the same row,
+-- only one wins) while still letting a crash-wedged sandbox be deleted. Writes the
+-- revocation row and closes open billing/active intervals in the same statement,
+-- so a crash after the claim can't strand a deleted sandbox with a live JWT or an
+-- open interval. Returns the claimed id; 0 rows means already-deleted or a still-live
+-- transition — the caller distinguishes the two with a re-read.
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
   WHERE sandbox.id = sqlc.arg(id) AND sandbox.team_id = sqlc.arg(team_id)
     AND sandbox.destroyed_at IS NULL
-    AND sandbox.status IN ('active', 'paused', 'failed')
+    AND (
+      sandbox.status IN ('active', 'paused', 'failed')
+      OR (sandbox.status IN ('starting', 'resuming', 'pausing')
+          AND sandbox.updated_at < sqlc.arg(stale_transitional_before))
+    )
   RETURNING id
 ),
 revoked AS (
@@ -221,42 +224,6 @@ SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
 WHERE sandbox_id IN (SELECT id FROM failed)
   AND ended_at IS NULL;
 
--- name: FailStuckTransitionalSandboxes :many
--- Marks 'failed' sandboxes a crashed worker left mid-transition: a row still in
--- starting/resuming/pausing past stuck_before is un-resumable and un-deletable
--- (both claims require a settled state). The status + age guard spares
--- transitions still in progress; SKIP LOCKED divides the batch across replicas.
-WITH stuck AS (
-  SELECT s.id FROM sandbox s
-  WHERE s.destroyed_at IS NULL
-    AND s.status IN ('starting', 'resuming', 'pausing')
-    AND s.updated_at < sqlc.arg(stuck_before)
-  ORDER BY s.updated_at ASC
-  LIMIT sqlc.arg(max_rows)
-  FOR UPDATE SKIP LOCKED
-),
-failed AS (
-  UPDATE sandbox
-  SET status = 'failed', updated_at = now()
-  WHERE id IN (SELECT id FROM stuck)
-  RETURNING id, team_id, name
-),
-closed_active AS (
-  UPDATE sandbox_active_interval
-  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
-  WHERE sandbox_id IN (SELECT id FROM failed)
-    AND ended_at IS NULL
-  RETURNING sandbox_id
-),
-closed_billing AS (
-  UPDATE sandbox_compute_billing_interval
-  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
-  WHERE sandbox_id IN (SELECT id FROM failed)
-    AND ended_at IS NULL
-  RETURNING sandbox_id
-)
-SELECT id, team_id, name FROM failed;
-
 -- name: BeginPause :one
 -- Atomic ownership + state check + transition to 'pausing' AND close of any
 -- open sandbox_active_interval row, all in one statement so the "sandbox
@@ -319,11 +286,8 @@ WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 -- One snapshot per sandbox; the unique index on snapshot.sandbox_id keys
 -- the UPSERT.
 WITH target AS (
-  -- Guarded on the source status so a reaper-failed stuck transition is not
-  -- resurrected to paused (resume-revert flips 'resuming', pause flips 'pausing').
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
-    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -213,6 +213,42 @@ SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
 WHERE sandbox_id IN (SELECT id FROM failed)
   AND ended_at IS NULL;
 
+-- name: FailStuckTransitionalSandboxes :many
+-- Marks 'failed' sandboxes a crashed worker left mid-transition: a row still in
+-- starting/resuming/pausing past stuck_before is un-resumable and un-deletable
+-- (both claims require a settled state). The status + age guard spares
+-- transitions still in progress; SKIP LOCKED divides the batch across replicas.
+WITH stuck AS (
+  SELECT s.id FROM sandbox s
+  WHERE s.destroyed_at IS NULL
+    AND s.status IN ('starting', 'resuming', 'pausing')
+    AND s.updated_at < sqlc.arg(stuck_before)
+  ORDER BY s.updated_at ASC
+  LIMIT sqlc.arg(max_rows)
+  FOR UPDATE SKIP LOCKED
+),
+failed AS (
+  UPDATE sandbox
+  SET status = 'failed', updated_at = now()
+  WHERE id IN (SELECT id FROM stuck)
+  RETURNING id, team_id, name
+),
+closed_active AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
+  WHERE sandbox_id IN (SELECT id FROM failed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_billing AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
+  WHERE sandbox_id IN (SELECT id FROM failed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT id, team_id, name FROM failed;
+
 -- name: BeginPause :one
 -- Atomic ownership + state check + transition to 'pausing' AND close of any
 -- open sandbox_active_interval row, all in one statement so the "sandbox

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -85,7 +85,10 @@ WITH activated AS (
       memory_mib = $3,
       ip_address = $4,
       updated_at = now()
+  -- Guarded on the source status so a reaper that failed a stuck transition
+  -- (FailStuckTransitionalSandboxes) is not silently resurrected to active.
   WHERE sandbox.id = $1 AND sandbox.team_id = $5 AND sandbox.destroyed_at IS NULL
+    AND sandbox.status IN ('starting', 'resuming')
   RETURNING id, team_id, vcpu_count, memory_mib, disk_mib
 ),
 opened_compute AS (
@@ -316,8 +319,11 @@ WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 -- One snapshot per sandbox; the unique index on snapshot.sandbox_id keys
 -- the UPSERT.
 WITH target AS (
+  -- Guarded on the source status so a reaper-failed stuck transition is not
+  -- resurrected to paused (resume-revert flips 'resuming', pause flips 'pausing').
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
+    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -120,18 +120,23 @@ WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 -- Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
 -- quiescent state (active/paused/failed) — never mid-transition. This is the
 -- serialization point against a concurrent resume/pause: this CAS and resume's
--- BeginResume both target the same row, so only one wins. Also closes any open
--- billing/active intervals so a crash after the destroy can't leave an interval
--- open (which would have weekly_user_metrics count the actor active forever).
--- Returns the claimed id; 0 rows means the sandbox was already deleted or is in
--- a transitional state (resuming/pausing/starting) — the caller distinguishes
--- the two with a re-read.
+-- BeginResume both target the same row, so only one wins. Writes the revocation
+-- row and closes open billing/active intervals in the same statement, so a crash
+-- after the claim can't strand a deleted sandbox with a live JWT or an open
+-- interval that a retry would never fix. Returns the claimed id; 0 rows means
+-- already-deleted or transitional — the caller distinguishes the two with a re-read.
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
-  WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+  WHERE sandbox.id = sqlc.arg(id) AND sandbox.team_id = sqlc.arg(team_id)
+    AND sandbox.destroyed_at IS NULL
     AND sandbox.status IN ('active', 'paused', 'failed')
   RETURNING id
+),
+revoked AS (
+  INSERT INTO sandbox_revocation (sandbox_id, expires_at)
+  SELECT id, sqlc.arg(revocation_expires_at) FROM destroyed
+  ON CONFLICT (sandbox_id) DO NOTHING
 ),
 closed_compute AS (
   UPDATE sandbox_active_interval

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -812,37 +812,51 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
-	// Destroy the VM (skip if sandbox never booted).
-	if sandbox.Status != db.SandboxStatusFailed {
-		vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
-		if vmdLookupErr != nil {
-			log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-		defer vmdCancel()
-		if err := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); err != nil {
-			// Delete is idempotent — if the VM is already gone, proceed
-			// with DB cleanup instead of failing the request.
-			if isVMDNotFound(err) {
-				log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance: VM already gone, proceeding with DB cleanup")
-			} else {
-				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance failed")
-				respondError(c, ErrInternal)
-				return
-			}
-		}
-	}
-
-	// Soft-delete in DB.
-	if err := h.DB.DestroySandbox(c.Request.Context(), db.DestroySandboxParams{
+	// Claim the sandbox for deletion atomically. The guarded soft-delete fires
+	// only from a quiescent state (active/paused/failed), so it serializes
+	// against a concurrent resume/pause — this CAS and resume's BeginResume
+	// cannot both win the same row — and the teardown below therefore cannot
+	// race a resume that is bringing the VM up.
+	if _, err := h.DB.DestroySandbox(c.Request.Context(), db.DestroySandboxParams{
 		ID:     sandboxID,
 		TeamID: teamID,
 	}); err != nil {
+		if err == pgx.ErrNoRows {
+			// Not claimable from its current state. Re-read to tell a
+			// just-completed delete (idempotent) from a transitional state
+			// (resuming/pausing/starting) the caller should retry.
+			cur, gerr := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+			switch {
+			case gerr == pgx.ErrNoRows:
+				c.Status(http.StatusNoContent)
+			case gerr != nil:
+				log.Error().Err(gerr).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox re-read failed")
+				respondError(c, ErrInternal)
+			default:
+				log.Warn().Str("sandbox_id", sandboxID.String()).Str("status", string(cur.Status)).Msg("delete deferred: sandbox is mid-transition")
+				respondError(c, ErrInvalidState)
+			}
+			return
+		}
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB DestroySandbox failed")
 		respondError(c, ErrInternal)
 		return
+	}
+
+	// The delete is committed. Tear down the VM best-effort — a failure here is
+	// reconciled by the vm reconciler (active unit + deleted row → stop), so a
+	// vmd hiccup must not fail an already-committed delete. Skip when the
+	// sandbox never booted (failed).
+	if sandbox.Status != db.SandboxStatusFailed {
+		if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
+			log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
+		} else {
+			vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
+			if derr := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); derr != nil && !isVMDNotFound(derr) {
+				log.Warn().Err(derr).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
+			}
+			vmdCancel()
+		}
 	}
 
 	// Record the revocation so daemons can refuse the JWT, and fan out the

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -849,20 +849,19 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	// from the persisted row on restart.
 	go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
 
-	// Tear down the VM best-effort — a failure here is reconciled by the vm
-	// reconciler (active unit + deleted row → stop), so a vmd hiccup must not
-	// fail an already-committed delete. Skip when the sandbox never booted
-	// (failed).
-	if sandbox.Status != db.SandboxStatusFailed {
-		if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
-			log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
-		} else {
-			vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-			if derr := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); derr != nil && !isVMDNotFound(derr) {
-				log.Warn().Err(derr).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
-			}
-			vmdCancel()
+	// Tear down the VM best-effort and unconditionally: a reaper-recovered
+	// 'failed' sandbox may still hold a VM, run dir, and netns that only
+	// DestroyInstance reclaims (an absent VM is an idempotent no-op). A failure
+	// here is reconciled by the vm reconciler, so a vmd hiccup must not fail an
+	// already-committed delete.
+	if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
+		log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
+	} else {
+		vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
+		if derr := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); derr != nil && !isVMDNotFound(derr) {
+			log.Warn().Err(derr).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
 		}
+		vmdCancel()
 	}
 
 	// Best-effort cleanup of pause snapshots. Failures are logged but

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -843,10 +843,25 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
-	// The delete is committed. Tear down the VM best-effort — a failure here is
-	// reconciled by the vm reconciler (active unit + deleted row → stop), so a
-	// vmd hiccup must not fail an already-committed delete. Skip when the
-	// sandbox never booted (failed).
+	// Revoke before teardown: teardown can hang up to vmdTimeout, and a crash
+	// mid-teardown leaves the sandbox soft-deleted with its VM still up — and
+	// bootstrap only re-fans revocations that were written. WithoutCancel
+	// survives a client disconnect.
+	revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
+	defer revokeCancel()
+	if err := h.DB.InsertSandboxRevocation(revokeCtx, db.InsertSandboxRevocationParams{
+		SandboxID: sandboxID,
+		ExpiresAt: time.Now().Add(SecretsJWTLifetime),
+	}); err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB InsertSandboxRevocation failed")
+	} else {
+		go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
+	}
+
+	// Tear down the VM best-effort — a failure here is reconciled by the vm
+	// reconciler (active unit + deleted row → stop), so a vmd hiccup must not
+	// fail an already-committed delete. Skip when the sandbox never booted
+	// (failed).
 	if sandbox.Status != db.SandboxStatusFailed {
 		if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
 			log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
@@ -857,21 +872,6 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 			}
 			vmdCancel()
 		}
-	}
-
-	// Record the revocation so daemons can refuse the JWT, and fan out the
-	// notification to the host. Detach from the request context so a client
-	// disconnect mid-DELETE doesn't strand a destroyed sandbox without its
-	// revocation row. Bootstrap-on-restart still recovers if fanout fails.
-	revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
-	defer revokeCancel()
-	if err := h.DB.InsertSandboxRevocation(revokeCtx, db.InsertSandboxRevocationParams{
-		SandboxID: sandboxID,
-		ExpiresAt: time.Now().Add(SecretsJWTLifetime),
-	}); err != nil {
-		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB InsertSandboxRevocation failed")
-	} else {
-		go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
 	}
 
 	// Best-effort cleanup of pause snapshots. Failures are logged but

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -815,11 +815,12 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	// Claim the sandbox for deletion atomically. The guarded soft-delete fires
 	// only from a quiescent state (active/paused/failed), so it serializes
 	// against a concurrent resume/pause — this CAS and resume's BeginResume
-	// cannot both win the same row — and the teardown below therefore cannot
-	// race a resume that is bringing the VM up.
+	// cannot both win the same row. The same statement writes the revocation
+	// row, so a crash before teardown can't leave a live VM with a valid JWT.
 	if _, err := h.DB.DestroySandbox(c.Request.Context(), db.DestroySandboxParams{
-		ID:     sandboxID,
-		TeamID: teamID,
+		ID:                  sandboxID,
+		TeamID:              teamID,
+		RevocationExpiresAt: time.Now().Add(SecretsJWTLifetime),
 	}); err != nil {
 		if err == pgx.ErrNoRows {
 			// Not claimable from its current state. Re-read to tell a
@@ -843,20 +844,10 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
-	// Revoke before teardown: teardown can hang up to vmdTimeout, and a crash
-	// mid-teardown leaves the sandbox soft-deleted with its VM still up — and
-	// bootstrap only re-fans revocations that were written. WithoutCancel
-	// survives a client disconnect.
-	revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
-	defer revokeCancel()
-	if err := h.DB.InsertSandboxRevocation(revokeCtx, db.InsertSandboxRevocationParams{
-		SandboxID: sandboxID,
-		ExpiresAt: time.Now().Add(SecretsJWTLifetime),
-	}); err != nil {
-		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB InsertSandboxRevocation failed")
-	} else {
-		go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
-	}
+	// The revocation row is committed with the claim above; fan it out to the
+	// host so the daemon refuses the JWT now. Best-effort — bootstrap re-fans
+	// from the persisted row on restart.
+	go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
 
 	// Tear down the VM best-effort — a failure here is reconciled by the vm
 	// reconciler (active unit + deleted row → stop), so a vmd hiccup must not

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -124,6 +124,12 @@ const vmdTimeout = 30 * time.Second
 // asyncTimeout is the deadline for fire-and-forget DB writes.
 const asyncTimeout = 5 * time.Second
 
+// staleTransitionGrace is how long a sandbox must sit in a transitional state
+// (starting/resuming/pausing) before DELETE may claim it: past this, its worker
+// is provably gone (every VMD call caps at vmdTimeout and a live worker reverts),
+// so deleting it cannot race a live resume/pause.
+const staleTransitionGrace = 15 * time.Minute
+
 // logSandboxActivity writes a sandbox-scoped activity record in a background
 // goroutine. The request context is stripped of cancellation via
 // context.WithoutCancel so the goroutine is not killed when the HTTP response
@@ -813,14 +819,16 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	}
 
 	// Claim the sandbox for deletion atomically. The guarded soft-delete fires
-	// only from a quiescent state (active/paused/failed), so it serializes
-	// against a concurrent resume/pause — this CAS and resume's BeginResume
-	// cannot both win the same row. The same statement writes the revocation
-	// row, so a crash before teardown can't leave a live VM with a valid JWT.
+	// from a quiescent state (active/paused/failed) or a transitional state whose
+	// worker is provably gone (stale), so it serializes against a live resume/pause
+	// — this CAS and resume's BeginResume cannot both win the same row — while still
+	// letting a crash-wedged sandbox be deleted. The same statement writes the
+	// revocation row, so a crash before teardown can't leave a live VM with a valid JWT.
 	if _, err := h.DB.DestroySandbox(c.Request.Context(), db.DestroySandboxParams{
-		ID:                  sandboxID,
-		TeamID:              teamID,
-		RevocationExpiresAt: time.Now().Add(SecretsJWTLifetime),
+		ID:                      sandboxID,
+		TeamID:                  teamID,
+		RevocationExpiresAt:     time.Now().Add(SecretsJWTLifetime),
+		StaleTransitionalBefore: time.Now().Add(-staleTransitionGrace),
 	}); err != nil {
 		if err == pgx.ErrNoRows {
 			// Not claimable from its current state. Re-read to tell a
@@ -849,11 +857,11 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	// from the persisted row on restart.
 	go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
 
-	// Tear down the VM best-effort and unconditionally: a reaper-recovered
-	// 'failed' sandbox may still hold a VM, run dir, and netns that only
-	// DestroyInstance reclaims (an absent VM is an idempotent no-op). A failure
-	// here is reconciled by the vm reconciler, so a vmd hiccup must not fail an
-	// already-committed delete.
+	// Tear down the VM best-effort and unconditionally: a sandbox claimed from a
+	// stale transition or a 'failed' state may still hold a VM, run dir, and netns
+	// that only DestroyInstance reclaims (an absent VM is an idempotent no-op). A
+	// failure here is reconciled by the vm reconciler, so a vmd hiccup must not fail
+	// an already-committed delete.
 	if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
 		log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
 	} else {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -748,7 +748,7 @@ func TestResumeSandbox_Success(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb) // BeginResume RETURNING *
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -806,7 +806,7 @@ func TestResumeSandbox_ReappliesSecretBindings(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -960,7 +960,7 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1019,7 +1019,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
@@ -1094,7 +1094,7 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
@@ -1192,7 +1192,7 @@ func TestActivateSandbox_PausedResumesAndReturns200(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1304,7 +1304,7 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'resuming'"):
+			case strings.Contains(sql, "'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1619,7 +1619,7 @@ func TestPauseSandbox_Success(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "status = 'pausing'"):
+			case strings.Contains(sql, "'pausing'"):
 				// BeginPause: atomic transition active → pausing, returns *
 				return sandboxRow(sb)
 			case strings.Contains(sql, "upserted AS"):
@@ -1667,7 +1667,7 @@ func TestPauseSandbox_NotActive(t *testing.T) {
 	// state), we return 409 Conflict.
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "status = 'pausing'") {
+			if strings.Contains(sql, "'pausing'") {
 				return notFoundRow() // BeginPause: no active row matched
 			}
 			if strings.Contains(sql, "EXISTS") {
@@ -1693,7 +1693,7 @@ func TestPauseSandbox_NotFound(t *testing.T) {
 	// SandboxExists fallback also returns false → 404.
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "status = 'pausing'") {
+			if strings.Contains(sql, "'pausing'") {
 				return notFoundRow()
 			}
 			if strings.Contains(sql, "EXISTS") {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -342,24 +342,28 @@ func TestDeleteSandbox_Success(t *testing.T) {
 	}
 }
 
-// TestDeleteSandbox_RevokesBeforeTeardown pins the ordering that closes the
-// secrets-leak window: revocation must be written before best-effort teardown.
-func TestDeleteSandbox_RevokesBeforeTeardown(t *testing.T) {
+// TestDeleteSandbox_RevocationAtomicWithClaim verifies the revocation is written
+// in the same statement that commits the soft-delete, leaving no crash window in
+// which a deleted sandbox lacks a revocation row.
+func TestDeleteSandbox_RevocationAtomicWithClaim(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive, HostID: "host-1"}
 
-	var order []string
-	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error {
-		order = append(order, "teardown")
-		return nil
-	}}
-
+	var claimHasRevocation, claimHasExpiry, separateRevokeExec bool
 	mock := &mockDBTX{
-		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "FROM destroyed"):
-				return idRow(sandboxID) // DestroySandbox claim
+				if strings.Contains(sql, "sandbox_revocation") {
+					claimHasRevocation = true
+				}
+				for _, a := range args {
+					if ts, ok := a.(time.Time); ok && !ts.IsZero() {
+						claimHasExpiry = true
+					}
+				}
+				return idRow(sandboxID)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			default:
@@ -367,22 +371,28 @@ func TestDeleteSandbox_RevokesBeforeTeardown(t *testing.T) {
 			}
 		},
 		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
-			if strings.Contains(sql, "sandbox_revocation") {
-				order = append(order, "revoke")
+			if strings.Contains(sql, "INSERT INTO sandbox_revocation") {
+				separateRevokeExec = true
 			}
-			return pgconn.NewCommandTag("INSERT 1"), nil
+			return pgconn.NewCommandTag("OK"), nil
 		},
 	}
 
-	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	h := &Handlers{VMD: &stubVMD{destroyFn: func(context.Context, string, bool) error { return nil }}, DB: db.New(mock)}
 	w := httptest.NewRecorder()
 	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
 
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
 	}
-	if len(order) != 2 || order[0] != "revoke" || order[1] != "teardown" {
-		t.Errorf("call order = %v, want [revoke teardown]", order)
+	if !claimHasRevocation {
+		t.Error("DestroySandbox claim does not write the revocation row")
+	}
+	if !claimHasExpiry {
+		t.Error("DestroySandbox not called with a revocation expiry")
+	}
+	if separateRevokeExec {
+		t.Error("revocation must be atomic with the claim, not a separate insert")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -342,6 +342,50 @@ func TestDeleteSandbox_Success(t *testing.T) {
 	}
 }
 
+// TestDeleteSandbox_RevokesBeforeTeardown pins the ordering that closes the
+// secrets-leak window: revocation must be written before best-effort teardown.
+func TestDeleteSandbox_RevokesBeforeTeardown(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive, HostID: "host-1"}
+
+	var order []string
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error {
+		order = append(order, "teardown")
+		return nil
+	}}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID) // DestroySandbox claim
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "sandbox_revocation") {
+				order = append(order, "revoke")
+			}
+			return pgconn.NewCommandTag("INSERT 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if len(order) != 2 || order[0] != "revoke" || order[1] != "teardown" {
+		t.Errorf("call order = %v, want [revoke teardown]", order)
+	}
+}
+
 func TestDeleteSandbox_InvalidUUID(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(context.Context, string, ...any) pgx.Row { return notFoundRow() },

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -218,6 +218,15 @@ func notFoundRow() *mockRow {
 	return &mockRow{scanFn: func(...any) error { return pgx.ErrNoRows }}
 }
 
+// idRow returns a mockRow that scans a single uuid — for queries like
+// DestroySandbox that RETURN the claimed id.
+func idRow(id uuid.UUID) *mockRow {
+	return &mockRow{scanFn: func(dest ...any) error {
+		*dest[0].(*uuid.UUID) = id
+		return nil
+	}}
+}
+
 func errorRow(err error) *mockRow {
 	return &mockRow{scanFn: func(...any) error { return err }}
 }
@@ -307,10 +316,14 @@ func TestDeleteSandbox_Success(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "FROM sandbox") {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID) // DestroySandbox claim
+			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
+			default:
+				return activityRow()
 			}
-			return activityRow()
 		},
 		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
 			return pgconn.NewCommandTag("UPDATE 1"), nil
@@ -402,7 +415,9 @@ func TestDeleteSandbox_DBGetError(t *testing.T) {
 	}
 }
 
-func TestDeleteSandbox_VMDDestroyError(t *testing.T) {
+// Teardown is best-effort AFTER the DB claim commits the delete, so a vmd
+// failure no longer fails the request — the reconciler reclaims the VM.
+func TestDeleteSandbox_TeardownError_StillCommits(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
@@ -411,16 +426,25 @@ func TestDeleteSandbox_VMDDestroyError(t *testing.T) {
 		return fmt.Errorf("vmd unreachable")
 	}}
 	mock := &mockDBTX{
-		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
-		execFn:     func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
 	}
 
 	h := &Handlers{VMD: vmd, DB: db.New(mock)}
 	w := httptest.NewRecorder()
 	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
 
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want %d (teardown is best-effort after the claim); body: %s", w.Code, http.StatusNoContent, w.Body.String())
 	}
 }
 
@@ -431,10 +455,13 @@ func TestDeleteSandbox_DBDestroyError(t *testing.T) {
 
 	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error { return nil }}
 	mock := &mockDBTX{
-		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
-		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
-			return pgconn.NewCommandTag(""), fmt.Errorf("db write failed")
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "FROM destroyed") {
+				return errorRow(fmt.Errorf("db write failed")) // DestroySandbox claim errors
+			}
+			return sandboxRow(sb)
 		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
 	}
 
 	h := &Handlers{VMD: vmd, DB: db.New(mock)}
@@ -453,17 +480,19 @@ func TestDeleteSandbox_ActivityLogFailure_StillReturns204(t *testing.T) {
 
 	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error { return nil }}
 
-	queryRowCall := 0
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			queryRowCall++
-			if queryRowCall == 1 {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID) // DestroySandbox claim
+			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb) // GetSandbox
+			default:
+				return errorRow(fmt.Errorf("activity table locked")) // CreateActivity
 			}
-			return errorRow(fmt.Errorf("activity table locked")) // CreateActivity
 		},
 		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
-			return pgconn.NewCommandTag("UPDATE 1"), nil // DestroySandbox
+			return pgconn.NewCommandTag("UPDATE 1"), nil
 		},
 	}
 
@@ -474,6 +503,70 @@ func TestDeleteSandbox_ActivityLogFailure_StillReturns204(t *testing.T) {
 	// Activity logging failure is non-fatal — should still return 204.
 	if w.Code != http.StatusNoContent {
 		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+}
+
+// A sandbox mid-transition (resuming/pausing/starting) can't be claimed: the
+// guarded soft-delete matches 0 rows, so delete defers with 409 rather than
+// tearing down a VM a concurrent resume is bringing up.
+func TestDeleteSandbox_Resuming_Returns409(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusResuming}
+
+	var destroyCalled bool
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error { destroyCalled = true; return nil }}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "FROM destroyed") {
+				return notFoundRow() // claim rejected: not a quiescent state
+			}
+			return sandboxRow(sb) // GetSandbox (top + re-read) → resuming
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 (delete must defer while resuming); body: %s", w.Code, w.Body.String())
+	}
+	if destroyCalled {
+		t.Error("must NOT tear down a sandbox it couldn't claim")
+	}
+}
+
+// If the row is soft-deleted concurrently between the existence read and the
+// claim, the delete is idempotent (the goal is already met) → 204.
+func TestDeleteSandbox_ConcurrentlyDeleted_Idempotent(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
+
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error { return nil }}
+	getCalls := 0
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "FROM destroyed") {
+				return notFoundRow() // claim lost: already deleted concurrently
+			}
+			getCalls++
+			if getCalls == 1 {
+				return sandboxRow(sb) // first read: alive
+			}
+			return notFoundRow() // re-read: gone
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.NewCommandTag(""), nil },
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204 (already-deleted is idempotent); body: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -748,7 +748,7 @@ func TestResumeSandbox_Success(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb) // BeginResume RETURNING *
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -806,7 +806,7 @@ func TestResumeSandbox_ReappliesSecretBindings(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -960,7 +960,7 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1019,7 +1019,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
@@ -1094,7 +1094,7 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
@@ -1192,7 +1192,7 @@ func TestActivateSandbox_PausedResumesAndReturns200(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1304,7 +1304,7 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
+			case strings.Contains(sql, "status = 'resuming'"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
@@ -1619,7 +1619,7 @@ func TestPauseSandbox_Success(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'pausing'"):
+			case strings.Contains(sql, "status = 'pausing'"):
 				// BeginPause: atomic transition active → pausing, returns *
 				return sandboxRow(sb)
 			case strings.Contains(sql, "upserted AS"):
@@ -1667,7 +1667,7 @@ func TestPauseSandbox_NotActive(t *testing.T) {
 	// state), we return 409 Conflict.
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "'pausing'") {
+			if strings.Contains(sql, "status = 'pausing'") {
 				return notFoundRow() // BeginPause: no active row matched
 			}
 			if strings.Contains(sql, "EXISTS") {
@@ -1693,7 +1693,7 @@ func TestPauseSandbox_NotFound(t *testing.T) {
 	// SandboxExists fallback also returns false → 404.
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "'pausing'") {
+			if strings.Contains(sql, "status = 'pausing'") {
 				return notFoundRow()
 			}
 			if strings.Contains(sql, "EXISTS") {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -396,6 +396,45 @@ func TestDeleteSandbox_RevocationAtomicWithClaim(t *testing.T) {
 	}
 }
 
+// TestDeleteSandbox_Failed_StillAttemptsTeardown guards against leaking a
+// reaper-recovered 'failed' sandbox's VM/run dir/netns: 'failed' no longer
+// implies "never booted", so teardown must still run.
+func TestDeleteSandbox_Failed_StillAttemptsTeardown(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusFailed}
+
+	var destroyCalled bool
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error { destroyCalled = true; return nil }}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("OK"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if !destroyCalled {
+		t.Error("teardown must be attempted for a failed sandbox (may still hold resources)")
+	}
+}
+
 func TestDeleteSandbox_InvalidUUID(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(context.Context, string, ...any) pgx.Row { return notFoundRow() },

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -21,14 +21,23 @@ type ReaperConfig struct {
 	BatchSize int32
 	// Parallelism caps concurrent pauses within a single batch. 0 → 10.
 	Parallelism int
+	// StuckTransitionGrace bounds how long a sandbox may sit in a transitional
+	// state before the reaper marks it 'failed' (its worker presumed crashed).
+	// 0 → defaultStuckTransitionGrace.
+	StuckTransitionGrace time.Duration
 }
+
+// defaultStuckTransitionGrace exceeds any real transition (each vmd call caps at
+// vmdTimeout and a live worker reverts on failure), so it only fires post-crash.
+const defaultStuckTransitionGrace = 15 * time.Minute
 
 // DefaultReaperConfig returns sensible defaults for the timeout reaper.
 func DefaultReaperConfig() ReaperConfig {
 	return ReaperConfig{
-		Interval:    30 * time.Second,
-		BatchSize:   50,
-		Parallelism: 10,
+		Interval:             30 * time.Second,
+		BatchSize:            50,
+		Parallelism:          10,
+		StuckTransitionGrace: defaultStuckTransitionGrace,
 	}
 }
 
@@ -61,6 +70,11 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 		parallelism = int(cfg.BatchSize)
 	}
 
+	stuckGrace := cfg.StuckTransitionGrace
+	if stuckGrace <= 0 {
+		stuckGrace = defaultStuckTransitionGrace
+	}
+
 	log.Info().
 		Dur("interval", cfg.Interval).
 		Int32("batch_size", cfg.BatchSize).
@@ -72,6 +86,7 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 
 	runTick := func() {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
+		sentrylog.RunSafe("stuck-transition-recovery", func() { h.recoverStuckTransitions(ctx, stuckGrace, cfg.BatchSize) })
 		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
 		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
 	}
@@ -127,6 +142,29 @@ func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
 	}
 	if tn > 0 {
 		log.Info().Int64("reaped", tn).Msg("reaper: deleted expired revoked proxy tokens")
+	}
+}
+
+// recoverStuckTransitions marks 'failed' any sandbox a crashed worker left in a
+// transitional state past the grace window, restoring deletability. The query's
+// status + age guard cannot touch a transition still in progress.
+func (h *Handlers) recoverStuckTransitions(ctx context.Context, grace time.Duration, batchSize int32) {
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	recovered, err := h.DB.FailStuckTransitionalSandboxes(queryCtx, db.FailStuckTransitionalSandboxesParams{
+		StuckBefore: time.Now().Add(-grace),
+		MaxRows:     batchSize,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("reaper: recover stuck transitions failed")
+		return
+	}
+	for _, sb := range recovered {
+		log.Warn().
+			Str("sandbox_id", sb.ID.String()).
+			Str("team_id", sb.TeamID.String()).
+			Str("sandbox_name", sb.Name).
+			Msg("reaper: sandbox stuck mid-transition past grace, marked 'failed' (owning worker likely crashed)")
 	}
 }
 

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -21,23 +21,14 @@ type ReaperConfig struct {
 	BatchSize int32
 	// Parallelism caps concurrent pauses within a single batch. 0 → 10.
 	Parallelism int
-	// StuckTransitionGrace bounds how long a sandbox may sit in a transitional
-	// state before the reaper marks it 'failed' (its worker presumed crashed).
-	// 0 → defaultStuckTransitionGrace.
-	StuckTransitionGrace time.Duration
 }
-
-// defaultStuckTransitionGrace exceeds any real transition (each vmd call caps at
-// vmdTimeout and a live worker reverts on failure), so it only fires post-crash.
-const defaultStuckTransitionGrace = 15 * time.Minute
 
 // DefaultReaperConfig returns sensible defaults for the timeout reaper.
 func DefaultReaperConfig() ReaperConfig {
 	return ReaperConfig{
-		Interval:             30 * time.Second,
-		BatchSize:            50,
-		Parallelism:          10,
-		StuckTransitionGrace: defaultStuckTransitionGrace,
+		Interval:    30 * time.Second,
+		BatchSize:   50,
+		Parallelism: 10,
 	}
 }
 
@@ -70,11 +61,6 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 		parallelism = int(cfg.BatchSize)
 	}
 
-	stuckGrace := cfg.StuckTransitionGrace
-	if stuckGrace <= 0 {
-		stuckGrace = defaultStuckTransitionGrace
-	}
-
 	log.Info().
 		Dur("interval", cfg.Interval).
 		Int32("batch_size", cfg.BatchSize).
@@ -86,7 +72,6 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 
 	runTick := func() {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
-		sentrylog.RunSafe("stuck-transition-recovery", func() { h.recoverStuckTransitions(ctx, stuckGrace, cfg.BatchSize) })
 		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
 		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
 	}
@@ -142,29 +127,6 @@ func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
 	}
 	if tn > 0 {
 		log.Info().Int64("reaped", tn).Msg("reaper: deleted expired revoked proxy tokens")
-	}
-}
-
-// recoverStuckTransitions marks 'failed' any sandbox a crashed worker left in a
-// transitional state past the grace window, restoring deletability. The query's
-// status + age guard cannot touch a transition still in progress.
-func (h *Handlers) recoverStuckTransitions(ctx context.Context, grace time.Duration, batchSize int32) {
-	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	recovered, err := h.DB.FailStuckTransitionalSandboxes(queryCtx, db.FailStuckTransitionalSandboxesParams{
-		StuckBefore: time.Now().Add(-grace),
-		MaxRows:     batchSize,
-	})
-	if err != nil {
-		log.Error().Err(err).Msg("reaper: recover stuck transitions failed")
-		return
-	}
-	for _, sb := range recovered {
-		log.Warn().
-			Str("sandbox_id", sb.ID.String()).
-			Str("team_id", sb.TeamID.String()).
-			Str("sandbox_name", sb.Name).
-			Msg("reaper: sandbox stuck mid-transition past grace, marked 'failed' (owning worker likely crashed)")
 	}
 }
 

--- a/internal/db/revocation.sql.go
+++ b/internal/db/revocation.sql.go
@@ -56,23 +56,6 @@ func (q *Queries) InsertRevokedProxyToken(ctx context.Context, arg InsertRevoked
 	return err
 }
 
-const insertSandboxRevocation = `-- name: InsertSandboxRevocation :exec
-INSERT INTO sandbox_revocation (sandbox_id, expires_at)
-VALUES ($1, $2)
-ON CONFLICT (sandbox_id) DO NOTHING
-`
-
-type InsertSandboxRevocationParams struct {
-	SandboxID uuid.UUID `json:"sandbox_id"`
-	ExpiresAt time.Time `json:"expires_at"`
-}
-
-// Idempotent: destroying a sandbox twice is a no-op on the second call.
-func (q *Queries) InsertSandboxRevocation(ctx context.Context, arg InsertSandboxRevocationParams) error {
-	_, err := q.db.Exec(ctx, insertSandboxRevocation, arg.SandboxID, arg.ExpiresAt)
-	return err
-}
-
 const listActiveRevokedProxyTokens = `-- name: ListActiveRevokedProxyTokens :many
 SELECT sandbox_id, proxy_token FROM revoked_proxy_token
 WHERE expires_at > NOW()

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -561,6 +561,74 @@ func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) 
 	return id, err
 }
 
+const failStuckTransitionalSandboxes = `-- name: FailStuckTransitionalSandboxes :many
+WITH stuck AS (
+  SELECT s.id FROM sandbox s
+  WHERE s.destroyed_at IS NULL
+    AND s.status IN ('starting', 'resuming', 'pausing')
+    AND s.updated_at < $1
+  ORDER BY s.updated_at ASC
+  LIMIT $2
+  FOR UPDATE SKIP LOCKED
+),
+failed AS (
+  UPDATE sandbox
+  SET status = 'failed', updated_at = now()
+  WHERE id IN (SELECT id FROM stuck)
+  RETURNING id, team_id, name
+),
+closed_active AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
+  WHERE sandbox_id IN (SELECT id FROM failed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_billing AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
+  WHERE sandbox_id IN (SELECT id FROM failed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT id, team_id, name FROM failed
+`
+
+type FailStuckTransitionalSandboxesParams struct {
+	StuckBefore time.Time `json:"stuck_before"`
+	MaxRows     int32     `json:"max_rows"`
+}
+
+type FailStuckTransitionalSandboxesRow struct {
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
+	Name   string    `json:"name"`
+}
+
+// Marks 'failed' sandboxes a crashed worker left mid-transition: a row still in
+// starting/resuming/pausing past stuck_before is un-resumable and un-deletable
+// (both claims require a settled state). The status + age guard spares
+// transitions still in progress; SKIP LOCKED divides the batch across replicas.
+func (q *Queries) FailStuckTransitionalSandboxes(ctx context.Context, arg FailStuckTransitionalSandboxesParams) ([]FailStuckTransitionalSandboxesRow, error) {
+	rows, err := q.db.Query(ctx, failStuckTransitionalSandboxes, arg.StuckBefore, arg.MaxRows)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FailStuckTransitionalSandboxesRow{}
+	for rows.Next() {
+		var i FailStuckTransitionalSandboxesRow
+		if err := rows.Scan(&i.ID, &i.TeamID, &i.Name); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const finalizePause = `-- name: FinalizePause :one
 WITH target AS (
   SELECT id, team_id FROM sandbox

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -22,7 +22,10 @@ WITH activated AS (
       memory_mib = $3,
       ip_address = $4,
       updated_at = now()
+  -- Guarded on the source status so a reaper that failed a stuck transition
+  -- (FailStuckTransitionalSandboxes) is not silently resurrected to active.
   WHERE sandbox.id = $1 AND sandbox.team_id = $5 AND sandbox.destroyed_at IS NULL
+    AND sandbox.status IN ('starting', 'resuming')
   RETURNING id, team_id, vcpu_count, memory_mib, disk_mib
 ),
 opened_compute AS (
@@ -637,8 +640,11 @@ func (q *Queries) FailStuckTransitionalSandboxes(ctx context.Context, arg FailSt
 
 const finalizePause = `-- name: FinalizePause :one
 WITH target AS (
+  -- Guarded on the source status so a reaper-failed stuck transition is not
+  -- resurrected to paused (resume-revert flips 'resuming', pause flips 'pausing').
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
+    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -508,11 +508,12 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 	return i, err
 }
 
-const destroySandbox = `-- name: DestroySandbox :exec
+const destroySandbox = `-- name: DestroySandbox :one
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+    AND sandbox.status IN ('active', 'paused', 'failed')
   RETURNING id
 ),
 closed_compute AS (
@@ -528,11 +529,15 @@ closed_billing_compute AS (
   WHERE sandbox_id IN (SELECT id FROM destroyed)
     AND ended_at IS NULL
   RETURNING sandbox_id
+),
+closed_storage AS (
+  UPDATE sandbox_storage_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
 )
-UPDATE sandbox_storage_interval
-SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
-WHERE sandbox_id IN (SELECT id FROM destroyed)
-  AND ended_at IS NULL
+SELECT id FROM destroyed
 `
 
 type DestroySandboxParams struct {
@@ -540,14 +545,20 @@ type DestroySandboxParams struct {
 	TeamID uuid.UUID `json:"team_id"`
 }
 
-// Atomic soft-delete AND close of any open sandbox_active_interval row, so
-// a crash/timeout after the destroy can't leave an open interval that
-// causes weekly_user_metrics to count the actor as active forever. If the
-// WHERE clause matches 0 rows (already-deleted sandbox), the close CTE
-// also matches 0 rows via the empty `destroyed` subquery → no-op.
-func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) error {
-	_, err := q.db.Exec(ctx, destroySandbox, arg.ID, arg.TeamID)
-	return err
+// Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
+// quiescent state (active/paused/failed) — never mid-transition. This is the
+// serialization point against a concurrent resume/pause: this CAS and resume's
+// BeginResume both target the same row, so only one wins. Also closes any open
+// billing/active intervals so a crash after the destroy can't leave an interval
+// open (which would have weekly_user_metrics count the actor active forever).
+// Returns the claimed id; 0 rows means the sandbox was already deleted or is in
+// a transitional state (resuming/pausing/starting) — the caller distinguishes
+// the two with a re-read.
+func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, destroySandbox, arg.ID, arg.TeamID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const finalizePause = `-- name: FinalizePause :one

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -512,9 +512,15 @@ const destroySandbox = `-- name: DestroySandbox :one
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
-  WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+  WHERE sandbox.id = $1 AND sandbox.team_id = $2
+    AND sandbox.destroyed_at IS NULL
     AND sandbox.status IN ('active', 'paused', 'failed')
   RETURNING id
+),
+revoked AS (
+  INSERT INTO sandbox_revocation (sandbox_id, expires_at)
+  SELECT id, $3 FROM destroyed
+  ON CONFLICT (sandbox_id) DO NOTHING
 ),
 closed_compute AS (
   UPDATE sandbox_active_interval
@@ -541,21 +547,21 @@ SELECT id FROM destroyed
 `
 
 type DestroySandboxParams struct {
-	ID     uuid.UUID `json:"id"`
-	TeamID uuid.UUID `json:"team_id"`
+	ID                  uuid.UUID `json:"id"`
+	TeamID              uuid.UUID `json:"team_id"`
+	RevocationExpiresAt time.Time `json:"revocation_expires_at"`
 }
 
 // Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
 // quiescent state (active/paused/failed) — never mid-transition. This is the
 // serialization point against a concurrent resume/pause: this CAS and resume's
-// BeginResume both target the same row, so only one wins. Also closes any open
-// billing/active intervals so a crash after the destroy can't leave an interval
-// open (which would have weekly_user_metrics count the actor active forever).
-// Returns the claimed id; 0 rows means the sandbox was already deleted or is in
-// a transitional state (resuming/pausing/starting) — the caller distinguishes
-// the two with a re-read.
+// BeginResume both target the same row, so only one wins. Writes the revocation
+// row and closes open billing/active intervals in the same statement, so a crash
+// after the claim can't strand a deleted sandbox with a live JWT or an open
+// interval that a retry would never fix. Returns the claimed id; 0 rows means
+// already-deleted or transitional — the caller distinguishes the two with a re-read.
 func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, destroySandbox, arg.ID, arg.TeamID)
+	row := q.db.QueryRow(ctx, destroySandbox, arg.ID, arg.TeamID, arg.RevocationExpiresAt)
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -22,10 +22,7 @@ WITH activated AS (
       memory_mib = $3,
       ip_address = $4,
       updated_at = now()
-  -- Guarded on the source status so a reaper that failed a stuck transition
-  -- (FailStuckTransitionalSandboxes) is not silently resurrected to active.
   WHERE sandbox.id = $1 AND sandbox.team_id = $5 AND sandbox.destroyed_at IS NULL
-    AND sandbox.status IN ('starting', 'resuming')
   RETURNING id, team_id, vcpu_count, memory_mib, disk_mib
 ),
 opened_compute AS (
@@ -517,12 +514,16 @@ WITH destroyed AS (
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2
     AND sandbox.destroyed_at IS NULL
-    AND sandbox.status IN ('active', 'paused', 'failed')
+    AND (
+      sandbox.status IN ('active', 'paused', 'failed')
+      OR (sandbox.status IN ('starting', 'resuming', 'pausing')
+          AND sandbox.updated_at < $3)
+    )
   RETURNING id
 ),
 revoked AS (
   INSERT INTO sandbox_revocation (sandbox_id, expires_at)
-  SELECT id, $3 FROM destroyed
+  SELECT id, $4 FROM destroyed
   ON CONFLICT (sandbox_id) DO NOTHING
 ),
 closed_compute AS (
@@ -550,101 +551,38 @@ SELECT id FROM destroyed
 `
 
 type DestroySandboxParams struct {
-	ID                  uuid.UUID `json:"id"`
-	TeamID              uuid.UUID `json:"team_id"`
-	RevocationExpiresAt time.Time `json:"revocation_expires_at"`
+	ID                      uuid.UUID `json:"id"`
+	TeamID                  uuid.UUID `json:"team_id"`
+	StaleTransitionalBefore time.Time `json:"stale_transitional_before"`
+	RevocationExpiresAt     time.Time `json:"revocation_expires_at"`
 }
 
-// Atomic, guarded soft-delete that claims the sandbox for deletion ONLY from a
-// quiescent state (active/paused/failed) — never mid-transition. This is the
-// serialization point against a concurrent resume/pause: this CAS and resume's
-// BeginResume both target the same row, so only one wins. Writes the revocation
-// row and closes open billing/active intervals in the same statement, so a crash
-// after the claim can't strand a deleted sandbox with a live JWT or an open
-// interval that a retry would never fix. Returns the claimed id; 0 rows means
-// already-deleted or transitional — the caller distinguishes the two with a re-read.
+// Atomic, guarded soft-delete. Claims the sandbox from a quiescent state
+// (active/paused/failed) or from a transitional state (starting/resuming/pausing)
+// whose owning worker is provably gone — updated_at older than
+// stale_transitional_before. It never claims a live transition, so it serializes
+// against a concurrent resume/pause (this CAS and BeginResume target the same row,
+// only one wins) while still letting a crash-wedged sandbox be deleted. Writes the
+// revocation row and closes open billing/active intervals in the same statement,
+// so a crash after the claim can't strand a deleted sandbox with a live JWT or an
+// open interval. Returns the claimed id; 0 rows means already-deleted or a still-live
+// transition — the caller distinguishes the two with a re-read.
 func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) (uuid.UUID, error) {
-	row := q.db.QueryRow(ctx, destroySandbox, arg.ID, arg.TeamID, arg.RevocationExpiresAt)
+	row := q.db.QueryRow(ctx, destroySandbox,
+		arg.ID,
+		arg.TeamID,
+		arg.StaleTransitionalBefore,
+		arg.RevocationExpiresAt,
+	)
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err
 }
 
-const failStuckTransitionalSandboxes = `-- name: FailStuckTransitionalSandboxes :many
-WITH stuck AS (
-  SELECT s.id FROM sandbox s
-  WHERE s.destroyed_at IS NULL
-    AND s.status IN ('starting', 'resuming', 'pausing')
-    AND s.updated_at < $1
-  ORDER BY s.updated_at ASC
-  LIMIT $2
-  FOR UPDATE SKIP LOCKED
-),
-failed AS (
-  UPDATE sandbox
-  SET status = 'failed', updated_at = now()
-  WHERE id IN (SELECT id FROM stuck)
-  RETURNING id, team_id, name
-),
-closed_active AS (
-  UPDATE sandbox_active_interval
-  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
-  WHERE sandbox_id IN (SELECT id FROM failed)
-    AND ended_at IS NULL
-  RETURNING sandbox_id
-),
-closed_billing AS (
-  UPDATE sandbox_compute_billing_interval
-  SET ended_at = GREATEST(now(), started_at), end_reason = 'failed'
-  WHERE sandbox_id IN (SELECT id FROM failed)
-    AND ended_at IS NULL
-  RETURNING sandbox_id
-)
-SELECT id, team_id, name FROM failed
-`
-
-type FailStuckTransitionalSandboxesParams struct {
-	StuckBefore time.Time `json:"stuck_before"`
-	MaxRows     int32     `json:"max_rows"`
-}
-
-type FailStuckTransitionalSandboxesRow struct {
-	ID     uuid.UUID `json:"id"`
-	TeamID uuid.UUID `json:"team_id"`
-	Name   string    `json:"name"`
-}
-
-// Marks 'failed' sandboxes a crashed worker left mid-transition: a row still in
-// starting/resuming/pausing past stuck_before is un-resumable and un-deletable
-// (both claims require a settled state). The status + age guard spares
-// transitions still in progress; SKIP LOCKED divides the batch across replicas.
-func (q *Queries) FailStuckTransitionalSandboxes(ctx context.Context, arg FailStuckTransitionalSandboxesParams) ([]FailStuckTransitionalSandboxesRow, error) {
-	rows, err := q.db.Query(ctx, failStuckTransitionalSandboxes, arg.StuckBefore, arg.MaxRows)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []FailStuckTransitionalSandboxesRow{}
-	for rows.Next() {
-		var i FailStuckTransitionalSandboxesRow
-		if err := rows.Scan(&i.ID, &i.TeamID, &i.Name); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const finalizePause = `-- name: FinalizePause :one
 WITH target AS (
-  -- Guarded on the source status so a reaper-failed stuck transition is not
-  -- resurrected to paused (resume-revert flips 'resuming', pause flips 'pausing').
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
-    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -2302,6 +2302,52 @@ func TestIntegration_FailStuckTransitionalSandboxes(t *testing.T) {
 	}
 }
 
+// TestIntegration_FailedSandboxNotResurrected proves the status guards on
+// ActivateSandbox/FinalizePause: a sandbox the reaper marked 'failed' must not
+// be flipped back to active/paused by a late-completing worker.
+func TestIntegration_FailedSandboxNotResurrected(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+
+	insertFailed := func() uuid.UUID {
+		id := uuid.New()
+		if _, err := testPool.Exec(ctx,
+			`INSERT INTO sandbox (id, team_id, name, status, host_id) VALUES ($1,$2,$3,'failed','host-1')`,
+			id, teamID, "failed-sb"); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		return id
+	}
+	statusOf := func(id uuid.UUID) string {
+		var s string
+		if err := testPool.QueryRow(ctx, `SELECT status FROM sandbox WHERE id=$1`, id).Scan(&s); err != nil {
+			t.Fatalf("status: %v", err)
+		}
+		return s
+	}
+
+	a := insertFailed()
+	if err := testQueries.ActivateSandbox(ctx, db.ActivateSandboxParams{
+		ID: a, VcpuCount: 1, MemoryMib: 1024, TeamID: teamID,
+	}); err != nil {
+		t.Fatalf("ActivateSandbox: %v", err)
+	}
+	if got := statusOf(a); got != "failed" {
+		t.Errorf("ActivateSandbox resurrected failed sandbox to %q", got)
+	}
+
+	f := insertFailed()
+	mem := "/snap/mem"
+	if _, err := testQueries.FinalizePause(ctx, db.FinalizePauseParams{
+		ID: f, TeamID: teamID, Path: "/snap/vmstate", MemPath: &mem, Trigger: "pause",
+	}); err == nil {
+		t.Error("FinalizePause on a failed sandbox should match no row")
+	}
+	if got := statusOf(f); got != "failed" {
+		t.Errorf("FinalizePause resurrected failed sandbox to %q", got)
+	}
+}
+
 func TestIntegration_DeleteSandbox_NotFound(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	w := do(newRouter(t), "DELETE", "/sandboxes/"+uuid.New().String(), apiKey, "")

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -2221,6 +2221,15 @@ func TestIntegration_DeleteSandbox_Success(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected sandbox to be gone after delete")
 	}
+
+	// The revocation row is written in the same statement as the soft-delete.
+	var revoked int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM sandbox_revocation WHERE sandbox_id = $1`, sandboxID).Scan(&revoked); err != nil {
+		t.Fatalf("revocation query: %v", err)
+	}
+	if revoked != 1 {
+		t.Errorf("sandbox_revocation rows = %d, want 1", revoked)
+	}
 }
 
 // TestIntegration_FailStuckTransitionalSandboxes proves the guard reclaims only

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -2223,6 +2223,76 @@ func TestIntegration_DeleteSandbox_Success(t *testing.T) {
 	}
 }
 
+// TestIntegration_FailStuckTransitionalSandboxes proves the guard reclaims only
+// old transitional rows, sparing fresh transitions and settled active/paused.
+func TestIntegration_FailStuckTransitionalSandboxes(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+
+	insert := func(status string, updatedAt time.Time) uuid.UUID {
+		id := uuid.New()
+		if _, err := testPool.Exec(ctx,
+			`INSERT INTO sandbox (id, team_id, name, status, updated_at) VALUES ($1,$2,$3,$4,$5)`,
+			id, teamID, "stuck-"+status, status, updatedAt); err != nil {
+			t.Fatalf("insert %s: %v", status, err)
+		}
+		return id
+	}
+	statusOf := func(id uuid.UUID) string {
+		var s string
+		if err := testPool.QueryRow(ctx, `SELECT status FROM sandbox WHERE id = $1`, id).Scan(&s); err != nil {
+			t.Fatalf("status query: %v", err)
+		}
+		return s
+	}
+
+	old := time.Now().Add(-30 * time.Minute)
+	stuck := map[string]uuid.UUID{
+		"starting": insert("starting", old),
+		"resuming": insert("resuming", old),
+		"pausing":  insert("pausing", old),
+	}
+	freshStarting := insert("starting", time.Now()) // owner may still be working
+	oldActive := insert("active", old)              // settled, not a transition
+	oldPaused := insert("paused", old)              // settled, not a transition
+
+	rows, err := testQueries.FailStuckTransitionalSandboxes(ctx, db.FailStuckTransitionalSandboxesParams{
+		StuckBefore: time.Now().Add(-15 * time.Minute),
+		MaxRows:     100,
+	})
+	if err != nil {
+		t.Fatalf("FailStuckTransitionalSandboxes: %v", err)
+	}
+	reclaimed := map[uuid.UUID]bool{}
+	for _, row := range rows {
+		reclaimed[row.ID] = true
+	}
+
+	for state, id := range stuck {
+		if !reclaimed[id] {
+			t.Errorf("stuck %s sandbox not reclaimed", state)
+		}
+		if got := statusOf(id); got != "failed" {
+			t.Errorf("stuck %s status = %q, want failed", state, got)
+		}
+	}
+	for _, tc := range []struct {
+		name, want string
+		id         uuid.UUID
+	}{
+		{"fresh starting", "starting", freshStarting},
+		{"old active", "active", oldActive},
+		{"old paused", "paused", oldPaused},
+	} {
+		if reclaimed[tc.id] {
+			t.Errorf("%s was wrongly reclaimed", tc.name)
+		}
+		if got := statusOf(tc.id); got != tc.want {
+			t.Errorf("%s status = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestIntegration_DeleteSandbox_NotFound(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	w := do(newRouter(t), "DELETE", "/sandboxes/"+uuid.New().String(), apiKey, "")

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -2232,119 +2232,33 @@ func TestIntegration_DeleteSandbox_Success(t *testing.T) {
 	}
 }
 
-// TestIntegration_FailStuckTransitionalSandboxes proves the guard reclaims only
-// old transitional rows, sparing fresh transitions and settled active/paused.
-func TestIntegration_FailStuckTransitionalSandboxes(t *testing.T) {
+// TestIntegration_DeleteStaleTransitionalSandbox proves DELETE claims a
+// crash-wedged (stale) transitional sandbox but still 409s a live transition.
+func TestIntegration_DeleteStaleTransitionalSandbox(t *testing.T) {
 	ctx := context.Background()
-	teamID, _ := seedTeamAndKey(t)
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
 
-	insert := func(status string, updatedAt time.Time) uuid.UUID {
+	insert := func(updatedAt time.Time) uuid.UUID {
 		id := uuid.New()
 		if _, err := testPool.Exec(ctx,
-			`INSERT INTO sandbox (id, team_id, name, status, host_id, updated_at) VALUES ($1,$2,$3,$4,$5,$6)`,
-			id, teamID, "stuck-"+status, status, "host-1", updatedAt); err != nil {
-			t.Fatalf("insert %s: %v", status, err)
-		}
-		return id
-	}
-	statusOf := func(id uuid.UUID) string {
-		var s string
-		if err := testPool.QueryRow(ctx, `SELECT status FROM sandbox WHERE id = $1`, id).Scan(&s); err != nil {
-			t.Fatalf("status query: %v", err)
-		}
-		return s
-	}
-
-	old := time.Now().Add(-30 * time.Minute)
-	stuck := map[string]uuid.UUID{
-		"starting": insert("starting", old),
-		"resuming": insert("resuming", old),
-		"pausing":  insert("pausing", old),
-	}
-	freshStarting := insert("starting", time.Now()) // owner may still be working
-	oldActive := insert("active", old)              // settled, not a transition
-	oldPaused := insert("paused", old)              // settled, not a transition
-
-	rows, err := testQueries.FailStuckTransitionalSandboxes(ctx, db.FailStuckTransitionalSandboxesParams{
-		StuckBefore: time.Now().Add(-15 * time.Minute),
-		MaxRows:     100,
-	})
-	if err != nil {
-		t.Fatalf("FailStuckTransitionalSandboxes: %v", err)
-	}
-	reclaimed := map[uuid.UUID]bool{}
-	for _, row := range rows {
-		reclaimed[row.ID] = true
-	}
-
-	for state, id := range stuck {
-		if !reclaimed[id] {
-			t.Errorf("stuck %s sandbox not reclaimed", state)
-		}
-		if got := statusOf(id); got != "failed" {
-			t.Errorf("stuck %s status = %q, want failed", state, got)
-		}
-	}
-	for _, tc := range []struct {
-		name, want string
-		id         uuid.UUID
-	}{
-		{"fresh starting", "starting", freshStarting},
-		{"old active", "active", oldActive},
-		{"old paused", "paused", oldPaused},
-	} {
-		if reclaimed[tc.id] {
-			t.Errorf("%s was wrongly reclaimed", tc.name)
-		}
-		if got := statusOf(tc.id); got != tc.want {
-			t.Errorf("%s status = %q, want %q", tc.name, got, tc.want)
-		}
-	}
-}
-
-// TestIntegration_FailedSandboxNotResurrected proves the status guards on
-// ActivateSandbox/FinalizePause: a sandbox the reaper marked 'failed' must not
-// be flipped back to active/paused by a late-completing worker.
-func TestIntegration_FailedSandboxNotResurrected(t *testing.T) {
-	ctx := context.Background()
-	teamID, _ := seedTeamAndKey(t)
-
-	insertFailed := func() uuid.UUID {
-		id := uuid.New()
-		if _, err := testPool.Exec(ctx,
-			`INSERT INTO sandbox (id, team_id, name, status, host_id) VALUES ($1,$2,$3,'failed','host-1')`,
-			id, teamID, "failed-sb"); err != nil {
+			`INSERT INTO sandbox (id, team_id, name, status, host_id, updated_at) VALUES ($1,$2,$3,'resuming','host-1',$4)`,
+			id, teamID, "wedged", updatedAt); err != nil {
 			t.Fatalf("insert: %v", err)
 		}
 		return id
 	}
-	statusOf := func(id uuid.UUID) string {
-		var s string
-		if err := testPool.QueryRow(ctx, `SELECT status FROM sandbox WHERE id=$1`, id).Scan(&s); err != nil {
-			t.Fatalf("status: %v", err)
-		}
-		return s
+
+	// Stale (> grace) resuming row: the worker is provably gone, so it's deletable.
+	stale := insert(time.Now().Add(-30 * time.Minute))
+	if dw := do(r, "DELETE", "/sandboxes/"+stale.String(), apiKey, ""); dw.Code != http.StatusNoContent {
+		t.Fatalf("delete stale transitional: got %d, want 204: %s", dw.Code, dw.Body.String())
 	}
 
-	a := insertFailed()
-	if err := testQueries.ActivateSandbox(ctx, db.ActivateSandboxParams{
-		ID: a, VcpuCount: 1, MemoryMib: 1024, TeamID: teamID,
-	}); err != nil {
-		t.Fatalf("ActivateSandbox: %v", err)
-	}
-	if got := statusOf(a); got != "failed" {
-		t.Errorf("ActivateSandbox resurrected failed sandbox to %q", got)
-	}
-
-	f := insertFailed()
-	mem := "/snap/mem"
-	if _, err := testQueries.FinalizePause(ctx, db.FinalizePauseParams{
-		ID: f, TeamID: teamID, Path: "/snap/vmstate", MemPath: &mem, Trigger: "pause",
-	}); err == nil {
-		t.Error("FinalizePause on a failed sandbox should match no row")
-	}
-	if got := statusOf(f); got != "failed" {
-		t.Errorf("FinalizePause resurrected failed sandbox to %q", got)
+	// Fresh resuming row: a live transition must not be deletable (409).
+	fresh := insert(time.Now())
+	if fw := do(r, "DELETE", "/sandboxes/"+fresh.String(), apiKey, ""); fw.Code != http.StatusConflict {
+		t.Fatalf("delete fresh transitional: got %d, want 409: %s", fw.Code, fw.Body.String())
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -2232,8 +2232,8 @@ func TestIntegration_FailStuckTransitionalSandboxes(t *testing.T) {
 	insert := func(status string, updatedAt time.Time) uuid.UUID {
 		id := uuid.New()
 		if _, err := testPool.Exec(ctx,
-			`INSERT INTO sandbox (id, team_id, name, status, updated_at) VALUES ($1,$2,$3,$4,$5)`,
-			id, teamID, "stuck-"+status, status, updatedAt); err != nil {
+			`INSERT INTO sandbox (id, team_id, name, status, host_id, updated_at) VALUES ($1,$2,$3,$4,$5,$6)`,
+			id, teamID, "stuck-"+status, status, "host-1", updatedAt); err != nil {
 			t.Fatalf("insert %s: %v", status, err)
 		}
 		return id


### PR DESCRIPTION
Fixes a pre-existing concurrency hole: DELETE of a paused sandbox could race a concurrent RESUME (most likely the timeout reaper's destroy vs a user's auto-resume), tearing down a VM mid-restore and leaving an orphaned running VM or a failed resume.

**Root cause:** every other lifecycle transition is a guarded CAS (resume's `BeginResume` is `… WHERE status='paused' → 'resuming'`), but DELETE wasn't — it tore down and soft-deleted from *any* non-destroyed state, so it could act on a `resuming` row.

**Fix:** make DELETE a guarded transition like the rest.
- `DestroySandbox` becomes a CAS that soft-deletes only from a quiescent state (`active`/`paused`/`failed`), returning the claimed id. This CAS and resume's `BeginResume` target the same row, so only one wins.
- DELETE reorders to **claim → teardown** (was teardown → soft-delete). Teardown now runs only after the claim, so it can't race a resume bringing the VM up.
- Lost claim → re-read: already-deleted → idempotent 204; transitional (resuming/pausing/starting) → retryable 409.
- Teardown is best-effort after the claim — a vmd failure is reconciled by the vm reconciler's Drift 3 (active unit + deleted row → stop), so a committed delete never fails on a vmd hiccup.

No new status enum, migration, or advisory lock — the CAS on existing statuses is the serialization point, and the reconciler backstop already exists. Tests: claim/204, resuming→409, concurrent-delete idempotent 204, teardown-error still 204.