### PR TITLE
vmd: abandon warm network slots on shutdown and adopt them at boot

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -564,7 +564,7 @@ func main() {
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
-	mgr.ReserveStartupSlots(ctx)
+	slotsReserved := mgr.ReserveStartupSlots(ctx)
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
@@ -600,7 +600,8 @@ func main() {
 		AbandonOnStop:     adoptNetPool,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
-	if adoptNetPool {
+	switch {
+	case adoptNetPool && slotsReserved:
 		// Adopt the slots the previous run abandoned (or crashed out of) in
 		// the background: the pool starts warm within seconds instead of
 		// refilling from scratch, and boot never blocks on the pass.
@@ -608,6 +609,11 @@ func main() {
 			defer sentrylog.Recover("netpool adoption")
 			netPool.AdoptOrphanSlots(ctx)
 		}()
+	case adoptNetPool:
+		// Without a completed reservation pass, adoption cannot tell live VM
+		// namespaces from orphans — leave everything in place; the pool
+		// refills fresh and the next healthy boot adopts.
+		log.Error().Msg("skipping network pool adoption: startup slot reservation did not complete")
 	}
 
 	// Leak gauge for network namespaces — independent of the launcher path, and

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -565,7 +565,12 @@ func main() {
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
 	mgr.ReserveStartupSlots(ctx)
-	mgr.SweepStartupOrphanNamespaces()
+	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
+	if !adoptNetPool {
+		// Under adoption, orphan namespaces are warm-pool candidates instead
+		// of garbage; the adoption pass below validates or sweeps each one.
+		mgr.SweepStartupOrphanNamespaces()
+	}
 
 	// Launcher launch path, enabled per host via VMD_LAUNCH_VIA_LAUNCHER_NS.
 	if launchViaLauncherNS {
@@ -592,8 +597,18 @@ func main() {
 		NewSize:           netPoolFresh,
 		RecycleSize:       netPoolRecycle,
 		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
+		AbandonOnStop:     adoptNetPool,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
+	if adoptNetPool {
+		// Adopt the slots the previous run abandoned (or crashed out of) in
+		// the background: the pool starts warm within seconds instead of
+		// refilling from scratch, and boot never blocks on the pass.
+		go func() {
+			defer sentrylog.Recover("netpool adoption")
+			netPool.AdoptOrphanSlots(ctx)
+		}()
+	}
 
 	// Leak gauge for network namespaces — independent of the launcher path, and
 	// started after StartPool so its first read observes an initialized pool.

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -224,6 +224,24 @@ func AttachFirewall(cfg FirewallConfig) (*Firewall, error) {
 	}, nil
 }
 
+// VerifyInstalled confirms the kernel actually holds this firewall's chains
+// with rules in them. AttachFirewall only binds names — it succeeds against a
+// half-built namespace (a crash between chain creation and rule install), so
+// callers re-binding to state of unknown provenance must verify before
+// trusting enforcement. Must be called from within the target namespace.
+func (fw *Firewall) VerifyInstalled() error {
+	for _, ch := range []*nftables.Chain{fw.filterChain, fw.natChain, fw.postChain, fw.fwdChain} {
+		rules, err := fw.conn.GetRules(fw.table, ch)
+		if err != nil {
+			return fmt.Errorf("verify chain %s: %w", ch.Name, err)
+		}
+		if len(rules) == 0 {
+			return fmt.Errorf("verify chain %s: no rules installed", ch.Name)
+		}
+	}
+	return nil
+}
+
 // Close tears down the nftables connection. Kernel-level table and
 // rules persist across the close — they're owned by the kernel, not
 // by this netlink handle. AttachFirewall can re-bind to them later.

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 	"sort"
@@ -224,22 +225,25 @@ func AttachFirewall(cfg FirewallConfig) (*Firewall, error) {
 	}, nil
 }
 
-// VerifyInstalled confirms the kernel actually holds this firewall's chains
-// with rules in them. AttachFirewall only binds names — it succeeds against a
-// half-built namespace (a crash between chain creation and rule install), so
-// callers re-binding to state of unknown provenance must verify before
-// trusting enforcement. Must be called from within the target namespace.
-func (fw *Firewall) VerifyInstalled() error {
-	for _, ch := range []*nftables.Chain{fw.filterChain, fw.natChain, fw.postChain, fw.fwdChain} {
-		rules, err := fw.conn.GetRules(fw.table, ch)
-		if err != nil {
-			return fmt.Errorf("verify chain %s: %w", ch.Name, err)
-		}
-		if len(rules) == 0 {
-			return fmt.Errorf("verify chain %s: no rules installed", ch.Name)
-		}
+// ReinstallFirewall replaces whatever nftables state a namespace carries with
+// the current base ruleset: any existing table — complete, stale, or half
+// built — is deleted, then NewFirewall installs from scratch. AttachFirewall
+// only binds names and would silently trust the previous writer's rules, so
+// re-binding to state of unknown provenance must rebuild instead. Must be
+// called from within the target namespace, with no live occupant (the delete
+// briefly drops enforcement).
+func ReinstallFirewall(cfg FirewallConfig) (*Firewall, error) {
+	conn, err := nftables.New()
+	if err != nil {
+		return nil, fmt.Errorf("new nftables conn: %w", err)
 	}
-	return nil
+	conn.DelTable(&nftables.Table{Name: tableName, Family: nftables.TableFamilyINet})
+	if err := conn.Flush(); err != nil && !errors.Is(err, unix.ENOENT) {
+		// Anything but "no such table" means the stale table may survive —
+		// installing over it would append duplicate rules, so fail instead.
+		return nil, fmt.Errorf("delete stale table: %w", err)
+	}
+	return NewFirewall(cfg)
 }
 
 // Close tears down the nftables connection. Kernel-level table and

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -94,6 +94,8 @@ type Manager struct {
 	//   - a VM/record vmID   (a live VM, or a record reserving its index)
 	//   - poolOwner          (a warm/mid-build pool slot not yet handed to a VM)
 	//   - teardownOwner      (a slot being torn down; held so no one re-claims it)
+	//   - withheldOwner      (kernel state known dirty and unremovable; parked
+	//                         for this process lifetime, next boot retries)
 	// An index is free (claimable) iff it has NO entry.
 	//
 	// Identity is load-bearing, not decoration: a release/teardown acts ONLY when
@@ -790,6 +792,7 @@ func slotFromNamespace(namespace string) (int, bool) {
 const (
 	poolOwner     = "\x00pool"     // warm/mid-build pool slot, not yet a VM's
 	teardownOwner = "\x00teardown" // slot mid-teardown; held so it isn't reclaimed
+	withheldOwner = "\x00withheld" // kernel state dirty and unremovable; parked until next boot
 )
 
 // assignSlotLocked sets the owner of idx (a fresh claim or an owner transfer,
@@ -826,15 +829,17 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	return true
 }
 
-// dropIfOwned removes owner's hold on idx WITHOUT returning it to freeSlots —
-// for indexes whose kernel state is still suspect (e.g. a stray host link
-// that failed to delete). The index stays unclaimable this lifetime; the next
-// boot's sweep retries it.
-func (m *Manager) dropIfOwned(idx int, owner string) {
+// withholdIfOwned converts owner's hold on idx into a process-lifetime park —
+// for indexes whose kernel state is known dirty but couldn't be removed (e.g.
+// a stray host link that failed to delete). Merely dropping ownership would
+// only protect until the sequential allocator's high-water mark reaches the
+// index; the sentinel keeps every allocation path off it. Next boot starts
+// clean and retries.
+func (m *Manager) withholdIfOwned(idx int, owner string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.slotOwner[idx] == owner {
-		delete(m.slotOwner, idx)
+		m.slotOwner[idx] = withheldOwner
 	}
 }
 
@@ -1208,11 +1213,11 @@ func (m *Manager) SweepStrayHostVeths() (swept int) {
 			m.releaseIfOwned(idx, teardownOwner)
 			continue
 		}
-		// The link may still exist: freeing the index would let the refill
-		// loop build here and collide with it on the move-to-host step. Keep
-		// it out of the free list; the next boot's sweep retries.
+		// The link may still exist: any future build here collides with it on
+		// the move-to-host step. Park the index for this process lifetime;
+		// the next boot's sweep retries.
 		m.log.Warn().Err(delErr).Str("veth", veth).Msg("stray host veth delete failed — index withheld")
-		m.dropIfOwned(idx, teardownOwner)
+		m.withholdIfOwned(idx, teardownOwner)
 	}
 	return swept
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -979,13 +979,19 @@ func (m *Manager) claimOrphanSlots() []int {
 		}
 		return nil
 	}
+	var outOfRange []int
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	var out []int
 	claimed := make(map[int]bool)
 	for _, e := range entries {
 		idx, ok := slotFromNamespace(e.Name())
 		if !ok {
+			continue
+		}
+		if idx >= MaxSlots {
+			// Outside the allocator's range: claiming it would push the
+			// high-water mark past the ceiling and starve fresh allocation.
+			outOfRange = append(outOfRange, idx)
 			continue
 		}
 		if _, owned := m.slotOwner[idx]; owned {
@@ -1008,6 +1014,16 @@ func (m *Manager) claimOrphanSlots() []int {
 			}
 		}
 		m.freeSlots = kept
+	}
+	m.mu.Unlock()
+
+	// Not adoptable — remove like the legacy sweep would (outside the lock:
+	// teardown execs kernel commands).
+	for _, idx := range outOfRange {
+		ns := nsNameForSlot(idx)
+		m.log.Warn().Str("ns", ns).Msg("adopt: namespace outside allocator range — sweeping")
+		killProcessesInNs(ns)
+		m.cleanupFull(ns, vethNameForSlot(idx))
 	}
 	return out
 }
@@ -1048,10 +1064,22 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		if err != nil {
 			return err
 		}
+		// Attach binds names without proving the ruleset exists; a crash
+		// mid-setup leaves adoptable-looking namespaces with no enforcement.
+		if err := f.VerifyInstalled(); err != nil {
+			_ = f.Close()
+			return err
+		}
+		// The previous owner's user egress sets must not survive into the
+		// pool — mirrors the recycle path's sanitation before Return.
+		if err := f.ReplaceUserRules(nil, nil); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("clear user rules: %w", err)
+		}
 		fw = f
 		return nil
 	}); err != nil {
-		return nil, "", fmt.Errorf("adopt slot %d: attach firewall: %w", idx, err)
+		return nil, "", fmt.Errorf("adopt slot %d: firewall: %w", idx, err)
 	}
 
 	// Heal the host route if it didn't survive; mirrors setupSlot's tolerance.

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1067,10 +1067,25 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	if !nsExists(nsName) {
 		return nil, "", fmt.Errorf("adopt slot %d: namespace vanished", idx)
 	}
-	// Kill first: everything below rewrites enforcement state, which must
-	// never happen around a live occupant (a crash can strand a workload here
-	// with its egress restrictions still configured).
+	// Kill any occupant and prove the namespace empty before touching
+	// enforcement: SIGKILL is asynchronous for a process in an uninterruptible
+	// wait, and the firewall rewrite below would leave a still-running
+	// workload without its egress restrictions (briefly without any table at
+	// all). A failed /proc scan is "don't know", never "empty". If emptiness
+	// can't be proven within the slot's budget, the caller skips the slot —
+	// with the occupant's rules untouched.
 	killProcessesInNs(nsName)
+	for {
+		pids, ok := pidsInNsFunc(nsName)
+		if ok && len(pids) == 0 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, "", fmt.Errorf("adopt slot %d: namespace still occupied: %w", idx, ctx.Err())
+		case <-time.After(defaultVerifyPollInterval):
+		}
+	}
 
 	if _, err := os.Stat("/sys/class/net/" + vethName); err != nil {
 		return nil, "", fmt.Errorf("adopt slot %d: host veth missing: %w", idx, err)

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -304,6 +304,14 @@ func hostIPForSlot(idx int) string {
 	return fmt.Sprintf("10.11.%d.%d", idx/256, idx%256)
 }
 
+// Deterministic slot identity: everything about a slot derives from its index,
+// which is what makes namespaces left by a previous vmd lifetime adoptable —
+// the kernel objects carry all the state, nothing needs to be persisted.
+func nsNameForSlot(idx int) string    { return fmt.Sprintf("ns-%d", idx) }
+func vethNameForSlot(idx int) string  { return fmt.Sprintf("veth-%d", idx) }
+func vpeerIPForSlot(idx int) string   { return fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256) }
+func macForSlot(idx int) string       { return fmt.Sprintf("AA:FC:00:%02X:%02X:%02X", 0, idx/256, idx%256) }
+
 // setupSlot runs the expensive network setup (namespace, veth, TAP,
 // nftables, routing) for a single slot index. Used by both SetupVM
 // (on-demand) and Pool (pre-allocation).
@@ -312,10 +320,10 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	// runs (pool/on-demand), and record paths reserve it. On success the slot is
 	// live and stays owned; on failure the caller releases idx (freeSlot).
 	hostIP := hostIPForSlot(idx)
-	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
+	vpeerIP := vpeerIPForSlot(idx)
 	vethIP := fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256)
-	nsName := fmt.Sprintf("ns-%d", idx)
-	vethName := fmt.Sprintf("veth-%d", idx)
+	nsName := nsNameForSlot(idx)
+	vethName := vethNameForSlot(idx)
 	vpeerName := "eth0"
 	hostCIDR := fmt.Sprintf("%s/32", hostIP)
 
@@ -400,7 +408,7 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		m.log.Debug().Err(err).Str("ns", nsName).Msg("host route (may already exist)")
 	}
 
-	mac := fmt.Sprintf("AA:FC:00:%02X:%02X:%02X", 0, idx/256, idx%256)
+	mac := macForSlot(idx)
 
 	info := &VMNetInfo{
 		Namespace:  nsName,
@@ -954,6 +962,145 @@ func (m *Manager) SweepOrphanNamespaces(keep map[string]bool) (swept int) {
 		}
 	}
 
+	return swept
+}
+
+// claimOrphanSlots takes ownership of every ns-N namespace present in the
+// kernel but owned by nothing — slots a previous vmd lifetime left behind
+// (graceful abandon and crash look identical here). Reservation happens in one
+// locked pass before any validation, so the refill loop can never build over a
+// namespace that is about to be adopted. Callers must either adopt or tear
+// down every returned index; the ownership taken here is not dropped otherwise.
+func (m *Manager) claimOrphanSlots() []int {
+	entries, err := os.ReadDir(netnsDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			m.log.Warn().Err(err).Msg("adopt: list netns dir failed")
+		}
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []int
+	claimed := make(map[int]bool)
+	for _, e := range entries {
+		idx, ok := slotFromNamespace(e.Name())
+		if !ok {
+			continue
+		}
+		if _, owned := m.slotOwner[idx]; owned {
+			continue
+		}
+		m.assignSlotLocked(idx, poolOwner)
+		claimed[idx] = true
+		if idx >= m.nextSlot {
+			m.nextSlot = idx + 1
+		}
+		out = append(out, idx)
+	}
+	if len(claimed) > 0 && len(m.freeSlots) > 0 {
+		// Preserve the freeSlots invariant (never overlaps slotOwner) rather
+		// than lean on claimSlotIndex's discard path to absorb the breach.
+		kept := m.freeSlots[:0]
+		for _, idx := range m.freeSlots {
+			if !claimed[idx] {
+				kept = append(kept, idx)
+			}
+		}
+		m.freeSlots = kept
+	}
+	return out
+}
+
+// adoptSlot rebuilds the in-memory identity of an existing ns-<idx> so it can
+// re-enter the pool: verifies the host-side veth and the in-namespace peer,
+// re-binds the in-namespace nftables handle (mirrors ReattachVM), and re-adds
+// the host route (idempotent). No kernel objects are created — validation
+// doubles as the layout/version check, so a namespace built by an incompatible
+// vmd simply fails here and gets torn down. tap0 is NOT checked: adopted slots
+// always rebuild it before recycling (unknown provenance — the previous owner
+// may have died holding its fd).
+func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
+	nsName := nsNameForSlot(idx)
+	vethName := vethNameForSlot(idx)
+	hostIP := hostIPForSlot(idx)
+
+	if !nsExists(nsName) {
+		return nil, "", fmt.Errorf("adopt slot %d: namespace vanished", idx)
+	}
+	if err := run(ctx, "ip", "link", "show", vethName); err != nil {
+		return nil, "", fmt.Errorf("adopt slot %d: host veth missing: %w", idx, err)
+	}
+	if err := nsRun(ctx, nsName, "ip", "link", "show", "eth0"); err != nil {
+		return nil, "", fmt.Errorf("adopt slot %d: in-namespace peer missing: %w", idx, err)
+	}
+
+	fwCfg := FirewallConfig{
+		TAPInterface: TAPName,
+		VethPeer:     "eth0",
+		VMIP:         VMInternalIP,
+		HostIP:       hostIP,
+		GatewayIP:    VMGatewayIP,
+	}
+	var fw *Firewall
+	if err := nsExecGo(nsName, func() error {
+		f, err := AttachFirewall(fwCfg)
+		if err != nil {
+			return err
+		}
+		fw = f
+		return nil
+	}); err != nil {
+		return nil, "", fmt.Errorf("adopt slot %d: attach firewall: %w", idx, err)
+	}
+
+	// Heal the host route if it didn't survive; mirrors setupSlot's tolerance.
+	if err := run(ctx, "ip", "route", "add", hostIP+"/32", "via", vpeerIPForSlot(idx), "dev", vethName); err != nil {
+		m.log.Debug().Err(err).Str("ns", nsName).Msg("host route (may already exist)")
+	}
+
+	return &VMNetInfo{
+		Namespace:  nsName,
+		TAPDevice:  TAPName,
+		VMIP:       VMInternalIP,
+		GatewayIP:  VMGatewayIP,
+		HostIP:     hostIP,
+		MACAddress: macForSlot(idx),
+		Firewall:   fw,
+	}, vethName, nil
+}
+
+// SweepStrayHostVeths deletes host-side veth-N interfaces whose namespace is
+// gone and whose slot nothing owns — leftovers of a namespace deletion that
+// raced the host-side link. Owned slots are skipped: a mid-build pool slot
+// parks its veth on the host before the namespace side is complete.
+func (m *Manager) SweepStrayHostVeths() (swept int) {
+	veths, err := listHostVeths()
+	if err != nil {
+		return 0
+	}
+	for _, veth := range veths {
+		idxStr, isVeth := strings.CutPrefix(veth, "veth-")
+		idx, err := strconv.Atoi(idxStr)
+		if !isVeth || err != nil || idx < 0 {
+			continue
+		}
+		if nsExists(nsNameForSlot(idx)) {
+			continue
+		}
+		m.mu.Lock()
+		_, owned := m.slotOwner[idx]
+		m.mu.Unlock()
+		if owned {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := run(ctx, "ip", "link", "del", veth); err == nil {
+			m.log.Info().Str("veth", veth).Msg("swept stray host veth")
+			swept++
+		}
+		cancel()
+	}
 	return swept
 }
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -988,13 +989,16 @@ func (m *Manager) claimOrphanSlots() []int {
 		if !ok {
 			continue
 		}
-		if idx >= MaxSlots {
-			// Outside the allocator's range: claiming it would push the
-			// high-water mark past the ceiling and starve fresh allocation.
-			outOfRange = append(outOfRange, idx)
+		// Ownership outranks everything: a record or pinned build may hold any
+		// index, including ones a changed ceiling would now call out of range.
+		if _, owned := m.slotOwner[idx]; owned {
 			continue
 		}
-		if _, owned := m.slotOwner[idx]; owned {
+		if idx > MaxSlots {
+			// Beyond the allocator's inclusive ceiling (claimSlotIndex hands
+			// out MaxSlots itself): claiming would push the high-water mark
+			// past it and starve fresh allocation.
+			outOfRange = append(outOfRange, idx)
 			continue
 		}
 		m.assignSlotLocked(idx, poolOwner)
@@ -1028,14 +1032,13 @@ func (m *Manager) claimOrphanSlots() []int {
 	return out
 }
 
-// adoptSlot rebuilds the in-memory identity of an existing ns-<idx> so it can
-// re-enter the pool: verifies the host-side veth and the in-namespace peer,
-// re-binds the in-namespace nftables handle (mirrors ReattachVM), and re-adds
-// the host route (idempotent). No kernel objects are created — validation
-// doubles as the layout/version check, so a namespace built by an incompatible
-// vmd simply fails here and gets torn down. tap0 is NOT checked: adopted slots
-// always rebuild it before recycling (unknown provenance — the previous owner
-// may have died holding its fd).
+// adoptSlot rebuilds the identity of an existing ns-<idx> so it can re-enter
+// the pool: kills any occupant, verifies the veth pair and the peer's derived
+// address, reinstalls the current base firewall from scratch, and re-adds the
+// host route (idempotent). The structural checks double as the layout/version
+// check, so a namespace built by an incompatible vmd fails here and gets torn
+// down. tap0 is NOT checked: adopted slots always rebuild it before recycling
+// (unknown provenance — the previous owner may have died holding its fd).
 func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
 	nsName := nsNameForSlot(idx)
 	vethName := vethNameForSlot(idx)
@@ -1044,11 +1047,13 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	if !nsExists(nsName) {
 		return nil, "", fmt.Errorf("adopt slot %d: namespace vanished", idx)
 	}
-	if err := run(ctx, "ip", "link", "show", vethName); err != nil {
+	// Kill first: everything below rewrites enforcement state, which must
+	// never happen around a live occupant (a crash can strand a workload here
+	// with its egress restrictions still configured).
+	killProcessesInNs(nsName)
+
+	if _, err := os.Stat("/sys/class/net/" + vethName); err != nil {
 		return nil, "", fmt.Errorf("adopt slot %d: host veth missing: %w", idx, err)
-	}
-	if err := nsRun(ctx, nsName, "ip", "link", "show", "eth0"); err != nil {
-		return nil, "", fmt.Errorf("adopt slot %d: in-namespace peer missing: %w", idx, err)
 	}
 
 	fwCfg := FirewallConfig{
@@ -1060,24 +1065,33 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	}
 	var fw *Firewall
 	if err := nsExecGo(nsName, func() error {
-		f, err := AttachFirewall(fwCfg)
+		iface, err := net.InterfaceByName("eth0")
+		if err != nil {
+			return fmt.Errorf("in-namespace peer missing: %w", err)
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return fmt.Errorf("peer addrs: %w", err)
+		}
+		want := vpeerIPForSlot(idx)
+		found := false
+		for _, a := range addrs {
+			if strings.HasPrefix(a.String(), want+"/") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("peer address mismatch: want %s", want)
+		}
+		f, err := ReinstallFirewall(fwCfg)
 		if err != nil {
 			return err
-		}
-		if err := f.VerifyInstalled(); err != nil {
-			_ = f.Close()
-			return err
-		}
-		// The previous owner's user egress sets must not survive into the
-		// pool — mirrors the recycle path's sanitation before Return.
-		if err := f.ReplaceUserRules(nil, nil); err != nil {
-			_ = f.Close()
-			return fmt.Errorf("clear user rules: %w", err)
 		}
 		fw = f
 		return nil
 	}); err != nil {
-		return nil, "", fmt.Errorf("adopt slot %d: firewall: %w", idx, err)
+		return nil, "", fmt.Errorf("adopt slot %d: %w", idx, err)
 	}
 
 	// Heal the host route if it didn't survive; mirrors setupSlot's tolerance.
@@ -1111,21 +1125,25 @@ func (m *Manager) SweepStrayHostVeths() (swept int) {
 		if !isVeth || err != nil || idx < 0 {
 			continue
 		}
-		if nsExists(nsNameForSlot(idx)) {
-			continue
-		}
+		// Hold the index through the delete: checking and then deleting
+		// unowned would race the refill loop building a fresh slot at this
+		// idx between the check and the `ip link del` — which would sever a
+		// brand-new live slot's host side.
 		m.mu.Lock()
-		_, owned := m.slotOwner[idx]
-		m.mu.Unlock()
-		if owned {
+		if _, owned := m.slotOwner[idx]; owned || nsExists(nsNameForSlot(idx)) {
+			m.mu.Unlock()
 			continue
 		}
+		m.assignSlotLocked(idx, teardownOwner)
+		m.mu.Unlock()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		if err := run(ctx, "ip", "link", "del", veth); err == nil {
 			m.log.Info().Str("veth", veth).Msg("swept stray host veth")
 			swept++
 		}
 		cancel()
+		m.releaseIfOwned(idx, teardownOwner)
 	}
 	return swept
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -826,6 +826,18 @@ func (m *Manager) releaseIfOwned(idx int, owner string) bool {
 	return true
 }
 
+// dropIfOwned removes owner's hold on idx WITHOUT returning it to freeSlots —
+// for indexes whose kernel state is still suspect (e.g. a stray host link
+// that failed to delete). The index stays unclaimable this lifetime; the next
+// boot's sweep retries it.
+func (m *Manager) dropIfOwned(idx int, owner string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.slotOwner[idx] == owner {
+		delete(m.slotOwner, idx)
+	}
+}
+
 // ClaimFreshSlot claims a fresh, unused slot index under owner without building
 // any kernel network state. The caller — a template-builder subprocess —
 // creates ns-<idx>/veth-<idx> itself; the reservation is what stops vmd's
@@ -1160,7 +1172,19 @@ func (m *Manager) SweepStrayHostVeths() (swept int) {
 	for _, veth := range veths {
 		idxStr, isVeth := strings.CutPrefix(veth, "veth-")
 		idx, err := strconv.Atoi(idxStr)
-		if !isVeth || err != nil || idx < 0 {
+		if !isVeth || err != nil {
+			continue
+		}
+		if idx < 1 || idx > MaxSlots {
+			// Outside the allocator's range nothing can race us building
+			// here, and the index must never become claimable — delete the
+			// stray link and move on.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := run(ctx, "ip", "link", "del", veth); err == nil {
+				m.log.Info().Str("veth", veth).Msg("swept stray host veth")
+				swept++
+			}
+			cancel()
 			continue
 		}
 		// Hold the index through the delete: checking and then deleting
@@ -1176,12 +1200,19 @@ func (m *Manager) SweepStrayHostVeths() (swept int) {
 		m.mu.Unlock()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := run(ctx, "ip", "link", "del", veth); err == nil {
+		delErr := run(ctx, "ip", "link", "del", veth)
+		cancel()
+		if delErr == nil {
 			m.log.Info().Str("veth", veth).Msg("swept stray host veth")
 			swept++
+			m.releaseIfOwned(idx, teardownOwner)
+			continue
 		}
-		cancel()
-		m.releaseIfOwned(idx, teardownOwner)
+		// The link may still exist: freeing the index would let the refill
+		// loop build here and collide with it on the move-to-host step. Keep
+		// it out of the free list; the next boot's sweep retries.
+		m.log.Warn().Err(delErr).Str("veth", veth).Msg("stray host veth delete failed — index withheld")
+		m.dropIfOwned(idx, teardownOwner)
 	}
 	return swept
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -995,10 +995,12 @@ func (m *Manager) claimOrphanSlots() []int {
 		if _, owned := m.slotOwner[idx]; owned {
 			continue
 		}
-		if idx > MaxSlots {
-			// Beyond the allocator's inclusive ceiling (claimSlotIndex hands
-			// out MaxSlots itself): claiming would push the high-water mark
-			// past it and starve fresh allocation.
+		if idx < 1 || idx > MaxSlots {
+			// Outside the allocator's range: it starts at 1 and hands out up
+			// to and including MaxSlots. Below it: ns-0 is never built (and a
+			// long-enough name overflows slotFromNamespace negative); above
+			// it, claiming would push the high-water mark past the ceiling
+			// and starve fresh allocation.
 			outOfRange = append(outOfRange, idx)
 			continue
 		}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1064,8 +1064,6 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		if err != nil {
 			return err
 		}
-		// Attach binds names without proving the ruleset exists; a crash
-		// mid-setup leaves adoptable-looking namespaces with no enforcement.
 		if err := f.VerifyInstalled(); err != nil {
 			_ = f.Close()
 			return err

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1063,40 +1063,68 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		HostIP:       hostIP,
 		GatewayIP:    VMGatewayIP,
 	}
-	var fw *Firewall
-	if err := nsExecGo(nsName, func() error {
-		iface, err := net.InterfaceByName("eth0")
-		if err != nil {
-			return fmt.Errorf("in-namespace peer missing: %w", err)
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return fmt.Errorf("peer addrs: %w", err)
-		}
-		want := vpeerIPForSlot(idx)
-		found := false
-		for _, a := range addrs {
-			if strings.HasPrefix(a.String(), want+"/") {
-				found = true
-				break
+	// The in-namespace work (netlink, nftables) cannot observe ctx once it is
+	// on the pinned thread, and a wedged netlink socket would otherwise hang
+	// the adoption worker forever — bound it from outside. On timeout the
+	// abandoned goroutine is reaped when (if) it finishes: its thread stays
+	// pinned until then, an accepted, bounded cost of surviving a wedge.
+	type nsResult struct {
+		fw  *Firewall
+		err error
+	}
+	resCh := make(chan nsResult, 1)
+	go func() {
+		var fw *Firewall
+		err := nsExecGo(nsName, func() error {
+			iface, err := net.InterfaceByName("eth0")
+			if err != nil {
+				return fmt.Errorf("in-namespace peer missing: %w", err)
 			}
+			addrs, err := iface.Addrs()
+			if err != nil {
+				return fmt.Errorf("peer addrs: %w", err)
+			}
+			want := vpeerIPForSlot(idx)
+			found := false
+			for _, a := range addrs {
+				if strings.HasPrefix(a.String(), want+"/") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("peer address mismatch: want %s", want)
+			}
+			f, err := ReinstallFirewall(fwCfg)
+			if err != nil {
+				return err
+			}
+			fw = f
+			return nil
+		})
+		resCh <- nsResult{fw: fw, err: err}
+	}()
+	var fw *Firewall
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			return nil, "", fmt.Errorf("adopt slot %d: %w", idx, res.err)
 		}
-		if !found {
-			return fmt.Errorf("peer address mismatch: want %s", want)
-		}
-		f, err := ReinstallFirewall(fwCfg)
-		if err != nil {
-			return err
-		}
-		fw = f
-		return nil
-	}); err != nil {
-		return nil, "", fmt.Errorf("adopt slot %d: %w", idx, err)
+		fw = res.fw
+	case <-ctx.Done():
+		go func() {
+			if res := <-resCh; res.fw != nil {
+				_ = res.fw.Close()
+			}
+		}()
+		return nil, "", fmt.Errorf("adopt slot %d: namespace validation: %w", idx, ctx.Err())
 	}
 
-	// Heal the host route if it didn't survive; mirrors setupSlot's tolerance.
-	if err := run(ctx, "ip", "route", "add", hostIP+"/32", "via", vpeerIPForSlot(idx), "dev", vethName); err != nil {
-		m.log.Debug().Err(err).Str("ns", nsName).Msg("host route (may already exist)")
+	// The host route must exist for the claimed VM to be reachable; replace is
+	// idempotent, so any failure means the slot is structurally broken.
+	if err := run(ctx, "ip", "route", "replace", hostIP+"/32", "via", vpeerIPForSlot(idx), "dev", vethName); err != nil {
+		_ = fw.Close()
+		return nil, "", fmt.Errorf("adopt slot %d: host route: %w", idx, err)
 	}
 
 	return &VMNetInfo{

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -311,6 +311,7 @@ func hostIPForSlot(idx int) string {
 func nsNameForSlot(idx int) string    { return fmt.Sprintf("ns-%d", idx) }
 func vethNameForSlot(idx int) string  { return fmt.Sprintf("veth-%d", idx) }
 func vpeerIPForSlot(idx int) string   { return fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256) }
+func vethIPForSlot(idx int) string    { return fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256) }
 func macForSlot(idx int) string       { return fmt.Sprintf("AA:FC:00:%02X:%02X:%02X", 0, idx/256, idx%256) }
 
 // setupSlot runs the expensive network setup (namespace, veth, TAP,
@@ -322,7 +323,7 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	// live and stays owned; on failure the caller releases idx (freeSlot).
 	hostIP := hostIPForSlot(idx)
 	vpeerIP := vpeerIPForSlot(idx)
-	vethIP := fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256)
+	vethIP := vethIPForSlot(idx)
 	nsName := nsNameForSlot(idx)
 	vethName := vethNameForSlot(idx)
 	vpeerName := "eth0"
@@ -1120,12 +1121,19 @@ func (m *Manager) adoptSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 		return nil, "", fmt.Errorf("adopt slot %d: namespace validation: %w", idx, ctx.Err())
 	}
 
-	// The host route must exist for the claimed VM to be reachable; replace is
+	// Both routes must exist for the claimed VM to work — host side to reach
+	// it, namespace side for its outbound traffic — and a crash can strand a
+	// namespace between address config and route install. Replace is
 	// idempotent, so any failure means the slot is structurally broken.
 	if err := run(ctx, "ip", "route", "replace", hostIP+"/32", "via", vpeerIPForSlot(idx), "dev", vethName); err != nil {
 		_ = fw.Close()
 		return nil, "", fmt.Errorf("adopt slot %d: host route: %w", idx, err)
 	}
+	if err := nsRun(ctx, nsName, "ip", "route", "replace", "default", "via", vethIPForSlot(idx)); err != nil {
+		_ = fw.Close()
+		return nil, "", fmt.Errorf("adopt slot %d: namespace default route: %w", idx, err)
+	}
+	_ = nsRun(ctx, nsName, "ip", "link", "set", "lo", "up")
 
 	return &VMNetInfo{
 		Namespace:  nsName,

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -69,10 +70,12 @@ type preallocSlot struct {
 	info *VMNetInfo
 	// vethName is needed for cleanup if the slot is never claimed.
 	vethName string
-	// forceTapReset rebuilds tap0 in verifyAndRecycle regardless of the
-	// pool-level flag. Set on adopted slots: their provenance is unknown, and
-	// a previous owner may have died holding the tap fd.
-	forceTapReset bool
+	// adopted marks a slot recovered from a previous vmd lifetime: its tap is
+	// rebuilt in verifyAndRecycle regardless of the pool-level flag (unknown
+	// provenance — a previous owner may have died holding the fd), and it may
+	// overflow into the fresh channel when the recycle channel is full, since
+	// it is fully built and counts against the refill target.
+	adopted bool
 }
 
 // pidsInNsFunc is a seam over pidsInNs so tests can simulate a namespace
@@ -175,6 +178,11 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			default:
 				return nil
 			}
+		}
+		if slot == nil {
+			// mustAllocate returns nil at shutdown and the refill select can
+			// still win the send arm — fall back to on-demand setup.
+			return nil
 		}
 		tPopped := time.Now()
 
@@ -281,12 +289,12 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 
 	// Process-free doesn't prove tap0's fd is released, so rebuild the tap
 	// before recycling; if it can't be rebuilt, tear down instead.
-	if p.resetTapOnRecycle || slot.forceTapReset {
-		// A full recycle pool means this slot is headed for teardown anyway —
-		// skip the rebuild rather than pay it for a slot about to be destroyed
+	if p.resetTapOnRecycle || slot.adopted {
+		// A full pool means this slot is headed for teardown anyway — skip
+		// the rebuild rather than pay it for a slot about to be destroyed
 		// (mass deletes overflow the pool by design). Racy but safe: the send
 		// below still has a default arm.
-		if len(p.recycled) == cap(p.recycled) {
+		if p.placementFull(slot) {
 			p.cleanup(slot)
 			return
 		}
@@ -304,7 +312,7 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 			defer func() { <-p.resetSem }()
 			// Recheck after queueing: a mass return can fill the pool while
 			// this slot waited, and a doomed slot shouldn't pay for a rebuild.
-			if len(p.recycled) == cap(p.recycled) {
+			if p.placementFull(slot) {
 				return true, nil
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), resetTapTimeout)
@@ -331,9 +339,29 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		// (pool shutting down mid-verify) can't race a send on a closed channel.
 		p.stopSlot(slot)
 	default:
-		// Recycle pool full — tear down (cleanup releases the pool's ownership).
+		// Recycle pool full. An adopted slot is fully built, so it counts as
+		// fresh inventory instead of being destroyed while the refill loop
+		// rebuilds its twin from scratch; otherwise tear down (cleanup
+		// releases the pool's ownership).
+		if slot.adopted {
+			select {
+			case p.fresh <- slot:
+				return
+			default:
+			}
+		}
 		p.cleanup(slot)
 	}
+}
+
+// placementFull reports that slot has nowhere to go, so pre-recycle work
+// (the tap rebuild) would be wasted on it. Adopted slots can also land in
+// the fresh channel; returned slots only ever recycle.
+func (p *Pool) placementFull(slot *preallocSlot) bool {
+	if len(p.recycled) < cap(p.recycled) {
+		return false
+	}
+	return !slot.adopted || len(p.fresh) == cap(p.fresh)
 }
 
 // stopSlot disposes of a slot the shutdown path can no longer place: torn
@@ -350,56 +378,41 @@ func (p *Pool) stopSlot(slot *preallocSlot) {
 // AdoptOrphanSlots claims every namespace a previous vmd lifetime left behind
 // and feeds the valid ones through the recycle verification path, so a restart
 // starts with a warm pool instead of rebuilding it from scratch. Slots that
-// fail validation are torn down. Must run after startup slot reservation (so
-// record-owned indexes are never candidates); returns when the pass completes.
-func (p *Pool) AdoptOrphanSlots(ctx context.Context) {
+// fail validation are torn down; slots that couldn't be judged (shutdown,
+// slow host) are left for a later pass. Must run after startup slot
+// reservation completed successfully — record-owned indexes must never be
+// candidates. Returns the pass's counts.
+func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped int64) {
 	indexes := p.mgr.claimOrphanSlots()
 	if len(indexes) > 0 {
 		p.log.Info().Int("candidates", len(indexes)).Msg("pool: adopting slots left by previous run")
 
-		var validated, invalid atomic.Int64
+		var nAdopted, nInvalid, nSkipped atomic.Int64
 		work := make(chan int)
 		var workers sync.WaitGroup
 		for i := 0; i < adoptConcurrency; i++ {
 			workers.Add(1)
-			p.wg.Add(1)
 			go func() {
 				defer workers.Done()
-				defer p.wg.Done()
 				defer sentrylog.Recover("netpool-adopt")
 				for idx := range work {
-					actx, cancel := context.WithTimeout(ctx, adoptSlotTimeout)
-					info, vethName, err := adoptSlotFunc(p.mgr, actx, idx)
-					cancel()
-					if err != nil {
-						p.log.Warn().Err(err).Int("slot", idx).
-							Msg("pool: orphan slot failed validation — tearing down")
-						// Kill occupants first (mirrors the startup sweep):
-						// deleting the netns name while a process holds it
-						// leaves the namespace running anonymously, beyond
-						// the reach of adoption, sweeps, and the leak gauge.
-						killProcessesInNs(nsNameForSlot(idx))
-						p.cleanup(&preallocSlot{
-							idx:      idx,
-							info:     &VMNetInfo{Namespace: nsNameForSlot(idx)},
-							vethName: vethNameForSlot(idx),
-						})
-						invalid.Add(1)
-						continue
-					}
-					p.verifyAndRecycle(&preallocSlot{
-						idx:           idx,
-						info:          info,
-						vethName:      vethName,
-						forceTapReset: true,
-					})
-					validated.Add(1)
+					p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped)
 				}
 			}()
 		}
 
 	feed:
 		for _, idx := range indexes {
+			// Priority check: once shutdown fires, no more work may be
+			// dispatched — the plain select below picks randomly among ready
+			// arms, which would keep feeding a dying process.
+			select {
+			case <-p.stopCh:
+				break feed
+			case <-ctx.Done():
+				break feed
+			default:
+			}
 			select {
 			case work <- idx:
 			case <-p.stopCh:
@@ -412,11 +425,69 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) {
 		}
 		close(work)
 		workers.Wait()
-		p.log.Info().Int64("adopted", validated.Load()).Int64("torn_down", invalid.Load()).
-			Msg("pool: adoption pass complete")
+		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
+			Int64("skipped", nSkipped.Load()).Msg("pool: adoption pass complete")
+		adopted, invalid, skipped = nAdopted.Load(), nInvalid.Load(), nSkipped.Load()
 	}
 
 	p.mgr.SweepStrayHostVeths()
+	return adopted, invalid, skipped
+}
+
+// adoptOne validates and places a single claimed orphan. Outcomes: adopted
+// (into the pool via the recycle verification path), torn down (definitively
+// invalid), or skipped — released but left intact in the kernel — when the
+// slot couldn't be judged: shutdown cancelled the pass, validation timed out
+// on a congested boot, or validation panicked. Skipped slots surface in the
+// leak gauge as orphans and are re-adopted on the next boot; destroying them
+// on an ambiguous signal would defeat abandon-on-stop.
+func (p *Pool) adoptOne(ctx context.Context, idx int, adopted, invalid, skipped *atomic.Int64) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.log.Error().Interface("panic", r).Int("slot", idx).
+				Msg("pool: adoption panicked — releasing slot")
+			p.mgr.releaseIfOwned(idx, poolOwner)
+			skipped.Add(1)
+		}
+	}()
+
+	actx, cancel := context.WithTimeout(ctx, adoptSlotTimeout)
+	info, vethName, err := adoptSlotFunc(p.mgr, actx, idx)
+	cancel()
+	if err != nil {
+		switch {
+		case ctx.Err() != nil:
+			// Shutdown, not a bad slot: keep it abandoned for the next boot.
+			skipped.Add(1)
+		case errors.Is(err, context.DeadlineExceeded):
+			p.log.Warn().Err(err).Int("slot", idx).
+				Msg("pool: orphan slot validation timed out — leaving for a later pass")
+			p.mgr.releaseIfOwned(idx, poolOwner)
+			skipped.Add(1)
+		default:
+			p.log.Warn().Err(err).Int("slot", idx).
+				Msg("pool: orphan slot failed validation — tearing down")
+			// Kill occupants first (mirrors the startup sweep): deleting the
+			// netns name while a process holds it leaves the namespace
+			// running anonymously, beyond the reach of adoption, sweeps, and
+			// the leak gauge.
+			killProcessesInNs(nsNameForSlot(idx))
+			p.cleanup(&preallocSlot{
+				idx:      idx,
+				info:     &VMNetInfo{Namespace: nsNameForSlot(idx)},
+				vethName: vethNameForSlot(idx),
+			})
+			invalid.Add(1)
+		}
+		return
+	}
+	p.verifyAndRecycle(&preallocSlot{
+		idx:      idx,
+		info:     info,
+		vethName: vethName,
+		adopted:  true,
+	})
+	adopted.Add(1)
 }
 
 // Stop shuts the pool down. Under abandon-on-stop, warm slots are left in the
@@ -535,6 +606,11 @@ func (p *Pool) allocate(ctx context.Context) (*preallocSlot, error) {
 func (p *Pool) cleanup(slot *preallocSlot) {
 	if slot == nil || slot.info == nil {
 		return
+	}
+	// Release the netlink handle with the slot (mirrors the VM teardown
+	// path) — adopted slots each carry one, and leaking it survives the ns.
+	if slot.info.Firewall != nil {
+		_ = slot.info.Firewall.Close()
 	}
 	nsName := slot.info.Namespace
 	p.mgr.cleanupFull(nsName, slot.vethName)

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -117,6 +117,12 @@ const (
 	// adoptSlotTimeout bounds one slot's validation (a handful of ip/netlink
 	// calls); a hung namespace shouldn't stall the whole adoption pass.
 	adoptSlotTimeout = 10 * time.Second
+	// adoptTimeoutAbort ends the whole pass after this many validation
+	// timeouts. Each timeout strands one pinned OS thread in the wedged
+	// syscall, and wedges are systemic (a stuck netlink wedges every
+	// candidate) — better to stop early and leave the rest for a healthier
+	// boot than to accumulate a thread per slot.
+	adoptTimeoutAbort = 3
 )
 
 // adoptSlotFunc is a seam over Manager.adoptSlot so tests can drive adoption
@@ -387,7 +393,7 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 	if len(indexes) > 0 {
 		p.log.Info().Int("candidates", len(indexes)).Msg("pool: adopting slots left by previous run")
 
-		var nAdopted, nInvalid, nSkipped atomic.Int64
+		var nAdopted, nInvalid, nSkipped, nTimeouts atomic.Int64
 		work := make(chan int)
 		var workers sync.WaitGroup
 		for i := 0; i < adoptConcurrency; i++ {
@@ -396,13 +402,14 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				defer workers.Done()
 				defer sentrylog.Recover("netpool-adopt")
 				for idx := range work {
-					p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped)
+					p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped, &nTimeouts)
 				}
 			}()
 		}
 
+		aborted := false
 	feed:
-		for _, idx := range indexes {
+		for i, idx := range indexes {
 			// Priority check: once shutdown fires, no more work may be
 			// dispatched — the plain select below picks randomly among ready
 			// arms, which would keep feeding a dying process.
@@ -412,6 +419,18 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 			case <-ctx.Done():
 				break feed
 			default:
+			}
+			if nTimeouts.Load() >= adoptTimeoutAbort {
+				// The host is wedged, not the slots: each timeout strands a
+				// pinned thread, so stop dispatching. Unlike a shutdown break
+				// this process lives on — release the remainder so it isn't
+				// held pool-owned and invisible to the leak gauge.
+				aborted = true
+				for _, rest := range indexes[i:] {
+					p.mgr.releaseIfOwned(rest, poolOwner)
+					nSkipped.Add(1)
+				}
+				break feed
 			}
 			select {
 			case work <- idx:
@@ -425,6 +444,10 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 		}
 		close(work)
 		workers.Wait()
+		if aborted {
+			p.log.Error().Int64("timeouts", nTimeouts.Load()).
+				Msg("pool: adoption aborted — validation timing out systemically; remaining slots left for a later boot")
+		}
 		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
 			Int64("skipped", nSkipped.Load()).Msg("pool: adoption pass complete")
 		adopted, invalid, skipped = nAdopted.Load(), nInvalid.Load(), nSkipped.Load()
@@ -441,7 +464,7 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 // on a congested boot, or validation panicked. Skipped slots surface in the
 // leak gauge as orphans and are re-adopted on the next boot; destroying them
 // on an ambiguous signal would defeat abandon-on-stop.
-func (p *Pool) adoptOne(ctx context.Context, idx int, adopted, invalid, skipped *atomic.Int64) {
+func (p *Pool) adoptOne(ctx context.Context, idx int, adopted, invalid, skipped, timeouts *atomic.Int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			p.log.Error().Interface("panic", r).Int("slot", idx).
@@ -464,6 +487,7 @@ func (p *Pool) adoptOne(ctx context.Context, idx int, adopted, invalid, skipped 
 				Msg("pool: orphan slot validation timed out — leaving for a later pass")
 			p.mgr.releaseIfOwned(idx, poolOwner)
 			skipped.Add(1)
+			timeouts.Add(1)
 		default:
 			p.log.Warn().Err(err).Int("slot", idx).
 				Msg("pool: orphan slot failed validation — tearing down")

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -374,6 +374,11 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) {
 					if err != nil {
 						p.log.Warn().Err(err).Int("slot", idx).
 							Msg("pool: orphan slot failed validation — tearing down")
+						// Kill occupants first (mirrors the startup sweep):
+						// deleting the netns name while a process holds it
+						// leaves the namespace running anonymously, beyond
+						// the reach of adoption, sweeps, and the leak gauge.
+						killProcessesInNs(nsNameForSlot(idx))
 						p.cleanup(&preallocSlot{
 							idx:      idx,
 							info:     &VMNetInfo{Namespace: nsNameForSlot(idx)},

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -23,6 +24,11 @@ type PoolConfig struct {
 	// ResetTapOnRecycle recreates a returned slot's tap0 before it is made
 	// claimable again (see verifyAndRecycle). Off by default.
 	ResetTapOnRecycle bool
+	// AbandonOnStop makes Stop leave warm slots in the kernel instead of
+	// tearing them down, so shutdown is near-instant regardless of pool depth
+	// and the next process adopts the slots via AdoptOrphanSlots. Off by
+	// default (legacy teardown).
+	AbandonOnStop bool
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
@@ -48,6 +54,9 @@ type Pool struct {
 
 	// resetTapOnRecycle recreates tap0 before a returned slot is recycled.
 	resetTapOnRecycle bool
+	// abandonOnStop: Stop leaves slots in the kernel for the next process
+	// to adopt instead of tearing them down (see PoolConfig.AbandonOnStop).
+	abandonOnStop bool
 	// resetSem bounds concurrent tap rebuilds so a mass delete's returns can't
 	// fork-storm the kernel's netlink lock.
 	resetSem chan struct{}
@@ -60,6 +69,10 @@ type preallocSlot struct {
 	info *VMNetInfo
 	// vethName is needed for cleanup if the slot is never claimed.
 	vethName string
+	// forceTapReset rebuilds tap0 in verifyAndRecycle regardless of the
+	// pool-level flag. Set on adopted slots: their provenance is unknown, and
+	// a previous owner may have died holding the tap fd.
+	forceTapReset bool
 }
 
 // pidsInNsFunc is a seam over pidsInNs so tests can simulate a namespace
@@ -90,7 +103,22 @@ const (
 	// under a second, and a tight bound keeps a stalled backlog (and Stop)
 	// from dragging.
 	resetTapTimeout = 3 * time.Second
+	// abandonStopWait bounds Stop's wait for in-flight pool goroutines under
+	// abandon-on-stop. Only quiesces logging — abandoned slots are recovered
+	// by boot-time adoption regardless.
+	abandonStopWait = 2 * time.Second
+	// adoptConcurrency bounds parallel orphan adoptions: each runs /proc
+	// scans and possibly a tap rebuild, and boot is exactly when the host is
+	// also reattaching VMs — keep the sweep gentle.
+	adoptConcurrency = 4
+	// adoptSlotTimeout bounds one slot's validation (a handful of ip/netlink
+	// calls); a hung namespace shouldn't stall the whole adoption pass.
+	adoptSlotTimeout = 10 * time.Second
 )
+
+// adoptSlotFunc is a seam over Manager.adoptSlot so tests can drive adoption
+// without real kernel namespaces.
+var adoptSlotFunc = (*Manager).adoptSlot
 
 // StartPool creates the network slot pool and fills it in the background, so
 // startup (and the gRPC readiness gate) doesn't block on ~newSize slot setups;
@@ -114,6 +142,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		recycled:          make(chan *preallocSlot, recycleSize),
 		stopCh:            make(chan struct{}),
 		resetTapOnRecycle: cfg.ResetTapOnRecycle,
+		abandonOnStop:     cfg.AbandonOnStop,
 		resetSem:          make(chan struct{}, resetTapConcurrency),
 	}
 	m.pool = p
@@ -245,14 +274,14 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		select {
 		case <-time.After(pollInterval):
 		case <-p.stopCh:
-			p.cleanup(slot)
+			p.stopSlot(slot)
 			return
 		}
 	}
 
 	// Process-free doesn't prove tap0's fd is released, so rebuild the tap
 	// before recycling; if it can't be rebuilt, tear down instead.
-	if p.resetTapOnRecycle {
+	if p.resetTapOnRecycle || slot.forceTapReset {
 		// A full recycle pool means this slot is headed for teardown anyway —
 		// skip the rebuild rather than pay it for a slot about to be destroyed
 		// (mass deletes overflow the pool by design). Racy but safe: the send
@@ -266,7 +295,7 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		select {
 		case p.resetSem <- struct{}{}:
 		case <-p.stopCh:
-			p.cleanup(slot)
+			p.stopSlot(slot)
 			return
 		}
 		poolFull, err := func() (bool, error) {
@@ -300,16 +329,115 @@ func (p *Pool) verifyAndRecycle(slot *preallocSlot) {
 		// Stop() closes p.recycled only after p.wg.Wait() returns, and this
 		// goroutine holds a wg slot until it returns — so stopCh firing here
 		// (pool shutting down mid-verify) can't race a send on a closed channel.
-		p.cleanup(slot)
+		p.stopSlot(slot)
 	default:
 		// Recycle pool full — tear down (cleanup releases the pool's ownership).
 		p.cleanup(slot)
 	}
 }
 
-// Stop drains both pools and cleans up unclaimed slots.
+// stopSlot disposes of a slot the shutdown path can no longer place: torn
+// down under legacy shutdown, left in the kernel under abandon-on-stop (the
+// next process adopts or sweeps it — a graceful stop and a crash leave the
+// host in the same state, so boot only needs one recovery path).
+func (p *Pool) stopSlot(slot *preallocSlot) {
+	if p.abandonOnStop {
+		return
+	}
+	p.cleanup(slot)
+}
+
+// AdoptOrphanSlots claims every namespace a previous vmd lifetime left behind
+// and feeds the valid ones through the recycle verification path, so a restart
+// starts with a warm pool instead of rebuilding it from scratch. Slots that
+// fail validation are torn down. Must run after startup slot reservation (so
+// record-owned indexes are never candidates); returns when the pass completes.
+func (p *Pool) AdoptOrphanSlots(ctx context.Context) {
+	indexes := p.mgr.claimOrphanSlots()
+	if len(indexes) > 0 {
+		p.log.Info().Int("candidates", len(indexes)).Msg("pool: adopting slots left by previous run")
+
+		var validated, invalid atomic.Int64
+		work := make(chan int)
+		var workers sync.WaitGroup
+		for i := 0; i < adoptConcurrency; i++ {
+			workers.Add(1)
+			p.wg.Add(1)
+			go func() {
+				defer workers.Done()
+				defer p.wg.Done()
+				defer sentrylog.Recover("netpool-adopt")
+				for idx := range work {
+					actx, cancel := context.WithTimeout(ctx, adoptSlotTimeout)
+					info, vethName, err := adoptSlotFunc(p.mgr, actx, idx)
+					cancel()
+					if err != nil {
+						p.log.Warn().Err(err).Int("slot", idx).
+							Msg("pool: orphan slot failed validation — tearing down")
+						p.cleanup(&preallocSlot{
+							idx:      idx,
+							info:     &VMNetInfo{Namespace: nsNameForSlot(idx)},
+							vethName: vethNameForSlot(idx),
+						})
+						invalid.Add(1)
+						continue
+					}
+					p.verifyAndRecycle(&preallocSlot{
+						idx:           idx,
+						info:          info,
+						vethName:      vethName,
+						forceTapReset: true,
+					})
+					validated.Add(1)
+				}
+			}()
+		}
+
+	feed:
+		for _, idx := range indexes {
+			select {
+			case work <- idx:
+			case <-p.stopCh:
+				// Shutdown mid-pass: un-fed indexes stay claimed and in the
+				// kernel — the same abandoned state the next boot adopts from.
+				break feed
+			case <-ctx.Done():
+				break feed
+			}
+		}
+		close(work)
+		workers.Wait()
+		p.log.Info().Int64("adopted", validated.Load()).Int64("torn_down", invalid.Load()).
+			Msg("pool: adoption pass complete")
+	}
+
+	p.mgr.SweepStrayHostVeths()
+}
+
+// Stop shuts the pool down. Under abandon-on-stop, warm slots are left in the
+// kernel for the next process to adopt and Stop returns near-instantly —
+// per-slot teardown scales with pool depth and host congestion, and vmd's
+// exit gates the restart's whole unavailability window. Legacy mode drains
+// both pools and cleans up every unclaimed slot.
 func (p *Pool) Stop() {
 	close(p.stopCh)
+
+	if p.abandonOnStop {
+		// Bounded wait purely to let in-flight goroutines observe stopCh and
+		// quiesce; slots stay in the kernel either way, so an expired wait
+		// abandons nothing that boot-time adoption doesn't already cover.
+		done := make(chan struct{})
+		go func() { p.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(abandonStopWait):
+			p.log.Warn().Msg("pool: in-flight workers still settling at exit — slots remain adoptable")
+		}
+		p.log.Info().Int("fresh", len(p.fresh)).Int("recycled", len(p.recycled)).
+			Msg("network pool stopped (slots abandoned for adoption)")
+		return
+	}
+
 	p.wg.Wait()
 
 	close(p.fresh)
@@ -354,10 +482,10 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		select {
 		case p.fresh <- slot:
 		case <-p.stopCh:
-			p.cleanup(slot)
+			p.stopSlot(slot)
 			return
 		case <-ctx.Done():
-			p.cleanup(slot)
+			p.stopSlot(slot)
 			return
 		}
 	}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -476,13 +476,18 @@ func (p *Pool) adoptOne(ctx context.Context, idx int, adopted, invalid, skipped,
 
 	actx, cancel := context.WithTimeout(ctx, adoptSlotTimeout)
 	info, vethName, err := adoptSlotFunc(p.mgr, actx, idx)
+	// Read the budget verdict from the context itself, BEFORE cancel makes
+	// Err() unconditionally non-nil: an exec killed by the deadline surfaces
+	// as an exit error ("signal: killed"), not as DeadlineExceeded, and
+	// misreading that as a bad slot would tear down an adoptable namespace.
+	budgetExpired := errors.Is(actx.Err(), context.DeadlineExceeded)
 	cancel()
 	if err != nil {
 		switch {
 		case ctx.Err() != nil:
 			// Shutdown, not a bad slot: keep it abandoned for the next boot.
 			skipped.Add(1)
-		case errors.Is(err, context.DeadlineExceeded):
+		case budgetExpired || errors.Is(err, context.DeadlineExceeded):
 			p.log.Warn().Err(err).Int("slot", idx).
 				Msg("pool: orphan slot validation timed out — leaving for a later pass")
 			p.mgr.releaseIfOwned(idx, poolOwner)

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -635,3 +635,25 @@ func TestClaimOrphanSlots_SkipsOwnedAndBumpsHighWater(t *testing.T) {
 		t.Fatalf("nextSlot must advance past adopted indexes, got %d", next)
 	}
 }
+
+func TestClaimOrphanSlots_RejectsOutOfRangeIndex(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-99999999") // beyond MaxSlots: must never enter the allocator
+	touchNS(t, dir, "ns-2")
+	m := newTestManager()
+
+	got := m.claimOrphanSlots()
+	if len(got) != 1 || got[0] != 2 {
+		t.Fatalf("expected only slot 2 claimed, got %v", got)
+	}
+	m.mu.Lock()
+	_, owned := m.slotOwner[99999999]
+	next := m.nextSlot
+	m.mu.Unlock()
+	if owned {
+		t.Fatal("out-of-range index must not be claimed")
+	}
+	if next > MaxSlots {
+		t.Fatalf("high-water mark must stay within the allocator range, got %d", next)
+	}
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -657,3 +657,114 @@ func TestClaimOrphanSlots_RejectsOutOfRangeIndex(t *testing.T) {
 		t.Fatalf("high-water mark must stay within the allocator range, got %d", next)
 	}
 }
+
+func TestClaimOrphanSlots_CeilingIndexIsAdoptable(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, fmt.Sprintf("ns-%d", MaxSlots)) // the allocator hands out MaxSlots itself
+	m := newTestManager()
+
+	got := m.claimOrphanSlots()
+	if len(got) != 1 || got[0] != MaxSlots {
+		t.Fatalf("the inclusive ceiling index must be adoptable, got %v", got)
+	}
+}
+
+func TestClaimOrphanSlots_OwnedOutOfRangeSurvives(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-99999998")
+	m := newTestManager()
+	m.mu.Lock()
+	m.assignSlotLocked(99999998, "vm-live") // e.g. a record above a lowered ceiling
+	m.mu.Unlock()
+
+	if got := m.claimOrphanSlots(); len(got) != 0 {
+		t.Fatalf("owned namespace must never be a candidate, got %v", got)
+	}
+	m.mu.Lock()
+	owner := m.slotOwner[99999998]
+	m.mu.Unlock()
+	if owner != "vm-live" {
+		t.Fatalf("ownership must be untouched, got %q", owner)
+	}
+}
+
+func TestAdoptOrphanSlots_OverflowLandsInFresh(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	// Recycle channel already full: the adopted slot must become fresh
+	// inventory, not be destroyed while refill would rebuild its twin.
+	for i := 0; i < cap(p.recycled); i++ {
+		p.recycled <- &preallocSlot{idx: 100 + i, info: &VMNetInfo{Namespace: "ns-x"}}
+	}
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		return &VMNetInfo{Namespace: nsNameForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	adopted, invalid, _ := p.AdoptOrphanSlots(context.Background())
+	if adopted != 1 || invalid != 0 {
+		t.Fatalf("expected 1 adopted / 0 torn down, got %d/%d", adopted, invalid)
+	}
+	if len(p.fresh) != 1 {
+		t.Fatalf("overflow adoptee must land in the fresh channel, got %d", len(p.fresh))
+	}
+}
+
+func TestAdoptOrphanSlots_TimeoutSkipsAndReleases(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	stubAdoptSlot(t, func(*Manager, context.Context, int) (*VMNetInfo, string, error) {
+		return nil, "", fmt.Errorf("host veth check: %w", context.DeadlineExceeded)
+	})
+
+	adopted, invalid, skipped := p.AdoptOrphanSlots(context.Background())
+	if adopted != 0 || invalid != 0 || skipped != 1 {
+		t.Fatalf("timeout must skip, not tear down: adopted=%d invalid=%d skipped=%d", adopted, invalid, skipped)
+	}
+	// Released for a later pass, namespace left intact for the leak gauge
+	// and the next boot.
+	m.mu.Lock()
+	_, owned := m.slotOwner[7]
+	m.mu.Unlock()
+	if owned {
+		t.Fatal("timed-out slot must be released, not held")
+	}
+}
+
+func TestAdoptOrphanSlots_WorkerPanicReleasesAndContinues(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	touchNS(t, dir, "ns-8")
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		if idx == 7 {
+			panic("unexpected kernel state")
+		}
+		return &VMNetInfo{Namespace: nsNameForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	adopted, _, skipped := p.AdoptOrphanSlots(context.Background())
+	if adopted != 1 || skipped != 1 {
+		t.Fatalf("panic must be contained per slot: adopted=%d skipped=%d", adopted, skipped)
+	}
+	m.mu.Lock()
+	_, owned7 := m.slotOwner[7]
+	m.mu.Unlock()
+	if owned7 {
+		t.Fatal("panicked slot must be released so it isn't stranded invisibly")
+	}
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -486,3 +486,152 @@ func TestPoolReturn_FailedScanIsNotTreatedAsClear(t *testing.T) {
 		t.Fatal("slot never recycled once scans started succeeding")
 	}
 }
+
+// stubAdoptSlot overrides adoptSlotFunc for the duration of the test, so
+// adoption runs without real kernel namespaces.
+func stubAdoptSlot(t *testing.T, fn func(m *Manager, ctx context.Context, idx int) (*VMNetInfo, string, error)) {
+	t.Helper()
+	old := adoptSlotFunc
+	adoptSlotFunc = fn
+	t.Cleanup(func() { adoptSlotFunc = old })
+}
+
+func TestPoolStop_AbandonLeavesSlotsOwnedAndIntact(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	// A verify goroutine is parked on an occupied namespace when Stop fires.
+	stubPidsInNs(t, func(string) ([]int, bool) { return []int{1234}, true })
+	m.mu.Lock()
+	m.assignSlotLocked(3, poolOwner)
+	m.mu.Unlock()
+	p.Return(&preallocSlot{idx: 3, info: &VMNetInfo{Namespace: "ns-3"}, vethName: "veth-3"})
+
+	// A warm slot is sitting in the fresh channel.
+	m.mu.Lock()
+	m.assignSlotLocked(4, poolOwner)
+	m.mu.Unlock()
+	p.fresh <- &preallocSlot{idx: 4, info: &VMNetInfo{Namespace: "ns-4"}, vethName: "veth-4"}
+
+	done := make(chan struct{})
+	go func() { p.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("abandon-on-stop Stop did not return promptly")
+	}
+
+	// Both slots must remain pool-owned (abandoned, not torn down) so the
+	// next process's adoption pass finds a consistent kernel state.
+	m.mu.Lock()
+	o3, o4 := m.slotOwner[3], m.slotOwner[4]
+	m.mu.Unlock()
+	if o3 != poolOwner || o4 != poolOwner {
+		t.Fatalf("abandoned slots must stay owned: slot3=%q slot4=%q", o3, o4)
+	}
+}
+
+func TestPoolStop_LegacyTearsDownParkedVerify(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+
+	stubPidsInNs(t, func(string) ([]int, bool) { return []int{1234}, true })
+	m.mu.Lock()
+	m.assignSlotLocked(3, poolOwner)
+	m.mu.Unlock()
+	p.Return(&preallocSlot{idx: 3, info: &VMNetInfo{Namespace: "ns-3"}, vethName: "veth-3"})
+
+	p.Stop()
+
+	m.mu.Lock()
+	_, owned := m.slotOwner[3]
+	m.mu.Unlock()
+	if owned {
+		t.Fatal("legacy Stop must tear down and release the parked slot")
+	}
+}
+
+func TestAdoptOrphanSlots_ValidSlotBecomesClaimable(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	var resets atomic.Int64
+	stubResetTap(t, func(*Manager, context.Context, string) error { resets.Add(1); return nil })
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	p.AdoptOrphanSlots(context.Background())
+
+	// Adoption must force the tap rebuild even with resetTapOnRecycle off.
+	if resets.Load() != 1 {
+		t.Fatalf("adopted slot must rebuild its tap, got %d resets", resets.Load())
+	}
+	info := p.Claim("vm-new")
+	if info == nil || info.Namespace != "ns-7" {
+		t.Fatalf("adopted slot must be claimable, got %+v", info)
+	}
+	m.mu.Lock()
+	owner := m.slotOwner[7]
+	m.mu.Unlock()
+	if owner != "vm-new" {
+		t.Fatalf("claimed adopted slot must transfer ownership, got %q", owner)
+	}
+}
+
+func TestAdoptOrphanSlots_InvalidSlotTornDown(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-7")
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	stubAdoptSlot(t, func(*Manager, context.Context, int) (*VMNetInfo, string, error) {
+		return nil, "", errors.New("host veth missing")
+	})
+
+	p.AdoptOrphanSlots(context.Background())
+
+	m.mu.Lock()
+	_, owned := m.slotOwner[7]
+	m.mu.Unlock()
+	if owned {
+		t.Fatal("invalid orphan must be torn down and its index released")
+	}
+	if got := p.Claim("vm-new"); got != nil {
+		t.Fatalf("nothing should be claimable, got %+v", got)
+	}
+}
+
+func TestClaimOrphanSlots_SkipsOwnedAndBumpsHighWater(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-1")
+	touchNS(t, dir, "ns-6")
+	touchNS(t, dir, "not-a-slot")
+	m := newTestManager()
+	m.mu.Lock()
+	m.assignSlotLocked(1, "vm-live") // reserved by a record: not adoptable
+	m.mu.Unlock()
+
+	got := m.claimOrphanSlots()
+	if len(got) != 1 || got[0] != 6 {
+		t.Fatalf("expected exactly slot 6 claimed, got %v", got)
+	}
+	m.mu.Lock()
+	owner := m.slotOwner[6]
+	next := m.nextSlot
+	m.mu.Unlock()
+	if owner != poolOwner {
+		t.Fatalf("claimed orphan must be pool-owned, got %q", owner)
+	}
+	if next <= 6 {
+		t.Fatalf("nextSlot must advance past adopted indexes, got %d", next)
+	}
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -639,6 +639,8 @@ func TestClaimOrphanSlots_SkipsOwnedAndBumpsHighWater(t *testing.T) {
 func TestClaimOrphanSlots_RejectsOutOfRangeIndex(t *testing.T) {
 	dir := withTestNetnsDir(t)
 	touchNS(t, dir, "ns-99999999") // beyond MaxSlots: must never enter the allocator
+	touchNS(t, dir, "ns-0")        // below it: the allocator starts at 1
+	touchNS(t, dir, "ns-9999999999999999999999") // overflows the parse negative
 	touchNS(t, dir, "ns-2")
 	m := newTestManager()
 

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -770,3 +770,40 @@ func TestAdoptOrphanSlots_WorkerPanicReleasesAndContinues(t *testing.T) {
 		t.Fatal("panicked slot must be released so it isn't stranded invisibly")
 	}
 }
+
+// Systemic validation timeouts (a wedged host) must abort the pass instead of
+// stranding one pinned thread per candidate; the remainder is released so
+// nothing stays pool-owned and invisible.
+func TestAdoptOrphanSlots_SystemicTimeoutsAbortPass(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	for i := 1; i <= 12; i++ {
+		touchNS(t, dir, fmt.Sprintf("ns-%d", i))
+	}
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	stubAdoptSlot(t, func(*Manager, context.Context, int) (*VMNetInfo, string, error) {
+		return nil, "", fmt.Errorf("wedged: %w", context.DeadlineExceeded)
+	})
+
+	adopted, invalid, skipped := p.AdoptOrphanSlots(context.Background())
+	if adopted != 0 || invalid != 0 {
+		t.Fatalf("wedged host must not adopt or tear down: adopted=%d invalid=%d", adopted, invalid)
+	}
+	if skipped != 12 {
+		t.Fatalf("every candidate must end up skipped (judged or released), got %d", skipped)
+	}
+	m.mu.Lock()
+	stranded := 0
+	for idx, owner := range m.slotOwner {
+		if owner == poolOwner {
+			stranded++
+			t.Logf("stranded slot %d", idx)
+		}
+	}
+	m.mu.Unlock()
+	if stranded != 0 {
+		t.Fatalf("aborted pass must release every claimed index, %d stranded", stranded)
+	}
+}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2220,12 +2220,17 @@ func (m *Manager) SweepStartupOrphanNamespaces() {
 	if m.state == nil {
 		return
 	}
+	recs, err := m.state.All()
+	if err != nil {
+		// Sweeping with an empty keep-set would delete every live VM's
+		// namespace — skip entirely when the records can't be read.
+		m.log.Error().Err(err).Msg("sweep: cannot read state — skipping orphan namespace sweep")
+		return
+	}
 	keepNs := make(map[string]bool)
-	if recs, err := m.state.All(); err == nil {
-		for _, rec := range recs {
-			if rec.Namespace != "" {
-				keepNs[rec.Namespace] = true
-			}
+	for _, rec := range recs {
+		if rec.Namespace != "" {
+			keepNs[rec.Namespace] = true
 		}
 	}
 	if swept := m.netMgr.SweepOrphanNamespaces(keepNs); swept > 0 {
@@ -2239,16 +2244,21 @@ func (m *Manager) SweepStartupOrphanNamespaces() {
 // an index a record holds. Every record is reserved unconditionally — a dead
 // record's slot is reclaimed later when the reattach cleans it up. Cheap: parses
 // slot indices, no kernel work, no systemctl.
-func (m *Manager) ReserveStartupSlots(context.Context) {
+//
+// Reports whether the reservation pass provably completed. Callers whose
+// safety depends on record slots being reserved — pool adoption treats every
+// unreserved namespace as claimable — must not proceed on false.
+func (m *Manager) ReserveStartupSlots(context.Context) bool {
 	if m.state == nil {
-		return
+		return false
 	}
 	recs, err := m.state.All()
 	if err != nil {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
-		return
+		return false
 	}
 	m.netMgr.ReserveSlotsAbove(collectStartupSlots(recs))
+	return true
 }
 
 // collectStartupSlots returns vmID→namespace for every record that has one, so


### PR DESCRIPTION
## Problem

Stopping vmd tears down the warm network pool slot by slot: \`Pool.Stop\` waits for every in-flight recycle verification, then serially deletes each pooled namespace. On hosts with large fleets this holds the old process's exit for tens of seconds — and since the daemon's socket only hands over to the new process after exit, that entire window is downtime for creates/resumes. The control plane's Unavailable-retry budget covers a normal restart, not a drain of that length, so requests landing in the window fail. The new process then also starts with an empty pool and refills it from scratch.

## Fix

Make shutdown crash-equivalent, behind \`VMD_NET_POOL_ADOPT\` (default off):

- **Shutdown abandons instead of tearing down.** \`Stop\` leaves warm slots in the kernel and returns near-instantly (bounded 2s quiesce). Every stop-path arm that used to clean up a slot now routes through \`stopSlot\`, which abandons under the flag and preserves legacy teardown without it.
- **Boot adopts instead of sweeping.** Slot identity is fully derivable from the index (\`ns-N\`/\`veth-N\`/IPs/MAC), so nothing needs persisting: after startup slot reservation, \`AdoptOrphanSlots\` claims every unowned namespace in one locked pass (so the refill loop can never build over a candidate), validates each one (host veth + in-namespace peer present, nftables handle re-attached, host route healed — validation doubles as the layout/version check), and feeds survivors through the existing \`verifyAndRecycle\` path with a **forced tap rebuild** (unknown provenance; same reasoning as the tap-EBUSY hardening). Failures are torn down. Bounded workers; never blocks the readiness gate.
- Graceful stop and crash now leave the host in the same state and share one recovery path — every deploy exercises crash recovery.
- Stray host-side veths (namespace gone, slot unowned) are still swept after adoption; mid-build slots are protected by the ownership check.

Net effect: restart unavailability drops to roughly the daemon's startup time, and the new process starts with a warm, verified pool instead of a cold one.

## Safety

- Flag off = byte-for-byte legacy behavior (boot sweep + teardown Stop).
- Adopted slots pass the same occupancy verification as recycled slots (stray processes killed, namespace confirmed empty, poisoned slots torn down).
- Adoption only ever claims indexes with no owner, after record reservation — a live VM's slot can never become a pool candidate.

## Tests

- Abandon-on-stop leaves parked and pooled slots owned and intact; legacy stop still tears down.
- Adoption: valid orphan becomes claimable with a forced tap rebuild; invalid orphan is torn down and its index released; owned/unparseable namespaces are skipped and the allocator high-water mark advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)