### PR TITLE
Add Multi-Region Host Monitoring and Terraform Safeguards

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -211,6 +211,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -329,6 +330,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -456,6 +458,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/terraform-plans.yml
+++ b/.github/workflows/terraform-plans.yml
@@ -25,15 +25,23 @@ jobs:
         include:
           - name: staging-us-central1
             dir: infra/envs/staging/us-central1
+            environment: staging
           - name: production-us-central1
             dir: infra/envs/production/us-central1
+            environment: production
           - name: production-us-west2
             dir: infra/envs/production/us-west2
+            environment: production
           - name: production-us-east4
             dir: infra/envs/production/us-east4
+            environment: production
+    environment: ${{ matrix.environment }}
     env:
       TF_IN_AUTOMATION: "true"
       HAS_GCP_AUTH: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_SERVICE_ACCOUNT != '' }}
+      # Existing Monitoring channel resource names are non-secret references;
+      # the channel's Slack credential remains owned by Cloud Monitoring.
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +80,37 @@ jobs:
             echo
           } > "$summary_file"
 
+          if [[ "${{ matrix.name }}" == production-* ]]; then
+            channel_ids="${TF_VAR_notification_channel_ids:-}"
+            case "$channel_ids" in
+              ""|"[]")
+                echo "::error title=Missing notification channels::Set the existing monitored channel resource names in the TF_VAR_NOTIFICATION_CHANNEL_IDS repository/environment variable."
+                echo "Plan stopped: monitored notification channels are required for production." >> "$summary_file"
+                exit 1
+                ;;
+              \[*\])
+                if [[ ! "$channel_ids" =~ ^\[\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\"(,\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\")*\]$ ]]; then
+                  echo "::error title=Invalid notification channels::TF_VAR_NOTIFICATION_CHANNEL_IDS contains an invalid channel resource name."
+                  echo "Plan stopped: notification channels must use projects/PROJECT_ID/notificationChannels/NUMERIC_ID." >> "$summary_file"
+                  exit 1
+                fi
+                ;;
+              projects/*/notificationChannels/*)
+                if [[ ! "$channel_ids" =~ ^projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+$ ]]; then
+                  echo "::error title=Invalid notification channels::TF_VAR_NOTIFICATION_CHANNEL_IDS must name a valid Cloud Monitoring channel."
+                  echo "Plan stopped: notification channels must use projects/PROJECT_ID/notificationChannels/NUMERIC_ID." >> "$summary_file"
+                  exit 1
+                fi
+                export TF_VAR_notification_channel_ids="[\"$channel_ids\"]"
+                ;;
+              *)
+                echo "::error title=Invalid notification channels::TF_VAR_NOTIFICATION_CHANNEL_IDS must be a Terraform list literal."
+                echo "Plan stopped: TF_VAR_NOTIFICATION_CHANNEL_IDS is not a Terraform list literal." >> "$summary_file"
+                exit 1
+                ;;
+            esac
+          fi
+
           cd "${{ matrix.dir }}"
 
           terraform init -input=false
@@ -92,9 +131,9 @@ jobs:
             echo "Changes detected."
             echo "Changes detected." >> "$summary_file"
             echo >> "$summary_file"
-            echo "Plan output:" >> "$summary_file"
+            echo "Sanitized plan summary:" >> "$summary_file"
             echo '```' >> "$summary_file"
-            terraform show -no-color tfplan | head -n 200 >> "$summary_file" || true
+            "${GITHUB_WORKSPACE}/scripts/sanitize-terraform-plan.sh" tfplan >> "$summary_file"
             echo '```' >> "$summary_file"
             exit 0
           fi

--- a/.github/workflows/terraform-plans.yml
+++ b/.github/workflows/terraform-plans.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "infra/**"
       - "scripts/terraform-*.sh"
+      - "scripts/sanitize-terraform-plan.sh"
       - ".github/workflows/terraform-*.yml"
 
 concurrency:
@@ -89,7 +90,7 @@ jobs:
                 exit 1
                 ;;
               \[*\])
-                if [[ ! "$channel_ids" =~ ^\[\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\"(,\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\")*\]$ ]]; then
+                if [[ ! "$channel_ids" =~ ^\[[[:space:]]*\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\"([[:space:]]*,[[:space:]]*\"projects/[a-z][a-z0-9-]*/notificationChannels/[0-9]+\")*[[:space:]]*\]$ ]]; then
                   echo "::error title=Invalid notification channels::TF_VAR_NOTIFICATION_CHANNEL_IDS contains an invalid channel resource name."
                   echo "Plan stopped: notification channels must use projects/PROJECT_ID/notificationChannels/NUMERIC_ID." >> "$summary_file"
                   exit 1

--- a/.github/workflows/terraform-rollout-production.yml
+++ b/.github/workflows/terraform-rollout-production.yml
@@ -27,6 +27,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
       API_BASE_URL: https://usw-api.superserve.ai
       API_KEY: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
       SANDBOX_BASE_URL: https://usw-sandbox.superserve.ai
@@ -83,6 +84,7 @@ jobs:
       id-token: write
     env:
       TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
       API_BASE_URL: https://usc-api.superserve.ai
       API_KEY: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
       SANDBOX_BASE_URL: https://usc-sandbox.superserve.ai

--- a/infra/README.md
+++ b/infra/README.md
@@ -52,5 +52,6 @@ drain the host if saturation persists. Roll back by removing the alert policy
 configuration from the relevant environment and planning the deletion; do not
 apply that plan until the owner confirms the channel and policy are no longer
 needed. After deployment, recheck the Vanta control for every production host
-and retain the sanitized plan as evidence. Terraform plans are review-only;
-this repository does not apply production changes directly.
+and retain the sanitized plan as evidence. The plan command documented here is
+review-only; the repository's explicitly authorized production workflows can
+apply Terraform changes after their normal approval gates.

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,4 +5,52 @@ Terraform skeleton layout for Superserve GCP adoption.
 - `modules/` defines resource-area contracts
 - `envs/` wires those contracts into staging, production, and a greenfield new-region target
 
-All modules are schema-only at this stage, so they can be reviewed and iterated without applying infrastructure.
+Production roots configure a shared Compute Engine CPU alert for each
+Terraform-managed sandbox host. The alert fires when the 60-second mean CPU
+utilization is above 80% for 15 minutes, with a 15-minute notification rate
+limit and 30-minute auto-close. Notifications are sent to the existing
+monitored Cloud Monitoring channel names supplied through
+`TF_VAR_notification_channel_ids`; the channel and its Slack credential are
+owned outside this repository.
+
+The current production host inventory is:
+
+| Region | Instance | Alert policy key |
+| --- | --- | --- |
+| us-central1 | `superserve-vmd-prod` | `sandbox_host` |
+| us-east4 | `superserve-vmd-use4` | `sandbox_host` |
+| us-west2 | `superserve-vmd-usw2` | `sandbox_host` |
+
+Before the first apply, the infrastructure owner must compare this inventory
+with the Vanta finding and run read-only checks such as
+`gcloud monitoring policies list --project PROJECT_ID` filtered for each
+instance name. If an existing policy covers a host, import or correct that
+policy instead of creating a duplicate. The owner must also verify the
+configured channel with `gcloud monitoring channels describe CHANNEL_ID`; this
+checks channel ownership and delivery configuration without exposing a Slack
+webhook credential. The reusable module contains one policy per instance only
+because the instance-ID filter keeps each host's Vanta evidence and response
+path unambiguous.
+
+For an existing matching policy, use its full Monitoring policy name with
+`terraform import module.observability.google_monitoring_alert_policy.compute_instance_cpu[\"sandbox_host\"] POLICY_NAME`
+before planning. If the policy is not a match, update it in place or remove it
+from the state/configuration deliberately before creating the managed policy.
+
+For a review-only plan, supply the same variable as a Terraform list literal,
+for example:
+
+```sh
+TF_VAR_notification_channel_ids='["projects/example-project/notificationChannels/123456789"]' \
+  terraform plan -input=false -no-color -out=tfplan
+scripts/sanitize-terraform-plan.sh infra/envs/production/us-central1/tfplan > plan.txt
+```
+
+Infrastructure Operations owns these alerts. On notification, verify the
+metric and active workload, inspect host and sandbox capacity, then scale or
+drain the host if saturation persists. Roll back by removing the alert policy
+configuration from the relevant environment and planning the deletion; do not
+apply that plan until the owner confirms the channel and policy are no longer
+needed. After deployment, recheck the Vanta control for every production host
+and retain the sanitized plan as evidence. Terraform plans are review-only;
+this repository does not apply production changes directly.

--- a/infra/README.md
+++ b/infra/README.md
@@ -42,7 +42,7 @@ for example:
 
 ```sh
 TF_VAR_notification_channel_ids='["projects/example-project/notificationChannels/123456789"]' \
-  terraform plan -input=false -no-color -out=tfplan
+  terraform -chdir=infra/envs/production/us-central1 plan -input=false -no-color -out=tfplan
 scripts/sanitize-terraform-plan.sh infra/envs/production/us-central1/tfplan > plan.txt
 ```
 

--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -241,9 +241,17 @@ module "sandbox_host" {
 module "observability" {
   source = "../../../modules/observability"
 
-  project_id  = local.project_id
-  environment = local.environment
-  labels      = local.common_labels
+  project_id               = local.project_id
+  environment              = local.environment
+  notification_channel_ids = var.notification_channel_ids
+  compute_instance_cpu_alerts = {
+    sandbox_host = {
+      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / CPU saturation"
+      instance_name = module.sandbox_host.instance_name
+      instance_id   = module.sandbox_host.instance_id
+    }
+  }
+  labels = local.common_labels
   dashboards = {
     sandbox_operations = {
       display_name = "Sandbox Telemetry / Production Operations"

--- a/infra/envs/production/us-central1/variables.tf
+++ b/infra/envs/production/us-central1/variables.tf
@@ -105,3 +105,9 @@ variable "system_team_id_secret_name" {
   type        = string
   default     = null
 }
+
+variable "notification_channel_ids" {
+  description = "Existing monitored Cloud Monitoring notification channel resource names for infrastructure alerts."
+  type        = list(string)
+  default     = []
+}

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -218,3 +218,19 @@ module "sandbox_host" {
     enable-oslogin  = "TRUE"
   }
 }
+
+module "observability" {
+  source = "../../../modules/observability"
+
+  project_id               = local.project_id
+  environment              = local.environment
+  notification_channel_ids = var.notification_channel_ids
+  compute_instance_cpu_alerts = {
+    sandbox_host = {
+      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / CPU saturation"
+      instance_name = module.sandbox_host.instance_name
+      instance_id   = module.sandbox_host.instance_id
+    }
+  }
+  labels = local.common_labels
+}

--- a/infra/envs/production/us-east4/variables.tf
+++ b/infra/envs/production/us-east4/variables.tf
@@ -124,3 +124,9 @@ variable "system_team_id_secret_name" {
   type        = string
   default     = null
 }
+
+variable "notification_channel_ids" {
+  description = "Existing monitored Cloud Monitoring notification channel resource names for infrastructure alerts."
+  type        = list(string)
+  default     = []
+}

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -206,7 +206,15 @@ module "sandbox_host" {
 module "observability" {
   source = "../../../modules/observability"
 
-  project_id  = local.project_id
-  environment = local.environment
-  labels      = local.common_labels
+  project_id               = local.project_id
+  environment              = local.environment
+  notification_channel_ids = var.notification_channel_ids
+  compute_instance_cpu_alerts = {
+    sandbox_host = {
+      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / CPU saturation"
+      instance_name = module.sandbox_host.instance_name
+      instance_id   = module.sandbox_host.instance_id
+    }
+  }
+  labels = local.common_labels
 }

--- a/infra/envs/production/us-west2/variables.tf
+++ b/infra/envs/production/us-west2/variables.tf
@@ -94,6 +94,12 @@ variable "system_team_id_secret_name" {
   default     = null
 }
 
+variable "notification_channel_ids" {
+  description = "Existing monitored Cloud Monitoring notification channel resource names for infrastructure alerts."
+  type        = list(string)
+  default     = []
+}
+
 variable "create_network" {
   type    = bool
   default = false

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -125,6 +125,20 @@ resource "google_compute_firewall" "rules" {
   }
 }
 
+locals {
+  # GCP firewall names are limited to 63 characters; network and region names
+  # can consume that budget, so long names are shortened and retain a hash to
+  # avoid collisions between distinct full names.
+  ssh_deny_name_base = "${var.network_name}-${var.region}-deny-unrestricted-ssh"
+  ssh_deny_name_hash = substr(md5(local.ssh_deny_name_base), 0, 8)
+  ssh_deny_ipv4_name = length(local.ssh_deny_name_base) <= 63 ? local.ssh_deny_name_base : "${substr(local.ssh_deny_name_base, 0, 54)}-${local.ssh_deny_name_hash}"
+  ssh_deny_ipv6_name = length(local.ssh_deny_name_base) <= 60 ? "${local.ssh_deny_name_base}-v6" : "${substr(local.ssh_deny_name_base, 0, 51)}-v6-${local.ssh_deny_name_hash}"
+
+  iap_ssh_name_base = "${var.network_name}-${var.region}-allow-iap-ssh"
+  iap_ssh_name_hash = substr(md5(local.iap_ssh_name_base), 0, 8)
+  iap_ssh_name      = length(local.iap_ssh_name_base) <= 63 ? local.iap_ssh_name_base : "${substr(local.iap_ssh_name_base, 0, 54)}-${local.iap_ssh_name_hash}"
+}
+
 resource "google_compute_firewall" "deny_unrestricted_ssh" {
   for_each = var.manage_public_ssh_deny ? {
     ipv4 = ["0.0.0.0/0"]
@@ -132,7 +146,7 @@ resource "google_compute_firewall" "deny_unrestricted_ssh" {
   } : {}
 
   project       = var.project_id
-  name          = "${var.network_name}-${var.region}-deny-unrestricted-ssh${each.key == "ipv4" ? "" : "-ipv6"}"
+  name          = each.key == "ipv4" ? local.ssh_deny_ipv4_name : local.ssh_deny_ipv6_name
   network       = local.network_self_link
   direction     = "INGRESS"
   priority      = 900
@@ -161,7 +175,7 @@ resource "google_compute_firewall" "allow_iap_ssh" {
   count = var.enable_iap_ssh ? 1 : 0
 
   project       = var.project_id
-  name          = "${var.network_name}-${var.region}-allow-iap-ssh"
+  name          = local.iap_ssh_name
   network       = local.network_self_link
   direction     = "INGRESS"
   priority      = 800

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -126,14 +126,17 @@ resource "google_compute_firewall" "rules" {
 }
 
 resource "google_compute_firewall" "deny_unrestricted_ssh" {
-  count = var.manage_public_ssh_deny ? 1 : 0
+  for_each = var.manage_public_ssh_deny ? {
+    ipv4 = ["0.0.0.0/0"]
+    ipv6 = ["::/0"]
+  } : {}
 
   project       = var.project_id
-  name          = "${var.network_name}-${var.region}-deny-unrestricted-ssh"
+  name          = "${var.network_name}-${var.region}-deny-unrestricted-ssh${each.key == "ipv4" ? "" : "-ipv6"}"
   network       = local.network_self_link
   direction     = "INGRESS"
   priority      = 900
-  source_ranges = ["0.0.0.0/0", "::/0"]
+  source_ranges = each.value
   target_tags   = var.iap_ssh_target_tags
 
   deny {
@@ -147,6 +150,11 @@ resource "google_compute_firewall" "deny_unrestricted_ssh" {
   }
 
   description = "Prevent unrestricted SSH ingress; use an approved private access path instead."
+}
+
+moved {
+  from = google_compute_firewall.deny_unrestricted_ssh[0]
+  to   = google_compute_firewall.deny_unrestricted_ssh["ipv4"]
 }
 
 resource "google_compute_firewall" "allow_iap_ssh" {
@@ -184,7 +192,7 @@ locals {
     vpc_connector_subnet_ip     = try(google_compute_subnetwork.connector[0].ip_cidr_range, var.vpc_connector_subnet_ip)
     firewall_rules              = { for key, rule in google_compute_firewall.rules : key => rule.name }
     iap_ssh_rule                = try(google_compute_firewall.allow_iap_ssh[0].name, null)
-    ssh_deny_rule               = try(google_compute_firewall.deny_unrestricted_ssh[0].name, null)
+    ssh_deny_rule               = try(google_compute_firewall.deny_unrestricted_ssh["ipv4"].name, null)
     labels                      = var.labels
   }
 }

--- a/infra/modules/observability/README.md
+++ b/infra/modules/observability/README.md
@@ -5,9 +5,14 @@ Terraform support for shared observability resources.
 Current scope:
 
 - Cloud Monitoring dashboards from checked-in JSON definitions
+- Terraform-managed Compute Engine CPU saturation alert policies
+
+Alert policies use the existing Cloud Monitoring notification channel resource
+names supplied by `notification_channel_ids`. The channel itself, including
+any Slack webhook credential, is managed outside this module and is never
+placed in Terraform configuration or state.
 
 Still intentionally out of scope here:
 
 - log buckets
-- alert policies
 - uptime checks

--- a/infra/modules/observability/README.md
+++ b/infra/modules/observability/README.md
@@ -8,9 +8,10 @@ Current scope:
 - Terraform-managed Compute Engine CPU saturation alert policies
 
 Alert policies use the existing Cloud Monitoring notification channel resource
-names supplied by `notification_channel_ids`. The channel itself, including
-any Slack webhook credential, is managed outside this module and is never
-placed in Terraform configuration or state.
+names supplied by `notification_channel_ids`. Every channel must belong to the
+configured project. The channel itself, including any Slack webhook credential,
+is managed outside this module and is never placed in Terraform configuration
+or state.
 
 Still intentionally out of scope here:
 

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -24,6 +24,15 @@ resource "google_monitoring_alert_policy" "compute_instance_cpu" {
       error_message = "notification_channel_ids must contain an existing monitored channel when CPU alerts are configured"
     }
     precondition {
+      condition = alltrue([
+        for channel_id in var.notification_channel_ids : can(regex(
+          "^projects/${var.project_id}/notificationChannels/[0-9]+$",
+          channel_id
+        ))
+      ])
+      error_message = "notification_channel_ids must reference monitored channels in the configured project using full resource names"
+    }
+    precondition {
       condition     = each.value.threshold > 0 && each.value.threshold <= 1
       error_message = "CPU alert thresholds must be greater than 0 and no greater than 1"
     }

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -9,15 +9,77 @@ resource "google_monitoring_dashboard" "dashboards" {
   dashboard_json = each.value.definition
 }
 
+resource "google_monitoring_alert_policy" "compute_instance_cpu" {
+  for_each = var.compute_instance_cpu_alerts
+
+  project               = var.project_id
+  display_name          = each.value.display_name
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.notification_channel_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(var.notification_channel_ids) > 0
+      error_message = "notification_channel_ids must contain an existing monitored channel when CPU alerts are configured"
+    }
+    precondition {
+      condition     = each.value.threshold > 0 && each.value.threshold <= 1
+      error_message = "CPU alert thresholds must be greater than 0 and no greater than 1"
+    }
+  }
+
+  conditions {
+    display_name = "${each.value.instance_name} CPU utilization"
+
+    condition_threshold {
+      filter          = "resource.type = \"gce_instance\" AND resource.labels.instance_id = \"${each.value.instance_id}\" AND metric.type = \"compute.googleapis.com/instance/cpu/utilization\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = each.value.threshold
+      duration        = each.value.evaluation_duration
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "900s"
+    }
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content = coalesce(each.value.documentation, <<-EOT
+      Sustained CPU utilization above ${format("%.0f", each.value.threshold * 100)}% was observed on ${each.value.instance_name} for ${each.value.evaluation_duration}.
+
+      Owner: Infrastructure Operations. Response: confirm host saturation in Cloud Monitoring, inspect running sandbox workload and host services, and scale or drain the host when capacity remains constrained. Record the incident and link the remediation before closing the alert.
+    EOT
+    )
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type    = "compute_cpu_saturation"
+    instance_name = each.value.instance_name
+    managed_by    = "terraform"
+  })
+}
+
 locals {
   observability_contract = {
-    project_id         = var.project_id
-    environment        = var.environment
-    notification_email = var.notification_email
-    log_buckets        = var.log_buckets
-    uptime_checks      = var.uptime_checks
-    alert_policies     = var.alert_policies
-    dashboards         = var.dashboards
-    labels             = var.labels
+    project_id                  = var.project_id
+    environment                 = var.environment
+    notification_email          = var.notification_email
+    notification_channel_ids    = var.notification_channel_ids
+    compute_instance_cpu_alerts = var.compute_instance_cpu_alerts
+    log_buckets                 = var.log_buckets
+    uptime_checks               = var.uptime_checks
+    alert_policies              = var.alert_policies
+    dashboards                  = var.dashboards
+    labels                      = var.labels
   }
 }

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -14,6 +14,25 @@ variable "notification_email" {
   default     = null
 }
 
+variable "notification_channel_ids" {
+  description = "Existing Cloud Monitoring notification channel resource names. Channel credentials are owned by Monitoring and are never stored here."
+  type        = list(string)
+  default     = []
+}
+
+variable "compute_instance_cpu_alerts" {
+  description = "CPU saturation alerts keyed by a stable logical name."
+  type = map(object({
+    display_name        = string
+    instance_name       = string
+    instance_id         = string
+    threshold           = optional(number, 0.8)
+    evaluation_duration = optional(string, "900s")
+    documentation       = optional(string, null)
+  }))
+  default = {}
+}
+
 variable "log_buckets" {
   description = "Logging bucket definitions keyed by logical name."
   type = map(object({

--- a/infra/modules/sandbox-host/outputs.tf
+++ b/infra/modules/sandbox-host/outputs.tf
@@ -8,6 +8,11 @@ output "instance_name" {
   value       = google_compute_instance.this.name
 }
 
+output "instance_id" {
+  description = "Stable numeric Compute Engine instance ID for Monitoring resource filters."
+  value       = google_compute_instance.this.instance_id
+}
+
 output "instance_self_link" {
   description = "Instance self link."
   value       = google_compute_instance.this.self_link

--- a/scripts/sanitize-terraform-plan.sh
+++ b/scripts/sanitize-terraform-plan.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plan_file="${1:-tfplan}"
+
+if [[ ! -f "$plan_file" ]]; then
+  echo "plan file not found: $plan_file" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to produce a sanitized Terraform plan summary" >&2
+  exit 1
+fi
+
+echo "Sanitized Terraform plan summary"
+echo "Planned values, prior state, configuration, and variable values are omitted."
+echo
+terraform show -json "$plan_file" | jq -r '
+  .resource_changes[]?
+  | [.address, (.change.actions | join(","))]
+  | @tsv
+' | while IFS=$'\t' read -r address actions; do
+  printf '%s: %s\n' "$address" "$actions"
+done


### PR DESCRIPTION
## Summary

- Add Terraform-managed CPU alert policies for monitored Compute Engine hosts across production regions.
- Route alerts through existing Cloud Monitoring notification channels supplied by the production GitHub Environment.
- Pass notification channels consistently through plan and production apply workflows, with validation for full channel resource names.
- Add sanitized Terraform plan evidence and document thresholds, response steps, rollback guidance, and verification.
- Split unrestricted SSH firewall rules into separate IPv4 and IPv6 resources while preserving the existing IPv4 rule state.
- Keep generated firewall names within Google Cloud's length limit while retaining deterministic uniqueness for long names.

## Validation

- `terraform fmt -check -recursive infra`
- `bash -n scripts/sanitize-terraform-plan.sh`
- `git diff --check`

No production Terraform apply is performed by this change.