### PR TITLE
docs: replace sub-second cold start claim with <50ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The infrastructure powering [Superserve](https://superserve.ai) sandboxes — fa
 
 ## Overview
 
-Superserve Sandbox provides sub-second VM cold starts using Firecracker microVMs and copy-on-write (COW) snapshot pools. It powers the Superserve sandbox API.
+Superserve Sandbox provides fast (<50ms) VM cold starts using Firecracker microVMs and copy-on-write (COW) snapshot pools. It powers the Superserve sandbox API.
 
 **Key components:**
 


### PR DESCRIPTION
## Summary
- README said "sub-second" VM cold starts — undersells actual latency and reads as vague in a public repo
- Changed to "fast (<50ms)"

## Testing
- Docs-only change