### PR TITLE
docs(openapi): document folder (zip) download on GET /files

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -955,20 +955,36 @@ paths:
         schema:
           type: string
         description: >
-          Absolute path of the file inside the sandbox (e.g.
-          `/home/user/out.txt`).
+          Absolute path inside the sandbox (e.g. `/home/user/out.txt`).
 
     get:
       operationId: readFile
       tags: [Files]
       summary: Read a file from a sandbox
+      description: >
+        Returns the file at `path` as raw bytes. To download a directory, set
+        `format=zip` to receive its contents as a zip archive.
       security:
         - accessToken: []
+      parameters:
+        - name: format
+          in: query
+          required: false
+          description: >
+            Set to `zip` to download the directory at `path` as a zip archive.
+            Omit when downloading a single file.
+          schema:
+            type: string
+            enum: [zip]
       responses:
         "200":
-          description: File contents.
+          description: File contents, or a zip archive when `format=zip`.
           content:
             application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            application/zip:
               schema:
                 type: string
                 format: binary


### PR DESCRIPTION
Documents the existing `?format=zip` behavior on the data-plane file download so the API reference reflects folder downloads (follow-up to the directory-download feature, per Amit's request).

- `GET /files` now notes that a directory `path` + `format=zip` returns a zip archive, adds the `format` query parameter (`enum: [zip]`), and lists `application/zip` as a 200 content type.
- User-facing wording only — no internal terms (no `boxd`); matches the existing file read/write descriptions.
- Kept the `Read a file from a sandbox` summary to preserve the existing reference URL; happy to broaden it if preferred.
- Does not change the documented host URLs.

The matching API-reference nav cleanup (dropping the `/exec` + `/exec/stream` pages removed in #78) is a separate PR in the superserve docs repo.