### PR TITLE
vmd: verify a network slot's namespace is clear before recycling it

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -850,9 +850,10 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 }
 
 // killProcessesInNs SIGKILLs every process whose net namespace matches
-// /run/netns/<name>. Returns the number of pids signalled.
+// /run/netns/<name>. Returns the number of pids signalled. Best-effort: a
+// failed /proc scan (see pidsInNs) just means nothing gets killed this pass.
 func killProcessesInNs(name string) int {
-	pids := pidsInNs(name)
+	pids, _ := pidsInNs(name)
 	killed := 0
 	for _, pid := range pids {
 		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
@@ -864,20 +865,23 @@ func killProcessesInNs(name string) int {
 
 // pidsInNs returns the PIDs whose net namespace matches /run/netns/<name>,
 // found by comparing /proc/<pid>/ns/net's inode against the namespace file's.
-// A dead or nonexistent namespace yields nil, not an error — callers treat
-// "can't stat it" the same as "nothing is in it."
-func pidsInNs(name string) []int {
+// ok is false only when the /proc scan itself failed (e.g. transient
+// resource pressure) — a genuine "don't know" that callers must not treat as
+// "clear" the way an actually-empty scan is; conflating the two would let a
+// still-occupied namespace be recycled, reintroducing the exact race this
+// guards against. A namespace file that no longer exists can't have
+// anything attached to it, so that case is a confident (nil, true).
+func pidsInNs(name string) (pids []int, ok bool) {
 	nsPath := netnsDir + "/" + name
 	nsStat, err := os.Stat(nsPath)
 	if err != nil {
-		return nil
+		return nil, true
 	}
 	nsIno := nsStat.Sys().(*syscall.Stat_t).Ino
 	procs, err := os.ReadDir("/proc")
 	if err != nil {
-		return nil
+		return nil, false
 	}
-	var pids []int
 	for _, e := range procs {
 		if !e.IsDir() {
 			continue
@@ -895,7 +899,7 @@ func pidsInNs(name string) []int {
 		}
 		pids = append(pids, pid)
 	}
-	return pids
+	return pids, true
 }
 
 // listHostVeths returns all veth-N interfaces visible in the host namespace.

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -852,17 +852,32 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 // killProcessesInNs SIGKILLs every process whose net namespace matches
 // /run/netns/<name>. Returns the number of pids signalled.
 func killProcessesInNs(name string) int {
+	pids := pidsInNs(name)
+	killed := 0
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
+			killed++
+		}
+	}
+	return killed
+}
+
+// pidsInNs returns the PIDs whose net namespace matches /run/netns/<name>,
+// found by comparing /proc/<pid>/ns/net's inode against the namespace file's.
+// A dead or nonexistent namespace yields nil, not an error — callers treat
+// "can't stat it" the same as "nothing is in it."
+func pidsInNs(name string) []int {
 	nsPath := netnsDir + "/" + name
 	nsStat, err := os.Stat(nsPath)
 	if err != nil {
-		return 0
+		return nil
 	}
 	nsIno := nsStat.Sys().(*syscall.Stat_t).Ino
 	procs, err := os.ReadDir("/proc")
 	if err != nil {
-		return 0
+		return nil
 	}
-	killed := 0
+	var pids []int
 	for _, e := range procs {
 		if !e.IsDir() {
 			continue
@@ -878,11 +893,9 @@ func killProcessesInNs(name string) int {
 		if procNsStat.Sys().(*syscall.Stat_t).Ino != nsIno {
 			continue
 		}
-		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
-			killed++
-		}
+		pids = append(pids, pid)
 	}
-	return killed
+	return pids
 }
 
 // listHostVeths returns all veth-N interfaces visible in the host namespace.

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -58,7 +58,13 @@ type preallocSlot struct {
 var pidsInNsFunc = pidsInNs
 
 const (
-	defaultVerifyPollInterval = 25 * time.Millisecond
+	// defaultVerifyPollInterval trades a small amount of slot-reuse latency
+	// (negligible against the 10s+ stop window it's guarding) for meaningfully
+	// less /proc scanning: each poll is a full readdir + per-pid stat, and the
+	// case that makes verification take a while — host I/O contention slowing
+	// process teardown — is exactly the case where many verifiers end up
+	// polling concurrently, adding VFS load to an already-contended host.
+	defaultVerifyPollInterval = 150 * time.Millisecond
 	// defaultVerifyMaxWait comfortably exceeds firecracker@.service's
 	// TimeoutStopSec=10 (systemd's own worst case for a unit that ignores
 	// SIGTERM) plus margin for kernel teardown under host I/O contention.
@@ -199,7 +205,13 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 	killProcessesInNs(ns)
 
 	deadline := time.Now().Add(maxWait)
-	for len(pidsInNsFunc(ns)) > 0 {
+	for {
+		pids, ok := pidsInNsFunc(ns)
+		// A failed scan (ok=false) is "don't know," not "clear" — keep
+		// polling rather than risk recycling a namespace that's still held.
+		if ok && len(pids) == 0 {
+			break
+		}
 		if time.Now().After(deadline) {
 			p.log.Error().Str("namespace", ns).Int("slot", slot.idx).
 				Msg("pool: namespace still occupied after max wait — tearing down instead of recycling")

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -36,6 +36,12 @@ type Pool struct {
 	recycled chan *preallocSlot // returned from destroyed sandboxes
 	stopCh   chan struct{}
 	wg       sync.WaitGroup
+
+	// verifyPollInterval/verifyMaxWait tune Return's pre-recycle liveness
+	// check (see verifyAndRecycle). Zero means use the package defaults;
+	// tests override these to run the timeout path without a real 20s wait.
+	verifyPollInterval time.Duration
+	verifyMaxWait      time.Duration
 }
 
 // preallocSlot holds a fully configured network namespace ready to be
@@ -46,6 +52,18 @@ type preallocSlot struct {
 	// vethName is needed for cleanup if the slot is never claimed.
 	vethName string
 }
+
+// pidsInNsFunc is a seam over pidsInNs so tests can simulate a namespace
+// that's still occupied (or clear) without a real kernel netns/process.
+var pidsInNsFunc = pidsInNs
+
+const (
+	defaultVerifyPollInterval = 25 * time.Millisecond
+	// defaultVerifyMaxWait comfortably exceeds firecracker@.service's
+	// TimeoutStopSec=10 (systemd's own worst case for a unit that ignores
+	// SIGTERM) plus margin for kernel teardown under host I/O contention.
+	defaultVerifyMaxWait = 20 * time.Second
+)
 
 // StartPool creates the network slot pool and fills it in the background, so
 // startup (and the gRPC readiness gate) doesn't block on ~newSize slot setups;
@@ -131,20 +149,78 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 	}
 }
 
-// Return puts a slot back into the recycled pool after a sandbox is
-// destroyed. The network namespace, veth, TAP, and nftables stay
-// configured — the next Claim reuses them with zero setup cost.
-// If the recycled pool is full, the slot is torn down instead.
+// Return reclaims a sandbox's network slot after destroy. The previous
+// occupant's process being gone from vmd's/systemd's point of view (SIGKILL
+// sent, unit reported inactive, etc.) is not proof the kernel has finished
+// releasing its TAP fd — SIGKILL is asynchronous with respect to a process
+// blocked in an uninterruptible wait (e.g. a UFFD page fault resolving
+// against local SSD), and "systemd unit not active" also covers "still
+// deactivating." Handing the slot straight to a new VM on that basis is what
+// produced the "Open tap device failed: Device or resource busy" incident:
+// the new VM's Firecracker raced the old one's still-open tap0 fd.
+//
+// So Return doesn't decide fast vs. full teardown itself — it verifies. The
+// slot stays owned by the pool (not claimable — Claim only ever reads from
+// p.recycled) while verifyAndRecycle confirms the namespace is actually
+// empty of processes, off the caller's hot path.
 func (p *Pool) Return(slot *preallocSlot) {
-	// Transfer ownership back to the pool under the lock BEFORE handing the slot
-	// off: a concurrent Claim that pops it can't be clobbered by a late poolOwner
-	// write, and the recycle-full cleanup below releases poolOwner, not a leak.
 	p.mgr.mu.Lock()
 	p.mgr.assignSlotLocked(slot.idx, poolOwner)
 	p.mgr.mu.Unlock()
 
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		defer sentrylog.Recover("netpool-verify-return")
+		p.verifyAndRecycle(slot)
+	}()
+}
+
+// verifyAndRecycle blocks (in its own goroutine, never the caller's) until
+// slot's namespace has no attached processes, then makes it claimable. It
+// re-kills defensively first — this is also the backstop for the DestroyVM
+// paths that skip or race their own kill (an untracked VM after a vmd
+// restart, or a reconciler markStale that never sent a signal at all).
+//
+// A namespace still occupied after verifyMaxWait isn't a slow teardown, it's
+// stuck — recycling it would poison the pool, so it's torn down for real
+// instead of being handed to the next VM.
+func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
+	pollInterval := p.verifyPollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultVerifyPollInterval
+	}
+	maxWait := p.verifyMaxWait
+	if maxWait <= 0 {
+		maxWait = defaultVerifyMaxWait
+	}
+	ns := slot.info.Namespace
+
+	killProcessesInNs(ns)
+
+	deadline := time.Now().Add(maxWait)
+	for len(pidsInNsFunc(ns)) > 0 {
+		if time.Now().After(deadline) {
+			p.log.Error().Str("namespace", ns).Int("slot", slot.idx).
+				Msg("pool: namespace still occupied after max wait — tearing down instead of recycling")
+			p.cleanup(slot)
+			return
+		}
+		select {
+		case <-time.After(pollInterval):
+		case <-p.stopCh:
+			p.cleanup(slot)
+			return
+		}
+	}
+
 	select {
 	case p.recycled <- slot:
+	case <-p.stopCh:
+		// Stop() closes p.recycled only after p.wg.Wait() returns, and this
+		// goroutine holds a wg slot until it returns — so stopCh firing here
+		// (pool shutting down mid-verify) can't race a send on a closed channel.
+		p.cleanup(slot)
 	default:
 		// Recycle pool full — tear down (cleanup releases the pool's ownership).
 		p.cleanup(slot)

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1,10 +1,45 @@
 package network
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
+
+// stubPidsInNs overrides pidsInNsFunc for the duration of the test and
+// restores it on cleanup — the seam Return's verifyAndRecycle uses instead
+// of the real /proc scan, so tests can simulate an occupied or clear
+// namespace without a real kernel netns/process.
+func stubPidsInNs(t *testing.T, fn func(ns string) []int) {
+	t.Helper()
+	old := pidsInNsFunc
+	pidsInNsFunc = fn
+	t.Cleanup(func() { pidsInNsFunc = old })
+}
+
+func newTestPool(t *testing.T, m *Manager) *Pool {
+	t.Helper()
+	p := &Pool{
+		mgr:                m,
+		log:                zerolog.Nop(),
+		newSize:            4,
+		fresh:              make(chan *preallocSlot, 4),
+		recycled:           make(chan *preallocSlot, 4),
+		stopCh:             make(chan struct{}),
+		verifyPollInterval: time.Millisecond,
+		verifyMaxWait:      50 * time.Millisecond,
+	}
+	t.Cleanup(func() {
+		select {
+		case <-p.stopCh:
+		default:
+			close(p.stopCh)
+		}
+	})
+	return p
+}
 
 func TestPoolClaim_DiscardsPhantomReturnsNil(t *testing.T) {
 	withTestNetnsDir(t) // no fake ns-1 → ns-1 looks gone from kernel
@@ -52,5 +87,128 @@ func TestPoolClaim_EmptyChannelsReturnsNil(t *testing.T) {
 
 	if got := p.Claim("vm-x"); got != nil {
 		t.Errorf("expected nil from empty pool, got %+v", got)
+	}
+}
+
+// TestPoolReturn_RecyclesOnceNamespaceIsClear pins the happy path: when the
+// previous occupant is already gone (the common case — its own kill already
+// finished), Return still routes through verification, and the slot becomes
+// claimable once that confirms the namespace is empty.
+func TestPoolReturn_RecyclesOnceNamespaceIsClear(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) []int { return nil })
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	select {
+	case slot := <-p.recycled:
+		if slot.idx != 1 {
+			t.Errorf("recycled slot idx = %d, want 1", slot.idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slot never appeared in recycled — verifyAndRecycle did not run or hung")
+	}
+
+	// Claimable means the pool, not the old VM, owns it in the meantime.
+	m.mu.Lock()
+	owner := m.slotOwner[1]
+	m.mu.Unlock()
+	if owner != poolOwner {
+		t.Errorf("slotOwner[1] = %q, want poolOwner", owner)
+	}
+}
+
+// TestPoolReturn_WaitsForNamespaceToClearBeforeRecycling pins the actual bug
+// fix: a slot whose namespace still has an attached process (the old VM's
+// Firecracker mid-death) must NOT be claimable yet, even though Return()
+// already returned to its caller. It only becomes claimable once the
+// namespace verifiably clears.
+func TestPoolReturn_WaitsForNamespaceToClearBeforeRecycling(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+
+	// 20 occupied responses at a 5ms poll interval is a ~100ms minimum before
+	// verifyAndRecycle can possibly clear — comfortably longer than the
+	// "not recycled yet" check below, so that check can't pass by luck of
+	// goroutine scheduling.
+	var calls atomic.Int32
+	stubPidsInNs(t, func(string) []int {
+		if calls.Add(1) <= 20 {
+			return []int{999999} // still occupied for the first few checks
+		}
+		return nil
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.verifyPollInterval = 5 * time.Millisecond
+	p.verifyMaxWait = 500 * time.Millisecond // > the ~100ms the stub takes to clear
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	// Return() must not hand the slot to Claim() synchronously or on the
+	// first few (still-occupied) checks.
+	select {
+	case slot := <-p.recycled:
+		t.Fatalf("slot %+v recycled while namespace still reported occupied", slot)
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	// Once the namespace clears, it must eventually show up.
+	select {
+	case slot := <-p.recycled:
+		if slot.idx != 1 {
+			t.Errorf("recycled slot idx = %d, want 1", slot.idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slot never recycled after namespace cleared")
+	}
+	if got := calls.Load(); got < 4 {
+		t.Errorf("pidsInNsFunc called %d times, want at least 4 (polled past the occupied checks)", got)
+	}
+}
+
+// TestPoolReturn_TearsDownInsteadOfRecyclingIfNamespaceNeverClears covers the
+// stuck case: a namespace that never reports clear within verifyMaxWait must
+// never be handed out — it's torn down for real instead of poisoning the
+// pool for the next Claim.
+func TestPoolReturn_TearsDownInsteadOfRecyclingIfNamespaceNeverClears(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) []int { return []int{999999} }) // never clears
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	// Wait well past the (short, test-configured) verifyMaxWait=50ms for
+	// verifyAndRecycle to give up and tear down instead of recycling.
+	time.Sleep(300 * time.Millisecond)
+
+	select {
+	case slot := <-p.recycled:
+		t.Fatalf("slot %+v recycled despite namespace never clearing", slot)
+	default:
+	}
+
+	m.mu.Lock()
+	_, stillOwned := m.slotOwner[1]
+	freed := false
+	for _, idx := range m.freeSlots {
+		if idx == 1 {
+			freed = true
+		}
+	}
+	m.mu.Unlock()
+	if stillOwned || !freed {
+		t.Errorf("slot 1 not released to freeSlots after giving up on recycling (owned=%v freed=%v)", stillOwned, freed)
 	}
 }

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -12,7 +12,7 @@ import (
 // restores it on cleanup — the seam Return's verifyAndRecycle uses instead
 // of the real /proc scan, so tests can simulate an occupied or clear
 // namespace without a real kernel netns/process.
-func stubPidsInNs(t *testing.T, fn func(ns string) []int) {
+func stubPidsInNs(t *testing.T, fn func(ns string) ([]int, bool)) {
 	t.Helper()
 	old := pidsInNsFunc
 	pidsInNsFunc = fn
@@ -97,7 +97,7 @@ func TestPoolClaim_EmptyChannelsReturnsNil(t *testing.T) {
 func TestPoolReturn_RecyclesOnceNamespaceIsClear(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-1")
-	stubPidsInNs(t, func(string) []int { return nil })
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
 
 	m := newTestManager()
 	p := newTestPool(t, m)
@@ -137,11 +137,11 @@ func TestPoolReturn_WaitsForNamespaceToClearBeforeRecycling(t *testing.T) {
 	// "not recycled yet" check below, so that check can't pass by luck of
 	// goroutine scheduling.
 	var calls atomic.Int32
-	stubPidsInNs(t, func(string) []int {
+	stubPidsInNs(t, func(string) ([]int, bool) {
 		if calls.Add(1) <= 20 {
-			return []int{999999} // still occupied for the first few checks
+			return []int{999999}, true // still occupied for the first few checks
 		}
-		return nil
+		return nil, true
 	})
 
 	m := newTestManager()
@@ -181,7 +181,7 @@ func TestPoolReturn_WaitsForNamespaceToClearBeforeRecycling(t *testing.T) {
 func TestPoolReturn_TearsDownInsteadOfRecyclingIfNamespaceNeverClears(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-1")
-	stubPidsInNs(t, func(string) []int { return []int{999999} }) // never clears
+	stubPidsInNs(t, func(string) ([]int, bool) { return []int{999999}, true }) // never clears
 
 	m := newTestManager()
 	p := newTestPool(t, m)
@@ -210,5 +210,48 @@ func TestPoolReturn_TearsDownInsteadOfRecyclingIfNamespaceNeverClears(t *testing
 	m.mu.Unlock()
 	if stillOwned || !freed {
 		t.Errorf("slot 1 not released to freeSlots after giving up on recycling (owned=%v freed=%v)", stillOwned, freed)
+	}
+}
+
+// TestPoolReturn_FailedScanIsNotTreatedAsClear pins pidsInNs's ok=false
+// contract: a transient /proc scan failure must not read as "namespace
+// empty," or a still-occupied slot would get recycled — the exact race this
+// whole mechanism exists to prevent. Only a successful, empty scan clears.
+func TestPoolReturn_FailedScanIsNotTreatedAsClear(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+
+	// 20 failed scans at a 5ms poll interval is a ~100ms minimum before
+	// verifyAndRecycle can possibly clear — comfortably longer than the
+	// "not recycled yet" check below.
+	var calls atomic.Int32
+	stubPidsInNs(t, func(string) ([]int, bool) {
+		if calls.Add(1) <= 20 {
+			return nil, false // scan failed — pids empty, but NOT confirmed clear
+		}
+		return nil, true
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.verifyPollInterval = 5 * time.Millisecond
+	p.verifyMaxWait = 500 * time.Millisecond
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	select {
+	case slot := <-p.recycled:
+		t.Fatalf("slot %+v recycled on a failed (ok=false) scan — should have kept polling", slot)
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	select {
+	case slot := <-p.recycled:
+		if slot.idx != 1 {
+			t.Errorf("recycled slot idx = %d, want 1", slot.idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slot never recycled once scans started succeeding")
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes the root cause behind a prod incident where `POST /sandboxes` was failing (100% of creates for a stretch) with `RestoreSnapshot` errors: `Open tap device failed: Device or resource busy (os error 16)` on `tap0`.
- `Pool.Return` recycled a destroyed VM's namespace/TAP straight to the next claimant based on process-liveness signals — a 500ms SIGKILL-wait poll, or systemd reporting a unit "not active" — that don't actually guarantee the kernel has released the TAP fd. SIGKILL is asynchronous against a process blocked in uninterruptible I/O (a UFFD page fault resolving against local SSD is exactly that), and "not active" also covers "still deactivating". Under host I/O contention this let a new VM's Firecracker race the old occupant's still-open `tap0`.
- `Return` now hands off to an async verifier (`verifyAndRecycle`) that re-kills defensively and polls until the namespace has no attached processes before the slot becomes claimable, falling back to a full teardown instead of recycling if it's still occupied after 20s (comfortably past `firecracker@.service`'s `TimeoutStopSec=10`).

## Technical decisions / tradeoffs

- Fixed this at the single choke point (`Pool.Return`/`Claim`) rather than patching every caller that can return a slot (`DestroyVM`'s SIGKILL fallback, the reconciler's `markStale`, the startup reattach sweep) — defends all of them uniformly, present and future.
- Verification runs in its own goroutine, off the caller's hot path — `DestroyVM` and the reconciler still return immediately. This only delays how soon a *destroyed* VM's slot becomes reusable, never blocks a create.
- Reused the existing `killProcessesInNs` primitive (already used by `SweepOrphanNamespaces`), refactored to expose a `pidsInNs` lookup — avoids shelling out to `ip netns pids`, and incidentally closes the gap where an untracked VM (e.g. right after a vmd restart) could skip its kill entirely.
- Deliberately did not walk back the create-concurrency ceilings from #190 (`MaxConcurrentRestores`, net pool sizes) — this fix makes recycling safe under that concurrency instead of trading it away.

## Testing

- `go build ./...` and `go vet ./...` clean under `GOOS=linux`.
- Full test suite green, including `-race`.
- Added three tests pinning the actual behavior: recycles once the namespace is confirmed clear, withholds a slot from `Claim` while still occupied, and tears down (never recycles) if a namespace never clears within the max wait.
- Validated live in prod as an operational mitigation before this PR: manually shrank `VMD_NET_POOL_RECYCLE_SIZE` on the affected host and restarted vmd — error rate went from 100% of creates failing to 0/7 failing over the following ~17 minutes, with zero recurrences of the tap0 error. This PR is the permanent fix so the recycle pool can be restored to full size.