### PR TITLE
vmd: batch the recycle tap rebuild into one exec and bound its concurrency

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -420,19 +420,17 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 // decline to recycle. nftables rules match tap0 by name, so reusing the name
 // keeps them valid. Also the tap-construction path for setupSlot (the delete
 // is a no-op on a fresh namespace), keeping fresh and recycled taps identical.
+//
+// The rebuild runs as a single exec: per-command `ip netns exec` invocations
+// fork twice each and serialize on the kernel's netlink lock, which under a
+// mass delete's concurrent resets was enough to blow the caller's deadline.
+// All interpolants are package constants.
 func (m *Manager) resetTap(ctx context.Context, nsName string) error {
-	_ = nsRun(ctx, nsName, "ip", "link", "del", TAPName)
-	if err := nsRun(ctx, nsName, "ip", "tuntap", "add", "dev", TAPName, "mode", "tap"); err != nil {
-		return fmt.Errorf("create TAP: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "up"); err != nil {
-		return fmt.Errorf("bring up TAP: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "link", "set", TAPName, "mtu", ifaceMTU); err != nil {
-		return fmt.Errorf("set TAP MTU: %w", err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "addr", "add", tapCIDR, "dev", TAPName); err != nil {
-		return fmt.Errorf("assign TAP IP: %w", err)
+	script := fmt.Sprintf(
+		"ip link del %[1]s 2>/dev/null; ip tuntap add dev %[1]s mode tap && ip link set %[1]s up && ip link set %[1]s mtu %[2]s && ip addr add %[3]s dev %[1]s",
+		TAPName, ifaceMTU, tapCIDR)
+	if err := nsRun(ctx, nsName, "sh", "-c", script); err != nil {
+		return fmt.Errorf("reset TAP: %w", err)
 	}
 	return nil
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -421,10 +421,9 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 // keeps them valid. Also the tap-construction path for setupSlot (the delete
 // is a no-op on a fresh namespace), keeping fresh and recycled taps identical.
 //
-// The rebuild runs as a single exec: per-command `ip netns exec` invocations
-// fork twice each and serialize on the kernel's netlink lock, which under a
-// mass delete's concurrent resets was enough to blow the caller's deadline.
-// All interpolants are package constants.
+// One exec for the whole rebuild: per-command `ip netns exec` invocations fork
+// twice each and serialize on the kernel's netlink lock under concurrent
+// resets. All interpolants are package constants.
 func (m *Manager) resetTap(ctx context.Context, nsName string) error {
 	script := fmt.Sprintf(
 		"ip link del %[1]s 2>/dev/null; ip tuntap add dev %[1]s mode tap && ip link set %[1]s up && ip link set %[1]s mtu %[2]s && ip addr add %[3]s dev %[1]s",

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1093,6 +1093,13 @@ func run(ctx context.Context, name string, args ...string) error {
 		ctx = context.Background()
 	}
 	cmd := exec.CommandContext(ctx, name, args...)
+	// Run in its own process group and cancel the whole group, so a timeout
+	// also kills any children the command spawned (resetTap's shell) — a lone
+	// process kill would orphan them to finish after the caller moved on.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s %v: %s: %w", name, args, string(out), err)
 	}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/shellquote"
 )
 
 // ---------------------------------------------------------------------------
@@ -423,11 +425,11 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 //
 // One exec for the whole rebuild: per-command `ip netns exec` invocations fork
 // twice each and serialize on the kernel's netlink lock under concurrent
-// resets. All interpolants are package constants.
+// resets. Interpolants are shell-quoted package constants.
 func (m *Manager) resetTap(ctx context.Context, nsName string) error {
 	script := fmt.Sprintf(
 		"ip link del %[1]s 2>/dev/null; ip tuntap add dev %[1]s mode tap && ip link set %[1]s up && ip link set %[1]s mtu %[2]s && ip addr add %[3]s dev %[1]s",
-		TAPName, ifaceMTU, tapCIDR)
+		shellquote.Single(TAPName), shellquote.Single(ifaceMTU), shellquote.Single(tapCIDR))
 	if err := nsRun(ctx, nsName, "sh", "-c", script); err != nil {
 		return fmt.Errorf("reset TAP: %w", err)
 	}
@@ -1097,8 +1099,21 @@ func run(ctx context.Context, name string, args ...string) error {
 	// process kill would orphan them to finish after the caller moved on.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			// Group already gone: report "done" so a command that finished
+			// just as the deadline fired isn't turned into a spurious failure.
+			return os.ErrProcessDone
+		}
+		return err
 	}
+	// Bound the post-kill wait for output pipes: a descendant that detached
+	// into its own group survives the group kill and would otherwise hold
+	// stdout open indefinitely.
+	cmd.WaitDelay = time.Second
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s %v: %s: %w", name, args, string(out), err)
 	}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -86,6 +86,10 @@ const (
 	// rebuilds are short once uncontended, so a small window drains a backlog
 	// quickly.
 	resetTapConcurrency = 8
+	// resetTapTimeout bounds one batched rebuild — a healthy one takes well
+	// under a second, and a tight bound keeps a stalled backlog (and Stop)
+	// from dragging.
+	resetTapTimeout = 3 * time.Second
 )
 
 // StartPool creates the network slot pool and fills it in the background, so
@@ -246,39 +250,42 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		}
 	}
 
-	// A full recycle pool means this slot is headed for teardown anyway — skip
-	// the tap rebuild rather than pay it for a slot about to be destroyed
-	// (mass deletes overflow the pool by design). Racy but safe: the send
-	// below still has a default arm.
-	if p.resetTapOnRecycle && len(p.recycled) == cap(p.recycled) {
-		p.cleanup(slot)
-		return
-	}
-
 	// Process-free doesn't prove tap0's fd is released, so rebuild the tap
-	// before recycling; if it can't be rebuilt, tear down instead. The
-	// semaphore is acquired before the deadline starts, so queueing behind a
-	// mass delete's backlog doesn't eat into a rebuild's own budget.
+	// before recycling; if it can't be rebuilt, tear down instead.
 	if p.resetTapOnRecycle {
+		// A full recycle pool means this slot is headed for teardown anyway —
+		// skip the rebuild rather than pay it for a slot about to be destroyed
+		// (mass deletes overflow the pool by design). Racy but safe: the send
+		// below still has a default arm.
+		if len(p.recycled) == cap(p.recycled) {
+			p.cleanup(slot)
+			return
+		}
+		// The semaphore is acquired before the deadline starts, so queueing
+		// behind a backlog doesn't eat into a rebuild's own budget.
 		select {
 		case p.resetSem <- struct{}{}:
 		case <-p.stopCh:
 			p.cleanup(slot)
 			return
 		}
-		// Recheck capacity after queueing: a mass return can fill the pool
-		// while this slot waited on the semaphore, and a slot headed for
-		// teardown shouldn't pay for a rebuild. Racy but safe, like the
-		// pre-check.
-		if len(p.recycled) == cap(p.recycled) {
-			<-p.resetSem
+		poolFull, err := func() (bool, error) {
+			// Deferred so a panicking rebuild can't leak the token — Return's
+			// goroutine recovers panics, and a leaked token outlives them.
+			defer func() { <-p.resetSem }()
+			// Recheck after queueing: a mass return can fill the pool while
+			// this slot waited, and a doomed slot shouldn't pay for a rebuild.
+			if len(p.recycled) == cap(p.recycled) {
+				return true, nil
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), resetTapTimeout)
+			defer cancel()
+			return false, resetTapFunc(p.mgr, ctx, ns)
+		}()
+		if poolFull {
 			p.cleanup(slot)
 			return
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := resetTapFunc(p.mgr, ctx, ns)
-		cancel()
-		<-p.resetSem
 		if err != nil {
 			p.log.Error().Err(err).Str("namespace", ns).Int("slot", slot.idx).
 				Msg("pool: tap reset failed on recycle — tearing down instead of recycling")

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -48,9 +48,8 @@ type Pool struct {
 
 	// resetTapOnRecycle recreates tap0 before a returned slot is recycled.
 	resetTapOnRecycle bool
-	// resetSem bounds concurrent tap rebuilds: a mass delete returns hundreds
-	// of slots at once, and unbounded rebuilds contend on the kernel's netlink
-	// lock until every one blows its deadline.
+	// resetSem bounds concurrent tap rebuilds so a mass delete's returns can't
+	// fork-storm the kernel's netlink lock.
 	resetSem chan struct{}
 }
 
@@ -83,9 +82,9 @@ const (
 	// TimeoutStopSec=10 (systemd's own worst case for a unit that ignores
 	// SIGTERM) plus margin for kernel teardown under host I/O contention.
 	defaultVerifyMaxWait = 20 * time.Second
-	// resetTapConcurrency caps in-flight tap rebuilds (see Pool.resetSem).
-	// Rebuilds are short once uncontended, so a small window drains a mass
-	// delete's backlog quickly without a fork storm.
+	// resetTapConcurrency caps in-flight tap rebuilds (see Pool.resetSem);
+	// rebuilds are short once uncontended, so a small window drains a backlog
+	// quickly.
 	resetTapConcurrency = 8
 )
 

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -266,6 +266,15 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 			p.cleanup(slot)
 			return
 		}
+		// Recheck capacity after queueing: a mass return can fill the pool
+		// while this slot waited on the semaphore, and a slot headed for
+		// teardown shouldn't pay for a rebuild. Racy but safe, like the
+		// pre-check.
+		if len(p.recycled) == cap(p.recycled) {
+			<-p.resetSem
+			p.cleanup(slot)
+			return
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		err := resetTapFunc(p.mgr, ctx, ns)
 		cancel()

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -48,6 +48,10 @@ type Pool struct {
 
 	// resetTapOnRecycle recreates tap0 before a returned slot is recycled.
 	resetTapOnRecycle bool
+	// resetSem bounds concurrent tap rebuilds: a mass delete returns hundreds
+	// of slots at once, and unbounded rebuilds contend on the kernel's netlink
+	// lock until every one blows its deadline.
+	resetSem chan struct{}
 }
 
 // preallocSlot holds a fully configured network namespace ready to be
@@ -79,6 +83,10 @@ const (
 	// TimeoutStopSec=10 (systemd's own worst case for a unit that ignores
 	// SIGTERM) plus margin for kernel teardown under host I/O contention.
 	defaultVerifyMaxWait = 20 * time.Second
+	// resetTapConcurrency caps in-flight tap rebuilds (see Pool.resetSem).
+	// Rebuilds are short once uncontended, so a small window drains a mass
+	// delete's backlog quickly without a fork storm.
+	resetTapConcurrency = 8
 )
 
 // StartPool creates the network slot pool and fills it in the background, so
@@ -103,6 +111,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		recycled:          make(chan *preallocSlot, recycleSize),
 		stopCh:            make(chan struct{}),
 		resetTapOnRecycle: cfg.ResetTapOnRecycle,
+		resetSem:          make(chan struct{}, resetTapConcurrency),
 	}
 	m.pool = p
 
@@ -248,11 +257,20 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 	}
 
 	// Process-free doesn't prove tap0's fd is released, so rebuild the tap
-	// before recycling; if it can't be rebuilt, tear down instead.
+	// before recycling; if it can't be rebuilt, tear down instead. The
+	// semaphore is acquired before the deadline starts, so queueing behind a
+	// mass delete's backlog doesn't eat into a rebuild's own budget.
 	if p.resetTapOnRecycle {
+		select {
+		case p.resetSem <- struct{}{}:
+		case <-p.stopCh:
+			p.cleanup(slot)
+			return
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		err := resetTapFunc(p.mgr, ctx, ns)
 		cancel()
+		<-p.resetSem
 		if err != nil {
 			p.log.Error().Err(err).Str("namespace", ns).Int("slot", slot.idx).
 				Msg("pool: tap reset failed on recycle — tearing down instead of recycling")

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -215,6 +215,31 @@ func TestPoolReturn_BoundsConcurrentTapResets(t *testing.T) {
 	}
 }
 
+// TestPoolReturn_ReleasesResetTokenOnPanic: a panicking rebuild must release
+// its semaphore token — Return's goroutine recovers panics, so a leaked token
+// would permanently shrink the reset window.
+func TestPoolReturn_ReleasesResetTokenOnPanic(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(_ *Manager, _ context.Context, _ string) error { panic("rebuild blew up") })
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.resetTapOnRecycle = true
+	m.assignSlotLocked(1, "old-vm")
+
+	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(p.resetSem) != 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := len(p.resetSem); got != 0 {
+		t.Errorf("resetSem holds %d token(s) after a panicking rebuild, want 0", got)
+	}
+}
+
 // TestPoolReturn_SkipsTapResetWhenRecycleFull: a slot that would overflow the
 // recycle pool is torn down without paying the tap rebuild first.
 func TestPoolReturn_SkipsTapResetWhenRecycleFull(t *testing.T) {

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -42,6 +43,7 @@ func newTestPool(t *testing.T, m *Manager) *Pool {
 		stopCh:             make(chan struct{}),
 		verifyPollInterval: time.Millisecond,
 		verifyMaxWait:      50 * time.Millisecond,
+		resetSem:           make(chan struct{}, resetTapConcurrency),
 	}
 	t.Cleanup(func() {
 		select {
@@ -165,6 +167,51 @@ func TestPoolReturn_ResetsTapBeforeRecycling(t *testing.T) {
 	}
 	if got, _ := resetNS.Load().(string); got != "ns-1" {
 		t.Errorf("resetTap called with ns %q, want ns-1", got)
+	}
+}
+
+// TestPoolReturn_BoundsConcurrentTapResets: a mass return drives many verify
+// goroutines at once, but at most resetTapConcurrency tap rebuilds may be in
+// flight — the rest queue on the semaphore instead of fork-storming the host.
+func TestPoolReturn_BoundsConcurrentTapResets(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+
+	var cur, peak atomic.Int32
+	stubResetTap(t, func(_ *Manager, _ context.Context, _ string) error {
+		c := cur.Add(1)
+		for {
+			p := peak.Load()
+			if c <= p || peak.CompareAndSwap(p, c) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		cur.Add(-1)
+		return nil
+	})
+
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.resetTapOnRecycle = true
+	p.recycled = make(chan *preallocSlot, 64) // don't trip the overflow skip
+
+	const n = 32
+	for i := 0; i < n; i++ {
+		ns := fmt.Sprintf("ns-%d", i)
+		touchNS(t, dir, ns)
+		m.assignSlotLocked(i, "old-vm")
+		p.Return(&preallocSlot{idx: i, info: &VMNetInfo{Namespace: ns}, vethName: fmt.Sprintf("veth-%d", i)})
+	}
+	for i := 0; i < n; i++ {
+		select {
+		case <-p.recycled:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d/%d slots recycled", i, n)
+		}
+	}
+	if got := peak.Load(); got > resetTapConcurrency {
+		t.Errorf("concurrent tap resets peaked at %d, want <= %d", got, resetTapConcurrency)
 	}
 }
 

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -231,10 +231,9 @@ func TestPoolReturn_ReleasesResetTokenOnPanic(t *testing.T) {
 
 	p.Return(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for len(p.resetSem) != 0 && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
+	// Wait for the verify goroutine (it holds a wg slot through the panic
+	// recovery) so the assertion — and the test's stub cleanup — can't race it.
+	p.wg.Wait()
 	if got := len(p.resetSem); got != 0 {
 		t.Errorf("resetSem holds %d token(s) after a panicking rebuild, want 0", got)
 	}


### PR DESCRIPTION
With `VMD_RECYCLE_TAP_RESET` enabled, a mass delete returns hundreds of slots at once and every recycle rebuilds its tap concurrently — five `ip netns exec` invocations each, all serializing on the kernel's netlink lock. Under that contention each rebuild blows its deadline, so every reset fails to the teardown fallback: safe, but it disables recycling under exactly the churn it exists for and emits an error per slot.

- Run the rebuild as a single `sh -c` exec (one netns entry instead of five fork pairs); interpolants are package constants.
- Bound in-flight rebuilds with a semaphore (8), acquired before the rebuild's deadline starts so queueing doesn't eat the budget.
- Add a test pinning the concurrency bound under a 32-slot mass return.

With this, a "tap reset failed" error is a rare, meaningful signal rather than mass-delete noise.
