### PR TITLE
ci: point us-central1 smoke test at the real API/proxy hosts

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -361,9 +361,9 @@ jobs:
       contents: read
       id-token: write
     env:
-      API_BASE_URL: https://usc-api.superserve.ai
+      API_BASE_URL: https://api.superserve.ai
       API_KEY: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
-      SANDBOX_BASE_URL: https://usc-sandbox.superserve.ai
+      SANDBOX_BASE_URL: https://sandbox.superserve.ai
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
The `Deploy API production/us-central1` CD job failed at the smoke test with:
```
Creating smoke-test sandbox ... expected HTTP 201, got 404
The deployment could not be found on Vercel.
```
The deploy and revision were healthy — the smoke test was just pointed at dead hostnames. The job overrode `API_BASE_URL`/`SANDBOX_BASE_URL` with `usc-api.superserve.ai` / `usc-sandbox.superserve.ai`, both of which resolve to **Vercel** (`DEPLOYMENT_NOT_FOUND`), so the request never reached the control plane.

## Fix
Point the overrides at the live hosts `api.superserve.ai` (Cloud Run) and `sandbox.superserve.ai` (edge proxy) — which are exactly `smoke-test-region.sh`'s built-in defaults for `production/us-central1`.

## Verification
- `api.superserve.ai/health` → 200 (Cloud Run); `sandbox.superserve.ai/` → 400 `invalid sandbox URL` (proxy).
- `usc-api.superserve.ai` / `usc-sandbox.superserve.ai` → 404 Vercel (confirmed dead).
- us-west2's smoke test already uses its real `usw-*` hosts and passed.

The prod rollout itself was fine; this only makes the smoke gate hit the real endpoints so CD goes green.