### PR TITLE
cd: seed the usw cell's templates after primary prod seeding

### DIFF
--- a/.github/workflows/seed-templates.yml
+++ b/.github/workflows/seed-templates.yml
@@ -141,7 +141,9 @@ jobs:
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 45
+    # Two blocking seeder invocations (primary, then the usw cell), each with
+    # the seeder's default 30-min build wait — 90 covers both plus slack.
+    timeout-minutes: 90
     needs: [seed-staging]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/seed-templates.yml
+++ b/.github/workflows/seed-templates.yml
@@ -203,3 +203,21 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           SYSTEM_TEAM_ID: ${{ secrets.SYSTEM_TEAM_ID_PROD }}
           FORCE_REBUILD: ${{ steps.stale.outputs.force }}
+
+      # The usw cell seeds after the primary — a step in this job, not a
+      # second environment-referencing job, so a protected production
+      # environment gates one approval (same shape as CD Migrate's cell
+      # step). Skipped until CLOUD_RUN_SERVICE_USW (the repo-level
+      # cell-exists flag) is set. Each cell's own build supervisor picks up
+      # the enqueued builds and runs them on that cell's hosts; the system
+      # team UUID is deliberately identical across cells, so the prod
+      # secret is reused.
+      - name: Seed usw cell
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
+        run: |
+          go run ./cmd/seed-templates --dir superserve_templates \
+            $( [ "${FORCE_REBUILD}" = "true" ] && echo "--force-rebuild" || true )
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
+          SYSTEM_TEAM_ID: ${{ secrets.SYSTEM_TEAM_ID_PROD }}
+          FORCE_REBUILD: ${{ steps.stale.outputs.force }}


### PR DESCRIPTION
Extends CD — Seed Templates so platform templates land in the usw cell: after the primary prod seed, the same seeder runs against the cell DB (`DATABASE_URL_USWEST`), and the cell's own build supervisor builds the artifacts on the cell's hosts. Part of the multi-region cell work pairs with the migrate (#169) and deploy (#170) cell steps already merged.

Decisions:
- Step inside `seed-prod`, not a second environment job — a protected production environment gates one approval, matching how #169 landed.
- Gated on the repo-level `CLOUD_RUN_SERVICE_USW` variable (the established cell-exists flag; already set), so the step is inert for forks and future cells until flipped — and environment-scoped vars don't resolve in job-level `if` anyway.
- `SYSTEM_TEAM_ID_PROD` is reused for the cell: the system team UUID is deliberately identical across cells (the cell DB's system team row was created with the same ID).
- Per-cell builds rather than artifact replication: specs in git are the source of truth and the seeder is spec-hash idempotent, so cells converge without shared storage; GCS-based replication is deferred until cells/hosts multiply (rationale on.

Testing: YAML structure validated; the step's skip/run behavior follows the same `if` guard pattern as the merged #170. First live run happens on the next seed-triggering push or dispatch — build completion in the cell requires the z3's VMD, which is registered and running as of tonight.