### PR TITLE
vmd: hardening — fix fc-cleanup RUN_DIR and egress-blocklist hot reload

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -296,18 +296,19 @@ func main() {
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
 	// blocklist.
 	var blockList *blocklist.Blocklist
+	blocklistPath := os.Getenv("VMD_EGRESS_BLOCKLIST_CONFIG")
 	// vmd is the daemon, so it owns and reconciles the shared egress port
 	// chain even when no ports are configured (so disabling the feature
 	// clears stale drops). template-builder must not pass this.
 	netMgrOpts := []network.ManagerOption{network.WithEgressPortChainOwner()}
-	if path := os.Getenv("VMD_EGRESS_BLOCKLIST_CONFIG"); path != "" {
-		blCfg, err := blocklist.LoadConfig(path)
+	if blocklistPath != "" {
+		blCfg, err := blocklist.LoadConfig(blocklistPath)
 		if err != nil {
-			log.Fatal().Err(err).Str("path", path).Msg("failed to load egress blocklist config")
+			log.Fatal().Err(err).Str("path", blocklistPath).Msg("failed to load egress blocklist config")
 		}
 		blockList = blocklist.New(blCfg, log)
 		netMgrOpts = append(netMgrOpts, network.WithBlockedEgressPorts(blCfg.BlockedEgressPorts))
-		log.Info().Str("path", path).Int("feeds", len(blCfg.DomainFeeds)).Int("blocked_ports", len(blCfg.BlockedEgressPorts)).Msg("egress blocklist configured")
+		log.Info().Str("path", blocklistPath).Int("feeds", len(blCfg.DomainFeeds)).Int("blocked_ports", len(blCfg.BlockedEgressPorts)).Msg("egress blocklist configured")
 	} else {
 		// Feature disabled — drop any host egress-block table a previous run
 		// installed so its CIDR drops stop affecting sandbox egress. The
@@ -553,6 +554,28 @@ func main() {
 			log.Info().Str("signal", sig.String()).Msg("received shutdown signal")
 			lc.signalShutdown()
 		case <-ctx.Done():
+		}
+	}()
+
+	// SIGHUP (ExecReload) reloads the egress blocklist config without a restart
+	// (domains + CIDRs; blocked ports still need a restart). Always trap it —
+	// the default SIGHUP action is to terminate, so an unhandled reload would
+	// kill the daemon even when no blocklist is configured.
+	hupCh := make(chan os.Signal, 1)
+	signal.Notify(hupCh, syscall.SIGHUP)
+	go func() {
+		for {
+			select {
+			case <-hupCh:
+				if blockList != nil && blocklistPath != "" {
+					log.Info().Msg("SIGHUP: reloading egress blocklist config")
+					blockList.Reload(blocklistPath)
+				} else {
+					log.Info().Msg("SIGHUP: no egress blocklist configured, nothing to reload")
+				}
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -289,6 +289,13 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Trap SIGHUP before any startup work. With ExecReload=kill -HUP on a
+	// Type=simple unit, a reload can arrive mid-init; without this the default
+	// SIGHUP action (terminate) would kill the daemon. The buffered signal is
+	// dispatched to the blocklist reload once it's up (below).
+	hupCh := make(chan os.Signal, 1)
+	signal.Notify(hupCh, syscall.SIGHUP)
+
 	lc := newLifecycle(log)
 
 	// ---- Egress blocklist (optional) ----
@@ -557,12 +564,8 @@ func main() {
 		}
 	}()
 
-	// SIGHUP (ExecReload) reloads the egress blocklist config without a restart
-	// (domains + CIDRs; blocked ports still need a restart). Always trap it —
-	// the default SIGHUP action is to terminate, so an unhandled reload would
-	// kill the daemon even when no blocklist is configured.
-	hupCh := make(chan os.Signal, 1)
-	signal.Notify(hupCh, syscall.SIGHUP)
+	// SIGHUP (ExecReload, trapped above) reloads the egress blocklist config
+	// without a restart — domains + CIDRs; blocked ports still need a restart.
 	go func() {
 		for {
 			select {

--- a/deploy/firecracker@.service
+++ b/deploy/firecracker@.service
@@ -8,6 +8,10 @@ CollectMode=inactive-or-failed
 Type=simple
 Slice=sandboxes.slice
 
+# fc-cleanup (ExecStopPost) runs under `set -u` and reads ${RUN_DIR}; without
+# this it aborts on the unbound variable and never removes the socket.
+Environment=RUN_DIR=/var/lib/sandbox/rundir
+
 ExecStart=/var/lib/sandbox/rundir/%i/start.sh
 ExecStopPost=/usr/local/bin/fc-cleanup %i
 

--- a/deploy/superserve-vmd.service
+++ b/deploy/superserve-vmd.service
@@ -7,6 +7,10 @@ Wants=network-online.target
 Type=simple
 ExecStart=/usr/local/bin/vmd
 
+# Reload the egress blocklist config (domains + CIDRs) without bouncing the
+# daemon. vmd handles SIGHUP; blocked-port changes still need a restart.
+ExecReload=/bin/kill -HUP $MAINPID
+
 # DO NOT add ExecStartPre commands that kill Firecracker processes or
 # remove network namespaces. VMs are managed by systemd units
 # (firecracker@.service) and must survive VMD restarts.

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -148,6 +148,11 @@ type Blocklist struct {
 	// sink, if set, receives the snapshot's CIDRs after every refresh so
 	// downstream enforcers (e.g. the host firewall) can mirror them.
 	sink func([]string)
+
+	// reloadCh carries a config-file path for a SIGHUP-triggered reload,
+	// handled on the single refresh goroutine so it never races feed state.
+	// Buffered and dropped when full, so a burst of reloads coalesces.
+	reloadCh chan string
 }
 
 // New builds a Blocklist seeded from the pinned config entries and
@@ -159,6 +164,7 @@ func New(cfg *Config, log zerolog.Logger) *Blocklist {
 		http:      &http.Client{Timeout: feedFetchTimeout},
 		feedCache: make(map[string]string),
 		maxBytes:  maxFeedBytes,
+		reloadCh:  make(chan string, 1),
 	}
 
 	seed := newSnapshotBuilder()
@@ -199,6 +205,32 @@ func (b *Blocklist) CIDRs() []string {
 // feed-sourced entries before it starts serving.
 func (b *Blocklist) Refresh(ctx context.Context) { b.refresh(ctx) }
 
+// Reload requests that the config at path be re-read on the next Start loop
+// iteration. Non-blocking; coalesces if a reload is already queued. No-op
+// unless Start is running.
+func (b *Blocklist) Reload(path string) {
+	select {
+	case b.reloadCh <- path:
+	default:
+	}
+}
+
+// reloadConfig re-reads the YAML config and rebuilds the snapshot from it plus
+// the cached feeds. Fail-safe: a bad config is logged and the current blocklist
+// is kept, never dropped. Domains and CIDRs are updated (CIDRs re-pushed to the
+// host firewall by refresh); blocked egress PORTS are fixed at startup and
+// still need a restart to change.
+func (b *Blocklist) reloadConfig(ctx context.Context, path string) {
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		b.log.Error().Err(err).Str("path", path).Msg("blocklist reload failed; keeping current config")
+		return
+	}
+	b.cfg = cfg
+	b.refresh(ctx)
+	b.log.Info().Str("path", path).Msg("egress blocklist config reloaded")
+}
+
 // Start fetches all feeds immediately, then refreshes on the configured
 // interval. Blocks until ctx is cancelled.
 func (b *Blocklist) Start(ctx context.Context) error {
@@ -211,6 +243,8 @@ func (b *Blocklist) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			b.refresh(ctx)
+		case path := <-b.reloadCh:
+			b.reloadConfig(ctx, path)
 		}
 	}
 }

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -218,8 +218,8 @@ func (b *Blocklist) Reload(path string) {
 // reloadConfig re-reads the YAML config and rebuilds the snapshot from it plus
 // the cached feeds. Fail-safe: a bad config is logged and the current blocklist
 // is kept, never dropped. Domains and CIDRs are updated (CIDRs re-pushed to the
-// host firewall by refresh); blocked egress PORTS are fixed at startup and
-// still need a restart to change.
+// host firewall by refresh); blocked egress ports and refresh_interval are
+// applied once at startup and still need a restart to change.
 func (b *Blocklist) reloadConfig(ctx context.Context, path string) {
 	cfg, err := LoadConfig(path)
 	if err != nil {

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -117,6 +117,59 @@ func TestBlocklistBlocked(t *testing.T) {
 	}
 }
 
+func TestReloadConfig_PicksUpNewConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blocklist.yaml")
+	write := func(domain string) {
+		if err := os.WriteFile(path, []byte("custom_domains:\n  - "+domain+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("old.example.com")
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(cfg, zerolog.Nop())
+	if got, _ := b.Blocked("old.example.com", nil); !got {
+		t.Fatal("old domain should be blocked initially")
+	}
+
+	// Operator edits the YAML and SIGHUPs.
+	write("new.example.com")
+	b.reloadConfig(t.Context(), path)
+
+	if got, _ := b.Blocked("new.example.com", nil); !got {
+		t.Error("reload should pick up the new domain")
+	}
+	if got, _ := b.Blocked("old.example.com", nil); got {
+		t.Error("reload replaces the config (not merge), so the removed domain unblocks")
+	}
+}
+
+func TestReloadConfig_BadConfigKeepsCurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blocklist.yaml")
+	if err := os.WriteFile(path, []byte("custom_domains:\n  - pool.example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := New(cfg, zerolog.Nop())
+
+	// Corrupt the file, then reload — the live blocklist must be preserved.
+	if err := os.WriteFile(path, []byte("custom_domains: [unterminated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b.reloadConfig(t.Context(), path)
+
+	if got, _ := b.Blocked("pool.example.com", nil); !got {
+		t.Error("a failed reload must keep the current blocklist, not drop it")
+	}
+}
+
 func TestRefreshKeepsLastGoodOnTotalFailure(t *testing.T) {
 	dir := t.TempDir()
 	feed := filepath.Join(dir, "feed.txt")

--- a/scripts/fc-cleanup
+++ b/scripts/fc-cleanup
@@ -3,7 +3,7 @@
 # Called by ExecStopPost in firecracker@.service.
 #
 # Usage: fc-cleanup <sandbox-id>
-# RUN_DIR is inherited from the unit's EnvironmentFile.
+# RUN_DIR is provided by the unit's Environment= (firecracker@.service).
 
 set -eu
 


### PR DESCRIPTION
PR 5 of the disk-GC plan — the two hardening items (Bugs 7 & 8).

**Bug 7 — fc-cleanup was broken.** `scripts/fc-cleanup` (ExecStopPost) runs under `set -u` and reads `${RUN_DIR}`, but `firecracker@.service` never set it — so it aborted on the unbound variable on every VM stop and never even removed the socket. Added `Environment=RUN_DIR=/var/lib/sandbox/rundir` to the unit.

**Bug 8 — egress blocklist needed a full restart to apply config edits.** Added an `ExecReload` (SIGHUP) and a vmd handler that hot-reloads the blocklist config: re-reads the YAML, rebuilds the snapshot (domains + CIDRs), and re-pushes CIDRs to the host firewall. Handled on the single refresh goroutine (no race with feed refresh), and **fail-safe** — a bad config is logged and the current blocklist is kept, never dropped. Blocked-port changes still need a restart (documented). SIGHUP is always trapped so `systemctl reload` can't terminate a vmd with no blocklist.

Tests: reload picks up new config / drops removed entries; a bad reload keeps the live blocklist.