### PR TITLE
secretsproxy: re-mint cached leaf certs before they expire

### DIFF
--- a/internal/secretsproxy/ca.go
+++ b/internal/secretsproxy/ca.go
@@ -260,6 +260,9 @@ func (c *leafCache) get(sni string) (*tls.Certificate, bool) {
 	}
 	entry := el.Value.(*leafCacheEntry)
 	if !c.now().Add(leafRenewBefore).Before(entry.notAfter) {
+		// Concurrent connections in the renew window each re-mint (set is
+		// last-writer-wins) until the first fresh cert lands — a handful of
+		// extra sub-ms signs once per 72h per SNI, not worth coalescing.
 		return nil, false
 	}
 	c.order.MoveToFront(el)

--- a/internal/secretsproxy/ca.go
+++ b/internal/secretsproxy/ca.go
@@ -32,6 +32,12 @@ type CA struct {
 const (
 	leafLifetime = 72 * time.Hour
 	rootLifetime = 10 * 365 * 24 * time.Hour
+
+	// leafRenewBefore re-mints a cached leaf this long before it expires, so a
+	// hot SNI that never falls out of the LRU can't be served a stale cert (and
+	// so a cert can't expire mid-connection). Comfortably larger than any single
+	// request, negligible waste against the 72h lifetime.
+	leafRenewBefore = 1 * time.Hour
 )
 
 // NewCA loads the CA from disk or generates a new one and persists the key with mode 0600.
@@ -155,11 +161,12 @@ func (ca *CA) MintLeaf(sni string) (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
+	notAfter := ca.cache.now().Add(leafLifetime)
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: sni},
-		NotBefore:    time.Now().Add(-5 * time.Minute),
-		NotAfter:     time.Now().Add(leafLifetime),
+		NotBefore:    ca.cache.now().Add(-5 * time.Minute),
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
@@ -177,7 +184,7 @@ func (ca *CA) MintLeaf(sni string) (*tls.Certificate, error) {
 		Certificate: [][]byte{der, ca.rootCert.Raw},
 		PrivateKey:  leafKey,
 	}
-	ca.cache.set(sni, cert)
+	ca.cache.set(sni, cert, notAfter)
 	return cert, nil
 }
 
@@ -217,11 +224,15 @@ type leafCache struct {
 	capacity int
 	items    map[string]*list.Element
 	order    *list.List
+	// now is the clock, injectable for tests. Both minting (leaf validity) and
+	// cache expiry read it, so a test can advance one clock past a leaf's life.
+	now func() time.Time
 }
 
 type leafCacheEntry struct {
-	sni  string
-	cert *tls.Certificate
+	sni      string
+	cert     *tls.Certificate
+	notAfter time.Time
 }
 
 func newLeafCache(capacity int) *leafCache {
@@ -232,9 +243,14 @@ func newLeafCache(capacity int) *leafCache {
 		capacity: capacity,
 		items:    make(map[string]*list.Element, capacity),
 		order:    list.New(),
+		now:      time.Now,
 	}
 }
 
+// get returns a cached leaf only while it stays valid past the renew window. A
+// leaf within leafRenewBefore of expiry is treated as a miss so the caller
+// re-mints — without this the LRU would serve a hot SNI's expired cert forever
+// (evicting only under capacity pressure, never on age).
 func (c *leafCache) get(sni string) (*tls.Certificate, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -242,19 +258,25 @@ func (c *leafCache) get(sni string) (*tls.Certificate, bool) {
 	if !ok {
 		return nil, false
 	}
+	entry := el.Value.(*leafCacheEntry)
+	if !c.now().Add(leafRenewBefore).Before(entry.notAfter) {
+		return nil, false
+	}
 	c.order.MoveToFront(el)
-	return el.Value.(*leafCacheEntry).cert, true
+	return entry.cert, true
 }
 
-func (c *leafCache) set(sni string, cert *tls.Certificate) {
+func (c *leafCache) set(sni string, cert *tls.Certificate, notAfter time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if el, ok := c.items[sni]; ok {
-		el.Value.(*leafCacheEntry).cert = cert
+		entry := el.Value.(*leafCacheEntry)
+		entry.cert = cert
+		entry.notAfter = notAfter
 		c.order.MoveToFront(el)
 		return
 	}
-	el := c.order.PushFront(&leafCacheEntry{sni: sni, cert: cert})
+	el := c.order.PushFront(&leafCacheEntry{sni: sni, cert: cert, notAfter: notAfter})
 	c.items[sni] = el
 	if c.order.Len() > c.capacity {
 		oldest := c.order.Back()

--- a/internal/secretsproxy/ca_test.go
+++ b/internal/secretsproxy/ca_test.go
@@ -9,7 +9,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
+
+// farFuture is an expiry well beyond any test's clock, so LRU-eviction tests
+// exercise capacity, not the leaf-expiry check.
+var farFuture = time.Now().Add(1000 * time.Hour)
 
 func TestNewCAGeneratesAndPersists(t *testing.T) {
 	dir := t.TempDir()
@@ -174,6 +179,47 @@ func TestMintLeafCachesHits(t *testing.T) {
 	}
 }
 
+// TestMintLeafRemintsExpiredCacheEntry guards the leaf-cache expiry bug: a hot
+// SNI never falls out of the LRU, so without an age check the cache would serve
+// the same leaf past its 72h validity forever (observed as CERT_HAS_EXPIRED
+// through the proxy). Advancing the clock past the renew window must force a
+// re-mint, not a stale hit.
+func TestMintLeafRemintsExpiredCacheEntry(t *testing.T) {
+	dir := t.TempDir()
+	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	ca.cache.now = func() time.Time { return base }
+
+	leaf1, err := ca.MintLeaf("api.anthropic.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Still inside the leaf's life, minus the renew window: cache hit.
+	ca.cache.now = func() time.Time { return base.Add(leafLifetime - leafRenewBefore - time.Minute) }
+	if leaf2, err := ca.MintLeaf("api.anthropic.com"); err != nil {
+		t.Fatal(err)
+	} else if leaf1 != leaf2 {
+		t.Errorf("expected cache hit before the renew window; got a re-mint")
+	}
+
+	// Inside the renew window (about to expire): must re-mint, not serve stale.
+	ca.cache.now = func() time.Time { return base.Add(leafLifetime - leafRenewBefore/2) }
+	leaf3, err := ca.MintLeaf("api.anthropic.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leaf1 == leaf3 {
+		t.Errorf("expected re-mint within the renew window; cache served the stale leaf")
+	}
+	if ca.cache.len() != 1 {
+		t.Errorf("re-mint should replace the entry in place, got %d entries", ca.cache.len())
+	}
+}
+
 func TestMintLeafConcurrentSafe(t *testing.T) {
 	dir := t.TempDir()
 	ca, err := NewCA(filepath.Join(dir, "ca.crt"), filepath.Join(dir, "ca.key"), 64)
@@ -208,9 +254,9 @@ func TestMintLeafConcurrentSafe(t *testing.T) {
 
 func TestLeafCacheEvictsLRU(t *testing.T) {
 	c := newLeafCache(2)
-	c.set("a", &tls.Certificate{})
-	c.set("b", &tls.Certificate{})
-	c.set("c", &tls.Certificate{}) // evicts a
+	c.set("a", &tls.Certificate{}, farFuture)
+	c.set("b", &tls.Certificate{}, farFuture)
+	c.set("c", &tls.Certificate{}, farFuture) // evicts a
 
 	if _, ok := c.get("a"); ok {
 		t.Errorf("a should have been evicted as LRU")
@@ -225,13 +271,13 @@ func TestLeafCacheEvictsLRU(t *testing.T) {
 
 func TestLeafCachePromotesOnGet(t *testing.T) {
 	c := newLeafCache(2)
-	c.set("a", &tls.Certificate{})
-	c.set("b", &tls.Certificate{})
+	c.set("a", &tls.Certificate{}, farFuture)
+	c.set("b", &tls.Certificate{}, farFuture)
 	// Touch a so it's no longer the LRU; b should evict next.
 	if _, ok := c.get("a"); !ok {
 		t.Fatal("a missing before LRU promotion")
 	}
-	c.set("c", &tls.Certificate{}) // should evict b, not a
+	c.set("c", &tls.Certificate{}, farFuture) // should evict b, not a
 	if _, ok := c.get("a"); !ok {
 		t.Errorf("a was unexpectedly evicted after being touched")
 	}
@@ -244,7 +290,7 @@ func TestLeafCacheZeroCapacityDefaults(t *testing.T) {
 	// A 0 capacity would otherwise immediately evict every entry; we
 	// expect a sensible default so callers can pass 0 safely.
 	c := newLeafCache(0)
-	c.set("a", &tls.Certificate{})
+	c.set("a", &tls.Certificate{}, farFuture)
 	if _, ok := c.get("a"); !ok {
 		t.Errorf("zero-capacity cache should have fallen back to a default")
 	}

--- a/internal/secretsproxy/ca_test.go
+++ b/internal/secretsproxy/ca_test.go
@@ -193,14 +193,14 @@ func TestMintLeafRemintsExpiredCacheEntry(t *testing.T) {
 	base := time.Now()
 	ca.cache.now = func() time.Time { return base }
 
-	leaf1, err := ca.MintLeaf("api.anthropic.com")
+	leaf1, err := ca.MintLeaf("api.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Still inside the leaf's life, minus the renew window: cache hit.
 	ca.cache.now = func() time.Time { return base.Add(leafLifetime - leafRenewBefore - time.Minute) }
-	if leaf2, err := ca.MintLeaf("api.anthropic.com"); err != nil {
+	if leaf2, err := ca.MintLeaf("api.example.com"); err != nil {
 		t.Fatal(err)
 	} else if leaf1 != leaf2 {
 		t.Errorf("expected cache hit before the renew window; got a re-mint")
@@ -208,7 +208,7 @@ func TestMintLeafRemintsExpiredCacheEntry(t *testing.T) {
 
 	// Inside the renew window (about to expire): must re-mint, not serve stale.
 	ca.cache.now = func() time.Time { return base.Add(leafLifetime - leafRenewBefore/2) }
-	leaf3, err := ca.MintLeaf("api.anthropic.com")
+	leaf3, err := ca.MintLeaf("api.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The proxy mints per-SNI TLS leaf certificates with a 72h validity and caches them in an LRU keyed by SNI. The cache only evicted under capacity pressure, never on age, so a frequently-used hostname's cached leaf was served indefinitely — including long after it expired. Clients then failed the TLS handshake with `CERT_HAS_EXPIRED` roughly 72h after the proxy last minted that host's leaf, and stayed broken until the cache was flushed (a proxy restart).

## Fix
- `leafCache.get` now treats a leaf within `leafRenewBefore` (1h) of its `NotAfter` as a miss, so the caller re-mints instead of serving a stale cert. The entry stores its expiry; the cache carries an injectable clock so minting and expiry read the same time source.
- Test mints a leaf, advances the clock into the renew window, and asserts a re-mint rather than a stale hit (fails without the fix).

## Note
This addresses expired *cached* leaves. A separate concern — a guest whose clock has drifted after repeated pause/resume could still misjudge a valid cert's window — is not covered here and is worth tracking on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)