### PR TITLE
phase 1 of user management

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -196,6 +196,18 @@ type ApiKey struct {
 	CreatedAt  time.Time          `json:"created_at"`
 }
 
+type AuditLog struct {
+	ID           int64       `json:"id"`
+	ActorUserID  pgtype.UUID `json:"actor_user_id"`
+	TargetUserID pgtype.UUID `json:"target_user_id"`
+	TeamID       pgtype.UUID `json:"team_id"`
+	EventType    string      `json:"event_type"`
+	OldValue     []byte      `json:"old_value"`
+	NewValue     []byte      `json:"new_value"`
+	Metadata     []byte      `json:"metadata"`
+	CreatedAt    time.Time   `json:"created_at"`
+}
+
 type BillingPeriodAnomaly struct {
 	ID          uuid.UUID          `json:"id"`
 	TeamID      uuid.UUID          `json:"team_id"`
@@ -301,6 +313,14 @@ type NetFlow struct {
 	DurationMs *int32     `json:"duration_ms"`
 }
 
+type Permission struct {
+	ID          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	Description *string   `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
 type PricingPlan struct {
 	Key       string    `json:"key"`
 	Name      string    `json:"name"`
@@ -370,6 +390,21 @@ type RevokedProxyToken struct {
 	ProxyToken string    `json:"proxy_token"`
 	RevokedAt  time.Time `json:"revoked_at"`
 	ExpiresAt  time.Time `json:"expires_at"`
+}
+
+type Role struct {
+	ID          uuid.UUID `json:"id"`
+	Name        string    `json:"name"`
+	ScopeType   string    `json:"scope_type"`
+	Description *string   `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type RolePermission struct {
+	RoleID       uuid.UUID `json:"role_id"`
+	PermissionID uuid.UUID `json:"permission_id"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 type Sandbox struct {
@@ -565,6 +600,15 @@ type TeamMember struct {
 	JoinedAt  time.Time `json:"joined_at"`
 }
 
+type TeamMembership struct {
+	ID        uuid.UUID `json:"id"`
+	TeamID    uuid.UUID `json:"team_id"`
+	UserID    uuid.UUID `json:"user_id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type TeamPricingPlan struct {
 	TeamID        uuid.UUID          `json:"team_id"`
 	PlanKey       string             `json:"plan_key"`
@@ -609,4 +653,17 @@ type TemplateBuild struct {
 	FinalizedAt   pgtype.Timestamptz  `json:"finalized_at"`
 	CreatedAt     time.Time           `json:"created_at"`
 	UpdatedAt     time.Time           `json:"updated_at"`
+}
+
+type UserRoleAssignment struct {
+	ID        uuid.UUID          `json:"id"`
+	UserID    uuid.UUID          `json:"user_id"`
+	RoleID    uuid.UUID          `json:"role_id"`
+	ScopeType string             `json:"scope_type"`
+	TeamID    pgtype.UUID        `json:"team_id"`
+	GrantedBy pgtype.UUID        `json:"granted_by"`
+	GrantedAt time.Time          `json:"granted_at"`
+	RevokedAt pgtype.Timestamptz `json:"revoked_at"`
+	CreatedAt time.Time          `json:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at"`
 }

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -489,6 +489,7 @@ func TestAuditLogAcceptsEvents(t *testing.T) {
 	}
 
 	var got struct {
+		ID        int64
 		ActorID   pgtype.UUID
 		TargetID  pgtype.UUID
 		TeamID    pgtype.UUID
@@ -498,12 +499,12 @@ func TestAuditLogAcceptsEvents(t *testing.T) {
 		Metadata  []byte
 	}
 	if err := testPool.QueryRow(ctx, `
-		SELECT actor_user_id, target_user_id, team_id, event_type, old_value, new_value, metadata
+		SELECT id, actor_user_id, target_user_id, team_id, event_type, old_value, new_value, metadata
 		FROM audit_logs
 		WHERE event_type = 'role_assigned'
 		ORDER BY created_at DESC
 		LIMIT 1
-	`).Scan(&got.ActorID, &got.TargetID, &got.TeamID, &got.EventType, &got.OldValue, &got.NewValue, &got.Metadata); err != nil {
+	`).Scan(&got.ID, &got.ActorID, &got.TargetID, &got.TeamID, &got.EventType, &got.OldValue, &got.NewValue, &got.Metadata); err != nil {
 		t.Fatalf("read audit log: %v", err)
 	}
 	if !got.ActorID.Valid || got.ActorID.Bytes != actorID {
@@ -517,6 +518,21 @@ func TestAuditLogAcceptsEvents(t *testing.T) {
 	}
 	if got.EventType != "role_assigned" {
 		t.Fatalf("event_type = %q, want role_assigned", got.EventType)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE audit_logs
+		SET event_type = 'tampered'
+		WHERE id = $1
+	`, got.ID); err == nil {
+		t.Fatal("expected audit log update to fail")
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		DELETE FROM audit_logs
+		WHERE id = $1
+	`, got.ID); err == nil {
+		t.Fatal("expected audit log delete to fail")
 	}
 }
 

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -206,14 +206,24 @@ func TestRbacAssignmentConstraints(t *testing.T) {
 		}
 	})
 
-	t.Run("user can have only one active membership", func(t *testing.T) {
+	t.Run("user can have active memberships in multiple teams", func(t *testing.T) {
 		otherTeamID := mustCreateTeam(t, ctx, "rbac-second-team-"+uuid.NewString()[:8])
 		_, err := testPool.Exec(ctx, `
 			INSERT INTO team_memberships (team_id, user_id, status)
 			VALUES ($1, $2, 'active')
 		`, otherTeamID, userID)
+		if err != nil {
+			t.Fatalf("insert second active membership: %v", err)
+		}
+	})
+
+	t.Run("duplicate active membership in same team is blocked", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO team_memberships (team_id, user_id, status)
+			VALUES ($1, $2, 'active')
+		`, teamID, userID)
 		if err == nil {
-			t.Fatal("expected second active membership for same user to fail")
+			t.Fatal("expected duplicate active membership for same team and user to fail")
 		}
 	})
 
@@ -437,6 +447,12 @@ func TestRbacBackfill(t *testing.T) {
 	seedLegacyMembership(t, ctx, ambiguousTeam, ambiguousA, "member")
 	seedLegacyMembership(t, ctx, ambiguousTeam, ambiguousB, "member")
 
+	multiTeamUser := seedRBACProfile(t)
+	multiTeamA := mustCreateTeam(t, ctx, "rbac-multi-user-a-"+uuid.NewString()[:8])
+	multiTeamB := mustCreateTeam(t, ctx, "rbac-multi-user-b-"+uuid.NewString()[:8])
+	seedLegacyMembership(t, ctx, multiTeamA, multiTeamUser, "member")
+	seedLegacyMembership(t, ctx, multiTeamB, multiTeamUser, "member")
+
 	runRBACBackfill(t, ctx)
 
 	assertActiveMembership(t, ctx, oneUserTeam, oneUser)
@@ -449,6 +465,11 @@ func TestRbacBackfill(t *testing.T) {
 	assertActiveMembership(t, ctx, ambiguousTeam, ambiguousB)
 	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousA, "viewer")
 	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousB, "viewer")
+
+	assertActiveMembership(t, ctx, multiTeamA, multiTeamUser)
+	assertActiveMembership(t, ctx, multiTeamB, multiTeamUser)
+	assertRoleAssignment(t, ctx, multiTeamA, multiTeamUser, "viewer")
+	assertRoleAssignment(t, ctx, multiTeamB, multiTeamUser, "viewer")
 }
 
 func TestAuditLogAcceptsEvents(t *testing.T) {

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -468,8 +468,8 @@ func TestRbacBackfill(t *testing.T) {
 
 	assertActiveMembership(t, ctx, multiTeamA, multiTeamUser)
 	assertActiveMembership(t, ctx, multiTeamB, multiTeamUser)
-	assertRoleAssignment(t, ctx, multiTeamA, multiTeamUser, "viewer")
-	assertRoleAssignment(t, ctx, multiTeamB, multiTeamUser, "viewer")
+	assertRoleAssignment(t, ctx, multiTeamA, multiTeamUser, "team_owner")
+	assertRoleAssignment(t, ctx, multiTeamB, multiTeamUser, "team_owner")
 }
 
 func TestAuditLogAcceptsEvents(t *testing.T) {

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -463,8 +463,7 @@ func TestRbacBackfill(t *testing.T) {
 
 	assertActiveMembership(t, ctx, ambiguousTeam, ambiguousA)
 	assertActiveMembership(t, ctx, ambiguousTeam, ambiguousB)
-	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousA, "viewer")
-	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousB, "viewer")
+	assertActiveOwnerCount(t, ctx, ambiguousTeam, 1)
 
 	assertActiveMembership(t, ctx, multiTeamA, multiTeamUser)
 	assertActiveMembership(t, ctx, multiTeamB, multiTeamUser)
@@ -653,26 +652,19 @@ func runRBACBackfill(t *testing.T, ctx context.Context) {
 			  AND m.status = 'active'
 		);
 
-		WITH team_sizes AS (
-			SELECT team_id, COUNT(*)::int AS member_count
-			FROM team_memberships
-			WHERE status = 'active'
-			GROUP BY team_id
-		),
-		legacy_memberships AS (
+		WITH legacy_memberships AS (
 			SELECT
-				m.team_id,
-				m.user_id,
-				m.created_at,
+				tm.team_id,
+				tm.profile_id AS user_id,
+				COALESCE(tm.joined_at, now()) AS created_at,
 				LOWER(COALESCE(tm.role, '')) AS legacy_role,
-				ts.member_count
-			FROM team_memberships m
-			JOIN team_sizes ts
-			  ON ts.team_id = m.team_id
-			LEFT JOIN team_member tm
-			  ON tm.team_id = m.team_id
-			 AND tm.profile_id = m.user_id
-			WHERE m.status = 'active'
+				BOOL_OR(LOWER(COALESCE(tm.role, '')) IN ('owner', 'team_owner'))
+					OVER (PARTITION BY tm.team_id) AS has_explicit_owner,
+				ROW_NUMBER() OVER (
+					PARTITION BY tm.team_id
+					ORDER BY COALESCE(tm.joined_at, 'infinity'::timestamptz), tm.profile_id
+				) AS owner_rank
+			FROM team_member tm
 		)
 		INSERT INTO user_role_assignments (
 			user_id, role_id, scope_type, team_id,
@@ -692,8 +684,8 @@ func runRBACBackfill(t *testing.T, ctx context.Context) {
 		JOIN roles r
 		  ON r.scope_type = 'team'
 		 AND r.name = CASE
-			WHEN lm.member_count = 1 THEN 'team_owner'
 			WHEN lm.legacy_role IN ('owner', 'team_owner') THEN 'team_owner'
+			WHEN NOT lm.has_explicit_owner AND lm.owner_rank = 1 THEN 'team_owner'
 			WHEN lm.legacy_role IN ('admin', 'team_admin') THEN 'team_admin'
 			ELSE 'viewer'
 		 END
@@ -726,6 +718,25 @@ func assertActiveMembership(t *testing.T, ctx context.Context, teamID, userID uu
 	}
 	if status != "active" {
 		t.Fatalf("membership status = %q, want active", status)
+	}
+}
+
+func assertActiveOwnerCount(t *testing.T, ctx context.Context, teamID uuid.UUID, want int) {
+	t.Helper()
+	var got int
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*)::int
+		FROM user_role_assignments a
+		JOIN roles r ON r.id = a.role_id
+		WHERE a.team_id = $1
+		  AND a.scope_type = 'team'
+		  AND a.revoked_at IS NULL
+		  AND r.name = 'team_owner'
+	`, teamID).Scan(&got); err != nil {
+		t.Fatalf("count active owners: %v", err)
+	}
+	if got != want {
+		t.Fatalf("active owner count = %d, want %d", got, want)
 	}
 }
 

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -1,0 +1,725 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestRbacSeedData(t *testing.T) {
+	ctx := context.Background()
+
+	wantRoles := map[string]string{
+		"platform_admin": "platform",
+		"team_owner":     "team",
+		"team_admin":     "team",
+		"billing_admin":  "team",
+		"user_admin":     "team",
+		"viewer":         "team",
+	}
+	gotRoles := make(map[string]string)
+	rows, err := testPool.Query(ctx, `SELECT name, scope_type FROM roles ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query roles: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, scope string
+		if err := rows.Scan(&name, &scope); err != nil {
+			t.Fatalf("scan role: %v", err)
+		}
+		gotRoles[name] = scope
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("roles rows: %v", err)
+	}
+	if len(gotRoles) != len(wantRoles) {
+		t.Fatalf("roles count = %d, want %d", len(gotRoles), len(wantRoles))
+	}
+	for name, wantScope := range wantRoles {
+		if gotRoles[name] != wantScope {
+			t.Fatalf("role %s scope = %q, want %q", name, gotRoles[name], wantScope)
+		}
+	}
+
+	wantPerms := []string{
+		"billing:read",
+		"billing:write",
+		"users:read",
+		"users:write",
+		"roles:read",
+		"roles:write",
+		"settings:read",
+		"settings:write",
+		"audit_logs:read",
+		"platform:teams:read",
+		"platform:team_users:write",
+		"platform:team_roles:write",
+		"platform:billing:write",
+	}
+	var gotPerms []string
+	rows, err = testPool.Query(ctx, `SELECT name FROM permissions ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query permissions: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan permission: %v", err)
+		}
+		gotPerms = append(gotPerms, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("permissions rows: %v", err)
+	}
+	if len(gotPerms) != len(wantPerms) {
+		t.Fatalf("permissions count = %d, want %d", len(gotPerms), len(wantPerms))
+	}
+	sort.Strings(gotPerms)
+	sort.Strings(wantPerms)
+	for i := range wantPerms {
+		if gotPerms[i] != wantPerms[i] {
+			t.Fatalf("permission[%d] = %q, want %q", i, gotPerms[i], wantPerms[i])
+		}
+	}
+
+	expectedMappings := map[string][]string{
+		"platform_admin": {
+			"platform:teams:read",
+			"platform:team_users:write",
+			"platform:team_roles:write",
+			"platform:billing:write",
+			"billing:read",
+			"billing:write",
+			"users:read",
+			"users:write",
+			"roles:read",
+			"roles:write",
+			"settings:read",
+			"settings:write",
+			"audit_logs:read",
+		},
+		"team_owner": {
+			"billing:read",
+			"billing:write",
+			"users:read",
+			"users:write",
+			"roles:read",
+			"roles:write",
+			"settings:read",
+			"settings:write",
+			"audit_logs:read",
+		},
+		"team_admin": {
+			"users:read",
+			"users:write",
+			"roles:read",
+			"settings:read",
+			"settings:write",
+			"billing:read",
+		},
+		"billing_admin": {
+			"billing:read",
+			"billing:write",
+		},
+		"user_admin": {
+			"users:read",
+			"users:write",
+			"roles:read",
+		},
+		"viewer": {
+			"billing:read",
+			"users:read",
+			"settings:read",
+		},
+	}
+	for roleName, want := range expectedMappings {
+		got, err := rolePermissionsFor(t, ctx, roleName)
+		if err != nil {
+			t.Fatalf("role permissions for %s: %v", roleName, err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("role %s mapping count = %d, want %d", roleName, len(got), len(want))
+		}
+		sort.Strings(got)
+		sort.Strings(want)
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("role %s permission[%d] = %q, want %q", roleName, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestRbacAssignmentConstraints(t *testing.T) {
+	ctx := context.Background()
+	teamID, userID := seedRBACUser(t)
+	platformRoleID := mustRoleID(t, ctx, "platform_admin")
+	teamOwnerRoleID := mustRoleID(t, ctx, "team_owner")
+
+	t.Run("platform role rejects team_id", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'platform', $3)
+		`, userID, platformRoleID, teamID)
+		if err == nil {
+			t.Fatal("expected platform assignment with team_id to fail")
+		}
+	})
+
+	t.Run("platform role cannot be assigned in team scope", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', $3)
+		`, userID, platformRoleID, teamID)
+		if err == nil {
+			t.Fatal("expected platform role in team scope to fail")
+		}
+	})
+
+	t.Run("team role cannot be assigned in platform scope", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'platform', NULL)
+		`, userID, teamOwnerRoleID)
+		if err == nil {
+			t.Fatal("expected team role in platform scope to fail")
+		}
+	})
+
+	t.Run("team role requires team_id", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', NULL)
+		`, userID, teamOwnerRoleID)
+		if err == nil {
+			t.Fatal("expected team assignment without team_id to fail")
+		}
+	})
+
+	t.Run("user can have only one active membership", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-second-team-"+uuid.NewString()[:8])
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO team_memberships (team_id, user_id, status)
+			VALUES ($1, $2, 'active')
+		`, otherTeamID, userID)
+		if err == nil {
+			t.Fatal("expected second active membership for same user to fail")
+		}
+	})
+
+	t.Run("active team assignment requires active membership", func(t *testing.T) {
+		otherUser := seedRBACProfile(t)
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', $3)
+		`, otherUser, teamOwnerRoleID, teamID)
+		if err == nil {
+			t.Fatal("expected team role assignment without active membership to fail")
+		}
+	})
+
+	t.Run("duplicate platform assignment is blocked", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'platform', NULL)
+		`, userID, platformRoleID)
+		if err != nil {
+			t.Fatalf("insert active platform assignment: %v", err)
+		}
+		_, err = testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'platform', NULL)
+		`, userID, platformRoleID)
+		if err == nil {
+			t.Fatal("expected duplicate active platform assignment to fail")
+		}
+	})
+
+	t.Run("duplicate active assignment is blocked", func(t *testing.T) {
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', $3)
+		`, userID, teamOwnerRoleID, teamID)
+		if err != nil {
+			t.Fatalf("insert active assignment: %v", err)
+		}
+		_, err = testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', $3)
+		`, userID, teamOwnerRoleID, teamID)
+		if err == nil {
+			t.Fatal("expected duplicate active assignment to fail")
+		}
+	})
+
+	t.Run("revoked assignment does not block new active row", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-regrant-"+uuid.NewString()[:8])
+		otherUser := seedRBACProfile(t)
+		seedMembership(t, ctx, otherTeamID, otherUser)
+		otherRoleID := mustRoleID(t, ctx, "team_admin")
+		_, err := testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (
+				user_id, role_id, scope_type, team_id, revoked_at
+			)
+			VALUES ($1, $2, 'team', $3, now())
+		`, otherUser, otherRoleID, otherTeamID)
+		if err != nil {
+			t.Fatalf("insert revoked assignment: %v", err)
+		}
+		_, err = testPool.Exec(ctx, `
+			INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+			VALUES ($1, $2, 'team', $3)
+		`, otherUser, otherRoleID, otherTeamID)
+		if err != nil {
+			t.Fatalf("insert active assignment after revoked history: %v", err)
+		}
+	})
+
+	t.Run("membership deactivation revokes team assignments", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-deactivate-"+uuid.NewString()[:8])
+		otherUser := seedRBACProfile(t)
+		seedMembership(t, ctx, otherTeamID, otherUser)
+		seedTeamRoleAssignment(t, ctx, otherUser, teamOwnerRoleID, otherTeamID)
+
+		if _, err := testPool.Exec(ctx, `
+			UPDATE team_memberships
+			SET status = 'inactive'
+			WHERE team_id = $1 AND user_id = $2
+		`, otherTeamID, otherUser); err != nil {
+			t.Fatalf("deactivate membership: %v", err)
+		}
+
+		var revokedAt pgtype.Timestamptz
+		if err := testPool.QueryRow(ctx, `
+			SELECT revoked_at
+			FROM user_role_assignments
+			WHERE team_id = $1 AND user_id = $2 AND role_id = $3
+		`, otherTeamID, otherUser, teamOwnerRoleID).Scan(&revokedAt); err != nil {
+			t.Fatalf("read revoked assignment: %v", err)
+		}
+		if !revokedAt.Valid {
+			t.Fatal("expected role assignment to be revoked")
+		}
+	})
+
+	t.Run("membership delete revokes team assignments", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-delete-membership-"+uuid.NewString()[:8])
+		otherUser := seedRBACProfile(t)
+		seedMembership(t, ctx, otherTeamID, otherUser)
+		seedTeamRoleAssignment(t, ctx, otherUser, teamOwnerRoleID, otherTeamID)
+
+		if _, err := testPool.Exec(ctx, `
+			DELETE FROM team_memberships
+			WHERE team_id = $1 AND user_id = $2
+		`, otherTeamID, otherUser); err != nil {
+			t.Fatalf("delete membership: %v", err)
+		}
+
+		var revokedAt pgtype.Timestamptz
+		if err := testPool.QueryRow(ctx, `
+			SELECT revoked_at
+			FROM user_role_assignments
+			WHERE team_id = $1 AND user_id = $2 AND role_id = $3
+		`, otherTeamID, otherUser, teamOwnerRoleID).Scan(&revokedAt); err != nil {
+			t.Fatalf("read revoked assignment: %v", err)
+		}
+		if !revokedAt.Valid {
+			t.Fatal("expected role assignment to be revoked after membership delete")
+		}
+	})
+
+	t.Run("membership identity updates are rejected", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-update-membership-"+uuid.NewString()[:8])
+		otherUser := seedRBACProfile(t)
+		seedMembership(t, ctx, otherTeamID, otherUser)
+
+		newTeamID := mustCreateTeam(t, ctx, "rbac-update-membership-target-"+uuid.NewString()[:8])
+		_, err := testPool.Exec(ctx, `
+			UPDATE team_memberships
+			SET team_id = $1
+			WHERE team_id = $2 AND user_id = $3
+		`, newTeamID, otherTeamID, otherUser)
+		if err == nil {
+			t.Fatal("expected membership team_id update to fail")
+		}
+
+		replacementUser := seedRBACProfile(t)
+		_, err = testPool.Exec(ctx, `
+			UPDATE team_memberships
+			SET user_id = $1
+			WHERE team_id = $2 AND user_id = $3
+		`, replacementUser, otherTeamID, otherUser)
+		if err == nil {
+			t.Fatal("expected membership user_id update to fail")
+		}
+	})
+}
+
+func TestRbacDeleteSemantics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("profile delete blocked by membership", func(t *testing.T) {
+		teamID := mustCreateTeam(t, ctx, "rbac-del-mem-"+uuid.NewString()[:8])
+		userID := seedRBACProfile(t)
+		seedMembership(t, ctx, teamID, userID)
+
+		_, err := testPool.Exec(ctx, `DELETE FROM profile WHERE id = $1`, userID)
+		assertFKViolation(t, err)
+	})
+
+	t.Run("team delete blocked by membership", func(t *testing.T) {
+		teamID := mustCreateTeam(t, ctx, "rbac-del-team-mem-"+uuid.NewString()[:8])
+		userID := seedRBACProfile(t)
+		seedMembership(t, ctx, teamID, userID)
+
+		_, err := testPool.Exec(ctx, `DELETE FROM team WHERE id = $1`, teamID)
+		assertFKViolation(t, err)
+	})
+
+	t.Run("profile delete blocked by role assignment", func(t *testing.T) {
+		teamID := mustCreateTeam(t, ctx, "rbac-del-role-"+uuid.NewString()[:8])
+		userID := seedRBACProfile(t)
+		seedMembership(t, ctx, teamID, userID)
+		roleID := mustRoleID(t, ctx, "team_owner")
+		seedTeamRoleAssignment(t, ctx, userID, roleID, teamID)
+
+		_, err := testPool.Exec(ctx, `DELETE FROM profile WHERE id = $1`, userID)
+		assertFKViolation(t, err)
+	})
+
+	t.Run("team delete blocked by role assignment", func(t *testing.T) {
+		teamID := mustCreateTeam(t, ctx, "rbac-del-team-role-"+uuid.NewString()[:8])
+		userID := seedRBACProfile(t)
+		seedMembership(t, ctx, teamID, userID)
+		roleID := mustRoleID(t, ctx, "team_owner")
+		seedTeamRoleAssignment(t, ctx, userID, roleID, teamID)
+
+		_, err := testPool.Exec(ctx, `DELETE FROM team WHERE id = $1`, teamID)
+		assertFKViolation(t, err)
+	})
+
+	t.Run("role delete blocked by role assignment history", func(t *testing.T) {
+		teamID := mustCreateTeam(t, ctx, "rbac-del-role-history-"+uuid.NewString()[:8])
+		userID := seedRBACProfile(t)
+		seedMembership(t, ctx, teamID, userID)
+		roleID := mustRoleID(t, ctx, "viewer")
+		seedTeamRoleAssignment(t, ctx, userID, roleID, teamID)
+
+		_, err := testPool.Exec(ctx, `DELETE FROM roles WHERE id = $1`, roleID)
+		assertFKViolation(t, err)
+	})
+}
+
+func TestRbacBackfill(t *testing.T) {
+	ctx := context.Background()
+
+	oneUserTeam := mustCreateTeam(t, ctx, "rbac-single-"+uuid.NewString()[:8])
+	oneUser := seedRBACProfile(t)
+	seedLegacyMembership(t, ctx, oneUserTeam, oneUser, "member")
+
+	soleAdminTeam := mustCreateTeam(t, ctx, "rbac-sole-admin-"+uuid.NewString()[:8])
+	soleAdmin := seedRBACProfile(t)
+	seedLegacyMembership(t, ctx, soleAdminTeam, soleAdmin, "admin")
+
+	ambiguousTeam := mustCreateTeam(t, ctx, "rbac-multi-"+uuid.NewString()[:8])
+	ambiguousA := seedRBACProfile(t)
+	ambiguousB := seedRBACProfile(t)
+	seedLegacyMembership(t, ctx, ambiguousTeam, ambiguousA, "member")
+	seedLegacyMembership(t, ctx, ambiguousTeam, ambiguousB, "member")
+
+	runRBACBackfill(t, ctx)
+
+	assertActiveMembership(t, ctx, oneUserTeam, oneUser)
+	assertRoleAssignment(t, ctx, oneUserTeam, oneUser, "team_owner")
+
+	assertActiveMembership(t, ctx, soleAdminTeam, soleAdmin)
+	assertRoleAssignment(t, ctx, soleAdminTeam, soleAdmin, "team_owner")
+
+	assertActiveMembership(t, ctx, ambiguousTeam, ambiguousA)
+	assertActiveMembership(t, ctx, ambiguousTeam, ambiguousB)
+	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousA, "viewer")
+	assertRoleAssignment(t, ctx, ambiguousTeam, ambiguousB, "viewer")
+}
+
+func TestAuditLogAcceptsEvents(t *testing.T) {
+	ctx := context.Background()
+	teamID := uuid.New()
+	actorID := seedRBACProfile(t)
+	targetID := seedRBACProfile(t)
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO audit_logs (
+			actor_user_id, target_user_id, team_id, event_type,
+			old_value, new_value, metadata
+		)
+		VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb)
+	`, actorID, targetID, teamID, "role_assigned", `{"role":"viewer"}`, `{"role":"team_owner"}`, `{"source":"test"}`); err != nil {
+		t.Fatalf("insert audit log: %v", err)
+	}
+
+	var got struct {
+		ActorID   pgtype.UUID
+		TargetID  pgtype.UUID
+		TeamID    pgtype.UUID
+		EventType string
+		OldValue  []byte
+		NewValue  []byte
+		Metadata  []byte
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT actor_user_id, target_user_id, team_id, event_type, old_value, new_value, metadata
+		FROM audit_logs
+		WHERE event_type = 'role_assigned'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`).Scan(&got.ActorID, &got.TargetID, &got.TeamID, &got.EventType, &got.OldValue, &got.NewValue, &got.Metadata); err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if !got.ActorID.Valid || got.ActorID.Bytes != actorID {
+		t.Fatalf("actor_user_id = %v, want %v", got.ActorID, actorID)
+	}
+	if !got.TargetID.Valid || got.TargetID.Bytes != targetID {
+		t.Fatalf("target_user_id = %v, want %v", got.TargetID, targetID)
+	}
+	if !got.TeamID.Valid || got.TeamID.Bytes != teamID {
+		t.Fatalf("team_id = %v, want %v", got.TeamID, teamID)
+	}
+	if got.EventType != "role_assigned" {
+		t.Fatalf("event_type = %q, want role_assigned", got.EventType)
+	}
+}
+
+func rolePermissionsFor(t *testing.T, ctx context.Context, roleName string) ([]string, error) {
+	t.Helper()
+	rows, err := testPool.Query(ctx, `
+		SELECT p.name
+		FROM role_permissions rp
+		JOIN roles r ON r.id = rp.role_id
+		JOIN permissions p ON p.id = rp.permission_id
+		WHERE r.name = $1
+		ORDER BY p.name
+	`, roleName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		got = append(got, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return got, nil
+}
+
+func mustRoleID(t *testing.T, ctx context.Context, roleName string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := testPool.QueryRow(ctx, `SELECT id FROM roles WHERE name = $1`, roleName).Scan(&id); err != nil {
+		t.Fatalf("lookup role %s: %v", roleName, err)
+	}
+	return id
+}
+
+func mustCreateTeam(t *testing.T, ctx context.Context, name string) uuid.UUID {
+	t.Helper()
+	team, err := testQueries.CreateTeam(ctx, name)
+	if err != nil {
+		t.Fatalf("create team %s: %v", name, err)
+	}
+	return team.ID
+}
+
+func seedRBACProfile(t *testing.T) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	id := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO profile (id, email)
+		VALUES ($1, $2)
+	`, id, fmt.Sprintf("user-%s@example.com", id.String()[:8])); err != nil {
+		t.Fatalf("insert profile: %v", err)
+	}
+	return id
+}
+
+func seedRBACUser(t *testing.T) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	teamID := mustCreateTeam(t, ctx, "rbac-constraints-"+uuid.NewString()[:8])
+	userID := seedRBACProfile(t)
+	seedMembership(t, ctx, teamID, userID)
+	return teamID, userID
+}
+
+func seedLegacyMembership(t *testing.T, ctx context.Context, teamID, userID uuid.UUID, role string) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_member (team_id, profile_id, role)
+		VALUES ($1, $2, $3)
+	`, teamID, userID, role); err != nil {
+		t.Fatalf("insert legacy team_member: %v", err)
+	}
+}
+
+func seedMembership(t *testing.T, ctx context.Context, teamID, userID uuid.UUID) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_memberships (team_id, user_id, status)
+		VALUES ($1, $2, 'active')
+	`, teamID, userID); err != nil {
+		t.Fatalf("insert team_memberships: %v", err)
+	}
+}
+
+func seedTeamRoleAssignment(t *testing.T, ctx context.Context, userID, roleID, teamID uuid.UUID) {
+	t.Helper()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id)
+		VALUES ($1, $2, 'team', $3)
+	`, userID, roleID, teamID); err != nil {
+		t.Fatalf("insert user_role_assignments: %v", err)
+	}
+}
+
+func runRBACBackfill(t *testing.T, ctx context.Context) {
+	t.Helper()
+	_, err := testPool.Exec(ctx, `
+		INSERT INTO team_memberships (team_id, user_id, status, created_at, updated_at)
+		SELECT
+			tm.team_id,
+			tm.profile_id,
+			'active',
+			COALESCE(tm.joined_at, now()),
+			COALESCE(tm.joined_at, now())
+		FROM team_member tm
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM team_memberships m
+			WHERE m.team_id = tm.team_id
+			  AND m.user_id = tm.profile_id
+			  AND m.status = 'active'
+		);
+
+		WITH team_sizes AS (
+			SELECT team_id, COUNT(*)::int AS member_count
+			FROM team_memberships
+			WHERE status = 'active'
+			GROUP BY team_id
+		),
+		legacy_memberships AS (
+			SELECT
+				m.team_id,
+				m.user_id,
+				m.created_at,
+				LOWER(COALESCE(tm.role, '')) AS legacy_role,
+				ts.member_count
+			FROM team_memberships m
+			JOIN team_sizes ts
+			  ON ts.team_id = m.team_id
+			LEFT JOIN team_member tm
+			  ON tm.team_id = m.team_id
+			 AND tm.profile_id = m.user_id
+			WHERE m.status = 'active'
+		)
+		INSERT INTO user_role_assignments (
+			user_id, role_id, scope_type, team_id,
+			granted_by, granted_at, revoked_at, created_at, updated_at
+		)
+		SELECT
+			lm.user_id,
+			r.id,
+			'team',
+			lm.team_id,
+			NULL,
+			lm.created_at,
+			NULL,
+			lm.created_at,
+			lm.created_at
+		FROM legacy_memberships lm
+		JOIN roles r
+		  ON r.scope_type = 'team'
+		 AND r.name = CASE
+			WHEN lm.member_count = 1 THEN 'team_owner'
+			WHEN lm.legacy_role IN ('owner', 'team_owner') THEN 'team_owner'
+			WHEN lm.legacy_role IN ('admin', 'team_admin') THEN 'team_admin'
+			ELSE 'viewer'
+		 END
+		WHERE NOT EXISTS (
+			SELECT 1
+			FROM user_role_assignments a
+			WHERE a.user_id = lm.user_id
+			  AND a.role_id = r.id
+			  AND a.scope_type = 'team'
+			  AND a.team_id = lm.team_id
+			  AND a.revoked_at IS NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("run backfill: %v", err)
+	}
+}
+
+func assertActiveMembership(t *testing.T, ctx context.Context, teamID, userID uuid.UUID) {
+	t.Helper()
+	var status string
+	if err := testPool.QueryRow(ctx, `
+		SELECT status
+		FROM team_memberships
+		WHERE team_id = $1 AND user_id = $2
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, teamID, userID).Scan(&status); err != nil {
+		t.Fatalf("read membership: %v", err)
+	}
+	if status != "active" {
+		t.Fatalf("membership status = %q, want active", status)
+	}
+}
+
+func assertRoleAssignment(t *testing.T, ctx context.Context, teamID, userID uuid.UUID, roleName string) {
+	t.Helper()
+	var got string
+	if err := testPool.QueryRow(ctx, `
+		SELECT r.name
+		FROM user_role_assignments a
+		JOIN roles r ON r.id = a.role_id
+		WHERE a.team_id = $1
+		  AND a.user_id = $2
+		  AND a.scope_type = 'team'
+		  AND a.revoked_at IS NULL
+		ORDER BY a.created_at DESC
+		LIMIT 1
+	`, teamID, userID).Scan(&got); err != nil {
+		t.Fatalf("read assignment: %v", err)
+	}
+	if got != roleName {
+		t.Fatalf("role assignment = %q, want %q", got, roleName)
+	}
+}
+
+func assertFKViolation(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected delete to be blocked by foreign key")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23503" {
+		t.Fatalf("expected foreign key violation 23503, got %v", err)
+	}
+}

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -322,6 +322,33 @@ func TestRbacAssignmentConstraints(t *testing.T) {
 		}
 	})
 
+	t.Run("membership invited transition revokes team assignments", func(t *testing.T) {
+		otherTeamID := mustCreateTeam(t, ctx, "rbac-invite-transition-"+uuid.NewString()[:8])
+		otherUser := seedRBACProfile(t)
+		seedMembership(t, ctx, otherTeamID, otherUser)
+		seedTeamRoleAssignment(t, ctx, otherUser, teamOwnerRoleID, otherTeamID)
+
+		if _, err := testPool.Exec(ctx, `
+			UPDATE team_memberships
+			SET status = 'invited'
+			WHERE team_id = $1 AND user_id = $2
+		`, otherTeamID, otherUser); err != nil {
+			t.Fatalf("move membership to invited: %v", err)
+		}
+
+		var revokedAt pgtype.Timestamptz
+		if err := testPool.QueryRow(ctx, `
+			SELECT revoked_at
+			FROM user_role_assignments
+			WHERE team_id = $1 AND user_id = $2 AND role_id = $3
+		`, otherTeamID, otherUser, teamOwnerRoleID).Scan(&revokedAt); err != nil {
+			t.Fatalf("read revoked assignment: %v", err)
+		}
+		if !revokedAt.Valid {
+			t.Fatal("expected role assignment to be revoked after membership moved to invited")
+		}
+	})
+
 	t.Run("membership delete revokes team assignments", func(t *testing.T) {
 		otherTeamID := mustCreateTeam(t, ctx, "rbac-delete-membership-"+uuid.NewString()[:8])
 		otherUser := seedRBACProfile(t)

--- a/rbac_phase_1.md
+++ b/rbac_phase_1.md
@@ -41,7 +41,7 @@
 - Legacy users may appear in multiple teams, and the migration preserves every membership row.
 - Existing single-user teams are granted `team_owner`.
 - If a legacy row explicitly looks like an owner/admin, that legacy hint is used after the single-member owner case.
-- If a team has multiple members and there is no stronger hint, the fallback role is `viewer`.
+- If a team has multiple members and no explicit owner hint, the earliest legacy member by `joined_at` and profile ID is granted `team_owner`; remaining members fall back to `viewer` unless their legacy role maps to `team_admin`.
 - Platform admin is never auto-granted.
 - The orphan check is scoped to profiles represented in legacy `team_member`; profiles without a legacy membership are left for a later explicit user-state cleanup.
 
@@ -55,7 +55,7 @@
 ## Ambiguity
 
 - If a team has multiple members and no legacy owner/admin hint, ownership is ambiguous.
-- In that case the migration uses `viewer` rather than guessing an owner.
+- In that case the migration chooses a deterministic fallback owner using earliest `joined_at`, then profile ID.
 
 ## Team Model
 

--- a/rbac_phase_1.md
+++ b/rbac_phase_1.md
@@ -3,6 +3,7 @@
 ## Schema Added
 
 - `team_memberships` to track active/inactive/invited membership state per user and team.
+- Users may belong to multiple teams.
 - `roles` with a `scope_type` of `platform` or `team`.
 - `permissions` as a global permission catalog.
 - `role_permissions` as the join table between roles and permissions.
@@ -37,7 +38,7 @@
 ## Backfill Behavior
 
 - Legacy `team_member` rows are copied into `team_memberships` as active memberships.
-- The migration refuses to guess when a legacy user belongs to multiple teams; this must be cleaned up before applying the migration.
+- Legacy users may appear in multiple teams, and the migration preserves every membership row.
 - Existing single-user teams are granted `team_owner`.
 - If a legacy row explicitly looks like an owner/admin, that legacy hint is used after the single-member owner case.
 - If a team has multiple members and there is no stronger hint, the fallback role is `viewer`.
@@ -47,7 +48,7 @@
 ## Assumptions
 
 - Existing user-to-team relationships that should be active are represented in `team_member`.
-- The product enforces one active team membership per user; the new schema enforces this with a partial unique index.
+- The schema allows a user to hold active memberships in multiple teams.
 - The new RBAC tables are internal and will be accessed by the service role in later phases.
 - RLS is intentionally fail-closed in this migration. Customer-facing policies are deferred until the application has explicit RBAC-aware access paths.
 
@@ -55,7 +56,13 @@
 
 - If a team has multiple members and no legacy owner/admin hint, ownership is ambiguous.
 - In that case the migration uses `viewer` rather than guessing an owner.
-- If a user belongs to multiple legacy teams, the migration raises instead of choosing one.
+
+## Team Model
+
+- New signup may create a personal/default team.
+- Joining another team should not delete or inactivate the personal team.
+- Resources remain scoped to the team where they were created.
+- Future UI/session work needs explicit team selection and current-team handling.
 
 ## Manual Platform Admin Bootstrap
 

--- a/rbac_phase_1.md
+++ b/rbac_phase_1.md
@@ -8,7 +8,7 @@
 - `permissions` as a global permission catalog.
 - `role_permissions` as the join table between roles and permissions.
 - `user_role_assignments` for scoped role grants with explicit platform/team scope.
-- `audit_logs` as an append-only event log foundation.
+- `audit_logs` as an append-only event log foundation with database-level UPDATE/DELETE protection.
 
 ## Seed Data Added
 

--- a/rbac_phase_1.md
+++ b/rbac_phase_1.md
@@ -1,0 +1,84 @@
+# RBAC Phase 1 Notes
+
+## Schema Added
+
+- `team_memberships` to track active/inactive/invited membership state per user and team.
+- `roles` with a `scope_type` of `platform` or `team`.
+- `permissions` as a global permission catalog.
+- `role_permissions` as the join table between roles and permissions.
+- `user_role_assignments` for scoped role grants with explicit platform/team scope.
+- `audit_logs` as an append-only event log foundation.
+
+## Seed Data Added
+
+- Roles:
+  - `platform_admin`
+  - `team_owner`
+  - `team_admin`
+  - `billing_admin`
+  - `user_admin`
+  - `viewer`
+- Permissions:
+  - `billing:read`
+  - `billing:write`
+  - `users:read`
+  - `users:write`
+  - `roles:read`
+  - `roles:write`
+  - `settings:read`
+  - `settings:write`
+  - `audit_logs:read`
+  - `platform:teams:read`
+  - `platform:team_users:write`
+  - `platform:team_roles:write`
+  - `platform:billing:write`
+- Role-to-permission mappings follow the phase-1 brief.
+
+## Backfill Behavior
+
+- Legacy `team_member` rows are copied into `team_memberships` as active memberships.
+- The migration refuses to guess when a legacy user belongs to multiple teams; this must be cleaned up before applying the migration.
+- Existing single-user teams are granted `team_owner`.
+- If a legacy row explicitly looks like an owner/admin, that legacy hint is used after the single-member owner case.
+- If a team has multiple members and there is no stronger hint, the fallback role is `viewer`.
+- Platform admin is never auto-granted.
+- The orphan check is scoped to profiles represented in legacy `team_member`; profiles without a legacy membership are left for a later explicit user-state cleanup.
+
+## Assumptions
+
+- Existing user-to-team relationships that should be active are represented in `team_member`.
+- The product enforces one active team membership per user; the new schema enforces this with a partial unique index.
+- The new RBAC tables are internal and will be accessed by the service role in later phases.
+- RLS is intentionally fail-closed in this migration. Customer-facing policies are deferred until the application has explicit RBAC-aware access paths.
+
+## Ambiguity
+
+- If a team has multiple members and no legacy owner/admin hint, ownership is ambiguous.
+- In that case the migration uses `viewer` rather than guessing an owner.
+- If a user belongs to multiple legacy teams, the migration raises instead of choosing one.
+
+## Manual Platform Admin Bootstrap
+
+Run a one-time SQL grant after choosing the user:
+
+```sql
+INSERT INTO user_role_assignments (user_id, role_id, scope_type, granted_by)
+SELECT $USER_ID, r.id, 'platform', NULL
+FROM roles r
+WHERE r.name = 'platform_admin';
+```
+
+## Delete Semantics
+
+RBAC tables intentionally use `NO ACTION` foreign keys for `profile`, `team`, and role assignment references. Normal lifecycle should use team/member inactive states and role revocation rather than hard deletes. This preserves membership, role, and audit context.
+
+If a service-role path hard-deletes a membership row, the database revokes that user's active team-scoped role assignments for the deleted membership. Membership `team_id` and `user_id` are immutable; moving a user requires creating a new membership rather than rewriting the old row.
+
+## Phase 2 Leftovers
+
+- Authorization helpers.
+- Endpoint/middleware enforcement.
+- UI for customer role management.
+- Billing authorization enforcement.
+- Step-up authentication.
+- Custom roles.

--- a/supabase/migrations/20260622000001_rbac_phase1.sql
+++ b/supabase/migrations/20260622000001_rbac_phase1.sql
@@ -1,0 +1,447 @@
+-- RBAC Phase 1: schema foundation, seed data, and legacy backfill.
+--
+-- This migration adds scoped roles/permissions, membership tracking, and an
+-- append-only audit log table. It does not add application-level enforcement.
+
+CREATE TABLE IF NOT EXISTS team_memberships (
+    id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id    uuid NOT NULL REFERENCES team(id),
+    user_id    uuid NOT NULL REFERENCES profile(id),
+    status     text NOT NULL DEFAULT 'active',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT team_memberships_status_check
+        CHECK (status IN ('active', 'inactive', 'invited'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_memberships_team_user
+    ON team_memberships(team_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_team_memberships_user
+    ON team_memberships(user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_memberships_active_team_user_unique
+    ON team_memberships(team_id, user_id)
+    WHERE status = 'active';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_team_memberships_active_user_unique
+    ON team_memberships(user_id)
+    WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS roles (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        text NOT NULL UNIQUE,
+    scope_type  text NOT NULL,
+    description text,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT roles_name_nonempty CHECK (name <> ''),
+    CONSTRAINT roles_scope_type_check CHECK (scope_type IN ('platform', 'team'))
+);
+
+ALTER TABLE roles
+    ADD CONSTRAINT roles_id_scope_unique UNIQUE (id, scope_type);
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        text NOT NULL UNIQUE,
+    description text,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT permissions_name_nonempty CHECK (name <> '')
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id        uuid NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id  uuid NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_role_assignments (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     uuid NOT NULL REFERENCES profile(id),
+    role_id     uuid NOT NULL REFERENCES roles(id),
+    scope_type  text NOT NULL,
+    team_id     uuid REFERENCES team(id),
+    granted_by  uuid REFERENCES profile(id),
+    granted_at  timestamptz NOT NULL DEFAULT now(),
+    revoked_at  timestamptz,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT user_role_assignments_scope_type_check
+        CHECK (scope_type IN ('platform', 'team')),
+    CONSTRAINT user_role_assignments_scope_team_check
+        CHECK (
+            (scope_type = 'platform' AND team_id IS NULL)
+            OR (scope_type = 'team' AND team_id IS NOT NULL)
+        )
+);
+
+ALTER TABLE user_role_assignments
+    ADD CONSTRAINT user_role_assignments_role_scope_fk
+    FOREIGN KEY (role_id, scope_type)
+    REFERENCES roles(id, scope_type);
+
+CREATE INDEX IF NOT EXISTS idx_user_role_assignments_user_scope_team
+    ON user_role_assignments(user_id, scope_type, team_id);
+CREATE INDEX IF NOT EXISTS idx_user_role_assignments_team
+    ON user_role_assignments(team_id);
+CREATE INDEX IF NOT EXISTS idx_user_role_assignments_role
+    ON user_role_assignments(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_role_assignments_revoked
+    ON user_role_assignments(revoked_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_role_assignments_platform_active_unique
+    ON user_role_assignments(user_id, role_id)
+    WHERE revoked_at IS NULL AND scope_type = 'platform';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_role_assignments_team_active_unique
+    ON user_role_assignments(user_id, role_id, team_id)
+    WHERE revoked_at IS NULL AND scope_type = 'team';
+
+CREATE OR REPLACE FUNCTION enforce_team_role_active_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.scope_type = 'team' AND NEW.revoked_at IS NULL THEN
+        -- Lock the membership row while accepting the grant. This prevents a
+        -- concurrent membership deactivation/delete from revoking only the
+        -- assignments visible before this transaction commits.
+        IF NOT EXISTS (
+            SELECT 1
+            FROM team_memberships m
+            WHERE m.team_id = NEW.team_id
+              AND m.user_id = NEW.user_id
+              AND m.status = 'active'
+            FOR UPDATE
+        ) THEN
+            RAISE EXCEPTION
+                'active team role assignment requires active team membership for user % in team %',
+                NEW.user_id,
+                NEW.team_id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_user_role_assignments_active_membership
+    BEFORE INSERT OR UPDATE OF user_id, scope_type, team_id, revoked_at
+    ON user_role_assignments
+    FOR EACH ROW
+    EXECUTE FUNCTION enforce_team_role_active_membership();
+
+CREATE OR REPLACE FUNCTION prevent_team_membership_identity_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.team_id IS DISTINCT FROM NEW.team_id
+       OR OLD.user_id IS DISTINCT FROM NEW.user_id THEN
+        RAISE EXCEPTION
+            'team_memberships team_id and user_id are immutable; create a new membership instead';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_team_memberships_prevent_identity_update
+    BEFORE UPDATE OF team_id, user_id
+    ON team_memberships
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_team_membership_identity_update();
+
+CREATE OR REPLACE FUNCTION revoke_team_role_assignments_on_membership_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.status = 'active' AND NEW.status <> 'active' THEN
+        UPDATE user_role_assignments
+        SET revoked_at = COALESCE(revoked_at, now()),
+            updated_at = now()
+        WHERE scope_type = 'team'
+          AND team_id = NEW.team_id
+          AND user_id = NEW.user_id
+          AND revoked_at IS NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_team_memberships_revoke_assignments
+    AFTER UPDATE OF status
+    ON team_memberships
+    FOR EACH ROW
+    EXECUTE FUNCTION revoke_team_role_assignments_on_membership_deactivation();
+
+CREATE OR REPLACE FUNCTION revoke_team_role_assignments_on_membership_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE user_role_assignments
+    SET revoked_at = COALESCE(revoked_at, now()),
+        updated_at = now()
+    WHERE scope_type = 'team'
+      AND team_id = OLD.team_id
+      AND user_id = OLD.user_id
+      AND revoked_at IS NULL;
+
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_team_memberships_revoke_assignments_on_delete
+    AFTER DELETE
+    ON team_memberships
+    FOR EACH ROW
+    EXECUTE FUNCTION revoke_team_role_assignments_on_membership_delete();
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id             bigserial PRIMARY KEY,
+    actor_user_id  uuid,
+    target_user_id uuid,
+    team_id        uuid,
+    event_type     text NOT NULL,
+    old_value      jsonb,
+    new_value      jsonb,
+    metadata       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT audit_logs_event_type_nonempty CHECK (event_type <> '')
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_team_created_at
+    ON audit_logs(team_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor_created_at
+    ON audit_logs(actor_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_target_created_at
+    ON audit_logs(target_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_event_created_at
+    ON audit_logs(event_type, created_at DESC);
+
+-- Fail closed until Phase 2 adds service-owned access paths and explicit
+-- policies. The API uses the service role for these internal RBAC tables.
+ALTER TABLE public.team_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.roles            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.permissions      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.role_permissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_role_assignments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_logs       ENABLE ROW LEVEL SECURITY;
+
+INSERT INTO roles (name, scope_type, description)
+VALUES
+    ('platform_admin', 'platform', 'Superserve internal platform administrator'),
+    ('team_owner', 'team', 'Team owner with full team-scoped privileges'),
+    ('team_admin', 'team', 'Team administrator with delegated management privileges'),
+    ('billing_admin', 'team', 'Team billing administrator'),
+    ('user_admin', 'team', 'Team user administrator'),
+    ('viewer', 'team', 'Read-only team member')
+ON CONFLICT (name) DO UPDATE
+SET scope_type = EXCLUDED.scope_type,
+    description = EXCLUDED.description,
+    updated_at = now();
+
+INSERT INTO permissions (name, description)
+VALUES
+    ('billing:read', 'Read billing state'),
+    ('billing:write', 'Mutate billing state'),
+    ('users:read', 'Read team users'),
+    ('users:write', 'Mutate team users'),
+    ('roles:read', 'Read roles and role assignments'),
+    ('roles:write', 'Mutate roles and role assignments'),
+    ('settings:read', 'Read team settings'),
+    ('settings:write', 'Mutate team settings'),
+    ('audit_logs:read', 'Read audit logs'),
+    ('platform:teams:read', 'Read platform teams'),
+    ('platform:team_users:write', 'Mutate platform team users'),
+    ('platform:team_roles:write', 'Mutate platform team roles'),
+    ('platform:billing:write', 'Mutate platform billing state')
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description,
+    updated_at = now();
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p
+  ON (
+      (r.name = 'platform_admin' AND p.name IN (
+          'platform:teams:read',
+          'platform:team_users:write',
+          'platform:team_roles:write',
+          'platform:billing:write',
+          'billing:read',
+          'billing:write',
+          'users:read',
+          'users:write',
+          'roles:read',
+          'roles:write',
+          'settings:read',
+          'settings:write',
+          'audit_logs:read'
+      ))
+      OR (r.name = 'team_owner' AND p.name IN (
+          'billing:read',
+          'billing:write',
+          'users:read',
+          'users:write',
+          'roles:read',
+          'roles:write',
+          'settings:read',
+          'settings:write',
+          'audit_logs:read'
+      ))
+      OR (r.name = 'team_admin' AND p.name IN (
+          'users:read',
+          'users:write',
+          'roles:read',
+          'settings:read',
+          'settings:write',
+          'billing:read'
+      ))
+      OR (r.name = 'billing_admin' AND p.name IN (
+          'billing:read',
+          'billing:write'
+      ))
+      OR (r.name = 'user_admin' AND p.name IN (
+          'users:read',
+          'users:write',
+          'roles:read'
+      ))
+      OR (r.name = 'viewer' AND p.name IN (
+          'billing:read',
+          'users:read',
+          'settings:read'
+      ))
+  )
+ON CONFLICT DO NOTHING;
+
+DO $$
+DECLARE
+    duplicate_user_count integer;
+BEGIN
+    SELECT COUNT(*)
+    INTO duplicate_user_count
+    FROM (
+        SELECT tm.profile_id
+        FROM team_member tm
+        GROUP BY tm.profile_id
+        HAVING COUNT(DISTINCT tm.team_id) > 1
+    ) multi_team_users;
+
+    IF duplicate_user_count > 0 THEN
+        RAISE EXCEPTION
+            'rbac backfill refused: % legacy users belong to multiple teams',
+            duplicate_user_count;
+    END IF;
+END $$;
+
+-- Backfill memberships from the legacy team_member table. The current product
+-- shape is one user per team, and this migration enforces that invariant with a
+-- partial unique index plus the preflight above.
+INSERT INTO team_memberships (team_id, user_id, status, created_at, updated_at)
+SELECT
+    tm.team_id,
+    tm.profile_id,
+    'active',
+    COALESCE(tm.joined_at, now()),
+    COALESCE(tm.joined_at, now())
+FROM team_member tm
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM team_memberships m
+    WHERE m.team_id = tm.team_id
+      AND m.user_id = tm.profile_id
+      AND m.status = 'active'
+);
+
+WITH team_sizes AS (
+    SELECT team_id, COUNT(*)::int AS member_count
+    FROM team_memberships
+    WHERE status = 'active'
+    GROUP BY team_id
+),
+legacy_memberships AS (
+    SELECT
+        m.team_id,
+        m.user_id,
+        m.created_at,
+        LOWER(COALESCE(tm.role, '')) AS legacy_role,
+        ts.member_count
+    FROM team_memberships m
+    JOIN team_sizes ts
+      ON ts.team_id = m.team_id
+    LEFT JOIN team_member tm
+      ON tm.team_id = m.team_id
+     AND tm.profile_id = m.user_id
+    WHERE m.status = 'active'
+)
+INSERT INTO user_role_assignments (
+    user_id, role_id, scope_type, team_id,
+    granted_by, granted_at, revoked_at, created_at, updated_at
+)
+SELECT
+    lm.user_id,
+    r.id,
+    'team',
+    lm.team_id,
+    NULL,
+    lm.created_at,
+    NULL,
+    lm.created_at,
+    lm.created_at
+FROM legacy_memberships lm
+    JOIN roles r
+      ON r.scope_type = 'team'
+     AND r.name = CASE
+        WHEN lm.member_count = 1 THEN 'team_owner'
+        WHEN lm.legacy_role IN ('owner', 'team_owner') THEN 'team_owner'
+        WHEN lm.legacy_role IN ('admin', 'team_admin') THEN 'team_admin'
+        ELSE 'viewer'
+     END
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM user_role_assignments a
+    WHERE a.user_id = lm.user_id
+      AND a.role_id = r.id
+      AND a.scope_type = 'team'
+      AND a.team_id = lm.team_id
+      AND a.revoked_at IS NULL
+);
+
+DO $$
+DECLARE
+    orphan_count integer;
+BEGIN
+    SELECT COUNT(*)
+    INTO orphan_count
+    FROM profile p
+    WHERE EXISTS (
+        SELECT 1
+        FROM team_member tm
+        WHERE tm.profile_id = p.id
+    )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM team_memberships m
+        WHERE m.user_id = p.id
+          AND m.status = 'active'
+    );
+
+    IF orphan_count > 0 THEN
+        RAISE EXCEPTION
+            'rbac backfill failed: % legacy profile rows have no active team membership',
+            orphan_count;
+    END IF;
+END $$;
+
+-- Platform admin assignment remains explicit. A bootstrap admin can be
+-- granted manually with an INSERT like:
+--   INSERT INTO user_role_assignments (user_id, role_id, scope_type, granted_by)
+--   SELECT $USER_ID, r.id, 'platform', NULL
+--   FROM roles r
+--   WHERE r.name = 'platform_admin';

--- a/supabase/migrations/20260622000001_rbac_phase1.sql
+++ b/supabase/migrations/20260622000001_rbac_phase1.sql
@@ -35,8 +35,13 @@ CREATE TABLE IF NOT EXISTS roles (
     CONSTRAINT roles_scope_type_check CHECK (scope_type IN ('platform', 'team'))
 );
 
-ALTER TABLE roles
-    ADD CONSTRAINT roles_id_scope_unique UNIQUE (id, scope_type);
+DO $$
+BEGIN
+    ALTER TABLE roles
+        ADD CONSTRAINT roles_id_scope_unique UNIQUE (id, scope_type);
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE TABLE IF NOT EXISTS permissions (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -77,10 +82,15 @@ CREATE TABLE IF NOT EXISTS user_role_assignments (
         )
 );
 
-ALTER TABLE user_role_assignments
-    ADD CONSTRAINT user_role_assignments_role_scope_fk
-    FOREIGN KEY (role_id, scope_type)
-    REFERENCES roles(id, scope_type);
+DO $$
+BEGIN
+    ALTER TABLE user_role_assignments
+        ADD CONSTRAINT user_role_assignments_role_scope_fk
+        FOREIGN KEY (role_id, scope_type)
+        REFERENCES roles(id, scope_type);
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_user_role_assignments_user_scope_team
     ON user_role_assignments(user_id, scope_type, team_id);
@@ -124,6 +134,8 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS trg_user_role_assignments_active_membership ON user_role_assignments;
+
 CREATE TRIGGER trg_user_role_assignments_active_membership
     BEFORE INSERT OR UPDATE OF user_id, scope_type, team_id, revoked_at
     ON user_role_assignments
@@ -144,6 +156,8 @@ BEGIN
 END;
 $$;
 
+DROP TRIGGER IF EXISTS trg_team_memberships_prevent_identity_update ON team_memberships;
+
 CREATE TRIGGER trg_team_memberships_prevent_identity_update
     BEFORE UPDATE OF team_id, user_id
     ON team_memberships
@@ -155,7 +169,7 @@ RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    IF OLD.status = 'active' AND NEW.status <> 'active' THEN
+    IF OLD.status = 'active' AND NEW.status = 'inactive' THEN
         UPDATE user_role_assignments
         SET revoked_at = COALESCE(revoked_at, now()),
             updated_at = now()
@@ -167,6 +181,8 @@ BEGIN
     RETURN NEW;
 END;
 $$;
+
+DROP TRIGGER IF EXISTS trg_team_memberships_revoke_assignments ON team_memberships;
 
 CREATE TRIGGER trg_team_memberships_revoke_assignments
     AFTER UPDATE OF status
@@ -190,6 +206,8 @@ BEGIN
     RETURN OLD;
 END;
 $$;
+
+DROP TRIGGER IF EXISTS trg_team_memberships_revoke_assignments_on_delete ON team_memberships;
 
 CREATE TRIGGER trg_team_memberships_revoke_assignments_on_delete
     AFTER DELETE
@@ -229,6 +247,8 @@ BEGIN
     RETURN OLD;
 END;
 $$;
+
+DROP TRIGGER IF EXISTS trg_audit_logs_prevent_mutation ON audit_logs;
 
 CREATE TRIGGER trg_audit_logs_prevent_mutation
     BEFORE UPDATE OR DELETE
@@ -351,26 +371,19 @@ WHERE NOT EXISTS (
       AND m.status = 'active'
 );
 
-WITH team_sizes AS (
-    SELECT team_id, COUNT(*)::int AS member_count
-    FROM team_memberships
-    WHERE status = 'active'
-    GROUP BY team_id
-),
-legacy_memberships AS (
+WITH legacy_memberships AS (
     SELECT
-        m.team_id,
-        m.user_id,
-        m.created_at,
+        tm.team_id,
+        tm.profile_id AS user_id,
+        COALESCE(tm.joined_at, now()) AS created_at,
         LOWER(COALESCE(tm.role, '')) AS legacy_role,
-        ts.member_count
-    FROM team_memberships m
-    JOIN team_sizes ts
-      ON ts.team_id = m.team_id
-    LEFT JOIN team_member tm
-      ON tm.team_id = m.team_id
-     AND tm.profile_id = m.user_id
-    WHERE m.status = 'active'
+        BOOL_OR(LOWER(COALESCE(tm.role, '')) IN ('owner', 'team_owner'))
+            OVER (PARTITION BY tm.team_id) AS has_explicit_owner,
+        ROW_NUMBER() OVER (
+            PARTITION BY tm.team_id
+            ORDER BY COALESCE(tm.joined_at, 'infinity'::timestamptz), tm.profile_id
+        ) AS owner_rank
+    FROM team_member tm
 )
 INSERT INTO user_role_assignments (
     user_id, role_id, scope_type, team_id,
@@ -390,8 +403,8 @@ FROM legacy_memberships lm
     JOIN roles r
       ON r.scope_type = 'team'
      AND r.name = CASE
-        WHEN lm.member_count = 1 THEN 'team_owner'
         WHEN lm.legacy_role IN ('owner', 'team_owner') THEN 'team_owner'
+        WHEN NOT lm.has_explicit_owner AND lm.owner_rank = 1 THEN 'team_owner'
         WHEN lm.legacy_role IN ('admin', 'team_admin') THEN 'team_admin'
         ELSE 'viewer'
      END

--- a/supabase/migrations/20260622000001_rbac_phase1.sql
+++ b/supabase/migrations/20260622000001_rbac_phase1.sql
@@ -169,7 +169,7 @@ RETURNS trigger
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    IF OLD.status = 'active' AND NEW.status = 'inactive' THEN
+    IF OLD.status = 'active' AND NEW.status <> 'active' THEN
         UPDATE user_role_assignments
         SET revoked_at = COALESCE(revoked_at, now()),
             updated_at = now()

--- a/supabase/migrations/20260622000001_rbac_phase1.sql
+++ b/supabase/migrations/20260622000001_rbac_phase1.sql
@@ -22,9 +22,6 @@ CREATE INDEX IF NOT EXISTS idx_team_memberships_user
 CREATE UNIQUE INDEX IF NOT EXISTS idx_team_memberships_active_team_user_unique
     ON team_memberships(team_id, user_id)
     WHERE status = 'active';
-CREATE UNIQUE INDEX IF NOT EXISTS idx_team_memberships_active_user_unique
-    ON team_memberships(user_id)
-    WHERE status = 'active';
 
 CREATE TABLE IF NOT EXISTS roles (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -320,29 +317,8 @@ JOIN permissions p
   )
 ON CONFLICT DO NOTHING;
 
-DO $$
-DECLARE
-    duplicate_user_count integer;
-BEGIN
-    SELECT COUNT(*)
-    INTO duplicate_user_count
-    FROM (
-        SELECT tm.profile_id
-        FROM team_member tm
-        GROUP BY tm.profile_id
-        HAVING COUNT(DISTINCT tm.team_id) > 1
-    ) multi_team_users;
-
-    IF duplicate_user_count > 0 THEN
-        RAISE EXCEPTION
-            'rbac backfill refused: % legacy users belong to multiple teams',
-            duplicate_user_count;
-    END IF;
-END $$;
-
--- Backfill memberships from the legacy team_member table. The current product
--- shape is one user per team, and this migration enforces that invariant with a
--- partial unique index plus the preflight above.
+-- Backfill memberships from the legacy team_member table. Users may belong to
+-- multiple teams, so every legacy row is preserved as an active membership.
 INSERT INTO team_memberships (team_id, user_id, status, created_at, updated_at)
 SELECT
     tm.team_id,

--- a/supabase/migrations/20260622000001_rbac_phase1.sql
+++ b/supabase/migrations/20260622000001_rbac_phase1.sql
@@ -220,6 +220,22 @@ CREATE INDEX IF NOT EXISTS idx_audit_logs_target_created_at
 CREATE INDEX IF NOT EXISTS idx_audit_logs_event_created_at
     ON audit_logs(event_type, created_at DESC);
 
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_logs is append-only; update/delete is not allowed';
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trg_audit_logs_prevent_mutation
+    BEFORE UPDATE OR DELETE
+    ON audit_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_mutation();
+
 -- Fail closed until Phase 2 adds service-owned access paths and explicit
 -- policies. The API uses the service role for these internal RBAC tables.
 ALTER TABLE public.team_memberships ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Add RBAC tables.
Add audit log table.
Add seed data for roles and permissions.
Backfill existing users into their current teams.
Allow users to belong to multiple active teams while preventing duplicate active memberships within the same team.