### PR TITLE
vmd: prefetch layered resumes from the base template's access log

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1199,12 +1199,20 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 		return false, RestoreSnapshot(socketPath, snapshotPath, memPath, "")
 	}
 
-	// No prefetch access log: only template builds record one (next to the template
-	// snapshot), pause snapshots don't — so resume-side prefetch is future work.
+	// Resume prefetch: the pause snapshot has no access log, but the layered base is
+	// a template whose access.log sits next to it — reuse it. Key off basePath, not
+	// memPath (memPath here is the per-VM diff overlay, whose dir has no log).
+	accessLogPath := ""
+	if basePath != "" && m.cfg.UffdPrefetchEnabled {
+		candidate := filepath.Join(filepath.Dir(basePath), accessLogFilename)
+		if _, err := os.Stat(candidate); err == nil {
+			accessLogPath = candidate
+		}
+	}
 	// basePath non-empty ⇒ layered restore (memPath is the diff overlay over basePath).
 	trackDirty := m.cfg.IncrementalSnapshotEnabled
 	return trackDirty, RestoreSnapshotUffdInternalWithOverrides(
-		socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
+		socketPath, snapshotPath, memPath, basePath, accessLogPath, "", "eth0", netInfo.TAPDevice, "", trackDirty,
 		m.cfg.HandlerDeathAbortEnabled,
 	)
 }


### PR DESCRIPTION
Reuse the base template's recorded access log as the prefetch trace on layered pause→resume — previously only template creates prefetched, so resumes faulted the shared base working set cold one page at a time. Keyed off `basePath` (the per-VM diff has no log of its own); inert unless resume-UFFD + prefetch are enabled.
