### PR TITLE
infra: create per-region Artifact Registry repos for us-west2 and us-east4

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -34,6 +34,24 @@ locals {
   }
 }
 
+module "artifact_storage" {
+  source = "../../../modules/artifact-storage"
+
+  project_id  = local.project_id
+  environment = local.environment
+  region      = local.region
+
+  artifact_registry = {
+    superserve = {
+      repository_id = "superserve-${local.resource_suffix}"
+      format        = "DOCKER"
+      description   = "Superserve control plane images for ${local.region}"
+    }
+  }
+
+  labels = local.common_labels
+}
+
 module "network" {
   source = "../../../modules/network"
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -37,6 +37,25 @@ locals {
 
   api_service_account_email = "superserve-api-runner@${local.project_id}.iam.gserviceaccount.com"
 }
+
+module "artifact_storage" {
+  source = "../../../modules/artifact-storage"
+
+  project_id  = local.project_id
+  environment = local.environment
+  region      = local.region
+
+  artifact_registry = {
+    superserve = {
+      repository_id = "superserve-${local.resource_suffix}"
+      format        = "DOCKER"
+      description   = "Superserve control plane images for ${local.region}"
+    }
+  }
+
+  labels = local.common_labels
+}
+
 module "network" {
   source = "../../../modules/network"
 


### PR DESCRIPTION
## Summary
Production CD has been failing on every run: the `Deploy API` step pushes the controlplane image to a per-region Artifact Registry repo, but no Terraform root created those repos. Pushes failed with `name unknown: Repository "superserve-usw2" not found`, which cascaded the downstream us-central1 deploys to `skipped`.

This instantiates the `artifact-storage` module in the us-west2 and us-east4 production roots to create the DOCKER repos (`superserve-usw2`, `superserve-use4`), keeping the per-region registry model. us-east4 also needs its repo before its host/API bring-up.

## Technical notes
- Repo names derive from each root's `resource_suffix` (`usw2` / `use4`), matching `deploy/environments.yaml`'s `image_repository`.
- **No IAM added**: the CI service account already holds `roles/artifactregistry.writer` at the project level on `rayai-prod` (verified), so it can push to any repo — same as the existing us-central1 `superserve` repo, which has no Terraform-managed IAM either.
- Purely additive: the module references nothing else, so `plan` should be a single `google_artifact_registry_repository` create per root, no changes/destroys.

## Testing
- `terraform fmt -check` and `terraform validate` (backendless) pass for both roots.
- Prod-state `plan`/`apply` to run in CI or manually with backend creds; expected `1 to add, 0 to change, 0 to destroy` per root.