### PR TITLE
vmd: launcher mount namespace to keep per-VM launch cost independent of fleet size

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/builder"
 	"github.com/superserve-ai/sandbox/internal/network"
+	"github.com/superserve-ai/sandbox/internal/shellquote"
 	"github.com/superserve-ai/sandbox/internal/vm"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
@@ -630,7 +631,7 @@ func runBuildStep(ctx context.Context, vmIP string, step builder.BuildStep, bc b
 			ownUser = "root"
 		}
 		mkdir := fmt.Sprintf("mkdir -p %s && chown -R %s:%s %s",
-			shellQuote(target), shellQuote(ownUser), shellQuote(ownUser), shellQuote(target))
+			shellquote.Single(target), shellquote.Single(ownUser), shellquote.Single(ownUser), shellquote.Single(target))
 		root := bc
 		root.user = "root" // ensure mkdir + chown run as root
 		if err := runShellCmd(ctx, vmIP, mkdir, root); err != nil {
@@ -646,7 +647,7 @@ func runBuildStep(ctx context.Context, vmIP string, step builder.BuildStep, bc b
 		root := bc
 		root.user = "root"
 		check := fmt.Sprintf("id -u %s >/dev/null 2>&1 || adduser --disabled-password --gecos \"\" %s",
-			shellQuote(name), shellQuote(name))
+			shellquote.Single(name), shellquote.Single(name))
 		if err := runShellCmd(ctx, vmIP, check, root); err != nil {
 			return bc, fmt.Errorf("ensure user %s: %w", name, err)
 		}
@@ -655,7 +656,7 @@ func runBuildStep(ctx context.Context, vmIP string, step builder.BuildStep, bc b
 				"usermod -aG sudo %s || true; passwd -d %s || true; "+
 					"grep -q '^%s ALL=(ALL:ALL) NOPASSWD: ALL' /etc/sudoers || "+
 					"echo '%s ALL=(ALL:ALL) NOPASSWD: ALL' >>/etc/sudoers",
-				shellQuote(name), shellQuote(name), name, name,
+				shellquote.Single(name), shellquote.Single(name), name, name,
 			)
 			if err := runShellCmd(ctx, vmIP, sudo, root); err != nil {
 				return bc, fmt.Errorf("grant sudo to %s: %w", name, err)
@@ -905,8 +906,4 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
-}
-
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -652,11 +652,13 @@ func runBuildStep(ctx context.Context, vmIP string, step builder.BuildStep, bc b
 			return bc, fmt.Errorf("ensure user %s: %w", name, err)
 		}
 		if step.User.Sudo {
+			// Quote the whole sudoers line (not just the name) and match it with
+			// grep -xF: the name stays literal for both the shell and grep.
+			sudoersLine := shellquote.Single(name + " ALL=(ALL:ALL) NOPASSWD: ALL")
 			sudo := fmt.Sprintf(
 				"usermod -aG sudo %s || true; passwd -d %s || true; "+
-					"grep -q '^%s ALL=(ALL:ALL) NOPASSWD: ALL' /etc/sudoers || "+
-					"echo '%s ALL=(ALL:ALL) NOPASSWD: ALL' >>/etc/sudoers",
-				shellquote.Single(name), shellquote.Single(name), name, name,
+					"grep -qxF %s /etc/sudoers || echo %s >>/etc/sudoers",
+				shellquote.Single(name), shellquote.Single(name), sudoersLine, sudoersLine,
 			)
 			if err := runShellCmd(ctx, vmIP, sudo, root); err != nil {
 				return bc, fmt.Errorf("grant sudo to %s: %w", name, err)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -361,6 +361,7 @@ func main() {
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
 	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
 	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
+	launchViaLauncherNS := envOrDefault("VMD_LAUNCH_VIA_LAUNCHER_NS", "false") == "true"
 
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
@@ -380,6 +381,8 @@ func main() {
 		VerifySnapshotEnabled:      verifySnapshotEnabled,
 		IncrementalSnapshotEnabled: incrementalSnapshotEnabled,
 		HandlerDeathAbortEnabled:   handlerDeathAbortEnabled,
+		LaunchViaLauncherNS:        launchViaLauncherNS,
+		LauncherNSPath:             os.Getenv("VMD_LAUNCHER_NS_PATH"),
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")
@@ -481,6 +484,17 @@ func main() {
 	// below; VMs it hasn't reached are loaded on-demand on first request.
 	mgr.ReserveStartupSlots(ctx)
 	mgr.SweepStartupOrphanNamespaces()
+
+	// Launcher launch path, enabled per host via VMD_LAUNCH_VIA_LAUNCHER_NS.
+	if launchViaLauncherNS {
+		// Build the pruned launcher mount namespace before any VM launches (see
+		// fcStartScript). Non-fatal: on failure, launches fall back to legacy.
+		if err := mgr.EnsureLauncherNamespace(ctx); err != nil {
+			log.Error().Err(err).Msg("launcher namespace unavailable — using legacy launch path")
+		}
+		// Periodically log the host mount-table size + revalidate the pin.
+		mgr.StartMountCountSampler(ctx, time.Minute)
+	}
 
 	// ---- Pre-allocate network slots ----
 	// Warm buffer of network namespaces so creation claims off the hot path.

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -487,11 +487,15 @@ func main() {
 
 	// Launcher launch path, enabled per host via VMD_LAUNCH_VIA_LAUNCHER_NS.
 	if launchViaLauncherNS {
-		// Build the pruned launcher mount namespace before any VM launches (see
-		// fcStartScript). Non-fatal: on failure, launches fall back to legacy.
-		if err := mgr.EnsureLauncherNamespace(ctx); err != nil {
-			log.Error().Err(err).Msg("launcher namespace unavailable — using legacy launch path")
-		}
+		// Build the pruned launcher mount namespace in the background: the prune is
+		// O(fleet) (up to launcherBuildTimeout), and launches fall back to legacy
+		// until the pin is ready, so boot and the warm pool aren't held behind it.
+		go func() {
+			defer sentrylog.Recover("launcher namespace build")
+			if err := mgr.EnsureLauncherNamespace(ctx); err != nil {
+				log.Error().Err(err).Msg("launcher namespace unavailable — using legacy launch path")
+			}
+		}()
 		// Periodically log the host mount-table size + revalidate the pin.
 		mgr.StartMountCountSampler(ctx, time.Minute)
 	}

--- a/internal/shellquote/shellquote.go
+++ b/internal/shellquote/shellquote.go
@@ -1,0 +1,12 @@
+// Package shellquote renders strings as shell-safe literal words for scripts
+// that run under `sh -c`.
+package shellquote
+
+import "strings"
+
+// Single renders s as a single-quoted POSIX shell word, so the shell treats it
+// literally — no $VAR, `...`, or $(...) expansion. An embedded single quote
+// becomes '\”. Use for any value interpolated into a script run via sh -c.
+func Single(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/shellquote/shellquote_test.go
+++ b/internal/shellquote/shellquote_test.go
@@ -1,0 +1,18 @@
+package shellquote
+
+import "testing"
+
+func TestSingle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`/run/vmd/x`, `'/run/vmd/x'`},
+		{`/a b`, `'/a b'`},
+		{`$FOO$(x)`, `'$FOO$(x)'`}, // expansion syntax kept literal
+		{"a`b`", "'a`b`'"},         // backticks kept literal
+		{`x'y`, `'x'\''y'`},        // embedded single quote escaped
+	}
+	for _, c := range cases {
+		if got := Single(c.in); got != c.want {
+			t.Errorf("Single(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,9 +142,7 @@ func ensurePrivateMount(ctx context.Context, dir string) error {
 // has private propagation. Scans /proc/self/mountinfo: fields left of " - " are
 // mount id, parent, major:minor, root, mount point, opts, then optional
 // propagation tags (shared:/master:/propagate_from:) — a private mount has none,
-// so exactly 6 left-fields. ponytail: compares the mount point raw — fine for the
-// fixed internal pin dir (/run/vmd, no spaces); a path with spaces would arrive
-// octal-escaped (\040) and need unescaping.
+// so exactly 6 left-fields.
 func mountState(dir string) (mounted, private bool, err error) {
 	data, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
@@ -159,11 +158,36 @@ func parseMountState(mountinfo []byte, dir string) (mounted, private bool) {
 		if !ok {
 			continue
 		}
-		if f := strings.Fields(left); len(f) >= 5 && f[4] == dir {
+		// The mount point (field 5) is octal-escaped by the kernel, so unescape it
+		// before comparing — otherwise a pin dir with a space matches nothing, is
+		// treated as unmounted, and stacks a fresh bind on every restart.
+		if f := strings.Fields(left); len(f) >= 5 && unescapeMountinfo(f[4]) == dir {
 			return true, len(f) == 6
 		}
 	}
 	return false, false
+}
+
+// unescapeMountinfo decodes the octal escapes the kernel writes for special
+// bytes in /proc/self/mountinfo path fields (space \040, tab \011, newline \012,
+// backslash \134). Other bytes pass through untouched.
+func unescapeMountinfo(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) {
+			if n, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
+				b.WriteByte(byte(n))
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }
 
 // StartMountCountSampler periodically logs the host mount-table size so the

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -108,17 +108,28 @@ func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 // (bind-mounting it to itself first if it isn't already a mount point).
 // Idempotent: a dir that is already a private mount is left as-is.
 func ensurePrivateMount(ctx context.Context, dir string) error {
-	// Detect the self-bind via /proc/self/mountinfo, not the `mountpoint` binary:
-	// it isn't preflighted, so on a minimal image its absence would read as "not a
+	// Read propagation from /proc/self/mountinfo, not the `mountpoint` binary: it
+	// isn't preflighted, so on a minimal image its absence would read as "not a
 	// mount point" and stack a fresh bind on every restart.
-	mounted, err := isMountpoint(dir)
+	mounted, private, err := mountState(dir)
 	if err != nil {
-		return fmt.Errorf("check mountpoint %s: %w", dir, err)
+		return fmt.Errorf("mount state %s: %w", dir, err)
 	}
-	if !mounted {
-		if out, err := exec.CommandContext(ctx, "mount", "--bind", dir, dir).CombinedOutput(); err != nil {
-			return fmt.Errorf("bind %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
+	if mounted {
+		// Already a mount. If private, it's our pin-dir bind from a prior boot —
+		// reuse it. If not, dir is a pre-existing host mount the pin path points
+		// under (e.g. VMD_LAUNCHER_NS_PATH directly beneath /run or /); refuse
+		// rather than make-private it, which would flip that mount's propagation
+		// host-wide. Legacy fallback covers the misconfiguration safely.
+		if !private {
+			return fmt.Errorf("pin dir %s is a pre-existing non-private mount; set VMD_LAUNCHER_NS_PATH under a dedicated directory", dir)
 		}
+		return nil
+	}
+	// Fresh dir: create a dedicated self-bind and make ONLY it private, so the pin
+	// gets a private parent without touching any host mount's propagation.
+	if out, err := exec.CommandContext(ctx, "mount", "--bind", dir, dir).CombinedOutput(); err != nil {
+		return fmt.Errorf("bind %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
 	}
 	if out, err := exec.CommandContext(ctx, "mount", "--make-private", dir).CombinedOutput(); err != nil {
 		return fmt.Errorf("make-private %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
@@ -126,21 +137,33 @@ func ensurePrivateMount(ctx context.Context, dir string) error {
 	return nil
 }
 
-// isMountpoint reports whether path is a mount point by scanning
-// /proc/self/mountinfo, whose 5th field is the mount point. ponytail: compares
-// the field raw — fine for the fixed internal pin dir (/run/vmd, no spaces); a
-// path with spaces would arrive octal-escaped (\040) and need unescaping.
-func isMountpoint(path string) (bool, error) {
+// mountState reports whether dir is a mount point and, if so, whether that mount
+// has private propagation. Scans /proc/self/mountinfo: fields left of " - " are
+// mount id, parent, major:minor, root, mount point, opts, then optional
+// propagation tags (shared:/master:/propagate_from:) — a private mount has none,
+// so exactly 6 left-fields. ponytail: compares the mount point raw — fine for the
+// fixed internal pin dir (/run/vmd, no spaces); a path with spaces would arrive
+// octal-escaped (\040) and need unescaping.
+func mountState(dir string) (mounted, private bool, err error) {
 	data, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if f := strings.Fields(line); len(f) >= 5 && f[4] == path {
-			return true, nil
+	mounted, private = parseMountState(data, dir)
+	return mounted, private, nil
+}
+
+func parseMountState(mountinfo []byte, dir string) (mounted, private bool) {
+	for _, line := range strings.Split(string(mountinfo), "\n") {
+		left, _, ok := strings.Cut(line, " - ")
+		if !ok {
+			continue
+		}
+		if f := strings.Fields(left); len(f) >= 5 && f[4] == dir {
+			return true, len(f) == 6
 		}
 	}
-	return false, nil
+	return false, false
 }
 
 // StartMountCountSampler periodically logs the host mount-table size so the

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -12,35 +12,25 @@ import (
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
 
-// launcherPruneScript reduces a freshly cloned mount namespace to a minimal
-// table by removing every /run/netns nsfs mount. A single `umount /run/netns`
-// only detaches the parent layer — one nsfs mount per netns remains, stacked on
-// the individual /run/netns/ns-N paths — so we also unmount each surviving
-// entry. make-rprivate MUST succeed before any umount — it severs the cloned
-// namespace's propagation from the host; without it, a umount could propagate
-// back and detach the host's live /run/netns pins. `|| exit 1` aborts before any
-// umount if it fails, so the build errors and launches fall back to legacy with
-// the host untouched.
+// launcherPruneScript strips every /run/netns nsfs mount from a freshly cloned
+// namespace. A single `umount /run/netns` detaches only the parent layer; the
+// per-netns nsfs mounts remain stacked on /run/netns/ns-N, so we unmount each.
+// make-rprivate MUST run first (|| exit 1) to sever propagation from the host —
+// without it a umount could propagate back and detach the host's live pins.
 const launcherPruneScript = `mount --make-rprivate / || exit 1
 umount -l /run/netns 2>/dev/null || true
 for m in $(grep ' /run/netns/' /proc/self/mounts | awk '{print $2}'); do umount -l "$m" 2>/dev/null || true; done`
 
-// EnsureLauncherNamespace makes sure the pruned launcher mount namespace exists
-// and is pinned at m.launcherNSPath(), building it if missing or stale. No-op
-// when the launcher launch mode is disabled.
-//
-// The pin is a point-in-time snapshot of the host mount table (propagation
-// severed), so we REBUILD it every boot rather than reuse a prior pin — a
-// launch-critical mount added since the last build (new storage volume, updated
-// firecracker binary) would otherwise be invisible in a stale pin and fail
-// launches. vmd restarts are the deploy/mount-change boundary, so rebuilding
-// then keeps the pin current; the O(fleet) prune cost is off the hot path.
-// launcherBuildTimeout bounds the boot-time launcher setup (mount/unshare/nsenter
-// execs), which run before vmd serves. It must exceed the O(fleet) prune, so it's
-// far larger than the 5s used for single host execs elsewhere; a wedged mount or
-// /run then degrades to a logged failure + legacy fallback instead of hanging boot.
+// launcherBuildTimeout bounds the boot-time launcher build. It must exceed the
+// O(fleet) prune, so it's far larger than the 5s single-exec bound used
+// elsewhere; on timeout the build errors and launches fall back to legacy.
 const launcherBuildTimeout = 90 * time.Second
 
+// EnsureLauncherNamespace builds and pins the pruned launcher mount namespace at
+// m.launcherNSPath(). No-op when launcher mode is disabled. The pin snapshots the
+// host mount table, so it's rebuilt every boot rather than reused — a launch-
+// critical mount added since the last build would be invisible in a stale pin,
+// and vmd restart is the mount-change boundary that keeps it current.
 func (m *Manager) EnsureLauncherNamespace(ctx context.Context) error {
 	pinPath := m.launcherNSPath()
 	if pinPath == "" {
@@ -87,14 +77,10 @@ func launcherNSValid(ctx context.Context, pinPath string) bool {
 }
 
 // buildLauncherNamespace creates a fresh mount namespace, prunes /run/netns from
-// it, and persists it at pinPath so it outlives the builder.
-//
-// util-linux `unshare --mount=<file>` persists the new mount namespace by
-// binding the process's OWN /proc/self/ns/mnt to the file — the kernel-supported
-// operation. (Binding another process's mount namespace cross-namespace is
-// rejected by the kernel, which is what a manual parent-side bind hit.) The
-// prune runs inside that same namespace, so the persisted pin refers to the
-// pruned table.
+// it, and persists it at pinPath. `unshare --mount=<file>` self-persists by
+// binding the process's own /proc/self/ns/mnt (binding another process's mount
+// namespace is kernel-rejected), and runs the prune in that same namespace so the
+// pin refers to the pruned table.
 func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 	dir := filepath.Dir(pinPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -122,10 +108,9 @@ func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 // (bind-mounting it to itself first if it isn't already a mount point).
 // Idempotent: a dir that is already a private mount is left as-is.
 func ensurePrivateMount(ctx context.Context, dir string) error {
-	// Detect the existing self-bind by reading /proc/self/mountinfo directly,
-	// not via the `mountpoint` binary — it isn't in vmd's preflight tool set, so
-	// on a minimal image its absence would be misread as "not a mount point" and
-	// stack a fresh bind mount on every restart, growing the host mount table.
+	// Detect the self-bind via /proc/self/mountinfo, not the `mountpoint` binary:
+	// it isn't preflighted, so on a minimal image its absence would read as "not a
+	// mount point" and stack a fresh bind on every restart.
 	mounted, err := isMountpoint(dir)
 	if err != nil {
 		return fmt.Errorf("check mountpoint %s: %w", dir, err)
@@ -180,16 +165,11 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 	}()
 }
 
-// revalidateLauncher keeps launcherReady in sync with the live pin. The startup
-// check is a point-in-time snapshot; if the pin is later unmounted/deleted while
-// vmd runs, every launch would keep building nsenter --mount=<stale-path> and
-// fail. Re-check each tick: drop to the legacy path if the pin went bad, and
-// resume ONLY the pin this boot built (launcherBuilt) if a transient check blip
-// cleared. A pin that merely looks valid again — e.g. a previous-boot pin left
-// mounted after this boot's rebuild failed — must not re-enable the launcher
-// path: it can be missing launch-critical mounts that rebuild-on-boot exists to
-// pick up. Recovery from a failed boot build is a vmd restart. No-op when
-// launcher mode is disabled.
+// revalidateLauncher re-syncs launcherReady with the live pin each tick: drop to
+// legacy if the pin went bad, and re-enable only the pin THIS boot built
+// (launcherBuilt) — a previous-boot pin left mounted after a failed rebuild may
+// be missing launch-critical mounts, so it must never resurrect the launcher
+// path. No-op when launcher mode is disabled.
 func (m *Manager) revalidateLauncher(ctx context.Context) {
 	pin := m.launcherNSPath()
 	if pin == "" {

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
@@ -77,6 +78,23 @@ func launcherNSValid(ctx context.Context, pinPath string) bool {
 	return !strings.Contains(string(out), " /run/netns")
 }
 
+// nsfsMagic is NSFS_MAGIC from linux/magic.h — the statfs f_type of a namespace
+// bind mount.
+const nsfsMagic = 0x6e736673
+
+// pinIsMounted reports whether pinPath still has the mount-namespace pin
+// bind-mounted over it (an unmounted pin statfs's as the underlying tmpfs, a
+// deleted one errors). One syscall, no fork — cheap and non-flaky enough for the
+// per-launch hot path, unlike launcherNSValid's nsenter exec, which stays the
+// deep check for boot and the sampler.
+func pinIsMounted(pinPath string) bool {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(pinPath, &st); err != nil {
+		return false
+	}
+	return st.Type == nsfsMagic
+}
+
 // buildLauncherNamespace creates a fresh mount namespace, prunes /run/netns from
 // it, and persists it at pinPath. `unshare --mount=<file>` self-persists by
 // binding the process's own /proc/self/ns/mnt (binding another process's mount
@@ -110,6 +128,12 @@ func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 // boot) is reused; a pre-existing NON-private mount is refused — never
 // make-private a mount we didn't create.
 func ensurePrivateMount(ctx context.Context, dir string) error {
+	// Resolve symlinks first: mountinfo records the resolved path (/var/run/… →
+	// /run/…), so comparing an unresolved dir would never match our prior bind
+	// and stack a fresh one every boot.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
 	// Read propagation from /proc/self/mountinfo, not the `mountpoint` binary: it
 	// isn't preflighted, so on a minimal image its absence would read as "not a
 	// mount point" and stack a fresh bind on every restart.

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -62,6 +62,7 @@ func (m *Manager) EnsureLauncherNamespace(ctx context.Context) error {
 	if !launcherNSValid(ctx, pinPath) {
 		return fmt.Errorf("launcher namespace %s built but still contains /run/netns (prune incomplete)", pinPath)
 	}
+	m.launcherBuilt.Store(true)
 	m.launcherReady.Store(true)
 	m.log.Info().Str("path", pinPath).Dur("took", time.Since(start)).
 		Msg("launcher namespace: built")
@@ -121,7 +122,15 @@ func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 // (bind-mounting it to itself first if it isn't already a mount point).
 // Idempotent: a dir that is already a private mount is left as-is.
 func ensurePrivateMount(ctx context.Context, dir string) error {
-	if exec.CommandContext(ctx, "mountpoint", "-q", dir).Run() != nil {
+	// Detect the existing self-bind by reading /proc/self/mountinfo directly,
+	// not via the `mountpoint` binary — it isn't in vmd's preflight tool set, so
+	// on a minimal image its absence would be misread as "not a mount point" and
+	// stack a fresh bind mount on every restart, growing the host mount table.
+	mounted, err := isMountpoint(dir)
+	if err != nil {
+		return fmt.Errorf("check mountpoint %s: %w", dir, err)
+	}
+	if !mounted {
 		if out, err := exec.CommandContext(ctx, "mount", "--bind", dir, dir).CombinedOutput(); err != nil {
 			return fmt.Errorf("bind %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
 		}
@@ -130,6 +139,23 @@ func ensurePrivateMount(ctx context.Context, dir string) error {
 		return fmt.Errorf("make-private %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// isMountpoint reports whether path is a mount point by scanning
+// /proc/self/mountinfo, whose 5th field is the mount point. ponytail: compares
+// the field raw — fine for the fixed internal pin dir (/run/vmd, no spaces); a
+// path with spaces would arrive octal-escaped (\040) and need unescaping.
+func isMountpoint(path string) (bool, error) {
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if f := strings.Fields(line); len(f) >= 5 && f[4] == path {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // StartMountCountSampler periodically logs the host mount-table size so the
@@ -157,8 +183,13 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 // revalidateLauncher keeps launcherReady in sync with the live pin. The startup
 // check is a point-in-time snapshot; if the pin is later unmounted/deleted while
 // vmd runs, every launch would keep building nsenter --mount=<stale-path> and
-// fail. Re-check each tick: drop to the legacy path if the pin went bad, resume
-// the launcher path if it's valid again. No-op when launcher mode is disabled.
+// fail. Re-check each tick: drop to the legacy path if the pin went bad, and
+// resume ONLY the pin this boot built (launcherBuilt) if a transient check blip
+// cleared. A pin that merely looks valid again — e.g. a previous-boot pin left
+// mounted after this boot's rebuild failed — must not re-enable the launcher
+// path: it can be missing launch-critical mounts that rebuild-on-boot exists to
+// pick up. Recovery from a failed boot build is a vmd restart. No-op when
+// launcher mode is disabled.
 func (m *Manager) revalidateLauncher(ctx context.Context) {
 	pin := m.launcherNSPath()
 	if pin == "" {
@@ -169,7 +200,7 @@ func (m *Manager) revalidateLauncher(ctx context.Context) {
 	case !valid && m.launcherReady.Load():
 		m.launcherReady.Store(false)
 		m.log.Error().Str("path", pin).Msg("launcher pin no longer valid — falling back to legacy launch path")
-	case valid && !m.launcherReady.Load():
+	case valid && m.launcherBuilt.Load() && !m.launcherReady.Load():
 		m.launcherReady.Store(true)
 		m.log.Info().Str("path", pin).Msg("launcher pin valid again — resuming launcher launch path")
 	}

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -105,9 +105,10 @@ func buildLauncherNamespace(ctx context.Context, pinPath string) error {
 	return nil
 }
 
-// ensurePrivateMount makes dir its own mount with private propagation
-// (bind-mounting it to itself first if it isn't already a mount point).
-// Idempotent: a dir that is already a private mount is left as-is.
+// ensurePrivateMount makes dir its own mount with private propagation by
+// self-binding it. Idempotent: an already-private dir (our bind from a prior
+// boot) is reused; a pre-existing NON-private mount is refused — never
+// make-private a mount we didn't create.
 func ensurePrivateMount(ctx context.Context, dir string) error {
 	// Read propagation from /proc/self/mountinfo, not the `mountpoint` binary: it
 	// isn't preflighted, so on a minimal image its absence would read as "not a

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -1,0 +1,203 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
+)
+
+// launcherPruneScript reduces a freshly cloned mount namespace to a minimal
+// table by removing every /run/netns nsfs mount. A single `umount /run/netns`
+// only detaches the parent layer — one nsfs mount per netns remains, stacked on
+// the individual /run/netns/ns-N paths — so we also unmount each surviving
+// entry. make-rprivate MUST succeed before any umount — it severs the cloned
+// namespace's propagation from the host; without it, a umount could propagate
+// back and detach the host's live /run/netns pins. `|| exit 1` aborts before any
+// umount if it fails, so the build errors and launches fall back to legacy with
+// the host untouched.
+const launcherPruneScript = `mount --make-rprivate / || exit 1
+umount -l /run/netns 2>/dev/null || true
+for m in $(grep ' /run/netns/' /proc/self/mounts | awk '{print $2}'); do umount -l "$m" 2>/dev/null || true; done`
+
+// EnsureLauncherNamespace makes sure the pruned launcher mount namespace exists
+// and is pinned at m.launcherNSPath(), building it if missing or stale. No-op
+// when the launcher launch mode is disabled.
+//
+// The pin is a point-in-time snapshot of the host mount table (propagation
+// severed), so we REBUILD it every boot rather than reuse a prior pin — a
+// launch-critical mount added since the last build (new storage volume, updated
+// firecracker binary) would otherwise be invisible in a stale pin and fail
+// launches. vmd restarts are the deploy/mount-change boundary, so rebuilding
+// then keeps the pin current; the O(fleet) prune cost is off the hot path.
+// launcherBuildTimeout bounds the boot-time launcher setup (mount/unshare/nsenter
+// execs), which run before vmd serves. It must exceed the O(fleet) prune, so it's
+// far larger than the 5s used for single host execs elsewhere; a wedged mount or
+// /run then degrades to a logged failure + legacy fallback instead of hanging boot.
+const launcherBuildTimeout = 90 * time.Second
+
+func (m *Manager) EnsureLauncherNamespace(ctx context.Context) error {
+	pinPath := m.launcherNSPath()
+	if pinPath == "" {
+		return nil // launcher mode disabled
+	}
+	ctx, cancel := context.WithTimeout(ctx, launcherBuildTimeout)
+	defer cancel()
+	// The launch path needs nsenter; without it, fail here (launcherReady stays
+	// false) so launches fall back to legacy instead of exiting 127 per-VM.
+	if _, err := exec.LookPath("nsenter"); err != nil {
+		return fmt.Errorf("nsenter not found (required for launcher launch path): %w", err)
+	}
+	start := time.Now()
+	if err := buildLauncherNamespace(ctx, pinPath); err != nil {
+		return fmt.Errorf("build launcher namespace %s: %w", pinPath, err)
+	}
+	// The prune tolerates umount errors, so the build can exit 0 while /run/netns
+	// is still present. Verify it's actually pruned before trusting it.
+	if !launcherNSValid(ctx, pinPath) {
+		return fmt.Errorf("launcher namespace %s built but still contains /run/netns (prune incomplete)", pinPath)
+	}
+	m.launcherReady.Store(true)
+	m.log.Info().Str("path", pinPath).Dur("took", time.Since(start)).
+		Msg("launcher namespace: built")
+	return nil
+}
+
+// launcherNSValid reports whether pinPath is a live mount-namespace pin whose
+// table has already been pruned of /run/netns. Absent, non-mount, or stale
+// (still carrying /run/netns) → false, so the caller rebuilds.
+func launcherNSValid(ctx context.Context, pinPath string) bool {
+	if fi, err := os.Stat(pinPath); err != nil || fi.IsDir() {
+		return false
+	}
+	// Match in Go, not `sh -c '! grep …'` — a missing grep would negate its 127
+	// to 0 and falsely pass. Any exec error (bad pin, missing tool) → false.
+	out, err := exec.CommandContext(ctx, "nsenter", "--mount="+pinPath, "--",
+		"cat", "/proc/self/mounts").Output()
+	if err != nil {
+		return false
+	}
+	return !strings.Contains(string(out), " /run/netns")
+}
+
+// buildLauncherNamespace creates a fresh mount namespace, prunes /run/netns from
+// it, and persists it at pinPath so it outlives the builder.
+//
+// util-linux `unshare --mount=<file>` persists the new mount namespace by
+// binding the process's OWN /proc/self/ns/mnt to the file — the kernel-supported
+// operation. (Binding another process's mount namespace cross-namespace is
+// rejected by the kernel, which is what a manual parent-side bind hit.) The
+// prune runs inside that same namespace, so the persisted pin refers to the
+// pruned table.
+func buildLauncherNamespace(ctx context.Context, pinPath string) error {
+	dir := filepath.Dir(pinPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir pin dir: %w", err)
+	}
+	// The mount point used to persist a mount namespace must have private
+	// propagation, or `unshare --mount` fails with EINVAL — systemd mounts / as
+	// shared by default, so the pin dir inherits shared propagation.
+	if err := ensurePrivateMount(ctx, dir); err != nil {
+		return err
+	}
+	// unshare --mount binds onto an existing file; detach any stale pin first.
+	_ = exec.CommandContext(ctx, "umount", "-l", pinPath).Run()
+	if err := ensurePinFile(pinPath); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "unshare", "--mount="+pinPath, "--", "sh", "-c", launcherPruneScript)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("unshare --mount=%s: %v: %s", pinPath, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ensurePrivateMount makes dir its own mount with private propagation
+// (bind-mounting it to itself first if it isn't already a mount point).
+// Idempotent: a dir that is already a private mount is left as-is.
+func ensurePrivateMount(ctx context.Context, dir string) error {
+	if exec.CommandContext(ctx, "mountpoint", "-q", dir).Run() != nil {
+		if out, err := exec.CommandContext(ctx, "mount", "--bind", dir, dir).CombinedOutput(); err != nil {
+			return fmt.Errorf("bind %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
+		}
+	}
+	if out, err := exec.CommandContext(ctx, "mount", "--make-private", dir).CombinedOutput(); err != nil {
+		return fmt.Errorf("make-private %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// StartMountCountSampler periodically logs the host mount-table size so the
+// O(1)-launch invariant — mount count should stay roughly flat, not grow with
+// the fleet — is observable in the log pipeline. One /proc/mounts read per tick.
+func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duration) {
+	go func() {
+		defer sentrylog.Recover("mount-count sampler")
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				total, nsfs := hostMountCounts()
+				m.log.Info().Int("host_mount_count", total).Int("host_nsfs_count", nsfs).
+					Msg("host mount table")
+				m.revalidateLauncher(ctx)
+			}
+		}
+	}()
+}
+
+// revalidateLauncher keeps launcherReady in sync with the live pin. The startup
+// check is a point-in-time snapshot; if the pin is later unmounted/deleted while
+// vmd runs, every launch would keep building nsenter --mount=<stale-path> and
+// fail. Re-check each tick: drop to the legacy path if the pin went bad, resume
+// the launcher path if it's valid again. No-op when launcher mode is disabled.
+func (m *Manager) revalidateLauncher(ctx context.Context) {
+	pin := m.launcherNSPath()
+	if pin == "" {
+		return
+	}
+	valid := launcherNSValid(ctx, pin)
+	switch {
+	case !valid && m.launcherReady.Load():
+		m.launcherReady.Store(false)
+		m.log.Error().Str("path", pin).Msg("launcher pin no longer valid — falling back to legacy launch path")
+	case valid && !m.launcherReady.Load():
+		m.launcherReady.Store(true)
+		m.log.Info().Str("path", pin).Msg("launcher pin valid again — resuming launcher launch path")
+	}
+}
+
+// hostMountCounts returns the total mount count and the nsfs subset (the
+// per-netns bind mounts) from /proc/mounts.
+func hostMountCounts() (total, nsfs int) {
+	data, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return 0, 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+		total++
+		if strings.Contains(line, " nsfs ") {
+			nsfs++
+		}
+	}
+	return total, nsfs
+}
+
+func ensurePinFile(pinPath string) error {
+	f, err := os.OpenFile(pinPath, os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("create pin file: %w", err)
+	}
+	return f.Close()
+}

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -133,14 +133,17 @@ func TestParseMountState(t *testing.T) {
 	// A private mount (no propagation tags) vs a shared one, plus an absent dir.
 	mountinfo := []byte(
 		"36 35 0:1 / /run/vmd rw,relatime - tmpfs tmpfs rw\n" +
-			"37 35 0:2 / /run rw,relatime shared:23 - tmpfs tmpfs rw\n")
+			"37 35 0:2 / /run rw,relatime shared:23 - tmpfs tmpfs rw\n" +
+			`38 35 0:3 / /run/my\040launcher rw,relatime - tmpfs tmpfs rw` + "\n")
 	cases := []struct {
 		dir                  string
 		wantMounted, private bool
 	}{
-		{"/run/vmd", true, true}, // dedicated private pin dir
-		{"/run", true, false},    // shared host mount — must not be made private
-		{"/nope", false, false},  // not present
+		{"/run/vmd", true, true},              // dedicated private pin dir
+		{"/run", true, false},                 // shared host mount — must not be made private
+		{"/run/my launcher", true, true},      // escaped mount point must unescape to match
+		{`/run/my\040launcher`, false, false}, // literal escaped form must NOT match
+		{"/nope", false, false},               // not present
 	}
 	for _, tc := range cases {
 		mounted, private := parseMountState(mountinfo, tc.dir)

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -27,6 +27,9 @@ func TestBuildLauncherNamespace_Integration(t *testing.T) {
 	if !launcherNSValid(ctx, pin) {
 		t.Fatal("launcherNSValid = false after a successful build")
 	}
+	if !pinIsMounted(pin) {
+		t.Fatal("pinIsMounted = false after a successful build")
+	}
 	// A rebuild over an existing pin must also succeed (stale-pin path).
 	if err := buildLauncherNamespace(ctx, pin); err != nil {
 		t.Fatalf("rebuild over existing pin: %v", err)
@@ -113,6 +116,24 @@ func TestFCStartScript_NoShellInjection(t *testing.T) {
 	if _, err := os.Stat(marker); err == nil {
 		_ = os.Remove(marker)
 		t.Fatal("SHELL INJECTION: embedded command substitution executed")
+	}
+}
+
+func TestPinIsMounted_NotAPin(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("statfs nsfs check (linux only)")
+	}
+	// Absent path and a plain file both fail the nsfs-magic check.
+	if pinIsMounted("/no/such/pin") {
+		t.Error("pinIsMounted(absent) = true, want false")
+	}
+	f, err := os.CreateTemp(t.TempDir(), "pin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if pinIsMounted(f.Name()) {
+		t.Error("pinIsMounted(regular file) = true, want false")
 	}
 }
 

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -1,0 +1,137 @@
+package vm
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/superserve-ai/sandbox/internal/shellquote"
+)
+
+// TestBuildLauncherNamespace_Integration exercises the real build + validity
+// check on a live kernel. Needs root + Linux + util-linux; opt in with
+// VMD_LAUNCHER_INTEGRATION=1 (run in a privileged container).
+func TestBuildLauncherNamespace_Integration(t *testing.T) {
+	if os.Getenv("VMD_LAUNCHER_INTEGRATION") != "1" {
+		t.Skip("set VMD_LAUNCHER_INTEGRATION=1 (root + linux) to run")
+	}
+	ctx := context.Background()
+	pin := "/run/vmd-test/launcher.mntns"
+	if err := buildLauncherNamespace(ctx, pin); err != nil {
+		t.Fatalf("buildLauncherNamespace: %v", err)
+	}
+	if !launcherNSValid(ctx, pin) {
+		t.Fatal("launcherNSValid = false after a successful build")
+	}
+	// A rebuild over an existing pin must also succeed (stale-pin path).
+	if err := buildLauncherNamespace(ctx, pin); err != nil {
+		t.Fatalf("rebuild over existing pin: %v", err)
+	}
+}
+
+func TestFCStartScript_LegacyPath(t *testing.T) {
+	got := fcStartScript("ns-7", "", "SETUP",
+		"/usr/bin/firecracker", "/run/x/fc.sock", "vm-abc")
+	if !strings.Contains(got, "ip netns exec ns-7 unshare -m -- sh -c ") {
+		t.Errorf("legacy script should use `ip netns exec`; got:\n%s", got)
+	}
+	if strings.Contains(got, "nsenter") {
+		t.Errorf("legacy script must not use nsenter; got:\n%s", got)
+	}
+	if strings.Contains(got, "mount -t sysfs") {
+		t.Errorf("legacy script must not remount /sys (ip netns exec already does); got:\n%s", got)
+	}
+	if !strings.Contains(got, "/usr/bin/firecracker") {
+		t.Errorf("legacy script missing firecracker binary; got:\n%s", got)
+	}
+}
+
+func TestFCStartScript_LauncherPath(t *testing.T) {
+	got := fcStartScript("ns-7", "/run/vmd/launcher.mntns", "SETUP",
+		"/usr/bin/firecracker", "/run/x/fc.sock", "vm-abc")
+	want := `nsenter --net=/run/netns/ns-7 --mount='/run/vmd/launcher.mntns' -- unshare -m`
+	if !strings.Contains(got, want) {
+		t.Errorf("launcher script missing %q; got:\n%s", want, got)
+	}
+	if strings.Contains(got, "ip netns exec") {
+		t.Errorf("launcher script must not use `ip netns exec`; got:\n%s", got)
+	}
+	// launcherNSPath (in the prefix, outside sh -c) must be single-quoted.
+	sp := fcStartScript("ns-7", "/run/vmd/a b.mntns", "SETUP", "/fc", "/s", "v")
+	if !strings.Contains(sp, `--mount='/run/vmd/a b.mntns'`) {
+		t.Errorf("launcher path with spaces not single-quoted; got:\n%s", sp)
+	}
+	ex := fcStartScript("ns-7", `/run/vmd/$FOO$(x)`, "SETUP", "/fc", "/s", "v")
+	if !strings.Contains(ex, `--mount='/run/vmd/$FOO$(x)'`) {
+		t.Errorf("launcher path with shell syntax not kept literal; got:\n%s", ex)
+	}
+	// The launcher path remounts /sys inside sh -c (survives the outer quoting).
+	if !strings.Contains(got, "mount -t sysfs sysfs /sys") {
+		t.Errorf("launcher script must remount /sys; got:\n%s", got)
+	}
+}
+
+func TestFCSetupCmds_QuotesCallerPaths(t *testing.T) {
+	// A caller-influenced base_path with shell syntax must be single-quoted, not
+	// interpolated raw.
+	evil := `/data/x$(touch /tmp/pwn)`
+	got := fcSetupCmds("/tmpl", evil, "/run/rootfs.ext4")
+	if !strings.Contains(got, shellquote.Single(evil)) {
+		t.Errorf("base_path not single-quoted; got:\n%s", got)
+	}
+	if strings.Contains(got, "ln -s "+evil) {
+		t.Errorf("base_path interpolated raw (unquoted); got:\n%s", got)
+	}
+}
+
+// TestFCStartScript_NoShellInjection proves the exact double-quoting fcStartScript
+// uses (each value single-quoted, then the whole inner script single-quoted as the
+// `sh -c` argument) keeps a hostile path literal — no command substitution runs.
+// Requires /bin/sh (runs in CI / the Linux test container).
+func TestFCStartScript_NoShellInjection(t *testing.T) {
+	marker := "/tmp/vmd_injtest_" + strconv.Itoa(os.Getpid())
+	_ = os.Remove(marker)
+	payload := "/data/x'$(touch " + marker + ")'`touch " + marker + "`.ext4"
+
+	// Mirror fcStartScript: the value is single-quoted inside the inner script,
+	// then the inner script is single-quoted as the `sh -c` argument. printf is
+	// a harmless stand-in for `ln -s <path> …`.
+	inner := "printf %s " + shellquote.Single(payload)
+	line := "sh -c " + shellquote.Single(inner)
+
+	out, err := exec.Command("/bin/sh", "-c", line).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v (%s)", err, out)
+	}
+	if string(out) != payload {
+		t.Fatalf("path not treated literally:\n got  %q\n want %q", string(out), payload)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		_ = os.Remove(marker)
+		t.Fatal("SHELL INJECTION: embedded command substitution executed")
+	}
+}
+
+func TestLauncherNSPath(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ManagerConfig
+		want string
+	}{
+		{"disabled", ManagerConfig{LaunchViaLauncherNS: false}, ""},
+		{"disabled ignores path", ManagerConfig{LaunchViaLauncherNS: false, LauncherNSPath: "/x"}, ""},
+		{"default path", ManagerConfig{LaunchViaLauncherNS: true}, defaultLauncherNSPath},
+		{"custom path", ManagerConfig{LaunchViaLauncherNS: true, LauncherNSPath: "/tmp/l.mntns"}, "/tmp/l.mntns"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{cfg: tc.cfg}
+			if got := m.launcherNSPath(); got != tc.want {
+				t.Errorf("launcherNSPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -116,15 +116,38 @@ func TestFCStartScript_NoShellInjection(t *testing.T) {
 	}
 }
 
-func TestIsMountpoint(t *testing.T) {
+func TestMountState(t *testing.T) {
 	if runtime.GOOS != "linux" {
-		t.Skip("isMountpoint reads /proc/self/mountinfo (linux only)")
+		t.Skip("mountState reads /proc/self/mountinfo (linux only)")
 	}
-	if ok, err := isMountpoint("/"); err != nil || !ok {
-		t.Errorf(`isMountpoint("/") = %v, %v; want true, nil`, ok, err)
+	// "/" is always a mount point; a made-up path never is.
+	if mounted, _, err := mountState("/"); err != nil || !mounted {
+		t.Errorf(`mountState("/") mounted = %v, %v; want true, nil`, mounted, err)
 	}
-	if ok, err := isMountpoint("/no/such/mount/xyz"); err != nil || ok {
-		t.Errorf(`isMountpoint("/no/such/mount/xyz") = %v, %v; want false, nil`, ok, err)
+	if mounted, _, err := mountState("/no/such/mount/xyz"); err != nil || mounted {
+		t.Errorf(`mountState("/no/such/mount/xyz") mounted = %v, %v; want false, nil`, mounted, err)
+	}
+}
+
+func TestParseMountState(t *testing.T) {
+	// A private mount (no propagation tags) vs a shared one, plus an absent dir.
+	mountinfo := []byte(
+		"36 35 0:1 / /run/vmd rw,relatime - tmpfs tmpfs rw\n" +
+			"37 35 0:2 / /run rw,relatime shared:23 - tmpfs tmpfs rw\n")
+	cases := []struct {
+		dir                  string
+		wantMounted, private bool
+	}{
+		{"/run/vmd", true, true}, // dedicated private pin dir
+		{"/run", true, false},    // shared host mount — must not be made private
+		{"/nope", false, false},  // not present
+	}
+	for _, tc := range cases {
+		mounted, private := parseMountState(mountinfo, tc.dir)
+		if mounted != tc.wantMounted || private != tc.private {
+			t.Errorf("parseMountState(%q) = (%v, %v); want (%v, %v)",
+				tc.dir, mounted, private, tc.wantMounted, tc.private)
+		}
 	}
 }
 

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -112,6 +113,18 @@ func TestFCStartScript_NoShellInjection(t *testing.T) {
 	if _, err := os.Stat(marker); err == nil {
 		_ = os.Remove(marker)
 		t.Fatal("SHELL INJECTION: embedded command substitution executed")
+	}
+}
+
+func TestIsMountpoint(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("isMountpoint reads /proc/self/mountinfo (linux only)")
+	}
+	if ok, err := isMountpoint("/"); err != nil || !ok {
+		t.Errorf(`isMountpoint("/") = %v, %v; want true, nil`, ok, err)
+	}
+	if ok, err := isMountpoint("/no/such/mount/xyz"); err != nil || ok {
+		t.Errorf(`isMountpoint("/no/such/mount/xyz") = %v, %v; want false, nil`, ok, err)
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -214,10 +214,9 @@ type Manager struct {
 	// legacy path. Set when the namespace is built/validated; kept in sync by
 	// revalidateLauncher.
 	launcherReady atomic.Bool
-	// launcherBuilt is true only after EnsureLauncherNamespace built and pinned
-	// the launcher THIS boot. revalidateLauncher requires it before re-enabling
-	// launcherReady, so a stale pin left mounted from a previous boot (whose
-	// rebuild failed) can never resurrect the launcher path.
+	// launcherBuilt is true only after a successful build THIS boot; gates
+	// revalidateLauncher's re-enable so a stale previous-boot pin can't resurrect
+	// the launcher path.
 	launcherBuilt atomic.Bool
 
 	mu  sync.RWMutex
@@ -2370,31 +2369,25 @@ func fcSetupCmds(templateDir, basePath, perVMRootfs string) string {
 
 // fcStartScript renders the per-VM start.sh that systemd's ExecStart runs.
 //
-// launcherNSPath == "" → legacy path: `ip netns exec <ns> unshare -m …`.
-// launcherNSPath != "" → launcher path: enter the VM's netns AND vmd's pruned
-// launcher mount namespace via nsenter, then `unshare -m` — so the per-VM
-// mount-namespace clone copies the launcher's small table instead of the
-// full host table. nsenter opens the netns + launcher fds from the host mount
-// view before setns, so entering the netns works even though the launcher
-// namespace has /run/netns pruned; `ip netns exec` cannot be used there
-// because it resolves /run/netns/<ns> from inside the (pruned) mount namespace.
+// launcherNSPath == "" → legacy: `ip netns exec <ns> unshare -m …`.
+// launcherNSPath != "" → launcher: `nsenter --net=<ns> --mount=<pin> -- unshare
+// -m …`, so the per-VM clone copies the launcher's small table, not the full host
+// table. nsenter opens both fds from the host mount view before setns, so the
+// netns resolves even though the launcher has /run/netns pruned — which is why
+// `ip netns exec` (resolves the netns from inside the mount ns) can't be used.
 func fcStartScript(netNS, launcherNSPath, setupCmds, fcBin, socketPath, vmID string) string {
 	prefix := fmt.Sprintf("ip netns exec %s", netNS)
 	sysfs := ""
 	if launcherNSPath != "" {
 		prefix = fmt.Sprintf("nsenter --net=/run/netns/%s --mount=%s --", netNS, shellquote.Single(launcherNSPath))
-		// nsenter — unlike `ip netns exec` — does not remount /sys, so
-		// /sys/class/net would reflect the host netns, not the VM's (the tap
-		// device would be absent). Remount a fresh, netns-aware sysfs inside the
-		// per-VM mount namespace (after make-rprivate, so it can't propagate to
-		// the host) so anything reading /sys sees the VM's interfaces.
+		// nsenter, unlike `ip netns exec`, doesn't remount /sys, so /sys/class/net
+		// would show the host's interfaces, not the VM's tap. Remount a netns-aware
+		// sysfs inside the per-VM ns (after make-rprivate, so it can't reach the host).
 		sysfs = " && mount -t sysfs sysfs /sys"
 	}
-	// Every value is single-quoted: setupCmds quoted its paths, the fc args are
-	// quoted here, and the whole inner script is then quoted as the `sh -c`
-	// argument. Two applications of shellquote.Single (once for the value, once
-	// for the outer sh -c arg) — so a caller-influenced path (base_path,
-	// perVMRootfs) can't close a quote and inject shell that runs as root.
+	// Each value is single-quoted, then the whole inner script is single-quoted as
+	// the `sh -c` arg — two shellquote.Single layers, so a caller-influenced path
+	// (base_path, perVMRootfs) can't close a quote and inject shell as root.
 	inner := fmt.Sprintf("%s%s && exec %s --api-sock %s --id %s",
 		setupCmds, sysfs, shellquote.Single(fcBin), shellquote.Single(socketPath), shellquote.Single(vmID))
 	return fmt.Sprintf("#!/bin/sh\nexec %s unshare -m -- sh -c %s\n", prefix, shellquote.Single(inner))
@@ -2415,12 +2408,9 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	setupCmds := fcSetupCmds(templateDir, basePath, perVMRootfs)
 
 	scriptPath := filepath.Join(filepath.Dir(socketPath), "start.sh")
-	// Launcher path only when the namespace is ready AND still valid at this
-	// moment — re-checking here (not just launcherReady) closes the window where
-	// a pin that went bad since the last revalidation tick would otherwise bake a
-	// dead nsenter --mount into start.sh and hard-fail the launch. On failure,
-	// fall back to legacy for this launch and stop trusting the pin until
-	// revalidateLauncher rebuilds/reconfirms it.
+	// Re-check validity here, not just launcherReady: a pin that went bad since the
+	// last revalidation tick would otherwise bake a dead nsenter --mount into
+	// start.sh and hard-fail. On failure, fall back to legacy and drop the pin.
 	launcherPath := ""
 	if m.launcherReady.Load() {
 		if pin := m.launcherNSPath(); launcherNSValid(ctx, pin) {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -214,6 +214,11 @@ type Manager struct {
 	// legacy path. Set when the namespace is built/validated; kept in sync by
 	// revalidateLauncher.
 	launcherReady atomic.Bool
+	// launcherBuilt is true only after EnsureLauncherNamespace built and pinned
+	// the launcher THIS boot. revalidateLauncher requires it before re-enabling
+	// launcherReady, so a stale pin left mounted from a previous boot (whose
+	// rebuild failed) can never resurrect the launcher path.
+	launcherBuilt atomic.Bool
 
 	mu  sync.RWMutex
 	vms map[string]*VMInstance

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2408,16 +2408,18 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	setupCmds := fcSetupCmds(templateDir, basePath, perVMRootfs)
 
 	scriptPath := filepath.Join(filepath.Dir(socketPath), "start.sh")
-	// Re-check validity here, not just launcherReady: a pin that went bad since the
+	// Re-check the pin here, not just launcherReady: a pin unmounted since the
 	// last revalidation tick would otherwise bake a dead nsenter --mount into
-	// start.sh and hard-fail. On failure, fall back to legacy and drop the pin.
+	// start.sh and hard-fail. pinIsMounted is one statfs — no fork on the hot
+	// path, no transient exec failure under burst load. On failure fall back to
+	// legacy for THIS launch only; launcherReady stays with the sampler, so one
+	// blip can't knock the whole fleet onto the O(fleet) legacy path for a tick.
 	launcherPath := ""
 	if m.launcherReady.Load() {
-		if pin := m.launcherNSPath(); launcherNSValid(ctx, pin) {
+		if pin := m.launcherNSPath(); pinIsMounted(pin) {
 			launcherPath = pin
 		} else {
-			m.launcherReady.Store(false)
-			m.log.Error().Str("path", pin).Msg("launcher pin invalid at launch — using legacy path")
+			m.log.Warn().Str("path", pin).Msg("launcher pin not mounted at launch — using legacy path for this launch")
 		}
 	}
 	scriptContent := fcStartScript(netNS, launcherPath, setupCmds, m.cfg.FirecrackerBin, socketPath, vmID)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/shellquote"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
@@ -184,6 +185,17 @@ type ManagerConfig struct {
 	// page fault). The dead VM then surfaces via the unit-inactive → reconciler path
 	// rather than hanging silently. Independent of the snapshot flags. Default false.
 	HandlerDeathAbortEnabled bool
+
+	// LaunchViaLauncherNS routes the Firecracker launch through a long-lived,
+	// pruned "launcher" mount namespace (pinned at LauncherNSPath); see
+	// fcStartScript for the mechanism. Keeps per-VM launch cost independent of
+	// fleet size. Default false; the legacy `ip netns exec` path is the fallback.
+	LaunchViaLauncherNS bool
+
+	// LauncherNSPath is where the launcher mount namespace is pinned (persisted
+	// via `unshare --mount`). Only used when LaunchViaLauncherNS is true.
+	// Empty → defaultLauncherNSPath.
+	LauncherNSPath string
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +209,11 @@ type Manager struct {
 	egressProxy *network.EgressProxy
 	log         zerolog.Logger
 	state       *StateStore // persistent local state (BoltDB); nil = no persistence
+
+	// launcherReady gates the launcher launch path: false → launches use the
+	// legacy path. Set when the namespace is built/validated; kept in sync by
+	// revalidateLauncher.
+	launcherReady atomic.Bool
 
 	mu  sync.RWMutex
 	vms map[string]*VMInstance
@@ -2277,6 +2294,70 @@ func (m *Manager) startFirecrackerColdBoot(ctx context.Context, vmID, socketPath
 	return pid, nil
 }
 
+// defaultLauncherNSPath is where the pruned launcher mount namespace is pinned
+// when LaunchViaLauncherNS is enabled without an explicit LauncherNSPath.
+const defaultLauncherNSPath = "/run/vmd/launcher.mntns"
+
+// launcherNSPath returns the launcher mount-namespace pin path when the
+// launcher launch mode is enabled, or "" to select the legacy launch path.
+func (m *Manager) launcherNSPath() string {
+	if !m.cfg.LaunchViaLauncherNS {
+		return ""
+	}
+	if m.cfg.LauncherNSPath != "" {
+		return m.cfg.LauncherNSPath
+	}
+	return defaultLauncherNSPath
+}
+
+// fcSetupCmds builds the rootfs-setup portion of the launch script — mount the
+// per-VM tmpfs and symlink the rootfs into it. Caller-influenced paths
+// (basePath, perVMRootfs) are single-quoted so they can't inject shell.
+func fcSetupCmds(templateDir, basePath, perVMRootfs string) string {
+	if basePath != "" {
+		baseLink := filepath.Join(templateDir, "base.ext4")
+		overlayLink := filepath.Join(templateDir, "overlay.ext4")
+		return fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %s && ln -s %s %s && ln -s %s %s",
+			shellquote.Single(templateDir), shellquote.Single(basePath), shellquote.Single(baseLink),
+			shellquote.Single(perVMRootfs), shellquote.Single(overlayLink))
+	}
+	rootfsLink := filepath.Join(templateDir, "rootfs.ext4")
+	return fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %s && ln -s %s %s",
+		shellquote.Single(templateDir), shellquote.Single(perVMRootfs), shellquote.Single(rootfsLink))
+}
+
+// fcStartScript renders the per-VM start.sh that systemd's ExecStart runs.
+//
+// launcherNSPath == "" → legacy path: `ip netns exec <ns> unshare -m …`.
+// launcherNSPath != "" → launcher path: enter the VM's netns AND vmd's pruned
+// launcher mount namespace via nsenter, then `unshare -m` — so the per-VM
+// mount-namespace clone copies the launcher's small table instead of the
+// full host table. nsenter opens the netns + launcher fds from the host mount
+// view before setns, so entering the netns works even though the launcher
+// namespace has /run/netns pruned; `ip netns exec` cannot be used there
+// because it resolves /run/netns/<ns> from inside the (pruned) mount namespace.
+func fcStartScript(netNS, launcherNSPath, setupCmds, fcBin, socketPath, vmID string) string {
+	prefix := fmt.Sprintf("ip netns exec %s", netNS)
+	sysfs := ""
+	if launcherNSPath != "" {
+		prefix = fmt.Sprintf("nsenter --net=/run/netns/%s --mount=%s --", netNS, shellquote.Single(launcherNSPath))
+		// nsenter — unlike `ip netns exec` — does not remount /sys, so
+		// /sys/class/net would reflect the host netns, not the VM's (the tap
+		// device would be absent). Remount a fresh, netns-aware sysfs inside the
+		// per-VM mount namespace (after make-rprivate, so it can't propagate to
+		// the host) so anything reading /sys sees the VM's interfaces.
+		sysfs = " && mount -t sysfs sysfs /sys"
+	}
+	// Every value is single-quoted: setupCmds quoted its paths, the fc args are
+	// quoted here, and the whole inner script is then quoted as the `sh -c`
+	// argument. Two applications of shellquote.Single (once for the value, once
+	// for the outer sh -c arg) — so a caller-influenced path (base_path,
+	// perVMRootfs) can't close a quote and inject shell that runs as root.
+	inner := fmt.Sprintf("%s%s && exec %s --api-sock %s --id %s",
+		setupCmds, sysfs, shellquote.Single(fcBin), shellquote.Single(socketPath), shellquote.Single(vmID))
+	return fmt.Sprintf("#!/bin/sh\nexec %s unshare -m -- sh -c %s\n", prefix, shellquote.Single(inner))
+}
+
 // startFirecrackerViaSystemd writes the start script and launches Firecracker
 // as a standalone systemd unit. The VM survives VMD restarts because systemd
 // owns the process, not VMD. Non-empty basePath switches the start script to
@@ -2289,21 +2370,25 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 
 	templateDir := m.templateRunDir()
 
-	var setupCmds string
-	if basePath != "" {
-		baseLink := filepath.Join(templateDir, "base.ext4")
-		overlayLink := filepath.Join(templateDir, "overlay.ext4")
-		setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q && ln -s %q %q",
-			templateDir, basePath, baseLink, perVMRootfs, overlayLink)
-	} else {
-		rootfsLink := filepath.Join(templateDir, "rootfs.ext4")
-		setupCmds = fmt.Sprintf("mount --make-rprivate / && mount -t tmpfs tmpfs %q && ln -s %q %q",
-			templateDir, perVMRootfs, rootfsLink)
-	}
+	setupCmds := fcSetupCmds(templateDir, basePath, perVMRootfs)
 
 	scriptPath := filepath.Join(filepath.Dir(socketPath), "start.sh")
-	scriptContent := fmt.Sprintf("#!/bin/sh\nexec ip netns exec %s unshare -m -- sh -c '%s && exec %q --api-sock %q --id %q'\n",
-		netNS, setupCmds, m.cfg.FirecrackerBin, socketPath, vmID)
+	// Launcher path only when the namespace is ready AND still valid at this
+	// moment — re-checking here (not just launcherReady) closes the window where
+	// a pin that went bad since the last revalidation tick would otherwise bake a
+	// dead nsenter --mount into start.sh and hard-fail the launch. On failure,
+	// fall back to legacy for this launch and stop trusting the pin until
+	// revalidateLauncher rebuilds/reconfirms it.
+	launcherPath := ""
+	if m.launcherReady.Load() {
+		if pin := m.launcherNSPath(); launcherNSValid(ctx, pin) {
+			launcherPath = pin
+		} else {
+			m.launcherReady.Store(false)
+			m.log.Error().Str("path", pin).Msg("launcher pin invalid at launch — using legacy path")
+		}
+	}
+	scriptContent := fcStartScript(netNS, launcherPath, setupCmds, m.cfg.FirecrackerBin, socketPath, vmID)
 	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0o755); err != nil {
 		return 0, fmt.Errorf("write start script: %w", err)
 	}


### PR DESCRIPTION
## Problem
Per-VM launch runs `unshare -m`, which clones the entire host mount table. That table grows with the number of network namespaces on the host (one per running VM), so under concurrent creates the clone serializes on the kernel mount lock and launch latency climbs as the fleet grows — eventually pushing creates past the socket-readiness deadline and failing them.

## Fix
Launch Firecracker from a long-lived, pruned "launcher" mount namespace, so each per-VM `unshare -m` clones a small table instead of the full host table — keeping launch cost independent of fleet size. The launcher namespace is persisted with `unshare --mount=` (its parent dir is made a private mount, required to persist a mount namespace), and pruned of `/run/netns`. `start.sh` switches from `ip netns exec` to `nsenter` (entering the VM's netns by path plus the launcher mount namespace) and remounts a netns-aware `/sys`.

Also adds a periodic log of the host mount count so the O(1) invariant is observable.

## Safety
- Behind `VMD_LAUNCH_VIA_LAUNCHER_NS`, default off — a no-op until enabled.
- Launcher-build failure or a missing `nsenter` is non-fatal: launches fall back to the legacy `ip netns exec` path.
- The launcher pin is revalidated periodically; if it goes stale mid-run, launches fall back to legacy until it's valid again.

## Validation
Unit tests for `start.sh` generation; the namespace mechanics (prune, persist/pin, `nsenter` entry, `/sys` remount) exercised on a Linux kernel including with a shared root mount, plus an end-to-end functional check on staging.