### PR TITLE
add AGENTS.md with OSS-visibility guidelines

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -134,7 +134,8 @@ jobs:
       # rather than silently skipping the cell.
       #
       # The deploy rewrites /etc/sandbox/proxy.env on the host, so the cell
-      # MUST NOT reuse the prod values: its domain differs per SS-143
+      # MUST NOT reuse the prod values: its domain differs per the
+      # regional hostname scheme
       # (PROXY_DOMAIN_USW = usw-sandbox.superserve.ai) and its token seed
       # lives in Secret Manager (`sandbox-access-token-seed`), which is what
       # the cell control plane signs with — writing the primary's seed here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent and contributor guidelines
+
+This repository is open source. Everything committed here — code, comments,
+test fixtures, commit messages — and everything attached to it on GitHub —
+PR titles, PR descriptions, review comments — is public.
+
+## Never reference internal context
+
+- **No customer names.** Do not name customers, their domains, or anything
+  that identifies a business relationship in code, fixtures, commits, or PR
+  text. Use neutral placeholders (`pilot-team`, `example-team`) in tests and
+  plain descriptions ("a customer with a large fleet") in prose.
+- **No internal ticket references.** Do not cite issue-tracker IDs
+  (`SS-123`-style) anywhere in the repo or in PR titles/descriptions. They
+  are dead links to outside readers and leak internal planning. Describe the
+  purpose in words instead: "part of the multi-region rollout", not a ticket
+  number.
+- **No internal URLs** (dashboards, trackers, internal docs) in committed
+  files or PR text.
+
+Cross-referencing public artifacts is fine: other PRs and issues in this
+repository, upstream project issues, and public documentation.
+
+## Code conventions
+
+- Match the style, comment density, and idiom of the surrounding code.
+- Comments explain constraints the code can't show — not what the next line
+  does, and not review-time justifications.
+- Test fixtures use invented data only: generated UUIDs, neutral names,
+  RFC-reserved IPs and example domains.


### PR DESCRIPTION
This repo and its PR metadata are public, so agent- and human-authored changes need the same hygiene bar: no customer names, no internal tracker IDs, no internal URLs — in code, fixtures, commits, or PR text. AGENTS.md writes that down where coding agents and contributors will find it. Also rewords one existing workflow comment that cited an internal ticket ID.

Testing: docs-only plus a comment-only workflow edit; YAML untouched semantically (actionlint clean).