### PR TITLE
api: cache successful API-key lookups in-process

### DIFF
--- a/internal/api/apikey_cache.go
+++ b/internal/api/apikey_cache.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// apiKeyCache is an in-process, TTL-bounded cache of successful API-key
+// lookups, keyed by the key's SHA-256 hash. It removes the per-request DB
+// round trip from the auth middleware — the dominant hot-path cost when the
+// control plane and database are in different regions.
+//
+// Only positive lookups are cached: an invalid or revoked key always misses
+// and hits the DB, so revocation takes effect within one TTL and a flood of
+// bad keys cannot grow the map. The key's own expires_at is stored and
+// checked on every hit, so expiry is exact even inside the TTL window.
+const (
+	defaultAPIKeyCacheTTL = 30 * time.Second
+	// apiKeyCacheMaxEntries bounds the map. Only valid keys enter the
+	// cache, so this is effectively "number of live keys used within one
+	// TTL" — the cap is a backstop, not an expected operating point.
+	apiKeyCacheMaxEntries = 4096
+	// lastUsedTouchInterval throttles the fire-and-forget last_used_at
+	// UPDATE to at most one write per key per interval, instead of one
+	// per request.
+	lastUsedTouchInterval = time.Minute
+)
+
+// apiKeyCacheTTLFromEnv reads API_KEY_CACHE_TTL (a Go duration, e.g. "30s").
+// Unset or unparsable values fall back to the default; "0" (or any
+// non-positive duration) disables caching.
+func apiKeyCacheTTLFromEnv() time.Duration {
+	raw := os.Getenv("API_KEY_CACHE_TTL")
+	if raw == "" {
+		return defaultAPIKeyCacheTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultAPIKeyCacheTTL
+	}
+	return d
+}
+
+type apiKeyCacheEntry struct {
+	id        string
+	teamID    string
+	createdBy pgtype.UUID
+	expiresAt pgtype.Timestamptz
+	fetchedAt time.Time
+	lastTouch time.Time
+}
+
+type apiKeyCache struct {
+	ttl time.Duration
+	mu  sync.Mutex
+	m   map[string]*apiKeyCacheEntry
+}
+
+func newAPIKeyCache(ttl time.Duration) *apiKeyCache {
+	if ttl <= 0 {
+		return nil // caching disabled; nil receiver is safe on get/put
+	}
+	return &apiKeyCache{ttl: ttl, m: make(map[string]*apiKeyCacheEntry)}
+}
+
+// get returns a copy of the cached entry for keyHash if it is still fresh
+// and the key itself has not expired. needTouch reports whether the caller
+// should update last_used_at (throttled to lastUsedTouchInterval).
+func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry, needTouch, ok bool) {
+	if c == nil {
+		return apiKeyCacheEntry{}, false, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, exists := c.m[keyHash]
+	if !exists {
+		return apiKeyCacheEntry{}, false, false
+	}
+	if now.Sub(e.fetchedAt) > c.ttl || (e.expiresAt.Valid && !now.Before(e.expiresAt.Time)) {
+		delete(c.m, keyHash)
+		return apiKeyCacheEntry{}, false, false
+	}
+	if now.Sub(e.lastTouch) >= lastUsedTouchInterval {
+		e.lastTouch = now
+		needTouch = true
+	}
+	return *e, needTouch, true
+}
+
+// put stores a fresh lookup result. lastTouch starts at now because the
+// caller just touched last_used_at on the miss path.
+func (c *apiKeyCache) put(keyHash string, e apiKeyCacheEntry, now time.Time) {
+	if c == nil {
+		return
+	}
+	e.fetchedAt = now
+	e.lastTouch = now
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.m) >= apiKeyCacheMaxEntries {
+		for h, old := range c.m {
+			if now.Sub(old.fetchedAt) > c.ttl {
+				delete(c.m, h)
+			}
+		}
+		// Still full after sweeping: reset rather than grow. Costs one
+		// DB lookup per live key to refill; unreachable in practice.
+		if len(c.m) >= apiKeyCacheMaxEntries {
+			c.m = make(map[string]*apiKeyCacheEntry)
+		}
+	}
+	c.m[keyHash] = &e
+}

--- a/internal/api/apikey_cache_test.go
+++ b/internal/api/apikey_cache_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestAPIKeyCache_HitReturnsEntry(t *testing.T) {
+	c := newAPIKeyCache(30 * time.Second)
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{id: "id1", teamID: "team1"}, now)
+
+	entry, needTouch, ok := c.get("hash1", now.Add(time.Second))
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if entry.id != "id1" || entry.teamID != "team1" {
+		t.Errorf("wrong entry: %+v", entry)
+	}
+	// put counts as a touch, so a hit 1s later must not touch again.
+	if needTouch {
+		t.Error("expected no touch within lastUsedTouchInterval of put")
+	}
+}
+
+func TestAPIKeyCache_MissAfterTTL(t *testing.T) {
+	c := newAPIKeyCache(30 * time.Second)
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{id: "id1", teamID: "team1"}, now)
+
+	if _, _, ok := c.get("hash1", now.Add(31*time.Second)); ok {
+		t.Error("expected miss after TTL")
+	}
+	// Expired entry must have been evicted, not just skipped.
+	c.mu.Lock()
+	_, exists := c.m["hash1"]
+	c.mu.Unlock()
+	if exists {
+		t.Error("expected expired entry to be deleted")
+	}
+}
+
+func TestAPIKeyCache_MissUnknownKey(t *testing.T) {
+	c := newAPIKeyCache(30 * time.Second)
+	if _, _, ok := c.get("nope", time.Now()); ok {
+		t.Error("expected miss for unknown key")
+	}
+}
+
+func TestAPIKeyCache_KeyExpiryCheckedOnHit(t *testing.T) {
+	c := newAPIKeyCache(30 * time.Second)
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{
+		id:        "id1",
+		teamID:    "team1",
+		expiresAt: pgtype.Timestamptz{Time: now.Add(10 * time.Second), Valid: true},
+	}, now)
+
+	// Inside TTL and before expires_at: hit.
+	if _, _, ok := c.get("hash1", now.Add(5*time.Second)); !ok {
+		t.Error("expected hit before expires_at")
+	}
+	// Inside TTL but past expires_at: miss, even though TTL hasn't lapsed.
+	if _, _, ok := c.get("hash1", now.Add(11*time.Second)); ok {
+		t.Error("expected miss after expires_at despite fresh TTL")
+	}
+}
+
+func TestAPIKeyCache_TouchThrottle(t *testing.T) {
+	c := newAPIKeyCache(10 * time.Minute) // TTL long enough to not interfere
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{id: "id1"}, now)
+
+	if _, needTouch, _ := c.get("hash1", now.Add(30*time.Second)); needTouch {
+		t.Error("expected no touch before interval elapses")
+	}
+	if _, needTouch, _ := c.get("hash1", now.Add(lastUsedTouchInterval)); !needTouch {
+		t.Error("expected touch once interval elapsed")
+	}
+	// The touch above reset the clock; immediately after, no touch again.
+	if _, needTouch, _ := c.get("hash1", now.Add(lastUsedTouchInterval+time.Second)); needTouch {
+		t.Error("expected no touch right after a touch")
+	}
+}
+
+func TestAPIKeyCache_DisabledNilSafe(t *testing.T) {
+	c := newAPIKeyCache(0) // disabled → nil
+	if c != nil {
+		t.Fatal("expected nil cache when TTL <= 0")
+	}
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{id: "id1"}, now) // must not panic
+	if _, _, ok := c.get("hash1", now); ok {
+		t.Error("disabled cache must always miss")
+	}
+}
+
+func TestAPIKeyCache_SweepAtCapacity(t *testing.T) {
+	c := newAPIKeyCache(30 * time.Second)
+	now := time.Now()
+	for i := 0; i < apiKeyCacheMaxEntries; i++ {
+		c.put(fmt.Sprintf("hash%d", i), apiKeyCacheEntry{id: "x"}, now)
+	}
+	// All entries are stale by the time the cap-triggering put happens:
+	// the sweep clears them and the new entry fits.
+	later := now.Add(31 * time.Second)
+	c.put("fresh", apiKeyCacheEntry{id: "fresh"}, later)
+
+	if _, _, ok := c.get("fresh", later); !ok {
+		t.Error("expected fresh entry after sweep")
+	}
+	c.mu.Lock()
+	size := len(c.m)
+	c.mu.Unlock()
+	if size != 1 {
+		t.Errorf("expected sweep to leave 1 entry, got %d", size)
+	}
+}
+
+func TestAPIKeyCache_ResetWhenFullOfFreshEntries(t *testing.T) {
+	c := newAPIKeyCache(10 * time.Minute)
+	now := time.Now()
+	for i := 0; i < apiKeyCacheMaxEntries; i++ {
+		c.put(fmt.Sprintf("hash%d", i), apiKeyCacheEntry{id: "x"}, now)
+	}
+	// Nothing is stale, so the cap forces a full reset; the map must not
+	// exceed the cap and the new entry must be present.
+	c.put("fresh", apiKeyCacheEntry{id: "fresh"}, now.Add(time.Second))
+
+	if _, _, ok := c.get("fresh", now.Add(2*time.Second)); !ok {
+		t.Error("expected fresh entry after reset")
+	}
+	c.mu.Lock()
+	size := len(c.m)
+	c.mu.Unlock()
+	if size > apiKeyCacheMaxEntries {
+		t.Errorf("cache exceeded cap: %d", size)
+	}
+}
+
+func TestAPIKeyCacheTTLFromEnv(t *testing.T) {
+	t.Setenv("API_KEY_CACHE_TTL", "")
+	if got := apiKeyCacheTTLFromEnv(); got != defaultAPIKeyCacheTTL {
+		t.Errorf("unset: expected default, got %v", got)
+	}
+	t.Setenv("API_KEY_CACHE_TTL", "45s")
+	if got := apiKeyCacheTTLFromEnv(); got != 45*time.Second {
+		t.Errorf("45s: got %v", got)
+	}
+	t.Setenv("API_KEY_CACHE_TTL", "0")
+	if got := apiKeyCacheTTLFromEnv(); got != 0 {
+		t.Errorf("0: got %v", got)
+	}
+	t.Setenv("API_KEY_CACHE_TTL", "garbage")
+	if got := apiKeyCacheTTLFromEnv(); got != defaultAPIKeyCacheTTL {
+		t.Errorf("garbage: expected default, got %v", got)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -18,7 +18,23 @@ import (
 // APIKeyAuth returns a Gin middleware that validates the X-API-Key header
 // by hashing the provided key and looking it up in the api_key table.
 // On success, sets "team_id" and "api_key_id" in the Gin context.
+//
+// Successful lookups are cached in-process for API_KEY_CACHE_TTL (default
+// 30s), so steady-state requests skip the DB round trip entirely. Revocation
+// therefore takes up to one TTL to propagate; key expiry (expires_at) is
+// exact because it is checked on every cache hit.
 func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
+	cache := newAPIKeyCache(apiKeyCacheTTLFromEnv())
+	touchLastUsed := func(ctx context.Context, id string) {
+		// Fire and forget. The context is extracted by the caller before
+		// spawning so the goroutine does not capture c — gin recycles
+		// *Context back to the pool after ServeHTTP returns, causing a
+		// data race if the goroutine reads c.Request later.
+		go func() {
+			_, _ = pool.Exec(ctx,
+				"UPDATE api_key SET last_used_at = now() WHERE id = $1", id)
+		}()
+	}
 	return func(c *gin.Context) {
 		apiKey := c.GetHeader("X-API-Key")
 		if apiKey == "" {
@@ -30,27 +46,39 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 		hash := sha256.Sum256([]byte(apiKey))
 		keyHash := hex.EncodeToString(hash[:])
 
+		if entry, needTouch, ok := cache.get(keyHash, time.Now()); ok {
+			if needTouch {
+				touchLastUsed(context.WithoutCancel(c.Request.Context()), entry.id)
+			}
+			c.Set("api_key_id", entry.id)
+			c.Set("team_id", entry.teamID)
+			if entry.createdBy.Valid {
+				c.Set("actor_id", uuid.UUID(entry.createdBy.Bytes))
+			}
+			c.Next()
+			return
+		}
+
 		var id, teamID string
 		var createdBy pgtype.UUID
+		var expiresAt pgtype.Timestamptz
 		err := pool.QueryRow(c.Request.Context(),
-			"SELECT id, team_id, created_by FROM api_key WHERE key_hash = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())",
+			"SELECT id, team_id, created_by, expires_at FROM api_key WHERE key_hash = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())",
 			keyHash,
-		).Scan(&id, &teamID, &createdBy)
+		).Scan(&id, &teamID, &createdBy, &expiresAt)
 		if err != nil {
 			respondErrorMsg(c, "auth_failed", "Invalid or missing X-API-Key header.", http.StatusUnauthorized)
 			c.Abort()
 			return
 		}
 
-		// Update last_used_at (fire and forget). Extract the context
-		// before spawning so the goroutine does not capture c — gin
-		// recycles *Context back to the pool after ServeHTTP returns,
-		// causing a data race if the goroutine reads c.Request later.
-		lastUsedCtx := context.WithoutCancel(c.Request.Context())
-		go func() {
-			_, _ = pool.Exec(lastUsedCtx,
-				"UPDATE api_key SET last_used_at = now() WHERE id = $1", id)
-		}()
+		cache.put(keyHash, apiKeyCacheEntry{
+			id:        id,
+			teamID:    teamID,
+			createdBy: createdBy,
+			expiresAt: expiresAt,
+		}, time.Now())
+		touchLastUsed(context.WithoutCancel(c.Request.Context()), id)
 
 		c.Set("api_key_id", id)
 		c.Set("team_id", teamID)


### PR DESCRIPTION
Caches successful X-API-Key lookups in-process so steady-state auth skips the per-request DB round trip — the largest hot-path cost with the control plane in us-west and the DB in us-east. Part of the two-region prep.

## Technical decisions

- Only positive lookups are cached: invalid/revoked keys always hit the DB, so revocation propagates within one TTL (default 30s, `API_KEY_CACHE_TTL`, `0` disables) and bad-key floods can't grow the map. Revocation happens out-of-band (Console writes the DB directly), so the TTL is the bound — no in-process invalidation is possible.
- `expires_at` is stored and checked on every hit, so key expiry stays exact inside the TTL window.
- The fire-and-forget `last_used_at` UPDATE — itself a hidden per-request DB write — is throttled to once per key per minute.

## Testing

9 new unit tests: hit/miss, TTL expiry, exact `expires_at` enforcement, touch throttling, disabled mode, capacity sweep/reset. Existing middleware tests pass unchanged.