### PR TITLE
api: server-side pagination, sorting & filtering for sandbox and template lists

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -389,9 +389,11 @@ paths:
         - name: status
           in: query
           required: false
-          description: Filter by exact sandbox status, e.g. `active` or `paused`.
+          description: Filter by exact sandbox status. Unknown values are a `400`.
           schema:
             type: string
+            enum:
+              [starting, active, pausing, paused, resuming, failed, deleted]
         - name: sort
           in: query
           required: false
@@ -1357,6 +1359,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/TemplateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -355,8 +355,16 @@ paths:
       tags: [Sandboxes]
       summary: List all sandboxes
       description: |
-        Returns sandboxes belonging to the authenticated team, optionally
-        filtered by metadata tags.
+        Returns sandboxes belonging to the authenticated team, ordered by
+        creation time (newest first) by default.
+
+        ## Pagination, sorting, and search
+
+        Pass `limit` (and `offset`) to fetch one page at a time; the
+        `X-Total-Count` response header reports the total across all pages.
+        Omitting `limit` returns the full list, so existing unpaginated
+        callers are unaffected. Sort with `sort` + `order`, filter by exact
+        `status`, and search names with `q` (case-insensitive substring).
 
         ## Filtering by metadata
 
@@ -377,9 +385,30 @@ paths:
             are always strings. Example: `?metadata.env=prod`.
           schema:
             type: string
+        - $ref: "#/components/parameters/ListSearch"
+        - name: status
+          in: query
+          required: false
+          description: Filter by exact sandbox status, e.g. `active` or `paused`.
+          schema:
+            type: string
+        - name: sort
+          in: query
+          required: false
+          description: Column to sort by (paired with `order`).
+          schema:
+            type: string
+            enum: [created_at, name, status]
+            default: created_at
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageOffset"
       responses:
         "200":
           description: List of sandboxes belonging to the authenticated team
+          headers:
+            X-Total-Count:
+              $ref: "#/components/headers/TotalCount"
           content:
             application/json:
               schema:
@@ -1274,19 +1303,54 @@ paths:
       description: |
         Returns the caller's team's templates plus the curated system
         templates (available to everyone, identified by the `superserve/` name
-        prefix — e.g. `superserve/base`, `superserve/python-3.11`, `superserve/node-22`). Filter
-        by `name_prefix=<text>`.
+        prefix — e.g. `superserve/base`, `superserve/python-3.11`, `superserve/node-22`),
+        ordered by creation time (newest first) by default.
+
+        ## Pagination, sorting, and search
+
+        Pass `limit` (and `offset`) to page; `X-Total-Count` reports the total
+        across all pages. Omitting `limit` returns the full list. Narrow the
+        shelves with `owner`, sort with `sort` + `order`, and search names with
+        `q` (case-insensitive substring). The legacy `name_prefix` prefix
+        filter is still honored for backward compatibility.
       security:
         - apiKey: []
       parameters:
         - name: name_prefix
           in: query
           required: false
+          description: Prefix match on the template `name` (legacy; prefer `q`).
           schema:
             type: string
+        - $ref: "#/components/parameters/ListSearch"
+        - name: owner
+          in: query
+          required: false
+          description: |
+            Which shelf to return: `all` (team + system, the default), `team`
+            (only the caller's own templates), or `system` (only the curated
+            Superserve templates).
+          schema:
+            type: string
+            enum: [all, team, system]
+            default: all
+        - name: sort
+          in: query
+          required: false
+          description: Column to sort by (paired with `order`).
+          schema:
+            type: string
+            enum: [created_at, name, status, size, built_at]
+            default: created_at
+        - $ref: "#/components/parameters/SortOrder"
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageOffset"
       responses:
         "200":
           description: List of templates
+          headers:
+            X-Total-Count:
+              $ref: "#/components/headers/TotalCount"
           content:
             application/json:
               schema:
@@ -1629,6 +1693,57 @@ components:
         type: string
         enum: [2xx, 3xx, 4xx, 5xx, errors]
       description: Narrow by HTTP status class; `errors` includes 4xx and 5xx.
+
+    PageLimit:
+      name: limit
+      in: query
+      required: false
+      description: |
+        Maximum rows to return (page size). Omit to return the full list
+        unpaginated — the default, preserved for backward compatibility with
+        callers that page client-side. Values above 200 are clamped to 200.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+
+    PageOffset:
+      name: offset
+      in: query
+      required: false
+      description: Rows to skip before the page. Combine with `limit` to paginate.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+
+    SortOrder:
+      name: order
+      in: query
+      required: false
+      description: Sort direction applied to `sort`.
+      schema:
+        type: string
+        enum: [asc, desc]
+        default: desc
+
+    ListSearch:
+      name: q
+      in: query
+      required: false
+      description: Case-insensitive substring match on the resource `name`.
+      schema:
+        type: string
+
+  headers:
+    TotalCount:
+      description: |
+        Total rows matching the query across all pages, ignoring `limit` and
+        `offset`. Read this alongside a `limit`/`offset` request to render
+        pagination controls (page count, "X–Y of Z").
+      schema:
+        type: integer
+        format: int64
 
   schemas:
     PublicSandboxId:

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -42,21 +42,44 @@ WHERE base_path = $1 AND destroyed_at IS NULL;
 SELECT DISTINCT base_path FROM sandbox
 WHERE base_path IS NOT NULL AND destroyed_at IS NULL;
 
--- name: ListSandboxesByTeam :many
+-- name: ListSandboxesByTeamPaged :many
+-- Paginated, sortable, filterable team sandbox list backing the console.
+--
+-- Filters (all optional, AND'd): metadata containment (@> — pass '{}'::jsonb
+-- to match everything), status equality, and a case-insensitive name
+-- substring. Sort column/direction come from @sort_by + @sort_dir: exactly one
+-- guarded CASE term is active per query (the sort params are constant across
+-- rows, so every other term evaluates to NULL for all rows and acts as a
+-- no-op), with created_at DESC as the stable tiebreaker and default. A NULL
+-- @row_limit returns all rows, preserving the pre-pagination "return
+-- everything" default so unpaginated SDK/MCP callers are unaffected.
 SELECT * FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL
-ORDER BY created_at DESC;
-
--- name: ListSandboxesByTeamWithFilter :many
--- Same as ListSandboxesByTeam but additionally filters rows whose metadata
--- contains every key/value pair in $2 (jsonb @> containment). Pass an empty
--- object '{}'::jsonb to match everything — but prefer ListSandboxesByTeam
--- in that case so we don't pay the (still tiny) cost of the @> evaluation.
-SELECT * FROM sandbox
-WHERE team_id = $1
+WHERE team_id = @team_id
   AND destroyed_at IS NULL
-  AND metadata @> $2
-ORDER BY created_at DESC;
+  AND metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+ORDER BY
+  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'asc'  THEN name END ASC,
+  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'desc' THEN name END DESC,
+  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'asc'  THEN status::text END ASC,
+  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'desc' THEN status::text END DESC,
+  CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN created_at END ASC,
+  created_at DESC
+LIMIT sqlc.narg('row_limit')::bigint
+OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
+
+-- name: CountSandboxesByTeamPaged :one
+-- Total rows matching the same filters as ListSandboxesByTeamPaged (ignoring
+-- pagination + sort). Backs the X-Total-Count response header.
+SELECT COUNT(*) FROM sandbox
+WHERE team_id = @team_id
+  AND destroyed_at IS NULL
+  AND metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%');
 
 -- name: UpdateSandboxStatus :exec
 UPDATE sandbox

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -108,10 +108,13 @@ ORDER BY
   CASE WHEN @sort_by::text = 'name'     AND @sort_dir::text = 'desc' THEN name END DESC,
   CASE WHEN @sort_by::text = 'status'   AND @sort_dir::text = 'asc'  THEN status::text END ASC,
   CASE WHEN @sort_by::text = 'status'   AND @sort_dir::text = 'desc' THEN status::text END DESC,
+  -- size_bytes and built_at are NULL until a build succeeds. DESC defaults to
+  -- NULLS FIRST in Postgres, which would rank never-built templates above the
+  -- most recently built, so pin NULLS LAST (ASC already defaults to it).
   CASE WHEN @sort_by::text = 'size'     AND @sort_dir::text = 'asc'  THEN size_bytes END ASC,
-  CASE WHEN @sort_by::text = 'size'     AND @sort_dir::text = 'desc' THEN size_bytes END DESC,
+  CASE WHEN @sort_by::text = 'size'     AND @sort_dir::text = 'desc' THEN size_bytes END DESC NULLS LAST,
   CASE WHEN @sort_by::text = 'built_at' AND @sort_dir::text = 'asc'  THEN built_at END ASC,
-  CASE WHEN @sort_by::text = 'built_at' AND @sort_dir::text = 'desc' THEN built_at END DESC,
+  CASE WHEN @sort_by::text = 'built_at' AND @sort_dir::text = 'desc' THEN built_at END DESC NULLS LAST,
   CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN created_at END ASC,
   created_at DESC
 LIMIT sqlc.narg('row_limit')::bigint

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -84,23 +84,53 @@ LIMIT 1;
 SELECT COUNT(*)::bigint FROM template
 WHERE team_id = $1 AND deleted_at IS NULL AND status != 'failed';
 
--- name: ListTemplatesForTeam :many
--- Return the caller's team's templates plus all system-team templates
--- (curated base set visible to everyone). Ordered by created_at desc.
+-- name: ListTemplatesForTeamPaged :many
+-- Paginated, sortable, filterable template list backing the console. The
+-- caller sees its own team's templates plus the curated system-team set; the
+-- @owner selector ('all' | 'team' | 'system') narrows which of the two shelves
+-- to return. Optional case-insensitive name substring filter. Sort follows the
+-- same guarded-CASE pattern as ListSandboxesByTeamPaged — exactly one term is
+-- active per query — with created_at DESC as the default + tiebreaker. A NULL
+-- @row_limit returns all rows, preserving the pre-pagination default.
 SELECT * FROM template
 WHERE deleted_at IS NULL
-  AND (team_id = $1 OR team_id = $2)
-ORDER BY created_at DESC;
-
--- name: ListTemplatesForTeamFiltered :many
--- Same as ListTemplatesForTeam with an optional name prefix filter. Pass
--- NULL to get the unfiltered list (but prefer the unfiltered query then).
-SELECT * FROM template
-WHERE deleted_at IS NULL
-  AND (team_id = $1 OR team_id = $2)
+  AND (
+    (@owner::text = 'all'    AND (team_id = @team_id OR team_id = @system_team_id))
+    OR (@owner::text = 'team'   AND team_id = @team_id)
+    OR (@owner::text = 'system' AND team_id = @system_team_id)
+  )
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
   AND (sqlc.narg('name_prefix')::text IS NULL
-       OR name LIKE sqlc.narg('name_prefix') || '%')
-ORDER BY created_at DESC;
+       OR name LIKE sqlc.narg('name_prefix')::text || '%')
+ORDER BY
+  CASE WHEN @sort_by::text = 'name'     AND @sort_dir::text = 'asc'  THEN name END ASC,
+  CASE WHEN @sort_by::text = 'name'     AND @sort_dir::text = 'desc' THEN name END DESC,
+  CASE WHEN @sort_by::text = 'status'   AND @sort_dir::text = 'asc'  THEN status::text END ASC,
+  CASE WHEN @sort_by::text = 'status'   AND @sort_dir::text = 'desc' THEN status::text END DESC,
+  CASE WHEN @sort_by::text = 'size'     AND @sort_dir::text = 'asc'  THEN size_bytes END ASC,
+  CASE WHEN @sort_by::text = 'size'     AND @sort_dir::text = 'desc' THEN size_bytes END DESC,
+  CASE WHEN @sort_by::text = 'built_at' AND @sort_dir::text = 'asc'  THEN built_at END ASC,
+  CASE WHEN @sort_by::text = 'built_at' AND @sort_dir::text = 'desc' THEN built_at END DESC,
+  CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN created_at END ASC,
+  created_at DESC
+LIMIT sqlc.narg('row_limit')::bigint
+OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
+
+-- name: CountTemplatesForTeamPaged :one
+-- Total rows matching the same filters as ListTemplatesForTeamPaged (ignoring
+-- pagination + sort). Backs the X-Total-Count response header.
+SELECT COUNT(*) FROM template
+WHERE deleted_at IS NULL
+  AND (
+    (@owner::text = 'all'    AND (team_id = @team_id OR team_id = @system_team_id))
+    OR (@owner::text = 'team'   AND team_id = @team_id)
+    OR (@owner::text = 'system' AND team_id = @system_team_id)
+  )
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+  AND (sqlc.narg('name_prefix')::text IS NULL
+       OR name LIKE sqlc.narg('name_prefix')::text || '%');
 
 -- name: SoftDeleteTemplateIfUnused :one
 -- Soft-deletes a template only if no live sandbox references it AND no

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/netip"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1252,6 +1253,21 @@ func decodeMetadata(raw []byte) map[string]string {
 // maps to a guarded ORDER BY term in ListSandboxesByTeamPaged.
 var sandboxSortColumns = []string{"created_at", "name", "status"}
 
+// sandboxStatusFilterValues are the values ListSandboxes accepts for
+// `?status=`, sourced from the sqlc-generated sandbox_status constants. An
+// unknown value would silently match zero rows in the SQL's text comparison,
+// so the handler rejects it with a 400 instead — mirroring the owner filter
+// on /templates.
+var sandboxStatusFilterValues = []string{
+	string(db.SandboxStatusStarting),
+	string(db.SandboxStatusActive),
+	string(db.SandboxStatusPausing),
+	string(db.SandboxStatusPaused),
+	string(db.SandboxStatusResuming),
+	string(db.SandboxStatusFailed),
+	string(db.SandboxStatusDeleted),
+}
+
 func (h *Handlers) ListSandboxes(c *gin.Context) {
 	teamID, err := teamIDFromContext(c)
 	if err != nil {
@@ -1292,8 +1308,14 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
 	}
-	statusFilter := optStr(c.Query("status"))
-	nameSearch := optStr(c.Query("q"))
+	statusFilter := nullableStr(c.Query("status"))
+	if statusFilter != nil && !slices.Contains(sandboxStatusFilterValues, *statusFilter) {
+		respondErrorMsg(c, "bad_request",
+			"status must be one of: "+strings.Join(sandboxStatusFilterValues, ", "),
+			http.StatusBadRequest)
+		return
+	}
+	nameSearch := searchTerm(c.Query("q"))
 
 	ctx := c.Request.Context()
 	sandboxes, err := h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
@@ -1312,22 +1334,18 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 		return
 	}
 
-	// When unpaginated (no limit) the returned slice is the whole result set,
-	// so its length is the total — skip the extra COUNT round trip. Only a
-	// limited page needs the DB to report the unpaginated total.
-	total := int64(len(sandboxes))
-	if pg.Limit != nil {
-		total, err = h.DB.CountSandboxesByTeamPaged(ctx, db.CountSandboxesByTeamPagedParams{
+	total, err := resolveTotal(pg, len(sandboxes), func() (int64, error) {
+		return h.DB.CountSandboxesByTeamPaged(ctx, db.CountSandboxesByTeamPagedParams{
 			TeamID:     teamID,
 			Metadata:   metadataJSON,
 			Status:     statusFilter,
 			NameSearch: nameSearch,
 		})
-		if err != nil {
-			log.Error().Err(err).Msg("DB CountSandboxesByTeamPaged failed")
-			respondError(c, ErrInternal)
-			return
-		}
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("DB CountSandboxesByTeamPaged failed")
+		respondError(c, ErrInternal)
+		return
 	}
 	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/netip"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1247,6 +1248,10 @@ func decodeMetadata(raw []byte) map[string]string {
 // Sandbox List + Get
 // ---------------------------------------------------------------------------
 
+// sandboxSortColumns are the columns ListSandboxes accepts for `?sort=`. Each
+// maps to a guarded ORDER BY term in ListSandboxesByTeamPaged.
+var sandboxSortColumns = []string{"created_at", "name", "status"}
+
 func (h *Handlers) ListSandboxes(c *gin.Context) {
 	teamID, err := teamIDFromContext(c)
 	if err != nil {
@@ -1272,22 +1277,59 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	var sandboxes []db.Sandbox
-	if len(filter) == 0 {
-		sandboxes, err = h.DB.ListSandboxesByTeam(c.Request.Context(), teamID)
-	} else {
-		filterJSON, _ := json.Marshal(filter) // map[string]string never fails
-		sandboxes, err = h.DB.ListSandboxesByTeamWithFilter(c.Request.Context(), db.ListSandboxesByTeamWithFilterParams{
-			TeamID:   teamID,
-			Metadata: filterJSON,
-		})
+	// Always a valid jsonb value: '{}' matches every row under @> containment,
+	// so the single paged query serves both filtered and unfiltered requests.
+	metadataJSON := []byte("{}")
+	if len(filter) > 0 {
+		metadataJSON, _ = json.Marshal(filter) // map[string]string never fails
 	}
+
+	// Pagination + sort + optional status/name filters. Omitting `limit`
+	// returns the full list in created_at-desc order — the pre-pagination
+	// contract that unpaginated SDK/MCP callers still rely on.
+	pg, err := parsePageParams(c, sandboxSortColumns, "created_at")
 	if err != nil {
-		log.Error().Err(err).Msg("DB ListSandboxesByTeam failed")
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	statusFilter := optStr(c.Query("status"))
+	nameSearch := optStr(c.Query("q"))
+
+	ctx := c.Request.Context()
+	sandboxes, err := h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
+		TeamID:     teamID,
+		Metadata:   metadataJSON,
+		Status:     statusFilter,
+		NameSearch: nameSearch,
+		SortBy:     pg.SortBy,
+		SortDir:    pg.SortDir,
+		RowOffset:  pg.Offset,
+		RowLimit:   pg.Limit,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("DB ListSandboxesByTeamPaged failed")
 		respondError(c, ErrInternal)
 		return
 	}
+
+	// When unpaginated (no limit) the returned slice is the whole result set,
+	// so its length is the total — skip the extra COUNT round trip. Only a
+	// limited page needs the DB to report the unpaginated total.
+	total := int64(len(sandboxes))
+	if pg.Limit != nil {
+		total, err = h.DB.CountSandboxesByTeamPaged(ctx, db.CountSandboxesByTeamPagedParams{
+			TeamID:     teamID,
+			Metadata:   metadataJSON,
+			Status:     statusFilter,
+			NameSearch: nameSearch,
+		})
+		if err != nil {
+			log.Error().Err(err).Msg("DB CountSandboxesByTeamPaged failed")
+			respondError(c, ErrInternal)
+			return
+		}
+	}
+	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
 
 	out := make([]sandboxResponse, len(sandboxes))
 	for i, s := range sandboxes {

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -629,8 +629,8 @@ func (h *Handlers) ListTemplates(c *gin.Context) {
 	// `q` is the console's case-insensitive substring search; `name_prefix` is
 	// the pre-existing prefix filter kept for the SDKs/MCP. Both are optional
 	// and AND together when supplied.
-	nameSearch := optStr(c.Query("q"))
-	namePrefix := optStr(c.Query("name_prefix"))
+	nameSearch := searchTerm(c.Query("q"))
+	namePrefix := nullableStr(c.Query("name_prefix"))
 	systemTeamID := h.systemTeamID()
 
 	ctx := c.Request.Context()
@@ -651,22 +651,19 @@ func (h *Handlers) ListTemplates(c *gin.Context) {
 		return
 	}
 
-	// Unpaginated request → the slice is the full set, so len is the total.
-	// A limited page asks the DB for the unpaginated total via the count query.
-	total := int64(len(rows))
-	if pg.Limit != nil {
-		total, err = h.DB.CountTemplatesForTeamPaged(ctx, db.CountTemplatesForTeamPagedParams{
+	total, err := resolveTotal(pg, len(rows), func() (int64, error) {
+		return h.DB.CountTemplatesForTeamPaged(ctx, db.CountTemplatesForTeamPagedParams{
 			Owner:        owner,
 			TeamID:       teamID,
 			SystemTeamID: systemTeamID,
 			NameSearch:   nameSearch,
 			NamePrefix:   namePrefix,
 		})
-		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountTemplatesForTeamPaged failed")
-			respondError(c, ErrInternal)
-			return
-		}
+	})
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountTemplatesForTeamPaged failed")
+		respondError(c, ErrInternal)
+		return
 	}
 	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
 

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -596,6 +597,11 @@ func (h *Handlers) GetTemplate(c *gin.Context) {
 	c.JSON(http.StatusOK, toTemplateResponse(tpl))
 }
 
+// templateSortColumns are the columns ListTemplates accepts for `?sort=`. Each
+// maps to a guarded ORDER BY term in ListTemplatesForTeamPaged ("size" →
+// size_bytes, "built_at" → the last successful build time).
+var templateSortColumns = []string{"created_at", "name", "status", "size", "built_at"}
+
 func (h *Handlers) ListTemplates(c *gin.Context) {
 	teamID, err := teamIDFromContext(c)
 	if err != nil {
@@ -605,26 +611,64 @@ func (h *Handlers) ListTemplates(c *gin.Context) {
 		return
 	}
 
-	namePrefix := c.Query("name_prefix")
-
-	var rows []db.Template
-	if namePrefix == "" {
-		rows, err = h.DB.ListTemplatesForTeam(c.Request.Context(), db.ListTemplatesForTeamParams{
-			TeamID:   teamID,
-			TeamID_2: h.systemTeamID(),
-		})
-	} else {
-		rows, err = h.DB.ListTemplatesForTeamFiltered(c.Request.Context(), db.ListTemplatesForTeamFilteredParams{
-			TeamID:     teamID,
-			TeamID_2:   h.systemTeamID(),
-			NamePrefix: &namePrefix,
-		})
+	// owner selects which shelf to return: the caller's team, the curated
+	// system templates, or both. Defaults to both (the pre-pagination
+	// behavior). An empty/unknown value would match no rows in the SQL, so
+	// reject it up front with a clear message.
+	owner := c.DefaultQuery("owner", "all")
+	if owner != "all" && owner != "team" && owner != "system" {
+		respondErrorMsg(c, "bad_request", "owner must be one of: all, team, system", http.StatusBadRequest)
+		return
 	}
+
+	pg, err := parsePageParams(c, templateSortColumns, "created_at")
 	if err != nil {
-		log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB ListTemplates failed")
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	// `q` is the console's case-insensitive substring search; `name_prefix` is
+	// the pre-existing prefix filter kept for the SDKs/MCP. Both are optional
+	// and AND together when supplied.
+	nameSearch := optStr(c.Query("q"))
+	namePrefix := optStr(c.Query("name_prefix"))
+	systemTeamID := h.systemTeamID()
+
+	ctx := c.Request.Context()
+	rows, err := h.DB.ListTemplatesForTeamPaged(ctx, db.ListTemplatesForTeamPagedParams{
+		Owner:        owner,
+		TeamID:       teamID,
+		SystemTeamID: systemTeamID,
+		NameSearch:   nameSearch,
+		NamePrefix:   namePrefix,
+		SortBy:       pg.SortBy,
+		SortDir:      pg.SortDir,
+		RowOffset:    pg.Offset,
+		RowLimit:     pg.Limit,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB ListTemplatesForTeamPaged failed")
 		respondError(c, ErrInternal)
 		return
 	}
+
+	// Unpaginated request → the slice is the full set, so len is the total.
+	// A limited page asks the DB for the unpaginated total via the count query.
+	total := int64(len(rows))
+	if pg.Limit != nil {
+		total, err = h.DB.CountTemplatesForTeamPaged(ctx, db.CountTemplatesForTeamPagedParams{
+			Owner:        owner,
+			TeamID:       teamID,
+			SystemTeamID: systemTeamID,
+			NameSearch:   nameSearch,
+			NamePrefix:   namePrefix,
+		})
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("DB CountTemplatesForTeamPaged failed")
+			respondError(c, ErrInternal)
+			return
+		}
+	}
+	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
 
 	out := make([]templateResponse, 0, len(rows))
 	for _, t := range rows {

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// maxPageSize caps the rows a single paginated list request can return.
+// Requests asking for more are silently clamped rather than rejected, so a
+// client that hard-codes a larger page size still gets a valid response.
+const maxPageSize = 200
+
+// pageParams holds the normalized pagination + sort inputs shared by the list
+// endpoints. Limit is nil when the caller supplied no `limit` query param,
+// which the SQL treats as "return everything" — preserving the pre-pagination
+// default for SDK/MCP callers that never send pagination.
+type pageParams struct {
+	Limit   *int64 // nil => no limit (return all rows)
+	Offset  *int64 // nil => 0
+	SortBy  string // validated against the caller's allow-list
+	SortDir string // "asc" | "desc"
+}
+
+// parsePageParams reads limit/offset/sort/order from the query string,
+// validates them against allowedSort, and applies defaults (sort=defaultSort,
+// order=desc). It returns a user-facing error suitable for a 400 when any
+// value is malformed; callers surface it via respondErrorMsg.
+func parsePageParams(c *gin.Context, allowedSort []string, defaultSort string) (pageParams, error) {
+	p := pageParams{SortBy: defaultSort, SortDir: "desc"}
+
+	if v := c.Query("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return p, fmt.Errorf("limit must be a positive integer")
+		}
+		if n > maxPageSize {
+			n = maxPageSize
+		}
+		lim := int64(n)
+		p.Limit = &lim
+	}
+
+	if v := c.Query("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return p, fmt.Errorf("offset must be a non-negative integer")
+		}
+		off := int64(n)
+		p.Offset = &off
+	}
+
+	if v := c.Query("sort"); v != "" {
+		if !slices.Contains(allowedSort, v) {
+			return p, fmt.Errorf("sort must be one of: %s", strings.Join(allowedSort, ", "))
+		}
+		p.SortBy = v
+	}
+
+	if v := c.Query("order"); v != "" {
+		if v != "asc" && v != "desc" {
+			return p, fmt.Errorf("order must be 'asc' or 'desc'")
+		}
+		p.SortDir = v
+	}
+
+	return p, nil
+}
+
+// optStr maps an empty query value to nil and a non-empty one to a pointer —
+// the shape the generated sqlc params want for optional text filters.
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -70,11 +70,38 @@ func parsePageParams(c *gin.Context, allowedSort []string, defaultSort string) (
 	return p, nil
 }
 
-// optStr maps an empty query value to nil and a non-empty one to a pointer —
-// the shape the generated sqlc params want for optional text filters.
-func optStr(s string) *string {
+// likeEscaper escapes the LIKE/ILIKE pattern metacharacters so a
+// user-supplied search term matches literally inside the '%…%' pattern the
+// queries build around it. Backslash is Postgres's default LIKE escape
+// character, so it must be escaped too (and first, which NewReplacer's
+// single-pass semantics guarantee).
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+// searchTerm normalizes a search query value for the sqlc name_search params:
+// empty → nil (filter off), non-empty → pointer to the LIKE-escaped term.
+func searchTerm(s string) *string {
 	if s == "" {
 		return nil
 	}
-	return &s
+	escaped := likeEscaper.Replace(s)
+	return &escaped
+}
+
+// resolveTotal computes the X-Total-Count value for a list response: the
+// number of rows matching the filters, ignoring limit and offset. It avoids
+// the COUNT round trip whenever the returned page already proves the total —
+// a page shorter than the limit (or with no limit at all) ends the list, so
+// total = offset + pageLen. Only a full page, or an empty page at a nonzero
+// offset (which proves nothing about how many rows precede it), needs the DB
+// count.
+func resolveTotal(pg pageParams, pageLen int, count func() (int64, error)) (int64, error) {
+	var offset int64
+	if pg.Offset != nil {
+		offset = *pg.Offset
+	}
+	short := pg.Limit == nil || int64(pageLen) < *pg.Limit
+	if short && (pageLen > 0 || offset == 0) {
+		return offset + int64(pageLen), nil
+	}
+	return count()
 }

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func pageCtx(t *testing.T, rawQuery string) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/?"+rawQuery, nil)
+	return c
+}
+
+var pageTestSortCols = []string{"created_at", "name", "status"}
+
+func TestParsePageParams_DefaultsToUnpaginatedCreatedDesc(t *testing.T) {
+	p, err := parsePageParams(pageCtx(t, ""), pageTestSortCols, "created_at")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Limit != nil {
+		t.Errorf("Limit = %d, want nil (no limit → return all)", *p.Limit)
+	}
+	if p.Offset != nil {
+		t.Errorf("Offset = %d, want nil", *p.Offset)
+	}
+	if p.SortBy != "created_at" || p.SortDir != "desc" {
+		t.Errorf("sort = %q %q, want created_at desc", p.SortBy, p.SortDir)
+	}
+}
+
+func TestParsePageParams_ValidValues(t *testing.T) {
+	p, err := parsePageParams(pageCtx(t, "limit=25&offset=50&sort=name&order=asc"), pageTestSortCols, "created_at")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Limit == nil || *p.Limit != 25 {
+		t.Errorf("Limit = %v, want 25", p.Limit)
+	}
+	if p.Offset == nil || *p.Offset != 50 {
+		t.Errorf("Offset = %v, want 50", p.Offset)
+	}
+	if p.SortBy != "name" || p.SortDir != "asc" {
+		t.Errorf("sort = %q %q, want name asc", p.SortBy, p.SortDir)
+	}
+}
+
+func TestParsePageParams_LimitClampedToMax(t *testing.T) {
+	p, err := parsePageParams(pageCtx(t, "limit=100000"), pageTestSortCols, "created_at")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Limit == nil || *p.Limit != maxPageSize {
+		t.Errorf("Limit = %v, want clamp to %d", p.Limit, maxPageSize)
+	}
+}
+
+func TestParsePageParams_Rejects(t *testing.T) {
+	cases := map[string]string{
+		"limit zero":         "limit=0",
+		"limit negative":     "limit=-5",
+		"limit non-numeric":  "limit=abc",
+		"offset negative":    "offset=-1",
+		"offset non-numeric": "offset=xyz",
+		"unknown sort":       "sort=bogus",
+		"bad order":          "order=sideways",
+	}
+	for name, query := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parsePageParams(pageCtx(t, query), pageTestSortCols, "created_at"); err == nil {
+				t.Errorf("expected error for %q, got nil", query)
+			}
+		})
+	}
+}
+
+func TestOptStr(t *testing.T) {
+	if optStr("") != nil {
+		t.Error(`optStr("") should be nil`)
+	}
+	if got := optStr("x"); got == nil || *got != "x" {
+		t.Errorf(`optStr("x") = %v, want pointer to "x"`, got)
+	}
+}

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -78,11 +78,62 @@ func TestParsePageParams_Rejects(t *testing.T) {
 	}
 }
 
-func TestOptStr(t *testing.T) {
-	if optStr("") != nil {
-		t.Error(`optStr("") should be nil`)
+func TestSearchTerm(t *testing.T) {
+	if searchTerm("") != nil {
+		t.Error(`searchTerm("") should be nil`)
 	}
-	if got := optStr("x"); got == nil || *got != "x" {
-		t.Errorf(`optStr("x") = %v, want pointer to "x"`, got)
+	cases := map[string]string{
+		"plain":   "plain",
+		"a_b":     `a\_b`,
+		"50%":     `50\%`,
+		`back\up`: `back\\up`,
+		`%_\`:    `\%\_\\`,
+	}
+	for in, want := range cases {
+		if got := searchTerm(in); got == nil || *got != want {
+			t.Errorf("searchTerm(%q) = %v, want %q", in, got, want)
+		}
+	}
+}
+
+func ptr64(n int64) *int64 { return &n }
+
+func TestResolveTotal(t *testing.T) {
+	countErr := func() (int64, error) {
+		t.Helper()
+		t.Error("count should not be called")
+		return 0, nil
+	}
+	count := func(n int64) func() (int64, error) {
+		return func() (int64, error) { return n, nil }
+	}
+
+	cases := []struct {
+		name  string
+		pg    pageParams
+		len   int
+		count func() (int64, error)
+		want  int64
+	}{
+		{"unpaginated", pageParams{}, 5, countErr, 5},
+		{"unpaginated empty", pageParams{}, 0, countErr, 0},
+		{"offset only", pageParams{Offset: ptr64(4)}, 1, countErr, 5},
+		{"offset only past end", pageParams{Offset: ptr64(10)}, 0, count(5), 5},
+		{"short page", pageParams{Limit: ptr64(10)}, 3, countErr, 3},
+		{"short page with offset", pageParams{Limit: ptr64(10), Offset: ptr64(4)}, 1, countErr, 5},
+		{"full page needs count", pageParams{Limit: ptr64(2)}, 2, count(9), 9},
+		{"empty page at offset needs count", pageParams{Limit: ptr64(2), Offset: ptr64(50)}, 0, count(7), 7},
+		{"empty page at zero offset", pageParams{Limit: ptr64(2)}, 0, countErr, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveTotal(tc.pg, tc.len, tc.count)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("total = %d, want %d", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -338,6 +338,37 @@ func (q *Queries) CountActiveSandboxesAtBasePath(ctx context.Context, basePath *
 	return column_1, err
 }
 
+const countSandboxesByTeamPaged = `-- name: CountSandboxesByTeamPaged :one
+SELECT COUNT(*) FROM sandbox
+WHERE team_id = $1
+  AND destroyed_at IS NULL
+  AND metadata @> $2
+  AND ($3::text IS NULL OR status::text = $3::text)
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+`
+
+type CountSandboxesByTeamPagedParams struct {
+	TeamID     uuid.UUID `json:"team_id"`
+	Metadata   []byte    `json:"metadata"`
+	Status     *string   `json:"status"`
+	NameSearch *string   `json:"name_search"`
+}
+
+// Total rows matching the same filters as ListSandboxesByTeamPaged (ignoring
+// pagination + sort). Backs the X-Total-Count response header.
+func (q *Queries) CountSandboxesByTeamPaged(ctx context.Context, arg CountSandboxesByTeamPagedParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countSandboxesByTeamPaged,
+		arg.TeamID,
+		arg.Metadata,
+		arg.Status,
+		arg.NameSearch,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createSandbox = `-- name: CreateSandbox :one
 INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
@@ -828,74 +859,57 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 	return items, nil
 }
 
-const listSandboxesByTeam = `-- name: ListSandboxesByTeam :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib FROM sandbox
-WHERE team_id = $1 AND destroyed_at IS NULL
-ORDER BY created_at DESC
-`
-
-func (q *Queries) ListSandboxesByTeam(ctx context.Context, teamID uuid.UUID) ([]Sandbox, error) {
-	rows, err := q.db.Query(ctx, listSandboxesByTeam, teamID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Sandbox{}
-	for rows.Next() {
-		var i Sandbox
-		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Status,
-			&i.VcpuCount,
-			&i.MemoryMib,
-			&i.HostID,
-			&i.IpAddress,
-			&i.Pid,
-			&i.SnapshotID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DestroyedAt,
-			&i.NetworkConfig,
-			&i.TimeoutSeconds,
-			&i.Metadata,
-			&i.TemplateID,
-			&i.SnapshotPath,
-			&i.MemPath,
-			&i.BasePath,
-			&i.DeltaPath,
-			&i.DiskMib,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listSandboxesByTeamWithFilter = `-- name: ListSandboxesByTeamWithFilter :many
+const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
 SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib FROM sandbox
 WHERE team_id = $1
   AND destroyed_at IS NULL
   AND metadata @> $2
-ORDER BY created_at DESC
+  AND ($3::text IS NULL OR status::text = $3::text)
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+ORDER BY
+  CASE WHEN $5::text = 'name'   AND $6::text = 'asc'  THEN name END ASC,
+  CASE WHEN $5::text = 'name'   AND $6::text = 'desc' THEN name END DESC,
+  CASE WHEN $5::text = 'status' AND $6::text = 'asc'  THEN status::text END ASC,
+  CASE WHEN $5::text = 'status' AND $6::text = 'desc' THEN status::text END DESC,
+  CASE WHEN $5::text = 'created_at' AND $6::text = 'asc' THEN created_at END ASC,
+  created_at DESC
+LIMIT $8::bigint
+OFFSET COALESCE($7::bigint, 0)
 `
 
-type ListSandboxesByTeamWithFilterParams struct {
-	TeamID   uuid.UUID `json:"team_id"`
-	Metadata []byte    `json:"metadata"`
+type ListSandboxesByTeamPagedParams struct {
+	TeamID     uuid.UUID `json:"team_id"`
+	Metadata   []byte    `json:"metadata"`
+	Status     *string   `json:"status"`
+	NameSearch *string   `json:"name_search"`
+	SortBy     string    `json:"sort_by"`
+	SortDir    string    `json:"sort_dir"`
+	RowOffset  *int64    `json:"row_offset"`
+	RowLimit   *int64    `json:"row_limit"`
 }
 
-// Same as ListSandboxesByTeam but additionally filters rows whose metadata
-// contains every key/value pair in $2 (jsonb @> containment). Pass an empty
-// object '{}'::jsonb to match everything — but prefer ListSandboxesByTeam
-// in that case so we don't pay the (still tiny) cost of the @> evaluation.
-func (q *Queries) ListSandboxesByTeamWithFilter(ctx context.Context, arg ListSandboxesByTeamWithFilterParams) ([]Sandbox, error) {
-	rows, err := q.db.Query(ctx, listSandboxesByTeamWithFilter, arg.TeamID, arg.Metadata)
+// Paginated, sortable, filterable team sandbox list backing the console.
+//
+// Filters (all optional, AND'd): metadata containment (@> — pass '{}'::jsonb
+// to match everything), status equality, and a case-insensitive name
+// substring. Sort column/direction come from @sort_by + @sort_dir: exactly one
+// guarded CASE term is active per query (the sort params are constant across
+// rows, so every other term evaluates to NULL for all rows and acts as a
+// no-op), with created_at DESC as the stable tiebreaker and default. A NULL
+// @row_limit returns all rows, preserving the pre-pagination "return
+// everything" default so unpaginated SDK/MCP callers are unaffected.
+func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxesByTeamPagedParams) ([]Sandbox, error) {
+	rows, err := q.db.Query(ctx, listSandboxesByTeamPaged,
+		arg.TeamID,
+		arg.Metadata,
+		arg.Status,
+		arg.NameSearch,
+		arg.SortBy,
+		arg.SortDir,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -102,6 +102,43 @@ func (q *Queries) CountInFlightBuildsForTeam(ctx context.Context, teamID uuid.UU
 	return count, err
 }
 
+const countTemplatesForTeamPaged = `-- name: CountTemplatesForTeamPaged :one
+SELECT COUNT(*) FROM template
+WHERE deleted_at IS NULL
+  AND (
+    ($1::text = 'all'    AND (team_id = $2 OR team_id = $3))
+    OR ($1::text = 'team'   AND team_id = $2)
+    OR ($1::text = 'system' AND team_id = $3)
+  )
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+  AND ($5::text IS NULL
+       OR name LIKE $5::text || '%')
+`
+
+type CountTemplatesForTeamPagedParams struct {
+	Owner        string    `json:"owner"`
+	TeamID       uuid.UUID `json:"team_id"`
+	SystemTeamID uuid.UUID `json:"system_team_id"`
+	NameSearch   *string   `json:"name_search"`
+	NamePrefix   *string   `json:"name_prefix"`
+}
+
+// Total rows matching the same filters as ListTemplatesForTeamPaged (ignoring
+// pagination + sort). Backs the X-Total-Count response header.
+func (q *Queries) CountTemplatesForTeamPaged(ctx context.Context, arg CountTemplatesForTeamPagedParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countTemplatesForTeamPaged,
+		arg.Owner,
+		arg.TeamID,
+		arg.SystemTeamID,
+		arg.NameSearch,
+		arg.NamePrefix,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createTemplate = `-- name: CreateTemplate :one
 INSERT INTO template (team_id, name, build_spec, vcpu, memory_mib, disk_mib)
 VALUES ($1, $2, $3, $4, $5, $6)
@@ -833,79 +870,64 @@ func (q *Queries) ListPendingBuildsOrdered(ctx context.Context, limit int32) ([]
 	return items, nil
 }
 
-const listTemplatesForTeam = `-- name: ListTemplatesForTeam :many
+const listTemplatesForTeamPaged = `-- name: ListTemplatesForTeamPaged :many
 SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at, base_path, delta_path FROM template
 WHERE deleted_at IS NULL
-  AND (team_id = $1 OR team_id = $2)
-ORDER BY created_at DESC
+  AND (
+    ($1::text = 'all'    AND (team_id = $2 OR team_id = $3))
+    OR ($1::text = 'team'   AND team_id = $2)
+    OR ($1::text = 'system' AND team_id = $3)
+  )
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+  AND ($5::text IS NULL
+       OR name LIKE $5::text || '%')
+ORDER BY
+  CASE WHEN $6::text = 'name'     AND $7::text = 'asc'  THEN name END ASC,
+  CASE WHEN $6::text = 'name'     AND $7::text = 'desc' THEN name END DESC,
+  CASE WHEN $6::text = 'status'   AND $7::text = 'asc'  THEN status::text END ASC,
+  CASE WHEN $6::text = 'status'   AND $7::text = 'desc' THEN status::text END DESC,
+  CASE WHEN $6::text = 'size'     AND $7::text = 'asc'  THEN size_bytes END ASC,
+  CASE WHEN $6::text = 'size'     AND $7::text = 'desc' THEN size_bytes END DESC,
+  CASE WHEN $6::text = 'built_at' AND $7::text = 'asc'  THEN built_at END ASC,
+  CASE WHEN $6::text = 'built_at' AND $7::text = 'desc' THEN built_at END DESC,
+  CASE WHEN $6::text = 'created_at' AND $7::text = 'asc' THEN created_at END ASC,
+  created_at DESC
+LIMIT $9::bigint
+OFFSET COALESCE($8::bigint, 0)
 `
 
-type ListTemplatesForTeamParams struct {
-	TeamID   uuid.UUID `json:"team_id"`
-	TeamID_2 uuid.UUID `json:"team_id_2"`
+type ListTemplatesForTeamPagedParams struct {
+	Owner        string    `json:"owner"`
+	TeamID       uuid.UUID `json:"team_id"`
+	SystemTeamID uuid.UUID `json:"system_team_id"`
+	NameSearch   *string   `json:"name_search"`
+	NamePrefix   *string   `json:"name_prefix"`
+	SortBy       string    `json:"sort_by"`
+	SortDir      string    `json:"sort_dir"`
+	RowOffset    *int64    `json:"row_offset"`
+	RowLimit     *int64    `json:"row_limit"`
 }
 
-// Return the caller's team's templates plus all system-team templates
-// (curated base set visible to everyone). Ordered by created_at desc.
-func (q *Queries) ListTemplatesForTeam(ctx context.Context, arg ListTemplatesForTeamParams) ([]Template, error) {
-	rows, err := q.db.Query(ctx, listTemplatesForTeam, arg.TeamID, arg.TeamID_2)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []Template{}
-	for rows.Next() {
-		var i Template
-		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Status,
-			&i.BuildSpec,
-			&i.Vcpu,
-			&i.MemoryMib,
-			&i.DiskMib,
-			&i.RootfsPath,
-			&i.SnapshotPath,
-			&i.MemPath,
-			&i.SizeBytes,
-			&i.ErrorMessage,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.BuiltAt,
-			&i.DeletedAt,
-			&i.BasePath,
-			&i.DeltaPath,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listTemplatesForTeamFiltered = `-- name: ListTemplatesForTeamFiltered :many
-SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at, base_path, delta_path FROM template
-WHERE deleted_at IS NULL
-  AND (team_id = $1 OR team_id = $2)
-  AND ($3::text IS NULL
-       OR name LIKE $3 || '%')
-ORDER BY created_at DESC
-`
-
-type ListTemplatesForTeamFilteredParams struct {
-	TeamID     uuid.UUID `json:"team_id"`
-	TeamID_2   uuid.UUID `json:"team_id_2"`
-	NamePrefix *string   `json:"name_prefix"`
-}
-
-// Same as ListTemplatesForTeam with an optional name prefix filter. Pass
-// NULL to get the unfiltered list (but prefer the unfiltered query then).
-func (q *Queries) ListTemplatesForTeamFiltered(ctx context.Context, arg ListTemplatesForTeamFilteredParams) ([]Template, error) {
-	rows, err := q.db.Query(ctx, listTemplatesForTeamFiltered, arg.TeamID, arg.TeamID_2, arg.NamePrefix)
+// Paginated, sortable, filterable template list backing the console. The
+// caller sees its own team's templates plus the curated system-team set; the
+// @owner selector ('all' | 'team' | 'system') narrows which of the two shelves
+// to return. Optional case-insensitive name substring filter. Sort follows the
+// same guarded-CASE pattern as ListSandboxesByTeamPaged — exactly one term is
+// active per query — with created_at DESC as the default + tiebreaker. A NULL
+// @row_limit returns all rows, preserving the pre-pagination default.
+func (q *Queries) ListTemplatesForTeamPaged(ctx context.Context, arg ListTemplatesForTeamPagedParams) ([]Template, error) {
+	rows, err := q.db.Query(ctx, listTemplatesForTeamPaged,
+		arg.Owner,
+		arg.TeamID,
+		arg.SystemTeamID,
+		arg.NameSearch,
+		arg.NamePrefix,
+		arg.SortBy,
+		arg.SortDir,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -887,10 +887,13 @@ ORDER BY
   CASE WHEN $6::text = 'name'     AND $7::text = 'desc' THEN name END DESC,
   CASE WHEN $6::text = 'status'   AND $7::text = 'asc'  THEN status::text END ASC,
   CASE WHEN $6::text = 'status'   AND $7::text = 'desc' THEN status::text END DESC,
+  -- size_bytes and built_at are NULL until a build succeeds. DESC defaults to
+  -- NULLS FIRST in Postgres, which would rank never-built templates above the
+  -- most recently built, so pin NULLS LAST (ASC already defaults to it).
   CASE WHEN $6::text = 'size'     AND $7::text = 'asc'  THEN size_bytes END ASC,
-  CASE WHEN $6::text = 'size'     AND $7::text = 'desc' THEN size_bytes END DESC,
+  CASE WHEN $6::text = 'size'     AND $7::text = 'desc' THEN size_bytes END DESC NULLS LAST,
   CASE WHEN $6::text = 'built_at' AND $7::text = 'asc'  THEN built_at END ASC,
-  CASE WHEN $6::text = 'built_at' AND $7::text = 'desc' THEN built_at END DESC,
+  CASE WHEN $6::text = 'built_at' AND $7::text = 'desc' THEN built_at END DESC NULLS LAST,
   CASE WHEN $6::text = 'created_at' AND $7::text = 'asc' THEN created_at END ASC,
   created_at DESC
 LIMIT $9::bigint

--- a/internal/integration/pagination_test.go
+++ b/internal/integration/pagination_test.go
@@ -128,12 +128,39 @@ func TestIntegration_ListSandboxes_Pagination(t *testing.T) {
 		t.Errorf("substring = %v, want %v", names(rows), want)
 	}
 
+	// Offset without limit still reports the unwindowed total.
+	w = do(r, "GET", "/sandboxes?offset=2", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("offset-only X-Total-Count = %q, want 5", got)
+	}
+	if want := []string{"charlie", "bravo", "alpha"}; !eqStrings(names(rows), want) {
+		t.Errorf("offset-only = %v, want %v", names(rows), want)
+	}
+
+	// LIKE metacharacters in q match literally, not as wildcards.
+	insertSandboxAt(t, teamID, "x_ray", "active", base.Add(6*time.Minute))
+	insertSandboxAt(t, teamID, "xtray", "active", base.Add(7*time.Minute))
+	w = do(r, "GET", "/sandboxes?q=x_ray", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"x_ray"}; !eqStrings(names(rows), want) {
+		t.Errorf("underscore search = %v, want %v (literal _, not wildcard)", names(rows), want)
+	}
+	w = do(r, "GET", "/sandboxes?q=%25", apiKey, "") // q=%
+	rows = decodeArray(t, w)
+	if len(rows) != 0 {
+		t.Errorf("q=%%%% matched %v, want none (literal %%, not wildcard)", names(rows))
+	}
+
 	// Malformed pagination → 400.
 	if w := do(r, "GET", "/sandboxes?limit=0", apiKey, ""); w.Code != 400 {
 		t.Errorf("limit=0 status = %d, want 400", w.Code)
 	}
 	if w := do(r, "GET", "/sandboxes?sort=nope", apiKey, ""); w.Code != 400 {
 		t.Errorf("bad sort status = %d, want 400", w.Code)
+	}
+	if w := do(r, "GET", "/sandboxes?status=activ", apiKey, ""); w.Code != 400 {
+		t.Errorf("bad status filter = %d, want 400", w.Code)
 	}
 }
 
@@ -196,6 +223,35 @@ func TestIntegration_ListTemplates_Pagination(t *testing.T) {
 	rows = decodeArray(t, w)
 	if want := []string{"img-three", "img-two"}; !eqStrings(names(rows), want) {
 		t.Errorf("name_prefix = %v, want %v", names(rows), want)
+	}
+
+	// Offset without limit still reports the unwindowed total.
+	w = do(r, "GET", "/templates?owner=team&offset=1", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("offset-only X-Total-Count = %q, want 3", got)
+	}
+	if want := []string{"img-two", "img-one"}; !eqStrings(names(rows), want) {
+		t.Errorf("offset-only = %v, want %v", names(rows), want)
+	}
+
+	// built_at DESC ranks built templates newest-first and never-built
+	// (built_at IS NULL) last, not first.
+	for name, builtAt := range map[string]time.Time{
+		"img-one": base.Add(10 * time.Minute),
+		"img-two": base.Add(20 * time.Minute),
+	} {
+		if _, err := testPool.Exec(context.Background(),
+			`UPDATE template SET built_at = $1 WHERE team_id = $2 AND name = $3`,
+			builtAt, teamID, name,
+		); err != nil {
+			t.Fatalf("set built_at for %q: %v", name, err)
+		}
+	}
+	w = do(r, "GET", "/templates?owner=team&sort=built_at&order=desc", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"img-two", "img-one", "img-three"}; !eqStrings(names(rows), want) {
+		t.Errorf("built_at desc = %v, want %v (NULLS LAST)", names(rows), want)
 	}
 
 	// Invalid owner → 400.

--- a/internal/integration/pagination_test.go
+++ b/internal/integration/pagination_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// insertSandboxAt inserts a sandbox with a controlled name, status, and
+// created_at so pagination + sort ordering can be asserted deterministically.
+func insertSandboxAt(t *testing.T, teamID uuid.UUID, name, status string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO sandbox (id, team_id, name, status, created_at)
+		 VALUES ($1, $2, $3, $4::sandbox_status, $5)`,
+		id, teamID, name, status, createdAt,
+	); err != nil {
+		t.Fatalf("insert sandbox %q: %v", name, err)
+	}
+	return id
+}
+
+func decodeArray(t *testing.T, w *httptest.ResponseRecorder) []map[string]any {
+	t.Helper()
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &arr); err != nil {
+		t.Fatalf("decode array: %v; body=%s", err, w.Body.String())
+	}
+	return arr
+}
+
+func names(rows []map[string]any) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i], _ = r["name"].(string)
+	}
+	return out
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestIntegration_ListSandboxes_Pagination exercises the paged sandbox list end
+// to end: default (unpaginated) ordering, limit/offset windowing, the
+// X-Total-Count header, sort, status filter, and name substring search.
+func TestIntegration_ListSandboxes_Pagination(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	// Five sandboxes, created oldest→newest a..e, mixed statuses.
+	base := time.Now().Add(-1 * time.Hour)
+	insertSandboxAt(t, teamID, "alpha", "active", base.Add(1*time.Minute))
+	insertSandboxAt(t, teamID, "bravo", "paused", base.Add(2*time.Minute))
+	insertSandboxAt(t, teamID, "charlie", "active", base.Add(3*time.Minute))
+	insertSandboxAt(t, teamID, "delta", "paused", base.Add(4*time.Minute))
+	insertSandboxAt(t, teamID, "echo", "active", base.Add(5*time.Minute))
+
+	// Default: full list, created_at DESC, total = 5.
+	w := do(r, "GET", "/sandboxes", apiKey, "")
+	rows := decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("X-Total-Count = %q, want 5", got)
+	}
+	if want := []string{"echo", "delta", "charlie", "bravo", "alpha"}; !eqStrings(names(rows), want) {
+		t.Errorf("default order = %v, want %v", names(rows), want)
+	}
+
+	// First page of 2 (created desc).
+	w = do(r, "GET", "/sandboxes?limit=2&offset=0", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("page1 X-Total-Count = %q, want 5", got)
+	}
+	if want := []string{"echo", "delta"}; !eqStrings(names(rows), want) {
+		t.Errorf("page1 = %v, want %v", names(rows), want)
+	}
+
+	// Third page of 2 → single trailing row.
+	w = do(r, "GET", "/sandboxes?limit=2&offset=4", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"alpha"}; !eqStrings(names(rows), want) {
+		t.Errorf("page3 = %v, want %v", names(rows), want)
+	}
+
+	// Sort by name ascending.
+	w = do(r, "GET", "/sandboxes?sort=name&order=asc&limit=50", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"alpha", "bravo", "charlie", "delta", "echo"}; !eqStrings(names(rows), want) {
+		t.Errorf("name asc = %v, want %v", names(rows), want)
+	}
+
+	// Status filter narrows both rows and the count.
+	w = do(r, "GET", "/sandboxes?status=paused&sort=name&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "2" {
+		t.Errorf("paused X-Total-Count = %q, want 2", got)
+	}
+	if want := []string{"bravo", "delta"}; !eqStrings(names(rows), want) {
+		t.Errorf("paused = %v, want %v", names(rows), want)
+	}
+
+	// Case-insensitive name substring.
+	w = do(r, "GET", "/sandboxes?q=LPH", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"alpha"}; !eqStrings(names(rows), want) {
+		t.Errorf("substring = %v, want %v", names(rows), want)
+	}
+
+	// Malformed pagination → 400.
+	if w := do(r, "GET", "/sandboxes?limit=0", apiKey, ""); w.Code != 400 {
+		t.Errorf("limit=0 status = %d, want 400", w.Code)
+	}
+	if w := do(r, "GET", "/sandboxes?sort=nope", apiKey, ""); w.Code != 400 {
+		t.Errorf("bad sort status = %d, want 400", w.Code)
+	}
+}
+
+// insertTemplateAt inserts a team template with a controlled name + created_at.
+func insertTemplateAt(t *testing.T, teamID uuid.UUID, name string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO template (id, team_id, name, status, build_spec, created_at)
+		 VALUES ($1, $2, $3, 'ready'::template_status, '{}'::jsonb, $4)`,
+		id, teamID, name, createdAt,
+	); err != nil {
+		t.Fatalf("insert template %q: %v", name, err)
+	}
+	return id
+}
+
+// TestIntegration_ListTemplates_Pagination covers the owner filter, pagination,
+// and X-Total-Count for templates. The team shelf is asserted in isolation via
+// owner=team so the count is independent of however many system templates the
+// shared test schema happens to carry.
+func TestIntegration_ListTemplates_Pagination(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	base := time.Now().Add(-1 * time.Hour)
+	insertTemplateAt(t, teamID, "img-one", base.Add(1*time.Minute))
+	insertTemplateAt(t, teamID, "img-two", base.Add(2*time.Minute))
+	insertTemplateAt(t, teamID, "img-three", base.Add(3*time.Minute))
+
+	// owner=team isolates this team's shelf: 3 rows, created_at DESC.
+	w := do(r, "GET", "/templates?owner=team", apiKey, "")
+	rows := decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("team X-Total-Count = %q, want 3", got)
+	}
+	if want := []string{"img-three", "img-two", "img-one"}; !eqStrings(names(rows), want) {
+		t.Errorf("team order = %v, want %v", names(rows), want)
+	}
+
+	// Paginated team shelf.
+	w = do(r, "GET", "/templates?owner=team&limit=2&offset=0&sort=name&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("team page X-Total-Count = %q, want 3", got)
+	}
+	if want := []string{"img-one", "img-three"}; !eqStrings(names(rows), want) {
+		t.Errorf("team page name asc = %v, want %v", names(rows), want)
+	}
+
+	// Substring search on the team shelf.
+	w = do(r, "GET", "/templates?owner=team&q=two", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"img-two"}; !eqStrings(names(rows), want) {
+		t.Errorf("template substring = %v, want %v", names(rows), want)
+	}
+
+	// Legacy name_prefix (prefix, not substring) still works for SDK/MCP.
+	w = do(r, "GET", "/templates?owner=team&name_prefix=img-t&sort=name&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"img-three", "img-two"}; !eqStrings(names(rows), want) {
+		t.Errorf("name_prefix = %v, want %v", names(rows), want)
+	}
+
+	// Invalid owner → 400.
+	if w := do(r, "GET", "/templates?owner=bogus", apiKey, ""); w.Code != 400 {
+		t.Errorf("bad owner status = %d, want 400", w.Code)
+	}
+}

--- a/internal/integration/pagination_test.go
+++ b/internal/integration/pagination_test.go
@@ -17,9 +17,12 @@ import (
 func insertSandboxAt(t *testing.T, teamID uuid.UUID, name, status string, createdAt time.Time) uuid.UUID {
 	t.Helper()
 	id := uuid.New()
+	// host_id is NOT NULL (migration 20260410000001); supply a placeholder like
+	// the other integration sandbox inserts do. created_at is set explicitly so
+	// the sort assertions are deterministic.
 	if _, err := testPool.Exec(context.Background(),
-		`INSERT INTO sandbox (id, team_id, name, status, created_at)
-		 VALUES ($1, $2, $3, $4::sandbox_status, $5)`,
+		`INSERT INTO sandbox (id, team_id, name, status, host_id, created_at)
+		 VALUES ($1, $2, $3, $4::sandbox_status, 'test-host', $5)`,
 		id, teamID, name, status, createdAt,
 	); err != nil {
 		t.Fatalf("insert sandbox %q: %v", name, err)


### PR DESCRIPTION
## What

Adds opt-in pagination, sorting, and filtering to `GET /sandboxes` and `GET /templates` so the console (and any client) can fetch one page at a time instead of the whole list.

New query params: `limit`, `offset`, `sort`, `order`, plus `status` (sandboxes) / `owner` (templates) and `q` (case-insensitive name substring). Total row count is returned in the **`X-Total-Count`** response header.

## How

- **SQL** (`db/queries/*.sql`, regenerated with sqlc 1.30.0): new paged + count queries. Dynamic sort is expressed with **guarded `CASE` ORDER BY terms** (one active per query, `created_at DESC` tiebreaker) so it stays type-safe in sqlc. `LIMIT NULL` returns all rows.
- **Handlers**: shared `parsePageParams` (whitelisted sort columns, `limit` clamped to 200, `400` on bad input; `owner` validated). The COUNT query is skipped on the unpaginated path (the returned slice length is the total).
- **OpenAPI**: documented the new params + `X-Total-Count` header; `TestOpenAPISpecMatchesRoutes` passes.

## Backward compatibility

The response body stays a **bare array**. Omitting `limit` returns the full list exactly as before, so the TS SDK, Python SDK, and MCP server are unaffected. The templates `name_prefix` (prefix) filter is kept alongside the new `q` (substring) for existing callers.

## Security

- **Tenancy**: every new query is team-scoped (`team_id = @team_id`, `destroyed_at`/`deleted_at IS NULL`); the count query uses the identical `WHERE`, so `X-Total-Count` can't leak cross-tenant totals. The template `owner` filter can only match the caller's team or the shared system team.
- **Injection**: all filters are bound params; `sort`/`order`/`owner` are compared to string literals inside `CASE`, never concatenated. `limit`/`offset` parsed to ints.
- **Resource bounds**: page size clamped to 200.

## Test plan

- [x] `go build ./internal/api/... ./internal/db/...` + `go vet` — clean
- [x] `sqlc generate` is idempotent (CI `sqlc-check` will pass)
- [x] `go test ./internal/api/` — unit tests pass (incl. new `pagination_test.go`)
- [x] `internal/integration/pagination_test.go` compiles; runs in CI against Postgres (verifies real sort/filter/pagination + `X-Total-Count` end-to-end)

## Paired change

Console consumer: superserve-ai/superserve#262 (backward-compatible, so merge order isn't strict).