### PR TITLE
infra: manage api-runner KMS grant out-of-band (unblock prod CD apply)

### DIFF
--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -134,11 +134,10 @@ resource "google_secret_manager_secret_iam_member" "api_runtime_secrets" {
   member    = "serviceAccount:${local.api_service_account_email}"
 }
 
-resource "google_kms_crypto_key_iam_member" "api_runtime_credentials_kms" {
-  crypto_key_id = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${local.api_service_account_email}"
-}
+# The api-runner SA's encrypt/decrypt grant on the credentials-kek KMS key is
+# managed out-of-band: the CD Terraform SA lacks KMS setIamPolicy on the key,
+# and the SA is shared across cells, so this follows the same out-of-band
+# pattern as the shared runtime secrets.
 
 module "api" {
   source = "../../../modules/api"
@@ -200,7 +199,6 @@ module "api" {
 
   depends_on = [
     google_secret_manager_secret_iam_member.api_runtime_secrets,
-    google_kms_crypto_key_iam_member.api_runtime_credentials_kms,
   ]
 }
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -84,11 +84,10 @@ data "google_service_account" "github_actions" {
   account_id = "superserve-github-actions"
 }
 
-resource "google_kms_crypto_key_iam_member" "api_runtime_credentials_kms" {
-  crypto_key_id = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${local.api_service_account_email}"
-}
+# The api-runner SA's encrypt/decrypt grant on the credentials-kek KMS key is
+# managed out-of-band and owned centrally: the CD Terraform SA lacks KMS
+# setIamPolicy on the key, and the SA is shared across cells, so this follows
+# the same out-of-band pattern as the shared runtime secrets.
 
 # The runtime grant for the shared system-team-id-production secret is owned
 # solely by production/us-central1 (its api_runtime_secrets set), matching how
@@ -170,10 +169,6 @@ module "api" {
   vpc_tags       = ["cr-usw2"]
 
   labels = local.common_labels
-
-  depends_on = [
-    google_kms_crypto_key_iam_member.api_runtime_credentials_kms,
-  ]
 }
 
 module "sandbox_host" {


### PR DESCRIPTION
## Summary
The prod CD terraform apply (from #232) failed at `google_kms_crypto_key_iam_member.api_runtime_credentials_kms`:

```
Error 403: Permission 'cloudkms.cryptoKeys.getIamPolicy' denied on ...credentials-kek — IAM_PERMISSION_DENIED
```

The CD Terraform SA can't manage IAM on the `credentials-kek` KMS key. Both prod roots declared this grant, so it blocked us-west2 and would have blocked us-central1.

## Change
- Granted the shared `api-runner` SA `roles/cloudkms.cryptoKeyEncrypterDecrypter` on `credentials-kek` **out-of-band** (via `gcloud`, already applied) — same pattern as the shared runtime secrets.
- Removed the Terraform-managed `api_runtime_credentials_kms` grant (and its `depends_on`) from **both** prod roots, so Terraform no longer touches KMS IAM.
- Also eliminates the cross-state double-management of that binding.

## Impact of the failed apply (no damage)
- **Primary us-central1 untouched** (was skipped) — `api.superserve.ai/health` = 200, still on its pre-#224 revision.
- **us-west2 service unchanged** (its Cloud Run update `depends_on` the failed grant).
- Only side effect: the redundant `system-team-id-usw2` grant was removed — intended cleanup.

## Verification (read-only plans, no apply)
- **us-central1:** `11 add / 2 change / 0 destroy`
- **us-west2:** `0 add / 1 change / 0 destroy`
- No KMS permission error; no destroys.

Merging re-triggers the prod CD apply. Since `production` has no approval gate, it applies immediately — the plans above are what run.