### PR TITLE
vmd: resume from pause via UFFD backend, flag-gated

### DIFF
--- a/cmd/snapcheck/main.go
+++ b/cmd/snapcheck/main.go
@@ -1,0 +1,112 @@
+// Command snapcheck compares two Firecracker guest-memory snapshot files page
+// by page and reports any pages that differ. It is the correctness gate for
+// incremental snapshots: a written page the change set misses makes the restored
+// VM's memory differ from the original — silent corruption this catches.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	pageSize := flag.Int("page-size", 4096, "page size in bytes")
+	maxReport := flag.Int("max-report", 20, "max differing page offsets to print")
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: snapcheck [flags] <mem-a> <mem-b>")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *pageSize <= 0 {
+		fmt.Fprintln(os.Stderr, "page-size must be positive")
+		os.Exit(2)
+	}
+
+	res, err := compareFiles(flag.Arg(0), flag.Arg(1), *pageSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "snapcheck: %v\n", err)
+		os.Exit(2)
+	}
+
+	fmt.Printf("pages: %d  differing: %d\n", res.totalPages, len(res.diffPages))
+	for i, p := range res.diffPages {
+		if i >= *maxReport {
+			fmt.Printf("  ... %d more\n", len(res.diffPages)-*maxReport)
+			break
+		}
+		fmt.Printf("  page %d  offset 0x%x\n", p, int64(p)*int64(*pageSize))
+	}
+	if len(res.diffPages) > 0 {
+		os.Exit(1)
+	}
+	fmt.Println("identical")
+}
+
+type compareResult struct {
+	totalPages int
+	diffPages  []int // page indices that differ
+}
+
+// compareFiles compares a and b page by page, erroring if they differ in length
+// (a mem file's size is fixed, so a mismatch means they aren't comparable).
+func compareFiles(pathA, pathB string, pageSize int) (compareResult, error) {
+	fa, err := os.Open(pathA)
+	if err != nil {
+		return compareResult{}, err
+	}
+	defer fa.Close()
+	fb, err := os.Open(pathB)
+	if err != nil {
+		return compareResult{}, err
+	}
+	defer fb.Close()
+
+	return comparePages(fa, fb, pageSize)
+}
+
+// comparePages reads a and b in lockstep, one page at a time, recording the
+// index of every page whose bytes differ.
+func comparePages(a, b io.Reader, pageSize int) (compareResult, error) {
+	bufA := make([]byte, pageSize)
+	bufB := make([]byte, pageSize)
+	var res compareResult
+
+	for page := 0; ; page++ {
+		nA, errA := io.ReadFull(a, bufA)
+		nB, errB := io.ReadFull(b, bufB)
+
+		endA := errors.Is(errA, io.EOF)
+		endB := errors.Is(errB, io.EOF)
+		if endA && endB {
+			return res, nil // both ended cleanly on a page boundary
+		}
+		if endA != endB || nA != nB {
+			return res, fmt.Errorf("mem files differ in length (page %d: %d vs %d bytes)", page, nA, nB)
+		}
+		// A short final page (io.ErrUnexpectedEOF) is fine as long as both match.
+		if errA != nil && !errors.Is(errA, io.ErrUnexpectedEOF) {
+			return res, fmt.Errorf("read a: %w", errA)
+		}
+		if errB != nil && !errors.Is(errB, io.ErrUnexpectedEOF) {
+			return res, fmt.Errorf("read b: %w", errB)
+		}
+
+		res.totalPages++
+		if !bytes.Equal(bufA[:nA], bufB[:nB]) {
+			res.diffPages = append(res.diffPages, page)
+		}
+
+		if errors.Is(errA, io.ErrUnexpectedEOF) {
+			return res, nil // last (partial) page consumed
+		}
+	}
+}

--- a/cmd/snapcheck/main.go
+++ b/cmd/snapcheck/main.go
@@ -89,15 +89,17 @@ func comparePages(a, b io.Reader, pageSize int) (compareResult, error) {
 		if endA && endB {
 			return res, nil // both ended cleanly on a page boundary
 		}
-		if endA != endB || nA != nB {
-			return res, fmt.Errorf("mem files differ in length (page %d: %d vs %d bytes)", page, nA, nB)
-		}
-		// A short final page (io.ErrUnexpectedEOF) is fine as long as both match.
-		if errA != nil && !errors.Is(errA, io.ErrUnexpectedEOF) {
+		// Surface a real read error (e.g. EIO) before inferring a length mismatch.
+		// EOF/ErrUnexpectedEOF aren't real errors: EOF is handled above and as a
+		// length mismatch below; a short final page (ErrUnexpectedEOF) is fine.
+		if errA != nil && !endA && !errors.Is(errA, io.ErrUnexpectedEOF) {
 			return res, fmt.Errorf("read a: %w", errA)
 		}
-		if errB != nil && !errors.Is(errB, io.ErrUnexpectedEOF) {
+		if errB != nil && !endB && !errors.Is(errB, io.ErrUnexpectedEOF) {
 			return res, fmt.Errorf("read b: %w", errB)
+		}
+		if endA != endB || nA != nB {
+			return res, fmt.Errorf("mem files differ in length (page %d: %d vs %d bytes)", page, nA, nB)
 		}
 
 		res.totalPages++

--- a/cmd/snapcheck/main_test.go
+++ b/cmd/snapcheck/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestComparePages(t *testing.T) {
+	const pageSize = 8
+
+	tests := []struct {
+		name    string
+		a, b    []byte
+		want    []int
+		wantErr string
+	}{
+		{
+			name: "identical",
+			a:    bytes.Repeat([]byte{0xAB}, pageSize*3),
+			b:    bytes.Repeat([]byte{0xAB}, pageSize*3),
+			want: nil,
+		},
+		{
+			name: "one page differs",
+			a:    append(bytes.Repeat([]byte{0x01}, pageSize), bytes.Repeat([]byte{0x02}, pageSize)...),
+			b:    append(bytes.Repeat([]byte{0x01}, pageSize), bytes.Repeat([]byte{0x99}, pageSize)...),
+			want: []int{1},
+		},
+		{
+			name: "all empty pages match",
+			a:    make([]byte, pageSize*4),
+			b:    make([]byte, pageSize*4),
+			want: nil,
+		},
+		{
+			name: "short final page, equal",
+			a:    bytes.Repeat([]byte{0x07}, pageSize+3),
+			b:    bytes.Repeat([]byte{0x07}, pageSize+3),
+			want: nil,
+		},
+		{
+			name:    "length mismatch",
+			a:       make([]byte, pageSize*2),
+			b:       make([]byte, pageSize*3),
+			wantErr: "differ in length",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := comparePages(bytes.NewReader(tc.a), bytes.NewReader(tc.b), pageSize)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalInts(res.diffPages, tc.want) {
+				t.Fatalf("diffPages = %v, want %v", res.diffPages, tc.want)
+			}
+		})
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -354,6 +354,7 @@ func main() {
 	uffdEnabled := envOrDefault("VMD_UFFD_ENABLED", "true") != "false"
 	uffdPrefetchEnabled := envOrDefault("VMD_UFFD_PREFETCH_ENABLED", "true") != "false"
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
+	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:        cfg.FirecrackerBin,
@@ -369,6 +370,7 @@ func main() {
 		UffdEnabled:           uffdEnabled,
 		UffdPrefetchEnabled:   uffdPrefetchEnabled,
 		UffdRecordMaxSeconds:  uffdRecordMaxSeconds,
+		ResumeUffdEnabled:     resumeUffdEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -665,6 +665,8 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
 	if err := m.restoreForResume(socketPath, snapshotPath, memPath, netInfo); err != nil {
+		// Firecracker is already running; stop the unit before returning or it leaks.
+		m.stopUnitDuringRestoreError(vmID)
 		if errors.Is(err, ErrTornSnapshot) {
 			return nil, status.Errorf(codes.DataLoss,
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
@@ -693,15 +695,10 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, net
 		return RestoreSnapshot(socketPath, snapshotPath, memPath, "")
 	}
 
-	accessLogPath := ""
-	if m.cfg.UffdPrefetchEnabled {
-		candidate := filepath.Join(filepath.Dir(memPath), accessLogFilename)
-		if _, err := os.Stat(candidate); err == nil {
-			accessLogPath = candidate
-		}
-	}
+	// No prefetch access log: only template builds record one (next to the template
+	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
 	return RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, accessLogPath, "", "eth0", netInfo.TAPDevice, "",
+		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "",
 	)
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -148,6 +148,11 @@ type ManagerConfig struct {
 	// UffdRecordMaxSeconds caps how long RecordAccessPattern waits for the
 	// guest's fault rate to settle before giving up. 0 → 10s default.
 	UffdRecordMaxSeconds int
+
+	// ResumeUffdEnabled routes resume-from-pause through the UFFD backend
+	// instead of File, reusing the existing tap. Requires UffdEnabled;
+	// default false, with File as the fallback.
+	ResumeUffdEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -644,9 +649,12 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	vmDir := filepath.Join(m.cfg.RunDir, rundirKey)
 	socketPath := filepath.Join(vmDir, "firecracker.sock")
 
+	var netInfo *network.VMNetInfo
 	if inst.Namespace != "" {
-		if _, err := m.netMgr.EnsureVMSlot(ctx, vmID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
-			return nil, fmt.Errorf("ensure network slot for resume: %w", err)
+		var nsErr error
+		netInfo, nsErr = m.netMgr.EnsureVMSlot(ctx, vmID, inst.Namespace, inst.IP, inst.MACAddress)
+		if nsErr != nil {
+			return nil, fmt.Errorf("ensure network slot for resume: %w", nsErr)
 		}
 	}
 
@@ -656,7 +664,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	if err := RestoreSnapshot(socketPath, snapshotPath, memPath, ""); err != nil {
+	if err := m.restoreForResume(socketPath, snapshotPath, memPath, netInfo); err != nil {
 		if errors.Is(err, ErrTornSnapshot) {
 			return nil, status.Errorf(codes.DataLoss,
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
@@ -674,6 +682,27 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	m.persistState(inst)
 	log.Info().Int("pid", pid).Msg("VM resumed from snapshot")
 	return inst, nil
+}
+
+// restoreForResume picks the resume memory backend: UFFD (reusing the existing
+// tap for the interface override) when enabled and a tap is present, else File,
+// which is also the fallback when ResumeUffdEnabled is off.
+func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, netInfo *network.VMNetInfo) error {
+	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
+	if !useUffd {
+		return RestoreSnapshot(socketPath, snapshotPath, memPath, "")
+	}
+
+	accessLogPath := ""
+	if m.cfg.UffdPrefetchEnabled {
+		candidate := filepath.Join(filepath.Dir(memPath), accessLogFilename)
+		if _, err := os.Stat(candidate); err == nil {
+			accessLogPath = candidate
+		}
+	}
+	return RestoreSnapshotUffdInternalWithOverrides(
+		socketPath, snapshotPath, memPath, accessLogPath, "", "eth0", netInfo.TAPDevice, "",
+	)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Routes resume-from-pause through the UFFD memory backend (instead of the legacy File backend), behind `VMD_RESUME_UFFD` — **default off, so merging is a no-op until flipped**. Unifies resume with the create path. Also adds `snapcheck`, a page-by-page mem-snapshot comparator (unit-tested).

**Tested on staging** with the flag on: resume works and is state-preserving — a live process + its in-memory data, filesystem, and networking all survive pause→resume on `base` and `python-ml`.