### PR TITLE
ci: add smoke test to us-west2 deploy job; fix its API host

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -249,7 +249,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      API_BASE_URL: https://usw-api.superserve.ai
+      API_BASE_URL: https://api-usw.superserve.ai
       API_KEY: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
       SANDBOX_BASE_URL: https://usw-sandbox.superserve.ai
     steps:
@@ -312,6 +312,12 @@ jobs:
             echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
             exit 1
           fi
+
+      - name: Smoke test production/us-west2
+        run: |
+          set -euo pipefail
+          scripts/smoke-test-region.sh production us-west2
+          echo "production/us-west2 deploy and smoke validation passed." >> "$GITHUB_STEP_SUMMARY"
 
   production-us-central1-infra:
     name: Apply production/us-central1


### PR DESCRIPTION
## Summary
Follow-up to #234. The `Deploy API production/us-west2` job set `API_BASE_URL`/`SANDBOX_BASE_URL` but **had no smoke-test step** — so us-west2 deploys shipped without the end-to-end validation us-central1 gets, and those env vars were dead. Its `API_BASE_URL` also pointed at `usw-api.superserve.ai`, which resolves to **Vercel** (`DEPLOYMENT_NOT_FOUND`).

## Changes
- `API_BASE_URL: usw-api.superserve.ai` → `api-usw.superserve.ai` (the real usw control-plane host, matching the SDK region map).
- Add the `Smoke test production/us-west2` step (mirrors us-central1) so usw2 deploys are validated create→exec→pause→resume→delete.

## Verification
Ran the smoke flow manually against `api-usw.superserve.ai` + `usw-sandbox.superserve.ai`:
```
initial: hello-world command passed
Pausing / Resuming sb-usw-…
after-resume: hello-world command passed
Sandbox smoke validation passed for production/us-west2
```
Uses the shared `PROD_INTERNAL_API_TOKEN` (same as us-central1); the first us-west2 deploy after merge exercises it in CI.