### PR TITLE
api: auto-delete paused sandboxes via auto_delete_seconds; patchable timeout_seconds

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -533,6 +533,17 @@ paths:
           they survive a future pause/resume cycle.
         - `metadata` — replaces the sandbox's metadata tags. Can be updated
           regardless of sandbox state (active, paused).
+        - `auto_delete_seconds` — sets or clears (`null`) the
+          garbage-collection window for the paused state. Can be updated
+          regardless of sandbox state. When applied to an already-paused
+          sandbox, the deletion deadline counts from the moment of this
+          request — never retroactively from when the sandbox paused — so
+          you always get the full window.
+        - `timeout_seconds` — sets or clears (`null`) the auto-pause
+          timeout. Can be updated regardless of sandbox state; on a paused
+          sandbox it applies to the next active session. The timeout is
+          evaluated against the current active session, so lowering it
+          below already-elapsed time pauses the sandbox promptly.
       security:
         - apiKey: []
       requestBody:
@@ -1785,12 +1796,25 @@ components:
           minimum: 1
           maximum: 604800
           description: >
-            Optional hard lifetime cap in seconds, measured from sandbox
-            creation. When set, the sandbox is destroyed this many seconds
-            after creation regardless of state (active, paused) or
-            activity — the user asked for a hard deadline.
-            When unset, the sandbox lives until explicitly paused or
-            deleted. Maximum 604800 (7 days).
+            Optional auto-pause timeout in seconds. The sandbox is paused
+            once its current active session has run this long; each resume
+            starts a fresh window. When unset, the sandbox stays active
+            until explicitly paused. Also settable later via
+            `PATCH /sandboxes/{sandbox_id}`. Maximum 604800 (7 days).
+        auto_delete_seconds:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2592000
+          description: >
+            Optional garbage-collection window for paused sandboxes, in
+            seconds. Once the sandbox has been continuously paused for this
+            long it is deleted automatically. The window arms each time the
+            sandbox pauses and is cancelled by resume, so a sandbox in use is
+            never eligible. `0` deletes the sandbox as soon as it pauses.
+            When unset, paused sandboxes are kept until explicitly deleted.
+            Also settable later via `PATCH /sandboxes/{sandbox_id}`.
+            Maximum 2592000 (30 days).
         metadata:
           type: object
           additionalProperties:
@@ -1876,8 +1900,22 @@ components:
           type: integer
           format: int32
           description: >
-            Hard lifetime cap in seconds from creation, if set at creation
-            time. Absent when no cap was configured.
+            Auto-pause timeout in seconds, if configured. Absent when
+            auto-pause is disabled.
+        auto_delete_seconds:
+          type: integer
+          format: int32
+          description: >
+            Garbage-collection window for the paused state, if configured.
+            Absent when auto-delete is disabled.
+        auto_delete_at:
+          type: string
+          format: date-time
+          description: >
+            When the sandbox will be deleted. Present only while the sandbox
+            is paused with `auto_delete_seconds` configured. The deadline is
+            armed when the sandbox pauses (or when the setting is applied to
+            an already-paused sandbox) and cleared on resume.
         network:
           $ref: "#/components/schemas/NetworkConfig"
           description: >
@@ -2092,6 +2130,30 @@ components:
             metadata — omitted keys are removed. Can be patched regardless of
             sandbox state. Same validation limits as on create (64 keys,
             256-byte keys, 2 KB values, 16 KB total).
+        auto_delete_seconds:
+          type: integer
+          format: int32
+          nullable: true
+          minimum: 0
+          maximum: 2592000
+          description: |
+            Set or clear the garbage-collection window for the paused state.
+            Once the sandbox has been continuously paused for this many
+            seconds it is deleted automatically. `0` deletes as soon as the
+            sandbox pauses; `null` disables auto-delete. On an already-paused
+            sandbox the deadline counts from this request, so the sandbox
+            gets the full window. Maximum 2592000 (30 days).
+        timeout_seconds:
+          type: integer
+          format: int32
+          nullable: true
+          minimum: 1
+          maximum: 604800
+          description: |
+            Set or clear the auto-pause timeout. Same semantics as on
+            create; `null` disables auto-pause. Evaluated against the
+            current active session, so lowering it below already-elapsed
+            time pauses the sandbox promptly. Maximum 604800 (7 days).
       example:
         metadata:
           env: prod

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -6,8 +6,8 @@
 -- template_id is optional (NULL when sandbox is not derived from a template).
 -- snapshot_path / mem_path / base_path / delta_path pin the sandbox to a
 -- specific build's artifacts so a later template rebuild can't corrupt it.
-INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 RETURNING *;
 
 -- name: CreateSandboxFromTemplate :one
@@ -22,8 +22,8 @@ WITH tpl AS (
     AND (t.team_id = $14 OR t.team_id = $15)
   FOR KEY SHARE
 )
-INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib)
-SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib FROM tpl
+INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib, $20 FROM tpl
 RETURNING *;
 
 -- name: GetSandbox :one
@@ -134,11 +134,6 @@ FROM activated a
 WHERE feature_enabled('billing_metrics_write', a.team_id)
 ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING;
 
--- name: SetSandboxSnapshot :exec
-UPDATE sandbox
-SET snapshot_id = $2, updated_at = now()
-WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
-
 -- name: DestroySandbox :one
 -- Atomic, guarded soft-delete. Claims the sandbox from a quiescent state
 -- (active/paused/failed) or from a transitional state (starting/resuming/pausing)
@@ -150,6 +145,9 @@ WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 -- so a crash after the claim can't strand a deleted sandbox with a live JWT or an
 -- open interval. Returns the claimed id; 0 rows means already-deleted or a still-live
 -- transition — the caller distinguishes the two with a re-read.
+--
+-- The revocation + interval-close CTEs are mirrored in ClaimAutoDeleteSandboxes;
+-- keep the side effects of both in sync.
 WITH destroyed AS (
   UPDATE sandbox
   SET destroyed_at = now(), status = 'deleted', updated_at = now()
@@ -219,7 +217,10 @@ WHERE host_id = sqlc.arg(host_id)
 -- interval open and have analytics count the actor as active forever.
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', updated_at = now()
+  -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
+  -- and a stale one would resurface (or instantly fire) if the sandbox is
+  -- ever returned to 'paused' by a recovery path.
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),
@@ -241,7 +242,7 @@ WHERE sandbox_id IN (SELECT id FROM failed)
 -- bundling of the active-interval close.
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),
@@ -301,7 +302,7 @@ LEFT JOIN closed_interval ci ON ci.sandbox_id = p.id;
 -- already claimed the sandbox, or it's not in paused state. Used to
 -- serialize concurrent /exec and /resume requests.
 UPDATE sandbox
-SET status = 'resuming', updated_at = now()
+SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
 RETURNING *;
 
@@ -310,17 +311,26 @@ RETURNING *;
 -- Guarded on status = 'resuming' so we never clobber a concurrent transition
 -- (e.g., ActivateSandbox has already flipped to 'active').
 UPDATE sandbox
-SET status = 'paused', updated_at = now()
+SET status = 'paused',
+    -- Re-arm the auto-delete deadline cleared by BeginResume; the sandbox is
+    -- paused again, so it gets a fresh window.
+    auto_delete_at = now() + make_interval(secs => auto_delete_seconds),
+    updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 
 -- name: FinalizePause :one
 -- Upsert the sandbox's live snapshot row and flip status to 'paused'.
--- Returns 0 rows if the sandbox is missing or soft-deleted (→ ErrSandboxGone).
+-- Returns 0 rows if the sandbox is missing, soft-deleted, or no longer in a
+-- pause-eligible transition (→ ErrSandboxGone). The status guard keeps a
+-- stale or duplicate finalize from clobbering a terminal state — without it,
+-- a late-landing write could flip a 'failed' sandbox back to 'paused' and
+-- arm its auto-delete deadline.
 -- One snapshot per sandbox; the unique index on snapshot.sandbox_id keys
 -- the UPSERT.
 WITH target AS (
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
+    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)
@@ -336,9 +346,14 @@ upserted AS (
 UPDATE sandbox
 SET snapshot_id = (SELECT snap_id FROM upserted),
     status = 'paused',
+    -- Arm the auto-delete deadline as the sandbox lands in 'paused'.
+    -- make_interval(NULL) propagates NULL, so an unset auto_delete_seconds
+    -- leaves the deadline NULL (never deleted).
+    auto_delete_at = now() + make_interval(secs => sandbox.auto_delete_seconds),
     updated_at = now()
 FROM upserted
 WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+  AND sandbox.status IN ('pausing', 'resuming')
 RETURNING upserted.snap_id::uuid AS snapshot_id;
 
 -- name: UpdateSandboxNetworkConfig :exec
@@ -425,3 +440,89 @@ closed_billing_compute AS (
 SELECT p.id, p.team_id, p.name, p.snapshot_id, p.host_id
 FROM paused p
 LEFT JOIN closed_intervals ci ON ci.sandbox_id = p.id;
+
+-- name: UpdateSandboxAutoDelete :execrows
+-- Set or clear (NULL) the auto-delete window. The deadline counts continuous
+-- paused time since the setting was applied: on an already-paused sandbox it
+-- is armed from now() — never retroactively from the pause — so applying a
+-- window can never destroy the sandbox in the same instant. On a non-paused
+-- sandbox the deadline stays NULL and FinalizePause arms it at the next pause.
+UPDATE sandbox
+SET auto_delete_seconds = sqlc.narg(auto_delete_seconds),
+    auto_delete_at = CASE WHEN status = 'paused'
+      THEN now() + make_interval(secs => sqlc.narg(auto_delete_seconds))
+      ELSE NULL
+    END,
+    updated_at = now()
+WHERE id = $1 AND team_id = sqlc.arg(team_id) AND destroyed_at IS NULL;
+
+-- name: UpdateSandboxTimeout :execrows
+-- Set or clear (NULL) the auto-pause timeout. Takes effect on the reaper's
+-- next tick: the window is evaluated against the current active session
+-- start, so lowering it below already-elapsed session time pauses the
+-- sandbox on the next sweep. On a paused sandbox it applies to the next
+-- active session after resume.
+UPDATE sandbox
+SET timeout_seconds = sqlc.narg(timeout_seconds),
+    updated_at = now()
+WHERE id = $1 AND team_id = sqlc.arg(team_id) AND destroyed_at IS NULL;
+
+-- name: ClaimAutoDeleteSandboxes :many
+-- Atomically soft-deletes paused sandboxes whose auto-delete deadline has
+-- passed. Deliberately narrower than DestroySandbox: it claims from 'paused'
+-- only, with the deadline re-checked under the row lock, so a concurrent
+-- BeginResume (also guarded on 'paused') and this claim can never both win
+-- the same row. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas skip
+-- in-flight rows.
+--
+-- Mirrors DestroySandbox's side effects: writes the revocation row and closes
+-- any open active/billing/storage intervals in the same statement, so a crash
+-- after the claim can't strand a deleted sandbox with a live JWT or an open
+-- interval. Returns the columns the caller needs for VM/artifact teardown.
+WITH due AS (
+  SELECT s.id
+  FROM sandbox s
+  WHERE s.destroyed_at IS NULL
+    AND s.status = 'paused'
+    AND s.auto_delete_at IS NOT NULL
+    AND s.auto_delete_at < now()
+  ORDER BY s.auto_delete_at ASC
+  LIMIT sqlc.arg(batch_size)
+  FOR UPDATE OF s SKIP LOCKED
+),
+destroyed AS (
+  UPDATE sandbox
+  SET destroyed_at = now(), status = 'deleted', updated_at = now()
+  FROM due
+  WHERE sandbox.id = due.id
+  RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.host_id,
+            sandbox.base_path, sandbox.template_id
+),
+revoked AS (
+  INSERT INTO sandbox_revocation (sandbox_id, expires_at)
+  SELECT id, sqlc.arg(revocation_expires_at) FROM destroyed
+  ON CONFLICT (sandbox_id) DO NOTHING
+),
+closed_compute AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_billing_compute AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_storage AS (
+  UPDATE sandbox_storage_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT d.id, d.team_id, d.name, d.host_id, d.base_path, d.template_id
+FROM destroyed d;

--- a/db/queries/snapshots.sql
+++ b/db/queries/snapshots.sql
@@ -28,5 +28,19 @@ WHERE team_id = $1
 ORDER BY created_at DESC;
 
 -- name: DeleteSnapshot :exec
+-- Invariant: only delete snapshots of destroyed sandboxes. fk_sandbox_snapshot
+-- is ON DELETE SET NULL, so deleting a live/paused sandbox's snapshot silently
+-- nulls its restore pointer (unrestorable) instead of erroring.
 DELETE FROM snapshot
 WHERE id = $1;
+
+-- name: DeleteSnapshotsOfDestroyedSandboxes :execrows
+-- Backstop for destroy teardown that never ran (crash/shutdown before
+-- cleanupSandboxSnapshots). Driven from snapshot (joined to sandbox by PK) so
+-- it scans only un-cleaned rows, not every accumulating soft-deleted sandbox.
+-- Files fall to the vm reconciler's disk scan.
+DELETE FROM snapshot s
+USING sandbox sb
+WHERE s.sandbox_id = sb.id
+  AND sb.destroyed_at IS NOT NULL
+  AND sb.destroyed_at < now() - interval '1 hour';

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -972,20 +972,36 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		return
 	}
 
-	// The revocation row is committed with the claim above; fan it out to the
+	h.teardownDestroyedSandbox(c.Request.Context(), sandboxID, sandbox.HostID, sandbox.BasePath, sandbox.TemplateID)
+
+	// DestroySandbox's CTE atomically closed the open sandbox_active_interval row.
+	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "deleted", "success", &sandbox.Name, nil, nil)
+	h.capture(c, "sandbox_deleted", map[string]any{"sandbox_id": sandboxID.String()})
+
+	c.Status(http.StatusNoContent)
+}
+
+// teardownDestroyedSandbox reclaims host-side state for a sandbox whose
+// guarded soft-delete has already committed: the VM (with its run dir and
+// netns), pause snapshots, and the per-build artifact dir. Best-effort
+// throughout — the vm reconciler backstops anything missed here. Shared by
+// user-initiated deletes and the auto-delete reaper so the two paths cannot
+// diverge.
+func (h *Handlers) teardownDestroyedSandbox(ctx context.Context, sandboxID uuid.UUID, hostID string, basePath *string, templateID pgtype.UUID) {
+	// The revocation row is committed with the delete claim; fan it out to the
 	// host so the daemon refuses the JWT now. Best-effort — bootstrap re-fans
 	// from the persisted row on restart.
-	go h.fanoutSandboxRevoke(context.Background(), sandboxID, sandbox.HostID)
+	go h.fanoutSandboxRevoke(context.Background(), sandboxID, hostID)
 
 	// Tear down the VM best-effort and unconditionally: a sandbox claimed from a
 	// stale transition or a 'failed' state may still hold a VM, run dir, and netns
 	// that only DestroyInstance reclaims (an absent VM is an idempotent no-op). A
 	// failure here is reconciled by the vm reconciler, so a vmd hiccup must not fail
 	// an already-committed delete.
-	if vmd, lookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID); lookupErr != nil {
+	if vmd, lookupErr := h.vmdForHost(ctx, hostID); lookupErr != nil {
 		log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
 	} else {
-		vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
+		vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
 		if derr := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); derr != nil && !isVMDNotFound(derr) {
 			log.Warn().Err(derr).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
 		}
@@ -995,31 +1011,26 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	// Best-effort cleanup of pause snapshots. Failures are logged but
 	// don't fail the delete — manual cleanup may be required if vmd was
 	// unreachable.
-	h.cleanupSandboxSnapshots(c.Request.Context(), sandboxID, sandbox.HostID)
+	h.cleanupSandboxSnapshots(ctx, sandboxID, hostID)
 
 	// Best-effort GC of the per-build artifact dir if this sandbox was the
 	// last reference and the template has since moved to a newer build.
-	h.gcOldBuildArtifacts(c.Request.Context(), sandbox)
-
-	// DestroySandbox's CTE atomically closed the open sandbox_active_interval row.
-	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "deleted", "success", &sandbox.Name, nil, nil)
-	h.capture(c, "sandbox_deleted", map[string]any{"sandbox_id": sandboxID.String()})
-
-	c.Status(http.StatusNoContent)
+	h.gcOldBuildArtifacts(ctx, hostID, basePath, templateID)
 }
 
-// gcOldBuildArtifacts deletes the per-build dir if this sandbox was the
-// last reference and the template has moved on. Best-effort.
-func (h *Handlers) gcOldBuildArtifacts(reqCtx context.Context, sandbox db.Sandbox) {
-	if sandbox.BasePath == nil || !sandbox.TemplateID.Valid {
+// gcOldBuildArtifacts deletes the per-build dir if the just-destroyed sandbox
+// at sandboxBasePath was the last reference and the template has moved on.
+// Best-effort.
+func (h *Handlers) gcOldBuildArtifacts(reqCtx context.Context, hostID string, sandboxBasePath *string, sandboxTemplateID pgtype.UUID) {
+	if sandboxBasePath == nil || !sandboxTemplateID.Valid {
 		return
 	}
-	basePath := *sandbox.BasePath
+	basePath := *sandboxBasePath
 	buildID := filepath.Base(filepath.Dir(basePath))
 	if buildID == "" || buildID == "." || buildID == string(filepath.Separator) {
 		return
 	}
-	templateID := uuid.UUID(sandbox.TemplateID.Bytes).String()
+	templateID := uuid.UUID(sandboxTemplateID.Bytes).String()
 
 	gcCtx, cancel := context.WithTimeout(reqCtx, 10*time.Second)
 	defer cancel()
@@ -1034,7 +1045,7 @@ func (h *Handlers) gcOldBuildArtifacts(reqCtx context.Context, sandbox db.Sandbo
 	}
 	// Team-blind: sandbox's team may not own the template (system templates),
 	// so GetTemplateForOwner would falsely report "not in use" → over-delete.
-	tplBase, err := h.DB.GetTemplateBasePath(gcCtx, sandbox.TemplateID.Bytes)
+	tplBase, err := h.DB.GetTemplateBasePath(gcCtx, sandboxTemplateID.Bytes)
 	if err != nil {
 		log.Warn().Err(err).Str("base_path", basePath).Msg("gc: GetTemplateBasePath")
 		return
@@ -1043,7 +1054,7 @@ func (h *Handlers) gcOldBuildArtifacts(reqCtx context.Context, sandbox db.Sandbo
 		return
 	}
 
-	vmd, err := h.vmdForHost(gcCtx, sandbox.HostID)
+	vmd, err := h.vmdForHost(gcCtx, hostID)
 	if err != nil {
 		return
 	}
@@ -1111,19 +1122,17 @@ type createSandboxRequest struct {
 	FromTemplate *string               `json:"from_template,omitempty"`
 	Network      *networkConfigRequest `json:"network,omitempty"`
 
-	// TimeoutSeconds is a hard lifetime cap in seconds, measured from
-	// created_at. When set, the reaper pauses the sandbox that many seconds
-	// after creation if it is still active. Already-paused sandboxes are left
-	// alone. Matches the user intent "stop this sandbox in N seconds so it
-	// cannot burn resources indefinitely."
-	//
-	// The field name includes "_seconds" so the unit is obvious at every
-	// call site without having to read the docs.
-	//
-	// Nil means no cap — the sandbox lives until explicitly paused or
-	// deleted (this is the default philosophy of the platform: sandboxes
-	// don't die on their own).
+	// TimeoutSeconds auto-pauses the sandbox after it has been active this
+	// long. The window tracks the current active session (re-armed on each
+	// resume), not creation time. Nil means no timeout — the sandbox lives
+	// until explicitly paused or deleted. Settable at create and via PATCH.
 	TimeoutSeconds *int32 `json:"timeout_seconds,omitempty"`
+
+	// AutoDeleteSeconds deletes the sandbox once it has been continuously
+	// paused this long. Re-arms on every pause, cancelled by resume; 0 means
+	// delete as soon as it pauses; nil (default) keeps paused sandboxes
+	// forever. Also settable after creation via PATCH /sandboxes/:id.
+	AutoDeleteSeconds *int32 `json:"auto_delete_seconds,omitempty"`
 
 	// Metadata is a flat string→string map of user-supplied tags that get
 	// attached to the sandbox at creation. Updatable after creation via
@@ -1154,18 +1163,23 @@ type createSandboxRequest struct {
 type sandboxResponse struct {
 	// ID is the public sandbox ID: a bare UUID today, sb-<region>-<uuid>
 	// once SANDBOX_ID_REGION is set on the cell (see publicid.go).
-	ID             string                 `json:"id"`
-	Name           string                 `json:"name"`
-	Status         string                 `json:"status"`
-	VcpuCount      int32                  `json:"vcpu_count"`
-	MemoryMib      int32                  `json:"memory_mib"`
-	AccessToken    string                 `json:"access_token,omitempty"`
-	SnapshotID     *uuid.UUID             `json:"snapshot_id,omitempty"`
-	CreatedAt      time.Time              `json:"created_at"`
-	TimeoutSeconds *int32                 `json:"timeout_seconds,omitempty"`
-	Network        *networkConfigRequest  `json:"network,omitempty"`
-	Metadata       map[string]string      `json:"metadata"`
-	Secrets        []sandboxSecretBinding `json:"secrets,omitempty"`
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Status            string     `json:"status"`
+	VcpuCount         int32      `json:"vcpu_count"`
+	MemoryMib         int32      `json:"memory_mib"`
+	AccessToken       string     `json:"access_token,omitempty"`
+	SnapshotID        *uuid.UUID `json:"snapshot_id,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+	TimeoutSeconds    *int32     `json:"timeout_seconds,omitempty"`
+	AutoDeleteSeconds *int32     `json:"auto_delete_seconds,omitempty"`
+	// AutoDeleteAt is the concrete deletion deadline. Present only while the
+	// sandbox is paused with an auto-delete window configured, so clients can
+	// see exactly when the sandbox will be removed.
+	AutoDeleteAt *time.Time             `json:"auto_delete_at,omitempty"`
+	Network      *networkConfigRequest  `json:"network,omitempty"`
+	Metadata     map[string]string      `json:"metadata"`
+	Secrets      []sandboxSecretBinding `json:"secrets,omitempty"`
 }
 
 // sandboxSecretBinding mirrors one (env_key → secret) binding on a sandbox.
@@ -1193,6 +1207,12 @@ func (h *Handlers) sandboxToResponse(s db.Sandbox) sandboxResponse {
 	}
 	if s.TimeoutSeconds != nil {
 		resp.TimeoutSeconds = s.TimeoutSeconds
+	}
+	if s.AutoDeleteSeconds != nil {
+		resp.AutoDeleteSeconds = s.AutoDeleteSeconds
+	}
+	if s.AutoDeleteAt.Valid {
+		resp.AutoDeleteAt = &s.AutoDeleteAt.Time
 	}
 	if len(s.NetworkConfig) > 0 {
 		var stored struct {
@@ -1471,19 +1491,13 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	}
 
-	// timeout_seconds validation — 1 second to 7 days. Must be positive
-	// (zero would mean "destroy immediately" which makes no sense). The
-	// 7-day cap is a safety ceiling so runaway "I set timeout=huge and
-	// forgot" sandboxes cannot live forever, while still supporting
-	// genuinely long-running workloads. Per-team overrides can come later.
-	const maxTimeoutSeconds int32 = 7 * 24 * 3600 // 7 days
-	if req.TimeoutSeconds != nil {
-		if *req.TimeoutSeconds < 1 || *req.TimeoutSeconds > maxTimeoutSeconds {
-			respondErrorMsg(c, "bad_request",
-				fmt.Sprintf("timeout_seconds must be between 1 and %d (7 days)", maxTimeoutSeconds),
-				http.StatusBadRequest)
-			return
-		}
+	if err := validateTimeoutSeconds(req.TimeoutSeconds); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateAutoDeleteSeconds(req.AutoDeleteSeconds); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	// Validate network rules up front so we fail before doing any DB or VMD work.
@@ -1648,39 +1662,41 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			// INSERT succeeds) or completes before us (we lose, 0 rows back).
 			// Pin artifact paths so a later rebuild can't shift them.
 			return q.CreateSandboxFromTemplate(insertCtx, db.CreateSandboxFromTemplateParams{
-				ID:             sandboxID,
-				TeamID:         teamID,
-				Name:           req.Name,
-				Status:         db.SandboxStatusStarting,
-				VcpuCount:      1, // placeholders; real values land via ActivateSandbox
-				MemoryMib:      1,
-				HostID:         hostID,
-				TimeoutSeconds: req.TimeoutSeconds,
-				Metadata:       metadataJSON,
-				ID_2:           uuid.UUID(templateID.Bytes),
-				TeamID_2:       teamID,
-				TeamID_3:       h.systemTeamID(),
-				SnapshotPath:   nullableStr(snapshotPath),
-				MemPath:        nullableStr(snapshotMemPath),
-				BasePath:       nullableStr(basePath),
-				DeltaPath:      nullableStr(deltaPath),
+				ID:                sandboxID,
+				TeamID:            teamID,
+				Name:              req.Name,
+				Status:            db.SandboxStatusStarting,
+				VcpuCount:         1, // placeholders; real values land via ActivateSandbox
+				MemoryMib:         1,
+				HostID:            hostID,
+				TimeoutSeconds:    req.TimeoutSeconds,
+				AutoDeleteSeconds: req.AutoDeleteSeconds,
+				Metadata:          metadataJSON,
+				ID_2:              uuid.UUID(templateID.Bytes),
+				TeamID_2:          teamID,
+				TeamID_3:          h.systemTeamID(),
+				SnapshotPath:      nullableStr(snapshotPath),
+				MemPath:           nullableStr(snapshotMemPath),
+				BasePath:          nullableStr(basePath),
+				DeltaPath:         nullableStr(deltaPath),
 			})
 		}
 		return q.CreateSandbox(insertCtx, db.CreateSandboxParams{
-			ID:             sandboxID,
-			TeamID:         teamID,
-			Name:           req.Name,
-			Status:         db.SandboxStatusStarting,
-			VcpuCount:      1,
-			MemoryMib:      1,
-			HostID:         hostID,
-			TimeoutSeconds: req.TimeoutSeconds,
-			Metadata:       metadataJSON,
-			TemplateID:     pgtype.UUID{Valid: false},
-			SnapshotPath:   nil,
-			MemPath:        nil,
-			BasePath:       nil,
-			DeltaPath:      nil,
+			ID:                sandboxID,
+			TeamID:            teamID,
+			Name:              req.Name,
+			Status:            db.SandboxStatusStarting,
+			VcpuCount:         1,
+			MemoryMib:         1,
+			HostID:            hostID,
+			TimeoutSeconds:    req.TimeoutSeconds,
+			AutoDeleteSeconds: req.AutoDeleteSeconds,
+			Metadata:          metadataJSON,
+			TemplateID:        pgtype.UUID{Valid: false},
+			SnapshotPath:      nil,
+			MemPath:           nil,
+			BasePath:          nil,
+			DeltaPath:         nil,
 		})
 	}
 	// insertWithBindings writes the sandbox row, and its secret bindings in the
@@ -2238,16 +2254,42 @@ func (h *Handlers) ListSandboxFiles(c *gin.Context) {
 // with 400. This guards against clients sending empty bodies by mistake and
 // silently no-opping.
 //
-// Patchable fields: `network` and `metadata`. Adding more in the future is
-// additive — declare a new pointer field and dispatch on its non-nil-ness.
+// Patchable fields: `network`, `metadata`, and `auto_delete_seconds`. Adding
+// more in the future is additive — declare a new pointer field and dispatch on
+// its non-nil-ness (or optionalInt32 when JSON null must mean "clear", which a
+// plain pointer can't distinguish from "absent").
 type patchSandboxRequest struct {
-	Network  *networkConfigRequest `json:"network,omitempty"`
-	Metadata map[string]string     `json:"metadata,omitempty"`
+	Network           *networkConfigRequest `json:"network,omitempty"`
+	Metadata          map[string]string     `json:"metadata,omitempty"`
+	AutoDeleteSeconds optionalInt32         `json:"auto_delete_seconds,omitempty"`
+	TimeoutSeconds    optionalInt32         `json:"timeout_seconds,omitempty"`
+}
+
+// optionalInt32 is a tri-state JSON field: absent (Set=false), explicit null
+// (Set=true, Value=nil), or a number (Set=true, Value=&n). UnmarshalJSON only
+// runs when the key is present, which is what distinguishes absent from null.
+type optionalInt32 struct {
+	Set   bool
+	Value *int32
+}
+
+func (o *optionalInt32) UnmarshalJSON(b []byte) error {
+	o.Set = true
+	if string(b) == "null" {
+		return nil
+	}
+	return json.Unmarshal(b, &o.Value)
 }
 
 // PatchSandbox applies a partial update to a sandbox.
-// - network: replaces egress rules; sandbox must be active.
-// - metadata: replaces metadata tags; can be patched in any non-deleted state.
+//   - network: replaces egress rules; sandbox must be active.
+//   - metadata: replaces metadata tags; can be patched in any non-deleted state.
+//   - auto_delete_seconds: sets/clears the paused-GC window; any non-deleted
+//     state. On an already-paused sandbox the deadline is armed from now, so
+//     the caller always gets the full window they asked for.
+//   - timeout_seconds: sets/clears the auto-pause timeout; any non-deleted
+//     state. Evaluated against the current active session on the next reaper
+//     tick, so lowering it below elapsed session time pauses promptly.
 func (h *Handlers) PatchSandbox(c *gin.Context) {
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {
@@ -2269,9 +2311,22 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 	}
 
 	// Reject empty patches.
-	if body.Network == nil && body.Metadata == nil {
-		respondErrorMsg(c, "bad_request", "patch body must include at least one field (network, metadata)", http.StatusBadRequest)
+	if body.Network == nil && body.Metadata == nil && !body.AutoDeleteSeconds.Set && !body.TimeoutSeconds.Set {
+		respondErrorMsg(c, "bad_request", "patch body must include at least one field (network, metadata, auto_delete_seconds, timeout_seconds)", http.StatusBadRequest)
 		return
+	}
+
+	if body.AutoDeleteSeconds.Set {
+		if err := validateAutoDeleteSeconds(body.AutoDeleteSeconds.Value); err != nil {
+			respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if body.TimeoutSeconds.Set {
+		if err := validateTimeoutSeconds(body.TimeoutSeconds.Value); err != nil {
+			respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
 
 	if body.Network != nil {
@@ -2389,7 +2444,79 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorIDFromContext(c), "sandbox", "metadata_updated", "success", &sandbox.Name, nil, nil)
 	}
 
+	if body.AutoDeleteSeconds.Set {
+		if !h.applyRowsAffectedPatch(c, sandbox, teamID, "auto_delete_updated", func() (int64, error) {
+			return h.DB.UpdateSandboxAutoDelete(c.Request.Context(), db.UpdateSandboxAutoDeleteParams{
+				ID:                sandboxID,
+				AutoDeleteSeconds: body.AutoDeleteSeconds.Value,
+				TeamID:            teamID,
+			})
+		}) {
+			return
+		}
+	}
+
+	if body.TimeoutSeconds.Set {
+		if !h.applyRowsAffectedPatch(c, sandbox, teamID, "timeout_updated", func() (int64, error) {
+			return h.DB.UpdateSandboxTimeout(c.Request.Context(), db.UpdateSandboxTimeoutParams{
+				ID:             sandboxID,
+				TimeoutSeconds: body.TimeoutSeconds.Value,
+				TeamID:         teamID,
+			})
+		}) {
+			return
+		}
+	}
+
 	c.Status(http.StatusNoContent)
+}
+
+// applyRowsAffectedPatch runs a rows-affected sandbox update and maps the
+// result: 500 on error, 404 on 0 rows (sandbox deleted between the read and the
+// update), activity log on success. Returns false if a response was written.
+func (h *Handlers) applyRowsAffectedPatch(c *gin.Context, sandbox db.Sandbox, teamID uuid.UUID, action string, exec func() (int64, error)) bool {
+	rows, err := exec()
+	if err != nil {
+		log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Str("patch", action).Msg("DB sandbox patch failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+	if rows == 0 {
+		respondError(c, ErrSandboxNotFound)
+		return false
+	}
+	h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorIDFromContext(c), "sandbox", action, "success", &sandbox.Name, nil, nil)
+	return true
+}
+
+// maxAutoDeleteSeconds caps the auto-delete window at 30 days — generous for
+// any delayed-cleanup flow while keeping the deadline arithmetic within sane
+// bounds.
+const maxAutoDeleteSeconds int32 = 30 * 24 * 3600
+
+// maxTimeoutSeconds caps the auto-pause timeout at 7 days — a safety ceiling
+// so runaway "I set timeout=huge and forgot" sandboxes cannot stay active
+// forever, while still supporting genuinely long-running workloads.
+const maxTimeoutSeconds int32 = 7 * 24 * 3600
+
+// validateTimeoutSeconds bounds-checks a timeout_seconds value from create or
+// patch. Nil is valid — it means no auto-pause. Zero is rejected: "pause
+// immediately" is not a meaningful timeout.
+func validateTimeoutSeconds(v *int32) error {
+	if v != nil && (*v < 1 || *v > maxTimeoutSeconds) {
+		return fmt.Errorf("timeout_seconds must be between 1 and %d (7 days), or null to disable", maxTimeoutSeconds)
+	}
+	return nil
+}
+
+// validateAutoDeleteSeconds bounds-checks an auto_delete_seconds value from
+// create or patch. Nil is valid — it means auto-delete is disabled. Zero is
+// valid and means "delete as soon as the sandbox pauses".
+func validateAutoDeleteSeconds(v *int32) error {
+	if v != nil && (*v < 0 || *v > maxAutoDeleteSeconds) {
+		return fmt.Errorf("auto_delete_seconds must be between 0 and %d (30 days), or null to disable", maxAutoDeleteSeconds)
+	}
+	return nil
 }
 
 // bindJSONStrict decodes the request body into v and rejects unknown fields.

--- a/internal/api/handlers_auto_delete_test.go
+++ b/internal/api/handlers_auto_delete_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The PATCH contract hangs on the absent/null/value tri-state: absent leaves
+// the setting untouched, null clears it, a number sets it. A plain pointer
+// can't represent all three, so verify the wrapper does.
+func TestOptionalInt32TriState(t *testing.T) {
+	var req patchSandboxRequest
+	if err := json.Unmarshal([]byte(`{"metadata":{}}`), &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.AutoDeleteSeconds.Set {
+		t.Error("absent field must not be Set")
+	}
+
+	req = patchSandboxRequest{}
+	if err := json.Unmarshal([]byte(`{"auto_delete_seconds":null}`), &req); err != nil {
+		t.Fatal(err)
+	}
+	if !req.AutoDeleteSeconds.Set || req.AutoDeleteSeconds.Value != nil {
+		t.Errorf("null must be Set with nil Value, got %+v", req.AutoDeleteSeconds)
+	}
+
+	req = patchSandboxRequest{}
+	if err := json.Unmarshal([]byte(`{"auto_delete_seconds":3600}`), &req); err != nil {
+		t.Fatal(err)
+	}
+	if !req.AutoDeleteSeconds.Set || req.AutoDeleteSeconds.Value == nil || *req.AutoDeleteSeconds.Value != 3600 {
+		t.Errorf("3600 must be Set with Value=3600, got %+v", req.AutoDeleteSeconds)
+	}
+
+	if err := json.Unmarshal([]byte(`{"auto_delete_seconds":"soon"}`), &req); err == nil {
+		t.Error("non-numeric value must fail to bind")
+	}
+}
+
+func TestValidateAutoDeleteSeconds(t *testing.T) {
+	for _, v := range []int32{0, 1, 3600, maxAutoDeleteSeconds} {
+		if err := validateAutoDeleteSeconds(&v); err != nil {
+			t.Errorf("%d should be valid: %v", v, err)
+		}
+	}
+	if err := validateAutoDeleteSeconds(nil); err != nil {
+		t.Errorf("nil (disabled) should be valid: %v", err)
+	}
+	for _, v := range []int32{-1, maxAutoDeleteSeconds + 1} {
+		if err := validateAutoDeleteSeconds(&v); err == nil {
+			t.Errorf("%d should be rejected", v)
+		}
+	}
+}
+
+func TestValidateTimeoutSeconds(t *testing.T) {
+	for _, v := range []int32{1, 3600, maxTimeoutSeconds} {
+		if err := validateTimeoutSeconds(&v); err != nil {
+			t.Errorf("%d should be valid: %v", v, err)
+		}
+	}
+	if err := validateTimeoutSeconds(nil); err != nil {
+		t.Errorf("nil (disabled) should be valid: %v", err)
+	}
+	for _, v := range []int32{0, -1, maxTimeoutSeconds + 1} {
+		if err := validateTimeoutSeconds(&v); err == nil {
+			t.Errorf("%d should be rejected", v)
+		}
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -159,10 +159,8 @@ func (emptyRows) RawValues() [][]byte                          { return nil }
 func (emptyRows) Conn() *pgx.Conn                              { return nil }
 
 // sandboxRow returns a mockRow that populates a Sandbox from GetSandbox's Scan
-// call (16 destination pointers matching the column order in sqlc-generated
-// queries: ID, TeamID, Name, Status, VcpuCount, MemoryMib, HostID, IpAddress,
-// Pid, SnapshotID, CreatedAt, UpdatedAt, DestroyedAt, NetworkConfig,
-// TimeoutSeconds, Metadata).
+// call, with destination pointers matching the sandbox column order in
+// sqlc-generated queries (see db.Sandbox field order in internal/db/models.go).
 func sandboxRow(s db.Sandbox) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
 		*dest[0].(*uuid.UUID) = s.ID
@@ -181,6 +179,14 @@ func sandboxRow(s db.Sandbox) *mockRow {
 		*dest[13].(*[]byte) = s.NetworkConfig
 		*dest[14].(**int32) = s.TimeoutSeconds
 		*dest[15].(*[]byte) = s.Metadata
+		*dest[16].(*pgtype.UUID) = s.TemplateID
+		*dest[17].(**string) = s.SnapshotPath
+		*dest[18].(**string) = s.MemPath
+		*dest[19].(**string) = s.BasePath
+		*dest[20].(**string) = s.DeltaPath
+		*dest[21].(*int32) = s.DiskMib
+		*dest[22].(**int32) = s.AutoDeleteSeconds
+		*dest[23].(*pgtype.Timestamptz) = s.AutoDeleteAt
 		return nil
 	}}
 }
@@ -1132,11 +1138,11 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):
@@ -1209,11 +1215,11 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
 			case strings.Contains(sql, "INSERT INTO snapshot"): // FinalizePause
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -34,9 +34,9 @@ func DefaultReaperConfig() ReaperConfig {
 }
 
 // StartTimeoutReaper launches a background goroutine that periodically
-// pauses active sandboxes whose `timeout_seconds` hard cap has elapsed since
-// their creation. The hard cap is measured from `created_at`. Already-paused
-// sandboxes are left alone — they are already stopped.
+// pauses active sandboxes whose `timeout_seconds` has elapsed. The window
+// tracks the current active session (re-armed on each resume), not total
+// lifetime. Already-paused sandboxes are left alone — they are already stopped.
 //
 // The reaper exits cleanly when ctx is cancelled. Call once at control
 // plane startup with the process-lifetime context.
@@ -75,6 +75,10 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
 		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
 		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
+		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx) })
+		// Auto-delete runs after the DB-only sweeps (interval/revocation/
+		// snapshot) so a slow host during its batch teardown can't delay them.
+		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism) })
 	}
 
 	// Run once immediately so a control plane restart does not delay
@@ -131,6 +135,29 @@ func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
 	}
 }
 
+// dispatchBounded runs fn for each item with at most `parallelism` concurrent
+// goroutines, stopping dispatch early on ctx cancellation and waiting for all
+// started goroutines before returning.
+func dispatchBounded[T any](ctx context.Context, items []T, parallelism int, fn func(T)) {
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+dispatch:
+	for _, item := range items {
+		select {
+		case <-ctx.Done():
+			break dispatch
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(item T) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fn(item)
+		}(item)
+	}
+	wg.Wait()
+}
+
 func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism int) {
 	// Atomically claim expired active sandboxes and mark them 'pausing' in one
 	// CTE+UPDATE. FOR UPDATE SKIP LOCKED inside the query ensures that
@@ -151,28 +178,79 @@ func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism in
 
 	log.Info().Int("count", len(expired)).Msg("reaper: pausing expired sandboxes")
 
-	sem := make(chan struct{}, parallelism)
-	var wg sync.WaitGroup
+	dispatchBounded(ctx, expired, parallelism, func(sbx db.ClaimExpiredSandboxesRow) {
+		h.pauseExpired(ctx, sbx)
+	})
+}
 
-dispatch:
-	for _, sbx := range expired {
-		// Labeled break: a plain break inside the select exits only the
-		// select, not the for loop.
-		select {
-		case <-ctx.Done():
-			break dispatch
-		case sem <- struct{}{}:
-		}
+// sweepOrphanedSnapshotRows deletes snapshot rows for long-destroyed
+// sandboxes — the backstop for destroy teardown that never ran (crash or
+// shutdown between the soft-delete claim and cleanupSandboxSnapshots).
+// Row deletion also unblocks the vm reconciler's disk scan, which reclaims
+// the now-orphaned files.
+func (h *Handlers) sweepOrphanedSnapshotRows(ctx context.Context) {
+	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	n, err := h.DB.DeleteSnapshotsOfDestroyedSandboxes(qctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("reaper: DeleteSnapshotsOfDestroyedSandboxes failed")
+		return
+	}
+	if n > 0 {
+		log.Warn().Int64("deleted", n).Msg("reaper: removed snapshot rows orphaned by unfinished destroy teardown")
+	}
+}
 
-		wg.Add(1)
-		go func(sbx db.ClaimExpiredSandboxesRow) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			h.pauseExpired(ctx, sbx)
-		}(sbx)
+// reapAutoDeleteOnce deletes paused sandboxes whose auto-delete deadline has
+// passed. ClaimAutoDeleteSandboxes soft-deletes the rows (revocation written,
+// intervals closed) in one guarded statement, so everything after the claim is
+// best-effort teardown of VM state and artifacts — same contract as the
+// user-initiated DeleteSandbox, where the vm reconciler backstops any teardown
+// step that fails.
+func (h *Handlers) reapAutoDeleteOnce(ctx context.Context, batchSize int32, parallelism int) {
+	queryCtx, queryCancel := context.WithTimeout(ctx, 10*time.Second)
+	due, err := h.DB.ClaimAutoDeleteSandboxes(queryCtx, db.ClaimAutoDeleteSandboxesParams{
+		BatchSize:           batchSize,
+		RevocationExpiresAt: time.Now().Add(SecretsJWTLifetime),
+	})
+	queryCancel()
+	if err != nil {
+		log.Error().Err(err).Msg("reaper: ClaimAutoDeleteSandboxes failed")
+		return
 	}
 
-	wg.Wait()
+	if len(due) == 0 {
+		return
+	}
+
+	log.Info().Int("count", len(due)).Msg("reaper: deleting expired paused sandboxes")
+
+	dispatchBounded(ctx, due, parallelism, func(sbx db.ClaimAutoDeleteSandboxesRow) {
+		h.teardownAutoDeleted(ctx, sbx)
+	})
+}
+
+// autoDeleteTeardownTimeout bounds one sandbox's teardown in the reaper.
+// The VMD calls inside carry their own timeouts, but the snapshot DB calls
+// do not — without this umbrella a hung query would pin a dispatch slot and
+// wedge the reaper loop on wg.Wait.
+const autoDeleteTeardownTimeout = 2 * time.Minute
+
+// teardownAutoDeleted reclaims VM state for one sandbox already soft-deleted
+// by ClaimAutoDeleteSandboxes, via the same teardown path as DeleteSandbox.
+func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDeleteSandboxesRow) {
+	l := log.With().
+		Str("sandbox_id", sbx.ID.String()).
+		Str("team_id", sbx.TeamID.String()).
+		Str("name", sbx.Name).
+		Logger()
+
+	tctx, cancel := context.WithTimeout(ctx, autoDeleteTeardownTimeout)
+	defer cancel()
+	h.teardownDestroyedSandbox(tctx, sbx.ID, sbx.HostID, sbx.BasePath, sbx.TemplateID)
+
+	l.Info().Msg("reaper: sandbox auto-deleted after paused window elapsed")
+	h.logSandboxActivity(tctx, sbx.ID, sbx.TeamID, nil, "sandbox", "auto_deleted", "success", &sbx.Name, nil, nil)
 }
 
 // pauseExpired pauses one sandbox that was atomically claimed by

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -423,16 +423,18 @@ type Sandbox struct {
 	UpdatedAt     time.Time          `json:"updated_at"`
 	DestroyedAt   pgtype.Timestamptz `json:"destroyed_at"`
 	NetworkConfig []byte             `json:"network_config"`
-	// Hard lifetime cap in seconds from created_at. NULL = no cap. The reaper destroys the sandbox when now() > created_at + (timeout_seconds || ' seconds')::interval, regardless of state (active, paused, idle).
+	// Auto-pause timeout in seconds, evaluated against the current active session (re-armed on each resume). NULL = no timeout. Settable at create and via PATCH. The reaper pauses the sandbox on expiry; it does not delete it.
 	TimeoutSeconds *int32 `json:"timeout_seconds"`
 	// User-supplied flat string→string tags attached at creation. Immutable. Filterable on list endpoints via jsonb @> containment. Always non-null; an absent value is the empty object {}, never NULL.
-	Metadata     []byte      `json:"metadata"`
-	TemplateID   pgtype.UUID `json:"template_id"`
-	SnapshotPath *string     `json:"snapshot_path"`
-	MemPath      *string     `json:"mem_path"`
-	BasePath     *string     `json:"base_path"`
-	DeltaPath    *string     `json:"delta_path"`
-	DiskMib      int32       `json:"disk_mib"`
+	Metadata          []byte             `json:"metadata"`
+	TemplateID        pgtype.UUID        `json:"template_id"`
+	SnapshotPath      *string            `json:"snapshot_path"`
+	MemPath           *string            `json:"mem_path"`
+	BasePath          *string            `json:"base_path"`
+	DeltaPath         *string            `json:"delta_path"`
+	DiskMib           int32              `json:"disk_mib"`
+	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
 }
 
 type SandboxActiveInterval struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -87,7 +87,7 @@ WITH paused AS (
     AND sandbox.team_id = $2
     AND sandbox.destroyed_at IS NULL
     AND sandbox.status = 'active'
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
 ),
 closed_interval AS (
   UPDATE sandbox_active_interval
@@ -103,7 +103,7 @@ closed_billing_compute AS (
     AND ended_at IS NULL
   RETURNING sandbox_id
 )
-SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib
+SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at
 FROM paused p
 LEFT JOIN closed_interval ci ON ci.sandbox_id = p.id
 `
@@ -114,28 +114,30 @@ type BeginPauseParams struct {
 }
 
 type BeginPauseRow struct {
-	ID             uuid.UUID          `json:"id"`
-	TeamID         uuid.UUID          `json:"team_id"`
-	Name           string             `json:"name"`
-	Status         SandboxStatus      `json:"status"`
-	VcpuCount      int32              `json:"vcpu_count"`
-	MemoryMib      int32              `json:"memory_mib"`
-	HostID         string             `json:"host_id"`
-	IpAddress      *netip.Addr        `json:"ip_address"`
-	Pid            *int32             `json:"pid"`
-	SnapshotID     pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt      time.Time          `json:"created_at"`
-	UpdatedAt      time.Time          `json:"updated_at"`
-	DestroyedAt    pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig  []byte             `json:"network_config"`
-	TimeoutSeconds *int32             `json:"timeout_seconds"`
-	Metadata       []byte             `json:"metadata"`
-	TemplateID     pgtype.UUID        `json:"template_id"`
-	SnapshotPath   *string            `json:"snapshot_path"`
-	MemPath        *string            `json:"mem_path"`
-	BasePath       *string            `json:"base_path"`
-	DeltaPath      *string            `json:"delta_path"`
-	DiskMib        int32              `json:"disk_mib"`
+	ID                uuid.UUID          `json:"id"`
+	TeamID            uuid.UUID          `json:"team_id"`
+	Name              string             `json:"name"`
+	Status            SandboxStatus      `json:"status"`
+	VcpuCount         int32              `json:"vcpu_count"`
+	MemoryMib         int32              `json:"memory_mib"`
+	HostID            string             `json:"host_id"`
+	IpAddress         *netip.Addr        `json:"ip_address"`
+	Pid               *int32             `json:"pid"`
+	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig     []byte             `json:"network_config"`
+	TimeoutSeconds    *int32             `json:"timeout_seconds"`
+	Metadata          []byte             `json:"metadata"`
+	TemplateID        pgtype.UUID        `json:"template_id"`
+	SnapshotPath      *string            `json:"snapshot_path"`
+	MemPath           *string            `json:"mem_path"`
+	BasePath          *string            `json:"base_path"`
+	DeltaPath         *string            `json:"delta_path"`
+	DiskMib           int32              `json:"disk_mib"`
+	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
 }
 
 // Atomic ownership + state check + transition to 'pausing' AND close of any
@@ -174,15 +176,17 @@ func (q *Queries) BeginPause(ctx context.Context, arg BeginPauseParams) (BeginPa
 		&i.BasePath,
 		&i.DeltaPath,
 		&i.DiskMib,
+		&i.AutoDeleteSeconds,
+		&i.AutoDeleteAt,
 	)
 	return i, err
 }
 
 const beginResume = `-- name: BeginResume :one
 UPDATE sandbox
-SET status = 'resuming', updated_at = now()
+SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
 `
 
 type BeginResumeParams struct {
@@ -220,8 +224,112 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 		&i.BasePath,
 		&i.DeltaPath,
 		&i.DiskMib,
+		&i.AutoDeleteSeconds,
+		&i.AutoDeleteAt,
 	)
 	return i, err
+}
+
+const claimAutoDeleteSandboxes = `-- name: ClaimAutoDeleteSandboxes :many
+WITH due AS (
+  SELECT s.id
+  FROM sandbox s
+  WHERE s.destroyed_at IS NULL
+    AND s.status = 'paused'
+    AND s.auto_delete_at IS NOT NULL
+    AND s.auto_delete_at < now()
+  ORDER BY s.auto_delete_at ASC
+  LIMIT $1
+  FOR UPDATE OF s SKIP LOCKED
+),
+destroyed AS (
+  UPDATE sandbox
+  SET destroyed_at = now(), status = 'deleted', updated_at = now()
+  FROM due
+  WHERE sandbox.id = due.id
+  RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.host_id,
+            sandbox.base_path, sandbox.template_id
+),
+revoked AS (
+  INSERT INTO sandbox_revocation (sandbox_id, expires_at)
+  SELECT id, $2 FROM destroyed
+  ON CONFLICT (sandbox_id) DO NOTHING
+),
+closed_compute AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_billing_compute AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+),
+closed_storage AS (
+  UPDATE sandbox_storage_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'deleted'
+  WHERE sandbox_id IN (SELECT id FROM destroyed)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT d.id, d.team_id, d.name, d.host_id, d.base_path, d.template_id
+FROM destroyed d
+`
+
+type ClaimAutoDeleteSandboxesParams struct {
+	BatchSize           int32     `json:"batch_size"`
+	RevocationExpiresAt time.Time `json:"revocation_expires_at"`
+}
+
+type ClaimAutoDeleteSandboxesRow struct {
+	ID         uuid.UUID   `json:"id"`
+	TeamID     uuid.UUID   `json:"team_id"`
+	Name       string      `json:"name"`
+	HostID     string      `json:"host_id"`
+	BasePath   *string     `json:"base_path"`
+	TemplateID pgtype.UUID `json:"template_id"`
+}
+
+// Atomically soft-deletes paused sandboxes whose auto-delete deadline has
+// passed. Deliberately narrower than DestroySandbox: it claims from 'paused'
+// only, with the deadline re-checked under the row lock, so a concurrent
+// BeginResume (also guarded on 'paused') and this claim can never both win
+// the same row. FOR UPDATE SKIP LOCKED lets concurrent reaper replicas skip
+// in-flight rows.
+//
+// Mirrors DestroySandbox's side effects: writes the revocation row and closes
+// any open active/billing/storage intervals in the same statement, so a crash
+// after the claim can't strand a deleted sandbox with a live JWT or an open
+// interval. Returns the columns the caller needs for VM/artifact teardown.
+func (q *Queries) ClaimAutoDeleteSandboxes(ctx context.Context, arg ClaimAutoDeleteSandboxesParams) ([]ClaimAutoDeleteSandboxesRow, error) {
+	rows, err := q.db.Query(ctx, claimAutoDeleteSandboxes, arg.BatchSize, arg.RevocationExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ClaimAutoDeleteSandboxesRow{}
+	for rows.Next() {
+		var i ClaimAutoDeleteSandboxesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.Name,
+			&i.HostID,
+			&i.BasePath,
+			&i.TemplateID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const claimExpiredSandboxes = `-- name: ClaimExpiredSandboxes :many
@@ -370,29 +478,30 @@ func (q *Queries) CountSandboxesByTeamPaged(ctx context.Context, arg CountSandbo
 }
 
 const createSandbox = `-- name: CreateSandbox :one
-INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib
+INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
 `
 
 type CreateSandboxParams struct {
-	ID             uuid.UUID     `json:"id"`
-	TeamID         uuid.UUID     `json:"team_id"`
-	Name           string        `json:"name"`
-	Status         SandboxStatus `json:"status"`
-	VcpuCount      int32         `json:"vcpu_count"`
-	MemoryMib      int32         `json:"memory_mib"`
-	HostID         string        `json:"host_id"`
-	IpAddress      *netip.Addr   `json:"ip_address"`
-	Pid            *int32        `json:"pid"`
-	SnapshotID     pgtype.UUID   `json:"snapshot_id"`
-	TimeoutSeconds *int32        `json:"timeout_seconds"`
-	Metadata       []byte        `json:"metadata"`
-	TemplateID     pgtype.UUID   `json:"template_id"`
-	SnapshotPath   *string       `json:"snapshot_path"`
-	MemPath        *string       `json:"mem_path"`
-	BasePath       *string       `json:"base_path"`
-	DeltaPath      *string       `json:"delta_path"`
+	ID                uuid.UUID     `json:"id"`
+	TeamID            uuid.UUID     `json:"team_id"`
+	Name              string        `json:"name"`
+	Status            SandboxStatus `json:"status"`
+	VcpuCount         int32         `json:"vcpu_count"`
+	MemoryMib         int32         `json:"memory_mib"`
+	HostID            string        `json:"host_id"`
+	IpAddress         *netip.Addr   `json:"ip_address"`
+	Pid               *int32        `json:"pid"`
+	SnapshotID        pgtype.UUID   `json:"snapshot_id"`
+	TimeoutSeconds    *int32        `json:"timeout_seconds"`
+	Metadata          []byte        `json:"metadata"`
+	TemplateID        pgtype.UUID   `json:"template_id"`
+	SnapshotPath      *string       `json:"snapshot_path"`
+	MemPath           *string       `json:"mem_path"`
+	BasePath          *string       `json:"base_path"`
+	DeltaPath         *string       `json:"delta_path"`
+	AutoDeleteSeconds *int32        `json:"auto_delete_seconds"`
 }
 
 // ID is supplied by the caller (generated in Go via uuid.New()) rather
@@ -421,6 +530,7 @@ func (q *Queries) CreateSandbox(ctx context.Context, arg CreateSandboxParams) (S
 		arg.MemPath,
 		arg.BasePath,
 		arg.DeltaPath,
+		arg.AutoDeleteSeconds,
 	)
 	var i Sandbox
 	err := row.Scan(
@@ -446,6 +556,8 @@ func (q *Queries) CreateSandbox(ctx context.Context, arg CreateSandboxParams) (S
 		&i.BasePath,
 		&i.DeltaPath,
 		&i.DiskMib,
+		&i.AutoDeleteSeconds,
+		&i.AutoDeleteAt,
 	)
 	return i, err
 }
@@ -458,31 +570,32 @@ WITH tpl AS (
     AND (t.team_id = $14 OR t.team_id = $15)
   FOR KEY SHARE
 )
-INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib)
-SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib FROM tpl
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib
+INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib, $20 FROM tpl
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
 `
 
 type CreateSandboxFromTemplateParams struct {
-	ID             uuid.UUID     `json:"id"`
-	TeamID         uuid.UUID     `json:"team_id"`
-	Name           string        `json:"name"`
-	Status         SandboxStatus `json:"status"`
-	VcpuCount      int32         `json:"vcpu_count"`
-	MemoryMib      int32         `json:"memory_mib"`
-	HostID         string        `json:"host_id"`
-	IpAddress      *netip.Addr   `json:"ip_address"`
-	Pid            *int32        `json:"pid"`
-	SnapshotID     pgtype.UUID   `json:"snapshot_id"`
-	TimeoutSeconds *int32        `json:"timeout_seconds"`
-	Metadata       []byte        `json:"metadata"`
-	ID_2           uuid.UUID     `json:"id_2"`
-	TeamID_2       uuid.UUID     `json:"team_id_2"`
-	TeamID_3       uuid.UUID     `json:"team_id_3"`
-	SnapshotPath   *string       `json:"snapshot_path"`
-	MemPath        *string       `json:"mem_path"`
-	BasePath       *string       `json:"base_path"`
-	DeltaPath      *string       `json:"delta_path"`
+	ID                uuid.UUID     `json:"id"`
+	TeamID            uuid.UUID     `json:"team_id"`
+	Name              string        `json:"name"`
+	Status            SandboxStatus `json:"status"`
+	VcpuCount         int32         `json:"vcpu_count"`
+	MemoryMib         int32         `json:"memory_mib"`
+	HostID            string        `json:"host_id"`
+	IpAddress         *netip.Addr   `json:"ip_address"`
+	Pid               *int32        `json:"pid"`
+	SnapshotID        pgtype.UUID   `json:"snapshot_id"`
+	TimeoutSeconds    *int32        `json:"timeout_seconds"`
+	Metadata          []byte        `json:"metadata"`
+	ID_2              uuid.UUID     `json:"id_2"`
+	TeamID_2          uuid.UUID     `json:"team_id_2"`
+	TeamID_3          uuid.UUID     `json:"team_id_3"`
+	SnapshotPath      *string       `json:"snapshot_path"`
+	MemPath           *string       `json:"mem_path"`
+	BasePath          *string       `json:"base_path"`
+	DeltaPath         *string       `json:"delta_path"`
+	AutoDeleteSeconds *int32        `json:"auto_delete_seconds"`
 }
 
 // CreateSandbox variant that holds FOR KEY SHARE on the template row
@@ -510,6 +623,7 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 		arg.MemPath,
 		arg.BasePath,
 		arg.DeltaPath,
+		arg.AutoDeleteSeconds,
 	)
 	var i Sandbox
 	err := row.Scan(
@@ -535,6 +649,8 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 		&i.BasePath,
 		&i.DeltaPath,
 		&i.DiskMib,
+		&i.AutoDeleteSeconds,
+		&i.AutoDeleteAt,
 	)
 	return i, err
 }
@@ -598,6 +714,9 @@ type DestroySandboxParams struct {
 // so a crash after the claim can't strand a deleted sandbox with a live JWT or an
 // open interval. Returns the claimed id; 0 rows means already-deleted or a still-live
 // transition — the caller distinguishes the two with a re-read.
+//
+// The revocation + interval-close CTEs are mirrored in ClaimAutoDeleteSandboxes;
+// keep the side effects of both in sync.
 func (q *Queries) DestroySandbox(ctx context.Context, arg DestroySandboxParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, destroySandbox,
 		arg.ID,
@@ -614,6 +733,7 @@ const finalizePause = `-- name: FinalizePause :one
 WITH target AS (
   SELECT id, team_id FROM sandbox
   WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
+    AND status IN ('pausing', 'resuming')
 ),
 upserted AS (
   INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)
@@ -629,9 +749,14 @@ upserted AS (
 UPDATE sandbox
 SET snapshot_id = (SELECT snap_id FROM upserted),
     status = 'paused',
+    -- Arm the auto-delete deadline as the sandbox lands in 'paused'.
+    -- make_interval(NULL) propagates NULL, so an unset auto_delete_seconds
+    -- leaves the deadline NULL (never deleted).
+    auto_delete_at = now() + make_interval(secs => sandbox.auto_delete_seconds),
     updated_at = now()
 FROM upserted
 WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
+  AND sandbox.status IN ('pausing', 'resuming')
 RETURNING upserted.snap_id::uuid AS snapshot_id
 `
 
@@ -645,7 +770,11 @@ type FinalizePauseParams struct {
 }
 
 // Upsert the sandbox's live snapshot row and flip status to 'paused'.
-// Returns 0 rows if the sandbox is missing or soft-deleted (→ ErrSandboxGone).
+// Returns 0 rows if the sandbox is missing, soft-deleted, or no longer in a
+// pause-eligible transition (→ ErrSandboxGone). The status guard keeps a
+// stale or duplicate finalize from clobbering a terminal state — without it,
+// a late-landing write could flip a 'failed' sandbox back to 'paused' and
+// arm its auto-delete deadline.
 // One snapshot per sandbox; the unique index on snapshot.sandbox_id keys
 // the UPSERT.
 func (q *Queries) FinalizePause(ctx context.Context, arg FinalizePauseParams) (uuid.UUID, error) {
@@ -663,7 +792,7 @@ func (q *Queries) FinalizePause(ctx context.Context, arg FinalizePauseParams) (u
 }
 
 const getSandbox = `-- name: GetSandbox :one
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
 `
 
@@ -698,6 +827,8 @@ func (q *Queries) GetSandbox(ctx context.Context, arg GetSandboxParams) (Sandbox
 		&i.BasePath,
 		&i.DeltaPath,
 		&i.DiskMib,
+		&i.AutoDeleteSeconds,
+		&i.AutoDeleteAt,
 	)
 	return i, err
 }
@@ -802,7 +933,7 @@ func (q *Queries) ListRecentlyDestroyedSandboxIDsByHost(ctx context.Context, arg
 }
 
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, snap.path AS snapshot_path
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, snap.path AS snapshot_path
 FROM sandbox s
 LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL
@@ -847,6 +978,8 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 			&i.Sandbox.BasePath,
 			&i.Sandbox.DeltaPath,
 			&i.Sandbox.DiskMib,
+			&i.Sandbox.AutoDeleteSeconds,
+			&i.Sandbox.AutoDeleteAt,
 			&i.SnapshotPath,
 		); err != nil {
 			return nil, err
@@ -860,7 +993,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 }
 
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
 WHERE team_id = $1
   AND destroyed_at IS NULL
   AND metadata @> $2
@@ -940,6 +1073,8 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 			&i.BasePath,
 			&i.DeltaPath,
 			&i.DiskMib,
+			&i.AutoDeleteSeconds,
+			&i.AutoDeleteAt,
 		); err != nil {
 			return nil, err
 		}
@@ -954,7 +1089,10 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 const markSandboxFailed = `-- name: MarkSandboxFailed :exec
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', updated_at = now()
+  -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
+  -- and a stale one would resurface (or instantly fire) if the sandbox is
+  -- ever returned to 'paused' by a recovery path.
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),
@@ -984,7 +1122,7 @@ func (q *Queries) MarkSandboxFailed(ctx context.Context, id uuid.UUID) error {
 const markSandboxFailedInTeam = `-- name: MarkSandboxFailedInTeam :exec
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),
@@ -1016,7 +1154,11 @@ func (q *Queries) MarkSandboxFailedInTeam(ctx context.Context, arg MarkSandboxFa
 
 const revertResumeToPaused = `-- name: RevertResumeToPaused :exec
 UPDATE sandbox
-SET status = 'paused', updated_at = now()
+SET status = 'paused',
+    -- Re-arm the auto-delete deadline cleared by BeginResume; the sandbox is
+    -- paused again, so it gets a fresh window.
+    auto_delete_at = now() + make_interval(secs => auto_delete_seconds),
+    updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
 `
 
@@ -1049,21 +1191,34 @@ func (q *Queries) SandboxExists(ctx context.Context, arg SandboxExistsParams) (b
 	return exists, err
 }
 
-const setSandboxSnapshot = `-- name: SetSandboxSnapshot :exec
+const updateSandboxAutoDelete = `-- name: UpdateSandboxAutoDelete :execrows
 UPDATE sandbox
-SET snapshot_id = $2, updated_at = now()
+SET auto_delete_seconds = $2,
+    auto_delete_at = CASE WHEN status = 'paused'
+      THEN now() + make_interval(secs => $2)
+      ELSE NULL
+    END,
+    updated_at = now()
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL
 `
 
-type SetSandboxSnapshotParams struct {
-	ID         uuid.UUID   `json:"id"`
-	SnapshotID pgtype.UUID `json:"snapshot_id"`
-	TeamID     uuid.UUID   `json:"team_id"`
+type UpdateSandboxAutoDeleteParams struct {
+	ID                uuid.UUID `json:"id"`
+	AutoDeleteSeconds *int32    `json:"auto_delete_seconds"`
+	TeamID            uuid.UUID `json:"team_id"`
 }
 
-func (q *Queries) SetSandboxSnapshot(ctx context.Context, arg SetSandboxSnapshotParams) error {
-	_, err := q.db.Exec(ctx, setSandboxSnapshot, arg.ID, arg.SnapshotID, arg.TeamID)
-	return err
+// Set or clear (NULL) the auto-delete window. The deadline counts continuous
+// paused time since the setting was applied: on an already-paused sandbox it
+// is armed from now() — never retroactively from the pause — so applying a
+// window can never destroy the sandbox in the same instant. On a non-paused
+// sandbox the deadline stays NULL and FinalizePause arms it at the next pause.
+func (q *Queries) UpdateSandboxAutoDelete(ctx context.Context, arg UpdateSandboxAutoDeleteParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateSandboxAutoDelete, arg.ID, arg.AutoDeleteSeconds, arg.TeamID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateSandboxHost = `-- name: UpdateSandboxHost :exec
@@ -1140,4 +1295,30 @@ type UpdateSandboxStatusParams struct {
 func (q *Queries) UpdateSandboxStatus(ctx context.Context, arg UpdateSandboxStatusParams) error {
 	_, err := q.db.Exec(ctx, updateSandboxStatus, arg.ID, arg.Status, arg.TeamID)
 	return err
+}
+
+const updateSandboxTimeout = `-- name: UpdateSandboxTimeout :execrows
+UPDATE sandbox
+SET timeout_seconds = $2,
+    updated_at = now()
+WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL
+`
+
+type UpdateSandboxTimeoutParams struct {
+	ID             uuid.UUID `json:"id"`
+	TimeoutSeconds *int32    `json:"timeout_seconds"`
+	TeamID         uuid.UUID `json:"team_id"`
+}
+
+// Set or clear (NULL) the auto-pause timeout. Takes effect on the reaper's
+// next tick: the window is evaluated against the current active session
+// start, so lowering it below already-elapsed session time pauses the
+// sandbox on the next sweep. On a paused sandbox it applies to the next
+// active session after resume.
+func (q *Queries) UpdateSandboxTimeout(ctx context.Context, arg UpdateSandboxTimeoutParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateSandboxTimeout, arg.ID, arg.TimeoutSeconds, arg.TeamID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/db/snapshots.sql.go
+++ b/internal/db/snapshots.sql.go
@@ -54,9 +54,32 @@ DELETE FROM snapshot
 WHERE id = $1
 `
 
+// Invariant: only delete snapshots of destroyed sandboxes. fk_sandbox_snapshot
+// is ON DELETE SET NULL, so deleting a live/paused sandbox's snapshot silently
+// nulls its restore pointer (unrestorable) instead of erroring.
 func (q *Queries) DeleteSnapshot(ctx context.Context, id uuid.UUID) error {
 	_, err := q.db.Exec(ctx, deleteSnapshot, id)
 	return err
+}
+
+const deleteSnapshotsOfDestroyedSandboxes = `-- name: DeleteSnapshotsOfDestroyedSandboxes :execrows
+DELETE FROM snapshot s
+USING sandbox sb
+WHERE s.sandbox_id = sb.id
+  AND sb.destroyed_at IS NOT NULL
+  AND sb.destroyed_at < now() - interval '1 hour'
+`
+
+// Backstop for destroy teardown that never ran (crash/shutdown before
+// cleanupSandboxSnapshots). Driven from snapshot (joined to sandbox by PK) so
+// it scans only un-cleaned rows, not every accumulating soft-deleted sandbox.
+// Files fall to the vm reconciler's disk scan.
+func (q *Queries) DeleteSnapshotsOfDestroyedSandboxes(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteSnapshotsOfDestroyedSandboxes)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getSnapshot = `-- name: GetSnapshot :one

--- a/supabase/migrations/20260705000001_sandbox_auto_delete.sql
+++ b/supabase/migrations/20260705000001_sandbox_auto_delete.sql
@@ -1,0 +1,30 @@
+-- Opt-in garbage collection for paused sandboxes. auto_delete_seconds is the
+-- configured window; auto_delete_at is the materialized deadline — armed on
+-- pause (or when the setting is applied while already paused), cleared on
+-- resume. Both NULL (the default) means paused sandboxes are kept forever.
+ALTER TABLE sandbox
+    ADD COLUMN IF NOT EXISTS auto_delete_seconds integer,
+    ADD COLUMN IF NOT EXISTS auto_delete_at timestamptz;
+
+ALTER TABLE sandbox
+    DROP CONSTRAINT IF EXISTS sandbox_auto_delete_seconds_valid;
+
+-- Defense in depth: mirror the API's 0..30-day cap so a non-handler write path
+-- can't set an unbounded retention window. 2592000 = 30 days.
+ALTER TABLE sandbox
+    ADD CONSTRAINT sandbox_auto_delete_seconds_valid
+    CHECK (auto_delete_seconds IS NULL
+           OR (auto_delete_seconds >= 0 AND auto_delete_seconds <= 2592000));
+
+-- Also fix the pre-existing timeout_seconds comment, which described the old
+-- destroy-from-creation semantics rather than today's auto-pause.
+COMMENT ON COLUMN sandbox.timeout_seconds IS
+    'Auto-pause timeout in seconds, evaluated against the current active '
+    'session (re-armed on each resume). NULL = no timeout. Settable at create '
+    'and via PATCH. The reaper pauses the sandbox on expiry; it does not delete it.';
+
+-- The delete sweep scans for due deadlines; almost all rows have none, so a
+-- partial index keeps it a near-empty btree.
+CREATE INDEX IF NOT EXISTS idx_sandbox_auto_delete_due
+    ON sandbox (auto_delete_at)
+    WHERE auto_delete_at IS NOT NULL AND destroyed_at IS NULL;

--- a/supabase/migrations/20260705000002_snapshot_fk_on_delete_set_null.sql
+++ b/supabase/migrations/20260705000002_snapshot_fk_on_delete_set_null.sql
@@ -1,0 +1,13 @@
+-- fk_sandbox_snapshot (sandbox.snapshot_id → snapshot.id) had no ON DELETE
+-- action, so deleting a snapshot row still referenced by a sandbox — including
+-- a soft-deleted one, whose row and FK still exist — raised a foreign-key
+-- violation (SQLSTATE 23503). Every snapshot-row cleanup path hit this and left
+-- the row behind. SET NULL nulls the back-reference instead of blocking;
+-- snapshots are only ever deleted for already-destroyed or unreferenced
+-- sandboxes, so no live sandbox loses a snapshot it still needs.
+ALTER TABLE sandbox
+    DROP CONSTRAINT IF EXISTS fk_sandbox_snapshot;
+
+ALTER TABLE sandbox
+    ADD CONSTRAINT fk_sandbox_snapshot
+    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE SET NULL;


### PR DESCRIPTION
Opt-in garbage collection for paused sandboxes, plus a patchable auto-pause timeout.

- **`auto_delete_seconds`** (create + PATCH): deletes a sandbox once it has been continuously paused that long. The deadline (`auto_delete_at`) arms on every pause, is cleared by resume, and — when set on an already-paused sandbox — counts from the request, never retroactively. `0` = delete on pause; unset = keep forever (default). Max 30 days.
- **`timeout_seconds` is now patchable**: PATCH can set or clear (`null`) the auto-pause timeout on an existing sandbox.
- Reaper sweep soft-deletes due rows in one guarded statement (claims from `paused` only, deadline re-checked under the row lock), then reuses the shared teardown path; a snapshot-row backstop sweep covers teardown abandoned by crash/shutdown.
- Migration is idempotent and a no-op for existing sandboxes.

Tests: `go test ./internal/api/...`. OpenAPI updated for create/PATCH/response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)