### PR TITLE
Boot-time local-SSD RAID + canonical bind-mounts for local-SSD hosts

### DIFF
--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -58,7 +58,9 @@ BUNDLE_FILES = [
     "deploy/firecracker@.service",
     "deploy/firecracker-netns@.service",
     "deploy/sandboxes.slice",
+    "deploy/sandbox-localssd.service",
     "scripts/fc-cleanup",
+    "scripts/setup-localssd.sh",
 ]
 
 
@@ -138,6 +140,12 @@ def main() -> int:
             sudo systemctl daemon-reload
 
             sudo install -m 0755 {extract_dir}/scripts/fc-cleanup {install_dir}/fc-cleanup
+
+            # Local-SSD boot setup (no-op on hosts without local SSD).
+            sudo install -m 0755 {extract_dir}/scripts/setup-localssd.sh {install_dir}/setup-localssd.sh
+            sudo install -m 0644 {extract_dir}/deploy/sandbox-localssd.service /etc/systemd/system/sandbox-localssd.service
+            sudo systemctl daemon-reload
+            sudo systemctl enable --quiet sandbox-localssd.service
 
             # Inject boxd + rebuild rootfs only when the new binary differs
             # from what's already installed. `-trimpath -ldflags '-s -w'`

--- a/deploy/sandbox-localssd.service
+++ b/deploy/sandbox-localssd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Local-SSD RAID + canonical bind-mounts for the sandbox data plane
+After=local-fs.target
+Before=superserve-vmd.service
+RequiredBy=superserve-vmd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/setup-localssd.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/setup-localssd.sh
+++ b/scripts/setup-localssd.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Boot-time local-SSD setup: RAID0 the local NVMe SSDs, mount them, and
+# bind-mount rundir/snapshots onto the canonical /var/lib/sandbox paths that
+# vmd and the firecracker@ units use. No-op on hosts without local SSD. Local
+# SSD is wiped on stop/start, so this runs on every boot to rebuild it.
+set -eu
+
+MNT=/mnt/localssd
+CANON_RUNDIR=/var/lib/sandbox/rundir
+CANON_SNAPS=/var/lib/sandbox/snapshots
+
+root_src=$(findmnt -no SOURCE / 2>/dev/null || true)
+boot_dev=$(lsblk -no PKNAME "$root_src" 2>/dev/null | head -1 || true)
+local_ssds=$(lsblk -dpno NAME | grep -E '^/dev/nvme[0-9]+n1$' | grep -vx "/dev/$boot_dev" || true)
+n=$(printf '%s\n' "$local_ssds" | grep -c . || true)
+
+if [ "${n:-0}" -eq 0 ]; then
+    echo "setup-localssd: no local SSD detected; nothing to do."
+    exit 0
+fi
+
+if mountpoint -q "$MNT" && mountpoint -q "$CANON_RUNDIR" && mountpoint -q "$CANON_SNAPS"; then
+    echo "setup-localssd: already set up; nothing to do."
+    exit 0
+fi
+
+[ -e /dev/md0 ] || mdadm --create /dev/md0 --level=0 --raid-devices="$n" $local_ssds --run
+blkid /dev/md0 >/dev/null 2>&1 || mkfs.xfs -f -b size=4096 /dev/md0
+
+mkdir -p "$MNT"
+mountpoint -q "$MNT" || mount -o noatime,discard /dev/md0 "$MNT"
+mkdir -p "$MNT/rundir" "$MNT/snapshots" "$CANON_RUNDIR" "$CANON_SNAPS"
+mountpoint -q "$CANON_RUNDIR" || mount --bind "$MNT/rundir" "$CANON_RUNDIR"
+mountpoint -q "$CANON_SNAPS"  || mount --bind "$MNT/snapshots" "$CANON_SNAPS"
+echo "setup-localssd: done."


### PR DESCRIPTION
On hosts with local NVMe SSD, a boot oneshot (`sandbox-localssd.service` → `setup-localssd.sh`) RAID0s the local SSDs, mounts them, and bind-mounts rundir/snapshots onto the canonical `/var/lib/sandbox` paths that vmd and the `firecracker@` units use — ordered before vmd. No-op on hosts without local SSD, and idempotent. Local SSD is wiped on stop/start, so this runs every boot to rebuild it. Wired into the vmd deploy bundle.