### PR TITLE
CD: cover the use4 primary cell (deploy-vmd, otel-collector, smoke-test)

### DIFF
--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -79,3 +79,17 @@ jobs:
           OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
           python3 .github/workflows/scripts/deploy-otel-collector.py
+
+      # The use4 cell host is the primary production host (api.superserve.ai).
+      # Same collector deploy scoped to us-east4; skipped until
+      # CLOUD_RUN_SERVICE_USE4 is set. (usw remains uncovered here — pre-existing
+      # gap, tracked separately.)
+      - name: Deploy OTEL Collector to use4 cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: us-east4
+          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-east4
+          OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
+        run: |
+          python3 .github/workflows/scripts/deploy-otel-collector.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -124,9 +124,29 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      # GCP_REGION keeps this fan-out on the primary region's hosts only;
-      # the usw cell host shares the project and label but deploys in the
-      # step below, after the primary succeeds.
+      # The use4 cell host is the primary production host — api.superserve.ai
+      # routes there — so it deploys FIRST, before the idle legacy primary and
+      # the usw secondary cell. A failure or zero-match in those must not stop
+      # the job and leave the public host on old vmd/boxd/secretsproxy binaries.
+      # Reuses the binaries built above; skipped until CLOUD_RUN_SERVICE_USE4 is
+      # set. Discovery is the VMD_LABEL filter scoped to GCP_REGION_USE4.
+      - name: Deploy to use4 cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 .github/workflows/scripts/deploy-vmd.py
+
+      # Legacy primary-region fan-out (us-central1), now idle and pending
+      # decommission. GCP_REGION scopes it to that region's hosts only. It still
+      # deploys to stay in sync until removed, but runs AFTER the use4 primary so
+      # its failure can't block the real primary host.
       - name: Discover and deploy to VMD instances
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
@@ -142,34 +162,15 @@ jobs:
       # The usw cell deploys as a step in this job — not a separate job —
       # for the same reason Deploy API / CD Migrate / Seed Templates do it
       # this way: a second job referencing the production environment would
-      # double any approval gate. Running after the primary step means a bad
-      # rollout stops at the primary, and the step reuses the binaries built
-      # above (build once, deploy per region). Skipped until
-      # CLOUD_RUN_SERVICE_USW (the repo-level cell-exists flag) is set.
-      # Discovery is the same VMD_LABEL filter scoped to GCP_REGION_USW, so
-      # the cell host must carry the label; zero matches fails the deploy
-      # rather than silently skipping the cell.
+      # double any approval gate. Reuses the binaries built above; skipped
+      # until CLOUD_RUN_SERVICE_USW is set. Discovery is the VMD_LABEL filter
+      # scoped to GCP_REGION_USW, so the cell host must carry the label; zero
+      # matches fails the deploy rather than silently skipping the cell.
       - name: Deploy to usw cell VMD instances
         if: vars.CLOUD_RUN_SERVICE_USW != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION_USW }}
-          VMD_LABEL: ${{ vars.VMD_LABEL }}
-          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
-          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
-          SHA: ${{ github.sha }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: |
-          python3 .github/workflows/scripts/deploy-vmd.py
-
-      # The use4 cell is the primary production host (api.superserve.ai routes
-      # there). Same step pattern as usw, scoped to GCP_REGION_USE4; reuses the
-      # binaries built above. Skipped until CLOUD_RUN_SERVICE_USE4 is set.
-      - name: Deploy to use4 cell VMD instances
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
-        env:
-          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -161,3 +161,19 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py
+
+      # The use4 cell is the primary production host (api.superserve.ai routes
+      # there). Same step pattern as usw, scoped to GCP_REGION_USE4; reuses the
+      # binaries built above. Skipped until CLOUD_RUN_SERVICE_USE4 is set.
+      - name: Deploy to use4 cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
+          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SHA: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 .github/workflows/scripts/deploy-vmd.py

--- a/scripts/smoke-test-region.sh
+++ b/scripts/smoke-test-region.sh
@@ -32,7 +32,9 @@ case "${ENVIRONMENT}/${REGION}" in
     API_BASE_URL="${API_BASE_URL:-https://superserve-api-eszjsyysqa-uc.a.run.app}"
     SANDBOX_BASE_URL="${SANDBOX_BASE_URL:-https://staging-sandbox.superserve.ai}"
     ;;
-  production/us-central1)
+  production/us-central1 | production/us-east4)
+    # The "use" cell — served by the shared api/sandbox domains regardless of
+    # which host (central or its us-east4 successor) is primary.
     API_BASE_URL="${API_BASE_URL:-https://api.superserve.ai}"
     SANDBOX_BASE_URL="${SANDBOX_BASE_URL:-https://sandbox.superserve.ai}"
     ;;


### PR DESCRIPTION
## Summary

Closes the remaining "host-local config didn't migrate" CD gaps for the us-east4 (use4) primary cell, found in a post-migration audit. `deploy-vmd`, `deploy-otel-collector`, and `smoke-test-region` never learned about use4 (only central + a conditional usw).

## What this does

- **`deploy-vmd.yml` (critical):** add a use4 cell step mirroring usw. This was the root cause — the east host got **no host-agent deploys** (vmd/boxd/secretsproxy/template-builder/fc-cleanup), which is why it had to be hand-staged during the migration and why secretsproxy was missing.
- **`deploy-otel-collector.yml`:** add a use4 deploy step (scoped to us-east4) so the primary host's collector is CD-managed.
- **`smoke-test-region.sh`:** fold `production/us-east4` into the shared use-cell case (api/sandbox.superserve.ai).

## Verified NOT gaps (no change)

- `cd.yml` migrations & `seed-templates.yml` per-cell steps use `DATABASE_URL_USWEST`; **use4 shares central's DB**, so the primary invocation already covers it.
- `terraform-rollout-production.yml` is a manual west-only helper; use4 infra is covered by the automated `terraform-cd.yml`.

## Prereqs verified

- East host **is discoverable**: labels `component=vmd, environment=production, region=us-east4`, status RUNNING — matches `deploy-vmd.py`'s filter (`labels.component=vmd AND status=RUNNING`, zone-scoped) and the otel `VMD_FILTER`.
- Repo vars `CLOUD_RUN_SERVICE_USE4` / `GCP_REGION_USE4` are set.

## Follow-ups (noted, not in this PR)

- usw otel collector is still uncovered by `deploy-otel-collector.yml` (pre-existing gap).
- East host label `sandbox_status=provisioning` is stale (it's live-serving) — cosmetic.
- East `otelopscol` SA lacks `logging.logEntries.create` — separate IAM fix (ties to host observability).
- At decommission, each workflow's **primary** block should swap central→use4.

## Testing

- Both workflow YAMLs parse; `smoke-test-region.sh` passes `bash -n`.
