### PR TITLE
controlplane: make ActivateSandbox + FinalizePause fire-and-forget

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -72,6 +72,54 @@ type Handlers struct {
 	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
 	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
 	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
+
+	// asyncMu/asyncCond/asyncCount track fire-and-forget bookkeeping goroutines
+	// (ActivateSandbox, FinalizePause) so tests can wait for quiescence;
+	// production never waits. Not a sync.WaitGroup: concurrent requests Add
+	// while a test's Wait is in flight, which WaitGroup forbids once the
+	// counter can touch zero mid-wait (the race detector flags the reuse).
+	asyncMu    sync.Mutex
+	asyncCond  *sync.Cond // lazily created by WaitAsyncBookkeeping, guarded by asyncMu
+	asyncCount int
+}
+
+// asyncBookkeeping runs a fire-and-forget post-VMD bookkeeping DB write in a
+// background goroutine. These writes are off the hot path by design: the gate
+// write (BeginPause/BeginResume/create INSERT) already owns the row, and every
+// subsequent transition is status-gated, so nothing can proceed until the
+// bookkeeping lands — a racing request just sees the transitional status and
+// 409s until the write commits.
+func (h *Handlers) asyncBookkeeping(name string, fn func()) {
+	h.asyncMu.Lock()
+	h.asyncCount++
+	h.asyncMu.Unlock()
+	go func() {
+		defer func() {
+			h.asyncMu.Lock()
+			h.asyncCount--
+			if h.asyncCount == 0 && h.asyncCond != nil {
+				h.asyncCond.Broadcast()
+			}
+			h.asyncMu.Unlock()
+		}()
+		defer sentrylog.Recover(name)
+		fn()
+	}()
+}
+
+// WaitAsyncBookkeeping blocks until no fire-and-forget bookkeeping goroutines
+// are in flight. Test-only: lets tests assert post-transition DB state
+// deterministically. Unlike WaitGroup.Wait it is safe to call while other
+// requests keep spawning bookkeeping work.
+func (h *Handlers) WaitAsyncBookkeeping() {
+	h.asyncMu.Lock()
+	defer h.asyncMu.Unlock()
+	if h.asyncCond == nil {
+		h.asyncCond = sync.NewCond(&h.asyncMu)
+	}
+	for h.asyncCount > 0 {
+		h.asyncCond.Wait()
+	}
 }
 
 // capture emits a usage event attributed to the API key's owner and team.
@@ -588,25 +636,35 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	if err := h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
-		ID:        sandboxID,
-		VcpuCount: int32(actualVcpu),
-		MemoryMib: int32(actualMemMiB),
-		IpAddress: ipAddr,
-		TeamID:    teamID,
-		ActorID:   actorUUID(actorIDFromContext(c)),
-	}); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ActivateSandbox failed")
-		pauseAndRevert()
-		respondError(c, ErrInternal)
-		return false
-	}
+	// Fire-and-forget: the resuming→active bookkeeping write is off the hot
+	// path. BeginResume's claim owns the row and every other transition is
+	// status-gated, so a racing pause/resume sees 'resuming' and 409s until
+	// this lands. On failure, re-pause in the background (overlay preserved);
+	// the client already holds a success response and the next request
+	// auto-resumes from the snapshot. Capture actor before the goroutine —
+	// gin.Context is recycled after ServeHTTP returns.
+	actorID := actorUUID(actorIDFromContext(c))
+	h.asyncBookkeeping("activate-sandbox", func() {
+		actx, acancel := context.WithTimeout(revertCtx, asyncTimeout)
+		defer acancel()
+		if err := h.DB.ActivateSandbox(actx, db.ActivateSandboxParams{
+			ID:        sandboxID,
+			VcpuCount: int32(actualVcpu),
+			MemoryMib: int32(actualMemMiB),
+			IpAddress: ipAddr,
+			TeamID:    teamID,
+			ActorID:   actorID,
+		}); err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async DB ActivateSandbox failed — re-pausing")
+			pauseAndRevert()
+		}
+	})
 
 	sandbox.VcpuCount = int32(actualVcpu)
 	sandbox.MemoryMib = int32(actualMemMiB)
 	sandbox.IpAddress = ipAddr
 
-	// ActivateSandbox's CTE atomically opened the sandbox_active_interval row.
+	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
 	return true
@@ -1758,21 +1816,20 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	sandbox.MemoryMib = int32(actualMemMiB)
 	sandbox.IpAddress = ipAddr
 
-	// ActivateSandbox (DB UPDATE) and network rule application (VMD call
-	// + DB UPDATE) are independent — both read VMD's result and write to
-	// their own sink. Run them in parallel so the response latency is
-	// max(activate, network) instead of activate + network.
-	hasNetworkRules := req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0)
-
-	// Capture before goroutine — gin.Context is recycled after ServeHTTP
-	// returns. The CTE inside ActivateSandbox uses this to open the
-	// matching sandbox_active_interval row in the same statement.
+	// Fire-and-forget: the starting→active bookkeeping write is off the hot
+	// path. The create INSERT owns the row and every other transition is
+	// status-gated, so a racing pause/exec sees 'starting' and 409s until
+	// this lands. Capture actor before the goroutine — gin.Context is
+	// recycled after ServeHTTP returns. The CTE inside ActivateSandbox uses
+	// it to open the matching sandbox_active_interval row in the same
+	// statement. postCtx is cancelled when the handler returns, so the
+	// goroutine derives its own detached deadline.
 	actorID := actorIDFromContext(c)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := h.DB.ActivateSandbox(postCtx, db.ActivateSandboxParams{
+	activateCtx := context.WithoutCancel(c.Request.Context())
+	h.asyncBookkeeping("activate-sandbox", func() {
+		actx, acancel := context.WithTimeout(activateCtx, asyncTimeout)
+		defer acancel()
+		if err := h.DB.ActivateSandbox(actx, db.ActivateSandboxParams{
 			ID:        sandbox.ID,
 			VcpuCount: int32(actualVcpu),
 			MemoryMib: int32(actualMemMiB),
@@ -1780,23 +1837,20 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			TeamID:    teamID,
 			ActorID:   actorUUID(actorID),
 		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("DB ActivateSandbox failed")
+			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("async DB ActivateSandbox failed")
 		}
-	}()
+	})
 
-	if hasNetworkRules {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			// network_config was persisted above (before env injection); this
-			// only pushes the nftables rules, which need the booted VM.
-			allowedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
-			if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, req.Network.DenyOut, allowedDomains); err != nil {
-				log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("failed to apply network rules at creation")
-			}
-		}()
+	// Network rules stay blocking: a 201 must imply "egress rules applied",
+	// so the client can't reach the sandbox before its policy is in place.
+	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
+		// network_config was persisted above (before env injection); this
+		// only pushes the nftables rules, which need the booted VM.
+		allowedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
+		if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, req.Network.DenyOut, allowedDomains); err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("failed to apply network rules at creation")
+		}
 	}
-	wg.Wait()
 	tPostDone := time.Now()
 
 	var createdMeta []byte
@@ -1806,7 +1860,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			"template_id":   fromTemplateID,
 		})
 	}
-	// ActivateSandbox's CTE atomically opened the sandbox_active_interval row.
+	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorID, "sandbox", "started", "success", &sandbox.Name, nil, createdMeta)
 	h.capture(c, "sandbox_created", map[string]any{
 		"sandbox_id":  sandbox.ID.String(),
@@ -1945,40 +1999,38 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		Str("mem_path", memPath).
 		Msg("VMD pause complete")
 
-	// Past this point the snapshot already exists on disk. Detach from
-	// cancellation so a client disconnect cannot orphan the snapshot
-	// files, but preserve the trace/span context so the snapshot row
-	// creation stays linked to the original pause request trace.
-	postCtx, postCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-	defer postCancel()
-
-	// Atomic post-VMD bookkeeping: upsert the snapshot row (keyed on the
-	// partial unique index over (sandbox_id) WHERE saved=false), link it
-	// to the sandbox, and flip status pausing → paused in a single CTE.
-	// The upsert replaces the old "insert a new row + delete the previous"
-	// flow, so there's no explicit prev-snapshot cleanup to schedule here.
-	if _, err := h.DB.FinalizePause(postCtx, db.FinalizePauseParams{
-		ID:        sandboxID,
-		TeamID:    teamID,
-		Path:      snapshotPath,
-		MemPath:   &memPath,
-		SizeBytes: 0,
-		Trigger:   "pause",
-	}); err != nil {
-		// ErrNoRows here means the sandbox was soft-deleted between
-		// BeginPause and FinalizePause (a rare race with DeleteSandbox).
-		// The VM is already stopped and its snapshot files are on disk —
-		// we can't finalize bookkeeping for a sandbox that no longer
-		// exists, so return 410 Gone.
-		if err == pgx.ErrNoRows {
-			log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
-			respondError(c, ErrSandboxGone)
-			return
+	// Past this point the snapshot already exists on disk — the pause has
+	// physically happened, so the bookkeeping (snapshot row upsert + status
+	// flip pausing → paused in a single CTE) is fire-and-forget. BeginPause's
+	// gate write owns the row and every other transition is status-gated, so
+	// a racing resume sees 'pausing' and 409s until this lands. Detached from
+	// cancellation so a client disconnect cannot orphan the bookkeeping;
+	// trace/span context preserved. The upsert replaces the old "insert a new
+	// row + delete the previous" flow, so there's no explicit prev-snapshot
+	// cleanup to schedule here.
+	finalizeCtx := context.WithoutCancel(c.Request.Context())
+	h.asyncBookkeeping("finalize-pause", func() {
+		fctx, fcancel := context.WithTimeout(finalizeCtx, asyncTimeout)
+		defer fcancel()
+		if _, err := h.DB.FinalizePause(fctx, db.FinalizePauseParams{
+			ID:        sandboxID,
+			TeamID:    teamID,
+			Path:      snapshotPath,
+			MemPath:   &memPath,
+			SizeBytes: 0,
+			Trigger:   "pause",
+		}); err != nil {
+			// ErrNoRows means the sandbox was soft-deleted between BeginPause
+			// and FinalizePause (a rare race with DeleteSandbox). The VM is
+			// already stopped and its snapshot files are on disk — nothing to
+			// finalize for a sandbox that no longer exists.
+			if err == pgx.ErrNoRows {
+				log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
+				return
+			}
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async DB FinalizePause failed — sandbox may be stuck in 'pausing'")
 		}
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB FinalizePause failed")
-		respondError(c, ErrInternal)
-		return
-	}
+	})
 
 	// Interval was already closed at BeginPause; FinalizePause is the
 	// end of the VMD pause work, not the moment the sandbox left active.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -180,6 +180,18 @@ const vmdTimeout = 30 * time.Second
 // asyncTimeout is the deadline for fire-and-forget DB writes.
 const asyncTimeout = 5 * time.Second
 
+// activateSettleWindow bounds how long status-gated read paths wait for the
+// fire-and-forget activate write to land. Create/resume respond before the
+// starting/resuming→active flip commits, so the owner's immediate follow-up
+// (create then exec — the canonical SDK flow) may read the pre-flip status;
+// waiting briefly preserves read-your-writes instead of 409ing it. Normally
+// the write lands in single-digit ms; a genuinely lost write still 409s once
+// the window expires. Var, not const, so tests can shrink it.
+var activateSettleWindow = 2 * time.Second
+
+// activateSettlePoll is the re-read interval within activateSettleWindow.
+const activateSettlePoll = 50 * time.Millisecond
+
 // staleTransitionGrace is how long a sandbox must sit in a transitional state
 // (starting/resuming/pausing) before DELETE may claim it: past this, its worker
 // is provably gone (every VMD call caps at vmdTimeout and a live worker reverts),
@@ -376,7 +388,9 @@ func (h *Handlers) loadActiveSandbox(c *gin.Context) *db.Sandbox {
 }
 
 // loadActiveOrResumeSandbox is like loadActiveSandbox but auto-resumes a
-// paused sandbox. Any other non-active state returns 409.
+// paused sandbox, and waits out the activate settle window on a
+// starting/resuming row before giving up. Any other non-active state
+// returns 409.
 func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {
@@ -386,31 +400,44 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
 	if err != nil {
 		return nil
 	}
-	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
-		ID:     sandboxID,
-		TeamID: teamID,
-	})
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			respondError(c, ErrSandboxNotFound)
-		} else {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
-			respondError(c, ErrInternal)
-		}
-		return nil
-	}
-	switch sandbox.Status {
-	case db.SandboxStatusActive:
-		return &sandbox
-	case db.SandboxStatusPaused:
-		if !h.resumePausedSandbox(c, &sandbox, teamID) {
+	deadline := time.Now().Add(activateSettleWindow)
+	for {
+		sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+			ID:     sandboxID,
+			TeamID: teamID,
+		})
+		if err != nil {
+			if err == pgx.ErrNoRows {
+				respondError(c, ErrSandboxNotFound)
+			} else {
+				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+				respondError(c, ErrInternal)
+			}
 			return nil
 		}
-		sandbox.Status = db.SandboxStatusActive
-		return &sandbox
-	default:
-		respondError(c, ErrInvalidState)
-		return nil
+		switch sandbox.Status {
+		case db.SandboxStatusActive:
+			return &sandbox
+		case db.SandboxStatusPaused:
+			if !h.resumePausedSandbox(c, &sandbox, teamID) {
+				return nil
+			}
+			sandbox.Status = db.SandboxStatusActive
+			return &sandbox
+		case db.SandboxStatusStarting, db.SandboxStatusResuming:
+			// Likely the fire-and-forget activate write in flight (or a
+			// concurrent create/resume finishing); wait for the flip
+			// rather than 409 the owner's own follow-up.
+			if time.Now().Before(deadline) {
+				time.Sleep(activateSettlePoll)
+				continue
+			}
+			respondError(c, ErrInvalidState)
+			return nil
+		default:
+			respondError(c, ErrInvalidState)
+			return nil
+		}
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1177,8 +1177,10 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	}
 }
 
-// A DB activate failure after the VM is up must re-pause (preserve the
-// overlay), never destroy — the path that previously bricked a sandbox.
+// ActivateSandbox is fire-and-forget: the client gets a success response
+// once the VM is up, and a DB activate failure re-pauses in the background
+// (preserving the overlay), never destroys — the path that previously
+// bricked a sandbox.
 func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
@@ -1231,9 +1233,12 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	w := httptest.NewRecorder()
 	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
 
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	// The activate write is fire-and-forget — the VM is up, so the client
+	// sees success; the failure is compensated in the background.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
 	}
+	h.WaitAsyncBookkeeping()
 	if got := atomic.LoadInt32(&destroyCalled); got != 0 {
 		t.Errorf("DestroyInstance calls = %d, want 0 (must not destroy a resumed VM)", got)
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1365,6 +1365,12 @@ func TestActivateSandbox_NotFound(t *testing.T) {
 }
 
 func TestActivateSandbox_NonResumableStates_409(t *testing.T) {
+	// starting/resuming rows are polled for the settle window before the
+	// 409; shrink it so the persistent-transitional cases stay fast.
+	prev := activateSettleWindow
+	activateSettleWindow = 100 * time.Millisecond
+	defer func() { activateSettleWindow = prev }()
+
 	cases := []db.SandboxStatus{
 		db.SandboxStatusFailed,
 		db.SandboxStatusPausing,
@@ -1388,6 +1394,35 @@ func TestActivateSandbox_NonResumableStates_409(t *testing.T) {
 				t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
 			}
 		})
+	}
+}
+
+// The owner's follow-up right after create/resume may read the row before the
+// fire-and-forget activate write lands. The settle window must absorb that:
+// a 'starting' row that flips to 'active' mid-poll returns 200, not 409.
+func TestActivateSandbox_SettlesStartingToActive(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+
+	var reads int32
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			status := db.SandboxStatusStarting
+			if atomic.AddInt32(&reads, 1) > 1 {
+				status = db.SandboxStatusActive // async activate landed
+			}
+			return sandboxRow(db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: status, VcpuCount: 1, MemoryMib: 512})
+		},
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (settle window must absorb the async activate); body: %s", w.Code, w.Body.String())
+	}
+	if got := atomic.LoadInt32(&reads); got < 2 {
+		t.Errorf("GetSandbox reads = %d, want >= 2 (must have polled)", got)
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -422,6 +422,24 @@ func roleIDByName(ctx context.Context, roleName string) (uuid.UUID, error) {
 // newRouter builds a router scoped to the current test. Using t.Context()
 // ensures the rate limiter's cleanup goroutine exits when the test ends,
 // preventing goroutine leaks across hundreds of test invocations.
+// testHandlers tracks every api.Handlers built for a test router so do()/
+// doBinary() can wait for fire-and-forget bookkeeping writes (ActivateSandbox,
+// FinalizePause) after each request. Integration tests chain lifecycle calls
+// (create → pause → resume) and assert DB state right after a response, so
+// they rely on transitions having landed; the async window itself is covered
+// by unit tests. Tests here never run in parallel, so a plain slice is fine.
+var testHandlers []*api.Handlers
+
+func registerTestHandlers(h *api.Handlers) {
+	testHandlers = append(testHandlers, h)
+}
+
+func waitBookkeeping() {
+	for _, h := range testHandlers {
+		h.WaitAsyncBookkeeping()
+	}
+}
+
 func newRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	cfg := &config.Config{
@@ -431,6 +449,7 @@ func newRouter(t *testing.T) *gin.Engine {
 	}
 	h := api.NewHandlers(&stubVMD{}, testQueries, cfg)
 	h.Pool = testPool
+	registerTestHandlers(h)
 	return api.SetupRouter(t.Context(), h, testPool)
 }
 
@@ -446,6 +465,7 @@ func do(r *gin.Engine, method, path, apiKey, body string) *httptest.ResponseReco
 	}
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
+	waitBookkeeping()
 	return w
 }
 
@@ -457,6 +477,7 @@ func doBinary(r *gin.Engine, method, path, apiKey string, body []byte) *httptest
 	}
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
+	waitBookkeeping()
 	return w
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1068,6 +1068,37 @@ func TestIntegration_ResumeSandbox_QuotaBlocked(t *testing.T) {
 	}
 }
 
+// Quota frees the slot at BeginPause ('pausing' left the counted set), so the
+// documented pause-then-create workflow can't transiently 429 while the
+// fire-and-forget FinalizePause is still in flight. Exercise the window
+// directly: gate write only, no finalize, then create at the cap.
+func TestIntegration_QuotaSlotFreedAtBeginPause(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	if _, err := testPool.Exec(ctx, `UPDATE team SET max_sandboxes = 1 WHERE id = $1`, teamID); err != nil {
+		t.Fatalf("set max_sandboxes: %v", err)
+	}
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"gate-a"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create A: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+
+	// The pause gate write alone — FinalizePause deliberately never runs,
+	// simulating the async bookkeeping still in flight (or lost to a crash).
+	if _, err := testQueries.BeginPause(ctx, db.BeginPauseParams{ID: sandboxID, TeamID: teamID}); err != nil {
+		t.Fatalf("BeginPause: %v", err)
+	}
+
+	cwB := do(r, "POST", "/sandboxes", apiKey, `{"name":"gate-b"}`)
+	if cwB.Code != http.StatusCreated {
+		t.Fatalf("create B while A is 'pausing': %d %s (slot must free at BeginPause)", cwB.Code, cwB.Body.String())
+	}
+}
+
 func TestIntegration_ResumeSandbox_ActiveConflict(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1099,6 +1099,50 @@ func TestIntegration_QuotaSlotFreedAtBeginPause(t *testing.T) {
 	}
 }
 
+// A pause revert (pausing→active) must never be quota-capped: the VM never
+// stopped, and the reaper escalates a failed revert to terminal 'failed' on a
+// healthy VM. At cap: A pausing, B created into the freed slot — reverting A
+// must succeed as a transient cap+1, not raise SS001.
+func TestIntegration_PauseRevertExemptFromQuota(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	if _, err := testPool.Exec(ctx, `UPDATE team SET max_sandboxes = 1 WHERE id = $1`, teamID); err != nil {
+		t.Fatalf("set max_sandboxes: %v", err)
+	}
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"revert-a"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create A: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+
+	if _, err := testQueries.BeginPause(ctx, db.BeginPauseParams{ID: sandboxID, TeamID: teamID}); err != nil {
+		t.Fatalf("BeginPause: %v", err)
+	}
+	if cwB := do(r, "POST", "/sandboxes", apiKey, `{"name":"revert-b"}`); cwB.Code != http.StatusCreated {
+		t.Fatalf("create B into freed slot: %d %s", cwB.Code, cwB.Body.String())
+	}
+
+	// The reaper/API revert path: pausing→active via UpdateSandboxStatus.
+	if err := testQueries.UpdateSandboxStatus(ctx, db.UpdateSandboxStatusParams{
+		ID:     sandboxID,
+		Status: db.SandboxStatusActive,
+		TeamID: teamID,
+	}); err != nil {
+		t.Fatalf("pausing→active revert must be exempt from the cap, got: %v", err)
+	}
+
+	var count int
+	if err := testPool.QueryRow(ctx, `SELECT active_sandbox_count FROM team WHERE id = $1`, teamID).Scan(&count); err != nil {
+		t.Fatalf("read count: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("active_sandbox_count = %d, want 2 (transient overcommit recorded, not blocked)", count)
+	}
+}
+
 func TestIntegration_ResumeSandbox_ActiveConflict(t *testing.T) {
 	_, apiKey := seedTeamAndKey(t)
 	r := newRouter(t)

--- a/internal/integration/rbac_phase3_test.go
+++ b/internal/integration/rbac_phase3_test.go
@@ -128,6 +128,7 @@ func newTokenRouter(t *testing.T) *gin.Engine {
 	}
 	h := api.NewHandlers(&stubVMD{}, testQueries, cfg)
 	h.Pool = testPool
+	registerTestHandlers(h)
 	return api.SetupRouter(t.Context(), h, testPool)
 }
 
@@ -141,6 +142,7 @@ func newSecretRouter(t *testing.T) *gin.Engine {
 	h := api.NewHandlers(&stubVMD{}, testQueries, cfg)
 	h.Pool = testPool
 	h.Encryptor = stubEncryptor{}
+	registerTestHandlers(h)
 	return api.SetupRouter(t.Context(), h, testPool)
 }
 

--- a/supabase/migrations/20260701000001_quota_exclude_pausing.sql
+++ b/supabase/migrations/20260701000001_quota_exclude_pausing.sql
@@ -16,6 +16,11 @@
 --   * A failed pause reverts pausing→active, which re-enters the counted set
 --     and is capped like resume; if the team filled the slot in between, the
 --     revert fails with SS001 and the row waits for stale-transition cleanup.
+--   * A crash between BeginPause and the VMD pause leaves a running VM whose
+--     row sits in 'pausing', now uncounted (before this migration the same
+--     crash leaked the slot in the opposite direction: counted but stuck).
+--     Either way the row is stranded transitional; the reconciler follow-up
+--     that repairs transitional rows covers both.
 
 BEGIN;
 

--- a/supabase/migrations/20260701000001_quota_exclude_pausing.sql
+++ b/supabase/migrations/20260701000001_quota_exclude_pausing.sql
@@ -13,9 +13,11 @@
 --   * While the VMD snapshot is in flight (seconds), a team can briefly run
 --     cap+1 physical VMs. The quota bounds sustained concurrency, not the
 --     instantaneous VM count.
---   * A failed pause reverts pausing→active, which re-enters the counted set
---     and is capped like resume; if the team filled the slot in between, the
---     revert fails with SS001 and the row waits for stale-transition cleanup.
+--   * A failed pause reverts pausing→active, re-entering the counted set.
+--     That revert is exempt from the cap (see sandbox_quota_on_update): the
+--     VM never stopped, so refusing the write can't reclaim anything — it
+--     would only strand truth, and the reaper's revert path escalates a
+--     failed revert to a terminal 'failed' on a healthy VM.
 --   * A crash between BeginPause and the VMD pause leaves a running VM whose
 --     row sits in 'pausing', now uncounted (before this migration the same
 --     crash leaked the slot in the opposite direction: counted but stuck).
@@ -74,15 +76,19 @@ BEGIN
     SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
     WHERE id = NEW.team_id;
   ELSIF NOT was_counted AND is_counted THEN
-    -- Entering the counted set (resume, or a pause revert) is capped like
-    -- creation.
     UPDATE team
     SET active_sandbox_count = active_sandbox_count + 1
     WHERE id = NEW.team_id
     RETURNING active_sandbox_count, max_sandboxes
     INTO new_count, effective_max;
 
-    IF new_count > effective_max THEN
+    -- Genuine admissions (resume: paused→resuming) are capped like creation.
+    -- A pause revert (pausing→active) is NOT: the VM never stopped, so the
+    -- write only records reality. Blocking it would let the reaper mark a
+    -- healthy VM 'failed' whenever a create raced into the freed slot —
+    -- routine under auto-pause, the default lifecycle. The transient cap+1
+    -- heals when the pause is retried.
+    IF OLD.status <> 'pausing' AND new_count > effective_max THEN
       RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
         USING ERRCODE = 'SS001';
     END IF;

--- a/supabase/migrations/20260701000001_quota_exclude_pausing.sql
+++ b/supabase/migrations/20260701000001_quota_exclude_pausing.sql
@@ -1,0 +1,113 @@
+-- Quota frees the slot at BeginPause, not FinalizePause: 'pausing' leaves the
+-- counted set. Counted = destroyed_at IS NULL AND status NOT IN
+-- ('failed','paused','pausing').
+--
+-- Why: FinalizePause is now a fire-and-forget write that lands after the pause
+-- response, so counting 'pausing' made the documented pause-then-create
+-- workflow transiently 429 for teams at max_sandboxes. BeginPause is the
+-- commitment point of a pause (the VM will stop or the row reverts), so it is
+-- also the right quota-release point — and it runs before the response, which
+-- makes pause→create deterministic again.
+--
+-- Tradeoffs, both bounded and rare:
+--   * While the VMD snapshot is in flight (seconds), a team can briefly run
+--     cap+1 physical VMs. The quota bounds sustained concurrency, not the
+--     instantaneous VM count.
+--   * A failed pause reverts pausing→active, which re-enters the counted set
+--     and is capped like resume; if the team filled the slot in between, the
+--     revert fails with SS001 and the row waits for stale-transition cleanup.
+
+BEGIN;
+
+-- Block sandbox writes so no transition lands between backfill and trigger swap.
+LOCK TABLE sandbox IN EXCLUSIVE MODE;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_insert() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  new_count integer;
+  effective_max integer;
+BEGIN
+  IF NEW.destroyed_at IS NOT NULL OR NEW.status IN ('failed', 'paused', 'pausing') THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE team
+  SET active_sandbox_count = active_sandbox_count + 1
+  WHERE id = NEW.team_id
+  RETURNING active_sandbox_count, max_sandboxes
+  INTO new_count, effective_max;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'team % does not exist', NEW.team_id;
+  END IF;
+
+  IF new_count > effective_max THEN
+    RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
+      USING ERRCODE = 'SS001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+  was_counted boolean;
+  is_counted boolean;
+  new_count integer;
+  effective_max integer;
+BEGIN
+  was_counted := (OLD.destroyed_at IS NULL AND OLD.status NOT IN ('failed', 'paused', 'pausing'));
+  is_counted  := (NEW.destroyed_at IS NULL AND NEW.status NOT IN ('failed', 'paused', 'pausing'));
+
+  IF was_counted AND NOT is_counted THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = NEW.team_id;
+  ELSIF NOT was_counted AND is_counted THEN
+    -- Entering the counted set (resume, or a pause revert) is capped like
+    -- creation.
+    UPDATE team
+    SET active_sandbox_count = active_sandbox_count + 1
+    WHERE id = NEW.team_id
+    RETURNING active_sandbox_count, max_sandboxes
+    INTO new_count, effective_max;
+
+    IF new_count > effective_max THEN
+      RAISE EXCEPTION 'sandbox quota exceeded (count=%, max=%)', new_count, effective_max
+        USING ERRCODE = 'SS001';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION sandbox_quota_on_delete() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.destroyed_at IS NULL AND OLD.status NOT IN ('failed', 'paused', 'pausing') THEN
+    UPDATE team
+    SET active_sandbox_count = GREATEST(active_sandbox_count - 1, 0)
+    WHERE id = OLD.team_id;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+-- Recompute every team's counter under the new definition. Idempotent.
+UPDATE team t
+SET active_sandbox_count = COALESCE((
+  SELECT COUNT(*)
+  FROM sandbox s
+  WHERE s.team_id = t.id
+    AND s.destroyed_at IS NULL
+    AND s.status NOT IN ('failed', 'paused', 'pausing')
+), 0);
+
+COMMIT;


### PR DESCRIPTION
Takes the post-VMD bookkeeping DB writes (`ActivateSandbox`, `FinalizePause`) off the hot path: create/pause/resume respond as soon as the VM transition physically happens, and the status flip lands in the background. First step of the two-region split — hot-path latency becomes gate write + VMD call regardless of where the bookkeeping DB lives.

**Technical decisions/tradeoffs**
- Safe by construction: every transition is a status-gated compare-and-swap (an UPDATE guarded on the expected current status, matching zero rows otherwise), and only the background write unlocks the next one — a racing request just 409s until it lands. Exec/get follow-ups additionally wait out a bounded settle window (2s, normally single-digit ms) on `starting`/`resuming` rows, so the canonical create→exec flow keeps read-your-writes; a mutating follow-up (pause right after create) may still need to retry on 409.
- Pause error paths change shape: deleted-mid-pause (was 410) and a failed finalize write (was 500) are now background log lines; the physical outcome is identical.
- Quota frees the slot at `BeginPause` instead of `FinalizePause` (pause→create at the cap would otherwise transiently 429). Pause reverts (`pausing→active`) are exempt from the cap: the VM never stopped, so the write only records reality — capping it would let the reaper mark a healthy VM `failed` when a create raced into the freed slot. Costs: cap+1 physical VMs for the seconds a snapshot takes (or until a reverted pause is retried), and a crash mid-pause leaves a running VM uncounted where it previously leaked the slot in the opposite direction — same stranded-transitional-row class, covered by the reconciler follow-up below.
- Create's egress-rule push stays blocking (201 still implies rules applied); reaper and error-path reverts keep their synchronous saga semantics.
- Known gap: a crash between the response and the background commit strands the row in a transitional state the reconciler doesn't repair. Pre-existing window, but wider now — reconciler repair of transitional rows is a follow-up before real multi-region traffic.

**Testing**
- New integration tests exercise the exact windows: pause gate write with no finalize then create at the cap (must 201), and a `pausing→active` revert at the cap (must not SS001). The `starting→active` settle is unit-tested; async failure paths are unit-tested.
- Bookkeeping goroutines are tracked (mutex+cond counter — WaitGroup forbids Add during Wait, which concurrent requests do) so tests can wait for quiescence; integration `do()` waits after every request.
- `go test -race ./internal/api/` and the full integration suite under `-race` pass locally; CI green.