### PR TITLE
api: resolve sandbox secret bindings in one batched query

### DIFF
--- a/db/queries/secrets.sql
+++ b/db/queries/secrets.sql
@@ -11,6 +11,10 @@ RETURNING *;
 SELECT * FROM secret
 WHERE team_id = $1 AND name = $2 AND deleted_at IS NULL;
 
+-- name: GetSecretsByNames :many
+SELECT * FROM secret
+WHERE team_id = $1 AND name = ANY($2::text[]) AND deleted_at IS NULL;
+
 -- name: GetSecretByID :one
 SELECT * FROM secret
 WHERE id = $1 AND team_id = $2 AND deleted_at IS NULL;

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -1072,21 +1072,39 @@ func (h *Handlers) resolveSecretBindingsForCreate(
 	if len(refs) == 0 {
 		return nil, nil, nil
 	}
+
+	// Fetch every referenced secret in one query rather than one round trip
+	// per env var. Distinct names only — several env keys may map to the same
+	// secret.
+	names := make([]string, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, name := range refs {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	rows, err := h.DB.GetSecretsByNames(ctx, db.GetSecretsByNamesParams{
+		TeamID: teamID, Column2: names,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("DB GetSecretsByNames during sandbox create")
+		return nil, nil, ErrInternal
+	}
+	byName := make(map[string]db.Secret, len(rows))
+	for _, row := range rows {
+		byName[row.Name] = row
+	}
+
 	bindings = make([]db.AddSandboxSecretParams, 0, len(refs))
 	meta = make([]SecretBindingMeta, 0, len(refs))
-
 	for envKey, name := range refs {
-		row, err := h.DB.GetSecretByName(ctx, db.GetSecretByNameParams{
-			TeamID: teamID, Name: name,
-		})
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, nil, NewAppError("secret_not_found",
-					fmt.Sprintf("secrets[%s] references %q, which does not exist for this team", envKey, name),
-					http.StatusBadRequest)
-			}
-			log.Error().Err(err).Str("name", name).Msg("DB GetSecretByName during sandbox create")
-			return nil, nil, ErrInternal
+		row, ok := byName[name]
+		if !ok {
+			return nil, nil, NewAppError("secret_not_found",
+				fmt.Sprintf("secrets[%s] references %q, which does not exist for this team", envKey, name),
+				http.StatusBadRequest)
 		}
 		bindings = append(bindings, db.AddSandboxSecretParams{
 			SecretID: row.ID,

--- a/internal/api/handlers_secret_test.go
+++ b/internal/api/handlers_secret_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http/httptest"
 	"regexp"
@@ -9,6 +10,10 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/superserve-ai/sandbox/internal/db"
 )
 
 func TestValidateSecretName(t *testing.T) {
@@ -893,4 +898,77 @@ func TestProviderShortcutsHaveDisplayNames(t *testing.T) {
 			t.Errorf("provider %q missing Display field", name)
 		}
 	}
+}
+
+// resolveSecretBindingsForCreate now fetches all referenced secrets in one
+// batched query. This exercises the mapping, de-duplication of shared names,
+// and the not-found error.
+func TestResolveSecretBindingsForCreate_Batches(t *testing.T) {
+	teamID := uuid.New()
+	shortcut := "anthropic"
+	secA := db.Secret{ID: uuid.New(), TeamID: teamID, Name: "anthropic-key", AuthType: "bearer", ProviderShortcut: &shortcut}
+	secB := db.Secret{ID: uuid.New(), TeamID: teamID, Name: "openai-key", AuthType: "bearer"}
+	byName := map[string]db.Secret{secA.Name: secA, secB.Name: secB}
+
+	var queryCount int
+	mock := &mockDBTX{
+		queryFn: func(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+			if !strings.Contains(sql, "GetSecretsByNames") {
+				t.Fatalf("unexpected query: %s", sql)
+			}
+			queryCount++
+			names := args[1].([]string)
+			rows := make([]func(dest ...any) error, 0, len(names))
+			for _, n := range names {
+				if s, ok := byName[n]; ok {
+					rows = append(rows, secretRow(s).scanFn)
+				}
+			}
+			return &scanRows{rows: rows}, nil
+		},
+	}
+	h := &Handlers{DB: db.New(mock)}
+
+	t.Run("distinct secrets, one query", func(t *testing.T) {
+		queryCount = 0
+		bindings, meta, appErr := h.resolveSecretBindingsForCreate(context.Background(), teamID, map[string]string{
+			"ANTHROPIC_API_KEY": "anthropic-key",
+			"OPENAI_API_KEY":    "openai-key",
+		})
+		if appErr != nil {
+			t.Fatalf("unexpected error: %+v", appErr)
+		}
+		if queryCount != 1 {
+			t.Fatalf("expected 1 batched query, got %d", queryCount)
+		}
+		if len(bindings) != 2 || len(meta) != 2 {
+			t.Fatalf("expected 2 bindings/meta, got %d/%d", len(bindings), len(meta))
+		}
+	})
+
+	t.Run("shared name de-duplicated", func(t *testing.T) {
+		queryCount = 0
+		bindings, _, appErr := h.resolveSecretBindingsForCreate(context.Background(), teamID, map[string]string{
+			"KEY_ONE": "anthropic-key",
+			"KEY_TWO": "anthropic-key",
+		})
+		if appErr != nil {
+			t.Fatalf("unexpected error: %+v", appErr)
+		}
+		if len(bindings) != 2 {
+			t.Fatalf("both env keys must bind, got %d", len(bindings))
+		}
+		if bindings[0].SecretID != secA.ID || bindings[1].SecretID != secA.ID {
+			t.Fatalf("both bindings must reference the shared secret")
+		}
+	})
+
+	t.Run("missing secret is a 400", func(t *testing.T) {
+		_, _, appErr := h.resolveSecretBindingsForCreate(context.Background(), teamID, map[string]string{
+			"GHOST": "does-not-exist",
+		})
+		if appErr == nil || appErr.Code != "secret_not_found" {
+			t.Fatalf("expected secret_not_found, got %+v", appErr)
+		}
+	})
 }

--- a/internal/db/secrets.sql.go
+++ b/internal/db/secrets.sql.go
@@ -268,6 +268,51 @@ func (q *Queries) GetSecretByName(ctx context.Context, arg GetSecretByNameParams
 	return i, err
 }
 
+const getSecretsByNames = `-- name: GetSecretsByNames :many
+SELECT id, team_id, name, auth_type, auth_config, provider_shortcut, hosts, ciphertext, encrypted_dek, kek_id, created_at, updated_at, last_used_at, deleted_at FROM secret
+WHERE team_id = $1 AND name = ANY($2::text[]) AND deleted_at IS NULL
+`
+
+type GetSecretsByNamesParams struct {
+	TeamID  uuid.UUID `json:"team_id"`
+	Column2 []string  `json:"column_2"`
+}
+
+func (q *Queries) GetSecretsByNames(ctx context.Context, arg GetSecretsByNamesParams) ([]Secret, error) {
+	rows, err := q.db.Query(ctx, getSecretsByNames, arg.TeamID, arg.Column2)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Secret{}
+	for rows.Next() {
+		var i Secret
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.Name,
+			&i.AuthType,
+			&i.AuthConfig,
+			&i.ProviderShortcut,
+			&i.Hosts,
+			&i.Ciphertext,
+			&i.EncryptedDek,
+			&i.KekID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastUsedAt,
+			&i.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const insertProxyAudit = `-- name: InsertProxyAudit :exec
 INSERT INTO proxy_audit (
     team_id, sandbox_id, secret_id,


### PR DESCRIPTION
Creating a sandbox with attached secrets resolved each reference with its own `GetSecretByName` round trip — N queries for N secrets, run sequentially before the create proceeds. Sandboxes with several secrets paid a query per secret on the create path.

This fetches all referenced secrets in a single `GetSecretsByNames` query (`WHERE name = ANY($1)`), builds a name→row map, then assembles the bindings and mints proxy tokens from it. Distinct names only — multiple env keys mapping to the same secret now cost one lookup, not one each. Behavior is unchanged: a reference to a secret the team does not own still returns the same `secret_not_found` 400, and creates with no secrets still short-circuit before any query.

Tests cover the batched happy path (one query for multiple secrets), de-duplication of a shared secret name across env keys, and the not-found error.