### PR TITLE
api, authz, scheduler: serve stale cache entries while refreshing in the background

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -217,7 +217,8 @@ func run() error {
 		return telemetry.WrapVMDClient(newGRPCVMDClient(conn), recorder, api.SandboxIDRegion(), hostID), nil
 	}
 	handlers.Hosts = hostreg.New(queries, dialVMD)
-	handlers.Scheduler = &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}
+	sched := &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}
+	handlers.Scheduler = sched
 
 	router := api.SetupRouter(ctx, handlers, dbPool)
 
@@ -249,7 +250,10 @@ func run() error {
 	// Launch the host health detector. Marks active hosts as unhealthy
 	// when their VMD heartbeat goes stale (>2 min). The scheduler
 	// excludes unhealthy hosts from placement.
-	go api.StartHostDetector(ctx, queries)
+	// The detector invalidates the scheduler's host cache when it marks a
+	// host unhealthy, so this instance stops routing to it at detection time
+	// rather than at cache expiry.
+	go api.StartHostDetector(ctx, queries, sched.Invalidate)
 
 	// Billing dashboard rollups are provisional and recomputable from raw
 	// interval rows. Team-level feature flags decide which tenants roll up.

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -219,7 +219,6 @@ func run() error {
 	handlers.Hosts = hostreg.New(queries, dialVMD)
 	sched := &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}
 	handlers.Scheduler = sched
-	handlers.HostCacheInvalidate = sched.Invalidate
 
 	router := api.SetupRouter(ctx, handlers, dbPool)
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -219,6 +219,7 @@ func run() error {
 	handlers.Hosts = hostreg.New(queries, dialVMD)
 	sched := &scheduler.LeastLoaded{DB: queries, DefaultHostID: cfg.DefaultHostID}
 	handlers.Scheduler = sched
+	handlers.HostCacheInvalidate = sched.Invalidate
 
 	router := api.SetupRouter(ctx, handlers, dbPool)
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -245,7 +245,7 @@ func run() error {
 		supervisor.DefaultBuildSupervisorConfig(cfg.DefaultHostID),
 		queries,
 		buildResolver,
-	).WithAnalytics(analyticsClient).Start(ctx)
+	).WithAnalytics(analyticsClient).WithFinalizeHook(api.InvalidateTemplateCache).Start(ctx)
 
 	// Launch the host health detector. Marks active hosts as unhealthy
 	// when their VMD heartbeat goes stale (>2 min). The scheduler

--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -24,18 +24,21 @@ WHERE id = $1;
 -- Returns the host row so the caller can verify the host exists. Also
 -- re-activates unhealthy hosts that resume heartbeating — this is the
 -- automatic recovery path after a transient network outage. prev_status lets
--- the caller detect that transition (the CTE reads the pre-update snapshot)
--- and invalidate the scheduler's host cache so recovered capacity is usable
--- immediately instead of after the cache TTL.
+-- the caller detect that transition and invalidate the scheduler's host cache
+-- so recovered capacity is usable immediately instead of after the cache TTL.
+-- The pre-image is read FOR UPDATE so it reflects the row version this
+-- statement actually modifies; a plain snapshot read racing a concurrent
+-- status write could report the transition as active→active and hide it.
 WITH prev AS (
-    SELECT h.status FROM host h WHERE h.id = $1
+    SELECT h.id, h.status FROM host h WHERE h.id = $1 FOR UPDATE
 )
 UPDATE host
 SET last_heartbeat_at = now(),
     status = CASE WHEN host.status = 'unhealthy' THEN 'active' ELSE host.status END,
     updated_at = now()
-WHERE host.id = $1
-RETURNING *, (SELECT prev.status FROM prev) AS prev_status;
+FROM prev
+WHERE host.id = prev.id
+RETURNING host.*, prev.status AS prev_status;
 
 -- name: MarkHostUnhealthy :exec
 UPDATE host

--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -23,13 +23,19 @@ WHERE id = $1;
 -- name: UpdateHostHeartbeat :one
 -- Returns the host row so the caller can verify the host exists. Also
 -- re-activates unhealthy hosts that resume heartbeating — this is the
--- automatic recovery path after a transient network outage.
+-- automatic recovery path after a transient network outage. prev_status lets
+-- the caller detect that transition (the CTE reads the pre-update snapshot)
+-- and invalidate the scheduler's host cache so recovered capacity is usable
+-- immediately instead of after the cache TTL.
+WITH prev AS (
+    SELECT h.status FROM host h WHERE h.id = $1
+)
 UPDATE host
 SET last_heartbeat_at = now(),
-    status = CASE WHEN status = 'unhealthy' THEN 'active' ELSE status END,
+    status = CASE WHEN host.status = 'unhealthy' THEN 'active' ELSE host.status END,
     updated_at = now()
-WHERE id = $1
-RETURNING *;
+WHERE host.id = $1
+RETURNING *, (SELECT prev.status FROM prev) AS prev_status;
 
 -- name: MarkHostUnhealthy :exec
 UPDATE host

--- a/internal/api/apikey_cache.go
+++ b/internal/api/apikey_cache.go
@@ -107,6 +107,17 @@ func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry
 	return *e, needTouch, age > c.ttl, true
 }
 
+// remove drops a cached entry. Used when a refresh returns a definitive
+// not-found: the key was revoked, so its stale entry must stop being servable.
+func (c *apiKeyCache) remove(keyHash string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	delete(c.m, keyHash)
+	c.mu.Unlock()
+}
+
 // fetch coalesces concurrent misses for the same key: one caller runs fn (the
 // DB lookup) and every concurrent waiter shares its result, so a burst hitting
 // an expired entry issues a single query instead of one per request.

--- a/internal/api/apikey_cache.go
+++ b/internal/api/apikey_cache.go
@@ -29,6 +29,11 @@ const (
 	// UPDATE to at most one write per key per interval, instead of one
 	// per request.
 	lastUsedTouchInterval = time.Minute
+	// apiKeyCacheStaleGrace: a TTL-expired entry is still served for this long
+	// while one background flight refreshes it, so a burst landing on an
+	// expired entry never queues behind the refresh. Widens the worst-case
+	// revocation window from ttl to ttl+grace.
+	apiKeyCacheStaleGrace = 2 * time.Second
 )
 
 // apiKeyCacheTTLFromEnv reads API_KEY_CACHE_TTL (a Go duration, e.g. "30s").
@@ -71,34 +76,35 @@ func newAPIKeyCache(ttl time.Duration) *apiKeyCache {
 	return &apiKeyCache{ttl: ttl, m: make(map[string]*apiKeyCacheEntry)}
 }
 
-// get returns a copy of the cached entry for keyHash if it is still fresh
-// and the key itself has not expired. needTouch reports whether the caller
+// get returns a copy of the cached entry for keyHash if the key itself has not
+// expired and the entry is within ttl+grace. stale reports that the entry is
+// past its TTL — served anyway, but the caller should kick a background
+// refresh. Past the grace window it is a miss (kept only so put can carry the
+// last_used_at throttle across refills). needTouch reports whether the caller
 // should update last_used_at (throttled to lastUsedTouchInterval).
-func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry, needTouch, ok bool) {
+func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry, needTouch, stale, ok bool) {
 	if c == nil {
-		return apiKeyCacheEntry{}, false, false
+		return apiKeyCacheEntry{}, false, false, false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e, exists := c.m[keyHash]
 	if !exists {
-		return apiKeyCacheEntry{}, false, false
+		return apiKeyCacheEntry{}, false, false, false
 	}
 	if e.expiresAt.Valid && !now.Before(e.expiresAt.Time) {
 		delete(c.m, keyHash)
-		return apiKeyCacheEntry{}, false, false
+		return apiKeyCacheEntry{}, false, false, false
 	}
-	if now.Sub(e.fetchedAt) > c.ttl {
-		// TTL-expired: report a miss but keep the entry — it is never served,
-		// and put reads its lastTouch so the last_used_at throttle survives
-		// refills (otherwise every TTL expiry would write last_used_at).
-		return apiKeyCacheEntry{}, false, false
+	age := now.Sub(e.fetchedAt)
+	if age > c.ttl+apiKeyCacheStaleGrace {
+		return apiKeyCacheEntry{}, false, false, false
 	}
 	if now.Sub(e.lastTouch) >= lastUsedTouchInterval {
 		e.lastTouch = now
 		needTouch = true
 	}
-	return *e, needTouch, true
+	return *e, needTouch, age > c.ttl, true
 }
 
 // fetch coalesces concurrent misses for the same key: one caller runs fn (the

--- a/internal/api/apikey_cache.go
+++ b/internal/api/apikey_cache.go
@@ -52,14 +52,15 @@ func apiKeyCacheTTLFromEnv() time.Duration {
 }
 
 type apiKeyCacheEntry struct {
-	id        string
-	teamID    string
-	name      string
-	scopes    []string
-	createdBy pgtype.UUID
-	expiresAt pgtype.Timestamptz
-	fetchedAt time.Time
-	lastTouch time.Time
+	id         string
+	teamID     string
+	name       string
+	scopes     []string
+	createdBy  pgtype.UUID
+	expiresAt  pgtype.Timestamptz
+	fetchedAt  time.Time
+	lastTouch  time.Time
+	refreshing bool // a stale-serve refresh is in flight; armed by get, cleared by put/refreshFailed
 }
 
 type apiKeyCache struct {
@@ -77,12 +78,13 @@ func newAPIKeyCache(ttl time.Duration) *apiKeyCache {
 }
 
 // get returns a copy of the cached entry for keyHash if the key itself has not
-// expired and the entry is within ttl+grace. stale reports that the entry is
-// past its TTL — served anyway, but the caller should kick a background
-// refresh. Past the grace window it is a miss (kept only so put can carry the
-// last_used_at throttle across refills). needTouch reports whether the caller
-// should update last_used_at (throttled to lastUsedTouchInterval).
-func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry, needTouch, stale, ok bool) {
+// expired and the entry is within ttl+grace. refresh reports that the entry is
+// past its TTL and THIS caller should kick the background refresh — at most
+// one is armed at a time; put and refreshFailed re-arm. Past the grace window
+// it is a miss (kept only so put can carry the last_used_at throttle across
+// refills). needTouch reports whether the caller should update last_used_at
+// (throttled to lastUsedTouchInterval).
+func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry, needTouch, refresh, ok bool) {
 	if c == nil {
 		return apiKeyCacheEntry{}, false, false, false
 	}
@@ -104,7 +106,11 @@ func (c *apiKeyCache) get(keyHash string, now time.Time) (entry apiKeyCacheEntry
 		e.lastTouch = now
 		needTouch = true
 	}
-	return *e, needTouch, age > c.ttl, true
+	if age > c.ttl && !e.refreshing {
+		e.refreshing = true
+		refresh = true
+	}
+	return *e, needTouch, refresh, true
 }
 
 // remove drops a cached entry. Used when a refresh returns a definitive
@@ -115,6 +121,20 @@ func (c *apiKeyCache) remove(keyHash string) {
 	}
 	c.mu.Lock()
 	delete(c.m, keyHash)
+	c.mu.Unlock()
+}
+
+// refreshFailed re-arms the stale-refresh trigger after a transient refresh
+// error, so a later request inside the grace window retries. (A successful
+// refresh re-arms via put; a revoked key is removed outright.)
+func (c *apiKeyCache) refreshFailed(keyHash string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if e, ok := c.m[keyHash]; ok {
+		e.refreshing = false
+	}
 	c.mu.Unlock()
 }
 

--- a/internal/api/apikey_cache_test.go
+++ b/internal/api/apikey_cache_test.go
@@ -35,14 +35,24 @@ func TestAPIKeyCache_StaleServeThenMiss(t *testing.T) {
 	now := time.Now()
 	c.put("hash1", apiKeyCacheEntry{id: "id1", teamID: "team1"}, now)
 
-	// Inside the grace window past the TTL: served, flagged stale.
-	entry, _, stale, ok := c.get("hash1", now.Add(31*time.Second))
-	if !ok || !stale || entry.id != "id1" {
-		t.Fatalf("expected stale serve inside grace, got ok=%v stale=%v", ok, stale)
+	// Inside the grace window past the TTL: served, and this caller is told
+	// to kick the refresh.
+	entry, _, refresh, ok := c.get("hash1", now.Add(31*time.Second))
+	if !ok || !refresh || entry.id != "id1" {
+		t.Fatalf("expected stale serve inside grace, got ok=%v refresh=%v", ok, refresh)
+	}
+	// The trigger is armed: further stale hits serve but must not re-kick.
+	if _, _, refresh, ok := c.get("hash1", now.Add(31*time.Second)); !ok || refresh {
+		t.Errorf("second stale hit must not arm another refresh, got ok=%v refresh=%v", ok, refresh)
+	}
+	// A transient refresh failure re-arms the trigger.
+	c.refreshFailed("hash1")
+	if _, _, refresh, ok := c.get("hash1", now.Add(31*time.Second)); !ok || !refresh {
+		t.Errorf("refreshFailed must re-arm the trigger, got ok=%v refresh=%v", ok, refresh)
 	}
 	// Fresh entries are not flagged.
-	if _, _, stale, ok := c.get("hash1", now.Add(time.Second)); !ok || stale {
-		t.Errorf("fresh entry must not be stale, got ok=%v stale=%v", ok, stale)
+	if _, _, refresh, ok := c.get("hash1", now.Add(time.Second)); !ok || refresh {
+		t.Errorf("fresh entry must not trigger a refresh, got ok=%v refresh=%v", ok, refresh)
 	}
 	// Past ttl+grace: a real miss.
 	if _, _, _, ok := c.get("hash1", now.Add(30*time.Second+apiKeyCacheStaleGrace+time.Second)); ok {

--- a/internal/api/apikey_cache_test.go
+++ b/internal/api/apikey_cache_test.go
@@ -17,7 +17,7 @@ func TestAPIKeyCache_HitReturnsEntry(t *testing.T) {
 	now := time.Now()
 	c.put("hash1", apiKeyCacheEntry{id: "id1", teamID: "team1"}, now)
 
-	entry, needTouch, ok := c.get("hash1", now.Add(time.Second))
+	entry, needTouch, _, ok := c.get("hash1", now.Add(time.Second))
 	if !ok {
 		t.Fatal("expected cache hit")
 	}
@@ -30,16 +30,26 @@ func TestAPIKeyCache_HitReturnsEntry(t *testing.T) {
 	}
 }
 
-func TestAPIKeyCache_MissAfterTTL(t *testing.T) {
+func TestAPIKeyCache_StaleServeThenMiss(t *testing.T) {
 	c := newAPIKeyCache(30 * time.Second)
 	now := time.Now()
 	c.put("hash1", apiKeyCacheEntry{id: "id1", teamID: "team1"}, now)
 
-	if _, _, ok := c.get("hash1", now.Add(31*time.Second)); ok {
-		t.Error("expected miss after TTL")
+	// Inside the grace window past the TTL: served, flagged stale.
+	entry, _, stale, ok := c.get("hash1", now.Add(31*time.Second))
+	if !ok || !stale || entry.id != "id1" {
+		t.Fatalf("expected stale serve inside grace, got ok=%v stale=%v", ok, stale)
 	}
-	// The expired entry is retained (never served) so put can carry its
-	// lastTouch across the refill; the capacity sweep reclaims it eventually.
+	// Fresh entries are not flagged.
+	if _, _, stale, ok := c.get("hash1", now.Add(time.Second)); !ok || stale {
+		t.Errorf("fresh entry must not be stale, got ok=%v stale=%v", ok, stale)
+	}
+	// Past ttl+grace: a real miss.
+	if _, _, _, ok := c.get("hash1", now.Add(30*time.Second+apiKeyCacheStaleGrace+time.Second)); ok {
+		t.Error("expected miss past the grace window")
+	}
+	// The entry is retained through the miss so put can carry its lastTouch
+	// across the refill; the capacity sweep reclaims it eventually.
 	c.mu.Lock()
 	_, exists := c.m["hash1"]
 	c.mu.Unlock()
@@ -67,7 +77,7 @@ func TestAPIKeyCache_TouchThrottleSurvivesRefill(t *testing.T) {
 
 func TestAPIKeyCache_MissUnknownKey(t *testing.T) {
 	c := newAPIKeyCache(30 * time.Second)
-	if _, _, ok := c.get("nope", time.Now()); ok {
+	if _, _, _, ok := c.get("nope", time.Now()); ok {
 		t.Error("expected miss for unknown key")
 	}
 }
@@ -82,11 +92,11 @@ func TestAPIKeyCache_KeyExpiryCheckedOnHit(t *testing.T) {
 	}, now)
 
 	// Inside TTL and before expires_at: hit.
-	if _, _, ok := c.get("hash1", now.Add(5*time.Second)); !ok {
+	if _, _, _, ok := c.get("hash1", now.Add(5*time.Second)); !ok {
 		t.Error("expected hit before expires_at")
 	}
 	// Inside TTL but past expires_at: miss, even though TTL hasn't lapsed.
-	if _, _, ok := c.get("hash1", now.Add(11*time.Second)); ok {
+	if _, _, _, ok := c.get("hash1", now.Add(11*time.Second)); ok {
 		t.Error("expected miss after expires_at despite fresh TTL")
 	}
 }
@@ -96,14 +106,14 @@ func TestAPIKeyCache_TouchThrottle(t *testing.T) {
 	now := time.Now()
 	c.put("hash1", apiKeyCacheEntry{id: "id1"}, now)
 
-	if _, needTouch, _ := c.get("hash1", now.Add(30*time.Second)); needTouch {
+	if _, needTouch, _, _ := c.get("hash1", now.Add(30*time.Second)); needTouch {
 		t.Error("expected no touch before interval elapses")
 	}
-	if _, needTouch, _ := c.get("hash1", now.Add(lastUsedTouchInterval)); !needTouch {
+	if _, needTouch, _, _ := c.get("hash1", now.Add(lastUsedTouchInterval)); !needTouch {
 		t.Error("expected touch once interval elapsed")
 	}
 	// The touch above reset the clock; immediately after, no touch again.
-	if _, needTouch, _ := c.get("hash1", now.Add(lastUsedTouchInterval+time.Second)); needTouch {
+	if _, needTouch, _, _ := c.get("hash1", now.Add(lastUsedTouchInterval+time.Second)); needTouch {
 		t.Error("expected no touch right after a touch")
 	}
 }
@@ -115,7 +125,7 @@ func TestAPIKeyCache_DisabledNilSafe(t *testing.T) {
 	}
 	now := time.Now()
 	c.put("hash1", apiKeyCacheEntry{id: "id1"}, now) // must not panic
-	if _, _, ok := c.get("hash1", now); ok {
+	if _, _, _, ok := c.get("hash1", now); ok {
 		t.Error("disabled cache must always miss")
 	}
 }
@@ -131,7 +141,7 @@ func TestAPIKeyCache_SweepAtCapacity(t *testing.T) {
 	later := now.Add(31 * time.Second)
 	c.put("fresh", apiKeyCacheEntry{id: "fresh"}, later)
 
-	if _, _, ok := c.get("fresh", later); !ok {
+	if _, _, _, ok := c.get("fresh", later); !ok {
 		t.Error("expected fresh entry after sweep")
 	}
 	c.mu.Lock()
@@ -152,7 +162,7 @@ func TestAPIKeyCache_ResetWhenFullOfFreshEntries(t *testing.T) {
 	// exceed the cap and the new entry must be present.
 	c.put("fresh", apiKeyCacheEntry{id: "fresh"}, now.Add(time.Second))
 
-	if _, _, ok := c.get("fresh", now.Add(2*time.Second)); !ok {
+	if _, _, _, ok := c.get("fresh", now.Add(2*time.Second)); !ok {
 		t.Error("expected fresh entry after reset")
 	}
 	c.mu.Lock()

--- a/internal/api/apikey_cache_test.go
+++ b/internal/api/apikey_cache_test.go
@@ -277,3 +277,15 @@ func TestAPIKeyCache_FetchContextContract(t *testing.T) {
 		t.Errorf("nil-cache fetch: %v", err)
 	}
 }
+
+func TestAPIKeyCache_RemoveDropsEntry(t *testing.T) {
+	c := newAPIKeyCache(10 * time.Second)
+	now := time.Now()
+	c.put("hash1", apiKeyCacheEntry{id: "id1"}, now)
+	c.remove("hash1")
+	if _, _, _, ok := c.get("hash1", now); ok {
+		t.Fatal("removed entry must not be served")
+	}
+	var disabled *apiKeyCache
+	disabled.remove("hash1") // nil-safe, must not panic
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -74,6 +74,9 @@ type Handlers struct {
 	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
 	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
 	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
+	// HostCacheInvalidate drops the scheduler's cached host list; wired to
+	// LeastLoaded.Invalidate so host status changes take effect immediately.
+	HostCacheInvalidate func()
 
 	// asyncMu/asyncCond/asyncCount track fire-and-forget bookkeeping goroutines
 	// (ActivateSandbox, FinalizePause) so tests can wait for quiescence;

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -56,6 +56,9 @@ func (h *Handlers) respondQuotaExceeded(c *gin.Context, teamID uuid.UUID) {
 // Scheduler selects a host for new sandboxes.
 type Scheduler interface {
 	SelectHost(ctx context.Context) (hostID string, err error)
+	// Invalidate drops any cached host state so the next SelectHost
+	// reflects host status changes immediately.
+	Invalidate()
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -74,9 +77,6 @@ type Handlers struct {
 	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
 	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
 	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
-	// HostCacheInvalidate drops the scheduler's cached host list; wired to
-	// LeastLoaded.Invalidate so host status changes take effect immediately.
-	HostCacheInvalidate func()
 
 	// asyncMu/asyncCond/asyncCount track fire-and-forget bookkeeping goroutines
 	// (ActivateSandbox, FinalizePause) so tests can wait for quiescence;

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -1065,9 +1065,8 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 			return e.tpl, nil
 		}
 		if now.Before(e.expiry.Add(templateCacheStaleGrace)) {
-			// Serve the just-expired entry and refresh behind the response, so
-			// a burst landing on an expired entry never queues. A refresh that
-			// finds the template gone drops the entry.
+			// Serve the just-expired entry, refresh behind the response; a
+			// refresh that finds the template gone drops the entry.
 			go h.refreshTemplateCache(sfKey, cacheKey, teamID, ref)
 			return e.tpl, nil
 		}

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -1000,6 +1000,11 @@ func (h *Handlers) refreshTemplateCache(sfKey string, cacheKey templateCacheKey,
 			tpl:    tpl,
 			expiry: time.Now().Add(templateCacheTTL),
 		})
+	} else {
+		// The name now resolves to a team-owned template (lookup prefers it
+		// over the system one). Only system templates are cached, and the old
+		// system entry must not keep shadowing the override for the grace window.
+		templateCache.Delete(cacheKey)
 	}
 }
 

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -975,6 +975,34 @@ var (
 
 const templateCacheTTL = 5 * time.Second
 
+// templateCacheStaleGrace: a TTL-expired entry is still served for this long
+// while one background flight refreshes it, so a burst landing on an expired
+// entry never queues behind the refresh. Bounds how long a rebuilt or deleted
+// template's old snapshot paths can still be handed out.
+const templateCacheStaleGrace = 30 * time.Second
+
+// refreshTemplateCache re-runs the coalesced lookup behind a stale-serve and
+// restores the cache entry; a template that is gone drops its entry.
+func (h *Handlers) refreshTemplateCache(sfKey string, cacheKey templateCacheKey, teamID uuid.UUID, ref string) {
+	result, err, _ := templateLookupGroup.Do(sfKey, func() (interface{}, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return h.pureLookupTemplate(ctx, teamID, ref)
+	})
+	if err != nil {
+		if errors.Is(err, errTemplateNotFound) {
+			templateCache.Delete(cacheKey)
+		}
+		return // transient error: the stale entry stays servable for the grace window
+	}
+	if tpl := result.(db.Template); tpl.TeamID == h.systemTeamID() {
+		templateCache.Store(cacheKey, &templateCacheEntry{
+			tpl:    tpl,
+			expiry: time.Now().Add(templateCacheTTL),
+		})
+	}
+}
+
 // pureLookupTemplate runs the DB query. Must stay free of HTTP side-effects
 // so it can safely sit under singleflight.Group.
 func (h *Handlers) pureLookupTemplate(ctx context.Context, teamID uuid.UUID, ref string) (db.Template, error) {
@@ -1029,16 +1057,24 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 	}
 
 	cacheKey := templateCacheKey{teamID: teamID, ref: ref}
+	sfKey := teamID.String() + "|" + ref
 	if entry, ok := templateCache.Load(cacheKey); ok {
 		e := entry.(*templateCacheEntry)
-		if time.Now().Before(e.expiry) {
+		now := time.Now()
+		if now.Before(e.expiry) {
+			return e.tpl, nil
+		}
+		if now.Before(e.expiry.Add(templateCacheStaleGrace)) {
+			// Serve the just-expired entry and refresh behind the response, so
+			// a burst landing on an expired entry never queues. A refresh that
+			// finds the template gone drops the entry.
+			go h.refreshTemplateCache(sfKey, cacheKey, teamID, ref)
 			return e.tpl, nil
 		}
 		// CompareAndDelete so a concurrent fresh Store isn't clobbered.
 		templateCache.CompareAndDelete(cacheKey, entry)
 	}
 
-	sfKey := teamID.String() + "|" + ref
 	result, err, _ := templateLookupGroup.Do(sfKey, func() (interface{}, error) {
 		// Detach: other coalesced waiters may still need the result.
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -976,7 +976,15 @@ type templateCacheEntry struct {
 var (
 	templateCache       sync.Map           // key: templateCacheKey, value: *templateCacheEntry
 	templateLookupGroup singleflight.Group // coalesces concurrent identical misses
+	templateCacheGen    atomic.Uint64      // bumped by InvalidateTemplateCache; retires in-flight lookups
 )
+
+// templateFlightResult carries the generation observed when the flight began,
+// so a result computed before an invalidation is never stored after it.
+type templateFlightResult struct {
+	tpl db.Template
+	gen uint64
+}
 
 const templateCacheTTL = 5 * time.Second
 
@@ -994,10 +1002,17 @@ const templateCacheStaleGrace = 30 * time.Second
 // slow result can never clobber or evict a newer entry; nil means there is
 // nothing to replace (the blocking miss path).
 func (h *Handlers) fetchTemplate(ctx context.Context, sfKey string, cacheKey templateCacheKey, teamID uuid.UUID, ref string, old *templateCacheEntry) (db.Template, error) {
-	result, err, _ := templateLookupGroup.Do(sfKey, func() (interface{}, error) {
+	// The generation is in the singleflight key: a lookup that starts after an
+	// invalidation never coalesces onto a flight that read the retired row.
+	startGen := templateCacheGen.Load()
+	result, err, _ := templateLookupGroup.Do(fmt.Sprintf("%s|%d", sfKey, startGen), func() (interface{}, error) {
 		qctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		return h.pureLookupTemplate(qctx, teamID, ref)
+		tpl, err := h.pureLookupTemplate(qctx, teamID, ref)
+		if err != nil {
+			return nil, err
+		}
+		return templateFlightResult{tpl: tpl, gen: startGen}, nil
 	})
 	if err != nil {
 		if errors.Is(err, errTemplateNotFound) && old != nil {
@@ -1005,22 +1020,30 @@ func (h *Handlers) fetchTemplate(ctx context.Context, sfKey string, cacheKey tem
 		}
 		return db.Template{}, err
 	}
-	tpl := result.(db.Template)
-	switch {
-	case tpl.TeamID != h.systemTeamID():
+	res := result.(templateFlightResult)
+	tpl := res.tpl
+	if tpl.TeamID != h.systemTeamID() {
 		if old != nil {
 			templateCache.CompareAndDelete(cacheKey, old)
 		}
-	case old != nil:
-		templateCache.CompareAndSwap(cacheKey, old, &templateCacheEntry{
-			tpl:    tpl,
-			expiry: time.Now().Add(templateCacheTTL),
-		})
-	default:
-		templateCache.Store(cacheKey, &templateCacheEntry{
-			tpl:    tpl,
-			expiry: time.Now().Add(templateCacheTTL),
-		})
+		return tpl, nil
+	}
+	if templateCacheGen.Load() != res.gen {
+		// An invalidation landed after this flight began: its row may predate
+		// the delete or rebuild, so serve it to this caller but store nothing.
+		return tpl, nil
+	}
+	entry := &templateCacheEntry{tpl: tpl, expiry: time.Now().Add(templateCacheTTL)}
+	stored := true
+	if old != nil {
+		stored = templateCache.CompareAndSwap(cacheKey, old, entry)
+	} else {
+		templateCache.Store(cacheKey, entry)
+	}
+	// Re-check after the store: an invalidation racing it has already swept the
+	// map, so a store that slipped past that sweep must undo itself.
+	if stored && templateCacheGen.Load() != res.gen {
+		templateCache.CompareAndDelete(cacheKey, entry)
 	}
 	return tpl, nil
 }
@@ -1041,6 +1064,10 @@ func (h *Handlers) refreshTemplateCache(sfKey string, cacheKey templateCacheKey,
 // of after the stale grace. System templates are cached once per calling team,
 // hence the sweep. Called on template deletion and on a finalized rebuild.
 func InvalidateTemplateCache(templateID uuid.UUID) {
+	// Bump first: lookups already in flight read the pre-invalidation row and
+	// are retired at store time; lookups starting after the bump use a new
+	// singleflight key, so they cannot coalesce onto those older flights.
+	templateCacheGen.Add(1)
 	templateCache.Range(func(k, v any) bool {
 		if v.(*templateCacheEntry).tpl.ID == templateID {
 			templateCache.Delete(k)

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -731,6 +732,9 @@ func (h *Handlers) DeleteTemplate(c *gin.Context) {
 		return
 	}
 
+	// The template is gone; cached entries must stop handing out its paths.
+	InvalidateTemplateCache(tplID)
+
 	c.Status(http.StatusNoContent)
 	h.logTemplateActivity(c.Request.Context(), tplID, teamID, actorIDFromContext(c), "template", "deleted", "success", nil)
 
@@ -964,8 +968,9 @@ type templateCacheKey struct {
 }
 
 type templateCacheEntry struct {
-	tpl    db.Template
-	expiry time.Time
+	tpl        db.Template
+	expiry     time.Time
+	refreshing atomic.Bool // a stale-serve refresh is in flight; at most one per entry
 }
 
 var (
@@ -981,31 +986,67 @@ const templateCacheTTL = 5 * time.Second
 // template's old snapshot paths can still be handed out.
 const templateCacheStaleGrace = 30 * time.Second
 
-// refreshTemplateCache re-runs the coalesced lookup behind a stale-serve and
-// restores the cache entry; a template that is gone drops its entry.
-func (h *Handlers) refreshTemplateCache(sfKey string, cacheKey templateCacheKey, teamID uuid.UUID, ref string) {
+// fetchTemplate runs the coalesced lookup and reconciles the cache: a system
+// template is (re)stored; a definitive not-found, or a name that now resolves
+// to a team-owned override (the lookup prefers team rows, and only system
+// templates are cached), removes the old entry so it can't keep shadowing.
+// old is the entry this call replaces — reconciliation is compare-based so a
+// slow result can never clobber or evict a newer entry; nil means there is
+// nothing to replace (the blocking miss path).
+func (h *Handlers) fetchTemplate(ctx context.Context, sfKey string, cacheKey templateCacheKey, teamID uuid.UUID, ref string, old *templateCacheEntry) (db.Template, error) {
 	result, err, _ := templateLookupGroup.Do(sfKey, func() (interface{}, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		qctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		return h.pureLookupTemplate(ctx, teamID, ref)
+		return h.pureLookupTemplate(qctx, teamID, ref)
 	})
 	if err != nil {
-		if errors.Is(err, errTemplateNotFound) {
-			templateCache.Delete(cacheKey)
+		if errors.Is(err, errTemplateNotFound) && old != nil {
+			templateCache.CompareAndDelete(cacheKey, old)
 		}
-		return // transient error: the stale entry stays servable for the grace window
+		return db.Template{}, err
 	}
-	if tpl := result.(db.Template); tpl.TeamID == h.systemTeamID() {
+	tpl := result.(db.Template)
+	switch {
+	case tpl.TeamID != h.systemTeamID():
+		if old != nil {
+			templateCache.CompareAndDelete(cacheKey, old)
+		}
+	case old != nil:
+		templateCache.CompareAndSwap(cacheKey, old, &templateCacheEntry{
+			tpl:    tpl,
+			expiry: time.Now().Add(templateCacheTTL),
+		})
+	default:
 		templateCache.Store(cacheKey, &templateCacheEntry{
 			tpl:    tpl,
 			expiry: time.Now().Add(templateCacheTTL),
 		})
-	} else {
-		// The name now resolves to a team-owned template (lookup prefers it
-		// over the system one). Only system templates are cached, and the old
-		// system entry must not keep shadowing the override for the grace window.
-		templateCache.Delete(cacheKey)
 	}
+	return tpl, nil
+}
+
+// refreshTemplateCache runs the fetch behind a stale serve. On a transient
+// error the stale entry stays servable for the grace window and the trigger
+// re-arms so a later request retries.
+func (h *Handlers) refreshTemplateCache(sfKey string, cacheKey templateCacheKey, teamID uuid.UUID, ref string, old *templateCacheEntry) {
+	_, err := h.fetchTemplate(context.Background(), sfKey, cacheKey, teamID, ref, old)
+	if err != nil && !errors.Is(err, errTemplateNotFound) {
+		log.Warn().Err(err).Str("ref", ref).Msg("template refresh failed; serving stale until the grace window expires")
+		old.refreshing.Store(false)
+	}
+}
+
+// InvalidateTemplateCache drops every cached entry for the given template, so
+// creates stop receiving its retired snapshot paths at the next lookup instead
+// of after the stale grace. System templates are cached once per calling team,
+// hence the sweep. Called on template deletion and on a finalized rebuild.
+func InvalidateTemplateCache(templateID uuid.UUID) {
+	templateCache.Range(func(k, v any) bool {
+		if v.(*templateCacheEntry).tpl.ID == templateID {
+			templateCache.Delete(k)
+		}
+		return true
+	})
 }
 
 // pureLookupTemplate runs the DB query. Must stay free of HTTP side-effects
@@ -1070,21 +1111,19 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 			return e.tpl, nil
 		}
 		if now.Before(e.expiry.Add(templateCacheStaleGrace)) {
-			// Serve the just-expired entry, refresh behind the response; a
-			// refresh that finds the template gone drops the entry.
-			go h.refreshTemplateCache(sfKey, cacheKey, teamID, ref)
+			// Serve the just-expired entry; the first observer kicks the one
+			// background refresh, which drops the entry if the template is gone.
+			if e.refreshing.CompareAndSwap(false, true) {
+				go h.refreshTemplateCache(sfKey, cacheKey, teamID, ref, e)
+			}
 			return e.tpl, nil
 		}
 		// CompareAndDelete so a concurrent fresh Store isn't clobbered.
 		templateCache.CompareAndDelete(cacheKey, entry)
 	}
 
-	result, err, _ := templateLookupGroup.Do(sfKey, func() (interface{}, error) {
-		// Detach: other coalesced waiters may still need the result.
-		ctx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 5*time.Second)
-		defer cancel()
-		return h.pureLookupTemplate(ctx, teamID, ref)
-	})
+	// Detach: other coalesced waiters may still need the result.
+	tpl, err := h.fetchTemplate(context.WithoutCancel(c.Request.Context()), sfKey, cacheKey, teamID, ref, nil)
 	if err != nil {
 		if errors.Is(err, errTemplateNotFound) {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
@@ -1094,15 +1133,6 @@ func (h *Handlers) lookupTemplateForCreate(c *gin.Context, teamID uuid.UUID, ref
 		respondError(c, ErrInternal)
 		return db.Template{}, err
 	}
-	tpl := result.(db.Template)
-
-	if tpl.TeamID == h.systemTeamID() {
-		templateCache.Store(cacheKey, &templateCacheEntry{
-			tpl:    tpl,
-			expiry: time.Now().Add(templateCacheTTL),
-		})
-	}
-
 	return tpl, nil
 }
 

--- a/internal/api/handlers_template_test.go
+++ b/internal/api/handlers_template_test.go
@@ -287,13 +287,30 @@ func TestTemplateCache_ExpiredEntry_RefetchedFromDB(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected entry present after first call")
 	}
-	v.(*templateCacheEntry).expiry = time.Now().Add(-time.Second)
 
+	// Expired but inside the stale grace: served immediately, refreshed in
+	// the background (one coalesced DB call).
+	v.(*templateCacheEntry).expiry = time.Now().Add(-time.Second)
 	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
-		t.Fatalf("second lookup: %v", err)
+		t.Fatalf("stale lookup: %v", err)
 	}
-	if got := env.dbCalls.Load(); got != 2 {
-		t.Errorf("after expired entry: db_calls=%d, want 2", got)
+	deadline := time.Now().Add(2 * time.Second)
+	for env.dbCalls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh never ran, db_calls=%d", env.dbCalls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Past the grace window: a blocking refetch.
+	if v, ok := templateCache.Load(key); ok {
+		v.(*templateCacheEntry).expiry = time.Now().Add(-templateCacheStaleGrace - time.Second)
+	}
+	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
+		t.Fatalf("past-grace lookup: %v", err)
+	}
+	if got := env.dbCalls.Load(); got != 3 {
+		t.Errorf("past-grace entry must block on a refetch: db_calls=%d, want 3", got)
 	}
 }
 

--- a/internal/api/handlers_template_test.go
+++ b/internal/api/handlers_template_test.go
@@ -184,6 +184,7 @@ type templateCacheTestEnv struct {
 	dbCalls      *atomic.Int64
 	tplReturned  db.Template
 	tplErr       error
+	onQuery      func() // when set, runs inside the template query, before the row returns
 }
 
 func newTemplateCacheTestEnv(t *testing.T) *templateCacheTestEnv {
@@ -196,6 +197,9 @@ func newTemplateCacheTestEnv(t *testing.T) *templateCacheTestEnv {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			if strings.Contains(sql, "FROM template") {
 				env.dbCalls.Add(1)
+				if env.onQuery != nil {
+					env.onQuery()
+				}
 				if env.tplErr != nil {
 					return errorRow(env.tplErr)
 				}
@@ -412,5 +416,38 @@ func TestInvalidateTemplateCache_DropsAllTeamsEntries(t *testing.T) {
 	}
 	if got := env.dbCalls.Load(); got != 4 {
 		t.Errorf("post-invalidate lookups must refetch: db_calls=%d, want 4", got)
+	}
+}
+
+// A lookup whose DB flight straddles an invalidation (template deleted or
+// rebuilt mid-flight) may serve its result but must not store it — otherwise
+// the retired row comes back with a fresh TTL right after eviction.
+func TestTemplateCache_MidFlightInvalidationVetoesStore(t *testing.T) {
+	env := newTemplateCacheTestEnv(t)
+	tplID := uuid.New()
+	env.tplReturned = db.Template{
+		ID:     tplID,
+		TeamID: env.systemTeamID,
+		Name:   "superserve/base",
+		Status: db.TemplateStatusReady,
+	}
+	env.onQuery = func() { InvalidateTemplateCache(tplID) }
+
+	callerTeam := uuid.New()
+	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	key := templateCacheKey{teamID: callerTeam, ref: "superserve/base"}
+	if _, ok := templateCache.Load(key); ok {
+		t.Fatal("a flight that began before the invalidation must not store its row")
+	}
+
+	// With no invalidation racing it, the next lookup stores normally.
+	env.onQuery = nil
+	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+	if _, ok := templateCache.Load(key); !ok {
+		t.Fatal("expected the entry to be cached once no invalidation raced the flight")
 	}
 }

--- a/internal/api/handlers_template_test.go
+++ b/internal/api/handlers_template_test.go
@@ -333,3 +333,51 @@ func TestTemplateCache_NotFound_NotCached(t *testing.T) {
 		t.Errorf("DB calls = %d, want 3 (not-found results must not be cached)", got)
 	}
 }
+
+// A team creating its own template with a cached system template's name must
+// stop being served the system entry once the stale refresh sees the override
+// (the lookup prefers team-owned rows).
+func TestTemplateCache_StaleRefreshEvictsOnTeamOverride(t *testing.T) {
+	env := newTemplateCacheTestEnv(t)
+	env.tplReturned = db.Template{
+		ID:     uuid.New(),
+		TeamID: env.systemTeamID,
+		Name:   "superserve/base",
+		Status: db.TemplateStatusReady,
+	}
+	callerTeam := uuid.New()
+	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// The team creates its own template under the same name; age the cached
+	// system entry into the stale window and serve once (kicks the refresh).
+	teamTpl := db.Template{ID: uuid.New(), TeamID: callerTeam, Name: "superserve/base", Status: db.TemplateStatusReady}
+	env.tplReturned = teamTpl
+	key := templateCacheKey{teamID: callerTeam, ref: "superserve/base"}
+	v, _ := templateCache.Load(key)
+	v.(*templateCacheEntry).expiry = time.Now().Add(-time.Second)
+	if _, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base"); err != nil {
+		t.Fatalf("stale serve: %v", err)
+	}
+
+	// The refresh resolves to the team-owned row and must evict the entry.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, ok := templateCache.Load(key); !ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("stale system entry kept shadowing the team override")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	// Next lookup returns the override.
+	tpl, err := env.h.lookupTemplateForCreate(env.c, callerTeam, "superserve/base")
+	if err != nil {
+		t.Fatalf("post-evict lookup: %v", err)
+	}
+	if tpl.TeamID != callerTeam {
+		t.Fatalf("expected the team-owned template, got team %s", tpl.TeamID)
+	}
+}

--- a/internal/api/handlers_template_test.go
+++ b/internal/api/handlers_template_test.go
@@ -381,3 +381,36 @@ func TestTemplateCache_StaleRefreshEvictsOnTeamOverride(t *testing.T) {
 		t.Fatalf("expected the team-owned template, got team %s", tpl.TeamID)
 	}
 }
+
+// Deleting or rebuilding a template must drop its cached entries immediately —
+// every calling team's — so the next lookup refetches instead of serving the
+// retired paths for the stale grace.
+func TestInvalidateTemplateCache_DropsAllTeamsEntries(t *testing.T) {
+	env := newTemplateCacheTestEnv(t)
+	env.tplReturned = db.Template{
+		ID:     uuid.New(),
+		TeamID: env.systemTeamID,
+		Name:   "superserve/base",
+		Status: db.TemplateStatusReady,
+	}
+	teamA, teamB := uuid.New(), uuid.New()
+	for _, team := range []uuid.UUID{teamA, teamB} {
+		if _, err := env.h.lookupTemplateForCreate(env.c, team, "superserve/base"); err != nil {
+			t.Fatalf("prime team %s: %v", team, err)
+		}
+	}
+	if got := env.dbCalls.Load(); got != 2 {
+		t.Fatalf("prime: db_calls=%d, want 2", got)
+	}
+
+	InvalidateTemplateCache(env.tplReturned.ID)
+
+	for _, team := range []uuid.UUID{teamA, teamB} {
+		if _, err := env.h.lookupTemplateForCreate(env.c, team, "superserve/base"); err != nil {
+			t.Fatalf("post-invalidate lookup team %s: %v", team, err)
+		}
+	}
+	if got := env.dbCalls.Load(); got != 4 {
+		t.Errorf("post-invalidate lookups must refetch: db_calls=%d, want 4", got)
+	}
+}

--- a/internal/api/host_detector.go
+++ b/internal/api/host_detector.go
@@ -26,8 +26,11 @@ const (
 
 // StartHostDetector launches a background goroutine that periodically
 // marks active hosts as unhealthy when their heartbeat goes stale.
+// onUnhealthy (optional) runs after a pass that marked at least one host —
+// wired to the scheduler's cache invalidation so this instance stops
+// routing to the host at detection time instead of at cache expiry.
 // Blocks until ctx is cancelled.
-func StartHostDetector(ctx context.Context, queries *db.Queries) {
+func StartHostDetector(ctx context.Context, queries *db.Queries, onUnhealthy func()) {
 	log.Info().
 		Dur("timeout", heartbeatTimeout).
 		Dur("interval", detectorInterval).
@@ -36,7 +39,7 @@ func StartHostDetector(ctx context.Context, queries *db.Queries) {
 	ticker := time.NewTicker(detectorInterval)
 	defer ticker.Stop()
 
-	sentrylog.RunSafe("host-detector", func() { detectOnce(ctx, queries) })
+	sentrylog.RunSafe("host-detector", func() { detectOnce(ctx, queries, onUnhealthy) })
 
 	for {
 		select {
@@ -45,13 +48,13 @@ func StartHostDetector(ctx context.Context, queries *db.Queries) {
 			return
 		case <-ticker.C:
 			runCtx, cancel := context.WithTimeout(ctx, detectorRunTimeout)
-			sentrylog.RunSafe("host-detector", func() { detectOnce(runCtx, queries) })
+			sentrylog.RunSafe("host-detector", func() { detectOnce(runCtx, queries, onUnhealthy) })
 			cancel()
 		}
 	}
 }
 
-func detectOnce(ctx context.Context, queries *db.Queries) {
+func detectOnce(ctx context.Context, queries *db.Queries, onUnhealthy func()) {
 	cutoff := time.Now().Add(-heartbeatTimeout)
 	stale, err := queries.ListStaleHosts(ctx, pgtype.Timestamptz{
 		Time:  cutoff,
@@ -62,6 +65,7 @@ func detectOnce(ctx context.Context, queries *db.Queries) {
 		return
 	}
 
+	marked := 0
 	for _, host := range stale {
 		log.Warn().Str("host_id", host.ID).
 			Time("last_heartbeat", host.LastHeartbeatAt.Time).
@@ -69,6 +73,11 @@ func detectOnce(ctx context.Context, queries *db.Queries) {
 
 		if err := queries.MarkHostUnhealthy(ctx, host.ID); err != nil {
 			log.Error().Err(err).Str("host_id", host.ID).Msg("host detector: MarkHostUnhealthy failed")
+			continue
 		}
+		marked++
+	}
+	if marked > 0 && onUnhealthy != nil {
+		onUnhealthy()
 	}
 }

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -31,5 +31,14 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		return
 	}
 
+	if host.PrevStatus == "unhealthy" && host.Status == "active" {
+		// The heartbeat just recovered this host; drop the scheduler's cached
+		// list so its capacity is usable now, not after the cache TTL.
+		log.Info().Str("host_id", hostID).Msg("host recovered via heartbeat")
+		if h.HostCacheInvalidate != nil {
+			h.HostCacheInvalidate()
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{"status": host.Status})
 }

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -35,8 +35,8 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		// The heartbeat just recovered this host; drop the scheduler's cached
 		// list so its capacity is usable now, not after the cache TTL.
 		log.Info().Str("host_id", hostID).Msg("host recovered via heartbeat")
-		if h.HostCacheInvalidate != nil {
-			h.HostCacheInvalidate()
+		if h.Scheduler != nil {
+			h.Scheduler.Invalidate()
 		}
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -94,9 +94,14 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 			}
 			if stale {
 				// Serve the just-expired entry, refresh behind the response.
-				// fetch coalesces concurrent refreshes; errors are ignored —
-				// a real revocation lands via the refreshed lookup.
-				go func() { _, _ = cache.fetch(context.Background(), keyHash, lookup) }()
+				// fetch coalesces concurrent refreshes. A definitive not-found
+				// means the key was revoked — evict so the stale entry stops
+				// being servable; transient errors leave it for the grace window.
+				go func() {
+					if _, err := cache.fetch(context.Background(), keyHash, lookup); errors.Is(err, pgx.ErrNoRows) {
+						cache.remove(keyHash)
+					}
+				}()
 			}
 			setAPIKeyContext(c, entry)
 			c.Set("auth_ms", time.Since(authStart).Milliseconds())

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -93,10 +93,8 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 				touchLastUsed(c.Request.Context(), entry.id)
 			}
 			if stale {
-				// Serve the just-expired entry and refresh behind the response,
-				// so a burst landing on an expired entry never queues. fetch's
-				// singleflight collapses concurrent refreshes; errors are
-				// ignored — the entry stays servable for the grace window and
+				// Serve the just-expired entry, refresh behind the response.
+				// fetch coalesces concurrent refreshes; errors are ignored —
 				// a real revocation lands via the refreshed lookup.
 				go func() { _, _ = cache.fetch(context.Background(), keyHash, lookup) }()
 			}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -70,21 +70,10 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 		hash := sha256.Sum256([]byte(apiKey))
 		keyHash := hex.EncodeToString(hash[:])
 
-		if entry, needTouch, ok := cache.get(keyHash, time.Now()); ok {
-			if needTouch {
-				touchLastUsed(c.Request.Context(), entry.id)
-			}
-			setAPIKeyContext(c, entry)
-			c.Set("auth_ms", time.Since(authStart).Milliseconds())
-			c.Next()
-			return
-		}
-
-		// Miss: fetch coalesces concurrent identical lookups, so a burst
-		// arriving on an expired entry runs one query, not one per request.
-		// The touch and put happen inside fn so only the executing caller
-		// performs them — waiters share the entry without re-touching.
-		entry, err := cache.fetch(c.Request.Context(), keyHash, func(qctx context.Context) (apiKeyCacheEntry, error) {
+		// lookup is the DB fetch used by both the blocking miss path and the
+		// stale-refresh path; put and the throttled touch happen inside so
+		// only the executing flight performs them.
+		lookup := func(qctx context.Context) (apiKeyCacheEntry, error) {
 			var e apiKeyCacheEntry
 			err := pool.QueryRow(qctx,
 				"SELECT id, team_id, name, scopes, created_by, expires_at FROM api_key WHERE key_hash = $1 AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > now())",
@@ -97,7 +86,29 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 				touchLastUsed(qctx, e.id)
 			}
 			return e, nil
-		})
+		}
+
+		if entry, needTouch, stale, ok := cache.get(keyHash, time.Now()); ok {
+			if needTouch {
+				touchLastUsed(c.Request.Context(), entry.id)
+			}
+			if stale {
+				// Serve the just-expired entry and refresh behind the response,
+				// so a burst landing on an expired entry never queues. fetch's
+				// singleflight collapses concurrent refreshes; errors are
+				// ignored — the entry stays servable for the grace window and
+				// a real revocation lands via the refreshed lookup.
+				go func() { _, _ = cache.fetch(context.Background(), keyHash, lookup) }()
+			}
+			setAPIKeyContext(c, entry)
+			c.Set("auth_ms", time.Since(authStart).Milliseconds())
+			c.Next()
+			return
+		}
+
+		// Miss: fetch coalesces concurrent identical lookups, so a burst
+		// arriving with nothing cached runs one query, not one per request.
+		entry, err := cache.fetch(c.Request.Context(), keyHash, lookup)
 		if err != nil {
 			switch {
 			case c.Request.Context().Err() != nil:

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -88,18 +88,25 @@ func APIKeyAuth(pool *pgxpool.Pool) gin.HandlerFunc {
 			return e, nil
 		}
 
-		if entry, needTouch, stale, ok := cache.get(keyHash, time.Now()); ok {
+		if entry, needTouch, refresh, ok := cache.get(keyHash, time.Now()); ok {
 			if needTouch {
 				touchLastUsed(c.Request.Context(), entry.id)
 			}
-			if stale {
-				// Serve the just-expired entry, refresh behind the response.
-				// fetch coalesces concurrent refreshes. A definitive not-found
-				// means the key was revoked — evict so the stale entry stops
-				// being servable; transient errors leave it for the grace window.
+			if refresh {
+				// Serve the just-expired entry, refresh behind the response;
+				// get arms at most one refresh per entry. A definitive
+				// not-found means the key was revoked — evict so the stale
+				// entry stops being servable; transient errors re-arm the
+				// trigger and leave it for the grace window.
 				go func() {
-					if _, err := cache.fetch(context.Background(), keyHash, lookup); errors.Is(err, pgx.ErrNoRows) {
+					_, err := cache.fetch(context.Background(), keyHash, lookup)
+					switch {
+					case err == nil:
+					case errors.Is(err, pgx.ErrNoRows):
 						cache.remove(keyHash)
+					default:
+						log.Warn().Err(err).Msg("API key refresh failed; serving stale until the grace window expires")
+						cache.refreshFailed(keyHash)
 					}
 				}()
 			}

--- a/internal/authz/canteam_cache_test.go
+++ b/internal/authz/canteam_cache_test.go
@@ -263,3 +263,110 @@ func TestCanTeamSingleflightCollapsesConcurrentMisses(t *testing.T) {
 		t.Fatalf("expected concurrent misses to coalesce (<=5 queries), got %d", n)
 	}
 }
+
+// ageTeamPermEntry rewinds a cached entry's expiry so tests can enter the
+// stale-grace and past-grace windows without waiting out real TTLs.
+func ageTeamPermEntry(s *Service, key teamPermCacheKey, expiry time.Time) {
+	s.cache.mu.Lock()
+	e := s.cache.m[key]
+	e.expiry = expiry
+	s.cache.m[key] = e
+	s.cache.mu.Unlock()
+}
+
+func waitForCalls(t *testing.T, c *atomic.Int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for c.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d calls, have %d", want, c.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func TestCanTeamStaleServeRefreshesInBackground(t *testing.T) {
+	store := &countingStore{result: true}
+	s := newCachedForTest(store)
+	user, team := uuid.New(), uuid.New()
+	key := teamPermCacheKey{userID: user, teamID: team, permission: "settings:write"}
+
+	if ok, _ := s.CanTeam(context.Background(), user, team, "settings:write"); !ok {
+		t.Fatal("prime failed")
+	}
+	ageTeamPermEntry(s, key, time.Now().Add(-time.Second)) // expired, inside grace
+
+	// Served instantly from the stale entry — no blocking on the refresh.
+	if ok, err := s.CanTeam(context.Background(), user, team, "settings:write"); !ok || err != nil {
+		t.Fatalf("stale entry must be served: ok=%v err=%v", ok, err)
+	}
+	// The background refresh runs exactly one more query and re-freshens the entry.
+	waitForCalls(t, &store.calls, 2)
+	s.cache.mu.Lock()
+	fresh := time.Now().Before(s.cache.m[key].expiry)
+	s.cache.mu.Unlock()
+	if !fresh {
+		t.Fatal("background refresh must restore a fresh expiry")
+	}
+}
+
+func TestCanTeamStaleNeverServedAcrossGenerationBump(t *testing.T) {
+	store := &countingStore{result: true}
+	s := newCachedForTest(store)
+	user, team := uuid.New(), uuid.New()
+	key := teamPermCacheKey{userID: user, teamID: team, permission: "settings:write"}
+
+	_, _ = s.CanTeam(context.Background(), user, team, "settings:write")
+	ageTeamPermEntry(s, key, time.Now().Add(-time.Second))
+	// Out-of-band generation bump (what a revocation does) without touching
+	// the entry: the stale grant must NOT be served on the old generation.
+	s.cache.mu.Lock()
+	s.cache.gen[team]++
+	s.cache.mu.Unlock()
+	store.result = false
+
+	if ok, _ := s.CanTeam(context.Background(), user, team, "settings:write"); ok {
+		t.Fatal("revoked (generation-bumped) grant was stale-served")
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("expected a blocking re-query, got %d calls", n)
+	}
+}
+
+func TestCanTeamStaleDenialRefreshDropsEntry(t *testing.T) {
+	store := &countingStore{result: true}
+	s := newCachedForTest(store)
+	user, team := uuid.New(), uuid.New()
+	key := teamPermCacheKey{userID: user, teamID: team, permission: "settings:write"}
+
+	_, _ = s.CanTeam(context.Background(), user, team, "settings:write")
+	ageTeamPermEntry(s, key, time.Now().Add(-time.Second))
+	store.result = false // the grant has been revoked upstream
+
+	// Grace window: the stale grant is served once while the refresh runs.
+	if ok, _ := s.CanTeam(context.Background(), user, team, "settings:write"); !ok {
+		t.Fatal("expected stale serve inside grace")
+	}
+	waitForCalls(t, &store.calls, 2)
+	// The refresh saw the denial and dropped the entry: no more stale serves.
+	if ok, _ := s.CanTeam(context.Background(), user, team, "settings:write"); ok {
+		t.Fatal("denial-refreshed entry must not be served")
+	}
+}
+
+func TestCanTeamPastGraceBlocks(t *testing.T) {
+	store := &countingStore{result: true}
+	s := newCachedForTest(store)
+	user, team := uuid.New(), uuid.New()
+	key := teamPermCacheKey{userID: user, teamID: team, permission: "settings:write"}
+
+	_, _ = s.CanTeam(context.Background(), user, team, "settings:write")
+	ageTeamPermEntry(s, key, time.Now().Add(-teamPermStaleGrace-time.Second))
+
+	if ok, _ := s.CanTeam(context.Background(), user, team, "settings:write"); !ok {
+		t.Fatal("past-grace check must still succeed via blocking query")
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("past-grace entry must block on a fresh query, got %d calls", n)
+	}
+}

--- a/internal/authz/service.go
+++ b/internal/authz/service.go
@@ -153,10 +153,9 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 			c.mu.Unlock()
 			return true, nil
 		case now.Before(e.expiry.Add(teamPermStaleGrace)):
-			// Serve the just-expired grant and refresh behind the response, so
-			// a burst landing on an expired entry never queues. Errors are
-			// ignored: the entry stays servable for the grace window, and a
-			// revocation lands via the refresh (or the generation bump).
+			// Serve the just-expired grant, refresh behind the response.
+			// Errors are ignored: the entry stays servable for the grace
+			// window, and a revocation lands via the refresh (or the bump).
 			c.mu.Unlock()
 			go func() { _, _ = s.flightTeamPerm(context.Background(), key, observed) }()
 			return true, nil

--- a/internal/authz/service.go
+++ b/internal/authz/service.go
@@ -111,6 +111,12 @@ const teamPermCacheTTL = 10 * time.Second
 // point (mirrors apiKeyCacheMaxEntries).
 const teamPermCacheMaxEntries = 4096
 
+// teamPermStaleGrace: a TTL-expired grant is still served for this long while
+// one background flight refreshes it, so a burst landing on an expired entry
+// never queues behind the refresh. Widens the worst-case revocation window to
+// ttl+grace; an invalidated (generation-bumped) entry is never stale-served.
+const teamPermStaleGrace = 2 * time.Second
+
 // Can checks either team-scoped or platform-scoped access depending on teamID.
 // Team permissions require a non-nil teamID. Platform permissions must use the
 // platform:* naming convention and must not pass a teamID.
@@ -138,21 +144,37 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 	c := s.cache
 
 	key := teamPermCacheKey{userID: userID, teamID: teamID, permission: permission}
+	now := time.Now()
 	c.mu.Lock()
 	observed := c.gen[teamID]
-	if e, ok := c.m[key]; ok {
-		if e.epoch == observed && time.Now().Before(e.expiry) {
+	if e, ok := c.m[key]; ok && e.epoch == observed {
+		switch {
+		case now.Before(e.expiry):
 			c.mu.Unlock()
 			return true, nil
+		case now.Before(e.expiry.Add(teamPermStaleGrace)):
+			// Serve the just-expired grant and refresh behind the response, so
+			// a burst landing on an expired entry never queues. Errors are
+			// ignored: the entry stays servable for the grace window, and a
+			// revocation lands via the refresh (or the generation bump).
+			c.mu.Unlock()
+			go func() { _, _ = s.flightTeamPerm(context.Background(), key, observed) }()
+			return true, nil
 		}
-		delete(c.m, key) // stale generation or expired
 	}
+	delete(c.m, key) // wrong generation or past grace
 	c.mu.Unlock()
 
-	// The generation is in the singleflight key: a request that observes a newer
-	// generation (post-revocation) will not coalesce onto an in-flight
-	// pre-revocation query, so it can't be handed that query's stale grant.
-	sfKey := fmt.Sprintf("%s|%s|%s|%d", userID, teamID, permission, observed)
+	return s.flightTeamPerm(ctx, key, observed)
+}
+
+// flightTeamPerm runs the coalesced permission query and stores a positive
+// result. The generation is in the singleflight key: a request that observes a
+// newer generation (post-revocation) will not coalesce onto an in-flight
+// pre-revocation query, so it can't be handed that query's stale grant.
+func (s *Service) flightTeamPerm(ctx context.Context, key teamPermCacheKey, observed uint64) (bool, error) {
+	c := s.cache
+	sfKey := fmt.Sprintf("%s|%s|%s|%d", key.userID, key.teamID, key.permission, observed)
 	result, err, _ := c.group.Do(sfKey, func() (interface{}, error) {
 		// Expiry is stamped from the query start so a slow query can't stretch
 		// the revocation window past the TTL.
@@ -161,7 +183,7 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 		// fresh deadline keeps a slow check from hanging.
 		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
-		allowed, err := s.canTeamQuery(qctx, userID, teamID, permission)
+		allowed, err := s.canTeamQuery(qctx, key.userID, key.teamID, key.permission)
 		if err != nil {
 			return nil, err
 		}
@@ -171,19 +193,22 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 		return false, err
 	}
 	res := result.(teamPermResult)
-	if res.allowed {
-		c.mu.Lock()
-		// Store only if the generation is still current: a revocation that
-		// landed while the query was in flight makes this result stale, and
-		// storing it would clobber a fresher post-revocation entry.
-		if c.gen[teamID] == res.epoch {
+	c.mu.Lock()
+	// Store only if the generation is still current: a revocation that landed
+	// while the query was in flight makes this result stale, and storing it
+	// would clobber a fresher post-revocation entry. A refreshed denial drops
+	// the entry so a revoked grant stops being stale-servable immediately.
+	if c.gen[key.teamID] == res.epoch {
+		if res.allowed {
 			if len(c.m) >= teamPermCacheMaxEntries {
 				c.sweepLocked(time.Now())
 			}
 			c.m[key] = teamPermCacheEntry{expiry: res.start.Add(c.ttl), epoch: res.epoch}
+		} else {
+			delete(c.m, key)
 		}
-		c.mu.Unlock()
 	}
+	c.mu.Unlock()
 	return res.allowed, nil
 }
 

--- a/internal/authz/service.go
+++ b/internal/authz/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/db"
@@ -83,8 +84,9 @@ type teamPermCacheKey struct {
 }
 
 type teamPermCacheEntry struct {
-	expiry time.Time
-	epoch  uint64
+	expiry     time.Time
+	epoch      uint64
+	refreshing bool // a stale-serve refresh is in flight; cleared when the entry is replaced or the refresh fails
 }
 
 // teamPermResult is the singleflight payload: the grant, the generation
@@ -96,13 +98,14 @@ type teamPermResult struct {
 	start   time.Time
 }
 
-// teamPermCacheTTL is the revocation contract: a role or membership change
-// takes effect within this window, everywhere. The cache is per-process and
-// instances don't coordinate, so InvalidateTeam can only tighten the instance
-// that handled the change — other instances, and RBAC writes that bypass the
-// API entirely (team-migration tooling, support SQL, the DB-trigger cascade on
-// membership rows), converge at TTL expiry. Same accepted window as the
-// API-key cache. If a permission ever requires immediate cross-instance
+// teamPermCacheTTL plus teamPermStaleGrace is the revocation contract: a role
+// or membership change takes effect within ttl+grace, everywhere. The cache is
+// per-process and instances don't coordinate, so InvalidateTeam can only
+// tighten the instance that handled the change — other instances, and RBAC
+// writes that bypass the API entirely (team-migration tooling, support SQL,
+// the DB-trigger cascade on membership rows), converge once their entries
+// expire and the stale-serve refresh observes the change. Same accepted window
+// as the API-key cache. If a permission ever requires immediate cross-instance
 // revocation, replace this cache with a DB-backed per-team generation.
 const teamPermCacheTTL = 10 * time.Second
 
@@ -153,11 +156,18 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 			c.mu.Unlock()
 			return true, nil
 		case now.Before(e.expiry.Add(teamPermStaleGrace)):
-			// Serve the just-expired grant, refresh behind the response.
-			// Errors are ignored: the entry stays servable for the grace
-			// window, and a revocation lands via the refresh (or the bump).
+			// Serve the just-expired grant; the first observer arms the one
+			// background refresh. A revocation lands via the refresh (a
+			// refreshed denial deletes the entry) or via the generation bump.
+			spawn := !e.refreshing
+			if spawn {
+				e.refreshing = true
+				c.m[key] = e
+			}
 			c.mu.Unlock()
-			go func() { _, _ = s.flightTeamPerm(context.Background(), key, observed) }()
+			if spawn {
+				go s.refreshTeamPerm(key, observed)
+			}
 			return true, nil
 		}
 	}
@@ -165,6 +175,23 @@ func (s *Service) CanTeam(ctx context.Context, userID, teamID uuid.UUID, permiss
 	c.mu.Unlock()
 
 	return s.flightTeamPerm(ctx, key, observed)
+}
+
+// refreshTeamPerm runs the background refresh behind a stale serve. On success
+// the flight replaces (or, on denial, deletes) the entry, which re-arms the
+// trigger; on a transient error the trigger re-arms here so a later request
+// inside the grace window retries, and the stale entry stays servable.
+func (s *Service) refreshTeamPerm(key teamPermCacheKey, observed uint64) {
+	if _, err := s.flightTeamPerm(context.Background(), key, observed); err != nil {
+		log.Warn().Err(err).Msg("team permission refresh failed; serving stale until the grace window expires")
+		c := s.cache
+		c.mu.Lock()
+		if e, ok := c.m[key]; ok && e.epoch == observed {
+			e.refreshing = false
+			c.m[key] = e
+		}
+		c.mu.Unlock()
+	}
 }
 
 // flightTeamPerm runs the coalesced permission query and stores a positive
@@ -229,8 +256,8 @@ func (c *teamPermCache) sweepLocked(now time.Time) {
 // role or membership change. Bumping the generation is the correctness
 // mechanism — in-flight misses that observed the old generation are discarded
 // at store time; the deletes just reclaim memory. Other instances converge
-// within the TTL (the cross-instance contract lives on defaultTeamPermCacheTTL).
-// No-op on uncached instances.
+// within ttl+grace (the cross-instance contract lives on teamPermCacheTTL and
+// teamPermStaleGrace). No-op on uncached instances.
 func (s *Service) InvalidateTeam(teamID uuid.UUID) {
 	if s == nil || s.cache == nil {
 		return

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -264,14 +264,15 @@ func (q *Queries) MarkHostUnhealthy(ctx context.Context, id string) error {
 
 const updateHostHeartbeat = `-- name: UpdateHostHeartbeat :one
 WITH prev AS (
-    SELECT h.status FROM host h WHERE h.id = $1
+    SELECT h.id, h.status FROM host h WHERE h.id = $1 FOR UPDATE
 )
 UPDATE host
 SET last_heartbeat_at = now(),
     status = CASE WHEN host.status = 'unhealthy' THEN 'active' ELSE host.status END,
     updated_at = now()
-WHERE host.id = $1
-RETURNING id, vmd_addr, proxy_addr, region, status, capacity_memory_mib, capacity_vcpus, last_heartbeat_at, created_at, updated_at, (SELECT prev.status FROM prev) AS prev_status
+FROM prev
+WHERE host.id = prev.id
+RETURNING host.id, host.vmd_addr, host.proxy_addr, host.region, host.status, host.capacity_memory_mib, host.capacity_vcpus, host.last_heartbeat_at, host.created_at, host.updated_at, prev.status AS prev_status
 `
 
 type UpdateHostHeartbeatRow struct {
@@ -291,9 +292,11 @@ type UpdateHostHeartbeatRow struct {
 // Returns the host row so the caller can verify the host exists. Also
 // re-activates unhealthy hosts that resume heartbeating — this is the
 // automatic recovery path after a transient network outage. prev_status lets
-// the caller detect that transition (the CTE reads the pre-update snapshot)
-// and invalidate the scheduler's host cache so recovered capacity is usable
-// immediately instead of after the cache TTL.
+// the caller detect that transition and invalidate the scheduler's host cache
+// so recovered capacity is usable immediately instead of after the cache TTL.
+// The pre-image is read FOR UPDATE so it reflects the row version this
+// statement actually modifies; a plain snapshot read racing a concurrent
+// status write could report the transition as active→active and hide it.
 func (q *Queries) UpdateHostHeartbeat(ctx context.Context, id string) (UpdateHostHeartbeatRow, error) {
 	row := q.db.QueryRow(ctx, updateHostHeartbeat, id)
 	var i UpdateHostHeartbeatRow

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -263,20 +263,40 @@ func (q *Queries) MarkHostUnhealthy(ctx context.Context, id string) error {
 }
 
 const updateHostHeartbeat = `-- name: UpdateHostHeartbeat :one
+WITH prev AS (
+    SELECT h.status FROM host h WHERE h.id = $1
+)
 UPDATE host
 SET last_heartbeat_at = now(),
-    status = CASE WHEN status = 'unhealthy' THEN 'active' ELSE status END,
+    status = CASE WHEN host.status = 'unhealthy' THEN 'active' ELSE host.status END,
     updated_at = now()
-WHERE id = $1
-RETURNING id, vmd_addr, proxy_addr, region, status, capacity_memory_mib, capacity_vcpus, last_heartbeat_at, created_at, updated_at
+WHERE host.id = $1
+RETURNING id, vmd_addr, proxy_addr, region, status, capacity_memory_mib, capacity_vcpus, last_heartbeat_at, created_at, updated_at, (SELECT prev.status FROM prev) AS prev_status
 `
+
+type UpdateHostHeartbeatRow struct {
+	ID                string             `json:"id"`
+	VmdAddr           string             `json:"vmd_addr"`
+	ProxyAddr         string             `json:"proxy_addr"`
+	Region            string             `json:"region"`
+	Status            string             `json:"status"`
+	CapacityMemoryMib int32              `json:"capacity_memory_mib"`
+	CapacityVcpus     int32              `json:"capacity_vcpus"`
+	LastHeartbeatAt   pgtype.Timestamptz `json:"last_heartbeat_at"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	PrevStatus        string             `json:"prev_status"`
+}
 
 // Returns the host row so the caller can verify the host exists. Also
 // re-activates unhealthy hosts that resume heartbeating — this is the
-// automatic recovery path after a transient network outage.
-func (q *Queries) UpdateHostHeartbeat(ctx context.Context, id string) (Host, error) {
+// automatic recovery path after a transient network outage. prev_status lets
+// the caller detect that transition (the CTE reads the pre-update snapshot)
+// and invalidate the scheduler's host cache so recovered capacity is usable
+// immediately instead of after the cache TTL.
+func (q *Queries) UpdateHostHeartbeat(ctx context.Context, id string) (UpdateHostHeartbeatRow, error) {
 	row := q.db.QueryRow(ctx, updateHostHeartbeat, id)
-	var i Host
+	var i UpdateHostHeartbeatRow
 	err := row.Scan(
 		&i.ID,
 		&i.VmdAddr,
@@ -288,6 +308,7 @@ func (q *Queries) UpdateHostHeartbeat(ctx context.Context, id string) (Host, err
 		&i.LastHeartbeatAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PrevStatus,
 	)
 	return i, err
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/superserve-ai/sandbox/internal/db"
@@ -34,9 +35,10 @@ type LeastLoaded struct {
 	DefaultHostID string        // fallback when no host rows exist
 	TTL           time.Duration // 0 = use defaultCacheTTL
 
-	mu       sync.RWMutex
-	cached   []db.ListActiveHostsByLoadRow
-	cachedAt time.Time
+	mu         sync.RWMutex
+	cached     []db.ListActiveHostsByLoadRow
+	cachedAt   time.Time
+	refreshing atomic.Bool // one background refresh at a time
 }
 
 func (s *LeastLoaded) ttl() time.Duration {
@@ -76,21 +78,41 @@ func (s *LeastLoaded) SelectHost(ctx context.Context) (string, error) {
 	return hosts[b].ID, nil
 }
 
+// loadHosts serves whatever list is cached — stale included — and refreshes it
+// in the background once the TTL lapses, so callers never queue behind the
+// refresh. Only the very first call (or the first after Invalidate) blocks.
+// Serving an arbitrarily stale list is safe here: the host set changes via ops
+// actions, which call Invalidate for an immediate reload.
 func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoadRow, error) {
 	s.mu.RLock()
-	if s.cached != nil && time.Since(s.cachedAt) < s.ttl() {
-		hosts := s.cached
-		s.mu.RUnlock()
-		return hosts, nil
-	}
+	cached, cachedAt := s.cached, s.cachedAt
 	s.mu.RUnlock()
+	if cached != nil {
+		if time.Since(cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
+			// Detached: the refresh outlives the triggering request. On error
+			// the stale list stays servable and the next expired call retries.
+			qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			go func() {
+				defer cancel()
+				defer s.refreshing.Store(false)
+				hosts, err := s.DB.ListActiveHostsByLoad(qctx)
+				if err != nil {
+					return
+				}
+				s.mu.Lock()
+				s.cached = hosts
+				s.cachedAt = time.Now()
+				s.mu.Unlock()
+			}()
+		}
+		return cached, nil
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cached != nil && time.Since(s.cachedAt) < s.ttl() {
+	if s.cached != nil {
 		return s.cached, nil
 	}
-
 	hosts, err := s.DB.ListActiveHostsByLoad(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list active hosts by load: %w", err)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/superserve-ai/sandbox/internal/db"
 )
 
@@ -38,7 +40,7 @@ type LeastLoaded struct {
 	mu         sync.RWMutex
 	cached     []db.ListActiveHostsByLoadRow
 	cachedAt   time.Time
-	gen        uint64      // bumped by Invalidate; discards refreshes that started earlier
+	gen        uint64      // bumped by Invalidate and blocking reloads; discards refreshes that started earlier
 	refreshing atomic.Bool // one background refresh at a time
 }
 
@@ -110,11 +112,13 @@ func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoad
 				defer s.refreshing.Store(false)
 				hosts, err := s.DB.ListActiveHostsByLoad(qctx)
 				if err != nil {
+					log.Warn().Err(err).Msg("host list refresh failed; serving stale until the grace window expires")
 					return
 				}
 				s.mu.Lock()
-				// Discard results from before the latest Invalidate: storing
-				// them would resurrect a host list the invalidation retired.
+				// Discard results from before the latest Invalidate or blocking
+				// reload: storing them would resurrect a host list a newer,
+				// fresher load already replaced.
 				if s.gen == startGen {
 					s.cached = hosts
 					s.cachedAt = time.Now()
@@ -136,6 +140,9 @@ func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoad
 	if err != nil {
 		return nil, fmt.Errorf("list active hosts by load: %w", err)
 	}
+	// Bump the generation so an older in-flight background refresh cannot
+	// land after this load and replace it with its earlier snapshot.
+	s.gen++
 	s.cached = hosts
 	s.cachedAt = time.Now()
 	return hosts, nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -79,15 +79,27 @@ func (s *LeastLoaded) SelectHost(ctx context.Context) (string, error) {
 	return hosts[b].ID, nil
 }
 
-// loadHosts serves whatever list is cached — stale included — and refreshes it
-// in the background once the TTL lapses, so callers never queue behind the
-// refresh. Only the very first call (or the first after Invalidate) blocks.
-// Serving an arbitrarily stale list is safe here: the host set changes via ops
-// actions, which call Invalidate for an immediate reload.
+// hostsStaleGrace bounds how long an expired host list keeps being served
+// while refreshes run (or fail) in the background. Host health flows through
+// the DB — the detector marks missed-heartbeat hosts unhealthy and the next
+// refresh drops them — so the worst case for routing to a dead host is
+// ttl+grace, and persistent refresh failures degrade to blocking (erroring)
+// loads instead of serving a dead list forever.
+const hostsStaleGrace = 30 * time.Second
+
+// loadHosts serves the cached list — stale included, up to hostsStaleGrace —
+// and refreshes it in the background once the TTL lapses, so callers never
+// queue behind the refresh. The very first call, a post-Invalidate call, and
+// any call past the grace window block on a fresh load.
 func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoadRow, error) {
 	s.mu.RLock()
 	cached, cachedAt, startGen := s.cached, s.cachedAt, s.gen
 	s.mu.RUnlock()
+	if cached != nil && time.Since(cachedAt) >= s.ttl()+hostsStaleGrace {
+		// Past the grace window (refreshes failing or never landing): stop
+		// serving the old list and force a blocking reload below.
+		cached = nil
+	}
 	if cached != nil {
 		if time.Since(cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
 			// Detached: the refresh outlives the triggering request. On error
@@ -115,7 +127,9 @@ func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoad
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cached != nil {
+	// Double-check: another blocked caller may have reloaded while we waited.
+	// A past-grace list does not count — it is what we are here to replace.
+	if s.cached != nil && time.Since(s.cachedAt) < s.ttl()+hostsStaleGrace {
 		return s.cached, nil
 	}
 	hosts, err := s.DB.ListActiveHostsByLoad(ctx)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -38,6 +38,7 @@ type LeastLoaded struct {
 	mu         sync.RWMutex
 	cached     []db.ListActiveHostsByLoadRow
 	cachedAt   time.Time
+	gen        uint64      // bumped by Invalidate; discards refreshes that started earlier
 	refreshing atomic.Bool // one background refresh at a time
 }
 
@@ -85,7 +86,7 @@ func (s *LeastLoaded) SelectHost(ctx context.Context) (string, error) {
 // actions, which call Invalidate for an immediate reload.
 func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoadRow, error) {
 	s.mu.RLock()
-	cached, cachedAt := s.cached, s.cachedAt
+	cached, cachedAt, startGen := s.cached, s.cachedAt, s.gen
 	s.mu.RUnlock()
 	if cached != nil {
 		if time.Since(cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
@@ -100,8 +101,12 @@ func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoad
 					return
 				}
 				s.mu.Lock()
-				s.cached = hosts
-				s.cachedAt = time.Now()
+				// Discard results from before the latest Invalidate: storing
+				// them would resurrect a host list the invalidation retired.
+				if s.gen == startGen {
+					s.cached = hosts
+					s.cachedAt = time.Now()
+				}
 				s.mu.Unlock()
 			}()
 		}
@@ -126,6 +131,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context) ([]db.ListActiveHostsByLoad
 // changes immediately.
 func (s *LeastLoaded) Invalidate() {
 	s.mu.Lock()
+	s.gen++
 	s.cached = nil
 	s.cachedAt = time.Time{}
 	s.mu.Unlock()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,8 +15,9 @@ import (
 
 // hostStore is a fake db.DBTX serving one host row per Query and counting calls.
 type hostStore struct {
-	calls atomic.Int64
-	block chan struct{} // non-nil: Query waits until closed
+	calls       atomic.Int64
+	block       chan struct{} // non-nil: Query waits until closed
+	blockOnCall int64         // 0 = block every call; N = block only the Nth
 }
 
 func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
@@ -23,15 +25,19 @@ func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.Comman
 }
 func (h *hostStore) QueryRow(context.Context, string, ...interface{}) pgx.Row { return nil }
 func (h *hostStore) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
-	h.calls.Add(1)
-	if h.block != nil {
+	n := h.calls.Add(1)
+	if h.block != nil && (h.blockOnCall == 0 || n == h.blockOnCall) {
 		<-h.block
 	}
-	return &hostRows{}, nil
+	return &hostRows{id: fmt.Sprintf("host-%d", n)}, nil
 }
 
-// hostRows yields a single minimal host row.
-type hostRows struct{ done bool }
+// hostRows yields a single minimal host row whose ID names the query that
+// produced it, so tests can tell which load's result the cache holds.
+type hostRows struct {
+	id   string
+	done bool
+}
 
 func (r *hostRows) Close()                                       {}
 func (r *hostRows) Err() error                                   { return nil }
@@ -48,7 +54,7 @@ func (r *hostRows) Next() bool {
 	return true
 }
 func (r *hostRows) Scan(dest ...any) error {
-	*dest[0].(*string) = "host-1" // id; remaining columns keep zero values
+	*dest[0].(*string) = r.id // remaining columns keep zero values
 	return nil
 }
 
@@ -217,5 +223,54 @@ func TestLoadHostsPastGraceBlocksInsteadOfServingStale(t *testing.T) {
 	}
 	if n := store.calls.Load(); n != 2 {
 		t.Fatalf("past-grace select must reload synchronously, got %d queries", n)
+	}
+}
+
+func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background()); err != nil { // query 1
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Hold only the background refresh (query 2) in flight.
+	store.block = make(chan struct{})
+	store.blockOnCall = 2
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-s.ttl() - 5*time.Second) // stale, inside grace
+	s.mu.Unlock()
+	if _, err := s.SelectHost(context.Background()); err != nil { // kicks the refresh
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 2 { // refresh goroutine reached its (blocked) query
+		if time.Now().After(deadline) {
+			t.Fatalf("refresh never started, calls=%d", store.calls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Age past grace: the next call reloads synchronously (query 3) and must
+	// retire the still-hanging refresh so its older result cannot land on top.
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("past-grace select: %v", err)
+	}
+	close(store.block) // the pre-reload refresh now returns
+
+	deadline = time.Now().Add(2 * time.Second)
+	for s.refreshing.Load() { // wait until the refresh goroutine finished
+		if time.Now().After(deadline) {
+			t.Fatal("refresh goroutine never finished")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	s.mu.RLock()
+	id := s.cached[0].ID
+	s.mu.RUnlock()
+	if id != "host-3" {
+		t.Fatalf("older refresh clobbered the blocking reload: cached %s, want host-3", id)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,154 @@
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// hostStore is a fake db.DBTX serving one host row per Query and counting calls.
+type hostStore struct {
+	calls atomic.Int64
+	block chan struct{} // non-nil: Query waits until closed
+}
+
+func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+func (h *hostStore) QueryRow(context.Context, string, ...interface{}) pgx.Row { return nil }
+func (h *hostStore) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
+	h.calls.Add(1)
+	if h.block != nil {
+		<-h.block
+	}
+	return &hostRows{}, nil
+}
+
+// hostRows yields a single minimal host row.
+type hostRows struct{ done bool }
+
+func (r *hostRows) Close()                                       {}
+func (r *hostRows) Err() error                                   { return nil }
+func (r *hostRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *hostRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *hostRows) Values() ([]any, error)                       { return nil, nil }
+func (r *hostRows) RawValues() [][]byte                          { return nil }
+func (r *hostRows) Conn() *pgx.Conn                              { return nil }
+func (r *hostRows) Next() bool {
+	if r.done {
+		return false
+	}
+	r.done = true
+	return true
+}
+func (r *hostRows) Scan(dest ...any) error {
+	*dest[0].(*string) = "host-1" // id; remaining columns keep zero values
+	return nil
+}
+
+func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+
+	// First call blocks and fills the cache.
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("first select: %v", err)
+	}
+	if n := store.calls.Load(); n != 1 {
+		t.Fatalf("expected 1 query, got %d", n)
+	}
+
+	// Age the cache far past the TTL; the next call must serve instantly from
+	// the stale list and refresh behind it.
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh never ran, calls=%d", store.calls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Refresh landed: cache is fresh again, further calls stay cached.
+	s.mu.RLock()
+	fresh := time.Since(s.cachedAt) < time.Minute
+	s.mu.RUnlock()
+	if !fresh {
+		t.Fatal("refresh must restore a fresh cachedAt")
+	}
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("post-refresh select: %v", err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("fresh cache must not re-query, got %d", n)
+	}
+}
+
+func TestLoadHostsStaleServeDoesNotBlockOnSlowRefresh(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Refresh query hangs; stale selects must return instantly anyway, and the
+	// CAS guard must keep it to a single in-flight refresh.
+	store.block = make(chan struct{})
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 10; i++ {
+			_, _ = s.SelectHost(context.Background())
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stale selects blocked behind the hanging refresh")
+	}
+	// Wait for the (single) guarded refresh goroutine to reach its query, then
+	// confirm the CAS kept it to exactly one despite 10 stale selects.
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("refresh goroutine never started, calls=%d", store.calls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if n := store.calls.Load(); n != 2 { // prime + one guarded refresh
+		t.Errorf("expected a single in-flight refresh, got %d queries", n)
+	}
+	close(store.block)
+}
+
+func TestInvalidateForcesBlockingReload(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	s.Invalidate()
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("post-invalidate select: %v", err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("invalidate must force a blocking reload, got %d queries", n)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -152,3 +152,49 @@ func TestInvalidateForcesBlockingReload(t *testing.T) {
 		t.Fatalf("invalidate must force a blocking reload, got %d queries", n)
 	}
 }
+
+func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Hold a background refresh in flight, then invalidate underneath it.
+	store.block = make(chan struct{})
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+	if _, err := s.SelectHost(context.Background()); err != nil { // triggers the refresh
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 2 { // refresh goroutine reached its (blocked) query
+		if time.Now().After(deadline) {
+			t.Fatalf("refresh never started, calls=%d", store.calls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	s.Invalidate()      // host retired while the refresh holds the old list
+	close(store.block)  // the pre-invalidation refresh now returns
+
+	// The stale refresh must be discarded: the cache stays empty until a
+	// fresh blocking load, not resurrected with the pre-invalidation list.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		s.mu.RLock()
+		resurrected := s.cached != nil
+		s.mu.RUnlock()
+		if !resurrected && !s.refreshing.Load() {
+			break // refresh finished and stored nothing
+		}
+		if resurrected {
+			t.Fatal("pre-invalidation refresh resurrected the retired host list")
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("refresh goroutine never finished")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -67,7 +67,7 @@ func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
 	// Age the cache far past the TTL; the next call must serve instantly from
 	// the stale list and refresh behind it.
 	s.mu.Lock()
-	s.cachedAt = time.Now().Add(-time.Hour)
+	s.cachedAt = time.Now().Add(-s.ttl() - 5*time.Second) // stale, inside grace
 	s.mu.Unlock()
 
 	if _, err := s.SelectHost(context.Background()); err != nil {
@@ -107,7 +107,7 @@ func TestLoadHostsStaleServeDoesNotBlockOnSlowRefresh(t *testing.T) {
 	// CAS guard must keep it to a single in-flight refresh.
 	store.block = make(chan struct{})
 	s.mu.Lock()
-	s.cachedAt = time.Now().Add(-time.Hour)
+	s.cachedAt = time.Now().Add(-s.ttl() - 5*time.Second) // stale, inside grace
 	s.mu.Unlock()
 
 	done := make(chan struct{})
@@ -163,7 +163,7 @@ func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 	// Hold a background refresh in flight, then invalidate underneath it.
 	store.block = make(chan struct{})
 	s.mu.Lock()
-	s.cachedAt = time.Now().Add(-time.Hour)
+	s.cachedAt = time.Now().Add(-s.ttl() - 5*time.Second) // stale, inside grace
 	s.mu.Unlock()
 	if _, err := s.SelectHost(context.Background()); err != nil { // triggers the refresh
 		t.Fatalf("stale select: %v", err)
@@ -196,5 +196,26 @@ func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 			t.Fatal("refresh goroutine never finished")
 		}
 		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func TestLoadHostsPastGraceBlocksInsteadOfServingStale(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// Way past ttl+grace (refreshes never landed): must block on a fresh
+	// load, not keep serving a possibly-dead host list.
+	s.mu.Lock()
+	s.cachedAt = time.Now().Add(-time.Hour)
+	s.mu.Unlock()
+
+	if _, err := s.SelectHost(context.Background()); err != nil {
+		t.Fatalf("past-grace select: %v", err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("past-grace select must reload synchronously, got %d queries", n)
 	}
 }

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -103,11 +103,12 @@ type Resolver func(ctx context.Context, hostID string) (vmdclient.Client, error)
 // state lives in the DB. Safe to instantiate once at controlplane boot and
 // Start() with the process-lifetime context.
 type BuildSupervisor struct {
-	cfg       BuildSupervisorConfig
-	q         *db.Queries
-	resolve   Resolver
-	log       zerolog.Logger
-	analytics *analytics.Client // when set, emits build-outcome events; nil is a no-op
+	cfg        BuildSupervisorConfig
+	q          *db.Queries
+	resolve    Resolver
+	log        zerolog.Logger
+	analytics  *analytics.Client   // when set, emits build-outcome events; nil is a no-op
+	onFinalize func(tpl uuid.UUID) // when set, runs after a build lands new template paths; nil is a no-op
 }
 
 // NewBuildSupervisor constructs a supervisor.
@@ -123,6 +124,14 @@ func NewBuildSupervisor(cfg BuildSupervisorConfig, q *db.Queries, resolve Resolv
 // WithAnalytics enables build-outcome events (succeeded/failed).
 func (s *BuildSupervisor) WithAnalytics(a *analytics.Client) *BuildSupervisor {
 	s.analytics = a
+	return s
+}
+
+// WithFinalizeHook runs fn with the template ID after a build finalizes new
+// snapshot paths — wired to the API's template-cache invalidation so creates
+// pick up a rebuilt template at the next lookup instead of at cache expiry.
+func (s *BuildSupervisor) WithFinalizeHook(fn func(tpl uuid.UUID)) *BuildSupervisor {
+	s.onFinalize = fn
 	return s
 }
 
@@ -443,7 +452,7 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 		if res.DeltaPath != "" {
 			deltaPathArg = &res.DeltaPath
 		}
-		_, err := s.q.FinalizeBuild(finCtx, db.FinalizeBuildParams{
+		tpl, err := s.q.FinalizeBuild(finCtx, db.FinalizeBuildParams{
 			ID:           row.ID,
 			RootfsPath:   &rootfs,
 			SnapshotPath: &snapPath,
@@ -460,6 +469,9 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 		if err != nil {
 			rowLog.Error().Err(err).Msg("finalize build")
 			return
+		}
+		if s.onFinalize != nil {
+			s.onFinalize(tpl.ID)
 		}
 		rowLog.Info().Str("digest", res.ResolvedDigest).Int64("size", size).Msg("build ready")
 		s.logBuildCompleted(ctx, row, "success", "", res.ResolvedDigest)


### PR DESCRIPTION
A burst arriving on an expired cache entry used to queue behind the refresh: singleflight kept it to one query, but every request arriving during that flight carried the wait. This applies stale-while-revalidate to the four control-plane caches — a just-expired entry is served immediately while one coalesced background flight refreshes it, so bursts never queue on cache expiry.

Per cache, with the staleness each can afford:

- **API key** (grace 2s): worst-case revocation widens ttl→ttl+2s; an expired `expires_at` on the key itself is still checked exactly and never stale-served.
- **Team permissions** (grace 2s): an invalidated (generation-bumped) entry is never stale-served, so same-instance revocation stays immediate; a background refresh that discovers a denial drops the entry, ending stale serves for it at once.
- **Template** (grace 30s): bounds how long a rebuilt/deleted template's old snapshot paths can be handed out; a refresh that finds the template gone drops the entry.
- **Host list** (unbounded): the host set changes via ops actions that call Invalidate for an immediate blocking reload; otherwise any cached list is servable while a CAS-guarded background refresh runs.

The only requests that ever block on a lookup are true first uses (nothing cached) and entries past their grace window.

Tests cover, per cache: stale-serve inside grace, background refresh landing (single coalesced flight), past-grace blocking, and the safety invariants — generation bump beats stale-serve, denial refresh drops the entry, key expiry never stale-served, Invalidate forces a blocking reload.