### PR TITLE
vmd: pause/resume lifecycle correctness under retries and interrupted stops

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2005,6 +2005,28 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 // Sandbox Pause
 // ---------------------------------------------------------------------------
 
+// pauseWithRetry pauses a VM, retrying once on a non-NotFound failure. A pause
+// that timed out or hit a transient error may have actually COMPLETED on the
+// host (the RPC deadline fired after vmd persisted paused), so reverting the
+// DB row to active on that error would drift DB-active against a paused VM.
+// PauseVM is idempotent — the retry blocks on vmd's per-sandbox lock until any
+// in-flight pause finishes, then its already-paused guard returns the recorded
+// snapshot, converging the DB to paused instead of a false revert. NotFound is
+// terminal (the VM is genuinely gone) and returns immediately.
+func pauseWithRetry(reqCtx context.Context, vmd vmdclient.Client, id string) (snapshotPath, memPath string, err error) {
+	ctx, cancel := context.WithTimeout(reqCtx, vmdTimeout)
+	snapshotPath, memPath, err = vmd.PauseInstance(ctx, id, "")
+	cancel()
+	if err == nil || isVMDNotFound(err) {
+		return snapshotPath, memPath, err
+	}
+	// Detach from the request ctx: the client's deadline may already have
+	// fired, but the reconciliation to a consistent state must still run.
+	rctx, rcancel := context.WithTimeout(context.WithoutCancel(reqCtx), vmdTimeout)
+	defer rcancel()
+	return vmd.PauseInstance(rctx, id, "")
+}
+
 func (h *Handlers) PauseSandbox(c *gin.Context) {
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {
@@ -2066,9 +2088,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 	}
 
 	// Call VMD to pause and snapshot the VM.
-	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-	defer vmdCancel()
-	snapshotPath, memPath, err := vmd.PauseInstance(vmdCtx, sandboxID.String(), "")
+	snapshotPath, memPath, err := pauseWithRetry(c.Request.Context(), vmd, sandboxID.String())
 	if err != nil {
 		// VMD says the VM doesn't exist — it crashed or was removed out-of-band.
 		// Mark the sandbox failed and return 410 Gone. No revert — the VM is

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2005,14 +2005,11 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 // Sandbox Pause
 // ---------------------------------------------------------------------------
 
-// pauseWithRetry pauses a VM, retrying once on a non-NotFound failure. A pause
-// that timed out or hit a transient error may have actually COMPLETED on the
-// host (the RPC deadline fired after vmd persisted paused), so reverting the
-// DB row to active on that error would drift DB-active against a paused VM.
-// PauseVM is idempotent — the retry blocks on vmd's per-sandbox lock until any
-// in-flight pause finishes, then its already-paused guard returns the recorded
-// snapshot, converging the DB to paused instead of a false revert. NotFound is
-// terminal (the VM is genuinely gone) and returns immediately.
+// pauseWithRetry pauses a VM, retrying once on a non-NotFound failure. A
+// timed-out pause may have actually completed on the host, so reverting the
+// row to active would drift it against a paused VM; PauseVM is idempotent, so
+// the retry returns the recorded snapshot and the row converges to paused.
+// NotFound is terminal — the VM is genuinely gone.
 func pauseWithRetry(reqCtx context.Context, vmd vmdclient.Client, id string) (snapshotPath, memPath string, err error) {
 	ctx, cancel := context.WithTimeout(reqCtx, vmdTimeout)
 	snapshotPath, memPath, err = vmd.PauseInstance(ctx, id, "")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2393,3 +2393,40 @@ func TestListSandboxFiles_PathTraversalRejected(t *testing.T) {
 		t.Error("ListDir should not be called for a traversal path")
 	}
 }
+
+func TestPauseWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	calls := 0
+	vmd := &stubVMD{pauseFn: func(ctx context.Context, id, dir string) (string, string, error) {
+		calls++
+		if calls == 1 {
+			return "", "", context.DeadlineExceeded
+		}
+		return "/snap/vmstate.snap", "/snap/mem.snap", nil
+	}}
+	snap, mem, err := pauseWithRetry(context.Background(), vmd, "vm-1")
+	if err != nil {
+		t.Fatalf("retry should recover a transient failure, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 1 retry (2 calls), got %d", calls)
+	}
+	if snap == "" || mem == "" {
+		t.Fatalf("expected snapshot artifacts, got (%q,%q)", snap, mem)
+	}
+}
+
+func TestPauseWithRetry_NotFoundIsTerminal(t *testing.T) {
+	calls := 0
+	notFound := status.Error(codes.NotFound, "no such vm")
+	vmd := &stubVMD{pauseFn: func(ctx context.Context, id, dir string) (string, string, error) {
+		calls++
+		return "", "", notFound
+	}}
+	_, _, err := pauseWithRetry(context.Background(), vmd, "vm-1")
+	if !isVMDNotFound(err) {
+		t.Fatalf("expected NotFound to surface, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("NotFound must not be retried, got %d calls", calls)
+	}
+}

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -291,12 +291,10 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 		return
 	}
 
-	vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
-	snapshotPath, memPath, err := vmd.PauseInstance(vmdCtx, sbx.ID.String(), "")
-	vmdCancel()
+	snapshotPath, memPath, err := pauseWithRetry(ctx, vmd, sbx.ID.String())
 	if err != nil {
-		// VM never stopped — safe to revert DB to active so the reaper
-		// retries on the next tick.
+		// Retry (see pauseWithRetry) didn't converge — the VM genuinely
+		// didn't pause, so revert to active and let the next tick retry.
 		l.Error().Err(err).Msg("reaper: VMD PauseInstance failed — reverting to active")
 		RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultError, sbx.HostID, time.Since(started))
 		h.revertToActiveOrFail(ctx, sbx, err, l)

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -225,11 +225,13 @@ func TestReaper_VMDFails(t *testing.T) {
 
 	h.reapOnce(context.Background(), 10, 1)
 
-	// Both sandboxes should be attempted even though VMD fails.
-	if got := atomic.LoadInt32(&pauseCallCount); got != 2 {
-		t.Fatalf("expected 2 PauseInstance calls, got %d", got)
+	// Both sandboxes are attempted, and pauseWithRetry retries each failure
+	// once (a timed-out pause may have completed on the host), so 2 sandboxes
+	// × 2 attempts = 4 calls.
+	if got := atomic.LoadInt32(&pauseCallCount); got != 4 {
+		t.Fatalf("expected 4 PauseInstance calls (2 sandboxes × retry), got %d", got)
 	}
-	// Each failure should trigger a revert to active.
+	// A failure that doesn't converge after the retry reverts to active.
 	if got := atomic.LoadInt32(&revertCallCount); got != 2 {
 		t.Fatalf("expected 2 revert-to-active calls, got %d", got)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -256,6 +256,39 @@ type Manager struct {
 	// until process exit so late pollers can read terminal outcomes.
 	buildsMu sync.RWMutex
 	builds   map[string]*buildRecord
+
+	// vmOpLocks serializes lifecycle operations (restore, resume, pause) for
+	// a single vmID, so a retry or a concurrent actor can't stomp an
+	// in-flight launch (kill a still-booting VM, re-diff a consumed dirty
+	// bitmap). Keyed by vmID → *sync.Mutex. Entries are never deleted:
+	// vmIDs are unique UUIDs so they don't collide, and deleting on destroy
+	// would let a same-vmID retry acquire a fresh mutex and lose mutual
+	// exclusion. DestroyVM deliberately does NOT take these locks — it must
+	// interrupt a wedged op (a hung firecracker socket call holds the lock
+	// until destroy SIGKILLs the process), so blocking it would turn a
+	// recoverable wedge into a permanent hang.
+	vmOpLocks sync.Map
+}
+
+// lockVMOp blocks until it holds vmID's lifecycle lock; the returned func
+// releases it. Never called from a read/reattach path (the mutex is not
+// reentrant) or from DestroyVM (see vmOpLocks).
+func (m *Manager) lockVMOp(vmID string) func() {
+	mu, _ := m.vmOpLocks.LoadOrStore(vmID, &sync.Mutex{})
+	l := mu.(*sync.Mutex)
+	l.Lock()
+	return l.Unlock
+}
+
+// tryLockVMOp acquires vmID's lifecycle lock without blocking. ok=false
+// means an operation is in flight for this vmID and the caller must not act.
+func (m *Manager) tryLockVMOp(vmID string) (unlock func(), ok bool) {
+	mu, _ := m.vmOpLocks.LoadOrStore(vmID, &sync.Mutex{})
+	l := mu.(*sync.Mutex)
+	if !l.TryLock() {
+		return nil, false
+	}
+	return l.Unlock, true
 }
 
 // NewManager creates a new VM manager.
@@ -643,6 +676,12 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 
 // PauseVM snapshots the VM state and then stops the process.
 func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
+	// Serialize with any other launch/pause for this vmID (see lockVMOp): a
+	// duplicate pause must wait and then hit the already-paused guard, not
+	// re-diff a dirty bitmap the first pass already consumed.
+	unlockOp := m.lockVMOp(vmID)
+	defer unlockOp()
+
 	inst, err := m.getInstance(vmID)
 	if err != nil {
 		return "", "", err
@@ -775,20 +814,25 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 	}
 
-	// Stop the Firecracker process — snapshot is already on disk. Detached
-	// ctx: the request budget may be spent after a slow snapshot. A stop
+	// Stop the Firecracker process — snapshot is already on disk. A stop
 	// that still fails must NOT fail the pause: the artifacts are valid and
 	// the record must reach Paused — a retry against a Running record would
 	// re-diff an already-consumed dirty bitmap and destroy the overlay. The
 	// straggler unit is replaced at the next launch and reclaimed by the
 	// reconciler meanwhile.
 	unit := systemdUnitName(vmID)
-	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
-	defer stopCancel()
-	if err := stopUnit(stopCtx, unit); err != nil {
+	if err := stopUnitWithBudget(ctx, unit); err != nil {
 		log.Warn().Err(err).Msg("systemctl stop failed during pause; retrying")
-		if serr := stopUnit(stopCtx, unit); serr != nil && !unitDefinitelyDead(stopCtx, unit) {
-			log.Error().Err(serr).Msg("unit still running after pause; reconciler will reclaim it")
+		// Fresh budget for the retry — sharing the first attempt's would
+		// leave the retry (and the dead-check) no time under host I/O
+		// contention, exactly when the retry is needed.
+		if serr := stopUnitWithBudget(ctx, unit); serr != nil {
+			deadCtx, deadCancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
+			dead := unitDefinitelyDead(deadCtx, unit)
+			deadCancel()
+			if !dead {
+				log.Error().Err(serr).Msg("unit still running after pause; reconciler will reclaim it")
+			}
 		}
 	}
 
@@ -915,6 +959,12 @@ func fileExists(path string) bool {
 func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath string) (*VMInstance, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
+	// Serialize with any other launch/pause for this vmID (see lockVMOp): a
+	// duplicate resume must wait and then be recognized as a retry, not
+	// relaunch over a VM the first attempt is still booting.
+	unlockOp := m.lockVMOp(vmID)
+	defer unlockOp()
+
 	inst, err := m.getInstance(vmID)
 	if err != nil {
 		return nil, err
@@ -934,7 +984,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	// the prior attempt. Relaunching would kill it and roll the guest back
 	// to the snapshot, so return the live instance — same guard as the
 	// stateless restore path.
-	if existing := m.retriedLaunchTarget(ctx, vmID, snapshotPath, memPath); existing != nil {
+	if existing := m.retriedLaunchTarget(vmID, snapshotPath, memPath); existing != nil {
 		log.Info().Msg("resume: VM already running and healthy, returning it")
 		return existing, nil
 	}
@@ -1122,6 +1172,12 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 // snapcheck). Non-destructive: stops the throwaway FC, leaving the sandbox paused.
 func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
+
+	// Serialize with launch/pause for this vmID (see lockVMOp): the
+	// throwaway firecracker this starts must not race a concurrent resume
+	// onto the same unit.
+	unlockOp := m.lockVMOp(vmID)
+	defer unlockOp()
 
 	inst, err := m.getInstance(vmID)
 	if err != nil {
@@ -1391,6 +1447,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		vmID = uuid.New().String()
 	}
 
+	// Serialize with any other launch/pause for this vmID, so a retry lands
+	// AFTER an in-flight attempt finishes (and is then recognized as a retry
+	// by retriedLaunchTarget below) instead of racing into the inPlace block
+	// and stopping a still-booting VM.
+	unlockOp := m.lockVMOp(vmID)
+	defer unlockOp()
+
 	// Deterministic artifact/config preconditions, checked before ANY state
 	// changes: no provisional instance published (a refusal must not leave a
 	// phantom StatusError record for retries to trip over as inPlace), no
@@ -1420,7 +1483,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
 	// attempt brought up would roll the guest back to the snapshot. Healthy
 	// boxd proves the prior restore completed — return that VM instead.
-	if existing := m.retriedLaunchTarget(ctx, vmID, snapshotPath, memPath); existing != nil {
+	if existing := m.retriedLaunchTarget(vmID, snapshotPath, memPath); existing != nil {
 		log.Info().Msg("restore: VM already running and healthy, returning it")
 		return existing, nil
 	}
@@ -2815,18 +2878,24 @@ func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Dur
 	return waitForHTTPHealth(ctx, vmIP, timeout)
 }
 
-// probeBoxdHealth is the retried-launch liveness probe; swappable in tests.
-var probeBoxdHealth = waitForHTTPHealth
-
 // retriedLaunchTarget returns the tracked instance for vmID when a resume or
-// restore request is a retry of one that already completed: Running, SAME
-// artifacts (a different snapshot must replace the VM as before), and boxd
-// answering. A deliberate reset-to-snapshot flow (none exists today) must
-// NOT reuse these RPCs as-is — it would need an explicit signal to bypass
-// this guard. Detached probe ctx — a spent retry deadline must not
-// false-negative a healthy VM into replacement; post-probe identity recheck
-// drops a VM destroyed during the probe.
-func (m *Manager) retriedLaunchTarget(ctx context.Context, vmID, snapshotPath, memPath string) *VMInstance {
+// restore request is a retry of one that already completed: Running with the
+// SAME artifacts (a different snapshot must replace the VM as before).
+//
+// Called only while holding vmID's lifecycle lock, which is what makes
+// Status trustworthy: no concurrent restore/resume/pause can be mid-flight,
+// so a Running instance is a finished prior attempt, not a still-booting or
+// about-to-be-paused one. That's why there is no boxd probe — an earlier
+// version used one as a stand-in for "the prior attempt finished", but it
+// couldn't tell a slow-booting boxd (up to the 30s warmup) from a dead one,
+// and a false negative relaunches over the live VM, rolling the guest back.
+// boxd readiness is the caller's concern; returning the Running VM is always
+// safer than relaunching it. DestroyVM bypasses the lock, so the final
+// recheck drops an instance a concurrent destroy removed.
+//
+// A deliberate reset-to-snapshot flow (none exists today) must NOT reuse
+// these RPCs as-is — it would need an explicit signal to bypass this guard.
+func (m *Manager) retriedLaunchTarget(vmID, snapshotPath, memPath string) *VMInstance {
 	m.mu.RLock()
 	existing := m.vms[vmID]
 	m.mu.RUnlock()
@@ -2834,13 +2903,10 @@ func (m *Manager) retriedLaunchTarget(ctx context.Context, vmID, snapshotPath, m
 		return nil
 	}
 	existing.mu.RLock()
-	running, ip := existing.Status == StatusRunning, existing.IP
+	running := existing.Status == StatusRunning
 	sameArtifacts := existing.SnapshotPath == snapshotPath && existing.MemFilePath == memPath
 	existing.mu.RUnlock()
-	if !running || !sameArtifacts || ip == "" {
-		return nil
-	}
-	if probeBoxdHealth(context.WithoutCancel(ctx), ip, 3*time.Second) != nil {
+	if !running || !sameArtifacts {
 		return nil
 	}
 	m.mu.RLock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -772,9 +772,20 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 	}
 
-	// Stop the Firecracker process — snapshot is already on disk.
-	if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
-		log.Warn().Err(err).Msg("systemctl stop failed during pause")
+	// Stop the Firecracker process — snapshot is already on disk. The stop
+	// must actually take: a unit left running pins the guest's RAM for as
+	// long as the sandbox sleeps. Detached ctx — the request budget may be
+	// nearly spent after a slow snapshot. Fail the pause (sandbox stays
+	// active, which is the truth) rather than report success with the VM
+	// still alive.
+	unit := systemdUnitName(vmID)
+	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer stopCancel()
+	if err := stopUnit(stopCtx, unit); err != nil {
+		log.Warn().Err(err).Msg("systemctl stop failed during pause; retrying")
+		if serr := stopUnit(stopCtx, unit); serr != nil && !unitDefinitelyDead(stopCtx, unit) {
+			return "", "", fmt.Errorf("stop unit after snapshot: %w", serr)
+		}
 	}
 
 	inst.mu.Lock()
@@ -2652,13 +2663,15 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	}
 
 	tStartUnit := time.Now()
-	if err := startUnit(ctx, systemdUnitName(vmID)); err != nil {
+	if err := restartUnit(ctx, systemdUnitName(vmID)); err != nil {
 		return 0, fmt.Errorf("start systemd unit: %w", err)
 	}
 	tStartUnitDone := time.Now()
 
 	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
 		status := unitFailureSummary(ctx, systemdUnitName(vmID))
+		m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
+			Msg("firecracker socket missing after launch")
 		_ = stopUnit(ctx, systemdUnitName(vmID))
 		return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2669,26 +2669,30 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 		return 0, fmt.Errorf("write start script: %w", err)
 	}
 
+	// Replacing a live stale unit spends the stop phase (TimeoutStopSec 10s)
+	// before the fresh process can even fork, so it needs a bigger socket
+	// budget. Decided up front: with Type=simple the restart job clears at
+	// fork, before the socket exists, so no at-timeout probe can tell a
+	// just-replaced unit from a stalled fresh one.
+	replacingLive := isUnitActive(ctx, systemdUnitName(vmID))
+
 	tStartUnit := time.Now()
 	if err := restartUnit(ctx, systemdUnitName(vmID)); err != nil {
 		return 0, fmt.Errorf("start systemd unit: %w", err)
 	}
 	tStartUnitDone := time.Now()
 
-	err := waitForSocket(socketPath, 5*time.Second)
-	if err != nil && unitJobPending(ctx, systemdUnitName(vmID)) {
-		// A restart that replaced a live stale unit may still be inside its
-		// stop phase (TimeoutStopSec 10s) with the start queued behind it —
-		// give that one bounded extension, capped by the caller's remaining
-		// budget, instead of killing a launch systemd is about to complete.
+	socketWait := 5 * time.Second
+	if replacingLive {
 		extra := 12 * time.Second
 		if dl, ok := ctx.Deadline(); ok {
 			extra = min(extra, time.Until(dl))
 		}
 		if extra > 0 {
-			err = waitForSocket(socketPath, extra)
+			socketWait += extra
 		}
 	}
+	err := waitForSocket(socketPath, socketWait)
 	if err != nil {
 		status := unitFailureSummary(ctx, systemdUnitName(vmID))
 		m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -650,6 +650,19 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
+	// Retried pause (response lost to a daemon restart or connection reset):
+	// re-snapshotting a stopped VM would dial the dead firecracker socket and
+	// end with handleVMError deleting the record. Return the recorded
+	// artifacts instead.
+	inst.mu.RLock()
+	if inst.Status == StatusPaused && inst.SnapshotPath != "" && inst.MemFilePath != "" {
+		snapshotPath, memPath = inst.SnapshotPath, inst.MemFilePath
+		inst.mu.RUnlock()
+		log.Info().Msg("pause: VM already paused, returning existing snapshot")
+		return snapshotPath, memPath, nil
+	}
+	inst.mu.RUnlock()
+
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID)
 	}
@@ -1379,6 +1392,23 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// path below reuses its slot instead of allocating a fresh one. No-op for a
 	// new VM (not in BoltDB).
 	m.lazyReattach(vmID)
+
+	// Retried restore (response lost to a daemon restart or connection
+	// reset): stopping and re-restoring a VM the previous attempt already
+	// brought up would roll the guest back to the snapshot. A healthy boxd
+	// is the proof the prior restore completed — return that VM instead.
+	m.mu.RLock()
+	existing := m.vms[vmID]
+	m.mu.RUnlock()
+	if existing != nil {
+		existing.mu.RLock()
+		running, ip := existing.Status == StatusRunning, existing.IP
+		existing.mu.RUnlock()
+		if running && ip != "" && probeBoxdHealth(ctx, ip, 3*time.Second) == nil {
+			log.Info().Msg("restore: VM already running and healthy, returning it")
+			return existing, nil
+		}
+	}
 
 	m.mu.Lock()
 	_, inPlace := m.vms[vmID]
@@ -2746,3 +2776,6 @@ func waitForSocketPolling(path string, timeout time.Duration) error {
 func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Duration) error {
 	return waitForHTTPHealth(ctx, vmIP, timeout)
 }
+
+// probeBoxdHealth is the retried-restore liveness probe; swappable in tests.
+var probeBoxdHealth = waitForHTTPHealth

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -650,10 +650,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
-	// Retried pause (response lost to a daemon restart or connection reset):
-	// re-snapshotting a stopped VM would dial the dead firecracker socket and
-	// end with handleVMError deleting the record. Return the recorded
-	// artifacts instead.
+	// Retried pause (response lost mid-RPC): re-snapshotting a stopped VM
+	// dials a dead socket and ends with the record deleted. Return the
+	// recorded artifacts instead.
 	inst.mu.RLock()
 	if inst.Status == StatusPaused && inst.SnapshotPath != "" && inst.MemFilePath != "" {
 		snapshotPath, memPath = inst.SnapshotPath, inst.MemFilePath
@@ -774,10 +773,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	// Stop the Firecracker process — snapshot is already on disk. The stop
 	// must actually take: a unit left running pins the guest's RAM for as
-	// long as the sandbox sleeps. Detached ctx — the request budget may be
-	// nearly spent after a slow snapshot. Fail the pause (sandbox stays
-	// active, which is the truth) rather than report success with the VM
-	// still alive.
+	// long as the sandbox sleeps. Detached ctx: the request budget may be
+	// spent after a slow snapshot. Fail the pause rather than report
+	// success with the VM still alive.
 	unit := systemdUnitName(vmID)
 	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer stopCancel()
@@ -1404,10 +1402,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// new VM (not in BoltDB).
 	m.lazyReattach(vmID)
 
-	// Retried restore (response lost to a daemon restart or connection
-	// reset): stopping and re-restoring a VM the previous attempt already
-	// brought up would roll the guest back to the snapshot. A healthy boxd
-	// is the proof the prior restore completed — return that VM instead.
+	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
+	// attempt brought up would roll the guest back to the snapshot. Healthy
+	// boxd proves the prior restore completed — return that VM instead.
 	m.mu.RLock()
 	existing := m.vms[vmID]
 	m.mu.RUnlock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -833,26 +833,26 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	}
 
 	// Stop the Firecracker process — snapshot is already on disk. A stop
-	// that still fails must NOT fail the pause: the artifacts are valid and
-	// the record must reach Paused — a retry against a Running record would
-	// re-diff an already-consumed dirty bitmap and destroy the overlay. The
-	// straggler unit is replaced at the next launch and reclaimed by the
-	// reconciler meanwhile.
+	// that fails must NOT fail the pause: the artifacts are valid and the
+	// record must reach Paused (a retry against a Running record would
+	// re-diff an already-consumed dirty bitmap and destroy the overlay).
+	//
+	// Bound the WHOLE stop path (both attempts + dead-check) to the caller's
+	// deadline: the control plane caps the pause RPC at ~30s and reverts the
+	// DB row to active on timeout, so a stop that finishes after that would
+	// leave DB-active-but-VM-stopped drift. If the stop can't finish in the
+	// remaining budget the straggler unit is reclaimed by the reconciler —
+	// self-healing, unlike the drift. This is why the path shares the
+	// caller's budget rather than taking fresh detached ones.
 	unit := systemdUnitName(vmID)
-	if err := stopUnitWithBudget(ctx, unit); err != nil {
+	stopCtx, stopCancel := context.WithTimeout(ctx, stopUnitBudget)
+	if err := stopUnit(stopCtx, unit); err != nil {
 		log.Warn().Err(err).Msg("systemctl stop failed during pause; retrying")
-		// Fresh budget for the retry — sharing the first attempt's would
-		// leave the retry (and the dead-check) no time under host I/O
-		// contention, exactly when the retry is needed.
-		if serr := stopUnitWithBudget(ctx, unit); serr != nil {
-			deadCtx, deadCancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
-			dead := unitDefinitelyDead(deadCtx, unit)
-			deadCancel()
-			if !dead {
-				log.Error().Err(serr).Msg("unit still running after pause; reconciler will reclaim it")
-			}
+		if serr := stopUnit(stopCtx, unit); serr != nil && !unitDefinitelyDead(stopCtx, unit) {
+			log.Error().Err(serr).Msg("unit still running after pause; reconciler will reclaim it")
 		}
 	}
+	stopCancel()
 
 	inst.mu.Lock()
 	inst.Status = StatusPaused

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -271,6 +271,21 @@ type Manager struct {
 	vmOpLocks sync.Map
 }
 
+// instanceRunning reports whether vmID's tracked instance is Running — the
+// authoritative signal that a resume/restore completed, used by the
+// reconciler to avoid stopping a just-relaunched unit.
+func (m *Manager) instanceRunning(vmID string) bool {
+	m.mu.RLock()
+	inst, ok := m.vms[vmID]
+	m.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	return inst.Status == StatusRunning
+}
+
 // vmOpCh returns vmID's capacity-1 lock channel, creating it once.
 func (m *Manager) vmOpCh(vmID string) chan struct{} {
 	if v, ok := m.vmOpLocks.Load(vmID); ok {
@@ -1507,8 +1522,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	m.lazyReattach(vmID)
 
 	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
-	// attempt brought up would roll the guest back to the snapshot. Healthy
-	// boxd proves the prior restore completed — return that VM instead.
+	// attempt brought up would roll the guest back to the snapshot. A live
+	// unit proves the prior restore completed — return that VM instead.
 	if existing := m.retriedLaunchTarget(vmID, snapshotPath, memPath); existing != nil {
 		log.Info().Msg("restore: VM already running and healthy, returning it")
 		return existing, nil
@@ -2778,8 +2793,11 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	// waitForSocket ignores ctx, so cap the TOTAL wait at the caller's
 	// remaining deadline — otherwise it overruns, the ctx expires, and the
 	// stopUnit cleanup below runs on a dead context and leaves the unit up.
+	// Floor it so a launch reached late in the deadline still gets a real
+	// chance: a ~0 cap would reap a healthy VM whose socket is milliseconds
+	// away. A small overrun of a near-spent deadline is the lesser evil.
 	if dl, ok := ctx.Deadline(); ok {
-		socketWait = min(socketWait, time.Until(dl))
+		socketWait = max(2*time.Second, min(socketWait, time.Until(dl)))
 	}
 	err := waitForSocket(socketPath, socketWait)
 	if err != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1428,6 +1428,18 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	tEntry := time.Now()
 
+	if vmID == "" {
+		vmID = uuid.New().String()
+	}
+
+	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate restore
+	// waits for the in-flight attempt, then retriedLaunchTarget recognizes
+	// it — instead of racing into the inPlace block and stopping it. Taken
+	// BEFORE restoreSem so a retry storm for one vmID blocks on the mutex
+	// without holding scarce restore slots, which would starve other VMs.
+	unlockOp := m.lockVMOp(vmID)
+	defer unlockOp()
+
 	// Bound concurrent restores so a burst of sandbox creates doesn't
 	// saturate host file I/O, netns setup, tmpfs, and Firecracker boots.
 	// Fail fast with ctx.Err() if the caller's deadline fires while we
@@ -1439,16 +1451,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		return nil, ctx.Err()
 	}
 	tSemAcquired := time.Now()
-
-	if vmID == "" {
-		vmID = uuid.New().String()
-	}
-
-	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate restore
-	// waits for the in-flight attempt, then retriedLaunchTarget recognizes
-	// it — instead of racing into the inPlace block and stopping it.
-	unlockOp := m.lockVMOp(vmID)
-	defer unlockOp()
 
 	// Deterministic artifact/config preconditions, checked before ANY state
 	// changes: no provisional instance published (a refusal must not leave a
@@ -2888,6 +2890,14 @@ func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Dur
 // drops an instance a concurrent destroy removed.
 //
 // A reset-to-snapshot flow (none today) must not reuse these RPCs as-is.
+// vmUnitDead reports a VM's systemd unit as definitively not-active;
+// swappable in tests. Inconclusive answers read as alive (not dead).
+var vmUnitDead = func(vmID string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return unitDefinitelyDead(ctx, systemdUnitName(vmID))
+}
+
 func (m *Manager) retriedLaunchTarget(vmID, snapshotPath, memPath string) *VMInstance {
 	m.mu.RLock()
 	existing := m.vms[vmID]
@@ -2900,6 +2910,15 @@ func (m *Manager) retriedLaunchTarget(vmID, snapshotPath, memPath string) *VMIns
 	sameArtifacts := existing.SnapshotPath == snapshotPath && existing.MemFilePath == memPath
 	existing.mu.RUnlock()
 	if !running || !sameArtifacts {
+		return nil
+	}
+	// Process-level liveness, not boxd readiness: a record can read Running
+	// while the firecracker died (crash while vmd was down, then a
+	// cleanupStale=false reattach loads it). A slow-booting VM's unit is
+	// still active, so this catches a corpse without false-negativing a
+	// warming one — the trap the removed boxd probe fell into. Inconclusive
+	// (systemctl slow) reads as alive: never relaunch on doubt.
+	if vmUnitDead(vmID) {
 		return nil
 	}
 	m.mu.RLock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2669,12 +2669,13 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 		return 0, fmt.Errorf("write start script: %w", err)
 	}
 
-	// Replacing a live stale unit spends the stop phase (TimeoutStopSec 10s)
-	// before the fresh process can even fork, so it needs a bigger socket
-	// budget. Decided up front: with Type=simple the restart job clears at
-	// fork, before the socket exists, so no at-timeout probe can tell a
-	// just-replaced unit from a stalled fresh one.
-	replacingLive := isUnitActive(ctx, systemdUnitName(vmID))
+	// Replacing a live (or still winding down) stale unit spends the stop
+	// phase (TimeoutStopSec 10s) before the fresh process can even fork, so
+	// it needs a bigger socket budget. Decided up front: with Type=simple
+	// the restart job clears at fork, before the socket exists, so no
+	// at-timeout probe can tell a just-replaced unit from a stalled fresh
+	// one.
+	replacingLive := unitLingering(ctx, systemdUnitName(vmID))
 
 	tStartUnit := time.Now()
 	if err := restartUnit(ctx, systemdUnitName(vmID)); err != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -304,6 +304,13 @@ func (m *Manager) lockVMOp(ctx context.Context, vmID string) (func(), error) {
 	ch := m.vmOpCh(vmID)
 	select {
 	case ch <- struct{}{}:
+		// select picks a ready case at random, so an already-cancelled
+		// caller can win the send even though ctx is done. Re-check and
+		// release rather than run abandoned work.
+		if err := ctx.Err(); err != nil {
+			<-ch
+			return nil, err
+		}
 		return func() { <-ch }, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -1483,6 +1490,18 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	defer unlockOp()
 
+	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
+	// attempt brought up would roll the guest back to the snapshot. A live
+	// unit proves the prior restore completed — return that VM instead.
+	// Checked BEFORE restoreSem so a no-op retry never consumes a scarce
+	// restore slot (or fails on the semaphore when all slots are busy).
+	// lazyReattach loads a paused VM the background reattach hasn't reached.
+	m.lazyReattach(vmID)
+	if existing := m.retriedLaunchTarget(vmID, snapshotPath, memPath); existing != nil {
+		log.Info().Msg("restore: VM already running and healthy, returning it")
+		return existing, nil
+	}
+
 	// Bound concurrent restores so a burst of sandbox creates doesn't
 	// saturate host file I/O, netns setup, tmpfs, and Firecracker boots.
 	// Fail fast with ctx.Err() if the caller's deadline fires while we
@@ -1514,19 +1533,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if gerr := m.gateOverlayPresence(memPath, log); gerr != nil {
 			return nil, status.Errorf(codes.FailedPrecondition, "%v", gerr)
 		}
-	}
-
-	// Load a paused VM the background reattach hasn't reached yet, so the inPlace
-	// path below reuses its slot instead of allocating a fresh one. No-op for a
-	// new VM (not in BoltDB).
-	m.lazyReattach(vmID)
-
-	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
-	// attempt brought up would roll the guest back to the snapshot. A live
-	// unit proves the prior restore completed — return that VM instead.
-	if existing := m.retriedLaunchTarget(vmID, snapshotPath, memPath); existing != nil {
-		log.Info().Msg("restore: VM already running and healthy, returning it")
-		return existing, nil
 	}
 
 	m.mu.Lock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2821,7 +2821,9 @@ var probeBoxdHealth = waitForHTTPHealth
 // retriedLaunchTarget returns the tracked instance for vmID when a resume or
 // restore request is a retry of one that already completed: Running, SAME
 // artifacts (a different snapshot must replace the VM as before), and boxd
-// answering. Detached probe ctx — a spent retry deadline must not
+// answering. A deliberate reset-to-snapshot flow (none exists today) must
+// NOT reuse these RPCs as-is — it would need an explicit signal to bypass
+// this guard. Detached probe ctx — a spent retry deadline must not
 // false-negative a healthy VM into replacement; post-probe identity recheck
 // drops a VM destroyed during the probe.
 func (m *Manager) retriedLaunchTarget(ctx context.Context, vmID, snapshotPath, memPath string) *VMInstance {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -652,11 +652,15 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 
 	// Retried pause (response lost mid-RPC): re-snapshotting a stopped VM
 	// dials a dead socket and ends with the record deleted. Return the
-	// recorded artifacts instead.
+	// recorded artifacts instead — after confirming they still exist, like
+	// ResumeVM does before acting on a record.
 	inst.mu.RLock()
 	if inst.Status == StatusPaused && inst.SnapshotPath != "" && inst.MemFilePath != "" {
 		snapshotPath, memPath = inst.SnapshotPath, inst.MemFilePath
 		inst.mu.RUnlock()
+		if !fileExists(snapshotPath) || !fileExists(memPath) {
+			return "", "", status.Errorf(codes.FailedPrecondition, "paused VM artifacts missing on host: %s", memPath)
+		}
 		log.Info().Msg("pause: VM already paused, returning existing snapshot")
 		return snapshotPath, memPath, nil
 	}
@@ -771,18 +775,20 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 	}
 
-	// Stop the Firecracker process — snapshot is already on disk. The stop
-	// must actually take: a unit left running pins the guest's RAM for as
-	// long as the sandbox sleeps. Detached ctx: the request budget may be
-	// spent after a slow snapshot. Fail the pause rather than report
-	// success with the VM still alive.
+	// Stop the Firecracker process — snapshot is already on disk. Detached
+	// ctx: the request budget may be spent after a slow snapshot. A stop
+	// that still fails must NOT fail the pause: the artifacts are valid and
+	// the record must reach Paused — a retry against a Running record would
+	// re-diff an already-consumed dirty bitmap and destroy the overlay. The
+	// straggler unit is replaced at the next launch and reclaimed by the
+	// reconciler meanwhile.
 	unit := systemdUnitName(vmID)
 	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer stopCancel()
 	if err := stopUnit(stopCtx, unit); err != nil {
 		log.Warn().Err(err).Msg("systemctl stop failed during pause; retrying")
 		if serr := stopUnit(stopCtx, unit); serr != nil && !unitDefinitelyDead(stopCtx, unit) {
-			return "", "", fmt.Errorf("stop unit after snapshot: %w", serr)
+			log.Error().Err(serr).Msg("unit still running after pause; reconciler will reclaim it")
 		}
 	}
 
@@ -922,6 +928,15 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 	if snapshotPath == "" || memPath == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "snapshot_path and mem_file_path are required")
+	}
+
+	// Retried resume (response lost mid-RPC): the VM may already be up from
+	// the prior attempt. Relaunching would kill it and roll the guest back
+	// to the snapshot, so return the live instance — same guard as the
+	// stateless restore path.
+	if existing := m.retriedLaunchTarget(ctx, vmID, snapshotPath, memPath); existing != nil {
+		log.Info().Msg("resume: VM already running and healthy, returning it")
+		return existing, nil
 	}
 
 	// Verify the snapshot files actually exist on disk. DB can claim
@@ -1405,20 +1420,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// Retried restore (response lost mid-RPC): re-restoring a VM the prior
 	// attempt brought up would roll the guest back to the snapshot. Healthy
 	// boxd proves the prior restore completed — return that VM instead.
-	m.mu.RLock()
-	existing := m.vms[vmID]
-	m.mu.RUnlock()
-	if existing != nil {
-		existing.mu.RLock()
-		running, ip := existing.Status == StatusRunning, existing.IP
-		// Only a request for the SAME artifacts is a retry; a different
-		// snapshot for this vmID must replace the VM as before.
-		sameArtifacts := existing.SnapshotPath == snapshotPath && existing.MemFilePath == memPath
-		existing.mu.RUnlock()
-		if running && sameArtifacts && ip != "" && probeBoxdHealth(ctx, ip, 3*time.Second) == nil {
-			log.Info().Msg("restore: VM already running and healthy, returning it")
-			return existing, nil
-		}
+	if existing := m.retriedLaunchTarget(ctx, vmID, snapshotPath, memPath); existing != nil {
+		log.Info().Msg("restore: VM already running and healthy, returning it")
+		return existing, nil
 	}
 
 	m.mu.Lock()
@@ -1647,8 +1651,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			break
 		}
 		m.stopUnitDuringRestoreError(vmID)
-		// systemctl start is a no-op on an active unit, so retry only when the
-		// unit is affirmatively dead — an inconclusive answer reads as alive.
+		// Retry only when the unit is affirmatively dead — an inconclusive
+		// answer reads as alive. Launches restart the unit these days, so a
+		// live leftover would be replaced; kept conservative because "not
+		// confirmed dead" here means systemctl itself is struggling, and
+		// relaxing this gate deserves its own change.
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
 		checkCancel()
@@ -2669,22 +2676,25 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	tStartUnitDone := time.Now()
 
 	err := waitForSocket(socketPath, 5*time.Second)
-	if err != nil {
-		status := unitFailureSummary(ctx, systemdUnitName(vmID))
+	if err != nil && unitJobPending(ctx, systemdUnitName(vmID)) {
 		// A restart that replaced a live stale unit may still be inside its
 		// stop phase (TimeoutStopSec 10s) with the start queued behind it —
-		// give that one bounded extension instead of killing a launch
-		// systemd is about to complete.
-		if unitTransitioning(status) {
-			err = waitForSocket(socketPath, 12*time.Second)
+		// give that one bounded extension, capped by the caller's remaining
+		// budget, instead of killing a launch systemd is about to complete.
+		extra := 12 * time.Second
+		if dl, ok := ctx.Deadline(); ok {
+			extra = min(extra, time.Until(dl))
 		}
-		if err != nil {
-			status = unitFailureSummary(ctx, systemdUnitName(vmID))
-			m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
-				Msg("firecracker socket missing after launch")
-			_ = stopUnit(ctx, systemdUnitName(vmID))
-			return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
+		if extra > 0 {
+			err = waitForSocket(socketPath, extra)
 		}
+	}
+	if err != nil {
+		status := unitFailureSummary(ctx, systemdUnitName(vmID))
+		m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
+			Msg("firecracker socket missing after launch")
+		_ = stopUnit(ctx, systemdUnitName(vmID))
+		return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
 	}
 	tSocketReady := time.Now()
 
@@ -2801,5 +2811,38 @@ func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Dur
 	return waitForHTTPHealth(ctx, vmIP, timeout)
 }
 
-// probeBoxdHealth is the retried-restore liveness probe; swappable in tests.
+// probeBoxdHealth is the retried-launch liveness probe; swappable in tests.
 var probeBoxdHealth = waitForHTTPHealth
+
+// retriedLaunchTarget returns the tracked instance for vmID when a resume or
+// restore request is a retry of one that already completed: instance Running,
+// requesting the SAME artifacts (a different snapshot must replace the VM as
+// before), and boxd answering. The probe runs on a detached ctx so a
+// nearly-spent retry deadline can't false-negative a healthy VM into being
+// replaced. The post-probe identity recheck drops a VM destroyed during the
+// probe (same threat the restore path's persist-then-verify recheck names).
+func (m *Manager) retriedLaunchTarget(ctx context.Context, vmID, snapshotPath, memPath string) *VMInstance {
+	m.mu.RLock()
+	existing := m.vms[vmID]
+	m.mu.RUnlock()
+	if existing == nil {
+		return nil
+	}
+	existing.mu.RLock()
+	running, ip := existing.Status == StatusRunning, existing.IP
+	sameArtifacts := existing.SnapshotPath == snapshotPath && existing.MemFilePath == memPath
+	existing.mu.RUnlock()
+	if !running || !sameArtifacts || ip == "" {
+		return nil
+	}
+	if probeBoxdHealth(context.WithoutCancel(ctx), ip, 3*time.Second) != nil {
+		return nil
+	}
+	m.mu.RLock()
+	still := m.vms[vmID] == existing
+	m.mu.RUnlock()
+	if !still {
+		return nil
+	}
+	return existing
+}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1414,8 +1414,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	if existing != nil {
 		existing.mu.RLock()
 		running, ip := existing.Status == StatusRunning, existing.IP
+		// Only a request for the SAME artifacts is a retry; a different
+		// snapshot for this vmID must replace the VM as before.
+		sameArtifacts := existing.SnapshotPath == snapshotPath && existing.MemFilePath == memPath
 		existing.mu.RUnlock()
-		if running && ip != "" && probeBoxdHealth(ctx, ip, 3*time.Second) == nil {
+		if running && sameArtifacts && ip != "" && probeBoxdHealth(ctx, ip, 3*time.Second) == nil {
 			log.Info().Msg("restore: VM already running and healthy, returning it")
 			return existing, nil
 		}
@@ -2668,12 +2671,23 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	}
 	tStartUnitDone := time.Now()
 
-	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
+	err := waitForSocket(socketPath, 5*time.Second)
+	if err != nil {
 		status := unitFailureSummary(ctx, systemdUnitName(vmID))
-		m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
-			Msg("firecracker socket missing after launch")
-		_ = stopUnit(ctx, systemdUnitName(vmID))
-		return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
+		// A restart that replaced a live stale unit may still be inside its
+		// stop phase (TimeoutStopSec 10s) with the start queued behind it —
+		// give that one bounded extension instead of killing a launch
+		// systemd is about to complete.
+		if unitTransitioning(status) {
+			err = waitForSocket(socketPath, 12*time.Second)
+		}
+		if err != nil {
+			status = unitFailureSummary(ctx, systemdUnitName(vmID))
+			m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
+				Msg("firecracker socket missing after launch")
+			_ = stopUnit(ctx, systemdUnitName(vmID))
+			return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
+		}
 	}
 	tSocketReady := time.Now()
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -260,35 +260,51 @@ type Manager struct {
 	// vmOpLocks serializes lifecycle operations (restore, resume, pause) for
 	// a single vmID, so a retry or a concurrent actor can't stomp an
 	// in-flight launch (kill a still-booting VM, re-diff a consumed dirty
-	// bitmap). Keyed by vmID → *sync.Mutex. Entries are never deleted:
-	// vmIDs are unique UUIDs so they don't collide, and deleting on destroy
-	// would let a same-vmID retry acquire a fresh mutex and lose mutual
-	// exclusion. DestroyVM deliberately does NOT take these locks — it must
-	// interrupt a wedged op (a hung firecracker socket call holds the lock
-	// until destroy SIGKILLs the process), so blocking it would turn a
-	// recoverable wedge into a permanent hang.
+	// bitmap). Keyed by vmID → chan struct{}{} used as a capacity-1
+	// semaphore, so acquisition can honor the caller's context. Entries are
+	// never deleted: vmIDs are unique UUIDs so they don't collide, and
+	// deleting on destroy would let a same-vmID retry acquire a fresh lock
+	// and lose mutual exclusion. DestroyVM deliberately does NOT take these
+	// locks — it must interrupt a wedged op (a hung firecracker socket call
+	// holds the lock until destroy SIGKILLs the process), so blocking it
+	// would turn a recoverable wedge into a permanent hang.
 	vmOpLocks sync.Map
 }
 
-// lockVMOp blocks until it holds vmID's lifecycle lock; the returned func
-// releases it. Never called from a read/reattach path (the mutex is not
-// reentrant) or from DestroyVM (see vmOpLocks).
-func (m *Manager) lockVMOp(vmID string) func() {
-	mu, _ := m.vmOpLocks.LoadOrStore(vmID, &sync.Mutex{})
-	l := mu.(*sync.Mutex)
-	l.Lock()
-	return l.Unlock
+// vmOpCh returns vmID's capacity-1 lock channel, creating it once.
+func (m *Manager) vmOpCh(vmID string) chan struct{} {
+	if v, ok := m.vmOpLocks.Load(vmID); ok {
+		return v.(chan struct{})
+	}
+	v, _ := m.vmOpLocks.LoadOrStore(vmID, make(chan struct{}, 1))
+	return v.(chan struct{})
+}
+
+// lockVMOp acquires vmID's lifecycle lock, honoring ctx while it waits — a
+// caller whose deadline expires in the queue behind another op returns
+// ctx.Err() instead of running abandoned pause/restore work. The returned
+// func releases it. Never called from a read/reattach path (not reentrant)
+// or from DestroyVM (see vmOpLocks).
+func (m *Manager) lockVMOp(ctx context.Context, vmID string) (func(), error) {
+	ch := m.vmOpCh(vmID)
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // tryLockVMOp acquires vmID's lifecycle lock without blocking. ok=false
 // means an operation is in flight for this vmID and the caller must not act.
 func (m *Manager) tryLockVMOp(vmID string) (unlock func(), ok bool) {
-	mu, _ := m.vmOpLocks.LoadOrStore(vmID, &sync.Mutex{})
-	l := mu.(*sync.Mutex)
-	if !l.TryLock() {
+	ch := m.vmOpCh(vmID)
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, true
+	default:
 		return nil, false
 	}
-	return l.Unlock, true
 }
 
 // NewManager creates a new VM manager.
@@ -678,7 +694,10 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
 	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate pause
 	// waits, then hits the already-paused guard.
-	unlockOp := m.lockVMOp(vmID)
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return "", "", err
+	}
 	defer unlockOp()
 
 	inst, err := m.getInstance(vmID)
@@ -960,7 +979,10 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 
 	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate resume
 	// waits, then is recognized as a retry rather than relaunching.
-	unlockOp := m.lockVMOp(vmID)
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return nil, err
+	}
 	defer unlockOp()
 
 	inst, err := m.getInstance(vmID)
@@ -1173,7 +1195,10 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 
 	// Serialize same-vmID lifecycle ops (see lockVMOp): the throwaway
 	// firecracker must not race a concurrent resume onto the same unit.
-	unlockOp := m.lockVMOp(vmID)
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return "", err
+	}
 	defer unlockOp()
 
 	inst, err := m.getInstance(vmID)
@@ -1435,9 +1460,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate restore
 	// waits for the in-flight attempt, then retriedLaunchTarget recognizes
 	// it — instead of racing into the inPlace block and stopping it. Taken
-	// BEFORE restoreSem so a retry storm for one vmID blocks on the mutex
+	// BEFORE restoreSem so a retry storm for one vmID blocks on the lock
 	// without holding scarce restore slots, which would starve other VMs.
-	unlockOp := m.lockVMOp(vmID)
+	unlockOp, lerr := m.lockVMOp(ctx, vmID)
+	if lerr != nil {
+		return nil, lerr
+	}
 	defer unlockOp()
 
 	// Bound concurrent restores so a burst of sandbox creates doesn't

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -676,9 +676,8 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 
 // PauseVM snapshots the VM state and then stops the process.
 func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
-	// Serialize with any other launch/pause for this vmID (see lockVMOp): a
-	// duplicate pause must wait and then hit the already-paused guard, not
-	// re-diff a dirty bitmap the first pass already consumed.
+	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate pause
+	// waits, then hits the already-paused guard.
 	unlockOp := m.lockVMOp(vmID)
 	defer unlockOp()
 
@@ -959,9 +958,8 @@ func fileExists(path string) bool {
 func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath string) (*VMInstance, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
-	// Serialize with any other launch/pause for this vmID (see lockVMOp): a
-	// duplicate resume must wait and then be recognized as a retry, not
-	// relaunch over a VM the first attempt is still booting.
+	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate resume
+	// waits, then is recognized as a retry rather than relaunching.
 	unlockOp := m.lockVMOp(vmID)
 	defer unlockOp()
 
@@ -1173,9 +1171,8 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
 
-	// Serialize with launch/pause for this vmID (see lockVMOp): the
-	// throwaway firecracker this starts must not race a concurrent resume
-	// onto the same unit.
+	// Serialize same-vmID lifecycle ops (see lockVMOp): the throwaway
+	// firecracker must not race a concurrent resume onto the same unit.
 	unlockOp := m.lockVMOp(vmID)
 	defer unlockOp()
 
@@ -1447,10 +1444,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		vmID = uuid.New().String()
 	}
 
-	// Serialize with any other launch/pause for this vmID, so a retry lands
-	// AFTER an in-flight attempt finishes (and is then recognized as a retry
-	// by retriedLaunchTarget below) instead of racing into the inPlace block
-	// and stopping a still-booting VM.
+	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate restore
+	// waits for the in-flight attempt, then retriedLaunchTarget recognizes
+	// it — instead of racing into the inPlace block and stopping it.
 	unlockOp := m.lockVMOp(vmID)
 	defer unlockOp()
 
@@ -2882,19 +2878,14 @@ func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Dur
 // restore request is a retry of one that already completed: Running with the
 // SAME artifacts (a different snapshot must replace the VM as before).
 //
-// Called only while holding vmID's lifecycle lock, which is what makes
-// Status trustworthy: no concurrent restore/resume/pause can be mid-flight,
-// so a Running instance is a finished prior attempt, not a still-booting or
-// about-to-be-paused one. That's why there is no boxd probe — an earlier
-// version used one as a stand-in for "the prior attempt finished", but it
-// couldn't tell a slow-booting boxd (up to the 30s warmup) from a dead one,
-// and a false negative relaunches over the live VM, rolling the guest back.
-// boxd readiness is the caller's concern; returning the Running VM is always
-// safer than relaunching it. DestroyVM bypasses the lock, so the final
-// recheck drops an instance a concurrent destroy removed.
+// Called while holding vmID's lifecycle lock, so Status is trustworthy: no
+// concurrent op is mid-flight, and a Running instance is a finished prior
+// attempt. Hence no boxd probe — it couldn't tell a slow-booting boxd (30s
+// warmup) from a dead one, and a false negative relaunches over the live
+// VM, rolling the guest back. DestroyVM bypasses the lock, so the recheck
+// drops an instance a concurrent destroy removed.
 //
-// A deliberate reset-to-snapshot flow (none exists today) must NOT reuse
-// these RPCs as-is — it would need an explicit signal to bypass this guard.
+// A reset-to-snapshot flow (none today) must not reuse these RPCs as-is.
 func (m *Manager) retriedLaunchTarget(vmID, snapshotPath, memPath string) *VMInstance {
 	m.mu.RLock()
 	existing := m.vms[vmID]

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2743,20 +2743,22 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 
 	socketWait := 5 * time.Second
 	if replacingLive {
-		extra := 12 * time.Second
-		if dl, ok := ctx.Deadline(); ok {
-			extra = min(extra, time.Until(dl))
-		}
-		if extra > 0 {
-			socketWait += extra
-		}
+		socketWait = 17 * time.Second // 5s + the stop-phase margin
+	}
+	// waitForSocket ignores ctx, so cap the TOTAL wait at the caller's
+	// remaining deadline — otherwise it overruns, the ctx expires, and the
+	// stopUnit cleanup below runs on a dead context and leaves the unit up.
+	if dl, ok := ctx.Deadline(); ok {
+		socketWait = min(socketWait, time.Until(dl))
 	}
 	err := waitForSocket(socketPath, socketWait)
 	if err != nil {
 		status := unitFailureSummary(ctx, systemdUnitName(vmID))
 		m.log.Warn().Str("vm_id", vmID).Str("unit_state", status).Err(err).
 			Msg("firecracker socket missing after launch")
-		_ = stopUnit(ctx, systemdUnitName(vmID))
+		// Detached budget: the caller's ctx may be at its deadline here, and
+		// this stop must run or the just-launched unit leaks.
+		_ = stopUnitWithBudget(ctx, systemdUnitName(vmID))
 		return 0, fmt.Errorf("wait for socket (unit %s): %w", status, err)
 	}
 	tSocketReady := time.Now()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1652,10 +1652,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		m.stopUnitDuringRestoreError(vmID)
 		// Retry only when the unit is affirmatively dead — an inconclusive
-		// answer reads as alive. Launches restart the unit these days, so a
-		// live leftover would be replaced; kept conservative because "not
-		// confirmed dead" here means systemctl itself is struggling, and
-		// relaxing this gate deserves its own change.
+		// answer reads as alive. Launches would replace a live leftover,
+		// but "not confirmed dead" means systemctl itself is struggling;
+		// kept conservative.
 		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
 		checkCancel()
@@ -2820,12 +2819,11 @@ func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Dur
 var probeBoxdHealth = waitForHTTPHealth
 
 // retriedLaunchTarget returns the tracked instance for vmID when a resume or
-// restore request is a retry of one that already completed: instance Running,
-// requesting the SAME artifacts (a different snapshot must replace the VM as
-// before), and boxd answering. The probe runs on a detached ctx so a
-// nearly-spent retry deadline can't false-negative a healthy VM into being
-// replaced. The post-probe identity recheck drops a VM destroyed during the
-// probe (same threat the restore path's persist-then-verify recheck names).
+// restore request is a retry of one that already completed: Running, SAME
+// artifacts (a different snapshot must replace the VM as before), and boxd
+// answering. Detached probe ctx — a spent retry deadline must not
+// false-negative a healthy VM into replacement; post-probe identity recheck
+// drops a VM destroyed during the probe.
 func (m *Manager) retriedLaunchTarget(ctx context.Context, vmID, snapshotPath, memPath string) *VMInstance {
 	m.mu.RLock()
 	existing := m.vms[vmID]

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -993,6 +993,20 @@ func TestVMOpLock_SerializesSameID_TryLockSkips(t *testing.T) {
 	if _, err := m.lockVMOp(cancelled, "vm-1"); err == nil {
 		t.Fatal("cancelled context must not acquire a held lock")
 	}
+	// Free lock + already-cancelled ctx: even if the random select picks
+	// the send case, the post-acquire recheck must release and return err,
+	// not leave the lock held.
+	freeCancel, cancel2 := context.WithCancel(context.Background())
+	cancel2()
+	if u, err := m.lockVMOp(freeCancel, "vm-free"); err == nil {
+		u()
+		t.Fatal("cancelled ctx must not acquire even a free lock")
+	}
+	if u, ok := m.tryLockVMOp("vm-free"); !ok {
+		t.Fatal("a cancelled acquire must not leave the lock held")
+	} else {
+		u()
+	}
 	unlock()
 	// Released — now acquirable.
 	if u, ok := m.tryLockVMOp("vm-1"); !ok {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -925,3 +925,24 @@ func TestRestoreVMSnapshot_DifferentArtifacts_NotTreatedAsRetry(t *testing.T) {
 		t.Fatal("a restore for different artifacts must not return the old VM")
 	}
 }
+
+func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
+	orig := probeBoxdHealth
+	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
+	defer func() { probeBoxdHealth = orig }()
+
+	existing := &VMInstance{
+		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
+		SnapshotPath: "/snapshots/vm-1/vmstate.snap",
+		MemFilePath:  "/snapshots/vm-1/mem.snap",
+	}
+	mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}}
+
+	inst, err := mgr.ResumeVM(context.Background(), "vm-1", "", "")
+	if err != nil {
+		t.Fatalf("retried resume of a healthy running VM should succeed, got %v", err)
+	}
+	if inst != existing {
+		t.Fatal("expected the existing running instance, not a relaunch")
+	}
+}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -971,7 +971,10 @@ func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 func TestVMOpLock_SerializesSameID_TryLockSkips(t *testing.T) {
 	m := &Manager{log: zerolog.Nop()}
 
-	unlock := m.lockVMOp("vm-1")
+	unlock, err := m.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
 	// A different vmID is independent — must acquire freely.
 	if u2, ok := m.tryLockVMOp("vm-2"); !ok {
 		t.Fatal("different vmID must not contend")
@@ -982,6 +985,13 @@ func TestVMOpLock_SerializesSameID_TryLockSkips(t *testing.T) {
 	// reconciler skip a unit a launch is mid-flight on).
 	if _, ok := m.tryLockVMOp("vm-1"); ok {
 		t.Fatal("held vmID must fail TryLock")
+	}
+	// A queued acquire whose context is already cancelled returns ctx.Err()
+	// instead of waiting for the lock — no abandoned pause/restore work.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := m.lockVMOp(cancelled, "vm-1"); err == nil {
+		t.Fatal("cancelled context must not acquire a held lock")
 	}
 	unlock()
 	// Released — now acquirable.

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -839,11 +839,19 @@ func TestWaitForPIDExit_DeadProcessReturnsPromptly(t *testing.T) {
 }
 
 func TestPauseVM_AlreadyPaused_ReturnsRecordedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vmstate.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	for _, p := range []string{snapPath, memPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 	inst := &VMInstance{
 		ID:           "vm-1",
 		Status:       StatusPaused,
-		SnapshotPath: "/snapshots/vm-1/vmstate.snap",
-		MemFilePath:  "/snapshots/vm-1/mem.snap",
+		SnapshotPath: snapPath,
+		MemFilePath:  memPath,
 	}
 	mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": inst}}
 
@@ -851,8 +859,24 @@ func TestPauseVM_AlreadyPaused_ReturnsRecordedSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("retried pause of a paused VM should succeed, got %v", err)
 	}
-	if snap != inst.SnapshotPath || mem != inst.MemFilePath {
+	if snap != snapPath || mem != memPath {
 		t.Fatalf("got (%q, %q), want the recorded snapshot artifacts", snap, mem)
+	}
+}
+
+func TestPauseVM_AlreadyPausedButArtifactsMissing_Fails(t *testing.T) {
+	dir := t.TempDir()
+	inst := &VMInstance{
+		ID:           "vm-1",
+		Status:       StatusPaused,
+		SnapshotPath: filepath.Join(dir, "gone-vmstate.snap"),
+		MemFilePath:  filepath.Join(dir, "gone-mem.snap"),
+	}
+	mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": inst}}
+
+	_, _, err := mgr.PauseVM(context.Background(), "vm-1", "")
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for dangling artifacts, got %v", err)
 	}
 }
 

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -837,3 +837,56 @@ func TestWaitForPIDExit_DeadProcessReturnsPromptly(t *testing.T) {
 		t.Errorf("returned after %v; expected a prompt return once the process exited", elapsed)
 	}
 }
+
+func TestPauseVM_AlreadyPaused_ReturnsRecordedSnapshot(t *testing.T) {
+	inst := &VMInstance{
+		ID:           "vm-1",
+		Status:       StatusPaused,
+		SnapshotPath: "/snapshots/vm-1/vmstate.snap",
+		MemFilePath:  "/snapshots/vm-1/mem.snap",
+	}
+	mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": inst}}
+
+	snap, mem, err := mgr.PauseVM(context.Background(), "vm-1", "")
+	if err != nil {
+		t.Fatalf("retried pause of a paused VM should succeed, got %v", err)
+	}
+	if snap != inst.SnapshotPath || mem != inst.MemFilePath {
+		t.Fatalf("got (%q, %q), want the recorded snapshot artifacts", snap, mem)
+	}
+}
+
+func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
+	orig := probeBoxdHealth
+	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
+	defer func() { probeBoxdHealth = orig }()
+
+	existing := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5"}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		vms:        map[string]*VMInstance{"vm-1": existing},
+		restoreSem: make(chan struct{}, 1),
+	}
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vmstate.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	for _, p := range []string{snapPath, memPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	inst, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{}, nil, "team", "owner")
+	if err != nil {
+		t.Fatalf("retried restore of a healthy running VM should succeed, got %v", err)
+	}
+	if inst != existing {
+		t.Fatal("expected the existing running instance, not a re-restore")
+	}
+	mgr.mu.RLock()
+	still := mgr.vms["vm-1"]
+	mgr.mu.RUnlock()
+	if still != existing {
+		t.Fatal("existing instance must remain tracked untouched")
+	}
+}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -881,6 +881,9 @@ func TestPauseVM_AlreadyPausedButArtifactsMissing_Fails(t *testing.T) {
 }
 
 func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
+	orig := vmUnitDead
+	vmUnitDead = func(string) bool { return false } // unit alive
+	defer func() { vmUnitDead = orig }()
 
 	dir := t.TempDir()
 	snapPath := filepath.Join(dir, "vmstate.snap")
@@ -945,6 +948,9 @@ func TestRestoreVMSnapshot_DifferentArtifacts_NotTreatedAsRetry(t *testing.T) {
 }
 
 func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
+	orig := vmUnitDead
+	vmUnitDead = func(string) bool { return false } // unit alive
+	defer func() { vmUnitDead = orig }()
 
 	existing := &VMInstance{
 		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
@@ -983,5 +989,32 @@ func TestVMOpLock_SerializesSameID_TryLockSkips(t *testing.T) {
 		t.Fatal("released vmID must be acquirable")
 	} else {
 		u()
+	}
+}
+
+func TestRestoreVMSnapshot_RunningRecordButUnitDead_NotReturned(t *testing.T) {
+	// A record can read Running while the firecracker process is gone. The
+	// retry guard must not hand back that corpse — it must fall through to
+	// a fresh restore.
+	orig := vmUnitDead
+	vmUnitDead = func(string) bool { return true } // unit definitively dead
+	defer func() { vmUnitDead = orig }()
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vmstate.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	for _, p := range []string{snapPath, memPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	existing := &VMInstance{
+		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
+		SnapshotPath: snapPath, MemFilePath: memPath,
+	}
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}}
+
+	if got := m.retriedLaunchTarget("vm-1", snapPath, memPath); got != nil {
+		t.Fatal("a dead-unit Running record must not be returned as a retry target")
 	}
 }

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -1028,3 +1028,22 @@ func TestRestoreVMSnapshot_RunningRecordButUnitDead_NotReturned(t *testing.T) {
 		t.Fatal("a dead-unit Running record must not be returned as a retry target")
 	}
 }
+
+func TestInstanceRunning(t *testing.T) {
+	m := &Manager{
+		log: zerolog.Nop(),
+		vms: map[string]*VMInstance{
+			"run":   {ID: "run", Status: StatusRunning},
+			"pause": {ID: "pause", Status: StatusPaused},
+		},
+	}
+	if !m.instanceRunning("run") {
+		t.Fatal("running instance must report running")
+	}
+	if m.instanceRunning("pause") {
+		t.Fatal("paused instance must not report running (a genuine stale-unit target)")
+	}
+	if m.instanceRunning("absent") {
+		t.Fatal("absent instance must not report running")
+	}
+}

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -861,12 +861,6 @@ func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
 	defer func() { probeBoxdHealth = orig }()
 
-	existing := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5"}
-	mgr := &Manager{
-		log:        zerolog.Nop(),
-		vms:        map[string]*VMInstance{"vm-1": existing},
-		restoreSem: make(chan struct{}, 1),
-	}
 	dir := t.TempDir()
 	snapPath := filepath.Join(dir, "vmstate.snap")
 	memPath := filepath.Join(dir, "mem.snap")
@@ -874,6 +868,15 @@ func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	existing := &VMInstance{
+		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
+		SnapshotPath: snapPath, MemFilePath: memPath,
+	}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		vms:        map[string]*VMInstance{"vm-1": existing},
+		restoreSem: make(chan struct{}, 1),
 	}
 
 	inst, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{}, nil, "team", "owner")
@@ -888,5 +891,37 @@ func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 	mgr.mu.RUnlock()
 	if still != existing {
 		t.Fatal("existing instance must remain tracked untouched")
+	}
+}
+
+func TestRestoreVMSnapshot_DifferentArtifacts_NotTreatedAsRetry(t *testing.T) {
+	orig := probeBoxdHealth
+	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
+	defer func() { probeBoxdHealth = orig }()
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vmstate.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	for _, p := range []string{snapPath, memPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The live VM was restored from other artifacts: the request must NOT
+	// short-circuit to it, even with boxd healthy.
+	existing := &VMInstance{
+		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
+		SnapshotPath: filepath.Join(dir, "old-vmstate.snap"),
+		MemFilePath:  filepath.Join(dir, "old-mem.snap"),
+	}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		vms:        map[string]*VMInstance{"vm-1": existing},
+		restoreSem: make(chan struct{}, 1),
+	}
+
+	inst, _ := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{}, nil, "team", "owner")
+	if inst == existing {
+		t.Fatal("a restore for different artifacts must not return the old VM")
 	}
 }

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -881,9 +881,6 @@ func TestPauseVM_AlreadyPausedButArtifactsMissing_Fails(t *testing.T) {
 }
 
 func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
-	orig := probeBoxdHealth
-	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
-	defer func() { probeBoxdHealth = orig }()
 
 	dir := t.TempDir()
 	snapPath := filepath.Join(dir, "vmstate.snap")
@@ -919,9 +916,6 @@ func TestRestoreVMSnapshot_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 }
 
 func TestRestoreVMSnapshot_DifferentArtifacts_NotTreatedAsRetry(t *testing.T) {
-	orig := probeBoxdHealth
-	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
-	defer func() { probeBoxdHealth = orig }()
 
 	dir := t.TempDir()
 	snapPath := filepath.Join(dir, "vmstate.snap")
@@ -951,9 +945,6 @@ func TestRestoreVMSnapshot_DifferentArtifacts_NotTreatedAsRetry(t *testing.T) {
 }
 
 func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
-	orig := probeBoxdHealth
-	probeBoxdHealth = func(ctx context.Context, vmIP string, timeout time.Duration) error { return nil }
-	defer func() { probeBoxdHealth = orig }()
 
 	existing := &VMInstance{
 		ID: "vm-1", Status: StatusRunning, IP: "10.11.0.5",
@@ -968,5 +959,29 @@ func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 	}
 	if inst != existing {
 		t.Fatal("expected the existing running instance, not a relaunch")
+	}
+}
+
+func TestVMOpLock_SerializesSameID_TryLockSkips(t *testing.T) {
+	m := &Manager{log: zerolog.Nop()}
+
+	unlock := m.lockVMOp("vm-1")
+	// A different vmID is independent — must acquire freely.
+	if u2, ok := m.tryLockVMOp("vm-2"); !ok {
+		t.Fatal("different vmID must not contend")
+	} else {
+		u2()
+	}
+	// The held vmID must not be re-acquirable (this is what makes the
+	// reconciler skip a unit a launch is mid-flight on).
+	if _, ok := m.tryLockVMOp("vm-1"); ok {
+		t.Fatal("held vmID must fail TryLock")
+	}
+	unlock()
+	// Released — now acquirable.
+	if u, ok := m.tryLockVMOp("vm-1"); !ok {
+		t.Fatal("released vmID must be acquirable")
+	} else {
+		u()
 	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -348,6 +348,36 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
+	// Drift 5: systemd unit active, DB says paused. An interrupted pause
+	// stop (or a vmd crash between snapshot and stop) leaves the old
+	// firecracker running, pinning the guest's RAM for as long as the
+	// sandbox sleeps. A resume replaces it at launch; a sandbox that stays
+	// paused needs this reclaim. The record stays — the snapshot is valid.
+	if dbSandboxes != nil {
+		for id := range active {
+			sb, known := dbSandboxes[id]
+			if !known || sb.Sandbox.Status != db.SandboxStatusPaused {
+				r.clearDrift("pausedunit:" + id)
+				continue
+			}
+			if !r.gracePeriodElapsed("pausedunit:"+id, now) {
+				continue
+			}
+			if !r.consumeAutoFailBudget(id) {
+				r.writeAudit(ctx, id, "budget_exhausted", "paused_unit_stop suppressed by rate limit", "systemd_active_db_paused")
+				continue
+			}
+			log.Warn().Str("vm_id", id).Str("drift", "systemd_active_db_paused").
+				Msg("live unit for paused sandbox — stopping")
+			if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
+				log.Error().Err(err).Str("vm_id", id).Msg("failed to stop paused sandbox's unit")
+				continue
+			}
+			r.writeAudit(ctx, id, "paused_unit_stop", "unit still running for paused sandbox", "systemd_active_db_paused")
+			r.clearDrift("pausedunit:" + id)
+		}
+	}
+
 	// Drift 4: DB says paused, snapshot file missing on disk → mark failed.
 	if dbSandboxes != nil {
 		for id, sb := range dbSandboxes {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -363,17 +363,19 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !r.gracePeriodElapsed("pausedunit:"+id, now) {
 				continue
 			}
-			if !r.consumeAutoFailBudget(id) {
-				r.writeAudit(ctx, id, "budget_exhausted", "paused_unit_stop suppressed by rate limit", "systemd_active_db_paused")
-				continue
-			}
-			// Skip (not block) if a launch/pause is in flight for this
-			// vmID: the DB snapshot is from the top of the pass, and a
-			// resume could have claimed and relaunched this exact unit
-			// since. TryLock keeps the single-threaded pass moving; a
-			// genuinely stale unit is reclaimed next tick.
+			// Take the lock BEFORE spending budget: if a launch/pause is in
+			// flight for this vmID (DB snapshot is from the top of the pass;
+			// a resume may have claimed and relaunched this unit since),
+			// TryLock fails and we skip — without burning an auto-fail slot
+			// on a stop we won't perform. A genuinely stale unit is
+			// reclaimed next tick.
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
+				continue
+			}
+			if !r.consumeAutoFailBudget(id) {
+				unlockOp()
+				r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "systemd_active_db_paused")
 				continue
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "systemd_active_db_paused").
@@ -384,7 +386,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				log.Error().Err(err).Str("vm_id", id).Msg("failed to stop paused sandbox's unit")
 				continue
 			}
-			r.writeAudit(ctx, id, "paused_unit_stop", "unit still running for paused sandbox", "systemd_active_db_paused")
+			// Reuse the orphan_stop action (both stop a unit that shouldn't
+			// run); the drift_kind column carries the paused-specific detail.
+			r.writeAudit(ctx, id, "orphan_stop", "unit still running for paused sandbox", "systemd_active_db_paused")
 			r.clearDrift("pausedunit:" + id)
 		}
 	}

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -348,15 +348,23 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
-	// Drift 5: systemd unit active, DB says paused. An interrupted pause
-	// stop (or a vmd crash between snapshot and stop) leaves the old
+	// Drift 5: systemd unit active for a paused sandbox (DB row when
+	// available, BoltDB record on the DB-down fallback). An interrupted
+	// pause stop (or a vmd crash between snapshot and stop) leaves the old
 	// firecracker running, pinning the guest's RAM for as long as the
 	// sandbox sleeps. A resume replaces it at launch; a sandbox that stays
 	// paused needs this reclaim. The record stays — the snapshot is valid.
-	if dbSandboxes != nil {
+	{
 		for id := range active {
-			sb, known := dbSandboxes[id]
-			if !known || sb.Sandbox.Status != db.SandboxStatusPaused {
+			paused := false
+			if dbSandboxes != nil {
+				sb, known := dbSandboxes[id]
+				paused = known && sb.Sandbox.Status == db.SandboxStatusPaused
+			} else {
+				rec, ok := bolted[id]
+				paused = ok && rec.Status == StatusPaused
+			}
+			if !paused {
 				r.clearDrift("pausedunit:" + id)
 				continue
 			}

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -348,7 +348,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
-	// Drift 6: systemd unit active, DB says paused — an interrupted pause
+	// Drift 7: systemd unit active, DB says paused — an interrupted pause
 	// stop left the old firecracker pinning guest RAM; stop it. DB rows
 	// only: a mid-resume sandbox reads 'resuming' there, clearing the
 	// drift, while its BoltDB record stays Paused until the resume

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -348,23 +348,15 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
-	// Drift 5: systemd unit active for a paused sandbox (DB row when
-	// available, BoltDB record on the DB-down fallback). An interrupted
-	// pause stop (or a vmd crash between snapshot and stop) leaves the old
-	// firecracker running, pinning the guest's RAM for as long as the
-	// sandbox sleeps. A resume replaces it at launch; a sandbox that stays
-	// paused needs this reclaim. The record stays — the snapshot is valid.
-	{
+	// Drift 5: systemd unit active, DB says paused — an interrupted pause
+	// stop left the old firecracker pinning guest RAM; stop it. DB rows
+	// only: a mid-resume sandbox reads 'resuming' there, clearing the
+	// drift, while its BoltDB record stays Paused until the resume
+	// persists — keying off records could kill a just-launched resume.
+	if dbSandboxes != nil {
 		for id := range active {
-			paused := false
-			if dbSandboxes != nil {
-				sb, known := dbSandboxes[id]
-				paused = known && sb.Sandbox.Status == db.SandboxStatusPaused
-			} else {
-				rec, ok := bolted[id]
-				paused = ok && rec.Status == StatusPaused
-			}
-			if !paused {
+			sb, known := dbSandboxes[id]
+			if !known || sb.Sandbox.Status != db.SandboxStatusPaused {
 				r.clearDrift("pausedunit:" + id)
 				continue
 			}

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -373,6 +373,17 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !ok {
 				continue
 			}
+			// Re-check liveness under the lock against the AUTHORITATIVE
+			// in-memory record, not the top-of-pass DB snapshot: a resume
+			// can complete mid-pass (relaunch the unit, set Running, release
+			// the lock) so tryLock succeeds while the snapshot still says
+			// paused. Stopping then would kill the freshly-resumed VM. A
+			// genuine stale unit has a Paused/absent record, not Running.
+			if r.mgr.instanceRunning(id) {
+				unlockOp()
+				r.clearDrift("pausedunit:" + id)
+				continue
+			}
 			if !r.consumeAutoFailBudget(id) {
 				unlockOp()
 				r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "systemd_active_db_paused")

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -348,7 +348,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
-	// Drift 5: systemd unit active, DB says paused — an interrupted pause
+	// Drift 6: systemd unit active, DB says paused — an interrupted pause
 	// stop left the old firecracker pinning guest RAM; stop it. DB rows
 	// only: a mid-resume sandbox reads 'resuming' there, clearing the
 	// drift, while its BoltDB record stays Paused until the resume
@@ -367,9 +367,20 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				r.writeAudit(ctx, id, "budget_exhausted", "paused_unit_stop suppressed by rate limit", "systemd_active_db_paused")
 				continue
 			}
+			// Skip (not block) if a launch/pause is in flight for this
+			// vmID: the DB snapshot is from the top of the pass, and a
+			// resume could have claimed and relaunched this exact unit
+			// since. TryLock keeps the single-threaded pass moving; a
+			// genuinely stale unit is reclaimed next tick.
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
 			log.Warn().Str("vm_id", id).Str("drift", "systemd_active_db_paused").
 				Msg("live unit for paused sandbox — stopping")
-			if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
+			err := stopUnit(ctx, systemdUnitName(id))
+			unlockOp()
+			if err != nil {
 				log.Error().Err(err).Str("vm_id", id).Msg("failed to stop paused sandbox's unit")
 				continue
 			}

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // systemdUnitName returns the systemd unit name for a sandbox.
@@ -55,6 +56,19 @@ func stopUnit(ctx context.Context, unit string) error {
 		return fmt.Errorf("systemctl stop %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+// stopUnitBudget covers `systemctl stop` blocking up to TimeoutStopSec plus
+// margin for host I/O contention. Each stop attempt gets its own.
+const stopUnitBudget = 15 * time.Second
+
+// stopUnitWithBudget stops a unit on a detached context with its own budget,
+// so the caller's possibly-spent deadline can't starve a stop that must
+// happen (e.g. after a pause's snapshot already landed).
+func stopUnitWithBudget(ctx context.Context, unit string) error {
+	c, cancel := context.WithTimeout(context.WithoutCancel(ctx), stopUnitBudget)
+	defer cancel()
+	return stopUnit(c, unit)
 }
 
 // unitLingering reports whether the unit has a live or winding-down process

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -46,6 +46,13 @@ func unitFailureSummary(ctx context.Context, unit string) string {
 	return s
 }
 
+// unitTransitioning reports whether a Result/SubState summary describes a
+// unit mid stop or start — e.g. a restart that replaced a live stale unit
+// and is still tearing the old process down (TimeoutStopSec allows 10s).
+func unitTransitioning(summary string) bool {
+	return strings.Contains(summary, "stop") || strings.Contains(summary, "start")
+}
+
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
 // unit is a no-op.
 func stopUnit(ctx context.Context, unit string) error {

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -14,14 +14,17 @@ func systemdUnitName(vmID string) string {
 	return "firecracker@" + vmID + ".service"
 }
 
-// startUnit starts a systemd unit. Idempotent — starting an already-running
-// unit is a no-op. Returns after the start job is queued; readiness is
-// signalled by the unit's own side effect (e.g., API socket appearing).
-func startUnit(ctx context.Context, unit string) error {
-	cmd := exec.CommandContext(ctx, "systemctl", "start", "--no-block", unit)
+// restartUnit (re)starts a systemd unit. For an inactive unit this is
+// exactly `start`; an already-active unit — a stale firecracker left by an
+// interrupted stop — is replaced rather than silently no-op'd, which would
+// strand the launch waiting on a socket the old process never re-binds.
+// Returns after the job is queued; readiness is signalled by the unit's own
+// side effect (e.g., API socket appearing).
+func restartUnit(ctx context.Context, unit string) error {
+	cmd := exec.CommandContext(ctx, "systemctl", "restart", "--no-block", unit)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("systemctl start %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
+		return fmt.Errorf("systemctl restart %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -57,6 +57,21 @@ func stopUnit(ctx context.Context, unit string) error {
 	return nil
 }
 
+// unitLingering reports whether the unit has a live or winding-down process
+// (active, activating, or deactivating) — i.e. a restart must wait out a
+// stop phase before the fresh process can bind its socket.
+func unitLingering(ctx context.Context, unit string) bool {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=ActiveState", "--value", unit).Output()
+	if err != nil {
+		return false
+	}
+	switch strings.TrimSpace(string(out)) {
+	case "active", "activating", "deactivating":
+		return true
+	}
+	return false
+}
+
 // isUnitActive checks if a systemd unit is currently active (running).
 func isUnitActive(ctx context.Context, unit string) bool {
 	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -59,7 +59,8 @@ func stopUnit(ctx context.Context, unit string) error {
 }
 
 // stopUnitBudget covers `systemctl stop` blocking up to TimeoutStopSec plus
-// margin for host I/O contention. Each stop attempt gets its own.
+// margin for host I/O contention. The pause path caps its whole stop phase
+// at this OR the caller's remaining deadline, whichever is shorter.
 const stopUnitBudget = 15 * time.Second
 
 // stopUnitWithBudget stops a unit on a detached context with its own budget,

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -46,20 +46,6 @@ func unitFailureSummary(ctx context.Context, unit string) string {
 	return s
 }
 
-// unitJobPending reports whether systemd has a queued or running job for the
-// unit — e.g. a restart that replaced a live stale unit and is still tearing
-// the old process down (TimeoutStopSec allows 10s) with the start queued
-// behind it. Settled states (running, dead, failed, start-limit-hit) have no
-// job, so this cannot false-positive on a unit that will never produce a
-// socket.
-func unitJobPending(ctx context.Context, unit string) bool {
-	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=Job", "--value", unit).Output()
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) != ""
-}
-
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
 // unit is a no-op.
 func stopUnit(ctx context.Context, unit string) error {

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -46,11 +46,18 @@ func unitFailureSummary(ctx context.Context, unit string) string {
 	return s
 }
 
-// unitTransitioning reports whether a Result/SubState summary describes a
-// unit mid stop or start — e.g. a restart that replaced a live stale unit
-// and is still tearing the old process down (TimeoutStopSec allows 10s).
-func unitTransitioning(summary string) bool {
-	return strings.Contains(summary, "stop") || strings.Contains(summary, "start")
+// unitJobPending reports whether systemd has a queued or running job for the
+// unit — e.g. a restart that replaced a live stale unit and is still tearing
+// the old process down (TimeoutStopSec allows 10s) with the start queued
+// behind it. Settled states (running, dead, failed, start-limit-hit) have no
+// job, so this cannot false-positive on a unit that will never produce a
+// socket.
+func unitJobPending(ctx context.Context, unit string) bool {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=Job", "--value", unit).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped


### PR DESCRIPTION
Two related classes of lifecycle bugs, one theme: an interrupted pause or a retried RPC must never condemn a healthy sandbox, roll back guest state, or leave a stale firecracker behind.

Retried RPCs (response lost to a daemon restart or connection reset):
- A retried pause of an already-paused VM returns the recorded snapshot artifacts (after confirming they still exist on disk). Previously it dialed the dead firecracker socket, failed, and the error handler deleted the VM's record.
- A retried resume or restore that finds the VM already running — same artifacts requested, boxd healthy, instance still tracked after the probe — returns the live instance instead of relaunching. Both paths share one guard (retriedLaunchTarget); previously a duplicate resume killed the healthy VM (the launch path removes the socket file first, so even the old no-op start ended in a timeout and an error-path stop).

Interrupted stops:
- Launch uses systemctl restart instead of start: an already-active unit — a stale firecracker left by an interrupted stop — is replaced inline instead of silently no-op'ing and stranding the launch on a socket the old process never re-binds.
- If the socket misses its 5s window while systemd still has a job in flight for the unit (a restart tearing down the old process, up to TimeoutStopSec), the wait extends once, capped by the caller's remaining deadline. Gating on the Job property means settled failures (exit-code, start-limit-hit) still fail fast.
- A pause whose stop fails still completes as paused — the snapshot is already valid, and failing the pause would leave the guest frozen-but-active and make a retried pause re-diff an already-consumed dirty bitmap (destroying the overlay). The stop is retried on a detached context and escalated to an error log.
- New reconciler drift rule: a systemd unit still active for a DB-paused sandbox is stopped after the grace period — reclaiming the guest RAM an interrupted stop would otherwise pin for as long as the sandbox sleeps. The record stays; the snapshot is valid.
- The socket-timeout launch failure now logs daemon-side with the VM id and unit state.