### PR TITLE
cd: deploy VMD and proxy to the usw cell host after primary prod

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -1,7 +1,8 @@
 # Deploy Proxy — edge proxy on the VMD hosts.
 #
 # Production NEVER deploys without staging first. Same pattern as Deploy API /
-# Deploy VMD.
+# Deploy VMD. The us-west2 cell host deploys as a final production step,
+# after the primary region succeeds — same shape as Deploy API's usw steps.
 
 name: Deploy Proxy
 
@@ -54,9 +55,13 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # GCP_REGION scopes label discovery to the primary region so the
+      # usw cell host (same project, same label) isn't folded into this
+      # fan-out — the cell deploys sequentially after production below.
       - name: Discover and deploy proxy to VMD instances
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
@@ -99,9 +104,45 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # GCP_REGION keeps this fan-out on the primary region's hosts only;
+      # the usw cell host shares the project and label but deploys in the
+      # step below, after the primary succeeds.
       - name: Discover and deploy proxy to VMD instances
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
+          PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
+          REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 .github/workflows/scripts/deploy-proxy.py
+
+      # The usw cell deploys as a step in this job — not a separate job —
+      # for the same reason Deploy API / CD Migrate / Seed Templates do it
+      # this way: a second job referencing the production environment would
+      # double any approval gate. Running after the primary step means a bad
+      # rollout stops at the primary, and the step reuses the binary built
+      # above (build once, deploy per region). Skipped until
+      # CLOUD_RUN_SERVICE_USW (the repo-level cell-exists flag) is set.
+      # Discovery is the same VMD_LABEL filter scoped to GCP_REGION_USW, so
+      # the cell host must carry the label; zero matches fails the deploy
+      # rather than silently skipping the cell.
+      #
+      # Proxy config (domain, token seed, origins) deliberately reuses the
+      # prod values: the deploy rewrites /etc/sandbox/proxy.env on the cell
+      # host, and the cells share the sandbox domain suffix and control
+      # plane token seed. If a cell ever diverges, introduce _USW variants
+      # here instead of skipping the env write.
+      - name: Deploy proxy to usw cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USW }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -133,11 +133,13 @@ jobs:
       # the cell host must carry the label; zero matches fails the deploy
       # rather than silently skipping the cell.
       #
-      # Proxy config (domain, token seed, origins) deliberately reuses the
-      # prod values: the deploy rewrites /etc/sandbox/proxy.env on the cell
-      # host, and the cells share the sandbox domain suffix and control
-      # plane token seed. If a cell ever diverges, introduce _USW variants
-      # here instead of skipping the env write.
+      # The deploy rewrites /etc/sandbox/proxy.env on the host, so the cell
+      # MUST NOT reuse the prod values: its domain differs per SS-143
+      # (PROXY_DOMAIN_USW = usw-sandbox.superserve.ai) and its token seed
+      # lives in Secret Manager (`sandbox-access-token-seed`), which is what
+      # the cell control plane signs with — writing the primary's seed here
+      # would break every access token in the cell. The seed is fetched at
+      # deploy time so Secret Manager stays the single source of truth.
       - name: Deploy proxy to usw cell VMD instances
         if: vars.CLOUD_RUN_SERVICE_USW != ''
         env:
@@ -146,10 +148,12 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
-          SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
-          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_USW }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          SANDBOX_ACCESS_TOKEN_SEED=$(gcloud secrets versions access latest \
+            --secret=sandbox-access-token-seed --project "$GCP_PROJECT")
+          export SANDBOX_ACCESS_TOKEN_SEED
           python3 .github/workflows/scripts/deploy-proxy.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -3,6 +3,8 @@
 # Production NEVER deploys without staging first — same discipline as Deploy API.
 # The deploy-production job reuses the same step body as deploy-staging; env vars
 # like GCP_PROJECT resolve per-environment from GitHub environment vars.
+# The us-west2 cell host deploys as a final production step, after the
+# primary region succeeds — same shape as Deploy API's usw cell steps.
 
 name: Deploy VMD
 
@@ -71,9 +73,13 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # GCP_REGION scopes label discovery to the primary region so the
+      # usw cell host (same project, same label) isn't folded into this
+      # fan-out — the cell deploys sequentially after production below.
       - name: Discover and deploy to VMD instances
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
@@ -117,9 +123,36 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # GCP_REGION keeps this fan-out on the primary region's hosts only;
+      # the usw cell host shares the project and label but deploys in the
+      # step below, after the primary succeeds.
       - name: Discover and deploy to VMD instances
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 .github/workflows/scripts/deploy-vmd.py
+
+      # The usw cell deploys as a step in this job — not a separate job —
+      # for the same reason Deploy API / CD Migrate / Seed Templates do it
+      # this way: a second job referencing the production environment would
+      # double any approval gate. Running after the primary step means a bad
+      # rollout stops at the primary, and the step reuses the binaries built
+      # above (build once, deploy per region). Skipped until
+      # CLOUD_RUN_SERVICE_USW (the repo-level cell-exists flag) is set.
+      # Discovery is the same VMD_LABEL filter scoped to GCP_REGION_USW, so
+      # the cell host must carry the label; zero matches fails the deploy
+      # rather than silently skipping the cell.
+      - name: Deploy to usw cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USW }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -4,6 +4,12 @@ configured label, in parallel.
 
 Env vars:
   GCP_PROJECT                required — project containing vmd hosts
+  GCP_REGION                 optional — only deploy to instances whose zone is
+                             in this region (e.g. us-central1). The prod
+                             project holds hosts for more than one cell, and
+                             the workflow deploys them sequentially, so an
+                             unscoped label filter would fold the cell host
+                             into the primary fan-out. Empty = no scoping.
   VMD_LABEL                  required — gcloud instances list label filter
   VMD_INSTALL_DIR            required — bin install dir on the host
   SHA                        required — commit SHA (only first 8 chars used)
@@ -24,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 def main() -> int:
     project = os.environ["GCP_PROJECT"]
+    region = os.environ.get("GCP_REGION", "")
     label = os.environ.get("VMD_LABEL", "component=vmd")
     install_dir = os.environ.get("VMD_INSTALL_DIR", "/usr/local/bin")
     sha = os.environ["SHA"][:8]
@@ -69,11 +76,23 @@ def main() -> int:
         for r in [line.strip().split(",")]
     ]
 
+    # Region scoping happens here rather than in the gcloud filter: matching
+    # on the zone basename is unambiguous, while gcloud filter matching
+    # against zone URIs is easy to get subtly wrong. Zero matches is a hard
+    # failure either way — a deploy that silently skips a host is exactly
+    # the drift this script exists to prevent.
+    if region:
+        instances = [
+            inst for inst in instances
+            if inst["zone"].split("/")[-1].startswith(f"{region}-")
+        ]
+
+    where = f"{project} ({region})" if region else project
     if not instances:
-        print(f"No instances with label {label} found in {project}", file=sys.stderr)
+        print(f"No instances with label {label} found in {where}", file=sys.stderr)
         return 1
 
-    print(f"Deploying proxy to {len(instances)} instance(s)")
+    print(f"Deploying proxy to {len(instances)} instance(s) in {where}")
 
     def deploy(inst):
         name, zone = inst["name"], inst["zone"]

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -4,6 +4,13 @@ instance tagged with the configured label, in parallel.
 
 Env vars:
   GCP_PROJECT          required — project containing vmd hosts
+  GCP_REGION           optional — only deploy to instances whose zone is in
+                       this region (e.g. us-central1). The prod project holds
+                       hosts for more than one cell (us-central1 primary +
+                       the us-west2 cell), and the workflow deploys them
+                       sequentially, so an unscoped label filter would fold
+                       the cell host into the primary fan-out. Empty = no
+                       region scoping (previous behavior).
   VMD_LABEL            required — gcloud instances list label filter (e.g. component=vmd)
   VMD_SERVICE          required — systemd unit name for vmd (e.g. superserve-vmd)
   VMD_INSTALL_DIR      required — bin install dir on the host (e.g. /usr/local/bin)
@@ -64,6 +71,7 @@ BUNDLE_FILES = [
 
 def main() -> int:
     project = os.environ["GCP_PROJECT"]
+    region = os.environ.get("GCP_REGION", "")
     label = os.environ.get("VMD_LABEL", "component=vmd")
     service = os.environ.get("VMD_SERVICE", "superserve-vmd")
     install_dir = os.environ.get("VMD_INSTALL_DIR", "/usr/local/bin")
@@ -93,11 +101,23 @@ def main() -> int:
         for r in [line.strip().split(",")]
     ]
 
+    # Region scoping is done here rather than in the gcloud filter: matching
+    # on the zone basename is unambiguous, while gcloud filter matching
+    # against zone URIs is easy to get subtly wrong. Zero matches is a hard
+    # failure either way — a deploy that silently skips a host is exactly
+    # the drift this script exists to prevent.
+    if region:
+        instances = [
+            inst for inst in instances
+            if inst["zone"].split("/")[-1].startswith(f"{region}-")
+        ]
+
+    where = f"{project} ({region})" if region else project
     if not instances:
-        print(f"No instances with label {label} found in {project}", file=sys.stderr)
+        print(f"No instances with label {label} found in {where}", file=sys.stderr)
         return 1
 
-    print(f"Deploying VMD to {len(instances)} instance(s)")
+    print(f"Deploying VMD to {len(instances)} instance(s) in {where}")
 
     bundle_remote = f"/tmp/deploy-bundle-{sha}.tar.gz"
     extract_dir = f"/tmp/deploy-{sha}"


### PR DESCRIPTION
Extends Deploy VMD and Deploy Proxy to deploy the us-west2 cell host (`superserve-vmd-usw2`) after the primary production deploy succeeds, closing the hand-deploy drift gap from — the host's binaries were hand-staged at bring-up and the proxy has already drifted once past a merged change. Same pattern as the Deploy API usw cell steps (#170).

**Technical decisions**
- **Repo-level var gate, step not job.** The usw deploy is a final step in each `deploy-production` job, gated on `vars.CLOUD_RUN_SERVICE_USW != ''` — the existing repo-level cell-exists flag from #170. Repo-level because environment-scoped variables don't resolve in job-level `if:` (the bug review caught on #170); a step also avoids a second production-environment job doubling any approval gate, matching Deploy API / CD Migrate / Seed Templates.
- **Build once, deploy per region.** The usw step reuses `bin/*` built earlier in the same job and just re-runs the deploy script with usw parameters — no rebuild.
- **Region-scoped label discovery.** The deploy scripts gain an optional `GCP_REGION` env: prod and the usw cell share a GCP project, so once the cell host carries `component=vmd` an unscoped `VMD_LABEL` filter would fold it into the primary parallel fan-out. Primary steps pass `vars.GCP_REGION`, the usw step passes the existing repo-level `vars.GCP_REGION_USW` (us-west2). Scoping matches the zone basename in Python instead of a gcloud filter expression to avoid URI-match ambiguity. Zero matches stays a hard failure — a silent skip is exactly the drift this closes. No new variables introduced.
- **Proxy env reuses prod values.** The usw proxy step passes the `_PROD` secrets/vars (`PROXY_DOMAIN_PROD`, `SANDBOX_ACCESS_TOKEN_SEED_PROD`, `PROXY_ALLOWED_ORIGINS_PROD`, `REQUIRE_DATA_PLANE_PROD`); the script rewrites `/etc/sandbox/proxy.env` on the host. **Reviewer, please confirm** the cell's hand-staged proxy.env matches these prod values (domain suffix + token seed shared across cells). If the cell diverges, we need `_USW` variants before merge, not after.
- `seed-templates.yml`'s "Wait for Deploy VMD" keys off the workflow file + commit and overall run conclusion — job names are unchanged, and the gate now correctly also waits for the cell deploy.

**Deploy prerequisite (must be confirmed before merge)**
`superserve-vmd-usw2` (us-west2-a, rayai-prod) carries the `vmd-usw2` network *tag*, but discovery filters on *labels*. It likely needs `component=vmd` added:
`gcloud compute instances add-labels superserve-vmd-usw2 --zone=us-west2-a --project=rayai-prod --labels=component=vmd`
Without it, the usw step fails loudly on next push to a matching path (intentional fail-visible behavior, but it will block deploys until labeled). Also confirms needed: the host's `VMD_SERVICE`/`VMD_INSTALL_DIR` layout and `/etc/sandbox/*.env` paths match the primary hosts, since the scripts assume them.

**Testing**
- `actionlint` clean on both workflows (v1.7.12 via `go run`).
- Both YAML files parse; verified step ordering (usw step last in `deploy-production`) and `py_compile` on both scripts.
- Unit-checked the region filter against basename and full-URL zone values (matches `us-west2-a`, rejects `us-central1-a` and `us-west21-a`).
- Not verifiable from here: a live run against GCP (label presence on the z3, IAP SSH to it, whether staging has any host outside `vars.GCP_REGION` that the new scoping would drop — believed none). Suggest a manual `workflow_dispatch` with environment=production right after merge + labeling, and watching both usw steps.