### PR TITLE
controlplane: retry vmd Unavailable long enough to cover a daemon restart

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -619,10 +619,9 @@ func (c *grpcVMDClient) CancelBuild(ctx context.Context, buildVMID string) error
 }
 
 func (c *grpcVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, onEvent func(vmdclient.BuildLogEvent) error) error {
-	// The unary retry interceptor doesn't cover streams, so ride out a
-	// daemon restart here — but only while no event has been delivered:
-	// vmd replays buffered history on a fresh stream, so retrying after
-	// delivery would duplicate events to the caller.
+	// The unary retry interceptor doesn't cover streams. Retry the open
+	// only while nothing was delivered — a fresh stream replays history,
+	// which would duplicate events.
 	deadline := time.Now().Add(retryUnavailableWindow)
 	backoff := 250 * time.Millisecond
 	for {
@@ -674,14 +673,10 @@ func (c *grpcVMDClient) streamBuildLogsOnce(ctx context.Context, buildVMID strin
 
 // retryUnavailableUnaryInterceptor retries codes.Unavailable — the daemon
 // is down or still starting — with deterministic backoff until the window
-// or the caller's context expires. Unavailable almost always means the
-// request never executed (connection refused, or the daemon's startup gate
-// rejecting before the handler). A connection severed mid-call also
-// surfaces as Unavailable though, so every retried RPC must stay safe to
-// re-execute — do not add a non-idempotent RPC relying on this retry.
+// or the caller's context expires. A connection severed mid-call also
+// surfaces as Unavailable, so every retried RPC must stay idempotent.
 // gRPC's built-in retryPolicy can't cover a daemon restart: attempts are
-// hard-capped at 5 with jittered backoff, so its worst-case envelope is a
-// few seconds.
+// hard-capped at 5, so its worst-case envelope is a few seconds.
 func retryUnavailableUnaryInterceptor(window time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		deadline := time.Now().Add(window)
@@ -692,25 +687,21 @@ func retryUnavailableUnaryInterceptor(window time.Duration) grpc.UnaryClientInte
 			err := invoker(ctx, method, req, reply, cc, opts...)
 			if err == nil || grpcstatus.Code(err) != grpccodes.Unavailable || !time.Now().Before(deadline) {
 				if err != nil && attempts > 1 {
-					// The only signal that the retry window is too small
-					// for however long the daemon is staying unreachable.
 					log.Warn().Err(err).Str("method", method).Int("attempts", attempts).
 						Msg("VMD RPC still failing after retry window")
 				}
 				return err
 			}
-			// The channel's own reconnect backoff spaces dials out to
-			// multi-second gaps that can overshoot this window even when
-			// the daemon recovers inside it; reset it so re-dials follow
-			// this loop's cadence instead. Nil cc only in tests.
+			// The channel's own reconnect backoff spaces dials out past
+			// this window; reset it so re-dials follow this loop's
+			// cadence. Nil cc only in tests.
 			if cc != nil {
 				cc.ResetConnectBackoff()
 			}
 			select {
 			case <-ctx.Done():
-				// Return the Unavailable seen before cancellation rather
-				// than ctx.Err(), so the dead-host interceptor above still
-				// observes it and evicts the cached client.
+				// Stale Unavailable, not ctx.Err(): the dead-host
+				// interceptor above keys off it.
 				return err
 			case <-time.After(min(backoff, time.Until(deadline))):
 			}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -634,7 +634,9 @@ func (c *grpcVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, o
 		}
 		select {
 		case <-ctx.Done():
-			return err
+			// Same as the unary interceptor: a caller giving up must not
+			// read as a dead host.
+			return fmt.Errorf("%w (last attempt: %v)", ctx.Err(), err)
 		case <-time.After(min(backoff, time.Until(deadline))):
 		}
 		backoff = min(backoff*2, 2*time.Second)
@@ -656,6 +658,7 @@ func (c *grpcVMDClient) streamBuildLogsOnce(ctx context.Context, buildVMID strin
 			}
 			return delivered, fmt.Errorf("recv build log: %w", err)
 		}
+		delivered = true
 		if cbErr := onEvent(vmdclient.BuildLogEvent{
 			TimestampUnixNanos: pbEv.GetTimestampUnixNanos(),
 			Stream:             pbEv.GetStream(),
@@ -700,9 +703,9 @@ func retryUnavailableUnaryInterceptor(window time.Duration) grpc.UnaryClientInte
 			}
 			select {
 			case <-ctx.Done():
-				// Stale Unavailable, not ctx.Err(): the dead-host
-				// interceptor above keys off it.
-				return err
+				// The caller gave up, not the host: don't surface
+				// Unavailable (the dead-host interceptor keys off it).
+				return fmt.Errorf("%w (last attempt: %v)", ctx.Err(), err)
 			case <-time.After(min(backoff, time.Until(deadline))):
 			}
 			backoff = min(backoff*2, 2*time.Second)

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -619,17 +619,43 @@ func (c *grpcVMDClient) CancelBuild(ctx context.Context, buildVMID string) error
 }
 
 func (c *grpcVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, onEvent func(vmdclient.BuildLogEvent) error) error {
+	// The unary retry interceptor doesn't cover streams, so ride out a
+	// daemon restart here — but only while no event has been delivered:
+	// vmd replays buffered history on a fresh stream, so retrying after
+	// delivery would duplicate events to the caller.
+	deadline := time.Now().Add(retryUnavailableWindow)
+	backoff := 250 * time.Millisecond
+	for {
+		delivered, err := c.streamBuildLogsOnce(ctx, buildVMID, onEvent)
+		if err == nil || delivered || grpcstatus.Code(err) != grpccodes.Unavailable || !time.Now().Before(deadline) {
+			return err
+		}
+		if c.conn != nil {
+			c.conn.ResetConnectBackoff()
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(min(backoff, time.Until(deadline))):
+		}
+		backoff = min(backoff*2, 2*time.Second)
+	}
+}
+
+// streamBuildLogsOnce opens one log stream and pumps it to onEvent.
+// delivered reports whether any event reached the callback.
+func (c *grpcVMDClient) streamBuildLogsOnce(ctx context.Context, buildVMID string, onEvent func(vmdclient.BuildLogEvent) error) (delivered bool, _ error) {
 	stream, err := c.client.StreamBuildLogs(ctx, &vmdpb.StreamBuildLogsRequest{BuildVmId: buildVMID})
 	if err != nil {
-		return fmt.Errorf("gRPC StreamBuildLogs: %w", err)
+		return false, fmt.Errorf("gRPC StreamBuildLogs: %w", err)
 	}
 	for {
 		pbEv, err := stream.Recv()
 		if err != nil {
 			if err == io.EOF {
-				return nil
+				return delivered, nil
 			}
-			return fmt.Errorf("recv build log: %w", err)
+			return delivered, fmt.Errorf("recv build log: %w", err)
 		}
 		if cbErr := onEvent(vmdclient.BuildLogEvent{
 			TimestampUnixNanos: pbEv.GetTimestampUnixNanos(),
@@ -638,34 +664,55 @@ func (c *grpcVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, o
 			Finished:           pbEv.GetFinished(),
 			Status:             pbEv.GetStatus(),
 		}); cbErr != nil {
-			return cbErr
+			return true, cbErr
 		}
 		if pbEv.GetFinished() {
-			return nil
+			return true, nil
 		}
 	}
 }
 
 // retryUnavailableUnaryInterceptor retries codes.Unavailable — the daemon
 // is down or still starting — with deterministic backoff until the window
-// or the caller's context expires. Unavailable guarantees the request never
-// executed on the server, so retries can't double-execute. gRPC's built-in
-// retryPolicy can't cover a daemon restart: attempts are hard-capped at 5
-// and each backoff is randomized in [0, backoff], so its worst-case
-// envelope is a few seconds.
+// or the caller's context expires. Unavailable almost always means the
+// request never executed (connection refused, or the daemon's startup gate
+// rejecting before the handler). A connection severed mid-call also
+// surfaces as Unavailable though, so every retried RPC must stay safe to
+// re-execute — do not add a non-idempotent RPC relying on this retry.
+// gRPC's built-in retryPolicy can't cover a daemon restart: attempts are
+// hard-capped at 5 with jittered backoff, so its worst-case envelope is a
+// few seconds.
 func retryUnavailableUnaryInterceptor(window time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		deadline := time.Now().Add(window)
 		backoff := 250 * time.Millisecond
+		attempts := 0
 		for {
+			attempts++
 			err := invoker(ctx, method, req, reply, cc, opts...)
 			if err == nil || grpcstatus.Code(err) != grpccodes.Unavailable || !time.Now().Before(deadline) {
+				if err != nil && attempts > 1 {
+					// The only signal that the retry window is too small
+					// for however long the daemon is staying unreachable.
+					log.Warn().Err(err).Str("method", method).Int("attempts", attempts).
+						Msg("VMD RPC still failing after retry window")
+				}
 				return err
+			}
+			// The channel's own reconnect backoff spaces dials out to
+			// multi-second gaps that can overshoot this window even when
+			// the daemon recovers inside it; reset it so re-dials follow
+			// this loop's cadence instead. Nil cc only in tests.
+			if cc != nil {
+				cc.ResetConnectBackoff()
 			}
 			select {
 			case <-ctx.Done():
+				// Return the Unavailable seen before cancellation rather
+				// than ctx.Err(), so the dead-host interceptor above still
+				// observes it and evicts the cached client.
 				return err
-			case <-time.After(backoff):
+			case <-time.After(min(backoff, time.Until(deadline))):
 			}
 			backoff = min(backoff*2, 2*time.Second)
 		}

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -39,21 +39,12 @@ import (
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
-// vmdRetryServiceConfig retries on UNAVAILABLE only — gRPC guarantees
-// such requests never reached the server, so create RPCs can't
-// double-execute. Other codes lack this guarantee.
-const vmdRetryServiceConfig = `{
-  "methodConfig": [{
-    "name": [{"service": "superserve.vmd.v1.VMDaemon"}],
-    "retryPolicy": {
-      "maxAttempts": 5,
-      "initialBackoff": "0.2s",
-      "maxBackoff": "2s",
-      "backoffMultiplier": 2.0,
-      "retryableStatusCodes": ["UNAVAILABLE"]
-    }
-  }]
-}`
+// retryUnavailableWindow bounds how long a unary RPC keeps retrying
+// codes.Unavailable. Sized to outlast a vmd deploy restart — several
+// seconds of connection-refused while the process swaps, plus the
+// startup gate that answers Unavailable until the daemon is serving —
+// with margin.
+const retryUnavailableWindow = 15 * time.Second
 
 func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
@@ -157,7 +148,7 @@ func run() error {
 	// Connect to VMD via gRPC.
 	grpcConn, err := grpc.NewClient(cfg.VMDAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(vmdRetryServiceConfig),
+		grpc.WithUnaryInterceptor(retryUnavailableUnaryInterceptor(retryUnavailableWindow)),
 	)
 	if err != nil {
 		return fmt.Errorf("dial VMD gRPC: %w", err)
@@ -211,11 +202,13 @@ func run() error {
 	// Interceptors below fire onDead on codes.Unavailable so the registry
 	// drops stale cached clients.
 	dialVMD := func(hostID, addr string, onDead func()) (vmdclient.Client, error) {
-		// Retry runs inside the invoker; the dead-host interceptor sees the post-retry outcome only.
+		// deadHost is chained outside retry, so it sees the post-retry outcome only.
 		conn, err := grpc.NewClient(addr,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithDefaultServiceConfig(vmdRetryServiceConfig),
-			grpc.WithUnaryInterceptor(deadHostUnaryInterceptor(onDead)),
+			grpc.WithChainUnaryInterceptor(
+				deadHostUnaryInterceptor(onDead),
+				retryUnavailableUnaryInterceptor(retryUnavailableWindow),
+			),
 			grpc.WithStreamInterceptor(deadHostStreamInterceptor(onDead)),
 		)
 		if err != nil {
@@ -649,6 +642,32 @@ func (c *grpcVMDClient) StreamBuildLogs(ctx context.Context, buildVMID string, o
 		}
 		if pbEv.GetFinished() {
 			return nil
+		}
+	}
+}
+
+// retryUnavailableUnaryInterceptor retries codes.Unavailable — the daemon
+// is down or still starting — with deterministic backoff until the window
+// or the caller's context expires. Unavailable guarantees the request never
+// executed on the server, so retries can't double-execute. gRPC's built-in
+// retryPolicy can't cover a daemon restart: attempts are hard-capped at 5
+// and each backoff is randomized in [0, backoff], so its worst-case
+// envelope is a few seconds.
+func retryUnavailableUnaryInterceptor(window time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		deadline := time.Now().Add(window)
+		backoff := 250 * time.Millisecond
+		for {
+			err := invoker(ctx, method, req, reply, cc, opts...)
+			if err == nil || grpcstatus.Code(err) != grpccodes.Unavailable || !time.Now().Before(deadline) {
+				return err
+			}
+			select {
+			case <-ctx.Done():
+				return err
+			case <-time.After(backoff):
+			}
+			backoff = min(backoff*2, 2*time.Second)
 		}
 	}
 }

--- a/cmd/controlplane/main_test.go
+++ b/cmd/controlplane/main_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+func TestRetryUnavailableRetriesUntilSuccess(t *testing.T) {
+	calls := 0
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		calls++
+		if calls < 3 {
+			return grpcstatus.Error(grpccodes.Unavailable, "connection refused")
+		}
+		return nil
+	}
+	err := retryUnavailableUnaryInterceptor(5*time.Second)(context.Background(), "m", nil, nil, nil, invoker)
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 attempts, got %d", calls)
+	}
+}
+
+func TestRetryUnavailableDoesNotRetryOtherCodes(t *testing.T) {
+	calls := 0
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		calls++
+		return grpcstatus.Error(grpccodes.NotFound, "no such vm")
+	}
+	err := retryUnavailableUnaryInterceptor(5*time.Second)(context.Background(), "m", nil, nil, nil, invoker)
+	if grpcstatus.Code(err) != grpccodes.NotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 attempt, got %d", calls)
+	}
+}
+
+func TestRetryUnavailableStopsAtWindow(t *testing.T) {
+	calls := 0
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		calls++
+		return grpcstatus.Error(grpccodes.Unavailable, "connection refused")
+	}
+	start := time.Now()
+	err := retryUnavailableUnaryInterceptor(600*time.Millisecond)(context.Background(), "m", nil, nil, nil, invoker)
+	if grpcstatus.Code(err) != grpccodes.Unavailable {
+		t.Fatalf("expected Unavailable after window, got %v", err)
+	}
+	if calls < 2 {
+		t.Fatalf("expected at least 2 attempts inside the window, got %d", calls)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("retry loop ran %v, expected to stop shortly after the 600ms window", elapsed)
+	}
+}
+
+func TestRetryUnavailableStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		calls++
+		cancel() // cancel while the interceptor is in its backoff sleep
+		return grpcstatus.Error(grpccodes.Unavailable, "connection refused")
+	}
+	err := retryUnavailableUnaryInterceptor(5*time.Second)(ctx, "m", nil, nil, nil, invoker)
+	if grpcstatus.Code(err) != grpccodes.Unavailable {
+		t.Fatalf("expected the last Unavailable error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected cancellation to stop after 1 attempt, got %d", calls)
+	}
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("test setup: ctx should be cancelled")
+	}
+}

--- a/cmd/controlplane/main_test.go
+++ b/cmd/controlplane/main_test.go
@@ -68,7 +68,7 @@ func TestRetryUnavailableStopsOnContextCancel(t *testing.T) {
 	calls := 0
 	invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 		calls++
-		cancel() // cancel while the interceptor is in its backoff sleep
+		cancel() // ctx is already cancelled when the backoff select runs
 		return grpcstatus.Error(grpccodes.Unavailable, "connection refused")
 	}
 	err := retryUnavailableUnaryInterceptor(5*time.Second)(ctx, "m", nil, nil, nil, invoker)

--- a/cmd/controlplane/main_test.go
+++ b/cmd/controlplane/main_test.go
@@ -3,12 +3,16 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
 func TestRetryUnavailableRetriesUntilSuccess(t *testing.T) {
@@ -72,13 +76,110 @@ func TestRetryUnavailableStopsOnContextCancel(t *testing.T) {
 		return grpcstatus.Error(grpccodes.Unavailable, "connection refused")
 	}
 	err := retryUnavailableUnaryInterceptor(5*time.Second)(ctx, "m", nil, nil, nil, invoker)
-	if grpcstatus.Code(err) != grpccodes.Unavailable {
-		t.Fatalf("expected the last Unavailable error, got %v", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx.Err(), got %v", err)
+	}
+	if grpcstatus.Code(err) == grpccodes.Unavailable {
+		t.Fatalf("a cancelled caller must not surface Unavailable (dead-host signal), got %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("expected cancellation to stop after 1 attempt, got %d", calls)
 	}
-	if !errors.Is(ctx.Err(), context.Canceled) {
-		t.Fatalf("test setup: ctx should be cancelled")
+}
+
+// fakeVMDClient stubs only StreamBuildLogs; other methods panic via the
+// embedded nil interface.
+type fakeVMDClient struct {
+	vmdpb.VMDaemonClient
+	opens   int
+	opensFn func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error)
+}
+
+func (f *fakeVMDClient) StreamBuildLogs(ctx context.Context, req *vmdpb.StreamBuildLogsRequest, opts ...grpc.CallOption) (vmdpb.VMDaemon_StreamBuildLogsClient, error) {
+	f.opens++
+	return f.opensFn(f.opens)
+}
+
+// fakeLogStream serves the given events, then errAfter (or io.EOF).
+type fakeLogStream struct {
+	grpc.ClientStream
+	events   []*vmdpb.BuildLogEvent
+	errAfter error
+	i        int
+}
+
+func (s *fakeLogStream) Recv() (*vmdpb.BuildLogEvent, error) {
+	if s.i < len(s.events) {
+		s.i++
+		return s.events[s.i-1], nil
+	}
+	if s.errAfter != nil {
+		return nil, s.errAfter
+	}
+	return nil, io.EOF
+}
+
+func TestStreamBuildLogs_RetriesOpenUntilSuccess(t *testing.T) {
+	fake := &fakeVMDClient{opensFn: func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error) {
+		if call < 3 {
+			return nil, grpcstatus.Error(grpccodes.Unavailable, "connection refused")
+		}
+		return &fakeLogStream{events: []*vmdpb.BuildLogEvent{{Text: "hi", Finished: true, Status: "ready"}}}, nil
+	}}
+	c := &grpcVMDClient{client: fake}
+
+	var got []vmdclient.BuildLogEvent
+	err := c.StreamBuildLogs(context.Background(), "b-1", func(ev vmdclient.BuildLogEvent) error {
+		got = append(got, ev)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after open retries, got %v", err)
+	}
+	if fake.opens != 3 {
+		t.Fatalf("expected 3 opens, got %d", fake.opens)
+	}
+	if len(got) != 1 || got[0].Text != "hi" || !got[0].Finished {
+		t.Fatalf("unexpected events: %+v", got)
+	}
+}
+
+func TestStreamBuildLogs_NoRetryAfterDelivery(t *testing.T) {
+	fake := &fakeVMDClient{opensFn: func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error) {
+		return &fakeLogStream{
+			events:   []*vmdpb.BuildLogEvent{{Text: "partial"}},
+			errAfter: grpcstatus.Error(grpccodes.Unavailable, "transport is closing"),
+		}, nil
+	}}
+	c := &grpcVMDClient{client: fake}
+
+	delivered := 0
+	err := c.StreamBuildLogs(context.Background(), "b-1", func(ev vmdclient.BuildLogEvent) error {
+		delivered++
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected the mid-stream error to surface")
+	}
+	if fake.opens != 1 {
+		t.Fatalf("a stream that delivered events must not be retried (would replay history), got %d opens", fake.opens)
+	}
+	if delivered != 1 {
+		t.Fatalf("expected 1 delivered event, got %d", delivered)
+	}
+}
+
+func TestStreamBuildLogs_NoRetryOnOtherCodes(t *testing.T) {
+	fake := &fakeVMDClient{opensFn: func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error) {
+		return nil, grpcstatus.Error(grpccodes.NotFound, "no such build")
+	}}
+	c := &grpcVMDClient{client: fake}
+
+	err := c.StreamBuildLogs(context.Background(), "b-1", func(vmdclient.BuildLogEvent) error { return nil })
+	if grpcstatus.Code(err) != grpccodes.NotFound {
+		t.Fatalf("expected NotFound to surface unretried, got %v", err)
+	}
+	if fake.opens != 1 {
+		t.Fatalf("expected 1 open, got %d", fake.opens)
 	}
 }


### PR DESCRIPTION
A vmd restart (e.g. during a deploy) refuses gRPC connections for several seconds, then answers Unavailable from its startup gate until it is serving. The existing service-config retry policy cannot cover that: gRPC hard-caps retry attempts at 5 with jittered backoff, so its worst-case envelope is a few seconds — creates and resumes that land in the restart window fail through to the client even though the daemon is seconds from healthy.

Replace the service-config policy with a client-side unary interceptor that retries Unavailable on a deterministic backoff (250ms doubling, capped at 2s) for up to 15s or until the caller's context expires. The dead-host interceptor is chained outside retry, preserving its view of the post-retry outcome only.

Details that matter:
- The interceptor calls ResetConnectBackoff between attempts: the channel's own reconnect backoff spaces dials out to multi-second gaps that can overshoot the retry window even when the daemon recovers inside it.
- StreamBuildLogs (not covered by a unary interceptor) gets an equivalent open-retry, gated on no event having been delivered yet — vmd replays buffered history on a fresh stream, so retrying after delivery would duplicate events.
- Exhausting the window logs a warning with the attempt count — the signal that the window no longer outlasts a restart.
- Unavailable almost always means the request never executed, but a connection severed mid-call also surfaces as Unavailable, so retried RPCs must stay idempotent (documented on the interceptor).

Trade-off: RPCs to a genuinely dead host now spend up to ~15s (bounded by the caller's context) before failing, instead of a few seconds.