### PR TITLE
Agent infra [7/8]: agent-loop e2e + full /state-on-restore vertical

### DIFF
--- a/cmd/agent-e2e/main.go
+++ b/cmd/agent-e2e/main.go
@@ -1,0 +1,119 @@
+// Command agent-e2e drives the durable-Actor agent loop end to end against a
+// REAL boxd in a REAL (networked) Firecracker microVM — the isolated full-stack
+// e2e for POST /v1/agents/send minus the vmd gRPC hop.
+//
+// It wires the PRODUCTION runtime — actor.Registry (single-writer lease) +
+// actor.Router (wake-on-reference, serial inbox) + the real vmdwaker.Waker +
+// the real boxddeliver.Deliverer over an HTTP exec/stream to boxd — and only
+// stubs the SandboxBooter, because the VM is already booted (by the host
+// harness script) and reachable over a dedicated TAP. For each turn it sends an
+// event through Router.Route and drains the turn's Relay, asserting the in-guest
+// harness saw the event (via $ACTOR_EVENT) and streamed its reply back through
+// the inbox → Relay path.
+//
+// Run (on the KVM host, after a networked boxd VM is up):
+//
+//	agent-e2e -boxd-url http://172.31.99.2:49983/exec/stream -turns 3
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/actor"
+	"github.com/superserve-ai/sandbox/internal/actor/boxddeliver"
+	"github.com/superserve-ai/sandbox/internal/actor/vmdwaker"
+)
+
+func main() {
+	boxdURL := flag.String("boxd-url", "", "boxd /exec/stream URL of the running sandbox VM (required)")
+	turns := flag.Int("turns", 3, "number of agent turns to drive")
+	agentName := flag.String("agent", "agent-1", "durable Actor name")
+	flag.Parse()
+	if *boxdURL == "" {
+		fail("-boxd-url is required")
+	}
+
+	// The harness "turn": a real in-guest command that reads the event from
+	// $ACTOR_EVENT (how boxddeliver delivers it) and streams a reply on stdout.
+	turnArgv := []string{"sh", "-c", `printf 'REPLY[%s]' "$ACTOR_EVENT"`}
+
+	// PRODUCTION delivery path: boxddeliver.Deliverer → HTTPExecStreamer → boxd
+	// /exec/stream. One VM serves the Actor, so urlFor is constant; boxd itself
+	// is unauthenticated (the edge proxy authenticates in prod), so no token.
+	streamer := boxddeliver.NewHTTPExecStreamer(
+		&http.Client{Timeout: 30 * time.Second},
+		func(string) string { return *boxdURL },
+		func(string) (string, error) { return "", nil },
+	)
+	deliverer := boxddeliver.New(streamer, turnArgv)
+
+	// REAL vmdwaker.Waker; only the SandboxBooter is stubbed (the VM is already
+	// up). Wake returns a Handler that runs the Deliverer per turn and closes the
+	// Relay at turn end — exactly the production path.
+	waker := vmdwaker.New(prebootedBooter{}, deliverer, func(actor.Actor) (vmdwaker.Target, error) {
+		return vmdwaker.Target{}, nil
+	})
+
+	reg := actor.NewRegistry(actor.NewMemStore(), nil)
+	router := actor.NewRouter(reg, waker, "agent-e2e", 16)
+	ctx := context.Background()
+
+	fmt.Printf("Driving %d agent turns through Registry+Lease+Router → vmdwaker → boxddeliver → real boxd:\n", *turns)
+	for i := 1; i <= *turns; i++ {
+		payload := fmt.Sprintf("event-%d", i)
+		relay := actor.NewRelay()
+		ev := actor.Event{ID: fmt.Sprintf("ev-%d", i), Type: "msg", Payload: []byte(payload), Out: relay}
+
+		start := time.Now()
+		if err := router.Route(ctx, "team-e2e", *agentName, actor.Actor{}, ev); err != nil {
+			fail(fmt.Sprintf("turn %d: Route: %v", i, err))
+		}
+		reply := drain(ctx, relay)
+		elapsed := time.Since(start)
+
+		want := "REPLY[" + payload + "]"
+		if !strings.Contains(reply, want) {
+			fail(fmt.Sprintf("turn %d: harness reply %q does not contain %q", i, reply, want))
+		}
+		fmt.Printf("  turn %d: sent %q → harness streamed %q  (%s) ✓\n", i, payload, reply, elapsed.Round(time.Millisecond))
+	}
+	fmt.Printf("\nPASS — %d turns delivered to the real in-guest harness and streamed back through the Actor loop.\n", *turns)
+}
+
+// drain reads the turn's Relay to completion, returning the concatenated reply.
+func drain(ctx context.Context, relay *actor.Relay) string {
+	var b strings.Builder
+	cur := int64(0)
+	for {
+		chunk, ok, err := relay.ReadFrom(ctx, cur)
+		if err != nil || !ok {
+			return b.String()
+		}
+		b.Write(chunk.Data)
+		cur = chunk.Seq
+	}
+}
+
+// prebootedBooter is a SandboxBooter for an already-running VM: "boot" is a
+// no-op that reports the sandbox live. The VM is started + networked by the host
+// harness; here we only exercise the runtime + delivery path.
+type prebootedBooter struct{}
+
+func (prebootedBooter) RestoreSnapshot(_ context.Context, id, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+	return id, 1, 256, nil
+}
+func (prebootedBooter) BareResumeInstance(_ context.Context, id string) (string, uint32, uint32, error) {
+	return id, 1, 256, nil
+}
+func (prebootedBooter) DestroyInstance(_ context.Context, _ string, _ bool) error { return nil }
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, "agent-e2e:", msg)
+	os.Exit(1)
+}

--- a/cmd/agent-e2e/main.go
+++ b/cmd/agent-e2e/main.go
@@ -39,51 +39,64 @@ func main() {
 		fail("-boxd-url is required")
 	}
 
-	// The harness "turn": a real in-guest command that reads the event from
-	// $ACTOR_EVENT (how boxddeliver delivers it) and streams a reply on stdout.
-	turnArgv := []string{"sh", "-c", `printf 'REPLY[%s]' "$ACTOR_EVENT"`}
+	fmt.Printf("Driving %d agent turns through Registry+Lease+Router → vmdwaker → boxddeliver → real boxd:\n", *turns)
+	results, err := driveTurns(*boxdURL, *agentName, *turns, harnessTurnArgv)
+	if err != nil {
+		fail(err.Error())
+	}
+	for _, r := range results {
+		want := "REPLY[" + r.payload + "]"
+		if !strings.Contains(r.reply, want) {
+			fail(fmt.Sprintf("turn %q: harness reply %q does not contain %q", r.payload, r.reply, want))
+		}
+		fmt.Printf("  sent %q → harness streamed %q  (%s) ✓\n", r.payload, r.reply, r.elapsed.Round(time.Millisecond))
+	}
+	fmt.Printf("\nPASS — %d turns delivered to the in-guest harness and streamed back through the Actor loop.\n", *turns)
+}
 
-	// PRODUCTION delivery path: boxddeliver.Deliverer → HTTPExecStreamer → boxd
-	// /exec/stream. One VM serves the Actor, so urlFor is constant; boxd itself
-	// is unauthenticated (the edge proxy authenticates in prod), so no token.
+// harnessTurnArgv is the in-guest "turn": read the event from $ACTOR_EVENT (how
+// boxddeliver delivers it) and stream a reply on stdout.
+var harnessTurnArgv = []string{"sh", "-c", `printf 'REPLY[%s]' "$ACTOR_EVENT"`}
+
+// turnResult is one driven turn's outcome.
+type turnResult struct {
+	payload string
+	reply   string
+	elapsed time.Duration
+}
+
+// driveTurns wires the PRODUCTION agent-loop runtime — actor.Registry (lease) +
+// actor.Router (wake-on-reference, serial inbox + Relay) + the real
+// vmdwaker.Waker + the real boxddeliver.Deliverer over HTTPExecStreamer at
+// boxdURL — and routes `turns` events through it, returning each turn's streamed
+// reply. Only the SandboxBooter is stubbed (the sandbox is pre-booted). Shared by
+// main (real boxd) and the test (httptest fake boxd).
+func driveTurns(boxdURL, agentName string, turns int, turnArgv []string) ([]turnResult, error) {
 	streamer := boxddeliver.NewHTTPExecStreamer(
 		&http.Client{Timeout: 30 * time.Second},
-		func(string) string { return *boxdURL },
+		func(string) string { return boxdURL },
 		func(string) (string, error) { return "", nil },
 	)
 	deliverer := boxddeliver.New(streamer, turnArgv)
-
-	// REAL vmdwaker.Waker; only the SandboxBooter is stubbed (the VM is already
-	// up). Wake returns a Handler that runs the Deliverer per turn and closes the
-	// Relay at turn end — exactly the production path.
 	waker := vmdwaker.New(prebootedBooter{}, deliverer, func(actor.Actor) (vmdwaker.Target, error) {
 		return vmdwaker.Target{}, nil
 	})
-
 	reg := actor.NewRegistry(actor.NewMemStore(), nil)
 	router := actor.NewRouter(reg, waker, "agent-e2e", 16)
 	ctx := context.Background()
 
-	fmt.Printf("Driving %d agent turns through Registry+Lease+Router → vmdwaker → boxddeliver → real boxd:\n", *turns)
-	for i := 1; i <= *turns; i++ {
+	var results []turnResult
+	for i := 1; i <= turns; i++ {
 		payload := fmt.Sprintf("event-%d", i)
 		relay := actor.NewRelay()
 		ev := actor.Event{ID: fmt.Sprintf("ev-%d", i), Type: "msg", Payload: []byte(payload), Out: relay}
-
 		start := time.Now()
-		if err := router.Route(ctx, "team-e2e", *agentName, actor.Actor{}, ev); err != nil {
-			fail(fmt.Sprintf("turn %d: Route: %v", i, err))
+		if err := router.Route(ctx, "team-e2e", agentName, actor.Actor{}, ev); err != nil {
+			return results, fmt.Errorf("turn %d (%q): Route: %w", i, payload, err)
 		}
-		reply := drain(ctx, relay)
-		elapsed := time.Since(start)
-
-		want := "REPLY[" + payload + "]"
-		if !strings.Contains(reply, want) {
-			fail(fmt.Sprintf("turn %d: harness reply %q does not contain %q", i, reply, want))
-		}
-		fmt.Printf("  turn %d: sent %q → harness streamed %q  (%s) ✓\n", i, payload, reply, elapsed.Round(time.Millisecond))
+		results = append(results, turnResult{payload: payload, reply: drain(ctx, relay), elapsed: time.Since(start)})
 	}
-	fmt.Printf("\nPASS — %d turns delivered to the real in-guest harness and streamed back through the Actor loop.\n", *turns)
+	return results, nil
 }
 
 // drain reads the turn's Relay to completion, returning the concatenated reply.

--- a/cmd/agent-e2e/main.go
+++ b/cmd/agent-e2e/main.go
@@ -34,22 +34,39 @@ func main() {
 	boxdURL := flag.String("boxd-url", "", "boxd /exec/stream URL of the running sandbox VM (required)")
 	turns := flag.Int("turns", 3, "number of agent turns to drive")
 	agentName := flag.String("agent", "agent-1", "durable Actor name")
+	turnCmd := flag.String("turn-cmd", "", "override the in-guest harness turn (sh -c); default echoes $ACTOR_EVENT")
+	finalMustContain := flag.String("final-must-contain", "", "if set, the LAST turn's reply must contain this (e.g. event-1, to prove /state persisted across turns)")
 	flag.Parse()
 	if *boxdURL == "" {
 		fail("-boxd-url is required")
 	}
 
+	turnArgv := harnessTurnArgv
+	if *turnCmd != "" {
+		turnArgv = []string{"sh", "-c", *turnCmd}
+	}
+
 	fmt.Printf("Driving %d agent turns through Registry+Lease+Router → vmdwaker → boxddeliver → real boxd:\n", *turns)
-	results, err := driveTurns(*boxdURL, *agentName, *turns, harnessTurnArgv)
+	results, err := driveTurns(*boxdURL, *agentName, *turns, turnArgv)
 	if err != nil {
 		fail(err.Error())
 	}
 	for _, r := range results {
-		want := "REPLY[" + r.payload + "]"
-		if !strings.Contains(r.reply, want) {
-			fail(fmt.Sprintf("turn %q: harness reply %q does not contain %q", r.payload, r.reply, want))
+		// Each turn's reply must carry its own event (proves the event reached the
+		// harness via $ACTOR_EVENT and the reply streamed back).
+		if !strings.Contains(r.reply, r.payload) {
+			fail(fmt.Sprintf("turn %q: harness reply %q does not contain the event", r.payload, r.reply))
 		}
 		fmt.Printf("  sent %q → harness streamed %q  (%s) ✓\n", r.payload, r.reply, r.elapsed.Round(time.Millisecond))
+	}
+	// Durability check: the last turn's reply still contains an earlier turn's
+	// data → the in-guest /state survived across turns.
+	if *finalMustContain != "" {
+		last := results[len(results)-1].reply
+		if !strings.Contains(last, *finalMustContain) {
+			fail(fmt.Sprintf("durability: final reply %q does not contain %q — /state did not persist across turns", last, *finalMustContain))
+		}
+		fmt.Printf("  durability ✓ — final turn still sees %q from an earlier turn (/state persisted)\n", *finalMustContain)
 	}
 	fmt.Printf("\nPASS — %d turns delivered to the in-guest harness and streamed back through the Actor loop.\n", *turns)
 }
@@ -118,7 +135,7 @@ func drain(ctx context.Context, relay *actor.Relay) string {
 // harness; here we only exercise the runtime + delivery path.
 type prebootedBooter struct{}
 
-func (prebootedBooter) RestoreSnapshot(_ context.Context, id, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (prebootedBooter) RestoreSnapshot(_ context.Context, id, _, _, _, _, _, _ string, _ map[string]string, _ string) (string, uint32, uint32, error) {
 	return id, 1, 256, nil
 }
 func (prebootedBooter) BareResumeInstance(_ context.Context, id string) (string, uint32, uint32, error) {

--- a/cmd/agent-e2e/main_test.go
+++ b/cmd/agent-e2e/main_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeBoxd mimics boxd's /exec/stream: it reads the exec request (command/args +
+// env), runs the harness logic that a real boxd would (echo $ACTOR_EVENT), and
+// streams the reply back as boxd-format SSE (`data: {json}\n\n`). This lets the
+// full agent-loop runtime be exercised end to end in CI without a VM — the same
+// path validated on real hardware with a real boxd.
+func fakeBoxd(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/exec/stream") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		event := req.Env["ACTOR_EVENT"] // how boxddeliver delivers the turn event
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl, _ := w.(http.Flusher)
+		// The harness turn is `printf 'REPLY[%s]' "$ACTOR_EVENT"`; mirror its output.
+		out, _ := json.Marshal(map[string]any{"stdout": "REPLY[" + event + "]"})
+		_, _ = w.Write([]byte("data: " + string(out) + "\n\n"))
+		if fl != nil {
+			fl.Flush()
+		}
+		fin, _ := json.Marshal(map[string]any{"exit_code": 0, "finished": true})
+		_, _ = w.Write([]byte("data: " + string(fin) + "\n\n"))
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+}
+
+// TestAgentLoopEndToEnd drives the real runtime (Registry+lease → Router+inbox →
+// vmdwaker → boxddeliver → /exec/stream → Relay) across multiple turns against a
+// boxd-shaped HTTP server, asserting each event reaches the harness (via
+// $ACTOR_EVENT) and its reply streams back through the loop in order.
+func TestAgentLoopEndToEnd(t *testing.T) {
+	srv := fakeBoxd(t)
+	defer srv.Close()
+
+	const turns = 3
+	results, err := driveTurns(srv.URL+"/exec/stream", "agent-1", turns, harnessTurnArgv)
+	if err != nil {
+		t.Fatalf("driveTurns: %v", err)
+	}
+	if len(results) != turns {
+		t.Fatalf("got %d turn results, want %d", len(results), turns)
+	}
+	for i, r := range results {
+		want := "REPLY[" + r.payload + "]"
+		if r.reply != want {
+			t.Errorf("turn %d (%q): reply = %q, want %q", i+1, r.payload, r.reply, want)
+		}
+	}
+}
+
+// TestAgentLoopHarnessFailureSurfaces: a boxd error event ends the turn with the
+// error rather than a phantom success — the delivery path propagates failures.
+func TestAgentLoopHarnessFailureSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		ev, _ := json.Marshal(map[string]any{"error": "harness crashed", "finished": true})
+		_, _ = w.Write([]byte("data: " + string(ev) + "\n\n"))
+	}))
+	defer srv.Close()
+
+	// The turn errors (the streamer returns the harness error), so the Relay
+	// closes with no stdout — driveTurns records an empty reply, not a fake one.
+	results, err := driveTurns(srv.URL+"/exec/stream", "agent-err", 1, harnessTurnArgv)
+	if err != nil {
+		t.Fatalf("driveTurns returned a transport error: %v", err)
+	}
+	if got := results[0].reply; strings.Contains(got, "REPLY[") {
+		t.Errorf("a failed turn must not yield a harness reply, got %q", got)
+	}
+}

--- a/cmd/agent-e2e/run-on-host-state.sh
+++ b/cmd/agent-e2e/run-on-host-state.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Durable-/state agent-loop e2e: boots the Actor's microVM with a SECOND drive
+# (a pre-formatted ext4 /state image — exactly what LocalBlockProvider produces),
+# boxd mounts it at /state, then drives agent turns whose in-guest harness writes
+# each event to /state and reads the whole log back. The final turn's reply must
+# still contain turn-1's event → /state persisted across turns in the live loop.
+set +e
+RESULT=/tmp/agent-e2e-state-result.txt
+: > "$RESULT"
+log() { echo "$@" >> "$RESULT"; }
+
+TAP=tape2es
+HOSTIP=172.31.99.5
+GUESTIP=172.31.99.6
+MASK=255.255.255.252
+MAC=06:00:AC:1F:63:06
+SOCK=/tmp/agent-state-fc.sock
+ALP=/tmp/alpine-minirootfs-3.20.3-x86_64.tar.gz
+
+cleanup() {
+  sudo pkill -f "$SOCK" 2>/dev/null
+  sudo ip link del "$TAP" 2>/dev/null
+  sudo rm -f "$SOCK" /tmp/agent-state-rootfs.ext4 /tmp/agent-state.ext4 /tmp/agent-state-fc.log
+  sudo rm -rf /tmp/asroot
+}
+trap cleanup EXIT
+
+sudo ip link del "$TAP" 2>/dev/null
+sudo ip tuntap add "$TAP" mode tap || { log "FAIL: tap add"; echo DONE; exit 1; }
+sudo ip addr add "$HOSTIP/30" dev "$TAP"; sudo ip link set "$TAP" up
+log "tap $TAP up at $HOSTIP/30"
+
+[ -f "$ALP" ] || curl -fsSL -o "$ALP" https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-minirootfs-3.20.3-x86_64.tar.gz
+sudo rm -rf /tmp/asroot && sudo mkdir -p /tmp/asroot && sudo tar -xzf "$ALP" -C /tmp/asroot
+sudo mkdir -p /tmp/asroot/usr/bin
+sudo cp /tmp/boxd.linux /tmp/asroot/usr/bin/boxd && sudo chmod 0755 /tmp/asroot/usr/bin/boxd
+sudo rm -f /tmp/asroot/sbin/init
+sudo tee /tmp/asroot/sbin/init >/dev/null <<EOS
+#!/bin/sh
+set +e
+mkdir -p /proc /sys /dev
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+ip link set eth0 up 2>/dev/null
+ip addr show eth0 2>/dev/null | grep -q $GUESTIP || ip addr add $GUESTIP/30 dev eth0 2>/dev/null
+exec /usr/bin/boxd
+EOS
+sudo chmod 0755 /tmp/asroot/sbin/init
+sudo rm -f /tmp/agent-state-rootfs.ext4
+sudo mke2fs -q -t ext4 -d /tmp/asroot -b 4096 /tmp/agent-state-rootfs.ext4 300M
+
+# The durable /state disk — a pre-formatted ext4 image, exactly what
+# LocalBlockProvider.Mount creates for an identity (mke2fs -F -q -t ext4).
+rm -f /tmp/agent-state.ext4
+mke2fs -F -q -t ext4 /tmp/agent-state.ext4 64M
+log "rootfs + pre-formatted /state ext4 built"
+
+sudo rm -f "$SOCK"
+sudo /usr/local/bin/firecracker --api-sock "$SOCK" > /tmp/agent-state-fc.log 2>&1 &
+sleep 1
+j() { sudo curl -s --unix-socket "$SOCK" -X "$1" "http://localhost$2" -H 'Content-Type: application/json' -d "$3" >/dev/null; }
+j PUT /boot-source "{\"kernel_image_path\":\"/tmp/fcassets/vmlinux\",\"boot_args\":\"console=ttyS0 reboot=k panic=1 pci=off ip=$GUESTIP::$HOSTIP:$MASK::eth0:off\"}"
+j PUT /drives/rootfs "{\"drive_id\":\"rootfs\",\"path_on_host\":\"/tmp/agent-state-rootfs.ext4\",\"is_root_device\":true,\"is_read_only\":false}"
+j PUT /drives/state "{\"drive_id\":\"state\",\"path_on_host\":\"/tmp/agent-state.ext4\",\"is_root_device\":false,\"is_read_only\":false}"
+j PUT /network-interfaces/eth0 "{\"iface_id\":\"eth0\",\"host_dev_name\":\"$TAP\",\"guest_mac\":\"$MAC\"}"
+j PUT /machine-config "{\"vcpu_count\":1,\"mem_size_mib\":256}"
+j PUT /actions "{\"action_type\":\"InstanceStart\"}"
+
+UP=0
+for i in $(seq 1 30); do curl -s -m 2 "http://$GUESTIP:49983/health" >/dev/null 2>&1 && { UP=1; break; }; sleep 1; done
+if [ "$UP" != 1 ]; then log "FAIL: boxd unreachable"; sudo tail -15 /tmp/agent-state-fc.log >> "$RESULT"; echo DONE; exit 1; fi
+log "microVM up; boxd reachable; /state drive attached (vdb)"
+
+# Confirm boxd mounted /state, then drive turns that persist to it.
+log "boxd /state mount log: $(sudo grep -h 'state:' /tmp/agent-state-fc.log | head -1)"
+log "=== agent-e2e (durable /state across turns) ==="
+chmod +x /tmp/agent-e2e.linux
+/tmp/agent-e2e.linux -boxd-url "http://$GUESTIP:49983/exec/stream" -turns 3 \
+  -turn-cmd 'printf "%s\n" "$ACTOR_EVENT" >> /state/agentlog; printf "STATELOG[%s]" "$(tr "\n" "," < /state/agentlog)"' \
+  -final-must-contain 'event-1' >> "$RESULT" 2>&1
+log "(agent-e2e exit=$?)"
+echo DONE

--- a/cmd/agent-e2e/run-on-host-state.sh
+++ b/cmd/agent-e2e/run-on-host-state.sh
@@ -44,6 +44,7 @@ mount -t sysfs sys /sys 2>/dev/null
 mount -t devtmpfs dev /dev 2>/dev/null
 ip link set eth0 up 2>/dev/null
 ip addr show eth0 2>/dev/null | grep -q $GUESTIP || ip addr add $GUESTIP/30 dev eth0 2>/dev/null
+export STATE_MOUNT_AT_BOOT=1
 exec /usr/bin/boxd
 EOS
 sudo chmod 0755 /tmp/asroot/sbin/init

--- a/cmd/agent-e2e/run-on-host.sh
+++ b/cmd/agent-e2e/run-on-host.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Isolated full-stack agent-loop e2e on the KVM host. Sets up a dedicated TAP
+# (172.31.99.0/30 — does NOT collide with vmd's 10.11/10.12), boots ONE networked
+# Firecracker microVM running boxd, then drives the real Actor runtime
+# (agent-e2e) against it over /exec/stream. Tears everything down at the end.
+set +e
+RESULT=/tmp/agent-e2e-result.txt
+: > "$RESULT"
+log() { echo "$@" >> "$RESULT"; }
+
+TAP=tape2e0
+HOSTIP=172.31.99.1
+GUESTIP=172.31.99.2
+MASK=255.255.255.252
+MAC=06:00:AC:1F:63:02
+ALP=/tmp/alpine-minirootfs-3.20.3-x86_64.tar.gz
+
+cleanup() {
+  sudo pkill -f /tmp/agent-fc.sock 2>/dev/null
+  sudo ip link del "$TAP" 2>/dev/null
+  sudo rm -f /tmp/agent-fc.sock /tmp/agent-rootfs.ext4 /tmp/agent-fc.log
+  sudo rm -rf /tmp/aroot
+}
+trap cleanup EXIT
+
+# 1) Dedicated TAP, isolated subnet.
+sudo ip link del "$TAP" 2>/dev/null
+sudo ip tuntap add "$TAP" mode tap || { log "FAIL: tap add"; exit 1; }
+sudo ip addr add "$HOSTIP/30" dev "$TAP"
+sudo ip link set "$TAP" up
+log "tap $TAP up at $HOSTIP/30"
+
+# 2) Build an alpine rootfs that runs boxd as init with eth0 configured.
+[ -f "$ALP" ] || curl -fsSL -o "$ALP" https://dl-cdn.alpinelinux.org/alpine/v3.20/releases/x86_64/alpine-minirootfs-3.20.3-x86_64.tar.gz
+sudo rm -rf /tmp/aroot && sudo mkdir -p /tmp/aroot && sudo tar -xzf "$ALP" -C /tmp/aroot
+sudo mkdir -p /tmp/aroot/usr/bin
+sudo cp /tmp/boxd.linux /tmp/aroot/usr/bin/boxd && sudo chmod 0755 /tmp/aroot/usr/bin/boxd
+sudo rm -f /tmp/aroot/sbin/init
+sudo tee /tmp/aroot/sbin/init >/dev/null <<EOS
+#!/bin/sh
+set +e
+mkdir -p /proc /sys /dev
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+# Bring up eth0 (belt-and-suspenders; kernel ip= may have already done it).
+ip link set eth0 up 2>/dev/null
+ip addr show eth0 2>/dev/null | grep -q $GUESTIP || ip addr add $GUESTIP/30 dev eth0 2>/dev/null
+exec /usr/bin/boxd
+EOS
+sudo chmod 0755 /tmp/aroot/sbin/init
+sudo rm -f /tmp/agent-rootfs.ext4
+sudo mke2fs -q -t ext4 -d /tmp/aroot -b 4096 /tmp/agent-rootfs.ext4 300M
+log "rootfs built (alpine + boxd init, eth0=$GUESTIP)"
+
+# 3) Boot the networked microVM.
+SOCK=/tmp/agent-fc.sock; sudo rm -f "$SOCK"
+sudo /usr/local/bin/firecracker --api-sock "$SOCK" > /tmp/agent-fc.log 2>&1 &
+sleep 1
+j() { sudo curl -s --unix-socket "$SOCK" -X "$1" "http://localhost$2" -H 'Content-Type: application/json' -d "$3" >/dev/null; }
+j PUT /boot-source "{\"kernel_image_path\":\"/tmp/fcassets/vmlinux\",\"boot_args\":\"console=ttyS0 reboot=k panic=1 pci=off ip=$GUESTIP::$HOSTIP:$MASK::eth0:off\"}"
+j PUT /drives/rootfs "{\"drive_id\":\"rootfs\",\"path_on_host\":\"/tmp/agent-rootfs.ext4\",\"is_root_device\":true,\"is_read_only\":false}"
+j PUT /network-interfaces/eth0 "{\"iface_id\":\"eth0\",\"host_dev_name\":\"$TAP\",\"guest_mac\":\"$MAC\"}"
+j PUT /machine-config "{\"vcpu_count\":1,\"mem_size_mib\":256}"
+j PUT /actions "{\"action_type\":\"InstanceStart\"}"
+log "microVM started; waiting for boxd at $GUESTIP:49983"
+
+# 4) Wait for boxd health over the TAP.
+UP=0
+for i in $(seq 1 30); do
+  if curl -s -m 2 "http://$GUESTIP:49983/health" >/dev/null 2>&1; then UP=1; break; fi
+  sleep 1
+done
+if [ "$UP" != 1 ]; then
+  log "FAIL: boxd never became reachable at $GUESTIP:49983"
+  log "--- guest console tail ---"; sudo tail -15 /tmp/agent-fc.log >> "$RESULT" 2>/dev/null
+  echo DONE; exit 1
+fi
+log "boxd reachable; health OK"
+
+# 5) Drive the real Actor agent loop against it.
+log "=== agent-e2e ==="
+chmod +x /tmp/agent-e2e.linux
+/tmp/agent-e2e.linux -boxd-url "http://$GUESTIP:49983/exec/stream" -turns 3 >> "$RESULT" 2>&1
+log "(agent-e2e exit=$?)"
+echo DONE

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -77,9 +77,14 @@ func main() {
 		log.Fatalf("chmod defaultHome %s: %v", defaultHome, err)
 	}
 
-	// Mount the durable /state block device, if one is attached. Best-effort: a
-	// sandbox without durable state still serves ephemeral work.
-	mountStateDisk()
+	// Mount the durable /state block device at boot ONLY when explicitly opted in
+	// (STATE_MOUNT_AT_BOOT=1). The production /state-on-restore path keeps /state
+	// UNMOUNTED in the template snapshot so the drive can be re-pointed to the
+	// Actor's per-identity image during the paused restore, then mounted via the
+	// vmd-triggered POST /state/mount. Boot-mount is for cold-boot/standalone use.
+	if os.Getenv("STATE_MOUNT_AT_BOOT") == "1" {
+		mountStateDisk()
+	}
 
 	mux := http.NewServeMux()
 

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -105,6 +105,7 @@ func main() {
 	mux.HandleFunc("/exec", procService.handleExec)
 	mux.HandleFunc("/exec/stream", procService.handleExecStream)
 	mux.HandleFunc("/start", handleStart(sup))
+	mux.HandleFunc("/state/mount", handleStateMount)
 
 	// Cold-boot path: if a start spec was baked into the rootfs and no child
 	// is already live, launch it. On snapshot restore the child is already in

--- a/cmd/boxd/state.go
+++ b/cmd/boxd/state.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -96,4 +97,33 @@ func isMountpoint(path string) (bool, error) {
 		return false, err
 	}
 	return st.Dev != parent.Dev, nil
+}
+
+// handleStateMount mounts the durable /state block device on demand. vmd calls
+// this on the durable-/state restore path: the template snapshot captured /state
+// UNMOUNTED (so the drive could be re-pointed to the Actor's per-identity image
+// during the paused restore), and the mount happens now, after the repoint. It
+// is idempotent — already-mounted and no-device are both reported as success-ish.
+// POST /state/mount[?device=/dev/vdb]
+func handleStateMount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	device := r.URL.Query().Get("device")
+	if device == "" {
+		device = defaultStateDevice
+	}
+	switch err := mountStateDiskAt(device, stateMountpoint, osStat, isMountpoint, syscall.Mount); err {
+	case nil:
+		log.Printf("state: mounted %s at %s (vmd-triggered)", device, stateMountpoint)
+		w.WriteHeader(http.StatusOK)
+	case errStateAlreadyMounted:
+		w.WriteHeader(http.StatusOK)
+	case errNoStateDevice:
+		http.Error(w, "no state device at "+device, http.StatusNotFound)
+	default:
+		log.Printf("state: vmd-triggered mount of %s failed: %v", device, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -462,16 +462,17 @@ func (c *grpcVMDClient) BareResumeInstance(ctx context.Context, vmID string) (st
 // instance from the snapshot files, bypassing any in-memory state. For
 // sandboxes with secrets the caller passes envVars=nil and pushes env via
 // InjectSandboxEnv after minting a JWT against the returned source IP.
-func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string, stateDiskPath string) (string, uint32, uint32, error) {
 	resp, err := c.client.RestoreSnapshot(ctx, &vmdpb.RestoreSnapshotRequest{
-		VmId:         vmID,
-		SnapshotPath: snapshotPath,
-		MemFilePath:  memPath,
-		BasePath:     basePath,
-		DeltaDir:     deltaDir,
-		TeamId:       teamID,
-		OwnerId:      ownerID,
-		EnvVars:      envVars,
+		VmId:          vmID,
+		SnapshotPath:  snapshotPath,
+		MemFilePath:   memPath,
+		BasePath:      basePath,
+		DeltaDir:      deltaDir,
+		TeamId:        teamID,
+		OwnerId:       ownerID,
+		EnvVars:       envVars,
+		StateDiskPath: stateDiskPath,
 	})
 	if err != nil {
 		return "", 0, 0, fmt.Errorf("gRPC RestoreSnapshot: %w", err)

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -191,6 +191,31 @@ func run() error {
 	handlers.Hosts = hostreg.New(queries, dialVMD)
 	handlers.Scheduler = &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}
 
+	// Durable /state provider (checkpoint/branch/rollback + per-Actor state
+	// volumes). Built BEFORE the Actor runtime so the runtime's target resolver
+	// can auto-provision each Actor's /state. Enabled by a local STATE_DIR
+	// (backend "local" directory ref / "local-block" ext4-image ref) or a SaaS
+	// backend (STATE_BACKEND=archil|mesa, which need no local dir).
+	var stateProvider state.Provider
+	if stateBackend, stateDir := os.Getenv("STATE_BACKEND"), os.Getenv("STATE_DIR"); stateDir != "" ||
+		stateBackend == string(state.BackendArchil) || stateBackend == string(state.BackendMesa) {
+		stateImageMiB, _ := strconv.Atoi(os.Getenv("STATE_IMAGE_MIB"))
+		sp, serr := state.NewProvider(state.Config{
+			Backend:       state.Backend(stateBackend),
+			BaseDir:       stateDir,
+			StateImageMiB: stateImageMiB,
+			Archil:        state.ArchilConfig{APIKey: os.Getenv("ARCHIL_API_KEY"), Region: os.Getenv("ARCHIL_REGION"), DiskID: os.Getenv("ARCHIL_DISK_ID")},
+			Mesa:          state.MesaConfig{APIKey: os.Getenv("MESA_API_KEY"), Org: os.Getenv("MESA_ORG")},
+		})
+		if serr != nil {
+			log.Warn().Err(serr).Msg("durable /state provider init failed; /state endpoints disabled")
+		} else {
+			stateProvider = sp
+			handlers.State = sp
+			log.Info().Str("backend", stateBackend).Msg("durable /state versioning enabled")
+		}
+	}
+
 	// Durable-Actor runtime (client plane, POST /v1/agents/send). Flag-gated and
 	// default-off so it has zero effect on existing behavior. Assembles the
 	// proven runtime: PgStore-backed Registry + single-writer Lease + serial
@@ -215,7 +240,9 @@ func run() error {
 		}
 		exec := boxddeliver.NewHTTPExecStreamer(http.DefaultClient, execURL, execToken)
 		deliverer := boxddeliver.New(exec, []string{"sh", "-c", "harness-turn"})
-		waker := vmdwaker.New(vmdClient, deliverer, api.AgentTargetResolver(queries, systemTeam))
+		// The resolver auto-provisions each Actor's durable /state via the provider
+		// (block backends carry the disk path in the Target for vmd to attach).
+		waker := vmdwaker.New(vmdClient, deliverer, api.AgentTargetResolverWithState(queries, systemTeam, stateProvider))
 		router := actorrt.NewRouter(actorrt.NewRegistry(pgstore.New(queries), nil), waker, cfg.DefaultHostID, 16)
 
 		// Tiered hibernation: a TierController demotes idle Actors down the
@@ -239,36 +266,6 @@ func run() error {
 
 		handlers.Agents = router
 		log.Info().Msg("durable-Actor runtime enabled (/v1/agents) with sandbox-exec delivery + tiered hibernation")
-	}
-
-	// Durable /state versioning (checkpoint/branch/rollback). Enabled when a
-	// local STATE_DIR is set (backend "local" the directory reference, or
-	// "local-block" the ext4-image block reference) or a SaaS backend is selected
-	// (STATE_BACKEND=archil|mesa, which need no local dir).
-	stateBackend := os.Getenv("STATE_BACKEND")
-	stateDir := os.Getenv("STATE_DIR")
-	if stateDir != "" || stateBackend == string(state.BackendArchil) || stateBackend == string(state.BackendMesa) {
-		stateImageMiB, _ := strconv.Atoi(os.Getenv("STATE_IMAGE_MIB"))
-		sp, serr := state.NewProvider(state.Config{
-			Backend:       state.Backend(stateBackend),
-			BaseDir:       stateDir,
-			StateImageMiB: stateImageMiB,
-			Archil: state.ArchilConfig{
-				APIKey: os.Getenv("ARCHIL_API_KEY"),
-				Region: os.Getenv("ARCHIL_REGION"),
-				DiskID: os.Getenv("ARCHIL_DISK_ID"),
-			},
-			Mesa: state.MesaConfig{
-				APIKey: os.Getenv("MESA_API_KEY"),
-				Org:    os.Getenv("MESA_ORG"),
-			},
-		})
-		if serr != nil {
-			log.Warn().Err(serr).Msg("durable /state provider init failed; /state endpoints disabled")
-		} else {
-			handlers.State = sp
-			log.Info().Str("backend", stateBackend).Msg("durable /state versioning enabled")
-		}
 	}
 
 	router := api.SetupRouter(ctx, handlers, dbPool)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -348,19 +348,20 @@ func main() {
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
-		FirecrackerBin:        cfg.FirecrackerBin,
-		JailerBin:             cfg.JailerBin,
-		KernelPath:            cfg.KernelPath,
-		BaseRootfsPath:        cfg.BaseRootfsPath,
-		SnapshotDir:           cfg.SnapshotDir,
-		RunDir:                cfg.RunDir,
-		TemplateBuilderBin:    cfg.TemplateBuilderBin,
-		BoxdBinaryPath:        cfg.BoxdBinaryPath,
-		HostInterface:         cfg.HostInterface,
-		MaxConcurrentRestores: maxRestores,
-		UffdEnabled:           uffdEnabled,
-		UffdPrefetchEnabled:   uffdPrefetchEnabled,
-		UffdRecordMaxSeconds:  uffdRecordMaxSeconds,
+		FirecrackerBin:           cfg.FirecrackerBin,
+		JailerBin:                cfg.JailerBin,
+		KernelPath:               cfg.KernelPath,
+		BaseRootfsPath:           cfg.BaseRootfsPath,
+		SnapshotDir:              cfg.SnapshotDir,
+		RunDir:                   cfg.RunDir,
+		TemplateBuilderBin:       cfg.TemplateBuilderBin,
+		BoxdBinaryPath:           cfg.BoxdBinaryPath,
+		HostInterface:            cfg.HostInterface,
+		StateTemplatePlaceholder: os.Getenv("STATE_TEMPLATE_PLACEHOLDER") == "1",
+		MaxConcurrentRestores:    maxRestores,
+		UffdEnabled:              uffdEnabled,
+		UffdPrefetchEnabled:      uffdPrefetchEnabled,
+		UffdRecordMaxSeconds:     uffdRecordMaxSeconds,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/actor/boxddeliver/httpexec_live_test.go
+++ b/internal/actor/boxddeliver/httpexec_live_test.go
@@ -1,0 +1,55 @@
+package boxddeliver
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHTTPExecStreamerAgainstRealBoxd drives the production streamer against a
+// REAL boxd over its /exec/stream endpoint. Gated on BOXD_ADDR (host:port of a
+// running boxd). It proves the full wire contract end to end: the request shape
+// (command/args + the event in $ACTOR_EVENT), boxd actually running the command
+// with that env, and decoding boxd's SSE reply back into the Relay's onOut.
+//
+// Run it against a boxd started on a Linux host:
+//
+//	boxd &                                  # listens on 0.0.0.0:49983
+//	BOXD_ADDR=127.0.0.1:49983 go test -run TestHTTPExecStreamerAgainstRealBoxd ./internal/actor/boxddeliver/
+func TestHTTPExecStreamerAgainstRealBoxd(t *testing.T) {
+	addr := os.Getenv("BOXD_ADDR")
+	if addr == "" {
+		t.Skip("set BOXD_ADDR=host:port of a running boxd to run the live exec test")
+	}
+
+	s := NewHTTPExecStreamer(
+		&http.Client{Timeout: 15 * time.Second},
+		func(string) string { return "http://" + addr + "/exec/stream" },
+		// boxd itself does not authenticate /exec/stream (the edge proxy does), so
+		// no token is needed when hitting boxd directly.
+		func(string) (string, error) { return "", nil },
+	)
+
+	var out bytes.Buffer
+	const payload = "hello-event-42"
+	err := s.ExecStream(
+		context.Background(),
+		"sbx-live",
+		// The harness "turn": echo the event payload back. A real harness reads
+		// $ACTOR_EVENT the same way.
+		[]string{"sh", "-c", "printf 'reply:%s' \"$ACTOR_EVENT\""},
+		[]byte(payload),
+		func(b []byte) { out.Write(b) },
+	)
+	if err != nil {
+		t.Fatalf("ExecStream against real boxd: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "reply:"+payload) {
+		t.Fatalf("harness reply did not carry the event payload; got %q, want it to contain %q",
+			got, "reply:"+payload)
+	}
+}

--- a/internal/actor/vmdwaker/waker.go
+++ b/internal/actor/vmdwaker/waker.go
@@ -48,6 +48,13 @@ type Target struct {
 	TeamID       string
 	OwnerID      string
 	Env          map[string]string
+	// StateDiskPath, when non-empty, is the host path to the Actor's durable
+	// /state block image (provisioned by the state.Provider, keyed by the Actor's
+	// durable identity). vmd attaches it as the sandbox's /state drive on the
+	// Actor's first (cold) boot; subsequent snapshot restores inherit it (the
+	// snapshot's device set already includes it). Empty for Actors without
+	// durable state or when the provider is directory-model (Mesa/FUSE).
+	StateDiskPath string
 }
 
 // Resolver maps an Actor to its boot Target.

--- a/internal/actor/vmdwaker/waker.go
+++ b/internal/actor/vmdwaker/waker.go
@@ -22,7 +22,7 @@ import (
 // vmdclient.Client satisfies this shape (RestoreSnapshot / BareResumeInstance /
 // DestroyInstance).
 type SandboxBooter interface {
-	RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, env map[string]string) (string, uint32, uint32, error)
+	RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, env map[string]string, stateDiskPath string) (string, uint32, uint32, error)
 	// BareResumeInstance is the Tier-1 wake: unpause a still-resident, bare-paused
 	// VM in place (sub-ms, no snapshot restore).
 	BareResumeInstance(ctx context.Context, id string) (string, uint32, uint32, error)
@@ -97,7 +97,7 @@ func (w *Waker) Wake(ctx context.Context, a actor.Actor, _ *actor.Lease) (actor.
 			return nil, fmt.Errorf("resolve actor %q: %w", a.Name, err)
 		}
 		if _, _, _, err := w.boot.RestoreSnapshot(ctx, sandboxID,
-			tgt.SnapshotPath, tgt.MemPath, tgt.BasePath, tgt.DeltaDir, tgt.TeamID, tgt.OwnerID, tgt.Env); err != nil {
+			tgt.SnapshotPath, tgt.MemPath, tgt.BasePath, tgt.DeltaDir, tgt.TeamID, tgt.OwnerID, tgt.Env, tgt.StateDiskPath); err != nil {
 			return nil, fmt.Errorf("restore sandbox for actor %q: %w", a.Name, err)
 		}
 	}

--- a/internal/actor/vmdwaker/waker_test.go
+++ b/internal/actor/vmdwaker/waker_test.go
@@ -18,7 +18,7 @@ type mockBooter struct {
 	restoreErr    error
 }
 
-func (m *mockBooter) RestoreSnapshot(_ context.Context, id, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (m *mockBooter) RestoreSnapshot(_ context.Context, id, _, _, _, _, _, _ string, _ map[string]string, _ string) (string, uint32, uint32, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.restoreErr != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -473,7 +473,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
 			// because resume is supposed to preserve whatever envs the sandbox
 			// already has baked into the snapshot — not inject new ones.
-			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
+			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil, "")
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
 				revertToPaused()
@@ -1536,7 +1536,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// InjectSandboxEnv pushes the env again together with the JWT minted
 	// against the now-known source IP.
 	tVmdStart := time.Now()
-	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
+	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars, "")
 	tVmdEnd := time.Now()
 
 	// Wait for the parallel INSERT to complete — its result determines

--- a/internal/api/handlers_agents.go
+++ b/internal/api/handlers_agents.go
@@ -12,6 +12,7 @@ import (
 	actorrt "github.com/superserve-ai/sandbox/internal/actor"
 	"github.com/superserve-ai/sandbox/internal/actor/vmdwaker"
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/state"
 )
 
 // AgentTargetResolver is the production vmdwaker.Resolver: it maps an Actor to
@@ -23,6 +24,20 @@ import (
 //	router := actor.NewRouter(actor.NewRegistry(pgstore.New(q), nil), waker, hostID, 16)
 //	handlers.Agents = router
 func AgentTargetResolver(q *db.Queries, systemTeam uuid.UUID) vmdwaker.Resolver {
+	return agentTargetResolver(q, systemTeam, nil)
+}
+
+// AgentTargetResolverWithState is AgentTargetResolver that also auto-provisions
+// the Actor's durable /state: on each resolve it ensures the per-Actor state
+// volume exists via the state.Provider (keyed by the Actor's durable identity)
+// and, for block-device backends, carries its host path in Target.StateDiskPath
+// for vmd to attach as the sandbox's /state drive. Directory/FUSE backends
+// (Mesa) provision the repo but leave StateDiskPath empty (the guest mounts it).
+func AgentTargetResolverWithState(q *db.Queries, systemTeam uuid.UUID, provider state.Provider) vmdwaker.Resolver {
+	return agentTargetResolver(q, systemTeam, provider)
+}
+
+func agentTargetResolver(q *db.Queries, systemTeam uuid.UUID, provider state.Provider) vmdwaker.Resolver {
 	return func(a actorrt.Actor) (vmdwaker.Target, error) {
 		tid, err := uuid.Parse(a.Template)
 		if err != nil {
@@ -45,6 +60,17 @@ func AgentTargetResolver(q *db.Queries, systemTeam uuid.UUID) vmdwaker.Resolver 
 		}
 		if tpl.DeltaPath != nil {
 			t.DeltaDir = filepath.Dir(*tpl.DeltaPath)
+		}
+		// Auto-provision the Actor's durable /state, addressed by its stable
+		// identity (a.ID) so state follows the Actor across sandboxes/hosts.
+		if provider != nil {
+			m, err := provider.Mount(context.Background(), a.ID, "/state")
+			if err != nil {
+				return vmdwaker.Target{}, fmt.Errorf("provision /state for actor %q: %w", a.Name, err)
+			}
+			if m.IsBlockDevice {
+				t.StateDiskPath = m.Path
+			}
 		}
 		return t, nil
 	}

--- a/internal/api/handlers_agents_test.go
+++ b/internal/api/handlers_agents_test.go
@@ -13,12 +13,16 @@ import (
 	actorrt "github.com/superserve-ai/sandbox/internal/actor"
 	"github.com/superserve-ai/sandbox/internal/actor/vmdwaker"
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/state"
 )
 
 // fakeBooter satisfies vmdwaker.SandboxBooter without a real vmd.
 type fakeBooter struct{}
 
 func (fakeBooter) RestoreSnapshot(context.Context, string, string, string, string, string, string, string, map[string]string) (string, uint32, uint32, error) {
+	return "10.0.0.1", 1, 1024, nil
+}
+func (fakeBooter) BareResumeInstance(context.Context, string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (fakeBooter) DestroyInstance(context.Context, string, bool) error { return nil }
@@ -102,5 +106,90 @@ func TestAgentTargetResolver_NoTemplateBinding(t *testing.T) {
 	resolve := AgentTargetResolver(db.New(&mockDBTX{}), uuid.Nil)
 	if _, err := resolve(actorrt.Actor{Template: "", TeamID: uuid.New().String(), Name: "x"}); err == nil {
 		t.Fatal("actor with no template binding should error")
+	}
+}
+
+// fakeStateProvider records the identity it provisioned and reports a block (or
+// directory) mount so the resolver's /state wiring is testable without a backend.
+type fakeStateProvider struct {
+	block     bool
+	mountedID string
+	mountErr  error
+}
+
+func (f *fakeStateProvider) Mount(_ context.Context, identity, _ string) (*state.Mount, error) {
+	if f.mountErr != nil {
+		return nil, f.mountErr
+	}
+	f.mountedID = identity
+	return &state.Mount{Identity: identity, Path: "/srv/state/" + identity + "/state.img", IsBlockDevice: f.block}, nil
+}
+func (f *fakeStateProvider) Checkpoint(context.Context, string, string) (state.Checkpoint, error) {
+	return state.Checkpoint{}, nil
+}
+func (f *fakeStateProvider) Branch(context.Context, string, string, string) error { return nil }
+func (f *fakeStateProvider) Rollback(context.Context, string, string) error       { return nil }
+func (f *fakeStateProvider) ListCheckpoints(context.Context, string) ([]state.Checkpoint, error) {
+	return nil, nil
+}
+
+func resolverWithTemplate(t *testing.T, provider state.Provider) (vmdwaker.Resolver, string) {
+	t.Helper()
+	tplID := uuid.New()
+	tpl := defaultReadyTemplate()
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+		if strings.Contains(sql, "FROM template") {
+			return templateRow(tpl)
+		}
+		return notFoundRow()
+	}}
+	return AgentTargetResolverWithState(db.New(mock), uuid.Nil, provider), tplID.String()
+}
+
+// TestAgentTargetResolverWithState_BlockDevice: a block-backed provider's image
+// path is carried into the Target (keyed by the Actor's durable id) for vmd to
+// attach as /state.
+func TestAgentTargetResolverWithState_BlockDevice(t *testing.T) {
+	fp := &fakeStateProvider{block: true}
+	resolve, tpl := resolverWithTemplate(t, fp)
+	act := actorrt.Actor{ID: "actor-xyz", Template: tpl, TeamID: uuid.New().String(), Name: "agent"}
+	target, err := resolve(act)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if fp.mountedID != "actor-xyz" {
+		t.Errorf("provider provisioned %q, want the Actor's durable id actor-xyz", fp.mountedID)
+	}
+	if target.StateDiskPath != "/srv/state/actor-xyz/state.img" {
+		t.Errorf("StateDiskPath = %q, want the provisioned block image", target.StateDiskPath)
+	}
+}
+
+// Directory/FUSE backends provision the volume but leave StateDiskPath empty (the
+// guest mounts it), so vmd attaches no /state drive.
+func TestAgentTargetResolverWithState_DirectoryBackendNoDrive(t *testing.T) {
+	fp := &fakeStateProvider{block: false}
+	resolve, tpl := resolverWithTemplate(t, fp)
+	target, err := resolve(actorrt.Actor{ID: "a1", Template: tpl, TeamID: uuid.New().String(), Name: "agent"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if target.StateDiskPath != "" {
+		t.Errorf("directory backend must not set StateDiskPath, got %q", target.StateDiskPath)
+	}
+	if fp.mountedID != "a1" {
+		t.Errorf("directory backend should still provision the volume, mountedID=%q", fp.mountedID)
+	}
+}
+
+// nil provider (no durable /state configured) → no provisioning, empty path.
+func TestAgentTargetResolverWithState_NilProvider(t *testing.T) {
+	resolve, tpl := resolverWithTemplate(t, nil)
+	target, err := resolve(actorrt.Actor{ID: "a1", Template: tpl, TeamID: uuid.New().String(), Name: "agent"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if target.StateDiskPath != "" {
+		t.Errorf("nil provider must leave StateDiskPath empty, got %q", target.StateDiskPath)
 	}
 }

--- a/internal/api/handlers_agents_test.go
+++ b/internal/api/handlers_agents_test.go
@@ -19,7 +19,7 @@ import (
 // fakeBooter satisfies vmdwaker.SandboxBooter without a real vmd.
 type fakeBooter struct{}
 
-func (fakeBooter) RestoreSnapshot(context.Context, string, string, string, string, string, string, string, map[string]string) (string, uint32, uint32, error) {
+func (fakeBooter) RestoreSnapshot(context.Context, string, string, string, string, string, string, string, map[string]string, string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (fakeBooter) BareResumeInstance(context.Context, string) (string, uint32, uint32, error) {

--- a/internal/api/handlers_from_image.go
+++ b/internal/api/handlers_from_image.go
@@ -151,7 +151,7 @@ func (h *Handlers) fromImageCacheHit(c *gin.Context, teamID uuid.UUID, tpl db.Te
 		deltaDir = filepath.Dir(*tpl.DeltaPath)
 	}
 	ip, vcpu, mem, vmdErr := vmd.RestoreSnapshot(c.Request.Context(), sandboxID.String(),
-		*tpl.SnapshotPath, *tpl.MemPath, base, deltaDir, teamID.String(), ownerIDFromContext(c), req.Env)
+		*tpl.SnapshotPath, *tpl.MemPath, base, deltaDir, teamID.String(), ownerIDFromContext(c), req.Env, "")
 	if vmdErr != nil {
 		_ = h.DB.UpdateSandboxStatus(insertCtx, db.UpdateSandboxStatusParams{ID: sandbox.ID, Status: db.SandboxStatusFailed, TeamID: teamID})
 		if isVMDFileMissing(vmdErr) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -58,7 +58,7 @@ func (s *stubVMD) BarePauseInstance(context.Context, string) error { return nil 
 func (s *stubVMD) BareResumeInstance(context.Context, string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _ string, _ map[string]string, _ string) (string, uint32, uint32, error) {
 	if s.restoreFn != nil {
 		ip, err := s.restoreFn(ctx, id, snapshotPath, memPath)
 		return ip, 1, 1024, err

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -167,7 +167,11 @@ func (s *stubVMD) PauseInstance(_ context.Context, _, _ string) (string, string,
 func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _ string, _ map[string]string) (string, uint32, uint32, error) {
+func (s *stubVMD) BarePauseInstance(_ context.Context, _ string) error { return nil }
+func (s *stubVMD) BareResumeInstance(_ context.Context, _ string) (string, uint32, uint32, error) {
+	return "10.0.0.1", 1, 1024, nil
+}
+func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _ string, _ map[string]string, _ string) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
 func (s *stubVMD) InjectSandboxEnv(_ context.Context, _ string, _ map[string]string, _ string) error {

--- a/internal/state/STATE-MOUNT-FINDINGS.md
+++ b/internal/state/STATE-MOUNT-FINDINGS.md
@@ -66,6 +66,40 @@ So per-identity `/state` needs a deliberate boot-path addition. The options:
    per-drive backing overrides to `LoadSnapshot`, mirroring `NetworkOverrides`.
    Cleanest long-term, but a firecracker-fork change + rebuild.
 
-**Recommendation: option 1.** It is fully validated end-to-end today and needs
-only controlplane wiring (resolve the Actor's identity → `provider.Mount(id)` →
-cold-boot with `StateDiskPath`), exercisable against the live integrated stack.
+## RESOLVED — drive-repoint on restore WORKS on hardware (option 2 wins)
+
+The boot-ordering concern in option 2 was the only thing making it "unvalidated."
+A direct experiment on `superserve-vmd-staging` settled it:
+
+- Booted a "template" VM with a `/state` **placeholder** drive (vdb) and boxd
+  configured to **not** mount it (so the snapshot captures the drive *unmounted*).
+- Snapshotted it; restored in a fresh Firecracker with `LoadSnapshot(resume_vm=false)`,
+  then `PATCH /drives/state {path_on_host: <per-actor image>}`, then `PATCH /vm Resumed`.
+- The guest kernel logged `vdb: detected capacity change` (the backing swapped),
+  and a post-restore in-guest `mount /dev/vdb /state && cat /state/marker`
+  returned **`REPOINTED-OK`** — the per-actor image's marker, exit 0.
+
+**So `PatchGuestDriveByID` after `LoadSnapshot(paused)` re-points a drive's backing
+file before resume.** That makes option 2 the production design — and the best one:
+per-Actor `/state` rides the **fast template-restore path**, no second (cold) boot.
+
+### Production design (de-risked, validated mechanism)
+
+1. **Templates** are built with a `/state` placeholder drive, and boxd is built to
+   **defer** the `/state` mount (don't mount at boot — so the snapshot captures it
+   unmounted; mount it post-restore, on first wake/turn).
+2. **vmd `RestoreSnapshot`** gains an optional `state_disk_path`: load the snapshot
+   `resume_vm=false`, `PatchGuestDriveByID("state", state_disk_path)`, then resume.
+   (The exact API sequence is the one proven above.)
+3. **Controlplane** resolves the Actor → `provider.Mount(identity)` → the per-Actor
+   block image, threaded through `Target.StateDiskPath` (already built) →
+   `vmdclient.RestoreInstance(state_disk_path)` → the proto field.
+
+Every mechanism this rides on is now hardware-validated: the block provider
+(mke2fs image), the drive attach (`FirecrackerConfig.StateDiskPath`), boxd
+mounting `/state`, `/state` surviving snapshot/restore, AND drive-repoint-on-restore.
+The remaining work is the additive wiring in 1–3 plus its e2e against the live
+controlplane+vmd stack — no architectural unknowns left.
+
+(Option 1, per-Actor cold boot, also works and is fully validated, but costs a
+slower first boot; option 2 is preferred now that repoint is proven.)

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -385,6 +385,66 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 	return nil
 }
 
+// RestoreSnapshotWithStateRepoint restores a snapshot that carries a /state
+// PLACEHOLDER drive and re-points that drive to this Actor's per-identity /state
+// image before the guest runs — the production durable-/state-on-restore path.
+//
+// The sequence is hardware-validated (see internal/state/STATE-MOUNT-FINDINGS.md):
+// load the snapshot PAUSED (resume_vm=false), PatchGuestDriveByID swaps the
+// /state drive's backing file, then resume. The template snapshot must capture
+// /state UNMOUNTED (boxd defers the mount to post-restore) so the swap is safe.
+// stateDriveID is the drive id the template baked (e.g. "state"); ifaceID/
+// tapDevice override the network like RestoreSnapshotWithOverrides.
+func RestoreSnapshotWithStateRepoint(socketPath, snapshotPath, memPath, ifaceID, tapDevice, blockDeltaDir, stateDriveID, stateDiskPath string) error {
+	if stateDriveID == "" || stateDiskPath == "" {
+		return fmt.Errorf("repoint restore requires stateDriveID and stateDiskPath")
+	}
+	fc := newFCClient(socketPath)
+	ctx := context.Background()
+
+	var netOverrides []*models.NetworkOverride
+	if ifaceID != "" {
+		netOverrides = []*models.NetworkOverride{{IfaceID: &ifaceID, HostDevName: &tapDevice}}
+	} else {
+		netOverrides = []*models.NetworkOverride{} // FC rejects null
+	}
+
+	// 1. Load PAUSED so drives can be re-pointed before the guest resumes.
+	if _, err := fc.Operations.LoadSnapshot(&operations.LoadSnapshotParams{
+		Context: ctx,
+		Body: &models.SnapshotLoadParams{
+			SnapshotPath:     &snapshotPath,
+			MemBackend:       &models.MemoryBackend{BackendType: strPtr(models.MemoryBackendBackendTypeFile), BackendPath: &memPath},
+			ResumeVM:         false,
+			NetworkOverrides: netOverrides,
+			BlockDeltaDir:    blockDeltaDir,
+		},
+	}); err != nil {
+		if isTornSnapshotErr(err) {
+			return fmt.Errorf("load snapshot: %w: %v", ErrTornSnapshot, err)
+		}
+		return fmt.Errorf("load snapshot: %w", err)
+	}
+
+	// 2. Re-point the /state drive to this Actor's per-identity image.
+	if _, err := fc.Operations.PatchGuestDriveByID(&operations.PatchGuestDriveByIDParams{
+		Context: ctx,
+		DriveID: stateDriveID,
+		Body:    &models.PartialDrive{DriveID: &stateDriveID, PathOnHost: stateDiskPath},
+	}); err != nil {
+		return fmt.Errorf("repoint /state drive %q to %q: %w", stateDriveID, stateDiskPath, err)
+	}
+
+	// 3. Resume.
+	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
+		Context: ctx,
+		Body:    &models.VM{State: strPtr(models.VMStateResumed)},
+	}); err != nil {
+		return fmt.Errorf("resume after /state repoint: %w", err)
+	}
+	return nil
+}
+
 // RestoreSnapshotUffdInternalWithOverrides loads a snapshot using Firecracker's
 // in-process UFFD handler. Pages are demand-loaded from `memPath` by a handler
 // thread inside the Firecracker process whose lifetime equals the VM's, so vmd

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -150,6 +150,16 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 		return nil, err
 	}
 
+	// Durable /state: the restore re-pointed the template's placeholder /state
+	// drive onto this Actor's per-identity image (paused-load → patch → resume);
+	// the template captured /state UNMOUNTED, so trigger boxd to mount it now.
+	// Hardware-validated flow (see internal/state/STATE-MOUNT-FINDINGS.md).
+	if req.GetStateDiskPath() != "" {
+		if err := postBoxdStateMount(ctx, inst.IP); err != nil {
+			return nil, status.Errorf(codes.Internal, "mount /state after restore: %v", err)
+		}
+	}
+
 	// Env vars are pushed in a separate InjectSandboxEnv call so the control
 	// plane can mint a JWT against the now-known source IP before injection.
 	return &vmdpb.RestoreSnapshotResponse{

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -133,6 +133,7 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 	}
 	vmCfg.BasePath = req.GetBasePath()
 	vmCfg.DeltaDir = req.GetDeltaDir()
+	vmCfg.StatePath = req.GetStateDiskPath()
 
 	var netCfg *network.Config
 	if nc := req.GetNetworkConfig(); nc != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -121,7 +121,16 @@ type VMConfig struct {
 	// DeltaDir hydrates a fresh per-VM overlay from <dir>/rootfs.delta on
 	// restore. Empty for in-place resume of an already-populated overlay.
 	DeltaDir string
+	// StatePath, when non-empty, is the Actor's per-identity durable /state block
+	// image. On restore it is re-pointed onto the template's placeholder /state
+	// drive (paused-load → patch-drive → resume); on cold boot it is attached as
+	// the sandbox's /state drive. Empty for sandboxes without durable /state.
+	StatePath string
 }
+
+// stateDriveID is the Firecracker drive id the template bakes as the /state
+// placeholder and that restore re-points to the per-Actor image.
+const stateDriveID = "state"
 
 // ManagerConfig holds paths and settings for the VM manager.
 type ManagerConfig struct {
@@ -1055,6 +1064,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	default:
 		// UFFD disabled but fresh restore — File backend with network overrides.
 		restoreErr = RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir)
+	}
+	// Durable /state: re-point the template's placeholder /state drive onto this
+	// Actor's per-identity image during the paused restore. Overrides the restore
+	// variant above (the repoint path is a File-backend load + drive-patch +
+	// resume; combining it with UFFD lazy page-in is a follow-up). Hardware-
+	// validated sequence; see internal/state/STATE-MOUNT-FINDINGS.md.
+	if resourceLimits.StatePath != "" {
+		restoreErr = RestoreSnapshotWithStateRepoint(
+			socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir, stateDriveID, resourceLimits.StatePath)
 	}
 	log.Info().
 		Int64("load_snapshot_ms", time.Since(tFcReady).Milliseconds()).

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -143,6 +143,12 @@ type ManagerConfig struct {
 	TemplateBuilderBin string // Path to template-builder binary.
 	BoxdBinaryPath     string // Path to boxd binary (passed to template-builder).
 	HostInterface      string // Host network interface (e.g. "ens4").
+	// StateTemplatePlaceholder, when true, attaches a /state placeholder drive to
+	// every template-build VM so the resulting template snapshots can carry a
+	// per-Actor /state (re-pointed on restore). Off by default — no change to
+	// existing builds until durable /state is rolled out.
+	StateTemplatePlaceholder bool
+
 	// MaxConcurrentRestores caps parallel RestoreVMSnapshot operations to
 	// prevent a spike of concurrent sandbox creates from saturating host
 	// file I/O, netns setup, and Firecracker boots. 0 → default 100.
@@ -362,6 +368,33 @@ func waitForPIDExit(pid int, timeout time.Duration) {
 	}
 }
 
+// ensureStatePlaceholder returns the path to the shared, empty ext4 image used
+// as the /state placeholder drive in template-build VMs, creating it once. Its
+// contents never matter — each Actor's restore re-points the /state drive to its
+// own per-identity image — so a single small image is reused across all builds.
+func (m *Manager) ensureStatePlaceholder() (string, error) {
+	path := filepath.Join(m.cfg.SnapshotDir, "state-placeholder.ext4")
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	// mke2fs -F makes a filesystem directly in a regular file (no loop, no root).
+	tmp := path + ".tmp"
+	_ = os.Remove(tmp)
+	out, err := exec.CommandContext(context.Background(), "mke2fs", "-F", "-q", "-t", "ext4", tmp, "64M").CombinedOutput()
+	if err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("mke2fs state placeholder: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	return path, nil
+}
+
 // coldBootFromRootfs is the parameterized form: boot a VM from a specific
 // rootfs at the requested vcpu/memory. Used by BuildTemplate to boot the
 // build VM from a freshly-produced rootfs at the template's target shape.
@@ -447,6 +480,20 @@ func (m *Manager) coldBootFromRootfs(ctx context.Context, vmID, rootfsPath strin
 		VMID:       vmID,
 		VMIP:       network.VMInternalIP,
 		GatewayIP:  network.VMGatewayIP,
+	}
+
+	// Attach a /state PLACEHOLDER drive so the template snapshot's device set
+	// includes a /state drive that each Actor's restore re-points to its own
+	// per-identity image (Firecracker LoadSnapshot can't add a drive not in the
+	// snapshot). boxd does not boot-mount it (STATE_MOUNT_AT_BOOT unset), so the
+	// snapshot captures /state unmounted — safe to re-point on restore. Gated on
+	// StateTemplatePlaceholder so it is a no-op for existing builds until enabled.
+	if m.cfg.StateTemplatePlaceholder {
+		if ph, perr := m.ensureStatePlaceholder(); perr != nil {
+			log.Warn().Err(perr).Msg("state placeholder unavailable; template will not carry durable /state")
+		} else {
+			fcCfg.StateDiskPath = ph
+		}
 	}
 
 	// 4. Start Firecracker inside the network namespace, configure, and boot.

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -53,7 +53,6 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 
 var boxdInitClient = &http.Client{Timeout: 5 * time.Second}
 
-
 // postBoxdInit sends sandbox-level configuration (env vars, hostname) to
 // boxd's /init endpoint.
 func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, hostname string) error {
@@ -87,6 +86,30 @@ func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, h
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("POST /init: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// postBoxdStateMount triggers boxd to mount the durable /state block device.
+// Called on the /state-on-restore path AFTER the placeholder /state drive has
+// been re-pointed to the Actor's per-identity image during the paused restore:
+// the template snapshot captured /state unmounted, so boxd mounts it now. boxd
+// is idempotent (already-mounted is success); a sandbox without /state never
+// hits this path.
+func postBoxdStateMount(ctx context.Context, vmIP string) error {
+	url := fmt.Sprintf("http://%s:%d/state/mount", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("create state-mount request: %w", err)
+	}
+	resp, err := boxdInitClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST /state/mount: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST /state/mount: status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -29,7 +29,10 @@ type Client interface {
 	// deltaDir are populated for overlay-mode templates, empty for legacy.
 	// For sandboxes with secrets the caller passes envVars=nil here and uses
 	// InjectSandboxEnv below once the source IP is known and a JWT is minted.
-	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	// stateDiskPath, when non-empty, is the Actor's per-identity durable /state
+	// image, re-pointed onto the template's placeholder /state drive during the
+	// paused restore. Empty for sandboxes without durable /state.
+	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string, stateDiskPath string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
 	// InjectSandboxEnv pushes env vars and the optional secrets JWT into a
 	// running sandbox's boxd. Idempotent.
 	InjectSandboxEnv(ctx context.Context, instanceID string, envVars map[string]string, secretsJWT string) error

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -337,6 +337,10 @@ message RestoreSnapshotRequest {
   // attribute exec/file activity without a database. Both may be empty.
   string team_id = 10;
   string owner_id = 11;
+  // Durable /state: the Actor's per-identity block image. When set, the
+  // template's placeholder /state drive is re-pointed onto it during the paused
+  // restore (load → patch-drive → resume). Empty for sandboxes without /state.
+  string state_disk_path = 12;
 }
 
 message RestoreSnapshotResponse {

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -1637,8 +1637,12 @@ type RestoreSnapshotRequest struct {
 	DeltaDir string `protobuf:"bytes,9,opt,name=delta_dir,json=deltaDir,proto3" json:"delta_dir,omitempty"`
 	// Owning team and creating user, carried so the data-plane proxy can
 	// attribute exec/file activity without a database. Both may be empty.
-	TeamId        string `protobuf:"bytes,10,opt,name=team_id,json=teamId,proto3" json:"team_id,omitempty"`
-	OwnerId       string `protobuf:"bytes,11,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`
+	TeamId  string `protobuf:"bytes,10,opt,name=team_id,json=teamId,proto3" json:"team_id,omitempty"`
+	OwnerId string `protobuf:"bytes,11,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`
+	// Durable /state: the Actor's per-identity block image. When set, the
+	// template's placeholder /state drive is re-pointed onto it during the paused
+	// restore (load → patch-drive → resume). Empty for sandboxes without /state.
+	StateDiskPath string `protobuf:"bytes,12,opt,name=state_disk_path,json=stateDiskPath,proto3" json:"state_disk_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1739,6 +1743,13 @@ func (x *RestoreSnapshotRequest) GetTeamId() string {
 func (x *RestoreSnapshotRequest) GetOwnerId() string {
 	if x != nil {
 		return x.OwnerId
+	}
+	return ""
+}
+
+func (x *RestoreSnapshotRequest) GetStateDiskPath() string {
+	if x != nil {
+		return x.StateDiskPath
 	}
 	return ""
 }
@@ -3102,7 +3113,7 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12&\n" +
-	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\x9c\x04\n" +
+	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xc4\x04\n" +
 	"\x16RestoreSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
@@ -3114,7 +3125,8 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\tdelta_dir\x18\t \x01(\tR\bdeltaDir\x12\x17\n" +
 	"\ateam_id\x18\n" +
 	" \x01(\tR\x06teamId\x12\x19\n" +
-	"\bowner_id\x18\v \x01(\tR\aownerId\x1a:\n" +
+	"\bowner_id\x18\v \x01(\tR\aownerId\x12&\n" +
+	"\x0fstate_disk_path\x18\f \x01(\tR\rstateDiskPath\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x04\x10\x05R\foverlay_path\"\xcc\x01\n" +


### PR DESCRIPTION
**Intention:** Prove the agent loop end-to-end against a real VM, and complete the per-Actor `/state`-on-restore vertical so durable state rides the fast template-restore path.

### What's here (Epic 5.x + 4.2)
- **Agent-loop e2e** against a real networked Firecracker microVM + real boxd (`Registry→Router→vmdwaker→boxddeliver→real boxd→Relay`), plus a permanent hermetic CI test and a host reproducer.
- **`/state`-on-restore vertical:** controlplane auto-provisions the per-Actor image (`Target.StateDiskPath`); vmd `RestoreSnapshot(state_disk_path)` re-points the template's `/state` placeholder to the Actor's image (`LoadSnapshot(paused)` → `PatchGuestDriveByID` → resume); vmd triggers boxd `POST /state/mount`. Template builds emit the placeholder drive (flag-gated); boxd boot-mount is opt-in.

### Technical decisions
- **Drive-repoint-on-restore** (not per-Actor cold boot) — validated on hardware that Firecracker allows re-pointing a drive after a paused `LoadSnapshot`, so per-Actor `/state` works on the fast restore path with no second boot.
- boxd defers its `/state` mount so the template snapshot captures `/state` unmounted (safe to repoint); vmd triggers the mount post-restore.

### Testing
Validated end-to-end on the staging host:
- Agent loop: 3 turns delivered to the in-guest harness and streamed back, sub-3ms/turn.
- Durable `/state` persists across turns in the live loop; `/state`-on-restore returns the repointed per-Actor data (`REPOINTED-OK`).
CI agent-loop test runs `-race` against a boxd-shaped server.

### Known gaps
- The template-BUILD→restore pipeline e2e rides the build infra (the consuming restore/mount side is proven). Flag-gated (`STATE_TEMPLATE_PLACEHOLDER`) off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)