### PR TITLE
api: raise template resource ceilings to 10 vCPU / 20 GiB memory / 30 GiB disk

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2544,17 +2544,17 @@ components:
         vcpu:
           type: integer
           minimum: 1
-          maximum: 8
+          maximum: 10
           default: 1
         memory_mib:
           type: integer
           minimum: 256
-          maximum: 10240
+          maximum: 20480
           default: 1024
         disk_mib:
           type: integer
           minimum: 1024
-          maximum: 20480
+          maximum: 30720
           default: 4096
         build_spec:
           $ref: "#/components/schemas/BuildSpec"

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -96,9 +96,9 @@ const (
 	maxName = 128
 
 	// Platform ceiling — applies to every team including system.
-	absoluteMaxVcpu      = 8
-	absoluteMaxMemoryMib = 10240
-	absoluteMaxDiskMib   = 20480
+	absoluteMaxVcpu      = 10
+	absoluteMaxMemoryMib = 20480
+	absoluteMaxDiskMib   = 30720
 
 	// Customer-team defaults (overridable via team.max_template_*).
 	defaultMaxVcpu      = 2

--- a/supabase/migrations/20260720000001_raise_template_size_ceilings.sql
+++ b/supabase/migrations/20260720000001_raise_template_size_ceilings.sql
@@ -1,0 +1,12 @@
+-- Raise template size CHECK constraints to match the new platform ceilings
+-- (10 vcpu, memory 20 GiB, disk 30 GiB).
+
+ALTER TABLE template
+  DROP CONSTRAINT IF EXISTS template_vcpu_range,
+  DROP CONSTRAINT IF EXISTS template_memory_range,
+  DROP CONSTRAINT IF EXISTS template_disk_range;
+
+ALTER TABLE template
+  ADD CONSTRAINT template_vcpu_range CHECK (vcpu BETWEEN 1 AND 10),
+  ADD CONSTRAINT template_memory_range CHECK (memory_mib BETWEEN 256 AND 20480),
+  ADD CONSTRAINT template_disk_range CHECK (disk_mib BETWEEN 1024 AND 30720);


### PR DESCRIPTION
Raises the platform-wide template shape ceilings:

| Resource | Before | After |
|---|---|---|
| vCPU | 8 | 10 |
| Memory | 10240 MiB | 20480 MiB |
| Disk | 20480 MiB | 30720 MiB |

These are upper bounds only — per-team caps still default to 2 vCPU / 2048 MiB / 8192 MiB and are raised individually, so no team can build larger templates unless its `max_template_*` overrides are changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)