### PR TITLE
vmd: incremental memory snapshots — append-only chain, async pause, flatten/GC

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -359,6 +359,7 @@ func main() {
 	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
 	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
 	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
+	asyncPauseEnabled := envOrDefault("VMD_ASYNC_PAUSE", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -379,6 +380,7 @@ func main() {
 		IncrementalSnapshotEnabled: incrementalSnapshotEnabled,
 		HandlerDeathAbortEnabled:   handlerDeathAbortEnabled,
 		LayerAppendEnabled:         layerAppendEnabled,
+		AsyncPauseEnabled:          asyncPauseEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -364,6 +364,7 @@ func main() {
 	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0"))                // 0 ⇒ default (16)
 	flattenChainBytes, _ := strconv.ParseInt(envOrDefault("VMD_FLATTEN_CHAIN_BYTES", "0"), 10, 64)    // 0 ⇒ depth-only
 	maxConcurrentAsyncPauses, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_ASYNC_PAUSES", "0")) // 0 ⇒ default (3)
+	sharedMemEnabled := envOrDefault("VMD_SHARED_MEM", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -389,6 +390,7 @@ func main() {
 		FlattenChainDepth:          flattenChainDepth,
 		FlattenChainBytes:          flattenChainBytes,
 		MaxConcurrentAsyncPauses:   maxConcurrentAsyncPauses,
+		SharedMemEnabled:           sharedMemEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -358,6 +358,7 @@ func main() {
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
 	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
 	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
+	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -377,6 +378,7 @@ func main() {
 		VerifySnapshotEnabled:      verifySnapshotEnabled,
 		IncrementalSnapshotEnabled: incrementalSnapshotEnabled,
 		HandlerDeathAbortEnabled:   handlerDeathAbortEnabled,
+		LayerAppendEnabled:         layerAppendEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -365,6 +365,7 @@ func main() {
 	flattenChainBytes, _ := strconv.ParseInt(envOrDefault("VMD_FLATTEN_CHAIN_BYTES", "0"), 10, 64)    // 0 ⇒ depth-only
 	maxConcurrentAsyncPauses, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_ASYNC_PAUSES", "0")) // 0 ⇒ default (3)
 	sharedMemEnabled := envOrDefault("VMD_SHARED_MEM", "false") == "true"
+	maxBridgeMemfds, _ := strconv.Atoi(envOrDefault("VMD_MAX_BRIDGE_MEMFDS", "0")) // 0 ⇒ default (4)
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -391,6 +392,7 @@ func main() {
 		FlattenChainBytes:          flattenChainBytes,
 		MaxConcurrentAsyncPauses:   maxConcurrentAsyncPauses,
 		SharedMemEnabled:           sharedMemEnabled,
+		MaxBridgeMemfds:            maxBridgeMemfds,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -361,6 +361,7 @@ func main() {
 	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
 	asyncPauseEnabled := envOrDefault("VMD_ASYNC_PAUSE", "false") == "true"
 	layerFlattenEnabled := envOrDefault("VMD_LAYER_FLATTEN", "false") == "true"
+	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0")) // 0 ⇒ default (16)
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -383,6 +384,7 @@ func main() {
 		LayerAppendEnabled:         layerAppendEnabled,
 		AsyncPauseEnabled:          asyncPauseEnabled,
 		LayerFlattenEnabled:        layerFlattenEnabled,
+		FlattenChainDepth:          flattenChainDepth,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -360,6 +360,7 @@ func main() {
 	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
 	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
 	asyncPauseEnabled := envOrDefault("VMD_ASYNC_PAUSE", "false") == "true"
+	layerFlattenEnabled := envOrDefault("VMD_LAYER_FLATTEN", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -381,6 +382,7 @@ func main() {
 		HandlerDeathAbortEnabled:   handlerDeathAbortEnabled,
 		LayerAppendEnabled:         layerAppendEnabled,
 		AsyncPauseEnabled:          asyncPauseEnabled,
+		LayerFlattenEnabled:        layerFlattenEnabled,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -361,8 +361,9 @@ func main() {
 	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
 	asyncPauseEnabled := envOrDefault("VMD_ASYNC_PAUSE", "false") == "true"
 	layerFlattenEnabled := envOrDefault("VMD_LAYER_FLATTEN", "false") == "true"
-	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0"))             // 0 ⇒ default (16)
-	flattenChainBytes, _ := strconv.ParseInt(envOrDefault("VMD_FLATTEN_CHAIN_BYTES", "0"), 10, 64) // 0 ⇒ depth-only
+	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0"))                // 0 ⇒ default (16)
+	flattenChainBytes, _ := strconv.ParseInt(envOrDefault("VMD_FLATTEN_CHAIN_BYTES", "0"), 10, 64)    // 0 ⇒ depth-only
+	maxConcurrentAsyncPauses, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_ASYNC_PAUSES", "0")) // 0 ⇒ default (3)
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -387,6 +388,7 @@ func main() {
 		LayerFlattenEnabled:        layerFlattenEnabled,
 		FlattenChainDepth:          flattenChainDepth,
 		FlattenChainBytes:          flattenChainBytes,
+		MaxConcurrentAsyncPauses:   maxConcurrentAsyncPauses,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -361,7 +361,8 @@ func main() {
 	layerAppendEnabled := envOrDefault("VMD_LAYER_APPEND", "false") == "true"
 	asyncPauseEnabled := envOrDefault("VMD_ASYNC_PAUSE", "false") == "true"
 	layerFlattenEnabled := envOrDefault("VMD_LAYER_FLATTEN", "false") == "true"
-	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0")) // 0 ⇒ default (16)
+	flattenChainDepth, _ := strconv.Atoi(envOrDefault("VMD_FLATTEN_CHAIN_DEPTH", "0"))             // 0 ⇒ default (16)
+	flattenChainBytes, _ := strconv.ParseInt(envOrDefault("VMD_FLATTEN_CHAIN_BYTES", "0"), 10, 64) // 0 ⇒ depth-only
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -385,6 +386,7 @@ func main() {
 		AsyncPauseEnabled:          asyncPauseEnabled,
 		LayerFlattenEnabled:        layerFlattenEnabled,
 		FlattenChainDepth:          flattenChainDepth,
+		FlattenChainBytes:          flattenChainBytes,
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")

--- a/internal/vm/async_pause_test.go
+++ b/internal/vm/async_pause_test.go
@@ -75,6 +75,17 @@ func TestCountHeldBridgeMemfds(t *testing.T) {
 	}
 }
 
+func TestHoldingBridgeMemfdPersists(t *testing.T) {
+	// The bridge-memfd hold must survive a vmd restart (toRecord → toInstance): a reattached
+	// fast-resumed FC still keeps the prior memfd mapped, so it must keep counting against the cap.
+	if got := toInstance(toRecord(&VMInstance{ID: "v", holdingBridgeMemfd: true})); !got.holdingBridgeMemfd {
+		t.Fatal("holdingBridgeMemfd did not survive the record round-trip")
+	}
+	if got := toInstance(toRecord(&VMInstance{ID: "w"})); got.holdingBridgeMemfd {
+		t.Fatal("holdingBridgeMemfd wrongly true after round-trip of a non-holder")
+	}
+}
+
 // TestTryClaimBridgeMemfd covers the atomic reserve: a slot goes only to an eligible
 // (mid-flush, in-flight files set) instance, the cap is enforced, and the count-and-claim is
 // atomic so a burst of concurrent claims can never exceed the cap.

--- a/internal/vm/async_pause_test.go
+++ b/internal/vm/async_pause_test.go
@@ -2,6 +2,9 @@ package vm
 
 import (
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -69,5 +72,75 @@ func TestCountHeldBridgeMemfds(t *testing.T) {
 	m.vms["c"] = &VMInstance{ID: "c", holdingBridgeMemfd: true}
 	if n := m.countHeldBridgeMemfds(); n != 2 {
 		t.Fatalf("count = %d, want 2", n)
+	}
+}
+
+// TestTryClaimBridgeMemfd covers the atomic reserve: a slot goes only to an eligible
+// (mid-flush, in-flight files set) instance, the cap is enforced, and the count-and-claim is
+// atomic so a burst of concurrent claims can never exceed the cap.
+func TestTryClaimBridgeMemfd(t *testing.T) {
+	mkInst := func(id string) *VMInstance {
+		return &VMInstance{
+			ID:                   id,
+			flushing:             true,
+			bridgeMemFdPath:      "/proc/1/fd/7",
+			bridgePendingVmstate: "/snap/" + id + "/vmstate.0.snap",
+			bridgePendingLayer:   "/snap/" + id + "/mem.0.diff",
+		}
+	}
+
+	// Ineligible instances are never granted, even with the cap wide open.
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}, cfg: ManagerConfig{MaxBridgeMemfds: 4}}
+	notFlushing := &VMInstance{ID: "x", bridgeMemFdPath: "/proc/1/fd/7", bridgePendingVmstate: "/v"}
+	m.vms["x"] = notFlushing
+	if _, _, _, ok := m.tryClaimBridgeMemfd(notFlushing); ok {
+		t.Fatal("granted a slot to a non-flushing instance")
+	}
+	noPaths := &VMInstance{ID: "y", flushing: true}
+	m.vms["y"] = noPaths
+	if _, _, _, ok := m.tryClaimBridgeMemfd(noPaths); ok {
+		t.Fatal("granted a slot with no in-flight files")
+	}
+
+	// A grant returns the in-flight files and marks the hold; the cap is then enforced.
+	m = &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}, cfg: ManagerConfig{MaxBridgeMemfds: 2}}
+	a, b, c := mkInst("a"), mkInst("b"), mkInst("c")
+	m.vms["a"], m.vms["b"], m.vms["c"] = a, b, c
+	if mp, vp, lp, ok := m.tryClaimBridgeMemfd(a); !ok || mp != a.bridgeMemFdPath || vp != a.bridgePendingVmstate || lp != a.bridgePendingLayer {
+		t.Fatalf("claim a = (%q,%q,%q,%v), want its files + true", mp, vp, lp, ok)
+	}
+	if !a.holdingBridgeMemfd {
+		t.Fatal("claim a did not mark the hold")
+	}
+	if _, _, _, ok := m.tryClaimBridgeMemfd(b); !ok {
+		t.Fatal("claim b under cap denied")
+	}
+	if _, _, _, ok := m.tryClaimBridgeMemfd(c); ok {
+		t.Fatal("claim c granted past the cap of 2")
+	}
+
+	// Atomic under a burst: cap 3 over many eligible instances → exactly 3 grants.
+	m = &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}, cfg: ManagerConfig{MaxBridgeMemfds: 3}}
+	const n = 24
+	insts := make([]*VMInstance, n)
+	for i := range insts {
+		id := fmt.Sprintf("vm%d", i)
+		insts[i] = mkInst(id)
+		m.vms[id] = insts[i]
+	}
+	var granted int64
+	var wg sync.WaitGroup
+	for _, in := range insts {
+		wg.Add(1)
+		go func(in *VMInstance) {
+			defer wg.Done()
+			if _, _, _, ok := m.tryClaimBridgeMemfd(in); ok {
+				atomic.AddInt64(&granted, 1)
+			}
+		}(in)
+	}
+	wg.Wait()
+	if granted != 3 {
+		t.Fatalf("concurrent grants = %d, want exactly 3 (the cap)", granted)
 	}
 }

--- a/internal/vm/async_pause_test.go
+++ b/internal/vm/async_pause_test.go
@@ -1,0 +1,49 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// TestWaitForFlush covers the async-pause flush handshake: idle is a no-op, a
+// waiter blocks until the flush ends and then sees its outcome, and once settled
+// it's idle again.
+func TestWaitForFlush(t *testing.T) {
+	m := &Manager{log: zerolog.Nop()}
+	inst := &VMInstance{ID: "vm1"}
+
+	// No flush in progress → returns nil immediately.
+	if err := m.waitForFlush(inst); err != nil {
+		t.Fatalf("waitForFlush(idle) = %v, want nil", err)
+	}
+
+	// Begin a flush; a waiter must block until endFlush, then get its error.
+	m.beginFlush(inst)
+	want := errors.New("flush boom")
+	done := make(chan error, 1)
+	go func() { done <- m.waitForFlush(inst) }()
+
+	select {
+	case <-done:
+		t.Fatal("waitForFlush returned before endFlush")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	m.endFlush(inst, want)
+	select {
+	case err := <-done:
+		if !errors.Is(err, want) {
+			t.Fatalf("waitForFlush = %v, want %v", err, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForFlush did not unblock after endFlush")
+	}
+
+	// Settled → idle again.
+	if err := m.waitForFlush(inst); err != nil {
+		t.Fatalf("waitForFlush(after) = %v, want nil", err)
+	}
+}

--- a/internal/vm/async_pause_test.go
+++ b/internal/vm/async_pause_test.go
@@ -47,3 +47,27 @@ func TestWaitForFlush(t *testing.T) {
 		t.Fatalf("waitForFlush(after) = %v, want nil", err)
 	}
 }
+
+// TestCountHeldBridgeMemfds covers the bridge-memfd cap accounting: the default cap,
+// an override, and counting only instances currently holding a memfd.
+func TestCountHeldBridgeMemfds(t *testing.T) {
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+
+	if got := m.maxBridgeMemfds(); got != 4 {
+		t.Fatalf("default cap = %d, want 4", got)
+	}
+	m.cfg.MaxBridgeMemfds = 2
+	if got := m.maxBridgeMemfds(); got != 2 {
+		t.Fatalf("configured cap = %d, want 2", got)
+	}
+
+	if n := m.countHeldBridgeMemfds(); n != 0 {
+		t.Fatalf("count(empty) = %d, want 0", n)
+	}
+	m.vms["a"] = &VMInstance{ID: "a", holdingBridgeMemfd: true}
+	m.vms["b"] = &VMInstance{ID: "b"}
+	m.vms["c"] = &VMInstance{ID: "c", holdingBridgeMemfd: true}
+	if n := m.countHeldBridgeMemfds(); n != 2 {
+		t.Fatalf("count = %d, want 2", n)
+	}
+}

--- a/internal/vm/fc/firecracker.yaml
+++ b/internal/vm/fc/firecracker.yaml
@@ -1618,6 +1618,14 @@ definitions:
           Directory for block device delta files. When set, overlay block
           devices write delta files (containing only dirty blocks) into this
           directory, named {drive_id}.delta.
+      async_snapshot:
+        type: boolean
+        default: false
+        description:
+          If true (and snapshot_type is Diff), write the memory diff on a
+          background thread and return at the snapshot point; the caller must
+          PUT /snapshot/complete to confirm durability. The vCPUs must stay
+          paused until then. Ignored for Full snapshots.
 
   NetworkOverride:
     type: object

--- a/internal/vm/fc/firecracker.yaml
+++ b/internal/vm/fc/firecracker.yaml
@@ -1445,6 +1445,16 @@ definitions:
         description: Optional base (template) memory file for a layered UffdInternal
           restore. When set, a page is served from backend_path if present there,
           else from this base. Only meaningful when backend_type is UffdInternal.
+      lower_overlay_paths:
+        type: array
+        items:
+          type: string
+        description: Optional intermediate overlay (diff) files between base_path and
+          backend_path, ordered oldest to newest, for a layered UffdInternal restore.
+          The chain is base_path -> lower_overlay_paths... -> backend_path (newest);
+          a page is served from the newest layer that owns it, else from base_path.
+          Empty for a single-overlay or non-layered restore. Only meaningful when
+          backend_type is UffdInternal; ignored otherwise.
       access_log_path:
         type: string
         description: Optional path to a recorded page-access trace replayed as

--- a/internal/vm/fc/models/memory_backend.go
+++ b/internal/vm/fc/models/memory_backend.go
@@ -29,6 +29,9 @@ type MemoryBackend struct {
 	// Optional base (template) memory file for a layered UffdInternal restore. When set, a page is served from backend_path if present there, else from this base. Only meaningful when backend_type is UffdInternal; ignored otherwise.
 	BasePath string `json:"base_path,omitempty"`
 
+	// Optional intermediate overlay (diff) files between base_path and backend_path, ordered oldest to newest, for a layered UffdInternal restore. The chain is base_path -> lower_overlay_paths... -> backend_path (newest); a page is served from the newest layer that owns it, else from base_path. Empty for a single-overlay or non-layered restore. Only meaningful when backend_type is UffdInternal; ignored otherwise.
+	LowerOverlayPaths []string `json:"lower_overlay_paths,omitempty"`
+
 	// Optional path to a recorded page-access trace replayed as prefetch on restore. Only meaningful when backend_type is UffdInternal; ignored otherwise.
 	AccessLogPath string `json:"access_log_path,omitempty"`
 

--- a/internal/vm/fc/models/snapshot_create_params.go
+++ b/internal/vm/fc/models/snapshot_create_params.go
@@ -26,6 +26,9 @@ type SnapshotCreateParams struct {
 	// If true (and snapshot_type is Diff), write the memory diff on a background thread and return at the snapshot point; the caller must PUT /snapshot/complete to confirm durability. The vCPUs must stay paused until then. Ignored for Full snapshots.
 	AsyncSnapshot bool `json:"async_snapshot,omitempty"`
 
+	// Memfd bridge (requires snapshot_type Diff): write the microVM state plus a dirty-page-offsets sidecar at this path and skip the memory dump. The orchestrator copies those pages from the held guest-memory memfd. The vCPUs must stay paused.
+	DirtyOffsetsPath string `json:"dirty_offsets_path,omitempty"`
+
 	// Path to the file that will contain the guest memory.
 	// Required: true
 	MemFilePath *string `json:"mem_file_path"`

--- a/internal/vm/fc/models/snapshot_create_params.go
+++ b/internal/vm/fc/models/snapshot_create_params.go
@@ -23,6 +23,9 @@ type SnapshotCreateParams struct {
 	// If true, bake each overlay's dirty blocks into its base.ext4 and zero the side-car bitmap. Only safe at template-creation time. Requires block_delta_dir.
 	Flatten bool `json:"flatten,omitempty"`
 
+	// If true (and snapshot_type is Diff), write the memory diff on a background thread and return at the snapshot point; the caller must PUT /snapshot/complete to confirm durability. The vCPUs must stay paused until then. Ignored for Full snapshots.
+	AsyncSnapshot bool `json:"async_snapshot,omitempty"`
+
 	// Path to the file that will contain the guest memory.
 	// Required: true
 	MemFilePath *string `json:"mem_file_path"`

--- a/internal/vm/fc/models/snapshot_load_params.go
+++ b/internal/vm/fc/models/snapshot_load_params.go
@@ -36,6 +36,9 @@ type SnapshotLoadParams struct {
 	// When set to true, the vm is also resumed if the snapshot load is successful.
 	ResumeVM bool `json:"resume_vm,omitempty"`
 
+	// Back the restored guest memory with a memfd (MAP_SHARED) instead of an anonymous mapping.
+	SharedMem bool `json:"shared_mem,omitempty"`
+
 	// Path to the file that contains the microVM state to be loaded.
 	// Required: true
 	SnapshotPath *string `json:"snapshot_path"`

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -384,9 +384,10 @@ func CompleteSnapshot(socketPath string) error {
 				return net.DialUnix("unix", nil, addr)
 			},
 		},
-		// Longer than Firecracker's internal completion wait so the HTTP call doesn't
-		// time out before the background write does.
-		Timeout: 60 * time.Second,
+		// Coarse backstop only: Firecracker owns real hang-detection (its writer trips a
+		// stall timeout if the dump stops making progress), so this just needs to exceed the
+		// longest legitimate write — generous so it never caps a large-but-progressing dump.
+		Timeout: 10 * time.Minute,
 	}
 	req, err := http.NewRequest(http.MethodPut, "http://localhost/snapshot/complete", strings.NewReader("{}"))
 	if err != nil {

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -419,6 +419,42 @@ func LoadSnapshotNoResume(socketPath, snapshotPath, memPath, ifaceID, tapDevice,
 	return nil
 }
 
+// LoadSnapshotNoResumeLayered loads a base + ordered overlay chain via the in-process
+// UFFD handler WITHOUT resuming the vCPUs (leaves the VM paused). For offline use —
+// verification and flatten — where the composed image must be read but not run.
+// memPath is the newest overlay; lowerOverlayPaths are the intermediate overlays
+// (oldest→newest); basePath is the template base. No dirty tracking is armed.
+func LoadSnapshotNoResumeLayered(socketPath, snapshotPath, memPath, basePath string, lowerOverlayPaths []string, ifaceID, tapDevice string) error {
+	overrides := []*models.NetworkOverride{}
+	if tapDevice != "" {
+		overrides = []*models.NetworkOverride{{IfaceID: &ifaceID, HostDevName: &tapDevice}}
+	}
+	fc := newFCClient(socketPath)
+	if _, err := fc.Operations.LoadSnapshot(&operations.LoadSnapshotParams{
+		Context: context.Background(),
+		Body: &models.SnapshotLoadParams{
+			SnapshotPath: &snapshotPath,
+			MemBackend: &models.MemoryBackend{
+				BackendType:       strPtr(models.MemoryBackendBackendTypeUffdInternal),
+				BackendPath:       &memPath,
+				BasePath:          basePath,
+				LowerOverlayPaths: lowerOverlayPaths,
+			},
+			ResumeVM:         false,
+			NetworkOverrides: overrides,
+		},
+	}); err != nil {
+		if isTornSnapshotErr(err) {
+			return fmt.Errorf("load snapshot (no-resume layered): %w: %v", ErrTornSnapshot, err)
+		}
+		if isLayeredInvalidErr(err) {
+			return fmt.Errorf("load snapshot (no-resume layered): %w: %v", ErrLayeredInvalidSnapshot, err)
+		}
+		return fmt.Errorf("load snapshot (no-resume layered): %w", err)
+	}
+	return nil
+}
+
 // SnapshotPausedVM creates a Full snapshot of an already-paused VM (e.g. one
 // loaded via LoadSnapshotNoResume), issuing no pause first as CreateSnapshot does.
 func SnapshotPausedVM(socketPath, snapshotPath, memPath string) error {

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -454,7 +454,8 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 // page offset (template-build mode). When recordToPath is set, prefetch is
 // suppressed on the Firecracker side regardless of accessLogPath.
 func RestoreSnapshotUffdInternalWithOverrides(
-	socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
+	socketPath, snapshotPath, memPath, basePath string, lowerOverlayPaths []string,
+	accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
 	trackDirty, abortOnHandlerDeath bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
@@ -468,9 +469,11 @@ func RestoreSnapshotUffdInternalWithOverrides(
 			MemBackend: &models.MemoryBackend{
 				BackendType: strPtr(models.MemoryBackendBackendTypeUffdInternal),
 				BackendPath: &memPath,
-				// Layered restore: pages absent from memPath (the overlay/diff) are
-				// served from this base (template). Empty ⇒ single-file restore.
+				// Layered restore: memPath is the newest overlay; pages absent from it
+				// fall through lowerOverlayPaths (oldest→newest) then to base (template).
+				// Empty base ⇒ single-file restore; empty chain ⇒ single-overlay restore.
 				BasePath:            basePath,
+				LowerOverlayPaths:   lowerOverlayPaths,
 				AccessLogPath:       accessLogPath,
 				RecordTo:            recordToPath,
 				AbortOnHandlerDeath: abortOnHandlerDeath,

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -305,7 +306,13 @@ func CreateSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string, mod
 //     dirty pages overwrite it and it stays a complete, standalone image.
 //   - layered overlay: memPath is fresh/sparse, so it ends up holding only the
 //     changed pages — restored over a separate base, never loaded standalone.
-func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
+//
+// When async is true the VM's memory diff is written on a Firecracker background
+// thread and the create call returns at the snapshot point; the caller must then
+// call CompleteSnapshot to confirm the write is durable, and must keep the VM
+// paused (do not unpause) until it does. async is only honored for the layered
+// (sparse-overlay) case, where the writer target is a fresh file it owns alone.
+func CreateDiffSnapshot(socketPath, snapshotPath, memPath string, async bool) error {
 	fc := newFCClient(socketPath)
 	ctx := context.Background()
 
@@ -319,12 +326,50 @@ func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
 	if _, err := fc.Operations.CreateSnapshot(&operations.CreateSnapshotParams{
 		Context: ctx,
 		Body: &models.SnapshotCreateParams{
-			SnapshotPath: &snapshotPath,
-			MemFilePath:  &memPath,
-			SnapshotType: models.SnapshotCreateParamsSnapshotTypeDiff,
+			SnapshotPath:  &snapshotPath,
+			MemFilePath:   &memPath,
+			SnapshotType:  models.SnapshotCreateParamsSnapshotTypeDiff,
+			AsyncSnapshot: async,
 		},
 	}); err != nil {
 		return fmt.Errorf("create diff snapshot: %w", err)
+	}
+	return nil
+}
+
+// CompleteSnapshot waits (PUT /snapshot/complete) for an async snapshot's background
+// write + fsync to finish, so the diff is durable on return; a no-op on the FC side
+// when no async snapshot is active. Issued as a raw request over the UDS (the
+// generated client has no such operation); FC requires a body on PUT /snapshot/*, so
+// a "{}" is sent and ignored.
+func CompleteSnapshot(socketPath string) error {
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				addr, err := net.ResolveUnixAddr("unix", socketPath)
+				if err != nil {
+					return nil, err
+				}
+				return net.DialUnix("unix", nil, addr)
+			},
+		},
+		// Longer than Firecracker's internal completion wait so the HTTP call doesn't
+		// time out before the background write does.
+		Timeout: 60 * time.Second,
+	}
+	req, err := http.NewRequest(http.MethodPut, "http://localhost/snapshot/complete", strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("complete snapshot: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("complete snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("complete snapshot: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
 }

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -537,7 +537,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 func RestoreSnapshotUffdInternalWithOverrides(
 	socketPath, snapshotPath, memPath, basePath string, lowerOverlayPaths []string,
 	accessLogPath, recordToPath, ifaceID, tapDevice, blockDeltaDir string,
-	trackDirty, abortOnHandlerDeath bool,
+	trackDirty, abortOnHandlerDeath, sharedMem bool,
 ) error {
 	// Bound LoadSnapshot so a hung Firecracker doesn't wedge vmd.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -563,6 +563,7 @@ func RestoreSnapshotUffdInternalWithOverrides(
 			// (Diff) snapshot instead of a Full one.
 			TrackDirtyPages: trackDirty,
 			ResumeVM:        true,
+			SharedMem:       sharedMem,
 			NetworkOverrides: []*models.NetworkOverride{
 				{IfaceID: &ifaceID, HostDevName: &tapDevice},
 			},

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -337,6 +337,37 @@ func CreateDiffSnapshot(socketPath, snapshotPath, memPath string, async bool) er
 	return nil
 }
 
+// CreateDiffSnapshotBridge takes the memfd-bridge variant of a diff pause: Firecracker
+// pauses the vCPUs, writes the microVM state to snapshotPath and the dirty page offsets to
+// dirtyOffsetsPath, and returns WITHOUT dumping guest memory. The caller holds the guest
+// memory memfd and copies exactly those pages from it (then stops Firecracker), so the VM
+// unit frees immediately for a fast resume. memPath is required by the API but unused here
+// (no memory dump happens). Requires shared_mem-backed guest memory.
+func CreateDiffSnapshotBridge(socketPath, snapshotPath, memPath, dirtyOffsetsPath string) error {
+	fc := newFCClient(socketPath)
+	ctx := context.Background()
+
+	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
+		Context: ctx,
+		Body:    &models.VM{State: strPtr(models.VMStatePaused)},
+	}); err != nil {
+		return fmt.Errorf("pause VM: %w", err)
+	}
+
+	if _, err := fc.Operations.CreateSnapshot(&operations.CreateSnapshotParams{
+		Context: ctx,
+		Body: &models.SnapshotCreateParams{
+			SnapshotPath:     &snapshotPath,
+			MemFilePath:      &memPath,
+			SnapshotType:     models.SnapshotCreateParamsSnapshotTypeDiff,
+			DirtyOffsetsPath: dirtyOffsetsPath,
+		},
+	}); err != nil {
+		return fmt.Errorf("create bridge snapshot: %w", err)
+	}
+	return nil
+}
+
 // CompleteSnapshot waits (PUT /snapshot/complete) for an async snapshot's background
 // write + fsync to finish, so the diff is durable on return; a no-op on the FC side
 // when no async snapshot is active. Issued as a raw request over the UDS (the

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -144,8 +144,9 @@ type VMInstance struct {
 
 	// holdingBridgeMemfd is true between a memfd fast-resume and the resumed VM's next
 	// pause/stop — the window where this sandbox pins ~2× its RAM (the new FC's mmap of
-	// the prior memfd). Counted against MaxBridgeMemfds. Not persisted; a vmd restart
-	// drops the memfd, so the count resets to zero on its own.
+	// the prior memfd). Counted against MaxBridgeMemfds. Persisted (VMRecord) so a
+	// reattached holder still counts after a vmd restart — its FC keeps the memfd mapped
+	// independently of vmd, so the RAM stays pinned; cleared at the next pause.
 	holdingBridgeMemfd bool
 
 	// restoring is true while a resume/verify is starting a Firecracker and loading a

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -702,12 +702,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// and doesn't race the background writer, FC stop, or layer deletion.
 	_ = m.waitForFlush(inst)
 	m.waitForFlatten(inst)
-
-	// If this VM was fast-resumed from a bridge memfd, pausing now stops that FC and
-	// frees the pinned RAM — drop the hold so it stops counting against MaxBridgeMemfds.
-	inst.mu.Lock()
-	inst.holdingBridgeMemfd = false
-	inst.mu.Unlock()
+	// A prior memfd fast-resume's hold (holdingBridgeMemfd) is dropped only once this pause has
+	// actually stopped that Firecracker — see clearBridgeHold at each stop point below. Clearing
+	// it here at entry would undercount the cap whenever the pause then fails with the FC (and
+	// its memfd mapping) still alive.
 
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID)
@@ -840,6 +838,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
 					log.Warn().Err(err).Msg("stop FC after bridge snapshot")
 				}
+				m.clearBridgeHold(inst) // prior fast-resume's FC is stopped; release its memfd hold
 				// Mark flushing BEFORE status=paused (same ordering as the in-FC async path)
 				// so the reconciler never mistakes the flush window for a stranded FC.
 				m.beginFlush(inst)
@@ -976,11 +975,17 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// resume loads this snapshot, not the old chain. See the `appended` comment above.
 	if !appended {
 		if man, merr := readManifest(snapshotDir); merr == nil && man != nil {
-			for _, name := range man.Overlays {
-				_ = os.Remove(filepath.Join(snapshotDir, name))
-			}
+			// Remove the manifest FIRST so it's no longer authoritative, THEN reclaim its
+			// layers. The reverse order would let a crash (or a removeManifest failure) leave a
+			// live manifest pointing at just-deleted files, so resume would fail the chain load
+			// instead of using the standalone snapshot. Only reclaim layers once the manifest
+			// is gone.
 			if rmErr := removeManifest(snapshotDir); rmErr != nil {
 				log.Warn().Err(rmErr).Msg("pause: remove stale manifest after standalone snapshot")
+			} else {
+				for _, name := range man.Overlays {
+					_ = os.Remove(filepath.Join(snapshotDir, name))
+				}
 			}
 		}
 	}
@@ -989,6 +994,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
 		log.Warn().Err(err).Msg("systemctl stop failed during pause")
 	}
+	m.clearBridgeHold(inst) // the fast-resumed FC (if any) is stopped; release its memfd hold
 
 	inst.mu.Lock()
 	inst.Status = StatusPaused
@@ -1029,6 +1035,7 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 			m.revertPriorVmstate(inst, vmstatePath)
 		}
 		m.stopAsyncPauseFC(vmID)
+		m.clearBridgeHold(inst) // FC stopped; release any prior fast-resume memfd hold
 		m.endFlush(inst, err)
 	}
 
@@ -1046,6 +1053,7 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	m.stopAsyncPauseFC(vmID)
+	m.clearBridgeHold(inst) // FC stopped; release any prior fast-resume memfd hold
 	log.Info().Msg("VM paused (async memory flush durable)")
 	// Arm/launch flatten BEFORE endFlush: maybeFlatten sets the flatten guard synchronously,
 	// so a resume/delete woken by endFlush observes the pending flatten (waitForFlatten) and
@@ -1184,6 +1192,16 @@ func (m *Manager) planLayerAppend(snapshotDir string, dirtyTracked bool, instBas
 		return "", nil, false
 	}
 	return instBaseMem, &snapshotManifest{Base: instBaseMem}, true
+}
+
+// clearBridgeHold drops a prior fast-resume's memfd hold once the Firecracker that mapped it
+// has been stopped (so it stops counting against MaxBridgeMemfds). Called at each pause stop
+// point — not at pause entry — so a failed pause that leaves the FC (and its mapping) alive
+// keeps the hold counted.
+func (m *Manager) clearBridgeHold(inst *VMInstance) {
+	inst.mu.Lock()
+	inst.holdingBridgeMemfd = false
+	inst.mu.Unlock()
 }
 
 // maxBridgeMemfds returns the configured cap on concurrently-held bridge memfds.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -138,6 +138,12 @@ type VMInstance struct {
 	bridgeMemFdPath    string
 	bridgePendingLayer string
 
+	// holdingBridgeMemfd is true between a memfd fast-resume and the resumed VM's next
+	// pause/stop — the window where this sandbox pins ~2× its RAM (the new FC's mmap of
+	// the prior memfd). Counted against MaxBridgeMemfds. Not persisted; a vmd restart
+	// drops the memfd, so the count resets to zero on its own.
+	holdingBridgeMemfd bool
+
 	mu sync.RWMutex
 }
 
@@ -262,6 +268,14 @@ type ManagerConfig struct {
 	// Inert on its own (the memfd is just allocated); the resume bridge consumes it.
 	// Default false.
 	SharedMemEnabled bool
+
+	// MaxBridgeMemfds bounds how many sandboxes may concurrently hold a bridge memfd
+	// for fast resume. A memfd-resume keeps the paused VM's frozen RAM resident (via the
+	// new FC's mmap) until that VM next pauses — roughly 2× that sandbox's RAM — so this
+	// caps the extra memory the feature can pin fleet-wide. When the cap is reached, a
+	// resume that could use the memfd falls back to the (correct, slower) wait-for-flush
+	// path. Default 4 when <= 0.
+	MaxBridgeMemfds int
 }
 
 // ---------------------------------------------------------------------------
@@ -684,6 +698,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	_ = m.waitForFlush(inst)
 	m.waitForFlatten(inst)
 
+	// If this VM was fast-resumed from a bridge memfd, pausing now stops that FC and
+	// frees the pinned RAM — drop the hold so it stops counting against MaxBridgeMemfds.
+	inst.mu.Lock()
+	inst.holdingBridgeMemfd = false
+	inst.mu.Unlock()
+
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID)
 	}
@@ -775,7 +795,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			if ferr != nil {
 				log.Warn().Err(ferr).Msg("memfd capture failed; falling back to in-FC async flush")
 			} else {
-				dirtyOffsetsPath := filepath.Join(snapshotDir, "mem.dirty.offsets")
+				dirtyOffsetsPath := filepath.Join(snapshotDir, bridgeDirtyOffsetsName)
 				log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).
 					Msg("pausing VM — memfd bridge (vmd flushes dirty pages)")
 				if err := CreateDiffSnapshotBridge(socketPath, snapshotPath, layerPath, dirtyOffsetsPath); err != nil {
@@ -1080,6 +1100,32 @@ func (m *Manager) planLayerAppend(snapshotDir string, dirtyTracked bool, instBas
 	return instBaseMem, &snapshotManifest{Base: instBaseMem}, true
 }
 
+// maxBridgeMemfds returns the configured cap on concurrently-held bridge memfds.
+func (m *Manager) maxBridgeMemfds() int {
+	if m.cfg.MaxBridgeMemfds > 0 {
+		return m.cfg.MaxBridgeMemfds
+	}
+	return 4
+}
+
+// countHeldBridgeMemfds returns how many sandboxes are currently holding a bridge memfd
+// for fast resume. Derived from per-inst flags (not a semaphore) so a crashed/reaped
+// holder can never leak a slot — an over-count is conservative (it only makes the cap
+// stricter) and self-corrects when the dead inst is removed.
+func (m *Manager) countHeldBridgeMemfds() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	n := 0
+	for _, inst := range m.vms {
+		inst.mu.RLock()
+		if inst.holdingBridgeMemfd {
+			n++
+		}
+		inst.mu.RUnlock()
+	}
+	return n
+}
+
 // beginFlush marks inst as having an in-progress async-pause flush, arming the
 // channel that endFlush closes when the flush finishes.
 func (m *Manager) beginFlush(inst *VMInstance) {
@@ -1278,15 +1324,21 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// the new FC mmaps it during restore and keeps it alive, so we drop our fd afterwards.
 	var memfdFd *os.File
 	var memfdResumePath, bridgePendingLayer string
-	inst.mu.Lock()
-	if inst.flushing && inst.bridgeMemFdPath != "" {
-		if f, oerr := os.Open(inst.bridgeMemFdPath); oerr == nil {
-			memfdFd = f
-			memfdResumePath = guestMemFdPath(f)
-			bridgePendingLayer = inst.bridgePendingLayer
+	// Only take the memfd fast path while under the held-memfd cap, so the feature can't
+	// pin unbounded extra RAM fleet-wide. Check the count BEFORE taking inst.mu
+	// (countHeldBridgeMemfds locks instances); this inst isn't counted yet, and a soft
+	// over-allow under concurrent resumes is acceptable.
+	if m.countHeldBridgeMemfds() < m.maxBridgeMemfds() {
+		inst.mu.Lock()
+		if inst.flushing && inst.bridgeMemFdPath != "" {
+			if f, oerr := os.Open(inst.bridgeMemFdPath); oerr == nil {
+				memfdFd = f
+				memfdResumePath = guestMemFdPath(f)
+				bridgePendingLayer = inst.bridgePendingLayer
+			}
 		}
+		inst.mu.Unlock()
 	}
-	inst.mu.Unlock()
 	useMemfd := memfdFd != nil
 	defer func() {
 		if memfdFd != nil {
@@ -1474,6 +1526,9 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = resumedMemFile
 	inst.BaseMemPath = basePath // re-cache (may have come from the on-disk sidecar)
+	// A memfd resume pins this sandbox's prior RAM (via the new FC's mmap) until its next
+	// pause; mark the hold so it counts against MaxBridgeMemfds. Cleared at the next pause.
+	inst.holdingBridgeMemfd = useMemfd
 	inst.mu.Unlock()
 
 	m.persistState(inst)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -779,6 +779,18 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			}
 			break
 		}
+		// Preserve the prior committed vmstate before this pause overwrites vmstate.snap, so
+		// a failed async/bridge flush can revert to a vmstate matching the prior memory chain
+		// (accumulating pauses only — the first layer has no prior committed state). Restored
+		// on any failure below, discarded once the new layer commits.
+		priorVmstateSaved := false
+		if newIndex > 0 {
+			saved, serr := savePriorVmstate(snapshotPath)
+			if serr != nil {
+				log.Warn().Err(serr).Msg("pause: save prior vmstate failed; a failed flush won't be revertible")
+			}
+			priorVmstateSaved = saved
+		}
 		// Async only when enabled AND a prior durable layer exists to fall back to if
 		// the background write is interrupted (first-pause-always-sync: newIndex 0 is
 		// the first layer, which has only the read-only template base under it).
@@ -817,6 +829,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 					memFile.Close()
 					<-m.pauseSem
 					_ = os.Remove(layerPath)
+					m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
 					return "", "", m.handleVMError(vmID, fmt.Errorf("bridge diff snapshot: %w", err))
 				}
 				// Stop the old FC now: vmd holds the memfd, so guest RAM stays resident and
@@ -841,7 +854,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				inst.bridgePendingLayer = layerPath
 				inst.mu.Unlock()
 				m.persistState(inst)
-				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, memFile, dirtyOffsetsPath, appendManifest)
+				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, memFile, dirtyOffsetsPath, appendManifest, priorVmstateSaved)
 				log.Info().Int("layer", newIndex).Msg("VM pausing (memfd bridge flush in background)")
 				return snapshotPath, layerPath, nil
 			}
@@ -856,6 +869,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			// previously committed chain stays intact and resumable. Drop the orphan so
 			// the next attempt at this index starts clean.
 			_ = os.Remove(layerPath)
+			m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
 			return "", "", m.handleVMError(vmID, fmt.Errorf("append layered diff snapshot: %w", err))
 		}
 		if async {
@@ -874,7 +888,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			inst.DirtyTracked = false
 			inst.mu.Unlock()
 			m.persistState(inst)
-			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, socketPath, appendManifest)
+			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, socketPath, appendManifest, priorVmstateSaved)
 			log.Info().Int("layer", newIndex).Msg("VM pausing (async memory flush in background)")
 			return snapshotPath, layerPath, nil
 		}
@@ -883,7 +897,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
 		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
 			_ = os.Remove(layerPath)
+			m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
 			return "", "", m.handleVMError(vmID, fmt.Errorf("publish snapshot manifest: %w", err))
+		}
+		// Committed: the new vmstate.snap pairs with the new chain, so drop the prior copy.
+		if priorVmstateSaved {
+			discardPriorVmstate(snapshotPath)
 		}
 	case layered:
 		memPath = overlayPath
@@ -977,26 +996,39 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 // previous durable chain in place. Either way the sandbox stays resumable: the
 // manifest names the prior chain until (and unless) the new layer commits. Always
 // ends the flush so waiters (resume/re-pause/delete) unblock.
-func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, socketPath string, manifest *snapshotManifest) {
+func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, socketPath string, manifest *snapshotManifest, priorVmstateSaved bool) {
 	defer func() { <-m.pauseSem }() // release the background-flush slot claimed in PauseVM
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
 
-	if err := CompleteSnapshot(socketPath); err != nil {
-		log.Error().Err(err).Msg("async pause flush failed; keeping previous durable snapshot")
+	// On failure, revert vmstate to the prior committed copy so it pairs with the prior
+	// (still-committed) memory chain — resume then loads a consistent stale-by-one snapshot.
+	// A resume can't have happened mid-flush on this path (it waits for the flush), so the
+	// sandbox is still paused; revert unconditionally. endFlush AFTER the revert so a waiting
+	// resume observes the reverted state.
+	failRevert := func(err error, msg string) {
+		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
+		if priorVmstateSaved {
+			m.revertPriorVmstate(inst, vmstatePath, false)
+		}
 		m.stopAsyncPauseFC(vmID)
 		m.endFlush(inst, err)
+	}
+
+	if err := CompleteSnapshot(socketPath); err != nil {
+		failRevert(err, "async pause flush failed; reverting to previous durable snapshot")
 		return
 	}
 	// Durable: commit the manifest, then stop FC.
 	manifest.Overlays = append(manifest.Overlays, layerName)
 	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
-		log.Error().Err(err).Msg("async pause manifest commit failed; keeping previous durable snapshot")
-		_ = os.Remove(layerPath)
-		m.stopAsyncPauseFC(vmID)
-		m.endFlush(inst, err)
+		failRevert(err, "async pause manifest commit failed; reverting to previous durable snapshot")
 		return
+	}
+	if priorVmstateSaved {
+		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	m.stopAsyncPauseFC(vmID)
 	log.Info().Msg("VM paused (async memory flush durable)")
@@ -1013,7 +1045,7 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 // sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
 // vmd's memfd fd is closed when the dump finishes; a resume that adopted the memfd during
 // the flush holds its own fd (and the new Firecracker's mmap keeps the pages resident).
-func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
+func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest, priorVmstateSaved bool) {
 	// Defers run LIFO: clear the handoff fields under mu FIRST, then close memFile, then
 	// release the sem. Clearing before the close (and under mu) means a concurrent resume
 	// either sees the path set and reopens its own fd while memFile is still open, or sees
@@ -1030,27 +1062,38 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	defer os.Remove(dirtyOffsetsPath)
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
+
+	// On failure, revert vmstate to the prior committed copy ONLY if the sandbox is still
+	// paused: a fast-resumed (Running) VM already loaded the new vmstate into its Firecracker,
+	// so reverting the file is pointless and could race that restore (it self-heals on the
+	// next pause). endFlush AFTER the revert so a waiting resume observes the reverted state.
+	failRevert := func(err error, msg string) {
+		log.Error().Err(err).Msg(msg)
+		_ = os.Remove(layerPath)
+		if priorVmstateSaved {
+			m.revertPriorVmstate(inst, vmstatePath, true)
+		}
+		m.endFlush(inst, err)
+	}
 
 	offsets, err := readDirtyOffsets(dirtyOffsetsPath)
 	if err != nil {
-		log.Error().Err(err).Msg("bridge pause: read dirty offsets failed; keeping previous durable snapshot")
-		_ = os.Remove(layerPath)
-		m.endFlush(inst, err)
+		failRevert(err, "bridge pause: read dirty offsets failed; reverting to previous durable snapshot")
 		return
 	}
 	if err := dumpMemfdPages(memFile, offsets, layerPath, os.Getpagesize()); err != nil {
-		log.Error().Err(err).Msg("bridge pause: memfd dump failed; keeping previous durable snapshot")
-		_ = os.Remove(layerPath)
-		m.endFlush(inst, err)
+		failRevert(err, "bridge pause: memfd dump failed; reverting to previous durable snapshot")
 		return
 	}
 	// Durable: commit the manifest with the new layer appended (atomic temp + rename).
 	manifest.Overlays = append(manifest.Overlays, layerName)
 	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
-		log.Error().Err(err).Msg("bridge pause: manifest commit failed; keeping previous durable snapshot")
-		_ = os.Remove(layerPath)
-		m.endFlush(inst, err)
+		failRevert(err, "bridge pause: manifest commit failed; reverting to previous durable snapshot")
 		return
+	}
+	if priorVmstateSaved {
+		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	log.Info().Int("pages", len(offsets)).Msg("VM paused (memfd bridge flush durable)")
 	m.endFlush(inst, nil)
@@ -1140,6 +1183,27 @@ func (m *Manager) countHeldBridgeMemfds() int {
 		inst.mu.RUnlock()
 	}
 	return n
+}
+
+// revertPriorVmstate reverts vmstate to the prior committed copy after a failed flush, so a
+// later resume loads a vmstate consistent with the prior (still-committed) memory chain.
+// onlyIfPaused is set on the bridge path: a fast-resumed (Running) VM has already loaded the
+// new vmstate into its Firecracker, so reverting the file would both be pointless and could
+// race that restore — leave it (the VM's next pause re-commits a consistent state, and a
+// crash before then is the same stale-by-one the prior chain already represents).
+func (m *Manager) revertPriorVmstate(inst *VMInstance, vmstatePath string, onlyIfPaused bool) {
+	if onlyIfPaused {
+		inst.mu.RLock()
+		running := inst.Status != StatusPaused
+		inst.mu.RUnlock()
+		if running {
+			discardPriorVmstate(vmstatePath)
+			return
+		}
+	}
+	if err := restorePriorVmstate(vmstatePath); err != nil {
+		m.log.Warn().Str("vm_id", inst.ID).Err(err).Msg("revert prior vmstate after failed flush")
+	}
 }
 
 // beginFlush marks inst as having an in-progress async-pause flush, arming the
@@ -1370,13 +1434,11 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}()
 	if !useMemfd {
 		// No memfd handoff — wait for any in-flight flush to commit the durable chain. If it
-		// FAILED, the memory chain reverted to the prior one while vmstate.snap holds the
-		// failed pause's state, so a resume would pair mismatched vmstate + memory. Refuse and
-		// mark failed rather than boot a torn VM.
+		// FAILED, completeAsyncPause/completeBridgePause already reverted vmstate to the prior
+		// committed copy, so the prior chain + vmstate are consistent: resume from it (the
+		// failed pause's changes are lost — stale by one pause), surfacing the failure loudly.
 		if ferr := m.waitForFlush(inst); ferr != nil {
-			m.setStatus(vmID, StatusError)
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"cannot resume %s: last async snapshot flush failed (%v); snapshot is not durable", vmID, ferr)
+			log.Warn().Err(ferr).Msg("last async flush failed; resuming from the prior durable snapshot (last pause's changes lost)")
 		}
 	}
 	m.waitForFlatten(inst)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -791,7 +791,13 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// immediate resume (A5) instead of keeping the old FC alive for the whole flush.
 		// Any capture/snapshot failure falls back to the in-FC async path (sem still held).
 		if async && m.cfg.SharedMemEnabled {
-			memFile, ferr := captureGuestMemFd(instPID)
+			// The cached PID is 0 right after a resume (the unit's MainPID is published
+			// asynchronously), so resolve it from systemd here rather than trust inst.PID.
+			fcPID := instPID
+			if fcPID <= 0 {
+				fcPID = m.firecrackerMainPID(ctx, vmID)
+			}
+			memFile, ferr := captureGuestMemFd(fcPID)
 			if ferr != nil {
 				log.Warn().Err(ferr).Msg("memfd capture failed; falling back to in-FC async flush")
 			} else {
@@ -2787,17 +2793,29 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	return 0, nil
 }
 
+// firecrackerMainPID resolves a systemd-managed VM's Firecracker PID via the unit's
+// MainPID. Returns 0 if it can't be determined. Used both to cache the PID after a
+// start/resume and to find the FC process at bridge-pause time (the cached inst.PID is
+// 0 right after a resume, since the start returns before MainPID is published).
+func (m *Manager) firecrackerMainPID(ctx context.Context, vmID string) int {
+	cmd := exec.CommandContext(ctx, "systemctl", "show", "--property=MainPID", "--value", systemdUnitName(vmID))
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &pid); err != nil {
+		return 0
+	}
+	return pid
+}
+
 func (m *Manager) resolveAndSetPID(vmID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "systemctl", "show", "--property=MainPID", "--value", systemdUnitName(vmID))
-	out, err := cmd.Output()
-	if err != nil {
-		return
-	}
-	var pid int
-	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &pid); err != nil || pid == 0 {
+	pid := m.firecrackerMainPID(ctx, vmID)
+	if pid == 0 {
 		return
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -244,6 +244,14 @@ type ManagerConfig struct {
 	// MaxConcurrentFlattens bounds simultaneous background flattens (each is
 	// I/O-heavy). Default 2 when <= 0.
 	MaxConcurrentFlattens int
+
+	// SharedMemEnabled backs restored guest memory with a memfd (MAP_SHARED) instead
+	// of an anonymous mapping, so a paused FC's frozen RAM can be handed to a new FC
+	// for an immediate resume that doesn't wait for the background flush. Requires
+	// ResumeUffdEnabled and an FC binary that accepts shared_mem on /snapshot/load.
+	// Inert on its own (the memfd is just allocated); the resume bridge consumes it.
+	// Default false.
+	SharedMemEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -1340,7 +1348,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
 		socketPath, snapshotPath, memPath, basePath, lowerOverlays, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
-		m.cfg.HandlerDeathAbortEnabled,
+		m.cfg.HandlerDeathAbortEnabled, m.cfg.SharedMemEnabled,
 	)
 }
 
@@ -1843,7 +1851,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if restoreErr == nil {
 			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
 				socketPath, snapshotPath, memPath, basePath, nil, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
-				m.cfg.HandlerDeathAbortEnabled,
+				m.cfg.HandlerDeathAbortEnabled, m.cfg.SharedMemEnabled,
 			)
 		}
 	case inPlace:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1098,9 +1098,10 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 			m.endFlush(inst, fmt.Errorf("bridge pause completion panicked: %v", r))
 		}
 	}()
-	// Ensure the old FC is stopped: the bridge pause's stop is warn-only, so a transient failure
-	// would leave a vCPU-paused FC pinning ~2x RAM. The held memfd keeps the RAM; re-stop is a no-op.
-	m.stopAsyncPauseFC(vmID)
+	// Do NOT re-stop the unit here: a bridge fast-resume can restart firecracker@<id> concurrently,
+	// and a delayed stop would kill the freshly-resumed FC. The old FC was already stopped at the
+	// pause point; a transient failure there is handled by ResumeVM's stranded-unit stop and the
+	// reconciler, not by racing the resume from this goroutine.
 
 	// On failure the manifest never commits, so the prior snapshot stays durable. Leave the
 	// uncommitted layer + vmstate (and its .overlay sidecar) on disk as orphans rather than
@@ -2057,6 +2058,20 @@ func (m *Manager) DeleteSnapshotFiles(vmID, snapshotPath, memPath string) error 
 		for _, p := range []string{manifestPath(memDir), manifestPath(memDir) + ".next"} {
 			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 				m.log.Warn().Err(err).Str("path", p).Msg("remove snapshot manifest")
+			}
+		}
+		// Older per-layer vmstates + their block-overlay sidecars + the bridge offsets sidecar
+		// aren't named in memPath/Overlays (only the newest vmstate is snapshotPath); once the
+		// manifest is gone gcOrphanLayers can't see them either. The whole snapshot is being
+		// deleted, so reclaim them here (else they leak block-overlay data for every prior layer).
+		if entries, rerr := os.ReadDir(memDir); rerr == nil {
+			for _, e := range entries {
+				n := e.Name()
+				if vmstateFileRe.MatchString(n) || vmstateOverlayFileRe.MatchString(n) || n == bridgeDirtyOffsetsName {
+					if err := os.Remove(filepath.Join(memDir, n)); err != nil && !os.IsNotExist(err) {
+						m.log.Warn().Err(err).Str("path", n).Msg("remove per-layer vmstate/sidecar")
+					}
+				}
 			}
 		}
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -971,15 +971,17 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// Drop a stale chain manifest (+ its orphaned overlays) left by a standalone pause, so
 	// resume loads this snapshot, not the old chain. See the `appended` comment above.
 	if !appended {
-		if man, merr := readManifest(snapshotDir); merr == nil && man != nil {
-			// Remove the manifest FIRST so it's no longer authoritative, THEN reclaim its
-			// layers. The reverse order would let a crash (or a removeManifest failure) leave a
-			// live manifest pointing at just-deleted files, so resume would fail the chain load
-			// instead of using the standalone snapshot. Only reclaim layers once the manifest
-			// is gone.
+		man, merr := readManifest(snapshotDir)
+		// A leftover manifest — stale chain, or corrupt/unreadable — must not shadow the standalone
+		// snapshot just written: ResumeVM treats a present-or-unreadable manifest as authoritative
+		// and would refuse, leaving the VM unrestorable. Drop it. Remove the manifest FIRST so it's
+		// no longer authoritative, THEN reclaim its layers — the reverse order would let a crash (or
+		// a removeManifest failure) leave a live manifest pointing at just-deleted files. A corrupt
+		// manifest yields no overlay list, so its layers (if any) fall to GC.
+		if merr != nil || man != nil {
 			if rmErr := removeManifest(snapshotDir); rmErr != nil {
 				log.Warn().Err(rmErr).Msg("pause: remove stale manifest after standalone snapshot")
-			} else {
+			} else if man != nil {
 				for _, name := range man.Overlays {
 					_ = os.Remove(filepath.Join(snapshotDir, name))
 				}
@@ -1208,6 +1210,35 @@ func (m *Manager) countHeldBridgeMemfds() int {
 		inst.mu.RUnlock()
 	}
 	return n
+}
+
+// tryClaimBridgeMemfd reserves a held-memfd slot for inst if it's mid-bridge-flush and the fleet
+// is under the cap, returning the in-flight files to reopen. Counting the held slots and setting
+// this inst's hold happen under m.mu, so the check-and-claim is atomic — a burst of concurrent
+// resumes can't all observe an under-cap count and then each take the fast path. A caller that
+// reserves a slot but doesn't finish holding it (reopen fails, restore fails, or it falls back off
+// the memfd path) must release it with clearBridgeHold.
+func (m *Manager) tryClaimBridgeMemfd(inst *VMInstance) (memFdPath, vmstatePath, pendingLayer string, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	held := 0
+	for _, i := range m.vms {
+		i.mu.RLock()
+		if i.holdingBridgeMemfd {
+			held++
+		}
+		i.mu.RUnlock()
+	}
+	if held >= m.maxBridgeMemfds() {
+		return "", "", "", false
+	}
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	if !inst.flushing || inst.bridgeMemFdPath == "" || inst.bridgePendingVmstate == "" {
+		return "", "", "", false
+	}
+	inst.holdingBridgeMemfd = true // reserve atomically with the count above
+	return inst.bridgeMemFdPath, inst.bridgePendingVmstate, inst.bridgePendingLayer, true
 }
 
 // beginFlush marks inst as having an in-progress async-pause flush, arming the
@@ -1440,21 +1471,24 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// the new FC mmaps it during restore and keeps it alive, so we drop our fd afterwards.
 	var memfdFd, vmstateFd *os.File
 	var memfdResumePath, memfdVmstatePath, bridgePendingLayer string
-	// Only take the memfd fast path while under the held-memfd cap, so the feature can't
-	// pin unbounded extra RAM fleet-wide. Gate on the flag first so a flags-off resume pays
-	// nothing (countHeldBridgeMemfds scans all VMs). Reopen vmd's own fds to the memfd AND the
-	// in-flight per-layer vmstate under the lock, so a concurrent commit/delete can't pull them
-	// out from under us; the new FC mmaps/reads them during restore and they're dropped after.
-	if m.cfg.SharedMemEnabled && m.countHeldBridgeMemfds() < m.maxBridgeMemfds() {
-		inst.mu.Lock()
-		if inst.flushing && inst.bridgeMemFdPath != "" && inst.bridgePendingVmstate != "" {
-			memf, merr := os.Open(inst.bridgeMemFdPath)
-			vmf, verr := os.Open(inst.bridgePendingVmstate)
+	// Take the memfd fast path only while a bridge flush is in progress AND the fleet is under
+	// the held-memfd cap, so the feature can't pin unbounded extra RAM. tryClaimBridgeMemfd
+	// reserves the slot atomically with the count (so a burst of concurrent resumes can't all
+	// pass the cap) and returns the files to reopen. We then reopen vmd's own fds to those paths,
+	// so a concurrent commit/delete can't pull them out from under us; the new FC mmaps/reads
+	// them during restore and they're dropped after. Gate on the flag first so a flags-off resume
+	// pays nothing.
+	claimedMemfd := false
+	if m.cfg.SharedMemEnabled {
+		if memFdPath, vmstatePath, pendingLayer, ok := m.tryClaimBridgeMemfd(inst); ok {
+			claimedMemfd = true
+			memf, merr := os.Open(memFdPath)
+			vmf, verr := os.Open(vmstatePath)
 			if merr == nil && verr == nil {
 				memfdFd, vmstateFd = memf, vmf
 				memfdResumePath = guestMemFdPath(memf)
 				memfdVmstatePath = guestMemFdPath(vmf)
-				bridgePendingLayer = inst.bridgePendingLayer
+				bridgePendingLayer = pendingLayer
 			} else {
 				if memf != nil {
 					_ = memf.Close()
@@ -1462,17 +1496,24 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 				if vmf != nil {
 					_ = vmf.Close()
 				}
+				m.clearBridgeHold(inst) // reopen failed — release the reserved slot
+				claimedMemfd = false
 			}
 		}
-		inst.mu.Unlock()
 	}
 	useMemfd := memfdFd != nil
+	resumeOK := false
 	defer func() {
 		if memfdFd != nil {
 			_ = memfdFd.Close()
 		}
 		if vmstateFd != nil {
 			_ = vmstateFd.Close()
+		}
+		// The slot was reserved at claim time; keep the hold only if the resume completed using
+		// the memfd. On early failure, or a fall-back off the memfd path, release the reservation.
+		if claimedMemfd && !(resumeOK && useMemfd) {
+			m.clearBridgeHold(inst)
 		}
 	}()
 	if !useMemfd {
@@ -1665,10 +1706,12 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = resumedMemFile
 	inst.BaseMemPath = basePath // re-cache (may have come from the on-disk sidecar)
-	// A memfd resume pins this sandbox's prior RAM (via the new FC's mmap) until its next
-	// pause; mark the hold so it counts against MaxBridgeMemfds. Cleared at the next pause.
-	inst.holdingBridgeMemfd = useMemfd
 	inst.mu.Unlock()
+
+	// A memfd resume pins this sandbox's prior RAM (via the new FC's mmap) until its next pause;
+	// the slot reserved at claim time stays held (it counts against MaxBridgeMemfds and is cleared
+	// at the next pause). resumeOK keeps the deferred release from dropping it.
+	resumeOK = true
 
 	m.persistState(inst)
 	log.Info().Int("pid", pid).Msg("VM resumed from snapshot")

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -182,6 +182,15 @@ type ManagerConfig struct {
 	// page fault). The dead VM then surfaces via the unit-inactive → reconciler path
 	// rather than hanging silently. Independent of the snapshot flags. Default false.
 	HandlerDeathAbortEnabled bool
+
+	// LayerAppendEnabled makes a layered pause append a new immutable diff layer
+	// (recorded in a per-sandbox manifest) instead of merging the diff in place into
+	// a single mem.diff. Restore then loads base → diff₁ → … → diffₙ via the layered
+	// chain. This is the on-disk foundation the async/durable pause path needs (an
+	// in-place merge has no surviving copy if a write is interrupted). Requires
+	// IncrementalSnapshotEnabled + ResumeUffdEnabled and an FC binary that accepts
+	// lower_overlay_paths. Default false.
+	LayerAppendEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -613,11 +622,53 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	layered := m.cfg.IncrementalSnapshotEnabled && dirtyTracked && instBaseMem != "" &&
 		(instMemFile == instBaseMem || overlayPath == instMemFile)
 	baseMemPath := ""
+	// Append-only layered: when enabled, a layered pause appends a NEW immutable diff
+	// layer and republishes the manifest, instead of merging in place. The committed
+	// manifest is the durability anchor — an interrupted layer write leaves the prior
+	// chain intact and resumable. This is the on-disk foundation the async/durable
+	// pause path needs. When disabled, the in-place paths below run unchanged.
+	appendBase, appendManifest, appendOK := m.planLayerAppend(snapshotDir, dirtyTracked, instBaseMem, instMemFile)
 	// CreateDiffSnapshot merges in place: an interrupted diff has no surviving copy
 	// of the file it overwrites (for layered, only the session delta — the template
 	// base is untouched; for in-place, the VM's own mem.snap). Crash-atomicity of the
 	// diff is the durability-boundary work, intentionally out of scope here.
 	switch {
+	case appendOK:
+		// Append the next layer to a fresh, dedicated file; the manifest records the
+		// ordered chain. CreateDiffSnapshot writes only this run's dirtied pages (a
+		// sparse layer), so the file is self-contained as one chain link.
+		newIndex := len(appendManifest.Overlays)
+		layerName := overlayLayerName(newIndex)
+		layerPath := filepath.Join(snapshotDir, layerName)
+		memPath = layerPath
+		baseMemPath = appendBase
+		// A leftover file at this index (a failed prior attempt) would survive as
+		// stale page extents over the chain — CreateDiffSnapshot writes only dirtied
+		// pages and never truncates. Start fresh; if it can't be removed, fall back to
+		// Full rather than diff onto stale data.
+		if rerr := os.Remove(layerPath); rerr != nil && !os.IsNotExist(rerr) {
+			log.Warn().Err(rerr).Str("path", layerPath).Msg("pause: stale layer removal failed; falling back to Full")
+			memPath, baseMemPath = fullPath, ""
+			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
+				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+			}
+			break
+		}
+		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Msg("pausing VM — appending layered diff snapshot")
+		if err := CreateDiffSnapshot(socketPath, snapshotPath, layerPath); err != nil {
+			// Leave the partial layer orphaned and do NOT republish the manifest — the
+			// previously committed chain stays intact and resumable. Drop the orphan so
+			// the next attempt at this index starts clean.
+			_ = os.Remove(layerPath)
+			return "", "", m.handleVMError(vmID, fmt.Errorf("append layered diff snapshot: %w", err))
+		}
+		// Commit point: republish the manifest with the new layer appended (atomic
+		// temp-write + rename). Until this lands, restore loads the prior chain.
+		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
+		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
+			_ = os.Remove(layerPath)
+			return "", "", m.handleVMError(vmID, fmt.Errorf("publish snapshot manifest: %w", err))
+		}
 	case layered:
 		memPath = overlayPath
 		baseMemPath = instBaseMem
@@ -717,6 +768,39 @@ func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeMemPath stri
 // standalone (which would read the base's pages as zero holes).
 func layeredBaseSidecarPath(memPath string) string { return memPath + ".base" }
 
+// planLayerAppend decides whether this pause may append a new immutable diff layer
+// to the sandbox's chain, returning the base and the manifest to extend. ok is
+// false (caller falls back to the in-place/Full paths) unless append is enabled,
+// dirty tracking is armed, and the VM resumed from a recognized chain position:
+// either straight from the template base (the first layer) or from the manifest's
+// newest overlay (an accumulating layer). Any other resume source (explicit
+// override, standalone mem file) would make this diff capture only part of the
+// state, so it falls back.
+func (m *Manager) planLayerAppend(snapshotDir string, dirtyTracked bool, instBaseMem, instMemFile string) (base string, manifest *snapshotManifest, ok bool) {
+	if !(m.cfg.LayerAppendEnabled && m.cfg.IncrementalSnapshotEnabled && dirtyTracked) {
+		return "", nil, false
+	}
+	man, err := readManifest(snapshotDir)
+	if err != nil {
+		// An unreadable manifest must not be silently overwritten — falling back to a
+		// Full snapshot is safe and preserves whatever chain is on disk.
+		return "", nil, false
+	}
+	if man != nil && len(man.Overlays) > 0 {
+		// Accumulating: the VM must have resumed from the chain's newest overlay.
+		newest := filepath.Join(snapshotDir, man.Overlays[len(man.Overlays)-1])
+		if instMemFile != newest {
+			return "", nil, false
+		}
+		return man.Base, man, true
+	}
+	// First layer: the VM loaded straight from the read-only template base.
+	if instBaseMem == "" || instMemFile != instBaseMem {
+		return "", nil, false
+	}
+	return instBaseMem, &snapshotManifest{Base: instBaseMem}, true
+}
+
 // freshenFirstPassOverlay removes any leftover overlay so a first layered pass starts
 // from a clean file (its dirty set is the whole overlay, so a stale one would leave
 // non-dirtied stale pages that override the base on restore). A missing overlay is the
@@ -788,6 +872,24 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, status.Errorf(codes.InvalidArgument, "snapshot_path and mem_file_path are required")
 	}
 
+	// Layered chain (append-only path): if a manifest is present, it is authoritative
+	// for the base + ordered overlay chain. Resolve it here (before starting FC) so a
+	// corrupt/empty manifest fails fast, and so the file checks below validate the
+	// chain's newest overlay. basePath drives the layered restore; an absent manifest
+	// leaves it "" and falls through to the legacy single-overlay resolution below.
+	basePath := ""
+	var lowerOverlays []string
+	snapshotDir := filepath.Dir(memPath)
+	if man, merr := readManifest(snapshotDir); merr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unreadable snapshot manifest in %s: %v", snapshotDir, merr)
+	} else if man != nil {
+		base, lower, newest, ok := man.chainPaths(snapshotDir)
+		if !ok {
+			return nil, status.Errorf(codes.FailedPrecondition, "snapshot manifest in %s has no overlays", snapshotDir)
+		}
+		basePath, lowerOverlays, memPath = base, lower, newest
+	}
+
 	// Verify the snapshot files actually exist on disk. DB can claim
 	// "ready" but the files be missing — common scenarios:
 	//   - vmd host replaced; new host has no cached snapshots
@@ -847,16 +949,17 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
-	// A base is needed only when memPath is itself a diff overlay. Keying on memPath
-	// (not the cached BaseMemPath) means a standalone/override resume clears any
-	// stale base, so the next pause won't wrongly diff against the old template.
+	// Legacy single-overlay resolution — only when the manifest above didn't already
+	// supply a base. A base is needed only when memPath is itself a diff overlay.
+	// Keying on memPath (not the cached BaseMemPath) means a standalone/override
+	// resume clears any stale base, so the next pause won't wrongly diff against the
+	// old template.
 	//
 	// The .base sidecar is authoritative for THIS overlay, so prefer it — the cached
 	// BaseMemPath only matches the cached overlay (inst.MemFilePath) and would supply
 	// the wrong base for an explicit override of a different mem.diff. Fall back to
 	// the cached base only when the sidecar is missing and this is the cached overlay.
-	basePath := ""
-	if isOverlayMemFile(memPath) {
+	if basePath == "" && isOverlayMemFile(memPath) {
 		if b, ok := readLayeredBase(memPath); ok {
 			basePath = b
 		} else if memPath == inst.MemFilePath {
@@ -868,7 +971,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
 		}
 	}
-	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo)
+	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, basePath, lowerOverlays, netInfo)
 	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
@@ -907,18 +1010,19 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 }
 
 // restoreForResume picks the resume memory backend: UFFD (reusing the existing tap
-// for the interface override, optionally layered over basePath) when enabled and a
-// tap is present, else File. A layered overlay (basePath set) requires UFFD. Reports
-// whether dirty-page tracking was armed so the caller can decide if the next pause
-// may write a Diff.
-func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
+// for the interface override, optionally layered over basePath + lowerOverlays)
+// when enabled and a tap is present, else File. A layered restore (basePath set,
+// memPath the newest overlay, lowerOverlays the intermediate diffs oldest→newest)
+// requires UFFD. Reports whether dirty-page tracking was armed so the caller can
+// decide if the next pause may write a Diff.
+func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, lowerOverlays []string, netInfo *network.VMNetInfo) (dirtyTracked bool, err error) {
 	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
 	if !useUffd {
 		// A layered overlay can only be served by the UFFD layered backend. If this
 		// host can't take that path (resume-UFFD/UFFD off, or no tap), refuse rather
 		// than load the sparse overlay via the File backend, which would read the
 		// base's pages as zero holes.
-		if basePath != "" {
+		if basePath != "" || len(lowerOverlays) > 0 {
 			return false, fmt.Errorf("layered overlay %q requires UFFD resume (resume-uffd + uffd + tap); refusing File-backend restore", memPath)
 		}
 		return false, RestoreSnapshot(socketPath, snapshotPath, memPath, "")
@@ -926,10 +1030,11 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 
 	// No prefetch access log: only template builds record one (next to the template
 	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
-	// basePath non-empty ⇒ layered restore (memPath is the diff overlay over basePath).
+	// basePath non-empty ⇒ layered restore: memPath is the newest overlay, served over
+	// lowerOverlays (oldest→newest) then basePath.
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, basePath, nil, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
+		socketPath, snapshotPath, memPath, basePath, lowerOverlays, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 		m.cfg.HandlerDeathAbortEnabled,
 	)
 }
@@ -1107,6 +1212,24 @@ func (m *Manager) DeleteSnapshotFiles(vmID, snapshotPath, memPath string) error 
 		sidecar := layeredBaseSidecarPath(memPath)
 		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
 			m.log.Warn().Err(err).Str("path", sidecar).Msg("remove layered base side-car")
+		}
+		// Append-only chain: the manifest names overlay layers that aren't passed in
+		// memPath (only the newest is). Remove every layer it lists, plus the manifest
+		// and any uncommitted .next, so no orphaned diff bodies leak. The base is a
+		// shared template image and is never removed here.
+		memDir := filepath.Dir(memPath)
+		if man, err := readManifest(memDir); err == nil && man != nil {
+			for _, name := range man.Overlays {
+				p := filepath.Join(memDir, name)
+				if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+					m.log.Warn().Err(err).Str("path", p).Msg("remove chain overlay layer")
+				}
+			}
+		}
+		for _, p := range []string{manifestPath(memDir), manifestPath(memDir) + ".next"} {
+			if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+				m.log.Warn().Err(err).Str("path", p).Msg("remove snapshot manifest")
+			}
 		}
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1187,12 +1187,32 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	if snapshotPath == "" || memPath == "" {
 		return "", status.Errorf(codes.InvalidArgument, "vm %s has no snapshot on record", vmID)
 	}
-	// This gate loads via the File backend (no base), so it can only verify a
-	// standalone image. A layered diff overlay would load with its base's pages as
-	// zero holes and produce a meaningless comparison — refuse instead.
-	if isOverlayMemFile(memPath) || inst.BaseMemPath != "" {
-		return "", status.Errorf(codes.FailedPrecondition,
-			"vm %s is a layered (diff-overlay) snapshot; the verify gate only supports standalone images", vmID)
+	// Resolve the layered chain (if any). The manifest is authoritative for the
+	// base + ordered overlays (so this also verifies a post-flatten chain whose
+	// inst fields may be stale); fall back to the single-overlay .base sidecar.
+	// A standalone image leaves basePath empty and loads via the File backend.
+	snapshotDir := filepath.Dir(memPath)
+	basePath := ""
+	var lowerOverlays []string
+	if man, merr := readManifest(snapshotDir); merr != nil {
+		return "", status.Errorf(codes.FailedPrecondition, "unreadable snapshot manifest in %s: %v", snapshotDir, merr)
+	} else if man != nil {
+		base, lower, newest, ok := man.chainPaths(snapshotDir)
+		if !ok {
+			return "", status.Errorf(codes.FailedPrecondition, "snapshot manifest in %s has no overlays", snapshotDir)
+		}
+		basePath, lowerOverlays, memPath = base, lower, newest
+	}
+	if basePath == "" && isOverlayMemFile(memPath) {
+		if b, ok := readLayeredBase(memPath); ok {
+			basePath = b
+		} else if memPath == inst.MemFilePath {
+			basePath = inst.BaseMemPath
+		}
+		if basePath == "" {
+			return "", status.Errorf(codes.FailedPrecondition,
+				"vm %s layered overlay %q has no recoverable base", vmID, memPath)
+		}
 	}
 	if _, err := os.Stat(memPath); err != nil {
 		return "", status.Errorf(codes.FailedPrecondition, "mem file missing on host: %s", memPath)
@@ -1230,11 +1250,19 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	}
 	defer func() { _ = stopUnit(context.Background(), systemdUnitName(vmID)) }()
 
-	if err := LoadSnapshotNoResume(socketPath, snapshotPath, memPath, "eth0", tapDevice, ""); err != nil {
-		return "", err
+	// Layered chain → UFFD no-resume load (composes base + overlays); standalone →
+	// File backend. The re-snapshot below then captures the fully composed image.
+	if basePath != "" {
+		if err := LoadSnapshotNoResumeLayered(socketPath, snapshotPath, memPath, basePath, lowerOverlays, "eth0", tapDevice); err != nil {
+			return "", err
+		}
+	} else {
+		if err := LoadSnapshotNoResume(socketPath, snapshotPath, memPath, "eth0", tapDevice, ""); err != nil {
+			return "", err
+		}
 	}
 
-	verifyDir := filepath.Join(filepath.Dir(memPath), "verify")
+	verifyDir := filepath.Join(snapshotDir, "verify")
 	if err := os.MkdirAll(verifyDir, 0o755); err != nil {
 		return "", fmt.Errorf("mkdir verify dir: %w", err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -771,10 +771,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		layerPath := filepath.Join(snapshotDir, layerName)
 		memPath = layerPath
 		baseMemPath = appendBase
-		// Per-layer vmstate: FC writes this pause's CPU/device state to its own file (not the
-		// shared vmstate.snap), and the manifest commit records it — so {chain + vmstate}
-		// commit atomically in one manifest rename. A failed/uncommitted pause never replaces
-		// the prior committed vmstate; its orphan file is GC'd.
+		// Per-layer vmstate (see snapshotManifest.Vmstate): FC writes this pause's CPU/device
+		// state to its own file, which the manifest commit records — so it never overwrites the
+		// prior committed vmstate.
 		vmstateName := vmstateLayerName(newIndex)
 		vmstatePath := filepath.Join(snapshotDir, vmstateName)
 		// A leftover file at this index (a failed prior attempt) would survive as
@@ -894,9 +893,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			log.Info().Int("layer", newIndex).Msg("VM pausing (async memory flush in background)")
 			return vmstatePath, layerPath, nil
 		}
-		// Sync commit point: the manifest records the new layer AND its vmstate, so the single
-		// atomic rename commits {chain + vmstate} together. Until it lands, restore loads the
-		// prior chain + prior vmstate (both intact).
+		// Sync commit point: the manifest rename commits the new layer + its vmstate together;
+		// until it lands, restore loads the prior (intact) snapshot.
 		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
 		appendManifest.Vmstate = vmstateName
 		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
@@ -1024,8 +1022,8 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
-	// On failure: the manifest never commits, so the prior chain + its vmstate stay the durable
-	// state — nothing to revert. Just drop the uncommitted layer + per-layer vmstate orphans.
+	// On failure the manifest never commits, so the prior snapshot stays durable — nothing to
+	// revert; just drop the uncommitted layer + vmstate orphans.
 	failClean := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
@@ -1085,9 +1083,9 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
-	// On failure: the manifest never commits, so the prior chain + its vmstate stay durable —
-	// nothing to revert. Drop the uncommitted layer + per-layer vmstate orphans. A fast-resume
-	// that adopted them holds its own fds, so the unlink doesn't disturb it.
+	// On failure, drop the uncommitted layer + vmstate orphans (the manifest never committed,
+	// so the prior snapshot stays durable). A fast-resume that adopted them holds its own fds,
+	// so the unlink doesn't disturb it.
 	failClean := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -817,7 +817,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			if fcPID <= 0 {
 				fcPID = m.firecrackerMainPID(ctx, vmID)
 			}
-			memFile, ferr := captureGuestMemFd(fcPID)
+			memFile, ferr := captureGuestMemFd(fcPID, vmID)
 			if ferr != nil {
 				log.Warn().Err(ferr).Msg("memfd capture failed; falling back to in-FC async flush")
 			} else {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -218,6 +218,12 @@ type ManagerConfig struct {
 	// Default false.
 	AsyncPauseEnabled bool
 
+	// MaxConcurrentAsyncPauses bounds simultaneous async-pause background flushes
+	// (each holds the flushing FC's RAM until durable). When the cap is full, a pause
+	// that would go async falls back to the synchronous path instead — it always
+	// completes, just inline. Default 3 when <= 0.
+	MaxConcurrentAsyncPauses int
+
 	// LayerFlattenEnabled turns on background chain flattening: once a sandbox's
 	// overlay chain reaches FlattenChainDepth, its overlays are merged into one
 	// sparse overlay (newest-wins, shared base preserved) off the hot path, bounding
@@ -263,6 +269,10 @@ type Manager struct {
 	// I/O-heavy). Buffered; capacity = effective MaxConcurrentFlattens.
 	flattenSem chan struct{}
 
+	// pauseSem bounds concurrent async-pause background flushes. Buffered; capacity =
+	// effective MaxConcurrentAsyncPauses.
+	pauseSem chan struct{}
+
 	// builds tracks in-flight and completed template builds. Keyed by
 	// build VM id (which is also "build-" + templateID). Entries survive
 	// until process exit so late pollers can read terminal outcomes.
@@ -285,6 +295,10 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 	if maxFlattens <= 0 {
 		maxFlattens = 2
 	}
+	maxAsyncPauses := cfg.MaxConcurrentAsyncPauses
+	if maxAsyncPauses <= 0 {
+		maxAsyncPauses = 3
+	}
 	// Magic mount target — every per-VM start script mounts tmpfs over it.
 	// Missing → "mount: failed" → opaque "wait for socket" timeout. Create
 	// at startup so an aggressive ops cleanup can't break sandbox/build paths.
@@ -300,6 +314,7 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 		vms:        make(map[string]*VMInstance),
 		restoreSem: make(chan struct{}, maxRestores),
 		flattenSem: make(chan struct{}, maxFlattens),
+		pauseSem:   make(chan struct{}, maxAsyncPauses),
 	}, nil
 }
 
@@ -720,9 +735,22 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// the background write is interrupted (first-pause-always-sync: newIndex 0 is
 		// the first layer, which has only the read-only template base under it).
 		async := m.cfg.AsyncPauseEnabled && newIndex > 0
+		// Claim a background-flush slot; if the cap is full, fall back to a synchronous
+		// pause rather than pile RAM-holding flushes on. Released in completeAsyncPause.
+		if async {
+			select {
+			case m.pauseSem <- struct{}{}:
+			default:
+				async = false
+				log.Info().Msg("async pause cap full; falling back to synchronous pause")
+			}
+		}
 		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Bool("async", async).
 			Msg("pausing VM — appending layered diff snapshot")
 		if err := CreateDiffSnapshot(socketPath, snapshotPath, layerPath, async); err != nil {
+			if async {
+				<-m.pauseSem // completeAsyncPause won't run; release the slot here
+			}
 			// Leave the partial layer orphaned and do NOT republish the manifest — the
 			// previously committed chain stays intact and resumable. Drop the orphan so
 			// the next attempt at this index starts clean.
@@ -846,6 +874,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 // manifest names the prior chain until (and unless) the new layer commits. Always
 // ends the flush so waiters (resume/re-pause/delete) unblock.
 func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, socketPath string, manifest *snapshotManifest) {
+	defer func() { <-m.pauseSem }() // release the background-flush slot claimed in PauseVM
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -121,6 +121,13 @@ type VMInstance struct {
 	flushDone chan struct{}
 	flushErr  error
 
+	// Background-flatten guard. While flattening is true, this sandbox's overlay
+	// chain is being merged + the manifest swapped + old layers deleted; resume/
+	// re-pause/delete wait on flattenDone so they don't read a half-swapped manifest
+	// or a layer flatten is removing. Not persisted.
+	flattening  bool
+	flattenDone chan struct{}
+
 	mu sync.RWMutex
 }
 
@@ -210,6 +217,21 @@ type ManagerConfig struct {
 	// back to). Requires LayerAppendEnabled and an FC binary with /snapshot/complete.
 	// Default false.
 	AsyncPauseEnabled bool
+
+	// LayerFlattenEnabled turns on background chain flattening: once a sandbox's
+	// overlay chain reaches FlattenChainDepth, its overlays are merged into one
+	// sparse overlay (newest-wins, shared base preserved) off the hot path, bounding
+	// chain depth and reclaiming pages duplicated across layers. Requires
+	// LayerAppendEnabled. Default false.
+	LayerFlattenEnabled bool
+
+	// FlattenChainDepth is the overlay count at/above which a chain is flattened.
+	// Default 16 when <= 0.
+	FlattenChainDepth int
+
+	// MaxConcurrentFlattens bounds simultaneous background flattens (each is
+	// I/O-heavy). Default 2 when <= 0.
+	MaxConcurrentFlattens int
 }
 
 // ---------------------------------------------------------------------------
@@ -231,6 +253,10 @@ type Manager struct {
 	// channel; capacity = effective MaxConcurrentRestores.
 	restoreSem chan struct{}
 
+	// flattenSem bounds concurrent background chain-flatten operations (each is
+	// I/O-heavy). Buffered; capacity = effective MaxConcurrentFlattens.
+	flattenSem chan struct{}
+
 	// builds tracks in-flight and completed template builds. Keyed by
 	// build VM id (which is also "build-" + templateID). Entries survive
 	// until process exit so late pollers can read terminal outcomes.
@@ -249,6 +275,10 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 	if maxRestores <= 0 {
 		maxRestores = 100
 	}
+	maxFlattens := cfg.MaxConcurrentFlattens
+	if maxFlattens <= 0 {
+		maxFlattens = 2
+	}
 	// Magic mount target — every per-VM start script mounts tmpfs over it.
 	// Missing → "mount: failed" → opaque "wait for socket" timeout. Create
 	// at startup so an aggressive ops cleanup can't break sandbox/build paths.
@@ -263,6 +293,7 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 		log:        log.With().Str("component", "vm_manager").Logger(),
 		vms:        make(map[string]*VMInstance),
 		restoreSem: make(chan struct{}, maxRestores),
+		flattenSem: make(chan struct{}, maxFlattens),
 	}, nil
 }
 
@@ -608,9 +639,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
-	// A prior async pause may still be flushing; wait so this pause sees the durable
-	// chain (committed manifest) and doesn't race the background writer or FC stop.
+	// A prior async pause may still be flushing, or a background flatten may be
+	// rewriting the chain; wait so this pause sees the durable, committed manifest
+	// and doesn't race the background writer, FC stop, or layer deletion.
 	_ = m.waitForFlush(inst)
+	m.waitForFlatten(inst)
 
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID)
@@ -792,6 +825,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	inst.mu.Unlock()
 
 	m.persistState(inst)
+	// Bound chain depth: if this (synchronous) pause grew the chain to the flatten
+	// threshold, merge it off the hot path. No-op for non-layered paths.
+	m.maybeFlatten(inst, snapshotDir)
 	log.Info().Msg("VM paused")
 	return snapshotPath, memPath, nil
 }
@@ -826,6 +862,8 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	m.stopAsyncPauseFC(vmID)
 	log.Info().Msg("VM paused (async memory flush durable)")
 	m.endFlush(inst, nil)
+	// Bound chain depth off the hot path now that this layer is durable.
+	m.maybeFlatten(inst, snapshotDir)
 }
 
 // stopAsyncPauseFC stops the still-alive paused Firecracker after an async flush
@@ -925,6 +963,76 @@ func (m *Manager) waitForFlush(inst *VMInstance) error {
 	return inst.flushErr
 }
 
+// waitForFlatten blocks until any in-progress background flatten for inst finishes.
+// Callers that read the manifest or load the chain (resume, re-pause, delete) must
+// call this so they never see a half-swapped manifest or a layer being deleted.
+func (m *Manager) waitForFlatten(inst *VMInstance) {
+	inst.mu.RLock()
+	flattening, ch := inst.flattening, inst.flattenDone
+	inst.mu.RUnlock()
+	if flattening && ch != nil {
+		<-ch
+	}
+}
+
+// maybeFlatten kicks off a background flatten when enabled and the chain has grown
+// to the configured depth. Non-blocking; bounded by flattenSem (skips this round if
+// the cap is full — the next pause will retry). Call after a durable pause commit.
+func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
+	if !m.cfg.LayerFlattenEnabled {
+		return
+	}
+	depth := m.cfg.FlattenChainDepth
+	if depth <= 0 {
+		depth = 16
+	}
+	man, err := readManifest(snapshotDir)
+	if err != nil || man == nil || len(man.Overlays) < depth {
+		return
+	}
+	select {
+	case m.flattenSem <- struct{}{}:
+		go func() {
+			defer func() { <-m.flattenSem }()
+			m.flattenInBackground(inst, snapshotDir)
+		}()
+	default:
+		// Cap full — skip; a later pause re-triggers.
+	}
+}
+
+// flattenInBackground serializes against any in-flight async flush, then flattens
+// the chain under the per-instance flatten guard (so resume/re-pause/delete wait).
+func (m *Manager) flattenInBackground(inst *VMInstance, snapshotDir string) {
+	_ = m.waitForFlush(inst)
+
+	inst.mu.Lock()
+	inst.flattening = true
+	inst.flattenDone = make(chan struct{})
+	ch := inst.flattenDone
+	inst.mu.Unlock()
+
+	err := m.flattenChain(snapshotDir)
+	if err == nil {
+		// Reclaim any interrupted-flatten leftovers / stale temps while still under
+		// the guard (resume/re-pause/delete are waiting on flattenDone).
+		if _, gcErr := m.gcOrphanLayers(snapshotDir); gcErr != nil {
+			m.log.Warn().Str("vm_id", inst.ID).Err(gcErr).Msg("gc after flatten")
+		}
+	}
+
+	inst.mu.Lock()
+	inst.flattening = false
+	inst.mu.Unlock()
+	close(ch)
+
+	if err != nil {
+		m.log.Warn().Str("vm_id", inst.ID).Err(err).Msg("background flatten failed; chain left intact")
+		return
+	}
+	m.log.Info().Str("vm_id", inst.ID).Msg("flattened overlay chain")
+}
+
 // freshenFirstPassOverlay removes any leftover overlay so a first layered pass starts
 // from a clean file (its dirty set is the whole overlay, so a stale one would leave
 // non-dirtied stale pages that override the base on restore). A missing overlay is the
@@ -986,9 +1094,10 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, err
 	}
 
-	// If an async pause is still flushing, wait for it to commit (and stop the old
-	// FC) before resuming — the chain we load must be the committed one.
+	// If an async pause is still flushing, or a flatten is rewriting the chain, wait
+	// for it to commit before resuming — the chain we load must be the committed one.
 	_ = m.waitForFlush(inst)
+	m.waitForFlatten(inst)
 
 	if snapshotPath == "" {
 		snapshotPath = inst.SnapshotPath
@@ -1335,9 +1444,10 @@ func (m *Manager) DeleteSnapshotFiles(vmID, snapshotPath, memPath string) error 
 	if snapshotPath == "" && memPath == "" {
 		return status.Error(codes.InvalidArgument, "at least one of snapshot_path/mem_file_path is required")
 	}
-	// Don't delete chain files out from under an in-progress async flush; wait it out.
+	// Don't delete chain files out from under an in-progress async flush or flatten.
 	if inst, ierr := m.getInstance(vmID); ierr == nil {
 		_ = m.waitForFlush(inst)
+		m.waitForFlatten(inst)
 	}
 	for _, p := range []string{snapshotPath, memPath} {
 		if p == "" {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -690,6 +690,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	dirtyTracked := inst.DirtyTracked
 	instBaseMem := inst.BaseMemPath
 	instMemFile := inst.MemFilePath
+	instPID := inst.PID
 	inst.mu.RUnlock()
 
 	// Layered incremental: a template-created, dirty-tracked VM writes a diff overlay
@@ -744,13 +745,55 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// the first layer, which has only the read-only template base under it).
 		async := m.cfg.AsyncPauseEnabled && newIndex > 0
 		// Claim a background-flush slot; if the cap is full, fall back to a synchronous
-		// pause rather than pile RAM-holding flushes on. Released in completeAsyncPause.
+		// pause rather than pile RAM-holding flushes on. Released in completeAsyncPause /
+		// completeBridgePause.
 		if async {
 			select {
 			case m.pauseSem <- struct{}{}:
 			default:
 				async = false
 				log.Info().Msg("async pause cap full; falling back to synchronous pause")
+			}
+		}
+		// Memfd bridge: when guest RAM is memfd-backed, capture it, take a vmstate +
+		// dirty-offsets snapshot (no mem dump), stop the old FC to free the unit, and copy
+		// the dirty pages from the held memfd in the background. This frees the unit for an
+		// immediate resume (A5) instead of keeping the old FC alive for the whole flush.
+		// Any capture/snapshot failure falls back to the in-FC async path (sem still held).
+		if async && m.cfg.SharedMemEnabled {
+			memFile, ferr := captureGuestMemFd(instPID)
+			if ferr != nil {
+				log.Warn().Err(ferr).Msg("memfd capture failed; falling back to in-FC async flush")
+			} else {
+				dirtyOffsetsPath := filepath.Join(snapshotDir, "mem.dirty.offsets")
+				log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).
+					Msg("pausing VM — memfd bridge (vmd flushes dirty pages)")
+				if err := CreateDiffSnapshotBridge(socketPath, snapshotPath, layerPath, dirtyOffsetsPath); err != nil {
+					memFile.Close()
+					<-m.pauseSem
+					_ = os.Remove(layerPath)
+					return "", "", m.handleVMError(vmID, fmt.Errorf("bridge diff snapshot: %w", err))
+				}
+				// Stop the old FC now: vmd holds the memfd, so guest RAM stays resident and
+				// the unit is free for a fast resume while vmd flushes.
+				if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
+					log.Warn().Err(err).Msg("stop FC after bridge snapshot")
+				}
+				// Mark flushing BEFORE status=paused (same ordering as the in-FC async path)
+				// so the reconciler never mistakes the flush window for a stranded FC.
+				m.beginFlush(inst)
+				inst.mu.Lock()
+				inst.Status = StatusPaused
+				inst.SnapshotPath = snapshotPath
+				inst.MemFilePath = layerPath
+				inst.BaseMemPath = baseMemPath
+				inst.DirtyTracked = false
+				inst.PID = 0 // FC stopped
+				inst.mu.Unlock()
+				m.persistState(inst)
+				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, memFile, dirtyOffsetsPath, appendManifest)
+				log.Info().Int("layer", newIndex).Msg("VM pausing (memfd bridge flush in background)")
+				return snapshotPath, layerPath, nil
 			}
 		}
 		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Bool("async", async).
@@ -907,6 +950,47 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	}
 	m.stopAsyncPauseFC(vmID)
 	log.Info().Msg("VM paused (async memory flush durable)")
+	m.endFlush(inst, nil)
+	// Bound chain depth off the hot path now that this layer is durable.
+	m.maybeFlatten(inst, snapshotDir)
+}
+
+// completeBridgePause runs after a memfd-bridge pause returned at the snapshot point.
+// The old Firecracker is already stopped; vmd holds the guest-memory memfd. It reads the
+// dirty-page offsets Firecracker wrote, copies exactly those pages from the memfd into a
+// fresh sparse diff layer, and on success commits the manifest (the durability point).
+// On any failure it drops the orphaned layer and keeps the previous durable chain — the
+// sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
+// The held memfd is released when the dump finishes (A5 extends the hold for fast resume).
+func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
+	defer func() { <-m.pauseSem }()  // release the background-flush slot claimed in PauseVM
+	defer memFile.Close()            // release the held memfd
+	defer os.Remove(dirtyOffsetsPath) // sidecar consumed
+	vmID := inst.ID
+	log := m.log.With().Str("vm_id", vmID).Logger()
+
+	offsets, err := readDirtyOffsets(dirtyOffsetsPath)
+	if err != nil {
+		log.Error().Err(err).Msg("bridge pause: read dirty offsets failed; keeping previous durable snapshot")
+		_ = os.Remove(layerPath)
+		m.endFlush(inst, err)
+		return
+	}
+	if err := dumpMemfdPages(memFile, offsets, layerPath, os.Getpagesize()); err != nil {
+		log.Error().Err(err).Msg("bridge pause: memfd dump failed; keeping previous durable snapshot")
+		_ = os.Remove(layerPath)
+		m.endFlush(inst, err)
+		return
+	}
+	// Durable: commit the manifest with the new layer appended (atomic temp + rename).
+	manifest.Overlays = append(manifest.Overlays, layerName)
+	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
+		log.Error().Err(err).Msg("bridge pause: manifest commit failed; keeping previous durable snapshot")
+		_ = os.Remove(layerPath)
+		m.endFlush(inst, err)
+		return
+	}
+	log.Info().Int("pages", len(offsets)).Msg("VM paused (memfd bridge flush durable)")
 	m.endFlush(inst, nil)
 	// Bound chain depth off the hot path now that this layer is durable.
 	m.maybeFlatten(inst, snapshotDir)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -788,7 +788,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// Memfd bridge: when guest RAM is memfd-backed, capture it, take a vmstate +
 		// dirty-offsets snapshot (no mem dump), stop the old FC to free the unit, and copy
 		// the dirty pages from the held memfd in the background. This frees the unit for an
-		// immediate resume (A5) instead of keeping the old FC alive for the whole flush.
+		// immediate resume instead of keeping the old FC alive for the whole flush.
 		// Any capture/snapshot failure falls back to the in-FC async path (sem still held).
 		if async && m.cfg.SharedMemEnabled {
 			// The cached PID is 0 right after a resume (the unit's MainPID is published
@@ -826,7 +826,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				inst.DirtyTracked = false
 				inst.PID = 0 // FC stopped
 				// Expose the held memfd so a resume during this flush serves faults from
-				// RAM instead of waiting for the dump (A5). Valid only while completeBridgePause
+				// RAM instead of waiting for the dump. Valid only while completeBridgePause
 				// holds memFile open; it clears these (under mu) before closing it.
 				inst.bridgeMemFdPath = guestMemFdPath(memFile)
 				inst.bridgePendingLayer = layerPath
@@ -1002,7 +1002,8 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 // fresh sparse diff layer, and on success commits the manifest (the durability point).
 // On any failure it drops the orphaned layer and keeps the previous durable chain — the
 // sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
-// The held memfd is released when the dump finishes (A5 extends the hold for fast resume).
+// vmd's memfd fd is closed when the dump finishes; a resume that adopted the memfd during
+// the flush holds its own fd (and the new Firecracker's mmap keeps the pages resident).
 func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
 	// Defers run LIFO: clear the handoff fields under mu FIRST, then close memFile, then
 	// release the sem. Clearing before the close (and under mu) means a concurrent resume
@@ -1323,7 +1324,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, err
 	}
 
-	// Memfd-bridge fast resume (A5): if a bridge pause is still flushing and its memfd is
+	// Memfd-bridge fast resume: if a bridge pause is still flushing and its memfd is
 	// available, serve faults from that RAM (as the newest overlay) instead of waiting for
 	// the disk flush — resume returns in ~constant time regardless of the dirty-set size.
 	// Reopen vmd's own fd to the memfd under the lock so it can't be closed mid-decision;

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -128,6 +128,16 @@ type VMInstance struct {
 	flattening  bool
 	flattenDone chan struct{}
 
+	// Memfd-bridge fast-resume handoff (set during a bridge pause's flush window).
+	// bridgeMemFdPath is the /proc path through which a resume can reopen the held
+	// guest-memory memfd to serve faults from RAM instead of waiting for the disk
+	// flush; bridgePendingLayer is the disk layer the flush is committing (which the
+	// resumed VM treats as its newest chain link for the next pause). Both are cleared
+	// (under mu) when the flush ends. Not persisted — a vmd restart drops the memfd and
+	// resume falls back to the committed disk chain.
+	bridgeMemFdPath    string
+	bridgePendingLayer string
+
 	mu sync.RWMutex
 }
 
@@ -789,6 +799,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				inst.BaseMemPath = baseMemPath
 				inst.DirtyTracked = false
 				inst.PID = 0 // FC stopped
+				// Expose the held memfd so a resume during this flush serves faults from
+				// RAM instead of waiting for the dump (A5). Valid only while completeBridgePause
+				// holds memFile open; it clears these (under mu) before closing it.
+				inst.bridgeMemFdPath = guestMemFdPath(memFile)
+				inst.bridgePendingLayer = layerPath
 				inst.mu.Unlock()
 				m.persistState(inst)
 				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, memFile, dirtyOffsetsPath, appendManifest)
@@ -963,9 +978,20 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 // sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
 // The held memfd is released when the dump finishes (A5 extends the hold for fast resume).
 func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
-	defer func() { <-m.pauseSem }()  // release the background-flush slot claimed in PauseVM
-	defer memFile.Close()            // release the held memfd
-	defer os.Remove(dirtyOffsetsPath) // sidecar consumed
+	// Defers run LIFO: clear the handoff fields under mu FIRST, then close memFile, then
+	// release the sem. Clearing before the close (and under mu) means a concurrent resume
+	// either sees the path set and reopens its own fd while memFile is still open, or sees
+	// it cleared and falls back to the disk chain — never a closed-fd path. A resume that
+	// already reopened keeps the memfd alive via its own fd / the new FC's mmap.
+	defer func() { <-m.pauseSem }()
+	defer memFile.Close()
+	defer func() {
+		inst.mu.Lock()
+		inst.bridgeMemFdPath = ""
+		inst.bridgePendingLayer = ""
+		inst.mu.Unlock()
+	}()
+	defer os.Remove(dirtyOffsetsPath)
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
@@ -1245,9 +1271,33 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, err
 	}
 
-	// If an async pause is still flushing, or a flatten is rewriting the chain, wait
-	// for it to commit before resuming — the chain we load must be the committed one.
-	_ = m.waitForFlush(inst)
+	// Memfd-bridge fast resume (A5): if a bridge pause is still flushing and its memfd is
+	// available, serve faults from that RAM (as the newest overlay) instead of waiting for
+	// the disk flush — resume returns in ~constant time regardless of the dirty-set size.
+	// Reopen vmd's own fd to the memfd under the lock so it can't be closed mid-decision;
+	// the new FC mmaps it during restore and keeps it alive, so we drop our fd afterwards.
+	var memfdFd *os.File
+	var memfdResumePath, bridgePendingLayer string
+	inst.mu.Lock()
+	if inst.flushing && inst.bridgeMemFdPath != "" {
+		if f, oerr := os.Open(inst.bridgeMemFdPath); oerr == nil {
+			memfdFd = f
+			memfdResumePath = guestMemFdPath(f)
+			bridgePendingLayer = inst.bridgePendingLayer
+		}
+	}
+	inst.mu.Unlock()
+	useMemfd := memfdFd != nil
+	defer func() {
+		if memfdFd != nil {
+			_ = memfdFd.Close()
+		}
+	}()
+	if !useMemfd {
+		// No memfd handoff — wait for any in-flight flush/flatten to commit the durable
+		// chain before resuming, so the chain we load is the committed one.
+		_ = m.waitForFlush(inst)
+	}
 	m.waitForFlatten(inst)
 
 	if snapshotPath == "" {
@@ -1275,7 +1325,24 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		if !ok {
 			return nil, status.Errorf(codes.FailedPrecondition, "snapshot manifest in %s has no overlays", snapshotDir)
 		}
-		basePath, lowerOverlays, memPath = base, lower, newest
+		if useMemfd {
+			// Lay the held memfd (the frozen RAM at the pause point) over the committed disk
+			// chain as the newest overlay: it owns every faulted page (shadowing the chain),
+			// and never-faulted pages fall through to the chain. The in-flight layer the
+			// flush is writing is NOT yet committed, so the chain here is the prior one.
+			basePath = base
+			lowerOverlays = append(lower, newest)
+			memPath = memfdResumePath
+		} else {
+			basePath, lowerOverlays, memPath = base, lower, newest
+		}
+	} else if useMemfd {
+		// A bridge pause always leaves a manifest; if it vanished, abandon the memfd path
+		// and fall back to a normal (post-flush) resume.
+		useMemfd = false
+		_ = memfdFd.Close()
+		memfdFd = nil
+		_ = m.waitForFlush(inst)
 	}
 
 	// Verify the snapshot files actually exist on disk. DB can claim
@@ -1388,6 +1455,14 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, fmt.Errorf("restore snapshot: %w", err)
 	}
 
+	// For a memfd resume, memPath is the transient /proc memfd path — not a chain link.
+	// Cache the disk layer the flush committed instead, so the next pause is recognized as
+	// an accumulating append onto the committed chain (and so a restart resolves to disk).
+	resumedMemFile := memPath
+	if useMemfd {
+		resumedMemFile = bridgePendingLayer
+	}
+
 	inst.mu.Lock()
 	inst.PID = pid
 	inst.SocketPath = socketPath
@@ -1397,7 +1472,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// that differs from the cached one) so the next pause's diff baseline matches
 	// what Firecracker's dirty bitmap is relative to.
 	inst.SnapshotPath = snapshotPath
-	inst.MemFilePath = memPath
+	inst.MemFilePath = resumedMemFile
 	inst.BaseMemPath = basePath // re-cache (may have come from the on-disk sidecar)
 	inst.mu.Unlock()
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -768,6 +768,15 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
 			}
+			// The Full image is now the durable state; drop the manifest (and its now-orphaned
+			// overlays) so resume loads this snapshot instead of the stale chain the manifest
+			// would otherwise still name as authoritative.
+			for _, name := range appendManifest.Overlays {
+				_ = os.Remove(filepath.Join(snapshotDir, name))
+			}
+			if merr := removeManifest(snapshotDir); merr != nil {
+				log.Warn().Err(merr).Msg("pause: remove manifest on Full fallback")
+			}
 			break
 		}
 		// Async only when enabled AND a prior durable layer exists to fall back to if
@@ -1222,6 +1231,13 @@ func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 	}
 	select {
 	case m.flattenSem <- struct{}{}:
+		// Arm the flatten guard synchronously, BEFORE the goroutine starts, so a resume/
+		// delete/re-pause arriving in the scheduling window waits on flattenDone instead of
+		// reading the chain while the goroutine swaps the manifest and deletes old layers.
+		inst.mu.Lock()
+		inst.flattening = true
+		inst.flattenDone = make(chan struct{})
+		inst.mu.Unlock()
 		go func() {
 			defer func() { <-m.flattenSem }()
 			m.flattenInBackground(inst, snapshotDir)
@@ -1234,13 +1250,13 @@ func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 // flattenInBackground serializes against any in-flight async flush, then flattens
 // the chain under the per-instance flatten guard (so resume/re-pause/delete wait).
 func (m *Manager) flattenInBackground(inst *VMInstance, snapshotDir string) {
+	// The guard (flattening=true, flattenDone) was armed by maybeFlatten before this
+	// goroutine started, so a concurrent resume/delete already waits on it.
 	_ = m.waitForFlush(inst)
 
-	inst.mu.Lock()
-	inst.flattening = true
-	inst.flattenDone = make(chan struct{})
+	inst.mu.RLock()
 	ch := inst.flattenDone
-	inst.mu.Unlock()
+	inst.mu.RUnlock()
 
 	err := m.flattenChain(snapshotDir)
 	if err == nil {
@@ -1353,9 +1369,15 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		}
 	}()
 	if !useMemfd {
-		// No memfd handoff — wait for any in-flight flush/flatten to commit the durable
-		// chain before resuming, so the chain we load is the committed one.
-		_ = m.waitForFlush(inst)
+		// No memfd handoff — wait for any in-flight flush to commit the durable chain. If it
+		// FAILED, the memory chain reverted to the prior one while vmstate.snap holds the
+		// failed pause's state, so a resume would pair mismatched vmstate + memory. Refuse and
+		// mark failed rather than boot a torn VM.
+		if ferr := m.waitForFlush(inst); ferr != nil {
+			m.setStatus(vmID, StatusError)
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"cannot resume %s: last async snapshot flush failed (%v); snapshot is not durable", vmID, ferr)
+		}
 	}
 	m.waitForFlatten(inst)
 
@@ -2049,8 +2071,27 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		isTemplate := m.isTemplateMemPath(memPath)
 		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
 		basePath := ""
+		var lowerOverlays []string
 		armLayered := false
+		// The manifest is authoritative for the full base → overlay chain (as in ResumeVM):
+		// a stateless restore of a multi-layer chain must load the whole chain, not just the
+		// newest overlay over the base, or the intermediate layers' pages are lost.
+		man, manErr := readManifest(filepath.Dir(memPath))
 		switch {
+		case manErr != nil:
+			restoreErr = fmt.Errorf("unreadable snapshot manifest in %s: %w", filepath.Dir(memPath), manErr)
+		case man != nil:
+			base, lower, newest, ok := man.chainPaths(filepath.Dir(memPath))
+			if !ok {
+				restoreErr = fmt.Errorf("snapshot manifest in %s has no overlays", filepath.Dir(memPath))
+				break
+			}
+			basePath, lowerOverlays, memPath = base, lower, newest
+			armLayered = m.cfg.IncrementalSnapshotEnabled
+			inst.mu.Lock()
+			inst.BaseMemPath = base
+			inst.DirtyTracked = armLayered
+			inst.mu.Unlock()
 		case hasSidecar:
 			// The outer overlayNeedsLayered guard already required resume-UFFD to reach
 			// here, so canLayered holds — serve the overlay over its recorded base.
@@ -2071,7 +2112,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		if restoreErr == nil {
 			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-				socketPath, snapshotPath, memPath, basePath, nil, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
+				socketPath, snapshotPath, memPath, basePath, lowerOverlays, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
 				m.cfg.HandlerDeathAbortEnabled, m.cfg.SharedMemEnabled,
 			)
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1411,12 +1411,15 @@ func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 		//
 		// The guard only protects callers that hit waitForFlatten before reading the chain. A memfd
 		// bridge fast-resume skips waitForFlush and is already past it, mid-restore with the
-		// committed chain open as its lower layers — flattening now would delete those files out
-		// from under it. Defer while a restore is in flight or a bridge memfd is held (atomic with
-		// the arm); a later pause retries.
+		// committed chain open as its lower layers — flattening then would delete those files while
+		// the restore is still opening them. Defer only while a restore is IN FLIGHT (restoring),
+		// checked atomically with the arm. NOT while a bridge memfd is merely held: once the restore
+		// finishes the new FC has the overlays mmap'd, so deleting the files is safe (the inodes
+		// live on via the mapping) — and gating on the whole hold would starve flatten forever under
+		// continuous bridge pause/resume, growing the chain unbounded.
 		armed := false
 		inst.mu.Lock()
-		if !inst.restoring && !inst.holdingBridgeMemfd && !inst.flattening {
+		if !inst.restoring && !inst.flattening {
 			inst.flattening = true
 			inst.flattenDone = make(chan struct{})
 			armed = true

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -225,9 +225,15 @@ type ManagerConfig struct {
 	// LayerAppendEnabled. Default false.
 	LayerFlattenEnabled bool
 
-	// FlattenChainDepth is the overlay count at/above which a chain is flattened.
-	// Default 16 when <= 0.
+	// FlattenChainDepth is the overlay count at/above which a chain is flattened
+	// (bounds restore fd/walk cost). Default 16 when <= 0.
 	FlattenChainDepth int
+
+	// FlattenChainBytes, when > 0, also flattens once the chain's overlays occupy at
+	// least this many allocated bytes (bounds storage — a sandbox that dirties a lot
+	// per pause hits a storage problem at a shallow depth). 0 disables the byte
+	// trigger (depth-only).
+	FlattenChainBytes int64
 
 	// MaxConcurrentFlattens bounds simultaneous background flattens (each is
 	// I/O-heavy). Default 2 when <= 0.
@@ -976,18 +982,25 @@ func (m *Manager) waitForFlatten(inst *VMInstance) {
 }
 
 // maybeFlatten kicks off a background flatten when enabled and the chain has grown
-// to the configured depth. Non-blocking; bounded by flattenSem (skips this round if
-// the cap is full — the next pause will retry). Call after a durable pause commit.
+// past the depth threshold (restore fd/walk cost) or the byte threshold (storage).
+// Non-blocking; bounded by flattenSem (skips this round if the cap is full — the
+// next pause will retry). Call after a durable pause commit.
 func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 	if !m.cfg.LayerFlattenEnabled {
 		return
 	}
-	depth := m.cfg.FlattenChainDepth
-	if depth <= 0 {
-		depth = 16
-	}
 	man, err := readManifest(snapshotDir)
-	if err != nil || man == nil || len(man.Overlays) < depth {
+	if err != nil || man == nil || len(man.Overlays) == 0 {
+		return
+	}
+	// Only stat the layers when a byte threshold is set (avoids the cost otherwise).
+	var allocated int64
+	if m.cfg.FlattenChainBytes > 0 {
+		for _, name := range man.Overlays {
+			allocated += allocatedBytes(filepath.Join(snapshotDir, name))
+		}
+	}
+	if !shouldFlatten(len(man.Overlays), allocated, m.cfg.FlattenChainDepth, m.cfg.FlattenChainBytes) {
 		return
 	}
 	select {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -144,6 +144,11 @@ type VMInstance struct {
 	// drops the memfd, so the count resets to zero on its own.
 	holdingBridgeMemfd bool
 
+	// restoring is true while a resume/verify is starting a Firecracker and loading a
+	// snapshot for this (still-paused-in-DB) sandbox, so the reconciler doesn't mistake the
+	// active unit for a stranded async-flush FC and stop it mid-restore. Not persisted.
+	restoring bool
+
 	mu sync.RWMutex
 }
 
@@ -744,12 +749,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// chain intact and resumable. This is the on-disk foundation the async/durable
 	// pause path needs. When disabled, the in-place paths below run unchanged.
 	appendBase, appendManifest, appendOK := m.planLayerAppend(snapshotDir, dirtyTracked, instBaseMem, instMemFile)
-	// appended is set once a pause commits a layer onto the chain (manifest republished). If a
-	// pause instead writes a STANDALONE snapshot (in-place mem.diff / Full mem.snap) while a
-	// chain manifest exists — e.g. flags turned off, dirty-tracking cleared, or planLayerAppend
-	// rejected the baseline — that manifest is now stale and would shadow the new snapshot on
-	// resume (ResumeVM treats a present manifest as authoritative). The post-switch tail
-	// reconciles it.
+	// appended is true once this pause commits a layer onto the chain. If it instead writes a
+	// standalone snapshot (in-place mem.diff / Full mem.snap) while a chain manifest lingers
+	// (flags off, dirty-tracking cleared, or planLayerAppend rejected the baseline), that
+	// manifest is stale and would shadow the new snapshot on resume — the post-switch tail
+	// drops it.
 	appended := false
 	// CreateDiffSnapshot merges in place: an interrupted diff has no surviving copy
 	// of the file it overwrites (for layered, only the session delta — the template
@@ -828,7 +832,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 					memFile.Close()
 					<-m.pauseSem
 					_ = os.Remove(layerPath)
-					m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
+					m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
 					return "", "", m.handleVMError(vmID, fmt.Errorf("bridge diff snapshot: %w", err))
 				}
 				// Stop the old FC now: vmd holds the memfd, so guest RAM stays resident and
@@ -868,7 +872,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			// previously committed chain stays intact and resumable. Drop the orphan so
 			// the next attempt at this index starts clean.
 			_ = os.Remove(layerPath)
-			m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
+			m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
 			return "", "", m.handleVMError(vmID, fmt.Errorf("append layered diff snapshot: %w", err))
 		}
 		if async {
@@ -896,7 +900,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
 		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
 			_ = os.Remove(layerPath)
-			m.revertPriorVmstate(inst, snapshotPath, false) // VM kept running; restore the committed vmstate
+			m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
 			return "", "", m.handleVMError(vmID, fmt.Errorf("publish snapshot manifest: %w", err))
 		}
 		// Committed: the new vmstate.snap pairs with the new chain, so drop the prior copy.
@@ -968,10 +972,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 	}
 
-	// Standalone snapshot (in-place / Full): if a chain manifest lingers from a prior
-	// append-mode run, drop it (and its now-orphaned overlays) so resume loads this snapshot
-	// instead of the stale chain. No-op when this pause appended (manifest is fresh) or when
-	// there's no manifest. (The Full-fallback above already handled its own removal.)
+	// Drop a stale chain manifest (+ its orphaned overlays) left by a standalone pause, so
+	// resume loads this snapshot, not the old chain. See the `appended` comment above.
 	if !appended {
 		if man, merr := readManifest(snapshotDir); merr == nil && man != nil {
 			for _, name := range man.Overlays {
@@ -1024,7 +1026,7 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
 		if priorVmstateSaved {
-			m.revertPriorVmstate(inst, vmstatePath, false)
+			m.revertPriorVmstate(inst, vmstatePath)
 		}
 		m.stopAsyncPauseFC(vmID)
 		m.endFlush(inst, err)
@@ -1079,13 +1081,24 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
 
-	// Revert on failure, but only-if-paused (revertPriorVmstate's guard): a fast-resumed VM
-	// owns the new vmstate and self-heals on its next pause. endFlush AFTER the revert.
+	// On failure, revert vmstate to the prior committed copy — but only if no resume adopted
+	// this pause's memfd. The claim-check and the block-further-claims must be atomic: read
+	// whether ResumeVM already cleared bridgeMemFdPath (claimed) AND clear it ourselves (so a
+	// later resume can't reopen the memfd and read a vmstate we're about to revert) under one
+	// lock. A claimed resume owns the vmstate (and self-heals on its next pause); otherwise the
+	// sandbox is still paused and the revert makes the prior chain + vmstate consistent.
 	failRevert := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
-		if priorVmstateSaved {
-			m.revertPriorVmstate(inst, vmstatePath, true)
+		inst.mu.Lock()
+		claimed := inst.bridgeMemFdPath == ""
+		inst.bridgeMemFdPath = ""
+		inst.bridgePendingLayer = ""
+		inst.mu.Unlock()
+		if priorVmstateSaved && !claimed {
+			if rerr := restorePriorVmstate(vmstatePath); rerr != nil {
+				log.Warn().Str("vm_id", vmID).Err(rerr).Msg("revert prior vmstate after failed bridge flush")
+			}
 		}
 		m.endFlush(inst, err)
 	}
@@ -1200,21 +1213,11 @@ func (m *Manager) countHeldBridgeMemfds() int {
 }
 
 // revertPriorVmstate reverts vmstate to the prior committed copy after a failed flush, so a
-// later resume loads a vmstate consistent with the prior (still-committed) memory chain.
-// onlyIfPaused is set on the bridge path: a fast-resumed (Running) VM has already loaded the
-// new vmstate into its Firecracker, so reverting the file would both be pointless and could
-// race that restore — leave it (the VM's next pause re-commits a consistent state, and a
-// crash before then is the same stale-by-one the prior chain already represents).
-func (m *Manager) revertPriorVmstate(inst *VMInstance, vmstatePath string, onlyIfPaused bool) {
-	if onlyIfPaused {
-		inst.mu.RLock()
-		running := inst.Status != StatusPaused
-		inst.mu.RUnlock()
-		if running {
-			discardPriorVmstate(vmstatePath)
-			return
-		}
-	}
+// later resume loads a vmstate consistent with the prior (still-committed) memory chain. Used
+// by the synchronous error paths and the in-FC async path, where no resume can be reading
+// vmstate.snap concurrently. (The bridge path can race a fast-resume, so it guards the revert
+// with the memfd-claim check inline in completeBridgePause instead.)
+func (m *Manager) revertPriorVmstate(inst *VMInstance, vmstatePath string) {
 	if err := restorePriorVmstate(vmstatePath); err != nil {
 		m.log.Warn().Str("vm_id", inst.ID).Err(err).Msg("revert prior vmstate after failed flush")
 	}
@@ -1271,6 +1274,20 @@ func (m *Manager) isFlushing(vmID string) bool {
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()
 	return inst.flushing
+}
+
+// isRestoring reports whether a resume/verify is mid-restore for vmID — the unit is active
+// while the record still reads paused (ResumeVM flips to running only after the snapshot load
+// + boxd wait finish). The reconciler uses it so a slow restore isn't mistaken for a stranded
+// FC and stopped. Not persisted: a vmd restart has no in-flight restore to protect.
+func (m *Manager) isRestoring(vmID string) bool {
+	inst, err := m.getInstance(vmID)
+	if err != nil {
+		return false
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.restoring
 }
 
 // waitForFlatten blocks until any in-progress background flatten for inst finishes.
@@ -1418,6 +1435,17 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, err
 	}
 
+	// Mark restoring so the reconciler doesn't stop our soon-to-be-active unit as a stranded
+	// FC while the record still reads paused (a slow snapshot load can outlast its grace).
+	inst.mu.Lock()
+	inst.restoring = true
+	inst.mu.Unlock()
+	defer func() {
+		inst.mu.Lock()
+		inst.restoring = false
+		inst.mu.Unlock()
+	}()
+
 	// Memfd-bridge fast resume: if a bridge pause is still flushing and its memfd is
 	// available, serve faults from that RAM (as the newest overlay) instead of waiting for
 	// the disk flush — resume returns in ~constant time regardless of the dirty-set size.
@@ -1436,6 +1464,10 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 				memfdFd = f
 				memfdResumePath = guestMemFdPath(f)
 				bridgePendingLayer = inst.bridgePendingLayer
+				// Claim it: clearing the path under the lock signals completeBridgePause that a
+				// resume adopted this pause's vmstate + memfd, so a failed flush must NOT revert
+				// vmstate.snap out from under the FC we're about to restore from it.
+				inst.bridgeMemFdPath = ""
 			}
 		}
 		inst.mu.Unlock()
@@ -1691,6 +1723,16 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	if snapshotPath == "" || memPath == "" {
 		return "", status.Errorf(codes.InvalidArgument, "vm %s has no snapshot on record", vmID)
 	}
+	// The throwaway verify FC uses this sandbox's unit while it stays paused; mark restoring so
+	// the reconciler doesn't stop it as a stranded FC mid-verify.
+	inst.mu.Lock()
+	inst.restoring = true
+	inst.mu.Unlock()
+	defer func() {
+		inst.mu.Lock()
+		inst.restoring = false
+		inst.mu.Unlock()
+	}()
 	// Resolve the layered chain (if any). The manifest is authoritative for the
 	// base + ordered overlays (so this also verifies a post-flatten chain whose
 	// inst fields may be stale); fall back to the single-overlay .base sidecar.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1060,17 +1060,17 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 // The old Firecracker is already stopped; vmd holds the guest-memory memfd. It reads the
 // dirty-page offsets Firecracker wrote, copies exactly those pages from the memfd into a
 // fresh sparse diff layer, and on success commits the manifest (the durability point).
-// On any failure it drops the orphaned layer and keeps the previous durable chain — the
-// sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
-// vmd's memfd fd is closed when the dump finishes; a resume that adopted the memfd + the
-// per-layer vmstate during the flush holds its own fds (and the new Firecracker's mmap keeps
-// the pages resident), so deleting the uncommitted files on failure can't pull them out from
-// under it.
+// On any failure it keeps the previous durable chain — the sandbox stays resumable from the
+// committed manifest (stale by one pause, never corrupt). vmd's memfd fd is closed when the dump
+// finishes; a resume that adopted the memfd during the flush holds its own fd (and the new
+// Firecracker's mmap keeps the pages resident). On failure the uncommitted layer + vmstate are
+// left on disk as orphans (not unlinked here): a resume may still be loading the vmstate by path,
+// and the manifest doesn't reference them, so gcOrphanLayers reclaims them after the grace period.
 func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName, vmstateName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
 	// Defers run LIFO: clear the handoff fields under mu FIRST, then close memFile, then
 	// release the sem. Clearing before the close (and under mu) means a concurrent resume
-	// either sees the paths set and reopens its own fds while the files exist, or sees them
-	// cleared and falls back to the committed disk chain — never a stale path.
+	// either sees the paths set and adopts the memfd (+ the vmstate disk path) while the files
+	// exist, or sees them cleared and falls back to the committed disk chain — never a stale handoff.
 	defer func() { <-m.pauseSem }()
 	defer memFile.Close()
 	defer func() {
@@ -1083,15 +1083,14 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	defer os.Remove(dirtyOffsetsPath)
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
-	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
-	// On failure, drop the uncommitted layer + vmstate orphans (the manifest never committed,
-	// so the prior snapshot stays durable). A fast-resume that adopted them holds its own fds,
-	// so the unlink doesn't disturb it.
+	// On failure the manifest never commits, so the prior snapshot stays durable. Leave the
+	// uncommitted layer + vmstate (and its .overlay sidecar) on disk as orphans rather than
+	// unlinking them here: an in-flight fast-resume may still be loading the vmstate by path, and
+	// a path-based delete would race it. The manifest doesn't reference them, so gcOrphanLayers
+	// reclaims them after the grace period.
 	failClean := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
-		_ = os.Remove(layerPath)
-		_ = os.Remove(vmstatePath)
 		m.endFlush(inst, err)
 	}
 
@@ -1469,33 +1468,27 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// the disk flush — resume returns in ~constant time regardless of the dirty-set size.
 	// Reopen vmd's own fd to the memfd under the lock so it can't be closed mid-decision;
 	// the new FC mmaps it during restore and keeps it alive, so we drop our fd afterwards.
-	var memfdFd, vmstateFd *os.File
-	var memfdResumePath, memfdVmstatePath, bridgePendingLayer string
+	var memfdFd *os.File
+	var memfdResumePath, bridgeVmstatePath, bridgePendingLayer string
 	// Take the memfd fast path only while a bridge flush is in progress AND the fleet is under
 	// the held-memfd cap, so the feature can't pin unbounded extra RAM. tryClaimBridgeMemfd
 	// reserves the slot atomically with the count (so a burst of concurrent resumes can't all
-	// pass the cap) and returns the files to reopen. We then reopen vmd's own fds to those paths,
-	// so a concurrent commit/delete can't pull them out from under us; the new FC mmaps/reads
-	// them during restore and they're dropped after. Gate on the flag first so a flags-off resume
-	// pays nothing.
+	// pass the cap) and returns the in-flight files. We hold our own fd to the guest-memory
+	// memfd — an anonymous object with no stable path; the fd both keeps its pages resident and
+	// gives the new FC a /proc path to mmap. The vmstate, by contrast, is a real on-disk file the
+	// new FC must open by its real path so Firecracker resolves the paired "<vmstate>.overlay"
+	// block-overlay sidecar; completeBridgePause leaves it on disk for GC rather than unlinking,
+	// so it needs no fd pin. Gate on the flag first so a flags-off resume pays nothing.
 	claimedMemfd := false
 	if m.cfg.SharedMemEnabled {
 		if memFdPath, vmstatePath, pendingLayer, ok := m.tryClaimBridgeMemfd(inst); ok {
 			claimedMemfd = true
-			memf, merr := os.Open(memFdPath)
-			vmf, verr := os.Open(vmstatePath)
-			if merr == nil && verr == nil {
-				memfdFd, vmstateFd = memf, vmf
+			if memf, merr := os.Open(memFdPath); merr == nil {
+				memfdFd = memf
 				memfdResumePath = guestMemFdPath(memf)
-				memfdVmstatePath = guestMemFdPath(vmf)
+				bridgeVmstatePath = vmstatePath
 				bridgePendingLayer = pendingLayer
 			} else {
-				if memf != nil {
-					_ = memf.Close()
-				}
-				if vmf != nil {
-					_ = vmf.Close()
-				}
 				m.clearBridgeHold(inst) // reopen failed — release the reserved slot
 				claimedMemfd = false
 			}
@@ -1506,9 +1499,6 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	defer func() {
 		if memfdFd != nil {
 			_ = memfdFd.Close()
-		}
-		if vmstateFd != nil {
-			_ = vmstateFd.Close()
 		}
 		// The slot was reserved at claim time; keep the hold only if the resume completed using
 		// the memfd. On early failure, or a fall-back off the memfd path, release the reservation.
@@ -1550,12 +1540,14 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		}
 		if useMemfd {
 			// Lay the held memfd (the frozen RAM at the pause point) over the committed disk
-			// chain as the newest overlay, and load the in-flight vmstate that matches it. The
-			// layer the flush is writing is NOT yet committed, so the chain here is the prior one.
+			// chain as the newest overlay, and load the in-flight vmstate that matches it — by its
+			// real on-disk path, so Firecracker finds the paired "<vmstate>.overlay" block-overlay
+			// sidecar. The layer the flush is writing is NOT yet committed, so the chain here is
+			// the prior one.
 			basePath = base
 			lowerOverlays = append(lower, newest)
 			memPath = memfdResumePath
-			snapshotPath = memfdVmstatePath
+			snapshotPath = bridgeVmstatePath
 		} else {
 			basePath, lowerOverlays, memPath = base, lower, newest
 			snapshotPath = manifestVmstatePath(snapshotDir, man) // committed vmstate for this chain
@@ -1566,8 +1558,6 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		useMemfd = false
 		_ = memfdFd.Close()
 		memfdFd = nil
-		_ = vmstateFd.Close()
-		vmstateFd = nil
 		_ = m.waitForFlush(inst)
 	}
 	if snapshotPath == "" {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -828,7 +828,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 					memFile.Close()
 					<-m.pauseSem
 					_ = os.Remove(layerPath)
-					_ = os.Remove(vmstatePath) // uncommitted per-layer vmstate; nothing references it
+					_ = os.Remove(vmstatePath)      // uncommitted per-layer vmstate; nothing references it
+					_ = os.Remove(dirtyOffsetsPath) // don't leave a stale offsets sidecar behind
 					return "", "", m.handleVMError(vmID, fmt.Errorf("bridge diff snapshot: %w", err))
 				}
 				// Stop the old FC now: vmd holds the memfd, so guest RAM stays resident and
@@ -1022,6 +1023,13 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	defer func() { <-m.pauseSem }() // release the background-flush slot claimed in PauseVM
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	// Recover so a panic can't crash all of vmd or strand flushing=true forever; endFlush is idempotent.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).Msg("panic in async pause completion; keeping previous durable snapshot")
+			m.endFlush(inst, fmt.Errorf("async pause completion panicked: %v", r))
+		}
+	}()
 	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
 	// On failure the manifest never commits, so the prior snapshot stays durable — nothing to
@@ -1083,6 +1091,16 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	defer os.Remove(dirtyOffsetsPath)
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	// Recover so a panic can't crash all of vmd or strand flushing=true forever; endFlush is idempotent.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).Msg("panic in bridge pause completion; keeping previous durable snapshot")
+			m.endFlush(inst, fmt.Errorf("bridge pause completion panicked: %v", r))
+		}
+	}()
+	// Ensure the old FC is stopped: the bridge pause's stop is warn-only, so a transient failure
+	// would leave a vCPU-paused FC pinning ~2x RAM. The held memfd keeps the RAM; re-stop is a no-op.
+	m.stopAsyncPauseFC(vmID)
 
 	// On failure the manifest never commits, so the prior snapshot stays durable. Leave the
 	// uncommitted layer + vmstate (and its .overlay sidecar) on disk as orphans rather than
@@ -1253,9 +1271,29 @@ func (m *Manager) beginFlush(inst *VMInstance) {
 // endFlush records the flush outcome and wakes any waiters.
 func (m *Manager) endFlush(inst *VMInstance, err error) {
 	inst.mu.Lock()
+	if !inst.flushing { // already ended — idempotent (a panic safety-net can't double-close)
+		inst.mu.Unlock()
+		return
+	}
 	inst.flushErr = err
 	inst.flushing = false
 	ch := inst.flushDone
+	inst.mu.Unlock()
+	if ch != nil {
+		close(ch)
+	}
+}
+
+// endFlatten clears the flatten guard and wakes waitForFlatten waiters. Idempotent so the
+// deferred safety-net in flattenInBackground can't double-close flattenDone.
+func (m *Manager) endFlatten(inst *VMInstance) {
+	inst.mu.Lock()
+	if !inst.flattening {
+		inst.mu.Unlock()
+		return
+	}
+	inst.flattening = false
+	ch := inst.flattenDone
 	inst.mu.Unlock()
 	if ch != nil {
 		close(ch)
@@ -1307,6 +1345,28 @@ func (m *Manager) isRestoring(vmID string) bool {
 	return inst.restoring
 }
 
+// resumableFromManifest reports whether snapshotDir holds a committed layered chain ResumeVM
+// could restore from (manifest resolves; base, vmstate, all overlays present on disk). Lets the
+// reconciler not fail a paused sandbox whose DB-recorded vmstate a flush failure deleted but
+// whose committed manifest chain is intact.
+func (m *Manager) resumableFromManifest(snapshotDir string) bool {
+	man, err := readManifest(snapshotDir)
+	if err != nil || man == nil {
+		return false
+	}
+	base, lower, newest, ok := man.chainPaths(snapshotDir)
+	if !ok {
+		return false
+	}
+	paths := append([]string{base, newest, manifestVmstatePath(snapshotDir, man)}, lower...)
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 // waitForFlatten blocks until any in-progress background flatten for inst finishes.
 // Callers that read the manifest or load the chain (resume, re-pause, delete) must
 // call this so they never see a half-swapped manifest or a layer being deleted.
@@ -1346,10 +1406,24 @@ func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 		// Arm the flatten guard synchronously, BEFORE the goroutine starts, so a resume/
 		// delete/re-pause arriving in the scheduling window waits on flattenDone instead of
 		// reading the chain while the goroutine swaps the manifest and deletes old layers.
+		//
+		// The guard only protects callers that hit waitForFlatten before reading the chain. A memfd
+		// bridge fast-resume skips waitForFlush and is already past it, mid-restore with the
+		// committed chain open as its lower layers — flattening now would delete those files out
+		// from under it. Defer while a restore is in flight or a bridge memfd is held (atomic with
+		// the arm); a later pause retries.
+		armed := false
 		inst.mu.Lock()
-		inst.flattening = true
-		inst.flattenDone = make(chan struct{})
+		if !inst.restoring && !inst.holdingBridgeMemfd && !inst.flattening {
+			inst.flattening = true
+			inst.flattenDone = make(chan struct{})
+			armed = true
+		}
 		inst.mu.Unlock()
+		if !armed {
+			<-m.flattenSem // release the slot we claimed; a later pause re-triggers
+			return
+		}
 		go func() {
 			defer func() { <-m.flattenSem }()
 			m.flattenInBackground(inst, snapshotDir)
@@ -1362,31 +1436,34 @@ func (m *Manager) maybeFlatten(inst *VMInstance, snapshotDir string) {
 // flattenInBackground serializes against any in-flight async flush, then flattens
 // the chain under the per-instance flatten guard (so resume/re-pause/delete wait).
 func (m *Manager) flattenInBackground(inst *VMInstance, snapshotDir string) {
-	// The guard (flattening=true, flattenDone) was armed by maybeFlatten before this
-	// goroutine started, so a concurrent resume/delete already waits on it.
+	// The guard was armed by maybeFlatten before this goroutine started. Always clear it + wake
+	// waiters, even on panic — else a panic crashes vmd and every future waitForFlatten hangs.
+	// endFlatten is idempotent.
+	defer func() {
+		if r := recover(); r != nil {
+			m.log.Error().Str("vm_id", inst.ID).Interface("panic", r).Msg("panic in background flatten; chain left intact")
+		}
+		m.endFlatten(inst)
+	}()
+
 	_ = m.waitForFlush(inst)
 
-	inst.mu.RLock()
-	ch := inst.flattenDone
-	inst.mu.RUnlock()
-
-	err := m.flattenChain(snapshotDir)
-	if err == nil {
-		// Reclaim any interrupted-flatten leftovers / stale temps while still under
-		// the guard (resume/re-pause/delete are waiting on flattenDone).
-		if _, gcErr := m.gcOrphanLayers(snapshotDir); gcErr != nil {
-			m.log.Warn().Str("vm_id", inst.ID).Err(gcErr).Msg("gc after flatten")
-		}
-	}
-
-	inst.mu.Lock()
-	inst.flattening = false
-	inst.mu.Unlock()
-	close(ch)
-
+	newest, err := m.flattenChain(snapshotDir)
 	if err != nil {
 		m.log.Warn().Str("vm_id", inst.ID).Err(err).Msg("background flatten failed; chain left intact")
 		return
+	}
+	// Refresh the cached newest layer so the next pause's planLayerAppend recognizes the flattened
+	// chain. Safe under the flatten guard — no resume runs concurrently to also update it.
+	if newest != "" {
+		inst.mu.Lock()
+		inst.MemFilePath = newest
+		inst.mu.Unlock()
+	}
+	// Reclaim any interrupted-flatten leftovers / stale temps while still under the guard
+	// (resume/re-pause/delete are waiting on flattenDone).
+	if _, gcErr := m.gcOrphanLayers(snapshotDir); gcErr != nil {
+		m.log.Warn().Str("vm_id", inst.ID).Err(gcErr).Msg("gc after flatten")
 	}
 	m.log.Info().Str("vm_id", inst.ID).Msg("flattened overlay chain")
 }
@@ -1414,10 +1491,13 @@ func readLayeredBase(memPath string) (string, bool) {
 	return base, base != ""
 }
 
-// isOverlayMemFile reports whether memPath names a layered diff overlay (which
-// must be restored over a base, never standalone).
+// isOverlayMemFile reports whether memPath names a layered diff overlay (must be restored over a
+// base, never standalone). Matches "mem.diff" and append-chain names ("mem.N.diff",
+// "mem.flat.N.diff") so a manifest-less restore refuses instead of loading a sparse layer as a
+// full image (absent pages read as zero holes).
 func isOverlayMemFile(memPath string) bool {
-	return filepath.Base(memPath) == "mem.diff"
+	base := filepath.Base(memPath)
+	return base == "mem.diff" || layerFileRe.MatchString(base)
 }
 
 // isTemplateMemPath reports whether memPath is an immutable template memory
@@ -1768,6 +1848,11 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 		inst.restoring = false
 		inst.mu.Unlock()
 	}()
+	// Wait out any in-flight async flush + background flatten before reading the chain (as
+	// ResumeVM/DeleteSnapshotFiles do): otherwise verify could load a not-yet-committed
+	// vmstate/memory pair or disrupt the still-flushing Firecracker.
+	_ = m.waitForFlush(inst)
+	m.waitForFlatten(inst)
 	// Resolve the layered chain (if any). The manifest is authoritative for the
 	// base + ordered overlays (so this also verifies a post-flatten chain whose
 	// inst fields may be stale); fall back to the single-overlay .base sidecar.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -137,6 +137,10 @@ type VMInstance struct {
 	// resume falls back to the committed disk chain.
 	bridgeMemFdPath    string
 	bridgePendingLayer string
+	// bridgePendingVmstate is the in-flight (not-yet-committed) per-layer vmstate file a
+	// bridge fast-resume reads (matching the held memfd). Cleared with the other handoff
+	// fields when the flush ends.
+	bridgePendingVmstate string
 
 	// holdingBridgeMemfd is true between a memfd fast-resume and the resumed VM's next
 	// pause/stop — the window where this sandbox pins ~2× its RAM (the new FC's mmap of
@@ -767,6 +771,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		layerPath := filepath.Join(snapshotDir, layerName)
 		memPath = layerPath
 		baseMemPath = appendBase
+		// Per-layer vmstate: FC writes this pause's CPU/device state to its own file (not the
+		// shared vmstate.snap), and the manifest commit records it — so {chain + vmstate}
+		// commit atomically in one manifest rename. A failed/uncommitted pause never replaces
+		// the prior committed vmstate; its orphan file is GC'd.
+		vmstateName := vmstateLayerName(newIndex)
+		vmstatePath := filepath.Join(snapshotDir, vmstateName)
 		// A leftover file at this index (a failed prior attempt) would survive as
 		// stale page extents over the chain — CreateDiffSnapshot writes only dirtied
 		// pages and never truncates. Start fresh; if it can't be removed, fall back to
@@ -780,17 +790,6 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			// appended stays false → the post-switch tail drops the now-stale manifest so
 			// resume loads this Full image, not the chain it would otherwise still name.
 			break
-		}
-		// Stash the prior committed vmstate (see savePriorVmstate) before this pause overwrites
-		// it, so a failed flush can revert. Accumulating pauses only — the first layer has no
-		// prior committed state.
-		priorVmstateSaved := false
-		if newIndex > 0 {
-			saved, serr := savePriorVmstate(snapshotPath)
-			if serr != nil {
-				log.Warn().Err(serr).Msg("pause: save prior vmstate failed; a failed flush won't be revertible")
-			}
-			priorVmstateSaved = saved
 		}
 		// Async only when enabled AND a prior durable layer exists to fall back to if
 		// the background write is interrupted (first-pause-always-sync: newIndex 0 is
@@ -826,11 +825,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				dirtyOffsetsPath := filepath.Join(snapshotDir, bridgeDirtyOffsetsName)
 				log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).
 					Msg("pausing VM — memfd bridge (vmd flushes dirty pages)")
-				if err := CreateDiffSnapshotBridge(socketPath, snapshotPath, layerPath, dirtyOffsetsPath); err != nil {
+				if err := CreateDiffSnapshotBridge(socketPath, vmstatePath, layerPath, dirtyOffsetsPath); err != nil {
 					memFile.Close()
 					<-m.pauseSem
 					_ = os.Remove(layerPath)
-					m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
+					_ = os.Remove(vmstatePath) // uncommitted per-layer vmstate; nothing references it
 					return "", "", m.handleVMError(vmID, fmt.Errorf("bridge diff snapshot: %w", err))
 				}
 				// Stop the old FC now: vmd holds the memfd, so guest RAM stays resident and
@@ -844,34 +843,35 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 				m.beginFlush(inst)
 				inst.mu.Lock()
 				inst.Status = StatusPaused
-				inst.SnapshotPath = snapshotPath
+				inst.SnapshotPath = vmstatePath
 				inst.MemFilePath = layerPath
 				inst.BaseMemPath = baseMemPath
 				inst.DirtyTracked = false
 				inst.PID = 0 // FC stopped
-				// Expose the held memfd so a resume during this flush serves faults from
-				// RAM instead of waiting for the dump. Valid only while completeBridgePause
-				// holds memFile open; it clears these (under mu) before closing it.
+				// Expose the held memfd + the in-flight (uncommitted) vmstate so a resume during
+				// this flush serves faults from RAM and loads the matching vmstate. Valid only
+				// while completeBridgePause holds the files; it clears these (under mu) first.
 				inst.bridgeMemFdPath = guestMemFdPath(memFile)
 				inst.bridgePendingLayer = layerPath
+				inst.bridgePendingVmstate = vmstatePath
 				inst.mu.Unlock()
 				m.persistState(inst)
-				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, memFile, dirtyOffsetsPath, appendManifest, priorVmstateSaved)
+				go m.completeBridgePause(inst, snapshotDir, layerPath, layerName, vmstateName, memFile, dirtyOffsetsPath, appendManifest)
 				log.Info().Int("layer", newIndex).Msg("VM pausing (memfd bridge flush in background)")
-				return snapshotPath, layerPath, nil
+				return vmstatePath, layerPath, nil
 			}
 		}
-		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Bool("async", async).
+		log.Info().Str("snapshot_path", vmstatePath).Int("layer", newIndex).Bool("async", async).
 			Msg("pausing VM — appending layered diff snapshot")
-		if err := CreateDiffSnapshot(socketPath, snapshotPath, layerPath, async); err != nil {
+		if err := CreateDiffSnapshot(socketPath, vmstatePath, layerPath, async); err != nil {
 			if async {
 				<-m.pauseSem // completeAsyncPause won't run; release the slot here
 			}
-			// Leave the partial layer orphaned and do NOT republish the manifest — the
-			// previously committed chain stays intact and resumable. Drop the orphan so
-			// the next attempt at this index starts clean.
+			// Leave the partial layer + vmstate orphaned and do NOT republish the manifest — the
+			// previously committed chain (and its vmstate) stays intact and resumable. Drop the
+			// orphans so the next attempt at this index starts clean.
 			_ = os.Remove(layerPath)
-			m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
+			_ = os.Remove(vmstatePath)
 			return "", "", m.handleVMError(vmID, fmt.Errorf("append layered diff snapshot: %w", err))
 		}
 		if async {
@@ -884,28 +884,27 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			m.beginFlush(inst)
 			inst.mu.Lock()
 			inst.Status = StatusPaused
-			inst.SnapshotPath = snapshotPath
+			inst.SnapshotPath = vmstatePath
 			inst.MemFilePath = layerPath
 			inst.BaseMemPath = baseMemPath
 			inst.DirtyTracked = false
 			inst.mu.Unlock()
 			m.persistState(inst)
-			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, socketPath, appendManifest, priorVmstateSaved)
+			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, vmstateName, socketPath, appendManifest)
 			log.Info().Int("layer", newIndex).Msg("VM pausing (async memory flush in background)")
-			return snapshotPath, layerPath, nil
+			return vmstatePath, layerPath, nil
 		}
-		// Sync commit point: republish the manifest with the new layer appended (atomic
-		// temp-write + rename). Until this lands, restore loads the prior chain.
+		// Sync commit point: the manifest records the new layer AND its vmstate, so the single
+		// atomic rename commits {chain + vmstate} together. Until it lands, restore loads the
+		// prior chain + prior vmstate (both intact).
 		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
+		appendManifest.Vmstate = vmstateName
 		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
 			_ = os.Remove(layerPath)
-			m.revertPriorVmstate(inst, snapshotPath) // VM kept running; restore the committed vmstate
+			_ = os.Remove(vmstatePath)
 			return "", "", m.handleVMError(vmID, fmt.Errorf("publish snapshot manifest: %w", err))
 		}
-		// Committed: the new vmstate.snap pairs with the new chain, so drop the prior copy.
-		if priorVmstateSaved {
-			discardPriorVmstate(snapshotPath)
-		}
+		snapshotPath = vmstatePath // committed vmstate, for the post-switch inst update
 		appended = true
 	case layered:
 		memPath = overlayPath
@@ -1019,38 +1018,33 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 // previous durable chain in place. Either way the sandbox stays resumable: the
 // manifest names the prior chain until (and unless) the new layer commits. Always
 // ends the flush so waiters (resume/re-pause/delete) unblock.
-func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, socketPath string, manifest *snapshotManifest, priorVmstateSaved bool) {
+func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, vmstateName, socketPath string, manifest *snapshotManifest) {
 	defer func() { <-m.pauseSem }() // release the background-flush slot claimed in PauseVM
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
-	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
+	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
-	// Revert unconditionally on failure: a resume can't have happened mid-flush here (it waits
-	// for the flush), so the sandbox is still paused. endFlush AFTER the revert so a waiting
-	// resume observes the reverted state.
-	failRevert := func(err error, msg string) {
+	// On failure: the manifest never commits, so the prior chain + its vmstate stay the durable
+	// state — nothing to revert. Just drop the uncommitted layer + per-layer vmstate orphans.
+	failClean := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
-		if priorVmstateSaved {
-			m.revertPriorVmstate(inst, vmstatePath)
-		}
+		_ = os.Remove(vmstatePath)
 		m.stopAsyncPauseFC(vmID)
 		m.clearBridgeHold(inst) // FC stopped; release any prior fast-resume memfd hold
 		m.endFlush(inst, err)
 	}
 
 	if err := CompleteSnapshot(socketPath); err != nil {
-		failRevert(err, "async pause flush failed; reverting to previous durable snapshot")
+		failClean(err, "async pause flush failed; keeping previous durable snapshot")
 		return
 	}
-	// Durable: commit the manifest, then stop FC.
+	// Durable commit: the single manifest rename records the new layer AND its vmstate.
 	manifest.Overlays = append(manifest.Overlays, layerName)
+	manifest.Vmstate = vmstateName
 	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
-		failRevert(err, "async pause manifest commit failed; reverting to previous durable snapshot")
+		failClean(err, "async pause manifest commit failed; keeping previous durable snapshot")
 		return
-	}
-	if priorVmstateSaved {
-		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	m.stopAsyncPauseFC(vmID)
 	m.clearBridgeHold(inst) // FC stopped; release any prior fast-resume memfd hold
@@ -1068,66 +1062,54 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 // fresh sparse diff layer, and on success commits the manifest (the durability point).
 // On any failure it drops the orphaned layer and keeps the previous durable chain — the
 // sandbox stays resumable from the committed manifest (stale by one pause, never corrupt).
-// vmd's memfd fd is closed when the dump finishes; a resume that adopted the memfd during
-// the flush holds its own fd (and the new Firecracker's mmap keeps the pages resident).
-func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest, priorVmstateSaved bool) {
+// vmd's memfd fd is closed when the dump finishes; a resume that adopted the memfd + the
+// per-layer vmstate during the flush holds its own fds (and the new Firecracker's mmap keeps
+// the pages resident), so deleting the uncommitted files on failure can't pull them out from
+// under it.
+func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, layerName, vmstateName string, memFile *os.File, dirtyOffsetsPath string, manifest *snapshotManifest) {
 	// Defers run LIFO: clear the handoff fields under mu FIRST, then close memFile, then
 	// release the sem. Clearing before the close (and under mu) means a concurrent resume
-	// either sees the path set and reopens its own fd while memFile is still open, or sees
-	// it cleared and falls back to the disk chain — never a closed-fd path. A resume that
-	// already reopened keeps the memfd alive via its own fd / the new FC's mmap.
+	// either sees the paths set and reopens its own fds while the files exist, or sees them
+	// cleared and falls back to the committed disk chain — never a stale path.
 	defer func() { <-m.pauseSem }()
 	defer memFile.Close()
 	defer func() {
 		inst.mu.Lock()
 		inst.bridgeMemFdPath = ""
 		inst.bridgePendingLayer = ""
+		inst.bridgePendingVmstate = ""
 		inst.mu.Unlock()
 	}()
 	defer os.Remove(dirtyOffsetsPath)
 	vmID := inst.ID
 	log := m.log.With().Str("vm_id", vmID).Logger()
-	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
+	vmstatePath := filepath.Join(snapshotDir, vmstateName)
 
-	// On failure, revert vmstate to the prior committed copy — but only if no resume adopted
-	// this pause's memfd. The claim-check and the block-further-claims must be atomic: read
-	// whether ResumeVM already cleared bridgeMemFdPath (claimed) AND clear it ourselves (so a
-	// later resume can't reopen the memfd and read a vmstate we're about to revert) under one
-	// lock. A claimed resume owns the vmstate (and self-heals on its next pause); otherwise the
-	// sandbox is still paused and the revert makes the prior chain + vmstate consistent.
-	failRevert := func(err error, msg string) {
+	// On failure: the manifest never commits, so the prior chain + its vmstate stay durable —
+	// nothing to revert. Drop the uncommitted layer + per-layer vmstate orphans. A fast-resume
+	// that adopted them holds its own fds, so the unlink doesn't disturb it.
+	failClean := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)
-		inst.mu.Lock()
-		claimed := inst.bridgeMemFdPath == ""
-		inst.bridgeMemFdPath = ""
-		inst.bridgePendingLayer = ""
-		inst.mu.Unlock()
-		if priorVmstateSaved && !claimed {
-			if rerr := restorePriorVmstate(vmstatePath); rerr != nil {
-				log.Warn().Str("vm_id", vmID).Err(rerr).Msg("revert prior vmstate after failed bridge flush")
-			}
-		}
+		_ = os.Remove(vmstatePath)
 		m.endFlush(inst, err)
 	}
 
 	offsets, err := readDirtyOffsets(dirtyOffsetsPath)
 	if err != nil {
-		failRevert(err, "bridge pause: read dirty offsets failed; reverting to previous durable snapshot")
+		failClean(err, "bridge pause: read dirty offsets failed; keeping previous durable snapshot")
 		return
 	}
 	if err := dumpMemfdPages(memFile, offsets, layerPath, os.Getpagesize()); err != nil {
-		failRevert(err, "bridge pause: memfd dump failed; reverting to previous durable snapshot")
+		failClean(err, "bridge pause: memfd dump failed; keeping previous durable snapshot")
 		return
 	}
-	// Durable: commit the manifest with the new layer appended (atomic temp + rename).
+	// Durable commit: the single manifest rename records the new layer AND its vmstate.
 	manifest.Overlays = append(manifest.Overlays, layerName)
+	manifest.Vmstate = vmstateName
 	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
-		failRevert(err, "bridge pause: manifest commit failed; reverting to previous durable snapshot")
+		failClean(err, "bridge pause: manifest commit failed; keeping previous durable snapshot")
 		return
-	}
-	if priorVmstateSaved {
-		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	log.Info().Int("pages", len(offsets)).Msg("VM paused (memfd bridge flush durable)")
 	// Arm/launch flatten BEFORE endFlush (see completeAsyncPause) so a woken resume/delete
@@ -1228,17 +1210,6 @@ func (m *Manager) countHeldBridgeMemfds() int {
 		inst.mu.RUnlock()
 	}
 	return n
-}
-
-// revertPriorVmstate reverts vmstate to the prior committed copy after a failed flush, so a
-// later resume loads a vmstate consistent with the prior (still-committed) memory chain. Used
-// by the synchronous error paths and the in-FC async path, where no resume can be reading
-// vmstate.snap concurrently. (The bridge path can race a fast-resume, so it guards the revert
-// with the memfd-claim check inline in completeBridgePause instead.)
-func (m *Manager) revertPriorVmstate(inst *VMInstance, vmstatePath string) {
-	if err := restorePriorVmstate(vmstatePath); err != nil {
-		m.log.Warn().Str("vm_id", inst.ID).Err(err).Msg("revert prior vmstate after failed flush")
-	}
 }
 
 // beginFlush marks inst as having an in-progress async-pause flush, arming the
@@ -1469,24 +1440,30 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// the disk flush — resume returns in ~constant time regardless of the dirty-set size.
 	// Reopen vmd's own fd to the memfd under the lock so it can't be closed mid-decision;
 	// the new FC mmaps it during restore and keeps it alive, so we drop our fd afterwards.
-	var memfdFd *os.File
-	var memfdResumePath, bridgePendingLayer string
+	var memfdFd, vmstateFd *os.File
+	var memfdResumePath, memfdVmstatePath, bridgePendingLayer string
 	// Only take the memfd fast path while under the held-memfd cap, so the feature can't
 	// pin unbounded extra RAM fleet-wide. Gate on the flag first so a flags-off resume pays
-	// nothing (countHeldBridgeMemfds scans all VMs). Check the count BEFORE taking inst.mu
-	// (it locks instances); this inst isn't counted yet, and a soft over-allow under concurrent
-	// resumes is acceptable.
+	// nothing (countHeldBridgeMemfds scans all VMs). Reopen vmd's own fds to the memfd AND the
+	// in-flight per-layer vmstate under the lock, so a concurrent commit/delete can't pull them
+	// out from under us; the new FC mmaps/reads them during restore and they're dropped after.
 	if m.cfg.SharedMemEnabled && m.countHeldBridgeMemfds() < m.maxBridgeMemfds() {
 		inst.mu.Lock()
-		if inst.flushing && inst.bridgeMemFdPath != "" {
-			if f, oerr := os.Open(inst.bridgeMemFdPath); oerr == nil {
-				memfdFd = f
-				memfdResumePath = guestMemFdPath(f)
+		if inst.flushing && inst.bridgeMemFdPath != "" && inst.bridgePendingVmstate != "" {
+			memf, merr := os.Open(inst.bridgeMemFdPath)
+			vmf, verr := os.Open(inst.bridgePendingVmstate)
+			if merr == nil && verr == nil {
+				memfdFd, vmstateFd = memf, vmf
+				memfdResumePath = guestMemFdPath(memf)
+				memfdVmstatePath = guestMemFdPath(vmf)
 				bridgePendingLayer = inst.bridgePendingLayer
-				// Claim it: clearing the path under the lock signals completeBridgePause that a
-				// resume adopted this pause's vmstate + memfd, so a failed flush must NOT revert
-				// vmstate.snap out from under the FC we're about to restore from it.
-				inst.bridgeMemFdPath = ""
+			} else {
+				if memf != nil {
+					_ = memf.Close()
+				}
+				if vmf != nil {
+					_ = vmf.Close()
+				}
 			}
 		}
 		inst.mu.Unlock()
@@ -1496,33 +1473,32 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		if memfdFd != nil {
 			_ = memfdFd.Close()
 		}
+		if vmstateFd != nil {
+			_ = vmstateFd.Close()
+		}
 	}()
 	if !useMemfd {
 		// No memfd handoff — wait for any in-flight flush to commit the durable chain. If it
-		// FAILED, completeAsyncPause/completeBridgePause already reverted vmstate to the prior
-		// committed copy, so the prior chain + vmstate are consistent: resume from it (the
-		// failed pause's changes are lost — stale by one pause), surfacing the failure loudly.
+		// FAILED, the manifest never committed (it's the single atomic commit for {chain +
+		// vmstate}), so the prior chain + its vmstate are still consistent: resume from them
+		// (the failed pause's changes are lost — stale by one pause), surfacing it loudly.
 		if ferr := m.waitForFlush(inst); ferr != nil {
 			log.Warn().Err(ferr).Msg("last async flush failed; resuming from the prior durable snapshot (last pause's changes lost)")
 		}
 	}
 	m.waitForFlatten(inst)
 
-	if snapshotPath == "" {
-		snapshotPath = inst.SnapshotPath
-	}
 	if memPath == "" {
 		memPath = inst.MemFilePath
 	}
-	if snapshotPath == "" || memPath == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "snapshot_path and mem_file_path are required")
+	if memPath == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "mem_file_path is required")
 	}
 
-	// Layered chain (append-only path): if a manifest is present, it is authoritative
-	// for the base + ordered overlay chain. Resolve it here (before starting FC) so a
-	// corrupt/empty manifest fails fast, and so the file checks below validate the
-	// chain's newest overlay. basePath drives the layered restore; an absent manifest
-	// leaves it "" and falls through to the legacy single-overlay resolution below.
+	// Layered chain (append-only path): a present manifest is authoritative for the base +
+	// ordered overlay chain AND the vmstate that pairs with it. Resolve it before starting FC
+	// so a corrupt/empty manifest fails fast. An absent manifest falls through to the legacy
+	// single-overlay resolution below, where vmstate is the passed/cached path.
 	basePath := ""
 	var lowerOverlays []string
 	snapshotDir := filepath.Dir(memPath)
@@ -1535,14 +1511,15 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		}
 		if useMemfd {
 			// Lay the held memfd (the frozen RAM at the pause point) over the committed disk
-			// chain as the newest overlay: it owns every faulted page (shadowing the chain),
-			// and never-faulted pages fall through to the chain. The in-flight layer the
-			// flush is writing is NOT yet committed, so the chain here is the prior one.
+			// chain as the newest overlay, and load the in-flight vmstate that matches it. The
+			// layer the flush is writing is NOT yet committed, so the chain here is the prior one.
 			basePath = base
 			lowerOverlays = append(lower, newest)
 			memPath = memfdResumePath
+			snapshotPath = memfdVmstatePath
 		} else {
 			basePath, lowerOverlays, memPath = base, lower, newest
+			snapshotPath = manifestVmstatePath(snapshotDir, man) // committed vmstate for this chain
 		}
 	} else if useMemfd {
 		// A bridge pause always leaves a manifest; if it vanished, abandon the memfd path
@@ -1550,7 +1527,15 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		useMemfd = false
 		_ = memfdFd.Close()
 		memfdFd = nil
+		_ = vmstateFd.Close()
+		vmstateFd = nil
 		_ = m.waitForFlush(inst)
+	}
+	if snapshotPath == "" {
+		snapshotPath = inst.SnapshotPath
+	}
+	if snapshotPath == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "snapshot_path is required")
 	}
 
 	// Verify the snapshot files actually exist on disk. DB can claim
@@ -1767,6 +1752,7 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 			return "", status.Errorf(codes.FailedPrecondition, "snapshot manifest in %s has no overlays", snapshotDir)
 		}
 		basePath, lowerOverlays, memPath = base, lower, newest
+		snapshotPath = manifestVmstatePath(snapshotDir, man) // verify the vmstate this chain commits to
 	}
 	if basePath == "" && isOverlayMemFile(memPath) {
 		if b, ok := readLayeredBase(memPath); ok {
@@ -2222,10 +2208,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				break
 			}
 			basePath, lowerOverlays, memPath = base, lower, newest
+			snapshotPath = manifestVmstatePath(filepath.Dir(memPath), man) // committed vmstate for this chain
 			armLayered = m.cfg.IncrementalSnapshotEnabled
 			inst.mu.Lock()
 			inst.BaseMemPath = base
 			inst.MemFilePath = newest // resolved chain newest, so the next pause appends onto it
+			inst.SnapshotPath = snapshotPath
 			inst.DirtyTracked = armLayered
 			inst.mu.Unlock()
 		case hasSidecar:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -744,6 +744,13 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// chain intact and resumable. This is the on-disk foundation the async/durable
 	// pause path needs. When disabled, the in-place paths below run unchanged.
 	appendBase, appendManifest, appendOK := m.planLayerAppend(snapshotDir, dirtyTracked, instBaseMem, instMemFile)
+	// appended is set once a pause commits a layer onto the chain (manifest republished). If a
+	// pause instead writes a STANDALONE snapshot (in-place mem.diff / Full mem.snap) while a
+	// chain manifest exists — e.g. flags turned off, dirty-tracking cleared, or planLayerAppend
+	// rejected the baseline — that manifest is now stale and would shadow the new snapshot on
+	// resume (ResumeVM treats a present manifest as authoritative). The post-switch tail
+	// reconciles it.
+	appended := false
 	// CreateDiffSnapshot merges in place: an interrupted diff has no surviving copy
 	// of the file it overwrites (for layered, only the session delta — the template
 	// base is untouched; for in-place, the VM's own mem.snap). Crash-atomicity of the
@@ -768,15 +775,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
 			}
-			// The Full image is now the durable state; drop the manifest (and its now-orphaned
-			// overlays) so resume loads this snapshot instead of the stale chain the manifest
-			// would otherwise still name as authoritative.
-			for _, name := range appendManifest.Overlays {
-				_ = os.Remove(filepath.Join(snapshotDir, name))
-			}
-			if merr := removeManifest(snapshotDir); merr != nil {
-				log.Warn().Err(merr).Msg("pause: remove manifest on Full fallback")
-			}
+			// appended stays false → the post-switch tail drops the now-stale manifest so
+			// resume loads this Full image, not the chain it would otherwise still name.
 			break
 		}
 		// Stash the prior committed vmstate (see savePriorVmstate) before this pause overwrites
@@ -903,6 +903,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		if priorVmstateSaved {
 			discardPriorVmstate(snapshotPath)
 		}
+		appended = true
 	case layered:
 		memPath = overlayPath
 		baseMemPath = instBaseMem
@@ -963,6 +964,21 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating snapshot")
 			if err := CreateSnapshot(socketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create snapshot: %w", err))
+			}
+		}
+	}
+
+	// Standalone snapshot (in-place / Full): if a chain manifest lingers from a prior
+	// append-mode run, drop it (and its now-orphaned overlays) so resume loads this snapshot
+	// instead of the stale chain. No-op when this pause appended (manifest is fresh) or when
+	// there's no manifest. (The Full-fallback above already handled its own removal.)
+	if !appended {
+		if man, merr := readManifest(snapshotDir); merr == nil && man != nil {
+			for _, name := range man.Overlays {
+				_ = os.Remove(filepath.Join(snapshotDir, name))
+			}
+			if rmErr := removeManifest(snapshotDir); rmErr != nil {
+				log.Warn().Err(rmErr).Msg("pause: remove stale manifest after standalone snapshot")
 			}
 		}
 	}
@@ -1029,9 +1045,11 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	}
 	m.stopAsyncPauseFC(vmID)
 	log.Info().Msg("VM paused (async memory flush durable)")
-	m.endFlush(inst, nil)
-	// Bound chain depth off the hot path now that this layer is durable.
+	// Arm/launch flatten BEFORE endFlush: maybeFlatten sets the flatten guard synchronously,
+	// so a resume/delete woken by endFlush observes the pending flatten (waitForFlatten) and
+	// won't read the chain while the background flatten swaps the manifest + deletes layers.
 	m.maybeFlatten(inst, snapshotDir)
+	m.endFlush(inst, nil)
 }
 
 // completeBridgePause runs after a memfd-bridge pause returned at the snapshot point.
@@ -1091,9 +1109,10 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 		discardPriorVmstate(vmstatePath) // new vmstate pairs with the new chain now
 	}
 	log.Info().Int("pages", len(offsets)).Msg("VM paused (memfd bridge flush durable)")
-	m.endFlush(inst, nil)
-	// Bound chain depth off the hot path now that this layer is durable.
+	// Arm/launch flatten BEFORE endFlush (see completeAsyncPause) so a woken resume/delete
+	// observes the pending flatten instead of racing the manifest swap.
 	m.maybeFlatten(inst, snapshotDir)
+	m.endFlush(inst, nil)
 }
 
 // stopAsyncPauseFC stops the still-alive paused Firecracker after an async flush
@@ -2095,14 +2114,19 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Msg("restoring snapshot")
 
 	var restoreErr error
-	// A diff overlay (mem.diff, or any file with a base sidecar) must be served by
-	// the UFFD layered backend. Catch it before backend selection so that with UFFD
-	// disabled / inPlace / resume-UFFD off it fails loud instead of falling to the
-	// File backend, which would load the sparse overlay as a full image (the base's
-	// pages read as zero holes).
+	// A diff overlay (mem.diff / a sidecar file) or a layered manifest chain must be served by
+	// the UFFD layered backend. Resolve those up front, before backend selection, so that with
+	// UFFD disabled / inPlace / resume-UFFD off it fails loud instead of falling to the File
+	// backend (which would load a sparse overlay as a full image — the base's pages read as
+	// zero holes). The manifest is read here too because an append-chain newest layer is
+	// mem.N.diff, which isOverlayMemFile (only "mem.diff") doesn't match.
 	sidecarBase, hasSidecar := readLayeredBase(memPath)
-	overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
+	man, manErr := readManifest(filepath.Dir(memPath))
+	hasManifest := manErr == nil && man != nil
+	overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar || hasManifest
 	switch {
+	case manErr != nil:
+		restoreErr = fmt.Errorf("unreadable snapshot manifest in %s: %w", filepath.Dir(memPath), manErr)
 	case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
 		restoreErr = fmt.Errorf(
 			"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
@@ -2121,22 +2145,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				accessLogPath = candidate
 			}
 		}
-		// Decide the layered base for this UFFD restore. An overlay (mem.diff) needs
-		// its base reconstructed from the sidecar (else refuse — loading it
-		// standalone reads the base as zero holes); a template create instead arms
-		// tracking and records the template as the base. Layered needs resume-UFFD.
+		// Decide the layered base for this UFFD restore. The manifest (resolved above) is
+		// authoritative for a multi-layer chain — load the whole chain, not just the newest
+		// overlay. Else an overlay needs its sidecar base; a template create arms tracking.
 		isTemplate := m.isTemplateMemPath(memPath)
 		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
 		basePath := ""
 		var lowerOverlays []string
 		armLayered := false
-		// The manifest is authoritative for the full base → overlay chain (as in ResumeVM):
-		// a stateless restore of a multi-layer chain must load the whole chain, not just the
-		// newest overlay over the base, or the intermediate layers' pages are lost.
-		man, manErr := readManifest(filepath.Dir(memPath))
 		switch {
-		case manErr != nil:
-			restoreErr = fmt.Errorf("unreadable snapshot manifest in %s: %w", filepath.Dir(memPath), manErr)
 		case man != nil:
 			base, lower, newest, ok := man.chainPaths(filepath.Dir(memPath))
 			if !ok {
@@ -2147,6 +2164,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			armLayered = m.cfg.IncrementalSnapshotEnabled
 			inst.mu.Lock()
 			inst.BaseMemPath = base
+			inst.MemFilePath = newest // resolved chain newest, so the next pause appends onto it
 			inst.DirtyTracked = armLayered
 			inst.mu.Unlock()
 		case hasSidecar:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1454,10 +1454,11 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	var memfdFd *os.File
 	var memfdResumePath, bridgePendingLayer string
 	// Only take the memfd fast path while under the held-memfd cap, so the feature can't
-	// pin unbounded extra RAM fleet-wide. Check the count BEFORE taking inst.mu
-	// (countHeldBridgeMemfds locks instances); this inst isn't counted yet, and a soft
-	// over-allow under concurrent resumes is acceptable.
-	if m.countHeldBridgeMemfds() < m.maxBridgeMemfds() {
+	// pin unbounded extra RAM fleet-wide. Gate on the flag first so a flags-off resume pays
+	// nothing (countHeldBridgeMemfds scans all VMs). Check the count BEFORE taking inst.mu
+	// (it locks instances); this inst isn't counted yet, and a soft over-allow under concurrent
+	// resumes is acceptable.
+	if m.cfg.SharedMemEnabled && m.countHeldBridgeMemfds() < m.maxBridgeMemfds() {
 		inst.mu.Lock()
 		if inst.flushing && inst.bridgeMemFdPath != "" {
 			if f, oerr := os.Open(inst.bridgeMemFdPath); oerr == nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -110,6 +110,17 @@ type VMInstance struct {
 	// live FC process, which a fresh resume re-establishes.
 	DirtyTracked bool
 
+	// Async-pause flush tracking. While flushing is true, an async pause's
+	// background memory write is still in progress: the new diff layer is being
+	// written and is NOT yet in the manifest, so the durable state is still the
+	// previous chain. flushDone is closed when the flush finishes (outcome in
+	// flushErr). Resume/re-pause/delete wait on it (waitForFlush) so they never act
+	// on a not-yet-durable layer. Not persisted — a vmd restart resolves any
+	// in-flight flush from on-disk state (the manifest), not this handle.
+	flushing  bool
+	flushDone chan struct{}
+	flushErr  error
+
 	mu sync.RWMutex
 }
 
@@ -191,6 +202,14 @@ type ManagerConfig struct {
 	// IncrementalSnapshotEnabled + ResumeUffdEnabled and an FC binary that accepts
 	// lower_overlay_paths. Default false.
 	LayerAppendEnabled bool
+
+	// AsyncPauseEnabled lets a layered append pause return at the snapshot point and
+	// write the diff layer on a Firecracker background thread, marking the snapshot
+	// durable (republishing the manifest, then stopping FC) once the write completes.
+	// The first pause of a chain stays synchronous (no prior durable layer to fall
+	// back to). Requires LayerAppendEnabled and an FC binary with /snapshot/complete.
+	// Default false.
+	AsyncPauseEnabled bool
 }
 
 // ---------------------------------------------------------------------------
@@ -589,6 +608,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
+	// A prior async pause may still be flushing; wait so this pause sees the durable
+	// chain (committed manifest) and doesn't race the background writer or FC stop.
+	_ = m.waitForFlush(inst)
+
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID)
 	}
@@ -654,15 +677,37 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			}
 			break
 		}
-		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Msg("pausing VM — appending layered diff snapshot")
-		if err := CreateDiffSnapshot(socketPath, snapshotPath, layerPath); err != nil {
+		// Async only when enabled AND a prior durable layer exists to fall back to if
+		// the background write is interrupted (first-pause-always-sync: newIndex 0 is
+		// the first layer, which has only the read-only template base under it).
+		async := m.cfg.AsyncPauseEnabled && newIndex > 0
+		log.Info().Str("snapshot_path", snapshotPath).Int("layer", newIndex).Bool("async", async).
+			Msg("pausing VM — appending layered diff snapshot")
+		if err := CreateDiffSnapshot(socketPath, snapshotPath, layerPath, async); err != nil {
 			// Leave the partial layer orphaned and do NOT republish the manifest — the
 			// previously committed chain stays intact and resumable. Drop the orphan so
 			// the next attempt at this index starts clean.
 			_ = os.Remove(layerPath)
 			return "", "", m.handleVMError(vmID, fmt.Errorf("append layered diff snapshot: %w", err))
 		}
-		// Commit point: republish the manifest with the new layer appended (atomic
+		if async {
+			// Returned at the snapshot point: FC is alive + paused, writing the layer in
+			// the background. Record the paused (resumable) state, then finish + commit
+			// off the hot path (see completeAsyncPause).
+			inst.mu.Lock()
+			inst.Status = StatusPaused
+			inst.SnapshotPath = snapshotPath
+			inst.MemFilePath = layerPath
+			inst.BaseMemPath = baseMemPath
+			inst.DirtyTracked = false
+			inst.mu.Unlock()
+			m.beginFlush(inst)
+			m.persistState(inst)
+			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, socketPath, appendManifest)
+			log.Info().Int("layer", newIndex).Msg("VM pausing (async memory flush in background)")
+			return snapshotPath, layerPath, nil
+		}
+		// Sync commit point: republish the manifest with the new layer appended (atomic
 		// temp-write + rename). Until this lands, restore loads the prior chain.
 		appendManifest.Overlays = append(appendManifest.Overlays, layerName)
 		if err := writeManifestAtomic(snapshotDir, appendManifest); err != nil {
@@ -699,7 +744,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 		if usable {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
-			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
+			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath, false); err != nil {
 				// A failed diff may have left a partial overlay. Drop the .base sidecar
 				// so a later restore can't treat that partial data as a valid layered
 				// overlay — without the sidecar it's refused (overlay-without-base),
@@ -722,7 +767,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// dirtied offsets are resident/never re-faulted, disjoint from clean reads.
 		if shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, dirtyTracked, memPath, instMemFile, fileExists(memPath)) {
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
-			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
+			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath, false); err != nil {
 				return "", "", m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
 			}
 		} else {
@@ -749,6 +794,46 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	m.persistState(inst)
 	log.Info().Msg("VM paused")
 	return snapshotPath, memPath, nil
+}
+
+// completeAsyncPause runs after an async pause returned at the snapshot point: it
+// waits for Firecracker's background write + fsync (CompleteSnapshot), then on
+// success commits the new layer (republish the manifest — the durability commit
+// point) and stops FC; on failure it drops the orphaned layer and leaves the
+// previous durable chain in place. Either way the sandbox stays resumable: the
+// manifest names the prior chain until (and unless) the new layer commits. Always
+// ends the flush so waiters (resume/re-pause/delete) unblock.
+func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, layerName, socketPath string, manifest *snapshotManifest) {
+	vmID := inst.ID
+	log := m.log.With().Str("vm_id", vmID).Logger()
+
+	if err := CompleteSnapshot(socketPath); err != nil {
+		log.Error().Err(err).Msg("async pause flush failed; keeping previous durable snapshot")
+		_ = os.Remove(layerPath)
+		m.stopAsyncPauseFC(vmID)
+		m.endFlush(inst, err)
+		return
+	}
+	// Durable: commit the manifest, then stop FC.
+	manifest.Overlays = append(manifest.Overlays, layerName)
+	if err := writeManifestAtomic(snapshotDir, manifest); err != nil {
+		log.Error().Err(err).Msg("async pause manifest commit failed; keeping previous durable snapshot")
+		_ = os.Remove(layerPath)
+		m.stopAsyncPauseFC(vmID)
+		m.endFlush(inst, err)
+		return
+	}
+	m.stopAsyncPauseFC(vmID)
+	log.Info().Msg("VM paused (async memory flush durable)")
+	m.endFlush(inst, nil)
+}
+
+// stopAsyncPauseFC stops the still-alive paused Firecracker after an async flush
+// settles. Best-effort: a stop failure is logged, not fatal (the snapshot is on disk).
+func (m *Manager) stopAsyncPauseFC(vmID string) {
+	if err := stopUnit(context.Background(), systemdUnitName(vmID)); err != nil {
+		m.log.Warn().Str("vm_id", vmID).Err(err).Msg("stop FC after async pause flush")
+	}
 }
 
 // shouldWriteDiff reports whether a pause may write a Diff instead of a Full.
@@ -799,6 +884,45 @@ func (m *Manager) planLayerAppend(snapshotDir string, dirtyTracked bool, instBas
 		return "", nil, false
 	}
 	return instBaseMem, &snapshotManifest{Base: instBaseMem}, true
+}
+
+// beginFlush marks inst as having an in-progress async-pause flush, arming the
+// channel that endFlush closes when the flush finishes.
+func (m *Manager) beginFlush(inst *VMInstance) {
+	inst.mu.Lock()
+	inst.flushing = true
+	inst.flushErr = nil
+	inst.flushDone = make(chan struct{})
+	inst.mu.Unlock()
+}
+
+// endFlush records the flush outcome and wakes any waiters.
+func (m *Manager) endFlush(inst *VMInstance, err error) {
+	inst.mu.Lock()
+	inst.flushErr = err
+	inst.flushing = false
+	ch := inst.flushDone
+	inst.mu.Unlock()
+	if ch != nil {
+		close(ch)
+	}
+}
+
+// waitForFlush blocks until any in-progress async-pause flush for inst finishes,
+// returning that flush's outcome (nil when none was in progress). Callers that act
+// on the durable snapshot — resume, re-pause, delete — must call this first so they
+// never read a not-yet-durable layer or race the background writer.
+func (m *Manager) waitForFlush(inst *VMInstance) error {
+	inst.mu.RLock()
+	flushing, ch := inst.flushing, inst.flushDone
+	inst.mu.RUnlock()
+	if !flushing || ch == nil {
+		return nil
+	}
+	<-ch
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.flushErr
 }
 
 // freshenFirstPassOverlay removes any leftover overlay so a first layered pass starts
@@ -861,6 +985,10 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	if err != nil {
 		return nil, err
 	}
+
+	// If an async pause is still flushing, wait for it to commit (and stop the old
+	// FC) before resuming — the chain we load must be the committed one.
+	_ = m.waitForFlush(inst)
 
 	if snapshotPath == "" {
 		snapshotPath = inst.SnapshotPath
@@ -1178,6 +1306,10 @@ func (m *Manager) DeleteSnapshotFiles(vmID, snapshotPath, memPath string) error 
 	}
 	if snapshotPath == "" && memPath == "" {
 		return status.Error(codes.InvalidArgument, "at least one of snapshot_path/mem_file_path is required")
+	}
+	// Don't delete chain files out from under an in-progress async flush; wait it out.
+	if inst, ierr := m.getInstance(vmID); ierr == nil {
+		_ = m.waitForFlush(inst)
 	}
 	for _, p := range []string{snapshotPath, memPath} {
 		if p == "" {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -761,6 +761,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			// Returned at the snapshot point: FC is alive + paused, writing the layer in
 			// the background. Record the paused (resumable) state, then finish + commit
 			// off the hot path (see completeAsyncPause).
+			//
+			// Mark flushing BEFORE status=paused so the reconciler never observes a live
+			// flush as (paused + unit active + not flushing) and mistakes it for stranded.
+			m.beginFlush(inst)
 			inst.mu.Lock()
 			inst.Status = StatusPaused
 			inst.SnapshotPath = snapshotPath
@@ -768,7 +772,6 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			inst.BaseMemPath = baseMemPath
 			inst.DirtyTracked = false
 			inst.mu.Unlock()
-			m.beginFlush(inst)
 			m.persistState(inst)
 			go m.completeAsyncPause(inst, snapshotDir, layerPath, layerName, socketPath, appendManifest)
 			log.Info().Int("layer", newIndex).Msg("VM pausing (async memory flush in background)")
@@ -998,6 +1001,20 @@ func (m *Manager) waitForFlush(inst *VMInstance) error {
 	return inst.flushErr
 }
 
+// isFlushing reports whether an async-pause background flush is in progress for
+// vmID in THIS process. The reconciler uses it to tell a live flush (FC legitimately
+// still up, writing the diff) from a stranded FC (a flush whose goroutine died, e.g.
+// across a vmd restart — where flushing is false because the process is fresh).
+func (m *Manager) isFlushing(vmID string) bool {
+	inst, err := m.getInstance(vmID)
+	if err != nil {
+		return false
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.flushing
+}
+
 // waitForFlatten blocks until any in-progress background flatten for inst finishes.
 // Callers that read the manifest or load the chain (resume, re-pause, delete) must
 // call this so they never see a half-swapped manifest or a layer being deleted.
@@ -1219,6 +1236,15 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		netInfo, nsErr = m.netMgr.EnsureVMSlot(ctx, vmID, inst.Namespace, inst.IP, inst.MACAddress)
 		if nsErr != nil {
 			return nil, fmt.Errorf("ensure network slot for resume: %w", nsErr)
+		}
+	}
+
+	// A stranded FC (interrupted async flush) may still hold this unit — waitForFlush
+	// above drained any live flush, so an active unit here means it's stranded. Stop
+	// it so we start a clean FC on the durable chain, not the stale one.
+	if isUnitActive(ctx, systemdUnitName(vmID)) {
+		if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
+			log.Warn().Err(err).Msg("resume: stop stranded FC unit before restart")
 		}
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -779,10 +779,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			}
 			break
 		}
-		// Preserve the prior committed vmstate before this pause overwrites vmstate.snap, so
-		// a failed async/bridge flush can revert to a vmstate matching the prior memory chain
-		// (accumulating pauses only — the first layer has no prior committed state). Restored
-		// on any failure below, discarded once the new layer commits.
+		// Stash the prior committed vmstate (see savePriorVmstate) before this pause overwrites
+		// it, so a failed flush can revert. Accumulating pauses only — the first layer has no
+		// prior committed state.
 		priorVmstateSaved := false
 		if newIndex > 0 {
 			saved, serr := savePriorVmstate(snapshotPath)
@@ -1002,10 +1001,8 @@ func (m *Manager) completeAsyncPause(inst *VMInstance, snapshotDir, layerPath, l
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
 
-	// On failure, revert vmstate to the prior committed copy so it pairs with the prior
-	// (still-committed) memory chain — resume then loads a consistent stale-by-one snapshot.
-	// A resume can't have happened mid-flush on this path (it waits for the flush), so the
-	// sandbox is still paused; revert unconditionally. endFlush AFTER the revert so a waiting
+	// Revert unconditionally on failure: a resume can't have happened mid-flush here (it waits
+	// for the flush), so the sandbox is still paused. endFlush AFTER the revert so a waiting
 	// resume observes the reverted state.
 	failRevert := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
@@ -1064,10 +1061,8 @@ func (m *Manager) completeBridgePause(inst *VMInstance, snapshotDir, layerPath, 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	vmstatePath := filepath.Join(snapshotDir, "vmstate.snap")
 
-	// On failure, revert vmstate to the prior committed copy ONLY if the sandbox is still
-	// paused: a fast-resumed (Running) VM already loaded the new vmstate into its Firecracker,
-	// so reverting the file is pointless and could race that restore (it self-heals on the
-	// next pause). endFlush AFTER the revert so a waiting resume observes the reverted state.
+	// Revert on failure, but only-if-paused (revertPriorVmstate's guard): a fast-resumed VM
+	// owns the new vmstate and self-heals on its next pause. endFlush AFTER the revert.
 	failRevert := func(err error, msg string) {
 		log.Error().Err(err).Msg(msg)
 		_ = os.Remove(layerPath)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -929,7 +929,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 	// basePath non-empty ⇒ layered restore (memPath is the diff overlay over basePath).
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
+		socketPath, snapshotPath, memPath, basePath, nil, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 		m.cfg.HandlerDeathAbortEnabled,
 	)
 }
@@ -1381,7 +1381,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		if restoreErr == nil {
 			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-				socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
+				socketPath, snapshotPath, memPath, basePath, nil, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
 				m.cfg.HandlerDeathAbortEnabled,
 			)
 		}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -747,4 +748,79 @@ func TestIsTemplateMemPath(t *testing.T) {
 	if isOverlayMemFile("/x/mem.diff") != true || isOverlayMemFile("/x/mem.snap") != false {
 		t.Fatal("isOverlayMemFile basename detection wrong")
 	}
+}
+
+func TestIsOverlayMemFile(t *testing.T) {
+	// Append-chain layer names must be recognized as overlays too, so the manifest-absent
+	// safety guards refuse to load a sparse mem.N.diff standalone (zero-hole memory).
+	overlays := []string{"mem.diff", "/p/mem.0.diff", "/p/mem.5.diff", "mem.flat.0.diff", "/p/mem.flat.12.diff"}
+	for _, p := range overlays {
+		if !isOverlayMemFile(p) {
+			t.Errorf("isOverlayMemFile(%q) = false, want true (sparse overlay must need a base)", p)
+		}
+	}
+	notOverlays := []string{"mem.snap", "/p/vmstate.snap", "/p/mem.base", "memXdiff", "mem.diff.bak", "mem..diff"}
+	for _, p := range notOverlays {
+		if isOverlayMemFile(p) {
+			t.Errorf("isOverlayMemFile(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestResumableFromManifest(t *testing.T) {
+	// The reconciler uses this to avoid failing a paused sandbox whose DB-recorded snapshot path
+	// was deleted by an async/bridge flush failure but whose committed manifest chain is intact.
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.mem")
+	write := func(p string) {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(base)
+	write(filepath.Join(dir, "mem.0.diff"))
+	write(filepath.Join(dir, "vmstate.0.snap"))
+	man := &snapshotManifest{Base: base, Overlays: []string{"mem.0.diff"}, Vmstate: "vmstate.0.snap"}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{log: zerolog.Nop()}
+
+	if !m.resumableFromManifest(dir) {
+		t.Fatal("want resumable: base + overlay + vmstate all present")
+	}
+	if err := os.Remove(filepath.Join(dir, "mem.0.diff")); err != nil {
+		t.Fatal(err)
+	}
+	if m.resumableFromManifest(dir) {
+		t.Fatal("want NOT resumable: a chain overlay is missing")
+	}
+	if m.resumableFromManifest(t.TempDir()) {
+		t.Fatal("want NOT resumable: no manifest present")
+	}
+}
+
+func TestEndFlushFlattenIdempotent(t *testing.T) {
+	// The deferred panic-safety nets in the background goroutines may call endFlush/endFlatten
+	// after the normal path already did; the guards must make the second call a no-op (a second
+	// close of flushDone/flattenDone would panic).
+	m := &Manager{}
+	inst := &VMInstance{ID: "x"}
+
+	m.beginFlush(inst)
+	m.endFlush(inst, nil)
+	m.endFlush(inst, errors.New("again")) // must not panic / double-close
+	if inst.flushing {
+		t.Fatal("flushing should be false after endFlush")
+	}
+
+	inst.flattening = true
+	inst.flattenDone = make(chan struct{})
+	m.endFlatten(inst)
+	m.endFlatten(inst) // must not panic / double-close
+	if inst.flattening {
+		t.Fatal("flattening should be false after endFlatten")
+	}
+	// A no-op endFlatten on an inst that never flattened must not panic on the nil channel.
+	m.endFlatten(&VMInstance{ID: "y"})
 }

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -306,23 +306,36 @@ func TestFreshenFirstPassOverlay(t *testing.T) {
 func TestDeleteSnapshotFiles_RemovesSidecars(t *testing.T) {
 	root := t.TempDir()
 	vmID := "vm-abc"
-	snap := filepath.Join(root, vmID, "vmstate.snap")
-	mem := filepath.Join(root, vmID, "mem.diff")
+	dir := filepath.Join(root, vmID)
+	snap := filepath.Join(dir, "vmstate.2.snap") // newest (committed) vmstate
+	mem := filepath.Join(dir, "mem.2.diff")      // newest overlay
 	overlay := snap + ".overlay"
-	base := layeredBaseSidecarPath(mem) // mem.diff.base
-	for _, p := range []string{snap, mem, overlay, base} {
+	base := layeredBaseSidecarPath(mem)
+	// A multi-pause append chain leaves older per-layer vmstates + sidecars + the bridge
+	// offsets sidecar; the manifest names only the newest. All must be reclaimed on delete.
+	older := []string{
+		filepath.Join(dir, "vmstate.0.snap"), filepath.Join(dir, "vmstate.0.snap.overlay"),
+		filepath.Join(dir, "vmstate.1.snap"), filepath.Join(dir, "vmstate.1.snap.overlay"),
+		filepath.Join(dir, "mem.0.diff"), filepath.Join(dir, "mem.1.diff"),
+		filepath.Join(dir, bridgeDirtyOffsetsName),
+	}
+	for _, p := range append([]string{snap, mem, overlay, base}, older...) {
 		writeFile(t, p)
 	}
+	man := &snapshotManifest{Base: "/tpl/mem.snap", Overlays: []string{"mem.0.diff", "mem.1.diff", "mem.2.diff"}, Vmstate: "vmstate.2.snap"}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
 
-	mgr := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: root}}
 	if err := mgr.DeleteSnapshotFiles(vmID, snap, mem); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	// A leftover sidecar would make a later restore mis-handle a non-layered
-	// mem file as a layered overlay — the fork-bug class both removals prevent.
-	for _, p := range []string{overlay, base} {
+	// Nothing snapshot-related must survive: leftover sidecars cause fork bugs, and leftover
+	// per-layer vmstates/overlays leak block-overlay data and keep the dir from being reclaimed.
+	for _, p := range append([]string{overlay, base}, older...) {
 		if _, err := os.Stat(p); !os.IsNotExist(err) {
-			t.Errorf("sidecar still exists: %s (%v)", p, err)
+			t.Errorf("still exists after delete: %s (%v)", p, err)
 		}
 	}
 }

--- a/internal/vm/memfd.go
+++ b/internal/vm/memfd.go
@@ -1,0 +1,59 @@
+package vm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// guestMemLink is the /proc/<pid>/fd readlink target of Firecracker's
+// MAP_SHARED guest-memory memfd (created as memfd_create("guest_mem", ...) when
+// shared_mem is set). The kernel reports a memfd as "/memfd:<name> (deleted)".
+const guestMemLink = "/memfd:guest_mem (deleted)"
+
+// captureGuestMemFd finds the guest-memory memfd of a running Firecracker
+// process and reopens it as a fd owned by vmd. Holding the returned file keeps
+// the guest RAM resident after that Firecracker exits — a memfd's pages live as
+// long as any fd references the inode — which is what lets a paused VM's frozen
+// memory be handed to a fresh Firecracker for an immediate resume.
+//
+// The Firecracker must have been restored with shared_mem on (VMD_SHARED_MEM);
+// otherwise its guest memory is an anonymous mapping with no memfd and this
+// returns an error. O_RDONLY is sufficient: a new Firecracker copies pages out
+// of this source via UFFDIO_COPY and never writes back to it.
+func captureGuestMemFd(fcPID int) (*os.File, error) {
+	if fcPID <= 0 {
+		return nil, fmt.Errorf("capture guest_mem fd: invalid pid %d", fcPID)
+	}
+	fdDir := fmt.Sprintf("/proc/%d/fd", fcPID)
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return nil, fmt.Errorf("capture guest_mem fd: read %s: %w", fdDir, err)
+	}
+	for _, e := range entries {
+		link := filepath.Join(fdDir, e.Name())
+		target, err := os.Readlink(link)
+		if err != nil {
+			continue // fd closed between ReadDir and Readlink
+		}
+		if target != guestMemLink {
+			continue
+		}
+		// Reopen through the magic symlink: yields a new fd to the SAME memfd
+		// inode (same pages), independent of Firecracker's fd.
+		f, err := os.OpenFile(link, os.O_RDONLY, 0)
+		if err != nil {
+			return nil, fmt.Errorf("capture guest_mem fd: reopen %s: %w", link, err)
+		}
+		return f, nil
+	}
+	return nil, fmt.Errorf("capture guest_mem fd: no guest_mem memfd in pid %d (shared_mem not enabled?)", fcPID)
+}
+
+// guestMemFdPath returns the path a freshly spawned Firecracker can use to
+// reopen the memfd vmd holds: vmd's own /proc fd entry. Valid only while vmd
+// keeps f open and the spawned process can read vmd's /proc (same user, no
+// chroot — Firecracker runs un-jailed on the fleet).
+func guestMemFdPath(f *os.File) string {
+	return fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), int(f.Fd()))
+}

--- a/internal/vm/memfd.go
+++ b/internal/vm/memfd.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,6 +49,64 @@ func captureGuestMemFd(fcPID int) (*os.File, error) {
 		return f, nil
 	}
 	return nil, fmt.Errorf("capture guest_mem fd: no guest_mem memfd in pid %d (shared_mem not enabled?)", fcPID)
+}
+
+// readDirtyOffsets parses the dirty-page-offsets sidecar Firecracker writes for a
+// memfd-bridge pause: a sequence of little-endian u64 byte offsets (ascending). These
+// are the exact pages a normal diff dump would have written.
+func readDirtyOffsets(path string) ([]uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read dirty offsets: %w", err)
+	}
+	if len(data)%8 != 0 {
+		return nil, fmt.Errorf("dirty offsets sidecar %q has truncated length %d", path, len(data))
+	}
+	offsets := make([]uint64, len(data)/8)
+	for i := range offsets {
+		offsets[i] = binary.LittleEndian.Uint64(data[i*8:])
+	}
+	return offsets, nil
+}
+
+// dumpMemfdPages copies the pages at `offsets` from the held guest-memory memfd into a
+// fresh sparse diff layer at dstPath, producing the same overlay a Firecracker diff dump
+// would have (only dirtied pages written; the rest left as holes that fall through to the
+// base on restore). The layer is sized to the full memfd (guest RAM) so the offsets are
+// valid and unwritten regions read as zero holes. Fsyncs before returning (the durability
+// point is the caller's manifest commit, which follows).
+func dumpMemfdPages(src *os.File, offsets []uint64, dstPath string, pageSize int) error {
+	info, err := src.Stat()
+	if err != nil {
+		return fmt.Errorf("stat memfd: %w", err)
+	}
+	total := info.Size()
+
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("open diff layer: %w", err)
+	}
+	defer dst.Close()
+	if err := dst.Truncate(total); err != nil {
+		return fmt.Errorf("size diff layer: %w", err)
+	}
+
+	buf := make([]byte, pageSize)
+	for _, off := range offsets {
+		if int64(off)+int64(pageSize) > total {
+			return fmt.Errorf("dirty offset %d + page exceeds guest RAM %d", off, total)
+		}
+		if _, err := src.ReadAt(buf, int64(off)); err != nil {
+			return fmt.Errorf("read page at %d from memfd: %w", off, err)
+		}
+		if _, err := dst.WriteAt(buf, int64(off)); err != nil {
+			return fmt.Errorf("write page at %d to diff layer: %w", off, err)
+		}
+	}
+	if err := dst.Sync(); err != nil {
+		return fmt.Errorf("fsync diff layer: %w", err)
+	}
+	return nil
 }
 
 // guestMemFdPath returns the path a freshly spawned Firecracker can use to

--- a/internal/vm/memfd.go
+++ b/internal/vm/memfd.go
@@ -12,12 +12,17 @@ import (
 // orphan GC reclaims a stale one left by a crash mid-bridge.
 const bridgeDirtyOffsetsName = "mem.dirty.offsets"
 
-// guestMemLink is the /proc/<pid>/fd readlink target of Firecracker's
-// MAP_SHARED guest-memory memfd (created as memfd_create("guest_mem", ...) when
-// shared_mem is set). The kernel reports a memfd as "/memfd:<name> (deleted)".
-const guestMemLink = "/memfd:guest_mem (deleted)"
+// guestMemLink is the /proc/<pid>/fd readlink target of Firecracker's MAP_SHARED guest-memory
+// memfd for vmID. Firecracker names it "guest_mem-<instance id>" (the instance id is the vmID vmd
+// passes as --id) and the kernel reports a memfd as "/memfd:<name> (deleted)". Matching the per-VM
+// name — not a generic "guest_mem" — ties the capture to the intended VM: on a mis-resolved PID the
+// names won't match, so capture fails and the caller falls back to the safe resume path rather than
+// handing back another tenant's memory.
+func guestMemLink(vmID string) string {
+	return fmt.Sprintf("/memfd:guest_mem-%s (deleted)", vmID)
+}
 
-// captureGuestMemFd finds the guest-memory memfd of a running Firecracker
+// captureGuestMemFd finds vmID's guest-memory memfd in a running Firecracker
 // process and reopens it as a fd owned by vmd. Holding the returned file keeps
 // the guest RAM resident after that Firecracker exits — a memfd's pages live as
 // long as any fd references the inode — which is what lets a paused VM's frozen
@@ -27,10 +32,11 @@ const guestMemLink = "/memfd:guest_mem (deleted)"
 // otherwise its guest memory is an anonymous mapping with no memfd and this
 // returns an error. O_RDONLY is sufficient: a new Firecracker copies pages out
 // of this source via UFFDIO_COPY and never writes back to it.
-func captureGuestMemFd(fcPID int) (*os.File, error) {
+func captureGuestMemFd(fcPID int, vmID string) (*os.File, error) {
 	if fcPID <= 0 {
 		return nil, fmt.Errorf("capture guest_mem fd: invalid pid %d", fcPID)
 	}
+	want := guestMemLink(vmID)
 	fdDir := fmt.Sprintf("/proc/%d/fd", fcPID)
 	entries, err := os.ReadDir(fdDir)
 	if err != nil {
@@ -42,7 +48,7 @@ func captureGuestMemFd(fcPID int) (*os.File, error) {
 		if err != nil {
 			continue // fd closed between ReadDir and Readlink
 		}
-		if target != guestMemLink {
+		if target != want {
 			continue
 		}
 		// Reopen through the magic symlink: yields a new fd to the SAME memfd
@@ -53,7 +59,7 @@ func captureGuestMemFd(fcPID int) (*os.File, error) {
 		}
 		return f, nil
 	}
-	return nil, fmt.Errorf("capture guest_mem fd: no guest_mem memfd in pid %d (shared_mem not enabled?)", fcPID)
+	return nil, fmt.Errorf("capture guest_mem fd: no %s memfd in pid %d (shared_mem not enabled? wrong pid?)", want, fcPID)
 }
 
 // readDirtyOffsets parses the dirty-page-offsets sidecar Firecracker writes for a

--- a/internal/vm/memfd.go
+++ b/internal/vm/memfd.go
@@ -7,6 +7,11 @@ import (
 	"path/filepath"
 )
 
+// bridgeDirtyOffsetsName is the per-sandbox sidecar a memfd-bridge pause writes (the
+// dirty page offsets vmd copies from the memfd). Removed when the flush completes; the
+// orphan GC reclaims a stale one left by a crash mid-bridge.
+const bridgeDirtyOffsetsName = "mem.dirty.offsets"
+
 // guestMemLink is the /proc/<pid>/fd readlink target of Firecracker's
 // MAP_SHARED guest-memory memfd (created as memfd_create("guest_mem", ...) when
 // shared_mem is set). The kernel reports a memfd as "/memfd:<name> (deleted)".

--- a/internal/vm/memfd_test.go
+++ b/internal/vm/memfd_test.go
@@ -1,0 +1,72 @@
+package vm
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestCaptureGuestMemFd exercises the locate-by-readlink + magic-symlink reopen
+// against a real memfd created in this process, named exactly like Firecracker's
+// guest-memory memfd. It proves the reopened fd refers to the same inode (same
+// pages) and survives the original fd being closed.
+func TestCaptureGuestMemFd(t *testing.T) {
+	// memfd_create("guest_mem") — same name Firecracker uses, so /proc/self/fd
+	// reports the readlink captureGuestMemFd matches on.
+	mfd, err := unix.MemfdCreate("guest_mem", 0)
+	if err != nil {
+		t.Fatalf("memfd_create: %v", err)
+	}
+	orig := os.NewFile(uintptr(mfd), "guest_mem")
+
+	const want = "page-zero-marker"
+	if err := orig.Truncate(4096); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if _, err := orig.WriteAt([]byte(want), 0); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	held, err := captureGuestMemFd(os.Getpid())
+	if err != nil {
+		t.Fatalf("captureGuestMemFd: %v", err)
+	}
+	defer held.Close()
+
+	// Same inode ⇒ same memory object, not a copy.
+	var origStat, heldStat unix.Stat_t
+	if err := unix.Fstat(int(orig.Fd()), &origStat); err != nil {
+		t.Fatalf("fstat orig: %v", err)
+	}
+	if err := unix.Fstat(int(held.Fd()), &heldStat); err != nil {
+		t.Fatalf("fstat held: %v", err)
+	}
+	if origStat.Ino != heldStat.Ino || origStat.Dev != heldStat.Dev {
+		t.Fatalf("captured fd is a different inode: orig dev=%d ino=%d held dev=%d ino=%d",
+			origStat.Dev, origStat.Ino, heldStat.Dev, heldStat.Ino)
+	}
+
+	// Close the original (simulating Firecracker exiting): pages must persist
+	// because the held fd still references the inode.
+	if err := orig.Close(); err != nil {
+		t.Fatalf("close orig: %v", err)
+	}
+	buf := make([]byte, len(want))
+	if _, err := held.ReadAt(buf, 0); err != nil {
+		t.Fatalf("read via held fd after orig close: %v", err)
+	}
+	if string(buf) != want {
+		t.Fatalf("held fd content = %q, want %q", buf, want)
+	}
+}
+
+func TestCaptureGuestMemFdAbsent(t *testing.T) {
+	// This test process has no guest_mem memfd ⇒ must error, not panic.
+	if _, err := captureGuestMemFd(os.Getpid()); err == nil {
+		t.Fatal("expected error when no guest_mem memfd is present")
+	}
+	if _, err := captureGuestMemFd(0); err == nil {
+		t.Fatal("expected error for invalid pid 0")
+	}
+}

--- a/internal/vm/memfd_test.go
+++ b/internal/vm/memfd_test.go
@@ -15,9 +15,10 @@ import (
 // guest-memory memfd. It proves the reopened fd refers to the same inode (same
 // pages) and survives the original fd being closed.
 func TestCaptureGuestMemFd(t *testing.T) {
-	// memfd_create("guest_mem") — same name Firecracker uses, so /proc/self/fd
+	const vmID = "sandbox-abc123"
+	// memfd_create("guest_mem-<vmID>") — the per-VM name Firecracker uses, so /proc/self/fd
 	// reports the readlink captureGuestMemFd matches on.
-	mfd, err := unix.MemfdCreate("guest_mem", 0)
+	mfd, err := unix.MemfdCreate("guest_mem-"+vmID, 0)
 	if err != nil {
 		t.Fatalf("memfd_create: %v", err)
 	}
@@ -31,11 +32,17 @@ func TestCaptureGuestMemFd(t *testing.T) {
 		t.Fatalf("write marker: %v", err)
 	}
 
-	held, err := captureGuestMemFd(os.Getpid())
+	held, err := captureGuestMemFd(os.Getpid(), vmID)
 	if err != nil {
 		t.Fatalf("captureGuestMemFd: %v", err)
 	}
 	defer held.Close()
+
+	// Per-VM safety: a capture for a different vmID must NOT match this memfd — so a
+	// mis-resolved PID pointing at another tenant's Firecracker can't hand back its RAM.
+	if _, err := captureGuestMemFd(os.Getpid(), "other-vm"); err == nil {
+		t.Fatal("captureGuestMemFd matched a memfd whose vmID differs; per-VM name safety broken")
+	}
 
 	// Same inode ⇒ same memory object, not a copy.
 	var origStat, heldStat unix.Stat_t
@@ -140,11 +147,11 @@ func TestReadDirtyOffsetsTruncated(t *testing.T) {
 }
 
 func TestCaptureGuestMemFdAbsent(t *testing.T) {
-	// This test process has no guest_mem memfd ⇒ must error, not panic.
-	if _, err := captureGuestMemFd(os.Getpid()); err == nil {
-		t.Fatal("expected error when no guest_mem memfd is present")
+	// This test process has no guest_mem memfd for this vmID ⇒ must error, not panic.
+	if _, err := captureGuestMemFd(os.Getpid(), "sandbox-none"); err == nil {
+		t.Fatal("expected error when no matching guest_mem memfd is present")
 	}
-	if _, err := captureGuestMemFd(0); err == nil {
+	if _, err := captureGuestMemFd(0, "sandbox-none"); err == nil {
 		t.Fatal("expected error for invalid pid 0")
 	}
 }

--- a/internal/vm/memfd_test.go
+++ b/internal/vm/memfd_test.go
@@ -1,7 +1,10 @@
 package vm
 
 import (
+	"bytes"
+	"encoding/binary"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -58,6 +61,81 @@ func TestCaptureGuestMemFd(t *testing.T) {
 	}
 	if string(buf) != want {
 		t.Fatalf("held fd content = %q, want %q", buf, want)
+	}
+}
+
+// TestDumpMemfdPages drives the bridge dump end to end: a memfd with two dirty pages,
+// a dirty-offsets sidecar naming them, then readDirtyOffsets + dumpMemfdPages must
+// reproduce exactly those pages in a sparse diff layer (the rest left as zero holes).
+func TestDumpMemfdPages(t *testing.T) {
+	ps := os.Getpagesize()
+	const npages = 5
+
+	fd, err := unix.MemfdCreate("guest_mem", 0)
+	if err != nil {
+		t.Fatalf("memfd_create: %v", err)
+	}
+	src := os.NewFile(uintptr(fd), "guest_mem")
+	defer src.Close()
+	if err := src.Truncate(int64(npages * ps)); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	// Dirty pages 1 (0xAA) and 3 (0xBB); pages 0,2,4 stay holes.
+	if _, err := src.WriteAt(bytes.Repeat([]byte{0xAA}, ps), int64(1*ps)); err != nil {
+		t.Fatalf("write page 1: %v", err)
+	}
+	if _, err := src.WriteAt(bytes.Repeat([]byte{0xBB}, ps), int64(3*ps)); err != nil {
+		t.Fatalf("write page 3: %v", err)
+	}
+
+	dir := t.TempDir()
+	sidecar := filepath.Join(dir, "mem.dirty.offsets")
+	var enc []byte
+	for _, off := range []uint64{uint64(1 * ps), uint64(3 * ps)} {
+		var b [8]byte
+		binary.LittleEndian.PutUint64(b[:], off)
+		enc = append(enc, b[:]...)
+	}
+	if err := os.WriteFile(sidecar, enc, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	offsets, err := readDirtyOffsets(sidecar)
+	if err != nil {
+		t.Fatalf("readDirtyOffsets: %v", err)
+	}
+	if want := []uint64{uint64(1 * ps), uint64(3 * ps)}; len(offsets) != 2 || offsets[0] != want[0] || offsets[1] != want[1] {
+		t.Fatalf("offsets = %v, want %v", offsets, want)
+	}
+
+	out := filepath.Join(dir, "mem.0.diff")
+	if err := dumpMemfdPages(src, offsets, out, ps); err != nil {
+		t.Fatalf("dumpMemfdPages: %v", err)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read out: %v", err)
+	}
+	if len(data) != npages*ps {
+		t.Fatalf("out size = %d, want %d", len(data), npages*ps)
+	}
+	for pg, want := range map[int]byte{0: 0x00, 1: 0xAA, 2: 0x00, 3: 0xBB, 4: 0x00} {
+		got := data[pg*ps : pg*ps+ps]
+		if !bytes.Equal(got, bytes.Repeat([]byte{want}, ps)) {
+			t.Fatalf("page %d: first byte 0x%02x, want all 0x%02x", pg, got[0], want)
+		}
+	}
+}
+
+func TestReadDirtyOffsetsTruncated(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "off")
+	if err := os.WriteFile(p, []byte{1, 2, 3}, 0o644); err != nil { // not a multiple of 8
+		t.Fatal(err)
+	}
+	if _, err := readDirtyOffsets(p); err == nil {
+		t.Fatal("expected error for truncated offsets file")
 	}
 }
 

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -391,6 +391,13 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				r.clearDrift("paused:" + id)
 				continue
 			}
+			// The DB-recorded path is gone, but an async/bridge flush failure can delete a
+			// not-yet-committed vmstate while the manifest still names the prior durable chain
+			// (which resume loads instead). Don't fail a sandbox still resumable from its manifest.
+			if r.mgr.resumableFromManifest(filepath.Dir(snapPath)) {
+				r.clearDrift("paused:" + id)
+				continue
+			}
 			if !r.gracePeriodElapsed("paused:"+id, now) {
 				continue
 			}

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -343,6 +343,35 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
+	// Drift 3b: a paused sandbox whose FC unit is still active and isn't flushing — a
+	// stranded Firecracker from an interrupted async flush (see isFlushing). Safe to
+	// stop: a paused sandbox should have no FC and its durable chain is on disk; only
+	// the stray FC is stopped (no markStale — it stays a valid paused sandbox).
+	// Guards: the grace period lets a normal resume-in-progress clear first, and
+	// isFlushing skips a live in-process flush.
+	for id := range active {
+		if r.mgr.isFlushing(id) {
+			r.clearDrift("stranded:" + id)
+			continue
+		}
+		rec, getErr := r.mgr.state.Get(id)
+		if getErr != nil || rec == nil || rec.Status != StatusPaused {
+			r.clearDrift("stranded:" + id)
+			continue
+		}
+		if !r.gracePeriodElapsed("stranded:"+id, now) {
+			continue
+		}
+		log.Warn().Str("vm_id", id).Str("drift", "paused_unit_active").
+			Msg("stranded Firecracker for paused sandbox (interrupted async flush) — stopping")
+		if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
+			log.Error().Err(err).Str("vm_id", id).Msg("failed to stop stranded FC")
+			continue
+		}
+		r.writeAudit(ctx, id, "stranded_stop", "interrupted async flush", "paused_unit_active")
+		r.clearDrift("stranded:" + id)
+	}
+
 	// Drift 4: DB says paused, snapshot file missing on disk → mark failed.
 	if dbSandboxes != nil {
 		for id, sb := range dbSandboxes {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -350,7 +350,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// Guards: the grace period lets a normal resume-in-progress clear first, and
 	// isFlushing skips a live in-process flush.
 	for id := range active {
-		if r.mgr.isFlushing(id) {
+		if r.mgr.isFlushing(id) || r.mgr.isRestoring(id) {
+			// A live flush or an in-progress resume/verify legitimately runs the unit while
+			// the record still reads paused — not a stranded FC.
 			r.clearDrift("stranded:" + id)
 			continue
 		}

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -218,7 +218,7 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 			continue
 		}
 		name := e.Name()
-		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName {
+		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName && name != vmstatePrevName {
 			continue
 		}
 		if referenced[name] {

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -193,6 +193,10 @@ const orphanGraceSeconds = 600
 // layerFileRe matches an overlay layer file name (mem.<n>.diff or mem.flat.<n>.diff).
 var layerFileRe = regexp.MustCompile(`^mem\.(?:\d+|flat\.\d+)\.diff$`)
 
+// vmstateFileRe matches a per-layer vmstate file (vmstate.<n>.snap). The one the manifest
+// records is kept; the rest are interrupted-pause orphans.
+var vmstateFileRe = regexp.MustCompile(`^vmstate\.\d+\.snap$`)
+
 // gcOrphanLayers reclaims layer/temp files the manifest doesn't reference that have
 // been untouched for the grace period — interrupted-flatten leftovers and stale
 // *.next temps. (Crashed-pause partials self-heal: the next append overwrites the
@@ -203,9 +207,12 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 	if err != nil || man == nil {
 		return 0, err
 	}
-	referenced := make(map[string]bool, len(man.Overlays))
+	referenced := make(map[string]bool, len(man.Overlays)+1)
 	for _, o := range man.Overlays {
 		referenced[o] = true
+	}
+	if man.Vmstate != "" {
+		referenced[man.Vmstate] = true // the committed vmstate pairs with this chain — keep it
 	}
 	entries, err := os.ReadDir(snapshotDir)
 	if err != nil {
@@ -218,7 +225,7 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 			continue
 		}
 		name := e.Name()
-		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName && name != vmstatePrevName {
+		if !layerFileRe.MatchString(name) && !vmstateFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName {
 			continue
 		}
 		if referenced[name] {

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -218,7 +218,7 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 			continue
 		}
 		name := e.Name()
-		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") {
+		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName {
 			continue
 		}
 		if referenced[name] {

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -59,21 +59,36 @@ const flattenPageSize = 4096
 // intact; a crash after it leaves the old layers as orphans for GC. The caller
 // must ensure the sandbox is quiescent (paused, no in-flight async flush). No-op
 // when the chain has fewer than two overlays.
-func (m *Manager) flattenChain(snapshotDir string) error {
+// flattenChain returns the merged overlay's path on success (empty for a no-op chain of < 2
+// overlays), so the caller can refresh the cached newest-layer for the next append.
+func (m *Manager) flattenChain(snapshotDir string) (string, error) {
 	man, err := readManifest(snapshotDir)
 	if err != nil {
-		return fmt.Errorf("flatten: read manifest: %w", err)
+		return "", fmt.Errorf("flatten: read manifest: %w", err)
 	}
 	if man == nil || len(man.Overlays) < 2 {
-		return nil
+		return "", nil
 	}
 
 	// All overlays share the base's logical size; stat the base for it.
 	baseInfo, err := os.Stat(man.Base)
 	if err != nil {
-		return fmt.Errorf("flatten: stat base %s: %w", man.Base, err)
+		return "", fmt.Errorf("flatten: stat base %s: %w", man.Base, err)
 	}
 	total := baseInfo.Size()
+
+	// Every overlay must cover full guest RAM (the base's size). The merge bounds each layer's scan
+	// by its own size, so a short/truncated overlay would silently drop its out-of-range pages to
+	// an older layer — reject it here (as the FC loader does at restore) rather than mis-merge.
+	for _, name := range man.Overlays {
+		info, err := os.Stat(filepath.Join(snapshotDir, name))
+		if err != nil {
+			return "", fmt.Errorf("flatten: stat overlay %s: %w", name, err)
+		}
+		if info.Size() != total {
+			return "", fmt.Errorf("flatten: overlay %s is %d bytes, expected %d (guest RAM)", name, info.Size(), total)
+		}
+	}
 
 	outName := nextFlatName(man.Overlays)
 	outTmp := filepath.Join(snapshotDir, outName+".next")
@@ -81,12 +96,12 @@ func (m *Manager) flattenChain(snapshotDir string) error {
 
 	out, err := os.OpenFile(outTmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
-		return fmt.Errorf("flatten: create %s: %w", outTmp, err)
+		return "", fmt.Errorf("flatten: create %s: %w", outTmp, err)
 	}
 	if err := out.Truncate(total); err != nil { // sparse: full logical size, no allocation
 		out.Close()
 		_ = os.Remove(outTmp)
-		return fmt.Errorf("flatten: size output: %w", err)
+		return "", fmt.Errorf("flatten: size output: %w", err)
 	}
 
 	written := make([]bool, (total+flattenPageSize-1)/flattenPageSize)
@@ -98,24 +113,24 @@ func (m *Manager) flattenChain(snapshotDir string) error {
 		if err := mergeOverlayPages(ov, out, written); err != nil {
 			out.Close()
 			_ = os.Remove(outTmp)
-			return fmt.Errorf("flatten: merge %s: %w", man.Overlays[i], err)
+			return "", fmt.Errorf("flatten: merge %s: %w", man.Overlays[i], err)
 		}
 	}
 	if err := out.Sync(); err != nil {
 		out.Close()
 		_ = os.Remove(outTmp)
-		return fmt.Errorf("flatten: sync output: %w", err)
+		return "", fmt.Errorf("flatten: sync output: %w", err)
 	}
 	if err := out.Close(); err != nil {
 		_ = os.Remove(outTmp)
-		return fmt.Errorf("flatten: close output: %w", err)
+		return "", fmt.Errorf("flatten: close output: %w", err)
 	}
 	if err := os.Rename(outTmp, outPath); err != nil {
 		_ = os.Remove(outTmp)
-		return fmt.Errorf("flatten: publish output: %w", err)
+		return "", fmt.Errorf("flatten: publish output: %w", err)
 	}
 	if err := fsyncDir(snapshotDir); err != nil {
-		return fmt.Errorf("flatten: fsync dir: %w", err)
+		return "", fmt.Errorf("flatten: fsync dir: %w", err)
 	}
 
 	// Commit point: the manifest now names only the merged overlay.
@@ -123,15 +138,22 @@ func (m *Manager) flattenChain(snapshotDir string) error {
 	man.Overlays = []string{outName}
 	if err := writeManifestAtomic(snapshotDir, man); err != nil {
 		_ = os.Remove(outPath)
-		return fmt.Errorf("flatten: commit manifest: %w", err)
+		return "", fmt.Errorf("flatten: commit manifest: %w", err)
 	}
-	// Reclaim the old layers — safe now, the manifest no longer references them.
+	// Flatten is about to UNLINK the prior chain, so the manifest rename must be durable first
+	// (writeManifestAtomic's own dir-fsync is best-effort — fine for an append, which falls back
+	// to the prior chain, but not here). On failure bail without deleting: the prior chain stays
+	// on disk and resumable.
+	if err := fsyncDir(snapshotDir); err != nil {
+		return "", fmt.Errorf("flatten: durable manifest commit: %w", err)
+	}
+	// Reclaim the old layers — safe now, the manifest no longer references them and is durable.
 	for _, name := range old {
 		if err := os.Remove(filepath.Join(snapshotDir, name)); err != nil && !os.IsNotExist(err) {
 			m.log.Warn().Err(err).Str("path", name).Msg("flatten: remove old layer")
 		}
 	}
-	return nil
+	return outPath, nil
 }
 
 // mergeOverlayPages copies every present page of ovPath (data extents found via

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -7,10 +7,41 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+// shouldFlatten reports whether a chain should be flattened: when it has at least
+// depthThreshold overlays (bounds restore fd/walk cost), OR — when bytesThreshold > 0
+// — its overlays occupy at least bytesThreshold allocated bytes (bounds storage).
+// depthThreshold <= 0 defaults to 16. A single overlay is never flattened.
+func shouldFlatten(overlayCount int, allocatedBytes int64, depthThreshold int, bytesThreshold int64) bool {
+	if overlayCount < 2 {
+		return false
+	}
+	if depthThreshold <= 0 {
+		depthThreshold = 16
+	}
+	if overlayCount >= depthThreshold {
+		return true
+	}
+	return bytesThreshold > 0 && allocatedBytes >= bytesThreshold
+}
+
+// allocatedBytes returns the on-disk bytes actually allocated to a (sparse) file
+// (st_blocks × 512), not its apparent size; 0 if it can't be stat'd.
+func allocatedBytes(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		return st.Blocks * 512
+	}
+	return info.Size()
+}
 
 // flattenPageSize is the granularity at which overlay pages are composed. Guest
 // RAM and the overlay files are page-aligned (guest RAM is MiB-sized), and the
@@ -19,10 +50,9 @@ import (
 const flattenPageSize = 4096
 
 // flattenChain merges a sandbox's overlay chain into a single sparse overlay
-// (newest owner of each page wins), keeping the shared read-only template base,
-// then republishes the manifest as base → merged. This bounds chain depth and
-// reclaims pages duplicated across layers, without copying the base (so base
-// sharing is preserved) and without spinning a VM or faulting guest RAM.
+// (newest owner of each page wins), keeping the shared template base, and
+// republishes the manifest as base → merged — bounding chain depth and reclaiming
+// pages duplicated across layers.
 //
 // Crash-safe: the merged overlay is written to a fresh name (never an input) and
 // the manifest swap is the commit point — a crash before it leaves the old chain
@@ -163,12 +193,11 @@ const orphanGraceSeconds = 600
 // layerFileRe matches an overlay layer file name (mem.<n>.diff or mem.flat.<n>.diff).
 var layerFileRe = regexp.MustCompile(`^mem\.(?:\d+|flat\.\d+)\.diff$`)
 
-// gcOrphanLayers reclaims layer and temp files in a chain sandbox's snapshot dir
-// that the current manifest does not reference and that have been untouched for the
-// grace period — interrupted-flatten leftovers and stale *.next temps. (Crashed-pause
-// partials self-heal: the next append removes the file at that index before reusing
-// it.) No-op for a non-chain dir (no manifest), so legacy/standalone snapshots are
-// never touched. Best-effort; returns apparent bytes reclaimed.
+// gcOrphanLayers reclaims layer/temp files the manifest doesn't reference that have
+// been untouched for the grace period — interrupted-flatten leftovers and stale
+// *.next temps. (Crashed-pause partials self-heal: the next append overwrites the
+// file at that index.) No-op for a non-chain dir, so legacy/standalone snapshots are
+// untouched. Best-effort; returns apparent bytes reclaimed.
 func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 	man, err := readManifest(snapshotDir)
 	if err != nil || man == nil {

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -151,6 +153,61 @@ func mergeOverlayPages(ovPath string, out *os.File, written []bool) error {
 		off = holeStart
 	}
 	return nil
+}
+
+// orphanGraceSeconds is how long an unreferenced layer/temp file must be
+// untouched before GC reclaims it, so a file an in-flight pause is mid-writing is
+// never removed.
+const orphanGraceSeconds = 600
+
+// layerFileRe matches an overlay layer file name (mem.<n>.diff or mem.flat.<n>.diff).
+var layerFileRe = regexp.MustCompile(`^mem\.(?:\d+|flat\.\d+)\.diff$`)
+
+// gcOrphanLayers reclaims layer and temp files in a chain sandbox's snapshot dir
+// that the current manifest does not reference and that have been untouched for the
+// grace period — interrupted-flatten leftovers and stale *.next temps. (Crashed-pause
+// partials self-heal: the next append removes the file at that index before reusing
+// it.) No-op for a non-chain dir (no manifest), so legacy/standalone snapshots are
+// never touched. Best-effort; returns apparent bytes reclaimed.
+func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
+	man, err := readManifest(snapshotDir)
+	if err != nil || man == nil {
+		return 0, err
+	}
+	referenced := make(map[string]bool, len(man.Overlays))
+	for _, o := range man.Overlays {
+		referenced[o] = true
+	}
+	entries, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		return 0, err
+	}
+	cutoff := time.Now().Add(-orphanGraceSeconds * time.Second)
+	var reclaimed int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !layerFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") {
+			continue
+		}
+		if referenced[name] {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue // recent → may be an in-flight write; leave it
+		}
+		p := filepath.Join(snapshotDir, name)
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			m.log.Warn().Err(err).Str("path", p).Msg("gc: remove orphan layer")
+			continue
+		}
+		reclaimed += info.Size()
+		m.log.Info().Str("file", name).Msg("gc: reclaimed orphan layer")
+	}
+	return reclaimed, nil
 }
 
 var flatNameRe = regexp.MustCompile(`^mem\.flat\.(\d+)\.diff$`)

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -197,6 +197,12 @@ var layerFileRe = regexp.MustCompile(`^mem\.(?:\d+|flat\.\d+)\.diff$`)
 // records is kept; the rest are interrupted-pause orphans.
 var vmstateFileRe = regexp.MustCompile(`^vmstate\.\d+\.snap$`)
 
+// vmstateOverlayFileRe matches a per-layer vmstate's block-overlay sidecar
+// (vmstate.<n>.snap.overlay — Firecracker reads "<vmstate>.overlay" on restore). The sidecar
+// paired with the manifest's committed vmstate is kept; the rest are orphans (older layers, or
+// an interrupted/failed pause).
+var vmstateOverlayFileRe = regexp.MustCompile(`^vmstate\.\d+\.snap\.overlay$`)
+
 // gcOrphanLayers reclaims layer/temp files the manifest doesn't reference that have
 // been untouched for the grace period — interrupted-flatten leftovers and stale
 // *.next temps. (Crashed-pause partials self-heal: the next append overwrites the
@@ -212,7 +218,8 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 		referenced[o] = true
 	}
 	if man.Vmstate != "" {
-		referenced[man.Vmstate] = true // the committed vmstate pairs with this chain — keep it
+		referenced[man.Vmstate] = true            // the committed vmstate pairs with this chain — keep it
+		referenced[man.Vmstate+".overlay"] = true // and its block-overlay sidecar (Firecracker reads <vmstate>.overlay)
 	}
 	entries, err := os.ReadDir(snapshotDir)
 	if err != nil {
@@ -225,7 +232,9 @@ func (m *Manager) gcOrphanLayers(snapshotDir string) (int64, error) {
 			continue
 		}
 		name := e.Name()
-		if !layerFileRe.MatchString(name) && !vmstateFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") && name != bridgeDirtyOffsetsName {
+		if !layerFileRe.MatchString(name) && !vmstateFileRe.MatchString(name) &&
+			!vmstateOverlayFileRe.MatchString(name) && !strings.HasSuffix(name, ".next") &&
+			name != bridgeDirtyOffsetsName {
 			continue
 		}
 		if referenced[name] {

--- a/internal/vm/snapshot_flatten.go
+++ b/internal/vm/snapshot_flatten.go
@@ -1,0 +1,170 @@
+package vm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// flattenPageSize is the granularity at which overlay pages are composed. Guest
+// RAM and the overlay files are page-aligned (guest RAM is MiB-sized), and the
+// loader requires the filesystem block size ≤ page size, so a data extent always
+// covers whole pages.
+const flattenPageSize = 4096
+
+// flattenChain merges a sandbox's overlay chain into a single sparse overlay
+// (newest owner of each page wins), keeping the shared read-only template base,
+// then republishes the manifest as base → merged. This bounds chain depth and
+// reclaims pages duplicated across layers, without copying the base (so base
+// sharing is preserved) and without spinning a VM or faulting guest RAM.
+//
+// Crash-safe: the merged overlay is written to a fresh name (never an input) and
+// the manifest swap is the commit point — a crash before it leaves the old chain
+// intact; a crash after it leaves the old layers as orphans for GC. The caller
+// must ensure the sandbox is quiescent (paused, no in-flight async flush). No-op
+// when the chain has fewer than two overlays.
+func (m *Manager) flattenChain(snapshotDir string) error {
+	man, err := readManifest(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("flatten: read manifest: %w", err)
+	}
+	if man == nil || len(man.Overlays) < 2 {
+		return nil
+	}
+
+	// All overlays share the base's logical size; stat the base for it.
+	baseInfo, err := os.Stat(man.Base)
+	if err != nil {
+		return fmt.Errorf("flatten: stat base %s: %w", man.Base, err)
+	}
+	total := baseInfo.Size()
+
+	outName := nextFlatName(man.Overlays)
+	outTmp := filepath.Join(snapshotDir, outName+".next")
+	outPath := filepath.Join(snapshotDir, outName)
+
+	out, err := os.OpenFile(outTmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("flatten: create %s: %w", outTmp, err)
+	}
+	if err := out.Truncate(total); err != nil { // sparse: full logical size, no allocation
+		out.Close()
+		_ = os.Remove(outTmp)
+		return fmt.Errorf("flatten: size output: %w", err)
+	}
+
+	written := make([]bool, (total+flattenPageSize-1)/flattenPageSize)
+	// Newest → oldest: the first layer to write a page is the newest owner, so
+	// older layers fill only pages the newer ones don't have. Pages owned by no
+	// overlay stay holes and fall through to the base on restore.
+	for i := len(man.Overlays) - 1; i >= 0; i-- {
+		ov := filepath.Join(snapshotDir, man.Overlays[i])
+		if err := mergeOverlayPages(ov, out, written); err != nil {
+			out.Close()
+			_ = os.Remove(outTmp)
+			return fmt.Errorf("flatten: merge %s: %w", man.Overlays[i], err)
+		}
+	}
+	if err := out.Sync(); err != nil {
+		out.Close()
+		_ = os.Remove(outTmp)
+		return fmt.Errorf("flatten: sync output: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(outTmp)
+		return fmt.Errorf("flatten: close output: %w", err)
+	}
+	if err := os.Rename(outTmp, outPath); err != nil {
+		_ = os.Remove(outTmp)
+		return fmt.Errorf("flatten: publish output: %w", err)
+	}
+	if err := fsyncDir(snapshotDir); err != nil {
+		return fmt.Errorf("flatten: fsync dir: %w", err)
+	}
+
+	// Commit point: the manifest now names only the merged overlay.
+	old := man.Overlays
+	man.Overlays = []string{outName}
+	if err := writeManifestAtomic(snapshotDir, man); err != nil {
+		_ = os.Remove(outPath)
+		return fmt.Errorf("flatten: commit manifest: %w", err)
+	}
+	// Reclaim the old layers — safe now, the manifest no longer references them.
+	for _, name := range old {
+		if err := os.Remove(filepath.Join(snapshotDir, name)); err != nil && !os.IsNotExist(err) {
+			m.log.Warn().Err(err).Str("path", name).Msg("flatten: remove old layer")
+		}
+	}
+	return nil
+}
+
+// mergeOverlayPages copies every present page of ovPath (data extents found via
+// SEEK_DATA/SEEK_HOLE — the same presence test the loader uses) into out at the
+// same offset, skipping any page a newer layer already wrote.
+func mergeOverlayPages(ovPath string, out *os.File, written []bool) error {
+	in, err := os.Open(ovPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	size := info.Size()
+	buf := make([]byte, flattenPageSize)
+	fd := int(in.Fd())
+
+	var off int64
+	for off < size {
+		dataStart, err := unix.Seek(fd, off, unix.SEEK_DATA)
+		if err != nil {
+			if err == unix.ENXIO { // no more data extents
+				break
+			}
+			return err
+		}
+		holeStart, err := unix.Seek(fd, dataStart, unix.SEEK_HOLE)
+		if err != nil {
+			return err
+		}
+		// Page-align the extent's start (a data extent always covers whole pages).
+		p := dataStart - (dataStart % flattenPageSize)
+		for p < holeStart {
+			idx := p / flattenPageSize
+			if idx < int64(len(written)) && !written[idx] {
+				n, rerr := in.ReadAt(buf, p)
+				if n != flattenPageSize {
+					return fmt.Errorf("short read at %d: %d bytes: %v", p, n, rerr)
+				}
+				if _, werr := out.WriteAt(buf, p); werr != nil {
+					return werr
+				}
+				written[idx] = true
+			}
+			p += flattenPageSize
+		}
+		off = holeStart
+	}
+	return nil
+}
+
+var flatNameRe = regexp.MustCompile(`^mem\.flat\.(\d+)\.diff$`)
+
+// nextFlatName returns a fresh "mem.flat.<n>.diff" name not present in overlays
+// (so the merge output never collides with one of its inputs).
+func nextFlatName(overlays []string) string {
+	max := -1
+	for _, o := range overlays {
+		if mm := flatNameRe.FindStringSubmatch(o); mm != nil {
+			if n, err := strconv.Atoi(mm[1]); err == nil && n > max {
+				max = n
+			}
+		}
+	}
+	return fmt.Sprintf("mem.flat.%d.diff", max+1)
+}

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -182,6 +182,31 @@ func TestGCOrphanLayers(t *testing.T) {
 	}
 }
 
+func TestShouldFlatten(t *testing.T) {
+	cases := []struct {
+		name      string
+		count     int
+		allocated int64
+		depth     int
+		bytes     int64
+		want      bool
+	}{
+		{"single overlay never flattens", 1, 1 << 40, 0, 1, false},
+		{"below both thresholds", 3, 100, 16, 1 << 30, false},
+		{"depth reached", 16, 0, 16, 0, true},
+		{"depth default when unset", 16, 0, 0, 0, true},
+		{"bytes reached below depth", 4, 2 << 30, 16, 1 << 30, true},
+		{"bytes disabled (0) below depth", 4, 1 << 40, 16, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldFlatten(c.count, c.allocated, c.depth, c.bytes); got != c.want {
+				t.Fatalf("shouldFlatten(%d,%d,%d,%d) = %v, want %v", c.count, c.allocated, c.depth, c.bytes, got, c.want)
+			}
+		})
+	}
+}
+
 func TestNextFlatName(t *testing.T) {
 	if n := nextFlatName([]string{"mem.0.diff", "mem.1.diff"}); n != "mem.flat.0.diff" {
 		t.Fatalf("got %q, want mem.flat.0.diff", n)

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -154,9 +154,15 @@ func TestGCOrphanLayers(t *testing.T) {
 	mk("mem.1.diff", true)         // aged orphan → reclaim
 	mk("manifest.json.next", true) // aged temp → reclaim
 	mk("mem.2.diff", false)        // recent orphan → keep (grace)
-	mk("vmstate.snap", true)       // not a layer/temp → keep
+	mk("vmstate.snap", true)       // legacy vmstate (no index) → not a layer/temp → keep
+	// Per-layer vmstate + its block-overlay sidecar: the committed one (man.Vmstate) and its
+	// sidecar are kept; an older/interrupted layer's vmstate + sidecar are aged orphans → reclaim.
+	mk("vmstate.5.snap", true)         // committed (man.Vmstate) → keep
+	mk("vmstate.5.snap.overlay", true) // committed sidecar → keep (FC reads <vmstate>.overlay)
+	mk("vmstate.1.snap", true)         // aged orphan vmstate → reclaim
+	mk("vmstate.1.snap.overlay", true) // aged orphan sidecar → reclaim
 
-	man := &snapshotManifest{Base: "/templates/x/mem.snap", Overlays: []string{"mem.0.diff"}}
+	man := &snapshotManifest{Base: "/templates/x/mem.snap", Overlays: []string{"mem.0.diff"}, Vmstate: "vmstate.5.snap"}
 	if err := writeManifestAtomic(dir, man); err != nil {
 		t.Fatal(err)
 	}
@@ -170,12 +176,12 @@ func TestGCOrphanLayers(t *testing.T) {
 		_, err := os.Stat(filepath.Join(dir, name))
 		return err == nil
 	}
-	for _, keep := range []string{"mem.0.diff", "mem.2.diff", "vmstate.snap", "manifest.json"} {
+	for _, keep := range []string{"mem.0.diff", "mem.2.diff", "vmstate.snap", "manifest.json", "vmstate.5.snap", "vmstate.5.snap.overlay"} {
 		if !exists(keep) {
 			t.Fatalf("%s was reclaimed but should be kept", keep)
 		}
 	}
-	for _, gone := range []string{"mem.1.diff", "manifest.json.next"} {
+	for _, gone := range []string{"mem.1.diff", "manifest.json.next", "vmstate.1.snap", "vmstate.1.snap.overlay"} {
 		if exists(gone) {
 			t.Fatalf("%s should have been reclaimed", gone)
 		}

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
@@ -128,6 +129,56 @@ func TestFlattenChain(t *testing.T) {
 	}
 	if !pageIsHole(t, merged, 3) {
 		t.Fatal("page 3 should be a hole (fall through to base), but it was written")
+	}
+}
+
+func TestGCOrphanLayers(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-time.Hour)
+
+	mk := func(name string, aged bool) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if aged {
+			if err := os.Chtimes(p, old, old); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Referenced layer (kept), an aged orphan layer (reclaimed), an aged temp
+	// (reclaimed), a recent orphan (kept — within grace), and an unrelated file (kept).
+	mk("mem.0.diff", true)         // referenced
+	mk("mem.1.diff", true)         // aged orphan → reclaim
+	mk("manifest.json.next", true) // aged temp → reclaim
+	mk("mem.2.diff", false)        // recent orphan → keep (grace)
+	mk("vmstate.snap", true)       // not a layer/temp → keep
+
+	man := &snapshotManifest{Base: "/templates/x/mem.snap", Overlays: []string{"mem.0.diff"}}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{log: zerolog.Nop()}
+	if _, err := m.gcOrphanLayers(dir); err != nil {
+		t.Fatalf("gcOrphanLayers: %v", err)
+	}
+
+	exists := func(name string) bool {
+		_, err := os.Stat(filepath.Join(dir, name))
+		return err == nil
+	}
+	for _, keep := range []string{"mem.0.diff", "mem.2.diff", "vmstate.snap", "manifest.json"} {
+		if !exists(keep) {
+			t.Fatalf("%s was reclaimed but should be kept", keep)
+		}
+	}
+	for _, gone := range []string{"mem.1.diff", "manifest.json.next"} {
+		if exists(gone) {
+			t.Fatalf("%s should have been reclaimed", gone)
+		}
 	}
 }
 

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -1,0 +1,141 @@
+package vm
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"golang.org/x/sys/unix"
+)
+
+const tPages = 4 // 4-page test images
+
+func tTotal() int64 { return tPages * flattenPageSize }
+
+// writeSparsePage writes a full page of byte b at page index idx into a file
+// pre-sized to the full image, leaving other pages as holes.
+func writeSparsePage(t *testing.T, path string, idx int, b byte) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := f.Truncate(tTotal()); err != nil {
+		t.Fatal(err)
+	}
+	page := bytes.Repeat([]byte{b}, flattenPageSize)
+	if _, err := f.WriteAt(page, int64(idx)*flattenPageSize); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readPage(t *testing.T, path string, idx int) []byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	buf := make([]byte, flattenPageSize)
+	if _, err := f.ReadAt(buf, int64(idx)*flattenPageSize); err != nil {
+		t.Fatal(err)
+	}
+	return buf
+}
+
+// pageIsHole reports whether the page at idx is a hole (not allocated) — i.e. the
+// flatten left it absent so restore falls through to the base.
+func pageIsHole(t *testing.T, path string, idx int) bool {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	off := int64(idx) * flattenPageSize
+	data, err := unix.Seek(int(f.Fd()), off, unix.SEEK_DATA)
+	if err == unix.ENXIO {
+		return true // no data at/after off
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data >= off+flattenPageSize // next data is past this page ⇒ this page is a hole
+}
+
+func TestFlattenChain(t *testing.T) {
+	dir := t.TempDir()
+
+	// Base: full image, all 'B'.
+	base := filepath.Join(dir, "base.mem")
+	bf, err := os.Create(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bf.WriteAt(bytes.Repeat([]byte{'B'}, int(tTotal())), 0); err != nil {
+		t.Fatal(err)
+	}
+	bf.Close()
+
+	// d0 owns pages 0 ('X') and 2 ('Y'); d1 (newest) owns page 0 ('Z').
+	writeSparsePage(t, filepath.Join(dir, "mem.0.diff"), 0, 'X')
+	writeSparsePage(t, filepath.Join(dir, "mem.0.diff"), 2, 'Y')
+	writeSparsePage(t, filepath.Join(dir, "mem.1.diff"), 0, 'Z')
+
+	man := &snapshotManifest{Base: base, Overlays: []string{"mem.0.diff", "mem.1.diff"}}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{log: zerolog.Nop()}
+	if err := m.flattenChain(dir); err != nil {
+		t.Fatalf("flattenChain: %v", err)
+	}
+
+	// Manifest collapsed to a single merged overlay; old layers gone.
+	got, err := readManifest(dir)
+	if err != nil || got == nil {
+		t.Fatalf("readManifest: %v", err)
+	}
+	if len(got.Overlays) != 1 || got.Overlays[0] != "mem.flat.0.diff" {
+		t.Fatalf("overlays = %v, want [mem.flat.0.diff]", got.Overlays)
+	}
+	if got.Base != base {
+		t.Fatalf("base = %q, want %q (base sharing must be preserved)", got.Base, base)
+	}
+	for _, old := range []string{"mem.0.diff", "mem.1.diff"} {
+		if _, err := os.Stat(filepath.Join(dir, old)); !os.IsNotExist(err) {
+			t.Fatalf("old layer %s not reclaimed", old)
+		}
+	}
+
+	merged := filepath.Join(dir, "mem.flat.0.diff")
+	// Page 0: newest owner (d1) wins → 'Z'.
+	if p0 := readPage(t, merged, 0); p0[0] != 'Z' {
+		t.Fatalf("page 0 = %q, want all 'Z' (newest-wins)", p0[0])
+	}
+	// Page 2: only d0 owns it → 'Y'.
+	if p2 := readPage(t, merged, 2); p2[0] != 'Y' {
+		t.Fatalf("page 2 = %q, want all 'Y'", p2[0])
+	}
+	// Pages 1 and 3: owned by no overlay → must stay holes (fall through to base),
+	// NOT written as zeros (which would shadow the base with zeros = corruption).
+	if !pageIsHole(t, merged, 1) {
+		t.Fatal("page 1 should be a hole (fall through to base), but it was written")
+	}
+	if !pageIsHole(t, merged, 3) {
+		t.Fatal("page 3 should be a hole (fall through to base), but it was written")
+	}
+}
+
+func TestNextFlatName(t *testing.T) {
+	if n := nextFlatName([]string{"mem.0.diff", "mem.1.diff"}); n != "mem.flat.0.diff" {
+		t.Fatalf("got %q, want mem.flat.0.diff", n)
+	}
+	if n := nextFlatName([]string{"mem.flat.0.diff", "mem.1.diff"}); n != "mem.flat.1.diff" {
+		t.Fatalf("got %q, want mem.flat.1.diff", n)
+	}
+}

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -92,8 +92,12 @@ func TestFlattenChain(t *testing.T) {
 	}
 
 	m := &Manager{log: zerolog.Nop()}
-	if err := m.flattenChain(dir); err != nil {
+	newest, err := m.flattenChain(dir)
+	if err != nil {
 		t.Fatalf("flattenChain: %v", err)
+	}
+	if filepath.Base(newest) != "mem.flat.0.diff" {
+		t.Fatalf("flattenChain returned newest %q, want …/mem.flat.0.diff", newest)
 	}
 
 	// Manifest collapsed to a single merged overlay; old layers gone.
@@ -129,6 +133,106 @@ func TestFlattenChain(t *testing.T) {
 	}
 	if !pageIsHole(t, merged, 3) {
 		t.Fatal("page 3 should be a hole (fall through to base), but it was written")
+	}
+}
+
+func TestFlattenChainRejectsShortOverlay(t *testing.T) {
+	// A truncated/short overlay would silently leave its out-of-range pages to an older layer.
+	// flattenChain must reject it (like the FC loader) and leave the chain intact, not mis-merge.
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.mem")
+	if err := os.WriteFile(base, bytes.Repeat([]byte{'B'}, int(tTotal())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSparsePage(t, filepath.Join(dir, "mem.0.diff"), 0, 'X') // full guest-RAM size
+	// mem.1.diff is one page long — shorter than guest RAM.
+	if err := os.WriteFile(filepath.Join(dir, "mem.1.diff"), bytes.Repeat([]byte{'Z'}, flattenPageSize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	man := &snapshotManifest{Base: base, Overlays: []string{"mem.0.diff", "mem.1.diff"}}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{log: zerolog.Nop()}
+	if _, err := m.flattenChain(dir); err == nil {
+		t.Fatal("flattenChain accepted a short overlay; want error")
+	}
+	if got, _ := readManifest(dir); got == nil || len(got.Overlays) != 2 {
+		t.Fatalf("chain not left intact after a rejected flatten: %+v", got)
+	}
+}
+
+func TestPlanLayerAppendAfterFlatten(t *testing.T) {
+	// After a flatten, a pause whose resumed mem file is the flattened newest must be recognized
+	// as an accumulating append — else VMD_LAYER_APPEND + VMD_LAYER_FLATTEN self-defeat (the pause
+	// falls back to standalone and drops the chain).
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.mem")
+	if err := os.WriteFile(base, bytes.Repeat([]byte{'B'}, int(tTotal())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSparsePage(t, filepath.Join(dir, "mem.0.diff"), 0, 'X')
+	writeSparsePage(t, filepath.Join(dir, "mem.1.diff"), 1, 'Y')
+	man := &snapshotManifest{Base: base, Overlays: []string{"mem.0.diff", "mem.1.diff"}}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{LayerAppendEnabled: true, IncrementalSnapshotEnabled: true}}
+	newest, err := m.flattenChain(dir)
+	if err != nil {
+		t.Fatalf("flattenChain: %v", err)
+	}
+	if _, _, ok := m.planLayerAppend(dir, true, base, newest); !ok {
+		t.Fatal("planLayerAppend rejected the flattened newest; append+flatten would drop the chain")
+	}
+}
+
+func TestMaybeFlattenDefersDuringRestore(t *testing.T) {
+	// A memfd bridge fast-resume skips waitForFlush and restores from the committed overlay
+	// chain while a bridge completion may call maybeFlatten. Flattening then would delete those
+	// overlay files out from under the in-flight restore. maybeFlatten must DEFER (not arm) while
+	// a restore is in flight (restoring) or a bridge memfd is held (holdingBridgeMemfd).
+	dir := t.TempDir()
+	man := &snapshotManifest{
+		Base:     "/templates/x/mem.snap",
+		Overlays: []string{"mem.0.diff", "mem.1.diff", "mem.2.diff"}, // depth 3 ≥ threshold 2 ⇒ flatten-worthy
+	}
+	if err := writeManifestAtomic(dir, man); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:        zerolog.Nop(),
+		flattenSem: make(chan struct{}, 2),
+		cfg:        ManagerConfig{LayerFlattenEnabled: true, FlattenChainDepth: 2},
+	}
+
+	armed := func(inst *VMInstance) bool {
+		m.maybeFlatten(inst, dir)
+		inst.mu.Lock()
+		defer inst.mu.Unlock()
+		return inst.flattening
+	}
+
+	if armed(&VMInstance{ID: "r", restoring: true}) {
+		t.Fatal("maybeFlatten armed flatten while a restore was in flight (would race the restore's lower-overlay reads)")
+	}
+	if armed(&VMInstance{ID: "h", holdingBridgeMemfd: true}) {
+		t.Fatal("maybeFlatten armed flatten while a bridge memfd was held for resume")
+	}
+	if len(m.flattenSem) != 0 {
+		t.Fatalf("deferred flatten leaked a flattenSem slot: len=%d, want 0", len(m.flattenSem))
+	}
+	// Sanity: with neither guard set, a flatten-worthy chain DOES arm.
+	clean := &VMInstance{ID: "c"}
+	m.maybeFlatten(clean, dir)
+	clean.mu.Lock()
+	gotArmed := clean.flattening
+	clean.mu.Unlock()
+	if !gotArmed {
+		t.Fatal("maybeFlatten did not arm flatten for a flatten-worthy chain with no restore in flight")
+	}
+	if clean.flattenDone != nil {
+		<-clean.flattenDone // let the background flatten finish (errors on the fake chain, but endFlatten still fires)
 	}
 }
 

--- a/internal/vm/snapshot_flatten_test.go
+++ b/internal/vm/snapshot_flatten_test.go
@@ -188,10 +188,12 @@ func TestPlanLayerAppendAfterFlatten(t *testing.T) {
 }
 
 func TestMaybeFlattenDefersDuringRestore(t *testing.T) {
-	// A memfd bridge fast-resume skips waitForFlush and restores from the committed overlay
-	// chain while a bridge completion may call maybeFlatten. Flattening then would delete those
-	// overlay files out from under the in-flight restore. maybeFlatten must DEFER (not arm) while
-	// a restore is in flight (restoring) or a bridge memfd is held (holdingBridgeMemfd).
+	// A memfd bridge fast-resume skips waitForFlush and restores from the committed overlay chain
+	// while a bridge completion may call maybeFlatten. Flattening then would delete those overlay
+	// files while the restore is still opening them, so maybeFlatten must DEFER while a restore is
+	// IN FLIGHT (restoring). It must NOT defer merely because a bridge memfd is held after the
+	// restore finished (the FC has the overlays mmap'd → deletion is safe), else continuous bridge
+	// pause/resume would starve flatten and grow the chain unbounded.
 	dir := t.TempDir()
 	man := &snapshotManifest{
 		Base:     "/templates/x/mem.snap",
@@ -206,33 +208,35 @@ func TestMaybeFlattenDefersDuringRestore(t *testing.T) {
 		cfg:        ManagerConfig{LayerFlattenEnabled: true, FlattenChainDepth: 2},
 	}
 
+	// armed reports whether maybeFlatten armed a flatten. flattenDone is set synchronously under
+	// the lock when arming and is never nil'd (endFlatten only closes it), so it's a race-free
+	// signal even after the background goroutine — which fails fast on the fake chain — completes.
+	// When it armed, we drain flattenDone so the goroutine releases its flattenSem slot.
 	armed := func(inst *VMInstance) bool {
 		m.maybeFlatten(inst, dir)
 		inst.mu.Lock()
-		defer inst.mu.Unlock()
-		return inst.flattening
+		ch := inst.flattenDone
+		inst.mu.Unlock()
+		if ch == nil {
+			return false
+		}
+		<-ch
+		return true
 	}
 
 	if armed(&VMInstance{ID: "r", restoring: true}) {
 		t.Fatal("maybeFlatten armed flatten while a restore was in flight (would race the restore's lower-overlay reads)")
 	}
-	if armed(&VMInstance{ID: "h", holdingBridgeMemfd: true}) {
-		t.Fatal("maybeFlatten armed flatten while a bridge memfd was held for resume")
+	// A held bridge memfd (restore already finished) must NOT defer flatten — else it starves.
+	if !armed(&VMInstance{ID: "h", holdingBridgeMemfd: true}) {
+		t.Fatal("maybeFlatten deferred flatten for a held-but-not-restoring bridge memfd (starves flatten)")
 	}
-	if len(m.flattenSem) != 0 {
-		t.Fatalf("deferred flatten leaked a flattenSem slot: len=%d, want 0", len(m.flattenSem))
-	}
-	// Sanity: with neither guard set, a flatten-worthy chain DOES arm.
-	clean := &VMInstance{ID: "c"}
-	m.maybeFlatten(clean, dir)
-	clean.mu.Lock()
-	gotArmed := clean.flattening
-	clean.mu.Unlock()
-	if !gotArmed {
+	// Neither guard set ⇒ arms.
+	if !armed(&VMInstance{ID: "c"}) {
 		t.Fatal("maybeFlatten did not arm flatten for a flatten-worthy chain with no restore in flight")
 	}
-	if clean.flattenDone != nil {
-		<-clean.flattenDone // let the background flatten finish (errors on the fake chain, but endFlatten still fires)
+	if len(m.flattenSem) != 0 {
+		t.Fatalf("flattenSem slot leaked: len=%d, want 0", len(m.flattenSem))
 	}
 }
 

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -3,7 +3,6 @@ package vm
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -29,6 +28,12 @@ type snapshotManifest struct {
 	// ordered oldest → newest. The newest is the active layer (the loader's
 	// snapshot path); the earlier ones are lower overlays.
 	Overlays []string `json:"overlays"`
+	// Vmstate is the file name (within the snapshot dir) of the CPU/device state that
+	// pairs with this chain. Recording it here makes the manifest the single atomic
+	// commit for {memory chain + vmstate}: the one manifest rename commits both, so a
+	// crash or failed flush can never leave a new vmstate paired with an old chain.
+	// Empty ⇒ legacy snapshot whose vmstate is the dir's "vmstate.snap".
+	Vmstate string `json:"vmstate,omitempty"`
 }
 
 const manifestFileName = "manifest.json"
@@ -86,59 +91,24 @@ func writeManifestAtomic(dir string, m *snapshotManifest) error {
 	return nil
 }
 
-// vmstatePrevName is the basename savePriorVmstate writes (the prior committed vmstate held
-// for revert during an async/bridge flush). The orphan GC reclaims a stale one left by a crash.
-const vmstatePrevName = "vmstate.snap.prev"
+// legacyVmstateName is the fixed vmstate file for non-layered / pre-manifest-vmstate
+// snapshots — used when a manifest doesn't record its own Vmstate.
+const legacyVmstateName = "vmstate.snap"
 
-// vmstatePrevPath is where savePriorVmstate stashes the prior committed vmstate.
-func vmstatePrevPath(vmstatePath string) string { return vmstatePath + ".prev" }
+// vmstateLayerName is the file name for the vmstate committed alongside chain index i. An
+// accumulating pause writes its CPU/device state here (not the shared vmstate.snap) and the
+// manifest commit records it, so {chain + vmstate} commit atomically and a failed/uncommitted
+// pause never replaces the prior committed vmstate.
+func vmstateLayerName(i int) string { return fmt.Sprintf("vmstate.%d.snap", i) }
 
-// savePriorVmstate copies the current committed vmstate aside before an accumulating async/
-// bridge pause overwrites it, so a failed background flush can revert to a vmstate that
-// matches the prior (still-committed) memory chain — otherwise resume would pair the failed
-// pause's new vmstate with old memory (torn). Copy, not move, so the live file stays valid
-// if the pause errors before writing a new one. Returns false when there's no prior vmstate.
-func savePriorVmstate(vmstatePath string) (bool, error) {
-	src, err := os.Open(vmstatePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
+// manifestVmstatePath resolves the committed vmstate file: the manifest's recorded Vmstate
+// when present, else the legacy dir/vmstate.snap.
+func manifestVmstatePath(dir string, m *snapshotManifest) string {
+	if m != nil && m.Vmstate != "" {
+		return filepath.Join(dir, m.Vmstate)
 	}
-	defer src.Close()
-	dst, err := os.Create(vmstatePrevPath(vmstatePath))
-	if err != nil {
-		return false, err
-	}
-	defer dst.Close()
-	if _, err := io.Copy(dst, src); err != nil {
-		return false, err
-	}
-	if err := dst.Sync(); err != nil {
-		return false, err
-	}
-	return true, nil
+	return filepath.Join(dir, legacyVmstateName)
 }
-
-// restorePriorVmstate reverts vmstate to the savePriorVmstate copy (on a failed flush) so
-// the on-disk vmstate matches the prior committed memory chain. No-op if absent.
-func restorePriorVmstate(vmstatePath string) error {
-	prev := vmstatePrevPath(vmstatePath)
-	if _, err := os.Stat(prev); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if err := os.Rename(prev, vmstatePath); err != nil {
-		return err
-	}
-	return fsyncDir(filepath.Dir(vmstatePath))
-}
-
-// discardPriorVmstate drops the saved copy once the flush commits (or is no longer needed).
-func discardPriorVmstate(vmstatePath string) { _ = os.Remove(vmstatePrevPath(vmstatePath)) }
 
 // removeManifest deletes the manifest so a standalone (non-layered) snapshot in the same
 // dir becomes authoritative for a resume. Used when a pause falls back to a Full image:

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -74,6 +75,60 @@ func writeManifestAtomic(dir string, m *snapshotManifest) error {
 	}
 	return fsyncDir(dir)
 }
+
+// vmstatePrevName is the basename savePriorVmstate writes (the prior committed vmstate held
+// for revert during an async/bridge flush). The orphan GC reclaims a stale one left by a crash.
+const vmstatePrevName = "vmstate.snap.prev"
+
+// vmstatePrevPath is where savePriorVmstate stashes the prior committed vmstate.
+func vmstatePrevPath(vmstatePath string) string { return vmstatePath + ".prev" }
+
+// savePriorVmstate copies the current committed vmstate aside before an accumulating async/
+// bridge pause overwrites it, so a failed background flush can revert to a vmstate that
+// matches the prior (still-committed) memory chain — otherwise resume would pair the failed
+// pause's new vmstate with old memory (torn). Copy, not move, so the live file stays valid
+// if the pause errors before writing a new one. Returns false when there's no prior vmstate.
+func savePriorVmstate(vmstatePath string) (bool, error) {
+	src, err := os.Open(vmstatePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer src.Close()
+	dst, err := os.Create(vmstatePrevPath(vmstatePath))
+	if err != nil {
+		return false, err
+	}
+	defer dst.Close()
+	if _, err := io.Copy(dst, src); err != nil {
+		return false, err
+	}
+	if err := dst.Sync(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// restorePriorVmstate reverts vmstate to the savePriorVmstate copy (on a failed flush) so
+// the on-disk vmstate matches the prior committed memory chain. No-op if absent.
+func restorePriorVmstate(vmstatePath string) error {
+	prev := vmstatePrevPath(vmstatePath)
+	if _, err := os.Stat(prev); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err := os.Rename(prev, vmstatePath); err != nil {
+		return err
+	}
+	return fsyncDir(filepath.Dir(vmstatePath))
+}
+
+// discardPriorVmstate drops the saved copy once the flush commits (or is no longer needed).
+func discardPriorVmstate(vmstatePath string) { _ = os.Remove(vmstatePrevPath(vmstatePath)) }
 
 // removeManifest deletes the manifest so a standalone (non-layered) snapshot in the same
 // dir becomes authoritative for a resume. Used when a pause falls back to a Full image:

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -1,0 +1,110 @@
+package vm
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// snapshotManifest records a layered memory snapshot as a read-only base image
+// plus an ordered chain of immutable diff overlays (oldest → newest). It is the
+// on-disk form for the append-only pause path: each pause appends a new overlay
+// and republishes the manifest, instead of merging the diff in place. An
+// interrupted write therefore can never corrupt a prior layer — the previously
+// committed manifest still points at the intact chain.
+//
+// It generalizes the single-overlay ".base" sidecar: that case is a one-element
+// chain. The manifest lives at <snapshotDir>/manifest.json alongside the overlay
+// files it names.
+type snapshotManifest struct {
+	// Base is the absolute path to the read-only template memory image — the
+	// chain's bottom layer (a full image), shared per template and living outside
+	// the sandbox's snapshot dir.
+	Base string `json:"base"`
+	// Overlays are the diff-layer file names (basenames within the snapshot dir),
+	// ordered oldest → newest. The newest is the active layer (the loader's
+	// snapshot path); the earlier ones are lower overlays.
+	Overlays []string `json:"overlays"`
+}
+
+const manifestFileName = "manifest.json"
+
+func manifestPath(dir string) string { return filepath.Join(dir, manifestFileName) }
+
+// overlayLayerName is the file name for the diff overlay at chain index i.
+func overlayLayerName(i int) string { return fmt.Sprintf("mem.%d.diff", i) }
+
+// readManifest loads the layered manifest from dir, or (nil, nil) when absent
+// (the non-layered / legacy single-overlay case).
+func readManifest(dir string) (*snapshotManifest, error) {
+	b, err := os.ReadFile(manifestPath(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var m snapshotManifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("parse snapshot manifest %s: %w", manifestPath(dir), err)
+	}
+	return &m, nil
+}
+
+// writeManifestAtomic publishes m via a temp file + rename, so a crash mid-write
+// leaves the previous manifest intact — the rename is the commit point. The temp
+// file and the directory are fsync'd so the published manifest is durable.
+func writeManifestAtomic(dir string, m *snapshotManifest) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	tmp := manifestPath(dir) + ".next"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	if err := fsyncFile(tmp); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, manifestPath(dir)); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return fsyncDir(dir)
+}
+
+// chainPaths resolves the manifest into absolute layer paths for a restore: the
+// base, the lower overlays (oldest → newest, all but the last), and the newest
+// overlay (the active snapshot path). ok is false when the chain has no overlays.
+func (m *snapshotManifest) chainPaths(dir string) (base string, lower []string, newest string, ok bool) {
+	if m == nil || len(m.Overlays) == 0 {
+		return "", nil, "", false
+	}
+	abs := make([]string, len(m.Overlays))
+	for i, name := range m.Overlays {
+		abs[i] = filepath.Join(dir, name)
+	}
+	return m.Base, abs[:len(abs)-1], abs[len(abs)-1], true
+}
+
+// fsyncFile flushes a file's contents to stable storage.
+func fsyncFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+// fsyncDir flushes a directory entry (so a rename within it is durable).
+func fsyncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/rs/zerolog/log"
 )
 
 // snapshotManifest records a layered memory snapshot as a read-only base image
@@ -73,7 +75,15 @@ func writeManifestAtomic(dir string, m *snapshotManifest) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	return fsyncDir(dir)
+	// The rename is the commit point — the manifest is now visible and names the new layer.
+	// A dir-fsync failure here only means the rename may not survive a power loss (which then
+	// falls back to the prior chain, still intact); it must NOT be returned, or callers would
+	// take it as a failed commit and delete the just-committed layer, leaving the live manifest
+	// pointing at a missing file. Surface it as a warning instead.
+	if err := fsyncDir(dir); err != nil {
+		log.Warn().Err(err).Str("dir", dir).Msg("manifest committed but dir fsync failed (not crash-durable)")
+	}
+	return nil
 }
 
 // vmstatePrevName is the basename savePriorVmstate writes (the prior committed vmstate held

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -75,6 +75,17 @@ func writeManifestAtomic(dir string, m *snapshotManifest) error {
 	return fsyncDir(dir)
 }
 
+// removeManifest deletes the manifest so a standalone (non-layered) snapshot in the same
+// dir becomes authoritative for a resume. Used when a pause falls back to a Full image:
+// the manifest must not keep naming the now-superseded chain. Absent manifest is not an
+// error. fsyncs the dir so the removal is durable before the caller relies on it.
+func removeManifest(dir string) error {
+	if err := os.Remove(manifestPath(dir)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return fsyncDir(dir)
+}
+
 // chainPaths resolves the manifest into absolute layer paths for a restore: the
 // base, the lower overlays (oldest → newest, all but the last), and the newest
 // overlay (the active snapshot path). ok is false when the chain has no overlays.

--- a/internal/vm/snapshot_manifest.go
+++ b/internal/vm/snapshot_manifest.go
@@ -95,10 +95,8 @@ func writeManifestAtomic(dir string, m *snapshotManifest) error {
 // snapshots — used when a manifest doesn't record its own Vmstate.
 const legacyVmstateName = "vmstate.snap"
 
-// vmstateLayerName is the file name for the vmstate committed alongside chain index i. An
-// accumulating pause writes its CPU/device state here (not the shared vmstate.snap) and the
-// manifest commit records it, so {chain + vmstate} commit atomically and a failed/uncommitted
-// pause never replaces the prior committed vmstate.
+// vmstateLayerName is the file name for the vmstate committed alongside chain index i
+// (recorded in the manifest's Vmstate — see that field).
 func vmstateLayerName(i int) string { return fmt.Sprintf("vmstate.%d.snap", i) }
 
 // manifestVmstatePath resolves the committed vmstate file: the manifest's recorded Vmstate

--- a/internal/vm/snapshot_manifest_test.go
+++ b/internal/vm/snapshot_manifest_test.go
@@ -1,0 +1,158 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSnapshotManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Absent manifest reads as (nil, nil), not an error.
+	if m, err := readManifest(dir); err != nil || m != nil {
+		t.Fatalf("readManifest(empty) = (%v, %v), want (nil, nil)", m, err)
+	}
+
+	want := &snapshotManifest{Base: "/templates/foo/mem.snap", Overlays: []string{"mem.0.diff", "mem.1.diff"}}
+	if err := writeManifestAtomic(dir, want); err != nil {
+		t.Fatalf("writeManifestAtomic: %v", err)
+	}
+	// The temp file must not survive a successful publish.
+	if _, err := os.Stat(manifestPath(dir) + ".next"); !os.IsNotExist(err) {
+		t.Fatalf("manifest .next survived publish: stat err = %v", err)
+	}
+	got, err := readManifest(dir)
+	if err != nil || got == nil {
+		t.Fatalf("readManifest after write = (%v, %v)", got, err)
+	}
+	if got.Base != want.Base || len(got.Overlays) != len(want.Overlays) {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+	for i := range want.Overlays {
+		if got.Overlays[i] != want.Overlays[i] {
+			t.Fatalf("overlay[%d] = %q, want %q", i, got.Overlays[i], want.Overlays[i])
+		}
+	}
+
+	// A corrupt manifest is an error, not a silent empty chain.
+	if err := os.WriteFile(manifestPath(dir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readManifest(dir); err == nil {
+		t.Fatal("readManifest(corrupt) = nil error, want parse error")
+	}
+}
+
+func TestChainPaths(t *testing.T) {
+	dir := "/snap/vm1"
+
+	// Empty chain → not ok.
+	empty := &snapshotManifest{Base: "/b"}
+	if _, _, _, ok := empty.chainPaths(dir); ok {
+		t.Fatal("chainPaths(empty) ok = true, want false")
+	}
+	if _, _, _, ok := (*snapshotManifest)(nil).chainPaths(dir); ok {
+		t.Fatal("chainPaths(nil) ok = true, want false")
+	}
+
+	m := &snapshotManifest{Base: "/templates/x/mem.snap", Overlays: []string{"mem.0.diff", "mem.1.diff", "mem.2.diff"}}
+	base, lower, newest, ok := m.chainPaths(dir)
+	if !ok {
+		t.Fatal("chainPaths ok = false, want true")
+	}
+	if base != "/templates/x/mem.snap" {
+		t.Fatalf("base = %q", base)
+	}
+	if newest != filepath.Join(dir, "mem.2.diff") {
+		t.Fatalf("newest = %q", newest)
+	}
+	wantLower := []string{filepath.Join(dir, "mem.0.diff"), filepath.Join(dir, "mem.1.diff")}
+	if len(lower) != len(wantLower) {
+		t.Fatalf("lower = %v, want %v", lower, wantLower)
+	}
+	for i := range wantLower {
+		if lower[i] != wantLower[i] {
+			t.Fatalf("lower[%d] = %q, want %q", i, lower[i], wantLower[i])
+		}
+	}
+
+	// Single overlay: no lower overlays, newest is that one.
+	one := &snapshotManifest{Base: "/b", Overlays: []string{"mem.0.diff"}}
+	_, lower1, newest1, _ := one.chainPaths(dir)
+	if len(lower1) != 0 || newest1 != filepath.Join(dir, "mem.0.diff") {
+		t.Fatalf("single overlay: lower=%v newest=%q", lower1, newest1)
+	}
+}
+
+func TestPlanLayerAppend(t *testing.T) {
+	tmpl := "/templates/x/mem.snap"
+
+	newMgr := func(layerAppend, incremental bool) *Manager {
+		return &Manager{
+			cfg: ManagerConfig{LayerAppendEnabled: layerAppend, IncrementalSnapshotEnabled: incremental},
+			log: zerolog.Nop(),
+		}
+	}
+
+	t.Run("disabled flags or no dirty tracking", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, _, ok := newMgr(false, true).planLayerAppend(dir, true, tmpl, tmpl); ok {
+			t.Fatal("append enabled with LayerAppend off")
+		}
+		if _, _, ok := newMgr(true, false).planLayerAppend(dir, true, tmpl, tmpl); ok {
+			t.Fatal("append enabled with Incremental off")
+		}
+		if _, _, ok := newMgr(true, true).planLayerAppend(dir, false, tmpl, tmpl); ok {
+			t.Fatal("append enabled without dirty tracking")
+		}
+	})
+
+	t.Run("first layer from template base", func(t *testing.T) {
+		dir := t.TempDir()
+		base, man, ok := newMgr(true, true).planLayerAppend(dir, true, tmpl, tmpl)
+		if !ok || base != tmpl || man == nil || len(man.Overlays) != 0 {
+			t.Fatalf("first layer = (%q, %+v, %v), want (%q, empty-overlays, true)", base, man, ok, tmpl)
+		}
+	})
+
+	t.Run("first layer rejected when not loaded from template", func(t *testing.T) {
+		dir := t.TempDir()
+		// instMemFile != instBaseMem → resumed from something else, not the base.
+		if _, _, ok := newMgr(true, true).planLayerAppend(dir, true, tmpl, "/some/other.diff"); ok {
+			t.Fatal("append allowed though VM didn't load from the template base")
+		}
+		// No base at all.
+		if _, _, ok := newMgr(true, true).planLayerAppend(dir, true, "", ""); ok {
+			t.Fatal("append allowed with no base")
+		}
+	})
+
+	t.Run("accumulating from newest overlay", func(t *testing.T) {
+		dir := t.TempDir()
+		man := &snapshotManifest{Base: tmpl, Overlays: []string{"mem.0.diff"}}
+		if err := writeManifestAtomic(dir, man); err != nil {
+			t.Fatal(err)
+		}
+		newest := filepath.Join(dir, "mem.0.diff")
+		base, got, ok := newMgr(true, true).planLayerAppend(dir, true, tmpl, newest)
+		if !ok || base != tmpl || got == nil || len(got.Overlays) != 1 {
+			t.Fatalf("accumulating = (%q, %+v, %v)", base, got, ok)
+		}
+	})
+
+	t.Run("accumulating rejected when not resumed from newest", func(t *testing.T) {
+		dir := t.TempDir()
+		man := &snapshotManifest{Base: tmpl, Overlays: []string{"mem.0.diff", "mem.1.diff"}}
+		if err := writeManifestAtomic(dir, man); err != nil {
+			t.Fatal(err)
+		}
+		// Resumed from mem.0.diff, but newest is mem.1.diff → a diff here would lose state.
+		stale := filepath.Join(dir, "mem.0.diff")
+		if _, _, ok := newMgr(true, true).planLayerAppend(dir, true, tmpl, stale); ok {
+			t.Fatal("append allowed though VM didn't resume from the newest overlay")
+		}
+	})
+}

--- a/internal/vm/snapshot_manifest_test.go
+++ b/internal/vm/snapshot_manifest_test.go
@@ -66,54 +66,40 @@ func TestRemoveManifest(t *testing.T) {
 	}
 }
 
-func TestPriorVmstatePreservation(t *testing.T) {
+func TestManifestVmstate(t *testing.T) {
 	dir := t.TempDir()
-	vmstate := filepath.Join(dir, "vmstate.snap")
-	if err := os.WriteFile(vmstate, []byte("committed-N"), 0o644); err != nil {
-		t.Fatal(err)
+
+	// A manifest that records its vmstate resolves to that per-layer file; the commit is
+	// atomic (the single manifest rename carries chain + vmstate), and round-trips.
+	want := &snapshotManifest{
+		Base:     "/templates/foo/mem.snap",
+		Overlays: []string{"mem.0.diff", "mem.1.diff"},
+		Vmstate:  vmstateLayerName(1),
+	}
+	if want.Vmstate != "vmstate.1.snap" {
+		t.Fatalf("vmstateLayerName(1) = %q, want vmstate.1.snap", want.Vmstate)
+	}
+	if err := writeManifestAtomic(dir, want); err != nil {
+		t.Fatalf("writeManifestAtomic: %v", err)
+	}
+	got, err := readManifest(dir)
+	if err != nil || got == nil {
+		t.Fatalf("readManifest = (%v, %v)", got, err)
+	}
+	if got.Vmstate != want.Vmstate {
+		t.Fatalf("round-trip Vmstate = %q, want %q", got.Vmstate, want.Vmstate)
+	}
+	if p := manifestVmstatePath(dir, got); p != filepath.Join(dir, "vmstate.1.snap") {
+		t.Fatalf("manifestVmstatePath = %q, want dir/vmstate.1.snap", p)
 	}
 
-	// Save copies the committed vmstate aside without disturbing the live file.
-	saved, err := savePriorVmstate(vmstate)
-	if err != nil || !saved {
-		t.Fatalf("savePriorVmstate = (%v, %v), want (true, nil)", saved, err)
+	// A manifest without a recorded vmstate (or no manifest) falls back to the legacy file.
+	legacy := &snapshotManifest{Base: "b", Overlays: []string{"mem.0.diff"}}
+	if p := manifestVmstatePath(dir, legacy); p != filepath.Join(dir, "vmstate.snap") {
+		t.Fatalf("legacy manifestVmstatePath = %q, want dir/vmstate.snap", p)
 	}
-	if b, _ := os.ReadFile(vmstate); string(b) != "committed-N" {
-		t.Fatalf("save disturbed the live vmstate: %q", b)
-	}
-
-	// The pause overwrites vmstate with the new (about-to-fail) state.
-	if err := os.WriteFile(vmstate, []byte("failed-N+1"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Restore (flush failed) reverts to the prior committed copy and clears it.
-	if err := restorePriorVmstate(vmstate); err != nil {
-		t.Fatalf("restorePriorVmstate: %v", err)
-	}
-	if b, _ := os.ReadFile(vmstate); string(b) != "committed-N" {
-		t.Fatalf("after restore vmstate = %q, want committed-N", b)
-	}
-	if _, err := os.Stat(vmstatePrevPath(vmstate)); !os.IsNotExist(err) {
-		t.Fatalf(".prev survived restore: %v", err)
-	}
-
-	// Discard (flush succeeded) just drops the copy; restore is then a no-op.
-	if _, err := savePriorVmstate(vmstate); err != nil {
-		t.Fatal(err)
-	}
-	discardPriorVmstate(vmstate)
-	if _, err := os.Stat(vmstatePrevPath(vmstate)); !os.IsNotExist(err) {
-		t.Fatalf(".prev survived discard: %v", err)
-	}
-	if err := restorePriorVmstate(vmstate); err != nil {
-		t.Fatalf("restorePriorVmstate(absent) = %v, want nil", err)
-	}
-
-	// No prior vmstate (first layer) ⇒ save reports nothing copied, no error.
-	empty := filepath.Join(dir, "missing.snap")
-	if saved, err := savePriorVmstate(empty); err != nil || saved {
-		t.Fatalf("savePriorVmstate(absent) = (%v, %v), want (false, nil)", saved, err)
+	if p := manifestVmstatePath(dir, nil); p != filepath.Join(dir, "vmstate.snap") {
+		t.Fatalf("nil manifestVmstatePath = %q, want dir/vmstate.snap", p)
 	}
 }
 

--- a/internal/vm/snapshot_manifest_test.go
+++ b/internal/vm/snapshot_manifest_test.go
@@ -66,6 +66,57 @@ func TestRemoveManifest(t *testing.T) {
 	}
 }
 
+func TestPriorVmstatePreservation(t *testing.T) {
+	dir := t.TempDir()
+	vmstate := filepath.Join(dir, "vmstate.snap")
+	if err := os.WriteFile(vmstate, []byte("committed-N"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save copies the committed vmstate aside without disturbing the live file.
+	saved, err := savePriorVmstate(vmstate)
+	if err != nil || !saved {
+		t.Fatalf("savePriorVmstate = (%v, %v), want (true, nil)", saved, err)
+	}
+	if b, _ := os.ReadFile(vmstate); string(b) != "committed-N" {
+		t.Fatalf("save disturbed the live vmstate: %q", b)
+	}
+
+	// The pause overwrites vmstate with the new (about-to-fail) state.
+	if err := os.WriteFile(vmstate, []byte("failed-N+1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore (flush failed) reverts to the prior committed copy and clears it.
+	if err := restorePriorVmstate(vmstate); err != nil {
+		t.Fatalf("restorePriorVmstate: %v", err)
+	}
+	if b, _ := os.ReadFile(vmstate); string(b) != "committed-N" {
+		t.Fatalf("after restore vmstate = %q, want committed-N", b)
+	}
+	if _, err := os.Stat(vmstatePrevPath(vmstate)); !os.IsNotExist(err) {
+		t.Fatalf(".prev survived restore: %v", err)
+	}
+
+	// Discard (flush succeeded) just drops the copy; restore is then a no-op.
+	if _, err := savePriorVmstate(vmstate); err != nil {
+		t.Fatal(err)
+	}
+	discardPriorVmstate(vmstate)
+	if _, err := os.Stat(vmstatePrevPath(vmstate)); !os.IsNotExist(err) {
+		t.Fatalf(".prev survived discard: %v", err)
+	}
+	if err := restorePriorVmstate(vmstate); err != nil {
+		t.Fatalf("restorePriorVmstate(absent) = %v, want nil", err)
+	}
+
+	// No prior vmstate (first layer) ⇒ save reports nothing copied, no error.
+	empty := filepath.Join(dir, "missing.snap")
+	if saved, err := savePriorVmstate(empty); err != nil || saved {
+		t.Fatalf("savePriorVmstate(absent) = (%v, %v), want (false, nil)", saved, err)
+	}
+}
+
 func TestChainPaths(t *testing.T) {
 	dir := "/snap/vm1"
 

--- a/internal/vm/snapshot_manifest_test.go
+++ b/internal/vm/snapshot_manifest_test.go
@@ -46,6 +46,26 @@ func TestSnapshotManifestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRemoveManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	// Removing an absent manifest is not an error (a Full-fallback dir may have none).
+	if err := removeManifest(dir); err != nil {
+		t.Fatalf("removeManifest(absent) = %v, want nil", err)
+	}
+
+	if err := writeManifestAtomic(dir, &snapshotManifest{Base: "b", Overlays: []string{"mem.0.diff"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeManifest(dir); err != nil {
+		t.Fatalf("removeManifest = %v", err)
+	}
+	// After removal a resume must not see a manifest (standalone snapshot is authoritative).
+	if m, err := readManifest(dir); err != nil || m != nil {
+		t.Fatalf("readManifest after remove = (%v, %v), want (nil, nil)", m, err)
+	}
+}
+
 func TestChainPaths(t *testing.T) {
 	dir := "/snap/vm1"
 

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -51,6 +51,11 @@ type VMRecord struct {
 	// Persisted so usage attribution survives a vmd restart.
 	TeamID  string `json:"team_id,omitempty"`
 	OwnerID string `json:"owner_id,omitempty"`
+	// Persisted so the bridge-memfd RAM cap holds across a vmd restart: a fast-resumed
+	// FC keeps the prior memfd mapped (~2× RAM) independent of vmd, so a reattached holder
+	// must still count against MaxBridgeMemfds. A stale true only makes the cap stricter
+	// (the safe direction) and clears at the sandbox's next pause.
+	HoldingBridgeMemfd bool `json:"holding_bridge_memfd,omitempty"`
 }
 
 // StateStore wraps a BoltDB database for VM state persistence.
@@ -152,51 +157,53 @@ func toRecord(inst *VMInstance) VMRecord {
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()
 	return VMRecord{
-		ID:           inst.ID,
-		PID:          inst.PID,
-		SocketPath:   inst.SocketPath,
-		VsockPath:    inst.VsockPath,
-		IP:           inst.IP,
-		TAPDevice:    inst.TAPDevice,
-		MACAddress:   inst.MACAddress,
-		Status:       inst.Status,
-		RunDirID:     inst.RunDirID,
-		Namespace:    inst.Namespace,
-		DiskPath:     inst.DiskPath,
-		SnapshotPath: inst.SnapshotPath,
-		MemFilePath:  inst.MemFilePath,
-		BaseMemPath:  inst.BaseMemPath,
-		CreatedAt:    inst.CreatedAt,
-		Metadata:     inst.Metadata,
-		VCPU:         inst.Config.VCPU,
-		MemoryMiB:    inst.Config.MemoryMiB,
-		BasePath:     inst.Config.BasePath,
-		TeamID:       inst.TeamID,
-		OwnerID:      inst.OwnerID,
+		ID:                 inst.ID,
+		PID:                inst.PID,
+		SocketPath:         inst.SocketPath,
+		VsockPath:          inst.VsockPath,
+		IP:                 inst.IP,
+		TAPDevice:          inst.TAPDevice,
+		MACAddress:         inst.MACAddress,
+		Status:             inst.Status,
+		RunDirID:           inst.RunDirID,
+		Namespace:          inst.Namespace,
+		DiskPath:           inst.DiskPath,
+		SnapshotPath:       inst.SnapshotPath,
+		MemFilePath:        inst.MemFilePath,
+		BaseMemPath:        inst.BaseMemPath,
+		CreatedAt:          inst.CreatedAt,
+		Metadata:           inst.Metadata,
+		VCPU:               inst.Config.VCPU,
+		MemoryMiB:          inst.Config.MemoryMiB,
+		BasePath:           inst.Config.BasePath,
+		TeamID:             inst.TeamID,
+		OwnerID:            inst.OwnerID,
+		HoldingBridgeMemfd: inst.holdingBridgeMemfd,
 	}
 }
 
 // toInstance converts a VMRecord back to a VMInstance.
 func toInstance(rec VMRecord) *VMInstance {
 	return &VMInstance{
-		ID:           rec.ID,
-		PID:          rec.PID,
-		SocketPath:   rec.SocketPath,
-		VsockPath:    rec.VsockPath,
-		IP:           rec.IP,
-		TAPDevice:    rec.TAPDevice,
-		MACAddress:   rec.MACAddress,
-		Status:       rec.Status,
-		RunDirID:     rec.RunDirID,
-		Namespace:    rec.Namespace,
-		DiskPath:     rec.DiskPath,
-		SnapshotPath: rec.SnapshotPath,
-		MemFilePath:  rec.MemFilePath,
-		BaseMemPath:  rec.BaseMemPath,
-		CreatedAt:    rec.CreatedAt,
-		Metadata:     rec.Metadata,
-		TeamID:       rec.TeamID,
-		OwnerID:      rec.OwnerID,
+		ID:                 rec.ID,
+		PID:                rec.PID,
+		SocketPath:         rec.SocketPath,
+		VsockPath:          rec.VsockPath,
+		IP:                 rec.IP,
+		TAPDevice:          rec.TAPDevice,
+		MACAddress:         rec.MACAddress,
+		Status:             rec.Status,
+		RunDirID:           rec.RunDirID,
+		Namespace:          rec.Namespace,
+		DiskPath:           rec.DiskPath,
+		SnapshotPath:       rec.SnapshotPath,
+		MemFilePath:        rec.MemFilePath,
+		BaseMemPath:        rec.BaseMemPath,
+		CreatedAt:          rec.CreatedAt,
+		Metadata:           rec.Metadata,
+		TeamID:             rec.TeamID,
+		OwnerID:            rec.OwnerID,
+		holdingBridgeMemfd: rec.HoldingBridgeMemfd,
 		Config: VMConfig{
 			VCPU:      rec.VCPU,
 			MemoryMiB: rec.MemoryMiB,


### PR DESCRIPTION
Server-side support for incremental, off-critical-path memory snapshots. **All behind flags, default off** — a flags-off vmd behaves identically to today, and new wire fields are omitted so an older Firecracker binary sees unchanged requests. Pairs with the companion Firecracker changes (layered chain loader + async write + memfd bridge).

## Append-only layered chain (`VMD_LAYER_APPEND`)
Immutable per-pause diff layers + an atomic manifest (`{base, overlays[], vmstate}`, published via temp-write + fsync + rename — the single commit point for the chain *and* its vmstate). Each pause appends a fresh `mem.N.diff`; restore composes `base → diff₁ → … → diffₙ` (newest-wins). An interrupted write can't corrupt a prior layer — the committed manifest still names the intact chain.

## Async pause (`VMD_ASYNC_PAUSE`)
A layered pause returns at the snapshot point and writes the diff on a Firecracker background thread; a goroutine awaits the write + fsync, commits the manifest (the durability point), then stops Firecracker. Resume / re-pause / delete wait for an in-flight flush so they only act on the committed chain. The first pause of a chain stays synchronous.

## Memfd-bridge fast resume (`VMD_SHARED_MEM`)
With memfd-backed guest RAM, a pause captures the memfd, snapshots vmstate + dirty offsets (no memory dump), stops the old Firecracker (the memfd keeps the RAM resident), and copies the dirty pages from the held memfd in the background. A resume *during* that flush serves faults from the memfd as the newest overlay instead of waiting for the disk write — so pause and resume stay ~constant regardless of dirty-set size. `VMD_MAX_BRIDGE_MEMFDS` bounds the extra RAM held fleet-wide.

## Flatten + GC (`VMD_LAYER_FLATTEN`)
Merges the overlay chain into one sparse overlay (newest-wins, shared base preserved) off the hot path once it reaches a depth or byte threshold (`VMD_FLATTEN_CHAIN_DEPTH` / `_BYTES`). Crash-safe (fresh output name + atomic manifest swap = commit point); orphan-GC reclaims interrupted-flatten leftovers and stale temps.
