### PR TITLE
Agent infra [6/8]: block-device /state — boxd mount, vmd attach, LocalBlock provider, live Mesa

### DIFF
--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -77,6 +77,10 @@ func main() {
 		log.Fatalf("chmod defaultHome %s: %v", defaultHome, err)
 	}
 
+	// Mount the durable /state block device, if one is attached. Best-effort: a
+	// sandbox without durable state still serves ephemeral work.
+	mountStateDisk()
+
 	mux := http.NewServeMux()
 
 	ctx := &sandboxContext{}

--- a/cmd/boxd/state.go
+++ b/cmd/boxd/state.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// The durable /state contract (SPEC §3, §9.1): an Actor's state lives on a
+// dedicated block device that the platform (vmd) attaches as the VM's second
+// drive and that survives crash, hibernation, and host migration — addressed by
+// a stable durable identity, not by VM instance. boxd's job on boot is simply to
+// mount it; the device is pre-formatted (ext4) once when the durable identity is
+// created, so boxd NEVER mkfs's a disk that may already hold state.
+const (
+	stateMountpoint    = "/state"
+	defaultStateDevice = "/dev/vdb" // second drive (vda is the rootfs)
+	stateFSType        = "ext4"
+)
+
+// mountStateDisk mounts the durable /state block device at /state. No-op when no
+// state device is attached (a sandbox booted without durable state) or when
+// /state is already mounted (snapshot restore carries the mount in the restored
+// namespace). Failures are logged, not fatal: a sandbox without /state is still
+// usable for ephemeral work, and turning a missing/unmountable disk into a boot
+// failure would be a worse outcome than a clear log line.
+func mountStateDisk() {
+	device := os.Getenv("STATE_DEVICE")
+	if device == "" {
+		device = defaultStateDevice
+	}
+	switch err := mountStateDiskAt(device, stateMountpoint, osStat, isMountpoint, syscall.Mount); err {
+	case errNoStateDevice:
+		// No durable state attached to this sandbox; nothing to do.
+	case errStateAlreadyMounted:
+		log.Printf("state: %s already mounted (restore)", stateMountpoint)
+	case nil:
+		log.Printf("state: mounted %s at %s (durable)", device, stateMountpoint)
+	default:
+		log.Printf("state: mount %s at %s failed: %v", device, stateMountpoint, err)
+	}
+}
+
+// Sentinel outcomes that are not errors the caller should surface.
+var (
+	errNoStateDevice       = sentinel("no state device")
+	errStateAlreadyMounted = sentinel("state already mounted")
+)
+
+type sentinel string
+
+func (s sentinel) Error() string { return string(s) }
+
+// mountFunc matches syscall.Mount so the real mount can be swapped for a fake in
+// tests (cmd/boxd is linux-only, but the decision logic stays exercisable).
+type mountFunc func(source, target, fstype string, flags uintptr, data string) error
+
+// mountStateDiskAt is the testable core: decide whether to mount, then mount.
+// Returns errNoStateDevice / errStateAlreadyMounted for the skip cases, nil on a
+// successful mount, or the mount error.
+func mountStateDiskAt(
+	device, mountpoint string,
+	statFn func(string) error,
+	mountedFn func(string) (bool, error),
+	doMount mountFunc,
+) error {
+	if statFn(device) != nil {
+		return errNoStateDevice
+	}
+	if mounted, _ := mountedFn(mountpoint); mounted {
+		return errStateAlreadyMounted
+	}
+	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
+		return err
+	}
+	// MS_NOSUID|MS_NODEV: /state holds an agent's data, never trusted executables
+	// or device nodes, so deny both to keep the durable disk from being a vector.
+	return doMount(device, mountpoint, stateFSType, syscall.MS_NOSUID|syscall.MS_NODEV, "")
+}
+
+func osStat(path string) error {
+	_, err := os.Stat(path)
+	return err
+}
+
+// isMountpoint reports whether path is a mount point by comparing its device id
+// to its parent's: a mounted filesystem has a different st_dev than the directory
+// it is mounted onto. Dependency-free (no /proc/mounts parse).
+func isMountpoint(path string) (bool, error) {
+	var st, parent syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return false, err
+	}
+	if err := syscall.Stat(filepath.Dir(path), &parent); err != nil {
+		return false, err
+	}
+	return st.Dev != parent.Dev, nil
+}

--- a/cmd/boxd/state_test.go
+++ b/cmd/boxd/state_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMountStateDiskAt(t *testing.T) {
+	present := func(string) error { return nil }
+	absent := func(string) error { return errors.New("no such device") }
+	unmounted := func(string) (bool, error) { return false, nil }
+	mounted := func(string) (bool, error) { return true, nil }
+
+	t.Run("no device → skip, never mounts", func(t *testing.T) {
+		called := false
+		err := mountStateDiskAt("/dev/vdb", t.TempDir(), absent, unmounted,
+			func(string, string, string, uintptr, string) error { called = true; return nil })
+		if err != errNoStateDevice {
+			t.Fatalf("want errNoStateDevice, got %v", err)
+		}
+		if called {
+			t.Fatal("must not mount when no device is present")
+		}
+	})
+
+	t.Run("already mounted → skip, never mounts", func(t *testing.T) {
+		called := false
+		err := mountStateDiskAt("/dev/vdb", t.TempDir(), present, mounted,
+			func(string, string, string, uintptr, string) error { called = true; return nil })
+		if err != errStateAlreadyMounted {
+			t.Fatalf("want errStateAlreadyMounted, got %v", err)
+		}
+		if called {
+			t.Fatal("must not re-mount an already-mounted /state (restore)")
+		}
+	})
+
+	t.Run("present + unmounted → mounts with the device, ext4, nosuid/nodev", func(t *testing.T) {
+		var gotSrc, gotTarget, gotFS string
+		var gotFlags uintptr
+		err := mountStateDiskAt("/dev/vdb", t.TempDir(), present, unmounted,
+			func(src, target, fs string, flags uintptr, _ string) error {
+				gotSrc, gotTarget, gotFS, gotFlags = src, target, fs, flags
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("expected a successful mount, got %v", err)
+		}
+		if gotSrc != "/dev/vdb" || gotFS != "ext4" {
+			t.Fatalf("mounted %s as %s, want /dev/vdb ext4", gotSrc, gotFS)
+		}
+		if gotTarget == "" {
+			t.Fatal("mount target should be the mountpoint")
+		}
+		// MS_NOSUID and MS_NODEV must both be set on the durable data disk.
+		const wantBits = 0x2 | 0x4 // MS_NOSUID | MS_NODEV
+		if gotFlags&wantBits != wantBits {
+			t.Fatalf("mount flags %#x missing nosuid/nodev", gotFlags)
+		}
+	})
+
+	t.Run("mount error propagates", func(t *testing.T) {
+		boom := errors.New("mount: wrong fs type")
+		err := mountStateDiskAt("/dev/vdb", t.TempDir(), present, unmounted,
+			func(string, string, string, uintptr, string) error { return boom })
+		if !errors.Is(err, boom) {
+			t.Fatalf("want the mount error, got %v", err)
+		}
+	})
+}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -241,16 +241,33 @@ func run() error {
 		log.Info().Msg("durable-Actor runtime enabled (/v1/agents) with sandbox-exec delivery + tiered hibernation")
 	}
 
-	// Durable /state versioning (checkpoint/branch/rollback). Enabled when
-	// STATE_DIR is set; backend defaults to the local reference provider,
-	// STATE_BACKEND=archil|mesa selects a SaaS adapter.
-	if stateDir := os.Getenv("STATE_DIR"); stateDir != "" {
-		sp, serr := state.NewProvider(state.Config{Backend: state.Backend(os.Getenv("STATE_BACKEND")), BaseDir: stateDir})
+	// Durable /state versioning (checkpoint/branch/rollback). Enabled when a
+	// local STATE_DIR is set (backend "local" the directory reference, or
+	// "local-block" the ext4-image block reference) or a SaaS backend is selected
+	// (STATE_BACKEND=archil|mesa, which need no local dir).
+	stateBackend := os.Getenv("STATE_BACKEND")
+	stateDir := os.Getenv("STATE_DIR")
+	if stateDir != "" || stateBackend == string(state.BackendArchil) || stateBackend == string(state.BackendMesa) {
+		stateImageMiB, _ := strconv.Atoi(os.Getenv("STATE_IMAGE_MIB"))
+		sp, serr := state.NewProvider(state.Config{
+			Backend:       state.Backend(stateBackend),
+			BaseDir:       stateDir,
+			StateImageMiB: stateImageMiB,
+			Archil: state.ArchilConfig{
+				APIKey: os.Getenv("ARCHIL_API_KEY"),
+				Region: os.Getenv("ARCHIL_REGION"),
+				DiskID: os.Getenv("ARCHIL_DISK_ID"),
+			},
+			Mesa: state.MesaConfig{
+				APIKey: os.Getenv("MESA_API_KEY"),
+				Org:    os.Getenv("MESA_ORG"),
+			},
+		})
 		if serr != nil {
 			log.Warn().Err(serr).Msg("durable /state provider init failed; /state endpoints disabled")
 		} else {
 			handlers.State = sp
-			log.Info().Str("backend", os.Getenv("STATE_BACKEND")).Msg("durable /state versioning enabled")
+			log.Info().Str("backend", stateBackend).Msg("durable /state versioning enabled")
 		}
 	}
 

--- a/internal/state/STATE-MOUNT-FINDINGS.md
+++ b/internal/state/STATE-MOUNT-FINDINGS.md
@@ -1,0 +1,71 @@
+# Durable `/state` mount — validated chain + the production-integration decision
+
+Status: **every mechanism built and hardware-validated; the production boot-path
+integration is a characterized architectural choice (below), not a thread-through.**
+
+## What is built and proven on the staging KVM host
+
+The durable `/state` is a **block device** — the Firecracker-native form, because
+Firecracker has no directory-sharing transport (no virtio-fs). The full chain:
+
+1. **`LocalBlockProvider`** (`internal/state/localblock.go`) — backs each durable
+   identity with a formatted ext4 image (`state.img`); whole-image versioning
+   (checkpoint = atomic copy, branch = fork, rollback = atomic swap).
+   - Unit-tested `-race`. `mke2fs -F -q -t ext4 <file> NM` (what it runs) produces
+     a mountable ext4 that data round-trips through — verified on the host.
+2. **vmd attach** (`FirecrackerConfig.StateDiskPath` → `ConfigureMachine`) —
+   attaches the image as the VM's second drive (vdb), non-root, rw.
+3. **boxd mount** (`cmd/boxd/state.go`) — mounts `/dev/vdb` at `/state` on boot,
+   `nosuid/nodev`, idempotent, mount-only (never mkfs's existing state).
+
+**End-to-end proofs (raw Firecracker on the host):**
+- Boot with the state drive → `state: mounted /dev/vdb at /state (durable)`, then
+  in-guest `cat /state/marker` returns the pre-seeded contents. `/state` is real
+  and durable inside the guest.
+- **Snapshot survival (the load-bearing claim):** cold-boot a `/state`-bearing
+  VM, write `pre-snapshot-v1` to `/state`, take a Full snapshot, restore in a
+  **fresh** Firecracker → the restored guest resumes with `/state` mounted and
+  `cat /state/marker` → `pre-snapshot-v1`. **A snapshot captures the `/state`
+  drive in its device set, and `LoadSnapshot` re-opens it — `/state` survives
+  hibernate intact.**
+
+That proof resolves the design question for Actors: an Actor that boots **once**
+with its `/state` drive keeps `/state` across every subsequent Tier-2 hibernation
+(its own snapshots inherit the drive; restore preserves it).
+
+## The remaining production-integration decision
+
+Production sandboxes do **not** cold-boot — they boot by **restoring a shared
+template snapshot** (`RestoreSnapshot`). Two facts constrain how per-identity
+`/state` reaches them:
+
+- Firecracker `LoadSnapshot` restores the **exact device set recorded in the
+  snapshot**; `SnapshotLoadParams` exposes `NetworkOverrides` and `BlockDeltaDir`
+  (rootfs overlay) but **no drive-path override**.
+- `coldBootFromRootfs` (the only path that configures drives freely, via
+  `ConfigureMachine`) is the **template-build** path — its VM is snapshotted into
+  a *shared* template, so a `/state` drive baked there would be one placeholder
+  shared by all sandboxes, not per-identity.
+
+So per-identity `/state` needs a deliberate boot-path addition. The options:
+
+1. **Per-identity cold boot for Actors** (recommended). Actors that need durable
+   `/state` cold-boot once with their own `state.img` attached (a new
+   Actor-boot path that calls the cold-boot primitive with `StateDiskPath`), then
+   hibernate — validated above to preserve `/state`. Generic non-Actor sandboxes
+   keep the fast template-restore path with no `/state`. Clean separation; uses
+   only validated mechanisms; the first-boot cost amortizes over the Actor's life.
+2. **Drive-repoint on restore.** Bake a `/state` placeholder drive into template
+   snapshots and re-point it per-identity after `LoadSnapshot(resume=false)` via
+   `PatchGuestDriveByID`, then resume. Avoids a second boot path but is
+   boot-ordering-fragile: boxd mounts `/state` at boot, so the template snapshot
+   would capture the placeholder *mounted* — swapping the backing under a mounted
+   fs is unsafe. Would require deferring the `/state` mount until after
+   restore+patch (a boxd/init ordering change) and is unvalidated.
+3. **Firecracker drive-override-on-load** — a fork feature (Rust change) adding
+   per-drive backing overrides to `LoadSnapshot`, mirroring `NetworkOverrides`.
+   Cleanest long-term, but a firecracker-fork change + rebuild.
+
+**Recommendation: option 1.** It is fully validated end-to-end today and needs
+only controlplane wiring (resolve the Actor's identity → `provider.Mount(id)` →
+cold-boot with `StateDiskPath`), exercisable against the live integrated stack.

--- a/internal/state/factory.go
+++ b/internal/state/factory.go
@@ -6,8 +6,13 @@ import "fmt"
 type Backend string
 
 const (
-	// BackendLocal is the on-disk reference provider (dev/test). Default.
+	// BackendLocal is the on-disk directory reference provider (dev/test). Default.
 	BackendLocal Backend = "local"
+	// BackendLocalBlock is the on-disk BLOCK-DEVICE reference provider: each
+	// identity is a formatted ext4 image vmd attaches as the /state drive. This
+	// is the Firecracker-native durable-disk path (vs the directory provider,
+	// which has no in-VM transport on Firecracker).
+	BackendLocalBlock Backend = "local-block"
 	// BackendArchil is the Archil NFSv3 adapter (stub until creds land).
 	BackendArchil Backend = "archil"
 	// BackendMesa is the Mesa SDK/FUSE adapter (stub until creds land).
@@ -20,9 +25,13 @@ type Config struct {
 	// Backend selects the implementation. Empty defaults to BackendLocal.
 	Backend Backend
 
-	// BaseDir is the host directory rooting LocalProvider state.
-	// Required for BackendLocal.
+	// BaseDir is the host directory rooting LocalProvider / LocalBlockProvider
+	// state. Required for BackendLocal and BackendLocalBlock.
 	BaseDir string
+
+	// StateImageMiB sizes a fresh /state image for BackendLocalBlock.
+	// <= 0 uses DefaultStateImageMiB.
+	StateImageMiB int
 
 	// Archil holds Archil adapter configuration (BackendArchil).
 	Archil ArchilConfig
@@ -39,6 +48,8 @@ func NewProvider(cfg Config) (Provider, error) {
 	switch cfg.Backend {
 	case "", BackendLocal:
 		return NewLocalProvider(cfg.BaseDir)
+	case BackendLocalBlock:
+		return NewLocalBlockProvider(cfg.BaseDir, cfg.StateImageMiB)
 	case BackendArchil:
 		return NewArchilProvider(cfg.Archil), nil
 	case BackendMesa:

--- a/internal/state/localblock.go
+++ b/internal/state/localblock.go
@@ -1,0 +1,273 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// LocalBlockProvider is the reference BLOCK-DEVICE Provider: it backs each
+// durable identity with a formatted ext4 IMAGE FILE rather than a directory.
+// This is the form the Firecracker platform needs — the VM attaches the image
+// as its /state drive (vdb) and boxd mounts it at /state — because Firecracker
+// has no directory-sharing transport (no virtio-fs). The SaaS adapters
+// (Archil-as-block) slot in behind the same Provider shape.
+//
+// Layout under baseDir (mirrors the directory LocalProvider, but with .img files
+// where it has directories):
+//
+//	<baseDir>/<identity>/state.img             live, writable block image (the mount)
+//	<baseDir>/<identity>/checkpoints/<name>.img immutable snapshots
+//	<baseDir>/<identity>/branches/<name>.img    writable forks of a checkpoint
+//
+// Versioning is whole-image: a checkpoint is an atomic copy of state.img, a
+// branch is a copy of a checkpoint into a new identity's state.img, and a
+// rollback atomically swaps a checkpoint back over state.img. Copies stage to a
+// temp file on the same filesystem and os.Rename into place (fsync'd), so a
+// failure mid-operation never leaves partial state — the same durability
+// contract the directory provider gives.
+type LocalBlockProvider struct {
+	baseDir string
+	sizeMiB int
+	// formatFn creates a fresh, formatted block image at path of the given size.
+	// Defaults to mke2fs (real ext4); injectable so the versioning logic is
+	// testable without e2fsprogs present.
+	formatFn func(path string, sizeMiB int) error
+}
+
+var _ Provider = (*LocalBlockProvider)(nil)
+
+// DefaultStateImageMiB is the size of a freshly-created /state image. ext4 on a
+// sparse file costs only the metadata until written, so this is a ceiling, not a
+// reservation.
+const DefaultStateImageMiB = 1024
+
+// NewLocalBlockProvider returns a block provider rooted at baseDir. sizeMiB <= 0
+// uses DefaultStateImageMiB.
+func NewLocalBlockProvider(baseDir string, sizeMiB int) (*LocalBlockProvider, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("state: local block provider base dir is empty")
+	}
+	abs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("state: resolve base dir %q: %w", baseDir, err)
+	}
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return nil, fmt.Errorf("state: create base dir %q: %w", abs, err)
+	}
+	if sizeMiB <= 0 {
+		sizeMiB = DefaultStateImageMiB
+	}
+	return &LocalBlockProvider{baseDir: abs, sizeMiB: sizeMiB, formatFn: mke2fsFormat}, nil
+}
+
+func (p *LocalBlockProvider) identityDir(identity string) (string, error) {
+	if err := validateName(identity); err != nil {
+		return "", fmt.Errorf("%w: identity %q: %s", ErrInvalidIdentity, identity, err)
+	}
+	return filepath.Join(p.baseDir, identity), nil
+}
+
+func (p *LocalBlockProvider) statePath(idDir string) string {
+	return filepath.Join(idDir, "state.img")
+}
+
+// Mount ensures the identity's state.img exists (formatting a fresh ext4 image
+// for a new identity) and returns a block-device handle to it. The Path is the
+// image file vmd attaches as the /state drive.
+func (p *LocalBlockProvider) Mount(ctx context.Context, identity, _ string) (*Mount, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	idDir, err := p.identityDir(identity)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(idDir, 0o700); err != nil {
+		return nil, fmt.Errorf("state: mount %q: %w", identity, err)
+	}
+	img := p.statePath(idDir)
+	switch _, err := os.Stat(img); {
+	case err == nil:
+		// Existing identity — reuse its image (durable state persists).
+	case os.IsNotExist(err):
+		if ferr := p.formatFn(img, p.sizeMiB); ferr != nil {
+			return nil, fmt.Errorf("state: format new image %q: %w", identity, ferr)
+		}
+	default:
+		return nil, fmt.Errorf("state: mount %q: %w", identity, err)
+	}
+	return &Mount{
+		Identity:      identity,
+		Path:          img,
+		IsBlockDevice: true,
+		unmount:       func() error { return nil },
+	}, nil
+}
+
+// Checkpoint snapshots state.img into checkpoints/<name>.img atomically.
+func (p *LocalBlockProvider) Checkpoint(ctx context.Context, identity, name string) (Checkpoint, error) {
+	if err := ctx.Err(); err != nil {
+		return Checkpoint{}, err
+	}
+	if err := validateName(name); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint name %q: %w", name, err)
+	}
+	idDir, err := p.identityDir(identity)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	src := p.statePath(idDir)
+	if _, err := os.Stat(src); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint %q: state image missing (mount first): %w", identity, err)
+	}
+	ckptParent := filepath.Join(idDir, "checkpoints")
+	if err := os.MkdirAll(ckptParent, 0o700); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint %q: %w", identity, err)
+	}
+	createdAt := time.Now().UTC()
+	dst := filepath.Join(ckptParent, name+imageExt)
+	if err := copyImageAtomic(dst, src); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint %q/%q: %w", identity, name, err)
+	}
+	return Checkpoint{Name: name, ID: checkpointID(name, createdAt), CreatedAt: createdAt}, nil
+}
+
+// Branch forks branches/<newBranch>.img from checkpoints/<fromCheckpoint>.img.
+func (p *LocalBlockProvider) Branch(ctx context.Context, identity, fromCheckpoint, newBranch string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validateName(fromCheckpoint); err != nil {
+		return fmt.Errorf("state: from-checkpoint %q: %w", fromCheckpoint, err)
+	}
+	if err := validateName(newBranch); err != nil {
+		return fmt.Errorf("state: branch name %q: %w", newBranch, err)
+	}
+	idDir, err := p.identityDir(identity)
+	if err != nil {
+		return err
+	}
+	src := filepath.Join(idDir, "checkpoints", fromCheckpoint+imageExt)
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("state: branch %q/%q: %w", identity, fromCheckpoint, ErrCheckpointNotFound)
+		}
+		return fmt.Errorf("state: branch %q: stat checkpoint: %w", identity, err)
+	}
+	branchParent := filepath.Join(idDir, "branches")
+	if err := os.MkdirAll(branchParent, 0o700); err != nil {
+		return fmt.Errorf("state: branch %q: %w", identity, err)
+	}
+	dst := filepath.Join(branchParent, newBranch+imageExt)
+	if err := copyImageAtomic(dst, src); err != nil {
+		return fmt.Errorf("state: branch %q/%q: %w", identity, newBranch, err)
+	}
+	return nil
+}
+
+// Rollback atomically swaps checkpoints/<toCheckpoint>.img back over state.img.
+func (p *LocalBlockProvider) Rollback(ctx context.Context, identity, toCheckpoint string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validateName(toCheckpoint); err != nil {
+		return fmt.Errorf("state: to-checkpoint %q: %w", toCheckpoint, err)
+	}
+	idDir, err := p.identityDir(identity)
+	if err != nil {
+		return err
+	}
+	src := filepath.Join(idDir, "checkpoints", toCheckpoint+imageExt)
+	if _, err := os.Stat(src); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("state: rollback %q/%q: %w", identity, toCheckpoint, ErrCheckpointNotFound)
+		}
+		return fmt.Errorf("state: rollback %q: stat checkpoint: %w", identity, err)
+	}
+	// copyImageAtomic replaces state.img via a same-dir rename, so current is
+	// never left half-restored.
+	if err := copyImageAtomic(p.statePath(idDir), src); err != nil {
+		return fmt.Errorf("state: rollback %q/%q: %w", identity, toCheckpoint, err)
+	}
+	return nil
+}
+
+// ListCheckpoints returns the identity's checkpoints ordered oldest-first.
+func (p *LocalBlockProvider) ListCheckpoints(ctx context.Context, identity string) ([]Checkpoint, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	idDir, err := p.identityDir(identity)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(filepath.Join(idDir, "checkpoints"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Checkpoint{}, nil
+		}
+		return nil, fmt.Errorf("state: list checkpoints %q: %w", identity, err)
+	}
+	out := make([]Checkpoint, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") || !strings.HasSuffix(e.Name(), imageExt) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			return nil, fmt.Errorf("state: list checkpoints %q: stat %q: %w", identity, e.Name(), err)
+		}
+		name := strings.TrimSuffix(e.Name(), imageExt)
+		createdAt := info.ModTime().UTC()
+		out = append(out, Checkpoint{Name: name, ID: checkpointID(name, createdAt), CreatedAt: createdAt})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+const imageExt = ".img"
+
+// mke2fsFormat creates a formatted ext4 image at path. mke2fs -F makes a
+// filesystem directly in a regular file (no loop device, no root). The file is a
+// sparse <sizeMiB>MiB ext4 image the guest can mount read-write.
+func mke2fsFormat(path string, sizeMiB int) error {
+	cmd := exec.Command("mke2fs", "-F", "-q", "-t", "ext4", path, fmt.Sprintf("%dM", sizeMiB))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.Remove(path) // don't leave a half-written image behind
+		return fmt.Errorf("mke2fs: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// copyImageAtomic copies src to dst via a temp file in dst's directory, fsync'd
+// and renamed into place, so dst is replaced atomically and is never partial.
+func copyImageAtomic(dst, src string) error {
+	dir := filepath.Dir(dst)
+	tmp, err := os.CreateTemp(dir, ".img-*")
+	if err != nil {
+		return fmt.Errorf("stage: %w", err)
+	}
+	tmpName := tmp.Name()
+	_ = tmp.Close()
+	_ = os.Remove(tmpName) // copyFile O_EXCL-creates; clear the placeholder first
+	if err := copyFile(src, tmpName, 0o600); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("swap: %w", err)
+	}
+	return nil
+}

--- a/internal/state/localblock_test.go
+++ b/internal/state/localblock_test.go
@@ -1,0 +1,155 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestBlockProvider returns a block provider whose "format" just writes a
+// marker file, so the whole-image versioning logic is exercisable without
+// e2fsprogs. Writes to the image are simulated by overwriting its bytes.
+func newTestBlockProvider(t *testing.T) *LocalBlockProvider {
+	t.Helper()
+	p, err := NewLocalBlockProvider(t.TempDir(), 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.formatFn = func(path string, _ int) error {
+		return os.WriteFile(path, []byte("FRESH-EXT4"), 0o600)
+	}
+	return p
+}
+
+func writeImage(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readImage(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestBlockMountFormatsThenReuses(t *testing.T) {
+	p := newTestBlockProvider(t)
+	ctx := context.Background()
+
+	m, err := p.Mount(ctx, "act-1", "/state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.IsBlockDevice {
+		t.Error("block provider mount must report IsBlockDevice=true")
+	}
+	if filepath.Base(m.Path) != "state.img" {
+		t.Errorf("Path = %s, want .../state.img", m.Path)
+	}
+	if got := readImage(t, m.Path); got != "FRESH-EXT4" {
+		t.Errorf("new image not formatted, got %q", got)
+	}
+
+	// Simulate the guest writing durable state, then re-Mount: the image is
+	// reused, not reformatted — state persists across "compute".
+	writeImage(t, m.Path, "agent-data")
+	m2, err := p.Mount(ctx, "act-1", "/state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readImage(t, m2.Path); got != "agent-data" {
+		t.Errorf("re-mount reformatted/lost state, got %q", got)
+	}
+}
+
+func TestBlockCheckpointRollbackBranchLifecycle(t *testing.T) {
+	p := newTestBlockProvider(t)
+	ctx := context.Background()
+
+	m, err := p.Mount(ctx, "act-1", "/state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeImage(t, m.Path, "v1")
+
+	if _, err := p.Checkpoint(ctx, "act-1", "cp1"); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	// List shows cp1.
+	cps, err := p.ListCheckpoints(ctx, "act-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cps) != 1 || cps[0].Name != "cp1" {
+		t.Fatalf("ListCheckpoints = %+v, want [cp1]", cps)
+	}
+
+	// Advance state, then roll back to cp1 → image restored to v1.
+	writeImage(t, m.Path, "v2-divergent")
+	if err := p.Rollback(ctx, "act-1", "cp1"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if got := readImage(t, m.Path); got != "v1" {
+		t.Errorf("rollback did not restore the image, got %q", got)
+	}
+
+	// Branch b1 from cp1 is an independent copy of the v1 image.
+	if err := p.Branch(ctx, "act-1", "cp1", "b1"); err != nil {
+		t.Fatalf("branch: %v", err)
+	}
+	branchImg := filepath.Join(p.baseDir, "act-1", "branches", "b1.img")
+	if got := readImage(t, branchImg); got != "v1" {
+		t.Errorf("branch image = %q, want v1", got)
+	}
+	// Writing the branch must not affect current.
+	writeImage(t, branchImg, "branch-only")
+	if got := readImage(t, m.Path); got != "v1" {
+		t.Errorf("branch write leaked into current: %q", got)
+	}
+}
+
+func TestBlockMissingCheckpointErrors(t *testing.T) {
+	p := newTestBlockProvider(t)
+	ctx := context.Background()
+	if _, err := p.Mount(ctx, "act-1", "/state"); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Branch(ctx, "act-1", "nope", "b1"); !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("branch from missing checkpoint: want ErrCheckpointNotFound, got %v", err)
+	}
+	if err := p.Rollback(ctx, "act-1", "nope"); !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("rollback to missing checkpoint: want ErrCheckpointNotFound, got %v", err)
+	}
+}
+
+func TestBlockInvalidIdentityRejected(t *testing.T) {
+	p := newTestBlockProvider(t)
+	ctx := context.Background()
+	for _, bad := range []string{"", "..", "a/b", "../escape"} {
+		if _, err := p.Mount(ctx, bad, "/state"); !errors.Is(err, ErrInvalidIdentity) {
+			t.Errorf("Mount(%q): want ErrInvalidIdentity, got %v", bad, err)
+		}
+	}
+}
+
+func TestBlockCheckpointBeforeMountErrors(t *testing.T) {
+	p := newTestBlockProvider(t)
+	if _, err := p.Checkpoint(context.Background(), "act-1", "cp1"); err == nil ||
+		!strings.Contains(err.Error(), "mount first") {
+		t.Errorf("checkpoint before mount should error about mounting first, got %v", err)
+	}
+}
+
+// TestBlockSatisfiesProvider compile-asserts the interface (also done in source).
+func TestBlockSatisfiesProvider(t *testing.T) {
+	var _ Provider = (*LocalBlockProvider)(nil)
+}

--- a/internal/state/mesa.go
+++ b/internal/state/mesa.go
@@ -1,82 +1,322 @@
 package state
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
 
 // MesaConfig configures the Mesa adapter. Values are sourced from
 // .context/secrets.env (see secrets.env.example):
 //
 //	MESA_API_KEY -> APIKey
+//	MESA_ORG     -> Org
 //
-// Mesa is in private beta and its backing store / region knobs are undisclosed,
-// so the API key is the only modeled field today; add more as the SDK surface
-// firms up.
+// Mesa is a versioned, git-compatible filesystem (https://docs.mesa.dev): a repo
+// is the durable FS, a "change" is a commit, and a "bookmark" is a named ref —
+// which maps cleanly onto the durable /state contract (checkpoint = bookmark a
+// change, branch = bookmark a change under a new name, rollback = move the
+// default bookmark back to a change).
 type MesaConfig struct {
-	// APIKey authenticates against the Mesa SDK/API. Empty => stub.
+	// APIKey is the bearer token for api.mesa.dev. Empty => stub (ErrNotConfigured).
 	APIKey string
+	// Org is the Mesa organization slug that owns the repos. Required when APIKey
+	// is set.
+	Org string
+	// BaseURL overrides the API base (default https://api.mesa.dev/v1). Used by
+	// tests to point at an httptest server.
+	BaseURL string
+	// DefaultBookmark is the repo's live ref (Mesa's default is "main"); rollback
+	// re-homes it onto a checkpoint's change.
+	DefaultBookmark string
 }
 
-// MesaProvider is the Mesa-backed durable /state adapter.
-//
-// Mesa is a versioned, git-compatible filesystem for agents: every write is
-// captured in history automatically, with named checkpoints, branches, diffs,
-// rollback/replay, and millisecond COW forks. It mounts via FUSE *or* an
-// in-process SDK (@mesadev/sdk — no FUSE/container required), and Mesa has
-// announced a partnership with Superserve to bring versioned filesystems to our
-// sandboxes, which makes it the likely blessed integration path (see .context
-// transcript + SPEC §3/§9.1).
-//
-// This is a STUB: every method returns ErrNotConfigured until the adapter is
-// wired up. To make it real:
-//
-//   - Mount: mount the identity's Mesa volume at `mountpoint` (FUSE) or attach
-//     it via the SDK and expose it under `mountpoint`. Map one Mesa volume per
-//     durable identity so state follows compute. Mount.unmount must detach the
-//     FUSE mount / close the SDK handle without destroying the volume. Validate
-//     `identity` with validateName (it maps to a volume-name segment).
-//   - Checkpoint: create a named checkpoint via the SDK; because Mesa versions
-//     every write automatically, a named checkpoint is a label over the live
-//     history head. Map its id/time onto Checkpoint.ID/CreatedAt.
-//   - Branch: create a branch from `fromCheckpoint` (millisecond COW fork);
-//     surface a missing checkpoint as ErrCheckpointNotFound. Branches are how
-//     Mesa avoids locking for parallel agents — writes stay per-branch.
-//   - Rollback: roll the identity's branch back to `toCheckpoint` via the SDK's
-//     rollback/replay primitive (Mesa exposes this first-class), keeping the
-//     atomicity the local provider guarantees.
-//   - ListCheckpoints: list the volume's named checkpoints, oldest-first.
-//
-// Validate before trusting on the hot path (transcript §"Things to validate"):
-// fsync durability semantics, the multi-writer/branch-merge consistency model,
-// in-VM mount latency, and whether the backing store is self-hostable on our
-// infra for the data-residency story.
+// MesaProvider is the Mesa-backed durable /state adapter. It speaks the Mesa REST
+// API (Bearer auth) and maps one repo per durable identity, so state follows the
+// identity, not the VM. Mesa exposes the repo as a FUSE/in-process mount; the
+// guest-side Mesa client realizes the actual /state mount (the directory model —
+// Mount.IsBlockDevice is false), while this adapter owns the repo + version
+// lifecycle.
 type MesaProvider struct {
-	cfg MesaConfig
+	cfg     MesaConfig
+	baseURL string
+	client  *http.Client
 }
 
-// NewMesaProvider returns the Mesa adapter. It always succeeds; the adapter
-// reports ErrNotConfigured from its methods until APIKey is wired up.
+const defaultMesaBaseURL = "https://api.mesa.dev/v1"
+const defaultMesaBookmark = "main"
+
+// NewMesaProvider returns the Mesa adapter. It always succeeds; methods report
+// ErrNotConfigured until APIKey (and Org) are set.
 func NewMesaProvider(cfg MesaConfig) *MesaProvider {
-	return &MesaProvider{cfg: cfg}
+	base := cfg.BaseURL
+	if base == "" {
+		base = defaultMesaBaseURL
+	}
+	if cfg.DefaultBookmark == "" {
+		cfg.DefaultBookmark = defaultMesaBookmark
+	}
+	return &MesaProvider{
+		cfg:     cfg,
+		baseURL: strings.TrimRight(base, "/"),
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
 }
 
-// MesaProvider implements Provider.
 var _ Provider = (*MesaProvider)(nil)
 
+func (p *MesaProvider) configured() error {
+	if p.cfg.APIKey == "" || p.cfg.Org == "" {
+		return ErrNotConfigured
+	}
+	return nil
+}
+
+// Mount ensures the identity's repo exists (creating it on first use) and returns
+// a directory-model handle. The guest-side Mesa client mounts the repo at
+// mountpoint over FUSE; the durable state persists in the repo regardless of any
+// single mount.
 func (p *MesaProvider) Mount(ctx context.Context, identity, mountpoint string) (*Mount, error) {
-	return nil, ErrNotConfigured
+	if err := p.configured(); err != nil {
+		return nil, err
+	}
+	if err := validateName(identity); err != nil {
+		return nil, fmt.Errorf("%w: identity %q: %s", ErrInvalidIdentity, identity, err)
+	}
+	if _, err := p.ensureRepo(ctx, identity); err != nil {
+		return nil, err
+	}
+	return &Mount{
+		Identity:      identity,
+		Path:          mountpoint,
+		IsBlockDevice: false,
+		unmount:       func() error { return nil },
+	}, nil
 }
 
+// Checkpoint names the repo's current head change as bookmark <name>. Because
+// Mesa captures every write in history, the current head IS the live state, so a
+// checkpoint is a label over it.
 func (p *MesaProvider) Checkpoint(ctx context.Context, identity, name string) (Checkpoint, error) {
-	return Checkpoint{}, ErrNotConfigured
+	if err := p.configured(); err != nil {
+		return Checkpoint{}, err
+	}
+	if err := validateName(name); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint name %q: %w", name, err)
+	}
+	repo, err := p.getRepo(ctx, identity)
+	if err != nil {
+		return Checkpoint{}, err
+	}
+	if repo.HeadChangeID == "" {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint %q: repo has no head change", identity)
+	}
+	createdAt := time.Now().UTC()
+	var bm mesaBookmark
+	if err := p.do(ctx, http.MethodPost, p.repoPath(identity, "bookmarks"),
+		mesaCreateBookmark{Name: name, ChangeID: repo.HeadChangeID}, &bm); err != nil {
+		return Checkpoint{}, fmt.Errorf("state: checkpoint %q/%q: %w", identity, name, err)
+	}
+	return Checkpoint{Name: name, ID: bm.ChangeID, CreatedAt: createdAt}, nil
 }
 
+// Branch creates bookmark <newBranch> at the change that <fromCheckpoint> points
+// at — Mesa's COW fork. Returns ErrCheckpointNotFound if fromCheckpoint is absent.
 func (p *MesaProvider) Branch(ctx context.Context, identity, fromCheckpoint, newBranch string) error {
-	return ErrNotConfigured
+	if err := p.configured(); err != nil {
+		return err
+	}
+	if err := validateName(fromCheckpoint); err != nil {
+		return fmt.Errorf("state: from-checkpoint %q: %w", fromCheckpoint, err)
+	}
+	if err := validateName(newBranch); err != nil {
+		return fmt.Errorf("state: branch name %q: %w", newBranch, err)
+	}
+	from, err := p.getBookmark(ctx, identity, fromCheckpoint)
+	if err != nil {
+		return err // already maps 404 -> ErrCheckpointNotFound
+	}
+	if err := p.do(ctx, http.MethodPost, p.repoPath(identity, "bookmarks"),
+		mesaCreateBookmark{Name: newBranch, ChangeID: from.ChangeID}, nil); err != nil {
+		return fmt.Errorf("state: branch %q/%q: %w", identity, newBranch, err)
+	}
+	return nil
 }
 
+// Rollback re-homes the repo's default bookmark onto the change <toCheckpoint>
+// points at. Returns ErrCheckpointNotFound if toCheckpoint is absent.
 func (p *MesaProvider) Rollback(ctx context.Context, identity, toCheckpoint string) error {
-	return ErrNotConfigured
+	if err := p.configured(); err != nil {
+		return err
+	}
+	if err := validateName(toCheckpoint); err != nil {
+		return fmt.Errorf("state: to-checkpoint %q: %w", toCheckpoint, err)
+	}
+	to, err := p.getBookmark(ctx, identity, toCheckpoint)
+	if err != nil {
+		return err
+	}
+	if err := p.do(ctx, http.MethodPatch, p.repoPath(identity, "bookmarks/"+p.cfg.DefaultBookmark),
+		mesaMoveBookmark{ChangeID: to.ChangeID}, nil); err != nil {
+		return fmt.Errorf("state: rollback %q/%q: %w", identity, toCheckpoint, err)
+	}
+	return nil
 }
 
+// ListCheckpoints lists the identity's bookmarks, excluding the default (live)
+// bookmark, which is not a checkpoint.
 func (p *MesaProvider) ListCheckpoints(ctx context.Context, identity string) ([]Checkpoint, error) {
-	return nil, ErrNotConfigured
+	if err := p.configured(); err != nil {
+		return nil, err
+	}
+	if err := validateName(identity); err != nil {
+		return nil, fmt.Errorf("%w: identity %q: %s", ErrInvalidIdentity, identity, err)
+	}
+	var resp mesaListBookmarks
+	if err := p.do(ctx, http.MethodGet, p.repoPath(identity, "bookmarks"), nil, &resp); err != nil {
+		return nil, fmt.Errorf("state: list checkpoints %q: %w", identity, err)
+	}
+	out := make([]Checkpoint, 0, len(resp.Bookmarks))
+	for _, b := range resp.Bookmarks {
+		if b.IsDefault || b.Name == p.cfg.DefaultBookmark {
+			continue
+		}
+		// Mesa's list omits per-bookmark timestamps; the ID carries the change.
+		out = append(out, Checkpoint{Name: b.Name, ID: b.ChangeID})
+	}
+	return out, nil
+}
+
+// --- Mesa REST plumbing ------------------------------------------------------
+
+type mesaRepo struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	DefaultBookmark string `json:"default_bookmark"`
+	HeadChangeID    string `json:"head_change_id"`
+}
+
+type mesaBookmark struct {
+	Name      string `json:"name"`
+	ChangeID  string `json:"change_id"`
+	IsDefault bool   `json:"is_default"`
+}
+
+type mesaListBookmarks struct {
+	Bookmarks  []mesaBookmark `json:"bookmarks"`
+	NextCursor string         `json:"next_cursor"`
+	HasMore    bool           `json:"has_more"`
+}
+
+type mesaCreateRepo struct {
+	Name            string `json:"name"`
+	DefaultBookmark string `json:"default_bookmark,omitempty"`
+}
+
+type mesaCreateBookmark struct {
+	Name     string `json:"name"`
+	ChangeID string `json:"change_id"`
+}
+
+type mesaMoveBookmark struct {
+	ChangeID string `json:"change_id"`
+}
+
+func (p *MesaProvider) repoPath(identity, sub string) string {
+	return "/" + p.cfg.Org + "/" + identity + "/" + sub
+}
+
+// ensureRepo returns the identity's repo, creating it if it does not exist.
+func (p *MesaProvider) ensureRepo(ctx context.Context, identity string) (*mesaRepo, error) {
+	repo, err := p.getRepo(ctx, identity)
+	if err == nil {
+		return repo, nil
+	}
+	if !isMesaNotFound(err) {
+		return nil, err
+	}
+	var created mesaRepo
+	if cerr := p.do(ctx, http.MethodPost, "/"+p.cfg.Org+"/repos",
+		mesaCreateRepo{Name: identity, DefaultBookmark: p.cfg.DefaultBookmark}, &created); cerr != nil {
+		return nil, fmt.Errorf("state: create repo %q: %w", identity, cerr)
+	}
+	return &created, nil
+}
+
+func (p *MesaProvider) getRepo(ctx context.Context, identity string) (*mesaRepo, error) {
+	var repo mesaRepo
+	if err := p.do(ctx, http.MethodGet, "/"+p.cfg.Org+"/"+identity, nil, &repo); err != nil {
+		return nil, err
+	}
+	return &repo, nil
+}
+
+func (p *MesaProvider) getBookmark(ctx context.Context, identity, name string) (*mesaBookmark, error) {
+	var bm mesaBookmark
+	if err := p.do(ctx, http.MethodGet, p.repoPath(identity, "bookmarks/"+name), nil, &bm); err != nil {
+		if isMesaNotFound(err) {
+			return nil, fmt.Errorf("state: %q/%q: %w", identity, name, ErrCheckpointNotFound)
+		}
+		return nil, err
+	}
+	return &bm, nil
+}
+
+// mesaError carries the HTTP status so callers can branch on 404.
+type mesaError struct {
+	status int
+	body   string
+}
+
+func (e *mesaError) Error() string {
+	return fmt.Sprintf("mesa api: status %d: %s", e.status, e.body)
+}
+
+func isMesaNotFound(err error) bool {
+	var me *mesaError
+	if errors.As(err, &me) {
+		return me.status == http.StatusNotFound
+	}
+	return false
+}
+
+// do performs a JSON request against the Mesa API. reqBody may be nil (no body);
+// out may be nil (response ignored). Non-2xx returns a *mesaError.
+func (p *MesaProvider) do(ctx context.Context, method, path string, reqBody, out any) error {
+	var body io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, p.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.cfg.APIKey)
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return &mesaError{status: resp.StatusCode, body: strings.TrimSpace(string(b))}
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
 }

--- a/internal/state/mesa_test.go
+++ b/internal/state/mesa_test.go
@@ -1,0 +1,273 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// fakeMesa is a minimal stateful stand-in for the Mesa REST API: enough to drive
+// the adapter's repo + bookmark lifecycle and assert it speaks the documented
+// shapes (POST /{org}/repos, GET/POST /{org}/{repo}/bookmarks, PATCH a bookmark).
+type fakeMesa struct {
+	org       string
+	head      string            // repo head change id (empty until repo created)
+	bookmarks map[string]string // name -> change_id
+	calls     []string          // "METHOD path" log
+	authSeen  string
+}
+
+func newFakeMesa(org string) *fakeMesa {
+	return &fakeMesa{org: org, bookmarks: map[string]string{}}
+}
+
+func (f *fakeMesa) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.authSeen = r.Header.Get("Authorization")
+		f.calls = append(f.calls, r.Method+" "+r.URL.Path)
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		// /{org}/repos
+		if len(parts) == 2 && parts[0] == f.org && parts[1] == "repos" && r.Method == http.MethodPost {
+			var body mesaCreateRepo
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.head = "chg-initial"
+			if body.DefaultBookmark != "" {
+				f.bookmarks[body.DefaultBookmark] = f.head
+			}
+			writeJSON(w, 201, mesaRepo{ID: "r1", Name: body.Name, DefaultBookmark: body.DefaultBookmark, HeadChangeID: f.head})
+			return
+		}
+		// /{org}/{repo}
+		if len(parts) == 2 && parts[0] == f.org && r.Method == http.MethodGet {
+			if f.head == "" {
+				w.WriteHeader(404)
+				return
+			}
+			writeJSON(w, 200, mesaRepo{ID: "r1", Name: parts[1], DefaultBookmark: "main", HeadChangeID: f.head})
+			return
+		}
+		// /{org}/{repo}/bookmarks  (list / create)
+		if len(parts) == 3 && parts[2] == "bookmarks" {
+			switch r.Method {
+			case http.MethodGet:
+				var bms []mesaBookmark
+				for n, c := range f.bookmarks {
+					bms = append(bms, mesaBookmark{Name: n, ChangeID: c, IsDefault: n == "main"})
+				}
+				writeJSON(w, 200, mesaListBookmarks{Bookmarks: bms})
+				return
+			case http.MethodPost:
+				var body mesaCreateBookmark
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				f.bookmarks[body.Name] = body.ChangeID
+				writeJSON(w, 201, mesaBookmark{Name: body.Name, ChangeID: body.ChangeID})
+				return
+			}
+		}
+		// /{org}/{repo}/bookmarks/{name}  (get / move)
+		if len(parts) == 4 && parts[2] == "bookmarks" {
+			name := parts[3]
+			switch r.Method {
+			case http.MethodGet:
+				c, ok := f.bookmarks[name]
+				if !ok {
+					w.WriteHeader(404)
+					return
+				}
+				writeJSON(w, 200, mesaBookmark{Name: name, ChangeID: c, IsDefault: name == "main"})
+				return
+			case http.MethodPatch:
+				var body mesaMoveBookmark
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				f.bookmarks[name] = body.ChangeID
+				writeJSON(w, 200, mesaBookmark{Name: name, ChangeID: body.ChangeID})
+				return
+			}
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newTestMesa(t *testing.T) (*MesaProvider, *fakeMesa) {
+	t.Helper()
+	fake := newFakeMesa("acme")
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	return NewMesaProvider(MesaConfig{APIKey: "k-test", Org: "acme", BaseURL: srv.URL}), fake
+}
+
+func TestMesaNotConfigured(t *testing.T) {
+	p := NewMesaProvider(MesaConfig{}) // no key/org
+	if _, err := p.Mount(context.Background(), "act-1", "/state"); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("want ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestMesaMountCreatesRepoThenReuses(t *testing.T) {
+	p, fake := newTestMesa(t)
+	ctx := context.Background()
+
+	m, err := p.Mount(ctx, "act-1", "/state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.IsBlockDevice {
+		t.Error("Mesa is a directory/FUSE provider; IsBlockDevice must be false")
+	}
+	if !strings.HasPrefix(fake.authSeen, "Bearer k-test") {
+		t.Errorf("missing/incorrect bearer auth: %q", fake.authSeen)
+	}
+	// First mount: GET repo (404) then POST /acme/repos.
+	if !contains(fake.calls, "POST /acme/repos") {
+		t.Fatalf("first mount should create the repo; calls=%v", fake.calls)
+	}
+	// Second mount reuses (GET repo 200, no second create).
+	fake.calls = nil
+	if _, err := p.Mount(ctx, "act-1", "/state"); err != nil {
+		t.Fatal(err)
+	}
+	if contains(fake.calls, "POST /acme/repos") {
+		t.Fatalf("second mount must not re-create the repo; calls=%v", fake.calls)
+	}
+}
+
+func TestMesaCheckpointBranchRollbackLifecycle(t *testing.T) {
+	p, fake := newTestMesa(t)
+	ctx := context.Background()
+	if _, err := p.Mount(ctx, "act-1", "/state"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Checkpoint bookmarks the current head change.
+	cp, err := p.Checkpoint(ctx, "act-1", "cp1")
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if cp.ID != "chg-initial" {
+		t.Errorf("checkpoint should point at head change, got %q", cp.ID)
+	}
+
+	// List shows cp1 but not the default bookmark.
+	cps, err := p.ListCheckpoints(ctx, "act-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cps) != 1 || cps[0].Name != "cp1" {
+		t.Fatalf("ListCheckpoints = %+v, want just [cp1] (default excluded)", cps)
+	}
+
+	// Branch b1 from cp1 → a new bookmark at cp1's change.
+	if err := p.Branch(ctx, "act-1", "cp1", "b1"); err != nil {
+		t.Fatalf("branch: %v", err)
+	}
+	if fake.bookmarks["b1"] != "chg-initial" {
+		t.Errorf("branch b1 should point at cp1's change, got %q", fake.bookmarks["b1"])
+	}
+
+	// Rollback moves the default bookmark onto cp1's change.
+	if err := p.Rollback(ctx, "act-1", "cp1"); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if fake.bookmarks["main"] != "chg-initial" {
+		t.Errorf("rollback should move main to cp1's change, got %q", fake.bookmarks["main"])
+	}
+}
+
+func TestMesaMissingCheckpointErrors(t *testing.T) {
+	p, _ := newTestMesa(t)
+	ctx := context.Background()
+	if _, err := p.Mount(ctx, "act-1", "/state"); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Branch(ctx, "act-1", "nope", "b1"); !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("branch from missing checkpoint: want ErrCheckpointNotFound, got %v", err)
+	}
+	if err := p.Rollback(ctx, "act-1", "nope"); !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("rollback to missing checkpoint: want ErrCheckpointNotFound, got %v", err)
+	}
+}
+
+// TestMesaLiveLifecycle exercises the REAL Mesa API. Gated on MESA_LIVE_API_KEY
+// (+ optional MESA_LIVE_ORG; whoami-derivable). It creates a throwaway repo, runs
+// the full checkpoint/branch/rollback lifecycle, and deletes the repo.
+func TestMesaLiveLifecycle(t *testing.T) {
+	key := os.Getenv("MESA_LIVE_API_KEY")
+	org := os.Getenv("MESA_LIVE_ORG")
+	if key == "" || org == "" {
+		t.Skip("set MESA_LIVE_API_KEY and MESA_LIVE_ORG to run the live Mesa test")
+	}
+	p := NewMesaProvider(MesaConfig{APIKey: key, Org: org})
+	ctx := context.Background()
+	repo := "ss-it-live"
+	mesaLiveDelete(key, org, repo) // ensure a clean slate
+	defer mesaLiveDelete(key, org, repo)
+
+	m, err := p.Mount(ctx, repo, "/state")
+	if err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+	if m.IsBlockDevice {
+		t.Error("Mesa mount should be directory-model")
+	}
+	cp, err := p.Checkpoint(ctx, repo, "cp1")
+	if err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if cp.ID == "" {
+		t.Error("checkpoint should carry the head change id")
+	}
+	cps, err := p.ListCheckpoints(ctx, repo)
+	if err != nil {
+		t.Fatalf("ListCheckpoints: %v", err)
+	}
+	if !checkpointNamed(cps, "cp1") {
+		t.Fatalf("cp1 not listed: %+v", cps)
+	}
+	if err := p.Branch(ctx, repo, "cp1", "b1"); err != nil {
+		t.Fatalf("Branch: %v", err)
+	}
+	if err := p.Rollback(ctx, repo, "cp1"); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := p.Branch(ctx, repo, "ghost", "b2"); !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("branch from missing checkpoint: want ErrCheckpointNotFound, got %v", err)
+	}
+}
+
+func mesaLiveDelete(key, org, repo string) {
+	req, _ := http.NewRequest(http.MethodDelete, defaultMesaBaseURL+"/"+org+"/"+repo, nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+}
+
+func checkpointNamed(cps []Checkpoint, name string) bool {
+	for _, c := range cps {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/provider.go
+++ b/internal/state/provider.go
@@ -48,7 +48,17 @@ type Mount struct {
 	Identity string
 	// Path is the resolved host path at which the identity's live, writable
 	// state is available. The Actor's runtime maps this onto /state.
+	//
+	// When IsBlockDevice is false (directory providers) Path is a directory the
+	// guest bind/NFS-mounts. When IsBlockDevice is true (block providers) Path is
+	// a formatted block-image file that vmd attaches as the VM's /state drive and
+	// boxd mounts at /state — the Firecracker-native durable-disk path.
 	Path string
+
+	// IsBlockDevice reports whether Path is a block-image file (true) or a
+	// directory (false). vmd attaches a block image as a drive; a directory is
+	// shared by a host-side mount.
+	IsBlockDevice bool
 
 	// unmount releases mount resources without touching durable state. It is
 	// supplied by the Provider that produced the Mount.

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -52,6 +52,11 @@ type FirecrackerConfig struct {
 	VsockPath  string
 	VMIP       string
 	GatewayIP  string
+	// StateDiskPath, when non-empty, is the host path to the Actor's durable
+	// /state block device (a pre-formatted ext4 image). It is attached as the
+	// VM's second drive (vdb); boxd mounts it at /state on boot. Empty for
+	// ephemeral sandboxes with no durable state.
+	StateDiskPath string
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +160,24 @@ func ConfigureMachine(socketPath string, cfg FirecrackerConfig) error {
 			return fmt.Errorf("attach drive rootfs: overlay-mode requires the firecracker fork (feat/block-overlay-cow-v1.15) on this host: %w", err)
 		}
 		return fmt.Errorf("attach drive rootfs: %w", err)
+	}
+
+	// 3b. Attach the durable /state disk as the second drive (vdb), if this VM
+	// has durable state. boxd mounts it at /state on boot. Non-root, read-write.
+	if cfg.StateDiskPath != "" {
+		stateID := "state"
+		if _, err := fc.Operations.PutGuestDriveByID(&operations.PutGuestDriveByIDParams{
+			Context: ctx,
+			DriveID: stateID,
+			Body: &models.Drive{
+				DriveID:      &stateID,
+				PathOnHost:   cfg.StateDiskPath,
+				IsRootDevice: boolPtr(false),
+				IsReadOnly:   false,
+			},
+		}); err != nil {
+			return fmt.Errorf("attach drive state: %w", err)
+		}
 	}
 
 	// 4. Attach network interface.


### PR DESCRIPTION
**Intention:** Make `/state` a real durable disk inside the guest. Firecracker has no virtio-fs, so `/state` is a block device — the same way the VM already attaches its rootfs.

### What's here (Epic 4.1/4.2)
- **boxd** mounts the `/state` block device on boot (idempotent across restore, `nosuid`/`nodev`; mount-only — never mkfs's a disk that may hold state).
- **vmd** `FirecrackerConfig.StateDiskPath` → attaches the pre-formatted ext4 as the VM's second drive.
- **`LocalBlockProvider`** — the block-device reference backend (mke2fs ext4 image per identity).
- **Real Mesa adapter**, validated against the live Mesa API.
- Findings doc capturing the validated chain + the boot-path decision.

### Technical decisions
- Block device (not a shared directory) because Firecracker can't share a host dir into the guest; the VM already uses block drives for rootfs, so this is the native path.

### Testing
Validated end-to-end on the staging host: booted a microVM with a pre-formatted `/state` ext4 as the second drive → `cat /state/marker` read the data back in-guest. Mesa adapter exercised against the live API. boxd mount logic unit-tested (injectable seams).

### Known gaps
- The full controlplane→vmd→boxd `/state`-on-restore wiring (repoint + mount trigger) lands in PR 7/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)