### PR TITLE
Codify us-east4 host migration resources (import-only)

### DIFF
--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -261,13 +261,18 @@ def main() -> int:
                 fi
             done
 
-            # Upsert the control-plane URL into vmd.env. Empty = skip (leave any
-            # value already provisioned out-of-band untouched).
+            # Upsert the control-plane URL. Empty = skip (leave any value already
+            # provisioned out-of-band untouched). secretsproxy reads
+            # CONTROL_PLANE_URL from its OWN env file and exits if it is unset, so
+            # write it into both vmd.env and secretsproxy.env.
             if [ -n '{control_plane_url}' ]; then
                 sudo install -d -m 0755 /etc/sandbox
-                sudo touch /etc/sandbox/vmd.env
-                sudo sed -i '/^CONTROL_PLANE_URL=/d' /etc/sandbox/vmd.env
-                echo 'CONTROL_PLANE_URL={control_plane_url}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                for f in /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env; do
+                    sudo touch "$f"
+                    sudo sed -i '/^CONTROL_PLANE_URL=/d' "$f"
+                    echo 'CONTROL_PLANE_URL={control_plane_url}' | sudo tee -a "$f" > /dev/null
+                done
+                sudo chmod 0600 /etc/sandbox/secretsproxy.env
             fi
 
             # Upsert the shared control-plane auth token. vmd reads it as
@@ -277,7 +282,8 @@ def main() -> int:
             if [ -n '{internal_api_token}' ]; then
                 sudo install -d -m 0755 /etc/sandbox
                 sudo touch /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env
-                sudo chmod 0600 /etc/sandbox/secretsproxy.env
+                # Both files hold the bearer token — keep them root-only.
+                sudo chmod 0600 /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env
                 sudo sed -i '/^INTERNAL_API_TOKEN=/d' /etc/sandbox/vmd.env
                 echo 'INTERNAL_API_TOKEN={internal_api_token}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
                 sudo sed -i '/^DAEMON_AUTH_TOKEN=/d' /etc/sandbox/secretsproxy.env

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -26,6 +26,12 @@ Env vars:
                        (secretsproxy authenticates callers with the same token
                        the control plane presents). Hosts previously had these
                        provisioned out-of-band via Packer/manual staging.
+  VMD_DNS_REDIRECT_PORT optional — local resolver port vmd REDIRECTs guest :53
+                       to via its SANDBOX_DNS_REDIRECT nat chain. Defaults to
+                       19053 and MUST match the unbound bootstrap's
+                       local_dns_port. Upserted into vmd.env so a rebuilt host
+                       actually wires the redirect (unbound answers there but
+                       vmd owns the redirect rules).
 
 All deploy artifacts (binaries + systemd units + scripts) are packed
 into a single tarball and SCP'd once per host. Each gcloud SCP/SSH
@@ -91,6 +97,8 @@ def main() -> int:
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
+    # Fleet-standard local resolver port; must match unbound's local_dns_port.
+    dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "19053")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -273,6 +281,17 @@ def main() -> int:
                     echo 'CONTROL_PLANE_URL={control_plane_url}' | sudo tee -a "$f" > /dev/null
                 done
                 sudo chmod 0600 /etc/sandbox/secretsproxy.env
+            fi
+
+            # Upsert the guest DNS redirect port so vmd rebuilds its
+            # SANDBOX_DNS_REDIRECT nat chain on a fresh host. unbound answers on
+            # this port; without the env var vmd never redirects guest :53 there
+            # and guests bypass the Cloudflare Gateway resolver.
+            if [ -n '{dns_redirect_port}' ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/vmd.env
+                sudo sed -i '/^VMD_DNS_REDIRECT_PORT=/d' /etc/sandbox/vmd.env
+                echo 'VMD_DNS_REDIRECT_PORT={dns_redirect_port}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
             # Upsert the shared control-plane auth token. vmd reads it as

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -27,11 +27,14 @@ Env vars:
                        the control plane presents). Hosts previously had these
                        provisioned out-of-band via Packer/manual staging.
   VMD_DNS_REDIRECT_PORT optional — local resolver port vmd REDIRECTs guest :53
-                       to via its SANDBOX_DNS_REDIRECT nat chain. Defaults to
-                       19053 and MUST match the unbound bootstrap's
-                       local_dns_port. Upserted into vmd.env so a rebuilt host
-                       actually wires the redirect (unbound answers there but
-                       vmd owns the redirect rules).
+                       to via its SANDBOX_DNS_REDIRECT nat chain. Empty = skip
+                       (like CONTROL_PLANE_URL). Do NOT default this fleet-wide:
+                       this script deploys to every selected host, and a host
+                       without an unbound listener on the port would blackhole
+                       guest DNS. Set it per host/region to match that host's
+                       unbound local_dns_port; upserted into vmd.env so a rebuilt
+                       host wires the redirect (unbound answers there but vmd
+                       owns the redirect rules).
 
 All deploy artifacts (binaries + systemd units + scripts) are packed
 into a single tarball and SCP'd once per host. Each gcloud SCP/SSH
@@ -97,8 +100,9 @@ def main() -> int:
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
-    # Fleet-standard local resolver port; must match unbound's local_dns_port.
-    dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "19053")
+    # Empty = skip, so a fleet-wide deploy never writes a redirect to a host
+    # whose resolver isn't on this port. Set per host/region to match unbound.
+    dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -48,6 +48,7 @@ preserving vmd's template cache.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 import textwrap
@@ -103,6 +104,20 @@ def main() -> int:
     # Empty = skip, so a fleet-wide deploy never writes a redirect to a host
     # whose resolver isn't on this port. Set per host/region to match unbound.
     dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "")
+
+    # Pre-quote every value injected into the remote shell script. These come
+    # from CI secrets / Secret Manager and must be treated as arbitrary text:
+    # shlex.quote makes each safe both as a shell `[ -n ... ]` operand and, as a
+    # full "KEY=value" token, as a literal env-file line via `echo`.
+    q_sentry = shlex.quote(sentry_dsn)
+    q_sentry_line = shlex.quote(f"SENTRY_DSN={sentry_dsn}")
+    q_cpu = shlex.quote(control_plane_url)
+    q_cpu_line = shlex.quote(f"CONTROL_PLANE_URL={control_plane_url}")
+    q_dns = shlex.quote(dns_redirect_port)
+    q_dns_line = shlex.quote(f"VMD_DNS_REDIRECT_PORT={dns_redirect_port}")
+    q_token = shlex.quote(internal_api_token)
+    q_iat_line = shlex.quote(f"INTERNAL_API_TOKEN={internal_api_token}")
+    q_dat_line = shlex.quote(f"DAEMON_AUTH_TOKEN={internal_api_token}")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -258,9 +273,9 @@ def main() -> int:
 
             # Upsert SENTRY_DSN in the vmd env file without touching other vars.
             # Only update when a non-empty value is provided; skip silently otherwise.
-            if [ -n '{sentry_dsn}' ]; then
+            if [ -n {q_sentry} ]; then
                 sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
-                echo 'SENTRY_DSN={sentry_dsn}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                echo {q_sentry_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
             # Upsert SECRETSPROXY_SOCKET on both env files. The daemon writes
@@ -273,44 +288,51 @@ def main() -> int:
                 fi
             done
 
-            # Upsert the control-plane URL. Empty = skip (leave any value already
-            # provisioned out-of-band untouched). secretsproxy reads
-            # CONTROL_PLANE_URL from its OWN env file and exits if it is unset, so
-            # write it into both vmd.env and secretsproxy.env.
-            if [ -n '{control_plane_url}' ]; then
+            # Upsert the control-plane URL. Empty = skip. vmd.env is safe to
+            # create; secretsproxy.env is only UPSERTED when it ALREADY exists —
+            # never create it here, because a partial file (missing
+            # DAEMON_AUTH_TOKEN/DATABASE_URL) makes the daemon exit and fails the
+            # health check below. The host bootstrap owns creating that file.
+            if [ -n {q_cpu} ]; then
                 sudo install -d -m 0755 /etc/sandbox
-                for f in /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env; do
-                    sudo touch "$f"
-                    sudo sed -i '/^CONTROL_PLANE_URL=/d' "$f"
-                    echo 'CONTROL_PLANE_URL={control_plane_url}' | sudo tee -a "$f" > /dev/null
-                done
-                sudo chmod 0600 /etc/sandbox/secretsproxy.env
+                sudo touch /etc/sandbox/vmd.env
+                sudo sed -i '/^CONTROL_PLANE_URL=/d' /etc/sandbox/vmd.env
+                echo {q_cpu_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                if [ -f /etc/sandbox/secretsproxy.env ]; then
+                    sudo sed -i '/^CONTROL_PLANE_URL=/d' /etc/sandbox/secretsproxy.env
+                    echo {q_cpu_line} | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
+                fi
             fi
 
             # Upsert the guest DNS redirect port so vmd rebuilds its
             # SANDBOX_DNS_REDIRECT nat chain on a fresh host. unbound answers on
             # this port; without the env var vmd never redirects guest :53 there
             # and guests bypass the Cloudflare Gateway resolver.
-            if [ -n '{dns_redirect_port}' ]; then
+            if [ -n {q_dns} ]; then
                 sudo install -d -m 0755 /etc/sandbox
                 sudo touch /etc/sandbox/vmd.env
                 sudo sed -i '/^VMD_DNS_REDIRECT_PORT=/d' /etc/sandbox/vmd.env
-                echo 'VMD_DNS_REDIRECT_PORT={dns_redirect_port}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                echo {q_dns_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
             # Upsert the shared control-plane auth token. vmd reads it as
             # INTERNAL_API_TOKEN; secretsproxy authenticates callers with the
             # same value as DAEMON_AUTH_TOKEN. Sourced from CI secrets / Secret
             # Manager — never hardcoded. Empty = leave existing values alone.
-            if [ -n '{internal_api_token}' ]; then
+            if [ -n {q_token} ]; then
                 sudo install -d -m 0755 /etc/sandbox
-                sudo touch /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env
-                # Both files hold the bearer token — keep them root-only.
-                sudo chmod 0600 /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env
+                sudo touch /etc/sandbox/vmd.env
+                # vmd.env holds the bearer token — keep it root-only.
+                sudo chmod 0600 /etc/sandbox/vmd.env
                 sudo sed -i '/^INTERNAL_API_TOKEN=/d' /etc/sandbox/vmd.env
-                echo 'INTERNAL_API_TOKEN={internal_api_token}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
-                sudo sed -i '/^DAEMON_AUTH_TOKEN=/d' /etc/sandbox/secretsproxy.env
-                echo 'DAEMON_AUTH_TOKEN={internal_api_token}' | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
+                echo {q_iat_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                # Upsert DAEMON_AUTH_TOKEN only into an EXISTING secretsproxy.env;
+                # never create it here (same reason as CONTROL_PLANE_URL above).
+                if [ -f /etc/sandbox/secretsproxy.env ]; then
+                    sudo chmod 0600 /etc/sandbox/secretsproxy.env
+                    sudo sed -i '/^DAEMON_AUTH_TOKEN=/d' /etc/sandbox/secretsproxy.env
+                    echo {q_dat_line} | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
+                fi
             fi
 
             # Stop before starting the socket unit: on the first deploy of

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -15,6 +15,17 @@ Env vars:
   VMD_SERVICE          required — systemd unit name for vmd (e.g. superserve-vmd)
   VMD_INSTALL_DIR      required — bin install dir on the host (e.g. /usr/local/bin)
   SHA                  required — commit SHA (only first 8 chars used)
+  SENTRY_DSN           optional — upserted into /etc/sandbox/vmd.env when set
+  CONTROL_PLANE_URL    optional — control-plane base URL (e.g.
+                       https://api.superserve.ai). Upserted into vmd.env when
+                       set. vmd reads it via os.Getenv("CONTROL_PLANE_URL").
+  INTERNAL_API_TOKEN   optional — shared control-plane/host auth token, sourced
+                       from CI secrets / Secret Manager (never hardcode). When
+                       set it is upserted into vmd.env as INTERNAL_API_TOKEN and
+                       into /etc/sandbox/secretsproxy.env as DAEMON_AUTH_TOKEN
+                       (secretsproxy authenticates callers with the same token
+                       the control plane presents). Hosts previously had these
+                       provisioned out-of-band via Packer/manual staging.
 
 All deploy artifacts (binaries + systemd units + scripts) are packed
 into a single tarball and SCP'd once per host. Each gcloud SCP/SSH
@@ -78,6 +89,8 @@ def main() -> int:
     install_dir = os.environ.get("VMD_INSTALL_DIR", "/usr/local/bin")
     sha = os.environ["SHA"][:8]
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
+    control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
+    internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -247,6 +260,29 @@ def main() -> int:
                     echo 'SECRETSPROXY_SOCKET=/run/secretsproxy/control.sock' | sudo tee -a "$env_file" > /dev/null
                 fi
             done
+
+            # Upsert the control-plane URL into vmd.env. Empty = skip (leave any
+            # value already provisioned out-of-band untouched).
+            if [ -n '{control_plane_url}' ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/vmd.env
+                sudo sed -i '/^CONTROL_PLANE_URL=/d' /etc/sandbox/vmd.env
+                echo 'CONTROL_PLANE_URL={control_plane_url}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            fi
+
+            # Upsert the shared control-plane auth token. vmd reads it as
+            # INTERNAL_API_TOKEN; secretsproxy authenticates callers with the
+            # same value as DAEMON_AUTH_TOKEN. Sourced from CI secrets / Secret
+            # Manager — never hardcoded. Empty = leave existing values alone.
+            if [ -n '{internal_api_token}' ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/vmd.env /etc/sandbox/secretsproxy.env
+                sudo chmod 0600 /etc/sandbox/secretsproxy.env
+                sudo sed -i '/^INTERNAL_API_TOKEN=/d' /etc/sandbox/vmd.env
+                echo 'INTERNAL_API_TOKEN={internal_api_token}' | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                sudo sed -i '/^DAEMON_AUTH_TOKEN=/d' /etc/sandbox/secretsproxy.env
+                echo 'DAEMON_AUTH_TOKEN={internal_api_token}' | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
+            fi
 
             # Stop before starting the socket unit: on the first deploy of
             # socket activation the old direct-bound vmd still holds the

--- a/deploy/environments.yaml
+++ b/deploy/environments.yaml
@@ -149,7 +149,12 @@ environments:
         # not a fresh cell: it shares the use-cell Supabase, secrets, and the
         # us-central1 Artifact Registry image repo. Only the Cloud Run service
         # name, region, and vmd host are region-local.
-        required: true
+        #
+        # required=false until the CD deploy steps for this cell land (the use4
+        # API step in deploy-api.yml and the use4 host step in deploy-vmd.yml).
+        # Declaring it required before then would mark a target CD doesn't yet
+        # push to, letting releases skew this cell. Flip to true with that wiring.
+        required: false
         api:
           platform: cloud_run
           service: superserve-api-use4

--- a/deploy/environments.yaml
+++ b/deploy/environments.yaml
@@ -144,3 +144,33 @@ environments:
         artifacts:
           docker_repository: us-west2-docker.pkg.dev/rayai-prod/superserve-usw2
           object_bucket: superserve-artifacts
+      - name: us-east4
+        # us-east4 is the "use" cell's new host home (a us-central1 host swap),
+        # not a fresh cell: it shares the use-cell Supabase, secrets, and the
+        # us-central1 Artifact Registry image repo. Only the Cloud Run service
+        # name, region, and vmd host are region-local.
+        required: true
+        api:
+          platform: cloud_run
+          service: superserve-api-use4
+          region: us-east4
+          image_repository: us-central1-docker.pkg.dev/rayai-prod/superserve/controlplane
+        host_deployments:
+          vmd:
+            enabled: true
+            selector:
+              environment: production
+              region: us-east4
+              sandbox_role: vmd
+              sandbox_status: ready
+          proxy:
+            enabled: true
+            selector:
+              environment: production
+              region: us-east4
+              sandbox_role: vmd
+              sandbox_status: ready
+            domain: use4-sandbox.superserve.ai
+        artifacts:
+          docker_repository: us-central1-docker.pkg.dev/rayai-prod/superserve
+          object_bucket: superserve-artifacts

--- a/deploy/unbound/unbound-bootstrap.sh.tftpl
+++ b/deploy/unbound/unbound-bootstrap.sh.tftpl
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Host startup step: stand up unbound as the guest DNS resolver.
+#
+# WHY: sandbox guests must not talk to arbitrary DNS. Guests are pointed at the
+# host on :53; the host redirects that to a local unbound instance which
+# forwards every query over DoT (DNS-over-TLS) to a Cloudflare Zero Trust
+# Gateway location. That gateway enforces the egress DNS policy for the fleet.
+# Only the guest range (${guest_cidr}) is allowed to query the resolver.
+#
+# This runs on boot. unbound + the redirect are idempotent, so re-runs are
+# safe. Shape mirrors deploy/otel/collector-bootstrap.sh.tftpl.
+set -euo pipefail
+
+exec >> /var/log/unbound-bootstrap.log 2>&1
+
+echo "=== Superserve unbound bootstrap $(date -Is) ==="
+
+if ! command -v unbound >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y unbound
+fi
+
+install -d -m 0755 /etc/unbound/unbound.conf.d
+cat <<'EOF' >/etc/unbound/unbound.conf.d/sandbox.conf
+# Managed by unbound-bootstrap.sh.tftpl — do not edit by hand.
+server:
+    # Guests are DNAT-redirected here; listen only on loopback.
+    interface: 127.0.0.1@${local_dns_port}
+    access-control: 127.0.0.0/8 allow
+    access-control: ${guest_cidr} allow
+    do-not-query-localhost: no
+    hide-identity: yes
+    hide-version: yes
+
+forward-zone:
+    name: "."
+    forward-tls-upstream: yes
+    # Cloudflare Zero Trust Gateway (DoT). The @853#hostname pins the TLS SNI /
+    # cert name to the location endpoint so the policy is applied.
+%{ for addr in dot_upstream_addrs ~}
+    forward-addr: ${addr}@853#${dot_hostname}
+%{ endfor ~}
+EOF
+
+# Redirect guest DNS (:53) to the local unbound. route_localnet lets forwarded
+# packets be DNAT'd to a loopback address.
+sysctl -w net.ipv4.conf.all.route_localnet=1
+
+for proto in udp tcp; do
+  if ! iptables -t nat -C PREROUTING -s ${guest_cidr} -p "$proto" --dport 53 \
+      -j DNAT --to-destination 127.0.0.1:${local_dns_port} 2>/dev/null; then
+    iptables -t nat -A PREROUTING -s ${guest_cidr} -p "$proto" --dport 53 \
+      -j DNAT --to-destination 127.0.0.1:${local_dns_port}
+  fi
+done
+
+systemctl enable --now unbound
+systemctl restart unbound
+
+echo "=== Superserve unbound bootstrap complete ==="

--- a/deploy/unbound/unbound-bootstrap.sh.tftpl
+++ b/deploy/unbound/unbound-bootstrap.sh.tftpl
@@ -1,14 +1,15 @@
 #!/bin/bash
 # Host startup step: stand up unbound as the guest DNS resolver.
 #
-# WHY: sandbox guests must not talk to arbitrary DNS. Guests are pointed at the
-# host on :53; the host redirects that to a local unbound instance which
-# forwards every query over DoT (DNS-over-TLS) to a Cloudflare Zero Trust
-# Gateway location. That gateway enforces the egress DNS policy for the fleet.
-# Only the guest range (${guest_cidr}) is allowed to query the resolver.
+# WHY: sandbox guests must not talk to arbitrary DNS. vmd transparently
+# REDIRECTs all guest :53 traffic (TCP+UDP) to :${local_dns_port} via its
+# SANDBOX_DNS_REDIRECT nat chain (internal/network/hostfw.go) — this script only
+# installs the resolver that answers there and forwards every query over DoT
+# (DNS-over-TLS) to a Cloudflare Zero Trust Gateway location, which enforces the
+# fleet egress DNS policy. Do NOT add DNS redirect rules here: vmd owns them
+# (managing them from two places conflicts).
 #
-# This runs on boot. unbound + the redirect are idempotent, so re-runs are
-# safe. Shape mirrors deploy/otel/collector-bootstrap.sh.tftpl.
+# Idempotent; safe to re-run on boot. Shape mirrors collector-bootstrap.sh.tftpl.
 set -euo pipefail
 
 exec >> /var/log/unbound-bootstrap.log 2>&1
@@ -25,35 +26,30 @@ install -d -m 0755 /etc/unbound/unbound.conf.d
 cat <<'EOF' >/etc/unbound/unbound.conf.d/sandbox.conf
 # Managed by unbound-bootstrap.sh.tftpl — do not edit by hand.
 server:
-    # Guests are DNAT-redirected here; listen only on loopback.
-    interface: 127.0.0.1@${local_dns_port}
+    # vmd REDIRECTs guest :53 to ${local_dns_port} on the inbound interface, so
+    # answer there on all interfaces; loopback covers host-local lookups.
+    interface: 127.0.0.1
+    interface: 0.0.0.0@${local_dns_port}
+    access-control: 0.0.0.0/0 refuse
     access-control: 127.0.0.0/8 allow
     access-control: ${guest_cidr} allow
-    do-not-query-localhost: no
-    hide-identity: yes
-    hide-version: yes
+    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+    module-config: "iterator"
+    cache-min-ttl: 60
+    cache-max-ttl: 3600
+    prefetch: yes
+    use-syslog: yes
+    verbosity: 1
 
 forward-zone:
     name: "."
     forward-tls-upstream: yes
     # Cloudflare Zero Trust Gateway (DoT). The @853#hostname pins the TLS SNI /
-    # cert name to the location endpoint so the policy is applied.
+    # cert name to the location endpoint so the DNS policy is applied.
 %{ for addr in dot_upstream_addrs ~}
     forward-addr: ${addr}@853#${dot_hostname}
 %{ endfor ~}
 EOF
-
-# Redirect guest DNS (:53) to the local unbound. route_localnet lets forwarded
-# packets be DNAT'd to a loopback address.
-sysctl -w net.ipv4.conf.all.route_localnet=1
-
-for proto in udp tcp; do
-  if ! iptables -t nat -C PREROUTING -s ${guest_cidr} -p "$proto" --dport 53 \
-      -j DNAT --to-destination 127.0.0.1:${local_dns_port} 2>/dev/null; then
-    iptables -t nat -A PREROUTING -s ${guest_cidr} -p "$proto" --dport 53 \
-      -j DNAT --to-destination 127.0.0.1:${local_dns_port}
-  fi
-done
 
 systemctl enable --now unbound
 systemctl restart unbound

--- a/infra/envs/production/us-central1/imports.tf
+++ b/infra/envs/production/us-central1/imports.tf
@@ -1,0 +1,8 @@
+# One-time state adoption. The api module now declares the public invoker
+# binding (allUsers -> roles/run.invoker) that has always existed out-of-band on
+# this service; import it so the CD apply is a no-op instead of showing a
+# (harmless but confusing) "add public access" create. iam_member is idempotent.
+import {
+  to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
+  id = "projects/rayai-prod/locations/us-central1/services/superserve-api roles/run.invoker allUsers"
+}

--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -197,9 +197,12 @@ module "api" {
       secret = "posthog-project-key"
     }
   }
-  cpu_limit         = "2"
-  memory_limit      = "1Gi"
-  min_instances     = 6
+  cpu_limit    = "2"
+  memory_limit = "1Gi"
+  # 0 matches the live service: this cell was scaled to idle after the us-east4
+  # cutover and is pending decommission. Declaring the live value keeps the plan
+  # a no-op instead of re-inflating the idle cell to 6 on the next apply.
+  min_instances     = 0
   max_instances     = 10
   startup_cpu_boost = true
   cpu_idle          = true

--- a/infra/envs/production/us-east4/imports.tf
+++ b/infra/envs/production/us-east4/imports.tf
@@ -1,0 +1,66 @@
+# One-time state adoption for resources created imperatively (gcloud) during the
+# us-central1 -> us-east4 host migration. Native `import {}` blocks make the CD
+# `terraform apply` ADOPT these into state instead of trying to create names that
+# already exist (which would fail AlreadyExists and turn the rollout red). Same
+# pattern as infra/envs/staging/us-central1/imports.tf. Safe to remove after the
+# first successful apply has populated state.
+
+# --- api.superserve.ai external HTTPS load balancer (module.api_cert_lb) ---
+
+import {
+  to = module.api_cert_lb.google_compute_region_network_endpoint_group.cloud_run
+  id = "projects/rayai-prod/regions/us-east4/networkEndpointGroups/superserve-api-use4-neg"
+}
+
+import {
+  to = module.api_cert_lb.google_compute_backend_service.cloud_run
+  id = "projects/rayai-prod/global/backendServices/superserve-api-backend-use4"
+}
+
+import {
+  to = module.api_cert_lb.google_compute_url_map.this
+  id = "projects/rayai-prod/global/urlMaps/superserve-api-url-map"
+}
+
+import {
+  to = module.api_cert_lb.google_certificate_manager_dns_authorization.this
+  id = "projects/rayai-prod/locations/global/dnsAuthorizations/api-superserve-dnsauth"
+}
+
+import {
+  to = module.api_cert_lb.google_certificate_manager_certificate.this
+  id = "projects/rayai-prod/locations/global/certificates/api-superserve-cert"
+}
+
+import {
+  to = module.api_cert_lb.google_certificate_manager_certificate_map.this
+  id = "projects/rayai-prod/locations/global/certificateMaps/api-superserve-certmap"
+}
+
+import {
+  to = module.api_cert_lb.google_certificate_manager_certificate_map_entry.this
+  id = "projects/rayai-prod/locations/global/certificateMaps/api-superserve-certmap/certificateMapEntries/api-superserve-entry"
+}
+
+import {
+  to = module.api_cert_lb.google_compute_global_address.this
+  id = "projects/rayai-prod/global/addresses/api-superserve-use4-ip"
+}
+
+import {
+  to = module.api_cert_lb.google_compute_target_https_proxy.this
+  id = "projects/rayai-prod/global/targetHttpsProxies/api-superserve-use4-proxy"
+}
+
+import {
+  to = module.api_cert_lb.google_compute_global_forwarding_rule.this
+  id = "projects/rayai-prod/global/forwardingRules/api-superserve-use4-fwd"
+}
+
+# Public invoker binding (allUsers -> roles/run.invoker), added out-of-band at
+# cutover so api.superserve.ai serves unauthenticated at the edge. iam_member is
+# idempotent, but importing keeps the plan a no-op.
+import {
+  to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
+  id = "projects/rayai-prod/locations/us-east4/services/superserve-api-use4 roles/run.invoker allUsers"
+}

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -230,11 +230,13 @@ module "sandbox_host" {
   # discovery labels CD and the scheduler key on. `labels` is NOT in the
   # module's ignore_changes, so these must be declared here or a `terraform
   # apply` would strip the ones added out-of-band at cutover and break host
-  # discovery (deploy-vmd / deploy-otel filter on component=vmd). Mirrors the
-  # us-central1 host.
+  # discovery (deploy-vmd / deploy-otel filter on component=vmd; the deployment
+  # registry selects sandbox_status=ready). Mirrors the us-central1 host's
+  # discovery labels; sandbox_status=ready because this host is serving.
   labels = merge(local.common_labels, {
     component               = "vmd"
     sandbox_role            = "vmd"
+    sandbox_status          = "ready"
     "goog-ops-agent-policy" = "v2-template-1-7-0"
   })
 

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -264,10 +264,9 @@ module "sandbox_host" {
       local_dns_port = "19053"
       # Cloudflare Zero Trust Gateway DoT location endpoint.
       dot_hostname = "j0mqwd9sm7.cloudflare-gateway.com"
-      # Anycast IPs the location endpoint resolves to. VERIFY these against the
-      # live host's unbound config before a rebuild — unbound needs an IP here,
-      # not a hostname, and the migration set these out-of-band.
-      dot_upstream_addrs = ["172.64.36.1", "172.64.36.2"]
+      # Anycast IPs the location endpoint resolves to (unbound needs an IP here,
+      # not a hostname). Matches the live host's unbound config, verified 2026-07-22.
+      dot_upstream_addrs = ["162.159.36.5", "162.159.46.5"]
     })
   }
 }

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -121,9 +121,12 @@ module "api" {
   # and ignore_changes keeps terraform from reverting that.
   image = "us-central1-docker.pkg.dev/${local.project_id}/superserve/controlplane:latest"
 
-  cpu_limit         = "2"
-  memory_limit      = "1Gi"
-  min_instances     = 2
+  cpu_limit    = "2"
+  memory_limit = "1Gi"
+  # 6 matches the live service (raised from 2 during burst tuning). scaling is
+  # in the module's ignore_changes, but that path is ineffective for the v2
+  # resource, so declaring the live value keeps the plan a no-op.
+  min_instances     = 6
   max_instances     = 100
   startup_cpu_boost = true
   cpu_idle          = true
@@ -137,16 +140,9 @@ module "api" {
     DB_MAX_CONNS           = "12"
     VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
-
-    # OTLP export to the host-local collector, mirroring us-central1. The
-    # allow_otel_ingress firewall rule already admits Cloud Run -> host on
-    # 4317/4318. These were set imperatively on the live service; keep them
-    # here so a later apply doesn't strip them.
-    OTEL_ENVIRONMENT            = local.environment
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${module.sandbox_host.internal_ip}:4318"
-    OTEL_EXPORT_INTERVAL        = "15s"
-    OTEL_METRICS_ENABLED        = "true"
-    OTEL_SERVICE_NAME           = "sandbox-controlplane"
+    # OTEL_* is intentionally omitted here: the live service has no OTEL env, so
+    # adding it would be a production change, not adoption. It lands in a
+    # separate OTEL-parity PR (mirroring us-central1's collector export).
   }
 
   secrets = {
@@ -226,17 +222,17 @@ module "sandbox_host" {
   internal_ip   = var.host_internal_ip
   tags          = ["vmd-use4"]
 
-  # Cutover complete: this is the live primary host, so it must carry the prod
-  # discovery labels CD and the scheduler key on. `labels` is NOT in the
-  # module's ignore_changes, so these must be declared here or a `terraform
-  # apply` would strip the ones added out-of-band at cutover and break host
-  # discovery (deploy-vmd / deploy-otel filter on component=vmd; the deployment
-  # registry selects sandbox_status=ready). Mirrors the us-central1 host's
-  # discovery labels; sandbox_status=ready because this host is serving.
+  # Declare the discovery labels CD and the scheduler key on (component=vmd,
+  # sandbox_role=vmd, ops-agent) — they were added out-of-band at cutover and
+  # `labels` is NOT in the module's ignore_changes, so declaring them keeps a
+  # later apply from stripping them. Values here match the LIVE host exactly so
+  # this stays a no-op adoption: sandbox_status is still "provisioning" live;
+  # flipping it to "ready" (to match the deployment-registry selector) is a
+  # separate, intentional change, not part of this import PR.
   labels = merge(local.common_labels, {
     component               = "vmd"
     sandbox_role            = "vmd"
-    sandbox_status          = "ready"
+    sandbox_status          = "provisioning"
     "goog-ops-agent-policy" = "v2-template-1-7-0"
   })
 

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -134,6 +134,16 @@ module "api" {
     DB_MAX_CONNS           = "12"
     VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
+
+    # OTLP export to the host-local collector, mirroring us-central1. The
+    # allow_otel_ingress firewall rule already admits Cloud Run -> host on
+    # 4317/4318. These were set imperatively on the live service; keep them
+    # here so a later apply doesn't strip them.
+    OTEL_ENVIRONMENT            = local.environment
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${module.sandbox_host.internal_ip}:4318"
+    OTEL_EXPORT_INTERVAL        = "15s"
+    OTEL_METRICS_ENABLED        = "true"
+    OTEL_SERVICE_NAME           = "sandbox-controlplane"
   }
 
   secrets = {
@@ -170,6 +180,34 @@ module "api" {
   vpc_tags       = ["cr-use4"]
 
   labels = local.common_labels
+}
+
+# api.superserve.ai external HTTPS load balancer (global). Fronts the use-cell
+# control-plane Cloud Run service in this region via a serverless NEG and
+# terminates TLS with a Certificate-Manager managed cert + cert map. Every
+# resource here was created imperatively (gcloud) during the host migration and
+# is adopted via `terraform import` — see the PR notes for the import commands.
+module "api_cert_lb" {
+  source = "../../../modules/cloud-run-cert-lb"
+
+  project_id        = local.project_id
+  region            = local.region
+  cloud_run_service = module.api.service_name
+  domain            = "api.superserve.ai"
+
+  dns_authorization_name     = "api-superserve-dnsauth"
+  certificate_name           = "api-superserve-cert"
+  certificate_map_name       = "api-superserve-certmap"
+  certificate_map_entry_name = "api-superserve-entry"
+  address_name               = "api-superserve-use4-ip"
+  https_proxy_name           = "api-superserve-use4-proxy"
+  forwarding_rule_name       = "api-superserve-use4-fwd"
+  url_map_name               = "superserve-api-url-map"
+  backend_service_name       = "superserve-api-backend-use4"
+  # NB: verify against the live NEG name before importing — the migration
+  # created it imperatively and its exact name was not captured. Correct this
+  # value to match `gcloud compute network-endpoint-groups list` output first.
+  neg_name = "superserve-api-use4-neg"
 }
 
 module "sandbox_host" {
@@ -213,8 +251,23 @@ module "sandbox_host" {
 
   reservation_name = var.reservation_name
 
+  # startup-script codifies the guest-DNS bootstrap (unbound + DoT to the
+  # Cloudflare Gateway). The live host was hand-staged, so this exists mainly
+  # for a clean rebuild — sandbox-host keeps `metadata` in ignore_changes, so
+  # adding it here does not perturb the running instance.
   metadata = {
     enable-osconfig = "TRUE"
     enable-oslogin  = "TRUE"
+    startup-script = templatefile("${path.module}/../../../../deploy/unbound/unbound-bootstrap.sh.tftpl", {
+      # Guest network range allowed to query the resolver.
+      guest_cidr     = "10.11.0.0/16"
+      local_dns_port = "19053"
+      # Cloudflare Zero Trust Gateway DoT location endpoint.
+      dot_hostname = "j0mqwd9sm7.cloudflare-gateway.com"
+      # Anycast IPs the location endpoint resolves to. VERIFY these against the
+      # live host's unbound config before a rebuild — unbound needs an IP here,
+      # not a hostname, and the migration set these out-of-band.
+      dot_upstream_addrs = ["172.64.36.1", "172.64.36.2"]
+    })
   }
 }

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -223,14 +223,16 @@ module "sandbox_host" {
   internal_ip   = var.host_internal_ip
   tags          = ["vmd-use4"]
 
-  # Label-last: deliberately NOT setting component=vmd/sandbox_role=vmd here.
-  # CD and the scheduler key on these labels, so the host stays out of prod
-  # rotation until host bring-up and pre-cutover validation are done. Flip to
-  # component=vmd / sandbox_role=vmd via `gcloud compute instances add-labels`
-  # at cutover — `labels` is in the module's ignore_changes, so a later
-  # `terraform apply` won't revert that.
+  # Cutover complete: this is the live primary host, so it must carry the prod
+  # discovery labels CD and the scheduler key on. `labels` is NOT in the
+  # module's ignore_changes, so these must be declared here or a `terraform
+  # apply` would strip the ones added out-of-band at cutover and break host
+  # discovery (deploy-vmd / deploy-otel filter on component=vmd). Mirrors the
+  # us-central1 host.
   labels = merge(local.common_labels, {
-    sandbox_status = "provisioning"
+    component               = "vmd"
+    sandbox_role            = "vmd"
+    "goog-ops-agent-policy" = "v2-template-1-7-0"
   })
 
   service_account_email = data.google_service_account.api_runner.email

--- a/infra/envs/production/us-west2/imports.tf
+++ b/infra/envs/production/us-west2/imports.tf
@@ -1,0 +1,8 @@
+# One-time state adoption. The api module now declares the public invoker
+# binding (allUsers -> roles/run.invoker) that has always existed out-of-band on
+# this service; import it so the CD apply is a no-op instead of showing a
+# (harmless but confusing) "add public access" create. iam_member is idempotent.
+import {
+  to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
+  id = "projects/rayai-prod/locations/us-west2/services/superserve-api-usw2 roles/run.invoker allUsers"
+}

--- a/infra/envs/staging/us-central1/imports.tf
+++ b/infra/envs/staging/us-central1/imports.tf
@@ -32,3 +32,10 @@ import {
   to = module.sandbox_host.google_compute_instance.this
   id = "projects/rayai-dev/zones/us-central1-a/instances/superserve-vmd-staging"
 }
+
+# The api module now declares the public invoker binding that already exists on
+# this service; import so the apply is a no-op. iam_member is idempotent.
+import {
+  to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
+  id = "projects/rayai-dev/locations/us-central1/services/superserve-api roles/run.invoker allUsers"
+}

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -100,6 +100,21 @@ resource "google_cloud_run_v2_service" "this" {
   deletion_protection = true
 }
 
+# Public, unauthenticated invoker. The API is reached through an external
+# HTTPS load balancer (serverless NEG -> this service), which forwards requests
+# as allUsers, so the service must grant run.invoker to allUsers. This binding
+# was applied imperatively (`gcloud run services add-iam-policy-binding`) in
+# every cell; declaring it here adopts the live grants via import.
+resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+  count = var.allow_public_invoker ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.this.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
 locals {
   api_contract = {
     project_id            = var.project_id

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -90,6 +90,9 @@ resource "google_cloud_run_v2_service" "this" {
     ignore_changes = [
       client,
       client_version,
+      # Deploy tooling adds transient service labels (e.g. cachebust) the module
+      # does not declare; ignore label drift so an apply doesn't strip them.
+      labels,
       scaling,
       template[0].containers[0].image,
       traffic,

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -113,3 +113,9 @@ variable "cpu_idle" {
   type    = bool
   default = false
 }
+
+variable "allow_public_invoker" {
+  description = "Grant allUsers roles/run.invoker on the service (public, unauthenticated ingress). Every prod cell fronts the API with a public HTTPS LB, so this defaults to true. The bindings already exist live across all cells — created imperatively — so enabling this and importing adopts them without a policy change."
+  type        = bool
+  default     = true
+}

--- a/infra/modules/cloud-run-cert-lb/main.tf
+++ b/infra/modules/cloud-run-cert-lb/main.tf
@@ -1,0 +1,98 @@
+# Global external HTTPS load balancer fronting a single regional Cloud Run
+# service, terminating TLS with a Certificate-Manager managed certificate via a
+# certificate map (not classic google_compute_managed_ssl_certificate).
+#
+# Shape borrows from two existing modules:
+#   - cloud-run-lb  : serverless NEG -> backend service -> url map
+#   - proxy-lb      : Certificate Manager dns_authorization/certificate/map
+#
+# Unlike cloud-run-lb this is HTTPS-only (no :80 redirect) and uses a cert map
+# on the target proxy instead of ssl_certificates, matching the live api.
+# superserve.ai LB that was stood up imperatively during the host migration.
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "google_compute_region_network_endpoint_group" "cloud_run" {
+  project               = var.project_id
+  name                  = var.neg_name
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = var.cloud_run_service
+  }
+}
+
+resource "google_compute_backend_service" "cloud_run" {
+  project               = var.project_id
+  name                  = var.backend_service_name
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  timeout_sec           = var.backend_timeout_sec
+
+  backend {
+    group = google_compute_region_network_endpoint_group.cloud_run.id
+  }
+}
+
+resource "google_compute_url_map" "this" {
+  project         = var.project_id
+  name            = var.url_map_name
+  default_service = google_compute_backend_service.cloud_run.id
+}
+
+resource "google_certificate_manager_dns_authorization" "this" {
+  project  = var.project_id
+  location = "global"
+  name     = var.dns_authorization_name
+  domain   = var.domain
+}
+
+resource "google_certificate_manager_certificate" "this" {
+  project  = var.project_id
+  location = "global"
+  name     = var.certificate_name
+
+  managed {
+    domains            = [var.domain]
+    dns_authorizations = [google_certificate_manager_dns_authorization.this.id]
+  }
+}
+
+resource "google_certificate_manager_certificate_map" "this" {
+  project = var.project_id
+  name    = var.certificate_map_name
+}
+
+resource "google_certificate_manager_certificate_map_entry" "this" {
+  project      = var.project_id
+  name         = var.certificate_map_entry_name
+  map          = google_certificate_manager_certificate_map.this.name
+  hostname     = var.domain
+  certificates = [google_certificate_manager_certificate.this.id]
+}
+
+# Reserved global external IP. Created without an explicit address, so GCP
+# assigned one (live value 34.49.216.194); the address is computed on import.
+resource "google_compute_global_address" "this" {
+  project = var.project_id
+  name    = var.address_name
+}
+
+resource "google_compute_target_https_proxy" "this" {
+  project         = var.project_id
+  name            = var.https_proxy_name
+  url_map         = google_compute_url_map.this.id
+  certificate_map = google_certificate_manager_certificate_map.this.id
+}
+
+resource "google_compute_global_forwarding_rule" "this" {
+  project               = var.project_id
+  name                  = var.forwarding_rule_name
+  ip_address            = google_compute_global_address.this.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  network_tier          = "PREMIUM"
+  target                = google_compute_target_https_proxy.this.id
+}

--- a/infra/modules/cloud-run-cert-lb/main.tf
+++ b/infra/modules/cloud-run-cert-lb/main.tf
@@ -81,10 +81,13 @@ resource "google_compute_global_address" "this" {
 }
 
 resource "google_compute_target_https_proxy" "this" {
-  project         = var.project_id
-  name            = var.https_proxy_name
-  url_map         = google_compute_url_map.this.id
-  certificate_map = google_certificate_manager_certificate_map.this.id
+  project = var.project_id
+  name    = var.https_proxy_name
+  url_map = google_compute_url_map.this.id
+  # A target HTTPS proxy needs the full Certificate Manager resource URI, not
+  # the bare `projects/.../certificateMaps/...` that `.id` returns — otherwise
+  # the post-import plan is not a no-op (the provider re-patches the proxy).
+  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.this.id}"
 }
 
 resource "google_compute_global_forwarding_rule" "this" {

--- a/infra/modules/cloud-run-cert-lb/main.tf
+++ b/infra/modules/cloud-run-cert-lb/main.tf
@@ -25,11 +25,15 @@ resource "google_compute_region_network_endpoint_group" "cloud_run" {
 }
 
 resource "google_compute_backend_service" "cloud_run" {
-  project               = var.project_id
-  name                  = var.backend_service_name
-  protocol              = "HTTP"
-  load_balancing_scheme = "EXTERNAL_MANAGED"
-  timeout_sec           = var.backend_timeout_sec
+  project  = var.project_id
+  name     = var.backend_service_name
+  protocol = "HTTP"
+  # Match the live backend created imperatively during the migration (classic
+  # external scheme, no connection draining) so the import plan is a no-op.
+  # Moving to EXTERNAL_MANAGED / draining would be a separate, reviewed change.
+  load_balancing_scheme           = "EXTERNAL"
+  connection_draining_timeout_sec = 0
+  timeout_sec                     = var.backend_timeout_sec
 
   backend {
     group = google_compute_region_network_endpoint_group.cloud_run.id

--- a/infra/modules/cloud-run-cert-lb/main.tf
+++ b/infra/modules/cloud-run-cert-lb/main.tf
@@ -31,7 +31,7 @@ resource "google_compute_backend_service" "cloud_run" {
   # Match the live backend created imperatively during the migration (classic
   # external scheme, no connection draining) so the import plan is a no-op.
   # Moving to EXTERNAL_MANAGED / draining would be a separate, reviewed change.
-  load_balancing_scheme           = "EXTERNAL"
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
   connection_draining_timeout_sec = 0
   timeout_sec                     = var.backend_timeout_sec
 
@@ -95,11 +95,13 @@ resource "google_compute_target_https_proxy" "this" {
 }
 
 resource "google_compute_global_forwarding_rule" "this" {
-  project               = var.project_id
-  name                  = var.forwarding_rule_name
-  ip_address            = google_compute_global_address.this.address
-  port_range            = "443"
-  load_balancing_scheme = "EXTERNAL_MANAGED"
+  project    = var.project_id
+  name       = var.forwarding_rule_name
+  ip_address = google_compute_global_address.this.address
+  port_range = "443"
+  # Live forwarding rule is EXTERNAL (the backend is EXTERNAL_MANAGED); match
+  # each resource's live scheme exactly so the import plan is a no-op.
+  load_balancing_scheme = "EXTERNAL"
   network_tier          = "PREMIUM"
   target                = google_compute_target_https_proxy.this.id
 }

--- a/infra/modules/cloud-run-cert-lb/main.tf
+++ b/infra/modules/cloud-run-cert-lb/main.tf
@@ -84,10 +84,10 @@ resource "google_compute_target_https_proxy" "this" {
   project = var.project_id
   name    = var.https_proxy_name
   url_map = google_compute_url_map.this.id
-  # A target HTTPS proxy needs the full Certificate Manager resource URI, not
-  # the bare `projects/.../certificateMaps/...` that `.id` returns — otherwise
-  # the post-import plan is not a no-op (the provider re-patches the proxy).
-  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.this.id}"
+  # A target HTTPS proxy stores certificate_map as the versioned Certificate
+  # Manager resource URL, not the bare `projects/.../certificateMaps/...` that
+  # `.id` returns. Match that exact form so the post-import plan is a no-op.
+  certificate_map = "https://certificatemanager.googleapis.com/v1/${google_certificate_manager_certificate_map.this.id}"
 }
 
 resource "google_compute_global_forwarding_rule" "this" {

--- a/infra/modules/cloud-run-cert-lb/outputs.tf
+++ b/infra/modules/cloud-run-cert-lb/outputs.tf
@@ -1,0 +1,17 @@
+output "address" {
+  description = "Global load balancer IPv4 address."
+  value       = google_compute_global_address.this.address
+}
+
+output "certificate_map_id" {
+  description = "Certificate Manager certificate map resource ID."
+  value       = google_certificate_manager_certificate_map.this.id
+}
+
+output "dns_authorization" {
+  description = "DNS authorization record the domain must be delegated to for cert issuance."
+  value = {
+    name        = google_certificate_manager_dns_authorization.this.name
+    record_data = try(google_certificate_manager_dns_authorization.this.dns_resource_record[0], null)
+  }
+}

--- a/infra/modules/cloud-run-cert-lb/variables.tf
+++ b/infra/modules/cloud-run-cert-lb/variables.tf
@@ -1,0 +1,75 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "Region of the backing Cloud Run service (serverless NEG region)."
+  type        = string
+}
+
+variable "cloud_run_service" {
+  description = "Name of the Cloud Run service to front."
+  type        = string
+}
+
+variable "domain" {
+  description = "Public hostname served by this load balancer."
+  type        = string
+}
+
+variable "neg_name" {
+  description = "Serverless network endpoint group name."
+  type        = string
+}
+
+variable "backend_service_name" {
+  description = "Backend service name."
+  type        = string
+}
+
+variable "url_map_name" {
+  description = "URL map name."
+  type        = string
+}
+
+variable "dns_authorization_name" {
+  description = "Certificate Manager DNS authorization name."
+  type        = string
+}
+
+variable "certificate_name" {
+  description = "Certificate Manager managed certificate name."
+  type        = string
+}
+
+variable "certificate_map_name" {
+  description = "Certificate Manager certificate map name."
+  type        = string
+}
+
+variable "certificate_map_entry_name" {
+  description = "Certificate Manager certificate map entry name."
+  type        = string
+}
+
+variable "address_name" {
+  description = "Global static IP address name."
+  type        = string
+}
+
+variable "https_proxy_name" {
+  description = "Target HTTPS proxy name."
+  type        = string
+}
+
+variable "forwarding_rule_name" {
+  description = "Global forwarding rule name."
+  type        = string
+}
+
+variable "backend_timeout_sec" {
+  description = "Backend timeout for proxied Cloud Run requests."
+  type        = number
+  default     = 30
+}


### PR DESCRIPTION
## Summary

Reconciles Terraform with the production resources that were created imperatively during the us-central1 → us-east4 primary-host migration. **Import-only**: this models the live resources so state matches reality — no create/replace is intended.

## What's included

- CP `allUsers → roles/run.invoker` as a module resource (`allow_public_invoker`, default true) — covers all three cells
- New `cloud-run-cert-lb` module for the `api.superserve.ai` external HTTPS LB: serverless NEG → backend → url-map, Certificate-Manager dns-auth/cert/map, HTTPS proxy, global IP, forwarding rule
- OTEL env for the us-east4 control plane
- `us-east4` entry in `deploy/environments.yaml`
- `unbound` host bootstrap (startup-script) + `deploy-vmd.py` env plumbing (`CONTROL_PLANE_URL` / `INTERNAL_API_TOKEN` / `DAEMON_AUTH_TOKEN`, sourced from CI — no secret values hardcoded)

## Technical decisions / tradeoffs

- Written to be adopted via `terraform import`; **each import's plan must be a no-op before any apply.**
- The unbound bootstrap does **not** manage the guest DNS redirect — vmd owns `SANDBOX_DNS_REDIRECT` (`internal/network/hostfw.go`), and managing it from two places conflicts on a rebuild. unbound config + DoT upstreams match the live host.
- The public-invoker binding is default-on; the existing bindings on all three cells must be imported before the next apply in those envs, or apply will (idempotently) re-assert them.

## Testing

- `terraform validate` passes in `infra/envs/production/us-east4`; `terraform fmt` clean; `deploy-vmd.py` parses. **Not applied.**

## Import commands

From `infra/envs/production/us-east4`:
```
terraform import 'module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]' 'projects/rayai-prod/locations/us-east4/services/superserve-api-use4 roles/run.invoker allUsers'
terraform import module.api_cert_lb.google_compute_region_network_endpoint_group.cloud_run projects/rayai-prod/regions/us-east4/networkEndpointGroups/superserve-api-use4-neg
terraform import module.api_cert_lb.google_compute_backend_service.cloud_run projects/rayai-prod/global/backendServices/superserve-api-backend-use4
terraform import module.api_cert_lb.google_compute_url_map.this projects/rayai-prod/global/urlMaps/superserve-api-url-map
terraform import module.api_cert_lb.google_certificate_manager_dns_authorization.this projects/rayai-prod/locations/global/dnsAuthorizations/api-superserve-dnsauth
terraform import module.api_cert_lb.google_certificate_manager_certificate.this projects/rayai-prod/locations/global/certificates/api-superserve-cert
terraform import module.api_cert_lb.google_certificate_manager_certificate_map.this projects/rayai-prod/locations/global/certificateMaps/api-superserve-certmap
terraform import module.api_cert_lb.google_certificate_manager_certificate_map_entry.this projects/rayai-prod/locations/global/certificateMaps/api-superserve-certmap/certificateMapEntries/api-superserve-entry
terraform import module.api_cert_lb.google_compute_global_address.this projects/rayai-prod/global/addresses/api-superserve-use4-ip
terraform import module.api_cert_lb.google_compute_target_https_proxy.this projects/rayai-prod/global/targetHttpsProxies/api-superserve-use4-proxy
terraform import module.api_cert_lb.google_compute_global_forwarding_rule.this projects/rayai-prod/global/forwardingRules/api-superserve-use4-fwd
```
Plus the matching invoker imports in `us-central1` (`superserve-api`) and `us-west2` (`superserve-api-usw2`).

## Open for review

- cert-map attribute format on the HTTPS proxy (provider v6 may want the full `//certificatemanager.googleapis.com/...` URL) — verify the post-import plan is a no-op
- confirm the shared us-central1 artifact repo is correct for use4 (vs a region-local repo)
