### PR TITLE
vmd: fix tap0 EBUSY on slot recycle and unblock benign orphan cleanup

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1904,26 +1904,25 @@ func isReservedRunDirName(name string) bool {
 // caller's gRPC ctx is often already cancelled (deadline exceeded under
 // load). Without this, the firecracker process leaks.
 func (m *Manager) stopUnitDuringRestoreError(vmID string) {
-	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := stopUnit(cleanupCtx, systemdUnitName(vmID)); err != nil {
+	if err := stopUnit(stopCtx, systemdUnitName(vmID)); err != nil {
 		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("systemctl stop failed during restore error cleanup")
 	}
-	removeUnitDropIn(vmID)
 
-	// Slot is recycled right after this returns; SIGKILL by PID and wait for
-	// exit so the tap0 fd is released first (stopUnit can time out under load).
-	if inst, err := m.getInstance(vmID); err == nil {
-		inst.mu.RLock()
-		pid := inst.PID
-		inst.mu.RUnlock()
-		if pid > 0 {
-			if proc, err := os.FindProcess(pid); err == nil {
-				_ = proc.Signal(syscall.SIGKILL)
-				waitForPIDExit(pid, 500*time.Millisecond)
-			}
+	// Slot is recycled right after this returns; if stopUnit timed out the FC
+	// may still hold tap0. Resolve the unit's live MainPID (inst.PID is set
+	// asynchronously and often still 0 this early), SIGKILL, and wait for exit.
+	killCtx, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	if pid := m.unitMainPID(killCtx, vmID); pid > 0 {
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Signal(syscall.SIGKILL)
+			waitForPIDExit(pid, 500*time.Millisecond)
 		}
 	}
+
+	removeUnitDropIn(vmID)
 }
 
 // RecordAccessPattern restores the snapshot in recording mode, waits a fixed
@@ -2118,17 +2117,26 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	return 0, nil
 }
 
+// unitMainPID returns the systemd MainPID for a VM's unit, or 0 when it can't
+// be resolved or the unit has no running process.
+func (m *Manager) unitMainPID(ctx context.Context, vmID string) int {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=MainPID", "--value", systemdUnitName(vmID)).Output()
+	if err != nil {
+		return 0
+	}
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &pid); err != nil {
+		return 0
+	}
+	return pid
+}
+
 func (m *Manager) resolveAndSetPID(vmID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "systemctl", "show", "--property=MainPID", "--value", systemdUnitName(vmID))
-	out, err := cmd.Output()
-	if err != nil {
-		return
-	}
-	var pid int
-	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &pid); err != nil || pid == 0 {
+	pid := m.unitMainPID(ctx, vmID)
+	if pid == 0 {
 		return
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1910,6 +1910,20 @@ func (m *Manager) stopUnitDuringRestoreError(vmID string) {
 		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("systemctl stop failed during restore error cleanup")
 	}
 	removeUnitDropIn(vmID)
+
+	// Slot is recycled right after this returns; SIGKILL by PID and wait for
+	// exit so the tap0 fd is released first (stopUnit can time out under load).
+	if inst, err := m.getInstance(vmID); err == nil {
+		inst.mu.RLock()
+		pid := inst.PID
+		inst.mu.RUnlock()
+		if pid > 0 {
+			if proc, err := os.FindProcess(pid); err == nil {
+				_ = proc.Signal(syscall.SIGKILL)
+				waitForPIDExit(pid, 500*time.Millisecond)
+			}
+		}
+	}
 }
 
 // RecordAccessPattern restores the snapshot in recording mode, waits a fixed

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -3,7 +3,9 @@ package vm
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -746,5 +748,52 @@ func TestIsTemplateMemPath(t *testing.T) {
 	}
 	if isOverlayMemFile("/x/mem.diff") != true || isOverlayMemFile("/x/mem.snap") != false {
 		t.Fatal("isOverlayMemFile basename detection wrong")
+	}
+}
+
+// waitForPIDExit is the primitive the restore-error tap0 fix relies on: after
+// SIGKILLing the lingering Firecracker, stopUnitDuringRestoreError must block
+// until the process is actually gone (its tap0 fd released) before the slot is
+// recycled. These pin both directions of that behavior.
+
+func TestWaitForPIDExit_LiveProcessWaitsFullTimeout(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+
+	start := time.Now()
+	waitForPIDExit(pid, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	// A live process is never reaped, so the wait must burn ~the full timeout —
+	// this is what forces the cleanup to wait for the tap fd before recycling.
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("returned after %v; expected to wait ~200ms for a live process", elapsed)
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Errorf("process should still be alive after the wait: %v", err)
+	}
+}
+
+func TestWaitForPIDExit_DeadProcessReturnsPromptly(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait() // reap so kill(pid,0) sees ESRCH, mirroring systemd reaping the FC
+
+	start := time.Now()
+	waitForPIDExit(pid, 2*time.Second)
+	elapsed := time.Since(start)
+
+	// Once the process is gone the wait must return promptly, not stall the
+	// restore-error cleanup for the whole timeout.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned after %v; expected a prompt return once the process exited", elapsed)
 	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -391,21 +391,20 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !r.gracePeriodElapsed("bolt-orphan:"+id, now) {
 				continue
 			}
-			if !r.consumeAutoFailBudget(id) {
-				r.writeAudit(ctx, id, "budget_exhausted", "stale_cleanup suppressed by rate limit", "boltdb_present_db_missing")
-				continue
-			}
 			rec, getErr := r.mgr.state.Get(id)
 			if getErr != nil || rec == nil {
 				r.clearDrift("bolt-orphan:" + id)
 				continue
 			}
-			log.Warn().Str("vm_id", id).Str("drift", "boltdb_present_db_missing").
-				Msg("BoltDB entry with no DB row — cleaning up")
-			// Stop the unit if it's still live. If the stop fails the VM may
-			// still be running, so leave the entry for next pass — markStale
-			// frees the network slot, which must never happen for a live VM.
+			// Only stopping a live unit is destructive; charge the budget there.
+			// Dropping a stale entry for a dead VM is benign and must not be gated.
 			if rec.Status == StatusRunning {
+				if !r.consumeAutoFailBudget(id) {
+					r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "boltdb_present_db_missing")
+					continue
+				}
+				log.Warn().Str("vm_id", id).Str("drift", "boltdb_present_db_missing").
+					Msg("live orphan systemd unit with no DB row — stopping")
 				if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
 					log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit from BoltDB — leaving for retry")
 					continue

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -397,9 +397,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			// Only stopping a live unit is destructive; charge the budget there.
-			// Gate on actual systemd liveness, not the cached status — a crashed
-			// VM often lingers as StatusRunning and must still clean up unbudgeted.
-			if r.isAlive(ctx, id) {
+			// Gate on the fail-closed `active` snapshot (the pass bailed if systemctl
+			// couldn't be listed) so an inconclusive check never frees a live VM's slot.
+			if active[id] {
 				if !r.consumeAutoFailBudget(id) {
 					r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "boltdb_present_db_missing")
 					continue

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -259,7 +259,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if sb.Sandbox.Status != db.SandboxStatusActive {
 				continue
 			}
-			if r.isAlive(ctx, id) {
+			if active[id] {
 				r.clearDrift(id)
 				continue
 			}
@@ -286,7 +286,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if rec.Status != StatusRunning {
 				continue
 			}
-			if r.isAlive(ctx, id) {
+			if active[id] {
 				r.clearDrift(id)
 				continue
 			}
@@ -755,11 +755,6 @@ func dirSize(ctx context.Context, paths []string) int64 {
 		})
 	}
 	return total
-}
-
-// isAlive returns true when the VM's systemd unit is currently active.
-func (r *Reconciler) isAlive(ctx context.Context, vmID string) bool {
-	return isUnitActive(ctx, systemdUnitName(vmID))
 }
 
 // gracePeriodElapsed records the first-seen timestamp for a drifted ID and

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -397,8 +397,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			// Only stopping a live unit is destructive; charge the budget there.
-			// Dropping a stale entry for a dead VM is benign and must not be gated.
-			if rec.Status == StatusRunning {
+			// Gate on actual systemd liveness, not the cached status — a crashed
+			// VM often lingers as StatusRunning and must still clean up unbudgeted.
+			if r.isAlive(ctx, id) {
 				if !r.consumeAutoFailBudget(id) {
 					r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "boltdb_present_db_missing")
 					continue


### PR DESCRIPTION
Two independent fixes in the VM lifecycle path.

**1. `tap0` EBUSY on slot recycle after a failed restore.**
The network pool recycles slots (netns + tap0) on the assumption the previous Firecracker is fully dead. `stopUnitDuringRestoreError` only ran `systemctl stop` (a best-effort call that can time out under load) before the slot was returned to the pool — with no PID-based kill or exit wait. When the process lingered, its tap0 fd stayed open, so the next VM to claim the slot failed to open tap0 with `Device or resource busy (os error 16)`. Fixed by SIGKILL-by-PID + `waitForPIDExit` before the slot is recycled, matching the guarantee `DestroyVM` already makes.

**2. Reconciler wedge from benign orphan cleanup.**
Drift 5 (BoltDB entry with no DB row) charged the per-host auto-fail budget *before* checking whether the VM was live — so removing a stale entry for a dead VM (pure bookkeeping) consumed the same 5/hour budget meant for destructive actions. A backlog of dead orphans larger than the budget permanently starved it: slots never returned to the pool and the reconciler re-logged `budget_exhausted` every pass. Fixed by charging the budget only for the destructive case (stopping a still-live unit); benign dead-orphan cleanup is no longer gated. The blast-radius guarantees are unchanged — the budget still bounds live-unit stops, `markStale` still only runs once a VM is confirmed not live, and the DB-reachability guard still prevents mass cleanup during a DB outage.
