### PR TITLE
proxy: give exec WebSocket frames their own size limit

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -972,7 +972,9 @@ paths:
         - Client frames: a binary frame is stdin, prefixed with channel `0x00`
           (`[0x00][bytes]`); a text frame is JSON control —
           `{"type":"stdin_close"}` or `{"type":"signal","name":"SIGINT"}`.
-          Frames are capped at 64 KiB, so chunk larger stdin.
+          Client frames are capped at 4 MiB (servers may enforce as low as
+          64 KiB during rollout); frames over the cap close the socket with
+          code 1009, so chunk larger stdin.
         - Server frames: a binary frame is output, prefixed with its channel
           (`0x01` stdout, `0x02` stderr); a text frame is JSON lifecycle —
           `{"exit_code":N,"finished":true}`, or `{"error":"...","code":"..."}`.

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -42,7 +41,9 @@ const (
 	// frames legitimately carry a whole command string (start frame) or a
 	// stdin chunk — unlike the terminal's keystroke-sized maxReadBytes — so
 	// this is sized for payloads, not keystrokes, while still capping what a
-	// single frame can make the bridge buffer.
+	// single frame can make the bridge buffer. The SDKs chunk stdin at
+	// 32 KiB; never lower this below that or chunked stdin starts dying
+	// with 1009 closes.
 	maxExecReadBytes = 4 << 20
 )
 
@@ -174,7 +175,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	typ, raw, err := ws.Read(readCtx)
 	readCancel()
 	if err != nil {
-		logExecReadEnd(l, err)
+		logWSReadEnd(l, err, maxExecReadBytes, "exec/ws")
 		_ = ws.Close(websocket.StatusPolicyViolation, "expected start message")
 		return
 	}
@@ -317,7 +318,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 			typ, data, err := ws.Read(bridgeCtx)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					logExecReadEnd(l, err)
+					logWSReadEnd(l, err, maxExecReadBytes, "exec/ws")
 				}
 				return
 			}
@@ -380,22 +381,6 @@ func (h *Handler) handleExecControl(ctx context.Context, client boxdpbconnect.Pr
 
 	default:
 		l.Debug().Str("type", msg.Type).Msg("exec/ws: unknown control type")
-	}
-}
-
-// logExecReadEnd separates a frame that blew the read limit — a client-visible
-// failure worth a warn — from routine socket teardown. The library reports the
-// limit breach only via error text, and has already closed the connection with
-// StatusMessageTooBig by the time Read returns.
-func logExecReadEnd(l zerolog.Logger, err error) {
-	if strings.Contains(err.Error(), "read limited at") {
-		l.Warn().Err(err).Int("limit_bytes", maxExecReadBytes).
-			Msg("exec/ws: client frame exceeded read limit")
-		return
-	}
-	closeErr := websocket.CloseStatus(err)
-	if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
-		l.Debug().Err(err).Msg("exec/ws: WS read ended")
 	}
 }
 

--- a/internal/proxy/exec_ws.go
+++ b/internal/proxy/exec_ws.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -36,6 +37,13 @@ const (
 	execChStdin  = 0x00
 	execChStdout = 0x01
 	execChStderr = 0x02
+
+	// maxExecReadBytes bounds a single client frame on the exec socket. Exec
+	// frames legitimately carry a whole command string (start frame) or a
+	// stdin chunk — unlike the terminal's keystroke-sized maxReadBytes — so
+	// this is sized for payloads, not keystrokes, while still capping what a
+	// single frame can make the bridge buffer.
+	maxExecReadBytes = 4 << 20
 )
 
 // execPingInterval is how often the bridge pings the client; a missed pong
@@ -143,7 +151,7 @@ func (h *Handler) serveExecWS(w http.ResponseWriter, r *http.Request, instanceID
 		h.log.Warn().Err(err).Msg("exec/ws: WS upgrade failed")
 		return
 	}
-	ws.SetReadLimit(maxReadBytes)
+	ws.SetReadLimit(maxExecReadBytes)
 
 	transport := h.transports.get(instanceID, info)
 	httpClient := &http.Client{Transport: transport}
@@ -166,6 +174,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 	typ, raw, err := ws.Read(readCtx)
 	readCancel()
 	if err != nil {
+		logExecReadEnd(l, err)
 		_ = ws.Close(websocket.StatusPolicyViolation, "expected start message")
 		return
 	}
@@ -308,10 +317,7 @@ func (h *Handler) bridgeExecWS(ctx context.Context, ws *websocket.Conn, procClie
 			typ, data, err := ws.Read(bridgeCtx)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					closeErr := websocket.CloseStatus(err)
-					if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
-						l.Debug().Err(err).Msg("exec/ws: WS read ended")
-					}
+					logExecReadEnd(l, err)
 				}
 				return
 			}
@@ -374,6 +380,22 @@ func (h *Handler) handleExecControl(ctx context.Context, client boxdpbconnect.Pr
 
 	default:
 		l.Debug().Str("type", msg.Type).Msg("exec/ws: unknown control type")
+	}
+}
+
+// logExecReadEnd separates a frame that blew the read limit — a client-visible
+// failure worth a warn — from routine socket teardown. The library reports the
+// limit breach only via error text, and has already closed the connection with
+// StatusMessageTooBig by the time Read returns.
+func logExecReadEnd(l zerolog.Logger, err error) {
+	if strings.Contains(err.Error(), "read limited at") {
+		l.Warn().Err(err).Int("limit_bytes", maxExecReadBytes).
+			Msg("exec/ws: client frame exceeded read limit")
+		return
+	}
+	closeErr := websocket.CloseStatus(err)
+	if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
+		l.Debug().Err(err).Msg("exec/ws: WS read ended")
 	}
 }
 

--- a/internal/proxy/exec_ws_test.go
+++ b/internal/proxy/exec_ws_test.go
@@ -67,6 +67,9 @@ func newExecWSTestEnv(t *testing.T) *execWSTestEnv {
 			t.Errorf("ws accept: %v", err)
 			return
 		}
+		// Mirror serveExecWS so tests exercise the production frame limit,
+		// not the library's much smaller default.
+		ws.SetReadLimit(maxExecReadBytes)
 		h.bridgeExecWS(r.Context(), ws, procClient, "sbx-test")
 	}))
 
@@ -238,6 +241,56 @@ func TestExecWS_BinaryFrameIsStdin(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SendInput")
+	}
+}
+
+// TestExecWS_LargeStdinFrameForwarded guards the exec socket's frame budget:
+// a stdin frame well past the terminal bridge's 64 KiB keystroke limit must
+// reach boxd intact, since exec frames carry command payloads, not keystrokes.
+func TestExecWS_LargeStdinFrameForwarded(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "cat")
+
+	payload := bytes.Repeat([]byte("x"), 128*1024)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := env.clientWS.Write(ctx, websocket.MessageBinary, append([]byte{execChStdin}, payload...)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	select {
+	case got := <-env.fake.inputs:
+		if !bytes.Equal(got.Data, payload) {
+			t.Errorf("SendInput.Data = %d bytes, want %d intact", len(got.Data), len(payload))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SendInput — large frame likely rejected by read limit")
+	}
+}
+
+// TestExecWS_OversizedFrameClosesTooBig pins the failure mode when a client
+// exceeds maxExecReadBytes: the bridge closes with StatusMessageTooBig so the
+// client sees why, instead of an unexplained drop.
+func TestExecWS_OversizedFrameClosesTooBig(t *testing.T) {
+	env := newExecWSTestEnv(t)
+	env.sendStart(7, "cat")
+
+	payload := bytes.Repeat([]byte("x"), maxExecReadBytes+2)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := env.clientWS.Write(ctx, websocket.MessageBinary, append([]byte{execChStdin}, payload...)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	for {
+		_, _, err := env.clientWS.Read(ctx)
+		if err == nil {
+			continue // drain any in-flight frames until the close arrives
+		}
+		if got := websocket.CloseStatus(err); got != websocket.StatusMessageTooBig {
+			t.Fatalf("close status = %v (err %v), want StatusMessageTooBig", got, err)
+		}
+		return
 	}
 }
 

--- a/internal/proxy/terminal.go
+++ b/internal/proxy/terminal.go
@@ -393,11 +393,7 @@ func (h *Handler) bridgeTerminal(ctx context.Context, ws *websocket.Conn, procCl
 			typ, data, err := ws.Read(bridgeCtx)
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
-					// Normal close is not an error.
-					closeErr := websocket.CloseStatus(err)
-					if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
-						l.Debug().Err(err).Msg("terminal: WS read ended")
-					}
+					logWSReadEnd(l, err, maxReadBytes, "terminal")
 				}
 				return
 			}
@@ -477,6 +473,23 @@ func (h *Handler) handleControlMessage(ctx context.Context, client boxdpbconnect
 // case-sensitively (the prefix is ASCII, no folding needed).
 //
 // Returns "" if no token entry is found. The caller logs and rejects.
+// logWSReadEnd classifies a bridge read error, shared by the terminal and
+// exec bridges: a frame that blew the connection's read limit is a
+// client-visible failure worth a warn (the library has already closed the
+// connection with StatusMessageTooBig); anything else that isn't a clean
+// close is routine teardown at debug.
+func logWSReadEnd(l zerolog.Logger, err error, limitBytes int, bridge string) {
+	if errors.Is(err, websocket.ErrMessageTooBig) {
+		l.Warn().Err(err).Int("limit_bytes", limitBytes).
+			Msg(bridge + ": client frame exceeded read limit")
+		return
+	}
+	closeErr := websocket.CloseStatus(err)
+	if closeErr != websocket.StatusNormalClosure && closeErr != websocket.StatusGoingAway {
+		l.Debug().Err(err).Msg(bridge + ": WS read ended")
+	}
+}
+
 func extractTerminalToken(r *http.Request) string {
 	for _, hv := range r.Header.Values("Sec-WebSocket-Protocol") {
 		for _, part := range strings.Split(hv, ",") {


### PR DESCRIPTION
The exec WebSocket reused the terminal bridge's 64 KiB per-frame read limit, which is sized for keystrokes. Exec frames legitimately carry a whole command string or a stdin chunk, so an oversized frame tore down the session with only a debug log and no clear signal to the client.

- Exec sockets now use a dedicated 4 MiB frame limit; the terminal bridge keeps its 64 KiB keystroke limit.
- A frame exceeding the limit is logged at warn with the limit value; the client receives a 1009 (message too big) close as before.
- New tests pin both behaviors: a 128 KiB stdin frame reaches boxd intact, and an over-limit frame closes with 1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)