### PR TITLE
infra: consume us-east4 reservation via default affinity (host bring-up)

### DIFF
--- a/infra/envs/production/us-east4/terraform.tfvars
+++ b/infra/envs/production/us-east4/terraform.tfvars
@@ -14,4 +14,4 @@ boot_disk_type         = "hyperdisk-balanced"
 # The reservation-us-east-c4-288-lssd-metal reservation is non-specific
 # (specificReservationRequired=false), so it can't be targeted by name. Null =
 # default affinity, which auto-consumes that matching reservation in the zone.
-reservation_name       = null
+reservation_name = null

--- a/infra/envs/production/us-east4/terraform.tfvars
+++ b/infra/envs/production/us-east4/terraform.tfvars
@@ -11,4 +11,7 @@ connector_subnet_cidr  = "10.2.0.0/24"
 host_internal_ip       = "10.2.0.2"
 machine_type           = "c4-highmem-288-lssd-metal"
 boot_disk_type         = "hyperdisk-balanced"
-reservation_name       = "reservation-us-east-c4-288-lssd-metal"
+# The reservation-us-east-c4-288-lssd-metal reservation is non-specific
+# (specificReservationRequired=false), so it can't be targeted by name. Null =
+# default affinity, which auto-consumes that matching reservation in the zone.
+reservation_name       = null

--- a/infra/envs/production/us-east4/variables.tf
+++ b/infra/envs/production/us-east4/variables.tf
@@ -65,9 +65,9 @@ variable "boot_disk_type" {
 }
 
 variable "reservation_name" {
-  description = "SPECIFIC_RESERVATION to consume for the vmd host. Must be in the same zone as var.zone."
+  description = "Name of a reservation to specifically target — only valid if that reservation has specificReservationRequired=true. Null uses default affinity, which automatically consumes a matching (non-specific) reservation in the zone. The us-east4 c4-metal reservation was created without specificReservationRequired, so it must be consumed this way rather than targeted by name."
   type        = string
-  default     = "reservation-us-east-c4-288-lssd-metal"
+  default     = null
 }
 
 variable "create_network" {


### PR DESCRIPTION
## Summary
Brings up the us-east4 bare-metal vmd host. The reservation `reservation-us-east-c4-288-lssd-metal` was created with `specificReservationRequired=false`, so targeting it by name (`SPECIFIC_RESERVATION`) is rejected:
```
Error 400: ... can not be targeted as specificReservationRequired is not set.
```
Set `reservation_name = null` → the host uses **default affinity**, which auto-consumes the matching non-specific reservation in the zone.

## Applied (out of CD — us-east4 isn't in the CD matrix)
Host is **RUNNING**, reservation **inUseCount = 1**, `terraform plan` is clean (no changes). State reconciled (the instance was imported after a timed-out apply had already created it on GCP).

## Note
This env is host-only for now (network + sandbox_host); it stays labeled `sandbox_status=provisioning` (out of rotation) until Phase B bootstrap + validation.