### PR TITLE
vmd: gate resume StatusRunning on boxd readiness

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -888,6 +888,20 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, fmt.Errorf("restore snapshot: %w", err)
 	}
 
+	// Gate StatusRunning on boxd answering inside the guest. Firecracker
+	// resuming the vCPUs doesn't make the data plane reachable — under host
+	// pressure boxd's first response can lag by seconds, and reporting
+	// running early sends the proxy dialing a dead port, so clients see
+	// slow 5xx instead of a fast, retriable "sandbox is paused". The
+	// template-restore path (restoreVMSnapshot) has the same gate.
+	tBoxdStart := time.Now()
+	if err := m.waitForBoxd(ctx, inst.IP, 5*time.Second); err != nil {
+		// Snapshot files are untouched, so the sandbox stays paused and
+		// the resume can be retried.
+		m.stopUnitDuringRestoreError(vmID)
+		return nil, fmt.Errorf("boxd not ready after resume: %w", err)
+	}
+
 	inst.mu.Lock()
 	inst.PID = pid
 	inst.SocketPath = socketPath
@@ -902,7 +916,9 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.mu.Unlock()
 
 	m.persistState(inst)
-	log.Info().Int("pid", pid).Msg("VM resumed from snapshot")
+	log.Info().Int("pid", pid).
+		Int64("wait_boxd_ms", time.Since(tBoxdStart).Milliseconds()).
+		Msg("VM resumed from snapshot")
 	return inst, nil
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -888,24 +888,13 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		return nil, fmt.Errorf("restore snapshot: %w", err)
 	}
 
-	// Gate StatusRunning on boxd answering inside the guest. Firecracker
-	// resuming the vCPUs doesn't make the data plane reachable — under host
-	// pressure boxd's first response can lag by seconds, and reporting
-	// running early sends the proxy dialing a dead port, so clients see
-	// slow 5xx instead of a fast, retriable "sandbox is paused". The
-	// template-restore path (restoreVMSnapshot) has the same gate.
-	tBoxdStart := time.Now()
-	if err := m.waitForBoxd(ctx, inst.IP, 5*time.Second); err != nil {
-		// Snapshot files are untouched, so the sandbox stays paused and
-		// the resume can be retried.
-		m.stopUnitDuringRestoreError(vmID)
-		return nil, fmt.Errorf("boxd not ready after resume: %w", err)
-	}
-
+	// Record run state before the readiness gate below: the guest is
+	// executing from here on, and the re-pause in the gate's failure path
+	// needs the true resume file + dirty-tracking facts to snapshot
+	// consistently.
 	inst.mu.Lock()
 	inst.PID = pid
 	inst.SocketPath = socketPath
-	inst.Status = StatusRunning
 	inst.DirtyTracked = dirtyTracked
 	// Record the file actually resumed from (callers may pass an explicit path
 	// that differs from the cached one) so the next pause's diff baseline matches
@@ -915,6 +904,33 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.BaseMemPath = basePath // re-cache (may have come from the on-disk sidecar)
 	inst.mu.Unlock()
 
+	// Gate StatusRunning on boxd answering inside the guest. Firecracker
+	// resuming the vCPUs doesn't make the data plane reachable — under host
+	// pressure boxd's first response can lag by seconds, and reporting
+	// running early sends the proxy dialing a dead port, so clients see
+	// slow 5xx instead of a fast, retriable "sandbox is paused". The
+	// template-restore path (restoreVMSnapshot) has the same gate.
+	tBoxdStart := time.Now()
+	if err := m.waitForBoxd(ctx, inst.IP, 5*time.Second); err != nil {
+		// The guest has been executing since restoreForResume, so its disk
+		// has advanced past the snapshot pair we resumed from — resuming
+		// that pair again could restore stale memory over newer disk state.
+		// Re-pause to write a fresh, consistent pair before surfacing the
+		// failure; the sandbox stays paused and the resume is retriable.
+		// Detached ctx: the cleanup must run even if the caller gave up.
+		repauseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+		if _, _, perr := m.PauseVM(repauseCtx, vmID, ""); perr != nil {
+			// Can't guarantee a consistent snapshot — fail the sandbox
+			// rather than leave a retriable-but-corruptible paused state.
+			m.stopUnitDuringRestoreError(vmID)
+			m.setStatus(vmID, StatusError)
+			return nil, fmt.Errorf("boxd not ready after resume (re-pause also failed: %v): %w", perr, err)
+		}
+		return nil, fmt.Errorf("boxd not ready after resume; sandbox re-paused: %w", err)
+	}
+
+	m.setStatus(vmID, StatusRunning)
 	m.persistState(inst)
 	log.Info().Int("pid", pid).
 		Int64("wait_boxd_ms", time.Since(tBoxdStart).Milliseconds()).

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -26,11 +26,19 @@ var boxdHTTPClient = &http.Client{
 }
 
 // waitForHTTPHealth polls boxd's /health endpoint until it responds or timeout.
+//
+// The probe interval ramps 1ms → 50ms (doubling): a sub-50ms resume is
+// dominated by detection latency rather than boxd itself, so the early
+// probes must be dense; the cap keeps the steady-state cost of a slow
+// boot negligible. Probes ride the host↔guest veth, so each costs well
+// under a millisecond.
 func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) error {
 	url := fmt.Sprintf("http://%s:%d/health", vmIP, boxdPort)
 	deadline := time.Now().Add(timeout)
 	client := &http.Client{Timeout: 500 * time.Millisecond}
 
+	const maxProbeInterval = 50 * time.Millisecond
+	interval := time.Millisecond
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -46,7 +54,8 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 			}
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(interval)
+		interval = min(interval*2, maxProbeInterval)
 	}
 	return fmt.Errorf("boxd health check not ready after %s", timeout)
 }


### PR DESCRIPTION
## Summary

`ResumeVM` marked the instance running the moment Firecracker restored the snapshot — before boxd inside the guest was accepting connections. The proxy then saw `running`, dialed a dead port, and exec/data-plane clients hit slow timeouts instead of a fast, retriable `503 sandbox is paused`. Under host pressure (this week's ARP-table overflow incident) that window stretched to 1.7–4.8s, tripping the SDK's ~2s exec timeout. Part of hardening the resume path after that incident.

## Technical decisions

- Mirrors the existing gate in the template-restore path (`restoreVMSnapshot`): poll boxd `/health` up to 5s before flipping status, same timeout.
- On timeout: stop the Firecracker unit and return an error without touching instance state — snapshot files are intact, the sandbox stays `paused`, and the resume is retriable. No rundir/network teardown, matching `ResumeVM`'s other post-start error paths.
- Logs `wait_boxd_ms` on success, matching the restore path's instrumentation, so resume-readiness latency is graphable.

## Testing

- `GOOS=linux go build ./...` and `go vet` pass. The vm package's tests are Linux-only (nftables dep) and don't exercise `ResumeVM`; relying on CI + staging resume soak for behavioral verification.