### PR TITLE
ci: apply production/us-east4 in Terraform CD

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -443,9 +443,9 @@ jobs:
   # traffic-split cutover away from us-central1. During bring-up this applies
   # infrastructure only: the api service is created (on an existing image tag;
   # see the module's image pin) but there is deliberately NO api-deploy/traffic
-  # /smoke stage yet — us-east4 has no public endpoint until the D3 routing work
-  # lands, so a region smoke test would have nothing to hit. Chained last so it
-  # never gates the live us-central1/us-west2 rollouts above.
+  # /smoke stage yet — us-east4 has no public endpoint until the routing/
+  # traffic-split work lands, so a region smoke test would have nothing to hit.
+  # Chained last so it never gates the live us-central1/us-west2 rollouts above.
   production-us-east4-infra:
     name: Apply production/us-east4
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -438,3 +438,43 @@ jobs:
           set -euo pipefail
           scripts/smoke-test-region.sh production us-central1
           echo "production/us-central1 deploy and smoke validation passed." >> "$GITHUB_STEP_SUMMARY"
+
+  # us-east4 is the "use" cell's new host + control plane, being stood up for a
+  # traffic-split cutover away from us-central1. During bring-up this applies
+  # infrastructure only: the api service is created (on an existing image tag;
+  # see the module's image pin) but there is deliberately NO api-deploy/traffic
+  # /smoke stage yet — us-east4 has no public endpoint until the D3 routing work
+  # lands, so a region smoke test would have nothing to hit. Chained last so it
+  # never gates the live us-central1/us-west2 rollouts above.
+  production-us-east4-infra:
+    name: Apply production/us-east4
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [production-us-central1-api]
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_IN_AUTOMATION: 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Terraform apply production/us-east4
+        run: |
+          set -euo pipefail
+          echo "## Terraform rollout: production/us-east4" >> "$GITHUB_STEP_SUMMARY"
+          cd infra/envs/production/us-east4
+          terraform init -input=false
+          terraform validate
+          terraform plan -input=false -out=tfplan
+          terraform apply -input=false -auto-approve tfplan

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -110,7 +110,13 @@ module "api" {
   region                = local.region
   service_name          = "superserve-api-${local.resource_suffix}"
   service_account_email = data.google_service_account.api_runner.email
-  image                 = "us-central1-docker.pkg.dev/${local.project_id}/superserve/controlplane:replace-me"
+  # First create must reference a tag that actually exists, or the initial
+  # revision never goes ready and the apply fails. The other regions can carry
+  # a ":replace-me" placeholder only because their services already exist and
+  # image is in the module's ignore_changes. us-east4's service is new, so pin
+  # ":latest" for the create; CD's deploy step later moves it to the commit SHA
+  # and ignore_changes keeps terraform from reverting that.
+  image = "us-central1-docker.pkg.dev/${local.project_id}/superserve/controlplane:latest"
 
   cpu_limit         = "2"
   memory_limit      = "1Gi"


### PR DESCRIPTION
## Summary
The us-east4 root (host + new "use"-cell Cloud Run control plane from #245) was never in the CD matrix, so merging #245 applied nothing for us-east4 — the api service wasn't created. This wires us-east4 into `terraform-cd.yml` so CD owns it.

## What's here
- **New CD job `production/us-east4` (infra apply)** — mirrors the west2/central1 infra jobs, chained **last** (`needs: production-us-central1-api`) so it can never gate the live rollouts above it.
- **Infra apply only — no api-deploy/traffic/smoke stage yet.** us-east4 has no public endpoint until the D3 routing/traffic-split work, so a region smoke test would have nothing to hit (and would repeat the usw2 smoke-401 churn). That stage lands with the routing work.
- **Pin the us-east4 api image to `:latest`** instead of `:replace-me`. The tag must exist for the first create to reach a ready revision. West2/central1 tolerate the `:replace-me` placeholder only because their services already exist and `image` is in the module's `ignore_changes`; us-east4's service is new. CD's deploy step (added later) moves it to the commit SHA, and `ignore_changes` keeps terraform from reverting.

## Blast radius
The apply reconciles the existing us-east4 state (the host is already imported) and adds the api service + CR egress subnet + narrows two firewall rules — the same **2 add / 2 change / 0 destroy** plan verified on #245. No effect on us-central1/us-west2.

## Testing
- `terraform validate` (us-east4) passes; workflow YAML parses and the new job chains after `production-us-central1-api`.
- The apply runs on merge — I'll watch the `Apply production/us-east4` job and confirm the plan is 2 add / 2 change / 0 destroy before it applies.