### PR TITLE
vmd: log boxd readiness latency after resume

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/network"
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
@@ -903,6 +904,29 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 
 	m.persistState(inst)
 	log.Info().Int("pid", pid).Msg("VM resumed from snapshot")
+
+	// Telemetry only: measure how long boxd takes to become reachable after
+	// the vCPUs resume. Detached — status is already running and the probe
+	// mutates nothing, so a slow or dead boxd can't affect the resume. The
+	// field name matches the restore path's wait_boxd_ms so both are
+	// queryable the same way; resume readiness was the blind spot in the
+	// exec-503 incidents.
+	probeStart := time.Now()
+	vmIP := inst.IP
+	go func() {
+		defer sentrylog.Recover("resume-boxd-probe")
+		probeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := m.waitForBoxd(probeCtx, vmIP, 30*time.Second); err != nil {
+			log.Warn().Err(err).
+				Int64("wait_boxd_ms", time.Since(probeStart).Milliseconds()).
+				Msg("boxd not reachable after resume")
+			return
+		}
+		log.Info().
+			Int64("wait_boxd_ms", time.Since(probeStart).Milliseconds()).
+			Msg("boxd reachable after resume")
+	}()
 	return inst, nil
 }
 

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -26,11 +26,19 @@ var boxdHTTPClient = &http.Client{
 }
 
 // waitForHTTPHealth polls boxd's /health endpoint until it responds or timeout.
+//
+// The probe interval ramps 1ms → 50ms (doubling): readiness in the tens of
+// milliseconds would otherwise be quantized to the poll interval, so the
+// early probes must be dense; the cap keeps the steady-state cost of a slow
+// boot negligible. Probes ride the host↔guest veth, so each costs well
+// under a millisecond.
 func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) error {
 	url := fmt.Sprintf("http://%s:%d/health", vmIP, boxdPort)
 	deadline := time.Now().Add(timeout)
 	client := &http.Client{Timeout: 500 * time.Millisecond}
 
+	const maxProbeInterval = 50 * time.Millisecond
+	interval := time.Millisecond
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -46,7 +54,8 @@ func waitForHTTPHealth(ctx context.Context, vmIP string, timeout time.Duration) 
 			}
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(interval)
+		interval = min(interval*2, maxProbeInterval)
 	}
 	return fmt.Errorf("boxd health check not ready after %s", timeout)
 }


### PR DESCRIPTION
## Summary

Resume-from-pause has no measurement of how long boxd takes to become reachable after the vCPUs resume — the blind spot behind the recent exec-503 incidents, where sandboxes reported running while boxd was still unreachable. This adds a detached probe of boxd `/health` after the status flip that logs `wait_boxd_ms` (matching the template-restore path's existing field), plus a warning line if boxd isn't reachable within 30s. Replaces the gating approach from #166, which was parked for its failure-path risks; this data decides whether gating is worth revisiting and with what timeout.

## Technical decisions

- Telemetry only: the probe runs in a detached goroutine after `StatusRunning` is set and persisted — no status gating, no added resume latency, no state mutation on probe failure. A dead in-guest boxd logs a warning instead of bricking the resume.
- Health-probe interval ramps 1ms → 50ms (was fixed 50ms) so sub-50ms readiness isn't quantized to the poll cadence. Shared helper, so the template-restore gate gets the same cadence.
- 30s probe cap keeps abandoned goroutines bounded on hosts where boxd never comes up.

## Testing

- `GOOS=linux go build ./...` and `go vet` pass; the vm package's tests are Linux-only (nftables dep). Verification is watching `wait_boxd_ms` / "boxd not reachable after resume" in journald/Sentry after deploy.