### PR TITLE
vmd: diff-equivalence check (flag-gated)

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -356,6 +356,7 @@ func main() {
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
 	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
+	diffEquivEnabled := envOrDefault("VMD_DIFF_EQUIV", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:        cfg.FirecrackerBin,
@@ -373,6 +374,7 @@ func main() {
 		UffdRecordMaxSeconds:  uffdRecordMaxSeconds,
 		ResumeUffdEnabled:     resumeUffdEnabled,
 		VerifySnapshotEnabled: verifySnapshotEnabled,
+		DiffEquivEnabled:      diffEquivEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -342,6 +342,36 @@ func SnapshotPausedVM(socketPath, snapshotPath, memPath string) error {
 	return nil
 }
 
+// SnapshotPausedVMDiff creates a Diff snapshot of an already-paused VM, merging
+// the dirty pages in place into memPath (which must already hold the base image
+// of the same size). Requires the VM to have been loaded with dirty tracking on.
+func SnapshotPausedVMDiff(socketPath, snapshotPath, memPath string) error {
+	fc := newFCClient(socketPath)
+	if _, err := fc.Operations.CreateSnapshot(&operations.CreateSnapshotParams{
+		Context: context.Background(),
+		Body: &models.SnapshotCreateParams{
+			SnapshotPath: &snapshotPath,
+			MemFilePath:  &memPath,
+			SnapshotType: models.SnapshotCreateParamsSnapshotTypeDiff,
+		},
+	}); err != nil {
+		return fmt.Errorf("create snapshot (diff, paused): %w", err)
+	}
+	return nil
+}
+
+// PauseVCPUs pauses a running VM's vCPUs without taking a snapshot. Inverse of UnpauseVM.
+func PauseVCPUs(socketPath string) error {
+	fc := newFCClient(socketPath)
+	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
+		Context: context.Background(),
+		Body:    &models.VM{State: strPtr(models.VMStatePaused)},
+	}); err != nil {
+		return fmt.Errorf("pause vCPUs: %w", err)
+	}
+	return nil
+}
+
 // RestoreSnapshot loads a snapshot and resumes the VM. Non-empty blockDeltaDir
 // hydrates a fresh per-VM overlay from <dir>/<drive_id>.delta — pass empty
 // for in-place resume (existing overlay already carries state).
@@ -406,6 +436,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 // suppressed on the Firecracker side regardless of accessLogPath.
 func RestoreSnapshotUffdInternalWithOverrides(
 	socketPath, snapshotPath, memPath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
+	trackDirty bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -421,7 +452,8 @@ func RestoreSnapshotUffdInternalWithOverrides(
 				AccessLogPath: accessLogPath,
 				RecordTo:      recordToPath,
 			},
-			ResumeVM: true,
+			TrackDirtyPages: trackDirty,
+			ResumeVM:        true,
 			NetworkOverrides: []*models.NetworkOverride{
 				{IfaceID: &ifaceID, HostDevName: &tapDevice},
 			},

--- a/internal/vm/local_http.go
+++ b/internal/vm/local_http.go
@@ -32,6 +32,7 @@ func NewLocalHTTPServer(mgr *Manager, log zerolog.Logger) *LocalHTTPServer {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/instances/", s.handleInstance)
 	mux.HandleFunc("/verify-snapshot/", s.handleVerifySnapshot)
+	mux.HandleFunc("/diff-equiv-check/", s.handleDiffEquivCheck)
 	s.server = &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -150,6 +151,45 @@ func (s *LocalHTTPServer) handleVerifySnapshot(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(verifySnapshotResponse{MemPath: memPath}); err != nil {
 		s.log.Error().Err(err).Str("vm_id", vmID).Msg("failed to encode verify response")
+	}
+}
+
+// diffEquivResponse is the JSON shape returned by POST /diff-equiv-check/{id}.
+type diffEquivResponse struct {
+	DiffPath string `json:"diff_path"` // base + dirty diff, merged
+	FullPath string `json:"full_path"` // full dump of the same frozen point
+}
+
+// handleDiffEquivCheck handles POST /diff-equiv-check/{vmID}: dump a Diff-merged
+// and a Full image of the same frozen point and return both for snapcheck (zero
+// differing pages ⇒ the Diff dirty-set is complete). Internal/debug only.
+func (s *LocalHTTPServer) handleDiffEquivCheck(w http.ResponseWriter, r *http.Request) {
+	if !s.mgr.cfg.DiffEquivEnabled {
+		http.Error(w, "diff-equiv-check disabled", http.StatusNotFound)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	vmID := strings.TrimPrefix(r.URL.Path, "/diff-equiv-check/")
+	if vmID == "" || strings.Contains(vmID, "/") {
+		http.Error(w, "missing vm ID", http.StatusBadRequest)
+		return
+	}
+
+	// Copying + dumping a multi-GB image outlasts the default write timeout.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(3 * time.Minute))
+
+	diffPath, fullPath, err := s.mgr.DiffEquivCheck(r.Context(), vmID)
+	if err != nil {
+		s.log.Error().Err(err).Str("vm_id", vmID).Msg("diff-equiv check failed")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(diffEquivResponse{DiffPath: diffPath, FullPath: fullPath}); err != nil {
+		s.log.Error().Err(err).Str("vm_id", vmID).Msg("failed to encode diff-equiv response")
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -158,6 +159,11 @@ type ManagerConfig struct {
 	// (re-snapshot a paused VM for bit-identical checks). Default false; intended
 	// for staging gate runs, not production.
 	VerifySnapshotEnabled bool
+
+	// DiffEquivEnabled arms dirty-page tracking on UFFD resume and exposes the
+	// debug POST /diff-equiv-check/{id} endpoint. Requires ResumeUffdEnabled.
+	// Default false; staging-only.
+	DiffEquivEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -702,8 +708,10 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, net
 
 	// No prefetch access log: only template builds record one (next to the template
 	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
+	// trackDirty arms dirty-page tracking so the diff-equiv check can take a Diff
+	// at the next pause; off by default (no overhead on the normal resume path).
 	return RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "",
+		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "", m.cfg.DiffEquivEnabled,
 	)
 }
 
@@ -778,6 +786,90 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 
 	log.Info().Str("mem_b", memBPath).Msg("verify snapshot: re-snapshotted frozen image")
 	return memBPath, nil
+}
+
+// DiffEquivCheck freezes a running, dirty-tracked UFFD-resumed VM once and dumps,
+// at that single frozen point, a Diff merged into a copy of the base and a fresh
+// Full, returning both paths. snapcheck of the two reports zero differing pages
+// iff the Diff dirty-set is complete. Non-destructive (the live VM is unpaused on
+// the way out); single-shot per resume, as the trailing Full resets the bitmap.
+func (m *Manager) DiffEquivCheck(ctx context.Context, vmID string) (diffPath, fullPath string, err error) {
+	log := m.log.With().Str("vm_id", vmID).Logger()
+
+	inst, err := m.getInstance(vmID)
+	if err != nil {
+		return "", "", err
+	}
+	// Dirty tracking is only armed on resume when the flag is on; without it the
+	// Diff would be empty/meaningless, so refuse rather than report a false pass.
+	if !m.cfg.DiffEquivEnabled {
+		return "", "", status.Errorf(codes.FailedPrecondition, "diff-equiv check disabled")
+	}
+	if inst.Status != StatusRunning {
+		return "", "", status.Errorf(codes.FailedPrecondition,
+			"vm %s is not running (status %s); diff-equiv runs on a live resumed VM", vmID, inst.Status)
+	}
+	base := inst.MemFilePath
+	if base == "" || inst.SocketPath == "" {
+		return "", "", status.Errorf(codes.FailedPrecondition, "vm %s has no live snapshot/socket on record", vmID)
+	}
+
+	equivDir := filepath.Join(filepath.Dir(base), "equiv")
+	if err := os.MkdirAll(equivDir, 0o755); err != nil {
+		return "", "", fmt.Errorf("mkdir equiv dir: %w", err)
+	}
+	diffPath = filepath.Join(equivDir, "mem_diff.snap")
+	fullPath = filepath.Join(equivDir, "mem_full.snap")
+
+	// The Diff merges into a copy of the exact base the VM resumed from, so
+	// base + dirty must reconstruct the live image. Copy before pausing — it's
+	// the largest step and the vCPUs need not be frozen for it.
+	if err := copyFile(base, diffPath); err != nil {
+		return "", "", fmt.Errorf("copy base for diff merge: %w", err)
+	}
+
+	if err := PauseVCPUs(inst.SocketPath); err != nil {
+		return "", "", err
+	}
+	// Best-effort unpause so the live VM keeps running even if a dump fails.
+	defer func() {
+		if uerr := UnpauseVM(inst.SocketPath); uerr != nil {
+			log.Error().Err(uerr).Msg("diff-equiv: failed to unpause live VM")
+			if err == nil {
+				err = uerr
+			}
+		}
+	}()
+
+	// Diff first (consumes the dirty bitmap), then Full (dumps everything; resets
+	// the bitmap). Order matters: a leading Full would clear the dirty set.
+	if err := SnapshotPausedVMDiff(inst.SocketPath, filepath.Join(equivDir, "vmstate_diff.snap"), diffPath); err != nil {
+		return "", "", err
+	}
+	if err := SnapshotPausedVM(inst.SocketPath, filepath.Join(equivDir, "vmstate_full.snap"), fullPath); err != nil {
+		return "", "", err
+	}
+
+	log.Info().Str("diff", diffPath).Str("full", fullPath).Msg("diff-equiv: dumped diff-merged + full")
+	return diffPath, fullPath, nil
+}
+
+// copyFile copies src to dst, overwriting dst.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 // ---------------------------------------------------------------------------
@@ -1089,7 +1181,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			}
 		}
 		restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-			socketPath, snapshotPath, memPath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir,
+			socketPath, snapshotPath, memPath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, false,
 		)
 	case inPlace:
 		restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)


### PR DESCRIPTION
Flag-gated (\`VMD_DIFF_EQUIV\`, default off) debug harness to test whether Firecracker native Diff snapshots (KVM dirty log ∪ FC mark_dirty bitmap) are byte-complete, deciding whether a WP_ASYNC dirty-tracking build is needed.

- Arms \`track_dirty_pages\` on UFFD resume when the flag is on (no-op otherwise).
- \`POST /diff-equiv-check/{id}\`: on a running resumed VM, freezes vCPUs once and dumps a Diff merged into a base copy + a fresh Full of the same frozen point; snapcheck of the two = zero differing pages iff the dirty-set is complete. Non-destructive.
- Off by default → inert in prod.