### PR TITLE
controlplane: use CacheDescribe query mode for Supabase transaction pooler

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -15,6 +15,7 @@ import (
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/getsentry/sentry-go"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -92,6 +93,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("parse database url: %w", err)
 	}
+	// Supabase's transaction pooler (PgBouncer) does not preserve named
+	// prepared statements across transactions — connections are swapped between
+	// clients, so a statement prepared on backend B1 is gone on B2. CacheDescribe
+	// uses unnamed prepared statements (which don't persist) while still using
+	// the extended protocol for typed/binary parameter encoding.
+	poolCfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe
 	if v := os.Getenv("DB_MAX_CONNS"); v != "" {
 		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
 			poolCfg.MaxConns = int32(n)


### PR DESCRIPTION
## Summary

- pgx v5's default `ExtendedProtocol` mode caches **named** prepared statements per connection
- Supabase's transaction pooler (PgBouncer) swaps backend connections between transactions, so a statement prepared on backend B1 doesn't exist on B2 — every sqlc query is affected, not just the quota watcher
- `QueryExecModeCacheDescribe` fixes this by using **unnamed** prepared statements on every execution; these don't need to persist across connections, while still using the extended protocol for typed/binary parameter encoding (not plain text like `SimpleProtocol`)

**Note on the `42P10` production error:** `CacheDescribe` does not directly fix `42P10` — that error is raised at parse time when Postgres can't find a constraint matching the `ON CONFLICT` columns, regardless of statement naming. If the `quota_alert_state` primary key has been confirmed as `(team_id, quota_type, channel)` via the dashboard but `42P10` is still occurring in production, the likely cause is that the dashboard connection and the controlplane's `DATABASE_URL` are resolving the table in different schemas or connecting as different roles. Running `SELECT current_schema(), current_user` and the constraint check from the actual production `DATABASE_URL` would confirm this.

## Test plan

- [ ] Run `SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'quota_alert_state'::regclass AND contype = 'p'` directly via the production `DATABASE_URL` (not the Supabase dashboard) to confirm the constraint is visible to the controlplane's connection
- [ ] Confirm no "prepared statement does not exist" errors appear in production logs after deploy
- [ ] Verify quota watcher still fires correctly (suppressed/alerted counts appear in logs on next tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)