### PR TITLE
vmd: add snapshot bit-identical verify (load-no-resume + re-snapshot)

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -355,6 +355,7 @@ func main() {
 	uffdPrefetchEnabled := envOrDefault("VMD_UFFD_PREFETCH_ENABLED", "true") != "false"
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
 	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
+	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:        cfg.FirecrackerBin,
@@ -371,6 +372,7 @@ func main() {
 		UffdPrefetchEnabled:   uffdPrefetchEnabled,
 		UffdRecordMaxSeconds:  uffdRecordMaxSeconds,
 		ResumeUffdEnabled:     resumeUffdEnabled,
+		VerifySnapshotEnabled: verifySnapshotEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -293,6 +293,51 @@ func UnpauseVM(socketPath string) error {
 	return nil
 }
 
+// LoadSnapshotNoResume loads a snapshot but leaves the vCPUs paused — used to
+// re-snapshot it (SnapshotPausedVM) and verify the memory round-trips. The TAP
+// override mirrors RestoreSnapshot* so device restore succeeds.
+func LoadSnapshotNoResume(socketPath, snapshotPath, memPath, ifaceID, tapDevice, blockDeltaDir string) error {
+	fc := newFCClient(socketPath)
+	if _, err := fc.Operations.LoadSnapshot(&operations.LoadSnapshotParams{
+		Context: context.Background(),
+		Body: &models.SnapshotLoadParams{
+			SnapshotPath: &snapshotPath,
+			MemBackend: &models.MemoryBackend{
+				BackendType: strPtr(models.MemoryBackendBackendTypeFile),
+				BackendPath: &memPath,
+			},
+			ResumeVM: false,
+			NetworkOverrides: []*models.NetworkOverride{
+				{IfaceID: &ifaceID, HostDevName: &tapDevice},
+			},
+			BlockDeltaDir: blockDeltaDir,
+		},
+	}); err != nil {
+		if isTornSnapshotErr(err) {
+			return fmt.Errorf("load snapshot (no-resume): %w: %v", ErrTornSnapshot, err)
+		}
+		return fmt.Errorf("load snapshot (no-resume): %w", err)
+	}
+	return nil
+}
+
+// SnapshotPausedVM creates a Full snapshot of an already-paused VM (e.g. one
+// loaded via LoadSnapshotNoResume), issuing no pause first as CreateSnapshot does.
+func SnapshotPausedVM(socketPath, snapshotPath, memPath string) error {
+	fc := newFCClient(socketPath)
+	if _, err := fc.Operations.CreateSnapshot(&operations.CreateSnapshotParams{
+		Context: context.Background(),
+		Body: &models.SnapshotCreateParams{
+			SnapshotPath: &snapshotPath,
+			MemFilePath:  &memPath,
+			SnapshotType: models.SnapshotCreateParamsSnapshotTypeFull,
+		},
+	}); err != nil {
+		return fmt.Errorf("create snapshot (paused): %w", err)
+	}
+	return nil
+}
+
 // RestoreSnapshot loads a snapshot and resumes the VM. Non-empty blockDeltaDir
 // hydrates a fresh per-VM overlay from <dir>/<drive_id>.delta — pass empty
 // for in-place resume (existing overlay already carries state).

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -297,6 +297,12 @@ func UnpauseVM(socketPath string) error {
 // re-snapshot it (SnapshotPausedVM) and verify the memory round-trips. The TAP
 // override mirrors RestoreSnapshot* so device restore succeeds.
 func LoadSnapshotNoResume(socketPath, snapshotPath, memPath, ifaceID, tapDevice, blockDeltaDir string) error {
+	// Empty, not nil — Firecracker rejects null. Only override the TAP when one
+	// is actually provided; a blank HostDevName is invalid.
+	overrides := []*models.NetworkOverride{}
+	if tapDevice != "" {
+		overrides = []*models.NetworkOverride{{IfaceID: &ifaceID, HostDevName: &tapDevice}}
+	}
 	fc := newFCClient(socketPath)
 	if _, err := fc.Operations.LoadSnapshot(&operations.LoadSnapshotParams{
 		Context: context.Background(),
@@ -306,11 +312,9 @@ func LoadSnapshotNoResume(socketPath, snapshotPath, memPath, ifaceID, tapDevice,
 				BackendType: strPtr(models.MemoryBackendBackendTypeFile),
 				BackendPath: &memPath,
 			},
-			ResumeVM: false,
-			NetworkOverrides: []*models.NetworkOverride{
-				{IfaceID: &ifaceID, HostDevName: &tapDevice},
-			},
-			BlockDeltaDir: blockDeltaDir,
+			ResumeVM:         false,
+			NetworkOverrides: overrides,
+			BlockDeltaDir:    blockDeltaDir,
 		},
 	}); err != nil {
 		if isTornSnapshotErr(err) {

--- a/internal/vm/local_http.go
+++ b/internal/vm/local_http.go
@@ -124,6 +124,10 @@ type verifySnapshotResponse struct {
 // handleVerifySnapshot handles POST /verify-snapshot/{vmID}: re-snapshot the
 // frozen image and return its path for comparison. Internal/debug only.
 func (s *LocalHTTPServer) handleVerifySnapshot(w http.ResponseWriter, r *http.Request) {
+	if !s.mgr.cfg.VerifySnapshotEnabled {
+		http.Error(w, "verify-snapshot disabled", http.StatusNotFound)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/internal/vm/local_http.go
+++ b/internal/vm/local_http.go
@@ -31,6 +31,7 @@ func NewLocalHTTPServer(mgr *Manager, log zerolog.Logger) *LocalHTTPServer {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/instances/", s.handleInstance)
+	mux.HandleFunc("/verify-snapshot/", s.handleVerifySnapshot)
 	s.server = &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -112,6 +113,39 @@ func (s *LocalHTTPServer) handleInstance(w http.ResponseWriter, r *http.Request)
 		OwnerID:   info.OwnerID,
 	}); err != nil {
 		s.log.Error().Err(err).Str("instance", instanceID).Msg("failed to encode instance response")
+	}
+}
+
+// verifySnapshotResponse is the JSON shape returned by POST /verify-snapshot/{id}.
+type verifySnapshotResponse struct {
+	MemPath string `json:"mem_path"` // re-snapshotted image to compare against the original
+}
+
+// handleVerifySnapshot handles POST /verify-snapshot/{vmID}: re-snapshot the
+// frozen image and return its path for comparison. Internal/debug only.
+func (s *LocalHTTPServer) handleVerifySnapshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	vmID := strings.TrimPrefix(r.URL.Path, "/verify-snapshot/")
+	if vmID == "" || strings.Contains(vmID, "/") {
+		http.Error(w, "missing vm ID", http.StatusBadRequest)
+		return
+	}
+
+	// Re-snapshotting a multi-GB image outlasts the default write timeout.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(2 * time.Minute))
+
+	memPath, err := s.mgr.VerifySnapshot(r.Context(), vmID)
+	if err != nil {
+		s.log.Error().Err(err).Str("vm_id", vmID).Msg("verify snapshot failed")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(verifySnapshotResponse{MemPath: memPath}); err != nil {
+		s.log.Error().Err(err).Str("vm_id", vmID).Msg("failed to encode verify response")
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -754,7 +754,10 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 		tapDevice = netInfo.TAPDevice
 	}
 
-	// Throwaway Firecracker in the sandbox's existing env; stopped on the way out.
+	// Throwaway Firecracker in the sandbox's existing unit/rundir, stopped on the
+	// way out. Safe because the VM is paused (no live FC to disrupt), but it must
+	// not run concurrently with a resume of the same sandbox — fine for the
+	// debug/staging use this endpoint is gated to.
 	if _, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace); err != nil {
 		return "", fmt.Errorf("start firecracker for verify: %w", err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -702,6 +702,70 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, net
 	)
 }
 
+// VerifySnapshot loads vmID's snapshot without resuming, re-snapshots the frozen
+// image to a temp file, and returns its path (compare with the original via
+// snapcheck). Non-destructive: stops the throwaway FC, leaving the sandbox paused.
+func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, error) {
+	log := m.log.With().Str("vm_id", vmID).Logger()
+
+	inst, err := m.getInstance(vmID)
+	if err != nil {
+		return "", err
+	}
+	snapshotPath, memPath := inst.SnapshotPath, inst.MemFilePath
+	if snapshotPath == "" || memPath == "" {
+		return "", status.Errorf(codes.InvalidArgument, "vm %s has no snapshot on record", vmID)
+	}
+	if _, err := os.Stat(memPath); err != nil {
+		return "", status.Errorf(codes.FailedPrecondition, "mem file missing on host: %s", memPath)
+	}
+
+	rundirKey := vmID
+	if inst.RunDirID != "" {
+		rundirKey = inst.RunDirID
+	}
+	rootfsPath := inst.DiskPath
+	if rootfsPath == "" {
+		fname := "rootfs.ext4"
+		if inst.Config.BasePath != "" {
+			fname = "overlay.ext4"
+		}
+		rootfsPath = filepath.Join(m.cfg.RunDir, rundirKey, fname)
+	}
+	socketPath := filepath.Join(m.cfg.RunDir, rundirKey, "firecracker.sock")
+
+	var tapDevice string
+	if inst.Namespace != "" {
+		netInfo, nsErr := m.netMgr.EnsureVMSlot(ctx, vmID, inst.Namespace, inst.IP, inst.MACAddress)
+		if nsErr != nil {
+			return "", fmt.Errorf("ensure network slot for verify: %w", nsErr)
+		}
+		tapDevice = netInfo.TAPDevice
+	}
+
+	// Throwaway Firecracker in the sandbox's existing env; stopped on the way out.
+	if _, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace); err != nil {
+		return "", fmt.Errorf("start firecracker for verify: %w", err)
+	}
+	defer func() { _ = stopUnit(context.Background(), systemdUnitName(vmID)) }()
+
+	if err := LoadSnapshotNoResume(socketPath, snapshotPath, memPath, "eth0", tapDevice, ""); err != nil {
+		return "", err
+	}
+
+	verifyDir := filepath.Join(filepath.Dir(memPath), "verify")
+	if err := os.MkdirAll(verifyDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir verify dir: %w", err)
+	}
+	memBPath := filepath.Join(verifyDir, "mem.snap")
+	if err := SnapshotPausedVM(socketPath, filepath.Join(verifyDir, "vmstate.snap"), memBPath); err != nil {
+		return "", err
+	}
+
+	log.Info().Str("mem_b", memBPath).Msg("verify snapshot: re-snapshotted frozen image")
+	return memBPath, nil
+}
+
 // ---------------------------------------------------------------------------
 // Snapshot management
 // ---------------------------------------------------------------------------

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -153,6 +153,11 @@ type ManagerConfig struct {
 	// instead of File, reusing the existing tap. Requires UffdEnabled;
 	// default false, with File as the fallback.
 	ResumeUffdEnabled bool
+
+	// VerifySnapshotEnabled exposes the debug POST /verify-snapshot/{id} endpoint
+	// (re-snapshot a paused VM for bit-identical checks). Default false; intended
+	// for staging gate runs, not production.
+	VerifySnapshotEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -711,6 +716,12 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	inst, err := m.getInstance(vmID)
 	if err != nil {
 		return "", err
+	}
+	// Only operate on a paused VM. Starting a throwaway Firecracker for a running
+	// sandbox (and stopping it on the way out) would disrupt the live VM.
+	if inst.Status != StatusPaused {
+		return "", status.Errorf(codes.FailedPrecondition,
+			"vm %s is not paused (status %s); verify only runs on paused snapshots", vmID, inst.Status)
 	}
 	snapshotPath, memPath := inst.SnapshotPath, inst.MemFilePath
 	if snapshotPath == "" || memPath == "" {


### PR DESCRIPTION
Adds the **bit-identical snapshot verify gate** — the correctness check for upcoming incremental snapshots. `VerifySnapshot` loads a paused snapshot **without resuming**, re-snapshots the frozen image, and `snapcheck` compares it to the original; any unexpected page diff = a lost/corrupted page. Exposed via vmd's local HTTP server (`POST localhost:9090/verify-snapshot/{id}`), behind `VMD_VERIFY_SNAPSHOT_ENABLED` (**default off**) and guarded to paused VMs only — dark and inert in prod by default. Stacked on #149.

**Tested on staging:** gate is sensitive and trustworthy — byte-flip control → `differing: 1`, two different VMs → `differing: 286`, and the no-resume baseline is a stable, deterministic **3-page floor** (virtio device-state restore, confirmed by byte-level diff), identical across `base`/`python-ml` and a memory workload.