### PR TITLE
cd: use4 collector first + deploy-vmd self-trigger (follow-up to #259)

### DIFF
--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -71,25 +71,28 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Deploy OTEL Collector to production VMD instances
-        env:
-          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: us-central1
-          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-central1
-          OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
-        run: |
-          python3 .github/workflows/scripts/deploy-otel-collector.py
-
-      # The use4 cell host is the primary production host (api.superserve.ai).
-      # Same collector deploy scoped to us-east4; skipped until
-      # CLOUD_RUN_SERVICE_USE4 is set. (usw remains uncovered here — pre-existing
-      # gap, tracked separately.)
+      # The use4 cell host is the primary production host (api.superserve.ai) —
+      # deploy its collector FIRST, before the idle us-central1 host, so a
+      # legacy-only failure can't stop the job and leave the public host without
+      # the collector update. Skipped until CLOUD_RUN_SERVICE_USE4 is set.
       - name: Deploy OTEL Collector to use4 cell VMD instances
         if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: us-east4
           VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-east4
+          OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
+        run: |
+          python3 .github/workflows/scripts/deploy-otel-collector.py
+
+      # Legacy us-central1 host, idle and pending decommission. Runs after the
+      # use4 primary so its failure can't block the real primary. (usw remains
+      # uncovered here — pre-existing gap, tracked separately.)
+      - name: Deploy OTEL Collector to production VMD instances
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: us-central1
+          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-central1
           OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
           python3 .github/workflows/scripts/deploy-otel-collector.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -37,6 +37,11 @@ on:
       - 'deploy/firecracker-netns@.service'
       - 'deploy/sandboxes.slice'
       - 'scripts/fc-cleanup'
+      # The workflow + its deploy script must self-trigger (as deploy-otel does),
+      # or a new cell/step lands without ever running until an unrelated vmd
+      # asset changes — leaving that host on stale binaries.
+      - '.github/workflows/deploy-vmd.yml'
+      - '.github/workflows/scripts/deploy-vmd.py'
 
 jobs:
   deploy-staging:


### PR DESCRIPTION
Addresses the two follow-up review comments on #259.

- **deploy-otel-collector.yml**: reorder the use4 (primary host) collector deploy ahead of the idle us-central1 step — a legacy-only failure was able to stop the job before the public host's collector updated. Mirrors the deploy-vmd/deploy-api use4-first ordering.
- **deploy-vmd.yml**: add `.github/workflows/deploy-vmd.yml` and `.github/workflows/scripts/deploy-vmd.py` to `push.paths`. Without them the workflow doesn't run when only the deploy tooling changes, so #259's new use4 host step never executed on merge — the use4 host is still on migration-era binaries. Adding these means **merging this PR self-triggers a vmd deploy that finally covers the use4 host** (deploy-otel already self-triggers).

Workflow-only; no infra apply.