### PR TITLE
vmd: make slot ownership authoritative so the pool can't hand one slot to two sandboxes

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -519,11 +519,13 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	}
 	m.slotOwner[idx] = teardownOwner
 	m.mu.Unlock()
+	// Release even if cleanupFull panics — otherwise the index stays stuck as
+	// teardownOwner forever (no other path releases that sentinel).
+	defer m.releaseIfOwned(idx, teardownOwner)
 
 	// Tear down both sides even if the netns is already gone: `ip netns del`
 	// only removes the in-namespace side, so the host-side veth-N can outlive it.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
-	m.releaseIfOwned(idx, teardownOwner)
 	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("reclaimed network slot for untracked VM")
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -81,21 +81,32 @@ type Manager struct {
 
 	mu        sync.Mutex
 	devices   map[string]*VMNetInfo
-	freeSlots []int // recycled slot indices
+	freeSlots []int // recycled slot indices, guaranteed NOT in owned
 	nextSlot  int   // next new slot (used when freeSlots is empty)
 
-	// relinquished holds slot indices freed for reuse at startup (running
-	// records whose netns was already gone). The pool may hand these to new
-	// sandboxes before the background reattach cleans up the stale record, so
-	// that stale cleanup must not tear the slot down once ns-N exists again.
-	relinquished map[int]bool
-
-	// inFlight marks slot indices whose kernel state is mid-mutation — claimed
-	// by an allocator but not yet built (nsExists still false), or being torn
-	// down by a stale-record cleanup. It closes the window between claimSlotIndex
-	// and setupSlot creating ns-N: without it, a concurrent relinquished cleanup
-	// sees nsExists==false and reclaims a slot the pool is actively building.
-	inFlight map[int]bool
+	// owned is the single source of truth for "slot index N is allocated": to a
+	// mid-build, a warm pool slot, a live VM, or a reserved existing record. An
+	// index is free (claimable by claimSlotIndex) iff it is NOT in owned.
+	//
+	// This closes the slot-duplication class of bug: because a warm pool slot's
+	// index stays owned for its whole life (build → warm-in-channel → claimed),
+	// claimSlotIndex can never rebuild the same index into a second warm slot,
+	// and because existing records reserve their index here, the pool can never
+	// build on an index a record already holds. Ownership by index (not by
+	// namespace name, which is reused) is what makes it collision-proof.
+	//
+	// Every slot path must maintain this invariant. The full transition table:
+	//   claimSlotIndex picks idx ∉ owned        → add(idx)
+	//   setupSlot fails (via caller)            → del(idx) + freeSlots
+	//   pool.Claim hands warm slot to a VM      → keep (pool→VM transfer)
+	//   pool.cleanup (phantom/drain)            → del(idx) + freeSlots
+	//   pool.Return recycles a slot             → keep (pool holds it)
+	//   CleanupVM full teardown                 → del(idx) + freeSlots
+	//   CleanupVM pool-return                   → keep
+	//   CleanupVMOrNamespace reclaim            → del(idx) + freeSlots
+	//   ReattachVM / EnsureVMSlot (records)     → add(idx) (idempotent; reserved)
+	//   ReserveSlotsAbove (startup)             → add(idx) for every record
+	owned map[int]struct{}
 
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
@@ -202,8 +213,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		hostInterface:  hostInterface,
 		log:            log.With().Str("component", "network").Logger(),
 		devices:        make(map[string]*VMNetInfo),
-		relinquished:   make(map[int]bool),
-		inFlight:       make(map[int]bool),
+		owned:          make(map[int]struct{}),
 		nextSlot:       1,
 		httpProxyPort:  DefaultHTTPProxyPort,
 		tlsProxyPort:   DefaultTLSProxyPort,
@@ -267,7 +277,8 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 
 	info, _, err := m.setupSlot(ctx, idx)
 	if err != nil {
-		// idx stays consumed — reusing a colliding idx would loop.
+		// Build failed — release the index so it isn't leaked from owned.
+		m.freeSlot(idx)
 		return nil, err
 	}
 
@@ -295,15 +306,9 @@ func hostIPForSlot(idx int) string {
 // nftables, routing) for a single slot index. Used by both SetupVM
 // (on-demand) and Pool (pre-allocation).
 func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
-	// Clear the in-flight mark once the slot is built (or on failure): on
-	// success ns-N now exists, so nsExists takes over guarding it against a
-	// stale-record cleanup; on failure the idx is abandoned. Runs on every exit.
-	defer func() {
-		m.mu.Lock()
-		delete(m.inFlight, idx)
-		m.mu.Unlock()
-	}()
-
+	// Ownership of idx is NOT touched here: claimSlotIndex owns it before this
+	// runs (pool/on-demand), and record paths reserve it. On success the slot is
+	// live and stays owned; on failure the caller releases idx (freeSlot).
 	hostIP := hostIPForSlot(idx)
 	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
 	vethIP := fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256)
@@ -461,10 +466,9 @@ func (m *Manager) CleanupVM(vmID string) {
 		return
 	}
 
-	// No pool — full teardown.
-	m.mu.Lock()
-	m.freeSlots = append(m.freeSlots, idx)
-	m.mu.Unlock()
+	// No pool — full teardown. Release the index from owned (the pool-return
+	// path above keeps it owned because the pool still holds the slot).
+	m.freeSlot(idx)
 
 	if info.Firewall != nil {
 		if err := info.Firewall.Close(); err != nil {
@@ -504,49 +508,16 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	if !ok {
 		return
 	}
-	// A slot relinquished at startup may have been claimed by the pool. If it's
-	// in-flight (claimed, ns-N not created yet) or ns-N already exists, it
-	// belongs to a new sandbox — tearing it down or reclaiming it would corrupt
-	// that tenant, so leave it alone. Both checks under one lock: the in-flight
-	// mark closes the claimSlotIndex→setupSlot window where nsExists is still
-	// false. Otherwise claim the slot ourselves (mark in-flight) so a concurrent
-	// allocator can't grab it while we mutate its kernel state below.
-	m.mu.Lock()
-	if m.relinquished[idx] && (m.inFlight[idx] || nsExists(fallbackNamespace)) {
-		m.mu.Unlock()
-		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
-			Msg("stale cleanup skipped — relinquished slot claimed/reused by pool")
-		return
-	}
-	m.inFlight[idx] = true
-	m.mu.Unlock()
-
-	// Tear down both sides even if the netns is already gone: `ip netns del`
-	// only removes the in-namespace side, so the host-side veth-N can outlive
-	// its namespace (a crash, or the peer moved back to the host before the ns
-	// delete). Both deletes are best-effort; then reclaim the slot so the pool
-	// reuses it instead of stranding it as a gap below nextSlot.
+	// This slot belongs to the stale record being cleaned up. Because existing
+	// records reserve their index in owned at startup, the pool never builds on
+	// it, so there is no live tenant to protect here — tear it down and release
+	// the index. Tear down both sides even if the netns is already gone:
+	// `ip netns del` only removes the in-namespace side, so the host-side veth-N
+	// can outlive its namespace.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
-	m.mu.Lock()
-	m.freeSlots = append(m.freeSlots, idx)
-	delete(m.inFlight, idx)
-	m.mu.Unlock()
+	m.freeSlot(idx)
 	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("reclaimed network slot for untracked VM")
-}
-
-// IsRelinquished reports whether the slot for namespace was freed for reuse at
-// startup (a running record whose netns was already gone). Reattaching such a
-// record would bind its old vmID onto a slot the pool may have handed to a new
-// sandbox, so callers must refuse it.
-func (m *Manager) IsRelinquished(namespace string) bool {
-	idx, ok := slotFromNamespace(namespace)
-	if !ok {
-		return false
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.relinquished[idx]
 }
 
 // Forget drops vmID from the in-memory device map without any kernel teardown,
@@ -596,8 +567,10 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	}
 
 	m.mu.Lock()
-	// Bump nextSlot past this idx so new VMs don't collide. Gap slots
-	// below nextSlot are wasted until bitmap allocation lands.
+	// Reserve this record's index in owned so the pool can't build on it, and
+	// bump nextSlot past it. (Startup reservation usually did this already; this
+	// keeps a lazy reattach safe too.)
+	m.ownSlotLocked(idx)
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
 	}
@@ -625,37 +598,27 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
-// ReserveSlotsAbove bumps nextSlot past slots owned by existing VMs so the pool
-// can't hand out a slot a not-yet-reattached VM will reclaim.
+// ReserveSlotsAbove reserves every existing record's slot index in owned (and
+// bumps nextSlot past it) so the pool can never build on an index a record
+// holds. Called once at startup with every record namespace, BEFORE StartPool.
 //
-// resumable slots (paused VMs) are reserved unconditionally: a paused VM keeps
-// its slot across a host reboot even though the reboot wipes its netns, and it
-// rebuilds that exact slot on resume — so a missing netns must NOT free it.
-// liveOnly slots (running VMs) are reserved only when their netns still exists;
-// a running record with no netns is stale (the process died, e.g. across a
-// reboot) and its slot is free, so reserving it would strand every lower slot.
-func (m *Manager) ReserveSlotsAbove(resumable, liveOnly []string) {
+// Every record is reserved unconditionally — including a stale/dead one whose
+// netns is gone. Reserving a dead slot only strands it transiently: the
+// background reattach reclaims it (freeSlot) when it cleans the stale record, so
+// the index returns to the recycle list. This is deliberately simpler (and
+// safer) than trying to free dead slots up front, which is what let the pool
+// collide with a record and duplicate a slot.
+func (m *Manager) ReserveSlotsAbove(namespaces []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	bump := func(ns string) {
-		if idx, ok := slotFromNamespace(ns); ok && idx >= m.nextSlot {
-			m.nextSlot = idx + 1
-		}
-	}
-	for _, ns := range resumable {
-		bump(ns)
-	}
-	for _, ns := range liveOnly {
-		if nsExists(ns) {
-			bump(ns)
+	for _, ns := range namespaces {
+		idx, ok := slotFromNamespace(ns)
+		if !ok {
 			continue
 		}
-		// Running record with no netns — the process is gone (a host reboot
-		// wipes every netns). Its slot is free for the pool to reuse; record
-		// that so a later stale-record cleanup won't tear the slot down again
-		// once the pool has handed ns-N to a new sandbox.
-		if idx, ok := slotFromNamespace(ns); ok {
-			m.relinquished[idx] = true
+		m.ownSlotLocked(idx)
+		if idx >= m.nextSlot {
+			m.nextSlot = idx + 1
 		}
 	}
 }
@@ -708,6 +671,9 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	}
 
 	m.mu.Lock()
+	// Reserve this record's index in owned so the pool can't build on it while
+	// this VM holds it, and remove it from the recycle list if present.
+	m.ownSlotLocked(idx)
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
 	}
@@ -743,10 +709,29 @@ func slotFromNamespace(namespace string) (int, bool) {
 	return idx, true
 }
 
-// claimSlotIndex picks a slot idx free in both freeSlots and the kernel.
-// Skips indices whose netns already exists (paused VM from a past lifetime,
-// etc.). Race window after the nsExists check remains; callers must still
-// handle setupSlot returning "already exists".
+// ownSlotLocked marks idx allocated. Caller must hold m.mu. Idempotent.
+func (m *Manager) ownSlotLocked(idx int) { m.owned[idx] = struct{}{} }
+
+// freeSlotLocked releases idx — drops ownership and returns it to the recycle
+// list so a later claimSlotIndex can reuse it. Caller must hold m.mu. This is
+// the ONLY way a slot leaves owned, so every teardown path must route through
+// it (directly or via freeSlot) to avoid leaking the index.
+func (m *Manager) freeSlotLocked(idx int) {
+	delete(m.owned, idx)
+	m.freeSlots = append(m.freeSlots, idx)
+}
+
+// freeSlot releases idx, taking the lock.
+func (m *Manager) freeSlot(idx int) {
+	m.mu.Lock()
+	m.freeSlotLocked(idx)
+	m.mu.Unlock()
+}
+
+// claimSlotIndex picks a slot idx that is unowned (see the owned invariant) and
+// not present in the kernel, marks it owned, and returns it. Ownership persists
+// until the slot is genuinely torn down, so the same idx can never be handed to
+// two builds — the root guarantee against slot duplication.
 func (m *Manager) claimSlotIndex() (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -764,16 +749,14 @@ func (m *Manager) claimSlotIndex() (int, error) {
 			m.nextSlot++
 		}
 
-		if m.inFlight[idx] || nsExists(fmt.Sprintf("ns-%d", idx)) {
-			// Being built/torn down elsewhere, or already in use. Discard;
-			// returning idx to freeSlots would loop on next call.
-			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — in-flight or kernel ns exists")
+		if _, isOwned := m.owned[idx]; isOwned || nsExists(fmt.Sprintf("ns-%d", idx)) {
+			// Owned by a live slot/record/build, or its kernel ns already
+			// exists. Discard; returning idx to freeSlots would loop.
+			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — owned or kernel ns exists")
 			continue
 		}
 
-		// Mark claimed so a concurrent stale-record cleanup won't reclaim this
-		// slot in the window before setupSlot creates ns-N. setupSlot clears it.
-		m.inFlight[idx] = true
+		m.ownSlotLocked(idx)
 		return idx, nil
 	}
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -507,11 +507,10 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	if !ok {
 		return
 	}
-	// Only tear down + reclaim if this vmID still owns the index. A stale cleanup
-	// (e.g. a DELETE that captured the old namespace) that races the pool reusing
-	// the slot for a new tenant must NOT destroy the new tenant's ns/veth. Claim
-	// the teardown atomically (vmID → teardownOwner) so a concurrent claimSlotIndex
-	// can't grab the index while we run cleanupFull below.
+	// Only tear down if this vmID still owns the index, so a stale cleanup racing
+	// the pool's reuse of the slot can't destroy a new tenant's ns/veth. Claim the
+	// teardown atomically (vmID → teardownOwner) so claimSlotIndex can't grab idx
+	// while cleanupFull runs below.
 	m.mu.Lock()
 	if m.slotOwner[idx] != vmID {
 		m.mu.Unlock()
@@ -531,13 +530,11 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 }
 
 // Forget reverses an in-memory reattach that raced a concurrent DestroyVM/
-// markStale: it drops vmID from devices and releases the reattach's slot
-// reservation — but ONLY the index this vmID still owns (releaseIfOwned). If the
-// racing destroy already freed or the pool already reused the index, ownership
-// has moved on and Forget leaves it untouched, so it neither double-frees nor
-// clobbers a new tenant. No kernel teardown here (the destroy path did that);
-// the host IP is left registered in the egress proxy (keyed by slot, a reused
-// slot's new owner may already hold it).
+// markStale: it drops vmID from devices and releases only the index this vmID
+// still owns (releaseIfOwned), so if the racing destroy already freed or the pool
+// reused it, Forget leaves it untouched. No kernel teardown here (the destroy
+// path did that); the host IP stays registered in the egress proxy (keyed by
+// slot, which a reused slot's new owner may already hold).
 func (m *Manager) Forget(vmID string) {
 	m.mu.Lock()
 	info, ok := m.devices[vmID]
@@ -585,10 +582,8 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	}
 
 	m.mu.Lock()
-	// Reserve this record's index under its vmID so the pool can't build on it,
-	// and bump nextSlot past it. (Startup reservation usually did this already;
-	// this keeps a lazy reattach safe too.) reserveSlotLocked also removes idx
-	// from freeSlots, keeping freeSlots ∩ slotOwner disjoint.
+	// Reserve this record's index under its vmID so the pool can't build on it.
+	// Usually done at startup already; idempotent, and keeps a lazy reattach safe.
 	m.reserveSlotLocked(idx, vmID)
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
@@ -620,15 +615,13 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 // ReserveSlotsAbove reserves every existing record's slot index under its vmID
 // (and bumps nextSlot past it) so the pool can never build on an index a record
 // holds. Called once at startup with vmID→namespace for every record, BEFORE
-// StartPool. Reserving under the vmID means a later stale cleanup for that vmID
-// can identity-match and release exactly its own index.
+// StartPool.
 //
-// Every record is reserved unconditionally — including a stale/dead one whose
-// netns is gone. Reserving a dead slot only strands it transiently: the
-// background reattach reclaims it when it cleans the stale record, so the index
-// returns to the recycle list. This is deliberately simpler (and safer) than
-// trying to free dead slots up front, which is what let the pool collide with a
-// record and duplicate a slot.
+// Records are reserved unconditionally — including stale/dead ones whose netns is
+// gone. A dead slot is only stranded transiently: the background reattach frees
+// it back to the recycle list when it cleans the record. That's deliberately
+// simpler and safer than freeing dead slots up front, which is what let the pool
+// collide with a record and duplicate a slot.
 func (m *Manager) ReserveSlotsAbove(reservations map[string]string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -737,9 +730,8 @@ const (
 // idx from freeSlots (claimSlotIndex pops it; transfers keep it out).
 func (m *Manager) assignSlotLocked(idx int, owner string) { m.slotOwner[idx] = owner }
 
-// reserveSlotLocked marks idx owned by a record and removes it from the recycle
-// list if present — the record-path acquire that keeps freeSlots ∩ slotOwner
-// disjoint. Caller must hold m.mu.
+// reserveSlotLocked marks idx owned by a record and removes it from freeSlots if
+// present — the record-path acquire. Caller must hold m.mu.
 func (m *Manager) reserveSlotLocked(idx int, owner string) {
 	m.slotOwner[idx] = owner
 	m.removeFromFreeSlotsLocked(idx)
@@ -755,8 +747,7 @@ func (m *Manager) removeFromFreeSlotsLocked(idx int) {
 }
 
 // releaseIfOwned releases idx only when it is still owned by owner, returning
-// whether it did. This is the identity guard that stops a stale cleanup for an
-// old vmID from freeing a slot the pool or another VM has since reused.
+// whether it did — the identity guard described on slotOwner.
 func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -769,10 +760,8 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 }
 
 // claimSlotIndex picks a slot idx that is unowned and not present in the kernel,
-// assigns it to owner, and returns it. Ownership persists until the slot is
-// genuinely torn down, so the same idx can never be handed to two builds — the
-// root guarantee against slot duplication. owner is poolOwner for pool
-// pre-allocation, or the vmID for an on-demand SetupVM.
+// assigns it to owner, and returns it. owner is poolOwner for pool pre-allocation
+// or the vmID for an on-demand SetupVM.
 func (m *Manager) claimSlotIndex(owner string) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -81,32 +81,27 @@ type Manager struct {
 
 	mu        sync.Mutex
 	devices   map[string]*VMNetInfo
-	freeSlots []int // recycled slot indices, guaranteed NOT in owned
+	freeSlots []int // recycled slot indices, guaranteed absent from slotOwner
 	nextSlot  int   // next new slot (used when freeSlots is empty)
 
-	// owned is the single source of truth for "slot index N is allocated": to a
-	// mid-build, a warm pool slot, a live VM, or a reserved existing record. An
-	// index is free (claimable by claimSlotIndex) iff it is NOT in owned.
+	// slotOwner is the single source of truth for slot allocation AND identity:
+	// slotOwner[idx] == the current owner of slot index idx, one of
+	//   - a VM/record vmID   (a live VM, or a record reserving its index)
+	//   - poolOwner          (a warm/mid-build pool slot not yet handed to a VM)
+	//   - teardownOwner      (a slot being torn down; held so no one re-claims it)
+	// An index is free (claimable) iff it has NO entry.
 	//
-	// This closes the slot-duplication class of bug: because a warm pool slot's
-	// index stays owned for its whole life (build → warm-in-channel → claimed),
-	// claimSlotIndex can never rebuild the same index into a second warm slot,
-	// and because existing records reserve their index here, the pool can never
-	// build on an index a record already holds. Ownership by index (not by
-	// namespace name, which is reused) is what makes it collision-proof.
+	// Identity is load-bearing, not decoration: a release/teardown acts ONLY when
+	// the caller still owns the index (releaseIfOwned), so a stale cleanup for an
+	// old vmID cannot tear down or free a slot the pool/another VM has since
+	// reused. And because a warm pool slot's index stays owned for its whole life
+	// (build → warm → claimed), claimSlotIndex can never rebuild the same index
+	// into a second warm slot — the root guarantee against slot duplication.
 	//
-	// Every slot path must maintain this invariant. The full transition table:
-	//   claimSlotIndex picks idx ∉ owned        → add(idx)
-	//   setupSlot fails (via caller)            → del(idx) + freeSlots
-	//   pool.Claim hands warm slot to a VM      → keep (pool→VM transfer)
-	//   pool.cleanup (phantom/drain)            → del(idx) + freeSlots
-	//   pool.Return recycles a slot             → keep (pool holds it)
-	//   CleanupVM full teardown                 → del(idx) + freeSlots
-	//   CleanupVM pool-return                   → keep
-	//   CleanupVMOrNamespace reclaim            → del(idx) + freeSlots
-	//   ReattachVM / EnsureVMSlot (records)     → add(idx) (idempotent; reserved)
-	//   ReserveSlotsAbove (startup)             → add(idx) for every record
-	owned map[int]struct{}
+	// The transition helpers below are the ONLY way slotOwner/freeSlots change;
+	// every slot path must route through them so ownership can never be dropped
+	// (leak) or duplicated (double hand-out).
+	slotOwner map[int]string
 
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
@@ -213,7 +208,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 		hostInterface:  hostInterface,
 		log:            log.With().Str("component", "network").Logger(),
 		devices:        make(map[string]*VMNetInfo),
-		owned:          make(map[int]struct{}),
+		slotOwner:      make(map[int]string),
 		nextSlot:       1,
 		httpProxyPort:  DefaultHTTPProxyPort,
 		tlsProxyPort:   DefaultTLSProxyPort,
@@ -270,15 +265,16 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		m.log.Info().Str("vm_id", vmID).Msg("network pool empty, falling back to on-demand setup")
 	}
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(vmID)
 	if err != nil {
 		return nil, err
 	}
 
 	info, _, err := m.setupSlot(ctx, idx)
 	if err != nil {
-		// Build failed — release the index so it isn't leaked from owned.
-		m.freeSlot(idx)
+		// Build failed — release the index (we are its sole owner) so it isn't
+		// leaked. releaseIfOwned keeps it correct even if state moved under us.
+		m.releaseIfOwned(idx, vmID)
 		return nil, err
 	}
 
@@ -446,8 +442,11 @@ func (m *Manager) CleanupVM(vmID string) {
 		return
 	}
 
-	var idx int
-	fmt.Sscanf(info.Namespace, "ns-%d", &idx)
+	idx, parsed := slotFromNamespace(info.Namespace)
+	if !parsed {
+		m.log.Warn().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("cleanup: unparseable namespace — skipping slot reclaim")
+		return
+	}
 	vethName := fmt.Sprintf("veth-%d", idx)
 
 	// Remove per-sandbox egress proxy rules.
@@ -459,16 +458,16 @@ func (m *Manager) CleanupVM(vmID string) {
 	// nftables stay configured; the next Claim re-adds vmID-specific
 	// rules. Skipped when info.Firewall is nil (reattached VM whose
 	// in-ns handle couldn't be rebound) — pooling would let the next
-	// Claim silently lose per-VM egress filtering.
+	// Claim silently lose per-VM egress filtering. Return transfers ownership
+	// from this VM back to the pool.
 	if m.pool != nil && info.Firewall != nil {
 		_ = info.Firewall.ReplaceUserRules(nil, nil)
 		m.pool.Return(&preallocSlot{idx: idx, info: info, vethName: vethName})
 		return
 	}
 
-	// No pool — full teardown. Release the index from owned (the pool-return
-	// path above keeps it owned because the pool still holds the slot).
-	m.freeSlot(idx)
+	// No pool — full teardown. Release the index only if this VM still owns it.
+	m.releaseIfOwned(idx, vmID)
 
 	if info.Firewall != nil {
 		if err := info.Firewall.Close(); err != nil {
@@ -508,29 +507,46 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	if !ok {
 		return
 	}
-	// This slot belongs to the stale record being cleaned up. Because existing
-	// records reserve their index in owned at startup, the pool never builds on
-	// it, so there is no live tenant to protect here — tear it down and release
-	// the index. Tear down both sides even if the netns is already gone:
-	// `ip netns del` only removes the in-namespace side, so the host-side veth-N
-	// can outlive its namespace.
+	// Only tear down + reclaim if this vmID still owns the index. A stale cleanup
+	// (e.g. a DELETE that captured the old namespace) that races the pool reusing
+	// the slot for a new tenant must NOT destroy the new tenant's ns/veth. Claim
+	// the teardown atomically (vmID → teardownOwner) so a concurrent claimSlotIndex
+	// can't grab the index while we run cleanupFull below.
+	m.mu.Lock()
+	if m.slotOwner[idx] != vmID {
+		m.mu.Unlock()
+		return
+	}
+	m.slotOwner[idx] = teardownOwner
+	m.mu.Unlock()
+
+	// Tear down both sides even if the netns is already gone: `ip netns del`
+	// only removes the in-namespace side, so the host-side veth-N can outlive it.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
-	m.freeSlot(idx)
+	m.releaseIfOwned(idx, teardownOwner)
 	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("reclaimed network slot for untracked VM")
 }
 
-// Forget drops vmID from the in-memory device map without any kernel teardown,
-// slot reclamation, or egress change. It reverses a reattach that raced a
-// concurrent DestroyVM/markStale: that path already tore down (or recycled to
-// the pool) the slot, so tearing it down again here would double-free it or
-// clobber the new owner of a recycled ns/veth. The host IP is left registered
-// in the egress proxy — it is keyed by slot, so a reused slot's new owner may
-// already hold it.
+// Forget reverses an in-memory reattach that raced a concurrent DestroyVM/
+// markStale: it drops vmID from devices and releases the reattach's slot
+// reservation — but ONLY the index this vmID still owns (releaseIfOwned). If the
+// racing destroy already freed or the pool already reused the index, ownership
+// has moved on and Forget leaves it untouched, so it neither double-frees nor
+// clobbers a new tenant. No kernel teardown here (the destroy path did that);
+// the host IP is left registered in the egress proxy (keyed by slot, a reused
+// slot's new owner may already hold it).
 func (m *Manager) Forget(vmID string) {
 	m.mu.Lock()
+	info, ok := m.devices[vmID]
 	delete(m.devices, vmID)
 	m.mu.Unlock()
+	if !ok {
+		return
+	}
+	if idx, parsed := slotFromNamespace(info.Namespace); parsed {
+		m.releaseIfOwned(idx, vmID)
+	}
 }
 
 // ReattachVM rebinds vmd's view of an already-running VM's network state
@@ -567,10 +583,11 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	}
 
 	m.mu.Lock()
-	// Reserve this record's index in owned so the pool can't build on it, and
-	// bump nextSlot past it. (Startup reservation usually did this already; this
-	// keeps a lazy reattach safe too.)
-	m.ownSlotLocked(idx)
+	// Reserve this record's index under its vmID so the pool can't build on it,
+	// and bump nextSlot past it. (Startup reservation usually did this already;
+	// this keeps a lazy reattach safe too.) reserveSlotLocked also removes idx
+	// from freeSlots, keeping freeSlots ∩ slotOwner disjoint.
+	m.reserveSlotLocked(idx, vmID)
 	if idx >= m.nextSlot {
 		m.nextSlot = idx + 1
 	}
@@ -598,25 +615,27 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	return nil
 }
 
-// ReserveSlotsAbove reserves every existing record's slot index in owned (and
-// bumps nextSlot past it) so the pool can never build on an index a record
-// holds. Called once at startup with every record namespace, BEFORE StartPool.
+// ReserveSlotsAbove reserves every existing record's slot index under its vmID
+// (and bumps nextSlot past it) so the pool can never build on an index a record
+// holds. Called once at startup with vmID→namespace for every record, BEFORE
+// StartPool. Reserving under the vmID means a later stale cleanup for that vmID
+// can identity-match and release exactly its own index.
 //
 // Every record is reserved unconditionally — including a stale/dead one whose
 // netns is gone. Reserving a dead slot only strands it transiently: the
-// background reattach reclaims it (freeSlot) when it cleans the stale record, so
-// the index returns to the recycle list. This is deliberately simpler (and
-// safer) than trying to free dead slots up front, which is what let the pool
-// collide with a record and duplicate a slot.
-func (m *Manager) ReserveSlotsAbove(namespaces []string) {
+// background reattach reclaims it when it cleans the stale record, so the index
+// returns to the recycle list. This is deliberately simpler (and safer) than
+// trying to free dead slots up front, which is what let the pool collide with a
+// record and duplicate a slot.
+func (m *Manager) ReserveSlotsAbove(reservations map[string]string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, ns := range namespaces {
+	for vmID, ns := range reservations {
 		idx, ok := slotFromNamespace(ns)
 		if !ok {
 			continue
 		}
-		m.ownSlotLocked(idx)
+		m.reserveSlotLocked(idx, vmID)
 		if idx >= m.nextSlot {
 			m.nextSlot = idx + 1
 		}
@@ -635,8 +654,15 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		return nil, fmt.Errorf("ensure %s: cannot parse slot from namespace %q", vmID, namespace)
 	}
 
+	// Reserve this record's index under its vmID BEFORE any rebuild, so the pool
+	// can't claim idx during the cleanupFull/setupSlot window below. Ownership was
+	// almost always taken at startup already; this is idempotent.
 	m.mu.Lock()
 	existing, hasDevice := m.devices[vmID]
+	m.reserveSlotLocked(idx, vmID)
+	if idx >= m.nextSlot {
+		m.nextSlot = idx + 1
+	}
 	m.mu.Unlock()
 
 	var info *VMNetInfo
@@ -671,18 +697,6 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 	}
 
 	m.mu.Lock()
-	// Reserve this record's index in owned so the pool can't build on it while
-	// this VM holds it, and remove it from the recycle list if present.
-	m.ownSlotLocked(idx)
-	if idx >= m.nextSlot {
-		m.nextSlot = idx + 1
-	}
-	for i, s := range m.freeSlots {
-		if s == idx {
-			m.freeSlots = append(m.freeSlots[:i], m.freeSlots[i+1:]...)
-			break
-		}
-	}
 	m.devices[vmID] = info
 	m.mu.Unlock()
 	m.registerEgress(vmID, info)
@@ -709,30 +723,55 @@ func slotFromNamespace(namespace string) (int, bool) {
 	return idx, true
 }
 
-// ownSlotLocked marks idx allocated. Caller must hold m.mu. Idempotent.
-func (m *Manager) ownSlotLocked(idx int) { m.owned[idx] = struct{}{} }
+// Sentinel owners (see slotOwner). Prefixed with NUL so they can never collide
+// with a real vmID.
+const (
+	poolOwner     = "\x00pool"     // warm/mid-build pool slot, not yet a VM's
+	teardownOwner = "\x00teardown" // slot mid-teardown; held so it isn't reclaimed
+)
 
-// freeSlotLocked releases idx — drops ownership and returns it to the recycle
-// list so a later claimSlotIndex can reuse it. Caller must hold m.mu. This is
-// the ONLY way a slot leaves owned, so every teardown path must route through
-// it (directly or via freeSlot) to avoid leaking the index.
-func (m *Manager) freeSlotLocked(idx int) {
-	delete(m.owned, idx)
-	m.freeSlots = append(m.freeSlots, idx)
+// assignSlotLocked sets the owner of idx (a fresh claim or an owner transfer,
+// e.g. pool→VM on Claim). Caller must hold m.mu and must have already removed
+// idx from freeSlots (claimSlotIndex pops it; transfers keep it out).
+func (m *Manager) assignSlotLocked(idx int, owner string) { m.slotOwner[idx] = owner }
+
+// reserveSlotLocked marks idx owned by a record and removes it from the recycle
+// list if present — the record-path acquire that keeps freeSlots ∩ slotOwner
+// disjoint. Caller must hold m.mu.
+func (m *Manager) reserveSlotLocked(idx int, owner string) {
+	m.slotOwner[idx] = owner
+	m.removeFromFreeSlotsLocked(idx)
 }
 
-// freeSlot releases idx, taking the lock.
-func (m *Manager) freeSlot(idx int) {
+func (m *Manager) removeFromFreeSlotsLocked(idx int) {
+	for i, s := range m.freeSlots {
+		if s == idx {
+			m.freeSlots = append(m.freeSlots[:i], m.freeSlots[i+1:]...)
+			return
+		}
+	}
+}
+
+// releaseIfOwned releases idx only when it is still owned by owner, returning
+// whether it did. This is the identity guard that stops a stale cleanup for an
+// old vmID from freeing a slot the pool or another VM has since reused.
+func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	m.mu.Lock()
-	m.freeSlotLocked(idx)
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+	if m.slotOwner[idx] != owner {
+		return false
+	}
+	delete(m.slotOwner, idx)
+	m.freeSlots = append(m.freeSlots, idx)
+	return true
 }
 
-// claimSlotIndex picks a slot idx that is unowned (see the owned invariant) and
-// not present in the kernel, marks it owned, and returns it. Ownership persists
-// until the slot is genuinely torn down, so the same idx can never be handed to
-// two builds — the root guarantee against slot duplication.
-func (m *Manager) claimSlotIndex() (int, error) {
+// claimSlotIndex picks a slot idx that is unowned and not present in the kernel,
+// assigns it to owner, and returns it. Ownership persists until the slot is
+// genuinely torn down, so the same idx can never be handed to two builds — the
+// root guarantee against slot duplication. owner is poolOwner for pool
+// pre-allocation, or the vmID for an on-demand SetupVM.
+func (m *Manager) claimSlotIndex(owner string) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -749,14 +788,14 @@ func (m *Manager) claimSlotIndex() (int, error) {
 			m.nextSlot++
 		}
 
-		if _, isOwned := m.owned[idx]; isOwned || nsExists(fmt.Sprintf("ns-%d", idx)) {
+		if _, isOwned := m.slotOwner[idx]; isOwned || nsExists(fmt.Sprintf("ns-%d", idx)) {
 			// Owned by a live slot/record/build, or its kernel ns already
 			// exists. Discard; returning idx to freeSlots would loop.
 			m.log.Warn().Int("slot", idx).Msg("allocator: skipping idx — owned or kernel ns exists")
 			continue
 		}
 
-		m.ownSlotLocked(idx)
+		m.assignSlotLocked(idx, owner)
 		return idx, nil
 	}
 }

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -30,34 +31,32 @@ func touchNS(t *testing.T, dir, name string) {
 
 func newTestManager() *Manager {
 	return &Manager{
-		log:          zerolog.Nop(),
-		devices:      make(map[string]*VMNetInfo),
-		relinquished: make(map[int]bool),
-		inFlight:     make(map[int]bool),
-		nextSlot:     1,
+		log:      zerolog.Nop(),
+		devices:  make(map[string]*VMNetInfo),
+		owned:    make(map[int]struct{}),
+		nextSlot: 1,
 	}
 }
 
 func TestReserveSlotsAbove(t *testing.T) {
-	dir := withTestNetnsDir(t)
+	withTestNetnsDir(t)
 	m := newTestManager()
-	// liveOnly: ns-5 exists (reserved), ns-9 does NOT (stale running record —
-	// skipped so its slot stays free). bogus is unparseable.
-	touchNS(t, dir, "ns-5")
-	m.ReserveSlotsAbove(nil, []string{"ns-5", "bogus", "ns-9"})
-	if m.nextSlot != 6 {
-		t.Fatalf("nextSlot = %d, want 6 (past live ns-5; ns-9 skipped — no netns)", m.nextSlot)
+	// Every record's slot is reserved into owned and bumps nextSlot — including
+	// ns-9 whose netns is absent (a dead record still holds its index until the
+	// reattach reclaims it). bogus is unparseable and skipped.
+	m.ReserveSlotsAbove([]string{"ns-5", "bogus", "ns-9"})
+	if m.nextSlot != 10 {
+		t.Fatalf("nextSlot = %d, want 10 (past highest reserved ns-9)", m.nextSlot)
 	}
-	// resumable: a paused VM's slot must be reserved even though its netns is
-	// gone (host reboot wiped it) — it rebuilds ns-20 on resume.
-	m.ReserveSlotsAbove([]string{"ns-20"}, nil)
-	if m.nextSlot != 21 {
-		t.Fatalf("nextSlot = %d, want 21 (paused ns-20 reserved despite missing netns)", m.nextSlot)
+	for _, idx := range []int{5, 9} {
+		if _, ok := m.owned[idx]; !ok {
+			t.Errorf("slot %d must be owned after reservation", idx)
+		}
 	}
-	// A lower existing index must never pull nextSlot back down.
-	m.ReserveSlotsAbove([]string{"ns-3"}, []string{"ns-4"})
-	if m.nextSlot != 21 {
-		t.Fatalf("nextSlot = %d, want 21 (unchanged by lower index)", m.nextSlot)
+	// A lower index reserves but must never pull nextSlot back down.
+	m.ReserveSlotsAbove([]string{"ns-3"})
+	if m.nextSlot != 10 {
+		t.Fatalf("nextSlot = %d, want 10 (unchanged by lower index)", m.nextSlot)
 	}
 }
 
@@ -271,77 +270,86 @@ func TestCleanupVMOrNamespace_ReclaimsUntrackedSlot(t *testing.T) {
 	}
 }
 
-// A slot relinquished at startup (running record whose netns was gone) that the
-// pool has since reused — ns-5 exists again — must NOT be torn down or reclaimed
-// by the stale record's deferred cleanup, or it corrupts the new sandbox.
-func TestCleanupVMOrNamespace_RelinquishedReusedSlotSkipped(t *testing.T) {
-	dir := withTestNetnsDir(t)
+// claimSlotIndex must never return an index that is already owned — the core
+// invariant that makes slot duplication impossible.
+func TestClaimSlotIndex_SkipsOwned(t *testing.T) {
+	withTestNetnsDir(t)
 	m := newTestManager()
+	m.owned[1] = struct{}{} // idx 1 reserved/owned; nextSlot still 1
 
-	// Startup: running record at ns-5 has no netns → relinquished.
-	m.ReserveSlotsAbove(nil, []string{"ns-5"})
-	// Pool reuses slot 5 for a new sandbox (recreates the netns).
-	touchNS(t, dir, "ns-5")
-
-	m.CleanupVMOrNamespace("stale-vm", "ns-5")
-
-	if len(m.freeSlots) != 0 {
-		t.Errorf("freeSlots = %v, want [] (reused slot must not be reclaimed)", m.freeSlots)
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("claimSlotIndex: %v", err)
+	}
+	if idx == 1 {
+		t.Fatal("claimSlotIndex returned owned idx 1")
+	}
+	if _, ok := m.owned[idx]; !ok {
+		t.Errorf("returned idx %d must be marked owned", idx)
 	}
 }
 
-// IsRelinquished reports true only for slots freed at startup (running record
-// with no netns), so the reattach path can refuse to bind a stale vmID onto a
-// slot the pool may have reused.
-func TestIsRelinquished(t *testing.T) {
-	dir := withTestNetnsDir(t)
+// Regression for the phantom-revival slot-duplication bug: a warm pool slot's
+// index stays owned even when its netns is momentarily absent, so the allocator
+// must NOT re-hand-out that index (which previously produced a second warm slot
+// on the same index → two sandboxes on one slot).
+func TestClaimSlotIndex_PhantomRevivalPrevented(t *testing.T) {
+	withTestNetnsDir(t) // ns-1 absent: the warm slot's netns was deleted (phantom)
 	m := newTestManager()
+	m.owned[1] = struct{}{} // idx 1 is a warm pool slot, still owned
 
-	touchNS(t, dir, "ns-7") // ns-7 live → reserved, not relinquished
-	m.ReserveSlotsAbove(nil, []string{"ns-7", "ns-5"})
-
-	if !m.IsRelinquished("ns-5") {
-		t.Error("ns-5 (running, no netns) must be relinquished")
+	idx, err := m.claimSlotIndex()
+	if err != nil {
+		t.Fatalf("claimSlotIndex: %v", err)
 	}
-	if m.IsRelinquished("ns-7") {
-		t.Error("ns-7 (live netns) must not be relinquished")
-	}
-	if m.IsRelinquished("ns-99") {
-		t.Error("ns-99 (never seen) must not be relinquished")
-	}
-	if m.IsRelinquished("bogus") {
-		t.Error("unparseable namespace must not be relinquished")
+	if idx == 1 {
+		t.Fatal("claimSlotIndex re-allocated a warm (owned) slot with a missing netns — phantom revival not prevented")
 	}
 }
 
-// A relinquished slot the pool has CLAIMED but not yet built (ns-N doesn't
-// exist yet, but it's marked in-flight) must NOT be reclaimed by a stale-record
-// cleanup — otherwise the slot is double-owned and later handed out twice.
-func TestCleanupVMOrNamespace_RelinquishedInFlightSlotSkipped(t *testing.T) {
-	withTestNetnsDir(t) // ns-5 intentionally absent: allocator is mid-setupSlot
+// Concurrent claims must never collide — every returned index is distinct.
+func TestClaimSlotIndex_ConcurrentDistinct(t *testing.T) {
+	withTestNetnsDir(t)
 	m := newTestManager()
-	m.ReserveSlotsAbove(nil, []string{"ns-5"}) // ns-5 relinquished at startup
-	m.mu.Lock()
-	m.inFlight[5] = true // pool claimed slot 5, before setupSlot creates ns-5
-	m.mu.Unlock()
 
-	m.CleanupVMOrNamespace("stale-vm", "ns-5")
+	const n = 64
+	var wg sync.WaitGroup
+	got := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			idx, err := m.claimSlotIndex()
+			if err != nil {
+				t.Errorf("claim: %v", err)
+				return
+			}
+			got[i] = idx
+		}(i)
+	}
+	wg.Wait()
 
-	if len(m.freeSlots) != 0 {
-		t.Errorf("freeSlots = %v, want [] (in-flight slot must not be reclaimed)", m.freeSlots)
+	seen := make(map[int]bool, n)
+	for _, idx := range got {
+		if seen[idx] {
+			t.Fatalf("duplicate slot index handed out: %d", idx)
+		}
+		seen[idx] = true
 	}
 }
 
-// A relinquished slot the pool did NOT reuse — netns still gone — is safely
-// reclaimed (and any leftover host veth removed) by the deferred cleanup.
-func TestCleanupVMOrNamespace_RelinquishedUnusedSlotReclaimed(t *testing.T) {
-	withTestNetnsDir(t) // ns-5 never recreated → still gone
+// CleanupVMOrNamespace releases the index from owned so it can be reused.
+func TestCleanupVMOrNamespace_ReleasesOwnership(t *testing.T) {
+	withTestNetnsDir(t) // ns-5 absent
 	m := newTestManager()
+	m.ReserveSlotsAbove([]string{"ns-5"}) // ns-5 owned (reserved record)
 
-	m.ReserveSlotsAbove(nil, []string{"ns-5"})
 	m.CleanupVMOrNamespace("stale-vm", "ns-5")
 
+	if _, ok := m.owned[5]; ok {
+		t.Error("slot 5 must be released from owned after cleanup")
+	}
 	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
-		t.Errorf("freeSlots = %v, want [5] (unused relinquished slot reclaimed)", m.freeSlots)
+		t.Errorf("freeSlots = %v, want [5] (slot reclaimed)", m.freeSlots)
 	}
 }

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -31,30 +31,28 @@ func touchNS(t *testing.T, dir, name string) {
 
 func newTestManager() *Manager {
 	return &Manager{
-		log:      zerolog.Nop(),
-		devices:  make(map[string]*VMNetInfo),
-		owned:    make(map[int]struct{}),
-		nextSlot: 1,
+		log:       zerolog.Nop(),
+		devices:   make(map[string]*VMNetInfo),
+		slotOwner: make(map[int]string),
+		nextSlot:  1,
 	}
 }
 
 func TestReserveSlotsAbove(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
-	// Every record's slot is reserved into owned and bumps nextSlot — including
-	// ns-9 whose netns is absent (a dead record still holds its index until the
-	// reattach reclaims it). bogus is unparseable and skipped.
-	m.ReserveSlotsAbove([]string{"ns-5", "bogus", "ns-9"})
+	// Every record's slot is reserved under its vmID and bumps nextSlot —
+	// including ns-9 whose netns is absent (a dead record still holds its index
+	// until the reattach reclaims it). bogus is unparseable and skipped.
+	m.ReserveSlotsAbove(map[string]string{"vm-5": "ns-5", "vm-b": "bogus", "vm-9": "ns-9"})
 	if m.nextSlot != 10 {
 		t.Fatalf("nextSlot = %d, want 10 (past highest reserved ns-9)", m.nextSlot)
 	}
-	for _, idx := range []int{5, 9} {
-		if _, ok := m.owned[idx]; !ok {
-			t.Errorf("slot %d must be owned after reservation", idx)
-		}
+	if m.slotOwner[5] != "vm-5" || m.slotOwner[9] != "vm-9" {
+		t.Errorf("slots must be owned by their vmIDs: slotOwner=%v", m.slotOwner)
 	}
 	// A lower index reserves but must never pull nextSlot back down.
-	m.ReserveSlotsAbove([]string{"ns-3"})
+	m.ReserveSlotsAbove(map[string]string{"vm-3": "ns-3"})
 	if m.nextSlot != 10 {
 		t.Fatalf("nextSlot = %d, want 10 (unchanged by lower index)", m.nextSlot)
 	}
@@ -94,7 +92,7 @@ func TestClaimSlotIndex_FreshNextSlot(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -111,7 +109,7 @@ func TestClaimSlotIndex_PrefersFreeSlotsLIFO(t *testing.T) {
 	m := newTestManager()
 	m.freeSlots = []int{5, 7}
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -132,7 +130,7 @@ func TestClaimSlotIndex_SkipsPhantomFromNextSlot(t *testing.T) {
 	touchNS(t, dir, "ns-2")
 	m := newTestManager()
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -150,7 +148,7 @@ func TestClaimSlotIndex_SkipsPhantomFromFreeSlots(t *testing.T) {
 	m := newTestManager()
 	m.freeSlots = []int{5, 7}
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -167,7 +165,7 @@ func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
 	m := newTestManager()
 	m.nextSlot = MaxSlots + 1
 
-	_, err := m.claimSlotIndex()
+	_, err := m.claimSlotIndex(poolOwner)
 	if !errors.Is(err, ErrNoSlots) {
 		t.Errorf("err = %v, want ErrNoSlots", err)
 	}
@@ -248,6 +246,7 @@ func TestCleanupVMOrNamespace_EmptyAndInvalidNamespaceNoop(t *testing.T) {
 func TestCleanupVMOrNamespace_MissingNamespaceStillReclaims(t *testing.T) {
 	withTestNetnsDir(t) // ns-5 intentionally not touched → netns already gone
 	m := newTestManager()
+	m.slotOwner[5] = "vm-u" // vm-u owns slot 5 (reserved record)
 
 	// The host-side veth-N can outlive its netns, so cleanup must still tear it
 	// down and reclaim the slot even when the namespace itself is already gone.
@@ -262,11 +261,34 @@ func TestCleanupVMOrNamespace_ReclaimsUntrackedSlot(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-5")
 	m := newTestManager()
+	m.slotOwner[5] = "vm-u" // vm-u owns slot 5
 
 	m.CleanupVMOrNamespace("vm-u", "ns-5")
 
 	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
 		t.Errorf("freeSlots = %v, want [5] (slot reclaimed)", m.freeSlots)
+	}
+	if _, ok := m.slotOwner[5]; ok {
+		t.Error("slot 5 must be released from slotOwner")
+	}
+}
+
+// Identity guard (the core fix): a stale cleanup for an old vmID must NOT tear
+// down or reclaim a slot the pool/another VM has since reused.
+func TestCleanupVMOrNamespace_SkipsSlotReusedByAnotherOwner(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-5")
+	m := newTestManager()
+	m.slotOwner[5] = "new-tenant" // slot 5 was freed and reused by a new VM
+
+	// A late cleanup for the OLD owner of ns-5 must be a no-op.
+	m.CleanupVMOrNamespace("old-vm", "ns-5")
+
+	if m.slotOwner[5] != "new-tenant" {
+		t.Errorf("slot 5 ownership must be untouched, got %q", m.slotOwner[5])
+	}
+	if len(m.freeSlots) != 0 {
+		t.Errorf("freeSlots = %v, want [] (must not reclaim a reused slot)", m.freeSlots)
 	}
 }
 
@@ -275,16 +297,16 @@ func TestCleanupVMOrNamespace_ReclaimsUntrackedSlot(t *testing.T) {
 func TestClaimSlotIndex_SkipsOwned(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
-	m.owned[1] = struct{}{} // idx 1 reserved/owned; nextSlot still 1
+	m.slotOwner[1] = "vm-a" // idx 1 owned by a VM; nextSlot still 1
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("claimSlotIndex: %v", err)
 	}
 	if idx == 1 {
 		t.Fatal("claimSlotIndex returned owned idx 1")
 	}
-	if _, ok := m.owned[idx]; !ok {
+	if _, ok := m.slotOwner[idx]; !ok {
 		t.Errorf("returned idx %d must be marked owned", idx)
 	}
 }
@@ -296,9 +318,9 @@ func TestClaimSlotIndex_SkipsOwned(t *testing.T) {
 func TestClaimSlotIndex_PhantomRevivalPrevented(t *testing.T) {
 	withTestNetnsDir(t) // ns-1 absent: the warm slot's netns was deleted (phantom)
 	m := newTestManager()
-	m.owned[1] = struct{}{} // idx 1 is a warm pool slot, still owned
+	m.slotOwner[1] = poolOwner // idx 1 is a warm pool slot, still owned
 
-	idx, err := m.claimSlotIndex()
+	idx, err := m.claimSlotIndex(poolOwner)
 	if err != nil {
 		t.Fatalf("claimSlotIndex: %v", err)
 	}
@@ -319,7 +341,7 @@ func TestClaimSlotIndex_ConcurrentDistinct(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			idx, err := m.claimSlotIndex()
+			idx, err := m.claimSlotIndex(poolOwner)
 			if err != nil {
 				t.Errorf("claim: %v", err)
 				return
@@ -342,11 +364,11 @@ func TestClaimSlotIndex_ConcurrentDistinct(t *testing.T) {
 func TestCleanupVMOrNamespace_ReleasesOwnership(t *testing.T) {
 	withTestNetnsDir(t) // ns-5 absent
 	m := newTestManager()
-	m.ReserveSlotsAbove([]string{"ns-5"}) // ns-5 owned (reserved record)
+	m.ReserveSlotsAbove(map[string]string{"stale-vm": "ns-5"}) // stale-vm owns ns-5
 
 	m.CleanupVMOrNamespace("stale-vm", "ns-5")
 
-	if _, ok := m.owned[5]; ok {
+	if _, ok := m.slotOwner[5]; ok {
 		t.Error("slot 5 must be released from owned after cleanup")
 	}
 	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -115,6 +115,8 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 
 		p.mgr.mu.Lock()
 		p.mgr.devices[vmID] = slot.info
+		// Transfer ownership of the index from the pool to this VM.
+		p.mgr.assignSlotLocked(slot.idx, vmID)
 		p.mgr.mu.Unlock()
 		tDone := time.Now()
 
@@ -136,8 +138,12 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 func (p *Pool) Return(slot *preallocSlot) {
 	select {
 	case p.recycled <- slot:
+		// Ownership transfers back from the VM to the pool.
+		p.mgr.mu.Lock()
+		p.mgr.assignSlotLocked(slot.idx, poolOwner)
+		p.mgr.mu.Unlock()
 	default:
-		// Recycle pool full — tear down.
+		// Recycle pool full — tear down (cleanup releases ownership).
 		p.cleanup(slot)
 	}
 }
@@ -216,7 +222,7 @@ func (p *Pool) mustAllocate(ctx context.Context) *preallocSlot {
 }
 
 func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
-	idx, err := p.mgr.claimSlotIndex()
+	idx, err := p.mgr.claimSlotIndex(poolOwner)
 	if err != nil {
 		return nil, err
 	}
@@ -225,9 +231,9 @@ func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
 	// This is the expensive part we're moving off the hot path.
 	info, vethName, err := p.mgr.setupSlot(ctx, idx)
 	if err != nil {
-		// Build failed — release the index so it isn't leaked from owned.
+		// Build failed — release the pool's index so it isn't leaked.
 		// claimSlotIndex's nsExists guard prevents re-looping on a colliding idx.
-		p.mgr.freeSlot(idx)
+		p.mgr.releaseIfOwned(idx, poolOwner)
 		return nil, err
 	}
 
@@ -240,6 +246,6 @@ func (p *Pool) cleanup(slot *preallocSlot) {
 	}
 	nsName := slot.info.Namespace
 	p.mgr.cleanupFull(nsName, slot.vethName)
-	// The slot is gone — release its index from owned back to the recycle list.
-	p.mgr.freeSlot(slot.idx)
+	// The pool slot is gone — release its index back to the recycle list.
+	p.mgr.releaseIfOwned(slot.idx, poolOwner)
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -225,7 +225,9 @@ func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
 	// This is the expensive part we're moving off the hot path.
 	info, vethName, err := p.mgr.setupSlot(ctx, idx)
 	if err != nil {
-		// idx stays consumed — reusing a colliding idx would loop.
+		// Build failed — release the index so it isn't leaked from owned.
+		// claimSlotIndex's nsExists guard prevents re-looping on a colliding idx.
+		p.mgr.freeSlot(idx)
 		return nil, err
 	}
 
@@ -238,7 +240,6 @@ func (p *Pool) cleanup(slot *preallocSlot) {
 	}
 	nsName := slot.info.Namespace
 	p.mgr.cleanupFull(nsName, slot.vethName)
-	p.mgr.mu.Lock()
-	p.mgr.freeSlots = append(p.mgr.freeSlots, slot.idx)
-	p.mgr.mu.Unlock()
+	// The slot is gone — release its index from owned back to the recycle list.
+	p.mgr.freeSlot(slot.idx)
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -136,14 +136,18 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 // configured — the next Claim reuses them with zero setup cost.
 // If the recycled pool is full, the slot is torn down instead.
 func (p *Pool) Return(slot *preallocSlot) {
+	// Transfer ownership from the VM back to the pool BEFORE handing the slot
+	// off. Doing it under the lock first means a concurrent Claim that pops the
+	// slot can't be clobbered by a late poolOwner write, and the recycle-full
+	// cleanup below releases the right owner (poolOwner) instead of leaking.
+	p.mgr.mu.Lock()
+	p.mgr.assignSlotLocked(slot.idx, poolOwner)
+	p.mgr.mu.Unlock()
+
 	select {
 	case p.recycled <- slot:
-		// Ownership transfers back from the VM to the pool.
-		p.mgr.mu.Lock()
-		p.mgr.assignSlotLocked(slot.idx, poolOwner)
-		p.mgr.mu.Unlock()
 	default:
-		// Recycle pool full — tear down (cleanup releases ownership).
+		// Recycle pool full — tear down (cleanup releases the pool's ownership).
 		p.cleanup(slot)
 	}
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -136,10 +136,9 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 // configured — the next Claim reuses them with zero setup cost.
 // If the recycled pool is full, the slot is torn down instead.
 func (p *Pool) Return(slot *preallocSlot) {
-	// Transfer ownership from the VM back to the pool BEFORE handing the slot
-	// off. Doing it under the lock first means a concurrent Claim that pops the
-	// slot can't be clobbered by a late poolOwner write, and the recycle-full
-	// cleanup below releases the right owner (poolOwner) instead of leaking.
+	// Transfer ownership back to the pool under the lock BEFORE handing the slot
+	// off: a concurrent Claim that pops it can't be clobbered by a late poolOwner
+	// write, and the recycle-full cleanup below releases poolOwner, not a leak.
 	p.mgr.mu.Lock()
 	p.mgr.assignSlotLocked(slot.idx, poolOwner)
 	p.mgr.mu.Unlock()

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -19,6 +19,9 @@ func TestPoolClaim_DiscardsPhantomReturnsNil(t *testing.T) {
 		stopCh:   make(chan struct{}),
 	}
 
+	// A slot in the pool is owned by poolOwner (allocate → claimSlotIndex).
+	// cleanup releases it back to freeSlots only because that ownership holds.
+	m.assignSlotLocked(1, poolOwner)
 	p.fresh <- &preallocSlot{
 		idx:      1,
 		info:     &VMNetInfo{Namespace: "ns-1", HostIP: "10.11.0.1"},

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1773,20 +1773,19 @@ func (m *Manager) ReserveStartupSlots(context.Context) {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return
 	}
-	nss := collectStartupSlots(recs)
-	m.netMgr.ReserveSlotsAbove(nss)
+	m.netMgr.ReserveSlotsAbove(collectStartupSlots(recs))
 }
 
-// collectStartupSlots returns the namespace of every record that has one. Pure,
-// so the reservation input is unit-testable without BoltDB.
-func collectStartupSlots(recs []VMRecord) []string {
-	nss := make([]string, 0, len(recs))
+// collectStartupSlots returns vmID→namespace for every record that has one, so
+// each slot is reserved under its owner. Pure — unit-testable without BoltDB.
+func collectStartupSlots(recs []VMRecord) map[string]string {
+	out := make(map[string]string, len(recs))
 	for _, rec := range recs {
 		if rec.Namespace != "" {
-			nss = append(nss, rec.Namespace)
+			out[rec.ID] = rec.Namespace
 		}
 	}
-	return nss
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1643,23 +1643,6 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 	}
 
-	// A running record whose netns was gone at startup had its slot relinquished
-	// for the pool to reuse. The FC is dead (a live one always has its netns), so
-	// this record is stale: reattaching it would bind its vmID onto the namespace
-	// the pool has since handed to a new sandbox, and a later firewall update or
-	// destroy for the stale vmID would then corrupt that live tenant. Refuse; the
-	// reconciler formally clears the record. Paused records are reserved, never
-	// relinquished, so a resumable VM is unaffected.
-	if rec.Status != StatusPaused && m.netMgr.IsRelinquished(rec.Namespace) {
-		log.Warn().Str("namespace", rec.Namespace).Msg("refusing reattach — slot relinquished at startup (stale record)")
-		// Clean the residue (veth/slot the pool hasn't reused) and drop the record
-		// here, so a DELETE that beats the background pass doesn't reach DestroyVM
-		// with no namespace and leak it. Cleanup skips teardown if ns-N was reused.
-		m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
-		m.state.Delete(rec.ID)
-		return nil, false
-	}
-
 	inst := toInstance(rec)
 
 	// Bail early if another caller (a request, or the background pass) already
@@ -1775,12 +1758,13 @@ func (m *Manager) SweepStartupOrphanNamespaces() {
 	}
 }
 
-// ReserveStartupSlots bumps the network pool's slot high-water mark past every
-// slot an existing VM occupies, so StartPool can run before the backgrounded
-// per-VM reattach without the pool handing out a slot that collides with a
-// not-yet-reattached VM. One systemctl call for the whole fleet; otherwise just
-// parses slot indices, no kernel work.
-func (m *Manager) ReserveStartupSlots(ctx context.Context) {
+// ReserveStartupSlots reserves every existing record's slot index in the network
+// allocator's owned set (and bumps the high-water mark past it) so StartPool can
+// run before the backgrounded per-VM reattach without the pool ever building on
+// an index a record holds. Every record is reserved unconditionally — a dead
+// record's slot is reclaimed later when the reattach cleans it up. Cheap: parses
+// slot indices, no kernel work, no systemctl.
+func (m *Manager) ReserveStartupSlots(context.Context) {
 	if m.state == nil {
 		return
 	}
@@ -1789,52 +1773,20 @@ func (m *Manager) ReserveStartupSlots(ctx context.Context) {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return
 	}
-
-	// Authoritative liveness for running records, one call for the whole fleet.
-	// A running FC keeps its network namespace alive even if the /run/netns name
-	// was removed, so nsExists alone would wrongly relinquish a live VM's slot
-	// and hand it to the pool. Fail closed: if the list errors, treat every
-	// running record as live and reserve its slot rather than risk giving one
-	// away.
-	activeUnits, listErr := listActiveFirecrackerUnits(ctx)
-	if listErr != nil {
-		m.log.Warn().Err(listErr).Msg("startup slot reservation: active-unit list failed — reserving all running slots")
-	}
-	active := make(map[string]bool, len(activeUnits))
-	for _, id := range activeUnits {
-		active[id] = true
-	}
-
-	resumable, liveOnly := classifyStartupSlots(recs, active, listErr != nil)
-	m.netMgr.ReserveSlotsAbove(resumable, liveOnly)
+	nss := collectStartupSlots(recs)
+	m.netMgr.ReserveSlotsAbove(nss)
 }
 
-// classifyStartupSlots splits records into slots reserved unconditionally
-// (resumable) vs. reserved only if their netns still exists (liveOnly), given
-// the set of active firecracker unit IDs. Pure, so the reserve/relinquish
-// policy is unit-testable without systemd or BoltDB.
-//
-//   - paused: reserved — keeps its slot across a reboot, rebuilt on resume.
-//   - running + active unit (or liveness unknown): reserved — the FC still owns
-//     its namespace even if its /run/netns name was removed, so its slot must
-//     not be relinquished to the pool.
-//   - running + no active unit: liveOnly — a dead FC; reserve only if its netns
-//     lingers, else relinquish the slot for reuse.
-func classifyStartupSlots(recs []VMRecord, active map[string]bool, livenessUnknown bool) (resumable, liveOnly []string) {
+// collectStartupSlots returns the namespace of every record that has one. Pure,
+// so the reservation input is unit-testable without BoltDB.
+func collectStartupSlots(recs []VMRecord) []string {
+	nss := make([]string, 0, len(recs))
 	for _, rec := range recs {
-		if rec.Namespace == "" {
-			continue
-		}
-		switch {
-		case rec.Status == StatusPaused:
-			resumable = append(resumable, rec.Namespace)
-		case livenessUnknown || active[rec.ID]:
-			resumable = append(resumable, rec.Namespace)
-		default:
-			liveOnly = append(liveOnly, rec.Namespace)
+		if rec.Namespace != "" {
+			nss = append(nss, rec.Namespace)
 		}
 	}
-	return resumable, liveOnly
+	return nss
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/reserve_test.go
+++ b/internal/vm/reserve_test.go
@@ -3,9 +3,8 @@ package vm
 import "testing"
 
 // TestCollectStartupSlots pins the reservation input: every record that has a
-// namespace is reserved (unconditionally, dead or alive), and records without
-// one are skipped. Reserving all records — rather than trying to free dead ones
-// up front — is what keeps the pool from ever colliding with a record's slot.
+// namespace is reserved under its own vmID (so a later cleanup can identity-match
+// and release exactly its slot), and records without one are skipped.
 func TestCollectStartupSlots(t *testing.T) {
 	recs := []VMRecord{
 		{ID: "paused", Namespace: "ns-1", Status: StatusPaused},
@@ -16,24 +15,16 @@ func TestCollectStartupSlots(t *testing.T) {
 
 	got := collectStartupSlots(recs)
 
-	for _, ns := range []string{"ns-1", "ns-2", "ns-3"} {
-		if !contains(got, ns) {
-			t.Errorf("%s must be reserved (all records reserve their slot); got %v", ns, got)
+	want := map[string]string{"paused": "ns-1", "running": "ns-2", "dead-running": "ns-3"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d reservations, want %d: %v", len(got), len(want), got)
+	}
+	for vmID, ns := range want {
+		if got[vmID] != ns {
+			t.Errorf("reservation[%q] = %q, want %q", vmID, got[vmID], ns)
 		}
 	}
-	if contains(got, "") {
-		t.Errorf("record without a namespace must be skipped; got %v", got)
+	if _, ok := got["no-ns"]; ok {
+		t.Error("record without a namespace must be skipped")
 	}
-	if len(got) != 3 {
-		t.Errorf("want exactly 3 reserved namespaces, got %d: %v", len(got), got)
-	}
-}
-
-func contains(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/vm/reserve_test.go
+++ b/internal/vm/reserve_test.go
@@ -2,44 +2,30 @@ package vm
 
 import "testing"
 
-// TestClassifyStartupSlots pins the reserve/relinquish policy — most importantly
-// awille's edge case: a running VM with an active unit but a missing /run/netns
-// bind mount must be reserved (resumable), never relinquished, because the FC
-// still holds the namespace.
-func TestClassifyStartupSlots(t *testing.T) {
+// TestCollectStartupSlots pins the reservation input: every record that has a
+// namespace is reserved (unconditionally, dead or alive), and records without
+// one are skipped. Reserving all records — rather than trying to free dead ones
+// up front — is what keeps the pool from ever colliding with a record's slot.
+func TestCollectStartupSlots(t *testing.T) {
 	recs := []VMRecord{
 		{ID: "paused", Namespace: "ns-1", Status: StatusPaused},
-		{ID: "running-active", Namespace: "ns-2", Status: StatusRunning},
-		{ID: "running-dead", Namespace: "ns-3", Status: StatusRunning},
+		{ID: "running", Namespace: "ns-2", Status: StatusRunning},
+		{ID: "dead-running", Namespace: "ns-3", Status: StatusRunning},
 		{ID: "no-ns", Namespace: "", Status: StatusRunning},
 	}
-	// running-active has a live unit even though its netns bind mount is gone;
-	// running-dead has no active unit.
-	active := map[string]bool{"running-active": true}
 
-	resumable, liveOnly := classifyStartupSlots(recs, active, false)
+	got := collectStartupSlots(recs)
 
-	if !contains(resumable, "ns-1") {
-		t.Errorf("paused ns-1 must be resumable; got %v", resumable)
+	for _, ns := range []string{"ns-1", "ns-2", "ns-3"} {
+		if !contains(got, ns) {
+			t.Errorf("%s must be reserved (all records reserve their slot); got %v", ns, got)
+		}
 	}
-	if !contains(resumable, "ns-2") {
-		t.Errorf("active-unit running ns-2 must be resumable (not relinquished) despite missing netns; got %v", resumable)
+	if contains(got, "") {
+		t.Errorf("record without a namespace must be skipped; got %v", got)
 	}
-	if len(liveOnly) != 1 || liveOnly[0] != "ns-3" {
-		t.Errorf("only dead-unit running ns-3 may be a relinquish candidate; liveOnly = %v", liveOnly)
-	}
-	if contains(resumable, "") || contains(liveOnly, "") {
-		t.Error("empty namespace must be skipped")
-	}
-
-	// Fail closed: liveness unknown → every running record reserved, none
-	// relinquished.
-	resumable2, liveOnly2 := classifyStartupSlots(recs, nil, true)
-	if len(liveOnly2) != 0 {
-		t.Errorf("liveOnly = %v, want [] when liveness unknown (fail closed)", liveOnly2)
-	}
-	if !contains(resumable2, "ns-3") {
-		t.Errorf("running-dead must be reserved when liveness unknown; resumable = %v", resumable2)
+	if len(got) != 3 {
+		t.Errorf("want exactly 3 reserved namespaces, got %d: %v", len(got), got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Under a burst of concurrent slot allocations, the warm network pool could hand
the same slot index to two sandboxes. The old scheme tracked slot state across
several sets (`owned` / `inFlight` / `relinquished`), and a slot whose namespace
was torn down and rebuilt under the same name could be handed out twice — leaving
two sandboxes on one slot and surfacing as EBUSY when the second tried to attach
its TAP device.

## Fix

Collapse slot state into a single authoritative map, `slotOwner[idx] -> owner`,
where owner is a VM/record id, the pool sentinel, or the teardown sentinel. An
index is claimable iff it has no entry. Two properties fall out:

- **Identity-guarded release.** A cleanup or teardown acts only when the caller
  still owns the index, so a stale cleanup for an old id can't free or destroy a
  slot the pool or another VM has since reused.
- **No duplication.** A pool slot's index stays owned for its whole life
  (build → warm → claimed), so the allocator can never rebuild the same index
  into a second warm slot.

All slot state changes route through a small set of locked transition helpers,
so ownership can't be silently dropped (leak) or duplicated (double hand-out).
`Return` transfers ownership back to the pool under the lock before handing the
slot off, closing a recycle race.

No change to the create/resume/pause/destroy hot paths and no added latency —
the allocator work is the same, just tracked correctly.

## Rollout

Verified on staging: a concurrent-allocation surge drove creates and a resume
storm past the warm-pool size, exercising the on-demand allocation path. No slot
was handed out twice — zero duplicate hand-outs and zero EBUSY on TAP attach
across the run — and lifecycle latency was unaffected. Next: a single-host canary
before full rollout.
