### PR TITLE
api,proxy: region-tagged public sandbox IDs (sb-<region>-<uuid>)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1573,8 +1573,7 @@ components:
       in: path
       required: true
       schema:
-        type: string
-        format: uuid
+        $ref: "#/components/schemas/PublicSandboxId"
       description: The unique identifier of the sandbox.
 
     TemplateId:
@@ -1632,6 +1631,15 @@ components:
       description: Narrow by HTTP status class; `errors` includes 4xx and 5xx.
 
   schemas:
+    PublicSandboxId:
+      type: string
+      pattern: '^(sb-[a-z0-9]+-)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+      description: >
+        Public sandbox ID: a bare UUID, or the region-tagged form
+        `sb-<region>-<uuid>` (e.g. `sb-use-1b4e28ba-…`). Treat as an opaque
+        string; the tagged form routes the request to the sandbox's home
+        region. Endpoints accept both forms interchangeably.
+
     CreateSandboxRequest:
       type: object
       required: [name]
@@ -1723,8 +1731,7 @@ components:
       type: object
       properties:
         id:
-          type: string
-          format: uuid
+          $ref: "#/components/schemas/PublicSandboxId"
         name:
           type: string
         status:
@@ -1805,8 +1812,7 @@ components:
       description: Returned by `POST /sandboxes/{id}/resume`.
       properties:
         id:
-          type: string
-          format: uuid
+          $ref: "#/components/schemas/PublicSandboxId"
         status:
           type: string
           enum: [active]

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -74,6 +74,12 @@ func run() error {
 	}
 	log.Info().Str("port", cfg.Port).Str("vmd_address", cfg.VMDAddress).Msg("configuration loaded")
 
+	// Fail closed on a malformed SANDBOX_ID_REGION rather than minting
+	// public sandbox IDs the API and proxy would reject.
+	if err := api.ValidateSandboxIDRegion(); err != nil {
+		return err
+	}
+
 	if cfg.SentryDSN != "" {
 		if err := sentry.Init(sentry.ClientOptions{Dsn: cfg.SentryDSN, EnableLogs: true}); err != nil {
 			return fmt.Errorf("sentry init: %w", err)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -782,10 +782,10 @@ func (h *Handlers) Health(c *gin.Context) {
 
 func parseSandboxID(c *gin.Context) (uuid.UUID, error) {
 	raw := c.Param("sandbox_id")
-	id, err := uuid.Parse(raw)
+	id, err := parsePublicSandboxID(raw)
 	if err != nil {
 		respondErrorMsg(c, "bad_request",
-			fmt.Sprintf("Invalid sandbox_id: %q is not a valid UUID", raw),
+			fmt.Sprintf("Invalid sandbox_id: %q is not a valid sandbox ID", raw),
 			http.StatusBadRequest)
 		return uuid.Nil, err
 	}
@@ -1144,7 +1144,9 @@ type createSandboxRequest struct {
 }
 
 type sandboxResponse struct {
-	ID             uuid.UUID              `json:"id"`
+	// ID is the public sandbox ID: a bare UUID today, sb-<region>-<uuid>
+	// once SANDBOX_ID_REGION is set on the cell (see publicid.go).
+	ID             string                 `json:"id"`
 	Name           string                 `json:"name"`
 	Status         string                 `json:"status"`
 	VcpuCount      int32                  `json:"vcpu_count"`
@@ -1169,7 +1171,7 @@ type sandboxSecretBinding struct {
 
 func (h *Handlers) sandboxToResponse(s db.Sandbox) sandboxResponse {
 	resp := sandboxResponse{
-		ID:        s.ID,
+		ID:        formatSandboxID(s.ID),
 		Name:      s.Name,
 		Status:    string(s.Status),
 		VcpuCount: s.VcpuCount,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -888,10 +888,14 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	}
 
 	resp := gin.H{
-		"id":     sandboxID.String(),
+		// Public form — clients refresh their stored ID from this response,
+		// so a bare UUID here would strand them off the tagged scheme.
+		"id":     formatSandboxID(sandboxID),
 		"status": string(db.SandboxStatusActive),
 	}
 	if h.Config != nil && h.Config.SandboxAccessTokenSeed != nil {
+		// The token HMAC stays keyed on the bare UUID: the proxy normalizes
+		// public IDs before verification.
 		resp["access_token"] = auth.ComputeAccessToken(h.Config.SandboxAccessTokenSeed, sandboxID.String())
 	}
 	c.JSON(http.StatusOK, resp)

--- a/internal/api/publicid.go
+++ b/internal/api/publicid.go
@@ -27,11 +27,32 @@ const sandboxIDPrefix = "sb-"
 // uuidStrLen is the canonical textual UUID length (8-4-4-4-12).
 const uuidStrLen = 36
 
+// maxRegionCodeLen bounds the region segment so the public ID still fits in a
+// DNS label when the proxy embeds it: "{port}-sb-<region>-<uuid>" with a
+// 5-digit port leaves 63 - 6 - 40 = 17 characters for the region.
+const maxRegionCodeLen = 17
+
 // sandboxIDRegionFromEnv returns the region code minted into new public
 // sandbox IDs, or "" to mint legacy bare UUIDs. Read per call: minting is
 // off the hot path and this keeps tests to t.Setenv.
 func sandboxIDRegionFromEnv() string {
 	return strings.TrimSpace(os.Getenv("SANDBOX_ID_REGION"))
+}
+
+// ValidateSandboxIDRegion rejects a malformed SANDBOX_ID_REGION at startup.
+// This env var is the tagged-ID rollout switch; a misconfigured cell (say
+// "us-east-1" or "USE") would otherwise mint public IDs that this same API's
+// parser and the proxy's data-plane routing reject — stranding every ID
+// returned until the config is fixed. Failing the boot is cheaper.
+func ValidateSandboxIDRegion() error {
+	region := sandboxIDRegionFromEnv()
+	if region == "" {
+		return nil
+	}
+	if !validRegionCode(region) || len(region) > maxRegionCodeLen {
+		return fmt.Errorf("SANDBOX_ID_REGION %q: must be 1-%d lowercase alphanumeric characters (no hyphens or uppercase — the region is embedded in public sandbox IDs and DNS labels)", region, maxRegionCodeLen)
+	}
+	return nil
 }
 
 // formatSandboxID renders a sandbox's public ID.

--- a/internal/api/publicid.go
+++ b/internal/api/publicid.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Public sandbox IDs optionally carry the cell's region as a prefix:
+//
+//	sb-<region>-<uuid>   e.g. sb-use-1b4e28ba-2fa1-11d2-883f-0016d3cca427
+//
+// The prefix lets the edge route a sandbox-scoped request to its home cell
+// from the ID string alone — the same scheme as ss_live_<region>_ API keys.
+// Unlike keys, sandbox IDs are embedded as hostname labels by the proxy
+// ({port}-{id}.{domain}), so the separator is a hyphen: underscores are not
+// DNS-safe. The DB primary key stays a bare uuid; the prefix exists only at
+// the API boundary.
+//
+// Rollout is two-phase to keep it non-breaking: parsing accepts both forms
+// unconditionally, while minting is gated on SANDBOX_ID_REGION (unset =
+// legacy bare UUIDs, byte-for-byte today's behavior).
+const sandboxIDPrefix = "sb-"
+
+// uuidStrLen is the canonical textual UUID length (8-4-4-4-12).
+const uuidStrLen = 36
+
+// sandboxIDRegionFromEnv returns the region code minted into new public
+// sandbox IDs, or "" to mint legacy bare UUIDs. Read per call: minting is
+// off the hot path and this keeps tests to t.Setenv.
+func sandboxIDRegionFromEnv() string {
+	return strings.TrimSpace(os.Getenv("SANDBOX_ID_REGION"))
+}
+
+// formatSandboxID renders a sandbox's public ID.
+func formatSandboxID(id uuid.UUID) string {
+	region := sandboxIDRegionFromEnv()
+	if region == "" {
+		return id.String()
+	}
+	return sandboxIDPrefix + region + "-" + id.String()
+}
+
+// parsePublicSandboxID accepts a legacy bare UUID or a region-tagged public
+// ID and returns the inner UUID. The region segment is validated for shape
+// but not against a region list — this cell serves whatever the edge routed
+// to it, and rejecting unknown codes here would couple every cell deploy to
+// the region vocabulary.
+func parsePublicSandboxID(raw string) (uuid.UUID, error) {
+	if !strings.HasPrefix(raw, sandboxIDPrefix) {
+		return uuid.Parse(raw)
+	}
+	rest := raw[len(sandboxIDPrefix):]
+	// The UUID is always the fixed-length tail; the region is whatever sits
+	// between the prefix and the "-<uuid>" suffix (region length may vary
+	// as cells launch).
+	if len(rest) < uuidStrLen+2 { // shortest region is 1 char + "-"
+		return uuid.Nil, fmt.Errorf("public sandbox ID %q too short", raw)
+	}
+	region, idPart := rest[:len(rest)-uuidStrLen-1], rest[len(rest)-uuidStrLen:]
+	if rest[len(rest)-uuidStrLen-1] != '-' || !validRegionCode(region) {
+		return uuid.Nil, fmt.Errorf("public sandbox ID %q has a malformed region segment", raw)
+	}
+	return uuid.Parse(idPart)
+}
+
+// validRegionCode: non-empty lowercase alphanumeric. Hyphens are excluded so
+// the region/uuid split stays unambiguous.
+func validRegionCode(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/publicid_test.go
+++ b/internal/api/publicid_test.go
@@ -50,6 +50,32 @@ func TestParsePublicSandboxID(t *testing.T) {
 	}
 }
 
+func TestValidateSandboxIDRegion(t *testing.T) {
+	for _, tc := range []struct {
+		env string
+		ok  bool
+	}{
+		{"", true},    // unset: legacy bare UUIDs
+		{"use", true},
+		{"usw", true},
+		{"euw1", true},
+		{"  use  ", true},      // whitespace is trimmed before minting too
+		{"us-east-1", false},   // hyphens break the region/uuid split
+		{"USE", false},         // uppercase is not DNS-label-safe here
+		{"ss_live", false},     // underscores are not DNS-safe
+		{"abcdefghijklmnopqr", false}, // 18 chars: over the DNS-label budget
+	} {
+		t.Setenv("SANDBOX_ID_REGION", tc.env)
+		err := ValidateSandboxIDRegion()
+		if tc.ok && err != nil {
+			t.Errorf("ValidateSandboxIDRegion(%q): unexpected error %v", tc.env, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("ValidateSandboxIDRegion(%q): expected error, got nil", tc.env)
+		}
+	}
+}
+
 func TestPublicSandboxIDRoundTrip(t *testing.T) {
 	t.Setenv("SANDBOX_ID_REGION", "usw")
 	id := uuid.New()

--- a/internal/api/publicid_test.go
+++ b/internal/api/publicid_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestFormatSandboxID(t *testing.T) {
+	id := uuid.MustParse("1b4e28ba-2fa1-11d2-883f-0016d3cca427")
+
+	t.Setenv("SANDBOX_ID_REGION", "")
+	if got := formatSandboxID(id); got != id.String() {
+		t.Errorf("flag off: want bare uuid, got %q", got)
+	}
+
+	t.Setenv("SANDBOX_ID_REGION", "use")
+	if got := formatSandboxID(id); got != "sb-use-"+id.String() {
+		t.Errorf("flag on: got %q", got)
+	}
+}
+
+func TestParsePublicSandboxID(t *testing.T) {
+	id := uuid.MustParse("1b4e28ba-2fa1-11d2-883f-0016d3cca427")
+
+	for _, tc := range []struct {
+		in   string
+		want uuid.UUID
+		ok   bool
+	}{
+		{id.String(), id, true},              // legacy bare uuid
+		{"sb-use-" + id.String(), id, true},  // current region codes
+		{"sb-usw-" + id.String(), id, true},
+		{"sb-euw1-" + id.String(), id, true}, // future longer code
+		{"sb--" + id.String(), uuid.Nil, false},        // empty region
+		{"sb-USE-" + id.String(), uuid.Nil, false},     // uppercase region
+		{"sb-use-not-a-uuid-padded-to-36-chars!!", uuid.Nil, false},
+		{"sb-use-", uuid.Nil, false},
+		{"sb-" + id.String(), uuid.Nil, false}, // prefix but no region segment
+		{"", uuid.Nil, false},
+		{"garbage", uuid.Nil, false},
+	} {
+		got, err := parsePublicSandboxID(tc.in)
+		if tc.ok && (err != nil || got != tc.want) {
+			t.Errorf("parse(%q): got (%v, %v), want %v", tc.in, got, err, tc.want)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("parse(%q): expected error, got %v", tc.in, got)
+		}
+	}
+}
+
+func TestPublicSandboxIDRoundTrip(t *testing.T) {
+	t.Setenv("SANDBOX_ID_REGION", "usw")
+	id := uuid.New()
+	got, err := parsePublicSandboxID(formatSandboxID(id))
+	if err != nil || got != id {
+		t.Fatalf("round trip: got (%v, %v), want %v", got, err, id)
+	}
+}

--- a/internal/proxy/host.go
+++ b/internal/proxy/host.go
@@ -33,9 +33,25 @@ func ParseRequest(host string, headers http.Header, domain string) (port int, in
 		if !validInstanceID.MatchString(id) {
 			return 0, "", fmt.Errorf("proxy: invalid sandbox ID in %s header", headerSandboxID)
 		}
-		return boxdPort, id, nil
+		return boxdPort, normalizeInstanceID(id), nil
 	}
 	return ParseHost(host, domain)
+}
+
+// normalizeInstanceID strips the public region prefix (sb-<region>-) from a
+// sandbox ID, returning the bare UUID that VMD, the resolver cache, and the
+// HMAC access tokens are all keyed on. Region-tagged public IDs exist only
+// at the API boundary; clients build proxy hostnames from whichever form
+// the API returned, so both must resolve identically. IDs that don't match
+// the public shape pass through untouched.
+func normalizeInstanceID(id string) string {
+	const prefix = "sb-"
+	const uuidLen = 36
+	rest, ok := strings.CutPrefix(id, prefix)
+	if !ok || len(rest) < uuidLen+2 || rest[len(rest)-uuidLen-1] != '-' {
+		return id
+	}
+	return rest[len(rest)-uuidLen:]
 }
 
 // isSharedHost reports whether host (with any :port stripped) equals the configured domain.
@@ -104,6 +120,7 @@ func ParseHost(host, domain string) (port int, instanceID string, err error) {
 	if !validInstanceID.MatchString(instanceID) {
 		return 0, "", fmt.Errorf("proxy: instance ID %q contains invalid characters", instanceID)
 	}
+	instanceID = normalizeInstanceID(instanceID)
 
 	// Reserved label for boxd.
 	if routing == boxdHostLabel {

--- a/internal/proxy/host.go
+++ b/internal/proxy/host.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // validInstanceID restricts instance IDs to alphanumeric + hyphen, max 64 chars.
@@ -42,8 +44,12 @@ func ParseRequest(host string, headers http.Header, domain string) (port int, in
 // sandbox ID, returning the bare UUID that VMD, the resolver cache, and the
 // HMAC access tokens are all keyed on. Region-tagged public IDs exist only
 // at the API boundary; clients build proxy hostnames from whichever form
-// the API returned, so both must resolve identically. IDs that don't match
-// the public shape pass through untouched.
+// the API returned, so both must resolve identically.
+//
+// The shape check mirrors the API parser (internal/api/publicid.go): valid
+// region segment plus a parseable UUID tail. Anything else passes through
+// untouched, so a malformed tagged ID can't alias to an internal-looking
+// bare ID before VMD lookup or access-token verification.
 func normalizeInstanceID(id string) string {
 	const prefix = "sb-"
 	const uuidLen = 36
@@ -51,7 +57,29 @@ func normalizeInstanceID(id string) string {
 	if !ok || len(rest) < uuidLen+2 || rest[len(rest)-uuidLen-1] != '-' {
 		return id
 	}
-	return rest[len(rest)-uuidLen:]
+	region, tail := rest[:len(rest)-uuidLen-1], rest[len(rest)-uuidLen:]
+	if !validRegionCode(region) {
+		return id
+	}
+	if _, err := uuid.Parse(tail); err != nil {
+		return id
+	}
+	return tail
+}
+
+// validRegionCode mirrors the API's public-ID region rule: non-empty
+// lowercase alphanumeric. Hyphens are excluded so the region/uuid split
+// stays unambiguous.
+func validRegionCode(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 // isSharedHost reports whether host (with any :port stripped) equals the configured domain.

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -31,6 +31,24 @@ func TestParseHost(t *testing.T) {
 			wantPort:       boxdPort,
 			wantInstanceID: "b150ee22-4956-4f5b-926a-f921ed8c37d6",
 		},
+		// Region-tagged public IDs (sb-<region>-<uuid>) normalize to the
+		// bare UUID that VMD and the token HMACs are keyed on.
+		{
+			host:           "boxd-sb-use-b150ee22-4956-4f5b-926a-f921ed8c37d6.sandbox.superserve.ai",
+			wantPort:       boxdPort,
+			wantInstanceID: "b150ee22-4956-4f5b-926a-f921ed8c37d6",
+		},
+		{
+			host:           "8080-sb-usw-b150ee22-4956-4f5b-926a-f921ed8c37d6.sandbox.superserve.ai",
+			wantPort:       8080,
+			wantInstanceID: "b150ee22-4956-4f5b-926a-f921ed8c37d6",
+		},
+		// "sb-" that isn't the public shape passes through untouched.
+		{
+			host:           "3000-sb-shortid.sandbox.superserve.ai",
+			wantPort:       3000,
+			wantInstanceID: "sb-shortid",
+		},
 		// User application ports — numeric label
 		{
 			host:           "3000-mybox.sandbox.superserve.ai",

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -49,6 +49,19 @@ func TestParseHost(t *testing.T) {
 			wantPort:       3000,
 			wantInstanceID: "sb-shortid",
 		},
+		// Right length but not a UUID tail: no alias to an internal-looking ID.
+		{
+			host:           "3000-sb-use-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.sandbox.superserve.ai",
+			wantPort:       3000,
+			wantInstanceID: "sb-use-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		// Hyphenated region segment: the API would never mint it, so the
+		// proxy passes it through rather than guessing a split.
+		{
+			host:           "3000-sb-us-east-1-b150ee22-4956-4f5b-926a-f921ed8c37d6.sandbox.superserve.ai",
+			wantPort:       3000,
+			wantInstanceID: "sb-us-east-1-b150ee22-4956-4f5b-926a-f921ed8c37d6",
+		},
 		// User application ports — numeric label
 		{
 			host:           "3000-mybox.sandbox.superserve.ai",


### PR DESCRIPTION
Public sandbox IDs gain an optional region segment — `sb-use-<uuid>` / `sb-usw-<uuid>` — so the edge can route sandbox-scoped requests to the home cell from the ID alone, mirroring the `ss_live_<region>_` API-key scheme. Part of the multi-region cell rollout. Safe to merge today: minting is flag-gated off, so responses are byte-for-byte unchanged until `SANDBOX_ID_REGION` is set on a cell.

## Technical decisions

- Hyphen separator, not underscore: sandbox IDs are embedded as hostname labels by the proxy (`{port}-{id}.{domain}`) and underscores aren't DNS-safe. Prefixed IDs fit the existing 64-char instance-ID cap (43 chars) and the label parser already splits on the first hyphen only.
- Accept-both is unconditional; minting is env-gated. Rollout: merge (no change) → flip `SANDBOX_ID_REGION=use` on the existing cell once we're ready → new sandboxes return tagged IDs while every stored bare-UUID keeps working.
- The proxy normalizes to the bare UUID before VMD lookup, resolver cache, and access-token HMAC verification — those are all keyed on the UUID, so clients can build hostnames from whichever form the API returned.
- The region segment is shape-validated but not checked against a region list: a cell serves whatever the edge routed to it, and a vocabulary check here would couple every cell deploy to region launches. Cell-match enforcement belongs to the edge-routing work.
- DB PK stays `uuid` — no schema or query changes.

## Testing

Codec unit tests (format flag on/off, both current region codes, a longer future code, malformed segments, round-trip), proxy ParseHost tests for tagged IDs under both boxd and numeric-port labels plus a non-matching `sb-` passthrough. api + proxy suites green; integration tests compile and parse `id` as UUID, which holds while the flag is off.