### PR TITLE
fix: cast auto_delete_seconds param so PATCH auto-delete stops 42P08-ing

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -447,10 +447,12 @@ LEFT JOIN closed_intervals ci ON ci.sandbox_id = p.id;
 -- is armed from now() — never retroactively from the pause — so applying a
 -- window can never destroy the sandbox in the same instant. On a non-paused
 -- sandbox the deadline stays NULL and FinalizePause arms it at the next pause.
+-- Keep the ::int::double precision cast: the param is used as both the integer
+-- column and make_interval's double arg; without it Postgres errors 42P08.
 UPDATE sandbox
 SET auto_delete_seconds = sqlc.narg(auto_delete_seconds),
     auto_delete_at = CASE WHEN status = 'paused'
-      THEN now() + make_interval(secs => sqlc.narg(auto_delete_seconds))
+      THEN now() + make_interval(secs => sqlc.narg(auto_delete_seconds)::int::double precision)
       ELSE NULL
     END,
     updated_at = now()

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1195,7 +1195,7 @@ const updateSandboxAutoDelete = `-- name: UpdateSandboxAutoDelete :execrows
 UPDATE sandbox
 SET auto_delete_seconds = $2,
     auto_delete_at = CASE WHEN status = 'paused'
-      THEN now() + make_interval(secs => $2)
+      THEN now() + make_interval(secs => $2::int::double precision)
       ELSE NULL
     END,
     updated_at = now()
@@ -1213,6 +1213,8 @@ type UpdateSandboxAutoDeleteParams struct {
 // is armed from now() — never retroactively from the pause — so applying a
 // window can never destroy the sandbox in the same instant. On a non-paused
 // sandbox the deadline stays NULL and FinalizePause arms it at the next pause.
+// Keep the ::int::double precision cast: the param is used as both the integer
+// column and make_interval's double arg; without it Postgres errors 42P08.
 func (q *Queries) UpdateSandboxAutoDelete(ctx context.Context, arg UpdateSandboxAutoDeleteParams) (int64, error) {
 	result, err := q.db.Exec(ctx, updateSandboxAutoDelete, arg.ID, arg.AutoDeleteSeconds, arg.TeamID)
 	if err != nil {

--- a/internal/integration/auto_delete_test.go
+++ b/internal/integration/auto_delete_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// Guards the 42P08 type-deduction bug that broke every PATCH auto_delete_seconds
+// in prod. Handler unit tests mock the DB, so only a real query catches it.
+func TestIntegration_UpdateSandboxAutoDelete(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+	sandboxID := insertSandboxAt(t, teamID, "autodel-"+uuid.New().String()[:8], "paused", time.Now())
+	secs := func(v int32) *int32 { return &v }
+
+	// Set a window on a paused sandbox — arms the deadline.
+	n, err := testQueries.UpdateSandboxAutoDelete(ctx, db.UpdateSandboxAutoDeleteParams{
+		ID: sandboxID, TeamID: teamID, AutoDeleteSeconds: secs(3600),
+	})
+	if err != nil {
+		t.Fatalf("UpdateSandboxAutoDelete(3600): %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rows affected = %d, want 1", n)
+	}
+	sb, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sb.AutoDeleteSeconds == nil || *sb.AutoDeleteSeconds != 3600 {
+		t.Fatalf("auto_delete_seconds = %v, want 3600", sb.AutoDeleteSeconds)
+	}
+	if !sb.AutoDeleteAt.Valid {
+		t.Fatal("auto_delete_at should be armed on a paused sandbox")
+	}
+
+	// 0 = delete on pause (deadline ~now); must not error either.
+	if _, err := testQueries.UpdateSandboxAutoDelete(ctx, db.UpdateSandboxAutoDeleteParams{
+		ID: sandboxID, TeamID: teamID, AutoDeleteSeconds: secs(0),
+	}); err != nil {
+		t.Fatalf("UpdateSandboxAutoDelete(0): %v", err)
+	}
+
+	// nil clears the window.
+	if _, err := testQueries.UpdateSandboxAutoDelete(ctx, db.UpdateSandboxAutoDeleteParams{
+		ID: sandboxID, TeamID: teamID, AutoDeleteSeconds: nil,
+	}); err != nil {
+		t.Fatalf("UpdateSandboxAutoDelete(nil): %v", err)
+	}
+	sb, err = testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sb.AutoDeleteSeconds != nil {
+		t.Fatalf("auto_delete_seconds should be nil after clear, got %v", *sb.AutoDeleteSeconds)
+	}
+}


### PR DESCRIPTION
`PATCH auto_delete_seconds` (SDK `update`/`updateById`) 500s in prod: `42P08 inconsistent types deduced for parameter $2`. The param is used as both the `integer` column and `make_interval`'s `double precision` arg, so Postgres deduces conflicting types — fails for every value.

Fix: cast `::int::double precision`. Added a real-Postgres regression test (`internal/integration/auto_delete_test.go`); handler unit tests mock the DB, so this wasn't caught. Validated against Postgres 16 — old query fails, fix passes.

Only the PATCH path was broken; create/pause/resume/reaper work.