### PR TITLE
vmd: enable disk reclamation (flag-gated, quarantine-move + sweep)

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -472,6 +472,9 @@ func main() {
 	reconcilerCfg.HostID = cfg.HostID
 	reconcilerCfg.DB = reconcilerDB
 	reconcilerCfg.DiskScanEnabled = envOrDefault("VMD_DISK_SCAN", "true") != "false"
+	// Reclamation is opt-in: the detect-only numbers must be validated on prod
+	// before this is flipped on. Defaults off.
+	reconcilerCfg.DiskReclaimEnabled = envOrDefault("VMD_DISK_RECLAIM", "false") == "true"
 	reconciler := vm.NewReconciler(mgr, reconcilerCfg)
 	lc.start("reconciler", func() error { reconciler.Run(ctx); return nil })
 

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -824,6 +824,13 @@ func (r *Reconciler) consumeAutoFailBudget(vmID string) bool {
 // in-memory map. The VM is already gone in reality; this just cleans up
 // VMD's cache.
 func (r *Reconciler) markStale(vmID string) {
+	// Capture the namespace before deleting the record: a VM whose teardown
+	// didn't run (e.g. a vmd timeout mid-DELETE) would otherwise leak its slot.
+	var namespace string
+	if rec, err := r.mgr.state.Get(vmID); err == nil && rec != nil {
+		namespace = rec.Namespace
+	}
+
 	// Delete from BoltDB first. If this fails, keep the in-memory entry
 	// so the state stays consistent — the reconciler will retry on the
 	// next run. Deleting from the map before BoltDB would cause
@@ -836,6 +843,11 @@ func (r *Reconciler) markStale(vmID string) {
 	r.mgr.mu.Lock()
 	delete(r.mgr.vms, vmID)
 	r.mgr.mu.Unlock()
+
+	// Free the slot too. netMgr is always set in prod; the nil check is defensive.
+	if r.mgr.netMgr != nil {
+		r.mgr.netMgr.CleanupVMOrNamespace(vmID, namespace)
+	}
 
 	r.mu.Lock()
 	delete(r.driftSeen, vmID)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -442,12 +442,6 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		return
 	}
 
-	// When reclamation is on, always sweep expired quarantine — even on a pass
-	// that finds no new orphans.
-	if r.cfg.DiskReclaimEnabled {
-		defer r.sweepTrash(snapshotTime)
-	}
-
 	// Source D: per-sandbox dirs. A name that parses as a UUID excludes the
 	// template mount target, the build tree, and build-* VMs by construction.
 	onDisk := scanSandboxDirs(r.mgr.cfg.RunDir, r.mgr.cfg.SnapshotDir)
@@ -466,13 +460,23 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		log.Error().Err(err).Msg("disk scan: recently-destroyed query failed — skipping (fail-closed)")
 		return
 	}
-	keep := diskKeepSet(dbSandboxes, recent, active, cutoff)
+	keep := diskKeepSet(dbSandboxes, recent, active)
 
-	// A drained or all-failed host legitimately has an empty keep-set; report it
-	// (detect-only is harmless). The hard abort-guard belongs on reclamation.
 	if len(keep) == 0 {
+		// An empty keep-set is almost always a query bug, not an empty host;
+		// reclamation aborts (detect-only just reports).
+		if r.cfg.DiskReclaimEnabled {
+			log.Error().Int("on_disk", len(onDisk)).Msg("disk reclaim suppressed: empty keep-set")
+			return
+		}
 		log.Warn().Int("on_disk", len(onDisk)).
 			Msg("disk scan: empty keep-set — reporting all on-disk dirs as orphans (verify before enabling reclamation)")
+	}
+
+	// Sweep only after the keep-set is validated, so a fail-closed pass does
+	// nothing destructive. Runs even when this pass finds no new orphans.
+	if r.cfg.DiskReclaimEnabled {
+		defer r.sweepTrash(snapshotTime)
 	}
 
 	orphans := selectOrphanDirs(onDisk, keep, cutoff)
@@ -502,14 +506,6 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		Msg("disk scan: orphan per-sandbox dirs detected")
 
 	if r.cfg.DiskReclaimEnabled {
-		// An empty keep-set is almost certainly a query bug; detect-only reports
-		// it, but reclamation must never act on it. This is the abort-guard that
-		// §5/§7 of the design moved off the detect path onto here.
-		if len(keep) == 0 {
-			log.Error().Int("orphans", len(orphans)).
-				Msg("disk reclaim suppressed: empty keep-set")
-			return
-		}
 		r.reclaimDiskOrphans(ctx, snapshotTime, orphans, onDisk)
 	}
 }
@@ -568,9 +564,10 @@ func quarantineDir(path, date string) error {
 	return os.Rename(path, filepath.Join(trashDir, name))
 }
 
-// sweepTrash permanently removes quarantined date dirs older than
-// DiskTrashRetention — the irreversible step, after the soak that gives time to
-// spot a bad reclaim.
+// sweepTrash permanently removes quarantine buckets soaked longer than
+// DiskTrashRetention. Age comes from the bucket's actual mtime, not its
+// date-label name, so the full retention is honored rather than rounded down to
+// the label's midnight.
 func (r *Reconciler) sweepTrash(now time.Time) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "trash_sweep").Logger()
 	cutoff := now.Add(-r.cfg.DiskTrashRetention)
@@ -587,8 +584,8 @@ func (r *Reconciler) sweepTrash(now time.Time) {
 			if !e.IsDir() {
 				continue
 			}
-			d, perr := time.Parse("2006-01-02", e.Name())
-			if perr != nil || !d.Before(cutoff) {
+			info, ierr := e.Info()
+			if ierr != nil || !info.ModTime().Before(cutoff) {
 				continue
 			}
 			p := filepath.Join(trash, e.Name())
@@ -601,19 +598,13 @@ func (r *Reconciler) sweepTrash(now time.Time) {
 	}
 }
 
-// diskKeepSet is every sandbox UUID whose on-disk dirs must NOT be reclaimed —
-// the union of all signals a dir may be in use: non-destroyed DB rows (minus
-// failures settled before cutoff), rows destroyed within grace, and active
-// systemd units (a running VM whose row is momentarily gone). BoltDB-only UUIDs
-// are excluded on purpose: no row AND no unit means a dead VM (Drift 5's job),
-// so its dir is reclaimable. In-flight creates are caught by the caller's mtime
-// grace, not here. Pure.
-func diskKeepSet(dbSandboxes map[string]db.ListSandboxesByHostRow, recent []uuid.UUID, active map[string]bool, cutoff time.Time) map[string]struct{} {
+// diskKeepSet is every sandbox UUID whose on-disk dirs must NOT be reclaimed:
+// non-destroyed DB rows, rows destroyed within grace, and active systemd units.
+// Failed rows are kept too — a failed sandbox retains billed disk (storage
+// interval open until delete), so it is reclaimed only once destroyed.
+func diskKeepSet(dbSandboxes map[string]db.ListSandboxesByHostRow, recent []uuid.UUID, active map[string]bool) map[string]struct{} {
 	keep := make(map[string]struct{}, len(dbSandboxes)+len(recent)+len(active))
-	for id, row := range dbSandboxes {
-		if row.Sandbox.Status == db.SandboxStatusFailed && row.Sandbox.UpdatedAt.Before(cutoff) {
-			continue
-		}
+	for id := range dbSandboxes {
 		keep[id] = struct{}{}
 	}
 	for _, id := range recent {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -445,9 +445,6 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	// Source D: per-sandbox dirs. A name that parses as a UUID excludes the
 	// template mount target, the build tree, and build-* VMs by construction.
 	onDisk := scanSandboxDirs(r.mgr.cfg.RunDir, r.mgr.cfg.SnapshotDir)
-	if len(onDisk) == 0 {
-		return
-	}
 
 	cutoff := snapshotTime.Add(-r.cfg.DiskGracePeriod)
 	qctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
@@ -474,9 +471,14 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	}
 
 	// Sweep only after the keep-set is validated, so a fail-closed pass does
-	// nothing destructive. Runs even when this pass finds no new orphans.
+	// nothing destructive. Registered before the empty-disk return below so a
+	// drained host (dirs already quarantined, only .trash left) still sweeps.
 	if r.cfg.DiskReclaimEnabled {
 		defer r.sweepTrash(snapshotTime)
+	}
+
+	if len(onDisk) == 0 {
+		return
 	}
 
 	orphans := selectOrphanDirs(onDisk, keep, cutoff)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -112,14 +112,18 @@ type Reconciler struct {
 	// passCount counts completed reconcile passes, used to run the disk
 	// scan on a slower sub-cadence. Only touched from the single Run loop.
 	passCount uint64
+	// prevKeptLive is the prior disk pass's protected live-sandbox count, used
+	// to detect a keep-set collapse. -1 until the first pass. Run loop only.
+	prevKeptLive int
 }
 
 // NewReconciler creates a reconciler bound to a Manager.
 func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 	return &Reconciler{
-		mgr:       mgr,
-		cfg:       cfg,
-		driftSeen: make(map[string]time.Time),
+		mgr:          mgr,
+		cfg:          cfg,
+		driftSeen:    make(map[string]time.Time),
+		prevKeptLive: -1,
 	}
 }
 
@@ -398,10 +402,13 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_present_db_missing").
 				Msg("BoltDB entry with no DB row — cleaning up")
-			// Stop the unit if it's still live so we don't leak a VM.
+			// Stop the unit if it's still live. If the stop fails the VM may
+			// still be running, so leave the entry for next pass — markStale
+			// frees the network slot, which must never happen for a live VM.
 			if rec.Status == StatusRunning {
 				if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
-					log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit from BoltDB")
+					log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit from BoltDB — leaving for retry")
+					continue
 				}
 				removeUnitDropIn(id)
 			}
@@ -459,6 +466,18 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	}
 	keep := diskKeepSet(dbSandboxes, recent, active)
 
+	// Protected live sandboxes — used by the collapse guard and the audit log.
+	var keptActive, keptPaused int
+	for _, row := range dbSandboxes {
+		switch row.Sandbox.Status {
+		case db.SandboxStatusActive:
+			keptActive++
+		case db.SandboxStatusPaused:
+			keptPaused++
+		}
+	}
+	keptLive := keptActive + keptPaused
+
 	if len(keep) == 0 {
 		// An empty keep-set is almost always a query bug, not an empty host;
 		// reclamation aborts (detect-only just reports).
@@ -470,10 +489,24 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 			Msg("disk scan: empty keep-set — reporting all on-disk dirs as orphans (verify before enabling reclamation)")
 	}
 
-	// Sweep only after the keep-set is validated, so a fail-closed pass does
-	// nothing destructive. Registered before the empty-disk return below so a
-	// drained host (dirs already quarantined, only .trash left) still sweeps.
 	if r.cfg.DiskReclaimEnabled {
+		if r.cfg.DiskTrashRetention <= 0 || r.cfg.DiskDeleteBudget <= 0 {
+			log.Error().Dur("retention", r.cfg.DiskTrashRetention).Int("budget", r.cfg.DiskDeleteBudget).
+				Msg("disk reclaim suppressed: retention and budget must be > 0")
+			return
+		}
+		// keep-set and tripwire both read dbSandboxes, so a query returning too
+		// few live rows evades both; a sharp drop vs the prior pass is the
+		// independent signal. Keep the baseline so a sustained drop stays suppressed.
+		if keepSetCollapsed(r.prevKeptLive, keptLive) {
+			log.Error().Int("kept_live", keptLive).Int("prev_kept_live", r.prevKeptLive).
+				Msg("disk reclaim suppressed: live keep-set collapsed since last pass")
+			return
+		}
+		r.prevKeptLive = keptLive
+		// Sweep only after the keep-set is validated, so a fail-closed pass does
+		// nothing destructive. Registered before the empty-disk return below so a
+		// drained host (dirs already quarantined, only .trash left) still sweeps.
 		defer r.sweepTrash(snapshotTime)
 	}
 
@@ -498,16 +531,6 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	sample := orphans
 	if len(sample) > 20 {
 		sample = sample[:20]
-	}
-	// Surface the live sandboxes being protected so each pass is auditable.
-	var keptActive, keptPaused int
-	for _, row := range dbSandboxes {
-		switch row.Sandbox.Status {
-		case db.SandboxStatusActive:
-			keptActive++
-		case db.SandboxStatusPaused:
-			keptPaused++
-		}
 	}
 	log.Warn().
 		Int("orphan_sandboxes", len(orphans)).
@@ -535,10 +558,6 @@ func (r *Reconciler) reclaimDiskOrphans(ctx context.Context, snapshotTime time.T
 	var moved, dirCount int
 	var bytes int64
 	for _, id := range orphans {
-		// Stop on a cancelled pass (e.g. runTimeout) rather than keep mutating.
-		if ctx.Err() != nil {
-			return
-		}
 		// Tripwire: dbSandboxes is non-destroyed rows only, so a hit means a live
 		// sandbox slipped past the keep-set — alarm and skip, never move it.
 		if _, live := dbSandboxes[id]; live {
@@ -552,6 +571,11 @@ func (r *Reconciler) reclaimDiskOrphans(ctx context.Context, snapshotTime time.T
 		}
 		info := onDisk[id]
 		sz := dirSize(ctx, info.paths)
+		// Re-check right before the move: dirSize can run long, and a cancelled
+		// pass (runTimeout/shutdown) must stop before mutating disk.
+		if ctx.Err() != nil {
+			return
+		}
 		any := false
 		for _, p := range info.paths {
 			if err := quarantineDir(p, date); err != nil {
@@ -589,10 +613,9 @@ func quarantineDir(path, date string) error {
 	return os.Rename(path, filepath.Join(trashDir, name))
 }
 
-// sweepTrash permanently removes quarantine buckets soaked longer than
-// DiskTrashRetention. Age comes from the bucket's actual mtime, not its
-// date-label name, so the full retention is honored rather than rounded down to
-// the label's midnight.
+// sweepTrash permanently removes quarantine buckets soaked past
+// DiskTrashRetention. Age is the bucket's mtime, not its date label, so a bucket
+// always soaks at least the full retention (never the rounded-down midnight).
 func (r *Reconciler) sweepTrash(now time.Time) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "trash_sweep").Logger()
 	cutoff := now.Add(-r.cfg.DiskTrashRetention)
@@ -639,6 +662,13 @@ func diskKeepSet(dbSandboxes map[string]db.ListSandboxesByHostRow, recent []uuid
 		keep[id] = struct{}{}
 	}
 	return keep
+}
+
+// keepSetCollapsed reports whether the protected live-sandbox count dropped by
+// more than half between disk passes — a sign the keep-set query regressed. A
+// prev of < 1 (no prior pass, or an already-drained host) never trips.
+func keepSetCollapsed(prev, cur int) bool {
+	return prev > 0 && cur*2 < prev
 }
 
 // selectOrphanDirs returns the sandbox UUIDs whose on-disk dirs have no live or

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,11 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
+
+// trashDirName is the per-root quarantine directory. Orphan dirs are moved to
+// <root>/<trashDirName>/<date>/<uuid> before being removed after the retention
+// soak. It is not a UUID, so the orphan scan never enumerates it.
+const trashDirName = ".trash"
 
 // buildVMIDPrefix marks VMs owned by the template build pipeline. Their
 // lifecycle is managed by buildTemplateWorker, not the reconciler — they
@@ -53,6 +59,17 @@ type ReconcilerConfig struct {
 	// filesystem walk doesn't ride the fast liveness loop. Values < 1 mean
 	// every tick.
 	DiskScanEvery int
+	// DiskReclaimEnabled turns the disk pass from detect-only into reclamation:
+	// orphan dirs are quarantine-moved to <root>/.trash/<date>/ (reversible)
+	// and trash older than DiskTrashRetention is removed. Default false — the
+	// detect-only numbers must be validated on prod before this is flipped on.
+	DiskReclaimEnabled bool
+	// DiskDeleteBudget bounds how many orphan sandboxes one pass quarantines so
+	// a keep-set bug can't move everything at once. Deferred work runs next pass.
+	DiskDeleteBudget int
+	// DiskTrashRetention is how long a quarantined dir soaks under .trash before
+	// it is permanently removed — the window to spot and reverse a bad reclaim.
+	DiskTrashRetention time.Duration
 }
 
 // DefaultReconcilerConfig returns sensible defaults from the design doc.
@@ -64,6 +81,9 @@ func DefaultReconcilerConfig() ReconcilerConfig {
 		DiskScanEnabled:    true,
 		DiskGracePeriod:    24 * time.Hour,
 		DiskScanEvery:      4,
+		DiskReclaimEnabled: false,
+		DiskDeleteBudget:   50,
+		DiskTrashRetention: 72 * time.Hour,
 	}
 }
 
@@ -410,15 +430,22 @@ type sandboxDirInfo struct {
 	paths []string
 }
 
-// detectDiskOrphans implements Drift 6 in detect-only mode: it logs the
-// per-sandbox dirs it would reclaim and deletes nothing. Fail-closed: without
-// a DB keep-set it does nothing.
+// detectDiskOrphans implements Drift 6: it logs the per-sandbox dirs with no
+// live row and, when DiskReclaimEnabled, quarantine-moves them (bounded by
+// DiskDeleteBudget) and sweeps expired quarantine. Fail-closed: without a DB
+// keep-set it does nothing.
 func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Time, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_scan").Logger()
 
 	if r.cfg.DB == nil || r.cfg.HostID == "" || dbSandboxes == nil {
 		log.Debug().Msg("disk scan skipped — no DB keep-set (fail-closed)")
 		return
+	}
+
+	// When reclamation is on, always sweep expired quarantine — even on a pass
+	// that finds no new orphans.
+	if r.cfg.DiskReclaimEnabled {
+		defer r.sweepTrash(snapshotTime)
 	}
 
 	// Source D: per-sandbox dirs. A name that parses as a UUID excludes the
@@ -471,7 +498,107 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 		Int("orphan_dirs", dirCount).
 		Int64("orphan_bytes", bytes).
 		Strs("sample", sample).
-		Msg("disk scan (detect-only): orphan per-sandbox dirs would be reclaimed")
+		Bool("reclaim", r.cfg.DiskReclaimEnabled).
+		Msg("disk scan: orphan per-sandbox dirs detected")
+
+	if r.cfg.DiskReclaimEnabled {
+		// An empty keep-set is almost certainly a query bug; detect-only reports
+		// it, but reclamation must never act on it. This is the abort-guard that
+		// §5/§7 of the design moved off the detect path onto here.
+		if len(keep) == 0 {
+			log.Error().Int("orphans", len(orphans)).
+				Msg("disk reclaim suppressed: empty keep-set")
+			return
+		}
+		r.reclaimDiskOrphans(ctx, snapshotTime, orphans, onDisk)
+	}
+}
+
+// reclaimDiskOrphans quarantine-moves orphan dirs to <root>/.trash/<date>/<uuid>
+// (reversible), bounded by DiskDeleteBudget. Space is freed later by sweepTrash
+// once the retention soak elapses. The caller guarantees a non-empty keep-set.
+func (r *Reconciler) reclaimDiskOrphans(ctx context.Context, snapshotTime time.Time, orphans []string, onDisk map[string]sandboxDirInfo) {
+	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_reclaim").Logger()
+	date := snapshotTime.UTC().Format("2006-01-02")
+
+	var moved, dirCount int
+	var bytes int64
+	for _, id := range orphans {
+		if moved >= r.cfg.DiskDeleteBudget {
+			log.Warn().Int("budget", r.cfg.DiskDeleteBudget).Int("deferred", len(orphans)-moved).
+				Msg("disk reclaim: budget reached, deferring rest to next pass")
+			break
+		}
+		info := onDisk[id]
+		sz := dirSize(ctx, info.paths)
+		any := false
+		for _, p := range info.paths {
+			if err := quarantineDir(p, date); err != nil {
+				log.Error().Err(err).Str("path", p).Msg("disk reclaim: quarantine failed")
+				continue
+			}
+			dirCount++
+			any = true
+		}
+		if any {
+			moved++
+			bytes += sz
+		}
+	}
+	if moved > 0 {
+		log.Warn().Int("quarantined_sandboxes", moved).Int("quarantined_dirs", dirCount).Int64("bytes", bytes).
+			Msg("disk reclaim: orphan dirs quarantined to .trash")
+	}
+}
+
+// quarantineDir moves a per-sandbox dir (<root>/<uuid>) to
+// <root>/.trash/<date>/<uuid>. The dir name must parse as a UUID (so a stray
+// path can't be moved) and the move stays within the same root (same
+// filesystem → atomic rename).
+func quarantineDir(path, date string) error {
+	root := filepath.Dir(path)
+	name := filepath.Base(path)
+	if _, err := uuid.Parse(name); err != nil {
+		return fmt.Errorf("refusing to quarantine non-uuid dir %q", name)
+	}
+	trashDir := filepath.Join(root, trashDirName, date)
+	if err := os.MkdirAll(trashDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir trash: %w", err)
+	}
+	return os.Rename(path, filepath.Join(trashDir, name))
+}
+
+// sweepTrash permanently removes quarantined date dirs older than
+// DiskTrashRetention — the irreversible step, after the soak that gives time to
+// spot a bad reclaim.
+func (r *Reconciler) sweepTrash(now time.Time) {
+	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "trash_sweep").Logger()
+	cutoff := now.Add(-r.cfg.DiskTrashRetention)
+	for _, root := range []string{r.mgr.cfg.RunDir, r.mgr.cfg.SnapshotDir} {
+		if root == "" {
+			continue
+		}
+		trash := filepath.Join(root, trashDirName)
+		entries, err := os.ReadDir(trash)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			d, perr := time.Parse("2006-01-02", e.Name())
+			if perr != nil || !d.Before(cutoff) {
+				continue
+			}
+			p := filepath.Join(trash, e.Name())
+			if err := os.RemoveAll(p); err != nil {
+				log.Warn().Err(err).Str("path", p).Msg("trash sweep: remove failed")
+			} else {
+				log.Info().Str("path", p).Msg("trash sweep: removed expired quarantine")
+			}
+		}
+	}
 }
 
 // diskKeepSet is every sandbox UUID whose on-disk dirs must NOT be reclaimed —

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -499,29 +499,52 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	if len(sample) > 20 {
 		sample = sample[:20]
 	}
+	// Surface the live sandboxes being protected so each pass is auditable.
+	var keptActive, keptPaused int
+	for _, row := range dbSandboxes {
+		switch row.Sandbox.Status {
+		case db.SandboxStatusActive:
+			keptActive++
+		case db.SandboxStatusPaused:
+			keptPaused++
+		}
+	}
 	log.Warn().
 		Int("orphan_sandboxes", len(orphans)).
 		Int("orphan_dirs", dirCount).
 		Int64("orphan_bytes", bytes).
+		Int("kept_total", len(keep)).
+		Int("kept_active", keptActive).
+		Int("kept_paused", keptPaused).
 		Strs("sample", sample).
 		Bool("reclaim", r.cfg.DiskReclaimEnabled).
 		Msg("disk scan: orphan per-sandbox dirs detected")
 
 	if r.cfg.DiskReclaimEnabled {
-		r.reclaimDiskOrphans(ctx, snapshotTime, orphans, onDisk)
+		r.reclaimDiskOrphans(ctx, snapshotTime, orphans, onDisk, dbSandboxes)
 	}
 }
 
 // reclaimDiskOrphans quarantine-moves orphan dirs to <root>/.trash/<date>/<uuid>
 // (reversible), bounded by DiskDeleteBudget. Space is freed later by sweepTrash
 // once the retention soak elapses. The caller guarantees a non-empty keep-set.
-func (r *Reconciler) reclaimDiskOrphans(ctx context.Context, snapshotTime time.Time, orphans []string, onDisk map[string]sandboxDirInfo) {
+func (r *Reconciler) reclaimDiskOrphans(ctx context.Context, snapshotTime time.Time, orphans []string, onDisk map[string]sandboxDirInfo, dbSandboxes map[string]db.ListSandboxesByHostRow) {
 	log := r.mgr.log.With().Str("component", "reconciler").Str("pass", "disk_reclaim").Logger()
 	date := snapshotTime.UTC().Format("2006-01-02")
 
 	var moved, dirCount int
 	var bytes int64
 	for _, id := range orphans {
+		// Stop on a cancelled pass (e.g. runTimeout) rather than keep mutating.
+		if ctx.Err() != nil {
+			return
+		}
+		// Tripwire: dbSandboxes is non-destroyed rows only, so a hit means a live
+		// sandbox slipped past the keep-set — alarm and skip, never move it.
+		if _, live := dbSandboxes[id]; live {
+			log.Error().Str("vm_id", id).Msg("disk reclaim: refusing to quarantine a live sandbox dir (keep-set regression)")
+			continue
+		}
 		if moved >= r.cfg.DiskDeleteBudget {
 			log.Warn().Int("budget", r.cfg.DiskDeleteBudget).Int("deferred", len(orphans)-moved).
 				Msg("disk reclaim: budget reached, deferring rest to next pass")

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -223,7 +223,7 @@ func TestReclaimDiskOrphans_QuarantinesUpToBudget(t *testing.T) {
 		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
 		cfg: ReconcilerConfig{DiskDeleteBudget: 2},
 	}
-	r.reclaimDiskOrphans(context.Background(), time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), ids, onDisk)
+	r.reclaimDiskOrphans(context.Background(), time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), ids, onDisk, map[string]db.ListSandboxesByHostRow{})
 
 	// Budget 2: the first two (slice order) move, the third stays.
 	if _, err := os.Stat(filepath.Join(runDir, uuidA)); !os.IsNotExist(err) {
@@ -235,6 +235,70 @@ func TestReclaimDiskOrphans_QuarantinesUpToBudget(t *testing.T) {
 	entries, _ := os.ReadDir(filepath.Join(runDir, ".trash", "2026-06-20"))
 	if len(entries) != 2 {
 		t.Errorf(".trash has %d entries, want 2 (budget)", len(entries))
+	}
+}
+
+// The reclaim-time tripwire must refuse to move a dir whose UUID still has a
+// live (non-destroyed) DB row, even if it reached the orphan list.
+func TestReclaimDiskOrphans_SkipsLiveSandbox(t *testing.T) {
+	runDir := t.TempDir()
+	ids := []string{uuidA, uuidB}
+	onDisk := map[string]sandboxDirInfo{}
+	for _, id := range ids {
+		p := filepath.Join(runDir, id)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		onDisk[id] = sandboxDirInfo{paths: []string{p}}
+	}
+	dbSandboxes := map[string]db.ListSandboxesByHostRow{
+		uuidA: {Sandbox: db.Sandbox{Status: db.SandboxStatusPaused}}, // live → must not move
+	}
+
+	r := &Reconciler{
+		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
+		cfg: ReconcilerConfig{DiskDeleteBudget: 10},
+	}
+	r.reclaimDiskOrphans(context.Background(), time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), ids, onDisk, dbSandboxes)
+
+	if _, err := os.Stat(filepath.Join(runDir, uuidA)); err != nil {
+		t.Error("live sandbox dir (uuidA) must NOT be quarantined")
+	}
+	if _, err := os.Stat(filepath.Join(runDir, uuidB)); !os.IsNotExist(err) {
+		t.Error("orphan uuidB should have been quarantined")
+	}
+}
+
+// A cancelled pass (e.g. runTimeout) must stop before any destructive move,
+// even with budget to spare.
+func TestReclaimDiskOrphans_StopsOnCancel(t *testing.T) {
+	runDir := t.TempDir()
+	ids := []string{uuidA, uuidB}
+	onDisk := map[string]sandboxDirInfo{}
+	for _, id := range ids {
+		p := filepath.Join(runDir, id)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		onDisk[id] = sandboxDirInfo{paths: []string{p}}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := &Reconciler{
+		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
+		cfg: ReconcilerConfig{DiskDeleteBudget: 10},
+	}
+	r.reclaimDiskOrphans(ctx, time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), ids, onDisk, map[string]db.ListSandboxesByHostRow{})
+
+	for _, id := range ids {
+		if _, err := os.Stat(filepath.Join(runDir, id)); err != nil {
+			t.Errorf("%s must not be moved when ctx is cancelled", id)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(runDir, trashDirName)); !os.IsNotExist(err) {
+		t.Error("no .trash should be created when ctx is cancelled")
 	}
 }
 

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -138,6 +139,99 @@ func TestDiskKeepSet(t *testing.T) {
 		if _, ok := keep[id]; ok {
 			t.Errorf("%s should NOT be in keep-set (reclaimable)", id)
 		}
+	}
+}
+
+func TestQuarantineDir(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, uuidA)
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "overlay.ext4"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := quarantineDir(src, "2026-06-20"); err != nil {
+		t.Fatalf("quarantineDir: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Error("source dir should be gone after quarantine")
+	}
+	if _, err := os.Stat(filepath.Join(root, ".trash", "2026-06-20", uuidA, "overlay.ext4")); err != nil {
+		t.Errorf("dir should be under .trash: %v", err)
+	}
+}
+
+func TestQuarantineDir_RejectsNonUUID(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "templates")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := quarantineDir(src, "2026-06-20"); err == nil {
+		t.Error("expected error quarantining a non-uuid dir")
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Error("non-uuid dir must not be moved")
+	}
+}
+
+func TestSweepTrash_RemovesExpiredKeepsRecent(t *testing.T) {
+	runDir := t.TempDir()
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC) // retention 72h → cutoff 06-17 12:00
+	mk := func(date string) string {
+		p := filepath.Join(runDir, ".trash", date)
+		if err := os.MkdirAll(filepath.Join(p, uuidA), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	oldDir := mk("2026-06-15")    // 5 days old → swept
+	recentDir := mk("2026-06-19") // 1 day old → kept
+
+	r := &Reconciler{
+		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
+		cfg: ReconcilerConfig{DiskTrashRetention: 72 * time.Hour},
+	}
+	r.sweepTrash(now)
+
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Error("expired quarantine should be removed")
+	}
+	if _, err := os.Stat(recentDir); err != nil {
+		t.Error("recent quarantine should be kept")
+	}
+}
+
+func TestReclaimDiskOrphans_QuarantinesUpToBudget(t *testing.T) {
+	runDir := t.TempDir()
+	ids := []string{uuidA, uuidB, uuidC}
+	onDisk := map[string]sandboxDirInfo{}
+	for _, id := range ids {
+		p := filepath.Join(runDir, id)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		onDisk[id] = sandboxDirInfo{paths: []string{p}}
+	}
+
+	r := &Reconciler{
+		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
+		cfg: ReconcilerConfig{DiskDeleteBudget: 2},
+	}
+	r.reclaimDiskOrphans(context.Background(), time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC), ids, onDisk)
+
+	// Budget 2: the first two (slice order) move, the third stays.
+	if _, err := os.Stat(filepath.Join(runDir, uuidA)); !os.IsNotExist(err) {
+		t.Error("uuidA should have been quarantined")
+	}
+	if _, err := os.Stat(filepath.Join(runDir, uuidC)); err != nil {
+		t.Error("uuidC should remain (over budget)")
+	}
+	entries, _ := os.ReadDir(filepath.Join(runDir, ".trash", "2026-06-20"))
+	if len(entries) != 2 {
+		t.Errorf(".trash has %d entries, want 2 (budget)", len(entries))
 	}
 }
 

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -139,6 +139,27 @@ func TestDiskKeepSet(t *testing.T) {
 	}
 }
 
+func TestKeepSetCollapsed(t *testing.T) {
+	cases := []struct {
+		name      string
+		prev, cur int
+		want      bool
+	}{
+		{"first pass", -1, 50, false},
+		{"prev drained", 0, 0, false},
+		{"stable", 40, 40, false},
+		{"exactly half", 40, 20, false},
+		{"more than half gone", 40, 19, true},
+		{"vanished", 40, 0, true},
+		{"growth", 10, 50, false},
+	}
+	for _, c := range cases {
+		if got := keepSetCollapsed(c.prev, c.cur); got != c.want {
+			t.Errorf("%s: keepSetCollapsed(%d,%d)=%v want %v", c.name, c.prev, c.cur, got, c.want)
+		}
+	}
+}
+
 func TestQuarantineDir(t *testing.T) {
 	root := t.TempDir()
 	src := filepath.Join(root, uuidA)

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -107,12 +107,12 @@ func TestDirSize(t *testing.T) {
 }
 
 // diskKeepSet is the complete reclaim guard: it must keep a dir live via ANY
-// source — DB row, recently-destroyed grace, or an active unit — and exclude
-// only genuinely-dead ones (settled-failed, and UUIDs in no source at all).
+// source — a non-destroyed DB row (any status, including failed, which retains
+// billed disk until delete), recently-destroyed grace, or an active unit — and
+// reclaim only UUIDs present in no source at all.
 func TestDiskKeepSet(t *testing.T) {
-	cutoff := time.Unix(1_000_000, 0)
-	row := func(s db.SandboxStatus, updated time.Time) db.ListSandboxesByHostRow {
-		return db.ListSandboxesByHostRow{Sandbox: db.Sandbox{Status: s, UpdatedAt: updated}}
+	row := func(s db.SandboxStatus) db.ListSandboxesByHostRow {
+		return db.ListSandboxesByHostRow{Sandbox: db.Sandbox{Status: s}}
 	}
 	const (
 		recentID = "44444444-4444-4444-4444-444444444444" // recently destroyed → kept
@@ -120,25 +120,22 @@ func TestDiskKeepSet(t *testing.T) {
 		orphanID = "66666666-6666-6666-6666-666666666666" // in no source → reclaimable
 	)
 	dbSandboxes := map[string]db.ListSandboxesByHostRow{
-		uuidA: row(db.SandboxStatusActive, cutoff.Add(-time.Hour)), // live → kept
-		uuidB: row(db.SandboxStatusPaused, cutoff.Add(-time.Hour)), // live → kept
-		uuidC: row(db.SandboxStatusFailed, cutoff.Add(-time.Hour)), // settled-failed → excluded
-		"new": row(db.SandboxStatusFailed, cutoff.Add(time.Hour)),  // within grace → kept
+		uuidA: row(db.SandboxStatusActive), // live → kept
+		uuidB: row(db.SandboxStatusPaused), // live → kept
+		uuidC: row(db.SandboxStatusFailed), // failed retains billed disk → kept until delete
 	}
 	recent := []uuid.UUID{uuid.MustParse(recentID)}
 	active := map[string]bool{activeID: true}
 
-	keep := diskKeepSet(dbSandboxes, recent, active, cutoff)
+	keep := diskKeepSet(dbSandboxes, recent, active)
 
-	for _, id := range []string{uuidA, uuidB, "new", recentID, activeID} {
+	for _, id := range []string{uuidA, uuidB, uuidC, recentID, activeID} {
 		if _, ok := keep[id]; !ok {
 			t.Errorf("%s should be in keep-set", id)
 		}
 	}
-	for _, id := range []string{uuidC, orphanID} {
-		if _, ok := keep[id]; ok {
-			t.Errorf("%s should NOT be in keep-set (reclaimable)", id)
-		}
+	if _, ok := keep[orphanID]; ok {
+		t.Errorf("%s should NOT be in keep-set (no source → reclaimable)", orphanID)
 	}
 }
 
@@ -180,15 +177,21 @@ func TestQuarantineDir_RejectsNonUUID(t *testing.T) {
 func TestSweepTrash_RemovesExpiredKeepsRecent(t *testing.T) {
 	runDir := t.TempDir()
 	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC) // retention 72h → cutoff 06-17 12:00
-	mk := func(date string) string {
-		p := filepath.Join(runDir, ".trash", date)
+	mk := func(label string, mtime time.Time) string {
+		p := filepath.Join(runDir, ".trash", label)
 		if err := os.MkdirAll(filepath.Join(p, uuidA), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Age is taken from the bucket's mtime, not its label.
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
 			t.Fatal(err)
 		}
 		return p
 	}
-	oldDir := mk("2026-06-15")    // 5 days old → swept
-	recentDir := mk("2026-06-19") // 1 day old → kept
+	expired := mk("2026-06-15", now.Add(-96*time.Hour)) // soaked 96h → swept
+	// Soaked only 48h: a date-label sweep could remove this early, but by actual
+	// mtime it has not reached the 72h window, so the full retention is honored.
+	young := mk("2026-06-18", now.Add(-48*time.Hour))
 
 	r := &Reconciler{
 		mgr: &Manager{cfg: ManagerConfig{RunDir: runDir}, log: zerolog.Nop()},
@@ -196,11 +199,11 @@ func TestSweepTrash_RemovesExpiredKeepsRecent(t *testing.T) {
 	}
 	r.sweepTrash(now)
 
-	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
-		t.Error("expired quarantine should be removed")
+	if _, err := os.Stat(expired); !os.IsNotExist(err) {
+		t.Error("quarantine soaked 96h should be removed")
 	}
-	if _, err := os.Stat(recentDir); err != nil {
-		t.Error("recent quarantine should be kept")
+	if _, err := os.Stat(young); err != nil {
+		t.Error("quarantine soaked only 48h should be kept (full 72h retention honored)")
 	}
 }
 


### PR DESCRIPTION
PR 3 of the disk-GC plan, stacked on #125. Turns Drift 6 from detect-only into reclamation — **behind a flag that defaults off**, so merging is a behavioral no-op until the detect-only numbers are validated on prod and `VMD_DISK_RECLAIM=true` is set.

When enabled, each pass quarantine-moves orphan dirs to `<root>/.trash/<date>/<uuid>` (reversible `rename`, same filesystem) up to `DiskDeleteBudget` (50), and a sweep permanently removes quarantine older than `DiskTrashRetention` (72h) — the soak window to spot and reverse a bad reclaim.

Safety stack (on top of #125's keep-set + grace):
- flag default off (`VMD_DISK_RECLAIM`); fail-closed (no DB keep-set → no-op)
- **empty-keep-set abort on the reclaim path** (the guard #125 deliberately moved off detect onto here)
- per-pass delete budget; UUID-leaf path containment in `quarantineDir`; `.trash` excluded from the scan by construction
- quarantine-move (reversible) → 72h soak → sweep `rm` (the only irreversible step, and only on aged-out trash)

Tests: quarantine moves a uuid dir / rejects non-uuid; sweep removes expired & keeps recent; reclaim respects the budget.