### PR TITLE
vmd: tag restore phase log with cold/hot segmentation dimensions

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -252,6 +253,11 @@ type Manager struct {
 	// channel; capacity = effective MaxConcurrentRestores.
 	restoreSem chan struct{}
 
+	// tplLastRestore: last restore time per template mem file, for the
+	// secs_since_template_restore phase tag (a page-cache warmth proxy).
+	tplMu          sync.Mutex
+	tplLastRestore map[string]time.Time
+
 	// builds tracks in-flight and completed template builds. Keyed by
 	// build VM id (which is also "build-" + templateID). Entries survive
 	// until process exit so late pollers can read terminal outcomes.
@@ -345,11 +351,12 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 		}
 	}
 	m := &Manager{
-		cfg:        cfg,
-		netMgr:     netMgr,
-		log:        log.With().Str("component", "vm_manager").Logger(),
-		vms:        make(map[string]*VMInstance),
-		restoreSem: make(chan struct{}, maxRestores),
+		cfg:            cfg,
+		netMgr:         netMgr,
+		log:            log.With().Str("component", "vm_manager").Logger(),
+		vms:            make(map[string]*VMInstance),
+		restoreSem:     make(chan struct{}, maxRestores),
+		tplLastRestore: make(map[string]time.Time),
 	}
 	m.loadPresenceConverged()
 	return m, nil
@@ -1465,6 +1472,50 @@ func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	return m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, teamID, ownerID, "")
 }
 
+// templateRestoreAge returns seconds since this host last restored the given
+// template mem file and records now, or -1 on first sighting. Only template
+// mem paths are tracked — per-VM resume snapshots are keyed by vmID and would
+// grow the map unbounded, so they short-circuit to -1. Best-effort.
+func (m *Manager) templateRestoreAge(memPath string) int64 {
+	if !m.isTemplateMemPath(memPath) {
+		return -1
+	}
+	key := filepath.Clean(memPath)
+	now := time.Now()
+	m.tplMu.Lock()
+	prev, seen := m.tplLastRestore[key]
+	m.tplLastRestore[key] = now
+	m.tplMu.Unlock()
+	if !seen {
+		return -1
+	}
+	return int64(now.Sub(prev).Seconds())
+}
+
+// psiSomeAvg10 returns the "some avg10" pressure-stall figure from a PSI file
+// (e.g. /proc/pressure/cpu), or -1 if unavailable. Best-effort.
+func psiSomeAvg10(path string) float64 {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return -1
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if !strings.HasPrefix(line, "some ") {
+			continue
+		}
+		for _, f := range strings.Fields(line) {
+			if v, ok := strings.CutPrefix(f, "avg10="); ok {
+				n, perr := strconv.ParseFloat(v, 64)
+				if perr != nil {
+					return -1
+				}
+				return n
+			}
+		}
+	}
+	return -1
+}
+
 // restoreVMSnapshot is the implementation. recordToPath is empty for normal
 // restores; set to a writable file path by template-build access-pattern
 // recording, in which case the in-firecracker UFFD handler writes each served
@@ -1513,6 +1564,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		return nil, ctx.Err()
 	}
 	tSemAcquired := time.Now()
+	// Cold/hot segmentation tags for the phase log, sampled once (not per
+	// attempt): concurrency, template-cache age, and host CPU/mem pressure.
+	inflight := len(m.restoreSem)
+	tplAgeSecs := m.templateRestoreAge(memPath)
+	cpuPSI := psiSomeAvg10("/proc/pressure/cpu")
+	memPSI := psiSomeAvg10("/proc/pressure/memory")
 
 	// Deterministic artifact/config preconditions, checked before ANY state
 	// changes: no provisional instance published (a refusal must not leave a
@@ -1673,6 +1730,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			Int64("disk_to_net_ms", tNetReady.Sub(netBase).Milliseconds()).
 			Int64("net_to_fc_ms", tFcReady.Sub(tNetReady).Milliseconds()).
 			Int64("entry_to_fc_ready_ms", tFcReady.Sub(tEntry).Milliseconds()).
+			Int("inflight", inflight).
+			Int64("secs_since_template_restore", tplAgeSecs).
+			Bool("inplace", inPlace).
+			Bool("uffd", useUffd).
+			Float64("cpu_psi_avg10", cpuPSI).
+			Float64("mem_psi_avg10", memPSI).
 			Int("attempt", attempt).
 			Msg("restoring snapshot")
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1579,7 +1579,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// warmthPath is the file that actually drives fault-in — for a layered
 	// overlay it's the recorded template base (memPath is then a per-VM diff),
 	// else memPath itself — so layered restores segment by the base they use.
-	inflight := len(m.restoreSem)
+	//
+	// inflight = other restores in flight (we already hold a slot, so subtract
+	// it); an uncontended restore reads 0. len >= 1 here, so no underflow.
+	inflight := len(m.restoreSem) - 1
 	warmthPath := memPath
 	if base, ok := readLayeredBase(memPath); ok {
 		warmthPath = base

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1576,8 +1576,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	tSemAcquired := time.Now()
 	// Cold/hot segmentation tags for the phase log, sampled once (not per
 	// attempt): concurrency, template-cache age, and host CPU/mem pressure.
+	// warmthPath is the file that actually drives fault-in — for a layered
+	// overlay it's the recorded template base (memPath is then a per-VM diff),
+	// else memPath itself — so layered restores segment by the base they use.
 	inflight := len(m.restoreSem)
-	tplAgeSecs := m.templateRestoreAge(memPath)
+	warmthPath := memPath
+	if base, ok := readLayeredBase(memPath); ok {
+		warmthPath = base
+	}
+	tplAgeSecs := m.templateRestoreAge(warmthPath)
 	cpuPSI := psiSomeAvg10("/proc/pressure/cpu")
 	memPSI := psiSomeAvg10("/proc/pressure/memory")
 
@@ -1919,9 +1926,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	// boxd is up → the guest has booted, so this template's working set is now
 	// in page cache: read eagerly at load (File) or faulted in during boot
-	// (UFFD). Stamp it here (not at the load) so the next restore's
+	// (UFFD). Stamp warmthPath (the layered base for an overlay restore, else
+	// memPath) here (not at the load) so the next restore's
 	// secs_since_template_restore reflects real warmth for either backend.
-	m.markTemplateRestored(memPath)
+	m.markTemplateRestored(warmthPath)
 
 	m.setStatus(vmID, StatusRunning)
 	m.persistState(inst)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1472,24 +1472,34 @@ func (m *Manager) RestoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	return m.restoreVMSnapshot(ctx, vmID, snapshotPath, memPath, resourceLimits, netCfg, teamID, ownerID, "")
 }
 
-// templateRestoreAge returns seconds since this host last restored the given
-// template mem file and records now, or -1 on first sighting. Only template
-// mem paths are tracked — per-VM resume snapshots are keyed by vmID and would
-// grow the map unbounded, so they short-circuit to -1. Best-effort.
+// templateRestoreAge returns seconds since this host last completed a restore of
+// the given template mem file (i.e. last warmed its page cache), or -1 if
+// untracked or first-seen. Read-only — markTemplateRestored does the recording,
+// so a restore that fails before the load can't stamp a false-warm reading.
 func (m *Manager) templateRestoreAge(memPath string) int64 {
 	if !m.isTemplateMemPath(memPath) {
 		return -1
 	}
-	key := filepath.Clean(memPath)
-	now := time.Now()
 	m.tplMu.Lock()
-	prev, seen := m.tplLastRestore[key]
-	m.tplLastRestore[key] = now
+	prev, seen := m.tplLastRestore[filepath.Clean(memPath)]
 	m.tplMu.Unlock()
 	if !seen {
 		return -1
 	}
-	return int64(now.Sub(prev).Seconds())
+	return int64(time.Since(prev).Seconds())
+}
+
+// markTemplateRestored records that a restore of the given template mem file
+// just loaded — when its page cache is warmed. Only template mem paths are
+// tracked (per-VM resume snapshots are keyed by vmID and would grow the map
+// unbounded), so those are a no-op.
+func (m *Manager) markTemplateRestored(memPath string) {
+	if !m.isTemplateMemPath(memPath) {
+		return
+	}
+	m.tplMu.Lock()
+	m.tplLastRestore[filepath.Clean(memPath)] = time.Now()
+	m.tplMu.Unlock()
 }
 
 // psiSomeAvg10 returns the "some avg10" pressure-stall figure from a PSI file
@@ -1816,6 +1826,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		restoreErr = attemptErr
 
 		if restoreErr == nil {
+			// The load just read the mem file → its page cache is now warm;
+			// stamp it so the next restore's secs_since_template_restore is real.
+			m.markTemplateRestored(memPath)
 			break
 		}
 		// Retriable only for a fresh-restore tap0 busy. The overlay and inst are

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1490,8 +1490,8 @@ func (m *Manager) templateRestoreAge(memPath string) int64 {
 }
 
 // markTemplateRestored records that a restore of the given template mem file
-// just loaded — when its page cache is warmed. Only template mem paths are
-// tracked (per-VM resume snapshots are keyed by vmID and would grow the map
+// completed (guest booted → working set now cached). Only template mem paths
+// are tracked (per-VM resume snapshots are keyed by vmID and would grow the map
 // unbounded), so those are a no-op.
 func (m *Manager) markTemplateRestored(memPath string) {
 	if !m.isTemplateMemPath(memPath) {
@@ -1826,9 +1826,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		restoreErr = attemptErr
 
 		if restoreErr == nil {
-			// The load just read the mem file → its page cache is now warm;
-			// stamp it so the next restore's secs_since_template_restore is real.
-			m.markTemplateRestored(memPath)
 			break
 		}
 		// Retriable only for a fresh-restore tap0 busy. The overlay and inst are
@@ -1919,6 +1916,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		return nil, fmt.Errorf("boxd not ready after restore: %w", err)
 	}
 	tBoxdReady := time.Now()
+
+	// boxd is up → the guest has booted, so this template's working set is now
+	// in page cache: read eagerly at load (File) or faulted in during boot
+	// (UFFD). Stamp it here (not at the load) so the next restore's
+	// secs_since_template_restore reflects real warmth for either backend.
+	m.markTemplateRestored(memPath)
 
 	m.setStatus(vmID, StatusRunning)
 	m.persistState(inst)

--- a/internal/vm/template_age_test.go
+++ b/internal/vm/template_age_test.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// TestTemplateRestoreAge covers the phase-tag warmth proxy: a template mem file
-// is -1 on first sighting then a non-negative delta; a per-VM resume snapshot is
-// never tracked (always -1, so the map can't grow unbounded on vmIDs).
+// TestTemplateRestoreAge covers the phase-tag warmth proxy and the read/mark
+// split: age is -1 until a restore is marked (so a failed restore can't stamp a
+// false-warm reading), and per-VM resume snapshots are never tracked.
 func TestTemplateRestoreAge(t *testing.T) {
 	m := &Manager{
 		cfg:            ManagerConfig{SnapshotDir: "/var/lib/sandbox/snapshots"},
@@ -17,19 +17,25 @@ func TestTemplateRestoreAge(t *testing.T) {
 	}
 	const tpl = "/var/lib/sandbox/snapshots/templates/tpl-abc/mem.snap"
 
+	// Read alone must NOT record — an unmarked template stays -1 no matter how
+	// many times its age is read (the pre-mark / failed-restore case).
 	if age := m.templateRestoreAge(tpl); age != -1 {
-		t.Fatalf("first restore of a template must be -1, got %d", age)
+		t.Fatalf("unmarked template must be -1, got %d", age)
 	}
+	if age := m.templateRestoreAge(tpl); age != -1 {
+		t.Fatalf("reading age must not record; still -1, got %d", age)
+	}
+	// After a successful load is marked, age becomes a non-negative delta.
+	m.markTemplateRestored(tpl)
 	if age := m.templateRestoreAge(tpl); age < 0 {
-		t.Fatalf("second restore must be a non-negative delta, got %d", age)
+		t.Fatalf("after mark, age must be non-negative, got %d", age)
 	}
-	// A paused sandbox's per-VM snapshot must never be tracked or keyed.
+
+	// A paused sandbox's per-VM snapshot is never tracked, even if marked.
 	resume := "/var/lib/sandbox/snapshots/vm123/mem.snap"
+	m.markTemplateRestored(resume)
 	if age := m.templateRestoreAge(resume); age != -1 {
 		t.Fatalf("resume snapshot must be -1, got %d", age)
-	}
-	if age := m.templateRestoreAge(resume); age != -1 {
-		t.Fatalf("resume snapshot must stay -1 (not recorded), got %d", age)
 	}
 	if _, keyed := m.tplLastRestore[filepath.Clean(resume)]; keyed {
 		t.Fatal("resume snapshot must not be inserted into the map")

--- a/internal/vm/template_age_test.go
+++ b/internal/vm/template_age_test.go
@@ -1,0 +1,66 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestTemplateRestoreAge covers the phase-tag warmth proxy: a template mem file
+// is -1 on first sighting then a non-negative delta; a per-VM resume snapshot is
+// never tracked (always -1, so the map can't grow unbounded on vmIDs).
+func TestTemplateRestoreAge(t *testing.T) {
+	m := &Manager{
+		cfg:            ManagerConfig{SnapshotDir: "/var/lib/sandbox/snapshots"},
+		tplLastRestore: make(map[string]time.Time),
+	}
+	const tpl = "/var/lib/sandbox/snapshots/templates/tpl-abc/mem.snap"
+
+	if age := m.templateRestoreAge(tpl); age != -1 {
+		t.Fatalf("first restore of a template must be -1, got %d", age)
+	}
+	if age := m.templateRestoreAge(tpl); age < 0 {
+		t.Fatalf("second restore must be a non-negative delta, got %d", age)
+	}
+	// A paused sandbox's per-VM snapshot must never be tracked or keyed.
+	resume := "/var/lib/sandbox/snapshots/vm123/mem.snap"
+	if age := m.templateRestoreAge(resume); age != -1 {
+		t.Fatalf("resume snapshot must be -1, got %d", age)
+	}
+	if age := m.templateRestoreAge(resume); age != -1 {
+		t.Fatalf("resume snapshot must stay -1 (not recorded), got %d", age)
+	}
+	if _, keyed := m.tplLastRestore[filepath.Clean(resume)]; keyed {
+		t.Fatal("resume snapshot must not be inserted into the map")
+	}
+	if age := m.templateRestoreAge(""); age != -1 {
+		t.Fatalf("empty path must be -1, got %d", age)
+	}
+}
+
+// TestPSISomeAvg10 covers the PSI parser: the "some avg10" figure is picked out
+// (not "full"), and unavailable/unparseable inputs yield -1.
+func TestPSISomeAvg10(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cpu := write("cpu", "some avg10=12.34 avg60=5.00 avg300=1.00 total=999\n")
+	if got := psiSomeAvg10(cpu); got != 12.34 {
+		t.Fatalf("cpu: want 12.34, got %v", got)
+	}
+	// memory has both "some" and "full" lines — must take "some".
+	mem := write("mem", "some avg10=0.50 avg60=0.10 avg300=0.00 total=1\nfull avg10=9.99 avg60=0.05 avg300=0.00 total=1\n")
+	if got := psiSomeAvg10(mem); got != 0.50 {
+		t.Fatalf("mem: want 0.50 (some, not full), got %v", got)
+	}
+	if got := psiSomeAvg10(filepath.Join(dir, "does-not-exist")); got != -1 {
+		t.Fatalf("missing file: want -1, got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds six segmentation fields to the existing `restoring snapshot` phase log so a
restore's latency can be attributed to the conditions it ran under:

| field | signal |
| --- | --- |
| `inflight` | concurrent restores at entry (contention on unit-start / socket-bind) |
| `secs_since_template_restore` | seconds since this template mem file last restored — a page-cache warmth proxy; `-1` on first sighting |
| `inplace` | resume vs fresh restore (separates two populations that otherwise blend) |
| `uffd` | memory backend in use (lazy-fault vs eager) |
| `cpu_psi_avg10` | host CPU pressure-stall at entry |
| `mem_psi_avg10` | host memory pressure-stall at entry |

## Why

The phase timings (`start_unit`, `wait_socket`, `wait_boxd`, …) already exist, but
nothing records *whether a given restore hit warm or cold conditions*. As a result
the percentiles blend cold and warm creates together, so p50 looks like "mostly
warm" and the tail looks like "unlucky cold," and neither is separable. These tags
make cold-path vs warm-path latency a first-class, groupable dimension instead of
something inferred by hand from timestamp clustering — the prerequisite for
measuring (and then flattening) temperature-driven latency variance.

## Safety

Observability-only. It adds no branch, return, or error path to the restore, and
the six captured values feed **only** the log line — remove them and the restore
is byte-identical.

- New `tplLastRestore` map is gated by `isTemplateMemPath`, so it keys on the
  finite set of template mem files only; per-VM resume snapshots short-circuit to
  `-1` and are never inserted (the map cannot grow unbounded on vmIDs).
- Guarded by a dedicated leaf mutex (`tplMu`) held only for the map op — no
  nesting with the manager lock, no channel/IO under it.
- PSI reads are best-effort `os.ReadFile` of `/proc/pressure/*`; missing or
  unparseable (older kernel) yields `-1`, never an error or panic.

Unit tests cover the template-age helper (first-seen, delta, resume-not-tracked)
and the PSI parser (some-vs-full line, missing file).
