### PR TITLE
infra: grant CI SA access to sandbox-access-token-seed for usw cell deploy

### DIFF
--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -79,6 +79,22 @@ data "google_service_account" "api_runner" {
   account_id = "superserve-api-runner"
 }
 
+data "google_service_account" "github_actions" {
+  project    = local.project_id
+  account_id = "superserve-github-actions"
+}
+
+# deploy-proxy.yml fetches this secret directly via `gcloud secrets versions
+# access` at deploy time for the usw cell step, instead of through a Cloud
+# Run secret binding — so the CI service account needs read access here too,
+# not just the Cloud Run runtime SA.
+resource "google_secret_manager_secret_iam_member" "github_actions_sandbox_access_token_seed" {
+  project   = local.project_id
+  secret_id = coalesce(var.sandbox_access_token_seed_secret_name, "sandbox-access-token-seed-${local.resource_suffix}")
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_service_account.github_actions.email}"
+}
+
 module "api" {
   source = "../../../modules/api"
 


### PR DESCRIPTION
## Summary
- Deploy Proxy's `deploy-production` job fails on the usw cell step (https://github.com/superserve-ai/sandbox/actions/runs/28897550096/job/85726190078) with `PERMISSION_DENIED` on `secretmanager.versions.access`
- That step fetches `sandbox-access-token-seed` directly via `gcloud secrets versions access` at deploy time (deploy-proxy.yml), since the west-cell proxy runs bare-metal rather than as a Cloud Run secret binding
- Checked the secret's IAM policy in `rayai-prod`: only `superserve-api-runner@` (Cloud Run runtime SA) had `secretmanager.secretAccessor`; the CI deploy SA (`superserve-github-actions@`) had none — missed when the usw cell deploy path was added in #177/#174
- Grants `roles/secretmanager.secretAccessor` scoped to just this secret (not project-wide) for the CI SA

## Testing
- `terraform init -backend=false && terraform validate` passes
- Live plan against prod state blocked locally by an expired gcloud reauth token, unrelated to this change — will apply via `terraform-cd.yml` on merge