### PR TITLE
controlplane: quiet shutdown-time DB error noise

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -259,6 +259,10 @@ func run() error {
 		}
 	}
 
+	// Stop background reconcilers before draining HTTP so they don't keep
+	// issuing DB queries (which time out and log as errors) while shutting down.
+	cancel()
+
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer shutdownCancel()
 

--- a/internal/sentrylog/writer.go
+++ b/internal/sentrylog/writer.go
@@ -4,11 +4,20 @@ package sentrylog
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+// benignCancellation matches shutdown/disconnect blips (cancelled context,
+// closed pool). Timeouts and connection failures are excluded on purpose —
+// those are real signals that must still reach Sentry.
+func benignCancellation(errStr string) bool {
+	return strings.Contains(errStr, "context canceled") ||
+		strings.Contains(errStr, "closed pool")
+}
 
 // Writer forwards error-level zerolog events to Sentry; a no-op until Sentry is
 // initialized. Use it in a zerolog.MultiLevelWriter beside the primary output.
@@ -34,6 +43,9 @@ func (w *Writer) WriteLevel(level zerolog.Level, p []byte) (int, error) {
 		msg, _ = fields["msg"].(string)
 	}
 	errStr, _ := fields["error"].(string)
+	if benignCancellation(errStr) {
+		return len(p), nil
+	}
 	caller, _ := fields["caller"].(string)
 
 	extras := make(map[string]interface{}, len(fields))

--- a/internal/sentrylog/writer_test.go
+++ b/internal/sentrylog/writer_test.go
@@ -1,6 +1,7 @@
 package sentrylog
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +52,36 @@ func TestWriter_ForwardsErrorsNotWarnings(t *testing.T) {
 	if logCtx, ok := e.Contexts["log"]; ok {
 		if _, dup := logCtx["caller"]; dup {
 			t.Error("caller duplicated in log context; it should be a tag only")
+		}
+	}
+}
+
+func TestWriter_DropsBenignCancellations(t *testing.T) {
+	mock := &sentry.MockTransport{}
+	if err := sentry.Init(sentry.ClientOptions{
+		Dsn:       "https://test@example.com/1",
+		Transport: mock,
+	}); err != nil {
+		t.Fatalf("sentry init: %v", err)
+	}
+
+	w := &Writer{}
+	// Benign shutdown / client-disconnect errors: must NOT reach Sentry.
+	w.WriteLevel(zerolog.ErrorLevel, []byte(`{"level":"error","message":"reaper: ClaimExpiredSandboxes failed","error":"closed pool"}`))
+	w.WriteLevel(zerolog.ErrorLevel, []byte(`{"level":"error","message":"exec: upstream error","error":"context canceled"}`))
+	// Real signals: must still reach Sentry — these are how an outage is detected.
+	w.WriteLevel(zerolog.ErrorLevel, []byte(`{"level":"error","message":"list active builds failed","error":"context deadline exceeded"}`))
+	w.WriteLevel(zerolog.ErrorLevel, []byte(`{"level":"error","message":"UpdateHostHeartbeat failed","error":"failed to connect to host"}`))
+
+	sentry.Flush(2 * time.Second)
+
+	events := mock.Events()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 forwarded events (deadline + connect), got %d", len(events))
+	}
+	for _, e := range events {
+		if strings.Contains(e.Message, "closed pool") || strings.Contains(e.Message, "context canceled") {
+			t.Errorf("benign cancellation forwarded to Sentry: %q", e.Message)
 		}
 	}
 }


### PR DESCRIPTION
Cancel background reconcilers on SIGTERM before draining HTTP so they stop querying a DB that's being torn down, and drop benign `context canceled`/`closed pool` errors from Sentry (real timeouts/connection failures still alert).