### PR TITLE
api: wrong-cell 401 names the key's region

### DIFF
--- a/internal/api/apikey_region.go
+++ b/internal/api/apikey_region.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// API keys optionally carry the issuing cell's region between the live prefix
+// and the random component:
+//
+//	ss_live_<region>_<random>   e.g. ss_live_usw_k3TQxV...
+//
+// Each cell's database holds only its own teams' keys, so a key presented to
+// the wrong cell fails the hash lookup exactly like an invalid key. When the
+// key names a different cell's region, the 401 says so — otherwise a valid
+// key pointed at the wrong endpoint reads as "invalid key" with no hint that
+// the fix is the URL, not the key.
+const apiKeyLivePrefix = "ss_live_"
+
+// knownRegions is the allowlist of region tokens with a launched cell, grown
+// by hand per cell launch. It exists to kill false positives: legacy key
+// randoms are base64url and may contain underscores, so a legacy
+// "ss_live_abc_..." key parses as region "abc" by coincidence — without the
+// allowlist we would point that user at a nonexistent api-abc endpoint. The
+// tradeoff is that a key from a cell launched after this deploy gets the
+// generic 401 instead of the redirect hint until the list catches up; cells
+// launch rarely, so that window is accepted.
+var knownRegions = map[string]bool{
+	"use": true,
+	"usw": true,
+}
+
+// cellRegion is this cell's own region token. Empty SANDBOX_ID_REGION means
+// the pre-multi-region primary cell, which is region "use".
+func cellRegion() string {
+	if r := sandboxIDRegionFromEnv(); r != "" {
+		return r
+	}
+	return "use"
+}
+
+// apiKeyRegion extracts the region token from a region-tagged API key. It
+// returns "" for legacy keys (ss_live_<random>, no region segment) and for
+// anything that does not parse — a non-conforming segment is treated as "no
+// region", never an error. Shape rules match sandbox IDs: 1-17 lowercase
+// alphanumeric characters.
+func apiKeyRegion(key string) string {
+	rest, ok := strings.CutPrefix(key, apiKeyLivePrefix)
+	if !ok {
+		return ""
+	}
+	region, random, ok := strings.Cut(rest, "_")
+	if !ok || random == "" {
+		return "" // legacy: random only, no region segment
+	}
+	if len(region) > maxRegionCodeLen || !validRegionCode(region) {
+		return ""
+	}
+	return region
+}
+
+// respondAuthFailed writes the 401 for a failed API-key lookup. When the key
+// is tagged with a known region other than this cell's, the body names the
+// fix; every other failure — invalid, legacy, same-region key not found,
+// unparseable — returns the identical generic 401, so the response reveals
+// nothing about whether a key exists. The region token is client-visible
+// plaintext, so echoing it back leaks nothing either.
+func respondAuthFailed(c *gin.Context, apiKey string) {
+	if region := apiKeyRegion(apiKey); region != "" && knownRegions[region] && region != cellRegion() {
+		respondErrorMsg(c, "wrong_region",
+			"this API key belongs to region '"+region+"'; use that region's endpoint (https://api-"+region+".superserve.ai) or upgrade your SDK, which routes automatically",
+			http.StatusUnauthorized)
+		return
+	}
+	respondErrorMsg(c, "auth_failed", "Invalid or missing X-API-Key header.", http.StatusUnauthorized)
+}

--- a/internal/api/apikey_region.go
+++ b/internal/api/apikey_region.go
@@ -19,17 +19,20 @@ import (
 // the fix is the URL, not the key.
 const apiKeyLivePrefix = "ss_live_"
 
-// knownRegions is the allowlist of region tokens with a launched cell, grown
-// by hand per cell launch. It exists to kill false positives: legacy key
-// randoms are base64url and may contain underscores, so a legacy
+// knownRegions maps region tokens with a launched cell to that cell's
+// canonical API endpoint, grown by hand per cell launch. Endpoints are
+// stored rather than derived because regional hostnames aren't uniform:
+// the primary cell predates the region scheme and lives at the bare api
+// hostname, not api-use. The allowlist half also kills false positives:
+// legacy key randoms are base64url and may contain underscores, so a legacy
 // "ss_live_abc_..." key parses as region "abc" by coincidence — without the
 // allowlist we would point that user at a nonexistent api-abc endpoint. The
 // tradeoff is that a key from a cell launched after this deploy gets the
-// generic 401 instead of the redirect hint until the list catches up; cells
+// generic 401 instead of the redirect hint until the map catches up; cells
 // launch rarely, so that window is accepted.
-var knownRegions = map[string]bool{
-	"use": true,
-	"usw": true,
+var knownRegions = map[string]string{
+	"use": "https://api.superserve.ai",
+	"usw": "https://api-usw.superserve.ai",
 }
 
 // cellRegion is this cell's own region token. Empty SANDBOX_ID_REGION means
@@ -68,11 +71,13 @@ func apiKeyRegion(key string) string {
 // nothing about whether a key exists. The region token is client-visible
 // plaintext, so echoing it back leaks nothing either.
 func respondAuthFailed(c *gin.Context, apiKey string) {
-	if region := apiKeyRegion(apiKey); region != "" && knownRegions[region] && region != cellRegion() {
-		respondErrorMsg(c, "wrong_region",
-			"this API key belongs to region '"+region+"'; use that region's endpoint (https://api-"+region+".superserve.ai) or upgrade your SDK, which routes automatically",
-			http.StatusUnauthorized)
-		return
+	if region := apiKeyRegion(apiKey); region != "" && region != cellRegion() {
+		if endpoint, known := knownRegions[region]; known {
+			respondErrorMsg(c, "wrong_region",
+				"this API key belongs to region '"+region+"'; use that region's endpoint ("+endpoint+") or upgrade your SDK, which routes automatically",
+				http.StatusUnauthorized)
+			return
+		}
 	}
 	respondErrorMsg(c, "auth_failed", "Invalid or missing X-API-Key header.", http.StatusUnauthorized)
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -67,7 +67,10 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 			keyHash,
 		).Scan(&id, &teamID, &createdBy, &expiresAt)
 		if err != nil {
-			respondErrorMsg(c, "auth_failed", "Invalid or missing X-API-Key header.", http.StatusUnauthorized)
+			// Lookup failed — usually a bad key, but with per-cell databases
+			// it is also how a valid key presented to the wrong cell fails.
+			// respondAuthFailed names the right region when the key says so.
+			respondAuthFailed(c, apiKey)
 			c.Abort()
 			return
 		}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -65,6 +67,127 @@ func TestAPIKeyAuth_EmptyHeader(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Wrong-cell 401 (region-tagged API keys)
+// ---------------------------------------------------------------------------
+
+// newUnreachablePool returns a pool whose every query errors: pgxpool
+// connects lazily, so construction succeeds and the middleware's key lookup
+// fails at Scan — the same branch a key-not-found takes.
+func newUnreachablePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), "postgres://u:p@127.0.0.1:1/db?connect_timeout=1")
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// doAuthRequest sends a request with the given API key and returns the status
+// code and decoded error object (nil if the body has none).
+func doAuthRequest(t *testing.T, r *gin.Engine, key string) (int, map[string]interface{}) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-API-Key", key)
+	r.ServeHTTP(w, req)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]interface{})
+	return w.Code, errObj
+}
+
+func TestAPIKeyAuth_WrongRegionKey(t *testing.T) {
+	t.Setenv("SANDBOX_ID_REGION", "use")
+	r := newAuthTestRouter(newUnreachablePool(t))
+
+	code, errObj := doAuthRequest(t, r, "ss_live_usw_dGVzdHJhbmRvbQ")
+	if code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", code)
+	}
+	if errObj["code"] != "wrong_region" {
+		t.Errorf("expected code=wrong_region, got %v", errObj["code"])
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "region 'usw'") || !strings.Contains(msg, "https://api-usw.superserve.ai") {
+		t.Errorf("message should name the region and its endpoint, got %q", msg)
+	}
+}
+
+func TestAPIKeyAuth_WrongRegionKey_DefaultCellRegion(t *testing.T) {
+	// Unset SANDBOX_ID_REGION means the pre-multi-region primary cell,
+	// region "use" — a usw-tagged key must still get the redirect hint.
+	t.Setenv("SANDBOX_ID_REGION", "")
+	r := newAuthTestRouter(newUnreachablePool(t))
+
+	code, errObj := doAuthRequest(t, r, "ss_live_usw_dGVzdHJhbmRvbQ")
+	if code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", code)
+	}
+	if errObj["code"] != "wrong_region" {
+		t.Errorf("expected code=wrong_region, got %v", errObj["code"])
+	}
+}
+
+func TestAPIKeyAuth_LookupFailureStaysGeneric(t *testing.T) {
+	t.Setenv("SANDBOX_ID_REGION", "use")
+	r := newAuthTestRouter(newUnreachablePool(t))
+
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"same-region key not in DB", "ss_live_use_dGVzdHJhbmRvbQ"},
+		{"legacy key", "ss_live_dGVzdHJhbmRvbQ"},
+		// Legacy randoms are base64url and may contain underscores; "abc"
+		// parses as a region but is not in knownRegions, so no hint.
+		{"legacy key with coincidental underscore segments", "ss_live_abc_ZGVm_NDU2"},
+		// "euw" could be a real region one day, but until it lands in
+		// knownRegions the hint is suppressed — the accepted tradeoff for
+		// never pointing legacy-key users at endpoints that do not exist.
+		{"unknown-region prefix", "ss_live_euw_dGVzdHJhbmRvbQ"},
+		{"unparseable key", "not-a-key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, errObj := doAuthRequest(t, r, tc.key)
+			if code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", code)
+			}
+			if errObj["code"] != "auth_failed" {
+				t.Errorf("expected code=auth_failed, got %v", errObj["code"])
+			}
+			if errObj["message"] != "Invalid or missing X-API-Key header." {
+				t.Errorf("expected the generic 401 message, got %v", errObj["message"])
+			}
+		})
+	}
+}
+
+func TestAPIKeyRegion(t *testing.T) {
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"ss_live_usw_dGVzdA", "usw"},
+		{"ss_live_use_dGVzdA", "use"},
+		{"ss_live_dGVzdA", ""},                    // legacy: no region segment
+		{"ss_live_ABC_def", ""},                   // uppercase: not a region shape
+		{"ss_live__abc", ""},                      // empty region segment
+		{"ss_live_usw_", ""},                      // empty random
+		{"ss_live_aaaaaaaaaaaaaaaaaa_dGVzdA", ""}, // 18 chars, over the cap
+		{"sk-something", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := apiKeyRegion(tc.key); got != tc.want {
+			t.Errorf("apiKeyRegion(%q) = %q, want %q", tc.key, got, tc.want)
+		}
 	}
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -134,6 +134,29 @@ func TestAPIKeyAuth_WrongRegionKey_DefaultCellRegion(t *testing.T) {
 	}
 }
 
+func TestAPIKeyAuth_WrongRegionKey_UseKeyOnUswCell(t *testing.T) {
+	// The primary cell predates the region scheme and lives at the bare api
+	// hostname — a use-tagged key misrouted to the usw cell must be pointed
+	// at https://api.superserve.ai, not a derived api-use that doesn't exist.
+	t.Setenv("SANDBOX_ID_REGION", "usw")
+	r := newAuthTestRouter(newUnreachablePool(t))
+
+	code, errObj := doAuthRequest(t, r, "ss_live_use_dGVzdHJhbmRvbQ")
+	if code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", code)
+	}
+	if errObj["code"] != "wrong_region" {
+		t.Errorf("expected code=wrong_region, got %v", errObj["code"])
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "region 'use'") || !strings.Contains(msg, "(https://api.superserve.ai)") {
+		t.Errorf("message should point at the bare canonical endpoint, got %q", msg)
+	}
+	if strings.Contains(msg, "api-use") {
+		t.Errorf("message must not reference the nonexistent api-use host, got %q", msg)
+	}
+}
+
 func TestAPIKeyAuth_LookupFailureStaysGeneric(t *testing.T) {
 	t.Setenv("SANDBOX_ID_REGION", "use")
 	r := newAuthTestRouter(newUnreachablePool(t))


### PR DESCRIPTION
With per-cell databases each cell holds only its own teams' API keys, so a valid key presented to the wrong cell fails the hash lookup like any invalid key and returned a generic 401. This change makes that failure name the fix: when a failed lookup involves an `ss_live_<region>_` key tagged with a known region other than this cell's (`SANDBOX_ID_REGION`, defaulting to `use`), the 401 says which region the key belongs to and points at that region's endpoint. Part of multi-region cell routing.

**Technical decisions**
- Parsed regions are checked against a hand-grown allowlist (`use`, `usw`): legacy key randoms are base64url and can contain underscores, so a coincidental `ss_live_abc_...` legacy key would otherwise be pointed at a nonexistent `api-abc` endpoint. Tradeoff: a region newer than the deployed allowlist gets the generic 401 until the list catches up.
- Only the lookup-failure path changes; the happy path (cache hit / DB hit) is untouched, so no added latency.
- Every other failure (invalid, legacy, same-region not found, unparseable) returns byte-identical generic 401s — nothing new is revealed about key validity. The region token is client-visible plaintext, so echoing it back leaks nothing.
- New error code `wrong_region` so SDKs can detect and reroute programmatically; same error body shape as existing responses.

**Testing**
`go test ./internal/api/` — new middleware tests cover wrong-region key (401 + region message, both explicit and defaulted cell region), same-region key not in DB, legacy key, legacy key with coincidental underscore segments, unknown-region prefix (all generic 401), plus a parser table test. `go build` on the touched package (full-repo build fails on macOS due to the Linux-only nftables dep, pre-existing).