### PR TITLE
deploy-api: deploy the use4 primary cell on every merge

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -306,13 +306,53 @@ jobs:
           fi
           curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"
 
+      # The use4 cell is the primary production cell — api.superserve.ai routes
+      # here — so it deploys BEFORE the optional secondary cells below: a
+      # secondary-cell (usw) failure must not stop the job and leave the public
+      # primary on the old image. Same step-based pattern; reuses the SHA-tagged
+      # image pushed above. Steps skip until CLOUD_RUN_SERVICE_USE4 is set. use4
+      # has a public invoker binding, so /health is a meaningful probe.
+      - name: Deploy use4 cell to Cloud Run
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
+            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ vars.GCP_REGION_USE4 }} \
+            --project ${{ vars.GCP_PROJECT }}
+
+      - name: Route use4 cell traffic to the new revision
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
+          if [ "$SERVING" != "$LATEST" ]; then
+            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
+          fi
+          gcloud run services update-traffic $SVC --to-latest $ARGS
+
+      - name: Verify use4 cell latest revision serves traffic
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
+          if [ "$PCT" != "100" ]; then
+            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
+            exit 1
+          fi
+          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"
+
       # The usw cell deploys as steps in this job — not a separate job — for
       # the same reason CD Migrate's cell push is a step: a second job
       # referencing the production environment would double any approval
-      # gate. Steps run after the primary verify, so a bad rollout stops at
-      # the primary. The cell reuses the SHA-tagged image pushed above
-      # (Cloud Run pulls cross-region from Artifact Registry); steps skip
-      # until CLOUD_RUN_SERVICE_USW is set (repo-level variable).
+      # gate. Runs after the primary verify and the use4 primary cell above.
+      # Reuses the SHA-tagged image pushed above (Cloud Run pulls cross-region
+      # from Artifact Registry); steps skip until CLOUD_RUN_SERVICE_USW is set.
       - name: Deploy usw cell to Cloud Run
         if: vars.CLOUD_RUN_SERVICE_USW != ''
         run: |
@@ -349,42 +389,3 @@ jobs:
             echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
             exit 1
           fi
-
-      # The use4 cell is the primary production cell — api.superserve.ai routes
-      # here. Same step-based pattern as usw; reuses the SHA-tagged image pushed
-      # above. Steps skip until CLOUD_RUN_SERVICE_USE4 is set. Unlike usw, use4
-      # has a public invoker binding, so /health is a meaningful probe.
-      - name: Deploy use4 cell to Cloud Run
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
-            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ vars.GCP_REGION_USE4 }} \
-            --project ${{ vars.GCP_PROJECT }}
-
-      - name: Route use4 cell traffic to the new revision
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
-          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
-          if [ "$SERVING" != "$LATEST" ]; then
-            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
-          fi
-          gcloud run services update-traffic $SVC --to-latest $ARGS
-
-      - name: Verify use4 cell latest revision serves traffic
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
-          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
-          if [ "$PCT" != "100" ]; then
-            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
-            exit 1
-          fi
-          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -349,3 +349,42 @@ jobs:
             echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
             exit 1
           fi
+
+      # The use4 cell is the primary production cell — api.superserve.ai routes
+      # here. Same step-based pattern as usw; reuses the SHA-tagged image pushed
+      # above. Steps skip until CLOUD_RUN_SERVICE_USE4 is set. Unlike usw, use4
+      # has a public invoker binding, so /health is a meaningful probe.
+      - name: Deploy use4 cell to Cloud Run
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
+            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ vars.GCP_REGION_USE4 }} \
+            --project ${{ vars.GCP_PROJECT }}
+
+      - name: Route use4 cell traffic to the new revision
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
+          if [ "$SERVING" != "$LATEST" ]; then
+            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
+          fi
+          gcloud run services update-traffic $SVC --to-latest $ARGS
+
+      - name: Verify use4 cell latest revision serves traffic
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
+          if [ "$PCT" != "100" ]; then
+            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
+            exit 1
+          fi
+          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -270,6 +270,50 @@ jobs:
           docker push ${IMAGE}:latest
           docker push ${IMAGE}:${{ github.sha }}
 
+      # use4 is the primary production cell — api.superserve.ai routes here — so
+      # it deploys FIRST, right after the image push, before the idle us-central1
+      # cell and the usw secondary cell. That way a transient failure updating or
+      # probing those cells can't stop the job and leave the public primary on
+      # the old image. Steps skip until CLOUD_RUN_SERVICE_USE4 is set; use4 has a
+      # public invoker binding, so /health is a meaningful probe.
+      - name: Deploy use4 cell to Cloud Run
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
+            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
+            --region ${{ vars.GCP_REGION_USE4 }} \
+            --project ${{ vars.GCP_PROJECT }}
+
+      - name: Route use4 cell traffic to the new revision
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
+          if [ "$SERVING" != "$LATEST" ]; then
+            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
+          fi
+          gcloud run services update-traffic $SVC --to-latest $ARGS
+
+      - name: Verify use4 cell latest revision serves traffic
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        run: |
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
+          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
+          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
+          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
+          if [ "$PCT" != "100" ]; then
+            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
+            exit 1
+          fi
+          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"
+
+      # us-central1 is the legacy primary, now idle (scaled to 0) and pending
+      # decommission. It still deploys to stay in sync until removed, but runs
+      # AFTER use4 so its cold-start/probe flakiness can't block the real primary.
       - name: Deploy to Cloud Run
         run: |
           gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
@@ -297,47 +341,6 @@ jobs:
         run: |
           SVC=${{ vars.CLOUD_RUN_SERVICE }}
           ARGS="--region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
-          if [ "$PCT" != "100" ]; then
-            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
-            exit 1
-          fi
-          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"
-
-      # The use4 cell is the primary production cell — api.superserve.ai routes
-      # here — so it deploys BEFORE the optional secondary cells below: a
-      # secondary-cell (usw) failure must not stop the job and leave the public
-      # primary on the old image. Same step-based pattern; reuses the SHA-tagged
-      # image pushed above. Steps skip until CLOUD_RUN_SERVICE_USE4 is set. use4
-      # has a public invoker binding, so /health is a meaningful probe.
-      - name: Deploy use4 cell to Cloud Run
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
-            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ vars.GCP_REGION_USE4 }} \
-            --project ${{ vars.GCP_PROJECT }}
-
-      - name: Route use4 cell traffic to the new revision
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
-          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
-          if [ "$SERVING" != "$LATEST" ]; then
-            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
-          fi
-          gcloud run services update-traffic $SVC --to-latest $ARGS
-
-      - name: Verify use4 cell latest revision serves traffic
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
-          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
           DESC=$(gcloud run services describe $SVC $ARGS --format=json)
           LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
           PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')


### PR DESCRIPTION
## Summary

`deploy-api.yml` never learned about the us-east4 (use4) cell. The `deploy-production` job deploys `CLOUD_RUN_SERVICE` (central) and a conditional `CLOUD_RUN_SERVICE_USW` (west) block — but nothing for use4. Since the host migration, **api.superserve.ai routes to use4**, so every API merge has been deploying central + west while the *primary* cell silently kept running a hand-deployed image from the migration window. Same "host-local config didn't migrate" class as the earlier deploy-proxy/vmd gaps.

## What this does

- Adds a `use4` cell block to `deploy-production` mirroring the usw pattern (deploy → route-to-latest → verify), gated on `vars.CLOUD_RUN_SERVICE_USE4 != ''`, reusing the SHA-tagged image already pushed to Artifact Registry.
- Unlike usw, use4 **has** a public invoker binding (it serves api.superserve.ai), so its verify step includes a `/health` probe.
- Repo vars set: `CLOUD_RUN_SERVICE_USE4=superserve-api-use4`, `GCP_REGION_USE4=us-east4`.

## Already done out-of-band (not in this PR)

- Un-staled use4 to current main: deployed `controlplane:<main-sha>` (SHA-pinned, matching central/west — it had been floating on `:latest`), verified `/health=200` at 100% traffic.

## Follow-up (not here)

- use4 is added as a *cell* step; central is still the workflow's "primary" block. When central is decommissioned (Phase E), the primary block should become use4 and the central steps removed. Until then a central hiccup would block the use4 step — acceptable short-term since central is idle.

## Testing

- YAML parses; workflow steps mirror the verified usw block. Vars set on the repo.
