### PR TITLE
CD access: use4 IAP SSH + codify CD service-account IAM grants

### DIFF
--- a/infra/envs/production/us-east4/imports.tf
+++ b/infra/envs/production/us-east4/imports.tf
@@ -65,6 +65,14 @@ import {
   id = "projects/rayai-prod/locations/us-east4/services/superserve-api-use4 roles/run.invoker allUsers"
 }
 
+# CD service account's certificatemanager.editor grant, added out-of-band during
+# the #257 incident to unblock the cert-map / dns-auth import. Import so the
+# apply adopts the existing binding instead of planning a create.
+import {
+  to = google_project_iam_member.cd_certificatemanager
+  id = "rayai-prod roles/certificatemanager.editor serviceAccount:superserve-github-actions@rayai-prod.iam.gserviceaccount.com"
+}
+
 # IAP SSH allow rule (enable_iap_ssh = true). Created imperatively (gcloud) to
 # unblock the vmd deploy after manage_public_ssh_deny closed :22 with no IAP
 # allow; import so the apply adopts it instead of failing AlreadyExists.

--- a/infra/envs/production/us-east4/imports.tf
+++ b/infra/envs/production/us-east4/imports.tf
@@ -64,3 +64,11 @@ import {
   to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
   id = "projects/rayai-prod/locations/us-east4/services/superserve-api-use4 roles/run.invoker allUsers"
 }
+
+# IAP SSH allow rule (enable_iap_ssh = true). Created imperatively (gcloud) to
+# unblock the vmd deploy after manage_public_ssh_deny closed :22 with no IAP
+# allow; import so the apply adopts it instead of failing AlreadyExists.
+import {
+  to = module.network.google_compute_firewall.allow_iap_ssh[0]
+  id = "projects/rayai-prod/global/firewalls/superserve-production-vpc-us-east4-allow-iap-ssh"
+}

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -95,6 +95,16 @@ data "google_service_account" "api_runner" {
   account_id = "superserve-api-runner"
 }
 
+# The CD service account needs Certificate Manager access to read/manage the
+# api.superserve.ai cert map + DNS authorization this cell owns (the plan's
+# import 403'd without it). Granted out-of-band to unblock; declared here so it
+# survives. google_project_iam_member is additive/idempotent — no import needed.
+resource "google_project_iam_member" "cd_certificatemanager" {
+  project = local.project_id
+  role    = "roles/certificatemanager.editor"
+  member  = "serviceAccount:superserve-github-actions@${local.project_id}.iam.gserviceaccount.com"
+}
+
 # A5: us-east4 control plane for the "use" cell.
 #
 # This is a host swap, not a new cell: us-east4 shares the use-cell Supabase,

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -47,8 +47,12 @@ module "network" {
   subnet_name            = "superserve-use4-subnet"
   subnet_cidr            = var.subnet_cidr
   manage_public_ssh_deny = true
-  enable_iap_ssh         = false
-  iap_ssh_target_tags    = ["vmd-use4"]
+  # true so CD (deploy-vmd/proxy/otel via `gcloud scp --tunnel-through-iap`) and
+  # operators can reach the host on :22 — matches us-central1/us-west2. With this
+  # false, manage_public_ssh_deny alone blocked ALL SSH to the host and broke the
+  # vmd deploy.
+  enable_iap_ssh      = true
+  iap_ssh_target_tags = ["vmd-use4"]
 
   # Cloud Run reaches the vmd host over direct VPC egress (no connector),
   # matching the usw2 cell. The dedicated egress subnet carries the Cloud Run

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -97,8 +97,9 @@ data "google_service_account" "api_runner" {
 
 # The CD service account needs Certificate Manager access to read/manage the
 # api.superserve.ai cert map + DNS authorization this cell owns (the plan's
-# import 403'd without it). Granted out-of-band to unblock; declared here so it
-# survives. google_project_iam_member is additive/idempotent — no import needed.
+# import 403'd without it). Granted out-of-band to unblock; imported (see
+# imports.tf) so the apply adopts the existing binding instead of creating a
+# duplicate.
 resource "google_project_iam_member" "cd_certificatemanager" {
   project = local.project_id
   role    = "roles/certificatemanager.editor"

--- a/infra/envs/staging/us-central1/imports.tf
+++ b/infra/envs/staging/us-central1/imports.tf
@@ -39,3 +39,11 @@ import {
   to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
   id = "projects/rayai-dev/locations/us-central1/services/superserve-api roles/run.invoker allUsers"
 }
+
+# CD service account's compute.networkAdmin grant, added out-of-band during the
+# #257 incident to unblock the VPC flow-log subnet update. Import so the apply
+# adopts the existing binding instead of planning a create.
+import {
+  to = module.iam.google_project_iam_member.project_bindings["cd_network_admin"]
+  id = "rayai-dev roles/compute.networkAdmin serviceAccount:superserve-github-actions@rayai-dev.iam.gserviceaccount.com"
+}

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -107,8 +107,9 @@ module "iam" {
       members = ["serviceAccount:superserve-api@${local.project_id}.iam.gserviceaccount.com"]
     }
     # The CD service account needs subnetworks.update to enable VPC flow logs
-    # (added in #257). Granted out-of-band to unblock the staging apply; declared
-    # here so a rebuild keeps it. Prod's CD SA already carries networkAdmin.
+    # (added in #257). Granted out-of-band to unblock the staging apply; imported
+    # (see imports.tf) so a rebuild adopts it instead of creating a duplicate.
+    # Prod's CD SA already carries networkAdmin.
     cd_network_admin = {
       role    = "roles/compute.networkAdmin"
       members = ["serviceAccount:superserve-github-actions@${local.project_id}.iam.gserviceaccount.com"]

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -106,6 +106,13 @@ module "iam" {
       role    = "roles/monitoring.metricWriter"
       members = ["serviceAccount:superserve-api@${local.project_id}.iam.gserviceaccount.com"]
     }
+    # The CD service account needs subnetworks.update to enable VPC flow logs
+    # (added in #257). Granted out-of-band to unblock the staging apply; declared
+    # here so a rebuild keeps it. Prod's CD SA already carries networkAdmin.
+    cd_network_admin = {
+      role    = "roles/compute.networkAdmin"
+      members = ["serviceAccount:superserve-github-actions@${local.project_id}.iam.gserviceaccount.com"]
+    }
   }
   labels = local.common_labels
 }


### PR DESCRIPTION
Consolidates the three access fixes that unblocked the terraform-cd + vmd-deploy runs, so a rebuild keeps them.

## 1. use4 IAP SSH (fixed the failing Deploy VMD)
#257's hardening added `deny-unrestricted-ssh` to the use4 host, but the env had `enable_iap_ssh = false` → no IAP-allow rule → port 22 fully blocked → `deploy-vmd` (`gcloud scp --tunnel-through-iap`) failed. Set `enable_iap_ssh = true` (matches central/west2) + import the allow rule I created out-of-band.

## 2. CD SA IAM grants (fixed the terraform-cd applies)
Both granted out-of-band during the incident; codified here as additive `google_project_iam_member` (idempotent, no import):
- **staging (rayai-dev)** → `compute.networkAdmin`: #257's VPC flow-log change needs `subnetworks.update` (the staging apply 403'd).
- **production us-east4 (rayai-prod)** → `certificatemanager.editor`: the cert-map / dns-auth import 403'd without it.

All three verified working live; this PR just makes them Terraform-managed. Additive/idempotent, so applies are no-ops. (Heads-up: overlaps awille's #260 IAM rework — whichever lands second reconciles.)