### PR TITLE
proxy: accept a set of sandbox domains via PROXY_DOMAINS

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -68,6 +68,7 @@ jobs:
           SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_STAGING }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_STAGING }}
           PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_STAGING }}
+          PROXY_DOMAINS: ${{ vars.PROXY_DOMAINS_STAGING }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_STAGING }}
         run: |
           python3 .github/workflows/scripts/deploy-proxy.py
@@ -117,6 +118,7 @@ jobs:
           SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
           PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
+          PROXY_DOMAINS: ${{ vars.PROXY_DOMAINS_PROD }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
@@ -151,6 +153,7 @@ jobs:
           SHA: ${{ github.sha }}
           PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
           PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_USW }}
+          PROXY_DOMAINS: ${{ vars.PROXY_DOMAINS_USW }}
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -14,6 +14,8 @@ Env vars:
   VMD_INSTALL_DIR            required — bin install dir on the host
   SHA                        required — commit SHA (only first 8 chars used)
   PROXY_DOMAIN               required — host suffix the proxy serves (e.g. sandbox.superserve.ai)
+  PROXY_DOMAINS              optional — comma-separated host suffixes; overrides
+                             PROXY_DOMAIN on the proxy when set (DNS transitions)
   SANDBOX_ACCESS_TOKEN_SEED  optional — hex, >=32 bytes (>=64 hex chars)
   PROXY_ALLOWED_ORIGINS      optional — comma-separated origin patterns
   REQUIRE_DATA_PLANE         optional — "", "0", or "1"
@@ -44,10 +46,14 @@ def main() -> int:
         return 1
     # Optional multi-domain set for DNS/hostname transitions; the proxy
     # prefers PROXY_DOMAINS over PROXY_DOMAIN when both are present.
+    # Validated per-entry (not as one blob) so a space-separated list
+    # fails loudly here instead of deploying a domain string that can
+    # never match a Host — the proxy only splits on commas.
     proxy_domains = os.environ.get("PROXY_DOMAINS", "")
-    if proxy_domains and not re.fullmatch(r"[A-Za-z0-9.,\- ]+", proxy_domains):
-        print("ERROR: PROXY_DOMAINS contains disallowed characters", file=sys.stderr)
-        return 1
+    for entry in filter(None, (s.strip() for s in proxy_domains.split(","))):
+        if not re.fullmatch(r"[A-Za-z0-9.\-]+", entry):
+            print("ERROR: PROXY_DOMAINS contains an invalid domain", file=sys.stderr)
+            return 1
     access_seed = os.environ.get("SANDBOX_ACCESS_TOKEN_SEED", "")
     if access_seed and not re.fullmatch(r"[0-9a-fA-F]{64,}", access_seed):
         print("ERROR: SANDBOX_ACCESS_TOKEN_SEED must be hex-encoded, >= 32 bytes (64 hex chars)", file=sys.stderr)

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -42,6 +42,12 @@ def main() -> int:
     if not re.fullmatch(r"[A-Za-z0-9.\-]+", proxy_domain):
         print("ERROR: PROXY_DOMAIN contains disallowed characters", file=sys.stderr)
         return 1
+    # Optional multi-domain set for DNS/hostname transitions; the proxy
+    # prefers PROXY_DOMAINS over PROXY_DOMAIN when both are present.
+    proxy_domains = os.environ.get("PROXY_DOMAINS", "")
+    if proxy_domains and not re.fullmatch(r"[A-Za-z0-9.,\- ]+", proxy_domains):
+        print("ERROR: PROXY_DOMAINS contains disallowed characters", file=sys.stderr)
+        return 1
     access_seed = os.environ.get("SANDBOX_ACCESS_TOKEN_SEED", "")
     if access_seed and not re.fullmatch(r"[0-9a-fA-F]{64,}", access_seed):
         print("ERROR: SANDBOX_ACCESS_TOKEN_SEED must be hex-encoded, >= 32 bytes (64 hex chars)", file=sys.stderr)
@@ -125,6 +131,7 @@ def main() -> int:
             sudo mkdir -p /etc/sandbox
             sudo tee /etc/sandbox/proxy.env > /dev/null <<PROXYENV
             PROXY_DOMAIN={proxy_domain}
+            PROXY_DOMAINS={proxy_domains}
             SANDBOX_ACCESS_TOKEN_SEED={access_seed}
             PROXY_ALLOWED_ORIGINS={terminal_origins}
             REQUIRE_DATA_PLANE={require_data_plane}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -38,19 +38,19 @@ func main() {
 	addr := envOrDefault("PROXY_ADDR", ":5007")
 	redirectAddr := envOrDefault("PROXY_REDIRECT_ADDR", ":5008")
 	vmdAddr := envOrDefault("VMD_ADDR", "http://127.0.0.1:9090")
-	domain := envOrDefault("PROXY_DOMAIN", "sandbox.superserve.ai")
+	domains := proxyDomains()
 
 	log.Info().
 		Str("addr", addr).
 		Str("vmd_addr", vmdAddr).
-		Str("domain", domain).
+		Strs("domains", domains).
 		Msg("starting edge proxy")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	resolver := proxy.NewVMDResolver(vmdAddr)
-	proxyHandler := proxy.NewHandler(domain, resolver, log)
+	proxyHandler := proxy.NewHandler(domains, resolver, log)
 	proxyHandler.StartSweeper(ctx)
 
 	// Product-usage analytics for exec/files — no-op when POSTHOG_KEY is unset.
@@ -101,16 +101,21 @@ func main() {
 
 	// Health check for the GCP LB. Only responds on non-sandbox hosts
 	// so the boxd-label lockdown isn't bypassed.
-	domainSuffix := "." + domain
+	domainSuffixes := make([]string, len(domains))
+	for i, d := range domains {
+		domainSuffixes[i] = "." + d
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
 		if i := strings.IndexByte(host, ':'); i >= 0 {
 			host = host[:i]
 		}
-		if strings.HasSuffix(host, domainSuffix) {
-			proxyHandler.ServeHTTP(w, r)
-			return
+		for _, suffix := range domainSuffixes {
+			if strings.HasSuffix(host, suffix) {
+				proxyHandler.ServeHTTP(w, r)
+				return
+			}
 		}
 		w.WriteHeader(http.StatusOK)
 	})
@@ -146,6 +151,18 @@ func main() {
 	_ = redirectSrv.Shutdown(shutCtx)
 
 	log.Info().Msg("proxy stopped")
+}
+
+// proxyDomains resolves the set of sandbox domains the proxy accepts.
+// PROXY_DOMAINS (comma-separated) takes precedence so one deploy can serve
+// both the legacy hostname and the region-prefixed hostname during a DNS
+// transition; otherwise the single-value PROXY_DOMAIN keeps existing
+// deploys unchanged.
+func proxyDomains() []string {
+	if domains := splitCSV(os.Getenv("PROXY_DOMAINS")); len(domains) > 0 {
+		return domains
+	}
+	return []string{envOrDefault("PROXY_DOMAIN", "sandbox.superserve.ai")}
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -39,6 +40,10 @@ func main() {
 	redirectAddr := envOrDefault("PROXY_REDIRECT_ADDR", ":5008")
 	vmdAddr := envOrDefault("VMD_ADDR", "http://127.0.0.1:9090")
 	domains := proxyDomains()
+	if legacy := os.Getenv("PROXY_DOMAIN"); legacy != "" && !slices.Contains(domains, legacy) {
+		log.Warn().Str("proxy_domain", legacy).Strs("effective_domains", domains).
+			Msg("PROXY_DOMAIN is set but not in the effective domain list — PROXY_DOMAINS overrides it and this host will stop serving it")
+	}
 
 	log.Info().
 		Str("addr", addr).
@@ -101,21 +106,11 @@ func main() {
 
 	// Health check for the GCP LB. Only responds on non-sandbox hosts
 	// so the boxd-label lockdown isn't bypassed.
-	domainSuffixes := make([]string, len(domains))
-	for i, d := range domains {
-		domainSuffixes[i] = "." + d
-	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		host := r.Host
-		if i := strings.IndexByte(host, ':'); i >= 0 {
-			host = host[:i]
-		}
-		for _, suffix := range domainSuffixes {
-			if strings.HasSuffix(host, suffix) {
-				proxyHandler.ServeHTTP(w, r)
-				return
-			}
+		if proxyHandler.ServesHost(r.Host) {
+			proxyHandler.ServeHTTP(w, r)
+			return
 		}
 		w.WriteHeader(http.StatusOK)
 	})

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProxyDomains(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains string // PROXY_DOMAINS
+		domain  string // PROXY_DOMAIN
+		want    []string
+	}{
+		{
+			name: "default when nothing configured",
+			want: []string{"sandbox.superserve.ai"},
+		},
+		{
+			name:   "single PROXY_DOMAIN fallback",
+			domain: "usw-sandbox.superserve.ai",
+			want:   []string{"usw-sandbox.superserve.ai"},
+		},
+		{
+			name:    "comma-separated list",
+			domains: "sandbox.superserve.ai,usw-sandbox.superserve.ai",
+			want:    []string{"sandbox.superserve.ai", "usw-sandbox.superserve.ai"},
+		},
+		{
+			name:    "whitespace and empty entries tolerated",
+			domains: " sandbox.superserve.ai , ,usw-sandbox.superserve.ai ",
+			want:    []string{"sandbox.superserve.ai", "usw-sandbox.superserve.ai"},
+		},
+		{
+			name:    "PROXY_DOMAINS wins over PROXY_DOMAIN",
+			domains: "usw-sandbox.superserve.ai",
+			domain:  "sandbox.superserve.ai",
+			want:    []string{"usw-sandbox.superserve.ai"},
+		},
+		{
+			name:    "blank PROXY_DOMAINS falls back",
+			domains: " , ",
+			domain:  "usw-sandbox.superserve.ai",
+			want:    []string{"usw-sandbox.superserve.ai"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PROXY_DOMAINS", tt.domains)
+			t.Setenv("PROXY_DOMAIN", tt.domain)
+			if got := proxyDomains(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("proxyDomains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -55,7 +55,7 @@ func newExecTestEnv(t *testing.T) *filesTestEnv {
 		},
 	}
 
-	env.handler = NewHandler(env.domain, env.resolver, zerolog.Nop())
+	env.handler = NewHandler([]string{env.domain}, env.resolver, zerolog.Nop())
 	env.handler.WithAuth(seedKey).WithExec()
 
 	// Redirect transport at the per-sandbox cache so the boxd-internal
@@ -181,7 +181,7 @@ func TestExec_NotEnabled_404(t *testing.T) {
 	domain := "sandbox.test"
 	sandboxID := "sbx-" + strings.Repeat("z", 8)
 
-	h := NewHandler(domain, &stubResolver{info: InstanceInfo{VMIP: "127.0.0.1", Status: "running"}}, zerolog.Nop())
+	h := NewHandler([]string{domain}, &stubResolver{info: InstanceInfo{VMIP: "127.0.0.1", Status: "running"}}, zerolog.Nop())
 	h.WithAuth(seedKey) // WithExec deliberately not called
 
 	req := httptest.NewRequest(http.MethodPost, "http://unused/exec", strings.NewReader(`{"command":"echo"}`))
@@ -201,7 +201,7 @@ func TestExec_WithoutWithAuth_Panics(t *testing.T) {
 			t.Error("expected panic when WithExec called before WithAuth")
 		}
 	}()
-	h := NewHandler("sandbox.test", &stubResolver{}, zerolog.Nop())
+	h := NewHandler([]string{"sandbox.test"}, &stubResolver{}, zerolog.Nop())
 	h.WithExec()
 }
 

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -305,7 +305,7 @@ func TestServeExecWS_ForeignOriginAccepted(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(domain, resolver, zerolog.Nop())
+	h := NewHandler([]string{domain}, resolver, zerolog.Nop())
 	// Deliberately restrict the terminal allowlist to a console origin —
 	// exec/ws must ignore it and accept a different (customer) origin.
 	h.WithAuth(seedKey).WithExec().WithTerminal([]string{"https://console.example.com"})

--- a/internal/proxy/files_test.go
+++ b/internal/proxy/files_test.go
@@ -107,7 +107,7 @@ func newFilesTestEnv(t *testing.T) *filesTestEnv {
 		},
 	}
 
-	env.handler = NewHandler(env.domain, env.resolver, zerolog.Nop())
+	env.handler = NewHandler([]string{env.domain}, env.resolver, zerolog.Nop())
 	env.handler.WithAuth(seedKey).WithTerminal([]string{"*"}).WithFiles()
 
 	upHost := upURL.Host

--- a/internal/proxy/host.go
+++ b/internal/proxy/host.go
@@ -20,14 +20,14 @@ const headerSandboxID = "X-Superserve-Sandbox-Id"
 // ParseRequest resolves the target sandbox + port from an incoming request.
 // Two routing modes:
 //
-//   - Shared-host: Host equals the configured domain and the
+//   - Shared-host: Host equals one of the configured domains and the
 //     X-Superserve-Sandbox-Id header carries the ID. Always boxdPort.
 //
 //   - Subdomain: Host is "{label}-{id}.{domain}", same as ParseHost.
 //
 // A subdomain-form Host is never overridden by a routing header.
-func ParseRequest(host string, headers http.Header, domain string) (port int, instanceID string, err error) {
-	if isSharedHost(host, domain) {
+func ParseRequest(host string, headers http.Header, domains []string) (port int, instanceID string, err error) {
+	if isSharedHost(host, domains) {
 		id := headers.Get(headerSandboxID)
 		if id == "" {
 			return 0, "", fmt.Errorf("proxy: shared host %q requires %s header", host, headerSandboxID)
@@ -37,7 +37,7 @@ func ParseRequest(host string, headers http.Header, domain string) (port int, in
 		}
 		return boxdPort, normalizeInstanceID(id), nil
 	}
-	return ParseHost(host, domain)
+	return ParseHost(host, domains)
 }
 
 // normalizeInstanceID strips the public region prefix (sb-<region>-) from a
@@ -82,13 +82,32 @@ func validRegionCode(s string) bool {
 	return true
 }
 
-// isSharedHost reports whether host (with any :port stripped) equals the configured domain.
-func isSharedHost(host, domain string) bool {
+// isSharedHost reports whether host (with any :port stripped) equals one of
+// the configured domains.
+func isSharedHost(host string, domains []string) bool {
 	hostname, _, err := net.SplitHostPort(host)
 	if err != nil {
 		hostname = host
 	}
-	return hostname == domain
+	for _, d := range domains {
+		if hostname == d {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesDomain reports whether hostname ends in "." plus one of the
+// configured domains. Each domain gets the same case-sensitive suffix
+// check the single-domain proxy used, so per-domain semantics are
+// unchanged — only the number of accepted suffixes grows.
+func matchesDomain(hostname string, domains []string) bool {
+	for _, d := range domains {
+		if strings.HasSuffix(hostname, "."+d) {
+			return true
+		}
+	}
+	return false
 }
 
 // boxdHostLabel is the reserved left-most label that addresses boxd's
@@ -114,10 +133,10 @@ const boxdHostLabel = "boxd"
 //     threshold, which routes to that user-application port on the
 //     VM.
 //
-// Returns ErrInvalidHost if the host doesn't end with the expected
-// domain suffix, so the proxy rejects forged Host headers pointing at
+// Returns an error if the host doesn't end with any of the expected
+// domain suffixes, so the proxy rejects forged Host headers pointing at
 // arbitrary backends.
-func ParseHost(host, domain string) (port int, instanceID string, err error) {
+func ParseHost(host string, domains []string) (port int, instanceID string, err error) {
 	// Strip TCP port from Host if present (e.g. "boxd-abc.sandbox.superserve.ai:443")
 	hostname, _, splitErr := net.SplitHostPort(host)
 	if splitErr != nil {
@@ -125,8 +144,8 @@ func ParseHost(host, domain string) (port int, instanceID string, err error) {
 	}
 
 	// Validate domain suffix — prevents accepting any Host: label-id.attacker.com
-	if !strings.HasSuffix(hostname, "."+domain) {
-		return 0, "", fmt.Errorf("proxy: host %q does not end in .%s", hostname, domain)
+	if !matchesDomain(hostname, domains) {
+		return 0, "", fmt.Errorf("proxy: host %q does not end in any accepted domain %v", hostname, domains)
 	}
 
 	// Take the leftmost label only: "boxd-abc123" or "3000-mybox"

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -246,6 +246,33 @@ func TestParseHost_MultiDomain(t *testing.T) {
 	}
 }
 
+// ServesHost backs the LB health-check gate, so it must accept exactly the
+// hosts ParseHost would route and reject everything else.
+func TestServesHost(t *testing.T) {
+	domains := []string{testDomain, "usw-sandbox.superserve.ai"}
+	h := NewHandler(domains, &stubResolver{}, zerolog.Nop())
+
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"boxd-abc123." + testDomain, true},
+		{"boxd-abc123.usw-sandbox.superserve.ai", true},
+		{"boxd-abc123.usw-sandbox.superserve.ai:443", true},
+		{testDomain, false}, // bare domain: shared-host form, not a subdomain
+		{"boxd-abc123.euw-sandbox.superserve.ai", false},
+		{"boxd-abc123." + testDomain + ".attacker.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := h.ServesHost(tt.host); got != tt.want {
+				t.Errorf("ServesHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 // Shared-host header routing works on any configured domain, not just the first.
 func TestParseRequest_MultiDomainSharedHost(t *testing.T) {
 	const sandboxID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"

--- a/internal/proxy/host_test.go
+++ b/internal/proxy/host_test.go
@@ -2,7 +2,10 @@ package proxy
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
 
 const testDomain = "sandbox.superserve.ai"
@@ -148,7 +151,7 @@ func TestParseHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
-			port, instanceID, err := ParseHost(tt.host, testDomain)
+			port, instanceID, err := ParseHost(tt.host, []string{testDomain})
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got port=%d instanceID=%q", port, instanceID)
@@ -163,6 +166,134 @@ func TestParseHost(t *testing.T) {
 			}
 			if instanceID != tt.wantInstanceID {
 				t.Errorf("instanceID: got %q, want %q", instanceID, tt.wantInstanceID)
+			}
+		})
+	}
+}
+
+// With several configured domains — during a DNS transition the legacy
+// hostname and the region-prefixed hostname must both route — every entry
+// gets the same suffix check a single domain got.
+func TestParseHost_MultiDomain(t *testing.T) {
+	domains := []string{testDomain, "usw-sandbox.superserve.ai"}
+
+	tests := []struct {
+		host           string
+		wantPort       int
+		wantInstanceID string
+		wantErr        bool
+	}{
+		// Each configured domain routes.
+		{
+			host:           "boxd-abc123." + testDomain,
+			wantPort:       boxdPort,
+			wantInstanceID: "abc123",
+		},
+		{
+			host:           "boxd-abc123.usw-sandbox.superserve.ai",
+			wantPort:       boxdPort,
+			wantInstanceID: "abc123",
+		},
+		// TCP ports in Host are stripped on every domain.
+		{
+			host:           "boxd-abc123.usw-sandbox.superserve.ai:443",
+			wantPort:       boxdPort,
+			wantInstanceID: "abc123",
+		},
+		{
+			host:           "3000-mybox.usw-sandbox.superserve.ai:8443",
+			wantPort:       3000,
+			wantInstanceID: "mybox",
+		},
+
+		// Unconfigured domains are rejected, including near-misses.
+		{
+			host:    "boxd-abc123.euw-sandbox.superserve.ai",
+			wantErr: true,
+		},
+		{
+			host:    "boxd-abc.usw-sandbox.superserve.ai.attacker.com",
+			wantErr: true,
+		},
+
+		// Matching stays case-sensitive, exactly like the single-domain
+		// check it generalizes.
+		{
+			host:    "boxd-abc123.USW-SANDBOX.SUPERSERVE.AI",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			port, instanceID, err := ParseHost(tt.host, domains)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got port=%d instanceID=%q", port, instanceID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tt.wantPort {
+				t.Errorf("port: got %d, want %d", port, tt.wantPort)
+			}
+			if instanceID != tt.wantInstanceID {
+				t.Errorf("instanceID: got %q, want %q", instanceID, tt.wantInstanceID)
+			}
+		})
+	}
+}
+
+// Shared-host header routing works on any configured domain, not just the first.
+func TestParseRequest_MultiDomainSharedHost(t *testing.T) {
+	const sandboxID = "b150ee22-4956-4f5b-926a-f921ed8c37d6"
+	domains := []string{testDomain, "usw-sandbox.superserve.ai"}
+
+	headers := http.Header{}
+	headers.Set(headerSandboxID, sandboxID)
+
+	port, gotID, err := ParseRequest("usw-sandbox.superserve.ai:443", headers, domains)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != boxdPort {
+		t.Errorf("port: got %d, want %d", port, boxdPort)
+	}
+	if gotID != sandboxID {
+		t.Errorf("instanceID: got %q, want %q", gotID, sandboxID)
+	}
+}
+
+// ServeHTTP accepts sandbox hosts on every configured domain and rejects the
+// rest before any resolver lookup: 404 means the host parsed and reached the
+// resolver; 400 means the domain check refused it.
+func TestHandler_MultiDomainHostCheck(t *testing.T) {
+	domains := []string{testDomain, "usw-sandbox.superserve.ai"}
+	h := NewHandler(domains, &stubResolver{err: ErrInstanceNotFound}, zerolog.Nop())
+
+	tests := []struct {
+		host       string
+		wantStatus int
+	}{
+		{"3000-mybox." + testDomain, http.StatusNotFound},
+		{"3000-mybox.usw-sandbox.superserve.ai", http.StatusNotFound},
+		{"3000-mybox.usw-sandbox.superserve.ai:443", http.StatusNotFound},
+		{"3000-mybox.euw-sandbox.superserve.ai", http.StatusBadRequest},
+		{"3000-mybox.attacker.com", http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://unused/", nil)
+			req.Host = tt.host
+			w := httptest.NewRecorder()
+
+			h.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status: got %d, want %d; body: %s", w.Code, tt.wantStatus, w.Body.String())
 			}
 		})
 	}
@@ -245,7 +376,7 @@ func TestParseRequest(t *testing.T) {
 			if tt.headerID != "" {
 				headers.Set(headerSandboxID, tt.headerID)
 			}
-			port, instanceID, err := ParseRequest(tt.host, headers, testDomain)
+			port, instanceID, err := ParseRequest(tt.host, headers, []string{testDomain})
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got port=%d instanceID=%q", port, instanceID)
@@ -273,7 +404,7 @@ func TestParseRequest_HeaderRoutingRequiresSharedHost(t *testing.T) {
 	headers := http.Header{}
 	headers.Set(headerSandboxID, attackerID)
 
-	_, gotID, err := ParseRequest("boxd-"+targetID+"."+testDomain, headers, testDomain)
+	_, gotID, err := ParseRequest("boxd-"+targetID+"."+testDomain, headers, []string{testDomain})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -56,9 +56,9 @@ const (
 type Handler struct {
 	// domains are the accepted hostname suffixes, e.g.
 	// ["sandbox.superserve.ai", "usw-sandbox.superserve.ai"]. All entries
-	// are valid for routing; the first is canonical should the proxy ever
-	// need to construct a sandbox URL (today it only validates Hosts and
-	// echoes them back, so ordering has no runtime effect).
+	// are equivalent for validation — the proxy only checks whether a
+	// Host ends in one of them and echoes the Host back, it never picks
+	// one to construct a URL from.
 	domains      []string
 	resolver     Resolver
 	transports   *transportCache
@@ -129,6 +129,18 @@ func NewHandler(domains []string, resolver Resolver, log zerolog.Logger) *Handle
 		log:          log,
 	}
 	return h
+}
+
+// ServesHost reports whether host (with any :port stripped) is a subdomain
+// of one of the configured domains — the same check ParseHost applies.
+// Used by the LB health-check gate so its accept set can't drift from
+// routing's via a second hand-rolled copy.
+func (h *Handler) ServesHost(host string) bool {
+	hostname, _, err := net.SplitHostPort(host)
+	if err != nil {
+		hostname = host
+	}
+	return matchesDomain(hostname, h.domains)
 }
 
 // WithAnalytics enables data-plane usage events (exec/files).

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -54,7 +54,12 @@ const (
 
 // Handler is the core reverse proxy handler.
 type Handler struct {
-	domain       string // expected hostname suffix, e.g. "sandbox.superserve.ai"
+	// domains are the accepted hostname suffixes, e.g.
+	// ["sandbox.superserve.ai", "usw-sandbox.superserve.ai"]. All entries
+	// are valid for routing; the first is canonical should the proxy ever
+	// need to construct a sandbox URL (today it only validates Hosts and
+	// echoes them back, so ordering has no runtime effect).
+	domains      []string
 	resolver     Resolver
 	transports   *transportCache
 	sandboxConns *connLimiter
@@ -113,10 +118,10 @@ func (h *Handler) originAllowed(origin string) bool {
 }
 
 // NewHandler creates a proxy Handler that only accepts requests whose Host
-// header ends in ".{domain}".
-func NewHandler(domain string, resolver Resolver, log zerolog.Logger) *Handler {
+// header ends in ".{domain}" for one of the given domains.
+func NewHandler(domains []string, resolver Resolver, log zerolog.Logger) *Handler {
 	h := &Handler{
-		domain:       domain,
+		domains:      domains,
 		resolver:     resolver,
 		transports:   newTransportCache(),
 		sandboxConns: newConnLimiter(maxConnsPerSandbox),
@@ -161,7 +166,7 @@ func (h *Handler) StartSweeper(ctx context.Context) {
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	port, instanceID, err := ParseRequest(r.Host, r.Header, h.domain)
+	port, instanceID, err := ParseRequest(r.Host, r.Header, h.domains)
 	if err != nil {
 		h.log.Warn().Err(err).Str("host", r.Host).Msg("bad host")
 		http.Error(w, "invalid sandbox URL", http.StatusBadRequest)

--- a/internal/proxy/terminal_test.go
+++ b/internal/proxy/terminal_test.go
@@ -535,7 +535,7 @@ func TestServeTerminal_AllowedOriginAccepted(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(domain, resolver, zerolog.Nop())
+	h := NewHandler([]string{domain}, resolver, zerolog.Nop())
 	h.WithAuth(seedKey).WithTerminal([]string{"http://127.0.0.1:*"}).WithFiles()
 
 	upHost := upURL.Host


### PR DESCRIPTION
## Summary

During the edge DNS/LB transition, sandbox traffic arrives on both the legacy hostname and the region-prefixed hostname, and the same proxy deployment has to serve both. This adds `PROXY_DOMAINS` (comma-separated, whitespace-tolerant); when unset, the single-value `PROXY_DOMAIN` is used as before, so current deploys are unaffected. The effective list is logged at startup.

## Technical decisions

- `ParseHost`/`ParseRequest`/`NewHandler` now take a domain slice; per-domain semantics (port stripping via `SplitHostPort`, case-sensitive suffix match, shared-host exact match) are unchanged — only the number of accepted suffixes grows.
- The proxy never constructs sandbox URLs from the configured domain (it only validates Hosts and echoes them back), so nothing needed a canonical pick; the `Handler.domains` field documents that the first entry is canonical should that ever change.
- The LB health-check gate in `cmd/proxy/main.go` checks all configured suffixes, so the boxd-label lockdown holds on every accepted domain.
- `EDGE_PROXY_DOMAIN` (control plane, `internal/config`) is deliberately untouched: the control plane keeps minting URLs on one canonical domain per cell; the proxy accepting more hostnames is what unblocks the DNS cutover.

## Testing

- New table-driven tests: multi-domain `ParseHost` (each domain accepted, unknown/near-miss rejected, port-suffixed Hosts, case variance), shared-host routing on a non-first domain, handler-level accept/reject, and `proxyDomains()` fallback/precedence/whitespace handling.
- `gofmt`, `go vet`, `go test ./cmd/proxy/... ./internal/proxy/...` all pass; `GOOS=linux go build ./...` clean.