### PR TITLE
ci: teach deploy-proxy about the us-east4 use-cell host

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -161,3 +161,30 @@ jobs:
             --secret=sandbox-access-token-seed --project "$GCP_PROJECT")
           export SANDBOX_ACCESS_TOKEN_SEED
           python3 .github/workflows/scripts/deploy-proxy.py
+
+      # us-east4 is NOT a new cell — it's the migration target for the primary
+      # "use" cell (the host is being moved us-central1 -> us-east4). So unlike
+      # the usw step above, it reuses the PRIMARY values verbatim: same domain
+      # (sandbox.superserve.ai) and the SAME token seed as us-central1, because
+      # both control planes sign access tokens with the one shared use-cell
+      # seed. Only the region differs. Gated on GCP_REGION_USE4 so this stays
+      # skipped until cutover — set that var only once the east host carries
+      # VMD_LABEL (flipped at the cutover window); discovery fails on zero
+      # matches rather than silently skipping, so an early flag would fail the
+      # deploy. After central is decommissioned this step becomes the primary.
+      - name: Deploy proxy to us-east4 use-cell VMD instance
+        if: vars.GCP_REGION_USE4 != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
+          PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
+          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
+          PROXY_DOMAINS: ${{ vars.PROXY_DOMAINS_PROD }}
+          REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 .github/workflows/scripts/deploy-proxy.py

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -162,16 +162,11 @@ jobs:
           export SANDBOX_ACCESS_TOKEN_SEED
           python3 .github/workflows/scripts/deploy-proxy.py
 
-      # us-east4 is NOT a new cell — it's the migration target for the primary
-      # "use" cell (the host is being moved us-central1 -> us-east4). So unlike
-      # the usw step above, it reuses the PRIMARY values verbatim: same domain
-      # (sandbox.superserve.ai) and the SAME token seed as us-central1, because
-      # both control planes sign access tokens with the one shared use-cell
-      # seed. Only the region differs. Gated on GCP_REGION_USE4 so this stays
-      # skipped until cutover — set that var only once the east host carries
-      # VMD_LABEL (flipped at the cutover window); discovery fails on zero
-      # matches rather than silently skipping, so an early flag would fail the
-      # deploy. After central is decommissioned this step becomes the primary.
+      # us-east4 is the same "use" cell as the primary region, so it reuses the
+      # primary proxy env (domain + seed) and only changes the region — unlike
+      # the usw step, a distinct cell with its own domain and seed. Gated on
+      # GCP_REGION_USE4; deploy-proxy.py fails on zero VMD_LABEL matches, so
+      # leave the var unset until the east host carries the label.
       - name: Deploy proxy to us-east4 use-cell VMD instance
         if: vars.GCP_REGION_USE4 != ''
         env:


### PR DESCRIPTION
## Summary
Adds a `deploy-proxy` step for the **us-east4** vmd host — piece 1 of standing up the east data-plane proxy for the primary bare-metal host migration (us-central1 → us-east4).

Key point: **us-east4 is the *same* "use" cell**, not a new one. So unlike the usw step (distinct cell → its own domain + seed), the east step **reuses the primary values verbatim**: `PROXY_DOMAIN=sandbox.superserve.ai` and `SANDBOX_ACCESS_TOKEN_SEED_PROD` — because both control planes sign access tokens with the one shared use-cell seed, and tokens must validate identically during the traffic split. Only `GCP_REGION` differs.

## Safety / gating
- Gated on `vars.GCP_REGION_USE4 != ''` → **skipped until you set that var**, which should happen only at the cutover window *after* the east host carries `VMD_LABEL`. Discovery fails on zero label matches (by design), so setting the flag early would fail the deploy — hence it stays off until the host is in rotation.
- Inert on merge: nothing changes for us-central1 / usw until the var is set.
- After central is decommissioned, this step effectively becomes the primary proxy deploy.

## Repo var you'll set at cutover
- `GCP_REGION_USE4 = us-east4`

## Testing
- YAML parses; the new step is the 4th proxy step in `deploy-production`, mirroring the usw step's structure with primary-cell values.
- Not exercised until `GCP_REGION_USE4` is set + the host is labeled.

Piece 2 (the east proxy IG/backend on the `sandbox-dataplane` LB) is a separate change — flagged an architecture fork on it (the existing proxy LB looks script-managed, not Terraform), writing that up next.