### PR TITLE
controlplane: add auth and scheduling phases to CreateSandbox breakdown

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1991,7 +1991,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	}
 	log.Info().
 		Str("sandbox_id", sandbox.ID.String()).
+		Int64("auth_ms", c.GetInt64("auth_ms")).
 		Int64("lookup_ms", tLookupDone.Sub(tStart).Milliseconds()).
+		Int64("sched_ms", tVmdStart.Sub(tLookupDone).Milliseconds()).
 		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
 		Int64("insert_ms", tInsertEnd.Sub(tInsertStart).Milliseconds()).
 		Int64("insert_wait_after_vmd_ms", tInsertReceive.Sub(tVmdEnd).Milliseconds()).

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -55,6 +55,7 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 		}()
 	}
 	return func(c *gin.Context) {
+		authStart := time.Now()
 		apiKey := c.GetHeader("X-API-Key")
 		if apiKey == "" {
 			respondErrorMsg(c, "auth_failed", "Invalid or missing X-API-Key header.", http.StatusUnauthorized)
@@ -76,6 +77,7 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 			if entry.createdBy.Valid && !isConsoleImpersonation(c) {
 				c.Set("actor_id", uuid.UUID(entry.createdBy.Bytes))
 			}
+			c.Set("auth_ms", time.Since(authStart).Milliseconds())
 			c.Next()
 			return
 		}
@@ -114,6 +116,7 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 		if createdBy.Valid && !isConsoleImpersonation(c) {
 			c.Set("actor_id", uuid.UUID(createdBy.Bytes))
 		}
+		c.Set("auth_ms", time.Since(authStart).Milliseconds())
 		c.Next()
 	}
 }


### PR DESCRIPTION
Closes the two gaps in the `CreateSandbox phases` log so the per-phase timings sum to the whole handler.

- `auth_ms` — `APIKeyAuth` middleware records its own elapsed time (cache hit ≈ 0, cache miss = the api_key DB lookup) into the request context; the handler reads it.
- `sched_ms` — `SelectHost` + `vmdForHost` segment, derived from existing timestamps (`tVmdStart − tLookupDone`).

Phases now account for the full handler: `lookup + sched + vmd + insert_wait + post = total`, with `auth_ms` the pre-handler slice and `insert_ms` parallel/diagnostic.