### PR TITLE
vmd: incremental + layered diff snapshots

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -357,6 +357,7 @@ func main() {
 	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
 	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
+	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -375,6 +376,7 @@ func main() {
 		ResumeUffdEnabled:          resumeUffdEnabled,
 		VerifySnapshotEnabled:      verifySnapshotEnabled,
 		IncrementalSnapshotEnabled: incrementalSnapshotEnabled,
+		HandlerDeathAbortEnabled:   handlerDeathAbortEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -356,23 +356,25 @@ func main() {
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
 	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
+	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
-		FirecrackerBin:        cfg.FirecrackerBin,
-		JailerBin:             cfg.JailerBin,
-		KernelPath:            cfg.KernelPath,
-		BaseRootfsPath:        cfg.BaseRootfsPath,
-		SnapshotDir:           cfg.SnapshotDir,
-		RunDir:                cfg.RunDir,
-		TemplateBuilderBin:    cfg.TemplateBuilderBin,
-		BoxdBinaryPath:        cfg.BoxdBinaryPath,
-		HostInterface:         cfg.HostInterface,
-		MaxConcurrentRestores: maxRestores,
-		UffdEnabled:           uffdEnabled,
-		UffdPrefetchEnabled:   uffdPrefetchEnabled,
-		UffdRecordMaxSeconds:  uffdRecordMaxSeconds,
-		ResumeUffdEnabled:     resumeUffdEnabled,
-		VerifySnapshotEnabled: verifySnapshotEnabled,
+		FirecrackerBin:             cfg.FirecrackerBin,
+		JailerBin:                  cfg.JailerBin,
+		KernelPath:                 cfg.KernelPath,
+		BaseRootfsPath:             cfg.BaseRootfsPath,
+		SnapshotDir:                cfg.SnapshotDir,
+		RunDir:                     cfg.RunDir,
+		TemplateBuilderBin:         cfg.TemplateBuilderBin,
+		BoxdBinaryPath:             cfg.BoxdBinaryPath,
+		HostInterface:              cfg.HostInterface,
+		MaxConcurrentRestores:      maxRestores,
+		UffdEnabled:                uffdEnabled,
+		UffdPrefetchEnabled:        uffdPrefetchEnabled,
+		UffdRecordMaxSeconds:       uffdRecordMaxSeconds,
+		ResumeUffdEnabled:          resumeUffdEnabled,
+		VerifySnapshotEnabled:      verifySnapshotEnabled,
+		IncrementalSnapshotEnabled: incrementalSnapshotEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/vm/fc/firecracker.yaml
+++ b/internal/vm/fc/firecracker.yaml
@@ -1440,6 +1440,11 @@ definitions:
           control payload and open file descriptor that it can use to serve this
           process's guest memory page faults (Uffd), or
           3) Path to the snapshot memory file backing guest RAM (UffdInternal).
+      base_path:
+        type: string
+        description: Optional base (template) memory file for a layered UffdInternal
+          restore. When set, a page is served from backend_path if present there,
+          else from this base. Only meaningful when backend_type is UffdInternal.
       access_log_path:
         type: string
         description: Optional path to a recorded page-access trace replayed as

--- a/internal/vm/fc/firecracker.yaml
+++ b/internal/vm/fc/firecracker.yaml
@@ -1455,6 +1455,13 @@ definitions:
         description: Optional path the in-process UFFD handler writes each served
           page offset to (template-build mode). Only meaningful when backend_type
           is UffdInternal; ignored otherwise. When present, prefetch is suppressed.
+      abort_on_handler_death:
+        type: boolean
+        default: false
+        description: When true, an unexpected UffdInternal handler death aborts
+          Firecracker instead of leaving the guest to freeze on its next page
+          fault. Only meaningful when backend_type is UffdInternal; ignored
+          otherwise.
 
   Metrics:
     type: object

--- a/internal/vm/fc/models/memory_backend.go
+++ b/internal/vm/fc/models/memory_backend.go
@@ -26,6 +26,9 @@ type MemoryBackend struct {
 	// Enum: ["File","Uffd","UffdInternal"]
 	BackendType *string `json:"backend_type"`
 
+	// Optional base (template) memory file for a layered UffdInternal restore. When set, a page is served from backend_path if present there, else from this base. Only meaningful when backend_type is UffdInternal; ignored otherwise.
+	BasePath string `json:"base_path,omitempty"`
+
 	// Optional path to a recorded page-access trace replayed as prefetch on restore. Only meaningful when backend_type is UffdInternal; ignored otherwise.
 	AccessLogPath string `json:"access_log_path,omitempty"`
 

--- a/internal/vm/fc/models/memory_backend.go
+++ b/internal/vm/fc/models/memory_backend.go
@@ -34,6 +34,9 @@ type MemoryBackend struct {
 
 	// Optional path the in-process UFFD handler writes each served page offset to (template-build mode). Only meaningful when backend_type is UffdInternal; ignored otherwise. When present, prefetch is suppressed.
 	RecordTo string `json:"record_to,omitempty"`
+
+	// When true, an unexpected UffdInternal handler death aborts Firecracker instead of leaving the guest to freeze on its next page fault. Only meaningful when backend_type is UffdInternal; ignored otherwise. Omitted (false) by default so the wire format is unchanged when off.
+	AbortOnHandlerDeath bool `json:"abort_on_handler_death,omitempty"`
 }
 
 // Validate validates this memory backend

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -432,7 +432,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 // page offset (template-build mode). When recordToPath is set, prefetch is
 // suppressed on the Firecracker side regardless of accessLogPath.
 func RestoreSnapshotUffdInternalWithOverrides(
-	socketPath, snapshotPath, memPath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
+	socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
 	trackDirty bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
@@ -444,8 +444,11 @@ func RestoreSnapshotUffdInternalWithOverrides(
 		Body: &models.SnapshotLoadParams{
 			SnapshotPath: &snapshotPath,
 			MemBackend: &models.MemoryBackend{
-				BackendType:   strPtr(models.MemoryBackendBackendTypeUffdInternal),
-				BackendPath:   &memPath,
+				BackendType: strPtr(models.MemoryBackendBackendTypeUffdInternal),
+				BackendPath: &memPath,
+				// Layered restore: pages absent from memPath (the overlay/diff) are
+				// served from this base (template). Empty ⇒ single-file restore.
+				BasePath:      basePath,
 				AccessLogPath: accessLogPath,
 				RecordTo:      recordToPath,
 			},

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -280,9 +280,15 @@ func CreateSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string, mod
 	return nil
 }
 
-// CreateDiffSnapshot pauses the VM and writes a Diff snapshot — the pages dirtied
-// since load, merged in place into memPath (which must already hold the base image
-// of the same size). Requires the VM to have been loaded with dirty tracking on.
+// CreateDiffSnapshot pauses the VM and writes a Diff snapshot: only the pages
+// dirtied since load, written at their offsets into memPath. Requires the VM to
+// have been loaded with dirty tracking on. Whether memPath ends up a complete
+// image or a sparse overlay is the caller's choice, set by what memPath holds
+// going in:
+//   - in-place merge: memPath already holds the base image (same size), so the
+//     dirty pages overwrite it and it stays a complete, standalone image.
+//   - layered overlay: memPath is fresh/sparse, so it ends up holding only the
+//     changed pages — restored over a separate base, never loaded standalone.
 func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
 	fc := newFCClient(socketPath)
 	ctx := context.Background()

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -280,6 +280,33 @@ func CreateSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string, mod
 	return nil
 }
 
+// CreateDiffSnapshot pauses the VM and writes a Diff snapshot — the pages dirtied
+// since load, merged in place into memPath (which must already hold the base image
+// of the same size). Requires the VM to have been loaded with dirty tracking on.
+func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
+	fc := newFCClient(socketPath)
+	ctx := context.Background()
+
+	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
+		Context: ctx,
+		Body:    &models.VM{State: strPtr(models.VMStatePaused)},
+	}); err != nil {
+		return fmt.Errorf("pause VM: %w", err)
+	}
+
+	if _, err := fc.Operations.CreateSnapshot(&operations.CreateSnapshotParams{
+		Context: ctx,
+		Body: &models.SnapshotCreateParams{
+			SnapshotPath: &snapshotPath,
+			MemFilePath:  &memPath,
+			SnapshotType: models.SnapshotCreateParamsSnapshotTypeDiff,
+		},
+	}); err != nil {
+		return fmt.Errorf("create diff snapshot: %w", err)
+	}
+	return nil
+}
+
 // UnpauseVM resumes a paused VM's vCPUs. Used after CreateSnapshot to make
 // snapshot creation non-destructive.
 func UnpauseVM(socketPath string) error {
@@ -406,6 +433,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 // suppressed on the Firecracker side regardless of accessLogPath.
 func RestoreSnapshotUffdInternalWithOverrides(
 	socketPath, snapshotPath, memPath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
+	trackDirty bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -421,7 +449,10 @@ func RestoreSnapshotUffdInternalWithOverrides(
 				AccessLogPath: accessLogPath,
 				RecordTo:      recordToPath,
 			},
-			ResumeVM: true,
+			// Arms dirty-page tracking so the next pause can write an incremental
+			// (Diff) snapshot instead of a Full one.
+			TrackDirtyPages: trackDirty,
+			ResumeVM:        true,
 			NetworkOverrides: []*models.NetworkOverride{
 				{IfaceID: &ifaceID, HostDevName: &tapDevice},
 			},

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -31,6 +31,22 @@ func isTornSnapshotErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), tornSnapshotMarker)
 }
 
+// ErrLayeredInvalidSnapshot is the firecracker fork's sentinel for a structurally
+// invalid layered restore (overlay/base size mismatch, huge-page overlay, block
+// size > page size, missing base). It is permanent — retrying or falling back to a
+// standalone load of the overlay won't help (the latter would read base pages as
+// zero holes), so the caller must use a Full/previous snapshot instead.
+var ErrLayeredInvalidSnapshot = errors.New("layered restore overlay/base pairing is invalid")
+
+// layeredInvalidMarker is the exact substring the forked Firecracker embeds in its
+// error for an invalid layered restore (the GuestMemoryFromUffdError::LayeredInvalid
+// display text). Named so a fork message change is updated here, not missed at runtime.
+const layeredInvalidMarker = "overlay/base pairing is invalid"
+
+func isLayeredInvalidErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), layeredInvalidMarker)
+}
+
 // ---------------------------------------------------------------------------
 // Firecracker config (our internal type, not a Firecracker API type)
 // ---------------------------------------------------------------------------
@@ -470,6 +486,9 @@ func RestoreSnapshotUffdInternalWithOverrides(
 	}); err != nil {
 		if isTornSnapshotErr(err) {
 			return fmt.Errorf("load snapshot (uffd-internal): %w: %v", ErrTornSnapshot, err)
+		}
+		if isLayeredInvalidErr(err) {
+			return fmt.Errorf("load snapshot (uffd-internal): %w: %v", ErrLayeredInvalidSnapshot, err)
 		}
 		return fmt.Errorf("load snapshot (uffd-internal): %w", err)
 	}

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -455,7 +455,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 // suppressed on the Firecracker side regardless of accessLogPath.
 func RestoreSnapshotUffdInternalWithOverrides(
 	socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
-	trackDirty bool,
+	trackDirty, abortOnHandlerDeath bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -470,9 +470,10 @@ func RestoreSnapshotUffdInternalWithOverrides(
 				BackendPath: &memPath,
 				// Layered restore: pages absent from memPath (the overlay/diff) are
 				// served from this base (template). Empty ⇒ single-file restore.
-				BasePath:      basePath,
-				AccessLogPath: accessLogPath,
-				RecordTo:      recordToPath,
+				BasePath:            basePath,
+				AccessLogPath:       accessLogPath,
+				RecordTo:            recordToPath,
+				AbortOnHandlerDeath: abortOnHandlerDeath,
 			},
 			// Arms dirty-page tracking so the next pause can write an incremental
 			// (Diff) snapshot instead of a Full one.

--- a/internal/vm/firecracker_test.go
+++ b/internal/vm/firecracker_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -139,4 +140,25 @@ func waitForUnixSocket(t *testing.T, socketPath string) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("server at %s never became ready", socketPath)
+}
+
+// TestIsLayeredInvalidErr guards the cross-repo string coupling: the matcher must
+// recognize the forked Firecracker's LayeredInvalid display text (and not generic
+// errors). If the fork changes that message, this test fails instead of the
+// classification silently degrading to a retryable Internal error at runtime.
+func TestIsLayeredInvalidErr(t *testing.T) {
+	// Representative of the full Display chain Firecracker surfaces on the API error.
+	fcErr := fmt.Errorf("load snapshot (uffd-internal): [PUT /snapshot/load][400] " +
+		"Error creating guest memory from uffd: Layered restore " +
+		"overlay/base pairing is invalid (permanent — do not retry): " +
+		"base \"/t/mem.base\" is 1048576 bytes, smaller than guest RAM 2097152")
+	if !isLayeredInvalidErr(fcErr) {
+		t.Errorf("isLayeredInvalidErr = false, want true for %q", fcErr)
+	}
+	if isLayeredInvalidErr(fmt.Errorf("load snapshot: connection refused")) {
+		t.Error("isLayeredInvalidErr = true for an unrelated error, want false")
+	}
+	if isLayeredInvalidErr(nil) {
+		t.Error("isLayeredInvalidErr(nil) = true, want false")
+	}
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -615,20 +615,40 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	case layered:
 		memPath = overlayPath
 		baseMemPath = instBaseMem
+		// A first layered pass (VM loaded straight from the template base, not from
+		// this overlay) must start from a fresh overlay: its dirty set is the whole
+		// overlay, so any leftover mem.diff from a failed/un-finalized earlier pause
+		// would survive as stale page extents — CreateDiffSnapshot writes only
+		// dirtied pages in place and never truncates — and override the base on the
+		// next layered restore, corrupting guest memory. Remove it; if it can't be
+		// removed, fall back to Full. An accumulating pass (resumed from this same
+		// overlay) must instead keep it, so this only runs for the first pass.
+		usable := true
+		if instMemFile == instBaseMem {
+			if rerr := os.Remove(overlayPath); rerr != nil && !os.IsNotExist(rerr) {
+				log.Warn().Err(rerr).Str("path", overlayPath).Msg("pause: stale overlay removal failed; falling back to Full")
+				usable = false
+			}
+		}
 		// Write the base sidecar BEFORE the diff so an overlay never exists on disk
 		// without its base record (a stateless cross-host restore relies on it). If
 		// the sidecar can't be written, fall back to a Full rather than produce an
 		// unrecoverable overlay.
-		if serr := os.WriteFile(layeredBaseSidecarPath(memPath), []byte(baseMemPath), 0o644); serr != nil {
-			log.Warn().Err(serr).Msg("pause: layered base sidecar write failed; falling back to Full")
-			memPath, baseMemPath = fullPath, ""
-			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
-				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+		if usable {
+			if serr := os.WriteFile(layeredBaseSidecarPath(memPath), []byte(baseMemPath), 0o644); serr != nil {
+				log.Warn().Err(serr).Msg("pause: layered base sidecar write failed; falling back to Full")
+				usable = false
 			}
-		} else {
+		}
+		if usable {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
 			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
+			}
+		} else {
+			memPath, baseMemPath = fullPath, ""
+			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
 			}
 		}
 	default:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -176,6 +176,12 @@ type ManagerConfig struct {
 	// merged into the existing mem.snap — instead of a Full one. Requires
 	// ResumeUffdEnabled. Default false.
 	IncrementalSnapshotEnabled bool
+
+	// HandlerDeathAbortEnabled tells the in-process UFFD handler to abort Firecracker
+	// on an unexpected handler death (instead of letting the guest freeze on its next
+	// page fault). The dead VM then surfaces via the unit-inactive → reconciler path
+	// rather than hanging silently. Independent of the snapshot flags. Default false.
+	HandlerDeathAbortEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -903,6 +909,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
 		socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
+		m.cfg.HandlerDeathAbortEnabled,
 	)
 }
 
@@ -1356,6 +1363,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if restoreErr == nil {
 			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
 				socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
+				m.cfg.HandlerDeathAbortEnabled,
 			)
 		}
 	case inPlace:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -802,13 +802,18 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
 	// A base is needed only when memPath is itself a diff overlay. Keying on memPath
 	// (not the cached BaseMemPath) means a standalone/override resume clears any
-	// stale base, so the next pause won't wrongly diff against the old template. For
-	// an overlay: in-memory base, then on-disk sidecar, else refuse.
+	// stale base, so the next pause won't wrongly diff against the old template.
+	//
+	// The .base sidecar is authoritative for THIS overlay, so prefer it — the cached
+	// BaseMemPath only matches the cached overlay (inst.MemFilePath) and would supply
+	// the wrong base for an explicit override of a different mem.diff. Fall back to
+	// the cached base only when the sidecar is missing and this is the cached overlay.
 	basePath := ""
 	if isOverlayMemFile(memPath) {
-		basePath = inst.BaseMemPath
-		if basePath == "" {
-			basePath, _ = readLayeredBase(memPath)
+		if b, ok := readLayeredBase(memPath); ok {
+			basePath = b
+		} else if memPath == inst.MemFilePath {
+			basePath = inst.BaseMemPath
 		}
 		if basePath == "" {
 			m.stopUnitDuringRestoreError(vmID)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -758,12 +758,10 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	// A base is needed only when memPath is itself a diff overlay; a standalone
-	// image (including an explicit override path) gets no base. Keying on memPath —
-	// not on the cached BaseMemPath — means a full-image resume clears any stale
-	// base below, so the next pause won't wrongly diff against the old template.
-	// For an overlay, prefer the in-memory base, fall back to the on-disk sidecar,
-	// and refuse rather than load a sparse overlay standalone.
+	// A base is needed only when memPath is itself a diff overlay. Keying on memPath
+	// (not the cached BaseMemPath) means a standalone/override resume clears any
+	// stale base, so the next pause won't wrongly diff against the old template. For
+	// an overlay: in-memory base, then on-disk sidecar, else refuse.
 	basePath := ""
 	if isOverlayMemFile(memPath) {
 		basePath = inst.BaseMemPath
@@ -1223,16 +1221,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				accessLogPath = candidate
 			}
 		}
-		// Decide the layered base for this UFFD restore:
-		//  - overlay (mem.diff) with a base sidecar → stateless resume of a layered
-		//    sandbox: reconstruct the base from disk and load layered.
-		//  - overlay with no recoverable base → refuse (loading the sparse diff
-		//    standalone would read the base's pages as zero holes).
-		//  - template create with incremental + resume-UFFD on → arm tracking and
-		//    record the template as the base; the load stays single-file (the base
-		//    only matters on the next resume).
-		// Require resume-UFFD for any layered path: only the UFFD layered backend can
-		// serve overlay-over-base.
+		// Decide the layered base for this UFFD restore. An overlay (mem.diff) needs
+		// its base reconstructed from the sidecar (else refuse — loading it
+		// standalone reads the base as zero holes); a template create instead arms
+		// tracking and records the template as the base. Layered needs resume-UFFD.
 		_, tmplErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
 		isTemplate := tmplErr == nil
 		sidecarBase, hasSidecar := readLayeredBase(memPath)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -631,7 +631,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// overlay) must instead keep it, so this only runs for the first pass.
 		usable := true
 		if instMemFile == instBaseMem {
-			if rerr := os.Remove(overlayPath); rerr != nil && !os.IsNotExist(rerr) {
+			if rerr := freshenFirstPassOverlay(overlayPath); rerr != nil {
 				log.Warn().Err(rerr).Str("path", overlayPath).Msg("pause: stale overlay removal failed; falling back to Full")
 				usable = false
 			}
@@ -649,6 +649,13 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		if usable {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
 			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
+				// A failed diff may have left a partial overlay. Drop the .base sidecar
+				// so a later restore can't treat that partial data as a valid layered
+				// overlay — without the sidecar it's refused (overlay-without-base),
+				// failing loud instead of loading corrupt memory. The overlay file
+				// itself is left in place: handleVMError keeps a still-running VM, which
+				// may still have it mmap'd. (True crash-atomicity is out of scope.)
+				_ = os.Remove(layeredBaseSidecarPath(memPath))
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
 			}
 		} else {
@@ -695,10 +702,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 // shouldWriteDiff reports whether a pause may write a Diff instead of a Full.
 // Diff is correct only when tracking was armed this run AND memPath is the exact
-// base this VM resumed from AND that base exists; any miss falls back to Full.
-// Diff onto a non-base or untracked run would silently corrupt the snapshot.
-func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeBasePath string, baseExists bool) bool {
-	return incremental && dirtyTracked && memPath == resumeBasePath && baseExists
+// mem file this VM resumed from AND that file exists; any miss falls back to Full.
+// Diff onto a non-resume-file or untracked run would silently corrupt the snapshot.
+// memFileExists is the on-disk presence of memPath itself (the VM's own mem.snap),
+// not a template/layered base — the in-place diff merges into that resume file.
+func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeMemPath string, memFileExists bool) bool {
+	return incremental && dirtyTracked && memPath == resumeMemPath && memFileExists
 }
 
 // layeredBaseSidecarPath is where the layered base (template) path is recorded
@@ -707,6 +716,18 @@ func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeBasePath str
 // loss) can still reconstruct the base instead of loading the sparse overlay
 // standalone (which would read the base's pages as zero holes).
 func layeredBaseSidecarPath(memPath string) string { return memPath + ".base" }
+
+// freshenFirstPassOverlay removes any leftover overlay so a first layered pass starts
+// from a clean file (its dirty set is the whole overlay, so a stale one would leave
+// non-dirtied stale pages that override the base on restore). A missing overlay is the
+// normal case (nil); a real overlay that can't be removed returns an error so the
+// caller falls back to a Full snapshot rather than diff onto stale data.
+func freshenFirstPassOverlay(overlayPath string) error {
+	if err := os.Remove(overlayPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
 
 // readLayeredBase returns the recorded base for an overlay mem file and whether
 // the sidecar is present and non-empty.
@@ -1341,16 +1362,14 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		armLayered := false
 		switch {
 		case hasSidecar:
-			if !canLayered {
-				restoreErr = fmt.Errorf("layered overlay %q requires resume-UFFD to restore", memPath)
-			} else {
-				basePath = sidecarBase
-				armLayered = m.cfg.IncrementalSnapshotEnabled
-				inst.mu.Lock()
-				inst.BaseMemPath = sidecarBase
-				inst.DirtyTracked = armLayered
-				inst.mu.Unlock()
-			}
+			// The outer overlayNeedsLayered guard already required resume-UFFD to reach
+			// here, so canLayered holds — serve the overlay over its recorded base.
+			basePath = sidecarBase
+			armLayered = m.cfg.IncrementalSnapshotEnabled
+			inst.mu.Lock()
+			inst.BaseMemPath = sidecarBase
+			inst.DirtyTracked = armLayered
+			inst.mu.Unlock()
 		case isOverlayMemFile(memPath):
 			restoreErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
 		case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
@@ -1385,6 +1404,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		m.cleanupRunDir(vmID)
 		m.setStatus(vmID, StatusError)
+		// armLayered may have set DirtyTracked=true on inst before the restore call;
+		// clear it on failure so a lingering instance can't later take a Diff against a
+		// baseline that never loaded. (The VM is StatusError + unit stopped, so this is
+		// belt-and-suspenders, but it keeps the flag honest.)
+		inst.mu.Lock()
+		inst.DirtyTracked = false
+		inst.mu.Unlock()
 		if errors.Is(restoreErr, ErrTornSnapshot) {
 			return nil, status.Errorf(codes.DataLoss,
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1003,17 +1003,19 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 		return "", "", fmt.Errorf("create snapshot: %w", err)
 	}
 
-	if err := UnpauseVM(inst.SocketPath); err != nil {
-		return snapshotPath, memPath, fmt.Errorf("resume after snapshot: %w", err)
-	}
-
 	// This Full snapshot reset Firecracker's dirty bitmap, so the diff baseline
-	// relative to the resume base is gone. Force the next pause back to Full — a
-	// Diff now would miss pages dirtied between resume and this ad-hoc snapshot.
+	// relative to the resume base is gone. Clear the flag now — before the unpause,
+	// which can fail and return early — so a later pause can't take the Diff path
+	// against the stale baseline and miss pages dirtied between resume and this
+	// ad-hoc snapshot. Forces the next pause back to Full.
 	inst.mu.Lock()
 	inst.DirtyTracked = false
 	inst.mu.Unlock()
 	m.persistState(inst)
+
+	if err := UnpauseVM(inst.SocketPath); err != nil {
+		return snapshotPath, memPath, fmt.Errorf("resume after snapshot: %w", err)
+	}
 
 	return snapshotPath, memPath, nil
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -670,6 +670,19 @@ func isOverlayMemFile(memPath string) bool {
 	return filepath.Base(memPath) == "mem.diff"
 }
 
+// isTemplateMemPath reports whether memPath is an immutable template memory
+// artifact (under <SnapshotDir>/templates/...), making it a valid layered base.
+// Covers both system and user-built templates and any nesting (e.g. the
+// build-<id> subdir the build pipeline writes), unlike the strict-shape
+// templateRootfsForSnapshot used for legacy disk resolution.
+func (m *Manager) isTemplateMemPath(memPath string) bool {
+	if m.cfg.SnapshotDir == "" || memPath == "" {
+		return false
+	}
+	root := filepath.Clean(filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)) + string(filepath.Separator)
+	return strings.HasPrefix(filepath.Clean(memPath), root)
+}
+
 // fileExists reports whether path exists and is a regular file.
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
@@ -1225,8 +1238,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// its base reconstructed from the sidecar (else refuse — loading it
 		// standalone reads the base as zero holes); a template create instead arms
 		// tracking and records the template as the base. Layered needs resume-UFFD.
-		_, tmplErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
-		isTemplate := tmplErr == nil
+		isTemplate := m.isTemplateMemPath(memPath)
 		sidecarBase, hasSidecar := readLayeredBase(memPath)
 		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
 		basePath := ""

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1034,12 +1034,21 @@ func (m *Manager) DeleteSnapshotFiles(vmID, snapshotPath, memPath string) error 
 		}
 	}
 
-	// Side-car (overlay-mode only). Missing is expected for legacy;
-	// any other error is logged — leftover side-cars caused fork bugs.
+	// Side-cars. Missing is expected for legacy; any other error is logged —
+	// leftover side-cars caused fork bugs. The .overlay record sits next to the
+	// vmstate snapshot; the layered .base record sits next to the mem overlay
+	// (mem.diff.base). A stray .base would make a later restore treat a
+	// non-layered mem file as a layered overlay, so it must go with the mem file.
 	if snapshotPath != "" {
 		sidecar := snapshotPath + ".overlay"
 		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
 			m.log.Warn().Err(err).Str("path", sidecar).Msg("remove overlay side-car")
+		}
+	}
+	if memPath != "" {
+		sidecar := layeredBaseSidecarPath(memPath)
+		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
+			m.log.Warn().Err(err).Str("path", sidecar).Msg("remove layered base side-car")
 		}
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -98,6 +98,12 @@ type VMInstance struct {
 	TeamID       string // owning team; carried for data-plane usage attribution
 	OwnerID      string // creating user; empty when unknown
 
+	// DirtyTracked is true when the current Firecracker run was loaded with
+	// dirty-page tracking armed (set on incremental UFFD resume). Gates whether
+	// the next pause may write a Diff snapshot. Not persisted: it describes the
+	// live FC process, which a fresh resume re-establishes.
+	DirtyTracked bool
+
 	mu sync.RWMutex
 }
 
@@ -158,6 +164,12 @@ type ManagerConfig struct {
 	// (re-snapshot a paused VM for bit-identical checks). Default false; intended
 	// for staging gate runs, not production.
 	VerifySnapshotEnabled bool
+
+	// IncrementalSnapshotEnabled makes a UFFD resume arm dirty-page tracking so the
+	// next pause writes an incremental (Diff) snapshot — only the dirtied pages,
+	// merged into the existing mem.snap — instead of a Full one. Requires
+	// ResumeUffdEnabled. Default false.
+	IncrementalSnapshotEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -566,9 +578,22 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	snapshotPath = filepath.Join(snapshotDir, "vmstate.snap")
 	memPath = filepath.Join(snapshotDir, "mem.snap")
 
-	log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
-	if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
-		return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+	// Diff merges into the same mem.snap the live UFFD handler faults from, but only
+	// at dirtied offsets — which are resident and never re-faulted, so disjoint from
+	// the clean offsets the handler reads. Safe while the VM is still up pre-stop.
+	useDiff := shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, inst.DirtyTracked,
+		memPath, inst.MemFilePath, fileExists(memPath))
+
+	if useDiff {
+		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
+		if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
+			return "", "", m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
+		}
+	} else {
+		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
+		if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+			return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+		}
 	}
 
 	// Stop the Firecracker process — snapshot is already on disk.
@@ -580,11 +605,26 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	inst.Status = StatusPaused
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = memPath
+	inst.DirtyTracked = false // FC process is stopping; a fresh resume re-arms tracking.
 	inst.mu.Unlock()
 
 	m.persistState(inst)
 	log.Info().Msg("VM paused")
 	return snapshotPath, memPath, nil
+}
+
+// shouldWriteDiff reports whether a pause may write a Diff instead of a Full.
+// Diff is correct only when tracking was armed this run AND memPath is the exact
+// base this VM resumed from AND that base exists; any miss falls back to Full.
+// Diff onto a non-base or untracked run would silently corrupt the snapshot.
+func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeBasePath string, baseExists bool) bool {
+	return incremental && dirtyTracked && memPath == resumeBasePath && baseExists
+}
+
+// fileExists reports whether path exists and is a regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // ---------------------------------------------------------------------------
@@ -669,7 +709,8 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	if err := m.restoreForResume(socketPath, snapshotPath, memPath, netInfo); err != nil {
+	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, netInfo)
+	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
 		if errors.Is(err, ErrTornSnapshot) {
@@ -684,6 +725,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.PID = pid
 	inst.SocketPath = socketPath
 	inst.Status = StatusRunning
+	inst.DirtyTracked = dirtyTracked
 	inst.mu.Unlock()
 
 	m.persistState(inst)
@@ -694,16 +736,20 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 // restoreForResume picks the resume memory backend: UFFD (reusing the existing
 // tap for the interface override) when enabled and a tap is present, else File,
 // which is also the fallback when ResumeUffdEnabled is off.
-func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, netInfo *network.VMNetInfo) error {
+// restoreForResume restores the VM and reports whether dirty-page tracking was
+// armed (true only on the incremental UFFD path) so the caller can decide if the
+// next pause may write a Diff.
+func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
 	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
 	if !useUffd {
-		return RestoreSnapshot(socketPath, snapshotPath, memPath, "")
+		return false, RestoreSnapshot(socketPath, snapshotPath, memPath, "")
 	}
 
 	// No prefetch access log: only template builds record one (next to the template
 	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
-	return RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "",
+	trackDirty := m.cfg.IncrementalSnapshotEnabled
+	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
+		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 	)
 }
 
@@ -1088,8 +1134,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				accessLogPath = candidate
 			}
 		}
+		// Cold create/restore from a template: no incremental tracking — the first
+		// pause writes a Full base. Tracking is armed only on a later resume.
 		restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-			socketPath, snapshotPath, memPath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir,
+			socketPath, snapshotPath, memPath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, false,
 		)
 	case inPlace:
 		restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -850,6 +850,14 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
 				snapshotPath, err)
 		}
+		if errors.Is(err, ErrLayeredInvalidSnapshot) {
+			// Permanent: the overlay/base pairing is structurally invalid, so retrying
+			// the layered restore can't succeed. FailedPrecondition tells the caller not
+			// to retry (vs the generic Internal below, which it may).
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"snapshot %q has an invalid layered overlay/base pairing; do not retry: %v",
+				snapshotPath, err)
+		}
 		return nil, fmt.Errorf("restore snapshot: %w", err)
 	}
 
@@ -1372,6 +1380,14 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if errors.Is(restoreErr, ErrTornSnapshot) {
 			return nil, status.Errorf(codes.DataLoss,
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
+				snapshotPath, restoreErr)
+		}
+		if errors.Is(restoreErr, ErrLayeredInvalidSnapshot) {
+			// Permanent: the overlay/base pairing is structurally invalid, so retrying
+			// the layered restore can't succeed. FailedPrecondition tells the caller not
+			// to retry (vs the generic Internal below, which it may).
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"snapshot %q has an invalid layered overlay/base pairing; do not retry: %v",
 				snapshotPath, restoreErr)
 		}
 		return nil, fmt.Errorf("restore snapshot: %w", restoreErr)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -587,11 +587,19 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// (mem.diff) holding only the pages changed vs its template base. The base is a
 	// distinct file from the overlay, so the merge never touches the template the
 	// handler still faults from; resume loads overlay+base lazily.
-	layered := m.cfg.IncrementalSnapshotEnabled && inst.DirtyTracked && inst.BaseMemPath != ""
+	//
+	// Only layer when this overlay is the one the VM accumulates into: the first
+	// pause after a template create (resumed from the base directly), or a later
+	// pause writing the exact overlay the VM resumed from. Otherwise (custom dir,
+	// explicit-override resume) the diff would capture only this run's changes and
+	// drop the prior overlay's pages, so fall back to a Full (complete) image.
+	overlayPath := filepath.Join(snapshotDir, "mem.diff")
+	layered := m.cfg.IncrementalSnapshotEnabled && inst.DirtyTracked && inst.BaseMemPath != "" &&
+		(inst.MemFilePath == inst.BaseMemPath || overlayPath == inst.MemFilePath)
 	baseMemPath := ""
 	switch {
 	case layered:
-		memPath = filepath.Join(snapshotDir, "mem.diff")
+		memPath = overlayPath
 		baseMemPath = inst.BaseMemPath
 		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
 		if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -825,15 +825,21 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	return inst, nil
 }
 
-// restoreForResume picks the resume memory backend: UFFD (reusing the existing
-// tap for the interface override) when enabled and a tap is present, else File,
-// which is also the fallback when ResumeUffdEnabled is off.
-// restoreForResume restores the VM and reports whether dirty-page tracking was
-// armed (true only on the incremental UFFD path) so the caller can decide if the
-// next pause may write a Diff.
+// restoreForResume picks the resume memory backend: UFFD (reusing the existing tap
+// for the interface override, optionally layered over basePath) when enabled and a
+// tap is present, else File. A layered overlay (basePath set) requires UFFD. Reports
+// whether dirty-page tracking was armed so the caller can decide if the next pause
+// may write a Diff.
 func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
 	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
 	if !useUffd {
+		// A layered overlay can only be served by the UFFD layered backend. If this
+		// host can't take that path (resume-UFFD/UFFD off, or no tap), refuse rather
+		// than load the sparse overlay via the File backend, which would read the
+		// base's pages as zero holes.
+		if basePath != "" {
+			return false, fmt.Errorf("layered overlay %q requires UFFD resume (resume-uffd + uffd + tap); refusing File-backend restore", memPath)
+		}
 		return false, RestoreSnapshot(socketPath, snapshotPath, memPath, "")
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -748,6 +748,11 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.SocketPath = socketPath
 	inst.Status = StatusRunning
 	inst.DirtyTracked = dirtyTracked
+	// Record the file actually resumed from (callers may pass an explicit path
+	// that differs from the cached one) so the next pause's diff baseline matches
+	// what Firecracker's dirty bitmap is relative to.
+	inst.SnapshotPath = snapshotPath
+	inst.MemFilePath = memPath
 	inst.mu.Unlock()
 
 	m.persistState(inst)
@@ -877,6 +882,14 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	if err := UnpauseVM(inst.SocketPath); err != nil {
 		return snapshotPath, memPath, fmt.Errorf("resume after snapshot: %w", err)
 	}
+
+	// This Full snapshot reset Firecracker's dirty bitmap, so the diff baseline
+	// relative to the resume base is gone. Force the next pause back to Full — a
+	// Diff now would miss pages dirtied between resume and this ad-hoc snapshot.
+	inst.mu.Lock()
+	inst.DirtyTracked = false
+	inst.mu.Unlock()
+	m.persistState(inst)
 
 	return snapshotPath, memPath, nil
 }
@@ -1161,8 +1174,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// tracking and records the template mem file as the base, so the first pause
 		// writes a small diff overlay vs the template. The load stays single-file;
 		// the base only matters on the next resume.
+		// Require resume-UFFD too: a layered pause writes mem.diff, which only
+		// resumes correctly via the UFFD layered backend. Without resume-UFFD the
+		// resume would fall back to the File backend and load the sparse diff as a
+		// full image, so don't arm layered tracking in that configuration.
 		_, tmplErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
-		layeredCreate := m.cfg.IncrementalSnapshotEnabled && recordToPath == "" && tmplErr == nil
+		layeredCreate := m.cfg.IncrementalSnapshotEnabled && m.cfg.ResumeUffdEnabled &&
+			m.cfg.UffdEnabled && recordToPath == "" && tmplErr == nil
 		if layeredCreate {
 			inst.mu.Lock()
 			inst.BaseMemPath = memPath // template mem file = the layered base

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -758,15 +758,19 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	// Layered resume: a non-empty base means memPath is a diff overlay to be served
-	// over that template base. Prefer the in-memory record; fall back to the on-disk
-	// sidecar so a layered overlay still resumes correctly if the instance record
-	// was lost. An overlay with no recoverable base must not be loaded standalone.
-	basePath := inst.BaseMemPath
-	if basePath == "" {
-		if b, ok := readLayeredBase(memPath); ok {
-			basePath = b
-		} else if isOverlayMemFile(memPath) {
+	// A base is needed only when memPath is itself a diff overlay; a standalone
+	// image (including an explicit override path) gets no base. Keying on memPath —
+	// not on the cached BaseMemPath — means a full-image resume clears any stale
+	// base below, so the next pause won't wrongly diff against the old template.
+	// For an overlay, prefer the in-memory base, fall back to the on-disk sidecar,
+	// and refuse rather than load a sparse overlay standalone.
+	basePath := ""
+	if isOverlayMemFile(memPath) {
+		basePath = inst.BaseMemPath
+		if basePath == "" {
+			basePath, _ = readLayeredBase(memPath)
+		}
+		if basePath == "" {
 			m.stopUnitDuringRestoreError(vmID)
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
@@ -842,6 +846,13 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	snapshotPath, memPath := inst.SnapshotPath, inst.MemFilePath
 	if snapshotPath == "" || memPath == "" {
 		return "", status.Errorf(codes.InvalidArgument, "vm %s has no snapshot on record", vmID)
+	}
+	// This gate loads via the File backend (no base), so it can only verify a
+	// standalone image. A layered diff overlay would load with its base's pages as
+	// zero holes and produce a meaningless comparison — refuse instead.
+	if isOverlayMemFile(memPath) || inst.BaseMemPath != "" {
+		return "", status.Errorf(codes.FailedPrecondition,
+			"vm %s is a layered (diff-overlay) snapshot; the verify gate only supports standalone images", vmID)
 	}
 	if _, err := os.Stat(memPath); err != nil {
 		return "", status.Errorf(codes.FailedPrecondition, "mem file missing on host: %s", memPath)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -98,6 +98,12 @@ type VMInstance struct {
 	TeamID       string // owning team; carried for data-plane usage attribution
 	OwnerID      string // creating user; empty when unknown
 
+	// BaseMemPath is the immutable base (template) memory file for a layered
+	// snapshot. Set at create-from-template; non-empty ⇒ this VM's pauses write a
+	// Diff overlay (mem.diff) against this base, and resume loads layered
+	// (overlay + base). Cleared when a pause falls back to a standalone Full.
+	BaseMemPath string
+
 	// DirtyTracked is true when the current Firecracker run was loaded with
 	// dirty-page tracking armed (set on incremental UFFD resume). Gates whether
 	// the next pause may write a Diff snapshot. Not persisted: it describes the
@@ -576,23 +582,36 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	}
 
 	snapshotPath = filepath.Join(snapshotDir, "vmstate.snap")
-	memPath = filepath.Join(snapshotDir, "mem.snap")
 
-	// Diff merges into the same mem.snap the live UFFD handler faults from, but only
-	// at dirtied offsets — which are resident and never re-faulted, so disjoint from
-	// the clean offsets the handler reads. Safe while the VM is still up pre-stop.
-	useDiff := shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, inst.DirtyTracked,
-		memPath, inst.MemFilePath, fileExists(memPath))
-
-	if useDiff {
-		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
+	// Layered incremental: a template-created, dirty-tracked VM writes a diff overlay
+	// (mem.diff) holding only the pages changed vs its template base. The base is a
+	// distinct file from the overlay, so the merge never touches the template the
+	// handler still faults from; resume loads overlay+base lazily.
+	layered := m.cfg.IncrementalSnapshotEnabled && inst.DirtyTracked && inst.BaseMemPath != ""
+	baseMemPath := ""
+	switch {
+	case layered:
+		memPath = filepath.Join(snapshotDir, "mem.diff")
+		baseMemPath = inst.BaseMemPath
+		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
 		if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
-			return "", "", m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
+			return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
 		}
-	} else {
-		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
-		if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
-			return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+	default:
+		memPath = filepath.Join(snapshotDir, "mem.snap")
+		// In-place diff (no template base): merge dirtied pages into the VM's own
+		// mem.snap when tracking was armed this run and mem.snap is the resume base —
+		// dirtied offsets are resident/never re-faulted, disjoint from clean reads.
+		if shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, inst.DirtyTracked, memPath, inst.MemFilePath, fileExists(memPath)) {
+			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
+			if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
+			}
+		} else {
+			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
+			if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+			}
 		}
 	}
 
@@ -605,7 +624,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	inst.Status = StatusPaused
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = memPath
-	inst.DirtyTracked = false // FC process is stopping; a fresh resume re-arms tracking.
+	inst.BaseMemPath = baseMemPath // template base for a layered overlay; "" when standalone
+	inst.DirtyTracked = false      // FC process is stopping; a fresh resume re-arms tracking.
 	inst.mu.Unlock()
 
 	m.persistState(inst)
@@ -709,7 +729,9 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, netInfo)
+	// Layered resume: a non-empty BaseMemPath means memPath is a diff overlay to be
+	// served over this template base. Empty ⇒ memPath is a standalone image.
+	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, inst.BaseMemPath, netInfo)
 	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
@@ -739,7 +761,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 // restoreForResume restores the VM and reports whether dirty-page tracking was
 // armed (true only on the incremental UFFD path) so the caller can decide if the
 // next pause may write a Diff.
-func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
+func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
 	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
 	if !useUffd {
 		return false, RestoreSnapshot(socketPath, snapshotPath, memPath, "")
@@ -747,9 +769,10 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath string, net
 
 	// No prefetch access log: only template builds record one (next to the template
 	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
+	// basePath non-empty ⇒ layered restore (memPath is the diff overlay over basePath).
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
+		socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 	)
 }
 
@@ -1134,10 +1157,20 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				accessLogPath = candidate
 			}
 		}
-		// Cold create/restore from a template: no incremental tracking — the first
-		// pause writes a Full base. Tracking is armed only on a later resume.
+		// Layered incremental: creating from a template with incremental on arms
+		// tracking and records the template mem file as the base, so the first pause
+		// writes a small diff overlay vs the template. The load stays single-file;
+		// the base only matters on the next resume.
+		_, tmplErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
+		layeredCreate := m.cfg.IncrementalSnapshotEnabled && recordToPath == "" && tmplErr == nil
+		if layeredCreate {
+			inst.mu.Lock()
+			inst.BaseMemPath = memPath // template mem file = the layered base
+			inst.DirtyTracked = true   // armed below, so the first pause writes a diff
+			inst.mu.Unlock()
+		}
 		restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-			socketPath, snapshotPath, memPath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, false,
+			socketPath, snapshotPath, memPath, "", accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, layeredCreate,
 		)
 	case inPlace:
 		restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -597,6 +597,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
 			return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
 		}
+		// Record the base on disk so a restore that only has the artifact (no
+		// BoltDB instance) can still resume this overlay layered.
+		if err := os.WriteFile(layeredBaseSidecarPath(memPath), []byte(baseMemPath), 0o644); err != nil {
+			log.Warn().Err(err).Msg("pause: failed to write layered base sidecar")
+		}
 	default:
 		memPath = filepath.Join(snapshotDir, "mem.snap")
 		// In-place diff (no template base): merge dirtied pages into the VM's own
@@ -639,6 +644,30 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 // Diff onto a non-base or untracked run would silently corrupt the snapshot.
 func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeBasePath string, baseExists bool) bool {
 	return incremental && dirtyTracked && memPath == resumeBasePath && baseExists
+}
+
+// layeredBaseSidecarPath is where the layered base (template) path is recorded
+// next to an overlay mem file, so a restore that has only the on-disk artifact
+// (no in-memory/BoltDB instance — e.g. a stateless RestoreVMSnapshot after host
+// loss) can still reconstruct the base instead of loading the sparse overlay
+// standalone (which would read the base's pages as zero holes).
+func layeredBaseSidecarPath(memPath string) string { return memPath + ".base" }
+
+// readLayeredBase returns the recorded base for an overlay mem file and whether
+// the sidecar is present and non-empty.
+func readLayeredBase(memPath string) (string, bool) {
+	b, err := os.ReadFile(layeredBaseSidecarPath(memPath))
+	if err != nil {
+		return "", false
+	}
+	base := strings.TrimSpace(string(b))
+	return base, base != ""
+}
+
+// isOverlayMemFile reports whether memPath names a layered diff overlay (which
+// must be restored over a base, never standalone).
+func isOverlayMemFile(memPath string) bool {
+	return filepath.Base(memPath) == "mem.diff"
 }
 
 // fileExists reports whether path exists and is a regular file.
@@ -729,9 +758,21 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	// Layered resume: a non-empty BaseMemPath means memPath is a diff overlay to be
-	// served over this template base. Empty ⇒ memPath is a standalone image.
-	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, inst.BaseMemPath, netInfo)
+	// Layered resume: a non-empty base means memPath is a diff overlay to be served
+	// over that template base. Prefer the in-memory record; fall back to the on-disk
+	// sidecar so a layered overlay still resumes correctly if the instance record
+	// was lost. An overlay with no recoverable base must not be loaded standalone.
+	basePath := inst.BaseMemPath
+	if basePath == "" {
+		if b, ok := readLayeredBase(memPath); ok {
+			basePath = b
+		} else if isOverlayMemFile(memPath) {
+			m.stopUnitDuringRestoreError(vmID)
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
+		}
+	}
+	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo)
 	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
@@ -753,6 +794,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// what Firecracker's dirty bitmap is relative to.
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = memPath
+	inst.BaseMemPath = basePath // re-cache (may have come from the on-disk sidecar)
 	inst.mu.Unlock()
 
 	m.persistState(inst)
@@ -1170,26 +1212,48 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				accessLogPath = candidate
 			}
 		}
-		// Layered incremental: creating from a template with incremental on arms
-		// tracking and records the template mem file as the base, so the first pause
-		// writes a small diff overlay vs the template. The load stays single-file;
-		// the base only matters on the next resume.
-		// Require resume-UFFD too: a layered pause writes mem.diff, which only
-		// resumes correctly via the UFFD layered backend. Without resume-UFFD the
-		// resume would fall back to the File backend and load the sparse diff as a
-		// full image, so don't arm layered tracking in that configuration.
+		// Decide the layered base for this UFFD restore:
+		//  - overlay (mem.diff) with a base sidecar → stateless resume of a layered
+		//    sandbox: reconstruct the base from disk and load layered.
+		//  - overlay with no recoverable base → refuse (loading the sparse diff
+		//    standalone would read the base's pages as zero holes).
+		//  - template create with incremental + resume-UFFD on → arm tracking and
+		//    record the template as the base; the load stays single-file (the base
+		//    only matters on the next resume).
+		// Require resume-UFFD for any layered path: only the UFFD layered backend can
+		// serve overlay-over-base.
 		_, tmplErr := templateRootfsForSnapshot(m.cfg.RunDir, snapshotPath)
-		layeredCreate := m.cfg.IncrementalSnapshotEnabled && m.cfg.ResumeUffdEnabled &&
-			m.cfg.UffdEnabled && recordToPath == "" && tmplErr == nil
-		if layeredCreate {
+		isTemplate := tmplErr == nil
+		sidecarBase, hasSidecar := readLayeredBase(memPath)
+		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
+		basePath := ""
+		armLayered := false
+		switch {
+		case hasSidecar:
+			if !canLayered {
+				restoreErr = fmt.Errorf("layered overlay %q requires resume-UFFD to restore", memPath)
+			} else {
+				basePath = sidecarBase
+				armLayered = m.cfg.IncrementalSnapshotEnabled
+				inst.mu.Lock()
+				inst.BaseMemPath = sidecarBase
+				inst.DirtyTracked = armLayered
+				inst.mu.Unlock()
+			}
+		case isOverlayMemFile(memPath):
+			restoreErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
+		case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
+			armLayered = true
 			inst.mu.Lock()
 			inst.BaseMemPath = memPath // template mem file = the layered base
-			inst.DirtyTracked = true   // armed below, so the first pause writes a diff
+			inst.DirtyTracked = true
 			inst.mu.Unlock()
 		}
-		restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-			socketPath, snapshotPath, memPath, "", accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, layeredCreate,
-		)
+		if restoreErr == nil {
+			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
+				socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
+			)
+		}
 	case inPlace:
 		restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)
 	default:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -583,6 +583,15 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	snapshotPath = filepath.Join(snapshotDir, "vmstate.snap")
 
+	// Read the fields that select Full vs in-place-diff vs layered together under the
+	// lock, so the decision can't see a torn mix written by a concurrent resume.
+	inst.mu.RLock()
+	socketPath := inst.SocketPath
+	dirtyTracked := inst.DirtyTracked
+	instBaseMem := inst.BaseMemPath
+	instMemFile := inst.MemFilePath
+	inst.mu.RUnlock()
+
 	// Layered incremental: a template-created, dirty-tracked VM writes a diff overlay
 	// (mem.diff) holding only the pages changed vs its template base. The base is a
 	// distinct file from the overlay, so the merge never touches the template the
@@ -594,35 +603,47 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// explicit-override resume) the diff would capture only this run's changes and
 	// drop the prior overlay's pages, so fall back to a Full (complete) image.
 	overlayPath := filepath.Join(snapshotDir, "mem.diff")
-	layered := m.cfg.IncrementalSnapshotEnabled && inst.DirtyTracked && inst.BaseMemPath != "" &&
-		(inst.MemFilePath == inst.BaseMemPath || overlayPath == inst.MemFilePath)
+	fullPath := filepath.Join(snapshotDir, "mem.snap")
+	layered := m.cfg.IncrementalSnapshotEnabled && dirtyTracked && instBaseMem != "" &&
+		(instMemFile == instBaseMem || overlayPath == instMemFile)
 	baseMemPath := ""
+	// CreateDiffSnapshot merges in place: an interrupted diff has no surviving copy
+	// of the file it overwrites (for layered, only the session delta — the template
+	// base is untouched; for in-place, the VM's own mem.snap). Crash-atomicity of the
+	// diff is the durability-boundary work, intentionally out of scope here.
 	switch {
 	case layered:
 		memPath = overlayPath
-		baseMemPath = inst.BaseMemPath
-		log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
-		if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
-			return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
-		}
-		// Record the base on disk so a restore that only has the artifact (no
-		// BoltDB instance) can still resume this overlay layered.
-		if err := os.WriteFile(layeredBaseSidecarPath(memPath), []byte(baseMemPath), 0o644); err != nil {
-			log.Warn().Err(err).Msg("pause: failed to write layered base sidecar")
+		baseMemPath = instBaseMem
+		// Write the base sidecar BEFORE the diff so an overlay never exists on disk
+		// without its base record (a stateless cross-host restore relies on it). If
+		// the sidecar can't be written, fall back to a Full rather than produce an
+		// unrecoverable overlay.
+		if serr := os.WriteFile(layeredBaseSidecarPath(memPath), []byte(baseMemPath), 0o644); serr != nil {
+			log.Warn().Err(serr).Msg("pause: layered base sidecar write failed; falling back to Full")
+			memPath, baseMemPath = fullPath, ""
+			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+			}
+		} else {
+			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
+			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create layered diff snapshot: %w", err))
+			}
 		}
 	default:
-		memPath = filepath.Join(snapshotDir, "mem.snap")
+		memPath = fullPath
 		// In-place diff (no template base): merge dirtied pages into the VM's own
 		// mem.snap when tracking was armed this run and mem.snap is the resume base —
 		// dirtied offsets are resident/never re-faulted, disjoint from clean reads.
-		if shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, inst.DirtyTracked, memPath, inst.MemFilePath, fileExists(memPath)) {
+		if shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, dirtyTracked, memPath, instMemFile, fileExists(memPath)) {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
-			if err := CreateDiffSnapshot(inst.SocketPath, snapshotPath, memPath); err != nil {
+			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
 			}
 		} else {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
-			if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
 			}
 		}
@@ -1233,7 +1254,18 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Msg("restoring snapshot")
 
 	var restoreErr error
+	// A diff overlay (mem.diff, or any file with a base sidecar) must be served by
+	// the UFFD layered backend. Catch it before backend selection so that with UFFD
+	// disabled / inPlace / resume-UFFD off it fails loud instead of falling to the
+	// File backend, which would load the sparse overlay as a full image (the base's
+	// pages read as zero holes).
+	sidecarBase, hasSidecar := readLayeredBase(memPath)
+	overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
 	switch {
+	case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
+		restoreErr = fmt.Errorf(
+			"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
+			memPath)
 	case useUffd:
 		// Skip prefetch trace when recording so the captured order reflects
 		// guest-driven access, not pages pulled in by the prefetcher.
@@ -1253,7 +1285,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// standalone reads the base as zero holes); a template create instead arms
 		// tracking and records the template as the base. Layered needs resume-UFFD.
 		isTemplate := m.isTemplateMemPath(memPath)
-		sidecarBase, hasSidecar := readLayeredBase(memPath)
 		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
 		basePath := ""
 		armLayered := false

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -244,6 +244,30 @@ func TestDeleteSnapshotFiles_UnderVMDir_OK(t *testing.T) {
 	}
 }
 
+func TestDeleteSnapshotFiles_RemovesSidecars(t *testing.T) {
+	root := t.TempDir()
+	vmID := "vm-abc"
+	snap := filepath.Join(root, vmID, "vmstate.snap")
+	mem := filepath.Join(root, vmID, "mem.diff")
+	overlay := snap + ".overlay"
+	base := layeredBaseSidecarPath(mem) // mem.diff.base
+	for _, p := range []string{snap, mem, overlay, base} {
+		writeFile(t, p)
+	}
+
+	mgr := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	if err := mgr.DeleteSnapshotFiles(vmID, snap, mem); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// A leftover sidecar would make a later restore mis-handle a non-layered
+	// mem file as a layered overlay — the fork-bug class both removals prevent.
+	for _, p := range []string{overlay, base} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("sidecar still exists: %s (%v)", p, err)
+		}
+	}
+}
+
 func TestDeleteSnapshotFiles_PathEqualSnapshotRoot_Rejected(t *testing.T) {
 	root := t.TempDir()
 	mgr := &Manager{cfg: ManagerConfig{SnapshotDir: root}}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -640,3 +640,29 @@ func TestShouldWriteDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTemplateMemPath(t *testing.T) {
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: "/var/lib/sandbox/snapshots"}}
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"flat template", "/var/lib/sandbox/snapshots/templates/abc/mem.snap", true},
+		{"build-nested template", "/var/lib/sandbox/snapshots/templates/abc/build-abc/mem.snap", true},
+		{"paused sandbox (not template)", "/var/lib/sandbox/snapshots/vm123/mem.snap", false},
+		{"layered overlay of a sandbox", "/var/lib/sandbox/snapshots/vm123/mem.diff", false},
+		{"empty", "", false},
+		{"templates substring elsewhere", "/var/lib/sandbox/snapshots/vm-templates-x/mem.snap", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := m.isTemplateMemPath(c.path); got != c.want {
+				t.Fatalf("isTemplateMemPath(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+	if isOverlayMemFile("/x/mem.diff") != true || isOverlayMemFile("/x/mem.snap") != false {
+		t.Fatal("isOverlayMemFile basename detection wrong")
+	}
+}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -244,6 +244,64 @@ func TestDeleteSnapshotFiles_UnderVMDir_OK(t *testing.T) {
 	}
 }
 
+func TestReadLayeredBase_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	mem := filepath.Join(dir, "mem.diff")
+	base := "/var/lib/sandbox/snapshots/templates/abc/build-1/mem.snap"
+
+	// Missing sidecar → not present.
+	if got, ok := readLayeredBase(mem); ok || got != "" {
+		t.Errorf("missing sidecar: got (%q,%v), want (\"\",false)", got, ok)
+	}
+
+	// Write via the canonical path, read back the exact base.
+	if err := os.WriteFile(layeredBaseSidecarPath(mem), []byte(base), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	if got, ok := readLayeredBase(mem); !ok || got != base {
+		t.Errorf("round-trip: got (%q,%v), want (%q,true)", got, ok, base)
+	}
+
+	// Empty sidecar → not present (a 0-byte record must not be trusted as a base).
+	if err := os.WriteFile(layeredBaseSidecarPath(mem), []byte("  \n"), 0o644); err != nil {
+		t.Fatalf("write empty sidecar: %v", err)
+	}
+	if got, ok := readLayeredBase(mem); ok || got != "" {
+		t.Errorf("empty sidecar: got (%q,%v), want (\"\",false)", got, ok)
+	}
+}
+
+func TestFreshenFirstPassOverlay(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing overlay → nil (the normal first-pause case).
+	if err := freshenFirstPassOverlay(filepath.Join(dir, "absent.diff")); err != nil {
+		t.Errorf("missing overlay: got %v, want nil", err)
+	}
+
+	// Existing overlay → removed, nil.
+	f := filepath.Join(dir, "mem.diff")
+	if err := os.WriteFile(f, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := freshenFirstPassOverlay(f); err != nil {
+		t.Errorf("existing overlay: got %v, want nil", err)
+	}
+	if _, err := os.Stat(f); !os.IsNotExist(err) {
+		t.Errorf("overlay not removed: %v", err)
+	}
+
+	// Un-removable overlay (non-empty dir stands in for any remove failure) → error,
+	// which drives the caller's fall-back-to-Full path.
+	stuck := filepath.Join(dir, "stuck.diff")
+	if err := os.MkdirAll(filepath.Join(stuck, "child"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := freshenFirstPassOverlay(stuck); err == nil {
+		t.Error("un-removable overlay: got nil, want error (so caller falls back to Full)")
+	}
+}
+
 func TestDeleteSnapshotFiles_RemovesSidecars(t *testing.T) {
 	root := t.TempDir()
 	vmID := "vm-abc"

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -616,3 +616,27 @@ func TestWaitForSocketPolling_AppearsAfterStart(t *testing.T) {
 		t.Errorf("waitForSocketPolling: %v", err)
 	}
 }
+
+func TestShouldWriteDiff(t *testing.T) {
+	const base = "/snap/vm/mem.snap"
+	cases := []struct {
+		name                      string
+		incremental, dirtyTracked bool
+		memPath, resumeBase       string
+		baseExists                bool
+		want                      bool
+	}{
+		{"all conditions met", true, true, base, base, true, true},
+		{"feature off", false, true, base, base, true, false},
+		{"tracking not armed (e.g. cold create or non-incremental resume)", true, false, base, base, true, false},
+		{"different path than resume base (custom snapshot dir)", true, true, "/snap/vm/other.snap", base, true, false},
+		{"base file missing (first pause)", true, true, base, base, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldWriteDiff(c.incremental, c.dirtyTracked, c.memPath, c.resumeBase, c.baseExists); got != c.want {
+				t.Fatalf("shouldWriteDiff = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -20,23 +20,28 @@ var bucketName = []byte("vms")
 // It contains everything VMD needs to reconstruct its in-memory map on
 // startup and reattach to a live Firecracker process.
 type VMRecord struct {
-	ID           string            `json:"id"`
-	PID          int               `json:"pid"`
-	SocketPath   string            `json:"socket_path"`
-	VsockPath    string            `json:"vsock_path,omitempty"`
-	IP           string            `json:"ip"`
-	TAPDevice    string            `json:"tap_device"`
-	MACAddress   string            `json:"mac_address"`
-	Status       VMStatus          `json:"status"`
-	RunDirID     string            `json:"rundir_id"`
-	Namespace    string            `json:"namespace"`
-	DiskPath     string            `json:"disk_path"`
-	SnapshotPath string            `json:"snapshot_path,omitempty"`
-	MemFilePath  string            `json:"mem_file_path,omitempty"`
-	CreatedAt    time.Time         `json:"created_at"`
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	VCPU         uint32            `json:"vcpu"`
-	MemoryMiB    uint32            `json:"memory_mib"`
+	ID           string   `json:"id"`
+	PID          int      `json:"pid"`
+	SocketPath   string   `json:"socket_path"`
+	VsockPath    string   `json:"vsock_path,omitempty"`
+	IP           string   `json:"ip"`
+	TAPDevice    string   `json:"tap_device"`
+	MACAddress   string   `json:"mac_address"`
+	Status       VMStatus `json:"status"`
+	RunDirID     string   `json:"rundir_id"`
+	Namespace    string   `json:"namespace"`
+	DiskPath     string   `json:"disk_path"`
+	SnapshotPath string   `json:"snapshot_path,omitempty"`
+	MemFilePath  string   `json:"mem_file_path,omitempty"`
+	// Persisted so a layered (diff-overlay) sandbox resumes correctly after a vmd
+	// restart: non-empty means MemFilePath is an overlay to be served over this
+	// base. Without it, resume would load the overlay standalone and read the
+	// base's pages as zero holes.
+	BaseMemPath string            `json:"base_mem_path,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	VCPU        uint32            `json:"vcpu"`
+	MemoryMiB   uint32            `json:"memory_mib"`
 	// Persisted so overlay-mode sandboxes can be resumed correctly after a
 	// vmd restart (the start script needs basePath to wire up the
 	// dual-symlink mount namespace). DeltaDir is intentionally NOT
@@ -160,6 +165,7 @@ func toRecord(inst *VMInstance) VMRecord {
 		DiskPath:     inst.DiskPath,
 		SnapshotPath: inst.SnapshotPath,
 		MemFilePath:  inst.MemFilePath,
+		BaseMemPath:  inst.BaseMemPath,
 		CreatedAt:    inst.CreatedAt,
 		Metadata:     inst.Metadata,
 		VCPU:         inst.Config.VCPU,
@@ -186,6 +192,7 @@ func toInstance(rec VMRecord) *VMInstance {
 		DiskPath:     rec.DiskPath,
 		SnapshotPath: rec.SnapshotPath,
 		MemFilePath:  rec.MemFilePath,
+		BaseMemPath:  rec.BaseMemPath,
 		CreatedAt:    rec.CreatedAt,
 		Metadata:     rec.Metadata,
 		TeamID:       rec.TeamID,


### PR DESCRIPTION
Reduces pause cost by writing incremental memory snapshots instead of a full image each time. Flag-gated by `VMD_INCREMENTAL_SNAPSHOT` (default off); no behavior change when off.

**Incremental pause:** when dirty-page tracking is armed on a UFFD resume, a pause writes a Diff (only the pages dirtied since resume, merged in place into the existing `mem.snap`) instead of a Full snapshot.

**Layered first pause:** a template-created VM arms tracking on create and records the template `mem.snap` as its base. The first pause then writes a small diff overlay (`mem.diff`) against the template instead of a full image, and resume loads layered (overlay if present, else the template base — served lazily). Later pauses merge into `mem.diff`. This requires the layered UFFD restore in the firecracker fork (superserve-ai/firecracker#13).

- `MemoryBackend.base_path` (model + swagger) threads the base through `/snapshot/load`.
- `VMInstance.BaseMemPath` (daemon-internal, persisted) tracks the layered base — no control-plane change.
- `PauseVM`: layered overlay when a base is set; else in-place diff when tracking is armed and `mem.snap` is the resume base; else Full. `shouldWriteDiff` is unit-tested.
- Backward compatible and opt-in; the layered path is inert unless the fork handler is present and the flag is on.