### PR TITLE
vmd: give restored VMs the same boxd-ready window as first boot

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1463,7 +1463,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 
 	tBoxdStart := time.Now()
-	if err := m.waitForBoxd(ctx, hostIP, 5*time.Second); err != nil {
+	// Same window as first boot: a restore that has to fault its memory and
+	// overlay from cold storage (first resume of a migrated VM, page cache
+	// evicted) legitimately needs more than a warm same-host resume, and a
+	// timeout here is destructive — the error path below tears down the VM.
+	if err := m.waitForBoxd(ctx, hostIP, 30*time.Second); err != nil {
 		m.stopUnitDuringRestoreError(vmID)
 		if !inPlace {
 			m.netMgr.CleanupVM(vmID)


### PR DESCRIPTION
## Summary

Restores waited a hardcoded 5s for boxd readiness while creates wait 30s. Warm same-host resumes never noticed, but a restore that faults memory/overlay from cold storage (first resume after artifacts land on a host) routinely exceeds 5s — and the timeout's error path tears the VM down, deleting the per-VM overlay and making every retry worse.

## Technical decisions

One line plus a comment: raise the restore window to match first boot. The wait polls and returns the moment boxd answers, so warm restores see zero added latency; only the failure deadline moves.

## Testing

`GOOS=linux go build/vet` clean. Verified live tonight: restores with warm artifacts succeed in well under a second (boxd ready in 31ms), cold restores exceed 5s and were failing 100% of the time on the west host; the failure signature and the destructive cleanup path are both eliminated by first-attempt success.