### PR TITLE
cd: migrate the usw cell after primary prod migration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,22 +60,12 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
 
-  # Every cell DB runs the identical migration set; a cell that misses a
-  # migration silently drifts until a deploy 500s against it. Cells migrate
-  # sequentially after the primary so a bad migration stops before spreading.
-  migrate-prod-usw:
-    name: Migrate Production (usw cell)
-    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
-    runs-on: ubuntu-latest
-    environment: production
-    needs: [migrate-prod]
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
+      # Every cell DB runs the identical migration set; a cell that misses a
+      # migration silently drifts until a deploy 500s against it. A step in
+      # this job — not a separate job — so a protected production environment
+      # gates ONE approval (a second env-referencing job would double-gate
+      # Deploy API, which waits on this whole workflow). Step order still
+      # stops a bad migration at the primary before it spreads.
       - name: Push migrations to usw cell
         run: supabase db push --db-url "$DATABASE_URL"
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,3 +59,24 @@ jobs:
         run: supabase db push --db-url "$DATABASE_URL"
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+
+  # Every cell DB runs the identical migration set; a cell that misses a
+  # migration silently drifts until a deploy 500s against it. Cells migrate
+  # sequentially after the primary so a bad migration stops before spreading.
+  migrate-prod-usw:
+    name: Migrate Production (usw cell)
+    if: github.event_name == 'push' || github.event.inputs.environment == 'production'
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [migrate-prod]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Push migrations to usw cell
+        run: supabase db push --db-url "$DATABASE_URL"
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}


### PR DESCRIPTION
Adds the us-west cell's Supabase DB to the CD Migrate chain: `migrate-prod-usw` runs the same `supabase db push` against `DATABASE_URL_USWEST` after the primary prod migration succeeds. First concrete piece of (N-cell migrations); the cell DB itself is live and schema-verified.

## Technical decisions

- Sequential (`needs: [migrate-prod]`), not parallel: a bad migration stops at the primary instead of spreading to every cell in one push.
- Fails hard when `DATABASE_URL_USWEST` is missing rather than skip-if-unset — a silent skip is exactly the drift this job exists to prevent. Consequence: **do not merge until the secret exists in the production environment** because Deploy API is gated on same-SHA CD Migrate success (#163) and a red usw job would block API deploys.
- Session-pooler URL for the secret, not the direct URL — the direct host is IPv6-only and GitHub runners are IPv4 (hit this during bring-up).

## Testing

YAML validates. Job logic is identical to the existing migrate-prod job with a different secret; the usw DB already has the full migration history seeded so the first CD run should be a clean no-op — that run is the real test.