### PR TITLE
vmd: raise restore and gRPC stream concurrency ceilings for create bursts

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -486,9 +486,11 @@ func main() {
 	// Warm buffer of network namespaces so creation claims off the hot path.
 	// StartPool returns immediately and fills in the background, so the gate
 	// below isn't held for the fill; creates fall back to on-demand until warm.
-	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "128"))
+	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "256"))
+	netPoolRecycle, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_RECYCLE_SIZE", "256"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
-		NewSize: netPoolFresh,
+		NewSize:     netPoolFresh,
+		RecycleSize: netPoolRecycle,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -353,7 +353,7 @@ func main() {
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
-	maxRestores, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_RESTORES", "100"))
+	maxRestores, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_RESTORES", "500"))
 	uffdEnabled := envOrDefault("VMD_UFFD_ENABLED", "true") != "false"
 	uffdPrefetchEnabled := envOrDefault("VMD_UFFD_PREFETCH_ENABLED", "true") != "false"
 	uffdRecordMaxSeconds, _ := strconv.Atoi(envOrDefault("VMD_UFFD_RECORD_MAX_SECONDS", "10"))
@@ -437,7 +437,11 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Int("port", cfg.GRPCPort).Msg("failed to listen")
 	}
+	// Set explicitly, else gRPC clients self-cap at 100 streams/conn
+	// (defaultMaxStreamsClient) because the server advertises no limit by default.
+	maxStreams, _ := strconv.Atoi(envOrDefault("VMD_MAX_CONCURRENT_STREAMS", "2000"))
 	grpcServer := grpc.NewServer(
+		grpc.MaxConcurrentStreams(uint32(maxStreams)),
 		grpc.MaxRecvMsgSize(64<<20), // 64 MiB
 		grpc.UnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 			if !startupReady.Load() {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -144,7 +144,7 @@ type ManagerConfig struct {
 	HostInterface      string // Host network interface (e.g. "ens4").
 	// MaxConcurrentRestores caps parallel RestoreVMSnapshot operations to
 	// prevent a spike of concurrent sandbox creates from saturating host
-	// file I/O, netns setup, and Firecracker boots. 0 → default 100.
+	// file I/O, netns setup, and Firecracker boots. 0 → default 500.
 	MaxConcurrentRestores int
 
 	// UffdEnabled gates the UFFD lazy-restore path. false → fresh
@@ -226,7 +226,7 @@ type Manager struct {
 func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) (*Manager, error) {
 	maxRestores := cfg.MaxConcurrentRestores
 	if maxRestores <= 0 {
-		maxRestores = 100
+		maxRestores = 500
 	}
 	// Magic mount target — every per-VM start script mounts tmpfs over it.
 	// Missing → "mount: failed" → opaque "wait for socket" timeout. Create


### PR DESCRIPTION
## Problem

Under a burst of concurrent sandbox creates/resumes, throughput is capped by two
conservative defaults, well below what the host can actually handle:

- **gRPC streams.** The vmd server never advertises a `MAX_CONCURRENT_STREAMS`
  limit (its default is effectively unlimited but is only sent when set
  explicitly), so gRPC clients fall back to their own built-in default of **100
  concurrent streams per connection** (`defaultMaxStreamsClient`). A dense burst
  of create/resume calls backs up behind that per-connection cap.
- **Restore concurrency.** `MaxConcurrentRestores` defaults to **100**, so no
  more than 100 snapshot restores run at once regardless of spare CPU/RAM.

When a burst exceeds these, calls queue and the strained connection can surface
transient `connection refused` / `Unavailable` errors that clients then retry —
adding latency and error noise exactly during bursts.

## Fix

- Set `grpc.MaxConcurrentStreams` explicitly (default **2000**) so the server
  advertises a real limit and clients stop self-capping at 100. Kept well above
  the restore-worker cap so a burst queues on the restore semaphore rather than
  being refused at the connection.
- Raise the `MaxConcurrentRestores` default **100 → 500**.
- Enlarge the warm network-slot pool so a burst is served from the fast path
  instead of falling back to slow on-demand namespace/veth/TAP setup: fresh
  `128 → 256`, recycled `100 → 256` (recycled is now env-tunable too).

Both are env-tunable so they can be retuned up or down without a rebuild:
`VMD_MAX_CONCURRENT_STREAMS`, `VMD_MAX_CONCURRENT_RESTORES`, `VMD_NET_POOL_FRESH_SIZE`, `VMD_NET_POOL_RECYCLE_SIZE`.

No change to the create/resume/pause/destroy logic — only the concurrency
ceilings. Restore concurrency should be sized to the host's real capacity
(memory is the practical bound, since each concurrent restore faults in guest
memory); 500 leaves comfortable headroom on current hardware, and the env knob
allows tuning per host.

## Rollout

Low-risk config change — concurrency ceilings only, both env-tunable. Deploy and
watch host memory/IO under a concurrent-create burst to confirm the higher
restore concurrency stays within headroom; if memory gets tight, dial the env
values back immediately without a rebuild.
