### PR TITLE
ci: fix reversed staging API domain in smoke test env vars

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -125,7 +125,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      API_BASE_URL: https://staging-api.superserve.ai
+      API_BASE_URL: https://api-staging.superserve.ai
       API_KEY: ${{ secrets.STAGING_INTERNAL_API_TOKEN }}
       SANDBOX_BASE_URL: https://staging-sandbox.superserve.ai
     steps:

--- a/.github/workflows/terraform-rollout-staging.yml
+++ b/.github/workflows/terraform-rollout-staging.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
-      API_BASE_URL: https://staging-api.superserve.ai
+      API_BASE_URL: https://api-staging.superserve.ai
       API_KEY: ${{ secrets.STAGING_INTERNAL_API_TOKEN }}
       SANDBOX_BASE_URL: https://staging-sandbox.superserve.ai
     steps:


### PR DESCRIPTION
## Summary
- `Deploy API staging/us-central1` failed its smoke test (https://github.com/superserve-ai/sandbox/actions/runs/28902518942/job/85742579744) with `expected HTTP 201, got 404` / `DEPLOYMENT_NOT_FOUND`
- The deploy itself succeeded (revision serving 100%, `/health` returned ok on the direct Cloud Run URL); the smoke test failed because `API_BASE_URL` pointed at `https://staging-api.superserve.ai`, which has never been mapped to anything — its DNS resolves to Vercel's edge, which 404s on every path
- The actual Cloud Run domain mapping for staging is `api-staging.superserve.ai` (confirmed via `gcloud beta run domain-mappings list --project rayai-dev` and a working `/health` response) — the two workflow files had the words reversed
- Both introduced in the same commit as #174/#181 (`awille-ai`, same day)

## Testing
- `curl https://api-staging.superserve.ai/health` → `{"status":"ok","version":"0.1.0"}`
- `curl https://staging-api.superserve.ai/health` → Vercel 404 `DEPLOYMENT_NOT_FOUND`