### PR TITLE
vmd: give the async launcher build a wedge-reaping timeout instead of a pacing one

### DIFF
--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -23,10 +23,12 @@ const launcherPruneScript = `mount --make-rprivate / || exit 1
 umount -l /run/netns 2>/dev/null || true
 for m in $(grep ' /run/netns/' /proc/self/mounts | awk '{print $2}'); do umount -l "$m" 2>/dev/null || true; done`
 
-// launcherBuildTimeout bounds the boot-time launcher build. It must exceed the
-// O(fleet) prune, so it's far larger than the 5s single-exec bound used
-// elsewhere; on timeout the build errors and launches fall back to legacy.
-const launcherBuildTimeout = 90 * time.Second
+// launcherBuildTimeout reaps a genuinely wedged mount syscall — it does not
+// pace the build, which runs async with legacy-path fallback until done, so a
+// slow build costs nothing. The prune is O(host mount table), so the bound
+// must stay comfortably ahead of fleet growth: a bound the prune catches up
+// to silently strands the host on the legacy launch path.
+const launcherBuildTimeout = 10 * time.Minute
 
 // EnsureLauncherNamespace builds and pins the pruned launcher mount namespace at
 // m.launcherNSPath(). No-op when launcher mode is disabled. The pin snapshots the


### PR DESCRIPTION
The launcher build timeout was sized when the build ran synchronously on the boot path, where a tight bound protected boot latency. The build now runs asynchronously and launches fall back to the legacy path until it completes, so a slow build costs nothing — the bound's only remaining job is to reap a genuinely wedged mount syscall.

The prune's duration is O(host mount table), which grows with the fleet. A bound the prune can catch up to would silently strand a host on the legacy launch path at exactly the fleet size that needs the launcher most, with only a boot-time error line as the tell. Raising the bound to 10 minutes keeps the wedge protection while making it unreachable by any legitimate build.

No behavior change on the happy path. Build duration is already logged (`took`) for trend monitoring, and a timed-out build logs at Error level, which forwards to the error tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)