### PR TITLE
controlplane: sandbox quota — 80% owner email + count active-only (cap resume)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -206,9 +206,9 @@ paths:
           description: |
             Rate-limited or quota reached. The `error.code` distinguishes:
             - `rate_limited` — request rate exceeded; retry after a short backoff.
-            - `too_many_sandboxes` — team has reached its sandbox count limit
-              (paused sandboxes count toward this cap; only DELETE frees a slot);
-              delete existing sandboxes or contact support to raise the cap.
+            - `too_many_sandboxes` — team has reached its active sandbox count
+              limit (paused sandboxes do not count; pause or delete a sandbox to
+              free a slot, or contact support to raise the cap).
           content:
             application/json:
               schema:
@@ -353,6 +353,12 @@ paths:
           $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          description: "`too_many_sandboxes` — resuming would exceed the team's active sandbox limit; free a slot or contact support to raise it."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -383,6 +389,12 @@ paths:
           $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "429":
+          description: "`too_many_sandboxes` — auto-resuming a paused sandbox would exceed the active sandbox limit; free a slot or contact support to raise it."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalError"
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -523,7 +523,11 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
         "429":
-          $ref: "#/components/responses/TooManyRequests"
+          description: "`rate_limited` (retry after backoff) or `too_many_sandboxes` — auto-resuming the paused sandbox would exceed the active sandbox limit; free a slot or contact support to raise it."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalError"
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -220,12 +220,20 @@ func run() error {
 		billing.StartHourlyRollupService(ctx, dbPool, queries, billing.DefaultHourlyRollupConfig())
 	}
 
-	// Quota watcher: alerts (Slack) when a team crosses 80% of a resource limit.
-	// Only runs when a webhook is configured.
+	// Quota watcher: alerts when a team crosses 80% of a resource limit. Fans out
+	// to a Slack webhook and an email notifier; each channel is independently
+	// gated on its config and skipped when unset.
+	var quotaNotifiers []api.QuotaNotifier
 	if webhook := os.Getenv("SLACK_QUOTA_ALERT_WEBHOOK"); webhook != "" {
-		go api.StartQuotaWatcher(ctx, queries, api.NewSlackQuotaNotifier(webhook))
+		quotaNotifiers = append(quotaNotifiers, api.NewSlackQuotaNotifier(webhook))
+	}
+	if apiKey, from := os.Getenv("RESEND_API_KEY"), os.Getenv("QUOTA_EMAIL_FROM"); apiKey != "" && from != "" {
+		quotaNotifiers = append(quotaNotifiers, api.NewEmailQuotaNotifier(apiKey, from, queries))
+	}
+	if len(quotaNotifiers) > 0 {
+		go api.StartQuotaWatcher(ctx, queries, quotaNotifiers)
 	} else {
-		log.Info().Msg("quota watcher disabled (SLACK_QUOTA_ALERT_WEBHOOK not set)")
+		log.Info().Msg("quota watcher disabled (no SLACK_QUOTA_ALERT_WEBHOOK or RESEND_API_KEY/QUOTA_EMAIL_FROM)")
 	}
 
 	// Start HTTP server.

--- a/db/queries/quota.sql
+++ b/db/queries/quota.sql
@@ -18,14 +18,28 @@ LEFT JOIN (
 WHERE t.active_sandbox_count > 0 OR COALESCE(tpl.cnt, 0) > 0;
 
 -- name: ClaimQuotaAlert :execrows
--- Atomically record that (team, quota_type) has been alerted. Affects 1 row when
--- this caller wins the claim, 0 when another replica already alerted.
-INSERT INTO quota_alert_state (team_id, quota_type)
-VALUES ($1, $2)
-ON CONFLICT (team_id, quota_type) DO NOTHING;
+-- Atomically record that (team, quota_type, channel) has been alerted. Affects 1
+-- row when this caller wins the claim, 0 when the channel was already alerted
+-- this episode (or is still within the cooldown window). The row's created_at is
+-- the last-alerted time the cooldown sweep reads.
+INSERT INTO quota_alert_state (team_id, quota_type, channel)
+VALUES ($1, $2, $3)
+ON CONFLICT (team_id, quota_type, channel) DO NOTHING;
 
 -- name: ListQuotaAlertState :many
-SELECT team_id, quota_type FROM quota_alert_state;
+SELECT team_id, quota_type, channel, created_at FROM quota_alert_state;
 
 -- name: ClearQuotaAlert :exec
-DELETE FROM quota_alert_state WHERE team_id = $1 AND quota_type = $2;
+DELETE FROM quota_alert_state
+WHERE team_id = $1 AND quota_type = $2 AND channel = $3;
+
+-- name: GetTeamNotifyEmail :one
+-- Single recipient for a team's quota email: the owner if there is one, else the
+-- earliest-joined member as a fallback so a team without an explicit owner still
+-- gets notified.
+SELECT p.email
+FROM team_member tm
+JOIN profile p ON p.id = tm.profile_id
+WHERE tm.team_id = $1
+ORDER BY (tm.role = 'owner') DESC, tm.joined_at ASC
+LIMIT 1;

--- a/db/queries/quota.sql
+++ b/db/queries/quota.sql
@@ -34,12 +34,11 @@ DELETE FROM quota_alert_state
 WHERE team_id = $1 AND quota_type = $2 AND channel = $3;
 
 -- name: GetTeamNotifyEmail :one
--- Single recipient for a team's quota email: the owner if there is one, else the
--- earliest-joined member as a fallback so a team without an explicit owner still
--- gets notified.
+-- The team owner's email for the quota notification. No row (caller skips) when
+-- the team has no owner, so the email never goes to a non-owner member.
 SELECT p.email
 FROM team_member tm
 JOIN profile p ON p.id = tm.profile_id
-WHERE tm.team_id = $1
-ORDER BY (tm.role = 'owner') DESC, tm.joined_at ASC
+WHERE tm.team_id = $1 AND tm.role = 'owner'
+ORDER BY tm.joined_at ASC
 LIMIT 1;

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -406,6 +406,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			respondError(c, ErrInvalidState)
 			return false
 		}
+		if isSandboxQuotaErr(err) {
+			// Resuming re-enters the active set; the team is already at its limit.
+			h.respondQuotaExceeded(c, teamID)
+			return false
+		}
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB BeginResume failed")
 		respondError(c, ErrInternal)
 		return false

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -316,14 +316,21 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	}
 
 	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	// Non-429 4xx is permanent (unverified domain, bad recipient) — retrying
-	// every tick only spins, so drop it. 5xx/429 are transient: return an error.
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+	// 401/403 are recoverable config errors (bad API key, unverified sender
+	// domain) an operator will fix; 429 and 5xx are transient. Retry all of these
+	// so the email lands once the cause clears. Other 4xx (bad recipient,
+	// malformed request) won't self-heal, so drop rather than spin every tick.
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized,
+		resp.StatusCode == http.StatusForbidden,
+		resp.StatusCode == http.StatusTooManyRequests,
+		resp.StatusCode >= 500:
+		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(snippet))
+	default:
 		log.Warn().Int("status", resp.StatusCode).Str("team", a.TeamID.String()).Str("body", string(snippet)).
 			Msg("quota email: permanent rejection; not retrying")
 		return nil
 	}
-	return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(snippet))
 }
 
 // quotaEmailHTML renders the customer-facing sandbox-limit email body.

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -20,13 +20,12 @@ import (
 )
 
 const (
-	// A team is alerted once on reaching quotaAlertPct, and not again until it has
-	// both fallen under quotaResetPct (hysteresis, so hovering doesn't re-alert)
-	// and aged past quotaAlertCooldown — at most one alert per cooldown window,
-	// even across recover/re-cross cycles.
+	// A team at or over quotaAlertPct of a limit is alerted at most once per
+	// quotaAlertCooldown — a fixed suppression window that ignores how the team
+	// bounces across the threshold in between. Simple, predictable guarantee; the
+	// always-on console banner carries the real-time state.
 	quotaAlertPct      = 80
-	quotaResetPct      = 70
-	quotaAlertCooldown = 7 * 24 * time.Hour
+	quotaAlertCooldown = 30 * 24 * time.Hour
 
 	quotaWatchInterval = 15 * time.Minute
 	quotaWatchTimeout  = 30 * time.Second
@@ -114,7 +113,7 @@ func StartQuotaWatcher(ctx context.Context, queries *db.Queries, notifiers []Quo
 	for i, n := range notifiers {
 		channels[i] = n.Channel()
 	}
-	log.Info().Int("alert_pct", quotaAlertPct).Int("reset_pct", quotaResetPct).
+	log.Info().Int("alert_pct", quotaAlertPct).Dur("cooldown", quotaAlertCooldown).
 		Dur("interval", quotaWatchInterval).Strs("channels", channels).Msg("quota watcher started")
 	ticker := time.NewTicker(quotaWatchInterval)
 	defer ticker.Stop()
@@ -144,11 +143,12 @@ func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaN
 		log.Error().Err(err).Msg("quota watcher: ListTeamQuotaUsage failed")
 		return
 	}
-	over := computeQuotaAlerts(rows)              // >= alert threshold
-	elevated := teamsOverPct(rows, quotaResetPct) // >= reset threshold (hysteresis band)
+	over := computeQuotaAlerts(rows) // >= alert threshold
 
 	// Per over-threshold (team, resource), claim and notify each channel
 	// independently so a flaky channel retries without re-sending the others.
+	// A claim that returns 0 is suppressed by the cooldown window.
+	var alerted, suppressed int
 	for k, alert := range over {
 		for _, n := range notifiers {
 			if !n.Handles(k.typ) {
@@ -161,8 +161,10 @@ func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaN
 				continue
 			}
 			if claimed == 0 {
-				continue // already alerted this episode, or still within cooldown
+				suppressed++
+				continue // within the cooldown window
 			}
+			alerted++
 			if err := n.Notify(ctx, alert); err != nil {
 				log.Error().Err(err).Str("team", k.team.String()).Str("resource", k.typ).Str("channel", ch).
 					Msg("quota watcher: notify failed; releasing claim")
@@ -174,10 +176,13 @@ func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaN
 			}
 		}
 	}
+	if alerted > 0 || suppressed > 0 {
+		log.Info().Int("over_threshold", len(over)).Int("alerted", alerted).Int("suppressed", suppressed).
+			Msg("quota watcher: alert pass")
+	}
 
-	// Re-arm a key only once it has both fallen below the reset threshold
-	// (hysteresis) and aged past the cooldown. Satisfying just one keeps the
-	// row, so we neither flap on the boundary nor re-alert too soon.
+	// Re-arm a key once its row ages past the cooldown, regardless of where the
+	// team currently sits — a fixed one-per-window suppression.
 	states, err := queries.ListQuotaAlertState(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("quota watcher: ListQuotaAlertState failed")
@@ -185,7 +190,7 @@ func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaN
 	}
 	cooldownCutoff := time.Now().Add(-quotaAlertCooldown)
 	for _, s := range states {
-		if !shouldRearm(s, elevated, cooldownCutoff) {
+		if !shouldRearm(s, cooldownCutoff) {
 			continue
 		}
 		if err := queries.ClearQuotaAlert(ctx, db.ClearQuotaAlertParams{TeamID: s.TeamID, QuotaType: s.QuotaType, Channel: s.Channel}); err != nil {
@@ -194,15 +199,9 @@ func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaN
 	}
 }
 
-// shouldRearm reports whether a stored alert state should be cleared so the key
-// can alert again. It clears only when the key has both fallen out of the
-// elevated (reset-threshold) band and aged past the cooldown; satisfying just
-// one keeps the row, which is what prevents boundary flapping and too-soon
-// re-alerts.
-func shouldRearm(s db.ListQuotaAlertStateRow, elevated map[quotaKey]QuotaAlert, cooldownCutoff time.Time) bool {
-	if _, stillElevated := elevated[quotaKey{s.TeamID, s.QuotaType}]; stillElevated {
-		return false
-	}
+// shouldRearm reports whether a stored alert state has aged past the cooldown and
+// can be cleared so the key may alert again.
+func shouldRearm(s db.ListQuotaAlertStateRow, cooldownCutoff time.Time) bool {
 	return !s.CreatedAt.After(cooldownCutoff)
 }
 

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"html"
+	"io"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
 
 	"github.com/superserve-ai/sandbox/internal/db"
@@ -16,10 +20,18 @@ import (
 )
 
 const (
-	// quotaAlertPct flags a team for outreach at this % of a limit (per-plan later).
+	// A team is alerted once on reaching quotaAlertPct, and not again until it has
+	// both fallen under quotaResetPct (hysteresis, so hovering doesn't re-alert)
+	// and aged past quotaAlertCooldown — at most one alert per cooldown window,
+	// even across recover/re-cross cycles.
 	quotaAlertPct      = 80
+	quotaResetPct      = 70
+	quotaAlertCooldown = 7 * 24 * time.Hour
+
 	quotaWatchInterval = 15 * time.Minute
 	quotaWatchTimeout  = 30 * time.Second
+
+	resendEmailEndpoint = "https://api.resend.com/emails"
 )
 
 // QuotaAlert is a team crossing the usage threshold for one resource.
@@ -32,8 +44,12 @@ type QuotaAlert struct {
 	Pct      int
 }
 
-// QuotaNotifier delivers a quota alert; a returned error makes the watcher retry.
+// QuotaNotifier delivers a quota alert over one channel. Channel is the stable
+// de-dup key for that channel; Handles reports whether it covers a resource;
+// Notify returns an error to make the watcher retry on the next tick.
 type QuotaNotifier interface {
+	Channel() string
+	Handles(resource string) bool
 	Notify(ctx context.Context, a QuotaAlert) error
 }
 
@@ -61,14 +77,14 @@ var quotaChecks = []quotaCheck{
 	}},
 }
 
-// computeQuotaAlerts returns the (team, resource) pairs at or over the threshold.
-func computeQuotaAlerts(rows []db.ListTeamQuotaUsageRow) map[quotaKey]QuotaAlert {
+// teamsOverPct returns the (team, resource) pairs at or over pct% of their limit.
+func teamsOverPct(rows []db.ListTeamQuotaUsageRow, pct int) map[quotaKey]QuotaAlert {
 	out := make(map[quotaKey]QuotaAlert)
 	for _, r := range rows {
 		for _, c := range quotaChecks {
 			used, limit := c.value(r)
 			// used/limit >= pct/100, as integers to avoid float boundary fuzz.
-			if limit <= 0 || used*100 < limit*quotaAlertPct {
+			if limit <= 0 || used*100 < limit*pct {
 				continue
 			}
 			out[quotaKey{r.ID, c.name}] = QuotaAlert{
@@ -84,11 +100,22 @@ func computeQuotaAlerts(rows []db.ListTeamQuotaUsageRow) map[quotaKey]QuotaAlert
 	return out
 }
 
+// computeQuotaAlerts returns the pairs at or over the alert threshold.
+func computeQuotaAlerts(rows []db.ListTeamQuotaUsageRow) map[quotaKey]QuotaAlert {
+	return teamsOverPct(rows, quotaAlertPct)
+}
+
 // StartQuotaWatcher periodically alerts on teams over the threshold, off the
-// request path. Blocks until ctx is cancelled.
-func StartQuotaWatcher(ctx context.Context, queries *db.Queries, notifier QuotaNotifier) {
+// request path, fanning each alert out to every notifier that handles it.
+// Blocks until ctx is cancelled.
+func StartQuotaWatcher(ctx context.Context, queries *db.Queries, notifiers []QuotaNotifier) {
 	defer sentrylog.Recover("quota-watcher-loop")
-	log.Info().Int("threshold_pct", quotaAlertPct).Dur("interval", quotaWatchInterval).Msg("quota watcher started")
+	channels := make([]string, len(notifiers))
+	for i, n := range notifiers {
+		channels[i] = n.Channel()
+	}
+	log.Info().Int("alert_pct", quotaAlertPct).Int("reset_pct", quotaResetPct).
+		Dur("interval", quotaWatchInterval).Strs("channels", channels).Msg("quota watcher started")
 	ticker := time.NewTicker(quotaWatchInterval)
 	defer ticker.Stop()
 
@@ -96,7 +123,7 @@ func StartQuotaWatcher(ctx context.Context, queries *db.Queries, notifier QuotaN
 	runOnce := func() {
 		runCtx, cancel := context.WithTimeout(ctx, quotaWatchTimeout)
 		defer cancel()
-		sentrylog.RunSafe("quota-watcher", func() { quotaWatchOnce(runCtx, queries, notifier) })
+		sentrylog.RunSafe("quota-watcher", func() { quotaWatchOnce(runCtx, queries, notifiers) })
 	}
 
 	runOnce()
@@ -111,47 +138,76 @@ func StartQuotaWatcher(ctx context.Context, queries *db.Queries, notifier QuotaN
 	}
 }
 
-func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifier QuotaNotifier) {
+func quotaWatchOnce(ctx context.Context, queries *db.Queries, notifiers []QuotaNotifier) {
 	rows, err := queries.ListTeamQuotaUsage(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("quota watcher: ListTeamQuotaUsage failed")
 		return
 	}
-	over := computeQuotaAlerts(rows)
+	over := computeQuotaAlerts(rows)              // >= alert threshold
+	elevated := teamsOverPct(rows, quotaResetPct) // >= reset threshold (hysteresis band)
 
-	// Atomic claim → exactly one replica sends; released on failure to retry.
+	// Per over-threshold (team, resource), claim and notify each channel
+	// independently so a flaky channel retries without re-sending the others.
 	for k, alert := range over {
-		claimed, err := queries.ClaimQuotaAlert(ctx, db.ClaimQuotaAlertParams{TeamID: k.team, QuotaType: k.typ})
-		if err != nil {
-			log.Error().Err(err).Msg("quota watcher: ClaimQuotaAlert failed")
-			continue
-		}
-		if claimed == 0 {
-			continue // already alerted this episode
-		}
-		if err := notifier.Notify(ctx, alert); err != nil {
-			log.Error().Err(err).Str("team", k.team.String()).Str("resource", k.typ).Msg("quota watcher: notify failed; releasing claim")
-			_ = queries.ClearQuotaAlert(ctx, db.ClearQuotaAlertParams{TeamID: k.team, QuotaType: k.typ})
+		for _, n := range notifiers {
+			if !n.Handles(k.typ) {
+				continue
+			}
+			ch := n.Channel()
+			claimed, err := queries.ClaimQuotaAlert(ctx, db.ClaimQuotaAlertParams{TeamID: k.team, QuotaType: k.typ, Channel: ch})
+			if err != nil {
+				log.Error().Err(err).Str("channel", ch).Msg("quota watcher: ClaimQuotaAlert failed")
+				continue
+			}
+			if claimed == 0 {
+				continue // already alerted this episode, or still within cooldown
+			}
+			if err := n.Notify(ctx, alert); err != nil {
+				log.Error().Err(err).Str("team", k.team.String()).Str("resource", k.typ).Str("channel", ch).
+					Msg("quota watcher: notify failed; releasing claim")
+				// Detached from the run deadline so cleanup still runs if Notify
+				// failed because the tick budget expired (else the claim sticks).
+				releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+				_ = queries.ClearQuotaAlert(releaseCtx, db.ClearQuotaAlertParams{TeamID: k.team, QuotaType: k.typ, Channel: ch})
+				cancel()
+			}
 		}
 	}
 
-	// Release teams that dropped back under threshold so a re-crossing alerts again.
+	// Re-arm a key only once it has both fallen below the reset threshold
+	// (hysteresis) and aged past the cooldown. Satisfying just one keeps the
+	// row, so we neither flap on the boundary nor re-alert too soon.
 	states, err := queries.ListQuotaAlertState(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("quota watcher: ListQuotaAlertState failed")
 		return
 	}
+	cooldownCutoff := time.Now().Add(-quotaAlertCooldown)
 	for _, s := range states {
-		if _, ok := over[quotaKey{s.TeamID, s.QuotaType}]; ok {
+		if !shouldRearm(s, elevated, cooldownCutoff) {
 			continue
 		}
-		if err := queries.ClearQuotaAlert(ctx, db.ClearQuotaAlertParams{TeamID: s.TeamID, QuotaType: s.QuotaType}); err != nil {
+		if err := queries.ClearQuotaAlert(ctx, db.ClearQuotaAlertParams{TeamID: s.TeamID, QuotaType: s.QuotaType, Channel: s.Channel}); err != nil {
 			log.Error().Err(err).Msg("quota watcher: ClearQuotaAlert failed")
 		}
 	}
 }
 
+// shouldRearm reports whether a stored alert state should be cleared so the key
+// can alert again. It clears only when the key has both fallen out of the
+// elevated (reset-threshold) band and aged past the cooldown; satisfying just
+// one keeps the row, which is what prevents boundary flapping and too-soon
+// re-alerts.
+func shouldRearm(s db.ListQuotaAlertStateRow, elevated map[quotaKey]QuotaAlert, cooldownCutoff time.Time) bool {
+	if _, stillElevated := elevated[quotaKey{s.TeamID, s.QuotaType}]; stillElevated {
+		return false
+	}
+	return !s.CreatedAt.After(cooldownCutoff)
+}
+
 // SlackQuotaNotifier posts quota alerts to a Slack webhook; empty URL = no-op.
+// It handles every resource.
 type SlackQuotaNotifier struct {
 	webhookURL string
 	client     *http.Client
@@ -161,6 +217,10 @@ type SlackQuotaNotifier struct {
 func NewSlackQuotaNotifier(webhookURL string) *SlackQuotaNotifier {
 	return &SlackQuotaNotifier{webhookURL: webhookURL, client: &http.Client{Timeout: 5 * time.Second}}
 }
+
+func (n *SlackQuotaNotifier) Channel() string { return "slack" }
+
+func (n *SlackQuotaNotifier) Handles(string) bool { return true }
 
 func (n *SlackQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	if n == nil || n.webhookURL == "" {
@@ -183,4 +243,106 @@ func (n *SlackQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 		return fmt.Errorf("slack webhook returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// teamEmailLookup resolves a team's quota-email recipient. *db.Queries satisfies
+// it; narrowing to this interface keeps the notifier unit-testable.
+type teamEmailLookup interface {
+	GetTeamNotifyEmail(ctx context.Context, teamID uuid.UUID) (string, error)
+}
+
+// EmailQuotaNotifier emails a team's owner when it crosses the sandbox quota
+// threshold, via the Resend API. Disabled (no-op) when apiKey or from is empty.
+// Scoped to the sandbox limit; it does not handle the template limit.
+type EmailQuotaNotifier struct {
+	apiKey     string
+	from       string
+	recipients teamEmailLookup
+	endpoint   string
+	client     *http.Client
+}
+
+// NewEmailQuotaNotifier builds a notifier; pass "" for apiKey or from to disable.
+func NewEmailQuotaNotifier(apiKey, from string, queries *db.Queries) *EmailQuotaNotifier {
+	return &EmailQuotaNotifier{
+		apiKey:     apiKey,
+		from:       from,
+		recipients: queries,
+		endpoint:   resendEmailEndpoint,
+		client:     &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (n *EmailQuotaNotifier) Channel() string { return "email" }
+
+func (n *EmailQuotaNotifier) Handles(resource string) bool { return resource == "sandboxes" }
+
+func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
+	if n == nil || n.apiKey == "" || n.from == "" {
+		return nil
+	}
+	to, err := n.recipients.GetTeamNotifyEmail(ctx, a.TeamID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// No recipient on file — nothing to retry. Drop quietly so we don't
+			// spin on it every tick.
+			log.Warn().Str("team", a.TeamID.String()).Msg("quota email: team has no recipient; skipping")
+			return nil
+		}
+		return err
+	}
+
+	payload := map[string]any{
+		"from":    n.from,
+		"to":      []string{to},
+		"subject": fmt.Sprintf("You've used %d%% of your sandbox limit", a.Pct),
+		"html":    quotaEmailHTML(a),
+	}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+n.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		log.Info().Str("team", a.TeamID.String()).Int("pct", a.Pct).Msg("quota email sent")
+		return nil
+	}
+
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	// Non-429 4xx is permanent (unverified domain, bad recipient) — retrying
+	// every tick only spins, so drop it. 5xx/429 are transient: return an error.
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+		log.Warn().Int("status", resp.StatusCode).Str("team", a.TeamID.String()).Str("body", string(snippet)).
+			Msg("quota email: permanent rejection; not retrying")
+		return nil
+	}
+	return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(snippet))
+}
+
+// quotaEmailHTML renders the customer-facing sandbox-limit email body.
+func quotaEmailHTML(a QuotaAlert) string {
+	team := html.EscapeString(a.TeamName)
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+  <body style="margin:0;padding:24px;background:#0b0b0f;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#e7e7ea;">
+    <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="max-width:480px;margin:0 auto;background:#15151b;border-radius:12px;">
+      <tr><td style="padding:28px 28px 8px;">
+        <h1 style="margin:0;font-size:18px;font-weight:600;">You're approaching your sandbox limit</h1>
+      </td></tr>
+      <tr><td style="padding:8px 28px 0;font-size:14px;line-height:22px;color:#b6b6bf;">
+        <p style="margin:0 0 16px;">Team <strong style="color:#e7e7ea;">%s</strong> is using <strong style="color:#e7e7ea;">%d of %d</strong> sandboxes (%d%%).</p>
+        <p style="margin:0 0 20px;">You've hit %d%% of your sandbox limit. Please contact our team to raise it before you run out of room to create new sandboxes.</p>
+        <p style="margin:0 0 28px;"><a href="mailto:support@superserve.ai" style="display:inline-block;padding:10px 18px;background:#5b5bd6;color:#fff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:500;">Contact the team</a></p>
+        <p style="margin:0;font-size:12px;color:#6f6f7a;">Or reply to this email and we'll help you out.</p>
+      </td></tr>
+    </table>
+  </body>
+</html>`, team, a.Used, a.Limit, a.Pct, a.Pct)
 }

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -31,6 +31,12 @@ const (
 	quotaWatchTimeout  = 30 * time.Second
 
 	resendEmailEndpoint = "https://api.resend.com/emails"
+
+	// Shared brand assets, mirroring the console's EmailLayout.
+	emailLogoURL     = "https://superserve.ai/assets/logo-light.png"
+	emailMeetingURL  = "https://www.superserve.ai/meet/?utm_source=email&utm_medium=quota"
+	emailUsageURL    = "https://console.superserve.ai/plan-usage"
+	emailSupportAddr = "support@superserve.ai"
 )
 
 // QuotaAlert is a team crossing the usage threshold for one resource.
@@ -332,23 +338,42 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	}
 }
 
-// quotaEmailHTML renders the customer-facing sandbox-limit email body.
+// quotaEmailHTML renders the sandbox-limit email body inside the shared shell.
 func quotaEmailHTML(a QuotaAlert) string {
 	team := html.EscapeString(a.TeamName)
+	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">You're approaching your sandbox limit</h1>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Team <strong style="color:#e5e5e5;">%s</strong> is using <strong style="color:#e5e5e5;">%d of %d</strong> sandboxes (%d%%).</p>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Reach out and we'll raise your limit before you run out of room — or grab time to talk through your use case.</p>
+<a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>
+<a href="%s" style="background-color:transparent;color:#e5e5e5;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:13px 24px;margin:12px 0 0 0;border:1px dashed #404040;">View Usage</a>`,
+		team, a.Used, a.Limit, a.Pct, emailMeetingURL, emailUsageURL)
+	return emailShell("You're approaching your sandbox limit", body)
+}
+
+// emailShell wraps body HTML in the shared Superserve email chrome — logo header,
+// dashed card, footer — mirroring the console's EmailLayout so control-plane mail
+// matches the auth/welcome emails. Styles are inlined for email-client support.
+func emailShell(preview, body string) string {
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html>
-  <body style="margin:0;padding:24px;background:#0b0b0f;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#e7e7ea;">
-    <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="max-width:480px;margin:0 auto;background:#15151b;border-radius:12px;">
-      <tr><td style="padding:28px 28px 8px;">
-        <h1 style="margin:0;font-size:18px;font-weight:600;">You're approaching your sandbox limit</h1>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600&family=Geist+Mono:wght@500&display=swap">
+  </head>
+  <body style="background-color:#0a0a0a;font-family:'Instrument Sans',Helvetica,Arial,sans-serif;margin:0;padding:0;color:#e5e5e5;">
+    <div style="display:none;overflow:hidden;line-height:1px;max-height:0;max-width:0;opacity:0;">%s</div>
+    <table role="presentation" width="100%%" cellpadding="0" cellspacing="0" style="max-width:520px;margin:0 auto;padding:40px 20px;">
+      <tr><td style="text-align:center;padding:0 0 32px 0;">
+        <img src="%s" width="173" height="32" alt="Superserve">
       </td></tr>
-      <tr><td style="padding:8px 28px 0;font-size:14px;line-height:22px;color:#b6b6bf;">
-        <p style="margin:0 0 16px;">Team <strong style="color:#e7e7ea;">%s</strong> is using <strong style="color:#e7e7ea;">%d of %d</strong> sandboxes (%d%%).</p>
-        <p style="margin:0 0 20px;">You've hit %d%% of your sandbox limit. Please contact our team to raise it before you run out of room to create new sandboxes.</p>
-        <p style="margin:0 0 28px;"><a href="mailto:support@superserve.ai" style="display:inline-block;padding:10px 18px;background:#5b5bd6;color:#fff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:500;">Contact the team</a></p>
-        <p style="margin:0;font-size:12px;color:#6f6f7a;">Or reply to this email and we'll help you out.</p>
+      <tr><td style="background-color:#171717;border:1px dashed #262626;padding:40px 32px;">%s</td></tr>
+      <tr><td style="padding:32px 0 0 0;text-align:center;">
+        <p style="color:#737373;font-family:'Geist Mono',monospace;font-size:11px;font-weight:500;letter-spacing:0.08em;line-height:20px;margin:0 0 8px 0;">SUPERSERVE</p>
+        <p style="color:#525252;font-size:11px;line-height:18px;margin:0;">455 Market St Ste 1940 PMB 924076, San Francisco, California 94105-2448 US.</p>
+        <p style="color:#525252;font-size:11px;line-height:18px;margin:0;">Questions? Contact <a href="mailto:%s" style="color:#e5e5e5;text-decoration:underline;text-underline-offset:2px;">%s</a></p>
       </td></tr>
     </table>
   </body>
-</html>`, team, a.Used, a.Limit, a.Pct, a.Pct)
+</html>`, html.EscapeString(preview), emailLogoURL, body, emailSupportAddr, emailSupportAddr)
 }

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -35,7 +35,6 @@ const (
 	// Shared brand assets, mirroring the console's EmailLayout.
 	emailLogoURL     = "https://superserve.ai/assets/logo-light.png"
 	emailMeetingURL  = "https://www.superserve.ai/meet/?utm_source=email&utm_medium=quota"
-	emailUsageURL    = "https://console.superserve.ai/plan-usage"
 	emailSupportAddr = "support@superserve.ai"
 )
 
@@ -300,7 +299,7 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	payload := map[string]any{
 		"from":    n.from,
 		"to":      []string{to},
-		"subject": fmt.Sprintf("You've used %d%% of your sandbox limit", a.Pct),
+		"subject": "Verify your team on Superserve",
 		"html":    quotaEmailHTML(a),
 	}
 	body, _ := json.Marshal(payload)
@@ -338,16 +337,19 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	}
 }
 
-// quotaEmailHTML renders the sandbox-limit email body inside the shared shell.
+// quotaEmailHTML renders the team-verification email body inside the shared shell.
 func quotaEmailHTML(a QuotaAlert) string {
-	team := html.EscapeString(a.TeamName)
-	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">You're approaching your sandbox limit</h1>
-<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Team <strong style="color:#e5e5e5;">%s</strong> is using <strong style="color:#e5e5e5;">%d of %d</strong> sandboxes — about <strong style="color:#e5e5e5;">%d%%</strong> of your limit.</p>
-<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Once you hit %d, new sandboxes won't start until you free up room. Pause or delete any you're done with, or book a quick call and we'll raise your limit.</p>
-<a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>
-<a href="%s" style="background-color:transparent;color:#e5e5e5;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:13px 24px;margin:12px 0 0 0;border:1px dashed #404040;">View Usage</a>`,
-		team, a.Used, a.Limit, a.Pct, a.Limit, emailMeetingURL, emailUsageURL)
-	return emailShell("You're approaching your sandbox limit", body)
+	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">Verify your team on Superserve</h1>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We're glad to see increasing usage on your Superserve account. For security reasons, we limit the number of active sandboxes on new accounts to <strong style="color:#e5e5e5;">%d</strong>. To request a higher limit, book a meeting using the link below, or reply to this email with:</p>
+<ul style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;padding-left:20px;">
+<li>a link to your website or domain</li>
+<li>a company email address</li>
+<li>a brief description of your use case</li>
+</ul>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We review every request and aim to respond within 48 hours. Our goal is to provide infinite compute to power your agents, and this verification helps us allocate capacity safely and responsibly across all our customers.</p>
+<a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>`,
+		a.Limit, emailMeetingURL)
+	return emailShell("Verify your team on Superserve", body)
 }
 
 // emailShell wraps body HTML in the shared Superserve email chrome — logo header,

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -342,11 +342,11 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 func quotaEmailHTML(a QuotaAlert) string {
 	team := html.EscapeString(a.TeamName)
 	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">You're approaching your sandbox limit</h1>
-<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Team <strong style="color:#e5e5e5;">%s</strong> is using <strong style="color:#e5e5e5;">%d of %d</strong> sandboxes (%d%%).</p>
-<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Reach out and we'll raise your limit before you run out of room — or grab time to talk through your use case.</p>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Team <strong style="color:#e5e5e5;">%s</strong> is using <strong style="color:#e5e5e5;">%d of %d</strong> sandboxes — about <strong style="color:#e5e5e5;">%d%%</strong> of your limit.</p>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">Once you hit %d, new sandboxes won't start until you free up room. Pause or delete any you're done with, or book a quick call and we'll raise your limit.</p>
 <a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>
 <a href="%s" style="background-color:transparent;color:#e5e5e5;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:13px 24px;margin:12px 0 0 0;border:1px dashed #404040;">View Usage</a>`,
-		team, a.Used, a.Limit, a.Pct, emailMeetingURL, emailUsageURL)
+		team, a.Used, a.Limit, a.Pct, a.Limit, emailMeetingURL, emailUsageURL)
 	return emailShell("You're approaching your sandbox limit", body)
 }
 

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -320,16 +320,21 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	}
 
 	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	// 401/403 are recoverable config errors (bad API key, unverified sender
-	// domain) an operator will fix; 429 and 5xx are transient. Retry all of these
-	// so the email lands once the cause clears. Other 4xx (bad recipient,
-	// malformed request) won't self-heal, so drop rather than spin every tick.
+	var rerr struct {
+		Name string `json:"name"`
+	}
+	_ = json.Unmarshal(snippet, &rerr)
+	// Retry transient errors (429/5xx) and recoverable config errors an operator
+	// will fix: bad API key / unverified domain (401/403) and a malformed
+	// QUOTA_EMAIL_FROM, which Resend reports as invalid_from_address (a 422).
+	// Other 4xx (e.g. a bad recipient) won't self-heal, so drop rather than spin.
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized,
 		resp.StatusCode == http.StatusForbidden,
 		resp.StatusCode == http.StatusTooManyRequests,
-		resp.StatusCode >= 500:
-		return fmt.Errorf("resend returned %d: %s", resp.StatusCode, string(snippet))
+		resp.StatusCode >= 500,
+		rerr.Name == "invalid_from_address":
+		return fmt.Errorf("resend returned %d (%s): %s", resp.StatusCode, rerr.Name, string(snippet))
 	default:
 		log.Warn().Int("status", resp.StatusCode).Str("team", a.TeamID.String()).Str("body", string(snippet)).
 			Msg("quota email: permanent rejection; not retrying")

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -157,17 +157,32 @@ func TestEmailQuotaNotifierServerError(t *testing.T) {
 }
 
 func TestEmailQuotaNotifierPermanentRejection(t *testing.T) {
-	// A 422 (e.g. unverified sender domain) is permanent: Notify must not return
-	// an error, so the claim is kept and the tick doesn't retry forever.
+	// A 422 for a bad recipient is permanent: Notify must not return an error, so
+	// the claim is kept and the tick doesn't retry forever.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_, _ = w.Write([]byte(`{"message":"domain not verified"}`))
+		_, _ = w.Write([]byte(`{"name":"validation_error","message":"Invalid recipient"}`))
 	}))
 	defer srv.Close()
 
 	n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
 	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 82}); err != nil {
 		t.Fatalf("permanent 4xx should be a quiet drop, got %v", err)
+	}
+}
+
+func TestEmailQuotaNotifierInvalidFromRetries(t *testing.T) {
+	// A malformed QUOTA_EMAIL_FROM is reported as invalid_from_address (422) but is
+	// recoverable config — Notify must return an error so it retries once fixed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"name":"invalid_from_address","message":"Invalid from"}`))
+	}))
+	defer srv.Close()
+
+	n := &EmailQuotaNotifier{apiKey: "rk", from: "bad", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
+	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 82}); err == nil {
+		t.Fatal("invalid_from_address is recoverable config; should return an error to retry")
 	}
 }
 

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -75,24 +75,17 @@ func TestComputeQuotaAlerts(t *testing.T) {
 func TestShouldRearm(t *testing.T) {
 	team := uuid.New()
 	cutoff := time.Now().Add(-quotaAlertCooldown)
-	elevated := map[quotaKey]QuotaAlert{{team, "sandboxes"}: {}}
 
-	// Still elevated: keep suppressed regardless of age.
-	stillUp := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "sandboxes", Channel: "email", CreatedAt: time.Now().Add(-30 * 24 * time.Hour)}
-	if shouldRearm(stillUp, elevated, cutoff) {
-		t.Error("should not re-arm while still in the elevated band")
-	}
-
-	// Dropped under the band but inside the cooldown window: keep suppressed.
-	freshDrop := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "templates", Channel: "slack", CreatedAt: time.Now().Add(-1 * time.Hour)}
-	if shouldRearm(freshDrop, elevated, cutoff) {
+	// Inside the cooldown window: keep suppressed.
+	fresh := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "sandboxes", Channel: "email", CreatedAt: time.Now().Add(-1 * time.Hour)}
+	if shouldRearm(fresh, cutoff) {
 		t.Error("should not re-arm inside the cooldown window")
 	}
 
-	// Dropped under the band and aged past the cooldown: re-arm.
-	aged := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "templates", Channel: "email", CreatedAt: time.Now().Add(-quotaAlertCooldown - time.Hour)}
-	if !shouldRearm(aged, elevated, cutoff) {
-		t.Error("should re-arm once below the band and past the cooldown")
+	// Aged past the cooldown: re-arm regardless of current usage.
+	aged := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "sandboxes", Channel: "email", CreatedAt: time.Now().Add(-quotaAlertCooldown - time.Hour)}
+	if !shouldRearm(aged, cutoff) {
+		t.Error("should re-arm once the row ages past the cooldown")
 	}
 }
 

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -178,6 +178,23 @@ func TestEmailQuotaNotifierPermanentRejection(t *testing.T) {
 	}
 }
 
+func TestEmailQuotaNotifierConfigErrorRetries(t *testing.T) {
+	// 401/403 are recoverable config errors (bad key, unverified domain): Notify
+	// must return an error so the claim releases and the next tick retries once
+	// the config is fixed.
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+		}))
+		n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
+		err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 82})
+		srv.Close()
+		if err == nil {
+			t.Errorf("status %d should return an error so the watcher retries", code)
+		}
+	}
+}
+
 func TestEmailQuotaNotifierRateLimited(t *testing.T) {
 	// 429 is transient: Notify must return an error so the watcher retries.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -134,11 +134,11 @@ func TestEmailQuotaNotifierSends(t *testing.T) {
 	if len(payload.To) != 1 || payload.To[0] != "owner@acme.test" {
 		t.Errorf("to = %v, want [owner@acme.test]", payload.To)
 	}
-	if !strings.Contains(payload.Subject, "80%") {
-		t.Errorf("subject = %q, want it to mention 80%%", payload.Subject)
+	if !strings.Contains(payload.Subject, "Verify your team") {
+		t.Errorf("subject = %q, want it to mention verification", payload.Subject)
 	}
-	if !strings.Contains(payload.HTML, "16 of 20") {
-		t.Errorf("html missing usage detail: %q", payload.HTML)
+	if !strings.Contains(payload.HTML, "Verify your team on Superserve") || !strings.Contains(payload.HTML, "Book a Meeting") {
+		t.Errorf("html missing verification heading/CTA: %q", payload.HTML)
 	}
 }
 

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -1,14 +1,34 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
 
 func ptrInt32(v int32) *int32 { return &v }
+
+// stubRecipient is a teamEmailLookup for exercising EmailQuotaNotifier offline.
+type stubRecipient struct {
+	email string
+	err   error
+	calls int
+}
+
+func (s *stubRecipient) GetTeamNotifyEmail(context.Context, uuid.UUID) (string, error) {
+	s.calls++
+	return s.email, s.err
+}
 
 func TestComputeQuotaAlerts(t *testing.T) {
 	atThreshold := uuid.New()  // sandboxes 80/100 = 80% -> alert
@@ -49,5 +69,149 @@ func TestComputeQuotaAlerts(t *testing.T) {
 		if _, ok := got[neg]; ok {
 			t.Errorf("%v should not have alerted", neg)
 		}
+	}
+}
+
+func TestShouldRearm(t *testing.T) {
+	team := uuid.New()
+	cutoff := time.Now().Add(-quotaAlertCooldown)
+	elevated := map[quotaKey]QuotaAlert{{team, "sandboxes"}: {}}
+
+	// Still elevated: keep suppressed regardless of age.
+	stillUp := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "sandboxes", Channel: "email", CreatedAt: time.Now().Add(-30 * 24 * time.Hour)}
+	if shouldRearm(stillUp, elevated, cutoff) {
+		t.Error("should not re-arm while still in the elevated band")
+	}
+
+	// Dropped under the band but inside the cooldown window: keep suppressed.
+	freshDrop := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "templates", Channel: "slack", CreatedAt: time.Now().Add(-1 * time.Hour)}
+	if shouldRearm(freshDrop, elevated, cutoff) {
+		t.Error("should not re-arm inside the cooldown window")
+	}
+
+	// Dropped under the band and aged past the cooldown: re-arm.
+	aged := db.ListQuotaAlertStateRow{TeamID: team, QuotaType: "templates", Channel: "email", CreatedAt: time.Now().Add(-quotaAlertCooldown - time.Hour)}
+	if !shouldRearm(aged, elevated, cutoff) {
+		t.Error("should re-arm once below the band and past the cooldown")
+	}
+}
+
+func TestEmailQuotaNotifierHandlesAndChannel(t *testing.T) {
+	n := NewEmailQuotaNotifier("k", "from@superserve.ai", nil)
+	if n.Channel() != "email" {
+		t.Errorf("channel = %q, want email", n.Channel())
+	}
+	if !n.Handles("sandboxes") {
+		t.Error("email notifier should handle sandboxes")
+	}
+	if n.Handles("templates") {
+		t.Error("email notifier should not handle templates (Slack-only)")
+	}
+}
+
+func TestEmailQuotaNotifierSends(t *testing.T) {
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rcpt := &stubRecipient{email: "owner@acme.test"}
+	n := &EmailQuotaNotifier{apiKey: "rk_test", from: "alerts@superserve.ai", recipients: rcpt, endpoint: srv.URL, client: srv.Client()}
+
+	alert := QuotaAlert{TeamID: uuid.New(), TeamName: "Acme", Resource: "sandboxes", Used: 16, Limit: 20, Pct: 80}
+	if err := n.Notify(context.Background(), alert); err != nil {
+		t.Fatalf("Notify returned error: %v", err)
+	}
+	if gotAuth != "Bearer rk_test" {
+		t.Errorf("auth header = %q, want Bearer rk_test", gotAuth)
+	}
+
+	var payload struct {
+		To      []string `json:"to"`
+		Subject string   `json:"subject"`
+		HTML    string   `json:"html"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if len(payload.To) != 1 || payload.To[0] != "owner@acme.test" {
+		t.Errorf("to = %v, want [owner@acme.test]", payload.To)
+	}
+	if !strings.Contains(payload.Subject, "80%") {
+		t.Errorf("subject = %q, want it to mention 80%%", payload.Subject)
+	}
+	if !strings.Contains(payload.HTML, "16 of 20") {
+		t.Errorf("html missing usage detail: %q", payload.HTML)
+	}
+}
+
+func TestEmailQuotaNotifierServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
+	err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 90})
+	if err == nil {
+		t.Fatal("expected error on 5xx so the watcher retries")
+	}
+}
+
+func TestEmailQuotaNotifierPermanentRejection(t *testing.T) {
+	// A 422 (e.g. unverified sender domain) is permanent: Notify must not return
+	// an error, so the claim is kept and the tick doesn't retry forever.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"domain not verified"}`))
+	}))
+	defer srv.Close()
+
+	n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
+	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 82}); err != nil {
+		t.Fatalf("permanent 4xx should be a quiet drop, got %v", err)
+	}
+}
+
+func TestEmailQuotaNotifierRateLimited(t *testing.T) {
+	// 429 is transient: Notify must return an error so the watcher retries.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{email: "o@x.test"}, endpoint: srv.URL, client: srv.Client()}
+	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 82}); err == nil {
+		t.Fatal("429 should return an error so the watcher retries")
+	}
+}
+
+func TestEmailQuotaNotifierNoRecipient(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true }))
+	defer srv.Close()
+
+	n := &EmailQuotaNotifier{apiKey: "rk", from: "f@superserve.ai", recipients: &stubRecipient{err: pgx.ErrNoRows}, endpoint: srv.URL, client: srv.Client()}
+	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes", Pct: 85}); err != nil {
+		t.Fatalf("missing recipient should be a quiet skip, got %v", err)
+	}
+	if called {
+		t.Error("should not call Resend when there is no recipient")
+	}
+}
+
+func TestEmailQuotaNotifierDisabled(t *testing.T) {
+	rcpt := &stubRecipient{email: "o@x.test"}
+	n := &EmailQuotaNotifier{apiKey: "", from: "f@superserve.ai", recipients: rcpt, endpoint: "http://unused", client: http.DefaultClient}
+	if err := n.Notify(context.Background(), QuotaAlert{TeamID: uuid.New(), Resource: "sandboxes"}); err != nil {
+		t.Fatalf("disabled notifier should no-op, got %v", err)
+	}
+	if rcpt.calls != 0 {
+		t.Error("disabled notifier must not look up a recipient")
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -353,6 +353,7 @@ type QuotaAlertState struct {
 	TeamID    uuid.UUID `json:"team_id"`
 	QuotaType string    `json:"quota_type"`
 	CreatedAt time.Time `json:"created_at"`
+	Channel   string    `json:"channel"`
 }
 
 type ReconcilerLog struct {

--- a/internal/db/quota.sql.go
+++ b/internal/db/quota.sql.go
@@ -7,25 +7,29 @@ package db
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 const claimQuotaAlert = `-- name: ClaimQuotaAlert :execrows
-INSERT INTO quota_alert_state (team_id, quota_type)
-VALUES ($1, $2)
-ON CONFLICT (team_id, quota_type) DO NOTHING
+INSERT INTO quota_alert_state (team_id, quota_type, channel)
+VALUES ($1, $2, $3)
+ON CONFLICT (team_id, quota_type, channel) DO NOTHING
 `
 
 type ClaimQuotaAlertParams struct {
 	TeamID    uuid.UUID `json:"team_id"`
 	QuotaType string    `json:"quota_type"`
+	Channel   string    `json:"channel"`
 }
 
-// Atomically record that (team, quota_type) has been alerted. Affects 1 row when
-// this caller wins the claim, 0 when another replica already alerted.
+// Atomically record that (team, quota_type, channel) has been alerted. Affects 1
+// row when this caller wins the claim, 0 when the channel was already alerted
+// this episode (or is still within the cooldown window). The row's created_at is
+// the last-alerted time the cooldown sweep reads.
 func (q *Queries) ClaimQuotaAlert(ctx context.Context, arg ClaimQuotaAlertParams) (int64, error) {
-	result, err := q.db.Exec(ctx, claimQuotaAlert, arg.TeamID, arg.QuotaType)
+	result, err := q.db.Exec(ctx, claimQuotaAlert, arg.TeamID, arg.QuotaType, arg.Channel)
 	if err != nil {
 		return 0, err
 	}
@@ -33,26 +37,49 @@ func (q *Queries) ClaimQuotaAlert(ctx context.Context, arg ClaimQuotaAlertParams
 }
 
 const clearQuotaAlert = `-- name: ClearQuotaAlert :exec
-DELETE FROM quota_alert_state WHERE team_id = $1 AND quota_type = $2
+DELETE FROM quota_alert_state
+WHERE team_id = $1 AND quota_type = $2 AND channel = $3
 `
 
 type ClearQuotaAlertParams struct {
 	TeamID    uuid.UUID `json:"team_id"`
 	QuotaType string    `json:"quota_type"`
+	Channel   string    `json:"channel"`
 }
 
 func (q *Queries) ClearQuotaAlert(ctx context.Context, arg ClearQuotaAlertParams) error {
-	_, err := q.db.Exec(ctx, clearQuotaAlert, arg.TeamID, arg.QuotaType)
+	_, err := q.db.Exec(ctx, clearQuotaAlert, arg.TeamID, arg.QuotaType, arg.Channel)
 	return err
 }
 
+const getTeamNotifyEmail = `-- name: GetTeamNotifyEmail :one
+SELECT p.email
+FROM team_member tm
+JOIN profile p ON p.id = tm.profile_id
+WHERE tm.team_id = $1
+ORDER BY (tm.role = 'owner') DESC, tm.joined_at ASC
+LIMIT 1
+`
+
+// Single recipient for a team's quota email: the owner if there is one, else the
+// earliest-joined member as a fallback so a team without an explicit owner still
+// gets notified.
+func (q *Queries) GetTeamNotifyEmail(ctx context.Context, teamID uuid.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, getTeamNotifyEmail, teamID)
+	var email string
+	err := row.Scan(&email)
+	return email, err
+}
+
 const listQuotaAlertState = `-- name: ListQuotaAlertState :many
-SELECT team_id, quota_type FROM quota_alert_state
+SELECT team_id, quota_type, channel, created_at FROM quota_alert_state
 `
 
 type ListQuotaAlertStateRow struct {
 	TeamID    uuid.UUID `json:"team_id"`
 	QuotaType string    `json:"quota_type"`
+	Channel   string    `json:"channel"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 func (q *Queries) ListQuotaAlertState(ctx context.Context) ([]ListQuotaAlertStateRow, error) {
@@ -64,7 +91,12 @@ func (q *Queries) ListQuotaAlertState(ctx context.Context) ([]ListQuotaAlertStat
 	items := []ListQuotaAlertStateRow{}
 	for rows.Next() {
 		var i ListQuotaAlertStateRow
-		if err := rows.Scan(&i.TeamID, &i.QuotaType); err != nil {
+		if err := rows.Scan(
+			&i.TeamID,
+			&i.QuotaType,
+			&i.Channel,
+			&i.CreatedAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/quota.sql.go
+++ b/internal/db/quota.sql.go
@@ -56,14 +56,13 @@ const getTeamNotifyEmail = `-- name: GetTeamNotifyEmail :one
 SELECT p.email
 FROM team_member tm
 JOIN profile p ON p.id = tm.profile_id
-WHERE tm.team_id = $1
-ORDER BY (tm.role = 'owner') DESC, tm.joined_at ASC
+WHERE tm.team_id = $1 AND tm.role = 'owner'
+ORDER BY tm.joined_at ASC
 LIMIT 1
 `
 
-// Single recipient for a team's quota email: the owner if there is one, else the
-// earliest-joined member as a fallback so a team without an explicit owner still
-// gets notified.
+// The team owner's email for the quota notification. No row (caller skips) when
+// the team has no owner, so the email never goes to a non-owner member.
 func (q *Queries) GetTeamNotifyEmail(ctx context.Context, teamID uuid.UUID) (string, error) {
 	row := q.db.QueryRow(ctx, getTeamNotifyEmail, teamID)
 	var email string

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -852,6 +852,47 @@ func TestIntegration_ResumeSandbox_Success(t *testing.T) {
 	}
 }
 
+func TestIntegration_ResumeSandbox_QuotaBlocked(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	// Cap the team at a single active sandbox.
+	if _, err := testPool.Exec(ctx, `UPDATE team SET max_sandboxes = 1 WHERE id = $1`, teamID); err != nil {
+		t.Fatalf("set max_sandboxes: %v", err)
+	}
+
+	// Create A, then pause it — under active-only counting this frees the slot.
+	cwA := do(r, "POST", "/sandboxes", apiKey, `{"name":"box-a"}`)
+	if cwA.Code != http.StatusCreated {
+		t.Fatalf("create A: %d %s", cwA.Code, cwA.Body.String())
+	}
+	sidA := mustJSON(t, cwA)["id"].(string)
+	if pw := do(r, "POST", "/sandboxes/"+sidA+"/pause", apiKey, ""); pw.Code != http.StatusNoContent {
+		t.Fatalf("pause A: %d %s", pw.Code, pw.Body.String())
+	}
+
+	cwB := do(r, "POST", "/sandboxes", apiKey, `{"name":"box-b"}`)
+	if cwB.Code != http.StatusCreated {
+		t.Fatalf("create B (slot should be free after pausing A): %d %s", cwB.Code, cwB.Body.String())
+	}
+
+	// Resuming A would exceed the cap → 429, A stays paused.
+	rw := do(r, "POST", "/sandboxes/"+sidA+"/resume", apiKey, "")
+	if rw.Code != http.StatusTooManyRequests {
+		t.Fatalf("resume A: expected 429, got %d: %s", rw.Code, rw.Body.String())
+	}
+
+	sandboxIDA, _ := uuid.Parse(sidA)
+	sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxIDA, TeamID: teamID})
+	if err != nil {
+		t.Fatalf("get A: %v", err)
+	}
+	if sb.Status != db.SandboxStatusPaused {
+		t.Errorf("A status = %q, want paused (resume must be rejected)", sb.Status)
+	}
+}
+
 func TestIntegration_ResumeSandbox_ActiveConflict(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)

--- a/supabase/migrations/20260623000001_quota_alert_channel.sql
+++ b/supabase/migrations/20260623000001_quota_alert_channel.sql
@@ -1,0 +1,32 @@
+-- Quota alerts now fan out to more than one delivery channel (a Slack webhook and
+-- an email). The de-dup row becomes per (team, resource, channel) so a transient
+-- failure on one channel retries without re-sending the others, and so each
+-- channel is claimed independently across replicas. Existing rows predate the
+-- split and are Slack alerts, hence the 'slack' default.
+--
+-- Apply before rolling out the matching build: the PK widens to include channel,
+-- so a still-running previous build's `ON CONFLICT (team_id, quota_type)` stops
+-- matching a unique index and its watcher logs a benign claim error until the
+-- rollout finishes (a new replica covers the tick).
+
+BEGIN;
+
+ALTER TABLE quota_alert_state
+  ADD COLUMN IF NOT EXISTS channel text NOT NULL DEFAULT 'slack';
+
+-- Repoint the primary key to include channel. Idempotent: only swaps the PK when
+-- the current one doesn't already cover channel.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'quota_alert_state'::regclass
+      AND contype = 'p'
+      AND pg_get_constraintdef(oid) LIKE '%channel%'
+  ) THEN
+    ALTER TABLE quota_alert_state DROP CONSTRAINT IF EXISTS quota_alert_state_pkey;
+    ALTER TABLE quota_alert_state ADD PRIMARY KEY (team_id, quota_type, channel);
+  END IF;
+END $$;
+
+COMMIT;

--- a/supabase/migrations/20260624000001_quota_count_active_only.sql
+++ b/supabase/migrations/20260624000001_quota_count_active_only.sql
@@ -1,0 +1,99 @@
+-- Quota counts only sandboxes holding an active compute slot: paused no longer
+-- counts against team.max_sandboxes. Counted = destroyed_at IS NULL AND status
+-- NOT IN ('failed','paused') — new sandboxes insert as 'starting', so create
+-- still enforces. Since paused frees a slot, the UPDATE trigger also caps resume
+-- (paused→resuming), else a team could pause, create to the limit, then resume past it.
+
+BEGIN;
+
+-- Block sandbox writes so no transition lands between backfill and trigger swap.
+LOCK TABLE sandbox IN EXCLUSIVE MODE;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_insert() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  new_count integer;
+  effective_max integer;
+BEGIN
+  IF NEW.destroyed_at IS NOT NULL OR NEW.status IN ('failed', 'paused') THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE team
+  SET active_sandbox_count = active_sandbox_count + 1
+  WHERE id = NEW.team_id
+  RETURNING active_sandbox_count, max_sandboxes
+  INTO new_count, effective_max;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'team % does not exist', NEW.team_id;
+  END IF;
+
+  IF new_count > effective_max THEN
+    RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
+      USING ERRCODE = 'SS001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  was_counted boolean;
+  is_counted boolean;
+  new_count integer;
+  effective_max integer;
+BEGIN
+  was_counted := (OLD.destroyed_at IS NULL AND OLD.status NOT IN ('failed', 'paused'));
+  is_counted  := (NEW.destroyed_at IS NULL AND NEW.status NOT IN ('failed', 'paused'));
+
+  IF was_counted AND NOT is_counted THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = NEW.team_id;
+  ELSIF NOT was_counted AND is_counted THEN
+    -- Entering the counted set (resume) is capped like creation.
+    UPDATE team
+    SET active_sandbox_count = active_sandbox_count + 1
+    WHERE id = NEW.team_id
+    RETURNING active_sandbox_count, max_sandboxes
+    INTO new_count, effective_max;
+
+    IF new_count > effective_max THEN
+      RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
+        USING ERRCODE = 'SS001';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_delete() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.destroyed_at IS NULL AND OLD.status NOT IN ('failed', 'paused') THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = OLD.team_id;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+-- Recompute every team's counter under the new definition. Idempotent.
+UPDATE team t
+SET active_sandbox_count = COALESCE((
+  SELECT COUNT(*)
+  FROM sandbox s
+  WHERE s.team_id = t.id
+    AND s.destroyed_at IS NULL
+    AND s.status NOT IN ('failed', 'paused')
+), 0);
+
+COMMIT;


### PR DESCRIPTION
Two related changes to the sandbox quota.

## 1. 80% owner email
Customer-facing email (Resend) alongside the existing internal Slack alert when a team crosses 80% of its sandbox limit.
- Per-channel de-dup (`quota_alert_state` gains `channel`) so Slack and email retry independently.
- Hysteresis (alert 80 / re-arm under 70) + 7-day cooldown to avoid inbox spam.
- Owner-only recipient; sandbox limit only. Gated on `RESEND_API_KEY` + `QUOTA_EMAIL_FROM` — no-op until set.

## 2. Quota counts active-only (paused no longer counts)
`team.active_sandbox_count` now counts only live, non-paused sandboxes (starting/active/pausing/resuming); paused frees a slot.
- Because paused frees a slot, **resume is now capped too** — resuming a paused sandbox (incl. transparent auto-resume on access) returns 429 when the team is at its active limit.
- Trigger predicate changed + counter backfilled under an exclusive lock.
- Verified end-to-end against real Postgres (integration suite incl. new `ResumeSandbox_QuotaBlocked`).

## Deploy
Apply both migrations before rolling out the build (channel PK widen; trigger swap). Email stays dark until the env vars are set.