### PR TITLE
migrate-team: split decommission into detach and purge

### DIFF
--- a/cmd/migrate-team/checksums.go
+++ b/cmd/migrate-team/checksums.go
@@ -106,7 +106,7 @@ func diffChecksums(src, dst map[string]int) (srcOnly, dstOnly int) {
 
 // contentDriftUnderLock re-compares the mutation-prone tables — sandbox
 // rows and secret bindings — between the locked source transaction and the
-// dest, transform-aware, so decommission's deletes act on exactly the rows
+// dest, transform-aware, so purge's deletes act on exactly the rows
 // validation approved. Runs on the transaction (not the pool): the FOR
 // UPDATE row locks and per-sandbox advisory locks it holds are the point.
 // Returns the first drifted table's name, or "".

--- a/cmd/migrate-team/main.go
+++ b/cmd/migrate-team/main.go
@@ -23,9 +23,19 @@
 //	              billing usage sums, artifact path completeness, member
 //	              profile presence, and role-assignment resolution. Exits
 //	              non-zero with a report on any mismatch.
-//	decommission  deletes the team's rows from the SOURCE in reverse FK order.
-//	              Requires --confirm-team-name to match the team's exact name,
-//	              and runs validate internally first — any mismatch aborts.
+//	detach        deletes ONLY the team's membership rows from the SOURCE —
+//	              user_role_assignments (team-scoped), team_memberships, and
+//	              team_member — in one transaction, after running validate
+//	              internally. With the RBAC chain gone no console or API path
+//	              reaches the source copy, so the team has exactly one live
+//	              home; everything else stays as a cold fallback for the soak
+//	              period. Requires --confirm-team-name. Reversible: re-insert
+//	              the membership rows, or run the tool in reverse.
+//	purge         deletes the team's rows from the SOURCE in reverse FK order,
+//	              run after the post-detach soak. Requires --confirm-team-name
+//	              to match the team's exact name, and runs validate internally
+//	              first — any mismatch aborts. (--phase decommission is a
+//	              deprecated alias.)
 //
 // Deliberately out of scope:
 //   - Artifact files on hosts (template rootfs/snapshots, sandbox snapshots)
@@ -64,8 +74,8 @@ func main() {
 	flag.StringVar(&cfg.destURL, "dest-db", os.Getenv("DEST_DATABASE_URL"), "dest cell Postgres URL (defaults to DEST_DATABASE_URL)")
 	flag.StringVar(&cfg.destHostID, "dest-host-id", "", "host row id in the dest cell (e.g. usw2); required for copy")
 	flag.StringVar(&cfg.destRegion, "dest-region", "", "dest region token (e.g. usw); required for copy")
-	flag.StringVar(&cfg.phase, "phase", phasePlan, "plan | copy | validate | decommission | release-rollups")
-	flag.StringVar(&confirmTeamName, "confirm-team-name", "", "exact team name; required for decommission")
+	flag.StringVar(&cfg.phase, "phase", phasePlan, "plan | copy | validate | detach | purge | release-rollups (decommission is a deprecated alias for purge)")
+	flag.StringVar(&confirmTeamName, "confirm-team-name", "", "exact team name; required for detach and purge")
 	flag.StringVar(&cfg.pathsOut, "paths-out", "", "file to write the artifact directory list to, one dir per line (plan/validate)")
 	flag.Parse()
 
@@ -79,28 +89,33 @@ func main() {
 	cfg.teamID = teamID
 	cfg.confirmTeamName = confirmTeamName
 
+	if cfg.phase == phaseDecommission {
+		log.Warn().Msg("--phase decommission is deprecated; running purge (the membership-only cutover step is --phase detach)")
+		cfg.phase = phasePurge
+	}
+
 	if cfg.sourceURL == "" {
 		log.Fatal().Msg("--source-db (or SOURCE_DATABASE_URL) is required")
 	}
 	switch cfg.phase {
 	case phasePlan:
 		// Read-only; dest is optional.
-	case phaseCopy, phaseValidate, phaseDecommission, phaseReleaseRollups:
+	case phaseCopy, phaseValidate, phaseDetach, phasePurge, phaseReleaseRollups:
 		if cfg.destURL == "" {
 			log.Fatal().Msg("--dest-db (or DEST_DATABASE_URL) is required for " + cfg.phase)
 		}
 	default:
-		log.Fatal().Str("phase", cfg.phase).Msg("unknown phase; want plan | copy | validate | decommission")
+		log.Fatal().Str("phase", cfg.phase).Msg("unknown phase; want plan | copy | validate | detach | purge | release-rollups")
 	}
-	// copy rewrites rows with these values; validate and decommission apply
+	// copy rewrites rows with these values; validate, detach, and purge apply
 	// the same transforms when checksumming the source, so running them
 	// without the flags would compare against empty rewrites and report
 	// false drift on every team and sandbox row.
 	if cfg.phase != phasePlan && cfg.phase != phaseReleaseRollups && (cfg.destHostID == "" || cfg.destRegion == "") {
 		log.Fatal().Msg("--dest-host-id and --dest-region are required for " + cfg.phase)
 	}
-	if cfg.phase == phaseDecommission && cfg.confirmTeamName == "" {
-		log.Fatal().Msg("--confirm-team-name is required for decommission")
+	if (cfg.phase == phaseDetach || cfg.phase == phasePurge) && cfg.confirmTeamName == "" {
+		log.Fatal().Msg("--confirm-team-name is required for " + cfg.phase)
 	}
 
 	if err := run(context.Background(), cfg); err != nil {

--- a/cmd/migrate-team/main_test.go
+++ b/cmd/migrate-team/main_test.go
@@ -993,9 +993,22 @@ func TestTeamMigration(t *testing.T) {
 			t.Fatalf("validate on a detached source: %v", err)
 		}
 
-		// Detach is re-runnable: a second pass deletes nothing and passes.
+		// Detach is re-runnable as a pure no-op: a second pass during the
+		// soak must not replay the cutover sweep or the rollup release over
+		// the now-live dest. The sentinel cursor would be overwritten by a
+		// replayed sweep (the source's frozen cursor differs).
+		sentinel := time.Date(2032, 6, 1, 0, 0, 0, 0, time.UTC)
+		mustExec(t, dstPool, `UPDATE billing_rollup_team_backfill_state SET next_hour_start = $2 WHERE team_id = $1`, f.team, sentinel)
 		if err := run(ctx, cfg); err != nil {
 			t.Fatalf("re-detach: %v", err)
+		}
+		var cursor time.Time
+		if err := dstPool.QueryRow(ctx, `
+			SELECT next_hour_start FROM billing_rollup_team_backfill_state WHERE team_id = $1`, f.team).Scan(&cursor); err != nil {
+			t.Fatal(err)
+		}
+		if !cursor.Equal(sentinel) {
+			t.Fatalf("re-detach replayed the cutover sweep over the live dest (cursor=%v)", cursor)
 		}
 	})
 

--- a/cmd/migrate-team/main_test.go
+++ b/cmd/migrate-team/main_test.go
@@ -880,6 +880,36 @@ func TestTeamMigration(t *testing.T) {
 		}
 	})
 
+	t.Run("detach refuses when the source is no longer quiescent", func(t *testing.T) {
+		mustExec(t, srcPool, `UPDATE sandbox SET status = 'active' WHERE id = $1`, f.sb1)
+		defer mustExec(t, srcPool, `UPDATE sandbox SET status = 'paused' WHERE id = $1`, f.sb1)
+
+		cfg := f.cfg(phaseDetach)
+		cfg.confirmTeamName = "migration-drill"
+		err := run(ctx, cfg)
+		if err == nil || !strings.Contains(err.Error(), f.sb1.String()) {
+			t.Fatalf("post-copy resume must block detach, got: %v", err)
+		}
+	})
+
+	t.Run("detach refuses when a build is in flight", func(t *testing.T) {
+		buildID := uuid.New()
+		mustExec(t, srcPool, `
+			INSERT INTO template_build (id, template_id, team_id, status, build_spec_hash, vmd_host_id)
+			VALUES ($1, $2, $3, 'building', 'race-hash', $4)`, buildID, f.tpl, f.team, sourceHostID)
+		defer mustExec(t, srcPool, `DELETE FROM template_build WHERE id = $1`, buildID)
+
+		cfg := f.cfg(phaseDetach)
+		cfg.confirmTeamName = "migration-drill"
+		err := run(ctx, cfg)
+		if err == nil || !strings.Contains(err.Error(), buildID.String()) {
+			t.Fatalf("in-flight build must block detach, got: %v", err)
+		}
+		if got := countScoped(t, srcPool, tableSpec{"team_memberships", "team_id = $1"}, f.team); got != 2 {
+			t.Fatal("refused detach must not delete anything")
+		}
+	})
+
 	t.Run("detach requires the exact team name", func(t *testing.T) {
 		cfg := f.cfg(phaseDetach)
 		cfg.confirmTeamName = "migration-dril" // one letter off
@@ -892,10 +922,25 @@ func TestTeamMigration(t *testing.T) {
 	})
 
 	t.Run("detach removes only the membership rows", func(t *testing.T) {
+		// Re-impose the copy's rollup hold on the dest (an earlier subtest
+		// released it via the standalone phase): detach is the cutover
+		// moment and must lift the hold itself, or the migrated team's
+		// hourly rollups stay suppressed for the whole soak.
+		mustExec(t, dstPool, `UPDATE team_feature_flag SET enabled = false WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team)
+
 		cfg := f.cfg(phaseDetach)
 		cfg.confirmTeamName = "migration-drill"
 		if err := run(ctx, cfg); err != nil {
 			t.Fatalf("detach: %v", err)
+		}
+
+		var rollups bool
+		if err := dstPool.QueryRow(ctx, `SELECT enabled FROM team_feature_flag
+			WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team).Scan(&rollups); err != nil {
+			t.Fatal(err)
+		}
+		if !rollups {
+			t.Fatal("detach must restore the source rollup flag in the dest at cutover")
 		}
 
 		// The RBAC chain is gone from the source; every other table keeps

--- a/cmd/migrate-team/main_test.go
+++ b/cmd/migrate-team/main_test.go
@@ -999,21 +999,77 @@ func TestTeamMigration(t *testing.T) {
 		}
 	})
 
-	t.Run("purge after detach removes the source copy", func(t *testing.T) {
+	t.Run("purge refuses when the dest lost the team", func(t *testing.T) {
+		// Blow away the dest membership chain: purge must refuse to delete
+		// what is now the only reachable copy of those rows.
+		rows, err := dstPool.Query(ctx, `SELECT user_id, status FROM team_memberships WHERE team_id = $1`, f.team)
+		if err != nil {
+			t.Fatal(err)
+		}
+		type membership struct {
+			userID uuid.UUID
+			status string
+		}
+		var saved []membership
+		for rows.Next() {
+			var m membership
+			if err := rows.Scan(&m.userID, &m.status); err != nil {
+				t.Fatal(err)
+			}
+			saved = append(saved, m)
+		}
+		rows.Close()
+		mustExec(t, dstPool, `DELETE FROM team_memberships WHERE team_id = $1`, f.team)
+		defer func() {
+			for _, m := range saved {
+				mustExec(t, dstPool, `INSERT INTO team_memberships (team_id, user_id, status) VALUES ($1, $2, $3)`, f.team, m.userID, m.status)
+			}
+		}()
+
+		cfg := f.cfg(phasePurge)
+		cfg.confirmTeamName = "migration-drill"
+		if err := run(ctx, cfg); err == nil || !strings.Contains(err.Error(), "mismatch") {
+			t.Fatalf("purge with an empty dest membership chain must refuse, got: %v", err)
+		}
+		if got := countScoped(t, srcPool, tableSpec{"sandbox", "team_id = $1"}, f.team); got != f.expectedCounts["sandbox"] {
+			t.Fatal("refused purge must not delete source rows")
+		}
+	})
+
+	t.Run("purge after a live detached soak removes the source copy", func(t *testing.T) {
+		// Simulate the soak: the dest is the live home and diverges — a
+		// sandbox resumes, a dest-only activity row lands, the rollup
+		// backfill cursor advances, and support flips the rollup flag off.
+		// None of that may block purge, and none of it may be overwritten
+		// by purge's dest writes (sweep, rollup restore) afterwards.
+		mustExec(t, dstPool, `UPDATE sandbox SET status = 'active' WHERE id = $1`, f.sb1)
+		mustExec(t, dstPool, `INSERT INTO activity (sandbox_id, team_id, actor_id, category, action, resource_type, sandbox_name)
+			VALUES ($1, $2, $3, 'sandbox', 'create', 'sandbox', 'drill-soak-sb')`, f.sb1, f.team, f.owner)
+		soakCursor := time.Date(2031, 1, 1, 0, 0, 0, 0, time.UTC)
+		mustExec(t, dstPool, `UPDATE billing_rollup_team_backfill_state SET next_hour_start = $2 WHERE team_id = $1`, f.team, soakCursor)
+		mustExec(t, dstPool, `UPDATE team_feature_flag SET enabled = false WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team)
+
 		cfg := f.cfg(phasePurge)
 		cfg.confirmTeamName = "migration-drill"
 		if err := run(ctx, cfg); err != nil {
 			t.Fatalf("purge: %v", err)
 		}
 
-		// Purge captures the source flag before deleting and restores it
-		// into dest itself — the fixture's explicit TRUE must survive even
-		// though the source rows are gone.
+		// The dest's live state survives: purge must not re-restore the
+		// frozen source's flag or sweep the frozen cursor over the live one.
 		var enabled bool
 		if err := dstPool.QueryRow(ctx, `
 			SELECT enabled FROM team_feature_flag
-			WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team).Scan(&enabled); err != nil || !enabled {
-			t.Fatalf("dest rollup flag not restored after purge (enabled=%v, err=%v)", enabled, err)
+			WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team).Scan(&enabled); err != nil || enabled {
+			t.Fatalf("detached purge clobbered the dest's live rollup flag (enabled=%v, err=%v)", enabled, err)
+		}
+		var cursor time.Time
+		if err := dstPool.QueryRow(ctx, `
+			SELECT next_hour_start FROM billing_rollup_team_backfill_state WHERE team_id = $1`, f.team).Scan(&cursor); err != nil {
+			t.Fatal(err)
+		}
+		if !cursor.Equal(soakCursor) {
+			t.Fatalf("detached purge rewound the dest's live backfill cursor to %v", cursor)
 		}
 
 		for _, spec := range migratedTables {
@@ -1054,7 +1110,11 @@ func TestTeamMigration(t *testing.T) {
 			t.Errorf("bystander team lost its sandbox (count=%d)", n)
 		}
 		for _, spec := range migratedTables {
-			if got, want := countScoped(t, dstPool, spec, f.team), f.expectedCounts[spec.name]; got != want {
+			want := f.expectedCounts[spec.name]
+			if spec.name == "activity" {
+				want++ // the dest-only soak-divergence row above
+			}
+			if got := countScoped(t, dstPool, spec, f.team); got != want {
 				t.Errorf("after purge, dest %s: got %d rows, want %d", spec.name, got, want)
 			}
 		}

--- a/cmd/migrate-team/main_test.go
+++ b/cmd/migrate-team/main_test.go
@@ -352,8 +352,14 @@ func seedFixture(t *testing.T) *fixture {
 	mustExec(t, srcPool, `
 		INSERT INTO audit_logs (actor_user_id, team_id, event_type) VALUES ($1, $2, 'role_granted')`, f.owner, f.team)
 
-	// A neighbor team that must survive decommission untouched.
+	// A neighbor team that must survive detach and purge untouched. It
+	// shares the owner, so detach's membership deletes must scope by team.
 	mustExec(t, srcPool, `INSERT INTO team (id, name) VALUES ($1, 'bystander-team')`, f.teamB)
+	mustExec(t, srcPool, `INSERT INTO team_member (team_id, profile_id, role) VALUES ($1, $2, 'owner')`, f.teamB, f.owner)
+	mustExec(t, srcPool, `INSERT INTO team_memberships (team_id, user_id, status) VALUES ($1, $2, 'active')`, f.teamB, f.owner)
+	mustExec(t, srcPool, `
+		INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id, granted_by)
+		SELECT $2, r.id, 'team', $1, $2 FROM roles r WHERE r.name = 'team_owner'`, f.teamB, f.owner)
 
 	// System template: owned by another team in source; the dest cell has
 	// its own seeded copy under a different id. sb4 boots from it, so the
@@ -765,14 +771,14 @@ func TestTeamMigration(t *testing.T) {
 		}
 	})
 
-	t.Run("decommission requires the exact team name", func(t *testing.T) {
-		cfg := f.cfg(phaseDecommission)
+	t.Run("purge requires the exact team name", func(t *testing.T) {
+		cfg := f.cfg(phasePurge)
 		cfg.confirmTeamName = "migration-dril" // one letter off
 		if err := run(ctx, cfg); err == nil {
-			t.Fatal("decommission with a wrong --confirm-team-name must fail")
+			t.Fatal("purge with a wrong --confirm-team-name must fail")
 		}
 		if got := countScoped(t, srcPool, tableSpec{"team", "id = $1"}, f.team); got != 1 {
-			t.Fatal("refused decommission must not delete anything")
+			t.Fatal("refused purge must not delete anything")
 		}
 	})
 
@@ -817,7 +823,7 @@ func TestTeamMigration(t *testing.T) {
 	})
 
 	t.Run("straggler sweep copies the transaction's own view", func(t *testing.T) {
-		// The decommission sweep runs copyTable off the locked transaction
+		// The purge sweep runs copyTable off the locked transaction
 		// so rows that landed after validate — invisible to any earlier
 		// pass — still reach the dest before the deletes. Simulate by
 		// sweeping from a transaction that holds an uncommitted straggler.
@@ -847,48 +853,122 @@ func TestTeamMigration(t *testing.T) {
 		}
 	})
 
-	t.Run("decommission refuses when a build starts during validate", func(t *testing.T) {
+	t.Run("purge refuses when a build starts during validate", func(t *testing.T) {
 		buildID := uuid.New()
 		mustExec(t, srcPool, `
 			INSERT INTO template_build (id, template_id, team_id, status, build_spec_hash, vmd_host_id)
 			VALUES ($1, $2, $3, 'pending', 'race-hash', $4)`, buildID, f.tpl, f.team, sourceHostID)
 		defer mustExec(t, srcPool, `DELETE FROM template_build WHERE id = $1`, buildID)
 
-		cfg := f.cfg(phaseDecommission)
+		cfg := f.cfg(phasePurge)
 		cfg.confirmTeamName = "migration-drill"
 		err := run(ctx, cfg)
 		if err == nil || !strings.Contains(err.Error(), buildID.String()) {
-			t.Fatalf("in-flight build must block decommission, got: %v", err)
+			t.Fatalf("in-flight build must block purge, got: %v", err)
 		}
 	})
 
-	t.Run("decommission refuses when the source is no longer quiescent", func(t *testing.T) {
+	t.Run("purge refuses when the source is no longer quiescent", func(t *testing.T) {
 		mustExec(t, srcPool, `UPDATE sandbox SET status = 'active' WHERE id = $1`, f.sb1)
 		defer mustExec(t, srcPool, `UPDATE sandbox SET status = 'paused' WHERE id = $1`, f.sb1)
 
-		cfg := f.cfg(phaseDecommission)
+		cfg := f.cfg(phasePurge)
 		cfg.confirmTeamName = "migration-drill"
 		err := run(ctx, cfg)
 		if err == nil || !strings.Contains(err.Error(), f.sb1.String()) {
-			t.Fatalf("post-copy resume must block decommission, got: %v", err)
+			t.Fatalf("post-copy resume must block purge, got: %v", err)
 		}
 	})
 
-	t.Run("decommission removes the source copy", func(t *testing.T) {
-		cfg := f.cfg(phaseDecommission)
+	t.Run("detach requires the exact team name", func(t *testing.T) {
+		cfg := f.cfg(phaseDetach)
+		cfg.confirmTeamName = "migration-dril" // one letter off
+		if err := run(ctx, cfg); err == nil {
+			t.Fatal("detach with a wrong --confirm-team-name must fail")
+		}
+		if got := countScoped(t, srcPool, tableSpec{"team_memberships", "team_id = $1"}, f.team); got != 2 {
+			t.Fatal("refused detach must not delete anything")
+		}
+	})
+
+	t.Run("detach removes only the membership rows", func(t *testing.T) {
+		cfg := f.cfg(phaseDetach)
 		cfg.confirmTeamName = "migration-drill"
 		if err := run(ctx, cfg); err != nil {
-			t.Fatalf("decommission: %v", err)
+			t.Fatalf("detach: %v", err)
 		}
 
-		// Decommission captures the source flag before deleting and
-		// restores it into dest itself — the fixture's explicit TRUE must
-		// survive even though the source rows are gone.
+		// The RBAC chain is gone from the source; every other table keeps
+		// its rows as the cold fallback. profile is asserted by id below —
+		// its scope is derived from the deleted membership rows — and the
+		// self-expiring exempt tables were pruned by an earlier subtest.
+		for _, spec := range migratedTables {
+			if spec.name == "profile" || validationExemptTables[spec.name] {
+				continue
+			}
+			want := f.expectedCounts[spec.name]
+			if membershipTables[spec.name] {
+				want = 0
+			}
+			if got := countScoped(t, srcPool, spec, f.team); got != want {
+				t.Errorf("after detach, source %s: got %d rows, want %d", spec.name, got, want)
+			}
+		}
+		for _, id := range []uuid.UUID{f.owner, f.member} {
+			var exists bool
+			if err := srcPool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM profile WHERE id = $1)`, id).Scan(&exists); err != nil {
+				t.Fatal(err)
+			}
+			if !exists {
+				t.Errorf("profile %s deleted from source; detach must not touch profiles", id)
+			}
+		}
+
+		// The bystander team's memberships (same owner) survive.
+		for _, table := range []string{"team_member", "team_memberships", "user_role_assignments"} {
+			var n int64
+			if err := srcPool.QueryRow(ctx, fmt.Sprintf(`SELECT count(*) FROM %s WHERE team_id = $1`, table), f.teamB).Scan(&n); err != nil {
+				t.Fatal(err)
+			}
+			if n != 1 {
+				t.Errorf("bystander %s: got %d rows, want 1", table, n)
+			}
+		}
+
+		// The dest is untouched, memberships included.
+		for _, spec := range migratedTables {
+			if got, want := countScoped(t, dstPool, spec, f.team), f.expectedCounts[spec.name]; got != want {
+				t.Errorf("after detach, dest %s: got %d rows, want %d", spec.name, got, want)
+			}
+		}
+
+		// A standalone validate during the soak must not read the detached
+		// membership tables as data loss.
+		if err := run(ctx, f.cfg(phaseValidate)); err != nil {
+			t.Fatalf("validate on a detached source: %v", err)
+		}
+
+		// Detach is re-runnable: a second pass deletes nothing and passes.
+		if err := run(ctx, cfg); err != nil {
+			t.Fatalf("re-detach: %v", err)
+		}
+	})
+
+	t.Run("purge after detach removes the source copy", func(t *testing.T) {
+		cfg := f.cfg(phasePurge)
+		cfg.confirmTeamName = "migration-drill"
+		if err := run(ctx, cfg); err != nil {
+			t.Fatalf("purge: %v", err)
+		}
+
+		// Purge captures the source flag before deleting and restores it
+		// into dest itself — the fixture's explicit TRUE must survive even
+		// though the source rows are gone.
 		var enabled bool
 		if err := dstPool.QueryRow(ctx, `
 			SELECT enabled FROM team_feature_flag
 			WHERE team_id = $1 AND key = 'billing_hourly_rollups'`, f.team).Scan(&enabled); err != nil || !enabled {
-			t.Fatalf("dest rollup flag not restored after decommission (enabled=%v, err=%v)", enabled, err)
+			t.Fatalf("dest rollup flag not restored after purge (enabled=%v, err=%v)", enabled, err)
 		}
 
 		for _, spec := range migratedTables {
@@ -930,8 +1010,87 @@ func TestTeamMigration(t *testing.T) {
 		}
 		for _, spec := range migratedTables {
 			if got, want := countScoped(t, dstPool, spec, f.team), f.expectedCounts[spec.name]; got != want {
-				t.Errorf("after decommission, dest %s: got %d rows, want %d", spec.name, got, want)
+				t.Errorf("after purge, dest %s: got %d rows, want %d", spec.name, got, want)
 			}
 		}
 	})
+}
+
+// TestPurgeWithoutDetach proves purge still stands alone: a source that never
+// went through detach keeps its membership rows, so the internal validate
+// must compare them in full (nothing is skipped) and the deletes take the
+// whole team in one pass — the pre-split decommission behavior.
+func TestPurgeWithoutDetach(t *testing.T) {
+	ctx := context.Background()
+	team := uuid.New()
+	owner := uuid.New()
+	sb := uuid.New()
+
+	mustExec(t, dstPool, `
+		INSERT INTO host (id, vmd_addr, proxy_addr, region, capacity_memory_mib, capacity_vcpus)
+		VALUES ($1, '10.1.0.1:50051', '10.1.0.1:8080', $2, 65536, 32)
+		ON CONFLICT (id) DO NOTHING`, destHostID, destRegion)
+
+	mustExec(t, srcPool, `INSERT INTO team (id, name) VALUES ($1, 'purge-direct-drill')`, team)
+	mustExec(t, srcPool, `INSERT INTO profile (id, email, provider, provider_id) VALUES ($1, 'direct-owner@example.com', 'google', 'google-direct')`, owner)
+	mustExec(t, srcPool, `INSERT INTO team_member (team_id, profile_id, role) VALUES ($1, $2, 'owner')`, team, owner)
+	mustExec(t, srcPool, `INSERT INTO team_memberships (team_id, user_id, status) VALUES ($1, $2, 'active')`, team, owner)
+	mustExec(t, srcPool, `
+		INSERT INTO user_role_assignments (user_id, role_id, scope_type, team_id, granted_by)
+		SELECT $2, r.id, 'team', $1, $2 FROM roles r WHERE r.name = 'team_owner'`, team, owner)
+	sbDir := "/srv/sandboxes/" + sb.String()
+	mustExec(t, srcPool, `
+		INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id,
+		                     snapshot_path, mem_path, base_path, delta_path)
+		VALUES ($1, $2, 'direct-sb', 'paused', 1, 1024, $3,
+		        $4||'/vmstate.snap', $4||'/mem.snap', $4||'/base.ext4', $4||'/delta.ext4')`,
+		sb, team, sourceHostID, sbDir)
+
+	cfg := config{
+		teamID:     team,
+		sourceURL:  srcURL,
+		destURL:    dstURL,
+		destHostID: destHostID,
+		destRegion: destRegion,
+	}
+
+	cfg.phase = phaseCopy
+	if err := run(ctx, cfg); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	cfg.phase = phasePurge
+	cfg.confirmTeamName = "purge-direct-drill"
+	if err := run(ctx, cfg); err != nil {
+		t.Fatalf("purge without a prior detach: %v", err)
+	}
+
+	for _, table := range []string{"team_member", "team_memberships", "sandbox"} {
+		var n int64
+		if err := srcPool.QueryRow(ctx, fmt.Sprintf(`SELECT count(*) FROM %s WHERE team_id = $1`, table), team).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("source %s still has %d team rows", table, n)
+		}
+	}
+	var n int64
+	if err := srcPool.QueryRow(ctx, `SELECT count(*) FROM team WHERE id = $1`, team).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Error("source team row survived the purge")
+	}
+	for table, want := range map[string]int64{"team": 1, "team_member": 1, "team_memberships": 1, "sandbox": 1} {
+		q := `SELECT count(*) FROM ` + table + ` WHERE team_id = $1`
+		if table == "team" {
+			q = `SELECT count(*) FROM team WHERE id = $1`
+		}
+		if err := dstPool.QueryRow(ctx, q, team).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != want {
+			t.Errorf("dest %s: got %d rows, want %d", table, n, want)
+		}
+	}
 }

--- a/cmd/migrate-team/migrate.go
+++ b/cmd/migrate-team/migrate.go
@@ -1157,6 +1157,28 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 		return fmt.Errorf("--confirm-team-name %q does not match team name %q; refusing to delete", cfg.confirmTeamName, teamName)
 	}
 
+	// Same quiescence re-check as purge: a sandbox resumed or a build
+	// started after the copy is invisible to validate (in-flight build rows
+	// sit outside the migration scope entirely), and detach would sever the
+	// only reachable copy while that work still writes source rows and
+	// artifacts that were never copied.
+	blockers, err := activeSandboxes(ctx, src, cfg.teamID)
+	if err != nil {
+		return err
+	}
+	if len(blockers) > 0 {
+		return fmt.Errorf("aborting detach: %d sandbox(es) no longer quiescent:\n  %s",
+			len(blockers), strings.Join(blockers, "\n  "))
+	}
+	builds, err := activeBuilds(ctx, src, cfg.teamID)
+	if err != nil {
+		return err
+	}
+	if len(builds) > 0 {
+		return fmt.Errorf("aborting detach: %d template build(s) in flight:\n  %s",
+			len(builds), strings.Join(builds, "\n  "))
+	}
+
 	// A validate pass is a precondition in the same invocation — after
 	// detach the dest is the only copy anyone can reach, so never sever
 	// access to a source we haven't just proven the dest matches.
@@ -1197,6 +1219,16 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 		return fmt.Errorf("commit: %w", err)
 	}
 	log.Info().Int64("deleted", total).Msg("detach: source membership rows removed; everything else stays as a cold fallback until purge")
+
+	// Detach is the cutover moment, so it lifts the copy's rollup hold
+	// itself — leaving that to purge would suppress the team's hourly
+	// rollups in the dest for the whole soak. The source flag row outlives
+	// detach (team_feature_flag is not a membership table), so this is the
+	// same source-state restore as the standalone release-rollups phase,
+	// and a no-op when the runbook already ran that phase at cutover.
+	if err := runReleaseRollups(ctx, src, dst, cfg); err != nil {
+		return fmt.Errorf("detach: release rollup hold: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/migrate-team/migrate.go
+++ b/cmd/migrate-team/migrate.go
@@ -18,9 +18,13 @@ import (
 )
 
 const (
-	phasePlan           = "plan"
-	phaseCopy           = "copy"
-	phaseValidate       = "validate"
+	phasePlan     = "plan"
+	phaseCopy     = "copy"
+	phaseValidate = "validate"
+	phaseDetach   = "detach"
+	phasePurge    = "purge"
+	// Deprecated alias for purge, from before detach split the phase in two;
+	// main normalizes it away.
 	phaseDecommission   = "decommission"
 	phaseReleaseRollups = "release-rollups"
 
@@ -42,7 +46,7 @@ type config struct {
 // identity plus database name — never by connection endpoint. The same
 // database reached through a pooler and directly must collapse to ONE
 // identity (endpoint-based fingerprints pass the guard and turn
-// copy/validate into self-comparisons before decommission deletes the only
+// copy/validate into self-comparisons before purge deletes the only
 // copy), while two databases in one cluster stay distinct via
 // current_database(). system_identifier is initdb-unique and stable across
 // restarts; where a managed provider restricts pg_control_system(), the
@@ -80,8 +84,8 @@ func run(ctx context.Context, cfg config) error {
 		// comparison can't catch pooler-vs-direct spellings of one DB, so
 		// compare live identity instead. With source == dest every later
 		// safeguard becomes a self-comparison: copy no-ops, validate
-		// passes against itself, and decommission would delete the only
-		// copy of the team.
+		// passes against itself, and purge would delete the only copy of
+		// the team.
 		srcID, err := dbIdentity(ctx, src)
 		if err != nil {
 			return fmt.Errorf("identify source database: %w", err)
@@ -111,8 +115,10 @@ func run(ctx context.Context, cfg config) error {
 		return runCopy(ctx, src, dst, cfg)
 	case phaseValidate:
 		return runValidate(ctx, src, dst, cfg)
-	case phaseDecommission:
-		return runDecommission(ctx, src, dst, cfg, teamName)
+	case phaseDetach:
+		return runDetach(ctx, src, dst, cfg, teamName)
+	case phasePurge:
+		return runPurge(ctx, src, dst, cfg, teamName)
 	case phaseReleaseRollups:
 		return runReleaseRollups(ctx, src, dst, cfg)
 	}
@@ -140,7 +146,7 @@ func runReleaseRollups(ctx context.Context, src, dst *pgxpool.Pool, cfg config) 
 
 // restoreRollupFlag writes the source's rollup-flag state into the dest: the
 // source's value when a row existed, absence when none did. Shared by the
-// standalone release-rollups phase (source still present) and decommission
+// standalone release-rollups phase (source still present) and purge
 // (which captures the state before deleting the source).
 func restoreRollupFlag(ctx context.Context, dst *pgxpool.Pool, teamID uuid.UUID, srcEnabled *bool) error {
 	if srcEnabled == nil {
@@ -444,7 +450,7 @@ func runCopy(ctx context.Context, src, dst *pgxpool.Pool, cfg config) error {
 	}
 	log.Info().Int64("relinked", relinked).Msg("copy: sandbox.snapshot_id relinked from source")
 
-	log.Info().Msg("copy: dest rollups remain HELD for this team — decommission releases the hold itself; for migrations that keep the source, run --phase release-rollups at cutover after validate")
+	log.Info().Msg("copy: dest rollups remain HELD for this team — purge releases the hold itself; for migrations that keep the source, run --phase release-rollups at cutover after validate")
 
 	for _, s := range skippedTables {
 		log.Info().Str("table", s.name).Str("reason", s.reason).Msg("copy: NOT copied")
@@ -884,10 +890,28 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	var mismatches []string
 	teamID := cfg.teamID
 
+	// After detach the source's membership tables are empty by design while
+	// the dest keeps its rows, so purge's validate pass must not read that
+	// asymmetry as data loss. The detached state also empties the source
+	// side of profileScope's membership-derived branches and the source
+	// role-assignment set, so those comparisons are skipped with it. A
+	// source that was never detached (the pre-split decommission path)
+	// still gets the full comparison.
+	detached, err := sourceDetached(ctx, src, teamID)
+	if err != nil {
+		return nil, err
+	}
+	if detached {
+		log.Info().Msg("validate: source is detached; membership-derived comparisons are skipped")
+	}
+
 	// 1. Per-table row-count parity over the team's scope.
 	for _, t := range migratedTables {
 		if validationExemptTables[t.name] {
 			continue // self-expiring advisory rows; see validationExemptTables.
+		}
+		if detached && (membershipTables[t.name] || t.name == "profile") {
+			continue // deleted on the source by detach; see above.
 		}
 		q := fmt.Sprintf(`SELECT count(*) FROM %s WHERE %s`, t.name, t.effectiveCopyScope())
 		var srcN, dstN int64
@@ -906,7 +930,7 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 
 	// 1b. Per-row content checksums, transform-aware. Counts can match while
 	// a source row changed after the copy (background writers run through
-	// the freeze); decommission must be gated on content equality.
+	// the freeze); purge must be gated on content equality.
 	transforms, err := buildTransforms(ctx, src, dst, cfg)
 	if err != nil {
 		return nil, err
@@ -914,6 +938,9 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	for _, t := range migratedTables {
 		if insertOnlyTables[t.name] || validationExemptTables[t.name] {
 			continue // see insertOnlyTables / validationExemptTables.
+		}
+		if detached && membershipTables[t.name] {
+			continue // deleted on the source by detach.
 		}
 		tf := transforms[t.name]
 		if t.name == "sandbox" {
@@ -1013,35 +1040,39 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 
 	// 5. Role assignments must resolve to the same (user, role name, active)
 	// set on both sides — this is what proves the by-name remap worked.
-	const assignmentQ = `
-		SELECT ura.user_id::text || '|' || r.name || '|' || (ura.revoked_at IS NULL)::text
-		FROM user_role_assignments ura JOIN roles r ON r.id = ura.role_id
-		WHERE ura.team_id = $1 ORDER BY 1`
-	srcRows, err := src.Query(ctx, assignmentQ, teamID)
-	if err != nil {
-		return nil, fmt.Errorf("source role assignments: %w", err)
-	}
-	srcAssign, err := collectStrings(srcRows)
-	if err != nil {
-		return nil, err
-	}
-	dstRows, err := dst.Query(ctx, assignmentQ, teamID)
-	if err != nil {
-		return nil, fmt.Errorf("dest role assignments: %w", err)
-	}
-	dstAssign, err := collectStrings(dstRows)
-	if err != nil {
-		return nil, err
-	}
-	if strings.Join(srcAssign, "\n") != strings.Join(dstAssign, "\n") {
-		mismatches = append(mismatches, fmt.Sprintf(
-			"role assignments differ (source=%d dest=%d):\n  source: %v\n  dest:   %v",
-			len(srcAssign), len(dstAssign), srcAssign, dstAssign))
+	// Skipped once detached: the source set is deliberately empty then, and
+	// the remap was proven by the validate pass detach itself ran.
+	if !detached {
+		const assignmentQ = `
+			SELECT ura.user_id::text || '|' || r.name || '|' || (ura.revoked_at IS NULL)::text
+			FROM user_role_assignments ura JOIN roles r ON r.id = ura.role_id
+			WHERE ura.team_id = $1 ORDER BY 1`
+		srcRows, err := src.Query(ctx, assignmentQ, teamID)
+		if err != nil {
+			return nil, fmt.Errorf("source role assignments: %w", err)
+		}
+		srcAssign, err := collectStrings(srcRows)
+		if err != nil {
+			return nil, err
+		}
+		dstRows, err := dst.Query(ctx, assignmentQ, teamID)
+		if err != nil {
+			return nil, fmt.Errorf("dest role assignments: %w", err)
+		}
+		dstAssign, err := collectStrings(dstRows)
+		if err != nil {
+			return nil, err
+		}
+		if strings.Join(srcAssign, "\n") != strings.Join(dstAssign, "\n") {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"role assignments differ (source=%d dest=%d):\n  source: %v\n  dest:   %v",
+				len(srcAssign), len(dstAssign), srcAssign, dstAssign))
+		}
 	}
 
 	// 6. The sandbox↔snapshot relink must reproduce the source's pairs.
 	const pairQ = `SELECT id::text || '|' || COALESCE(snapshot_id::text, '') FROM sandbox WHERE team_id = $1 ORDER BY 1`
-	srcRows, err = src.Query(ctx, pairQ, teamID)
+	srcRows, err := src.Query(ctx, pairQ, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("source snapshot pairs: %w", err)
 	}
@@ -1049,7 +1080,7 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	if err != nil {
 		return nil, err
 	}
-	dstRows, err = dst.Query(ctx, pairQ, teamID)
+	dstRows, err := dst.Query(ctx, pairQ, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("dest snapshot pairs: %w", err)
 	}
@@ -1094,9 +1125,85 @@ func collectStrings(rows pgx.Rows) ([]string, error) {
 }
 
 // ---------------------------------------------------------------------------
-// decommission
+// detach
 
-func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName string) error {
+// sourceDetached reports whether the source has already been through detach:
+// every membership table empty for the team.
+func sourceDetached(ctx context.Context, src *pgxpool.Pool, teamID uuid.UUID) (bool, error) {
+	for _, t := range migratedTables {
+		if !membershipTables[t.name] {
+			continue
+		}
+		var n int64
+		q := fmt.Sprintf(`SELECT count(*) FROM %s WHERE %s`, t.name, t.scope)
+		if err := src.QueryRow(ctx, q, teamID).Scan(&n); err != nil {
+			return false, fmt.Errorf("count source %s: %w", t.name, err)
+		}
+		if n > 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// runDetach deletes the team's membership rows — the RBAC chain — from the
+// source. With user_role_assignments, team_memberships, and team_member gone
+// no console or API path resolves the team in the source cell, so the dest
+// is the team's only live home, while every other row (and the artifacts)
+// stays as a cold fallback for the soak period before purge. Rollback is
+// re-inserting the membership rows, or running the tool in reverse.
+func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName string) error {
+	if cfg.confirmTeamName != teamName {
+		return fmt.Errorf("--confirm-team-name %q does not match team name %q; refusing to delete", cfg.confirmTeamName, teamName)
+	}
+
+	// A validate pass is a precondition in the same invocation — after
+	// detach the dest is the only copy anyone can reach, so never sever
+	// access to a source we haven't just proven the dest matches.
+	log.Info().Msg("detach: running validate first")
+	mismatches, err := validateTeam(ctx, src, dst, cfg)
+	if err != nil {
+		return err
+	}
+	if len(mismatches) > 0 {
+		for _, m := range mismatches {
+			log.Error().Msg("detach: MISMATCH — " + m)
+		}
+		return fmt.Errorf("aborting detach: validate found %d mismatch(es); source not touched", len(mismatches))
+	}
+
+	// One transaction: the RBAC chain goes atomically or not at all — a
+	// partial delete would leave the team half-reachable in the source cell.
+	tx, err := src.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var total int64
+	for i := len(migratedTables) - 1; i >= 0; i-- {
+		t := migratedTables[i]
+		if !membershipTables[t.name] {
+			continue
+		}
+		tag, err := tx.Exec(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s`, t.name, t.scope), cfg.teamID)
+		if err != nil {
+			return fmt.Errorf("delete from %s: %w", t.name, err)
+		}
+		total += tag.RowsAffected()
+		log.Info().Str("table", t.name).Int64("deleted", tag.RowsAffected()).Msg("detach")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	log.Info().Int64("deleted", total).Msg("detach: source membership rows removed; everything else stays as a cold fallback until purge")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// purge
+
+func runPurge(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName string) error {
 	if cfg.confirmTeamName != teamName {
 		return fmt.Errorf("--confirm-team-name %q does not match team name %q; refusing to delete", cfg.confirmTeamName, teamName)
 	}
@@ -1110,7 +1217,7 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 		return err
 	}
 	if len(blockers) > 0 {
-		return fmt.Errorf("aborting decommission: %d sandbox(es) no longer quiescent:\n  %s",
+		return fmt.Errorf("aborting purge: %d sandbox(es) no longer quiescent:\n  %s",
 			len(blockers), strings.Join(blockers, "\n  "))
 	}
 	builds, err := activeBuilds(ctx, src, cfg.teamID)
@@ -1118,22 +1225,22 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 		return err
 	}
 	if len(builds) > 0 {
-		return fmt.Errorf("aborting decommission: %d template build(s) in flight:\n  %s",
+		return fmt.Errorf("aborting purge: %d template build(s) in flight:\n  %s",
 			len(builds), strings.Join(builds, "\n  "))
 	}
 
 	// A validate pass is a precondition in the same invocation — never
 	// delete a source we haven't just proven the dest matches.
-	log.Info().Msg("decommission: running validate first")
+	log.Info().Msg("purge: running validate first")
 	mismatches, err := validateTeam(ctx, src, dst, cfg)
 	if err != nil {
 		return err
 	}
 	if len(mismatches) > 0 {
 		for _, m := range mismatches {
-			log.Error().Msg("decommission: MISMATCH — " + m)
+			log.Error().Msg("purge: MISMATCH — " + m)
 		}
-		return fmt.Errorf("aborting decommission: validate found %d mismatch(es); source not touched", len(mismatches))
+		return fmt.Errorf("aborting purge: validate found %d mismatch(es); source not touched", len(mismatches))
 	}
 
 	// Validate takes real time; a sandbox resume or build dispatch could
@@ -1144,12 +1251,12 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 	if blockers, err := activeSandboxes(ctx, src, cfg.teamID); err != nil {
 		return err
 	} else if len(blockers) > 0 {
-		return fmt.Errorf("aborting decommission: sandbox became non-quiescent during validate:\n  %s", strings.Join(blockers, "\n  "))
+		return fmt.Errorf("aborting purge: sandbox became non-quiescent during validate:\n  %s", strings.Join(blockers, "\n  "))
 	}
 	if builds, err := activeBuilds(ctx, src, cfg.teamID); err != nil {
 		return err
 	} else if len(builds) > 0 {
-		return fmt.Errorf("aborting decommission: template build started during validate:\n  %s", strings.Join(builds, "\n  "))
+		return fmt.Errorf("aborting purge: template build started during validate:\n  %s", strings.Join(builds, "\n  "))
 	}
 
 	// One transaction: the source either loses the whole team or nothing.
@@ -1189,10 +1296,10 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 	if builds, err := activeBuilds(ctx, tx, cfg.teamID); err != nil {
 		return err
 	} else if len(builds) > 0 {
-		return fmt.Errorf("aborting decommission: template build slipped in before the locks:\n  %s", strings.Join(builds, "\n  "))
+		return fmt.Errorf("aborting purge: template build slipped in before the locks:\n  %s", strings.Join(builds, "\n  "))
 	}
 	// The source rows die below, so capture the rollup-flag state now and
-	// restore it into the dest after the deletes commit — decommissioned
+	// restore it into the dest after the deletes commit — purged
 	// migrations must not depend on a later release-rollups run that would
 	// find no source to read.
 	var srcRollupEnabled *bool
@@ -1209,7 +1316,7 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 		return err
 	}
 	if drift != "" {
-		return fmt.Errorf("aborting decommission: %s changed after validate (auto-delete, resume, or secret detach raced the window) — re-run copy and validate", drift)
+		return fmt.Errorf("aborting purge: %s changed after validate (auto-delete, resume, or secret detach raced the window) — re-run copy and validate", drift)
 	}
 
 	// Async writers (logSandboxActivity fires-and-forgets; revocation rows
@@ -1239,7 +1346,7 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 			return fmt.Errorf("final sweep of %s: %w", name, err)
 		}
 		if copied > 0 {
-			log.Info().Str("table", name).Int64("swept", copied).Msg("decommission: straggler rows copied to dest before delete")
+			log.Info().Str("table", name).Int64("swept", copied).Msg("purge: straggler rows copied to dest before delete")
 		}
 	}
 
@@ -1260,7 +1367,7 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 			return fmt.Errorf("delete from %s: %w", t.name, err)
 		}
 		total += tag.RowsAffected()
-		log.Info().Str("table", t.name).Int64("deleted", tag.RowsAffected()).Msg("decommission")
+		log.Info().Str("table", t.name).Int64("deleted", tag.RowsAffected()).Msg("purge")
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit: %w", err)
@@ -1268,8 +1375,8 @@ func runDecommission(ctx context.Context, src, dst *pgxpool.Pool, cfg config, te
 	if err := restoreRollupFlag(ctx, dst, cfg.teamID, srcRollupEnabled); err != nil {
 		return fmt.Errorf("source deleted but dest rollup flag not restored — apply release-rollups semantics by hand: %w", err)
 	}
-	log.Info().Msg("decommission: dest rollup hold released to the source's pre-delete state")
+	log.Info().Msg("purge: dest rollup hold released to the source's pre-delete state")
 
-	log.Info().Int64("deleted", total).Msg("decommission: source rows removed (profiles and append-only audit tables retained)")
+	log.Info().Int64("deleted", total).Msg("purge: source rows removed (profiles and append-only audit tables retained)")
 	return nil
 }

--- a/cmd/migrate-team/migrate.go
+++ b/cmd/migrate-team/migrate.go
@@ -890,28 +890,26 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	var mismatches []string
 	teamID := cfg.teamID
 
-	// After detach the source's membership tables are empty by design while
-	// the dest keeps its rows, so purge's validate pass must not read that
-	// asymmetry as data loss. The detached state also empties the source
-	// side of profileScope's membership-derived branches and the source
-	// role-assignment set, so those comparisons are skipped with it. A
-	// source that was never detached (the pre-split decommission path)
-	// still gets the full comparison.
+	// Parity validation only means something while the source is the live
+	// copy. Detach proved source==dest at cutover and then made the dest
+	// the team's only live home — from that point the dest legitimately
+	// diverges (new sandboxes, activity, rollups) while the source is a
+	// frozen fallback, so requiring parity would make a post-soak purge
+	// unsatisfiable by design. Once detached, validation reduces to the
+	// one thing purge still must know: the dest really holds the team.
 	detached, err := sourceDetached(ctx, src, teamID)
 	if err != nil {
 		return nil, err
 	}
 	if detached {
-		log.Info().Msg("validate: source is detached; membership-derived comparisons are skipped")
+		log.Info().Msg("validate: source is detached; parity no longer applies, checking dest liveness instead")
+		return validateDetachedDest(ctx, dst, cfg)
 	}
 
 	// 1. Per-table row-count parity over the team's scope.
 	for _, t := range migratedTables {
 		if validationExemptTables[t.name] {
 			continue // self-expiring advisory rows; see validationExemptTables.
-		}
-		if detached && (membershipTables[t.name] || t.name == "profile") {
-			continue // deleted on the source by detach; see above.
 		}
 		q := fmt.Sprintf(`SELECT count(*) FROM %s WHERE %s`, t.name, t.effectiveCopyScope())
 		var srcN, dstN int64
@@ -938,9 +936,6 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	for _, t := range migratedTables {
 		if insertOnlyTables[t.name] || validationExemptTables[t.name] {
 			continue // see insertOnlyTables / validationExemptTables.
-		}
-		if detached && membershipTables[t.name] {
-			continue // deleted on the source by detach.
 		}
 		tf := transforms[t.name]
 		if t.name == "sandbox" {
@@ -1040,39 +1035,35 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 
 	// 5. Role assignments must resolve to the same (user, role name, active)
 	// set on both sides — this is what proves the by-name remap worked.
-	// Skipped once detached: the source set is deliberately empty then, and
-	// the remap was proven by the validate pass detach itself ran.
-	if !detached {
-		const assignmentQ = `
-			SELECT ura.user_id::text || '|' || r.name || '|' || (ura.revoked_at IS NULL)::text
-			FROM user_role_assignments ura JOIN roles r ON r.id = ura.role_id
-			WHERE ura.team_id = $1 ORDER BY 1`
-		srcRows, err := src.Query(ctx, assignmentQ, teamID)
-		if err != nil {
-			return nil, fmt.Errorf("source role assignments: %w", err)
-		}
-		srcAssign, err := collectStrings(srcRows)
-		if err != nil {
-			return nil, err
-		}
-		dstRows, err := dst.Query(ctx, assignmentQ, teamID)
-		if err != nil {
-			return nil, fmt.Errorf("dest role assignments: %w", err)
-		}
-		dstAssign, err := collectStrings(dstRows)
-		if err != nil {
-			return nil, err
-		}
-		if strings.Join(srcAssign, "\n") != strings.Join(dstAssign, "\n") {
-			mismatches = append(mismatches, fmt.Sprintf(
-				"role assignments differ (source=%d dest=%d):\n  source: %v\n  dest:   %v",
-				len(srcAssign), len(dstAssign), srcAssign, dstAssign))
-		}
+	const assignmentQ = `
+		SELECT ura.user_id::text || '|' || r.name || '|' || (ura.revoked_at IS NULL)::text
+		FROM user_role_assignments ura JOIN roles r ON r.id = ura.role_id
+		WHERE ura.team_id = $1 ORDER BY 1`
+	srcRows, err := src.Query(ctx, assignmentQ, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("source role assignments: %w", err)
+	}
+	srcAssign, err := collectStrings(srcRows)
+	if err != nil {
+		return nil, err
+	}
+	dstRows, err := dst.Query(ctx, assignmentQ, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("dest role assignments: %w", err)
+	}
+	dstAssign, err := collectStrings(dstRows)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Join(srcAssign, "\n") != strings.Join(dstAssign, "\n") {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"role assignments differ (source=%d dest=%d):\n  source: %v\n  dest:   %v",
+			len(srcAssign), len(dstAssign), srcAssign, dstAssign))
 	}
 
 	// 6. The sandbox↔snapshot relink must reproduce the source's pairs.
 	const pairQ = `SELECT id::text || '|' || COALESCE(snapshot_id::text, '') FROM sandbox WHERE team_id = $1 ORDER BY 1`
-	srcRows, err := src.Query(ctx, pairQ, teamID)
+	srcRows, err = src.Query(ctx, pairQ, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("source snapshot pairs: %w", err)
 	}
@@ -1080,7 +1071,7 @@ func validateTeam(ctx context.Context, src, dst *pgxpool.Pool, cfg config) ([]st
 	if err != nil {
 		return nil, err
 	}
-	dstRows, err := dst.Query(ctx, pairQ, teamID)
+	dstRows, err = dst.Query(ctx, pairQ, teamID)
 	if err != nil {
 		return nil, fmt.Errorf("dest snapshot pairs: %w", err)
 	}
@@ -1146,6 +1137,47 @@ func sourceDetached(ctx context.Context, src *pgxpool.Pool, teamID uuid.UUID) (b
 	return true, nil
 }
 
+// validateDetachedDest is what validation means after detach: the source is
+// a frozen fallback and the dest diverges legitimately, so parity is
+// unprovable and no longer the point. The one disaster purge must still rule
+// out is deleting the source while the dest no longer actually holds the
+// team — so check that the dest has the team row, homed in the expected
+// region, with a live membership chain.
+func validateDetachedDest(ctx context.Context, dst *pgxpool.Pool, cfg config) ([]string, error) {
+	var mismatches []string
+
+	var homeRegion string
+	err := dst.QueryRow(ctx, `SELECT home_region FROM team WHERE id = $1`, cfg.teamID).Scan(&homeRegion)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return []string{"dest has no team row — the source is the only copy left"}, nil
+	case err != nil:
+		return nil, fmt.Errorf("check dest team: %w", err)
+	case cfg.destRegion != "" && homeRegion != cfg.destRegion:
+		mismatches = append(mismatches, fmt.Sprintf(
+			"dest team home_region is %q, want %q", homeRegion, cfg.destRegion))
+	}
+
+	for _, t := range migratedTables {
+		if !membershipTables[t.name] {
+			continue
+		}
+		var n int64
+		if err := dst.QueryRow(ctx,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE %s`, t.name, t.scope), cfg.teamID).Scan(&n); err != nil {
+			return nil, fmt.Errorf("count dest %s: %w", t.name, err)
+		}
+		if n == 0 {
+			mismatches = append(mismatches, fmt.Sprintf(
+				"dest %s is empty — the team has no live membership chain there", t.name))
+		}
+	}
+	if len(mismatches) == 0 {
+		log.Info().Msg("validate: dest holds the team with a live membership chain")
+	}
+	return mismatches, nil
+}
+
 // runDetach deletes the team's membership rows — the RBAC chain — from the
 // source. With user_role_assignments, team_memberships, and team_member gone
 // no console or API path resolves the team in the source cell, so the dest
@@ -1194,6 +1226,18 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 		return fmt.Errorf("aborting detach: validate found %d mismatch(es); source not touched", len(mismatches))
 	}
 
+	// Validate takes real time; re-run the blockers behind it, same as
+	// purge. For sandboxes this is a recheck, not a lock: detach keeps the
+	// rows, so a resume that lands after commit is a soak-window fact of
+	// life that purge's own guards catch — the recheck only closes the
+	// validate-sized gap. The build race IS closed for real below, under
+	// the app's build-admission lock.
+	if blockers, err := activeSandboxes(ctx, src, cfg.teamID); err != nil {
+		return err
+	} else if len(blockers) > 0 {
+		return fmt.Errorf("aborting detach: sandbox became non-quiescent during validate:\n  %s", strings.Join(blockers, "\n  "))
+	}
+
 	// One transaction: the RBAC chain goes atomically or not at all — a
 	// partial delete would leave the team half-reachable in the source cell.
 	tx, err := src.Begin(ctx)
@@ -1201,6 +1245,44 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 		return fmt.Errorf("begin: %w", err)
 	}
 	defer tx.Rollback(ctx)
+
+	// Build admission serializes on the app's per-TEAM advisory lock
+	// (CountInFlightBuildsForTeam's caller contract) — take it so a
+	// CreateTemplateBuild that would slip a pending row past the earlier
+	// check blocks behind this transaction, then recheck under the lock.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, cfg.teamID.String()); err != nil {
+		return fmt.Errorf("advisory-lock team builds: %w", err)
+	}
+	if builds, err := activeBuilds(ctx, tx, cfg.teamID); err != nil {
+		return err
+	} else if len(builds) > 0 {
+		return fmt.Errorf("aborting detach: template build slipped in before the lock:\n  %s", strings.Join(builds, "\n  "))
+	}
+
+	// Detach is the last moment the dest is guaranteed un-diverged, so the
+	// straggler sweep happens HERE, not at purge: async writers (activity,
+	// revocations from the freeze's key revocations, rollup ticks over
+	// already-copied intervals) may have landed source rows since copy, and
+	// upserting them into the dest is only safe before the dest goes live.
+	// A detached purge deliberately never sweeps — by then the dest is
+	// authoritative and a sweep would overwrite its live rows (e.g. the
+	// rollup backfill cursor) with the frozen source's.
+	for _, name := range []string{
+		"activity", "sandbox_revocation", "revoked_proxy_token",
+		"billing_rollup_job", "billing_rollup_team_backfill_state", "team_billing_usage_hourly",
+	} {
+		spec, ok := tableByName(name)
+		if !ok {
+			return fmt.Errorf("sweep: unknown table %s", name)
+		}
+		copied, _, err := copyTable(ctx, tx, dst, spec, cfg.teamID, nil)
+		if err != nil {
+			return fmt.Errorf("cutover sweep of %s: %w", name, err)
+		}
+		if copied > 0 {
+			log.Info().Str("table", name).Int64("swept", copied).Msg("detach: straggler rows copied to dest at cutover")
+		}
+	}
 
 	var total int64
 	for i := len(migratedTables) - 1; i >= 0; i-- {
@@ -1238,6 +1320,19 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 func runPurge(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName string) error {
 	if cfg.confirmTeamName != teamName {
 		return fmt.Errorf("--confirm-team-name %q does not match team name %q; refusing to delete", cfg.confirmTeamName, teamName)
+	}
+
+	// A detached source flips purge's relationship to the dest: the dest
+	// has been the live home since detach, so source↔dest comparisons and
+	// dest writes (drift check, straggler sweep, rollup restore) are
+	// skipped below — detach already did each of those at cutover, and
+	// doing them again would judge or overwrite a legitimately diverged
+	// dest. The state can't change mid-run: only detach empties the
+	// membership tables, and re-inserting rows mid-purge flips nothing
+	// we've already read.
+	detached, err := sourceDetached(ctx, src, cfg.teamID)
+	if err != nil {
+		return err
 	}
 
 	// Re-check quiescence immediately before deleting: a sandbox resumed or
@@ -1342,13 +1437,16 @@ func runPurge(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName 
 	}
 	// Under the locks, re-verify that sandbox rows and secret bindings
 	// still match the dest — catches anything (auto-delete, secret detach)
-	// that mutated them between validate and the locks landing.
-	drift, err := contentDriftUnderLock(ctx, tx, dst, cfg)
-	if err != nil {
-		return err
-	}
-	if drift != "" {
-		return fmt.Errorf("aborting purge: %s changed after validate (auto-delete, resume, or secret detach raced the window) — re-run copy and validate", drift)
+	// that mutated them between validate and the locks landing. Meaningless
+	// once detached: the dest diverged legitimately during the soak.
+	if !detached {
+		drift, err := contentDriftUnderLock(ctx, tx, dst, cfg)
+		if err != nil {
+			return err
+		}
+		if drift != "" {
+			return fmt.Errorf("aborting purge: %s changed after validate (auto-delete, resume, or secret detach raced the window) — re-run copy and validate", drift)
+		}
 	}
 
 	// Async writers (logSandboxActivity fires-and-forgets; revocation rows
@@ -1365,20 +1463,26 @@ func runPurge(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName 
 	// hourly rows from the already-copied intervals, none of which touch
 	// the locked sandbox/secret rows. Same remedy as the async writers:
 	// sweep them into dest under this transaction before deleting.
-	for _, name := range []string{
-		"activity", "sandbox_revocation", "revoked_proxy_token",
-		"billing_rollup_job", "billing_rollup_team_backfill_state", "team_billing_usage_hourly",
-	} {
-		spec, ok := tableByName(name)
-		if !ok {
-			return fmt.Errorf("sweep: unknown table %s", name)
-		}
-		copied, _, err := copyTable(ctx, tx, dst, spec, cfg.teamID, nil)
-		if err != nil {
-			return fmt.Errorf("final sweep of %s: %w", name, err)
-		}
-		if copied > 0 {
-			log.Info().Str("table", name).Int64("swept", copied).Msg("purge: straggler rows copied to dest before delete")
+	// Never once detached: detach swept at cutover, and sweeping now would
+	// overwrite the live dest's rows (rollup cursor included) with the
+	// frozen source's — post-detach source stragglers are byproducts of a
+	// dead cell, not customer data.
+	if !detached {
+		for _, name := range []string{
+			"activity", "sandbox_revocation", "revoked_proxy_token",
+			"billing_rollup_job", "billing_rollup_team_backfill_state", "team_billing_usage_hourly",
+		} {
+			spec, ok := tableByName(name)
+			if !ok {
+				return fmt.Errorf("sweep: unknown table %s", name)
+			}
+			copied, _, err := copyTable(ctx, tx, dst, spec, cfg.teamID, nil)
+			if err != nil {
+				return fmt.Errorf("final sweep of %s: %w", name, err)
+			}
+			if copied > 0 {
+				log.Info().Str("table", name).Int64("swept", copied).Msg("purge: straggler rows copied to dest before delete")
+			}
 		}
 	}
 
@@ -1404,10 +1508,15 @@ func runPurge(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName 
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
-	if err := restoreRollupFlag(ctx, dst, cfg.teamID, srcRollupEnabled); err != nil {
-		return fmt.Errorf("source deleted but dest rollup flag not restored — apply release-rollups semantics by hand: %w", err)
+	// Detached: the dest's flag has been live-owned since detach released
+	// the hold at cutover — restoring the frozen source's value now would
+	// clobber any change support made during the soak.
+	if !detached {
+		if err := restoreRollupFlag(ctx, dst, cfg.teamID, srcRollupEnabled); err != nil {
+			return fmt.Errorf("source deleted but dest rollup flag not restored — apply release-rollups semantics by hand: %w", err)
+		}
+		log.Info().Msg("purge: dest rollup hold released to the source's pre-delete state")
 	}
-	log.Info().Msg("purge: dest rollup hold released to the source's pre-delete state")
 
 	log.Info().Int64("deleted", total).Msg("purge: source rows removed (profiles and append-only audit tables retained)")
 	return nil

--- a/cmd/migrate-team/migrate.go
+++ b/cmd/migrate-team/migrate.go
@@ -1189,6 +1189,19 @@ func runDetach(ctx context.Context, src, dst *pgxpool.Pool, cfg config, teamName
 		return fmt.Errorf("--confirm-team-name %q does not match team name %q; refusing to delete", cfg.confirmTeamName, teamName)
 	}
 
+	// A re-run during the soak must be a pure no-op, not a replay: the
+	// sweep and the rollup release below write to the dest, which has been
+	// live-owned since the first detach — replaying them would upsert
+	// frozen source rows (rollup cursor included) over live dest state.
+	alreadyDetached, err := sourceDetached(ctx, src, cfg.teamID)
+	if err != nil {
+		return err
+	}
+	if alreadyDetached {
+		log.Info().Msg("detach: source is already detached; nothing to do")
+		return nil
+	}
+
 	// Same quiescence re-check as purge: a sandbox resumed or a build
 	// started after the copy is invisible to validate (in-flight build rows
 	// sit outside the migration scope entirely), and detach would sever the

--- a/cmd/migrate-team/tables.go
+++ b/cmd/migrate-team/tables.go
@@ -1,7 +1,7 @@
 package main
 
 // The team's dataset, in FK dependency order. copy walks this list forward;
-// decommission walks it backward (profiles excluded — they are global and may
+// purge walks it backward (profiles excluded — they are global and may
 // belong to other teams).
 //
 // Scope conditions take the team id as $1 and must be valid in both a SELECT
@@ -33,7 +33,7 @@ type tableSpec struct {
 	scope string
 }
 
-// copyScopes narrows what copy and validation see for a table; decommission
+// copyScopes narrows what copy and validation see for a table; purge
 // still deletes by the full scope. Used to carve rows out of the generic
 // pipeline that the tool manages explicitly: the rollup-hold flag row must
 // not be copied, or an explicit TRUE from the source would overwrite the
@@ -49,6 +49,15 @@ func (t tableSpec) effectiveCopyScope() string {
 		return s
 	}
 	return t.scope
+}
+
+// membershipTables are the team's RBAC chain — the rows detach deletes so
+// the source copy stays unreachable through the console and API while the
+// rest of the dataset waits out the soak period as a cold fallback.
+var membershipTables = map[string]bool{
+	"team_member":           true,
+	"team_memberships":      true,
+	"user_role_assignments": true,
 }
 
 var migratedTables = []tableSpec{


### PR DESCRIPTION
## Summary

Splits the migration tool's decommission into two phases, so a migrated team keeps a cold fallback during a soak period:

- `detach` (new, runs at cutover): one transaction on the source deleting only the team's membership rows — `user_role_assignments` (team-scoped), `team_memberships`, `team_member`. With the RBAC chain gone, no console or API path reaches the source copy, so the team has exactly one live home; all data rows and artifacts stay. Reversible by re-inserting the memberships or reverse-running the tool.
- `purge` (the old decommission behavior, renamed; `--phase decommission` kept as a deprecated alias): the full reverse-FK delete with all existing machinery — FOR UPDATE + per-sandbox advisory locks, in-transaction straggler sweep, content-drift validation under lock, `--confirm-team-name`. Runs days later, after the soak.

## Technical decisions

- `detach` runs a full validate pass in the same invocation before deleting: it is the moment the dest becomes the only reachable copy, so it inherits decommission's never-sever-unproven precondition.
- `purge` after `detach` must not read the deliberately empty source membership tables as data loss: once every membership table is empty (`sourceDetached`), validate skips those tables' count/checksum comparisons, the membership-derived `profile` count parity, and the role-assignment set check (proven by detach's own validate). A never-detached source gets the unchanged full comparison.
- `detach` takes no locks: it touches only membership rows, is idempotent, and a raced membership insert just flips `sourceDetached` false so the later purge validate fails loudly.

## Testing

Full two-DB integration suite with `-race` (postgres:16, same setup as CI): detach deletes exactly the membership rows and nothing else (bystander teams sharing the owner untouched, dest untouched, standalone validate passes on a detached source, re-run is a no-op); purge after detach reaches the same end state as the old single-shot path; purge without detach still fully validates and deletes; detach refuses a wrong `--confirm-team-name`.