### PR TITLE
vmd: persistent systemd D-Bus connection for unit operations

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -378,6 +378,12 @@ func main() {
 	}
 	launchViaLauncherNS := envOrDefault("VMD_LAUNCH_VIA_LAUNCHER_NS", "false") == "true"
 
+	// Persistent systemd D-Bus connection for unit operations (vs forking
+	// systemctl per call). Falls back to systemctl per call when unavailable.
+	systemdDBus := envOrDefault("VMD_SYSTEMD_DBUS", "false") == "true"
+	vm.SetSystemdDBusEnabled(systemdDBus)
+	log.Info().Bool("systemd_dbus", systemdDBus).Msg("systemd unit-operations transport")
+
 	mgr, err := vm.NewManager(vm.ManagerConfig{
 		FirecrackerBin:             cfg.FirecrackerBin,
 		JailerBin:                  cfg.JailerBin,

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	connectrpc.com/connect v1.19.1
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-iptables v0.8.0
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/getsentry/sentry-go v0.46.2
@@ -17,6 +18,7 @@ require (
 	github.com/go-openapi/strfmt v0.26.1
 	github.com/go-openapi/swag v0.25.5
 	github.com/go-openapi/validate v0.25.2
+	github.com/godbus/dbus/v5 v5.0.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-containerregistry v0.21.5
 	github.com/google/nftables v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz
 github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
 github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
 github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -133,6 +134,7 @@ github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2651,6 +2651,11 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 // unitMainPID returns the systemd MainPID for a VM's unit, or 0 when it can't
 // be resolved or the unit has no running process.
 func (m *Manager) unitMainPID(ctx context.Context, vmID string) int {
+	if val, err, ok := sdbusUnitProperty(ctx, systemdUnitName(vmID), "Service", "MainPID"); ok && err == nil {
+		if pid, isU32 := val.(uint32); isU32 {
+			return int(pid)
+		}
+	}
 	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=MainPID", "--value", systemdUnitName(vmID)).Output()
 	if err != nil {
 		return 0

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2585,18 +2585,22 @@ func (m *Manager) RecordAccessPattern(ctx context.Context, vmID, snapshotPath, m
 
 	// Bounded, not Background: an unbounded destroy could pin the shared
 	// systemd job lock behind a wedged PID1 and queue every stop on the host.
-	dctx, dcancel := context.WithTimeout(context.Background(), time.Minute)
-	defer dcancel()
+	// The clock starts at the destroy, not before the warmup sleep.
+	destroyRecordingVM := func() error {
+		dctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		return m.DestroyVM(dctx, inst.ID, true)
+	}
 
 	if recordWarmup(ctx, warmup) == warmupCancelled {
-		if err := m.DestroyVM(dctx, inst.ID, true); err != nil {
+		if err := destroyRecordingVM(); err != nil {
 			m.log.Warn().Err(err).Str("template_vm", vmID).
 				Msg("destroy after cancelled recording warmup failed; reconciler will clean up")
 		}
 		return ctx.Err()
 	}
 
-	if err := m.DestroyVM(dctx, inst.ID, true); err != nil {
+	if err := destroyRecordingVM(); err != nil {
 		return fmt.Errorf("destroy recording VM: %w", err)
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -860,13 +860,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// record must reach Paused (a retry against a Running record would
 	// re-diff an already-consumed dirty bitmap and destroy the overlay).
 	//
-	// Bound the WHOLE stop path (both attempts + dead-check) to the caller's
-	// deadline: the control plane caps the pause RPC at ~30s and reverts the
-	// DB row to active on timeout, so a stop that finishes after that would
-	// leave DB-active-but-VM-stopped drift. If the stop can't finish in the
-	// remaining budget the straggler unit is reclaimed by the reconciler —
-	// self-healing, unlike the drift. This is why the path shares the
-	// caller's budget rather than taking fresh detached ones.
+	// Bound the stop path (both attempts + dead-check) to the caller's
+	// deadline so the handler can't run long past the ~30s pause RPC cap
+	// (stopUnit's expiry settle may probe ≤2s past it — bounded, and it only
+	// affects the log below, never what gets persisted). A timed-out pause
+	// converges anyway: the control plane retries pause to paused rather than
+	// reverting, and a straggler unit is reclaimed by the reconciler.
 	unit := systemdUnitName(vmID)
 	stopCtx, stopCancel := context.WithTimeout(ctx, stopUnitBudget)
 	if err := stopUnit(stopCtx, unit); err != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1278,7 +1278,7 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	if _, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace); err != nil {
 		return "", fmt.Errorf("start firecracker for verify: %w", err)
 	}
-	defer func() { _ = stopUnit(context.Background(), systemdUnitName(vmID)) }()
+	defer func() { _ = stopUnitWithBudget(context.Background(), systemdUnitName(vmID)) }()
 
 	if err := LoadSnapshotNoResume(socketPath, snapshotPath, memPath, "eth0", tapDevice, ""); err != nil {
 		return "", err
@@ -2583,15 +2583,20 @@ func (m *Manager) RecordAccessPattern(ctx context.Context, vmID, snapshotPath, m
 		warmup = time.Duration(m.cfg.UffdRecordMaxSeconds) * time.Second
 	}
 
+	// Bounded, not Background: an unbounded destroy could pin the shared
+	// systemd job lock behind a wedged PID1 and queue every stop on the host.
+	dctx, dcancel := context.WithTimeout(context.Background(), time.Minute)
+	defer dcancel()
+
 	if recordWarmup(ctx, warmup) == warmupCancelled {
-		if err := m.DestroyVM(context.Background(), inst.ID, true); err != nil {
+		if err := m.DestroyVM(dctx, inst.ID, true); err != nil {
 			m.log.Warn().Err(err).Str("template_vm", vmID).
 				Msg("destroy after cancelled recording warmup failed; reconciler will clean up")
 		}
 		return ctx.Err()
 	}
 
-	if err := m.DestroyVM(context.Background(), inst.ID, true); err != nil {
+	if err := m.DestroyVM(dctx, inst.ID, true); err != nil {
 		return fmt.Errorf("destroy recording VM: %w", err)
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2651,7 +2651,10 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 // unitMainPID returns the systemd MainPID for a VM's unit, or 0 when it can't
 // be resolved or the unit has no running process.
 func (m *Manager) unitMainPID(ctx context.Context, vmID string) int {
-	if val, err, ok := sdbusUnitProperty(ctx, systemdUnitName(vmID), "Service", "MainPID"); ok && err == nil {
+	if val, notLoaded, ok := sdbusUnitProperty(ctx, systemdUnitName(vmID), "Service", "MainPID"); ok {
+		if notLoaded {
+			return 0 // unit gone == no process, definitively
+		}
 		if pid, isU32 := val.(uint32); isU32 {
 			return int(pid)
 		}

--- a/internal/vm/sdbus.go
+++ b/internal/vm/sdbus.go
@@ -14,10 +14,10 @@ package vm
 //     ends, so a per-request context would kill it seconds after birth.
 //   - No caller ever blocks on connection state. Acquisition is a
 //     non-blocking check; if there is no healthy connection, one background
-//     dial is kicked off (single-flight, bounded by its own timer since
-//     dial+auth I/O ignores context deadlines) and the caller falls back to
-//     exec immediately. A wedged PID1 can therefore never stall helpers
-//     behind a mutex.
+//     dial is kicked off (single-flight, held until it truly returns) and
+//     the caller falls back to exec immediately. A wedged PID1 can
+//     therefore never stall helpers behind a mutex, and never costs more
+//     than one blocked dial goroutine.
 //   - Connected() is checked on every acquisition: the library's Conn is
 //     two sockets, and the signal socket can die alone, which would
 //     otherwise strand every job-completion wait while method calls keep
@@ -49,10 +49,6 @@ func SetSystemdDBusEnabled(v bool) {
 		sdbusAcquire()
 	}
 }
-
-// sdbusDialTimeout bounds a background dial attempt; an attempt that
-// overruns is abandoned (and closed if it ever completes).
-const sdbusDialTimeout = 5 * time.Second
 
 // sdbusRedialCooldown is the minimum gap between dial attempts, so a host
 // where systemd is unreachable doesn't burn a dial per helper call.
@@ -86,42 +82,23 @@ func sdbusAcquire() *sddbus.Conn {
 }
 
 // sdbusDial runs one background dial. The connection context is detached —
-// its lifetime is the daemon's, not any request's. The dial itself is
-// bounded by a timer, not a context deadline: the library's dial+auth I/O
-// ignores deadlines, and a deadline on the connection context would close
-// the connection when it fired.
+// its lifetime is the daemon's, not any request's (a deadline on it would
+// close the connection when it fired). The attempt stays marked in flight
+// until it truly returns: the library's dial+auth I/O has no deadline, so
+// abandoning a hung attempt and retrying would leak a goroutine per retry;
+// held single-flight, a wedged PID1 costs at most one blocked goroutine
+// while every caller keeps exec-falling-back.
 func sdbusDial() {
-	type result struct{ conn *sddbus.Conn }
-	ch := make(chan result, 1)
-	go func() {
-		conn, err := sddbus.NewSystemdConnectionContext(context.Background())
-		if err != nil {
-			ch <- result{nil}
-			return
-		}
-		ch <- result{conn}
-	}()
-
-	var conn *sddbus.Conn
-	select {
-	case r := <-ch:
-		conn = r.conn
-	case <-time.After(sdbusDialTimeout):
-		// Abandoned: if the dial ever completes, close the orphan.
-		go func() {
-			if r := <-ch; r.conn != nil {
-				r.conn.Close()
-			}
-		}()
-	}
+	conn, err := sddbus.NewSystemdConnectionContext(context.Background())
 
 	sdbus.mu.Lock()
 	sdbus.dialing = false
-	if conn != nil {
+	sdbus.lastDial = time.Now() // cooldown runs from completion, not start
+	if err == nil {
 		if sdbus.conn == nil {
 			sdbus.conn = conn
 		} else {
-			// Lost a race with another successful dial.
+			// Lost a race with a connection cached by someone else.
 			defer conn.Close()
 		}
 	}

--- a/internal/vm/sdbus.go
+++ b/internal/vm/sdbus.go
@@ -157,10 +157,22 @@ func sdbusDo(fn func(*sddbus.Conn) error) (err error, handled bool) {
 	if merr, answered := sdbusAnswer(err); answered {
 		return merr, true
 	}
-	// Transport-shaped failure: drop the corpse so a later call redials,
-	// and let the exec path handle this call with today's semantics.
-	sdbusDrop(conn)
+	// Transport-shaped failure: drop the corpse so a later call redials —
+	// unless it's the CALLER's cancellation, which is this call's result,
+	// not evidence the shared bus is dead. Either way the exec path
+	// handles this call with today's semantics.
+	if sdbusCondemns(err) {
+		sdbusDrop(conn)
+	}
 	return nil, false
+}
+
+// sdbusCondemns reports whether a non-answer error condemns the shared
+// connection. Caller ctx expiry doesn't: the library surfaces it without
+// the connection being unhealthy, and dropping would tear the bus down
+// under every other in-flight operation.
+func sdbusCondemns(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 // sdbusAnswer reports whether systemd answered the call: nil, or a D-Bus

--- a/internal/vm/sdbus.go
+++ b/internal/vm/sdbus.go
@@ -1,18 +1,36 @@
 package vm
 
 // One persistent connection to systemd's private socket replaces per-call
-// systemctl forks. Under a concurrent launch burst the forks are the
+// systemctl forks. Under a large concurrent launch burst the forks are the
 // dominant cost: each pays fork+exec plus a D-Bus connect/handshake that
-// grows with the number of loaded units, and 100 simultaneous spawns
+// grows with the number of loaded units, and the simultaneous spawns
 // compete with PID1 and the starting units for the scheduler. Every helper
 // falls back to exec'ing systemctl when the connection is unavailable, so
 // the worst case is exactly the exec-only behavior.
+//
+// Design rules, each load-bearing:
+//   - The connection is dialed with its own lifetime context, never a
+//     caller's: the library closes the connection when the dialing context
+//     ends, so a per-request context would kill it seconds after birth.
+//   - No caller ever blocks on connection state. Acquisition is a
+//     non-blocking check; if there is no healthy connection, one background
+//     dial is kicked off (single-flight, bounded by its own timer since
+//     dial+auth I/O ignores context deadlines) and the caller falls back to
+//     exec immediately. A wedged PID1 can therefore never stall helpers
+//     behind a mutex.
+//   - Connected() is checked on every acquisition: the library's Conn is
+//     two sockets, and the signal socket can die alone, which would
+//     otherwise strand every job-completion wait while method calls keep
+//     succeeding.
 
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
@@ -23,33 +41,96 @@ import (
 var systemdDBusEnabled atomic.Bool
 
 // SetSystemdDBusEnabled turns the persistent systemd D-Bus path on or off.
-func SetSystemdDBusEnabled(v bool) { systemdDBusEnabled.Store(v) }
-
-// sdbus holds the shared connection. nil until first use and after a
-// transport failure; redialed lazily. The private socket requires root and
-// bypasses dbus-daemon entirely.
-var sdbus struct {
-	mu   sync.Mutex
-	conn *sddbus.Conn
+// Enabling kicks off the background dial so the first helper call after
+// startup doesn't need the exec fallback.
+func SetSystemdDBusEnabled(v bool) {
+	systemdDBusEnabled.Store(v)
+	if v {
+		sdbusAcquire()
+	}
 }
 
-func sdbusGet(ctx context.Context) (*sddbus.Conn, error) {
+// sdbusDialTimeout bounds a background dial attempt; an attempt that
+// overruns is abandoned (and closed if it ever completes).
+const sdbusDialTimeout = 5 * time.Second
+
+// sdbusRedialCooldown is the minimum gap between dial attempts, so a host
+// where systemd is unreachable doesn't burn a dial per helper call.
+const sdbusRedialCooldown = 3 * time.Second
+
+var sdbus struct {
+	mu       sync.Mutex
+	conn     *sddbus.Conn
+	dialing  bool
+	lastDial time.Time
+}
+
+// sdbusAcquire returns a healthy connection or nil, without ever blocking
+// on dial or I/O. A nil return means: use the exec fallback for this call.
+func sdbusAcquire() *sddbus.Conn {
 	sdbus.mu.Lock()
 	defer sdbus.mu.Unlock()
 	if sdbus.conn != nil {
-		return sdbus.conn, nil
+		if sdbus.conn.Connected() {
+			return sdbus.conn
+		}
+		sdbus.conn.Close()
+		sdbus.conn = nil
 	}
-	conn, err := sddbus.NewSystemdConnectionContext(ctx)
-	if err != nil {
-		return nil, err
+	if !sdbus.dialing && time.Since(sdbus.lastDial) >= sdbusRedialCooldown {
+		sdbus.dialing = true
+		sdbus.lastDial = time.Now()
+		go sdbusDial()
 	}
-	sdbus.conn = conn
-	return conn, nil
+	return nil
 }
 
-// sdbusDrop closes and forgets a connection after a transport failure so
-// the next call redials — a systemd daemon-reexec kills the socket and the
-// library never reconnects on its own. Only drops the current connection.
+// sdbusDial runs one background dial. The connection context is detached —
+// its lifetime is the daemon's, not any request's. The dial itself is
+// bounded by a timer, not a context deadline: the library's dial+auth I/O
+// ignores deadlines, and a deadline on the connection context would close
+// the connection when it fired.
+func sdbusDial() {
+	type result struct{ conn *sddbus.Conn }
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := sddbus.NewSystemdConnectionContext(context.Background())
+		if err != nil {
+			ch <- result{nil}
+			return
+		}
+		ch <- result{conn}
+	}()
+
+	var conn *sddbus.Conn
+	select {
+	case r := <-ch:
+		conn = r.conn
+	case <-time.After(sdbusDialTimeout):
+		// Abandoned: if the dial ever completes, close the orphan.
+		go func() {
+			if r := <-ch; r.conn != nil {
+				r.conn.Close()
+			}
+		}()
+	}
+
+	sdbus.mu.Lock()
+	sdbus.dialing = false
+	if conn != nil {
+		if sdbus.conn == nil {
+			sdbus.conn = conn
+		} else {
+			// Lost a race with another successful dial.
+			defer conn.Close()
+		}
+	}
+	sdbus.mu.Unlock()
+}
+
+// sdbusDrop closes and forgets a connection after a transport failure so a
+// later acquisition redials — a systemd daemon-reexec kills the socket and
+// the library never reconnects on its own. Only drops the current one.
 func sdbusDrop(c *sddbus.Conn) {
 	sdbus.mu.Lock()
 	if sdbus.conn == c {
@@ -60,47 +141,38 @@ func sdbusDrop(c *sddbus.Conn) {
 }
 
 // sdbusDo runs fn against the shared connection. handled=false means the
-// D-Bus path could not produce an answer (flag off, dial failed, connection
-// closed twice) and the caller must fall back to exec'ing systemctl.
+// D-Bus path could not produce an answer (flag off, no healthy connection,
+// transport failure) and the caller must fall back to exec'ing systemctl.
 // handled=true means systemd answered: err is nil or a real method error
-// (e.g. NoSuchUnit) that the fallback would hit too.
-func sdbusDo(ctx context.Context, fn func(*sddbus.Conn) error) (err error, handled bool) {
+// (e.g. NoSuchUnit) that exec'd systemctl would hit identically.
+func sdbusDo(fn func(*sddbus.Conn) error) (err error, handled bool) {
 	if !systemdDBusEnabled.Load() {
 		return nil, false
 	}
-	conn, derr := sdbusGet(ctx)
-	if derr != nil {
+	conn := sdbusAcquire()
+	if conn == nil {
 		return nil, false
 	}
 	err = fn(conn)
-	if sdbusClosed(err) {
-		sdbusDrop(conn)
-		if conn, derr = sdbusGet(ctx); derr != nil {
-			return nil, false
-		}
-		err = fn(conn)
-		if sdbusClosed(err) {
-			sdbusDrop(conn)
-			return nil, false
-		}
-	}
 	if merr, answered := sdbusAnswer(err); answered {
 		return merr, true
 	}
-	// Transport-shaped failure (net error, ctx expiry mid-call): let the
-	// exec path try; it either succeeds or fails with today's semantics.
+	// Transport-shaped failure: drop the corpse so a later call redials,
+	// and let the exec path handle this call with today's semantics.
+	sdbusDrop(conn)
 	return nil, false
 }
 
-// sdbusClosed reports a dead connection — the one error worth a redial.
-func sdbusClosed(err error) bool { return errors.Is(err, dbus.ErrClosed) }
-
 // sdbusAnswer reports whether systemd answered the call: nil, or a D-Bus
 // method error (NoSuchUnit, start-limit, ...) that exec'd systemctl would
-// hit identically. Anything else is transport-shaped → not answered.
+// hit identically. Anything else — ErrClosed, raw socket EOF/reset from a
+// call in flight at transport death, ctx expiry — is transport-shaped.
 func sdbusAnswer(err error) (error, bool) {
 	if err == nil {
 		return nil, true
+	}
+	if errors.Is(err, dbus.ErrClosed) || errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+		return nil, false
 	}
 	var de dbus.Error
 	if errors.As(err, &de) {
@@ -109,11 +181,31 @@ func sdbusAnswer(err error) (error, bool) {
 	return nil, false
 }
 
+// sdbusNotLoaded reports the method errors meaning "systemd has no such
+// unit loaded" — for template instances that is the normal state of every
+// stopped/dead VM, and it is a definitive answer (not active, no PID), not
+// a reason to fall back to exec.
+func sdbusNotLoaded(err error) bool {
+	var de dbus.Error
+	if !errors.As(err, &de) {
+		return false
+	}
+	switch de.Name {
+	case "org.freedesktop.systemd1.NoSuchUnit",
+		"org.freedesktop.DBus.Error.UnknownObject",
+		"org.freedesktop.DBus.Error.UnknownInterface":
+		return true
+	}
+	return false
+}
+
 // sdbusUnitProperty reads one property of a unit (iface "" = the generic
-// Unit interface, "Service" = the service-specific one).
-func sdbusUnitProperty(ctx context.Context, unit, iface, name string) (any, error, bool) {
-	var val any
-	err, handled := sdbusDo(ctx, func(c *sddbus.Conn) error {
+// Unit interface, "Service" = the service-specific one). The ctx bounds
+// only this method call, never the connection. notLoaded=true is the
+// definitive "unit does not exist" answer — for template instances that is
+// the normal state of every stopped VM, not a fallback case.
+func sdbusUnitProperty(ctx context.Context, unit, iface, name string) (val any, notLoaded, handled bool) {
+	err, ok := sdbusDo(func(c *sddbus.Conn) error {
 		var p *sddbus.Property
 		var e error
 		if iface == "Service" {
@@ -127,5 +219,14 @@ func sdbusUnitProperty(ctx context.Context, unit, iface, name string) (any, erro
 		val = p.Value.Value()
 		return nil
 	})
-	return val, err, handled
+	if !ok {
+		return nil, false, false
+	}
+	if err != nil {
+		if sdbusNotLoaded(err) {
+			return nil, true, true
+		}
+		return nil, false, false
+	}
+	return val, false, true
 }

--- a/internal/vm/sdbus.go
+++ b/internal/vm/sdbus.go
@@ -1,0 +1,131 @@
+package vm
+
+// One persistent connection to systemd's private socket replaces per-call
+// systemctl forks. Under a concurrent launch burst the forks are the
+// dominant cost: each pays fork+exec plus a D-Bus connect/handshake that
+// grows with the number of loaded units, and 100 simultaneous spawns
+// compete with PID1 and the starting units for the scheduler. Every helper
+// falls back to exec'ing systemctl when the connection is unavailable, so
+// the worst case is exactly the exec-only behavior.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	sddbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+)
+
+// systemdDBusEnabled gates the D-Bus path; set once at startup from
+// VMD_SYSTEMD_DBUS. Off → helpers exec systemctl as before.
+var systemdDBusEnabled atomic.Bool
+
+// SetSystemdDBusEnabled turns the persistent systemd D-Bus path on or off.
+func SetSystemdDBusEnabled(v bool) { systemdDBusEnabled.Store(v) }
+
+// sdbus holds the shared connection. nil until first use and after a
+// transport failure; redialed lazily. The private socket requires root and
+// bypasses dbus-daemon entirely.
+var sdbus struct {
+	mu   sync.Mutex
+	conn *sddbus.Conn
+}
+
+func sdbusGet(ctx context.Context) (*sddbus.Conn, error) {
+	sdbus.mu.Lock()
+	defer sdbus.mu.Unlock()
+	if sdbus.conn != nil {
+		return sdbus.conn, nil
+	}
+	conn, err := sddbus.NewSystemdConnectionContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sdbus.conn = conn
+	return conn, nil
+}
+
+// sdbusDrop closes and forgets a connection after a transport failure so
+// the next call redials — a systemd daemon-reexec kills the socket and the
+// library never reconnects on its own. Only drops the current connection.
+func sdbusDrop(c *sddbus.Conn) {
+	sdbus.mu.Lock()
+	if sdbus.conn == c {
+		sdbus.conn = nil
+		c.Close()
+	}
+	sdbus.mu.Unlock()
+}
+
+// sdbusDo runs fn against the shared connection. handled=false means the
+// D-Bus path could not produce an answer (flag off, dial failed, connection
+// closed twice) and the caller must fall back to exec'ing systemctl.
+// handled=true means systemd answered: err is nil or a real method error
+// (e.g. NoSuchUnit) that the fallback would hit too.
+func sdbusDo(ctx context.Context, fn func(*sddbus.Conn) error) (err error, handled bool) {
+	if !systemdDBusEnabled.Load() {
+		return nil, false
+	}
+	conn, derr := sdbusGet(ctx)
+	if derr != nil {
+		return nil, false
+	}
+	err = fn(conn)
+	if sdbusClosed(err) {
+		sdbusDrop(conn)
+		if conn, derr = sdbusGet(ctx); derr != nil {
+			return nil, false
+		}
+		err = fn(conn)
+		if sdbusClosed(err) {
+			sdbusDrop(conn)
+			return nil, false
+		}
+	}
+	if merr, answered := sdbusAnswer(err); answered {
+		return merr, true
+	}
+	// Transport-shaped failure (net error, ctx expiry mid-call): let the
+	// exec path try; it either succeeds or fails with today's semantics.
+	return nil, false
+}
+
+// sdbusClosed reports a dead connection — the one error worth a redial.
+func sdbusClosed(err error) bool { return errors.Is(err, dbus.ErrClosed) }
+
+// sdbusAnswer reports whether systemd answered the call: nil, or a D-Bus
+// method error (NoSuchUnit, start-limit, ...) that exec'd systemctl would
+// hit identically. Anything else is transport-shaped → not answered.
+func sdbusAnswer(err error) (error, bool) {
+	if err == nil {
+		return nil, true
+	}
+	var de dbus.Error
+	if errors.As(err, &de) {
+		return err, true
+	}
+	return nil, false
+}
+
+// sdbusUnitProperty reads one property of a unit (iface "" = the generic
+// Unit interface, "Service" = the service-specific one).
+func sdbusUnitProperty(ctx context.Context, unit, iface, name string) (any, error, bool) {
+	var val any
+	err, handled := sdbusDo(ctx, func(c *sddbus.Conn) error {
+		var p *sddbus.Property
+		var e error
+		if iface == "Service" {
+			p, e = c.GetServicePropertyContext(ctx, unit, name)
+		} else {
+			p, e = c.GetUnitPropertyContext(ctx, unit, name)
+		}
+		if e != nil {
+			return e
+		}
+		val = p.Value.Value()
+		return nil
+	})
+	return val, err, handled
+}

--- a/internal/vm/sdbus.go
+++ b/internal/vm/sdbus.go
@@ -34,6 +34,7 @@ import (
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
+	zlog "github.com/rs/zerolog/log"
 )
 
 // systemdDBusEnabled gates the D-Bus path; set once at startup from
@@ -90,6 +91,14 @@ func sdbusAcquire() *sddbus.Conn {
 // while every caller keeps exec-falling-back.
 func sdbusDial() {
 	conn, err := sddbus.NewSystemdConnectionContext(context.Background())
+
+	// The dial outcome is the only signal of which transport the helpers
+	// are using — surfaced for the flag rollout.
+	if err != nil {
+		zlog.Warn().Err(err).Msg("systemd dbus dial failed; helpers exec systemctl")
+	} else {
+		zlog.Info().Msg("systemd dbus connected")
+	}
 
 	sdbus.mu.Lock()
 	sdbus.dialing = false

--- a/internal/vm/sdbus_test.go
+++ b/internal/vm/sdbus_test.go
@@ -1,7 +1,9 @@
 package vm
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -39,6 +41,16 @@ func TestSdbusAnswer(t *testing.T) {
 		if _, ok := sdbusAnswer(terr); ok {
 			t.Fatalf("%v must be transport-shaped, not an answer", terr)
 		}
+	}
+}
+
+func TestSdbusCondemns(t *testing.T) {
+	// Caller cancellation must not condemn the shared connection.
+	if sdbusCondemns(context.Canceled) || sdbusCondemns(fmt.Errorf("call: %w", context.DeadlineExceeded)) {
+		t.Fatal("caller ctx expiry is the call's result, not a dead bus")
+	}
+	if !sdbusCondemns(io.EOF) || !sdbusCondemns(dbus.ErrClosed) {
+		t.Fatal("real transport death must condemn the connection")
 	}
 }
 

--- a/internal/vm/sdbus_test.go
+++ b/internal/vm/sdbus_test.go
@@ -1,0 +1,41 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sddbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+)
+
+func TestSdbusDo_FlagOff_NotHandled(t *testing.T) {
+	SetSystemdDBusEnabled(false)
+	called := false
+	err, handled := sdbusDo(context.Background(), func(*sddbus.Conn) error {
+		called = true
+		return nil
+	})
+	if handled || err != nil || called {
+		t.Fatalf("flag off must not touch D-Bus: handled=%v err=%v called=%v", handled, err, called)
+	}
+}
+
+func TestSdbusAnswer(t *testing.T) {
+	if _, ok := sdbusAnswer(nil); !ok {
+		t.Fatal("nil is an answer")
+	}
+	methodErr := dbus.Error{Name: "org.freedesktop.systemd1.NoSuchUnit"}
+	if err, ok := sdbusAnswer(methodErr); !ok || err == nil {
+		t.Fatal("a D-Bus method error is an answer and must surface")
+	}
+	if _, ok := sdbusAnswer(errors.New("write unix @->/run/systemd/private: broken pipe")); ok {
+		t.Fatal("a transport error is not an answer (must fall back to exec)")
+	}
+	if sdbusClosed(methodErr) {
+		t.Fatal("a method error is not a closed connection")
+	}
+	if !sdbusClosed(dbus.ErrClosed) {
+		t.Fatal("ErrClosed must trigger the redial path")
+	}
+}

--- a/internal/vm/sdbus_test.go
+++ b/internal/vm/sdbus_test.go
@@ -1,8 +1,8 @@
 package vm
 
 import (
-	"context"
 	"errors"
+	"io"
 	"testing"
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
@@ -12,7 +12,7 @@ import (
 func TestSdbusDo_FlagOff_NotHandled(t *testing.T) {
 	SetSystemdDBusEnabled(false)
 	called := false
-	err, handled := sdbusDo(context.Background(), func(*sddbus.Conn) error {
+	err, handled := sdbusDo(func(*sddbus.Conn) error {
 		called = true
 		return nil
 	})
@@ -29,13 +29,30 @@ func TestSdbusAnswer(t *testing.T) {
 	if err, ok := sdbusAnswer(methodErr); !ok || err == nil {
 		t.Fatal("a D-Bus method error is an answer and must surface")
 	}
-	if _, ok := sdbusAnswer(errors.New("write unix @->/run/systemd/private: broken pipe")); ok {
-		t.Fatal("a transport error is not an answer (must fall back to exec)")
+	// Transport-shaped errors must NOT count as answers — they route the
+	// call to the exec fallback.
+	for _, terr := range []error{
+		dbus.ErrClosed,
+		io.EOF, // what an in-flight call sees when the transport dies
+		errors.New("read unix @->/run/systemd/private: use of closed network connection"),
+	} {
+		if _, ok := sdbusAnswer(terr); ok {
+			t.Fatalf("%v must be transport-shaped, not an answer", terr)
+		}
 	}
-	if sdbusClosed(methodErr) {
-		t.Fatal("a method error is not a closed connection")
+}
+
+func TestSdbusNotLoaded(t *testing.T) {
+	if !sdbusNotLoaded(dbus.Error{Name: "org.freedesktop.systemd1.NoSuchUnit"}) {
+		t.Fatal("NoSuchUnit is the definitive not-loaded answer")
 	}
-	if !sdbusClosed(dbus.ErrClosed) {
-		t.Fatal("ErrClosed must trigger the redial path")
+	if !sdbusNotLoaded(dbus.Error{Name: "org.freedesktop.DBus.Error.UnknownObject"}) {
+		t.Fatal("UnknownObject (unloaded template instance) is not-loaded")
+	}
+	if sdbusNotLoaded(dbus.Error{Name: "org.freedesktop.DBus.Error.AccessDenied"}) {
+		t.Fatal("other method errors are not the not-loaded answer")
+	}
+	if sdbusNotLoaded(io.EOF) {
+		t.Fatal("transport errors are not the not-loaded answer")
 	}
 }

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -54,13 +54,8 @@ const stopJobWaitCap = 15 * time.Second
 func stopUnit(ctx context.Context, unit string) error {
 	// Buffered channel: the library's dispatcher does one blocking send;
 	// buffer 1 keeps an abandoned wait from wedging every job on the
-	// connection.
-	//
-	// A non-nil channel makes the library hold its job lock across the
-	// ENQUEUE round trip (ms-scale on the private socket), so concurrent
-	// stops serialize there — accepted: the completion wait below happens
-	// outside that lock, so stops never serialize on each other's 10s stop
-	// phase, and the enqueue is still far cheaper than a systemctl fork.
+	// connection. Non-nil ch also serializes concurrent stops on the
+	// library's job lock — enqueue round trip only, not the stop itself.
 	ch := make(chan string, 1)
 	err, enqueued := sdbusDo(func(c *sddbus.Conn) error {
 		_, e := c.StopUnitContext(ctx, unit, "replace", ch)
@@ -103,8 +98,8 @@ func stopUnit(ctx context.Context, unit string) error {
 // Result/SubState for embedding in error messages. Best-effort —
 // returns "unknown" on any error.
 func unitFailureSummary(ctx context.Context, unit string) string {
-	// Result lives on the Service interface, SubState on Unit — two reads
-	// by necessity, not atomic; a torn pair is fine for a log-only string.
+	// Result lives on the Service interface, SubState on Unit — two reads,
+	// not atomic; fine for a log-only string.
 	if res, notLoaded, ok := sdbusUnitProperty(ctx, unit, "Service", "Result"); ok {
 		if notLoaded {
 			return "not-loaded"
@@ -188,10 +183,8 @@ func unitLingering(ctx context.Context, unit string) bool {
 }
 
 // isUnitActive checks if a systemd unit is currently active (running).
-// Inconclusive checks (ctx already spent by the D-Bus attempt, transport
-// failure) report ACTIVE: its caller treats "not active" as license to
-// declare the VM dead and drop it, so only a definitive answer may say no.
-// unitDefinitelyDead already implements exactly those guards.
+// Inconclusive (ctx spent, transport failure) reports active — the caller
+// treats "not active" as a dead VM, so only a definitive answer may say no.
 func isUnitActive(ctx context.Context, unit string) bool {
 	return !unitDefinitelyDead(ctx, unit)
 }

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -118,8 +118,10 @@ func stopJobResult(unit, res string) error {
 // settleExpiredStopWait decides the outcome of a stop whose wait expired. The
 // result may have landed together with the deadline (select picks randomly
 // among ready cases), and a completed job's signal may have been lost with the
-// connection — check both on a fresh, detached deadline before reporting
-// failure, so a stop that actually finished never reads as failed.
+// connection — check both before reporting failure, so a stop that actually
+// finished never reads as failed. The probe is detached and bounded: at most
+// 2s past a spent caller deadline, buying one truthful answer; it changes only
+// the reported outcome, never any persisted state.
 func settleExpiredStopWait(ctx context.Context, unit string, ch <-chan string, waitErr error) error {
 	select {
 	case res := <-ch:

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -55,6 +55,12 @@ func stopUnit(ctx context.Context, unit string) error {
 	// Buffered channel: the library's dispatcher does one blocking send;
 	// buffer 1 keeps an abandoned wait from wedging every job on the
 	// connection.
+	//
+	// A non-nil channel makes the library hold its job lock across the
+	// ENQUEUE round trip (ms-scale on the private socket), so concurrent
+	// stops serialize there — accepted: the completion wait below happens
+	// outside that lock, so stops never serialize on each other's 10s stop
+	// phase, and the enqueue is still far cheaper than a systemctl fork.
 	ch := make(chan string, 1)
 	err, enqueued := sdbusDo(func(c *sddbus.Conn) error {
 		_, e := c.StopUnitContext(ctx, unit, "replace", ch)
@@ -97,7 +103,8 @@ func stopUnit(ctx context.Context, unit string) error {
 // Result/SubState for embedding in error messages. Best-effort —
 // returns "unknown" on any error.
 func unitFailureSummary(ctx context.Context, unit string) string {
-	// Result lives on the Service interface, SubState on Unit.
+	// Result lives on the Service interface, SubState on Unit — two reads
+	// by necessity, not atomic; a torn pair is fine for a log-only string.
 	if res, notLoaded, ok := sdbusUnitProperty(ctx, unit, "Service", "Result"); ok {
 		if notLoaded {
 			return "not-loaded"
@@ -181,12 +188,12 @@ func unitLingering(ctx context.Context, unit string) bool {
 }
 
 // isUnitActive checks if a systemd unit is currently active (running).
+// Inconclusive checks (ctx already spent by the D-Bus attempt, transport
+// failure) report ACTIVE: its caller treats "not active" as license to
+// declare the VM dead and drop it, so only a definitive answer may say no.
+// unitDefinitelyDead already implements exactly those guards.
 func isUnitActive(ctx context.Context, unit string) bool {
-	if active, ok := unitActiveState(ctx, unit); ok {
-		return active
-	}
-	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
-	return cmd.Run() == nil
+	return !unitDefinitelyDead(ctx, unit)
 }
 
 // unitDefinitelyDead reports whether systemd definitively reports the unit

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -67,6 +67,9 @@ func stopUnit(ctx context.Context, unit string) error {
 	// buffer 1 keeps an abandoned wait from wedging every job on the
 	// connection. Non-nil ch also serializes concurrent stops on the
 	// library's job lock — enqueue round trip only, not the stop itself.
+	// Concurrent stops of the SAME unit merge into one systemd job, whose
+	// single registered channel goes to the last caller; an earlier caller
+	// waits out its budget and converges via settleExpiredStopWait.
 	ch := make(chan string, 1)
 	err, enqueued := sdbusDo(func(c *sddbus.Conn) error {
 		ectx, cancel := context.WithTimeout(ctx, stopEnqueueCap)

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -44,10 +44,17 @@ func restartUnit(ctx context.Context, unit string) error {
 	return nil
 }
 
-// stopJobWaitCap bounds the wait for a stop job's completion signal. Above
-// the unit's TimeoutStopSec (10s) + kill margin: past this the signal is
-// considered lost (dead signal socket), not the job slow.
-const stopJobWaitCap = 15 * time.Second
+// stopJobWaitCap bounds the wait for a stop job's completion signal when the
+// caller's ctx allows more. A legitimate stop can take two full TimeoutStopSec
+// windows (SIGTERM phase, then a second window after SIGKILL) plus ExecStopPost,
+// so this sits above that worst case. Distinct from stopUnitBudget below, which
+// is the pause path's deliberately tighter policy.
+const stopJobWaitCap = 35 * time.Second
+
+// stopEnqueueCap bounds the StopUnit enqueue round trip. The library holds its
+// job lock across this call, so one slow enqueue against a wedged PID1 would
+// otherwise queue every other stop on the host behind it indefinitely.
+const stopEnqueueCap = 5 * time.Second
 
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
 // unit is a no-op. Blocks until the stop job completes.
@@ -58,7 +65,9 @@ func stopUnit(ctx context.Context, unit string) error {
 	// library's job lock — enqueue round trip only, not the stop itself.
 	ch := make(chan string, 1)
 	err, enqueued := sdbusDo(func(c *sddbus.Conn) error {
-		_, e := c.StopUnitContext(ctx, unit, "replace", ch)
+		ectx, cancel := context.WithTimeout(ctx, stopEnqueueCap)
+		defer cancel()
+		_, e := c.StopUnitContext(ectx, unit, "replace", ch)
 		return e
 	})
 	if enqueued {
@@ -74,15 +83,13 @@ func stopUnit(ctx context.Context, unit string) error {
 		defer timer.Stop()
 		select {
 		case res := <-ch:
-			if res != "done" && res != "skipped" {
-				return fmt.Errorf("stop unit %s: job result %q", unit, res)
-			}
-			return nil
+			return stopJobResult(unit, res)
 		case <-ctx.Done():
-			return fmt.Errorf("stop unit %s: %w", unit, ctx.Err())
+			return settleExpiredStopWait(ctx, unit, ch,
+				fmt.Errorf("stop unit %s: %w", unit, ctx.Err()))
 		case <-timer.C:
-			// Completion signal lost (e.g. signal socket died mid-wait).
-			return fmt.Errorf("stop unit %s: no job completion within %s", unit, stopJobWaitCap)
+			return settleExpiredStopWait(ctx, unit, ch,
+				fmt.Errorf("stop unit %s: no job completion within %s", unit, stopJobWaitCap))
 		}
 	}
 
@@ -92,6 +99,32 @@ func stopUnit(ctx context.Context, unit string) error {
 		return fmt.Errorf("systemctl stop %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+func stopJobResult(unit, res string) error {
+	if res != "done" && res != "skipped" {
+		return fmt.Errorf("stop unit %s: job result %q", unit, res)
+	}
+	return nil
+}
+
+// settleExpiredStopWait decides the outcome of a stop whose wait expired. The
+// result may have landed together with the deadline (select picks randomly
+// among ready cases), and a completed job's signal may have been lost with the
+// connection — check both on a fresh, detached deadline before reporting
+// failure, so a stop that actually finished never reads as failed.
+func settleExpiredStopWait(ctx context.Context, unit string, ch <-chan string, waitErr error) error {
+	select {
+	case res := <-ch:
+		return stopJobResult(unit, res)
+	default:
+	}
+	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	if unitDefinitelyDead(cctx, unit) {
+		return nil
+	}
+	return waitErr
 }
 
 // unitFailureSummary returns a one-line summary of a unit's
@@ -165,17 +198,22 @@ func unitLingering(ctx context.Context, unit string) bool {
 		if notLoaded {
 			return false
 		}
-		switch s, _ := val.(string); s {
-		case "active", "activating", "deactivating":
-			return true
+		// Unexpected value shape falls through to exec, like unitActiveState.
+		if s, isStr := val.(string); isStr && s != "" {
+			return lingeringState(s)
 		}
-		return false
 	}
 	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=ActiveState", "--value", unit).Output()
 	if err != nil {
 		return false
 	}
-	switch strings.TrimSpace(string(out)) {
+	return lingeringState(strings.TrimSpace(string(out)))
+}
+
+// lingeringState reports whether an ActiveState means a live or winding-down
+// process (a restart must wait out a stop phase before the socket can rebind).
+func lingeringState(s string) bool {
+	switch s {
 	case "active", "activating", "deactivating":
 		return true
 	}

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
 )
@@ -23,7 +24,7 @@ func startUnit(ctx context.Context, unit string) error {
 	// mode "replace" + nil result channel == `systemctl start --no-block`:
 	// the call returns at job-enqueue. nil also skips the library's
 	// job-tracking lock, so concurrent launches pipeline on the socket.
-	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
+	if err, ok := sdbusDo(func(c *sddbus.Conn) error {
 		_, e := c.StartUnitContext(ctx, unit, "replace", nil)
 		return e
 	}); ok {
@@ -40,13 +41,65 @@ func startUnit(ctx context.Context, unit string) error {
 	return nil
 }
 
+// stopJobWaitCap bounds the wait for a stop job's completion signal. Above
+// the unit's TimeoutStopSec (10s) + kill margin: past this the signal is
+// considered lost (dead signal socket), not the job slow.
+const stopJobWaitCap = 15 * time.Second
+
+// stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
+// unit is a no-op. Blocks until the stop job completes.
+func stopUnit(ctx context.Context, unit string) error {
+	// Buffered channel: the library's dispatcher does one blocking send;
+	// buffer 1 keeps an abandoned wait from wedging every job on the
+	// connection.
+	ch := make(chan string, 1)
+	err, enqueued := sdbusDo(func(c *sddbus.Conn) error {
+		_, e := c.StopUnitContext(ctx, unit, "replace", ch)
+		return e
+	})
+	if enqueued {
+		if err != nil {
+			if sdbusNotLoaded(err) {
+				return nil // not loaded == already stopped
+			}
+			return fmt.Errorf("stop unit %s: %w", unit, err)
+		}
+		// systemd accepted the job — from here we only report the outcome,
+		// never re-drive the stop via exec (that would double-execute).
+		timer := time.NewTimer(stopJobWaitCap)
+		defer timer.Stop()
+		select {
+		case res := <-ch:
+			if res != "done" && res != "skipped" {
+				return fmt.Errorf("stop unit %s: job result %q", unit, res)
+			}
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("stop unit %s: %w", unit, ctx.Err())
+		case <-timer.C:
+			// Completion signal lost (e.g. signal socket died mid-wait).
+			return fmt.Errorf("stop unit %s: no job completion within %s", unit, stopJobWaitCap)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, "systemctl", "stop", unit)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("systemctl stop %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // unitFailureSummary returns a one-line summary of a unit's
 // Result/SubState for embedding in error messages. Best-effort —
 // returns "unknown" on any error.
 func unitFailureSummary(ctx context.Context, unit string) string {
 	// Result lives on the Service interface, SubState on Unit.
-	if res, err, ok := sdbusUnitProperty(ctx, unit, "Service", "Result"); ok && err == nil {
-		if sub, serr, sok := sdbusUnitProperty(ctx, unit, "", "SubState"); sok && serr == nil {
+	if res, notLoaded, ok := sdbusUnitProperty(ctx, unit, "Service", "Result"); ok {
+		if notLoaded {
+			return "not-loaded"
+		}
+		if sub, _, sok := sdbusUnitProperty(ctx, unit, "", "SubState"); sok {
 			r, _ := res.(string)
 			s, _ := sub.(string)
 			if r != "" || s != "" {
@@ -67,55 +120,28 @@ func unitFailureSummary(ctx context.Context, unit string) string {
 	return s
 }
 
-// stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
-// unit is a no-op. Blocks until the stop job completes.
-func stopUnit(ctx context.Context, unit string) error {
-	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
-		// Buffered channel: the library's job dispatcher does one blocking
-		// send; buffer 1 keeps an abandoned wait (ctx expiry) from wedging
-		// every job on the connection.
-		ch := make(chan string, 1)
-		if _, e := c.StopUnitContext(ctx, unit, "replace", ch); e != nil {
-			return e
-		}
-		select {
-		case res := <-ch:
-			if res != "done" && res != "skipped" {
-				return fmt.Errorf("stop job result %q", res)
-			}
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}); ok {
-		if err != nil {
-			return fmt.Errorf("stop unit %s: %w", unit, err)
-		}
-		return nil
+// unitActiveState answers whether the unit counts as active, matching
+// `systemctl is-active` (which accepts both "active" and "reloading").
+// handled=false → no D-Bus answer, use the exec path.
+func unitActiveState(ctx context.Context, unit string) (activeNow, handled bool) {
+	val, notLoaded, ok := sdbusUnitProperty(ctx, unit, "", "ActiveState")
+	if !ok {
+		return false, false
 	}
-	cmd := exec.CommandContext(ctx, "systemctl", "stop", unit)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("systemctl stop %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
-	}
-	return nil
-}
-
-// unitActiveState returns the unit's ActiveState over D-Bus.
-// handled=false → answer unavailable, use the exec path.
-func unitActiveState(ctx context.Context, unit string) (state string, handled bool) {
-	val, err, ok := sdbusUnitProperty(ctx, unit, "", "ActiveState")
-	if !ok || err != nil {
-		return "", false
+	if notLoaded {
+		return false, true // not loaded == not active, definitively
 	}
 	s, _ := val.(string)
-	return s, s != ""
+	if s == "" {
+		return false, false
+	}
+	return s == "active" || s == "reloading", true
 }
 
 // isUnitActive checks if a systemd unit is currently active (running).
 func isUnitActive(ctx context.Context, unit string) bool {
-	if state, ok := unitActiveState(ctx, unit); ok {
-		return state == "active"
+	if active, ok := unitActiveState(ctx, unit); ok {
+		return active
 	}
 	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
 	return cmd.Run() == nil
@@ -129,8 +155,8 @@ func unitDefinitelyDead(ctx context.Context, unit string) bool {
 	if ctx.Err() != nil {
 		return false
 	}
-	if state, ok := unitActiveState(ctx, unit); ok {
-		return state != "active"
+	if active, ok := unitActiveState(ctx, unit); ok {
+		return !active
 	}
 	err := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run()
 	if err == nil {
@@ -147,7 +173,7 @@ func unitDefinitelyDead(ctx context.Context, unit string) bool {
 // firecracker@ units. Used during startup reattach.
 func listActiveFirecrackerUnits(ctx context.Context) ([]string, error) {
 	var units []sddbus.UnitStatus
-	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
+	if err, ok := sdbusDo(func(c *sddbus.Conn) error {
 		var e error
 		units, e = c.ListUnitsByPatternsContext(ctx, []string{"active"}, []string{"firecracker@*.service"})
 		return e

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -36,6 +36,10 @@ func restartUnit(ctx context.Context, unit string) error {
 		}
 		return nil
 	}
+	// At-least-once: a reply lost mid-call reads as unhandled and re-drives
+	// here, possibly replace-restarting the job the lost call already
+	// enqueued. Accepted — the ambiguity is irreducible without job
+	// tracking, and the replace converges to one fresh process.
 	cmd := exec.CommandContext(ctx, "systemctl", "restart", "--no-block", unit)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	sddbus "github.com/coreos/go-systemd/v22/dbus"
 )
 
 // systemdUnitName returns the systemd unit name for a sandbox.
@@ -18,6 +20,18 @@ func systemdUnitName(vmID string) string {
 // unit is a no-op. Returns after the start job is queued; readiness is
 // signalled by the unit's own side effect (e.g., API socket appearing).
 func startUnit(ctx context.Context, unit string) error {
+	// mode "replace" + nil result channel == `systemctl start --no-block`:
+	// the call returns at job-enqueue. nil also skips the library's
+	// job-tracking lock, so concurrent launches pipeline on the socket.
+	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
+		_, e := c.StartUnitContext(ctx, unit, "replace", nil)
+		return e
+	}); ok {
+		if err != nil {
+			return fmt.Errorf("start unit %s: %w", unit, err)
+		}
+		return nil
+	}
 	cmd := exec.CommandContext(ctx, "systemctl", "start", "--no-block", unit)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -30,6 +44,16 @@ func startUnit(ctx context.Context, unit string) error {
 // Result/SubState for embedding in error messages. Best-effort —
 // returns "unknown" on any error.
 func unitFailureSummary(ctx context.Context, unit string) string {
+	// Result lives on the Service interface, SubState on Unit.
+	if res, err, ok := sdbusUnitProperty(ctx, unit, "Service", "Result"); ok && err == nil {
+		if sub, serr, sok := sdbusUnitProperty(ctx, unit, "", "SubState"); sok && serr == nil {
+			r, _ := res.(string)
+			s, _ := sub.(string)
+			if r != "" || s != "" {
+				return strings.TrimSpace(r + " " + s)
+			}
+		}
+	}
 	cmd := exec.CommandContext(ctx, "systemctl", "show", "--property=Result,SubState", "--value", unit)
 	out, err := cmd.Output()
 	if err != nil {
@@ -44,8 +68,31 @@ func unitFailureSummary(ctx context.Context, unit string) string {
 }
 
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
-// unit is a no-op.
+// unit is a no-op. Blocks until the stop job completes.
 func stopUnit(ctx context.Context, unit string) error {
+	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
+		// Buffered channel: the library's job dispatcher does one blocking
+		// send; buffer 1 keeps an abandoned wait (ctx expiry) from wedging
+		// every job on the connection.
+		ch := make(chan string, 1)
+		if _, e := c.StopUnitContext(ctx, unit, "replace", ch); e != nil {
+			return e
+		}
+		select {
+		case res := <-ch:
+			if res != "done" && res != "skipped" {
+				return fmt.Errorf("stop job result %q", res)
+			}
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}); ok {
+		if err != nil {
+			return fmt.Errorf("stop unit %s: %w", unit, err)
+		}
+		return nil
+	}
 	cmd := exec.CommandContext(ctx, "systemctl", "stop", unit)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -54,19 +101,36 @@ func stopUnit(ctx context.Context, unit string) error {
 	return nil
 }
 
+// unitActiveState returns the unit's ActiveState over D-Bus.
+// handled=false → answer unavailable, use the exec path.
+func unitActiveState(ctx context.Context, unit string) (state string, handled bool) {
+	val, err, ok := sdbusUnitProperty(ctx, unit, "", "ActiveState")
+	if !ok || err != nil {
+		return "", false
+	}
+	s, _ := val.(string)
+	return s, s != ""
+}
+
 // isUnitActive checks if a systemd unit is currently active (running).
 func isUnitActive(ctx context.Context, unit string) bool {
+	if state, ok := unitActiveState(ctx, unit); ok {
+		return state == "active"
+	}
 	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
 	return cmd.Run() == nil
 }
 
 // unitDefinitelyDead reports whether systemd definitively reports the unit
 // not-active. Unlike !isUnitActive it returns false on an inconclusive result
-// (ctx cancelled, systemctl timeout/error), so an overloaded or shutting-down
-// host never mistakes a live VM for a dead one. Only a clean non-zero exit counts.
+// (ctx cancelled, transport failure), so an overloaded or shutting-down host
+// never mistakes a live VM for a dead one. Only a real answer counts.
 func unitDefinitelyDead(ctx context.Context, unit string) bool {
 	if ctx.Err() != nil {
 		return false
+	}
+	if state, ok := unitActiveState(ctx, unit); ok {
+		return state != "active"
 	}
 	err := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run()
 	if err == nil {
@@ -82,6 +146,25 @@ func unitDefinitelyDead(ctx context.Context, unit string) bool {
 // listActiveFirecrackerUnits returns the sandbox IDs of all running
 // firecracker@ units. Used during startup reattach.
 func listActiveFirecrackerUnits(ctx context.Context) ([]string, error) {
+	var units []sddbus.UnitStatus
+	if err, ok := sdbusDo(ctx, func(c *sddbus.Conn) error {
+		var e error
+		units, e = c.ListUnitsByPatternsContext(ctx, []string{"active"}, []string{"firecracker@*.service"})
+		return e
+	}); ok {
+		if err != nil {
+			return nil, fmt.Errorf("list firecracker units: %w", err)
+		}
+		ids := make([]string, 0, len(units))
+		for _, u := range units {
+			id := strings.TrimSuffix(strings.TrimPrefix(u.Name, "firecracker@"), ".service")
+			if id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids, nil
+	}
+
 	cmd := exec.CommandContext(ctx, "systemctl", "list-units",
 		"firecracker@*.service", "--state=active", "--no-legend", "--plain")
 	out, err := cmd.Output()

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -1,0 +1,38 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A job result buffered at deadline-time must win over the wait error — the
+// select in stopUnit can wake on either when both are ready.
+func TestSettleExpiredStopWait_DrainsBufferedResult(t *testing.T) {
+	ch := make(chan string, 1)
+	ch <- "done"
+	if err := settleExpiredStopWait(context.Background(), "u.service", ch, errors.New("deadline")); err != nil {
+		t.Fatalf("buffered done should win over the wait error: %v", err)
+	}
+
+	ch2 := make(chan string, 1)
+	ch2 <- "failed"
+	err := settleExpiredStopWait(context.Background(), "u.service", ch2, errors.New("deadline"))
+	if err == nil || !strings.Contains(err.Error(), `job result "failed"`) {
+		t.Fatalf("buffered failure should surface the job result, got %v", err)
+	}
+}
+
+func TestLingeringState(t *testing.T) {
+	for _, s := range []string{"active", "activating", "deactivating"} {
+		if !lingeringState(s) {
+			t.Errorf("%s should linger", s)
+		}
+	}
+	for _, s := range []string{"inactive", "failed", "reloading", ""} {
+		if lingeringState(s) {
+			t.Errorf("%s should not linger", s)
+		}
+	}
+}


### PR DESCRIPTION
Every unit operation (start, stop, state reads, unit listing, MainPID) forked a `systemctl` process. Each fork pays exec + a D-Bus connect/handshake whose cost grows with the number of loaded units, and under a concurrent launch burst the spawns also compete with systemd and the starting units for the scheduler — the launch enqueue alone inflated ~4x at 100-way concurrency.

Replace the transport: one persistent connection to systemd's private socket (root, no dbus-daemon), with every helper falling back to exec'd `systemctl` per call when the connection is unavailable — worst case is exactly the previous behavior.

Design points:
- Fire-and-forget starts (`RestartUnit/StartUnit` with a nil result channel) return at job-enqueue, matching `--no-block`, and skip the library's job-tracking lock so concurrent launches pipeline on the socket.
- Blocking stops use a buffered result channel — the library's dispatcher does one blocking send, so an abandoned wait cannot wedge the connection.
- A closed connection (systemd re-exec kills the socket; the library never reconnects) is redialed once per call; a second failure falls back to exec.
- D-Bus method errors (NoSuchUnit, start-limit) surface to callers as before; only transport-shaped failures trigger the exec fallback.
- Gated by `VMD_SYSTEMD_DBUS` (default off) for a staged rollout.