### PR TITLE
infra: us-east4 control plane (Cloud Run api + VPC egress)

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -47,11 +47,13 @@ module "network" {
   subnet_name = "superserve-use4-subnet"
   subnet_cidr = var.subnet_cidr
 
-  # Cloud Run networking (connector or direct-VPC-egress subnet) is deferred
-  # to the us-east4 Cloud Run rollout — this environment stands up the vmd
-  # host only.
+  # Cloud Run reaches the vmd host over direct VPC egress (no connector),
+  # matching the usw2 cell. The dedicated egress subnet carries the Cloud Run
+  # sender range; the firewall rules below admit it to vmd gRPC + host OTLP.
   create_vpc_connector        = false
-  create_vpc_connector_subnet = false
+  create_vpc_connector_subnet = true
+  vpc_connector_subnet        = "superserve-use4-cr-subnet"
+  vpc_connector_subnet_ip     = var.connector_subnet_cidr
 
   firewall_rules = {
     allow_vmd_grpc = {
@@ -84,6 +86,84 @@ module "network" {
 data "google_service_account" "api_runner" {
   project    = local.project_id
   account_id = "superserve-api-runner"
+}
+
+# A5: us-east4 control plane for the "use" cell.
+#
+# This is a host swap, not a new cell: us-east4 shares the use-cell Supabase,
+# runtime secrets, api-runner service account, and KMS key with us-central1.
+# Only the service name, region, and VMD address are region-local — traffic
+# splits between this service and the us-central1 one during cutover, then
+# us-central1 drains. Secrets resolve to the shared (suffix-less) use-cell
+# names via the *_secret_name overrides in terraform.tfvars.
+#
+# No per-root secret IAM here: the shared api-runner SA already holds the
+# runtime accessor grants (owned by us-central1's api_runtime_secrets) and the
+# credentials-kek encrypt/decrypt grant (owned out-of-band). Re-declaring them
+# from this state would double-manage the same bindings — the same split we
+# settled for usw2 in #232/#233.
+module "api" {
+  source = "../../../modules/api"
+
+  project_id            = local.project_id
+  environment           = local.environment
+  region                = local.region
+  service_name          = "superserve-api-${local.resource_suffix}"
+  service_account_email = data.google_service_account.api_runner.email
+  image                 = "us-central1-docker.pkg.dev/${local.project_id}/superserve/controlplane:replace-me"
+
+  cpu_limit         = "2"
+  memory_limit      = "1Gi"
+  min_instances     = 2
+  max_instances     = 100
+  startup_cpu_boost = true
+  cpu_idle          = true
+
+  env = {
+    API_PORT               = "8080"
+    EDGE_PROXY_DOMAIN      = "sandbox.superserve.ai"
+    SUPABASE_URL           = var.supabase_url
+    SECRETS_SIGNING_KEY_ID = "v1"
+    ALLOW_EPHEMERAL_SEED   = "0"
+    DB_MAX_CONNS           = "12"
+    VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
+    KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
+  }
+
+  secrets = {
+    DATABASE_URL = {
+      secret = coalesce(var.database_url_secret_name, "database-url-${local.resource_suffix}")
+    }
+    INTERNAL_API_TOKEN = {
+      secret = coalesce(var.internal_api_token_secret_name, "internal-api-token-${local.resource_suffix}")
+    }
+    SANDBOX_ACCESS_TOKEN_SEED = {
+      secret = coalesce(var.sandbox_access_token_seed_secret_name, "sandbox-access-token-seed-${local.resource_suffix}")
+    }
+    SECRETS_SIGNING_KEY = {
+      secret = coalesce(var.secrets_signing_key_secret_name, "secretsproxy-signing-key-${local.resource_suffix}")
+    }
+    SENTRY_DSN = {
+      secret = coalesce(var.sentry_dsn_secret_name, "sentry-dsn")
+    }
+    SYSTEM_TEAM_ID = {
+      secret = coalesce(var.system_team_id_secret_name, "system-team-id-${local.resource_suffix}")
+    }
+    SLACK_QUOTA_ALERT_WEBHOOK = {
+      secret = "slack-quota-alert-webhook"
+    }
+    POSTHOG_KEY = {
+      secret = "posthog-project-key"
+    }
+  }
+
+  vpc_connector  = null
+  vpc_egress     = "PRIVATE_RANGES_ONLY"
+  vpc_network    = var.network_name
+  vpc_subnetwork = module.network.vpc_connector_subnetwork_name
+  vpc_tags       = ["cr-use4"]
+
+  labels = local.common_labels
 }
 
 module "sandbox_host" {

--- a/infra/envs/production/us-east4/terraform.tfvars
+++ b/infra/envs/production/us-east4/terraform.tfvars
@@ -7,11 +7,25 @@ network_name           = "superserve-production-vpc"
 resource_suffix        = "use4"
 service_account_suffix = "use4"
 subnet_cidr            = "10.2.0.0/24"
-connector_subnet_cidr  = "10.2.0.0/24"
-host_internal_ip       = "10.2.0.2"
-machine_type           = "c4-highmem-288-lssd-metal"
-boot_disk_type         = "hyperdisk-balanced"
+# Direct-VPC-egress subnet for the Cloud Run control plane — its own /28 in
+# the region range, distinct from the host subnet. Sourced by the vmd-gRPC and
+# OTLP firewall rules so Cloud Run can reach the host.
+connector_subnet_cidr = "10.2.1.0/28"
+host_internal_ip      = "10.2.0.2"
+machine_type          = "c4-highmem-288-lssd-metal"
+boot_disk_type        = "hyperdisk-balanced"
 # The reservation-us-east-c4-288-lssd-metal reservation is non-specific
 # (specificReservationRequired=false), so it can't be targeted by name. Null =
 # default affinity, which auto-consumes that matching reservation in the zone.
 reservation_name = null
+
+# A5 control plane — same "use" cell as us-central1. Point every runtime secret
+# at the shared, suffix-less use-cell secrets (not per-region "-use4" names) so
+# this service reads the same DB, seeds, and signing keys as us-central1 during
+# the traffic split.
+supabase_url                          = "https://use.supabase.co"
+database_url_secret_name              = "database-url"
+internal_api_token_secret_name        = "internal-api-token"
+sandbox_access_token_seed_secret_name = "sandbox-access-token-seed"
+secrets_signing_key_secret_name       = "secretsproxy-signing-key"
+system_team_id_secret_name            = "system-team-id-production"

--- a/infra/envs/production/us-east4/terraform.tfvars
+++ b/infra/envs/production/us-east4/terraform.tfvars
@@ -7,10 +7,12 @@ network_name           = "superserve-production-vpc"
 resource_suffix        = "use4"
 service_account_suffix = "use4"
 subnet_cidr            = "10.2.0.0/24"
-# Direct-VPC-egress subnet for the Cloud Run control plane — its own /28 in
-# the region range, distinct from the host subnet. Sourced by the vmd-gRPC and
-# OTLP firewall rules so Cloud Run can reach the host.
-connector_subnet_cidr = "10.2.1.0/28"
+# Direct-VPC-egress subnet for the Cloud Run control plane — distinct from the
+# host subnet, sourced by the vmd-gRPC + OTLP firewall rules so Cloud Run can
+# reach the host. Direct VPC egress allocates instance IPs from this range and
+# needs ~2x max_instances of headroom (Google's documented minimum is /26), so
+# this is a /22, mirroring the usw2 cell's 10.1.4.0/22 in the 10.2 block.
+connector_subnet_cidr = "10.2.4.0/22"
 host_internal_ip      = "10.2.0.2"
 machine_type          = "c4-highmem-288-lssd-metal"
 boot_disk_type        = "hyperdisk-balanced"

--- a/infra/envs/production/us-east4/variables.tf
+++ b/infra/envs/production/us-east4/variables.tf
@@ -79,3 +79,48 @@ variable "network_name" {
   type    = string
   default = "superserve-production-vpc"
 }
+
+# A5 control-plane inputs. The *_secret_name defaults are null so the api
+# module falls back to per-suffix names via coalesce(); terraform.tfvars
+# overrides them to the shared (suffix-less) use-cell secrets.
+variable "supabase_url" {
+  description = "Supabase project URL for this deployment."
+  type        = string
+  default     = "https://use.supabase.co"
+}
+
+variable "database_url_secret_name" {
+  description = "Secret Manager secret name containing the DATABASE_URL for this deployment."
+  type        = string
+  default     = null
+}
+
+variable "internal_api_token_secret_name" {
+  description = "Secret Manager secret name for INTERNAL_API_TOKEN."
+  type        = string
+  default     = null
+}
+
+variable "sandbox_access_token_seed_secret_name" {
+  description = "Secret Manager secret name for SANDBOX_ACCESS_TOKEN_SEED."
+  type        = string
+  default     = null
+}
+
+variable "secrets_signing_key_secret_name" {
+  description = "Secret Manager secret name for SECRETS_SIGNING_KEY."
+  type        = string
+  default     = null
+}
+
+variable "sentry_dsn_secret_name" {
+  description = "Secret Manager secret name for SENTRY_DSN."
+  type        = string
+  default     = null
+}
+
+variable "system_team_id_secret_name" {
+  description = "Secret Manager secret name for SYSTEM_TEAM_ID."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary
Stands up the **us-east4 Cloud Run api** service as a **host swap within the existing "use" cell** — not a new cell. It shares the use-cell Supabase, runtime secrets, api-runner SA, and KMS key with us-central1; only the service name, region, and VMD address (the new bare-metal host, `10.2.0.2:50051`) are region-local. That lets traffic split between this service and the us-central1 one during cutover, then us-central1 drains.

Part of the primary bare-metal migration to us-east4 (A5). The host itself is already live (#238); this is the control-plane half.

## What's here
- **VPC egress**: network module now creates a dedicated `/28` Cloud Run egress subnet (`10.2.1.0/28`, distinct from the host subnet) using direct VPC egress like usw2. The existing vmd-gRPC + OTLP firewall rules already source `connector_subnet_cidr`.
- **api module**: mirrors us-central1 exactly — same env (incl. `EDGE_PROXY_DOMAIN=sandbox.superserve.ai`, no `SANDBOX_ID_REGION`) and all 8 runtime secrets. Region-local diffs: `service_name=superserve-api-use4`, `VMD_GRPC_ADDRESS` → new host, `cr-use4` egress tag, central `superserve` image.
- **Shared secrets**: `*_secret_name` tfvars overrides point at the suffix-less use-cell secrets (`database-url`, `internal-api-token`, `sandbox-access-token-seed`, `secretsproxy-signing-key`, `system-team-id-production`) so this service reads the *same* DB/seeds/keys as us-central1.

## Technical decisions
- **No per-root secret/KMS IAM.** The shared api-runner SA already holds the runtime accessor grants (owned by us-central1's `api_runtime_secrets`) and the `credentials-kek` encrypt/decrypt grant (out-of-band). Re-declaring them here would double-manage the same bindings — the split we settled for usw2 in #232/#233.
- **External IP stays out-of-band.** The sandbox-host module keeps `access_config` in `ignore_changes`; the host's egress IP is added via gcloud, matching the source host's posture. Nothing to codify.

## Testing
- `terraform fmt` + `terraform validate` pass.
- **Not applied.** Staged for plan review — the plan should show the api service, the CR egress subnet, and no destroys. Please review the plan before we apply.