### PR TITLE
vmd: treat a socket as ready only once it accepts connections

### DIFF
--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -415,7 +415,7 @@ func startFirecracker(ctx context.Context, fcBin, socketPath string, cfg vm.Fire
 	}
 	pid := cmd.Process.Pid
 
-	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
+	if err := vm.WaitForAPISocket(socketPath, 5*time.Second); err != nil {
 		_ = cmd.Process.Kill()
 		return 0, fmt.Errorf("wait for socket: %w", err)
 	}
@@ -432,17 +432,6 @@ func startFirecracker(ctx context.Context, fcBin, socketPath string, cfg vm.Fire
 
 	go func() { _ = cmd.Wait() }()
 	return pid, nil
-}
-
-func waitForSocket(path string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); err == nil {
-			return nil
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return fmt.Errorf("socket %s not ready after %s", path, timeout)
 }
 
 func killProcess(pid int) {

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
@@ -99,17 +100,36 @@ type FirecrackerConfig struct {
 func newFCClient(socketPath string) *fcclient.Firecracker {
 	transport := httptransport.New(fcclient.DefaultHost, fcclient.DefaultBasePath, fcclient.DefaultSchemes)
 	transport.Transport = &http.Transport{
-		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-			addr, err := net.ResolveUnixAddr("unix", socketPath)
-			if err != nil {
-				return nil, err
-			}
-			return net.DialUnix("unix", nil, addr)
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialUnixRetryRefused(ctx, socketPath)
 		},
 	}
 	c := fcclient.NewHTTPClient(strfmt.NewFormats())
 	c.SetTransport(transport)
 	return c
+}
+
+// dialUnixRetryRefused dials the API socket, retrying briefly on a refused
+// connection: the socket file exists from bind() but refuses until
+// listen(), and scheduler pressure under a launch burst can stretch that
+// gap to milliseconds. The bound stays tight so a dead firecracker still
+// fails fast; the fast path is a single dial.
+func dialUnixRetryRefused(ctx context.Context, socketPath string) (net.Conn, error) {
+	addr, err := net.ResolveUnixAddr("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(100 * time.Millisecond)
+	interval := time.Millisecond
+	for {
+		conn, dErr := net.DialUnix("unix", nil, addr)
+		if dErr == nil || !errors.Is(dErr, syscall.ECONNREFUSED) ||
+			!time.Now().Before(deadline) || ctx.Err() != nil {
+			return conn, dErr
+		}
+		time.Sleep(interval)
+		interval = min(interval*2, 10*time.Millisecond)
+	}
 }
 
 func strPtr(s string) *string { return &s }

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"syscall"
 	"time"
 
 	httptransport "github.com/go-openapi/runtime/client"
@@ -100,36 +99,17 @@ type FirecrackerConfig struct {
 func newFCClient(socketPath string) *fcclient.Firecracker {
 	transport := httptransport.New(fcclient.DefaultHost, fcclient.DefaultBasePath, fcclient.DefaultSchemes)
 	transport.Transport = &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return dialUnixRetryRefused(ctx, socketPath)
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			addr, err := net.ResolveUnixAddr("unix", socketPath)
+			if err != nil {
+				return nil, err
+			}
+			return net.DialUnix("unix", nil, addr)
 		},
 	}
 	c := fcclient.NewHTTPClient(strfmt.NewFormats())
 	c.SetTransport(transport)
 	return c
-}
-
-// dialUnixRetryRefused dials the API socket, retrying briefly on a refused
-// connection: the socket file exists from bind() but refuses until
-// listen(), and scheduler pressure under a launch burst can stretch that
-// gap to milliseconds. The bound stays tight so a dead firecracker still
-// fails fast; the fast path is a single dial.
-func dialUnixRetryRefused(ctx context.Context, socketPath string) (net.Conn, error) {
-	addr, err := net.ResolveUnixAddr("unix", socketPath)
-	if err != nil {
-		return nil, err
-	}
-	deadline := time.Now().Add(100 * time.Millisecond)
-	interval := time.Millisecond
-	for {
-		conn, dErr := net.DialUnix("unix", nil, addr)
-		if dErr == nil || !errors.Is(dErr, syscall.ECONNREFUSED) ||
-			!time.Now().Before(deadline) || ctx.Err() != nil {
-			return conn, dErr
-		}
-		time.Sleep(interval)
-		interval = min(interval*2, 10*time.Millisecond)
-	}
 }
 
 func strPtr(s string) *string { return &s }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2692,27 +2692,41 @@ func (m *Manager) resolveAndSetPID(vmID string) {
 // at bind(), and a connect() in the bind()→listen() gap is refused.
 func waitForSocket(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	if err := waitForSocketFile(path, deadline); err != nil {
+	if err := waitForSocketFile(path, deadline, timeout); err != nil {
 		return err
 	}
-	return waitForSocketConnectable(path, deadline)
+	// The connect phase gets its own bounded window from file-appearance:
+	// capped at 1s so a process that bound and then died fails fast (its
+	// socket refuses just like the gap does), floored at 250ms so a socket
+	// appearing at the edge of the file budget still gets a real chance to
+	// reach listen() — a bounded overrun of the nominal timeout.
+	connWindow := min(time.Until(deadline), time.Second)
+	connWindow = max(connWindow, 250*time.Millisecond)
+	return waitForSocketConnectable(path, time.Now().Add(connWindow))
+}
+
+// WaitForAPISocket is the exported readiness wait for a firecracker API
+// socket: file existence AND accepting connections. For use by every
+// spawn site, in and out of this package.
+func WaitForAPISocket(path string, timeout time.Duration) error {
+	return waitForSocket(path, timeout)
 }
 
 // waitForSocketFile waits for the socket file to exist — inotify with a
-// polling fallback.
-func waitForSocketFile(path string, deadline time.Time) error {
+// polling fallback. timeout is only for the error message.
+func waitForSocketFile(path string, deadline time.Time, timeout time.Duration) error {
 	if _, err := os.Stat(path); err == nil {
 		return nil
 	}
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return waitForSocketFilePolling(path, deadline)
+		return waitForSocketFilePolling(path, deadline, timeout)
 	}
 	defer watcher.Close()
 
 	if err := watcher.Add(filepath.Dir(path)); err != nil {
-		return waitForSocketFilePolling(path, deadline)
+		return waitForSocketFilePolling(path, deadline, timeout)
 	}
 
 	// Recheck after the watch is active: the socket could have appeared
@@ -2729,36 +2743,39 @@ func waitForSocketFile(path string, deadline time.Time) error {
 		select {
 		case ev, ok := <-watcher.Events:
 			if !ok {
-				return waitForSocketFilePolling(path, deadline)
+				return waitForSocketFilePolling(path, deadline, timeout)
 			}
 			if (ev.Op&fsnotify.Create) != 0 && filepath.Base(ev.Name) == name {
 				return nil
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok || err != nil {
-				return waitForSocketFilePolling(path, deadline)
+				return waitForSocketFilePolling(path, deadline, timeout)
 			}
 		case <-timer.C:
-			return fmt.Errorf("socket %s did not appear within deadline", path)
+			return fmt.Errorf("socket %s did not appear within %s", path, timeout)
 		}
 	}
 }
 
-func waitForSocketFilePolling(path string, deadline time.Time) error {
+func waitForSocketFilePolling(path string, deadline time.Time, timeout time.Duration) error {
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(path); err == nil {
 			return nil
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return fmt.Errorf("socket %s did not appear within deadline", path)
+	return fmt.Errorf("socket %s did not appear within %s", path, timeout)
 }
 
 // waitForSocketConnectable dials until the socket accepts a connection.
 // The bind()→listen() gap is normally sub-microsecond but scheduler
 // pressure under a launch burst stretches it to milliseconds, and an
-// immediate API call used to fail hard there. Fast path: one successful
-// connect+close (tens of µs).
+// immediate API call used to fail hard there. ONLY a refused connection
+// (the gap, or a dead process's lingering socket) is worth waiting out;
+// any other error — ENOENT from a teardown race, ENOTSOCK, EACCES — is
+// surfaced immediately. Fast path: one successful connect+close (tens
+// of µs).
 func waitForSocketConnectable(path string, deadline time.Time) error {
 	interval := time.Millisecond
 	for {
@@ -2766,6 +2783,9 @@ func waitForSocketConnectable(path string, deadline time.Time) error {
 		if err == nil {
 			c.Close()
 			return nil
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			return fmt.Errorf("socket %s: %w", path, err)
 		}
 		if !time.Now().Before(deadline) {
 			return fmt.Errorf("socket %s not accepting connections: %w", path, err)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2686,21 +2687,32 @@ func (m *Manager) resolveAndSetPID(vmID string) {
 	m.log.Debug().Str("vm_id", vmID).Int("pid", pid).Msg("resolved systemd MainPID")
 }
 
-// waitForSocket blocks until the given socket path appears or the timeout
-// elapses. Falls back to polling if inotify setup fails.
+// waitForSocket blocks until the socket at path ACCEPTS connections or the
+// timeout elapses. File existence alone is not readiness: the file appears
+// at bind(), and a connect() in the bind()→listen() gap is refused.
 func waitForSocket(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	if err := waitForSocketFile(path, deadline); err != nil {
+		return err
+	}
+	return waitForSocketConnectable(path, deadline)
+}
+
+// waitForSocketFile waits for the socket file to exist — inotify with a
+// polling fallback.
+func waitForSocketFile(path string, deadline time.Time) error {
 	if _, err := os.Stat(path); err == nil {
 		return nil
 	}
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return waitForSocketPolling(path, timeout)
+		return waitForSocketFilePolling(path, deadline)
 	}
 	defer watcher.Close()
 
 	if err := watcher.Add(filepath.Dir(path)); err != nil {
-		return waitForSocketPolling(path, timeout)
+		return waitForSocketFilePolling(path, deadline)
 	}
 
 	// Recheck after the watch is active: the socket could have appeared
@@ -2710,37 +2722,57 @@ func waitForSocket(path string, timeout time.Duration) error {
 	}
 
 	name := filepath.Base(path)
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
 
 	for {
 		select {
 		case ev, ok := <-watcher.Events:
 			if !ok {
-				return waitForSocketPolling(path, timeout)
+				return waitForSocketFilePolling(path, deadline)
 			}
 			if (ev.Op&fsnotify.Create) != 0 && filepath.Base(ev.Name) == name {
 				return nil
 			}
 		case err, ok := <-watcher.Errors:
 			if !ok || err != nil {
-				return waitForSocketPolling(path, timeout)
+				return waitForSocketFilePolling(path, deadline)
 			}
-		case <-deadline.C:
-			return fmt.Errorf("socket %s did not appear within %s", path, timeout)
+		case <-timer.C:
+			return fmt.Errorf("socket %s did not appear within deadline", path)
 		}
 	}
 }
 
-func waitForSocketPolling(path string, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
+func waitForSocketFilePolling(path string, deadline time.Time) error {
 	for time.Now().Before(deadline) {
 		if _, err := os.Stat(path); err == nil {
 			return nil
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return fmt.Errorf("socket %s did not appear within %s", path, timeout)
+	return fmt.Errorf("socket %s did not appear within deadline", path)
+}
+
+// waitForSocketConnectable dials until the socket accepts a connection.
+// The bind()→listen() gap is normally sub-microsecond but scheduler
+// pressure under a launch burst stretches it to milliseconds, and an
+// immediate API call used to fail hard there. Fast path: one successful
+// connect+close (tens of µs).
+func waitForSocketConnectable(path string, deadline time.Time) error {
+	interval := time.Millisecond
+	for {
+		c, err := net.Dial("unix", path)
+		if err == nil {
+			c.Close()
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("socket %s not accepting connections: %w", path, err)
+		}
+		time.Sleep(interval)
+		interval = min(interval*2, 10*time.Millisecond)
+	}
 }
 
 func (m *Manager) waitForBoxd(ctx context.Context, vmIP string, timeout time.Duration) error {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -692,6 +692,18 @@ func TestInspectRecordedTrace_CountsLines(t *testing.T) {
 	}
 }
 
+// shortSockPath returns a socket path safely under sun_path's ~108-byte
+// cap — t.TempDir embeds long test names that can blow it.
+func shortSockPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "fcs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
+
 // bindOnlySocket creates a unix socket file via bind() WITHOUT listen() —
 // the exact state a connect() gets ECONNREFUSED from. Returns the fd so the
 // test can listen() later.
@@ -709,8 +721,7 @@ func bindOnlySocket(t *testing.T, path string) int {
 }
 
 func TestWaitForSocket_AlreadyListening(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
+	path := shortSockPath(t)
 	l, err := net.Listen("unix", path)
 	if err != nil {
 		t.Fatal(err)
@@ -722,16 +733,19 @@ func TestWaitForSocket_AlreadyListening(t *testing.T) {
 }
 
 func TestWaitForSocket_AppearsAfterStart(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
+	path := shortSockPath(t)
 
-	var l net.Listener
+	lch := make(chan net.Listener, 1)
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		l, _ = net.Listen("unix", path)
+		l, err := net.Listen("unix", path)
+		if err != nil {
+			t.Error(err)
+		}
+		lch <- l
 	}()
 	defer func() {
-		if l != nil {
+		if l := <-lch; l != nil {
 			l.Close()
 		}
 	}()
@@ -753,13 +767,15 @@ func TestWaitForSocket_TimesOut(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected timeout error, got nil")
 	}
+	if !strings.Contains(err.Error(), "did not appear within 50ms") {
+		t.Errorf("error should state the budget, got: %v", err)
+	}
 }
 
 func TestWaitForSocket_BindListenGap(t *testing.T) {
 	// The socket FILE exists (bind done) but refuses connections until
 	// listen() — waitForSocket must wait out the gap, not return early.
-	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
+	path := shortSockPath(t)
 	fd := bindOnlySocket(t, path)
 
 	go func() {
@@ -772,35 +788,39 @@ func TestWaitForSocket_BindListenGap(t *testing.T) {
 	}
 }
 
-func TestWaitForSocket_NeverListens(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
+func TestWaitForSocket_NeverListens_FailsWithinCap(t *testing.T) {
+	// A bound-but-dead socket refuses forever; the connect phase must give
+	// up at its 1s cap, not spin the caller's full budget.
+	path := shortSockPath(t)
 	bindOnlySocket(t, path) // file exists, never listens
 
-	err := waitForSocket(path, 60*time.Millisecond)
+	start := time.Now()
+	err := waitForSocket(path, 10*time.Second)
 	if err == nil {
 		t.Fatal("expected an error for a socket that never accepts")
 	}
 	if !strings.Contains(err.Error(), "not accepting connections") {
 		t.Errorf("error should name the refused state, got: %v", err)
 	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("gave up after %s; the connect phase is capped at 1s", elapsed)
+	}
 }
 
-func TestDialUnixRetryRefused_BindListenGap(t *testing.T) {
+func TestWaitForSocketConnectable_NonRefusedFailsFast(t *testing.T) {
+	// Anything but ECONNREFUSED (here: ENOENT from a teardown race) must
+	// surface immediately, not spin until the deadline.
 	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
-	fd := bindOnlySocket(t, path)
+	path := filepath.Join(dir, "gone")
 
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		_ = syscall.Listen(fd, 8)
-	}()
-
-	conn, err := dialUnixRetryRefused(context.Background(), path)
-	if err != nil {
-		t.Fatalf("dial across the bind→listen gap: %v", err)
+	start := time.Now()
+	err := waitForSocketConnectable(path, time.Now().Add(5*time.Second))
+	if err == nil {
+		t.Fatal("expected an error for a missing socket")
 	}
-	conn.Close()
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("non-refused error took %s to surface; must fail fast", elapsed)
+	}
 }
 
 func TestShouldWriteDiff(t *testing.T) {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -3,9 +3,11 @@ package vm
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -690,14 +692,32 @@ func TestInspectRecordedTrace_CountsLines(t *testing.T) {
 	}
 }
 
-func TestWaitForSocket_AlreadyPresent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "sock")
-	if err := os.WriteFile(path, nil, 0o644); err != nil {
+// bindOnlySocket creates a unix socket file via bind() WITHOUT listen() —
+// the exact state a connect() gets ECONNREFUSED from. Returns the fd so the
+// test can listen() later.
+func bindOnlySocket(t *testing.T, path string) int {
+	t.Helper()
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
+	if err := syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = syscall.Close(fd) })
+	return fd
+}
+
+func TestWaitForSocket_AlreadyListening(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sock")
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
 	if err := waitForSocket(path, time.Second); err != nil {
-		t.Errorf("waitForSocket on existing file: %v", err)
+		t.Errorf("waitForSocket on listening socket: %v", err)
 	}
 }
 
@@ -705,9 +725,15 @@ func TestWaitForSocket_AppearsAfterStart(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sock")
 
+	var l net.Listener
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		_ = os.WriteFile(path, nil, 0o644)
+		l, _ = net.Listen("unix", path)
+	}()
+	defer func() {
+		if l != nil {
+			l.Close()
+		}
 	}()
 
 	start := time.Now()
@@ -729,16 +755,52 @@ func TestWaitForSocket_TimesOut(t *testing.T) {
 	}
 }
 
-func TestWaitForSocketPolling_AppearsAfterStart(t *testing.T) {
+func TestWaitForSocket_BindListenGap(t *testing.T) {
+	// The socket FILE exists (bind done) but refuses connections until
+	// listen() — waitForSocket must wait out the gap, not return early.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sock")
+	fd := bindOnlySocket(t, path)
+
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		_ = os.WriteFile(path, nil, 0o644)
+		_ = syscall.Listen(fd, 8)
 	}()
-	if err := waitForSocketPolling(path, time.Second); err != nil {
-		t.Errorf("waitForSocketPolling: %v", err)
+
+	if err := waitForSocket(path, time.Second); err != nil {
+		t.Errorf("waitForSocket across the bind→listen gap: %v", err)
 	}
+}
+
+func TestWaitForSocket_NeverListens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sock")
+	bindOnlySocket(t, path) // file exists, never listens
+
+	err := waitForSocket(path, 60*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error for a socket that never accepts")
+	}
+	if !strings.Contains(err.Error(), "not accepting connections") {
+		t.Errorf("error should name the refused state, got: %v", err)
+	}
+}
+
+func TestDialUnixRetryRefused_BindListenGap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sock")
+	fd := bindOnlySocket(t, path)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = syscall.Listen(fd, 8)
+	}()
+
+	conn, err := dialUnixRetryRefused(context.Background(), path)
+	if err != nil {
+		t.Fatalf("dial across the bind→listen gap: %v", err)
+	}
+	conn.Close()
 }
 
 func TestShouldWriteDiff(t *testing.T) {


### PR DESCRIPTION
A unix socket file appears at bind(), but connect() is refused until listen(). The launch readiness check treated file existence as readiness, so under a concurrent burst — where scheduler pressure stretches the normally sub-microsecond bind→listen gap to milliseconds — the very first API call could land in the gap, get connection refused, and fail the whole launch. A small fraction of burst creates failed this way.

The fix: waitForSocket now has a connectability phase after file existence, and the same policy covers every spawn site — template-builder's stat-only copy is deleted in favor of the exported WaitForAPISocket.

Shape of the connect phase, each rule load-bearing:
- ONLY a refused connection is waited out (the gap, or a dead process's lingering socket). Any other error — ENOENT from a teardown race, ENOTSOCK — surfaces immediately with the true errno, preserving fast failure.
- The wait is capped at 1s past file-appearance: a firecracker that bound and then died also refuses, and must fail in bounded time rather than spinning the caller's full budget.
- It is floored at 250ms so a socket appearing at the edge of the file budget still gets a real chance to reach listen() — a bounded overrun of the nominal timeout, never a cliff.
- Fast path: one successful connect+close (tens of microseconds). Error texts keep the actual budget for log greppability.

Tests reproduce the exact race with bind()-without-listen() sockets: the gap is waited out, a never-listening socket fails within the cap, and a non-refused error fails fast.