### PR TITLE
api: raise platform template ceilings to 10GiB memory / 20GiB disk

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2420,17 +2420,17 @@ components:
         vcpu:
           type: integer
           minimum: 1
-          maximum: 4
+          maximum: 8
           default: 1
         memory_mib:
           type: integer
           minimum: 256
-          maximum: 4096
+          maximum: 10240
           default: 1024
         disk_mib:
           type: integer
           minimum: 1024
-          maximum: 8192
+          maximum: 20480
           default: 4096
         build_spec:
           $ref: "#/components/schemas/BuildSpec"

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -97,8 +97,8 @@ const (
 
 	// Platform ceiling — applies to every team including system.
 	absoluteMaxVcpu      = 4
-	absoluteMaxMemoryMib = 4096
-	absoluteMaxDiskMib   = 8192
+	absoluteMaxMemoryMib = 10240
+	absoluteMaxDiskMib   = 20480
 
 	// Customer-team defaults (overridable via team.max_template_*).
 	defaultMaxVcpu      = 2

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -96,7 +96,7 @@ const (
 	maxName = 128
 
 	// Platform ceiling — applies to every team including system.
-	absoluteMaxVcpu      = 4
+	absoluteMaxVcpu      = 8
 	absoluteMaxMemoryMib = 10240
 	absoluteMaxDiskMib   = 20480
 

--- a/supabase/migrations/20260710000001_raise_template_size_limits.sql
+++ b/supabase/migrations/20260710000001_raise_template_size_limits.sql
@@ -1,10 +1,12 @@
 -- Raise template size CHECK constraints to match the new platform ceilings
--- (memory 10 GiB, disk 20 GiB).
+-- (8 vcpu, memory 10 GiB, disk 20 GiB).
 
 ALTER TABLE template
+  DROP CONSTRAINT IF EXISTS template_vcpu_range,
   DROP CONSTRAINT IF EXISTS template_memory_range,
   DROP CONSTRAINT IF EXISTS template_disk_range;
 
 ALTER TABLE template
+  ADD CONSTRAINT template_vcpu_range CHECK (vcpu BETWEEN 1 AND 8),
   ADD CONSTRAINT template_memory_range CHECK (memory_mib BETWEEN 256 AND 10240),
   ADD CONSTRAINT template_disk_range CHECK (disk_mib BETWEEN 1024 AND 20480);

--- a/supabase/migrations/20260710000001_raise_template_size_limits.sql
+++ b/supabase/migrations/20260710000001_raise_template_size_limits.sql
@@ -1,0 +1,10 @@
+-- Raise template size CHECK constraints to match the new platform ceilings
+-- (memory 10 GiB, disk 20 GiB).
+
+ALTER TABLE template
+  DROP CONSTRAINT IF EXISTS template_memory_range,
+  DROP CONSTRAINT IF EXISTS template_disk_range;
+
+ALTER TABLE template
+  ADD CONSTRAINT template_memory_range CHECK (memory_mib BETWEEN 256 AND 10240),
+  ADD CONSTRAINT template_disk_range CHECK (disk_mib BETWEEN 1024 AND 20480);


### PR DESCRIPTION
Raises the absolute template size ceilings (memory 4GiB -> 10GiB, disk 8GiB -> 20GiB) so per-team overrides above the old caps can take effect. Per-team defaults are unchanged, so no team's effective limit changes without an explicit override.