### PR TITLE
vmd: rebuild tap0 on slot recycle and reliably reclaim untracked VMs

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -498,7 +498,6 @@ func main() {
 		}()
 		// Periodically log the host mount-table size + revalidate the pin.
 		mgr.StartMountCountSampler(ctx, time.Minute)
-		mgr.StartNetnsLeakSampler(ctx, time.Minute)
 	}
 
 	// ---- Pre-allocate network slots ----
@@ -513,6 +512,10 @@ func main() {
 		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
+
+	// Leak gauge for network namespaces — independent of the launcher path, and
+	// started after StartPool so its first read observes an initialized pool.
+	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -498,6 +498,7 @@ func main() {
 		}()
 		// Periodically log the host mount-table size + revalidate the pin.
 		mgr.StartMountCountSampler(ctx, time.Minute)
+		mgr.StartNetnsLeakSampler(ctx, time.Minute)
 	}
 
 	// ---- Pre-allocate network slots ----
@@ -507,8 +508,9 @@ func main() {
 	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "256"))
 	netPoolRecycle, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_RECYCLE_SIZE", "256"))
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
-		NewSize:     netPoolFresh,
-		RecycleSize: netPoolRecycle,
+		NewSize:           netPoolFresh,
+		RecycleSize:       netPoolRecycle,
+		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -477,11 +477,8 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	}
 	vethName := fmt.Sprintf("veth-%d", idx)
 
-	// Ownership gates every slot-keyed side effect below: the egress rules
-	// (keyed by the slot-derived HostIP), the firewall, and the kernel state
-	// belong to whoever owns the index now, so a stale cleanup for a moved-on
-	// slot must touch none of them — stripping the egress rules alone would
-	// silently remove the new tenant's filtering.
+	// Ownership gates every slot-keyed side effect below (egress rules, firewall,
+	// kernel state): they belong to whoever owns the index now.
 
 	// Recycle the slot into the pool — namespace, veth, TAP, and base
 	// nftables stay configured; the next Claim re-adds vmID-specific
@@ -921,9 +918,8 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 			continue
 		}
 
-		// Strict ns-<int> parse (same as the gauge): a Sscanf-style parse would
-		// accept trailing garbage ("ns-5abc" → 5) and tear down veth-5 — the
-		// host side of whatever legitimately owns slot 5.
+		// Strict ns-<int> parse: trailing garbage must not map a foreign
+		// namespace onto another slot's veth.
 		idx, ok := slotFromNamespace(name)
 		if !ok {
 			continue
@@ -942,8 +938,7 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 	// before ns deletion, or when a crash left the host side orphaned).
 	if veths, err := listHostVeths(); err == nil {
 		for _, veth := range veths {
-			// Same strict parse: reject veth-<int><junk> rather than mapping it
-			// onto another slot's keep entry.
+			// Same strict parse as the ns loop.
 			idxStr, isVeth := strings.CutPrefix(veth, "veth-")
 			idx, err := strconv.Atoi(idxStr)
 			if !isVeth || err != nil || idx < 0 {
@@ -1070,13 +1065,10 @@ func (m *Manager) cleanupFull(nsName, vethName string) {
 	_ = run(ctx, "ip", "netns", "del", nsName)
 }
 
-// NetnsStats reports how many ns-N network namespaces exist on the host, how
-// many slot indices are currently owned (live VMs, pool-held slots, build and
-// record reservations, in-flight teardowns — slotOwner is the allocator's
-// single source of truth), and how many namespaces are orphaned: present in
-// the kernel with no owner. Orphaned is the leak signal — measured per
-// namespace, it is immune to owners with no backing namespace (record slots
-// reserved at startup for VMs whose netns a reboot destroyed).
+// NetnsStats reports the ns-N namespaces on the host, the owned slot indices
+// (slotOwner covers every legitimate holder), and orphaned — namespaces with
+// no owner, the leak signal. Measured per namespace so owners without a
+// backing namespace (e.g. record reservations after a reboot) don't distort it.
 func (m *Manager) NetnsStats() (netnsTotal, ownedSlots, orphaned int) {
 	var indices []int
 	if entries, err := os.ReadDir(netnsDir); err == nil {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -457,7 +457,17 @@ func (m *Manager) GetVMNetInfo(vmID string) *VMNetInfo {
 	return &cp
 }
 
-func (m *Manager) CleanupVM(vmID string) {
+// CleanupVM releases a VM's network slot, recycling it into the pool when one
+// is configured.
+func (m *Manager) CleanupVM(vmID string) { m.cleanupVM(vmID, true) }
+
+// TeardownVM releases a VM's network slot with a full teardown, never recycling
+// it. Used when the slot is suspect — e.g. a create that failed to attach tap0 —
+// so its index is rebuilt from scratch (fresh tap) before reuse instead of being
+// handed straight to the next claim, which could inherit the same bad tap.
+func (m *Manager) TeardownVM(vmID string) { m.cleanupVM(vmID, false) }
+
+func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	m.mu.Lock()
 	info, ok := m.devices[vmID]
 	if ok {
@@ -487,13 +497,14 @@ func (m *Manager) CleanupVM(vmID string) {
 	// in-ns handle couldn't be rebound) — pooling would let the next
 	// Claim silently lose per-VM egress filtering. Return transfers ownership
 	// from this VM back to the pool.
-	if m.pool != nil && info.Firewall != nil {
+	if recycle && m.pool != nil && info.Firewall != nil {
 		_ = info.Firewall.ReplaceUserRules(nil, nil)
 		m.pool.Return(&preallocSlot{idx: idx, info: info, vethName: vethName})
 		return
 	}
 
-	// No pool — full teardown. Release the index only if this VM still owns it.
+	// Full teardown (no pool, or a forced teardown of a suspect slot). Release
+	// the index only if this VM still owns it.
 	m.releaseIfOwned(idx, vmID)
 
 	if info.Firewall != nil {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -477,10 +477,11 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	}
 	vethName := fmt.Sprintf("veth-%d", idx)
 
-	// Remove per-sandbox egress proxy rules.
-	if m.egressProxy != nil {
-		m.egressProxy.RemoveRules(info.HostIP)
-	}
+	// Ownership gates every slot-keyed side effect below: the egress rules
+	// (keyed by the slot-derived HostIP), the firewall, and the kernel state
+	// belong to whoever owns the index now, so a stale cleanup for a moved-on
+	// slot must touch none of them — stripping the egress rules alone would
+	// silently remove the new tenant's filtering.
 
 	// Recycle the slot into the pool — namespace, veth, TAP, and base
 	// nftables stay configured; the next Claim re-adds vmID-specific
@@ -489,32 +490,41 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	// Claim silently lose per-VM egress filtering. Return transfers ownership
 	// from this VM back to the pool.
 	if recycle && m.pool != nil && info.Firewall != nil {
+		m.mu.Lock()
+		owned := m.slotOwner[idx] == vmID
+		m.mu.Unlock()
+		if !owned {
+			m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+				Msg("cleanup skipped — slot no longer owned by this VM")
+			return
+		}
+		if m.egressProxy != nil {
+			m.egressProxy.RemoveRules(info.HostIP)
+		}
 		_ = info.Firewall.ReplaceUserRules(nil, nil)
 		m.pool.Return(&preallocSlot{idx: idx, info: info, vethName: vethName})
 		return
 	}
 
-	// Full teardown (no pool, or a forced teardown of a suspect slot).
+	// Full teardown (no pool, or a forced teardown of a suspect slot). Park the
+	// index as teardownOwner for the duration — releasing it first would let a
+	// concurrent claim pop the idx, see the netns still present, and discard it
+	// for good.
+	if !m.claimTeardown(idx, vmID) {
+		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+			Msg("teardown skipped — slot no longer owned by this VM")
+		return
+	}
+	defer m.releaseIfOwned(idx, teardownOwner)
+
+	if m.egressProxy != nil {
+		m.egressProxy.RemoveRules(info.HostIP)
+	}
 	if info.Firewall != nil {
 		if err := info.Firewall.Close(); err != nil {
 			m.log.Warn().Err(err).Str("vm_id", vmID).Msg("error closing namespace firewall")
 		}
 	}
-
-	// Park the index as teardownOwner for the duration of the kernel teardown —
-	// releasing it first would let a concurrent claim pop the idx, see the netns
-	// still present, and discard it for good. Skip when this VM no longer owns
-	// the index: the slot has moved on and tearing down would hit the new tenant.
-	m.mu.Lock()
-	if m.slotOwner[idx] != vmID {
-		m.mu.Unlock()
-		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
-			Msg("teardown skipped — slot no longer owned by this VM")
-		return
-	}
-	m.slotOwner[idx] = teardownOwner
-	m.mu.Unlock()
-	defer m.releaseIfOwned(idx, teardownOwner)
 
 	// Kill any process still in the namespace before removing it — `ip netns
 	// del` only unlinks the name, so a live holder (e.g. the still-attached tap
@@ -558,16 +568,10 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 		return
 	}
 	// Only tear down if this vmID still owns the index, so a stale cleanup racing
-	// the pool's reuse of the slot can't destroy a new tenant's ns/veth. Claim the
-	// teardown atomically (vmID → teardownOwner) so claimSlotIndex can't grab idx
-	// while cleanupFull runs below.
-	m.mu.Lock()
-	if m.slotOwner[idx] != vmID {
-		m.mu.Unlock()
+	// the pool's reuse of the slot can't destroy a new tenant's ns/veth.
+	if !m.claimTeardown(idx, vmID) {
 		return
 	}
-	m.slotOwner[idx] = teardownOwner
-	m.mu.Unlock()
 	// Release even if cleanupFull panics — otherwise the index stays stuck as
 	// teardownOwner forever (no other path releases that sentinel).
 	defer m.releaseIfOwned(idx, teardownOwner)
@@ -835,19 +839,28 @@ func (m *Manager) ClaimFreshSlot(owner string) (int, error) {
 // reserved index. Owns the namespace naming so callers never reconstruct
 // "ns-<idx>"; a no-op if owner no longer owns idx (already reclaimed/reused).
 func (m *Manager) ReleaseSlot(owner string, idx int) {
-	// Claim the teardown atomically (owner → teardownOwner) so claimSlotIndex
-	// can't grab idx while cleanupFull runs below.
-	m.mu.Lock()
-	if m.slotOwner[idx] != owner {
-		m.mu.Unlock()
+	if !m.claimTeardown(idx, owner) {
 		return
 	}
-	m.slotOwner[idx] = teardownOwner
-	m.mu.Unlock()
 	// Release even if cleanupFull panics — otherwise idx stays stuck as
 	// teardownOwner forever (no other path releases that sentinel).
 	defer m.releaseIfOwned(idx, teardownOwner)
 	m.cleanupFull(fmt.Sprintf("ns-%d", idx), fmt.Sprintf("veth-%d", idx))
+}
+
+// claimTeardown atomically transfers idx from owner to the teardown sentinel so
+// claimSlotIndex can't grab it mid-teardown. False when owner no longer holds
+// idx — the slot moved on and its state belongs to the new tenant, so the
+// caller must touch none of it. Pair with `defer m.releaseIfOwned(idx,
+// teardownOwner)`.
+func (m *Manager) claimTeardown(idx int, owner string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.slotOwner[idx] != owner {
+		return false
+	}
+	m.slotOwner[idx] = teardownOwner
+	return true
 }
 
 // claimSlotIndex picks a slot idx that is unowned and not present in the kernel,
@@ -904,15 +917,15 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 
 	for _, entry := range entries {
 		name := entry.Name()
-		if !strings.HasPrefix(name, "ns-") {
-			continue
-		}
 		if keep[name] {
 			continue
 		}
 
-		var idx int
-		if _, err := fmt.Sscanf(name, "ns-%d", &idx); err != nil {
+		// Strict ns-<int> parse (same as the gauge): a Sscanf-style parse would
+		// accept trailing garbage ("ns-5abc" → 5) and tear down veth-5 — the
+		// host side of whatever legitimately owns slot 5.
+		idx, ok := slotFromNamespace(name)
+		if !ok {
 			continue
 		}
 		if killed := killProcessesInNs(name); killed > 0 {
@@ -929,8 +942,11 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 	// before ns deletion, or when a crash left the host side orphaned).
 	if veths, err := listHostVeths(); err == nil {
 		for _, veth := range veths {
-			var idx int
-			if _, err := fmt.Sscanf(veth, "veth-%d", &idx); err != nil {
+			// Same strict parse: reject veth-<int><junk> rather than mapping it
+			// onto another slot's keep entry.
+			idxStr, isVeth := strings.CutPrefix(veth, "veth-")
+			idx, err := strconv.Atoi(idxStr)
+			if !isVeth || err != nil || idx < 0 {
 				continue
 			}
 			if keep[fmt.Sprintf("ns-%d", idx)] {
@@ -1054,26 +1070,32 @@ func (m *Manager) cleanupFull(nsName, vethName string) {
 	_ = run(ctx, "ip", "netns", "del", nsName)
 }
 
-// NetnsStats reports how many ns-N network namespaces exist on the host and
-// how many slot indices are currently owned (live VMs, pool-held slots, build
-// reservations, record reservations, in-flight teardowns — slotOwner is the
-// allocator's single source of truth). netnsTotal - ownedSlots approximates
-// leaked namespaces; sustained growth is the signal to alert on, and a
-// negative value flags an accounting inconsistency rather than health.
-func (m *Manager) NetnsStats() (netnsTotal, ownedSlots int) {
+// NetnsStats reports how many ns-N network namespaces exist on the host, how
+// many slot indices are currently owned (live VMs, pool-held slots, build and
+// record reservations, in-flight teardowns — slotOwner is the allocator's
+// single source of truth), and how many namespaces are orphaned: present in
+// the kernel with no owner. Orphaned is the leak signal — measured per
+// namespace, it is immune to owners with no backing namespace (record slots
+// reserved at startup for VMs whose netns a reboot destroyed).
+func (m *Manager) NetnsStats() (netnsTotal, ownedSlots, orphaned int) {
+	var indices []int
 	if entries, err := os.ReadDir(netnsDir); err == nil {
 		for _, e := range entries {
-			// Same strict ns-<int> parse the sweeper uses, so the gauge and the
-			// sweep agree on what counts as a managed namespace.
-			if _, ok := slotFromNamespace(e.Name()); ok {
+			if idx, ok := slotFromNamespace(e.Name()); ok {
 				netnsTotal++
+				indices = append(indices, idx)
 			}
 		}
 	}
 	m.mu.Lock()
 	ownedSlots = len(m.slotOwner)
+	for _, idx := range indices {
+		if _, ok := m.slotOwner[idx]; !ok {
+			orphaned++
+		}
+	}
 	m.mu.Unlock()
-	return netnsTotal, ownedSlots
+	return netnsTotal, ownedSlots, orphaned
 }
 
 func run(ctx context.Context, name string, args ...string) error {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -79,12 +79,12 @@ type Manager struct {
 	hostInterface string
 	log           zerolog.Logger
 
-	mu        sync.Mutex
-	devices   map[string]*VMNetInfo
-	freeSlots []int // recycled slot indices, guaranteed absent from slotOwner
-	nextSlot   int  // next new slot (used when freeSlots is empty)
-	maxSlot    int  // new-slot ceiling; meaningful only when slotPinned (WithExactSlot)
-	slotPinned bool // WithExactSlot: allocate exactly maxSlot or fail, never advance
+	mu         sync.Mutex
+	devices    map[string]*VMNetInfo
+	freeSlots  []int // recycled slot indices, guaranteed absent from slotOwner
+	nextSlot   int   // next new slot (used when freeSlots is empty)
+	maxSlot    int   // new-slot ceiling; meaningful only when slotPinned (WithExactSlot)
+	slotPinned bool  // WithExactSlot: allocate exactly maxSlot or fail, never advance
 
 	// slotOwner is the single source of truth for slot allocation AND identity:
 	// slotOwner[idx] == the current owner of slot index idx, one of
@@ -423,6 +423,29 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	return info, vethName, nil
 }
 
+// resetTap deletes and recreates tap0 in nsName so a recycled slot's TAP is
+// unattached by construction, rather than relying on the namespace being
+// process-free (which doesn't guarantee the previous owner's fd is released).
+// Returns an error if the tap can't be rebuilt, so the caller can decline to
+// recycle. nftables rules match tap0 by name, so reusing the name keeps them
+// valid. Mirrors setupSlot's tap block.
+func (m *Manager) resetTap(ctx context.Context, nsName string) error {
+	_ = nsRun(ctx, nsName, "ip", "link", "del", TAPName)
+	if err := nsRun(ctx, nsName, "ip", "tuntap", "add", "dev", TAPName, "mode", "tap"); err != nil {
+		return fmt.Errorf("recreate TAP: %w", err)
+	}
+	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "up"); err != nil {
+		return fmt.Errorf("bring up TAP: %w", err)
+	}
+	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "mtu", ifaceMTU); err != nil {
+		return fmt.Errorf("set TAP MTU: %w", err)
+	}
+	if err := nsRun(ctx, nsName, "ip", "addr", "add", tapCIDR, "dev", TAPName); err != nil {
+		return fmt.Errorf("assign TAP IP: %w", err)
+	}
+	return nil
+}
+
 func (m *Manager) GetVMNetInfo(vmID string) *VMNetInfo {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -526,6 +549,13 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	// teardownOwner forever (no other path releases that sentinel).
 	defer m.releaseIfOwned(idx, teardownOwner)
 
+	// Kill any process still in the namespace before removing it — `ip netns del`
+	// only unlinks the name, so a namespace with a live holder lingers (keeping
+	// its tap0) until that process exits. Mirrors SweepOrphanNamespaces.
+	if killed := killProcessesInNs(fallbackNamespace); killed > 0 {
+		m.log.Info().Str("namespace", fallbackNamespace).Int("killed", killed).
+			Msg("cleanup: killed lingering processes before namespace teardown")
+	}
 	// Tear down both sides even if the netns is already gone: `ip netns del`
 	// only removes the in-namespace side, so the host-side veth-N can outlive it.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
@@ -999,6 +1029,24 @@ func (m *Manager) cleanupFull(nsName, vethName string) {
 	defer cancel()
 	_ = run(ctx, "ip", "link", "del", vethName)
 	_ = run(ctx, "ip", "netns", "del", nsName)
+}
+
+// NetnsStats reports how many ns-N network namespaces exist on the host and how
+// many the pool is holding ready (fresh + recycled). Callers subtract the live
+// VM count too: netnsTotal - poolHeld - liveVMs approximates leaked namespaces
+// (teardown that failed to remove a netns), which is the signal to alert on.
+func (m *Manager) NetnsStats() (netnsTotal, poolHeld int) {
+	if entries, err := os.ReadDir(netnsDir); err == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), "ns-") {
+				netnsTotal++
+			}
+		}
+	}
+	if m.pool != nil {
+		poolHeld = len(m.pool.fresh) + len(m.pool.recycled)
+	}
+	return netnsTotal, poolHeld
 }
 
 func run(ctx context.Context, name string, args ...string) error {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -364,21 +364,11 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		return nil, "", fmt.Errorf("assign veth IP: %w", err)
 	}
 
-	if err := nsRun(ctx, nsName, "ip", "tuntap", "add", "dev", TAPName, "mode", "tap"); err != nil {
+	// One tap-construction path for fresh and recycled slots, so their tap
+	// config can't diverge (the leading delete is a no-op on a fresh namespace).
+	if err := m.resetTap(ctx, nsName); err != nil {
 		m.cleanupFull(nsName, vethName)
-		return nil, "", fmt.Errorf("create TAP: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "up"); err != nil {
-		m.cleanupFull(nsName, vethName)
-		return nil, "", fmt.Errorf("bring up TAP: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "mtu", ifaceMTU); err != nil {
-		m.cleanupFull(nsName, vethName)
-		return nil, "", fmt.Errorf("set TAP MTU: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "addr", "add", tapCIDR, "dev", TAPName); err != nil {
-		m.cleanupFull(nsName, vethName)
-		return nil, "", fmt.Errorf("assign TAP IP: %w", err)
+		return nil, "", err
 	}
 
 	_ = nsRun(ctx, nsName, "ip", "link", "set", "lo", "up")
@@ -423,16 +413,17 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	return info, vethName, nil
 }
 
-// resetTap deletes and recreates tap0 in nsName so a recycled slot's TAP is
-// unattached by construction, rather than relying on the namespace being
-// process-free (which doesn't guarantee the previous owner's fd is released).
-// Returns an error if the tap can't be rebuilt, so the caller can decline to
-// recycle. nftables rules match tap0 by name, so reusing the name keeps them
-// valid. Mirrors setupSlot's tap block.
+// resetTap deletes and recreates tap0 in nsName, leaving a TAP that is
+// unattached by construction — a recycled slot can't rely on the namespace
+// being process-free (that doesn't guarantee the previous owner's fd is
+// released). Returns an error if the tap can't be rebuilt, so the caller can
+// decline to recycle. nftables rules match tap0 by name, so reusing the name
+// keeps them valid. Also the tap-construction path for setupSlot (the delete
+// is a no-op on a fresh namespace), keeping fresh and recycled taps identical.
 func (m *Manager) resetTap(ctx context.Context, nsName string) error {
 	_ = nsRun(ctx, nsName, "ip", "link", "del", TAPName)
 	if err := nsRun(ctx, nsName, "ip", "tuntap", "add", "dev", TAPName, "mode", "tap"); err != nil {
-		return fmt.Errorf("recreate TAP: %w", err)
+		return fmt.Errorf("create TAP: %w", err)
 	}
 	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "up"); err != nil {
 		return fmt.Errorf("bring up TAP: %w", err)
@@ -503,14 +494,35 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 		return
 	}
 
-	// Full teardown (no pool, or a forced teardown of a suspect slot). Release
-	// the index only if this VM still owns it.
-	m.releaseIfOwned(idx, vmID)
-
+	// Full teardown (no pool, or a forced teardown of a suspect slot).
 	if info.Firewall != nil {
 		if err := info.Firewall.Close(); err != nil {
 			m.log.Warn().Err(err).Str("vm_id", vmID).Msg("error closing namespace firewall")
 		}
+	}
+
+	// Park the index as teardownOwner for the duration of the kernel teardown —
+	// releasing it first would let a concurrent claim pop the idx, see the netns
+	// still present, and discard it for good. Skip when this VM no longer owns
+	// the index: the slot has moved on and tearing down would hit the new tenant.
+	m.mu.Lock()
+	if m.slotOwner[idx] != vmID {
+		m.mu.Unlock()
+		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+			Msg("teardown skipped — slot no longer owned by this VM")
+		return
+	}
+	m.slotOwner[idx] = teardownOwner
+	m.mu.Unlock()
+	defer m.releaseIfOwned(idx, teardownOwner)
+
+	// Kill any process still in the namespace before removing it — `ip netns
+	// del` only unlinks the name, so a live holder (e.g. the still-attached tap
+	// owner on the teardown-not-recycle path) would keep the namespace and its
+	// tap alive but anonymous: unfindable by pidsInNs, the sweep, or the gauge.
+	if killed := killProcessesInNs(info.Namespace); killed > 0 {
+		m.log.Info().Str("namespace", info.Namespace).Int("killed", killed).
+			Msg("cleanup: killed lingering processes before namespace teardown")
 	}
 
 	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
@@ -1042,22 +1054,26 @@ func (m *Manager) cleanupFull(nsName, vethName string) {
 	_ = run(ctx, "ip", "netns", "del", nsName)
 }
 
-// NetnsStats reports how many ns-N network namespaces exist on the host and how
-// many the pool is holding ready (fresh + recycled). Callers subtract the live
-// VM count too: netnsTotal - poolHeld - liveVMs approximates leaked namespaces
-// (teardown that failed to remove a netns), which is the signal to alert on.
-func (m *Manager) NetnsStats() (netnsTotal, poolHeld int) {
+// NetnsStats reports how many ns-N network namespaces exist on the host and
+// how many slot indices are currently owned (live VMs, pool-held slots, build
+// reservations, record reservations, in-flight teardowns — slotOwner is the
+// allocator's single source of truth). netnsTotal - ownedSlots approximates
+// leaked namespaces; sustained growth is the signal to alert on, and a
+// negative value flags an accounting inconsistency rather than health.
+func (m *Manager) NetnsStats() (netnsTotal, ownedSlots int) {
 	if entries, err := os.ReadDir(netnsDir); err == nil {
 		for _, e := range entries {
-			if strings.HasPrefix(e.Name(), "ns-") {
+			// Same strict ns-<int> parse the sweeper uses, so the gauge and the
+			// sweep agree on what counts as a managed namespace.
+			if _, ok := slotFromNamespace(e.Name()); ok {
 				netnsTotal++
 			}
 		}
 	}
-	if m.pool != nil {
-		poolHeld = len(m.pool.fresh) + len(m.pool.recycled)
-	}
-	return netnsTotal, poolHeld
+	m.mu.Lock()
+	ownedSlots = len(m.slotOwner)
+	m.mu.Unlock()
+	return netnsTotal, ownedSlots
 }
 
 func run(ctx context.Context, name string, args ...string) error {

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -20,6 +20,10 @@ type PoolConfig struct {
 	// setup (namespace, veth, TAP, nftables are already configured).
 	// Default: 100.
 	RecycleSize int
+	// ResetTapOnRecycle recreates a returned slot's tap0 before it is made
+	// claimable again (see verifyAndRecycle). Off by default so it can be
+	// enabled per cell during rollout.
+	ResetTapOnRecycle bool
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
@@ -42,6 +46,9 @@ type Pool struct {
 	// tests override these to run the timeout path without a real 20s wait.
 	verifyPollInterval time.Duration
 	verifyMaxWait      time.Duration
+
+	// resetTapOnRecycle recreates tap0 before a returned slot is recycled.
+	resetTapOnRecycle bool
 }
 
 // preallocSlot holds a fully configured network namespace ready to be
@@ -56,6 +63,12 @@ type preallocSlot struct {
 // pidsInNsFunc is a seam over pidsInNs so tests can simulate a namespace
 // that's still occupied (or clear) without a real kernel netns/process.
 var pidsInNsFunc = pidsInNs
+
+// resetTapFunc is a seam over Manager.resetTap so tests can drive the
+// recycle-vs-teardown decision without building a real netns + tap device.
+var resetTapFunc = func(m *Manager, ctx context.Context, ns string) error {
+	return m.resetTap(ctx, ns)
+}
 
 const (
 	// defaultVerifyPollInterval trades a small amount of slot-reuse latency
@@ -86,16 +99,18 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	}
 
 	p := &Pool{
-		mgr:      m,
-		log:      m.log.With().Str("component", "net_pool").Logger(),
-		newSize:  newSize,
-		fresh:    make(chan *preallocSlot, newSize),
-		recycled: make(chan *preallocSlot, recycleSize),
-		stopCh:   make(chan struct{}),
+		mgr:               m,
+		log:               m.log.With().Str("component", "net_pool").Logger(),
+		newSize:           newSize,
+		fresh:             make(chan *preallocSlot, newSize),
+		recycled:          make(chan *preallocSlot, recycleSize),
+		stopCh:            make(chan struct{}),
+		resetTapOnRecycle: cfg.ResetTapOnRecycle,
 	}
 	m.pool = p
 
-	p.log.Info().Int("target", newSize).Int("recycle_cap", recycleSize).Msg("network pool starting (filling in background)")
+	p.log.Info().Int("target", newSize).Int("recycle_cap", recycleSize).
+		Bool("reset_tap_on_recycle", p.resetTapOnRecycle).Msg("network pool starting (filling in background)")
 	p.wg.Add(1)
 	go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 
@@ -221,6 +236,20 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		select {
 		case <-time.After(pollInterval):
 		case <-p.stopCh:
+			p.cleanup(slot)
+			return
+		}
+	}
+
+	// Process-free doesn't prove tap0's fd is released, so rebuild the tap
+	// before recycling; if it can't be rebuilt, tear down instead.
+	if p.resetTapOnRecycle {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := resetTapFunc(p.mgr, ctx, ns)
+		cancel()
+		if err != nil {
+			p.log.Error().Err(err).Str("namespace", ns).Int("slot", slot.idx).
+				Msg("pool: tap reset failed on recycle — tearing down instead of recycling")
 			p.cleanup(slot)
 			return
 		}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -66,9 +66,7 @@ var pidsInNsFunc = pidsInNs
 
 // resetTapFunc is a seam over Manager.resetTap so tests can drive the
 // recycle-vs-teardown decision without building a real netns + tap device.
-var resetTapFunc = func(m *Manager, ctx context.Context, ns string) error {
-	return m.resetTap(ctx, ns)
-}
+var resetTapFunc = (*Manager).resetTap
 
 const (
 	// defaultVerifyPollInterval trades a small amount of slot-reuse latency
@@ -239,6 +237,15 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 			p.cleanup(slot)
 			return
 		}
+	}
+
+	// A full recycle pool means this slot is headed for teardown anyway — skip
+	// the tap rebuild rather than pay it for a slot about to be destroyed
+	// (mass deletes overflow the pool by design). Racy but safe: the send
+	// below still has a default arm.
+	if p.resetTapOnRecycle && len(p.recycled) == cap(p.recycled) {
+		p.cleanup(slot)
+		return
 	}
 
 	// Process-free doesn't prove tap0's fd is released, so rebuild the tap

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -21,8 +21,7 @@ type PoolConfig struct {
 	// Default: 100.
 	RecycleSize int
 	// ResetTapOnRecycle recreates a returned slot's tap0 before it is made
-	// claimable again (see verifyAndRecycle). Off by default so it can be
-	// enabled per cell during rollout.
+	// claimable again (see verifyAndRecycle). Off by default.
 	ResetTapOnRecycle bool
 }
 

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -168,6 +168,46 @@ func TestPoolReturn_ResetsTapBeforeRecycling(t *testing.T) {
 	}
 }
 
+// TestPoolReturn_SkipsTapResetWhenRecycleFull: a slot that would overflow the
+// recycle pool is torn down without paying the tap rebuild first.
+func TestPoolReturn_SkipsTapResetWhenRecycleFull(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(_ *Manager, _ context.Context, _ string) error {
+		t.Error("resetTap ran for a slot the full recycle pool was about to discard")
+		return nil
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.resetTapOnRecycle = true
+	for i := 0; i < cap(p.recycled); i++ {
+		p.recycled <- &preallocSlot{idx: 100 + i, info: &VMNetInfo{Namespace: "ns-x"}}
+	}
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	// Synchronize with the verify goroutine via the slot release under m.mu.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		m.mu.Lock()
+		_, owned := m.slotOwner[1]
+		m.mu.Unlock()
+		if !owned || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	m.mu.Lock()
+	_, stillOwned := m.slotOwner[1]
+	m.mu.Unlock()
+	if stillOwned {
+		t.Error("slot 1 never released — overflow cleanup did not run")
+	}
+}
+
 // TestPoolReturn_TearsDownWhenTapResetFails: if tap0 can't be rebuilt, the slot
 // is torn down instead of recycled — never handed to the next VM.
 func TestPoolReturn_TearsDownWhenTapResetFails(t *testing.T) {

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,6 +19,16 @@ func stubPidsInNs(t *testing.T, fn func(ns string) ([]int, bool)) {
 	old := pidsInNsFunc
 	pidsInNsFunc = fn
 	t.Cleanup(func() { pidsInNsFunc = old })
+}
+
+// stubResetTap overrides resetTapFunc for the duration of the test and restores
+// it on cleanup, so the recycle path's tap0 rebuild is driven without a real
+// netns/tap device.
+func stubResetTap(t *testing.T, fn func(m *Manager, ctx context.Context, ns string) error) {
+	t.Helper()
+	old := resetTapFunc
+	resetTapFunc = fn
+	t.Cleanup(func() { resetTapFunc = old })
 }
 
 func newTestPool(t *testing.T, m *Manager) *Pool {
@@ -120,6 +132,64 @@ func TestPoolReturn_RecyclesOnceNamespaceIsClear(t *testing.T) {
 	m.mu.Unlock()
 	if owner != poolOwner {
 		t.Errorf("slotOwner[1] = %q, want poolOwner", owner)
+	}
+}
+
+// TestPoolReturn_ResetsTapBeforeRecycling: with the reset enabled, a cleared
+// namespace has its tap0 rebuilt before the slot is made claimable.
+func TestPoolReturn_ResetsTapBeforeRecycling(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+
+	var resetNS atomic.Value
+	stubResetTap(t, func(_ *Manager, _ context.Context, ns string) error {
+		resetNS.Store(ns)
+		return nil
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.resetTapOnRecycle = true
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	select {
+	case slot := <-p.recycled:
+		if slot.idx != 1 {
+			t.Errorf("recycled slot idx = %d, want 1", slot.idx)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("slot never appeared in recycled — reset-then-recycle did not complete")
+	}
+	if got, _ := resetNS.Load().(string); got != "ns-1" {
+		t.Errorf("resetTap called with ns %q, want ns-1", got)
+	}
+}
+
+// TestPoolReturn_TearsDownWhenTapResetFails: if tap0 can't be rebuilt, the slot
+// is torn down instead of recycled — never handed to the next VM.
+func TestPoolReturn_TearsDownWhenTapResetFails(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(_ *Manager, _ context.Context, _ string) error {
+		return errors.New("tap busy")
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.resetTapOnRecycle = true
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	// The slot must never become claimable; cleanup (not recycle) runs instead.
+	select {
+	case slot := <-p.recycled:
+		t.Fatalf("slot idx %d was recycled despite tap reset failure", slot.idx)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -185,11 +185,29 @@ func TestPoolReturn_TearsDownWhenTapResetFails(t *testing.T) {
 
 	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
 
-	// The slot must never become claimable; cleanup (not recycle) runs instead.
+	// Let verifyAndRecycle run: it clears the namespace, fails the tap reset, and
+	// tears down instead of recycling.
+	time.Sleep(200 * time.Millisecond)
+
 	select {
 	case slot := <-p.recycled:
 		t.Fatalf("slot idx %d was recycled despite tap reset failure", slot.idx)
-	case <-time.After(200 * time.Millisecond):
+	default:
+	}
+
+	// Reading the released slot under m.mu synchronizes with verifyAndRecycle's
+	// teardown so the test doesn't race its goroutine on the stub globals.
+	m.mu.Lock()
+	_, stillOwned := m.slotOwner[1]
+	freed := false
+	for _, idx := range m.freeSlots {
+		if idx == 1 {
+			freed = true
+		}
+	}
+	m.mu.Unlock()
+	if stillOwned || !freed {
+		t.Errorf("slot 1 not released after tap reset failure (owned=%v freed=%v)", stillOwned, freed)
 	}
 }
 

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -211,6 +211,38 @@ func TestPoolReturn_TearsDownWhenTapResetFails(t *testing.T) {
 	}
 }
 
+// TestTeardownVM_ReclaimsSlotWithoutRecycling: a forced teardown of a suspect
+// slot reclaims its index to freeSlots and never hands it to the pool, so a
+// failed create's slot can't be immediately re-claimed with the same bad tap.
+func TestTeardownVM_ReclaimsSlotWithoutRecycling(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	m.pool = p
+	m.devices["vm-t"] = &VMNetInfo{Namespace: "ns-7", HostIP: "10.11.0.7"}
+	m.assignSlotLocked(7, "vm-t")
+
+	m.TeardownVM("vm-t")
+
+	if _, tracked := m.devices["vm-t"]; tracked {
+		t.Error("vm-t still tracked after TeardownVM")
+	}
+	freed := false
+	for _, idx := range m.freeSlots {
+		if idx == 7 {
+			freed = true
+		}
+	}
+	if !freed {
+		t.Errorf("slot 7 not reclaimed to freeSlots = %v", m.freeSlots)
+	}
+	select {
+	case slot := <-p.recycled:
+		t.Fatalf("slot %+v was recycled; TeardownVM must never recycle", slot)
+	default:
+	}
+}
+
 // TestPoolReturn_WaitsForNamespaceToClearBeforeRecycling pins the actual bug
 // fix: a slot whose namespace still has an attached process (the old VM's
 // Firecracker mid-death) must NOT be claimable yet, even though Return()

--- a/internal/vm/build_cleanup.go
+++ b/internal/vm/build_cleanup.go
@@ -97,7 +97,6 @@ func killOrphanFirecracker(buildVMID string) int {
 		return 0
 	}
 	killed := 0
-	marker := []byte("--id\x00" + buildVMID + "\x00")
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -110,13 +109,7 @@ func killOrphanFirecracker(buildVMID string) int {
 		if err != nil {
 			continue
 		}
-		if !bytes.Contains(cmdline, marker) {
-			continue
-		}
-		// Only kill firecracker — don't touch other processes that happen
-		// to mention the build id in their args.
-		if !bytes.HasPrefix(cmdline, []byte("firecracker")) &&
-			!bytes.Contains(cmdline, []byte("/firecracker\x00")) {
+		if !firecrackerCmdlineMatches(cmdline, buildVMID) {
 			continue
 		}
 		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
@@ -124,4 +117,16 @@ func killOrphanFirecracker(buildVMID string) int {
 		}
 	}
 	return killed
+}
+
+// firecrackerCmdlineMatches is the identity predicate over a /proc/<pid>/cmdline:
+// the NUL-delimited `--id <vmID>` argv token plus the firecracker binary name.
+// Only firecracker matches — never another process that happens to mention the
+// id in its args.
+func firecrackerCmdlineMatches(cmdline []byte, vmID string) bool {
+	if !bytes.Contains(cmdline, []byte("--id\x00"+vmID+"\x00")) {
+		return false
+	}
+	return bytes.HasPrefix(cmdline, []byte("firecracker")) ||
+		bytes.Contains(cmdline, []byte("/firecracker\x00"))
 }

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -47,6 +47,26 @@ func isLayeredInvalidErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), layeredInvalidMarker)
 }
 
+// Firecracker's tap-attach failure when a previous owner still holds the
+// device (TUNSETIFF EBUSY). Both substrings must match: the tap-open prefix
+// alone wraps every tap errno (EPERM, ENODEV, ...), which retrying on a
+// different slot can't fix. Named so a fork message change is updated here,
+// not missed at runtime.
+const (
+	tapOpenMarker = "Open tap device failed"
+	tapBusyMarker = "resource busy"
+)
+
+// isTapDeviceBusyErr reports whether err is the still-held-tap attach failure —
+// the one restore error worth retrying on a different network slot.
+func isTapDeviceBusyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, tapOpenMarker) && strings.Contains(s, tapBusyMarker)
+}
+
 // ---------------------------------------------------------------------------
 // Firecracker config (our internal type, not a Firecracker API type)
 // ---------------------------------------------------------------------------

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -50,10 +50,11 @@ func isLayeredInvalidErr(err error) bool {
 // Firecracker's tap-attach failure when a previous owner still holds the
 // device (TUNSETIFF EBUSY). Both substrings must match: the tap-open prefix
 // alone wraps every tap errno (EPERM, ENODEV, ...), which retrying on a
-// different slot can't fix. Named so a fork message change is updated here,
-// not missed at runtime.
+// different slot can't fix. Lower-case; matching is case-insensitive so a
+// casing drift in the message can't silently disable the retry. Named so a
+// fork message change is updated here, not missed at runtime.
 const (
-	tapOpenMarker = "Open tap device failed"
+	tapOpenMarker = "open tap device failed"
 	tapBusyMarker = "resource busy"
 )
 
@@ -63,7 +64,7 @@ func isTapDeviceBusyErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	s := err.Error()
+	s := strings.ToLower(err.Error())
 	return strings.Contains(s, tapOpenMarker) && strings.Contains(s, tapBusyMarker)
 }
 

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -239,6 +239,36 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 	}()
 }
 
+// StartNetnsLeakSampler periodically logs the host network-namespace count
+// against the live-VM and pool-held counts so leaked namespaces are observable
+// and alertable: netns_leak_estimate ≈ netns_total - live_vms - pool_held. One
+// /run/netns readdir per tick.
+func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration) {
+	go func() {
+		defer sentrylog.Recover("netns-leak sampler")
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				netnsTotal, poolHeld := m.netMgr.NetnsStats()
+				m.mu.RLock()
+				liveVMs := len(m.vms)
+				m.mu.RUnlock()
+				leak := netnsTotal - liveVMs - poolHeld
+				if leak < 0 {
+					leak = 0
+				}
+				m.log.Info().Int("netns_total", netnsTotal).Int("live_vms", liveVMs).
+					Int("pool_held", poolHeld).Int("netns_leak_estimate", leak).
+					Msg("netns leak gauge")
+			}
+		}
+	}()
+}
+
 // revalidateLauncher re-syncs launcherReady with the live pin each tick: drop to
 // legacy if the pin went bad, and re-enable only the pin THIS boot built
 // (launcherBuilt) — a previous-boot pin left mounted after a failed rebuild may

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -247,18 +247,16 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 	})
 }
 
-// StartNetnsLeakSampler periodically logs the host network-namespace count
-// against the slot allocator's owned-index count so leaked namespaces are
-// observable and alertable: netns_leak_estimate = netns_total - owned_slots.
-// The owned set covers every legitimate holder (live VMs, pool-held slots,
-// build and record reservations, in-flight teardowns), so a sustained positive
-// estimate means teardown is leaking; a negative one is logged as-is since it
-// flags an accounting inconsistency. One /run/netns readdir per tick.
+// StartNetnsLeakSampler periodically logs the host's network-namespace counts.
+// netns_orphaned — namespaces present in the kernel with no owning slot — is
+// the leak signal: sustained growth means teardown is leaking. Owned covers
+// every legitimate holder (live VMs, pool-held slots, build and record
+// reservations, in-flight teardowns). One /run/netns readdir per tick.
 func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration) {
 	m.startSampler(ctx, "netns-leak sampler", every, func() {
-		netnsTotal, ownedSlots := m.netMgr.NetnsStats()
+		netnsTotal, ownedSlots, orphaned := m.netMgr.NetnsStats()
 		m.log.Info().Int("netns_total", netnsTotal).Int("owned_slots", ownedSlots).
-			Int("netns_leak_estimate", netnsTotal-ownedSlots).
+			Int("netns_orphaned", orphaned).
 			Msg("netns leak gauge")
 	})
 }

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -217,12 +217,11 @@ func unescapeMountinfo(s string) string {
 	return b.String()
 }
 
-// StartMountCountSampler periodically logs the host mount-table size so the
-// O(1)-launch invariant — mount count should stay roughly flat, not grow with
-// the fleet — is observable in the log pipeline. One /proc/mounts read per tick.
-func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duration) {
+// startSampler runs fn on a ticker until ctx is done. Shared scaffold for the
+// periodic host gauges below.
+func (m *Manager) startSampler(ctx context.Context, name string, every time.Duration, fn func()) {
 	go func() {
-		defer sentrylog.Recover("mount-count sampler")
+		defer sentrylog.Recover(name)
 		t := time.NewTicker(every)
 		defer t.Stop()
 		for {
@@ -230,43 +229,38 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				total, nsfs := hostMountCounts()
-				m.log.Info().Int("host_mount_count", total).Int("host_nsfs_count", nsfs).
-					Msg("host mount table")
-				m.revalidateLauncher(ctx)
+				fn()
 			}
 		}
 	}()
 }
 
+// StartMountCountSampler periodically logs the host mount-table size so the
+// O(1)-launch invariant — mount count should stay roughly flat, not grow with
+// the fleet — is observable in the log pipeline. One /proc/mounts read per tick.
+func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duration) {
+	m.startSampler(ctx, "mount-count sampler", every, func() {
+		total, nsfs := hostMountCounts()
+		m.log.Info().Int("host_mount_count", total).Int("host_nsfs_count", nsfs).
+			Msg("host mount table")
+		m.revalidateLauncher(ctx)
+	})
+}
+
 // StartNetnsLeakSampler periodically logs the host network-namespace count
-// against the live-VM and pool-held counts so leaked namespaces are observable
-// and alertable: netns_leak_estimate ≈ netns_total - live_vms - pool_held. One
-// /run/netns readdir per tick.
+// against the slot allocator's owned-index count so leaked namespaces are
+// observable and alertable: netns_leak_estimate = netns_total - owned_slots.
+// The owned set covers every legitimate holder (live VMs, pool-held slots,
+// build and record reservations, in-flight teardowns), so a sustained positive
+// estimate means teardown is leaking; a negative one is logged as-is since it
+// flags an accounting inconsistency. One /run/netns readdir per tick.
 func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration) {
-	go func() {
-		defer sentrylog.Recover("netns-leak sampler")
-		t := time.NewTicker(every)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				netnsTotal, poolHeld := m.netMgr.NetnsStats()
-				m.mu.RLock()
-				liveVMs := len(m.vms)
-				m.mu.RUnlock()
-				leak := netnsTotal - liveVMs - poolHeld
-				if leak < 0 {
-					leak = 0
-				}
-				m.log.Info().Int("netns_total", netnsTotal).Int("live_vms", liveVMs).
-					Int("pool_held", poolHeld).Int("netns_leak_estimate", leak).
-					Msg("netns leak gauge")
-			}
-		}
-	}()
+	m.startSampler(ctx, "netns-leak sampler", every, func() {
+		netnsTotal, ownedSlots := m.netMgr.NetnsStats()
+		m.log.Info().Int("netns_total", netnsTotal).Int("owned_slots", ownedSlots).
+			Int("netns_leak_estimate", netnsTotal-ownedSlots).
+			Msg("netns leak gauge")
+	})
 }
 
 // revalidateLauncher re-syncs launcherReady with the live pin each tick: drop to

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -248,10 +248,8 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 }
 
 // StartNetnsLeakSampler periodically logs the host's network-namespace counts.
-// netns_orphaned — namespaces present in the kernel with no owning slot — is
-// the leak signal: sustained growth means teardown is leaking. Owned covers
-// every legitimate holder (live VMs, pool-held slots, build and record
-// reservations, in-flight teardowns). One /run/netns readdir per tick.
+// netns_orphaned (namespaces with no owning slot) is the leak signal: sustained
+// growth means teardown is leaking. One /run/netns readdir per tick.
 func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration) {
 	m.startSampler(ctx, "netns-leak sampler", every, func() {
 		netnsTotal, ownedSlots, orphaned := m.netMgr.NetnsStats()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -420,13 +420,11 @@ func sigkillPID(pid int, wait time.Duration) {
 	}
 }
 
-// pidIsVMFirecracker reports whether pid is this VM's Firecracker. A stored PID
-// can be stale (a paused VM keeps the PID of a Firecracker that died at pause),
-// and after PID-space reuse it may belong to an unrelated live process — so any
-// kill fed by stored state must verify identity first. Substring matching is
-// not identity (a tail/cp on the VM's rundir path would pass it); this requires
-// the exact `--id <vmID>` argv token and the firecracker binary, the same
-// predicate killOrphanFirecracker uses.
+// pidIsVMFirecracker reports whether pid is this VM's Firecracker. A stored
+// PID can be stale (paused VMs keep the PID of a process that died at pause)
+// and reused by an unrelated process, so kills fed by stored state verify
+// identity first — the exact `--id <vmID>` argv token plus the firecracker
+// binary, not a substring match.
 func pidIsVMFirecracker(pid int, vmID string) bool {
 	if pid <= 0 || vmID == "" {
 		return false
@@ -594,9 +592,8 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	}
 
 	// No-op for systemd VMs (stopUnit already killed them); the real kill for
-	// cold-boot VMs and record orphans. Identity-gated regardless of source: a
-	// paused VM's PID is stale whether it came from memory or the record, and
-	// after PID reuse an unverified kill hits an unrelated process.
+	// cold-boot VMs and record orphans. Identity-gated regardless of source —
+	// a paused VM's PID is stale whether it came from memory or the record.
 	if pidIsVMFirecracker(pid, vmID) {
 		sigkillPID(pid, 500*time.Millisecond)
 	}
@@ -1518,11 +1515,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			break
 		}
 		m.stopUnitDuringRestoreError(vmID)
-		// systemctl start is a no-op on an active unit, so a retry against a
-		// surviving Firecracker can't boot a new one — retry only when the unit
-		// is affirmatively dead. An inconclusive answer (systemctl error or
-		// timeout under the same host contention that causes tap-busy) must
-		// read as alive, not as permission to retry.
+		// systemctl start is a no-op on an active unit, so retry only when the
+		// unit is affirmatively dead — an inconclusive answer reads as alive.
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
 		checkCancel()
@@ -1597,12 +1591,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	m.setStatus(vmID, StatusRunning)
 	m.persistState(inst)
-	// Persist-then-verify: a concurrent DestroyVM may have completed while we
-	// were restoring (its network cleanup no-ops during the retry window, and
-	// removeVM deletes the record — possibly between our persist and here, or
-	// our persist may have resurrected an already-deleted record). Checking
-	// AFTER the write leaves no window: a destroy that raced us either erased
-	// the record itself or is caught now, and we erase it and tear down.
+	// Persist-then-verify: checking AFTER the write leaves no window — a
+	// concurrent DestroyVM either erased the record itself or is caught here,
+	// and we erase our write and tear down instead of resurrecting it.
 	m.mu.RLock()
 	_, stillTracked := m.vms[vmID]
 	m.mu.RUnlock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -390,18 +390,47 @@ func templateRootfsForSnapshot(runDir, snapshotPath string) (string, error) {
 // ---------------------------------------------------------------------------
 
 // waitForPIDExit polls until the process at pid is gone (kill(pid, 0)
-// returns ESRCH) or the deadline expires. Best-effort: returns silently
-// either way. Used after SIGKILL to ensure the kernel has actually
-// reaped the process and released its fds before we reuse its resources.
-func waitForPIDExit(pid int, timeout time.Duration) {
+// returns ESRCH) or the deadline expires. Returns true when the process is
+// gone. Used after SIGKILL to ensure the kernel has actually reaped the
+// process and released its fds before we reuse its resources.
+func waitForPIDExit(pid int, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		// syscall.Kill(pid, 0) returns ESRCH when the process is gone.
 		if err := syscall.Kill(pid, 0); err != nil {
-			return
+			return true
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	return false
+}
+
+// sigkillPID SIGKILLs pid and waits up to wait for the kernel to reap it, so
+// its fds (including a tap device) are released before the caller reuses the
+// process's resources. The single kill path for orphan Firecrackers.
+func sigkillPID(pid int, wait time.Duration) {
+	if pid <= 0 {
+		return
+	}
+	if proc, err := os.FindProcess(pid); err == nil {
+		_ = proc.Signal(syscall.SIGKILL)
+		if wait > 0 {
+			waitForPIDExit(pid, wait)
+		}
+	}
+}
+
+// pidIsVMFirecracker reports whether pid's command line names vmID. Record
+// PIDs can be stale (a paused record keeps the PID of a Firecracker that died
+// at pause), and after PID-space reuse a stale PID may belong to an unrelated
+// live process — so record-sourced kills must verify identity first. The
+// per-VM rundir path on the command line embeds vmID.
+func pidIsVMFirecracker(pid int, vmID string) bool {
+	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(b), vmID)
 }
 
 // coldBootFromRootfs is the parameterized form: boot a VM from a specific
@@ -542,7 +571,9 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	// in memory; an untracked one (paused or post-restart, absent from m.vms) has
 	// them only in the record. Without the record fallback a cold-boot VM's
 	// Firecracker is never killed (stopUnit is a no-op for it) and its slot is
-	// never reclaimed (ns is ""). Mirrors the reconciler's orphan teardown.
+	// never reclaimed (ns is ""). A record PID is killed only after verifying it
+	// still names this VM — a paused record keeps its dead Firecracker's PID, and
+	// after PID reuse that number can be an unrelated live process.
 	var pid int
 	var sockPath, ns string
 	if instErr == nil {
@@ -553,20 +584,17 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 		inst.mu.RUnlock()
 	} else if m.state != nil {
 		if rec, err := m.state.Get(vmID); err == nil && rec != nil {
-			pid = rec.PID
+			if pidIsVMFirecracker(rec.PID, vmID) {
+				pid = rec.PID
+			}
 			sockPath = rec.SocketPath
 			ns = rec.Namespace
 		}
 	}
 
-	if pid > 0 {
-		if proc, err := os.FindProcess(pid); err == nil {
-			// No-op for systemd VMs (stopUnit already killed them); the real kill
-			// for cold-boot VMs. Best-effort by record PID, as the reconciler does.
-			_ = proc.Signal(syscall.SIGKILL)
-			waitForPIDExit(pid, 500*time.Millisecond)
-		}
-	}
+	// No-op for systemd VMs (stopUnit already killed them); the real kill for
+	// cold-boot VMs and verified record orphans.
+	sigkillPID(pid, 500*time.Millisecond)
 	if sockPath != "" {
 		_ = os.Remove(sockPath)
 	}
@@ -1320,20 +1348,21 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// ops circuit breaker that forces fresh restores onto File too.
 	useUffd := !inPlace && m.cfg.UffdEnabled
 
-	// Loop-carried across restore attempts (see the retry at the end of the loop).
+	// Loop-carried across restore attempts: only what the post-loop code reads.
 	var (
-		tapDevice, macAddr, hostIP, nsName string
-		pid                                int
-		tNetReady, tFcReady                time.Time
-		restoreErr                         error
+		hostIP     string
+		pid        int
+		restoreErr error
 	)
 
-	// A fresh restore that fails with a still-held tap0 (see isTapDeviceBusy) is
-	// retried on a different slot; the failed slot is released back to the pool.
-	// inPlace resumes reuse a specific VM's own slot and never retry.
+	// A fresh restore that fails with a still-held tap0 (isTapDeviceBusyErr) is
+	// retried on a different slot; the failed slot is torn down. inPlace resumes
+	// reuse a specific VM's own slot and never retry.
 	const maxRestoreAttempts = 3
 	for attempt := 1; ; attempt++ {
-		tapDevice, macAddr, hostIP, nsName = "", "", "", ""
+		tAttemptStart := time.Now()
+		var tapDevice, macAddr, nsName string
+		hostIP = ""
 		if inPlace {
 			existingNet := m.netMgr.GetVMNetInfo(vmID)
 			if existingNet != nil {
@@ -1356,7 +1385,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			hostIP = netInfo.HostIP
 			nsName = netInfo.Namespace
 		}
-		tNetReady = time.Now()
+		tNetReady := time.Now()
 
 		// Publish all the network/disk/socket fields before starting Firecracker
 		// so the in-memory view is consistent for concurrent readers.
@@ -1382,18 +1411,27 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		inst.mu.Lock()
 		inst.PID = pid
 		inst.mu.Unlock()
-		tFcReady = time.Now()
+		tFcReady := time.Now()
 
+		// Attempts after the first measure from the attempt start, so a retry's
+		// disk_to_net_ms doesn't absorb the whole failed previous attempt.
+		netBase := tDiskReady
+		if attempt > 1 {
+			netBase = tAttemptStart
+		}
 		log.Info().
 			Int64("entry_to_sem_ms", tSemAcquired.Sub(tEntry).Milliseconds()).
 			Int64("sem_to_disk_ms", tDiskReady.Sub(tSemAcquired).Milliseconds()).
-			Int64("disk_to_net_ms", tNetReady.Sub(tDiskReady).Milliseconds()).
+			Int64("disk_to_net_ms", tNetReady.Sub(netBase).Milliseconds()).
 			Int64("net_to_fc_ms", tFcReady.Sub(tNetReady).Milliseconds()).
 			Int64("entry_to_fc_ready_ms", tFcReady.Sub(tEntry).Milliseconds()).
 			Int("attempt", attempt).
 			Msg("restoring snapshot")
 
-		restoreErr = nil
+		// attemptErr is this attempt's result alone; it lands in restoreErr after
+		// the load log so a stale prior-attempt error can never leak into the
+		// UFFD branch's attemptErr==nil gate below.
+		var attemptErr error
 		// A diff overlay (mem.diff, or any file with a base sidecar) must be served by
 		// the UFFD layered backend. Catch it before backend selection so that with UFFD
 		// disabled / inPlace / resume-UFFD off it fails loud instead of falling to the
@@ -1403,7 +1441,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
 		switch {
 		case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
-			restoreErr = fmt.Errorf(
+			attemptErr = fmt.Errorf(
 				"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
 				memPath)
 		case useUffd:
@@ -1439,7 +1477,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				inst.DirtyTracked = armLayered
 				inst.mu.Unlock()
 			case isOverlayMemFile(memPath):
-				restoreErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
+				attemptErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
 			case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
 				armLayered = true
 				inst.mu.Lock()
@@ -1447,35 +1485,47 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				inst.DirtyTracked = true
 				inst.mu.Unlock()
 			}
-			if restoreErr == nil {
-				restoreErr = RestoreSnapshotUffdInternalWithOverrides(
+			if attemptErr == nil {
+				attemptErr = RestoreSnapshotUffdInternalWithOverrides(
 					socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
 					m.cfg.HandlerDeathAbortEnabled,
 				)
 			}
 		case inPlace:
-			restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)
+			attemptErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)
 		default:
 			// UFFD disabled but fresh restore — File backend with network overrides.
-			restoreErr = RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir)
+			attemptErr = RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir)
 		}
 		log.Info().
 			Int64("load_snapshot_ms", time.Since(tFcReady).Milliseconds()).
-			Bool("ok", restoreErr == nil).
+			Bool("ok", attemptErr == nil).
 			Int("attempt", attempt).
 			Msg("snapshot loaded")
+		restoreErr = attemptErr
 
 		if restoreErr == nil {
 			break
 		}
 		// Retriable only for a fresh-restore tap0 busy. The overlay and inst are
 		// kept for the next attempt; terminal cleanup lives below the loop.
-		if inPlace || attempt >= maxRestoreAttempts || !isTapDeviceBusy(restoreErr) {
+		if inPlace || attempt >= maxRestoreAttempts || !isTapDeviceBusyErr(restoreErr) {
+			break
+		}
+		m.stopUnitDuringRestoreError(vmID)
+		// systemctl start is a no-op on an active unit, so a retry against a
+		// surviving Firecracker can't boot a new one — verify the unit is gone
+		// before reusing its name, and give up if it isn't.
+		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		survivor := m.unitMainPID(checkCtx, vmID)
+		checkCancel()
+		if survivor > 0 && !waitForPIDExit(survivor, 2*time.Second) {
+			log.Warn().Int("pid", survivor).Int("attempt", attempt).
+				Msg("unit still alive after stop — not retrying restore")
 			break
 		}
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
 			Msg("restore failed with tap0 busy — retrying with a fresh slot")
-		m.stopUnitDuringRestoreError(vmID)
 		// Full teardown, not recycle: a fast recycle could return this same busy
 		// slot to the pool and the next attempt could re-claim it.
 		m.netMgr.TeardownVM(vmID)
@@ -1491,7 +1541,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if !inPlace {
 			// A tap-busy slot is suspect — tear it down rather than recycle it,
 			// so it isn't handed to another create with the same bad tap.
-			if isTapDeviceBusy(restoreErr) {
+			if isTapDeviceBusyErr(restoreErr) {
 				m.netMgr.TeardownVM(vmID)
 			} else {
 				m.netMgr.CleanupVM(vmID)
@@ -1538,6 +1588,22 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	tBoxdReady := time.Now()
 
+	// A concurrent DestroyVM may have completed while we were restoring (its
+	// network cleanup no-ops during the retry window, and removeVM deletes the
+	// record). Persisting would resurrect the destroyed VM as an untracked
+	// zombie, so tear down instead.
+	m.mu.RLock()
+	_, stillTracked := m.vms[vmID]
+	m.mu.RUnlock()
+	if !stillTracked {
+		m.stopUnitDuringRestoreError(vmID)
+		if !inPlace {
+			m.netMgr.CleanupVM(vmID)
+		}
+		cleanupAfterRestoreFailure()
+		return nil, status.Errorf(codes.NotFound, "vm %s was destroyed during restore", vmID)
+	}
+
 	m.setStatus(vmID, StatusRunning)
 	m.persistState(inst)
 	tPersisted := time.Now()
@@ -1548,18 +1614,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Int64("persist_state_ms", tPersisted.Sub(tBoxdReady).Milliseconds()).
 		Msg("VM restored from snapshot")
 	return inst, nil
-}
-
-// isTapDeviceBusy reports whether err is Firecracker's tap0-attach EBUSY —
-// "Open tap device failed: ... Device or resource busy" — surfaced through the
-// snapshot-load error. It marks a restore failure as retriable on a fresh slot.
-func isTapDeviceBusy(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "Open tap device failed") ||
-		(strings.Contains(s, "tap0") && strings.Contains(s, "resource busy"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1688,13 +1742,13 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		if unitDefinitelyDead(ctx, systemdUnitName(rec.ID)) {
 			log.Warn().Msg("VM in BoltDB but not running — cleaning up stale record")
 			// Cold-booted VMs (old build path) ran with Setsid and no unit, so
-			// they survive vmd restarts as orphans holding TAP fds — SIGKILL by PID.
-			if rec.PID > 0 {
-				if proc, err := os.FindProcess(rec.PID); err == nil {
-					if killErr := proc.Signal(syscall.SIGKILL); killErr == nil {
-						log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
-					}
-				}
+			// they survive vmd restarts as orphans holding TAP fds — SIGKILL by
+			// PID, but only after verifying the PID still names this VM (a stale
+			// record PID may have been reused by an unrelated process). The wait
+			// lets the kernel release the tap fd before the netns teardown below.
+			if pidIsVMFirecracker(rec.PID, rec.ID) {
+				sigkillPID(rec.PID, 500*time.Millisecond)
+				log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
 			}
 			m.state.Delete(rec.ID)
 			// Free this record's namespace/slot directly instead of a broad
@@ -2238,12 +2292,7 @@ func (m *Manager) stopUnitDuringRestoreError(vmID string) {
 	// asynchronously and often still 0 this early), SIGKILL, and wait for exit.
 	killCtx, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel2()
-	if pid := m.unitMainPID(killCtx, vmID); pid > 0 {
-		if proc, err := os.FindProcess(pid); err == nil {
-			_ = proc.Signal(syscall.SIGKILL)
-			waitForPIDExit(pid, 500*time.Millisecond)
-		}
-	}
+	sigkillPID(m.unitMainPID(killCtx, vmID), 500*time.Millisecond)
 
 	removeUnitDropIn(vmID)
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -538,44 +538,39 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	}
 	removeUnitDropIn(vmID)
 
-	// Fallback: cold-booted VMs (template build VMs from startFirecrackerColdBoot
-	// and the default-template cold boot) aren't systemd-managed — they run as
-	// plain child processes of vmd. stopUnit is a no-op for them, so we have
-	// to SIGKILL by PID or Firecracker keeps holding its TAP fd, causing the
-	// network pool to hand out a "reusable" slot whose tap0 is still in use.
-	// Next VM that claims the slot fails with EBUSY ("Open tap device failed:
-	// Resource busy"). See internal/network/manager.go:344 for the pool
-	// return path that assumes the previous owner is dead.
+	// Recover the PID, socket, and namespace to tear down. A tracked VM has them
+	// in memory; an untracked one (paused or post-restart, absent from m.vms) has
+	// them only in the record. Without the record fallback a cold-boot VM's
+	// Firecracker is never killed (stopUnit is a no-op for it) and its slot is
+	// never reclaimed (ns is ""). Mirrors the reconciler's orphan teardown.
+	var pid int
+	var sockPath, ns string
 	if instErr == nil {
 		inst.mu.RLock()
-		pid := inst.PID
-		sockPath := inst.SocketPath
+		pid = inst.PID
+		sockPath = inst.SocketPath
+		ns = inst.Namespace
 		inst.mu.RUnlock()
-		if pid > 0 {
-			if proc, err := os.FindProcess(pid); err == nil {
-				// SIGKILL is safe here: we're tearing down, no graceful shutdown
-				// is expected. For systemd-managed VMs this is a no-op because
-				// stopUnit already killed the process.
-				_ = proc.Signal(syscall.SIGKILL)
-				// Give the kernel a moment to actually release fds before we
-				// hand the namespace + TAP back to the pool. 100ms is enough
-				// in practice — Linux process teardown is fast once all fds
-				// are dropped.
-				waitForPIDExit(pid, 500*time.Millisecond)
-			}
-		}
-		if sockPath != "" {
-			_ = os.Remove(sockPath)
+	} else if m.state != nil {
+		if rec, err := m.state.Get(vmID); err == nil && rec != nil {
+			pid = rec.PID
+			sockPath = rec.SocketPath
+			ns = rec.Namespace
 		}
 	}
 
-	// Reclaim the network slot even if the VM isn't tracked in the devices
-	// map (e.g. a paused VM reattached without network state) — pass the
-	// known namespace so the slot isn't leaked.
-	ns := ""
-	if instErr == nil {
-		ns = inst.Namespace
+	if pid > 0 {
+		if proc, err := os.FindProcess(pid); err == nil {
+			// No-op for systemd VMs (stopUnit already killed them); the real kill
+			// for cold-boot VMs. Best-effort by record PID, as the reconciler does.
+			_ = proc.Signal(syscall.SIGKILL)
+			waitForPIDExit(pid, 500*time.Millisecond)
+		}
 	}
+	if sockPath != "" {
+		_ = os.Remove(sockPath)
+	}
+
 	m.netMgr.CleanupVMOrNamespace(vmID, ns)
 
 	// Fall back to vmID when the instance is absent (RunDirID == vmID anyway).
@@ -1318,143 +1313,175 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	tDiskReady := time.Now()
 
-	var tapDevice, macAddr, hostIP, nsName string
-
-	if inPlace {
-		existingNet := m.netMgr.GetVMNetInfo(vmID)
-		if existingNet != nil {
-			tapDevice = existingNet.TAPDevice
-			macAddr = existingNet.MACAddress
-			hostIP = existingNet.HostIP
-			nsName = existingNet.Namespace
-		}
-	}
-
-	if tapDevice == "" {
-		netInfo, netErr := m.netMgr.SetupVM(ctx, vmID, netCfg)
-		if netErr != nil {
-			cleanupAfterRestoreFailure()
-			m.setStatus(vmID, StatusError)
-			return nil, fmt.Errorf("setup network: %w", netErr)
-		}
-		tapDevice = netInfo.TAPDevice
-		macAddr = netInfo.MACAddress
-		hostIP = netInfo.HostIP
-		nsName = netInfo.Namespace
-	}
-	tNetReady := time.Now()
-
 	vmDir := filepath.Join(m.cfg.RunDir, vmID)
 	socketPath := filepath.Join(vmDir, "firecracker.sock")
-
-	// Publish all the network/disk/socket fields before starting
-	// Firecracker so the in-memory view is consistent for concurrent
-	// readers. Lock once for the batch.
-	inst.mu.Lock()
-	inst.DiskPath = diskPath
-	inst.IP = hostIP
-	inst.TAPDevice = tapDevice
-	inst.MACAddress = macAddr
-	inst.Namespace = nsName
-	inst.SocketPath = socketPath
-	inst.mu.Unlock()
 
 	// inPlace resume always uses the File backend; UffdEnabled=false is the
 	// ops circuit breaker that forces fresh restores onto File too.
 	useUffd := !inPlace && m.cfg.UffdEnabled
 
-	pid, startErr := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName)
-	if startErr != nil {
-		if !inPlace {
-			m.netMgr.CleanupVM(vmID)
-		}
-		cleanupAfterRestoreFailure()
-		m.setStatus(vmID, StatusError)
-		return nil, fmt.Errorf("start firecracker: %w", startErr)
-	}
-	inst.mu.Lock()
-	inst.PID = pid
-	inst.mu.Unlock()
-	tFcReady := time.Now()
+	// Loop-carried across restore attempts (see the retry at the end of the loop).
+	var (
+		tapDevice, macAddr, hostIP, nsName string
+		pid                                int
+		tNetReady, tFcReady                time.Time
+		restoreErr                         error
+	)
 
-	log.Info().
-		Int64("entry_to_sem_ms", tSemAcquired.Sub(tEntry).Milliseconds()).
-		Int64("sem_to_disk_ms", tDiskReady.Sub(tSemAcquired).Milliseconds()).
-		Int64("disk_to_net_ms", tNetReady.Sub(tDiskReady).Milliseconds()).
-		Int64("net_to_fc_ms", tFcReady.Sub(tNetReady).Milliseconds()).
-		Int64("entry_to_fc_ready_ms", tFcReady.Sub(tEntry).Milliseconds()).
-		Msg("restoring snapshot")
-
-	var restoreErr error
-	// A diff overlay (mem.diff, or any file with a base sidecar) must be served by
-	// the UFFD layered backend. Catch it before backend selection so that with UFFD
-	// disabled / inPlace / resume-UFFD off it fails loud instead of falling to the
-	// File backend, which would load the sparse overlay as a full image (the base's
-	// pages read as zero holes).
-	sidecarBase, hasSidecar := readLayeredBase(memPath)
-	overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
-	switch {
-	case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
-		restoreErr = fmt.Errorf(
-			"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
-			memPath)
-	case useUffd:
-		// Skip prefetch trace when recording so the captured order reflects
-		// guest-driven access, not pages pulled in by the prefetcher.
-		// Firecracker enforces this same invariant on its side (record_to set
-		// ⇒ no prefetch regardless of access_log_path); this branch is the
-		// stat-avoidance optimisation that keeps us from probing the disk for
-		// a file we already know we won't pass through.
-		accessLogPath := ""
-		if recordToPath == "" && m.cfg.UffdPrefetchEnabled {
-			candidate := filepath.Join(filepath.Dir(memPath), accessLogFilename)
-			if _, err := os.Stat(candidate); err == nil {
-				accessLogPath = candidate
+	// A fresh restore that fails with a still-held tap0 (see isTapDeviceBusy) is
+	// retried on a different slot; the failed slot is released back to the pool.
+	// inPlace resumes reuse a specific VM's own slot and never retry.
+	const maxRestoreAttempts = 3
+	for attempt := 1; ; attempt++ {
+		tapDevice, macAddr, hostIP, nsName = "", "", "", ""
+		if inPlace {
+			existingNet := m.netMgr.GetVMNetInfo(vmID)
+			if existingNet != nil {
+				tapDevice = existingNet.TAPDevice
+				macAddr = existingNet.MACAddress
+				hostIP = existingNet.HostIP
+				nsName = existingNet.Namespace
 			}
 		}
-		// Decide the layered base for this UFFD restore. An overlay (mem.diff) needs
-		// its base reconstructed from the sidecar (else refuse — loading it
-		// standalone reads the base as zero holes); a template create instead arms
-		// tracking and records the template as the base. Layered needs resume-UFFD.
-		isTemplate := m.isTemplateMemPath(memPath)
-		canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
-		basePath := ""
-		armLayered := false
+
+		if tapDevice == "" {
+			netInfo, netErr := m.netMgr.SetupVM(ctx, vmID, netCfg)
+			if netErr != nil {
+				cleanupAfterRestoreFailure()
+				m.setStatus(vmID, StatusError)
+				return nil, fmt.Errorf("setup network: %w", netErr)
+			}
+			tapDevice = netInfo.TAPDevice
+			macAddr = netInfo.MACAddress
+			hostIP = netInfo.HostIP
+			nsName = netInfo.Namespace
+		}
+		tNetReady = time.Now()
+
+		// Publish all the network/disk/socket fields before starting Firecracker
+		// so the in-memory view is consistent for concurrent readers.
+		inst.mu.Lock()
+		inst.DiskPath = diskPath
+		inst.IP = hostIP
+		inst.TAPDevice = tapDevice
+		inst.MACAddress = macAddr
+		inst.Namespace = nsName
+		inst.SocketPath = socketPath
+		inst.mu.Unlock()
+
+		var startErr error
+		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName)
+		if startErr != nil {
+			if !inPlace {
+				m.netMgr.CleanupVM(vmID)
+			}
+			cleanupAfterRestoreFailure()
+			m.setStatus(vmID, StatusError)
+			return nil, fmt.Errorf("start firecracker: %w", startErr)
+		}
+		inst.mu.Lock()
+		inst.PID = pid
+		inst.mu.Unlock()
+		tFcReady = time.Now()
+
+		log.Info().
+			Int64("entry_to_sem_ms", tSemAcquired.Sub(tEntry).Milliseconds()).
+			Int64("sem_to_disk_ms", tDiskReady.Sub(tSemAcquired).Milliseconds()).
+			Int64("disk_to_net_ms", tNetReady.Sub(tDiskReady).Milliseconds()).
+			Int64("net_to_fc_ms", tFcReady.Sub(tNetReady).Milliseconds()).
+			Int64("entry_to_fc_ready_ms", tFcReady.Sub(tEntry).Milliseconds()).
+			Int("attempt", attempt).
+			Msg("restoring snapshot")
+
+		restoreErr = nil
+		// A diff overlay (mem.diff, or any file with a base sidecar) must be served by
+		// the UFFD layered backend. Catch it before backend selection so that with UFFD
+		// disabled / inPlace / resume-UFFD off it fails loud instead of falling to the
+		// File backend, which would load the sparse overlay as a full image (the base's
+		// pages read as zero holes).
+		sidecarBase, hasSidecar := readLayeredBase(memPath)
+		overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
 		switch {
-		case hasSidecar:
-			// The outer overlayNeedsLayered guard already required resume-UFFD to reach
-			// here, so canLayered holds — serve the overlay over its recorded base.
-			basePath = sidecarBase
-			armLayered = m.cfg.IncrementalSnapshotEnabled
-			inst.mu.Lock()
-			inst.BaseMemPath = sidecarBase
-			inst.DirtyTracked = armLayered
-			inst.mu.Unlock()
-		case isOverlayMemFile(memPath):
-			restoreErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
-		case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
-			armLayered = true
-			inst.mu.Lock()
-			inst.BaseMemPath = memPath // template mem file = the layered base
-			inst.DirtyTracked = true
-			inst.mu.Unlock()
+		case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
+			restoreErr = fmt.Errorf(
+				"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
+				memPath)
+		case useUffd:
+			// Skip prefetch trace when recording so the captured order reflects
+			// guest-driven access, not pages pulled in by the prefetcher.
+			// Firecracker enforces this same invariant on its side (record_to set
+			// ⇒ no prefetch regardless of access_log_path); this branch is the
+			// stat-avoidance optimisation that keeps us from probing the disk for
+			// a file we already know we won't pass through.
+			accessLogPath := ""
+			if recordToPath == "" && m.cfg.UffdPrefetchEnabled {
+				candidate := filepath.Join(filepath.Dir(memPath), accessLogFilename)
+				if _, err := os.Stat(candidate); err == nil {
+					accessLogPath = candidate
+				}
+			}
+			// Decide the layered base for this UFFD restore. An overlay (mem.diff) needs
+			// its base reconstructed from the sidecar (else refuse — loading it
+			// standalone reads the base as zero holes); a template create instead arms
+			// tracking and records the template as the base. Layered needs resume-UFFD.
+			isTemplate := m.isTemplateMemPath(memPath)
+			canLayered := m.cfg.UffdEnabled && m.cfg.ResumeUffdEnabled
+			basePath := ""
+			armLayered := false
+			switch {
+			case hasSidecar:
+				// The outer overlayNeedsLayered guard already required resume-UFFD to reach
+				// here, so canLayered holds — serve the overlay over its recorded base.
+				basePath = sidecarBase
+				armLayered = m.cfg.IncrementalSnapshotEnabled
+				inst.mu.Lock()
+				inst.BaseMemPath = sidecarBase
+				inst.DirtyTracked = armLayered
+				inst.mu.Unlock()
+			case isOverlayMemFile(memPath):
+				restoreErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
+			case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
+				armLayered = true
+				inst.mu.Lock()
+				inst.BaseMemPath = memPath // template mem file = the layered base
+				inst.DirtyTracked = true
+				inst.mu.Unlock()
+			}
+			if restoreErr == nil {
+				restoreErr = RestoreSnapshotUffdInternalWithOverrides(
+					socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
+					m.cfg.HandlerDeathAbortEnabled,
+				)
+			}
+		case inPlace:
+			restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)
+		default:
+			// UFFD disabled but fresh restore — File backend with network overrides.
+			restoreErr = RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir)
 		}
+		log.Info().
+			Int64("load_snapshot_ms", time.Since(tFcReady).Milliseconds()).
+			Bool("ok", restoreErr == nil).
+			Int("attempt", attempt).
+			Msg("snapshot loaded")
+
 		if restoreErr == nil {
-			restoreErr = RestoreSnapshotUffdInternalWithOverrides(
-				socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
-				m.cfg.HandlerDeathAbortEnabled,
-			)
+			break
 		}
-	case inPlace:
-		restoreErr = RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir)
-	default:
-		// UFFD disabled but fresh restore — File backend with network overrides.
-		restoreErr = RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir)
+		// Retriable only for a fresh-restore tap0 busy. The overlay and inst are
+		// kept for the next attempt; terminal cleanup lives below the loop.
+		if inPlace || attempt >= maxRestoreAttempts || !isTapDeviceBusy(restoreErr) {
+			break
+		}
+		log.Warn().Err(restoreErr).Int("attempt", attempt).
+			Msg("restore failed with tap0 busy — retrying with a fresh slot")
+		m.stopUnitDuringRestoreError(vmID)
+		m.netMgr.CleanupVM(vmID)
+		inst.mu.Lock()
+		inst.DirtyTracked = false
+		inst.mu.Unlock()
 	}
-	log.Info().
-		Int64("load_snapshot_ms", time.Since(tFcReady).Milliseconds()).
-		Bool("ok", restoreErr == nil).
-		Msg("snapshot loaded")
+
 	if restoreErr != nil {
 		// Firecracker is already running; stop the unit before other
 		// cleanup or it leaks. See stopUnitDuringRestoreError comment.
@@ -1513,6 +1540,18 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Int64("persist_state_ms", tPersisted.Sub(tBoxdReady).Milliseconds()).
 		Msg("VM restored from snapshot")
 	return inst, nil
+}
+
+// isTapDeviceBusy reports whether err is Firecracker's tap0-attach EBUSY —
+// "Open tap device failed: ... Device or resource busy" — surfaced through the
+// snapshot-load error. It marks a restore failure as retriable on a fresh slot.
+func isTapDeviceBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "Open tap device failed") ||
+		(strings.Contains(s, "tap0") && strings.Contains(s, "resource busy"))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -420,17 +420,22 @@ func sigkillPID(pid int, wait time.Duration) {
 	}
 }
 
-// pidIsVMFirecracker reports whether pid's command line names vmID. Record
-// PIDs can be stale (a paused record keeps the PID of a Firecracker that died
-// at pause), and after PID-space reuse a stale PID may belong to an unrelated
-// live process — so record-sourced kills must verify identity first. The
-// per-VM rundir path on the command line embeds vmID.
+// pidIsVMFirecracker reports whether pid is this VM's Firecracker. A stored PID
+// can be stale (a paused VM keeps the PID of a Firecracker that died at pause),
+// and after PID-space reuse it may belong to an unrelated live process — so any
+// kill fed by stored state must verify identity first. Substring matching is
+// not identity (a tail/cp on the VM's rundir path would pass it); this requires
+// the exact `--id <vmID>` argv token and the firecracker binary, the same
+// predicate killOrphanFirecracker uses.
 func pidIsVMFirecracker(pid int, vmID string) bool {
-	b, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if pid <= 0 || vmID == "" {
+		return false
+	}
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(b), vmID)
+	return firecrackerCmdlineMatches(cmdline, vmID)
 }
 
 // coldBootFromRootfs is the parameterized form: boot a VM from a specific
@@ -571,9 +576,7 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 	// in memory; an untracked one (paused or post-restart, absent from m.vms) has
 	// them only in the record. Without the record fallback a cold-boot VM's
 	// Firecracker is never killed (stopUnit is a no-op for it) and its slot is
-	// never reclaimed (ns is ""). A record PID is killed only after verifying it
-	// still names this VM — a paused record keeps its dead Firecracker's PID, and
-	// after PID reuse that number can be an unrelated live process.
+	// never reclaimed (ns is "").
 	var pid int
 	var sockPath, ns string
 	if instErr == nil {
@@ -584,17 +587,19 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 		inst.mu.RUnlock()
 	} else if m.state != nil {
 		if rec, err := m.state.Get(vmID); err == nil && rec != nil {
-			if pidIsVMFirecracker(rec.PID, vmID) {
-				pid = rec.PID
-			}
+			pid = rec.PID
 			sockPath = rec.SocketPath
 			ns = rec.Namespace
 		}
 	}
 
 	// No-op for systemd VMs (stopUnit already killed them); the real kill for
-	// cold-boot VMs and verified record orphans.
-	sigkillPID(pid, 500*time.Millisecond)
+	// cold-boot VMs and record orphans. Identity-gated regardless of source: a
+	// paused VM's PID is stale whether it came from memory or the record, and
+	// after PID reuse an unverified kill hits an unrelated process.
+	if pidIsVMFirecracker(pid, vmID) {
+		sigkillPID(pid, 500*time.Millisecond)
+	}
 	if sockPath != "" {
 		_ = os.Remove(sockPath)
 	}
@@ -1514,14 +1519,16 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		m.stopUnitDuringRestoreError(vmID)
 		// systemctl start is a no-op on an active unit, so a retry against a
-		// surviving Firecracker can't boot a new one — verify the unit is gone
-		// before reusing its name, and give up if it isn't.
+		// surviving Firecracker can't boot a new one — retry only when the unit
+		// is affirmatively dead. An inconclusive answer (systemctl error or
+		// timeout under the same host contention that causes tap-busy) must
+		// read as alive, not as permission to retry.
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		survivor := m.unitMainPID(checkCtx, vmID)
+		dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
 		checkCancel()
-		if survivor > 0 && !waitForPIDExit(survivor, 2*time.Second) {
-			log.Warn().Int("pid", survivor).Int("attempt", attempt).
-				Msg("unit still alive after stop — not retrying restore")
+		if !dead {
+			log.Warn().Int("attempt", attempt).
+				Msg("unit not confirmed dead after stop — not retrying restore")
 			break
 		}
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
@@ -1588,14 +1595,19 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	tBoxdReady := time.Now()
 
-	// A concurrent DestroyVM may have completed while we were restoring (its
-	// network cleanup no-ops during the retry window, and removeVM deletes the
-	// record). Persisting would resurrect the destroyed VM as an untracked
-	// zombie, so tear down instead.
+	m.setStatus(vmID, StatusRunning)
+	m.persistState(inst)
+	// Persist-then-verify: a concurrent DestroyVM may have completed while we
+	// were restoring (its network cleanup no-ops during the retry window, and
+	// removeVM deletes the record — possibly between our persist and here, or
+	// our persist may have resurrected an already-deleted record). Checking
+	// AFTER the write leaves no window: a destroy that raced us either erased
+	// the record itself or is caught now, and we erase it and tear down.
 	m.mu.RLock()
 	_, stillTracked := m.vms[vmID]
 	m.mu.RUnlock()
 	if !stillTracked {
+		m.deleteState(vmID)
 		m.stopUnitDuringRestoreError(vmID)
 		if !inPlace {
 			m.netMgr.CleanupVM(vmID)
@@ -1603,9 +1615,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		cleanupAfterRestoreFailure()
 		return nil, status.Errorf(codes.NotFound, "vm %s was destroyed during restore", vmID)
 	}
-
-	m.setStatus(vmID, StatusRunning)
-	m.persistState(inst)
 	tPersisted := time.Now()
 
 	log.Info().

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1476,7 +1476,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
 			Msg("restore failed with tap0 busy — retrying with a fresh slot")
 		m.stopUnitDuringRestoreError(vmID)
-		m.netMgr.CleanupVM(vmID)
+		// Full teardown, not recycle: a fast recycle could return this same busy
+		// slot to the pool and the next attempt could re-claim it.
+		m.netMgr.TeardownVM(vmID)
 		inst.mu.Lock()
 		inst.DirtyTracked = false
 		inst.mu.Unlock()
@@ -1487,7 +1489,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// cleanup or it leaks. See stopUnitDuringRestoreError comment.
 		m.stopUnitDuringRestoreError(vmID)
 		if !inPlace {
-			m.netMgr.CleanupVM(vmID)
+			// A tap-busy slot is suspect — tear it down rather than recycle it,
+			// so it isn't handed to another create with the same bad tap.
+			if isTapDeviceBusy(restoreErr) {
+				m.netMgr.TeardownVM(vmID)
+			} else {
+				m.netMgr.CleanupVM(vmID)
+			}
 		}
 		cleanupAfterRestoreFailure()
 		m.setStatus(vmID, StatusError)


### PR DESCRIPTION
Recycling a network slot could hand it to a new VM before the previous owner's `tap0` fd was released, so the next Firecracker's attach failed with `EBUSY`. Separately, destroying a VM that wasn't tracked in memory skipped the process kill and slot reclaim, leaking its namespace.

- Rebuild `tap0` when a slot is recycled so reuse can't inherit a still-held tap. Gated behind `VMD_RECYCLE_TAP_RESET` (off by default) for staged rollout.
- Retry a fresh restore that still hits a busy tap on a different slot.
- On destroy, recover the PID and namespace from the persisted record for untracked VMs so Firecracker is killed and the slot reclaimed; kill any straggler before removing a namespace.
- Add a periodic gauge (namespaces vs live VMs + pool held) to surface namespace leaks.

Rollout: enable `VMD_RECYCLE_TAP_RESET` per host, confirm no `EBUSY` under create bursts and the leak gauge stays flat, then make it the default and drop the flag.
