### PR TITLE
ci: add --no-cache to docker build to prevent stale binary deploys

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Build and push
         run: |
           IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane"
-          docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
+          # --no-cache prevents BuildKit from importing stale inline cache metadata
+          # from the existing :latest tag in the registry, which caused prod to deploy
+          # an old binary even when the source had changed (SQLSTATE 42P10 incident).
+          docker build --no-cache --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
           docker push ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
@@ -132,7 +135,7 @@ jobs:
       - name: Build and push
         run: |
           IMAGE="${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane"
-          docker build --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
+          docker build --no-cache --platform linux/amd64 -t ${IMAGE}:latest -t ${IMAGE}:${{ github.sha }} .
           docker push ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 


### PR DESCRIPTION
## What

Adds `--no-cache` to both the staging and production `docker build` commands in `deploy-api.yml`.

## Why

Docker BuildKit can automatically import inline cache metadata from an existing image tag in the registry (the `:latest` tag that was pushed by the previous run). On a fresh ephemeral runner, this is the only cache source available — but it's enough to cause BuildKit to reuse old layer content, including the compiled Go binary, even when the source files have changed.

This is what happened in the SQLSTATE 42P10 incident:

1. Migration `20260623000001_quota_alert_channel.sql` widened `quota_alert_state`'s PK from `(team_id, quota_type)` to `(team_id, quota_type, channel)`, removing the 2-column constraint.
2. The matching binary change (commit `69fa155`) compiled correctly and deployed.
3. A subsequent merge (`6b696b4`) triggered a fresh CI run, but the production Docker build resolved to the same old image digest (`sha256:3df7ff25...`) — the pre-`69fa155` binary with `ON CONFLICT (team_id, quota_type)`.
4. Cloud Run deployed the old binary against the new schema → every quota watcher tick hit `42P10`.

`--no-cache` forces Docker to rebuild all layers from scratch on every CI run, so the binary always reflects the checked-out source.

## Tradeoff

Builds take longer (~2–3 min extra for `go mod download` + `go build`). That's acceptable given the correctness guarantee. The alternative — a build-once-promote-to-production pattern — would be strictly better but requires granting the production service account `roles/artifactregistry.reader` on the staging project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)