### PR TITLE
observability: drop invalid notification_rate_limit from metric alert policy

### DIFF
--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -55,9 +55,10 @@ resource "google_monitoring_alert_policy" "compute_instance_cpu" {
   }
 
   alert_strategy {
-    notification_rate_limit {
-      period = "900s"
-    }
+    # notification_rate_limit is only valid on log-based alert policies; this is
+    # a metric-threshold policy, so GCP rejects it (Error 400: "only log-based
+    # alert policies may specify a notification rate limit"). auto_close is valid
+    # for metric policies and is kept.
     auto_close = "1800s"
   }
 


### PR DESCRIPTION
**Unblocks the production terraform-cd chain.** After #257 merged, `Apply production/us-west2` fails:

```
Error 400: alertStrategy.notificationRateLimit ... only log-based alert policies may specify a notification rate limit
```

`module.observability.google_monitoring_alert_policy.compute_instance_cpu` is a **metric-threshold** policy, and `notification_rate_limit` is only valid on **log-based** policies. Remove it; keep `auto_close` (valid for metric policies).

Staging already applied clean (the #254 firewall + rayai-dev grant are resolved), so this is the only thing left blocking the prod apply.