### PR TITLE
Fold snapshot lookup into the resume claim

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -282,6 +282,31 @@ SET status = 'resuming', updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
 RETURNING *;
 
+-- name: BeginResumeWithSnapshot :one
+-- Same atomic paused→resuming claim as BeginResume, but also returns the
+-- snapshot's path/mem_path so resume needs one DB round trip instead of a
+-- follow-up GetSnapshot. The LEFT JOIN returns NULL snap_path when the
+-- snapshot is missing (rather than dropping the row, as an inner join would),
+-- so the caller still gets the claimed sandbox and can revert — matching the
+-- separate-query path, where a missing snapshot errors after the claim.
+WITH claimed AS (
+    UPDATE sandbox
+    SET status = 'resuming', updated_at = now()
+    WHERE sandbox.id = $1 AND sandbox.team_id = $2
+      AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
+    RETURNING *
+)
+SELECT
+    claimed.id, claimed.team_id, claimed.name, claimed.status, claimed.vcpu_count,
+    claimed.memory_mib, claimed.host_id, claimed.ip_address, claimed.pid,
+    claimed.snapshot_id, claimed.created_at, claimed.updated_at, claimed.destroyed_at,
+    claimed.network_config, claimed.timeout_seconds, claimed.metadata, claimed.template_id,
+    claimed.snapshot_path, claimed.mem_path, claimed.base_path, claimed.delta_path,
+    claimed.disk_mib,
+    s.path AS snap_path, s.mem_path AS snap_mem_path
+FROM claimed
+LEFT JOIN snapshot s ON s.id = claimed.snapshot_id AND s.team_id = claimed.team_id;
+
 -- name: RevertResumeToPaused :exec
 -- Compensate a failed resume attempt by flipping status back to 'paused'.
 -- Guarded on status = 'resuming' so we never clobber a concurrent transition

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -376,16 +376,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// under it, so across API instances a mutation can't read a stale 'paused' and
 	// land a binding this resume won't pick up. Once the claim flips status to
 	// 'resuming', those handlers see it under the lock and reject with 409.
-	claimResume := func(q *db.Queries) (db.Sandbox, error) {
+	claimResume := func(q *db.Queries) (db.BeginResumeWithSnapshotRow, error) {
 		if h.Pool != nil {
 			if lerr := q.LockSandboxForSecretWrites(c.Request.Context(), sandboxID.String()); lerr != nil {
-				return db.Sandbox{}, lerr
+				return db.BeginResumeWithSnapshotRow{}, lerr
 			}
 		}
-		return q.BeginResume(c.Request.Context(), db.BeginResumeParams{ID: sandboxID, TeamID: teamID})
+		return q.BeginResumeWithSnapshot(c.Request.Context(), db.BeginResumeWithSnapshotParams{ID: sandboxID, TeamID: teamID})
 	}
 	var (
-		claimed db.Sandbox
+		claimed db.BeginResumeWithSnapshotRow
 		err     error
 	)
 	if h.Pool == nil {
@@ -410,7 +410,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		respondError(c, ErrInternal)
 		return false
 	}
-	*sandbox = claimed
+	*sandbox = sandboxFromResumeRow(claimed)
 
 	revertCtx := context.WithoutCancel(c.Request.Context())
 	revertToPaused := func() {
@@ -424,17 +424,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	snapshot, err := h.DB.GetSnapshot(c.Request.Context(), db.GetSnapshotParams{
-		ID:     sandbox.SnapshotID.Bytes,
-		TeamID: teamID,
-	})
-	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
+	// The claim's LEFT JOIN already returned the snapshot paths. A NULL snap_path
+	// means the snapshot row is missing despite a set snapshot_id (corrupt state) —
+	// revert and surface as before, when GetSnapshot would have errored post-claim.
+	if claimed.SnapPath == nil {
+		log.Error().Str("sandbox_id", sandboxID.String()).Msg("resume: snapshot row missing for snapshot_id")
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return false
 	}
-
+	snapshot := db.Snapshot{Path: *claimed.SnapPath, MemPath: claimed.SnapMemPath}
 	snapshotPath := snapshot.Path
 	memPath := resolveMemPath(snapshot)
 
@@ -597,6 +596,20 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
 	return true
+}
+
+// sandboxFromResumeRow projects the sandbox columns out of a
+// BeginResumeWithSnapshot row, which also carries the joined snapshot paths.
+func sandboxFromResumeRow(r db.BeginResumeWithSnapshotRow) db.Sandbox {
+	return db.Sandbox{
+		ID: r.ID, TeamID: r.TeamID, Name: r.Name, Status: r.Status,
+		VcpuCount: r.VcpuCount, MemoryMib: r.MemoryMib, HostID: r.HostID,
+		IpAddress: r.IpAddress, Pid: r.Pid, SnapshotID: r.SnapshotID,
+		CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt, DestroyedAt: r.DestroyedAt,
+		NetworkConfig: r.NetworkConfig, TimeoutSeconds: r.TimeoutSeconds, Metadata: r.Metadata,
+		TemplateID: r.TemplateID, SnapshotPath: r.SnapshotPath, MemPath: r.MemPath,
+		BasePath: r.BasePath, DeltaPath: r.DeltaPath, DiskMib: r.DiskMib,
+	}
 }
 
 // resolveMemPath returns the memory snapshot path from a Snapshot record.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -792,6 +792,39 @@ func snapshotRow(s db.Snapshot) *mockRow {
 	}}
 }
 
+// beginResumeWithSnapshotRow mocks the claim+snapshot-join row: the 22 sandbox
+// columns (BeginResume RETURNING * order) followed by snap_path, snap_mem_path.
+func beginResumeWithSnapshotRow(s db.Sandbox, snap db.Snapshot) *mockRow {
+	return &mockRow{scanFn: func(dest ...any) error {
+		*dest[0].(*uuid.UUID) = s.ID
+		*dest[1].(*uuid.UUID) = s.TeamID
+		*dest[2].(*string) = s.Name
+		*dest[3].(*db.SandboxStatus) = s.Status
+		*dest[4].(*int32) = s.VcpuCount
+		*dest[5].(*int32) = s.MemoryMib
+		*dest[6].(*string) = s.HostID
+		*dest[7].(**netip.Addr) = s.IpAddress
+		*dest[8].(**int32) = s.Pid
+		*dest[9].(*pgtype.UUID) = s.SnapshotID
+		*dest[10].(*time.Time) = s.CreatedAt
+		*dest[11].(*time.Time) = s.UpdatedAt
+		*dest[12].(*pgtype.Timestamptz) = s.DestroyedAt
+		*dest[13].(*[]byte) = s.NetworkConfig
+		*dest[14].(**int32) = s.TimeoutSeconds
+		*dest[15].(*[]byte) = s.Metadata
+		*dest[16].(*pgtype.UUID) = s.TemplateID
+		*dest[17].(**string) = s.SnapshotPath
+		*dest[18].(**string) = s.MemPath
+		*dest[19].(**string) = s.BasePath
+		*dest[20].(**string) = s.DeltaPath
+		*dest[21].(*int32) = s.DiskMib
+		snapPath := snap.Path
+		*dest[22].(**string) = &snapPath
+		*dest[23].(**string) = snap.MemPath
+		return nil
+	}}
+}
+
 // finalizePauseRow mocks the single-column RETURNING of FinalizePause.
 func finalizePauseRow(snapshotID uuid.UUID) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
@@ -862,7 +895,7 @@ func TestResumeSandbox_Success(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb) // BeginResume RETURNING *
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -920,7 +953,7 @@ func TestResumeSandbox_ReappliesSecretBindings(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -1074,7 +1107,7 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			default:
@@ -1133,7 +1166,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
@@ -1208,7 +1241,7 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
@@ -1306,7 +1339,7 @@ func TestActivateSandbox_PausedResumesAndReturns200(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -1418,7 +1451,7 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return beginResumeWithSnapshotRow(sb, snap)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -224,6 +224,96 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 	return i, err
 }
 
+const beginResumeWithSnapshot = `-- name: BeginResumeWithSnapshot :one
+WITH claimed AS (
+    UPDATE sandbox
+    SET status = 'resuming', updated_at = now()
+    WHERE sandbox.id = $1 AND sandbox.team_id = $2
+      AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
+    RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib
+)
+SELECT
+    claimed.id, claimed.team_id, claimed.name, claimed.status, claimed.vcpu_count,
+    claimed.memory_mib, claimed.host_id, claimed.ip_address, claimed.pid,
+    claimed.snapshot_id, claimed.created_at, claimed.updated_at, claimed.destroyed_at,
+    claimed.network_config, claimed.timeout_seconds, claimed.metadata, claimed.template_id,
+    claimed.snapshot_path, claimed.mem_path, claimed.base_path, claimed.delta_path,
+    claimed.disk_mib,
+    s.path AS snap_path, s.mem_path AS snap_mem_path
+FROM claimed
+LEFT JOIN snapshot s ON s.id = claimed.snapshot_id AND s.team_id = claimed.team_id
+`
+
+type BeginResumeWithSnapshotParams struct {
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
+}
+
+type BeginResumeWithSnapshotRow struct {
+	ID             uuid.UUID          `json:"id"`
+	TeamID         uuid.UUID          `json:"team_id"`
+	Name           string             `json:"name"`
+	Status         SandboxStatus      `json:"status"`
+	VcpuCount      int32              `json:"vcpu_count"`
+	MemoryMib      int32              `json:"memory_mib"`
+	HostID         string             `json:"host_id"`
+	IpAddress      *netip.Addr        `json:"ip_address"`
+	Pid            *int32             `json:"pid"`
+	SnapshotID     pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+	DestroyedAt    pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig  []byte             `json:"network_config"`
+	TimeoutSeconds *int32             `json:"timeout_seconds"`
+	Metadata       []byte             `json:"metadata"`
+	TemplateID     pgtype.UUID        `json:"template_id"`
+	SnapshotPath   *string            `json:"snapshot_path"`
+	MemPath        *string            `json:"mem_path"`
+	BasePath       *string            `json:"base_path"`
+	DeltaPath      *string            `json:"delta_path"`
+	DiskMib        int32              `json:"disk_mib"`
+	SnapPath       *string            `json:"snap_path"`
+	SnapMemPath    *string            `json:"snap_mem_path"`
+}
+
+// Same atomic paused→resuming claim as BeginResume, but also returns the
+// snapshot's path/mem_path so resume needs one DB round trip instead of a
+// follow-up GetSnapshot. The LEFT JOIN returns NULL snap_path when the
+// snapshot is missing (rather than dropping the row, as an inner join would),
+// so the caller still gets the claimed sandbox and can revert — matching the
+// separate-query path, where a missing snapshot errors after the claim.
+func (q *Queries) BeginResumeWithSnapshot(ctx context.Context, arg BeginResumeWithSnapshotParams) (BeginResumeWithSnapshotRow, error) {
+	row := q.db.QueryRow(ctx, beginResumeWithSnapshot, arg.ID, arg.TeamID)
+	var i BeginResumeWithSnapshotRow
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.Name,
+		&i.Status,
+		&i.VcpuCount,
+		&i.MemoryMib,
+		&i.HostID,
+		&i.IpAddress,
+		&i.Pid,
+		&i.SnapshotID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DestroyedAt,
+		&i.NetworkConfig,
+		&i.TimeoutSeconds,
+		&i.Metadata,
+		&i.TemplateID,
+		&i.SnapshotPath,
+		&i.MemPath,
+		&i.BasePath,
+		&i.DeltaPath,
+		&i.DiskMib,
+		&i.SnapPath,
+		&i.SnapMemPath,
+	)
+	return i, err
+}
+
 const claimExpiredSandboxes = `-- name: ClaimExpiredSandboxes :many
 WITH open_sessions AS (
   -- Current session start per sandbox: the open interval, computed once.


### PR DESCRIPTION
## What

Resume's control-plane path made two separate DB round trips back to back: the `BeginResume` claim (paused→resuming), then a follow-up `GetSnapshot` to read the snapshot's path/mem_path. This combines them into a single query, `BeginResumeWithSnapshot`, that claims the sandbox and returns the snapshot paths in one round trip.

## How

- New query: a data-modifying CTE does the same atomic `paused→resuming` `UPDATE ... RETURNING`, then `LEFT JOIN`s `snapshot` to return `snap_path`/`snap_mem_path`.
- `LEFT JOIN` (not inner) so a row with a missing snapshot still comes back with `NULL snap_path`; the handler detects that and reverts — preserving the exact error behavior of the old separate-query path (where `GetSnapshot` errored after the claim).
- The claim transaction and advisory lock are unchanged; this only removes the second round trip.
- `BeginResume` and `GetSnapshot` are left in place (no other callers affected).

## Behavior

No functional change. Same claim semantics, same revert paths, same HTTP results. Existing resume/activate unit tests pass with the mock updated to the combined row shape.

## Why draft

This saves exactly one DB round trip. Its value depends entirely on per-query latency — meaningful only if per-query latency is high. Holding as a draft to measure the real impact on prod before deciding whether to merge.