### PR TITLE
vmd: serve during startup with on-demand reattach instead of blocking on full-fleet reattach

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -475,7 +475,7 @@ func main() {
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
-	mgr.ReserveStartupSlots()
+	mgr.ReserveStartupSlots(ctx)
 	mgr.SweepStartupOrphanNamespaces()
 
 	// ---- Pre-allocate network slots ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/blocklist"
 	dbq "github.com/superserve-ai/sandbox/internal/db"
@@ -423,15 +426,57 @@ func main() {
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
-	// ---- Reattach to running VMs from previous VMD lifetime ----
-	// Runs BEFORE StartPool so the Phase C orphan-namespace sweep can
-	// clear leaked ns-N/veth-N from prior lifetimes. Otherwise the pool
-	// burns startup retrying colliding slots and ends up with an empty
-	// fresh buffer ("initial pool fill incomplete").
-	reattached, stale := mgr.ReattachAll(ctx)
-	if reattached > 0 || stale > 0 {
-		log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
+	// ---- gRPC server ----
+	// Bind and serve BEFORE the reattach so a restart doesn't refuse connections
+	// during it; requests are gated Unavailable until startupReady flips.
+	startupReady := &atomic.Bool{}
+	notReady := func() error {
+		return status.Error(codes.Unavailable, "vmd is starting up (reattaching VMs), retry shortly")
 	}
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
+	if err != nil {
+		log.Fatal().Err(err).Int("port", cfg.GRPCPort).Msg("failed to listen")
+	}
+	grpcServer := grpc.NewServer(
+		grpc.MaxRecvMsgSize(64<<20), // 64 MiB
+		grpc.UnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			if !startupReady.Load() {
+				return nil, notReady()
+			}
+			return handler(ctx, req)
+		}),
+		grpc.StreamInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			if !startupReady.Load() {
+				return notReady()
+			}
+			return handler(srv, ss)
+		}),
+	)
+	adapter := vm.NewGRPCAdapter(mgr).
+		WithSecretsBroker(cfg.SecretsProxySocket, cfg.SecretsProxySandboxAddr)
+	vmdpb.RegisterVMDaemonServer(grpcServer, adapter)
+	if cfg.SecretsProxySocket != "" {
+		log.Info().
+			Str("socket", cfg.SecretsProxySocket).
+			Str("sandbox_addr", cfg.SecretsProxySandboxAddr).
+			Msg("secretsproxy daemon integration enabled")
+	}
+	lc.start("grpc server", func() error {
+		log.Info().Int("port", cfg.GRPCPort).Msg("gRPC server listening")
+		if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
+			return fmt.Errorf("grpc serve: %w", err)
+		}
+		return nil
+	})
+	// Closer is registered later (after the manager/pool closers) so it runs
+	// first on shutdown — stop accepting before those are torn down.
+
+	// ---- Startup network prep (fast; must precede StartPool) ----
+	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
+	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
+	// below; VMs it hasn't reached are loaded on-demand on first request.
+	mgr.ReserveStartupSlots()
+	mgr.SweepStartupOrphanNamespaces()
 
 	// ---- Pre-allocate network slots ----
 	// Keeps a buffer of ready-to-use network namespaces so sandbox creation
@@ -441,6 +486,18 @@ func main() {
 		NewSize: netPoolFresh,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
+
+	// ---- Background full reattach ----
+	// Off the critical path (requests load their VM on demand); proactively
+	// populates the map and GCs stale records. Plain goroutine, not an lc
+	// service — a completing lc service trips lifecycle shutdown.
+	go func() {
+		defer sentrylog.Recover("startup reattach")
+		reattached, stale := mgr.ReattachAll(ctx)
+		if reattached > 0 || stale > 0 {
+			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
+		}
+	}()
 
 	// ---- Optional DB connection for the reconciler ----
 	// VMD does not need the DB for its request path (that stays on gRPC).
@@ -523,30 +580,8 @@ func main() {
 		return localHTTP.Shutdown(shutdownCtx)
 	})
 
-	// ---- gRPC server ----
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPCPort))
-	if err != nil {
-		log.Fatal().Err(err).Int("port", cfg.GRPCPort).Msg("failed to listen")
-	}
-	grpcServer := grpc.NewServer(
-		grpc.MaxRecvMsgSize(64 << 20), // 64 MiB
-	)
-	adapter := vm.NewGRPCAdapter(mgr).
-		WithSecretsBroker(cfg.SecretsProxySocket, cfg.SecretsProxySandboxAddr)
-	vmdpb.RegisterVMDaemonServer(grpcServer, adapter)
-	if cfg.SecretsProxySocket != "" {
-		log.Info().
-			Str("socket", cfg.SecretsProxySocket).
-			Str("sandbox_addr", cfg.SecretsProxySandboxAddr).
-			Msg("secretsproxy daemon integration enabled")
-	}
-	lc.start("grpc server", func() error {
-		log.Info().Int("port", cfg.GRPCPort).Msg("gRPC server listening")
-		if err := grpcServer.Serve(lis); err != nil && err != grpc.ErrServerStopped {
-			return fmt.Errorf("grpc serve: %w", err)
-		}
-		return nil
-	})
+	// Registered last so it closes first on SIGTERM: stop accepting requests
+	// before the VM manager and network pool are torn down.
 	lc.addCloser("grpc server", func(shutdownCtx context.Context) error {
 		done := make(chan struct{})
 		go func() {
@@ -562,6 +597,12 @@ func main() {
 		}
 		return nil
 	})
+
+	// Fast pre-serve init is done (slots reserved, namespaces swept, pool primed).
+	// Open the gate; the full reattach continues in the background and requests
+	// load any not-yet-reattached VM on demand.
+	startupReady.Store(true)
+	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -479,8 +479,9 @@ func main() {
 	mgr.SweepStartupOrphanNamespaces()
 
 	// ---- Pre-allocate network slots ----
-	// Keeps a buffer of ready-to-use network namespaces so sandbox creation
-	// claims one off the hot path instead of building it inline.
+	// Warm buffer of network namespaces so creation claims off the hot path.
+	// StartPool returns immediately and fills in the background, so the gate
+	// below isn't held for the fill; creates fall back to on-demand until warm.
 	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "128"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
 		NewSize: netPoolFresh,
@@ -598,9 +599,9 @@ func main() {
 		return nil
 	})
 
-	// Fast pre-serve init is done (slots reserved, namespaces swept, pool primed).
-	// Open the gate; the full reattach continues in the background and requests
-	// load any not-yet-reattached VM on demand.
+	// Fast pre-serve init is done (slots reserved, namespaces swept, pool fill
+	// backgrounded). Open the gate; pool warm-up and full reattach continue in
+	// the background, and requests load any not-yet-reattached VM on demand.
 	startupReady.Store(true)
 	log.Info().Msg("startup complete — gRPC serving requests")
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -588,8 +588,15 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		MACAddress: macAddress,
 		Firewall:   fw, // nil if AttachFirewall failed; CleanupVM tolerates it
 	}
+	// Idempotent: if a concurrent reattach of the same VM already bound a handle,
+	// close it before replacing so a double restore doesn't leak the nftables
+	// connection.
+	prev := m.devices[vmID]
 	m.devices[vmID] = info
 	m.mu.Unlock()
+	if prev != nil && prev.Firewall != nil && prev.Firewall != fw {
+		_ = prev.Firewall.Close()
+	}
 	m.registerEgress(vmID, info)
 
 	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -466,7 +466,7 @@ func (m *Manager) CleanupVM(vmID string) {
 // pool). When it is not tracked — e.g. a reattached VM whose network state was
 // never restored into devices — it reclaims the slot directly from the
 // namespace so the ns/veth/slot isn't leaked until the next restart sweep.
-// A no-op when the namespace is empty, malformed, or already gone.
+// A no-op only when the namespace is empty or malformed.
 func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	m.mu.Lock()
 	_, tracked := m.devices[vmID]
@@ -477,9 +477,14 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	}
 
 	idx, ok := slotFromNamespace(fallbackNamespace)
-	if !ok || !nsExists(fallbackNamespace) {
+	if !ok {
 		return
 	}
+	// Tear down both sides even if the netns is already gone: `ip netns del`
+	// only removes the in-namespace side, so the host-side veth-N can outlive
+	// its namespace (a crash, or the peer moved back to the host before the ns
+	// delete). Both deletes are best-effort; then reclaim the slot so the pool
+	// reuses it instead of stranding it as a gap below nextSlot.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
 	m.mu.Lock()
 	m.freeSlots = append(m.freeSlots, idx)
@@ -544,16 +549,29 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
-// ReserveSlotsAbove bumps nextSlot past every slot whose namespace still exists,
-// so the pool won't hand out a slot a not-yet-reattached VM holds. The nsExists
-// guard is load-bearing: reserving a swept stale record's high index would
-// strand the slots below it and could hit ErrNoSlots.
-func (m *Manager) ReserveSlotsAbove(namespaces []string) {
+// ReserveSlotsAbove bumps nextSlot past slots owned by existing VMs so the pool
+// can't hand out a slot a not-yet-reattached VM will reclaim.
+//
+// resumable slots (paused VMs) are reserved unconditionally: a paused VM keeps
+// its slot across a host reboot even though the reboot wipes its netns, and it
+// rebuilds that exact slot on resume — so a missing netns must NOT free it.
+// liveOnly slots (running VMs) are reserved only when their netns still exists;
+// a running record with no netns is stale (the process died, e.g. across a
+// reboot) and its slot is free, so reserving it would strand every lower slot.
+func (m *Manager) ReserveSlotsAbove(resumable, liveOnly []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, ns := range namespaces {
-		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot && nsExists(ns) {
+	bump := func(ns string) {
+		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot {
 			m.nextSlot = idx + 1
+		}
+	}
+	for _, ns := range resumable {
+		bump(ns)
+	}
+	for _, ns := range liveOnly {
+		if nsExists(ns) {
+			bump(ns)
 		}
 	}
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -544,11 +544,10 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
-// ReserveSlotsAbove bumps nextSlot past every slot index whose namespace still
-// exists in the kernel, so the pool won't hand out a slot a not-yet-reattached
-// VM holds. The nsExists guard is load-bearing: a stale record whose ns was
-// already swept must not bump nextSlot, or its (never-reclaimed) index strands
-// every slot below it and can push nextSlot past MaxSlots into ErrNoSlots.
+// ReserveSlotsAbove bumps nextSlot past every slot whose namespace still exists,
+// so the pool won't hand out a slot a not-yet-reattached VM holds. The nsExists
+// guard is load-bearing: reserving a swept stale record's high index would
+// strand the slots below it and could hit ErrNoSlots.
 func (m *Manager) ReserveSlotsAbove(namespaces []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -513,6 +513,20 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 		Msg("reclaimed network slot for untracked VM")
 }
 
+// IsRelinquished reports whether the slot for namespace was freed for reuse at
+// startup (a running record whose netns was already gone). Reattaching such a
+// record would bind its old vmID onto a slot the pool may have handed to a new
+// sandbox, so callers must refuse it.
+func (m *Manager) IsRelinquished(namespace string) bool {
+	idx, ok := slotFromNamespace(namespace)
+	if !ok {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.relinquished[idx]
+}
+
 // Forget drops vmID from the in-memory device map without any kernel teardown,
 // slot reclamation, or egress change. It reverses a reattach that raced a
 // concurrent DestroyVM/markStale: that path already tore down (or recycled to

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -513,6 +513,19 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 		Msg("reclaimed network slot for untracked VM")
 }
 
+// Forget drops vmID from the in-memory device map without any kernel teardown,
+// slot reclamation, or egress change. It reverses a reattach that raced a
+// concurrent DestroyVM/markStale: that path already tore down (or recycled to
+// the pool) the slot, so tearing it down again here would double-free it or
+// clobber the new owner of a recycled ns/veth. The host IP is left registered
+// in the egress proxy — it is keyed by slot, so a reused slot's new owner may
+// already hold it.
+func (m *Manager) Forget(vmID string) {
+	m.mu.Lock()
+	delete(m.devices, vmID)
+	m.mu.Unlock()
+}
+
 // ReattachVM rebinds vmd's view of an already-running VM's network state
 // at startup. After this call: the slot is marked in-use (no SetupVM
 // collisions), devices[vmID] is populated (CleanupVM can tear it down),

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -544,6 +544,20 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
+// ReserveSlotsAbove bumps nextSlot past every slot index named by the given
+// namespaces, so the pre-allocation pool never hands out a fresh slot that
+// collides with a VM not yet reattached. Cheap: parses indices and bumps a
+// counter, no kernel work — safe to call before the full per-VM reattach.
+func (m *Manager) ReserveSlotsAbove(namespaces []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, ns := range namespaces {
+		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot {
+			m.nextSlot = idx + 1
+		}
+	}
+}
+
 // EnsureVMSlot guarantees the kernel network state for vmID is present and
 // tracked. Idempotent.
 //

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -90,6 +90,13 @@ type Manager struct {
 	// that stale cleanup must not tear the slot down once ns-N exists again.
 	relinquished map[int]bool
 
+	// inFlight marks slot indices whose kernel state is mid-mutation — claimed
+	// by an allocator but not yet built (nsExists still false), or being torn
+	// down by a stale-record cleanup. It closes the window between claimSlotIndex
+	// and setupSlot creating ns-N: without it, a concurrent relinquished cleanup
+	// sees nsExists==false and reclaims a slot the pool is actively building.
+	inFlight map[int]bool
+
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
 
@@ -196,6 +203,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		log:            log.With().Str("component", "network").Logger(),
 		devices:        make(map[string]*VMNetInfo),
 		relinquished:   make(map[int]bool),
+		inFlight:       make(map[int]bool),
 		nextSlot:       1,
 		httpProxyPort:  DefaultHTTPProxyPort,
 		tlsProxyPort:   DefaultTLSProxyPort,
@@ -287,6 +295,15 @@ func hostIPForSlot(idx int) string {
 // nftables, routing) for a single slot index. Used by both SetupVM
 // (on-demand) and Pool (pre-allocation).
 func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
+	// Clear the in-flight mark once the slot is built (or on failure): on
+	// success ns-N now exists, so nsExists takes over guarding it against a
+	// stale-record cleanup; on failure the idx is abandoned. Runs on every exit.
+	defer func() {
+		m.mu.Lock()
+		delete(m.inFlight, idx)
+		m.mu.Unlock()
+	}()
+
 	hostIP := hostIPForSlot(idx)
 	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
 	vethIP := fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256)
@@ -487,19 +504,23 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	if !ok {
 		return
 	}
-	// A slot relinquished at startup may have been reused by the pool. If ns-N
-	// exists again it belongs to a new sandbox — tearing it down or reclaiming
-	// the slot would corrupt that live tenant, so leave it alone. (When the
-	// netns is still gone, the slot wasn't reused and the cleanup below safely
-	// reclaims it and removes any host-side veth the reboot didn't.)
+	// A slot relinquished at startup may have been claimed by the pool. If it's
+	// in-flight (claimed, ns-N not created yet) or ns-N already exists, it
+	// belongs to a new sandbox — tearing it down or reclaiming it would corrupt
+	// that tenant, so leave it alone. Both checks under one lock: the in-flight
+	// mark closes the claimSlotIndex→setupSlot window where nsExists is still
+	// false. Otherwise claim the slot ourselves (mark in-flight) so a concurrent
+	// allocator can't grab it while we mutate its kernel state below.
 	m.mu.Lock()
-	wasRelinquished := m.relinquished[idx]
-	m.mu.Unlock()
-	if wasRelinquished && nsExists(fallbackNamespace) {
+	if m.relinquished[idx] && (m.inFlight[idx] || nsExists(fallbackNamespace)) {
+		m.mu.Unlock()
 		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
-			Msg("stale cleanup skipped — relinquished slot reused by pool")
+			Msg("stale cleanup skipped — relinquished slot claimed/reused by pool")
 		return
 	}
+	m.inFlight[idx] = true
+	m.mu.Unlock()
+
 	// Tear down both sides even if the netns is already gone: `ip netns del`
 	// only removes the in-namespace side, so the host-side veth-N can outlive
 	// its namespace (a crash, or the peer moved back to the host before the ns
@@ -508,6 +529,7 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
 	m.mu.Lock()
 	m.freeSlots = append(m.freeSlots, idx)
+	delete(m.inFlight, idx)
 	m.mu.Unlock()
 	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("reclaimed network slot for untracked VM")
@@ -742,12 +764,16 @@ func (m *Manager) claimSlotIndex() (int, error) {
 			m.nextSlot++
 		}
 
-		if nsExists(fmt.Sprintf("ns-%d", idx)) {
-			// Discard; returning idx to freeSlots would loop on next call.
-			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — kernel ns already exists")
+		if m.inFlight[idx] || nsExists(fmt.Sprintf("ns-%d", idx)) {
+			// Being built/torn down elsewhere, or already in use. Discard;
+			// returning idx to freeSlots would loop on next call.
+			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — in-flight or kernel ns exists")
 			continue
 		}
 
+		// Mark claimed so a concurrent stale-record cleanup won't reclaim this
+		// slot in the window before setupSlot creates ns-N. setupSlot clears it.
+		m.inFlight[idx] = true
 		return idx, nil
 	}
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -84,6 +84,12 @@ type Manager struct {
 	freeSlots []int // recycled slot indices
 	nextSlot  int   // next new slot (used when freeSlots is empty)
 
+	// relinquished holds slot indices freed for reuse at startup (running
+	// records whose netns was already gone). The pool may hand these to new
+	// sandboxes before the background reattach cleans up the stale record, so
+	// that stale cleanup must not tear the slot down once ns-N exists again.
+	relinquished map[int]bool
+
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
 
@@ -189,6 +195,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		hostInterface:  hostInterface,
 		log:            log.With().Str("component", "network").Logger(),
 		devices:        make(map[string]*VMNetInfo),
+		relinquished:   make(map[int]bool),
 		nextSlot:       1,
 		httpProxyPort:  DefaultHTTPProxyPort,
 		tlsProxyPort:   DefaultTLSProxyPort,
@@ -480,6 +487,19 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	if !ok {
 		return
 	}
+	// A slot relinquished at startup may have been reused by the pool. If ns-N
+	// exists again it belongs to a new sandbox — tearing it down or reclaiming
+	// the slot would corrupt that live tenant, so leave it alone. (When the
+	// netns is still gone, the slot wasn't reused and the cleanup below safely
+	// reclaims it and removes any host-side veth the reboot didn't.)
+	m.mu.Lock()
+	wasRelinquished := m.relinquished[idx]
+	m.mu.Unlock()
+	if wasRelinquished && nsExists(fallbackNamespace) {
+		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+			Msg("stale cleanup skipped — relinquished slot reused by pool")
+		return
+	}
 	// Tear down both sides even if the netns is already gone: `ip netns del`
 	// only removes the in-namespace side, so the host-side veth-N can outlive
 	// its namespace (a crash, or the peer moved back to the host before the ns
@@ -572,6 +592,14 @@ func (m *Manager) ReserveSlotsAbove(resumable, liveOnly []string) {
 	for _, ns := range liveOnly {
 		if nsExists(ns) {
 			bump(ns)
+			continue
+		}
+		// Running record with no netns — the process is gone (a host reboot
+		// wipes every netns). Its slot is free for the pool to reuse; record
+		// that so a later stale-record cleanup won't tear the slot down again
+		// once the pool has handed ns-N to a new sandbox.
+		if idx, ok := slotFromNamespace(ns); ok {
+			m.relinquished[idx] = true
 		}
 	}
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -544,15 +544,16 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
-// ReserveSlotsAbove bumps nextSlot past every slot index named by the given
-// namespaces, so the pre-allocation pool never hands out a fresh slot that
-// collides with a VM not yet reattached. Cheap: parses indices and bumps a
-// counter, no kernel work — safe to call before the full per-VM reattach.
+// ReserveSlotsAbove bumps nextSlot past every slot index whose namespace still
+// exists in the kernel, so the pool won't hand out a slot a not-yet-reattached
+// VM holds. The nsExists guard is load-bearing: a stale record whose ns was
+// already swept must not bump nextSlot, or its (never-reclaimed) index strands
+// every slot below it and can push nextSlot past MaxSlots into ErrNoSlots.
 func (m *Manager) ReserveSlotsAbove(namespaces []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, ns := range namespaces {
-		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot {
+		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot && nsExists(ns) {
 			m.nextSlot = idx + 1
 		}
 	}

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -30,9 +30,10 @@ func touchNS(t *testing.T, dir, name string) {
 
 func newTestManager() *Manager {
 	return &Manager{
-		log:      zerolog.Nop(),
-		devices:  make(map[string]*VMNetInfo),
-		nextSlot: 1,
+		log:          zerolog.Nop(),
+		devices:      make(map[string]*VMNetInfo),
+		relinquished: make(map[int]bool),
+		nextSlot:     1,
 	}
 }
 
@@ -266,5 +267,38 @@ func TestCleanupVMOrNamespace_ReclaimsUntrackedSlot(t *testing.T) {
 
 	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
 		t.Errorf("freeSlots = %v, want [5] (slot reclaimed)", m.freeSlots)
+	}
+}
+
+// A slot relinquished at startup (running record whose netns was gone) that the
+// pool has since reused — ns-5 exists again — must NOT be torn down or reclaimed
+// by the stale record's deferred cleanup, or it corrupts the new sandbox.
+func TestCleanupVMOrNamespace_RelinquishedReusedSlotSkipped(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+
+	// Startup: running record at ns-5 has no netns → relinquished.
+	m.ReserveSlotsAbove(nil, []string{"ns-5"})
+	// Pool reuses slot 5 for a new sandbox (recreates the netns).
+	touchNS(t, dir, "ns-5")
+
+	m.CleanupVMOrNamespace("stale-vm", "ns-5")
+
+	if len(m.freeSlots) != 0 {
+		t.Errorf("freeSlots = %v, want [] (reused slot must not be reclaimed)", m.freeSlots)
+	}
+}
+
+// A relinquished slot the pool did NOT reuse — netns still gone — is safely
+// reclaimed (and any leftover host veth removed) by the deferred cleanup.
+func TestCleanupVMOrNamespace_RelinquishedUnusedSlotReclaimed(t *testing.T) {
+	withTestNetnsDir(t) // ns-5 never recreated → still gone
+	m := newTestManager()
+
+	m.ReserveSlotsAbove(nil, []string{"ns-5"})
+	m.CleanupVMOrNamespace("stale-vm", "ns-5")
+
+	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
+		t.Errorf("freeSlots = %v, want [5] (unused relinquished slot reclaimed)", m.freeSlots)
 	}
 }

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -289,6 +289,30 @@ func TestCleanupVMOrNamespace_RelinquishedReusedSlotSkipped(t *testing.T) {
 	}
 }
 
+// IsRelinquished reports true only for slots freed at startup (running record
+// with no netns), so the reattach path can refuse to bind a stale vmID onto a
+// slot the pool may have reused.
+func TestIsRelinquished(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+
+	touchNS(t, dir, "ns-7") // ns-7 live → reserved, not relinquished
+	m.ReserveSlotsAbove(nil, []string{"ns-7", "ns-5"})
+
+	if !m.IsRelinquished("ns-5") {
+		t.Error("ns-5 (running, no netns) must be relinquished")
+	}
+	if m.IsRelinquished("ns-7") {
+		t.Error("ns-7 (live netns) must not be relinquished")
+	}
+	if m.IsRelinquished("ns-99") {
+		t.Error("ns-99 (never seen) must not be relinquished")
+	}
+	if m.IsRelinquished("bogus") {
+		t.Error("unparseable namespace must not be relinquished")
+	}
+}
+
 // A relinquished slot the pool did NOT reuse — netns still gone — is safely
 // reclaimed (and any leftover host veth removed) by the deferred cleanup.
 func TestCleanupVMOrNamespace_RelinquishedUnusedSlotReclaimed(t *testing.T) {

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -36,6 +36,21 @@ func newTestManager() *Manager {
 	}
 }
 
+func TestReserveSlotsAbove(t *testing.T) {
+	m := newTestManager()
+	// nextSlot must jump past the highest occupied slot so the pool never hands
+	// out a slot a not-yet-reattached VM still holds. Unparseable names ignored.
+	m.ReserveSlotsAbove([]string{"ns-5", "ns-2", "bogus", "ns-9"})
+	if m.nextSlot != 10 {
+		t.Fatalf("nextSlot = %d, want 10 (past max slot 9)", m.nextSlot)
+	}
+	// A lower index must never pull nextSlot back down.
+	m.ReserveSlotsAbove([]string{"ns-3"})
+	if m.nextSlot != 10 {
+		t.Fatalf("nextSlot = %d, want 10 (unchanged by lower index)", m.nextSlot)
+	}
+}
+
 func TestSlotFromNamespace(t *testing.T) {
 	cases := []struct {
 		in      string

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -313,6 +313,24 @@ func TestIsRelinquished(t *testing.T) {
 	}
 }
 
+// A relinquished slot the pool has CLAIMED but not yet built (ns-N doesn't
+// exist yet, but it's marked in-flight) must NOT be reclaimed by a stale-record
+// cleanup — otherwise the slot is double-owned and later handed out twice.
+func TestCleanupVMOrNamespace_RelinquishedInFlightSlotSkipped(t *testing.T) {
+	withTestNetnsDir(t) // ns-5 intentionally absent: allocator is mid-setupSlot
+	m := newTestManager()
+	m.ReserveSlotsAbove(nil, []string{"ns-5"}) // ns-5 relinquished at startup
+	m.mu.Lock()
+	m.inFlight[5] = true // pool claimed slot 5, before setupSlot creates ns-5
+	m.mu.Unlock()
+
+	m.CleanupVMOrNamespace("stale-vm", "ns-5")
+
+	if len(m.freeSlots) != 0 {
+		t.Errorf("freeSlots = %v, want [] (in-flight slot must not be reclaimed)", m.freeSlots)
+	}
+}
+
 // A relinquished slot the pool did NOT reuse — netns still gone — is safely
 // reclaimed (and any leftover host veth removed) by the deferred cleanup.
 func TestCleanupVMOrNamespace_RelinquishedUnusedSlotReclaimed(t *testing.T) {

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -33,6 +33,7 @@ func newTestManager() *Manager {
 		log:          zerolog.Nop(),
 		devices:      make(map[string]*VMNetInfo),
 		relinquished: make(map[int]bool),
+		inFlight:     make(map[int]bool),
 		nextSlot:     1,
 	}
 }

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -39,19 +39,23 @@ func newTestManager() *Manager {
 func TestReserveSlotsAbove(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	m := newTestManager()
-	// ns-5 and ns-2 exist; ns-9 does NOT — the nsExists guard must skip it, since
-	// a stale record whose namespace was already swept must not bump nextSlot.
+	// liveOnly: ns-5 exists (reserved), ns-9 does NOT (stale running record —
+	// skipped so its slot stays free). bogus is unparseable.
 	touchNS(t, dir, "ns-5")
-	touchNS(t, dir, "ns-2")
-	m.ReserveSlotsAbove([]string{"ns-5", "ns-2", "bogus", "ns-9"})
+	m.ReserveSlotsAbove(nil, []string{"ns-5", "bogus", "ns-9"})
 	if m.nextSlot != 6 {
-		t.Fatalf("nextSlot = %d, want 6 (past existing ns-5; ns-9 skipped — no netns; bogus unparseable)", m.nextSlot)
+		t.Fatalf("nextSlot = %d, want 6 (past live ns-5; ns-9 skipped — no netns)", m.nextSlot)
+	}
+	// resumable: a paused VM's slot must be reserved even though its netns is
+	// gone (host reboot wiped it) — it rebuilds ns-20 on resume.
+	m.ReserveSlotsAbove([]string{"ns-20"}, nil)
+	if m.nextSlot != 21 {
+		t.Fatalf("nextSlot = %d, want 21 (paused ns-20 reserved despite missing netns)", m.nextSlot)
 	}
 	// A lower existing index must never pull nextSlot back down.
-	touchNS(t, dir, "ns-3")
-	m.ReserveSlotsAbove([]string{"ns-3"})
-	if m.nextSlot != 6 {
-		t.Fatalf("nextSlot = %d, want 6 (unchanged by lower index)", m.nextSlot)
+	m.ReserveSlotsAbove([]string{"ns-3"}, []string{"ns-4"})
+	if m.nextSlot != 21 {
+		t.Fatalf("nextSlot = %d, want 21 (unchanged by lower index)", m.nextSlot)
 	}
 }
 
@@ -240,14 +244,16 @@ func TestCleanupVMOrNamespace_EmptyAndInvalidNamespaceNoop(t *testing.T) {
 	}
 }
 
-func TestCleanupVMOrNamespace_MissingNamespaceNoop(t *testing.T) {
-	withTestNetnsDir(t) // ns-5 intentionally not touched → nsExists is false
+func TestCleanupVMOrNamespace_MissingNamespaceStillReclaims(t *testing.T) {
+	withTestNetnsDir(t) // ns-5 intentionally not touched → netns already gone
 	m := newTestManager()
 
+	// The host-side veth-N can outlive its netns, so cleanup must still tear it
+	// down and reclaim the slot even when the namespace itself is already gone.
 	m.CleanupVMOrNamespace("vm-u", "ns-5")
 
-	if len(m.freeSlots) != 0 {
-		t.Errorf("freeSlots = %v, want [] (namespace gone, nothing to reclaim)", m.freeSlots)
+	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
+		t.Errorf("freeSlots = %v, want [5] (slot reclaimed despite missing netns)", m.freeSlots)
 	}
 }
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -37,17 +37,21 @@ func newTestManager() *Manager {
 }
 
 func TestReserveSlotsAbove(t *testing.T) {
+	dir := withTestNetnsDir(t)
 	m := newTestManager()
-	// nextSlot must jump past the highest occupied slot so the pool never hands
-	// out a slot a not-yet-reattached VM still holds. Unparseable names ignored.
+	// ns-5 and ns-2 exist; ns-9 does NOT — the nsExists guard must skip it, since
+	// a stale record whose namespace was already swept must not bump nextSlot.
+	touchNS(t, dir, "ns-5")
+	touchNS(t, dir, "ns-2")
 	m.ReserveSlotsAbove([]string{"ns-5", "ns-2", "bogus", "ns-9"})
-	if m.nextSlot != 10 {
-		t.Fatalf("nextSlot = %d, want 10 (past max slot 9)", m.nextSlot)
+	if m.nextSlot != 6 {
+		t.Fatalf("nextSlot = %d, want 6 (past existing ns-5; ns-9 skipped — no netns; bogus unparseable)", m.nextSlot)
 	}
-	// A lower index must never pull nextSlot back down.
+	// A lower existing index must never pull nextSlot back down.
+	touchNS(t, dir, "ns-3")
 	m.ReserveSlotsAbove([]string{"ns-3"})
-	if m.nextSlot != 10 {
-		t.Fatalf("nextSlot = %d, want 10 (unchanged by lower index)", m.nextSlot)
+	if m.nextSlot != 6 {
+		t.Fatalf("nextSlot = %d, want 6 (unchanged by lower index)", m.nextSlot)
 	}
 }
 

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -47,8 +47,10 @@ type preallocSlot struct {
 	vethName string
 }
 
-// StartPool creates and starts the network slot pool. Blocks until the
-// initial batch of fresh slots is filled, then refills in the background.
+// StartPool creates the network slot pool and fills it in the background, so
+// startup (and the gRPC readiness gate) doesn't block on ~newSize slot setups;
+// SetupVM falls back to on-demand setup until it warms. m.pool is set before the
+// gate opens, and the fill only touches the pool's concurrency-safe channels.
 func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	newSize := cfg.NewSize
 	if newSize <= 0 {
@@ -67,25 +69,12 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		recycled: make(chan *preallocSlot, recycleSize),
 		stopCh:   make(chan struct{}),
 	}
+	m.pool = p
 
-	// Fill initial batch synchronously so the pool is warm on first create.
-	// Transient slot failures don't abort — the refill loop catches up.
-	filled := 0
-	for i := 0; i < newSize; i++ {
-		slot, err := p.allocate(ctx)
-		if err != nil {
-			p.log.Warn().Err(err).Int("attempt", i+1).Msg("initial pool slot failed; continuing")
-			continue
-		}
-		p.fresh <- slot
-		filled++
-	}
-	p.log.Info().Int("fresh", filled).Int("target", newSize).Int("recycle_cap", recycleSize).Msg("network pool ready")
-
+	p.log.Info().Int("target", newSize).Int("recycle_cap", recycleSize).Msg("network pool starting (filling in background)")
 	p.wg.Add(1)
 	go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 
-	m.pool = p
 	return p
 }
 

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -48,6 +48,14 @@ const (
 	defaultCacheTTL  = 500 * time.Millisecond // VMD is on localhost, latency is negligible
 	negativeCacheTTL = 1 * time.Second        // cache "not found" slightly longer to absorb spam
 	maxCacheSize     = 10_000                  // cap against random instance ID amplification
+
+	// vmdRequestTimeout bounds a single resolve call. A steady-state lookup is a
+	// localhost map read (sub-ms), but a miss right after a VMD restart triggers
+	// an on-demand reattach (netlink/nftables setup that takes no client ctx and
+	// can run into the low seconds under host load). Keep this above VMD's own
+	// 5s per-VM reattach bound so a would-succeed reattach isn't cut short into a
+	// data-plane timeout; singleflight + the negative cache bound amplification.
+	vmdRequestTimeout = 6 * time.Second
 )
 
 type cacheEntry struct {
@@ -78,7 +86,7 @@ func NewVMDResolver(vmdAddr string) *VMDResolver {
 	return &VMDResolver{
 		vmdAddr: vmdAddr,
 		ttl:     defaultCacheTTL,
-		client:  &http.Client{Timeout: 2 * time.Second},
+		client:  &http.Client{Timeout: vmdRequestTimeout},
 		cache:   make(map[string]cacheEntry),
 	}
 }

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -316,6 +316,13 @@ func (a *GRPCAdapter) UpdateSandboxNetwork(ctx context.Context, req *vmdpb.Updat
 		return nil, status.Error(codes.InvalidArgument, "egress config is required")
 	}
 
+	// This RPC reads netMgr state directly (below), which the background startup
+	// reattach may not have restored yet. Resolve the VM through getInstance first
+	// so it's reattached on demand (or NotFound if it's genuinely gone).
+	if _, err := a.mgr.getInstance(vmID); err != nil {
+		return nil, err
+	}
+
 	// Update nftables rules (non-TCP traffic).
 	if err := a.mgr.netMgr.UpdateFirewallRules(vmID, egress.GetAllowedCidrs(), egress.GetDeniedCidrs()); err != nil {
 		return nil, status.Errorf(codes.Internal, "update firewall rules: %v", err)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1730,13 +1730,22 @@ func (m *Manager) ReserveStartupSlots() {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return
 	}
-	nss := make([]string, 0, len(recs))
+	// Paused VMs keep their slot across a host reboot (which wipes every netns)
+	// and rebuild the same slot on resume, so reserve them unconditionally.
+	// Running records only hold a slot while their process — and thus their
+	// netns — is live; the network layer drops any whose netns is already gone.
+	var resumable, liveOnly []string
 	for _, rec := range recs {
-		if rec.Namespace != "" {
-			nss = append(nss, rec.Namespace)
+		if rec.Namespace == "" {
+			continue
+		}
+		if rec.Status == StatusPaused {
+			resumable = append(resumable, rec.Namespace)
+		} else {
+			liveOnly = append(liveOnly, rec.Namespace)
 		}
 	}
-	m.netMgr.ReserveSlotsAbove(nss)
+	m.netMgr.ReserveSlotsAbove(resumable, liveOnly)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1649,10 +1649,9 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 	}
 
-	// Commit only if the record wasn't deleted (DestroyVM) during reattach —
-	// the gate is open, so a delete can race the background pass. Running VMs
-	// persist atomically (write-if-present); paused VMs don't re-persist, so just
-	// re-check existence. Either way, undo the in-memory reattach if it's gone.
+	// Commit only if a concurrent DestroyVM didn't delete the record during
+	// reattach (the gate is open, so deletes race the background pass); otherwise
+	// undo the in-memory reattach.
 	if rec.Status == StatusPaused {
 		if m.recordDeleted(rec.ID) {
 			m.undoReattach(rec.ID, inst.Namespace)
@@ -1942,11 +1941,9 @@ func (m *Manager) persistState(inst *VMInstance) {
 	}
 }
 
-// persistStateIfPresent persists inst only if its record still exists, atomically.
-// Returns false when the record was deleted (a DestroyVM landed during the
-// background reattach) so the caller undoes the in-memory reattach instead of
-// resurrecting a deleted sandbox. A missing store or transient error returns true
-// (nothing to resurrect / don't undo a live reattach on a flaky write).
+// persistStateIfPresent persists inst only if its record still exists (atomic),
+// returning false when a concurrent DestroyVM deleted it — so the caller undoes
+// the reattach instead of resurrecting it. No store / write error → true.
 func (m *Manager) persistStateIfPresent(inst *VMInstance) bool {
 	if m.state == nil || isBuildVM(inst.ID) {
 		return true

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -199,6 +200,11 @@ type Manager struct {
 
 	mu  sync.RWMutex
 	vms map[string]*VMInstance
+
+	// reattachSF dedups concurrent on-demand reattach of the same VM, so a
+	// request that arrives before the background startup pass has reached its
+	// VM loads it once from BoltDB instead of racing.
+	reattachSF singleflight.Group
 
 	// restoreSem bounds concurrent RestoreVMSnapshot operations. Buffered
 	// channel; capacity = effective MaxConcurrentRestores.
@@ -1227,6 +1233,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		vmID = uuid.New().String()
 	}
 
+	// Load a paused VM the background reattach hasn't reached yet, so the inPlace
+	// path below reuses its slot instead of allocating a fresh one. No-op for a
+	// new VM (not in BoltDB).
+	m.lazyReattach(vmID)
+
 	m.mu.Lock()
 	_, inPlace := m.vms[vmID]
 	if inPlace {
@@ -1529,80 +1540,26 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		m.log.Info().Int("count", len(records)).Msg("reattaching VMs from BoltDB")
 	}
 
-	// Phase A: reattach from BoltDB.
-	for _, rec := range records {
-		log := m.log.With().Str("vm_id", rec.ID).Logger()
-
-		// Paused VMs legitimately have no running systemd unit — they
-		// were stopped during pause and are waiting for a resume via
-		// their snapshot. Reattach them with their paused status so the
-		// resume path can find them.
-		if rec.Status == StatusPaused {
-			inst := toInstance(rec)
-			m.mu.Lock()
-			m.vms[rec.ID] = inst
-			m.mu.Unlock()
-			// Repopulate the network slot like running VMs do, so a paused
-			// sandbox deleted before its next resume can reclaim its slot.
-			// Resume's EnsureVMSlot is idempotent, so this is safe.
-			if inst.Namespace != "" && inst.IP != "" {
-				if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
-					log.Error().Err(err).Msg("reattach: restore paused VM network state failed")
-				}
-			}
-			log.Info().Msg("reattached paused VM")
+	// Phase A: reattach from BoltDB. Requests take the same reattachRecord path
+	// on-demand, so this eager pass and any concurrent lazy load converge on the
+	// same in-memory state (deduped by the double-checked map write).
+	for _, snap := range records {
+		// Stop on shutdown: a cancelled ctx makes liveness checks fail, which
+		// would otherwise misfire the stale-cleanup path against live VMs.
+		if ctx.Err() != nil {
+			break
+		}
+		// Re-read: the record may have been deleted (DestroyVM) since the
+		// snapshot above, so acting on the stale copy could resurrect it.
+		rec, getErr := m.state.Get(snap.ID)
+		if getErr != nil || rec == nil {
+			continue
+		}
+		if _, ok := m.reattachRecord(ctx, *rec, true); ok {
 			reattached++
-			continue
-		}
-
-		// For running VMs, verify the systemd unit is still active.
-		if !isUnitActive(ctx, systemdUnitName(rec.ID)) {
-			log.Warn().Msg("VM in BoltDB but not running — cleaning up stale record")
-			// Kill the orphaned Firecracker process if it's still alive.
-			// Cold-booted VMs (from the old build path) were launched with
-			// Setsid: true and no systemd unit, so they survive vmd restarts
-			// as orphans holding TAP fds and contaminating the network pool.
-			if rec.PID > 0 {
-				if proc, err := os.FindProcess(rec.PID); err == nil {
-					if killErr := proc.Signal(syscall.SIGKILL); killErr == nil {
-						log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
-					}
-				}
-			}
-			m.state.Delete(rec.ID)
+		} else {
 			stale++
-			continue
 		}
-
-		// Verify the Firecracker API socket is actually reachable.
-		if rec.SocketPath != "" {
-			if _, statErr := os.Stat(rec.SocketPath); statErr != nil {
-				log.Warn().Str("socket", rec.SocketPath).Msg("VM unit active but socket missing — cleaning up")
-				m.state.Delete(rec.ID)
-				stale++
-				continue
-			}
-		}
-
-		// Reattach: add to in-memory map.
-		inst := toInstance(rec)
-
-		m.mu.Lock()
-		m.vms[rec.ID] = inst
-		m.mu.Unlock()
-
-		// Restore network manager state for this VM: slot tracking,
-		// devices map, host firewall rules (re-installed via idempotent
-		// AddVM in case the kernel rules were lost).
-		if inst.Namespace != "" && inst.IP != "" {
-			if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
-				log.Error().Err(err).Msg("reattach: restore network state failed")
-			}
-		}
-
-		m.persistState(inst)
-		log.Info().Int("pid", inst.PID).Str("ip", inst.IP).Msg("reattached to running VM")
-		reattached++
 	}
 
 	// Phase B: detect orphan systemd units not in BoltDB.
@@ -1617,15 +1574,121 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		}
 	}
 
-	// Phase C: sweep host network namespaces (ns-N / veth-N) that do not
-	// correspond to any live BoltDB record. Template builds never touch
-	// BoltDB, so a crashed build always leaks; sandbox teardown can also
-	// race the kernel-level delete. Without this sweep the pre-allocated
-	// pool wastes startup retrying colliding slots and kernel state degrades
-	// over time. Re-reading records reflects Phase A's stale deletions.
+	// Phase C: re-sweep orphan namespaces now that Phase A's stale deletions are
+	// reflected in BoltDB (startup already swept once before the pool filled).
+	m.SweepStartupOrphanNamespaces()
+
+	return reattached, stale
+}
+
+// reattachRecord rebuilds one VM's in-memory and network state from its BoltDB
+// record. Returns (nil, false) when cleanupStale deleted a dead record.
+//
+// cleanupStale must be false on the request path: the dead-VM check would SIGKILL
+// and delete a live VM whenever systemctl is merely slow. Only the eager GC pass
+// sets it. Concurrent-safe: the map write is double-checked under the lock.
+func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale bool) (*VMInstance, bool) {
+	m.mu.RLock()
+	if inst, ok := m.vms[rec.ID]; ok {
+		m.mu.RUnlock()
+		return inst, true
+	}
+	m.mu.RUnlock()
+
+	log := m.log.With().Str("vm_id", rec.ID).Logger()
+
+	// Running VMs must have a live systemd unit and a reachable API socket; a
+	// dead one is a stale record. Paused VMs legitimately have no unit — they
+	// were stopped at pause and wait for a resume — so they skip these checks.
+	if cleanupStale && rec.Status != StatusPaused {
+		if unitDefinitelyDead(ctx, systemdUnitName(rec.ID)) {
+			log.Warn().Msg("VM in BoltDB but not running — cleaning up stale record")
+			// Cold-booted VMs (old build path) ran with Setsid and no unit, so
+			// they survive vmd restarts as orphans holding TAP fds — SIGKILL by PID.
+			if rec.PID > 0 {
+				if proc, err := os.FindProcess(rec.PID); err == nil {
+					if killErr := proc.Signal(syscall.SIGKILL); killErr == nil {
+						log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
+					}
+				}
+			}
+			m.state.Delete(rec.ID)
+			return nil, false
+		}
+		if rec.SocketPath != "" {
+			if _, statErr := os.Stat(rec.SocketPath); statErr != nil {
+				log.Warn().Str("socket", rec.SocketPath).Msg("VM unit active but socket missing — cleaning up")
+				m.state.Delete(rec.ID)
+				return nil, false
+			}
+		}
+	}
+
+	inst := toInstance(rec)
+	m.mu.Lock()
+	if existing, ok := m.vms[rec.ID]; ok {
+		m.mu.Unlock()
+		return existing, true
+	}
+	m.vms[rec.ID] = inst
+	m.mu.Unlock()
+
+	// Restore network state: slot tracking, devices map, host firewall rules
+	// (idempotent, in case the kernel rules were lost).
+	if inst.Namespace != "" && inst.IP != "" {
+		if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+			log.Error().Err(err).Msg("reattach: restore network state failed")
+		}
+	}
+
+	if rec.Status == StatusPaused {
+		log.Info().Msg("reattached paused VM")
+	} else {
+		m.persistState(inst)
+		log.Info().Int("pid", inst.PID).Str("ip", inst.IP).Msg("reattached to running VM")
+	}
+	return inst, true
+}
+
+// lazyReattach loads a VM's record from BoltDB and reattaches it on demand, so
+// a request that arrives before the background startup pass has reached its VM
+// resolves it here instead of getting a spurious NotFound. Deduped per VM by
+// singleflight. Returns nil when the VM is unknown to this host (not in BoltDB).
+func (m *Manager) lazyReattach(vmID string) *VMInstance {
+	if m.state == nil {
+		return nil
+	}
+	v, _, _ := m.reattachSF.Do(vmID, func() (any, error) {
+		m.mu.RLock()
+		inst, ok := m.vms[vmID]
+		m.mu.RUnlock()
+		if ok {
+			return inst, nil
+		}
+		rec, err := m.state.Get(vmID)
+		if err != nil || rec == nil {
+			return (*VMInstance)(nil), nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		got, _ := m.reattachRecord(ctx, *rec, false)
+		return got, nil
+	})
+	inst, _ := v.(*VMInstance)
+	return inst
+}
+
+// SweepStartupOrphanNamespaces removes host network namespaces (ns-N / veth-N)
+// that no live BoltDB record claims — leaked by crashed template builds or a
+// teardown that raced the kernel delete. Reads BoltDB directly, so it is safe
+// to run before the eager reattach and before the network pool fills.
+func (m *Manager) SweepStartupOrphanNamespaces() {
+	if m.state == nil {
+		return
+	}
 	keepNs := make(map[string]bool)
-	if freshRecords, readErr := m.state.All(); readErr == nil {
-		for _, rec := range freshRecords {
+	if recs, err := m.state.All(); err == nil {
+		for _, rec := range recs {
 			if rec.Namespace != "" {
 				keepNs[rec.Namespace] = true
 			}
@@ -1634,8 +1697,28 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 	if swept := m.netMgr.SweepOrphanNamespaces(keepNs); swept > 0 {
 		m.log.Info().Int("swept", swept).Msg("sweep: removed orphan namespaces")
 	}
+}
 
-	return reattached, stale
+// ReserveStartupSlots bumps the network pool's slot high-water mark past every
+// slot an existing VM occupies, so StartPool can run before the backgrounded
+// per-VM reattach without the pool handing out a slot that collides with a
+// not-yet-reattached VM. Cheap: parses slot indices, no kernel work.
+func (m *Manager) ReserveStartupSlots() {
+	if m.state == nil {
+		return
+	}
+	recs, err := m.state.All()
+	if err != nil {
+		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
+		return
+	}
+	nss := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		if rec.Namespace != "" {
+			nss = append(nss, rec.Namespace)
+		}
+	}
+	m.netMgr.ReserveSlotsAbove(nss)
 }
 
 // ---------------------------------------------------------------------------
@@ -1777,7 +1860,9 @@ func (m *Manager) LookupInstance(vmID string) (InstanceInfo, bool) {
 	inst, ok := m.vms[vmID]
 	m.mu.RUnlock()
 	if !ok {
-		return InstanceInfo{}, false
+		if inst = m.lazyReattach(vmID); inst == nil {
+			return InstanceInfo{}, false
+		}
 	}
 	inst.mu.RLock()
 	info := InstanceInfo{
@@ -1797,12 +1882,17 @@ func (m *Manager) LookupInstance(vmID string) (InstanceInfo, bool) {
 
 func (m *Manager) getInstance(vmID string) (*VMInstance, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	inst, ok := m.vms[vmID]
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "vm %s not found", vmID)
+	m.mu.RUnlock()
+	if ok {
+		return inst, nil
 	}
-	return inst, nil
+	// Not in the map — during the startup window it may not be reattached yet;
+	// load it on demand before declaring it gone.
+	if inst := m.lazyReattach(vmID); inst != nil {
+		return inst, nil
+	}
+	return nil, status.Errorf(codes.NotFound, "vm %s not found", vmID)
 }
 
 func (m *Manager) setStatus(vmID string, s VMStatus) {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1644,6 +1644,11 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	// relinquished, so a resumable VM is unaffected.
 	if rec.Status != StatusPaused && m.netMgr.IsRelinquished(rec.Namespace) {
 		log.Warn().Str("namespace", rec.Namespace).Msg("refusing reattach — slot relinquished at startup (stale record)")
+		// Clean the residue (veth/slot the pool hasn't reused) and drop the record
+		// here, so a DELETE that beats the background pass doesn't reach DestroyVM
+		// with no namespace and leak it. Cleanup skips teardown if ns-N was reused.
+		m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
+		m.state.Delete(rec.ID)
 		return nil, false
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1579,12 +1579,20 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 }
 
 // reattachRecord rebuilds one VM's in-memory and network state from its BoltDB
+// reattachHook, when non-nil, is invoked at the start of every reattachRecord
+// call. Test-only seam for asserting that concurrent reattaches of the same VM
+// dedupe through the singleflight group. Always nil in production.
+var reattachHook func(vmID string)
+
 // record. Returns (nil, false) when cleanupStale deleted a dead record.
 //
 // cleanupStale must be false on the request path: the dead-VM check would SIGKILL
 // and delete a live VM whenever systemctl is merely slow. Only the eager GC pass
 // sets it. Concurrent-safe: the map write is double-checked under the lock.
 func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale bool) (*VMInstance, bool) {
+	if reattachHook != nil {
+		reattachHook(rec.ID)
+	}
 	// Already present. A lazy load inserts optimistically (no liveness check), so
 	// a dead record it inserted isn't GC'd here — that's the reconciler's job
 	// (Drift 1/5 → markStale), deliberately, to avoid racing the request path.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1649,10 +1649,21 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 	}
 
+	// Commit only if the record wasn't deleted (DestroyVM) during reattach —
+	// the gate is open, so a delete can race the background pass. Running VMs
+	// persist atomically (write-if-present); paused VMs don't re-persist, so just
+	// re-check existence. Either way, undo the in-memory reattach if it's gone.
 	if rec.Status == StatusPaused {
+		if m.recordDeleted(rec.ID) {
+			m.undoReattach(rec.ID, inst.Namespace)
+			return nil, false
+		}
 		log.Info().Msg("reattached paused VM")
 	} else {
-		m.persistState(inst)
+		if !m.persistStateIfPresent(inst) {
+			m.undoReattach(rec.ID, inst.Namespace)
+			return nil, false
+		}
 		log.Info().Int("pid", inst.PID).Str("ip", inst.IP).Msg("reattached to running VM")
 	}
 	return inst, true
@@ -1928,6 +1939,44 @@ func (m *Manager) persistState(inst *VMInstance) {
 	}
 	if err := m.state.Put(toRecord(inst)); err != nil {
 		m.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to persist VM state to BoltDB")
+	}
+}
+
+// persistStateIfPresent persists inst only if its record still exists, atomically.
+// Returns false when the record was deleted (a DestroyVM landed during the
+// background reattach) so the caller undoes the in-memory reattach instead of
+// resurrecting a deleted sandbox. A missing store or transient error returns true
+// (nothing to resurrect / don't undo a live reattach on a flaky write).
+func (m *Manager) persistStateIfPresent(inst *VMInstance) bool {
+	if m.state == nil || isBuildVM(inst.ID) {
+		return true
+	}
+	wrote, err := m.state.PutIfPresent(toRecord(inst))
+	if err != nil {
+		m.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to persist VM state to BoltDB")
+		return true
+	}
+	return wrote
+}
+
+// recordDeleted reports whether vmID's record is gone from the store (deleted
+// concurrently). False when there's no store or the read errors.
+func (m *Manager) recordDeleted(vmID string) bool {
+	if m.state == nil || isBuildVM(vmID) {
+		return false
+	}
+	present, err := m.state.Has(vmID)
+	return err == nil && !present
+}
+
+// undoReattach reverses an in-memory reattach when the record turns out to have
+// been deleted concurrently: drop it from the map and release its network slot.
+func (m *Manager) undoReattach(vmID, namespace string) {
+	m.mu.Lock()
+	delete(m.vms, vmID)
+	m.mu.Unlock()
+	if namespace != "" {
+		m.netMgr.CleanupVMOrNamespace(vmID, namespace)
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1574,9 +1574,10 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		}
 	}
 
-	// Phase C: re-sweep orphan namespaces now that Phase A's stale deletions are
-	// reflected in BoltDB (startup already swept once before the pool filled).
-	m.SweepStartupOrphanNamespaces()
+	// No broad re-sweep here. Startup already swept once before StartPool filled
+	// the pool; re-sweeping now would delete the pool's warm netns (which are not
+	// BoltDB records). Stale records deleted in Phase A free their own namespace
+	// inline (see reattachRecord), so a re-sweep isn't needed.
 
 	return reattached, stale
 }
@@ -1616,12 +1617,16 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 				}
 			}
 			m.state.Delete(rec.ID)
+			// Free this record's namespace/slot directly instead of a broad
+			// re-sweep (which would also delete the warm pool's netns).
+			m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
 			return nil, false
 		}
 		if rec.SocketPath != "" {
 			if _, statErr := os.Stat(rec.SocketPath); statErr != nil {
 				log.Warn().Str("socket", rec.SocketPath).Msg("VM unit active but socket missing — cleaning up")
 				m.state.Delete(rec.ID)
+				m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
 				return nil, false
 			}
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1652,6 +1652,30 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	}
 
 	inst := toInstance(rec)
+
+	// Bail early if another caller (a request, or the background pass) already
+	// published this VM.
+	m.mu.RLock()
+	existing, present := m.vms[rec.ID]
+	m.mu.RUnlock()
+	if present {
+		return existing, true
+	}
+
+	// Restore network state (slot tracking, devices map, host firewall rules)
+	// BEFORE publishing to m.vms, so any concurrent getInstance that sees the
+	// map entry is guaranteed devices[vmID] is already populated — otherwise its
+	// UpdateSandboxNetwork/DestroyVM could race a half-restored VM. ReattachVM is
+	// idempotent, so a rare double restore (background pass and a request both
+	// reaching here) is harmless.
+	if inst.Namespace != "" && inst.IP != "" {
+		if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+			log.Error().Err(err).Msg("reattach: restore network state failed")
+		}
+	}
+
+	// Publish, re-checking under the write lock in case another caller won the
+	// race while we restored network state; if so, keep theirs.
 	m.mu.Lock()
 	if existing, ok := m.vms[rec.ID]; ok {
 		m.mu.Unlock()
@@ -1659,14 +1683,6 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	}
 	m.vms[rec.ID] = inst
 	m.mu.Unlock()
-
-	// Restore network state: slot tracking, devices map, host firewall rules
-	// (idempotent, in case the kernel rules were lost).
-	if inst.Namespace != "" && inst.IP != "" {
-		if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
-			log.Error().Err(err).Msg("reattach: restore network state failed")
-		}
-	}
 
 	// Commit only if a concurrent DestroyVM didn't delete the record during
 	// reattach (the gate is open, so deletes race the background pass); otherwise

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1540,22 +1540,18 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 		m.log.Info().Int("count", len(records)).Msg("reattaching VMs from BoltDB")
 	}
 
-	// Phase A: reattach from BoltDB. Requests take the same reattachRecord path
-	// on-demand, so this eager pass and any concurrent lazy load converge on the
-	// same in-memory state (deduped by the double-checked map write).
+	// Phase A: reattach from BoltDB. Routed through reattachByID (singleflight)
+	// so this eager pass and any concurrent lazy request serialize per VM — a
+	// lazy load can't run reattachRecord for a vmID while the eager pass is mid
+	// stale-cleanup for the same one. reattachByID re-reads the record inside the
+	// flight, so a DestroyVM between the snapshot and here can't resurrect it.
 	for _, snap := range records {
 		// Stop on shutdown: a cancelled ctx makes liveness checks fail, which
 		// would otherwise misfire the stale-cleanup path against live VMs.
 		if ctx.Err() != nil {
 			break
 		}
-		// Re-read: the record may have been deleted (DestroyVM) since the
-		// snapshot above, so acting on the stale copy could resurrect it.
-		rec, getErr := m.state.Get(snap.ID)
-		if getErr != nil || rec == nil {
-			continue
-		}
-		if _, ok := m.reattachRecord(ctx, *rec, true); ok {
+		if m.reattachByID(snap.ID, true) != nil {
 			reattached++
 		} else {
 			stale++
@@ -1708,6 +1704,20 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 // resolves it here instead of getting a spurious NotFound. Deduped per VM by
 // singleflight. Returns nil when the VM is unknown to this host (not in BoltDB).
 func (m *Manager) lazyReattach(vmID string) *VMInstance {
+	return m.reattachByID(vmID, false)
+}
+
+// reattachByID runs a single-flighted reattach for vmID. Routing BOTH the eager
+// startup pass and lazy request loads through the same singleflight group
+// serializes them per VM: only one reattachRecord runs for a given vmID at a
+// time, so the eager pass's stale-cleanup can't free a slot back to the pool
+// while a concurrent lazy load is mid-flight binding that VM's network state.
+//
+// cleanupStale is honored by whichever caller wins the flight; a joiner shares
+// that result. The reattach uses a detached, bounded context so a caller's
+// cancellation can't abort work another caller is waiting on. Returns nil when
+// the VM is unknown to this host or was cleaned up as stale.
+func (m *Manager) reattachByID(vmID string, cleanupStale bool) *VMInstance {
 	if m.state == nil {
 		return nil
 	}
@@ -1724,7 +1734,7 @@ func (m *Manager) lazyReattach(vmID string) *VMInstance {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		got, _ := m.reattachRecord(ctx, *rec, false)
+		got, _ := m.reattachRecord(ctx, *rec, cleanupStale)
 		return got, nil
 	})
 	inst, _ := v.(*VMInstance)
@@ -1781,32 +1791,37 @@ func (m *Manager) ReserveStartupSlots(ctx context.Context) {
 	for _, id := range activeUnits {
 		active[id] = true
 	}
-	livenessUnknown := listErr != nil
 
-	// resumable slots are reserved unconditionally; liveOnly slots are reserved
-	// only if their netns still exists (a dead FC's slot is free for reuse).
-	var resumable, liveOnly []string
+	resumable, liveOnly := classifyStartupSlots(recs, active, listErr != nil)
+	m.netMgr.ReserveSlotsAbove(resumable, liveOnly)
+}
+
+// classifyStartupSlots splits records into slots reserved unconditionally
+// (resumable) vs. reserved only if their netns still exists (liveOnly), given
+// the set of active firecracker unit IDs. Pure, so the reserve/relinquish
+// policy is unit-testable without systemd or BoltDB.
+//
+//   - paused: reserved — keeps its slot across a reboot, rebuilt on resume.
+//   - running + active unit (or liveness unknown): reserved — the FC still owns
+//     its namespace even if its /run/netns name was removed, so its slot must
+//     not be relinquished to the pool.
+//   - running + no active unit: liveOnly — a dead FC; reserve only if its netns
+//     lingers, else relinquish the slot for reuse.
+func classifyStartupSlots(recs []VMRecord, active map[string]bool, livenessUnknown bool) (resumable, liveOnly []string) {
 	for _, rec := range recs {
 		if rec.Namespace == "" {
 			continue
 		}
 		switch {
 		case rec.Status == StatusPaused:
-			// Paused VMs keep their slot across a host reboot (which wipes every
-			// netns) and rebuild it on resume.
 			resumable = append(resumable, rec.Namespace)
 		case livenessUnknown || active[rec.ID]:
-			// Running with a live unit (or liveness unknown): the FC still owns
-			// its namespace even if its /run/netns name is gone. Reserve the
-			// slot — never relinquish one a live VM may still hold.
 			resumable = append(resumable, rec.Namespace)
 		default:
-			// Running but no live unit — a dead FC (e.g. after a host reboot).
-			// Reserve only if its netns lingers; otherwise relinquish for reuse.
 			liveOnly = append(liveOnly, rec.Namespace)
 		}
 	}
-	m.netMgr.ReserveSlotsAbove(resumable, liveOnly)
+	return resumable, liveOnly
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1639,6 +1639,18 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 	}
 
+	// A running record whose netns was gone at startup had its slot relinquished
+	// for the pool to reuse. The FC is dead (a live one always has its netns), so
+	// this record is stale: reattaching it would bind its vmID onto the namespace
+	// the pool has since handed to a new sandbox, and a later firewall update or
+	// destroy for the stale vmID would then corrupt that live tenant. Refuse; the
+	// reconciler formally clears the record. Paused records are reserved, never
+	// relinquished, so a resumable VM is unaffected.
+	if rec.Status != StatusPaused && m.netMgr.IsRelinquished(rec.Namespace) {
+		log.Warn().Str("namespace", rec.Namespace).Msg("refusing reattach — slot relinquished at startup (stale record)")
+		return nil, false
+	}
+
 	inst := toInstance(rec)
 	m.mu.Lock()
 	if existing, ok := m.vms[rec.ID]; ok {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1624,7 +1624,14 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 		if rec.SocketPath != "" {
 			if _, statErr := os.Stat(rec.SocketPath); statErr != nil {
-				log.Warn().Str("socket", rec.SocketPath).Msg("VM unit active but socket missing — cleaning up")
+				log.Warn().Str("socket", rec.SocketPath).Msg("VM unit active but socket missing — stopping and cleaning up")
+				// The unit is still active, so stop Firecracker before we forget
+				// the record and tear down its netns — otherwise it keeps running
+				// as an orphan burning CPU/RAM and holding TAP fds in a namespace
+				// we're about to delete out from under it.
+				if err := stopUnit(ctx, systemdUnitName(rec.ID)); err != nil {
+					log.Warn().Err(err).Msg("systemctl stop failed for socket-missing VM")
+				}
 				m.state.Delete(rec.ID)
 				m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
 				return nil, false
@@ -1654,13 +1661,13 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	// undo the in-memory reattach.
 	if rec.Status == StatusPaused {
 		if m.recordDeleted(rec.ID) {
-			m.undoReattach(rec.ID, inst.Namespace)
+			m.undoReattach(rec.ID)
 			return nil, false
 		}
 		log.Info().Msg("reattached paused VM")
 	} else {
 		if !m.persistStateIfPresent(inst) {
-			m.undoReattach(rec.ID, inst.Namespace)
+			m.undoReattach(rec.ID)
 			return nil, false
 		}
 		log.Info().Int("pid", inst.PID).Str("ip", inst.IP).Msg("reattached to running VM")
@@ -1976,14 +1983,15 @@ func (m *Manager) recordDeleted(vmID string) bool {
 }
 
 // undoReattach reverses an in-memory reattach when the record turns out to have
-// been deleted concurrently: drop it from the map and release its network slot.
-func (m *Manager) undoReattach(vmID, namespace string) {
+// been deleted concurrently. It only forgets the in-memory entries: whoever
+// deleted the record (DestroyVM or the reconciler's markStale) already tore down
+// or recycled the slot, so a second physical teardown here would double-free it
+// or clobber the new owner of a recycled ns/veth.
+func (m *Manager) undoReattach(vmID string) {
 	m.mu.Lock()
 	delete(m.vms, vmID)
 	m.mu.Unlock()
-	if namespace != "" {
-		m.netMgr.CleanupVMOrNamespace(vmID, namespace)
-	}
+	m.netMgr.Forget(vmID)
 }
 
 // deleteState removes a VM record from BoltDB.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1739,8 +1739,9 @@ func (m *Manager) SweepStartupOrphanNamespaces() {
 // ReserveStartupSlots bumps the network pool's slot high-water mark past every
 // slot an existing VM occupies, so StartPool can run before the backgrounded
 // per-VM reattach without the pool handing out a slot that collides with a
-// not-yet-reattached VM. Cheap: parses slot indices, no kernel work.
-func (m *Manager) ReserveStartupSlots() {
+// not-yet-reattached VM. One systemctl call for the whole fleet; otherwise just
+// parses slot indices, no kernel work.
+func (m *Manager) ReserveStartupSlots(ctx context.Context) {
 	if m.state == nil {
 		return
 	}
@@ -1749,18 +1750,43 @@ func (m *Manager) ReserveStartupSlots() {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return
 	}
-	// Paused VMs keep their slot across a host reboot (which wipes every netns)
-	// and rebuild the same slot on resume, so reserve them unconditionally.
-	// Running records only hold a slot while their process — and thus their
-	// netns — is live; the network layer drops any whose netns is already gone.
+
+	// Authoritative liveness for running records, one call for the whole fleet.
+	// A running FC keeps its network namespace alive even if the /run/netns name
+	// was removed, so nsExists alone would wrongly relinquish a live VM's slot
+	// and hand it to the pool. Fail closed: if the list errors, treat every
+	// running record as live and reserve its slot rather than risk giving one
+	// away.
+	activeUnits, listErr := listActiveFirecrackerUnits(ctx)
+	if listErr != nil {
+		m.log.Warn().Err(listErr).Msg("startup slot reservation: active-unit list failed — reserving all running slots")
+	}
+	active := make(map[string]bool, len(activeUnits))
+	for _, id := range activeUnits {
+		active[id] = true
+	}
+	livenessUnknown := listErr != nil
+
+	// resumable slots are reserved unconditionally; liveOnly slots are reserved
+	// only if their netns still exists (a dead FC's slot is free for reuse).
 	var resumable, liveOnly []string
 	for _, rec := range recs {
 		if rec.Namespace == "" {
 			continue
 		}
-		if rec.Status == StatusPaused {
+		switch {
+		case rec.Status == StatusPaused:
+			// Paused VMs keep their slot across a host reboot (which wipes every
+			// netns) and rebuild it on resume.
 			resumable = append(resumable, rec.Namespace)
-		} else {
+		case livenessUnknown || active[rec.ID]:
+			// Running with a live unit (or liveness unknown): the FC still owns
+			// its namespace even if its /run/netns name is gone. Reserve the
+			// slot — never relinquish one a live VM may still hold.
+			resumable = append(resumable, rec.Namespace)
+		default:
+			// Running but no live unit — a dead FC (e.g. after a host reboot).
+			// Reserve only if its netns lingers; otherwise relinquish for reuse.
 			liveOnly = append(liveOnly, rec.Namespace)
 		}
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1588,6 +1588,9 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 // and delete a live VM whenever systemctl is merely slow. Only the eager GC pass
 // sets it. Concurrent-safe: the map write is double-checked under the lock.
 func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale bool) (*VMInstance, bool) {
+	// Already present. A lazy load inserts optimistically (no liveness check), so
+	// a dead record it inserted isn't GC'd here — that's the reconciler's job
+	// (Drift 1/5 → markStale), deliberately, to avoid racing the request path.
 	m.mu.RLock()
 	if inst, ok := m.vms[rec.ID]; ok {
 		m.mu.RUnlock()

--- a/internal/vm/reattach_concurrency_test.go
+++ b/internal/vm/reattach_concurrency_test.go
@@ -1,0 +1,73 @@
+package vm
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// TestReattachByID_ConcurrentCallersDedupe pins the guarantee that the eager
+// startup pass and lazy request loads, routed through the same singleflight
+// group, never run reattachRecord more than once for a given vmID — even when
+// they race with different cleanupStale values. Run under -race, it also guards
+// the shared m.vms / m.reattachSF access.
+func TestReattachByID_ConcurrentCallersDedupe(t *testing.T) {
+	s, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	defer s.Close()
+
+	// Paused record with no namespace/IP: reattachRecord skips the liveness
+	// checks and all network work, so no netMgr is needed.
+	if err := s.Put(VMRecord{ID: "vm-x", Status: StatusPaused}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	mgr := &Manager{
+		state: s,
+		vms:   make(map[string]*VMInstance),
+		log:   zerolog.Nop(),
+	}
+
+	var execCount atomic.Int32
+	reattachHook = func(string) {
+		execCount.Add(1)
+		// Hold the in-flight singleflight call open long enough that every
+		// concurrent caller joins it instead of starting a fresh flight.
+		time.Sleep(100 * time.Millisecond)
+	}
+	defer func() { reattachHook = nil }()
+
+	const n = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make([]*VMInstance, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			// Mix cleanupStale to mirror eager (true) vs lazy (false) callers.
+			results[i] = mgr.reattachByID("vm-x", i%2 == 0)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := execCount.Load(); got != 1 {
+		t.Fatalf("reattachRecord ran %d times, want 1 (singleflight must dedupe concurrent callers)", got)
+	}
+	if len(mgr.vms) != 1 {
+		t.Fatalf("m.vms has %d entries, want exactly 1", len(mgr.vms))
+	}
+	for i, r := range results {
+		if r == nil || r != results[0] {
+			t.Fatalf("caller %d returned %p, want the single shared instance %p", i, r, results[0])
+		}
+	}
+}

--- a/internal/vm/reserve_test.go
+++ b/internal/vm/reserve_test.go
@@ -1,0 +1,53 @@
+package vm
+
+import "testing"
+
+// TestClassifyStartupSlots pins the reserve/relinquish policy — most importantly
+// awille's edge case: a running VM with an active unit but a missing /run/netns
+// bind mount must be reserved (resumable), never relinquished, because the FC
+// still holds the namespace.
+func TestClassifyStartupSlots(t *testing.T) {
+	recs := []VMRecord{
+		{ID: "paused", Namespace: "ns-1", Status: StatusPaused},
+		{ID: "running-active", Namespace: "ns-2", Status: StatusRunning},
+		{ID: "running-dead", Namespace: "ns-3", Status: StatusRunning},
+		{ID: "no-ns", Namespace: "", Status: StatusRunning},
+	}
+	// running-active has a live unit even though its netns bind mount is gone;
+	// running-dead has no active unit.
+	active := map[string]bool{"running-active": true}
+
+	resumable, liveOnly := classifyStartupSlots(recs, active, false)
+
+	if !contains(resumable, "ns-1") {
+		t.Errorf("paused ns-1 must be resumable; got %v", resumable)
+	}
+	if !contains(resumable, "ns-2") {
+		t.Errorf("active-unit running ns-2 must be resumable (not relinquished) despite missing netns; got %v", resumable)
+	}
+	if len(liveOnly) != 1 || liveOnly[0] != "ns-3" {
+		t.Errorf("only dead-unit running ns-3 may be a relinquish candidate; liveOnly = %v", liveOnly)
+	}
+	if contains(resumable, "") || contains(liveOnly, "") {
+		t.Error("empty namespace must be skipped")
+	}
+
+	// Fail closed: liveness unknown → every running record reserved, none
+	// relinquished.
+	resumable2, liveOnly2 := classifyStartupSlots(recs, nil, true)
+	if len(liveOnly2) != 0 {
+		t.Errorf("liveOnly = %v, want [] when liveness unknown (fail closed)", liveOnly2)
+	}
+	if !contains(resumable2, "ns-3") {
+		t.Errorf("running-dead must be reserved when liveness unknown; resumable = %v", resumable2)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -117,11 +117,9 @@ func (s *StateStore) Delete(vmID string) error {
 	})
 }
 
-// PutIfPresent writes rec only if a record for rec.ID still exists, in a single
-// transaction. Returns false (no write) when the key is absent — e.g. a
-// concurrent Delete removed it. bbolt serializes write transactions, so the
-// get-then-put is atomic against Delete: a record deleted mid-startup can't be
-// resurrected by a stale reattach persist.
+// PutIfPresent writes rec only if its key still exists, returning false if not.
+// bbolt serializes writes, so the get-then-put is atomic against a concurrent
+// Delete — a record deleted mid-startup can't be resurrected by a stale persist.
 func (s *StateStore) PutIfPresent(rec VMRecord) (bool, error) {
 	data, err := json.Marshal(rec)
 	if err != nil {

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -117,6 +117,41 @@ func (s *StateStore) Delete(vmID string) error {
 	})
 }
 
+// PutIfPresent writes rec only if a record for rec.ID still exists, in a single
+// transaction. Returns false (no write) when the key is absent — e.g. a
+// concurrent Delete removed it. bbolt serializes write transactions, so the
+// get-then-put is atomic against Delete: a record deleted mid-startup can't be
+// resurrected by a stale reattach persist.
+func (s *StateStore) PutIfPresent(rec VMRecord) (bool, error) {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return false, fmt.Errorf("marshal vm record: %w", err)
+	}
+	wrote := false
+	err = s.db.Batch(func(tx *bolt.Tx) error {
+		// Batch may retry this closure (coalesced transactions), so recompute
+		// wrote each run — the final successful run is authoritative.
+		wrote = false
+		b := tx.Bucket(bucketName)
+		if b.Get([]byte(rec.ID)) == nil {
+			return nil
+		}
+		wrote = true
+		return b.Put([]byte(rec.ID), data)
+	})
+	return wrote, err
+}
+
+// Has reports whether a record for vmID exists.
+func (s *StateStore) Has(vmID string) (bool, error) {
+	exists := false
+	err := s.db.View(func(tx *bolt.Tx) error {
+		exists = tx.Bucket(bucketName).Get([]byte(vmID)) != nil
+		return nil
+	})
+	return exists, err
+}
+
 // All returns every persisted VM record.
 func (s *StateStore) All() ([]VMRecord, error) {
 	var records []VMRecord

--- a/internal/vm/state_test.go
+++ b/internal/vm/state_test.go
@@ -1,0 +1,50 @@
+package vm
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestPutIfPresent pins the atomic conditional write the background reattach
+// relies on: it must write when the record exists and be a no-op (never
+// resurrect) once the record has been deleted.
+func TestPutIfPresent(t *testing.T) {
+	s, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	rec := VMRecord{ID: "vm-1", Status: StatusRunning}
+
+	// Absent key → no write.
+	if wrote, err := s.PutIfPresent(rec); err != nil || wrote {
+		t.Fatalf("PutIfPresent on absent key = (%v, %v), want (false, nil)", wrote, err)
+	}
+	if has, _ := s.Has("vm-1"); has {
+		t.Fatal("record must not exist after PutIfPresent on an absent key")
+	}
+
+	// Present key → writes (and updates).
+	if err := s.Put(rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	rec.Status = StatusPaused
+	if wrote, err := s.PutIfPresent(rec); err != nil || !wrote {
+		t.Fatalf("PutIfPresent on present key = (%v, %v), want (true, nil)", wrote, err)
+	}
+	if got, _ := s.Get("vm-1"); got == nil || got.Status != StatusPaused {
+		t.Fatalf("record not updated: %+v", got)
+	}
+
+	// Deleted key → must NOT resurrect (the whole point of the fix).
+	if err := s.Delete("vm-1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if wrote, err := s.PutIfPresent(rec); err != nil || wrote {
+		t.Fatalf("PutIfPresent after delete = (%v, %v), want (false, nil)", wrote, err)
+	}
+	if has, _ := s.Has("vm-1"); has {
+		t.Fatal("record resurrected after delete — PutIfPresent must be a no-op")
+	}
+}

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -57,6 +58,25 @@ func stopUnit(ctx context.Context, unit string) error {
 func isUnitActive(ctx context.Context, unit string) bool {
 	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
 	return cmd.Run() == nil
+}
+
+// unitDefinitelyDead reports whether systemd definitively reports the unit
+// not-active. Unlike !isUnitActive it returns false on an inconclusive result
+// (ctx cancelled, systemctl timeout/error), so an overloaded or shutting-down
+// host never mistakes a live VM for a dead one. Only a clean non-zero exit counts.
+func unitDefinitelyDead(ctx context.Context, unit string) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	err := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run()
+	if err == nil {
+		return false // active
+	}
+	if ctx.Err() != nil {
+		return false // cancelled or timed out mid-call, not a real answer
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr)
 }
 
 // listActiveFirecrackerUnits returns the sandbox IDs of all running


### PR DESCRIPTION
On restart, vmd reattached every VM in BoltDB before binding the gRPC port, so a large host spent minutes not listening — every control-plane call during that window failed with `connection refused`. Startup work scaled with fleet size and blocked serving.

This binds and serves gRPC immediately, gated with a retriable `Unavailable` until fast pre-serve init (slot reservation + orphan-namespace sweep + pool prime) completes. The full per-VM reattach moves to a background pass, and any VM a request touches before that pass reaches it is reattached on demand (singleflight, shared with the eager path). Slot indices held by existing VMs are reserved before the pool starts, so the pool never hands out a colliding slot.

Correctness details:
- Liveness uses `unitDefinitelyDead`, which treats a cancelled/timed-out/errored `systemctl` as "unknown, don't destroy" — so a shutdown or an overloaded host can't mistake a live VM for a dead one and SIGKILL + delete it. The eager loop also bails on context cancellation.
- Resume loads its VM before the in-place check, so it reuses the existing slot/IP instead of allocating a fresh one.
- The eager pass re-reads each record before acting, so a VM destroyed mid-startup isn't resurrected.
- gRPC graceful-shutdown stays registered last (closes first on SIGTERM); resume/create latency is unchanged in steady state.

Rewrites startup and request resolution — validate on staging (restart + chaos, especially SIGTERM mid-reattach) before enabling in prod.
