### PR TITLE
vmd: allocate template-build network slots from the authoritative allocator

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -361,7 +361,7 @@ func fsyncBuildArtifacts(snapDir string, paths ...string) error {
 func setupNetwork(ctx context.Context, hostIface string, slotIndex int, vmID string) (*network.Manager, *network.VMNetInfo, func(), error) {
 	log := newLogger("network")
 	mgr, err := network.NewManager(ctx, hostIface, log,
-		network.WithStartSlot(slotIndex),
+		network.WithExactSlot(slotIndex),
 		network.WithHTTPProxyPort(0), // no egress proxy for builds
 	)
 	if err != nil {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -82,8 +82,9 @@ type Manager struct {
 	mu        sync.Mutex
 	devices   map[string]*VMNetInfo
 	freeSlots []int // recycled slot indices, guaranteed absent from slotOwner
-	nextSlot  int   // next new slot (used when freeSlots is empty)
-	maxSlot   int   // upper bound for new-slot allocation (0 = MaxSlots); WithExactSlot pins to one
+	nextSlot   int  // next new slot (used when freeSlots is empty)
+	maxSlot    int  // new-slot ceiling; meaningful only when slotPinned (WithExactSlot)
+	slotPinned bool // WithExactSlot: allocate exactly maxSlot or fail, never advance
 
 	// slotOwner is the single source of truth for slot allocation AND identity:
 	// slotOwner[idx] == the current owner of slot index idx, one of
@@ -158,7 +159,7 @@ type ManagerOption func(*Manager)
 // ReserveSlot; if that slot is somehow unavailable the build fails cleanly
 // instead of silently running on an index vmd never reserved.
 func WithExactSlot(idx int) ManagerOption {
-	return func(m *Manager) { m.nextSlot = idx; m.maxSlot = idx }
+	return func(m *Manager) { m.nextSlot = idx; m.maxSlot = idx; m.slotPinned = true }
 }
 
 // WithHTTPProxyPort sets the HTTP proxy port for egress REDIRECT rules.
@@ -793,7 +794,7 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 			m.freeSlots = m.freeSlots[:len(m.freeSlots)-1]
 		} else {
 			ceiling := MaxSlots
-			if m.maxSlot > 0 {
+			if m.slotPinned {
 				ceiling = m.maxSlot // WithExactSlot: allow only the pinned index
 			}
 			if m.nextSlot > ceiling {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -83,6 +83,7 @@ type Manager struct {
 	devices   map[string]*VMNetInfo
 	freeSlots []int // recycled slot indices, guaranteed absent from slotOwner
 	nextSlot  int   // next new slot (used when freeSlots is empty)
+	maxSlot   int   // upper bound for new-slot allocation (0 = MaxSlots); WithExactSlot pins to one
 
 	// slotOwner is the single source of truth for slot allocation AND identity:
 	// slotOwner[idx] == the current owner of slot index idx, one of
@@ -151,12 +152,13 @@ func (m *Manager) SetEgressProxy(p *EgressProxy) {
 // ManagerOption configures optional Manager behavior.
 type ManagerOption func(*Manager)
 
-// WithStartSlot sets the starting slot index for network allocation. Used by a
-// template-builder subprocess to build exactly the one slot vmd reserved for it
-// via ReserveSlot — the reservation, not a disjoint range, is what keeps a build
-// from colliding with vmd's sandbox slots.
-func WithStartSlot(idx int) ManagerOption {
-	return func(m *Manager) { m.nextSlot = idx }
+// WithExactSlot pins the Manager to exactly slot idx: it claims that one index
+// or fails with ErrNoSlots, never advancing to idx+1. A template-builder
+// subprocess uses this to build precisely the slot vmd reserved for it via
+// ReserveSlot; if that slot is somehow unavailable the build fails cleanly
+// instead of silently running on an index vmd never reserved.
+func WithExactSlot(idx int) ManagerOption {
+	return func(m *Manager) { m.nextSlot = idx; m.maxSlot = idx }
 }
 
 // WithHTTPProxyPort sets the HTTP proxy port for egress REDIRECT rules.
@@ -764,10 +766,17 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 // kernel network state. The caller — a template-builder subprocess — creates
 // ns-<idx>/veth-<idx> itself; the reservation is what stops vmd's sandbox
 // allocator from handing the same index to a VM, so builds and sandboxes draw
-// from one authoritative allocator instead of racing disjoint ranges. Release it
-// (and tear down any residue) with CleanupVMOrNamespace(owner, "ns-<idx>").
+// from one authoritative allocator instead of racing disjoint ranges. Pair every
+// ReserveSlot with a ReleaseSlot.
 func (m *Manager) ReserveSlot(owner string) (int, error) {
 	return m.claimSlotIndex(owner)
+}
+
+// ReleaseSlot frees a slot reserved via ReserveSlot and tears down any ns/veth
+// the caller built at idx. The inverse of ReserveSlot; it owns the namespace
+// naming so callers never reconstruct "ns-<idx>" themselves.
+func (m *Manager) ReleaseSlot(owner string, idx int) {
+	m.CleanupVMOrNamespace(owner, fmt.Sprintf("ns-%d", idx))
 }
 
 // claimSlotIndex picks a slot idx that is unowned and not present in the kernel,
@@ -783,7 +792,11 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 			idx = m.freeSlots[len(m.freeSlots)-1]
 			m.freeSlots = m.freeSlots[:len(m.freeSlots)-1]
 		} else {
-			if m.nextSlot > MaxSlots {
+			ceiling := MaxSlots
+			if m.maxSlot > 0 {
+				ceiling = m.maxSlot // WithExactSlot: allow only the pinned index
+			}
+			if m.nextSlot > ceiling {
 				return 0, ErrNoSlots
 			}
 			idx = m.nextSlot

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -763,21 +763,38 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	return true
 }
 
-// ReserveSlot claims a fresh, unused slot index under owner without building any
-// kernel network state. The caller — a template-builder subprocess — creates
-// ns-<idx>/veth-<idx> itself; the reservation is what stops vmd's sandbox
-// allocator from handing the same index to a VM, so builds and sandboxes draw
-// from one authoritative allocator instead of racing disjoint ranges. Pair every
-// ReserveSlot with a ReleaseSlot.
-func (m *Manager) ReserveSlot(owner string) (int, error) {
+// ClaimFreshSlot claims a fresh, unused slot index under owner without building
+// any kernel network state. The caller — a template-builder subprocess —
+// creates ns-<idx>/veth-<idx> itself; the reservation is what stops vmd's
+// sandbox allocator from handing the same index to a VM, so builds and
+// sandboxes draw from one authoritative allocator instead of racing disjoint
+// ranges. Distinct from ReserveSlotsAbove, which pins already-known indices
+// via reserveSlotLocked (bypassing the owned/nsExists checks). Pair every
+// ClaimFreshSlot with a ReleaseSlot.
+func (m *Manager) ClaimFreshSlot(owner string) (int, error) {
 	return m.claimSlotIndex(owner)
 }
 
-// ReleaseSlot frees a slot reserved via ReserveSlot and tears down any ns/veth
-// the caller built at idx. The inverse of ReserveSlot; it owns the namespace
-// naming so callers never reconstruct "ns-<idx>" themselves.
+// ReleaseSlot frees a slot claimed via ClaimFreshSlot and tears down any ns/veth
+// the caller built at idx. It releases strictly by (owner, idx) — never routing
+// through the tracked-VM path — so a caller-supplied build ID that collides with
+// a live sandbox's VM ID can't tear down that sandbox's namespace or leak the
+// reserved index. Owns the namespace naming so callers never reconstruct
+// "ns-<idx>"; a no-op if owner no longer owns idx (already reclaimed/reused).
 func (m *Manager) ReleaseSlot(owner string, idx int) {
-	m.CleanupVMOrNamespace(owner, fmt.Sprintf("ns-%d", idx))
+	// Claim the teardown atomically (owner → teardownOwner) so claimSlotIndex
+	// can't grab idx while cleanupFull runs below.
+	m.mu.Lock()
+	if m.slotOwner[idx] != owner {
+		m.mu.Unlock()
+		return
+	}
+	m.slotOwner[idx] = teardownOwner
+	m.mu.Unlock()
+	// Release even if cleanupFull panics — otherwise idx stays stuck as
+	// teardownOwner forever (no other path releases that sentinel).
+	defer m.releaseIfOwned(idx, teardownOwner)
+	m.cleanupFull(fmt.Sprintf("ns-%d", idx), fmt.Sprintf("veth-%d", idx))
 }
 
 // claimSlotIndex picks a slot idx that is unowned and not present in the kernel,
@@ -789,7 +806,10 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 
 	for {
 		var idx int
-		if len(m.freeSlots) > 0 {
+		// A pinned Manager (WithExactSlot) must claim exactly maxSlot or fail —
+		// so it never draws from freeSlots (which could hand back a different
+		// index); it only takes the pinned nextSlot path below.
+		if !m.slotPinned && len(m.freeSlots) > 0 {
 			idx = m.freeSlots[len(m.freeSlots)-1]
 			m.freeSlots = m.freeSlots[:len(m.freeSlots)-1]
 		} else {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -151,9 +151,10 @@ func (m *Manager) SetEgressProxy(p *EgressProxy) {
 // ManagerOption configures optional Manager behavior.
 type ManagerOption func(*Manager)
 
-// WithStartSlot sets the starting slot index for network allocation.
-// Use to avoid collision when multiple processes manage VMs on the
-// same host (e.g. vmd uses 1-100, template-builder uses 200+).
+// WithStartSlot sets the starting slot index for network allocation. Used by a
+// template-builder subprocess to build exactly the one slot vmd reserved for it
+// via ReserveSlot — the reservation, not a disjoint range, is what keeps a build
+// from colliding with vmd's sandbox slots.
 func WithStartSlot(idx int) ManagerOption {
 	return func(m *Manager) { m.nextSlot = idx }
 }
@@ -757,6 +758,16 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	delete(m.slotOwner, idx)
 	m.freeSlots = append(m.freeSlots, idx)
 	return true
+}
+
+// ReserveSlot claims a fresh, unused slot index under owner without building any
+// kernel network state. The caller — a template-builder subprocess — creates
+// ns-<idx>/veth-<idx> itself; the reservation is what stops vmd's sandbox
+// allocator from handing the same index to a VM, so builds and sandboxes draw
+// from one authoritative allocator instead of racing disjoint ranges. Release it
+// (and tear down any residue) with CleanupVMOrNamespace(owner, "ns-<idx>").
+func (m *Manager) ReserveSlot(owner string) (int, error) {
+	return m.claimSlotIndex(owner)
 }
 
 // claimSlotIndex picks a slot idx that is unowned and not present in the kernel,

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -104,6 +104,38 @@ func TestClaimSlotIndex_FreshNextSlot(t *testing.T) {
 	}
 }
 
+// TestReserveSlot_NoCollisionWithSandbox pins the build-slot invariant: a slot
+// reserved for a template build goes through the one authoritative allocator, so
+// a concurrent sandbox claim can't get the same index — and the index is
+// reclaimed once the build releases it (what CleanupVMOrNamespace does on exit).
+func TestReserveSlot_NoCollisionWithSandbox(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	build, err := m.ReserveSlot("build-tmpl")
+	if err != nil {
+		t.Fatalf("ReserveSlot: %v", err)
+	}
+	sandbox, err := m.claimSlotIndex("vm-1")
+	if err != nil {
+		t.Fatalf("claimSlotIndex: %v", err)
+	}
+	if build == sandbox {
+		t.Fatalf("build and sandbox got the same slot %d", build)
+	}
+
+	if !m.releaseIfOwned(build, "build-tmpl") {
+		t.Fatalf("releaseIfOwned(%d, build-tmpl) = false, want true", build)
+	}
+	reused, err := m.claimSlotIndex("vm-2")
+	if err != nil {
+		t.Fatalf("claimSlotIndex after release: %v", err)
+	}
+	if reused != build {
+		t.Errorf("reused = %d, want %d (released build slot reclaimed)", reused, build)
+	}
+}
+
 func TestClaimSlotIndex_PrefersFreeSlotsLIFO(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -104,17 +104,17 @@ func TestClaimSlotIndex_FreshNextSlot(t *testing.T) {
 	}
 }
 
-// TestReserveSlot_NoCollisionWithSandbox pins the build-slot invariant: a slot
-// reserved for a template build goes through the one authoritative allocator, so
-// a concurrent sandbox claim can't get the same index — and the index is
-// reclaimed once the build releases it (what CleanupVMOrNamespace does on exit).
-func TestReserveSlot_NoCollisionWithSandbox(t *testing.T) {
+// TestClaimFreshSlot_NoCollisionWithSandbox pins the build-slot invariant: a
+// slot claimed for a template build goes through the one authoritative
+// allocator, so a concurrent sandbox claim can't get the same index — and the
+// index is reclaimed once the build releases it.
+func TestClaimFreshSlot_NoCollisionWithSandbox(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
 
-	build, err := m.ReserveSlot("build-tmpl")
+	build, err := m.ClaimFreshSlot("build-tmpl")
 	if err != nil {
-		t.Fatalf("ReserveSlot: %v", err)
+		t.Fatalf("ClaimFreshSlot: %v", err)
 	}
 	sandbox, err := m.claimSlotIndex("vm-1")
 	if err != nil {
@@ -133,6 +133,39 @@ func TestReserveSlot_NoCollisionWithSandbox(t *testing.T) {
 	}
 	if reused != build {
 		t.Errorf("reused = %d, want %d (released build slot reclaimed)", reused, build)
+	}
+}
+
+// TestReleaseSlot_ReleasesByIndexNotTrackedVM pins the collision guard: when a
+// build's owner id happens to match a live sandbox's tracked VM id, ReleaseSlot
+// must free only the build's reserved index and leave the sandbox's slot and
+// devices entry untouched — never route through CleanupVM.
+func TestReleaseSlot_ReleasesByIndexNotTrackedVM(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	// A live sandbox tracked under a vm id, holding slot 3...
+	m.devices["collide"] = &VMNetInfo{Namespace: "ns-3"}
+	m.assignSlotLocked(3, "collide")
+	// ...and a build that reserved slot 5 under the SAME id.
+	m.assignSlotLocked(5, "collide")
+
+	m.ReleaseSlot("collide", 5)
+
+	m.mu.Lock()
+	_, buildStillOwned := m.slotOwner[5]
+	_, sandboxStillOwned := m.slotOwner[3]
+	_, stillTracked := m.devices["collide"]
+	m.mu.Unlock()
+
+	if buildStillOwned {
+		t.Errorf("slot 5 still owned after ReleaseSlot — build index not freed")
+	}
+	if !sandboxStillOwned {
+		t.Errorf("sandbox slot 3 was released — ReleaseSlot tore down a tracked VM")
+	}
+	if !stillTracked {
+		t.Errorf("sandbox devices entry removed — ReleaseSlot routed through CleanupVM")
 	}
 }
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -136,6 +136,32 @@ func TestReserveSlot_NoCollisionWithSandbox(t *testing.T) {
 	}
 }
 
+// TestClaimSlotIndex_ExactSlotDoesNotAdvance pins the WithExactSlot invariant: a
+// Manager bounded to one slot claims exactly that index or fails — it never
+// advances to idx+1, which vmd would not have reserved for the build.
+func TestClaimSlotIndex_ExactSlotDoesNotAdvance(t *testing.T) {
+	withTestNetnsDir(t)
+
+	// Pinned slot already taken → must fail, not fall through to 8.
+	taken := newTestManager()
+	taken.nextSlot, taken.maxSlot = 7, 7 // WithExactSlot(7)
+	taken.slotOwner[7] = "other"
+	if _, err := taken.claimSlotIndex("build-x"); err == nil {
+		t.Fatal("want ErrNoSlots when the pinned slot is taken, got nil (advanced past the pin)")
+	}
+
+	// Pinned slot free → claims exactly 7.
+	free := newTestManager()
+	free.nextSlot, free.maxSlot = 7, 7
+	idx, err := free.claimSlotIndex("build-x")
+	if err != nil {
+		t.Fatalf("claimSlotIndex: %v", err)
+	}
+	if idx != 7 {
+		t.Errorf("idx = %d, want 7 (pinned)", idx)
+	}
+}
+
 func TestClaimSlotIndex_PrefersFreeSlotsLIFO(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -144,7 +144,7 @@ func TestClaimSlotIndex_ExactSlotDoesNotAdvance(t *testing.T) {
 
 	// Pinned slot already taken → must fail, not fall through to 8.
 	taken := newTestManager()
-	taken.nextSlot, taken.maxSlot = 7, 7 // WithExactSlot(7)
+	taken.nextSlot, taken.maxSlot, taken.slotPinned = 7, 7, true // WithExactSlot(7)
 	taken.slotOwner[7] = "other"
 	if _, err := taken.claimSlotIndex("build-x"); err == nil {
 		t.Fatal("want ErrNoSlots when the pinned slot is taken, got nil (advanced past the pin)")
@@ -152,7 +152,7 @@ func TestClaimSlotIndex_ExactSlotDoesNotAdvance(t *testing.T) {
 
 	// Pinned slot free → claims exactly 7.
 	free := newTestManager()
-	free.nextSlot, free.maxSlot = 7, 7
+	free.nextSlot, free.maxSlot, free.slotPinned = 7, 7, true
 	idx, err := free.claimSlotIndex("build-x")
 	if err != nil {
 		t.Fatalf("claimSlotIndex: %v", err)

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -121,7 +121,7 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	if err != nil {
 		return nil, fmt.Errorf("reserve build network slot: %w", err)
 	}
-	defer m.netMgr.CleanupVMOrNamespace(buildVMID, fmt.Sprintf("ns-%d", slotIndex))
+	defer m.netMgr.ReleaseSlot(buildVMID, slotIndex)
 
 	cmd := exec.CommandContext(ctx, m.cfg.TemplateBuilderBin,
 		"--template-id", req.TemplateID,

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -114,7 +114,14 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 		return nil, fmt.Errorf("marshal spec: %w", err)
 	}
 
-	slotIndex := int(m.nextBuildSlot.Add(1)) + 199
+	// Reserve a slot from vmd's authoritative allocator so the subprocess's
+	// ns-<idx>/veth-<idx> can't collide with a sandbox slot, and release it (with
+	// any kernel residue) when the build exits — success, failure, or panic.
+	slotIndex, err := m.netMgr.ReserveSlot(buildVMID)
+	if err != nil {
+		return nil, fmt.Errorf("reserve build network slot: %w", err)
+	}
+	defer m.netMgr.CleanupVMOrNamespace(buildVMID, fmt.Sprintf("ns-%d", slotIndex))
 
 	cmd := exec.CommandContext(ctx, m.cfg.TemplateBuilderBin,
 		"--template-id", req.TemplateID,

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -114,10 +114,10 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 		return nil, fmt.Errorf("marshal spec: %w", err)
 	}
 
-	// Reserve a slot from vmd's authoritative allocator so the subprocess's
+	// Claim a slot from vmd's authoritative allocator so the subprocess's
 	// ns-<idx>/veth-<idx> can't collide with a sandbox slot, and release it (with
 	// any kernel residue) when the build exits — success, failure, or panic.
-	slotIndex, err := m.netMgr.ReserveSlot(buildVMID)
+	slotIndex, err := m.netMgr.ClaimFreshSlot(buildVMID)
 	if err != nil {
 		return nil, fmt.Errorf("reserve build network slot: %w", err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -215,11 +214,6 @@ type Manager struct {
 	// until process exit so late pollers can read terminal outcomes.
 	buildsMu sync.RWMutex
 	builds   map[string]*buildRecord
-
-	// nextBuildSlot assigns unique network slot indices to concurrent
-	// template-builder subprocesses. Starts at 200 to avoid collision
-	// with vmd's sandbox pool (indices 1-100).
-	nextBuildSlot atomic.Int32
 }
 
 // NewManager creates a new VM manager.


### PR DESCRIPTION
## Problem

Template builds and sandboxes share one kernel namespace space (`ns-<idx>` /
`veth-<idx>`), but they were allocated by **two independent allocators with no
authority between them**:

- Sandboxes go through vmd's `network.Manager` slot allocator (`slotOwner` map,
  reclaims freed indices), which runs 1 → `MaxSlots`.
- Builds used a separate `nextBuildSlot` counter (base 200) in the vm manager,
  and the build ran in a subprocess with its own `network.Manager`.

Two problems fell out:

1. **Overlapping ranges.** The "sandboxes stay 1–100, builds start at 200"
   assumption no longer holds — a host routinely runs far more than 200
   concurrent sandboxes, so sandbox slots extend well past 200 and overlap the
   build range. The only thing standing between a build and a sandbox on the
   same `ns-<idx>` was a cross-process `nsExists` TOCTOU check that both sides
   can pass before either creates the namespace.
2. **No reclamation.** `nextBuildSlot` only ever increments, so build slot
   indices climb for the life of the process and are never reused.

## Fix

Make vmd's **one authoritative allocator** own the build slot too. Before
spawning the subprocess, vmd reserves an index through the same allocator that
hands out sandbox slots (`ReserveSlot` → the `slotOwner` map), passes it to the
subprocess, and releases it — tearing down any kernel residue — when the build
exits (success, failure, or panic):

- New `network.Manager.ReserveSlot(owner)` claims a fresh index under the build's
  ID without building kernel state (the subprocess builds `ns/veth` itself). The
  reservation is what prevents a sandbox from being handed the same index — no
  disjoint range needed.
- `buildTemplateSync` reserves via `ReserveSlot` and `defer`s
  `CleanupVMOrNamespace` to release the index and reap any leftover namespace.
- Deleted the `nextBuildSlot` counter and the fixed 200 base.

Result: builds and sandboxes draw from a single allocator, so they can't collide;
the index is reclaimed on build exit instead of leaking upward; and the fragile
cross-process `nsExists` race is gone (the reservation is taken before the
subprocess creates the namespace, and the allocator already skips
kernel-present indices).

This is independent of the concurrency-limit change — it's a pre-existing
allocation bug, surfaced while reviewing that work.
