### PR TITLE
Add OpenTelemetry metrics config

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/secrets"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/supervisor"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
@@ -93,6 +94,31 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	recorder := telemetry.NewNoopRecorder()
+	if cfg.OTelMetricsEnabled {
+		otelRecorder, err := telemetry.NewOTelRecorder(ctx, telemetry.OTelConfig{
+			ServiceName:    cfg.OTelServiceName,
+			ServiceVersion: cfg.OTelServiceVersion,
+			Environment:    cfg.OTelEnvironment,
+			Endpoint:       cfg.OTelEndpoint,
+			Insecure:       cfg.OTelInsecure,
+			ExportInterval: cfg.OTelExportInterval,
+		})
+		if err != nil {
+			return fmt.Errorf("init otel metrics: %w", err)
+		}
+		recorder = otelRecorder
+		defer func() {
+			flushCtx, flushCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer flushCancel()
+			if err := otelRecorder.Shutdown(flushCtx); err != nil {
+				log.Warn().Err(err).Msg("otel metrics shutdown failed")
+			}
+		}()
+		log.Info().Str("endpoint", cfg.OTelEndpoint).Dur("interval", cfg.OTelExportInterval).Msg("otel metrics initialized")
+	}
+	api.SetTelemetryRecorder(recorder)
+
 	// Connect to PostgreSQL. DB_MAX_CONNS overrides the pool size; unset
 	// uses the pgxpool default of max(4, NumCPU).
 	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
@@ -119,6 +145,10 @@ func run() error {
 		return fmt.Errorf("ping database: %w", err)
 	}
 	log.Info().Msg("connected to database")
+	if cfg.OTelMetricsEnabled {
+		telemetry.StartDBPoolSampler(ctx, dbPool, recorder, cfg.OTelExportInterval)
+		telemetry.StartHostCapacitySampler(ctx, dbPool, recorder, cfg.OTelExportInterval)
+	}
 
 	reconcileSystemTeamQuota(ctx, dbPool, cfg.SystemTeamID)
 
@@ -134,7 +164,8 @@ func run() error {
 	log.Info().Str("address", cfg.VMDAddress).Msg("connected to VMD gRPC")
 
 	// Build handlers and router.
-	vmdClient := newGRPCVMDClient(grpcConn)
+	var vmdClient vmdclient.Client = newGRPCVMDClient(grpcConn)
+	vmdClient = telemetry.WrapVMDClient(vmdClient, recorder, api.SandboxIDRegion(), cfg.DefaultHostID)
 	queries := dbq.New(dbPool)
 
 	handlers := api.NewHandlers(vmdClient, queries, cfg)
@@ -177,7 +208,7 @@ func run() error {
 	// Host registry: resolves host_id → VMDClient via DB lookup + gRPC dial.
 	// Interceptors below fire onDead on codes.Unavailable so the registry
 	// drops stale cached clients.
-	dialVMD := func(addr string, onDead func()) (vmdclient.Client, error) {
+	dialVMD := func(hostID, addr string, onDead func()) (vmdclient.Client, error) {
 		// Retry runs inside the invoker; the dead-host interceptor sees the post-retry outcome only.
 		conn, err := grpc.NewClient(addr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -188,7 +219,7 @@ func run() error {
 		if err != nil {
 			return nil, err
 		}
-		return newGRPCVMDClient(conn), nil
+		return telemetry.WrapVMDClient(newGRPCVMDClient(conn), recorder, api.SandboxIDRegion(), hostID), nil
 	}
 	handlers.Hosts = hostreg.New(queries, dialVMD)
 	handlers.Scheduler = &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}

--- a/deploy/otel/README.md
+++ b/deploy/otel/README.md
@@ -1,0 +1,38 @@
+# OpenTelemetry metrics
+
+Phase 1 sends a small internal metrics set from the control plane to a local OpenTelemetry Collector. The app exports OTLP to localhost; the checked-in local collector config prints detailed metrics with the debug exporter so names and labels can be reviewed before GMP ingestion.
+
+Start the local collector:
+
+```bash
+docker run --rm --name sandbox-otel-collector \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -v "$PWD/deploy/otel/collector-local.yaml:/etc/otelcol/config.yaml:ro" \
+  otel/opentelemetry-collector-contrib:0.104.0 \
+  --config=/etc/otelcol/config.yaml
+```
+
+The Docker config binds OTLP receivers to `0.0.0.0` inside the container so Docker port publishing works from the host. For a host-installed collector, prefer `127.0.0.1` receiver endpoints so OTLP is not exposed as a network-ingress surface.
+
+Run the control plane with metrics enabled:
+
+```bash
+export OTEL_METRICS_ENABLED=true
+export OTEL_SERVICE_NAME=sandbox-controlplane
+export OTEL_ENVIRONMENT=dev
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_EXPORT_INTERVAL=15s
+```
+
+`OTEL_EXPORTER_OTLP_INSECURE` defaults to false. HTTP endpoints such as `http://localhost:4318` are treated as insecure automatically; set the env var only when you need to override that behavior explicitly.
+
+The debug exporter should show metrics such as `sandbox_transition_total`, `vmd_call_duration_seconds`, `db_pool_acquired_conns`, `db_pool_acquire_total`, and `db_pool_acquire_duration_seconds_total`. Metric attributes are intentionally limited to bounded operational labels: `operation`, `result`, `region`, `host_id`, `method`, `service.name`, and `environment`.
+
+For average DB pool acquire wait over time, use the cumulative counters rather than histogram percentiles:
+
+```promql
+rate(db_pool_acquire_duration_seconds_total[5m]) / rate(db_pool_acquire_total[5m])
+```
+
+Do not add customer, user, sandbox, request, raw URL, or raw error-message labels to Phase 1 metrics. The collector config also defensively drops known high-cardinality internal labels, but application code should avoid emitting them in the first place.

--- a/deploy/otel/collector-local.yaml
+++ b/deploy/otel/collector-local.yaml
@@ -1,0 +1,47 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        # Docker local debug binds to all container interfaces so host port
+        # publishing can reach the receiver. For a host-installed collector,
+        # prefer 127.0.0.1:4318 so OTLP is not exposed as network ingress.
+        endpoint: 0.0.0.0:4318
+      grpc:
+        # Docker local debug binds to all container interfaces so host port
+        # publishing can reach the receiver. For a host-installed collector,
+        # prefer 127.0.0.1:4317 so OTLP is not exposed as network ingress.
+        endpoint: 0.0.0.0:4317
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+    spike_limit_mib: 64
+  attributes/drop_internal_high_cardinality:
+    actions:
+      - key: sandbox_id
+        action: delete
+      - key: team_id
+        action: delete
+      - key: user_id
+        action: delete
+      - key: api_key_id
+        action: delete
+      - key: request_id
+        action: delete
+      - key: url
+        action: delete
+      - key: error
+        action: delete
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, attributes/drop_internal_high_cardinality, batch]
+      exporters: [debug]

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,11 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/vishvananda/netns v0.0.5
 	go.etcd.io/bbolt v1.4.3
+	go.opentelemetry.io/otel v1.42.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0
+	go.opentelemetry.io/otel/metric v1.42.0
+	go.opentelemetry.io/otel/sdk v1.42.0
+	go.opentelemetry.io/otel/sdk/metric v1.42.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
@@ -46,6 +51,7 @@ require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
@@ -83,6 +89,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -112,9 +119,8 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.42.0 // indirect
-	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uS
 github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
 github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
@@ -151,6 +153,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -253,6 +257,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6h
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.42.0 h1:lSQGzTgVR3+sgJDAU/7/ZMjN9Z+vUip7leaqBKy4sho=
 go.opentelemetry.io/otel v1.42.0/go.mod h1:lJNsdRMxCUIWuMlVJWzecSMuNjE7dOYyWlqOXWkdqCc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0 h1:H7O6RlGOMTizyl3R08Kn5pdM06bnH8oscSj7o11tmLA=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0/go.mod h1:mBFWu/WOVDkWWsR7Tx7h6EpQB8wsv7P0Yrh0Pb7othc=
 go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUlaFdF/4=
 go.opentelemetry.io/otel/metric v1.42.0/go.mod h1:RlUN/7vTU7Ao/diDkEpQpnz3/92J9ko05BIwxYa2SSI=
 go.opentelemetry.io/otel/sdk v1.42.0 h1:LyC8+jqk6UJwdrI/8VydAq/hvkFKNHZVIWuslJXYsDo=
@@ -261,6 +267,8 @@ go.opentelemetry.io/otel/sdk/metric v1.42.0 h1:D/1QR46Clz6ajyZ3G8SgNlTJKBdGp84q9
 go.opentelemetry.io/otel/sdk/metric v1.42.0/go.mod h1:Ua6AAlDKdZ7tdvaQKfSmnFTdHx37+J4ba8MwVCYM5hc=
 go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4LenLmOYY=
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
+go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
+go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -615,7 +615,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// VM unreachable — nothing to preserve; mark failed rather than
 			// wedge in 'resuming' (the CTE also closes any open interval).
 			log.Error().Err(perr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: PauseInstance failed, marking sandbox failed")
-			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID)
+			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID, sandbox.HostID)
 			return
 		}
 		// Fresh deadline so a slow snapshot above can't starve the DB write.
@@ -879,6 +879,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	SetTelemetryHostID(c, sandbox.HostID)
 
 	if sandbox.Status != db.SandboxStatusPaused {
 		respondError(c, ErrInvalidState)
@@ -936,6 +937,7 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
+	SetTelemetryHostID(c, sandbox.HostID)
 	// Claim the sandbox for deletion atomically. The guarded soft-delete fires
 	// from a quiescent state (active/paused/failed) or a transitional state whose
 	// worker is provably gone (stale), so it serializes against a live resume/pause
@@ -1613,6 +1615,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	} else {
 		hostID = "default"
 	}
+	SetTelemetryHostID(c, hostID)
 
 	// Resolve the VMD client up front so we don't waste a DB INSERT on
 	// a host we can't reach.
@@ -1803,16 +1806,19 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	case vmdErr != nil:
 		// VMD failed but DB row exists — mark it failed so the reaper
-		// doesn't leave it stuck in "starting".
+		// doesn't leave it stuck in "starting". The request middleware
+		// records the create failure metric from the HTTP status, so avoid
+		// emitting a second request-scoped transition here.
 		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Msg("VMD create/resume failed")
 		failCtx, failCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), asyncTimeout)
 		defer failCancel()
-		_ = h.DB.UpdateSandboxStatus(failCtx, db.UpdateSandboxStatusParams{
+		if err := h.DB.UpdateSandboxStatus(failCtx, db.UpdateSandboxStatusParams{
 			ID:     sandbox.ID,
 			Status: db.SandboxStatusFailed,
 			TeamID: teamID,
-		})
-		// Bindings are written before RestoreSnapshot, so a restore failure
+		}); err != nil {
+			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("mark failed after VMD create failure")
+		} // Bindings are written before RestoreSnapshot, so a restore failure
 		// leaves them; clear them or this dead sandbox still shows as bound.
 		_ = h.DB.DeleteSandboxSecrets(failCtx, sandbox.ID)
 		// FailedPrecondition from vmd = snapshot/mem file missing on host.
@@ -1852,7 +1858,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		jwt, jerr := h.mintSecretsJWT(sandboxID.String(), teamID.String(), ipAddress, secretMeta)
 		if jerr != nil {
 			log.Error().Err(jerr).Str("sandbox_id", sandboxID.String()).Msg("mint secrets JWT")
-			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String())
+			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID, false)
 			respondError(c, ErrInternal)
 			return
 		}
@@ -1865,7 +1871,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			log.Warn().Str("sandbox_id", sandboxID.String()).Msg("vmd lacks InjectSandboxEnv; env applied during restore")
 		} else {
 			log.Error().Err(injErr).Str("sandbox_id", sandboxID.String()).Msg("VMD InjectSandboxEnv failed")
-			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String())
+			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID, false)
 			respondError(c, ErrInternal)
 			return
 		}
@@ -2027,6 +2033,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		respondError(c, ErrInvalidState)
 		return
 	}
+	SetTelemetryHostID(c, sandbox.HostID)
 
 	// BeginPause's CTE atomically closed the open active interval together
 	// with the status transition; nothing to do here. If the pause
@@ -2050,7 +2057,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		// already dead, "active" was a lie.
 		if isVMDNotFound(err) {
 			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
-			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID)
+			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, sandbox.HostID)
 			respondError(c, ErrSandboxGone)
 			return
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2252,7 +2252,7 @@ func TestFailSandboxAfterBootDestroysOnSandboxHost(t *testing.T) {
 	}
 	h := &Handlers{VMD: defaultVMD, DB: db.New(mock)}
 
-	h.failSandboxAfterBoot(context.Background(), hostVMD, uuid.New(), uuid.New(), "instance-xyz")
+	h.failSandboxAfterBoot(context.Background(), hostVMD, uuid.New(), uuid.New(), "instance-xyz", "host-a", false)
 
 	if hostDestroyed != "instance-xyz" {
 		t.Errorf("destroy routed to host client = %q, want instance-xyz", hostDestroyed)

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -87,7 +87,7 @@ func TestSearchTerm(t *testing.T) {
 		"a_b":     `a\_b`,
 		"50%":     `50\%`,
 		`back\up`: `back\\up`,
-		`%_\`:    `\%\_\\`,
+		`%_\`:     `\%\_\\`,
 	}
 	for in, want := range cases {
 		if got := searchTerm(in); got == nil || *got != want {

--- a/internal/api/publicid_test.go
+++ b/internal/api/publicid_test.go
@@ -28,12 +28,12 @@ func TestParsePublicSandboxID(t *testing.T) {
 		want uuid.UUID
 		ok   bool
 	}{
-		{id.String(), id, true},              // legacy bare uuid
-		{"sb-use-" + id.String(), id, true},  // current region codes
+		{id.String(), id, true},             // legacy bare uuid
+		{"sb-use-" + id.String(), id, true}, // current region codes
 		{"sb-usw-" + id.String(), id, true},
-		{"sb-euw1-" + id.String(), id, true}, // future longer code
-		{"sb--" + id.String(), uuid.Nil, false},        // empty region
-		{"sb-USE-" + id.String(), uuid.Nil, false},     // uppercase region
+		{"sb-euw1-" + id.String(), id, true},       // future longer code
+		{"sb--" + id.String(), uuid.Nil, false},    // empty region
+		{"sb-USE-" + id.String(), uuid.Nil, false}, // uppercase region
 		{"sb-use-not-a-uuid-padded-to-36-chars!!", uuid.Nil, false},
 		{"sb-use-", uuid.Nil, false},
 		{"sb-" + id.String(), uuid.Nil, false}, // prefix but no region segment
@@ -55,14 +55,14 @@ func TestValidateSandboxIDRegion(t *testing.T) {
 		env string
 		ok  bool
 	}{
-		{"", true},    // unset: legacy bare UUIDs
+		{"", true}, // unset: legacy bare UUIDs
 		{"use", true},
 		{"usw", true},
 		{"euw1", true},
-		{"  use  ", true},      // whitespace is trimmed before minting too
-		{"us-east-1", false},   // hyphens break the region/uuid split
-		{"USE", false},         // uppercase is not DNS-label-safe here
-		{"ss_live", false},     // underscores are not DNS-safe
+		{"  use  ", true},             // whitespace is trimmed before minting too
+		{"us-east-1", false},          // hyphens break the region/uuid split
+		{"USE", false},                // uppercase is not DNS-label-safe here
+		{"ss_live", false},            // underscores are not DNS-safe
 		{"abcdefghijklmnopqr", false}, // 18 chars: over the DNS-label budget
 	} {
 		t.Setenv("SANDBOX_ID_REGION", tc.env)

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
 // ReaperConfig controls the timeout reaper loop.
@@ -198,6 +199,7 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 		Str("team_id", sbx.TeamID.String()).
 		Str("name", sbx.Name).
 		Logger()
+	started := time.Now()
 
 	// ClaimExpiredSandboxes's CTE atomically closed the open active
 	// interval together with the status transition; nothing to do here.
@@ -238,6 +240,7 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 	}
 
 	l.Info().Msg("reaper: sandbox paused due to timeout")
+	RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultSuccess, sbx.HostID, time.Since(started))
 	// Interval was already closed at the top of pauseExpired; FinalizePause
 	// is the end of the VMD pause work, not the leave-active moment.
 	h.logSandboxActivity(ctx, sbx.ID, sbx.TeamID, nil, "sandbox", "timeout_paused", "success", &sbx.Name, nil, nil)
@@ -330,6 +333,7 @@ func (h *Handlers) revertToActiveOrFail(ctx context.Context, sbx db.ClaimExpired
 // that point the sandbox is stuck in 'pausing', but the reaper loop is
 // already bounded because future ticks only claim 'active' sandboxes.
 func (h *Handlers) markSandboxFailed(ctx context.Context, sbx db.ClaimExpiredSandboxesRow, reason string, l zerolog.Logger) {
+	started := time.Now()
 	failCtx, failCancel := context.WithTimeout(ctx, asyncTimeout)
 	defer failCancel()
 	// MarkSandboxFailedInTeam's CTE bundles the active-interval close into
@@ -338,8 +342,10 @@ func (h *Handlers) markSandboxFailed(ctx context.Context, sbx db.ClaimExpiredSan
 		ID:     sbx.ID,
 		TeamID: sbx.TeamID,
 	}); err != nil {
+		RecordSandboxTransition(ctx, "fail", telemetry.ResultError, sbx.HostID, time.Since(started))
 		l.Error().Err(err).Str("reason", reason).Msg("reaper: TERMINAL — sandbox stuck in 'pausing', mark-failed also failed, manual recovery required")
 		return
 	}
+	RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, sbx.HostID, time.Since(started))
 	l.Error().Str("reason", reason).Msg("reaper: TERMINAL — sandbox marked 'failed', manual recovery required")
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,7 +30,7 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 	// customer gets a dedicated bucket regardless of source IP. Behind a
 	// load balancer the per-IP limit collapses tenants onto one bucket
 	// and becomes meaningless for fairness.
-	api.Use(APIKeyAuth(pool), TeamRateLimit(ctx, DefaultTeamRateLimitConfig()))
+	api.Use(APIKeyAuth(pool), TeamRateLimit(ctx, DefaultTeamRateLimitConfig()), SandboxLifecycleTelemetry())
 	{
 		// Sandbox lifecycle.
 		api.POST("/sandboxes", h.CreateSandbox)

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+const telemetryHostIDKey = "telemetry_host_id"
+
+type telemetryRecorderHolder struct {
+	recorder telemetry.Recorder
+}
+
+var telemetryRecorder atomic.Value
+
+func init() {
+	telemetryRecorder.Store(&telemetryRecorderHolder{recorder: telemetry.NewNoopRecorder()})
+}
+
+// SetTelemetryRecorder installs the app-level metrics recorder used by the API
+// package. Nil resets to the noop recorder so tests and local runs stay safe.
+func SetTelemetryRecorder(recorder telemetry.Recorder) {
+	if recorder == nil {
+		recorder = telemetry.NewNoopRecorder()
+	}
+	telemetryRecorder.Store(&telemetryRecorderHolder{recorder: recorder})
+}
+
+// SandboxIDRegion returns the low-cardinality region label for telemetry. Empty
+// means the deployment is still minting legacy untagged sandbox IDs.
+func SandboxIDRegion() string {
+	return sandboxIDRegionFromEnv()
+}
+
+func currentTelemetryRecorder() telemetry.Recorder {
+	if holder, ok := telemetryRecorder.Load().(*telemetryRecorderHolder); ok && holder != nil && holder.recorder != nil {
+		return holder.recorder
+	}
+	return telemetry.NewNoopRecorder()
+}
+
+// SetTelemetryHostID attaches a bounded host_id label to the current request's
+// route-level lifecycle metric. It is best-effort; callers should only pass
+// host IDs already loaded from trusted control-plane state.
+func SetTelemetryHostID(c *gin.Context, hostID string) {
+	if c != nil && hostID != "" {
+		c.Set(telemetryHostIDKey, hostID)
+	}
+}
+
+func telemetryHostID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	v, ok := c.Get(telemetryHostIDKey)
+	if !ok {
+		return ""
+	}
+	hostID, _ := v.(string)
+	return hostID
+}
+
+func RecordSandboxTransition(ctx context.Context, operation, result, hostID string, duration time.Duration) {
+	currentTelemetryRecorder().RecordSandboxTransition(ctx, telemetry.SandboxTransition{
+		Operation: operation,
+		Result:    result,
+		Region:    SandboxIDRegion(),
+		HostID:    hostID,
+		Duration:  duration,
+	})
+}
+
+// SandboxLifecycleTelemetry records coarse user-visible sandbox lifecycle
+// transitions from the routed API surface. It intentionally emits only bounded
+// labels; sandbox IDs, team IDs, user IDs, request IDs, URLs, and raw errors are
+// never used as metric attributes.
+func SandboxLifecycleTelemetry() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		operation, ok := sandboxLifecycleOperation(c.Request.Method, c.FullPath())
+		if !ok {
+			c.Next()
+			return
+		}
+
+		started := time.Now()
+		c.Next()
+
+		RecordSandboxTransition(
+			c.Request.Context(),
+			operation,
+			lifecycleResult(c.Writer.Status()),
+			telemetryHostID(c),
+			time.Since(started),
+		)
+	}
+}
+
+func sandboxLifecycleOperation(method, route string) (string, bool) {
+	switch {
+	case method == http.MethodPost && route == "/sandboxes":
+		return "create", true
+	case method == http.MethodPost && route == "/sandboxes/:sandbox_id/pause":
+		return "pause", true
+	case method == http.MethodPost && route == "/sandboxes/:sandbox_id/resume":
+		return "resume", true
+	case method == http.MethodDelete && route == "/sandboxes/:sandbox_id":
+		return "delete", true
+	default:
+		return "", false
+	}
+}
+
+func lifecycleResult(status int) string {
+	switch {
+	case status >= 200 && status < 400:
+		return telemetry.ResultSuccess
+	case status == http.StatusConflict:
+		return telemetry.ResultConflict
+	case status == http.StatusRequestTimeout || status == http.StatusGatewayTimeout:
+		return telemetry.ResultTimeout
+	default:
+		return telemetry.ResultError
+	}
+}

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
 // ErrSandboxGone is returned when a handler detects that the underlying VM
@@ -108,18 +110,22 @@ func vmdErrorMessage(err error) string {
 // the two writes is unreachable. Detaches cancellation so the state
 // transition survives client disconnect, but keeps the request's trace
 // context so the write appears in the same span.
-func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, teamID uuid.UUID) {
+func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, teamID uuid.UUID, hostID string) {
 	asyncCtx := context.WithoutCancel(reqCtx)
 	go func() {
 		defer sentrylog.Recover("mark-failed-async")
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
+		started := time.Now()
 		if err := h.DB.MarkSandboxFailedInTeam(ctx, db.MarkSandboxFailedInTeamParams{
 			ID:     sandboxID,
 			TeamID: teamID,
 		}); err != nil {
+			RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async mark-failed write failed")
+			return
 		}
+		RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
 	}()
 }
 
@@ -128,16 +134,24 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 // the VM is already running but unusable. vmd must be the client for the host the
 // VM booted on — destroying through the default client would leave the VM running
 // on a non-default host.
-func (h *Handlers) failSandboxAfterBoot(ctx context.Context, vmd VMDClient, sandboxID, teamID uuid.UUID, instanceID string) {
+func (h *Handlers) failSandboxAfterBoot(ctx context.Context, vmd VMDClient, sandboxID, teamID uuid.UUID, instanceID, hostID string, recordTransition bool) {
 	if err := vmd.DestroyInstance(ctx, instanceID, true); err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("destroy after failed boot")
 	}
+	started := time.Now()
 	if err := h.DB.UpdateSandboxStatus(ctx, db.UpdateSandboxStatusParams{
 		ID:     sandboxID,
 		Status: db.SandboxStatusFailed,
 		TeamID: teamID,
 	}); err != nil {
+		if recordTransition {
+			RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
+		}
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("mark-failed after destroy")
+	} else {
+		if recordTransition {
+			RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
+		}
 	}
 	// A failed sandbox keeps status=failed with destroyed_at NULL, and the
 	// secret-binding queries filter only on destroyed_at, so clear the bindings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/rs/zerolog/log"
 
@@ -52,6 +54,16 @@ type Config struct {
 	// SecretsSigningKeyID is the kid stamped on minted JWTs and served by
 	// the JWKS endpoint. Defaults to "v1".
 	SecretsSigningKeyID string
+
+	// OTelMetricsEnabled gates app-level operational metrics export. Defaults
+	// false so local/test behavior remains unchanged unless explicitly enabled.
+	OTelMetricsEnabled bool
+	OTelServiceName    string
+	OTelServiceVersion string
+	OTelEnvironment    string
+	OTelEndpoint       string
+	OTelInsecure       bool
+	OTelExportInterval time.Duration
 }
 
 // Load reads configuration from environment variables.
@@ -69,6 +81,11 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("SANDBOX_ACCESS_TOKEN_SEED: %w", err)
 	}
 
+	exportInterval, err := durationEnv("OTEL_EXPORT_INTERVAL", 15*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Port:                   envOrDefault("API_PORT", "8080"),
 		VMDAddress:             envOrDefault("VMD_GRPC_ADDRESS", "localhost:50051"),
@@ -81,6 +98,13 @@ func Load() (*Config, error) {
 		KMSKeyResource:         os.Getenv("KMS_KEY_RESOURCE"),
 		SecretsSigningKey:      os.Getenv("SECRETS_SIGNING_KEY"),
 		SecretsSigningKeyID:    envOrDefault("SECRETS_SIGNING_KEY_ID", "v1"),
+		OTelMetricsEnabled:     boolEnv("OTEL_METRICS_ENABLED", false),
+		OTelServiceName:        envOrDefault("OTEL_SERVICE_NAME", "sandbox-controlplane"),
+		OTelServiceVersion:     os.Getenv("OTEL_SERVICE_VERSION"),
+		OTelEnvironment:        envOrDefault("OTEL_ENVIRONMENT", "dev"),
+		OTelEndpoint:           envOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
+		OTelInsecure:           boolEnv("OTEL_EXPORTER_OTLP_INSECURE", false),
+		OTelExportInterval:     exportInterval,
 	}
 	return cfg, nil
 }
@@ -113,4 +137,29 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+func boolEnv(key string, fallback bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Warn().Err(err).Str("key", key).Str("value", v).Bool("fallback", fallback).Msg("invalid boolean env var")
+		return fallback
+	}
+	return parsed
+}
+
+func durationEnv(key string, fallback time.Duration) (time.Duration, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback, nil
+	}
+	parsed, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return parsed, nil
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -12,7 +12,7 @@ import (
 // DialFunc creates a VMD client for the given gRPC address. onDead is
 // called when the transport reports the peer unreachable; the registry
 // wires it to Invalidate.
-type DialFunc func(addr string, onDead func()) (vmdclient.Client, error)
+type DialFunc func(hostID, addr string, onDead func()) (vmdclient.Client, error)
 
 // Registry maps host IDs to VMD clients, cached on first use.
 type Registry struct {
@@ -54,7 +54,7 @@ func (r *Registry) ClientFor(ctx context.Context, hostID string) (vmdclient.Clie
 		return nil, fmt.Errorf("get host %q: %w", hostID, err)
 	}
 
-	c, err = r.dial(host.VmdAddr, func() { r.Invalidate(hostID) })
+	c, err = r.dial(hostID, host.VmdAddr, func() { r.Invalidate(hostID) })
 	if err != nil {
 		return nil, fmt.Errorf("dial VMD at %s for host %q: %w", host.VmdAddr, hostID, err)
 	}

--- a/internal/telemetry/dbpool.go
+++ b/internal/telemetry/dbpool.go
@@ -1,0 +1,90 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StartDBPoolSampler periodically records pgxpool stats until ctx is canceled.
+// It emits deltas for cumulative pgx counters so OpenTelemetry counters remain
+// monotonic without double-counting each sample.
+func StartDBPoolSampler(ctx context.Context, pool *pgxpool.Pool, recorder Recorder, interval time.Duration) {
+	if pool == nil || recorder == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+
+	go func() {
+		var prevAcquire int64
+		var prevEmptyAcquire int64
+		var prevCanceledAcquire int64
+		var prevAcquireDuration time.Duration
+		var seeded bool
+
+		sample := func() {
+			stat := pool.Stat()
+			acquire := stat.AcquireCount()
+			emptyAcquire := stat.EmptyAcquireCount()
+			canceledAcquire := stat.CanceledAcquireCount()
+			acquireDuration := stat.AcquireDuration()
+			acquireDelta, emptyAcquireDelta, canceledAcquireDelta, acquireDurationDelta :=
+				dbPoolDeltas(seeded, acquire, prevAcquire, emptyAcquire, prevEmptyAcquire, canceledAcquire, prevCanceledAcquire, acquireDuration, prevAcquireDuration)
+
+			recorder.RecordDBPoolStats(ctx, DBPoolStats{
+				AcquiredConns:               int64(stat.AcquiredConns()),
+				IdleConns:                   int64(stat.IdleConns()),
+				TotalConns:                  int64(stat.TotalConns()),
+				AcquireDelta:                acquireDelta,
+				EmptyAcquireDelta:           emptyAcquireDelta,
+				CanceledAcquireDelta:        canceledAcquireDelta,
+				AcquireDurationSecondsDelta: acquireDurationDelta.Seconds(),
+			})
+
+			prevAcquire = acquire
+			prevEmptyAcquire = emptyAcquire
+			prevCanceledAcquire = canceledAcquire
+			prevAcquireDuration = acquireDuration
+			seeded = true
+		}
+
+		sample()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sample()
+			}
+		}
+	}()
+}
+
+func nonNegativeDelta(cur, prev int64) int64 {
+	if cur < prev {
+		return 0
+	}
+	return cur - prev
+}
+
+func nonNegativeDurationDelta(cur, prev time.Duration) time.Duration {
+	if cur < prev {
+		return 0
+	}
+	return cur - prev
+}
+
+func dbPoolDeltas(seeded bool, acquire, prevAcquire, emptyAcquire, prevEmptyAcquire, canceledAcquire, prevCanceledAcquire int64, acquireDuration, prevAcquireDuration time.Duration) (int64, int64, int64, time.Duration) {
+	if !seeded {
+		return 0, 0, 0, 0
+	}
+	return nonNegativeDelta(acquire, prevAcquire),
+		nonNegativeDelta(emptyAcquire, prevEmptyAcquire),
+		nonNegativeDelta(canceledAcquire, prevCanceledAcquire),
+		nonNegativeDurationDelta(acquireDuration, prevAcquireDuration)
+}

--- a/internal/telemetry/host_capacity.go
+++ b/internal/telemetry/host_capacity.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog/log"
+)
+
+const hostCapacityQuery = `
+SELECT
+	h.id,
+	h.region,
+	COALESCE(SUM(s.vcpu_count), 0)::bigint AS used_vcpu,
+	COALESCE(SUM(s.memory_mib), 0)::bigint AS used_memory_mib,
+	COALESCE(COUNT(s.id), 0)::bigint AS sandboxes
+FROM host h
+LEFT JOIN sandbox s
+  ON s.host_id = h.id
+ AND s.destroyed_at IS NULL
+ AND s.status IN ('starting', 'active', 'resuming', 'pausing')
+WHERE h.status = 'active'
+GROUP BY h.id, h.region
+ORDER BY h.id
+`
+
+const hostCapacityQueryTimeout = 5 * time.Second
+
+// StartHostCapacitySampler records aggregate per-host sandbox resource usage.
+// It derives capacity usage from trusted control-plane state rather than from
+// sandbox-emitted metrics, and intentionally stays host-scoped.
+func StartHostCapacitySampler(ctx context.Context, pool *pgxpool.Pool, recorder Recorder, interval time.Duration) {
+	if pool == nil || recorder == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+
+	go func() {
+		sample := func() {
+			sampleCtx, cancel := context.WithTimeout(ctx, hostCapacityQueryTimeoutForInterval(interval))
+			defer cancel()
+
+			rows, err := pool.Query(sampleCtx, hostCapacityQuery)
+			if err != nil {
+				log.Warn().Err(err).Msg("host capacity telemetry query failed")
+				return
+			}
+			defer rows.Close()
+
+			for rows.Next() {
+				var c HostCapacity
+				if err := rows.Scan(&c.HostID, &c.Region, &c.UsedVCPU, &c.UsedMemoryMiB, &c.Sandboxes); err != nil {
+					log.Warn().Err(err).Msg("host capacity telemetry row scan failed")
+					return
+				}
+				recorder.RecordHostCapacity(sampleCtx, c)
+			}
+			if err := rows.Err(); err != nil {
+				log.Warn().Err(err).Msg("host capacity telemetry rows failed")
+			}
+		}
+
+		sample()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sample()
+			}
+		}
+	}()
+}
+
+func hostCapacityQueryTimeoutForInterval(_ time.Duration) time.Duration {
+	return hostCapacityQueryTimeout
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -1,0 +1,269 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+const instrumentationName = "github.com/superserve-ai/sandbox/internal/telemetry"
+
+// OTelConfig contains the app-level metrics settings needed by the recorder.
+type OTelConfig struct {
+	ServiceName    string
+	ServiceVersion string
+	Environment    string
+	Endpoint       string
+	Insecure       bool
+	ExportInterval time.Duration
+}
+
+// OTelRecorder emits the sandbox control plane's bounded operational metrics
+// through OTLP. It intentionally exposes only a small label vocabulary.
+type OTelRecorder struct {
+	provider *sdkmetric.MeterProvider
+
+	serviceName string
+	environment string
+
+	sandboxTransitions       metric.Int64Counter
+	sandboxDuration          metric.Float64Histogram
+	vmdCalls                 metric.Int64Counter
+	vmdDuration              metric.Float64Histogram
+	hostVCPU                 metric.Int64Gauge
+	hostMemoryMiB            metric.Int64Gauge
+	hostSandboxes            metric.Int64Gauge
+	dbAcquiredConns          metric.Int64Gauge
+	dbIdleConns              metric.Int64Gauge
+	dbTotalConns             metric.Int64Gauge
+	dbAcquire                metric.Int64Counter
+	dbEmptyAcquire           metric.Int64Counter
+	dbCanceledAcquire        metric.Int64Counter
+	dbAcquireDurationSeconds metric.Float64Counter
+}
+
+// NewOTelRecorder constructs an OTLP/HTTP metrics recorder. Call Shutdown on
+// process exit to flush briefly without blocking shutdown indefinitely.
+func NewOTelRecorder(ctx context.Context, cfg OTelConfig) (*OTelRecorder, error) {
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = "sandbox-controlplane"
+	}
+	if cfg.Environment == "" {
+		cfg.Environment = "dev"
+	}
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = "http://localhost:4318"
+	}
+	if cfg.ExportInterval <= 0 {
+		cfg.ExportInterval = 15 * time.Second
+	}
+
+	exporterOpts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(cfg.Endpoint)}
+	if cfg.Insecure || strings.HasPrefix(cfg.Endpoint, "http://") {
+		exporterOpts = append(exporterOpts, otlpmetrichttp.WithInsecure())
+	}
+	exporter, err := otlpmetrichttp.New(ctx, exporterOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("create otlp metric exporter: %w", err)
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes("",
+			attribute.String("service.name", cfg.ServiceName),
+			attribute.String("service.version", cfg.ServiceVersion),
+			attribute.String("environment", cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create otel resource: %w", err)
+	}
+
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(cfg.ExportInterval))),
+	)
+	meter := provider.Meter(instrumentationName)
+
+	r := &OTelRecorder{
+		provider:    provider,
+		serviceName: cfg.ServiceName,
+		environment: cfg.Environment,
+	}
+	if r.sandboxTransitions, err = meter.Int64Counter("sandbox_transition_total"); err != nil {
+		return nil, err
+	}
+	if r.sandboxDuration, err = meter.Float64Histogram("sandbox_transition_duration_seconds"); err != nil {
+		return nil, err
+	}
+	if r.vmdCalls, err = meter.Int64Counter("vmd_call_total"); err != nil {
+		return nil, err
+	}
+	if r.vmdDuration, err = meter.Float64Histogram("vmd_call_duration_seconds"); err != nil {
+		return nil, err
+	}
+	if r.hostVCPU, err = meter.Int64Gauge("host_capacity_used_vcpu"); err != nil {
+		return nil, err
+	}
+	if r.hostMemoryMiB, err = meter.Int64Gauge("host_capacity_used_memory_mib"); err != nil {
+		return nil, err
+	}
+	if r.hostSandboxes, err = meter.Int64Gauge("host_capacity_running_sandboxes"); err != nil {
+		return nil, err
+	}
+	if r.dbAcquiredConns, err = meter.Int64Gauge("db_pool_acquired_conns"); err != nil {
+		return nil, err
+	}
+	if r.dbIdleConns, err = meter.Int64Gauge("db_pool_idle_conns"); err != nil {
+		return nil, err
+	}
+	if r.dbTotalConns, err = meter.Int64Gauge("db_pool_total_conns"); err != nil {
+		return nil, err
+	}
+	if r.dbAcquire, err = meter.Int64Counter("db_pool_acquire_total"); err != nil {
+		return nil, err
+	}
+	if r.dbEmptyAcquire, err = meter.Int64Counter("db_pool_empty_acquire_total"); err != nil {
+		return nil, err
+	}
+	if r.dbCanceledAcquire, err = meter.Int64Counter("db_pool_canceled_acquire_total"); err != nil {
+		return nil, err
+	}
+	if r.dbAcquireDurationSeconds, err = meter.Float64Counter("db_pool_acquire_duration_seconds_total"); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *OTelRecorder) Shutdown(ctx context.Context) error {
+	if r == nil || r.provider == nil {
+		return nil
+	}
+	return r.provider.Shutdown(ctx)
+}
+
+func (r *OTelRecorder) RecordSandboxTransition(ctx context.Context, t SandboxTransition) {
+	if r == nil {
+		return
+	}
+	attrs := r.attrs(
+		attribute.String("operation", safeOperation(t.Operation)),
+		attribute.String("result", safeResult(t.Result)),
+		attribute.String("region", safeRegion(t.Region)),
+		attribute.String("host_id", safeHostID(t.HostID)),
+	)
+	opt := metric.WithAttributes(attrs...)
+	r.sandboxTransitions.Add(ctx, 1, opt)
+	if t.Duration > 0 {
+		r.sandboxDuration.Record(ctx, t.Duration.Seconds(), opt)
+	}
+}
+
+func (r *OTelRecorder) RecordVMDCall(ctx context.Context, c VMDCall) {
+	if r == nil {
+		return
+	}
+	attrs := r.attrs(
+		attribute.String("method", safeMethod(c.Method)),
+		attribute.String("result", safeResult(c.Result)),
+		attribute.String("region", safeRegion(c.Region)),
+		attribute.String("host_id", safeHostID(c.HostID)),
+	)
+	opt := metric.WithAttributes(attrs...)
+	r.vmdCalls.Add(ctx, 1, opt)
+	if c.Duration > 0 {
+		r.vmdDuration.Record(ctx, c.Duration.Seconds(), opt)
+	}
+}
+
+func (r *OTelRecorder) RecordHostCapacity(ctx context.Context, c HostCapacity) {
+	if r == nil {
+		return
+	}
+	attrs := r.attrs(attribute.String("region", safeRegion(c.Region)), attribute.String("host_id", safeHostID(c.HostID)))
+	opt := metric.WithAttributes(attrs...)
+	r.hostVCPU.Record(ctx, c.UsedVCPU, opt)
+	r.hostMemoryMiB.Record(ctx, c.UsedMemoryMiB, opt)
+	r.hostSandboxes.Record(ctx, c.Sandboxes, opt)
+}
+
+func (r *OTelRecorder) RecordDBPoolStats(ctx context.Context, s DBPoolStats) {
+	if r == nil {
+		return
+	}
+	attrs := r.attrs()
+	opt := metric.WithAttributes(attrs...)
+	r.dbAcquiredConns.Record(ctx, s.AcquiredConns, opt)
+	r.dbIdleConns.Record(ctx, s.IdleConns, opt)
+	r.dbTotalConns.Record(ctx, s.TotalConns, opt)
+	if s.AcquireDelta > 0 {
+		r.dbAcquire.Add(ctx, s.AcquireDelta, opt)
+	}
+	if s.EmptyAcquireDelta > 0 {
+		r.dbEmptyAcquire.Add(ctx, s.EmptyAcquireDelta, opt)
+	}
+	if s.CanceledAcquireDelta > 0 {
+		r.dbCanceledAcquire.Add(ctx, s.CanceledAcquireDelta, opt)
+	}
+	if s.AcquireDurationSecondsDelta > 0 {
+		r.dbAcquireDurationSeconds.Add(ctx, s.AcquireDurationSecondsDelta, opt)
+	}
+}
+
+func (r *OTelRecorder) attrs(extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("service.name", r.serviceName),
+		attribute.String("environment", r.environment),
+	}
+	return append(attrs, extra...)
+}
+
+func safeResult(v string) string {
+	switch v {
+	case ResultSuccess, ResultError, ResultConflict, ResultTimeout:
+		return v
+	default:
+		return ResultError
+	}
+}
+
+func safeOperation(v string) string {
+	switch v {
+	case "create", "pause", "resume", "delete", "fail", "timeout_pause":
+		return v
+	default:
+		return "unknown"
+	}
+}
+
+func safeMethod(v string) string {
+	switch v {
+	case "CreateVM", "PauseVM", "ResumeVM", "DeleteVM", "BuildTemplate", "GetBuildStatus", "CancelBuild":
+		return v
+	case "RestoreSnapshot":
+		return "CreateVM"
+	default:
+		return "unknown"
+	}
+}
+
+func safeRegion(v string) string {
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}
+
+func safeHostID(v string) string {
+	if v == "" {
+		return "unknown"
+	}
+	return v
+}

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -1,0 +1,86 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSafeResultBoundsValues(t *testing.T) {
+	for _, result := range []string{ResultSuccess, ResultError, ResultConflict, ResultTimeout} {
+		if got := safeResult(result); got != result {
+			t.Fatalf("safeResult(%q) = %q", result, got)
+		}
+	}
+	if got := safeResult("raw error: secret token leaked"); got != ResultError {
+		t.Fatalf("unexpected fallback result: %q", got)
+	}
+}
+
+func TestSafeOperationBoundsValues(t *testing.T) {
+	for _, op := range []string{"create", "pause", "resume", "delete", "fail", "timeout_pause"} {
+		if got := safeOperation(op); got != op {
+			t.Fatalf("safeOperation(%q) = %q", op, got)
+		}
+	}
+	if got := safeOperation("sandbox_id=abc"); got != "unknown" {
+		t.Fatalf("unexpected fallback operation: %q", got)
+	}
+}
+
+func TestSafeMethodBoundsValues(t *testing.T) {
+	for _, method := range []string{"CreateVM", "PauseVM", "ResumeVM", "DeleteVM", "BuildTemplate", "GetBuildStatus", "CancelBuild"} {
+		if got := safeMethod(method); got != method {
+			t.Fatalf("safeMethod(%q) = %q", method, got)
+		}
+	}
+	if got := safeMethod("https://raw-url.example/vm/123"); got != "unknown" {
+		t.Fatalf("unexpected fallback method: %q", got)
+	}
+}
+
+func TestDeltasNeverNegative(t *testing.T) {
+	if got := nonNegativeDelta(10, 7); got != 3 {
+		t.Fatalf("delta = %d", got)
+	}
+	if got := nonNegativeDelta(1, 7); got != 0 {
+		t.Fatalf("reset delta = %d", got)
+	}
+	if got := nonNegativeDurationDelta(10*time.Second, 7*time.Second); got != 3*time.Second {
+		t.Fatalf("duration delta = %s", got)
+	}
+	if got := nonNegativeDurationDelta(time.Second, 7*time.Second); got != 0 {
+		t.Fatalf("reset duration delta = %s", got)
+	}
+}
+
+func TestDBPoolDeltasSeedFromFirstSample(t *testing.T) {
+	acquire, emptyAcquire, canceledAcquire, acquireDuration := dbPoolDeltas(
+		false,
+		10, 0,
+		4, 0,
+		2, 0,
+		15*time.Second, 0,
+	)
+	if acquire != 0 || emptyAcquire != 0 || canceledAcquire != 0 || acquireDuration != 0 {
+		t.Fatalf("first sample deltas = (%d, %d, %d, %s), want all zero", acquire, emptyAcquire, canceledAcquire, acquireDuration)
+	}
+
+	acquire, emptyAcquire, canceledAcquire, acquireDuration = dbPoolDeltas(
+		true,
+		15, 10,
+		6, 4,
+		3, 2,
+		21*time.Second, 15*time.Second,
+	)
+	if acquire != 5 || emptyAcquire != 2 || canceledAcquire != 1 || acquireDuration != 6*time.Second {
+		t.Fatalf("seeded sample deltas = (%d, %d, %d, %s)", acquire, emptyAcquire, canceledAcquire, acquireDuration)
+	}
+}
+
+func TestHostCapacityQueryTimeoutIndependentOfInterval(t *testing.T) {
+	for _, interval := range []time.Duration{500 * time.Millisecond, 2 * time.Second, 15 * time.Second} {
+		if got := hostCapacityQueryTimeoutForInterval(interval); got != hostCapacityQueryTimeout {
+			t.Fatalf("timeout(%s) = %s, want %s", interval, got, hostCapacityQueryTimeout)
+		}
+	}
+}

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -5,6 +5,13 @@ import (
 	"time"
 )
 
+const (
+	ResultSuccess  = "success"
+	ResultError    = "error"
+	ResultConflict = "conflict"
+	ResultTimeout  = "timeout"
+)
+
 // SandboxTransition records low-cardinality operational lifecycle metrics.
 // Keep tenant, user, API key, and sandbox identifiers out of metric labels;
 // use logs or traces for per-sandbox investigation.
@@ -37,6 +44,18 @@ type HostCapacity struct {
 	Sandboxes     int64
 }
 
+// DBPoolStats records pgxpool pressure and acquisition health. The *Delta
+// fields are per-sample deltas from pgxpool.Stat() cumulative counters.
+type DBPoolStats struct {
+	AcquiredConns               int64
+	IdleConns                   int64
+	TotalConns                  int64
+	AcquireDelta                int64
+	EmptyAcquireDelta           int64
+	CanceledAcquireDelta        int64
+	AcquireDurationSecondsDelta float64
+}
+
 // Recorder is the operational metrics boundary. Implementations should emit
 // OpenTelemetry metrics through a collector; callers should not write ad hoc
 // operational metrics into Postgres.
@@ -44,6 +63,7 @@ type Recorder interface {
 	RecordSandboxTransition(context.Context, SandboxTransition)
 	RecordVMDCall(context.Context, VMDCall)
 	RecordHostCapacity(context.Context, HostCapacity)
+	RecordDBPoolStats(context.Context, DBPoolStats)
 }
 
 type noopRecorder struct{}
@@ -52,3 +72,4 @@ func NewNoopRecorder() Recorder                                                 
 func (noopRecorder) RecordSandboxTransition(context.Context, SandboxTransition) {}
 func (noopRecorder) RecordVMDCall(context.Context, VMDCall)                     {}
 func (noopRecorder) RecordHostCapacity(context.Context, HostCapacity)           {}
+func (noopRecorder) RecordDBPoolStats(context.Context, DBPoolStats)             {}

--- a/internal/telemetry/vmd_client.go
+++ b/internal/telemetry/vmd_client.go
@@ -1,0 +1,129 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+type instrumentedVMDClient struct {
+	next     vmdclient.Client
+	recorder Recorder
+	region   string
+	hostID   string
+}
+
+// WrapVMDClient records bounded VMD RPC metrics for high-value lifecycle and
+// build operations. It never records VM IDs, sandbox IDs, paths, URLs, or raw
+// error strings as labels.
+func WrapVMDClient(next vmdclient.Client, recorder Recorder, region, hostID string) vmdclient.Client {
+	if next == nil || recorder == nil {
+		return next
+	}
+	return &instrumentedVMDClient{next: next, recorder: recorder, region: region, hostID: hostID}
+}
+
+func (c *instrumentedVMDClient) record(ctx context.Context, method string, started time.Time, err error) {
+	result := ResultSuccess
+	if err != nil {
+		result = ResultError
+	}
+	c.recorder.RecordVMDCall(ctx, VMDCall{
+		Method:   method,
+		Result:   result,
+		Region:   c.region,
+		HostID:   c.hostID,
+		Duration: time.Since(started),
+	})
+}
+
+func (c *instrumentedVMDClient) DestroyInstance(ctx context.Context, instanceID string, force bool) (err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "DeleteVM", started, err) }()
+	return c.next.DestroyInstance(ctx, instanceID, force)
+}
+
+func (c *instrumentedVMDClient) PauseInstance(ctx context.Context, instanceID, snapshotDir string) (snapshotPath, memPath string, err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "PauseVM", started, err) }()
+	return c.next.PauseInstance(ctx, instanceID, snapshotDir)
+}
+
+func (c *instrumentedVMDClient) ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "ResumeVM", started, err) }()
+	return c.next.ResumeInstance(ctx, instanceID, snapshotPath, memPath)
+}
+
+func (c *instrumentedVMDClient) RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, envVars map[string]string) (ipAddress string, actualVcpu, actualMemMiB uint32, err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "CreateVM", started, err) }()
+	return c.next.RestoreSnapshot(ctx, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID, envVars)
+}
+
+func (c *instrumentedVMDClient) InjectSandboxEnv(ctx context.Context, instanceID string, envVars map[string]string, secretsJWT string) error {
+	return c.next.InjectSandboxEnv(ctx, instanceID, envVars, secretsJWT)
+}
+
+func (c *instrumentedVMDClient) DeleteSnapshot(ctx context.Context, instanceID, snapshotPath, memPath string) error {
+	return c.next.DeleteSnapshot(ctx, instanceID, snapshotPath, memPath)
+}
+
+func (c *instrumentedVMDClient) DeleteSandboxSnapshots(ctx context.Context, instanceID string) error {
+	return c.next.DeleteSandboxSnapshots(ctx, instanceID)
+}
+
+func (c *instrumentedVMDClient) DeleteTemplateArtifacts(ctx context.Context, templateID string) error {
+	return c.next.DeleteTemplateArtifacts(ctx, templateID)
+}
+
+func (c *instrumentedVMDClient) DeleteBuildArtifacts(ctx context.Context, templateID, buildID string) error {
+	return c.next.DeleteBuildArtifacts(ctx, templateID, buildID)
+}
+
+func (c *instrumentedVMDClient) ListBuildArtifacts(ctx context.Context) ([]vmdclient.BuildArtifactEntry, error) {
+	return c.next.ListBuildArtifacts(ctx)
+}
+
+func (c *instrumentedVMDClient) ListDir(ctx context.Context, instanceID, path string) ([]vmdclient.DirEntry, error) {
+	return c.next.ListDir(ctx, instanceID, path)
+}
+
+func (c *instrumentedVMDClient) UpdateSandboxNetwork(ctx context.Context, instanceID string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error {
+	return c.next.UpdateSandboxNetwork(ctx, instanceID, allowedCIDRs, deniedCIDRs, allowedDomains)
+}
+
+func (c *instrumentedVMDClient) InvalidateSecret(ctx context.Context, secretID string) error {
+	return c.next.InvalidateSecret(ctx, secretID)
+}
+
+func (c *instrumentedVMDClient) RevokeSandbox(ctx context.Context, sandboxID string) error {
+	return c.next.RevokeSandbox(ctx, sandboxID)
+}
+
+func (c *instrumentedVMDClient) InvalidateSandboxRules(ctx context.Context, sandboxID string) error {
+	return c.next.InvalidateSandboxRules(ctx, sandboxID)
+}
+
+func (c *instrumentedVMDClient) BuildTemplate(ctx context.Context, req vmdclient.BuildTemplateInput) (buildVMID string, err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "BuildTemplate", started, err) }()
+	return c.next.BuildTemplate(ctx, req)
+}
+
+func (c *instrumentedVMDClient) GetBuildStatus(ctx context.Context, buildVMID string) (res vmdclient.BuildStatusResult, err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "GetBuildStatus", started, err) }()
+	return c.next.GetBuildStatus(ctx, buildVMID)
+}
+
+func (c *instrumentedVMDClient) CancelBuild(ctx context.Context, buildVMID string) (err error) {
+	started := time.Now()
+	defer func() { c.record(ctx, "CancelBuild", started, err) }()
+	return c.next.CancelBuild(ctx, buildVMID)
+}
+
+func (c *instrumentedVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, onEvent func(vmdclient.BuildLogEvent) error) error {
+	return c.next.StreamBuildLogs(ctx, buildVMID, onEvent)
+}


### PR DESCRIPTION
Adds Phase 1 OpenTelemetry metrics for the sandbox control plane. The branch wires a bounded telemetry recorder through config/control-plane startup, emits sandbox lifecycle, VMD RPC, DB pool, and host capacity metrics, and includes local OTEL Collector debug config plus docs for validating metrics before GMP ingestion.

Telemetry is disabled by default, avoids high-cardinality/customer identifiers, and keeps labels limited to operational fields like operation, result, region, host_id, method, service.name, and environment.