### PR TITLE
feat: add paginated GET /activity endpoint for team audit log

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1196,6 +1196,109 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /activity:
+    get:
+      operationId: listActivity
+      tags: [Activity]
+      summary: List team audit-log activity
+      description: |
+        Returns audit-log activity for the authenticated team, ordered by
+        creation time (newest first) by default. Backs the console Audit Logs
+        page.
+
+        Pass `limit` (and `offset`) to fetch one page at a time; the
+        `X-Total-Count` response header reports the total across all pages.
+        The activity log grows without bound, so omitting `limit` returns only
+        the most recent page (up to the 200-row maximum) — page through older
+        history with `limit` + `offset`. Filter by exact `category` or
+        `status`, restrict to a window with `start`/`end`, and search with `q`
+        (case-insensitive substring across sandbox name, secret name, action,
+        and category).
+      security:
+        - apiKey: []
+      parameters:
+        - name: category
+          in: query
+          required: false
+          description: >
+            Filter by exact activity category (e.g. `sandbox`, `template`,
+            `secret`, `network`).
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: false
+          description: Filter by exact status. Pass `error` to show only failed events.
+          schema:
+            type: string
+        - name: q
+          in: query
+          required: false
+          description: >
+            Case-insensitive substring match across sandbox name, secret name,
+            action, and category.
+          schema:
+            type: string
+        - name: start
+          in: query
+          required: false
+          description: Only include events at or after this RFC3339 timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: end
+          in: query
+          required: false
+          description: Only include events at or before this RFC3339 timestamp.
+          schema:
+            type: string
+            format: date-time
+        - name: sort
+          in: query
+          required: false
+          description: Column to sort by (paired with `order`).
+          schema:
+            type: string
+            enum: [created_at]
+            default: created_at
+        - $ref: "#/components/parameters/SortOrder"
+        # Not the shared PageLimit param: the activity log is unbounded, so
+        # omitting `limit` returns only the most recent page (not the full
+        # list, as it does for the bounded sandbox/template lists).
+        - name: limit
+          in: query
+          required: false
+          description: |
+            Maximum rows to return (page size). The activity log is unbounded,
+            so omitting `limit` returns only the most recent page (200 rows) —
+            not the full history. Values above 200 are clamped to 200.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 200
+        - $ref: "#/components/parameters/PageOffset"
+      responses:
+        "200":
+          description: Audit-log activity for the authenticated team
+          headers:
+            X-Total-Count:
+              $ref: "#/components/headers/TotalCount"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ActivityResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /providers:
     get:
       operationId: listProviders
@@ -1868,6 +1971,62 @@ components:
           example:
             ANTHROPIC_API_KEY: anthropic-prod
             GITHUB_TOKEN: ghp-readonly
+
+    ActivityResponse:
+      description: One audit-log activity row returned by the activity list endpoint.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sandbox_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Set on sandbox events; null for events not tied to a sandbox.
+        template_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Set on template events; null otherwise.
+        actor_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: >
+            The team member who performed the action; null for
+            system-initiated events (e.g. auto-pause, auto-delete).
+        category:
+          type: string
+        action:
+          type: string
+        status:
+          type: string
+          nullable: true
+        sandbox_name:
+          type: string
+          nullable: true
+        secret_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Set on secret events; null once the secret is purged.
+        secret_name:
+          type: string
+          nullable: true
+        duration_ms:
+          type: integer
+          format: int32
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
 
     SandboxListItem:
       description: Sandbox shape returned by list endpoints.

--- a/db/queries/activity.sql
+++ b/db/queries/activity.sql
@@ -40,3 +40,48 @@ SELECT * FROM activity
 WHERE team_id = $1 AND category = $2
 ORDER BY created_at DESC
 LIMIT $3;
+
+-- name: ListActivityByTeamPaged :many
+-- Paginated, filterable team activity list backing the console audit log.
+--
+-- Filters (all optional, AND'd): category equality, status equality (the
+-- console sends status='error' for the Errors tab), a case-insensitive
+-- substring across sandbox_name/secret_name/action/category, and a created_at
+-- window. Sort is created_at only (asc via the guarded CASE, otherwise the
+-- created_at DESC default + stable tiebreaker). A NULL @row_limit returns all
+-- rows, preserving the pre-pagination "return everything" default so
+-- unpaginated callers are unaffected.
+SELECT * FROM activity
+WHERE team_id = @team_id
+  AND (sqlc.narg('category')::text IS NULL OR category = sqlc.narg('category')::text)
+  AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status')::text)
+  AND (sqlc.narg('search')::text IS NULL
+       OR sandbox_name ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR secret_name ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR action ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR category ILIKE '%' || sqlc.narg('search')::text || '%')
+  AND (sqlc.narg('created_after')::timestamptz IS NULL OR created_at >= sqlc.narg('created_after')::timestamptz)
+  AND (sqlc.narg('created_before')::timestamptz IS NULL OR created_at <= sqlc.narg('created_before')::timestamptz)
+ORDER BY
+  CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN created_at END ASC,
+  created_at DESC,
+  -- id is a stable final tiebreaker so rows sharing a created_at (bulk events
+  -- written in one operation) keep a deterministic order across page boundaries.
+  id DESC
+LIMIT sqlc.narg('row_limit')::bigint
+OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
+
+-- name: CountActivityByTeamPaged :one
+-- Total rows matching the same filters as ListActivityByTeamPaged (ignoring
+-- pagination). Backs the X-Total-Count response header.
+SELECT COUNT(*) FROM activity
+WHERE team_id = @team_id
+  AND (sqlc.narg('category')::text IS NULL OR category = sqlc.narg('category')::text)
+  AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status')::text)
+  AND (sqlc.narg('search')::text IS NULL
+       OR sandbox_name ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR secret_name ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR action ILIKE '%' || sqlc.narg('search')::text || '%'
+       OR category ILIKE '%' || sqlc.narg('search')::text || '%')
+  AND (sqlc.narg('created_after')::timestamptz IS NULL OR created_at >= sqlc.narg('created_after')::timestamptz)
+  AND (sqlc.narg('created_before')::timestamptz IS NULL OR created_at <= sqlc.narg('created_before')::timestamptz);

--- a/internal/api/handlers_activity.go
+++ b/internal/api/handlers_activity.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// activitySortColumns is the sort allow-list for GET /activity. created_at is
+// the only sortable dimension the audit log exposes today; parsePageParams
+// rejects anything else with a 400.
+var activitySortColumns = []string{"created_at"}
+
+// activityResponse is the JSON shape of one audit-log row. Field names and
+// nullability mirror the console's ActivityResponse type so existing audit
+// table rows render unchanged.
+type activityResponse struct {
+	ID          string          `json:"id"`
+	SandboxID   *string         `json:"sandbox_id"`
+	TemplateID  *string         `json:"template_id"`
+	SecretID    *string         `json:"secret_id"`
+	ActorID     *string         `json:"actor_id"`
+	Category    string          `json:"category"`
+	Action      string          `json:"action"`
+	Status      *string         `json:"status"`
+	SandboxName *string         `json:"sandbox_name"`
+	SecretName  *string         `json:"secret_name"`
+	DurationMs  *int32          `json:"duration_ms"`
+	Error       *string         `json:"error"`
+	Metadata    json.RawMessage `json:"metadata"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+func activityToResponse(a db.Activity) activityResponse {
+	// metadata is arbitrary jsonb — pass it through verbatim rather than
+	// coercing to a fixed shape. NULL/empty renders as `{}` so the console
+	// always gets an object, never `null`.
+	meta := json.RawMessage(a.Metadata)
+	if len(meta) == 0 {
+		meta = json.RawMessage("{}")
+	}
+	return activityResponse{
+		ID:          a.ID.String(),
+		SandboxID:   nullableUUIDString(a.SandboxID),
+		TemplateID:  nullableUUIDString(a.TemplateID),
+		SecretID:    nullableUUIDString(a.SecretID),
+		ActorID:     nullableUUIDString(a.ActorID),
+		Category:    a.Category,
+		Action:      a.Action,
+		Status:      a.Status,
+		SandboxName: a.SandboxName,
+		SecretName:  a.SecretName,
+		DurationMs:  a.DurationMs,
+		Error:       a.Error,
+		Metadata:    meta,
+		CreatedAt:   a.CreatedAt,
+	}
+}
+
+// nullableUUIDString renders a nullable pgtype.UUID as a *string for JSON
+// (null when the column is NULL), matching how the console consumes
+// sandbox_id / secret_id.
+func nullableUUIDString(u pgtype.UUID) *string {
+	if !u.Valid {
+		return nil
+	}
+	s := uuid.UUID(u.Bytes).String()
+	return &s
+}
+
+// parseTimeFilter parses an optional RFC3339 timestamp query param into a
+// pgtype.Timestamptz. Empty → NULL (filter off); unparseable → error so the
+// handler can respond 400.
+func parseTimeFilter(v string) (pgtype.Timestamptz, error) {
+	if v == "" {
+		return pgtype.Timestamptz{}, nil
+	}
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		return pgtype.Timestamptz{}, err
+	}
+	return pgtype.Timestamptz{Time: t, Valid: true}, nil
+}
+
+// ListActivity serves the paginated, filterable team audit log backing the
+// console Audit Logs page. Mirrors ListSandboxes: parsePageParams + optional
+// filters (category, status, q substring, created_at window) + resolveTotal +
+// X-Total-Count, returning a bare JSON array so omitting `limit` yields the
+// full list.
+func (h *Handlers) ListActivity(c *gin.Context) {
+	teamID, err := teamIDFromContext(c)
+	if err != nil {
+		return
+	}
+	if !h.requireTeamSandboxRead(c, teamID) {
+		return
+	}
+
+	pg, err := parsePageParams(c, activitySortColumns, "created_at")
+	if err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	// The activity table is an unbounded, ever-growing event log — unlike the
+	// bounded sandbox/template lists (capped by quota, few-per-team, and
+	// filtered to non-destroyed rows). It also has no pre-existing unpaginated
+	// callers to preserve. So an omitted `limit` defaults to maxPageSize
+	// instead of "return everything", so a raw GET /activity can't force a
+	// full-history scan + serialize. (Do NOT lift this to match the sandbox
+	// list — that list is bounded; this one is not.)
+	if pg.Limit == nil {
+		lim := int64(maxPageSize)
+		pg.Limit = &lim
+	}
+
+	createdAfter, err := parseTimeFilter(c.Query("start"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", "start must be an RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+	createdBefore, err := parseTimeFilter(c.Query("end"))
+	if err != nil {
+		respondErrorMsg(c, "bad_request", "end must be an RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+
+	category := nullableStr(c.Query("category"))
+	statusFilter := nullableStr(c.Query("status"))
+	search := searchTerm(c.Query("q"))
+
+	ctx := c.Request.Context()
+	rows, err := h.DB.ListActivityByTeamPaged(ctx, db.ListActivityByTeamPagedParams{
+		TeamID:        teamID,
+		Category:      category,
+		Status:        statusFilter,
+		Search:        search,
+		CreatedAfter:  createdAfter,
+		CreatedBefore: createdBefore,
+		SortBy:        pg.SortBy,
+		SortDir:       pg.SortDir,
+		RowOffset:     pg.Offset,
+		RowLimit:      pg.Limit,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("DB ListActivityByTeamPaged failed")
+		respondError(c, ErrInternal)
+		return
+	}
+
+	total, err := resolveTotal(pg, len(rows), func() (int64, error) {
+		return h.DB.CountActivityByTeamPaged(ctx, db.CountActivityByTeamPagedParams{
+			TeamID:        teamID,
+			Category:      category,
+			Status:        statusFilter,
+			Search:        search,
+			CreatedAfter:  createdAfter,
+			CreatedBefore: createdBefore,
+		})
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("DB CountActivityByTeamPaged failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
+
+	out := make([]activityResponse, len(rows))
+	for i, a := range rows {
+		out[i] = activityToResponse(a)
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -69,6 +69,12 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 		api.GET("/secrets/:name/audit", h.GetSecretAudit)
 		api.GET("/secrets/:name/sandboxes", h.GetSecretSandboxes)
 
+		// Team-wide audit log backing the console Audit Logs page.
+		// Paginated + filterable. Unlike the bounded sandbox/template lists,
+		// the activity table is unbounded, so an omitted `limit` returns only
+		// the most recent page (capped at maxPageSize), not the full history.
+		api.GET("/activity", h.ListActivity)
+
 		api.GET("/providers", h.ListProviders)
 
 		api.GET("/sandboxes/:sandbox_id/network", h.GetSandboxNetwork)

--- a/internal/db/activity.sql.go
+++ b/internal/db/activity.sql.go
@@ -12,6 +12,45 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countActivityByTeamPaged = `-- name: CountActivityByTeamPaged :one
+SELECT COUNT(*) FROM activity
+WHERE team_id = $1
+  AND ($2::text IS NULL OR category = $2::text)
+  AND ($3::text IS NULL OR status = $3::text)
+  AND ($4::text IS NULL
+       OR sandbox_name ILIKE '%' || $4::text || '%'
+       OR secret_name ILIKE '%' || $4::text || '%'
+       OR action ILIKE '%' || $4::text || '%'
+       OR category ILIKE '%' || $4::text || '%')
+  AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)
+  AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)
+`
+
+type CountActivityByTeamPagedParams struct {
+	TeamID        uuid.UUID          `json:"team_id"`
+	Category      *string            `json:"category"`
+	Status        *string            `json:"status"`
+	Search        *string            `json:"search"`
+	CreatedAfter  pgtype.Timestamptz `json:"created_after"`
+	CreatedBefore pgtype.Timestamptz `json:"created_before"`
+}
+
+// Total rows matching the same filters as ListActivityByTeamPaged (ignoring
+// pagination). Backs the X-Total-Count response header.
+func (q *Queries) CountActivityByTeamPaged(ctx context.Context, arg CountActivityByTeamPagedParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countActivityByTeamPaged,
+		arg.TeamID,
+		arg.Category,
+		arg.Status,
+		arg.Search,
+		arg.CreatedAfter,
+		arg.CreatedBefore,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createActivity = `-- name: CreateActivity :one
 INSERT INTO activity (
   sandbox_id, template_id, secret_id, secret_name, resource_type,
@@ -245,6 +284,98 @@ type ListActivityByTeamParams struct {
 
 func (q *Queries) ListActivityByTeam(ctx context.Context, arg ListActivityByTeamParams) ([]Activity, error) {
 	rows, err := q.db.Query(ctx, listActivityByTeam, arg.TeamID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Activity{}
+	for rows.Next() {
+		var i Activity
+		if err := rows.Scan(
+			&i.ID,
+			&i.SandboxID,
+			&i.TeamID,
+			&i.ActorID,
+			&i.Category,
+			&i.Action,
+			&i.Status,
+			&i.SandboxName,
+			&i.DurationMs,
+			&i.Error,
+			&i.Metadata,
+			&i.CreatedAt,
+			&i.TemplateID,
+			&i.ResourceType,
+			&i.SecretID,
+			&i.SecretName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActivityByTeamPaged = `-- name: ListActivityByTeamPaged :many
+SELECT id, sandbox_id, team_id, actor_id, category, action, status, sandbox_name, duration_ms, error, metadata, created_at, template_id, resource_type, secret_id, secret_name FROM activity
+WHERE team_id = $1
+  AND ($2::text IS NULL OR category = $2::text)
+  AND ($3::text IS NULL OR status = $3::text)
+  AND ($4::text IS NULL
+       OR sandbox_name ILIKE '%' || $4::text || '%'
+       OR secret_name ILIKE '%' || $4::text || '%'
+       OR action ILIKE '%' || $4::text || '%'
+       OR category ILIKE '%' || $4::text || '%')
+  AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)
+  AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)
+ORDER BY
+  CASE WHEN $7::text = 'created_at' AND $8::text = 'asc' THEN created_at END ASC,
+  created_at DESC,
+  -- id is a stable final tiebreaker so rows sharing a created_at (bulk events
+  -- written in one operation) keep a deterministic order across page boundaries.
+  id DESC
+LIMIT $10::bigint
+OFFSET COALESCE($9::bigint, 0)
+`
+
+type ListActivityByTeamPagedParams struct {
+	TeamID        uuid.UUID          `json:"team_id"`
+	Category      *string            `json:"category"`
+	Status        *string            `json:"status"`
+	Search        *string            `json:"search"`
+	CreatedAfter  pgtype.Timestamptz `json:"created_after"`
+	CreatedBefore pgtype.Timestamptz `json:"created_before"`
+	SortBy        string             `json:"sort_by"`
+	SortDir       string             `json:"sort_dir"`
+	RowOffset     *int64             `json:"row_offset"`
+	RowLimit      *int64             `json:"row_limit"`
+}
+
+// Paginated, filterable team activity list backing the console audit log.
+//
+// Filters (all optional, AND'd): category equality, status equality (the
+// console sends status='error' for the Errors tab), a case-insensitive
+// substring across sandbox_name/secret_name/action/category, and a created_at
+// window. Sort is created_at only (asc via the guarded CASE, otherwise the
+// created_at DESC default + stable tiebreaker). A NULL @row_limit returns all
+// rows, preserving the pre-pagination "return everything" default so
+// unpaginated callers are unaffected.
+func (q *Queries) ListActivityByTeamPaged(ctx context.Context, arg ListActivityByTeamPagedParams) ([]Activity, error) {
+	rows, err := q.db.Query(ctx, listActivityByTeamPaged,
+		arg.TeamID,
+		arg.Category,
+		arg.Status,
+		arg.Search,
+		arg.CreatedAfter,
+		arg.CreatedBefore,
+		arg.SortBy,
+		arg.SortDir,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/activity_pagination_test.go
+++ b/internal/integration/activity_pagination_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// insertSandboxActivity inserts a resource_type='sandbox' audit row tied to an
+// existing sandbox, with controlled category/action/status/name/created_at so
+// filter + ordering assertions are deterministic.
+func insertSandboxActivity(t *testing.T, teamID, sandboxID uuid.UUID, category, action, status, sandboxName string, createdAt time.Time) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO activity (id, sandbox_id, team_id, category, action, status, sandbox_name, resource_type, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, 'sandbox', $8)`,
+		uuid.New(), sandboxID, teamID, category, action, status, sandboxName, createdAt,
+	); err != nil {
+		t.Fatalf("insert sandbox activity %q/%q: %v", category, action, err)
+	}
+}
+
+// insertSecretActivity inserts a resource_type='secret' audit row. Secret rows
+// carry no sandbox FK; secret_name is the denormalized snapshot the CHECK
+// constraint requires.
+func insertSecretActivity(t *testing.T, teamID uuid.UUID, action, secretName string, createdAt time.Time) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO activity (id, team_id, category, action, secret_name, resource_type, created_at)
+		 VALUES ($1, $2, 'secret', $3, $4, 'secret', $5)`,
+		uuid.New(), teamID, action, secretName, createdAt,
+	); err != nil {
+		t.Fatalf("insert secret activity %q: %v", action, err)
+	}
+}
+
+func actions(rows []map[string]any) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i], _ = r["action"].(string)
+	}
+	return out
+}
+
+// TestIntegration_ListActivity_Pagination exercises the paged audit-log list
+// end to end: default (unpaginated) created_at ordering, limit/offset
+// windowing, X-Total-Count, sort direction, category + status filters, the
+// multi-column substring search, the created_at window, and 400s on bad input.
+func TestIntegration_ListActivity_Pagination(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	sandboxID := insertSandboxAt(t, teamID, "audit-sbx", "active", time.Now().Add(-2*time.Hour))
+
+	// Truncate to the second so RFC3339 date-window params compare exactly
+	// against the stored timestamps (no fractional-second drift).
+	base := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	// oldest → newest, mixed categories + statuses.
+	insertSandboxActivity(t, teamID, sandboxID, "sandbox", "started", "success", "audit-sbx", base.Add(1*time.Minute))
+	insertSandboxActivity(t, teamID, sandboxID, "sandbox", "paused", "success", "audit-sbx", base.Add(2*time.Minute))
+	insertSandboxActivity(t, teamID, sandboxID, "network", "updated", "error", "audit-sbx", base.Add(3*time.Minute))
+	insertSecretActivity(t, teamID, "rotated", "db-password", base.Add(4*time.Minute))
+	insertSandboxActivity(t, teamID, sandboxID, "sandbox", "deleted", "error", "audit-sbx", base.Add(5*time.Minute))
+
+	// Default: full list, created_at DESC, total = 5.
+	w := do(r, "GET", "/activity", apiKey, "")
+	rows := decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("X-Total-Count = %q, want 5", got)
+	}
+	if want := []string{"deleted", "rotated", "updated", "paused", "started"}; !eqStrings(actions(rows), want) {
+		t.Errorf("default order = %v, want %v", actions(rows), want)
+	}
+
+	// First page of 2 (created desc).
+	w = do(r, "GET", "/activity?limit=2&offset=0", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("page1 X-Total-Count = %q, want 5", got)
+	}
+	if want := []string{"deleted", "rotated"}; !eqStrings(actions(rows), want) {
+		t.Errorf("page1 = %v, want %v", actions(rows), want)
+	}
+
+	// created_at ascending.
+	w = do(r, "GET", "/activity?sort=created_at&order=asc&limit=50", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"started", "paused", "updated", "rotated", "deleted"}; !eqStrings(actions(rows), want) {
+		t.Errorf("asc order = %v, want %v", actions(rows), want)
+	}
+
+	// Category filter narrows both rows and the count.
+	w = do(r, "GET", "/activity?category=sandbox&sort=created_at&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("category X-Total-Count = %q, want 3", got)
+	}
+	if want := []string{"started", "paused", "deleted"}; !eqStrings(actions(rows), want) {
+		t.Errorf("category=sandbox = %v, want %v", actions(rows), want)
+	}
+
+	// Errors tab → status=error.
+	w = do(r, "GET", "/activity?status=error&sort=created_at&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "2" {
+		t.Errorf("error X-Total-Count = %q, want 2", got)
+	}
+	if want := []string{"updated", "deleted"}; !eqStrings(actions(rows), want) {
+		t.Errorf("status=error = %v, want %v", actions(rows), want)
+	}
+
+	// Case-insensitive substring across secret_name.
+	w = do(r, "GET", "/activity?q=PASSWORD", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"rotated"}; !eqStrings(actions(rows), want) {
+		t.Errorf("secret_name search = %v, want %v", actions(rows), want)
+	}
+
+	// Substring across action.
+	w = do(r, "GET", "/activity?q=delet", apiKey, "")
+	rows = decodeArray(t, w)
+	if want := []string{"deleted"}; !eqStrings(actions(rows), want) {
+		t.Errorf("action search = %v, want %v", actions(rows), want)
+	}
+
+	// created_at window [t2, t4] inclusive → paused, updated, rotated.
+	after := base.Add(2 * time.Minute).UTC().Format(time.RFC3339)
+	before := base.Add(4 * time.Minute).UTC().Format(time.RFC3339)
+	w = do(r, "GET", "/activity?start="+after+"&end="+before+"&sort=created_at&order=asc", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "3" {
+		t.Errorf("date window X-Total-Count = %q, want 3", got)
+	}
+	if want := []string{"paused", "updated", "rotated"}; !eqStrings(actions(rows), want) {
+		t.Errorf("date window = %v, want %v", actions(rows), want)
+	}
+
+	// Offset without limit still reports the unwindowed total.
+	w = do(r, "GET", "/activity?offset=2", apiKey, "")
+	rows = decodeArray(t, w)
+	if got := w.Header().Get("X-Total-Count"); got != "5" {
+		t.Errorf("offset-only X-Total-Count = %q, want 5", got)
+	}
+
+	// Malformed pagination / filters → 400.
+	if w := do(r, "GET", "/activity?limit=0", apiKey, ""); w.Code != 400 {
+		t.Errorf("limit=0 status = %d, want 400", w.Code)
+	}
+	if w := do(r, "GET", "/activity?sort=nope", apiKey, ""); w.Code != 400 {
+		t.Errorf("bad sort status = %d, want 400", w.Code)
+	}
+	if w := do(r, "GET", "/activity?start=notatime", apiKey, ""); w.Code != 400 {
+		t.Errorf("bad start status = %d, want 400", w.Code)
+	}
+}
+
+// TestIntegration_ListActivity_DefaultLimitCap proves a request that omits
+// `limit` is capped at maxPageSize (200) rather than returning the whole
+// unbounded history — while X-Total-Count still reports the true total so the
+// caller knows to page. Guards the handler's omitted-limit default; without it
+// the activity list would happily serialize an entire team's event history.
+func TestIntegration_ListActivity_DefaultLimitCap(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	// 205 secret events (no sandbox FK needed), each with a distinct created_at.
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO activity (id, team_id, category, action, secret_name, resource_type, created_at)
+		 SELECT gen_random_uuid(), $1, 'secret', 'bulk', 'db-password', 'secret',
+		        now() - (g || ' seconds')::interval
+		 FROM generate_series(1, 205) AS g`,
+		teamID,
+	); err != nil {
+		t.Fatalf("bulk insert activity: %v", err)
+	}
+
+	// No `limit` → capped at maxPageSize (200), not all 205 rows.
+	w := do(r, "GET", "/activity", apiKey, "")
+	rows := decodeArray(t, w)
+	if len(rows) != 200 {
+		t.Errorf("no-limit page size = %d, want 200 (capped at maxPageSize)", len(rows))
+	}
+	if got := w.Header().Get("X-Total-Count"); got != "205" {
+		t.Errorf("X-Total-Count = %q, want 205 (true total despite the cap)", got)
+	}
+}
+
+// insertTemplateActivity inserts a resource_type='template' audit row tied to
+// an existing template.
+func insertTemplateActivity(t *testing.T, teamID, templateID uuid.UUID, action string, createdAt time.Time) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(),
+		`INSERT INTO activity (id, team_id, template_id, category, action, resource_type, created_at)
+		 VALUES ($1, $2, $3, 'template', $4, 'template', $5)`,
+		uuid.New(), teamID, templateID, action, createdAt,
+	); err != nil {
+		t.Fatalf("insert template activity %q: %v", action, err)
+	}
+}
+
+// TestIntegration_ListActivity_ResourceFields verifies the response exposes
+// every resource/actor FK — sandbox_id, template_id, secret_id, actor_id — and
+// that metadata renders as an object, not null. template_id in particular was
+// silently dropped before, leaving template events unidentifiable.
+func TestIntegration_ListActivity_ResourceFields(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	base := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	sandboxID := insertSandboxAt(t, teamID, "rf-sbx", "active", base)
+	templateID := insertTemplateAt(t, teamID, "rf-tpl", base)
+
+	insertSandboxActivity(t, teamID, sandboxID, "sandbox", "started", "success", "rf-sbx", base.Add(1*time.Minute))
+	insertTemplateActivity(t, teamID, templateID, "created", base.Add(2*time.Minute))
+	insertSecretActivity(t, teamID, "rotated", "db-password", base.Add(3*time.Minute))
+
+	w := do(r, "GET", "/activity?sort=created_at&order=asc", apiKey, "")
+	rows := decodeArray(t, w)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	sbx, tpl, sec := rows[0], rows[1], rows[2]
+
+	// Every row serializes all four resource/actor keys plus metadata (present
+	// even when null) — no silently-dropped columns.
+	for _, row := range rows {
+		for _, k := range []string{"sandbox_id", "template_id", "secret_id", "actor_id", "metadata"} {
+			if _, ok := row[k]; !ok {
+				t.Errorf("row %v missing key %q", row["action"], k)
+			}
+		}
+	}
+
+	// Sandbox event: sandbox_id set; template_id/secret_id null.
+	if sbx["sandbox_id"] == nil {
+		t.Error("sandbox event: sandbox_id is null, want set")
+	}
+	if sbx["template_id"] != nil {
+		t.Errorf("sandbox event: template_id = %v, want null", sbx["template_id"])
+	}
+	// Template event: template_id set (previously dropped), sandbox_id null.
+	if tpl["template_id"] != templateID.String() {
+		t.Errorf("template event: template_id = %v, want %s", tpl["template_id"], templateID)
+	}
+	if tpl["sandbox_id"] != nil {
+		t.Errorf("template event: sandbox_id = %v, want null", tpl["sandbox_id"])
+	}
+	// Secret event: metadata defaults to an empty object, never null.
+	if m, ok := sec["metadata"].(map[string]any); !ok || len(m) != 0 {
+		t.Errorf("secret event: metadata = %v, want empty object {}", sec["metadata"])
+	}
+	// actor_id is null for these system-inserted rows (no actor set).
+	if sbx["actor_id"] != nil {
+		t.Errorf("actor_id = %v, want null", sbx["actor_id"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds `GET /activity` — a paginated, filterable, team-scoped audit-log endpoint backing the console Audit Logs page. The console previously read the `activity` table directly (via Supabase) and rendered the whole list client-side; this moves it onto the REST API with real server-side pagination.

Mirrors the existing `GET /sandboxes` list: bare JSON array + `X-Total-Count`, shared `parsePageParams` + `resolveTotal`, new `ListActivityByTeamPaged` / `CountActivityByTeamPaged` sqlc queries. Gated on `settings:read`; team scoping is enforced in SQL from the authenticated context (never a request param).

**Filters** (all optional, AND'd): `category`, `status` (the console sends `error` for its Errors tab), `q` (case-insensitive substring across sandbox name, secret name, action, category), and a `start`/`end` `created_at` window. Every filter is covered by an existing `activity` index.

**Bounding:** unlike the sandbox/template lists (bounded by quota / few-per-team), the `activity` table is unbounded and ever-growing, and has no pre-existing unpaginated callers. So an omitted `limit` returns only the most recent page (capped at `maxPageSize` = 200), not the full history. `X-Total-Count` still reports the true total.

**Response** exposes every resource/actor FK — `sandbox_id`, `template_id`, `secret_id`, `actor_id` — so events of every category are identifiable, plus `metadata` (raw jsonb, `{}` when empty). A stable `id` tiebreaker keeps pagination deterministic under same-timestamp bursts.

## Test plan

- [x] `go build ./internal/api/... ./internal/db/...`, `go vet` (+ `-tags integration`)
- [x] `go test ./internal/api/...` — includes the OpenAPI route-sync test (endpoint added to `api/openapi.yaml`)
- [x] Integration tests (`internal/integration/activity_pagination_test.go`, run in CI with Postgres):
  - pagination window / created_at ordering / offset; `category`, `status=error`, `q` substring, and `start`/`end` filters; `X-Total-Count` including the `resolveTotal` short-circuit
  - omitted-`limit` cap: 205 rows → returns 200 with `X-Total-Count: 205`
  - resource-field exposure: `sandbox_id` / `template_id` / `secret_id` / `actor_id` present per category, `metadata` renders as `{}` not `null`

## Notes

- Paired with a console PR (superserve-ai/superserve) that consumes this endpoint. **Deploy this first** — the console and its docs nav entry depend on the route being live.
- Reviewed for tenancy (team-scoped, id from auth context), injection (all sqlc-parameterized, `q` LIKE-escaped), and resource bounds.
- Deferred follow-ups: a friendly template *name* in the UI needs `template_name` denormalized at write time; deep-`offset` paging over very large histories would benefit from keyset/cursor pagination (date filters mitigate today).
