### PR TITLE
Decommission the us-central1 primary control plane + vmd host, and its deploy targets

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -271,13 +271,13 @@ jobs:
           docker push ${IMAGE}:${{ github.sha }}
 
       # use4 is the primary production cell — api.superserve.ai routes here — so
-      # it deploys FIRST, right after the image push, before the idle us-central1
-      # cell and the usw secondary cell. That way a transient failure updating or
-      # probing those cells can't stop the job and leave the public primary on
-      # the old image. Steps skip until CLOUD_RUN_SERVICE_USE4 is set; use4 has a
-      # public invoker binding, so /health is a meaningful probe.
+      # it deploys FIRST, right after the image push, before the usw secondary
+      # cell. That way a transient failure updating or probing usw can't stop the
+      # job and leave the public primary on the old image. These steps are
+      # unguarded: use4 is the permanent primary, so a missing CLOUD_RUN_SERVICE_USE4
+      # must fail the deploy rather than silently skip the only primary update.
+      # use4 has a public invoker binding, so /health is a meaningful probe.
       - name: Deploy use4 cell to Cloud Run
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         run: |
           gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
             --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
@@ -285,7 +285,6 @@ jobs:
             --project ${{ vars.GCP_PROJECT }}
 
       - name: Route use4 cell traffic to the new revision
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         run: |
           SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
           ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
@@ -298,49 +297,9 @@ jobs:
           gcloud run services update-traffic $SVC --to-latest $ARGS
 
       - name: Verify use4 cell latest revision serves traffic
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         run: |
           SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
           ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
-          if [ "$PCT" != "100" ]; then
-            echo "::error::$SVC: latest revision $LATEST serving ${PCT}% (want 100); deploy is not live."
-            exit 1
-          fi
-          curl -sf "$(echo "$DESC" | jq -r '.status.url')/health"
-
-      # us-central1 is the legacy primary, now idle (scaled to 0) and pending
-      # decommission. It still deploys to stay in sync until removed, but runs
-      # AFTER use4 so its cold-start/probe flakiness can't block the real primary.
-      - name: Deploy to Cloud Run
-        run: |
-          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
-            --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ vars.GCP_REGION }} \
-            --project ${{ vars.GCP_PROJECT }}
-
-      # Cloud Run only auto-routes to the new revision while traffic tracks
-      # "latest"; force it so a leftover pin can't keep prod on the old one.
-      - name: Route traffic to the new revision
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE }}
-          ARGS="--region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }}"
-          DESC=$(gcloud run services describe $SVC $ARGS --format=json)
-          LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
-          SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
-          if [ "$SERVING" != "$LATEST" ]; then
-            echo "::warning::$SVC traffic was pinned to $SERVING (latest is $LATEST); auto-routing to latest — investigate the pin."
-          fi
-          gcloud run services update-traffic $SVC --to-latest $ARGS
-
-      # A plain /health curl hits whatever serves traffic, so confirm the
-      # just-deployed revision is the one actually at 100%.
-      - name: Verify latest revision serves traffic
-        run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE }}
-          ARGS="--region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }}"
           DESC=$(gcloud run services describe $SVC $ARGS --format=json)
           LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
           PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')

--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -71,28 +71,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      # The use4 cell host is the primary production host (api.superserve.ai) —
-      # deploy its collector FIRST, before the idle us-central1 host, so a
-      # legacy-only failure can't stop the job and leave the public host without
-      # the collector update. Skipped until CLOUD_RUN_SERVICE_USE4 is set.
+      # The use4 cell host is the primary production host (api.superserve.ai).
+      # Skipped until CLOUD_RUN_SERVICE_USE4 is set. (usw remains uncovered here
+      # — pre-existing gap, tracked separately.)
       - name: Deploy OTEL Collector to use4 cell VMD instances
         if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: us-east4
           VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-east4
-          OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
-        run: |
-          python3 .github/workflows/scripts/deploy-otel-collector.py
-
-      # Legacy us-central1 host, idle and pending decommission. Runs after the
-      # use4 primary so its failure can't block the real primary. (usw remains
-      # uncovered here — pre-existing gap, tracked separately.)
-      - name: Deploy OTEL Collector to production VMD instances
-        env:
-          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: us-central1
-          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-central1
           OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
           python3 .github/workflows/scripts/deploy-otel-collector.py

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -105,13 +105,17 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      # GCP_REGION keeps this fan-out on the primary region's hosts only;
-      # the usw cell host shares the project and label but deploys in the
-      # step below, after the primary succeeds.
-      - name: Discover and deploy proxy to VMD instances
+      # us-east4 is the "use" cell's primary host (api.superserve.ai routes to
+      # the use-cell control plane there). It deploys FIRST so a usw-cell failure
+      # below can't leave the primary host on a stale proxy. Reuses the primary
+      # proxy env (domain + seed) since it is the same cell. Unguarded: use4 is
+      # the permanent primary, so a missing GCP_REGION_USE4 must fail the deploy
+      # rather than silently skip the only primary-host proxy rollout
+      # (deploy-proxy.py fails on zero VMD_LABEL matches).
+      - name: Deploy proxy to us-east4 use-cell VMD instance
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: ${{ vars.GCP_REGION }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
@@ -160,26 +164,4 @@ jobs:
           SANDBOX_ACCESS_TOKEN_SEED=$(gcloud secrets versions access latest \
             --secret=sandbox-access-token-seed --project "$GCP_PROJECT")
           export SANDBOX_ACCESS_TOKEN_SEED
-          python3 .github/workflows/scripts/deploy-proxy.py
-
-      # us-east4 is the same "use" cell as the primary region, so it reuses the
-      # primary proxy env (domain + seed) and only changes the region — unlike
-      # the usw step, a distinct cell with its own domain and seed. Gated on
-      # GCP_REGION_USE4; deploy-proxy.py fails on zero VMD_LABEL matches, so
-      # leave the var unset until the east host carries the label.
-      - name: Deploy proxy to us-east4 use-cell VMD instance
-        if: vars.GCP_REGION_USE4 != ''
-        env:
-          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
-          VMD_LABEL: ${{ vars.VMD_LABEL }}
-          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
-          SHA: ${{ github.sha }}
-          SANDBOX_ACCESS_TOKEN_SEED: ${{ secrets.SANDBOX_ACCESS_TOKEN_SEED_PROD }}
-          PROXY_ALLOWED_ORIGINS: ${{ vars.PROXY_ALLOWED_ORIGINS_PROD }}
-          PROXY_DOMAIN: ${{ vars.PROXY_DOMAIN_PROD }}
-          PROXY_DOMAINS: ${{ vars.PROXY_DOMAINS_PROD }}
-          REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: |
           python3 .github/workflows/scripts/deploy-proxy.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -130,32 +130,17 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       # The use4 cell host is the primary production host — api.superserve.ai
-      # routes there — so it deploys FIRST, before the idle legacy primary and
-      # the usw secondary cell. A failure or zero-match in those must not stop
-      # the job and leave the public host on old vmd/boxd/secretsproxy binaries.
-      # Reuses the binaries built above; skipped until CLOUD_RUN_SERVICE_USE4 is
-      # set. Discovery is the VMD_LABEL filter scoped to GCP_REGION_USE4.
+      # routes there — so it deploys FIRST, before the usw secondary cell. A
+      # failure or zero-match in usw must not stop the job and leave the public
+      # host on old vmd/boxd/secretsproxy binaries. Reuses the binaries built
+      # above. Unguarded: use4 is the permanent primary, so a missing
+      # CLOUD_RUN_SERVICE_USE4/GCP_REGION_USE4 must fail the deploy rather than
+      # silently skip the only primary-host rollout. Discovery is the VMD_LABEL
+      # filter scoped to GCP_REGION_USE4 (deploy-vmd.py fails on zero matches).
       - name: Deploy to use4 cell VMD instances
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
-          VMD_LABEL: ${{ vars.VMD_LABEL }}
-          VMD_SERVICE: ${{ vars.VMD_SERVICE }}
-          VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
-          SHA: ${{ github.sha }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-        run: |
-          python3 .github/workflows/scripts/deploy-vmd.py
-
-      # Legacy primary-region fan-out (us-central1), now idle and pending
-      # decommission. GCP_REGION scopes it to that region's hosts only. It still
-      # deploys to stay in sync until removed, but runs AFTER the use4 primary so
-      # its failure can't block the real primary host.
-      - name: Discover and deploy to VMD instances
-        env:
-          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: ${{ vars.GCP_REGION }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -360,11 +360,56 @@ jobs:
           terraform plan -input=false -out=tfplan
           terraform apply -input=false -auto-approve tfplan
 
-  production-us-central1-api:
-    name: Deploy API production/us-central1
+  # us-east4 is the "use" cell's control plane + vmd host (api.superserve.ai) —
+  # the production primary. Applies infrastructure; the api deploy/traffic/smoke
+  # then runs in production-us-east4-api below. That api job replaces the retired
+  # us-central1 api deploy, so infra-inclusive pushes (which skip Deploy API via
+  # its infra_changed guard) still roll the primary to the new image.
+  #
+  # Branches off staging directly (NOT off the us-west2/us-central1 chain) so a
+  # secondary-region deploy/traffic/smoke failure can never block the primary's
+  # rollout. us-east4 only reads the shared api-runner SA (a data source) and
+  # re-declares no us-central1-owned resource, so it needs no apply ordering
+  # against that cell.
+  production-us-east4-infra:
+    name: Apply production/us-east4
     runs-on: ubuntu-latest
     environment: production
-    needs: [build-api-image, production-us-central1-infra]
+    needs: [staging-us-central1-api]
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Terraform apply production/us-east4
+        run: |
+          set -euo pipefail
+          echo "## Terraform rollout: production/us-east4" >> "$GITHUB_STEP_SUMMARY"
+          cd infra/envs/production/us-east4
+          terraform init -input=false
+          terraform validate
+          terraform plan -input=false -out=tfplan
+          terraform apply -input=false -auto-approve tfplan
+
+  production-us-east4-api:
+    name: Deploy API production/us-east4
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [build-api-image, production-us-east4-infra]
     permissions:
       contents: read
       id-token: write
@@ -404,15 +449,15 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
-          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE }} \
+          gcloud run services update ${{ vars.CLOUD_RUN_SERVICE_USE4 }} \
             --image ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/superserve/controlplane:${{ github.sha }} \
-            --region ${{ vars.GCP_REGION }} \
+            --region ${{ vars.GCP_REGION_USE4 }} \
             --project ${{ vars.GCP_PROJECT }}
 
       - name: Route traffic to the new revision
         run: |
-          SVC=${{ vars.CLOUD_RUN_SERVICE }}
-          ARGS="--region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }}"
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
           DESC=$(gcloud run services describe $SVC $ARGS --format=json)
           LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
           SERVING=$(echo "$DESC" | jq -r '[.status.traffic[]? | select(.percent == 100) | .revisionName] | first // "none"')
@@ -424,8 +469,8 @@ jobs:
       - name: Verify latest revision serves traffic
         run: |
           set -euo pipefail
-          SVC=${{ vars.CLOUD_RUN_SERVICE }}
-          ARGS="--region ${{ vars.GCP_REGION }} --project ${{ vars.GCP_PROJECT }}"
+          SVC=${{ vars.CLOUD_RUN_SERVICE_USE4 }}
+          ARGS="--region ${{ vars.GCP_REGION_USE4 }} --project ${{ vars.GCP_PROJECT }}"
           DESC=$(gcloud run services describe $SVC $ARGS --format=json)
           LATEST=$(echo "$DESC" | jq -r '.status.latestReadyRevisionName')
           PCT=$(echo "$DESC" | jq --arg r "$LATEST" '[.status.traffic[]? | select(.revisionName == $r or .latestRevision == true) | .percent] | add // 0')
@@ -435,49 +480,8 @@ jobs:
           fi
           curl -sf "$(echo "$DESC" | jq -r '.status.url')/health" >/dev/null
 
-      - name: Smoke test production/us-central1
+      - name: Smoke test production/us-east4
         run: |
           set -euo pipefail
-          scripts/smoke-test-region.sh production us-central1
-          echo "production/us-central1 deploy and smoke validation passed." >> "$GITHUB_STEP_SUMMARY"
-
-  # us-east4 is the "use" cell's new host + control plane, being stood up for a
-  # traffic-split cutover away from us-central1. During bring-up this applies
-  # infrastructure only: the api service is created (on an existing image tag;
-  # see the module's image pin) but there is deliberately NO api-deploy/traffic
-  # /smoke stage yet — us-east4 has no public endpoint until the routing/
-  # traffic-split work lands, so a region smoke test would have nothing to hit.
-  # Chained last so it never gates the live us-central1/us-west2 rollouts above.
-  production-us-east4-infra:
-    name: Apply production/us-east4
-    runs-on: ubuntu-latest
-    environment: production
-    needs: [production-us-central1-api]
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      TF_IN_AUTOMATION: 'true'
-      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      - name: Terraform apply production/us-east4
-        run: |
-          set -euo pipefail
-          echo "## Terraform rollout: production/us-east4" >> "$GITHUB_STEP_SUMMARY"
-          cd infra/envs/production/us-east4
-          terraform init -input=false
-          terraform validate
-          terraform plan -input=false -out=tfplan
-          terraform apply -input=false -auto-approve tfplan
+          scripts/smoke-test-region.sh production us-east4
+          echo "production/us-east4 deploy and smoke validation passed." >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/environments.yaml
+++ b/deploy/environments.yaml
@@ -92,32 +92,10 @@ environments:
     terraform_dir: infra/envs/production
     project: rayai-prod
     regions:
-      - name: us-central1
-        required: true
-        api:
-          platform: cloud_run
-          service: superserve-api
-          region: us-central1
-          image_repository: us-central1-docker.pkg.dev/rayai-prod/superserve/controlplane
-        host_deployments:
-          vmd:
-            enabled: true
-            selector:
-              environment: production
-              region: us-central1
-              sandbox_role: vmd
-              sandbox_status: ready
-          proxy:
-            enabled: true
-            selector:
-              environment: production
-              region: us-central1
-              sandbox_role: vmd
-              sandbox_status: ready
-            domain: usc-sandbox.superserve.ai
-        artifacts:
-          docker_repository: us-central1-docker.pkg.dev/rayai-prod/superserve
-          object_bucket: superserve-artifacts
+      # The use cell's control plane and vmd host now live in us-east4 (below);
+      # the retired us-central1 primary was removed with the host decommission.
+      # us-central1 remains only the shared Artifact Registry image repo (see the
+      # image_repository fields), not a deploy target.
       - name: us-west2
         required: true
         api:

--- a/infra/envs/production/us-central1/imports.tf
+++ b/infra/envs/production/us-central1/imports.tf
@@ -1,8 +1,0 @@
-# One-time state adoption. The api module now declares the public invoker
-# binding (allUsers -> roles/run.invoker) that has always existed out-of-band on
-# this service; import it so the CD apply is a no-op instead of showing a
-# (harmless but confusing) "add public access" create. iam_member is idempotent.
-import {
-  to = module.api.google_cloud_run_v2_service_iam_member.public_invoker[0]
-  id = "projects/rayai-prod/locations/us-central1/services/superserve-api roles/run.invoker allUsers"
-}

--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -145,116 +145,20 @@ resource "google_secret_manager_secret_iam_member" "api_runtime_secrets" {
 # and the SA is shared across cells, so this follows the same out-of-band
 # pattern as the shared runtime secrets.
 
-module "api" {
-  source = "../../../modules/api"
 
-  project_id            = local.project_id
-  environment           = local.environment
-  region                = local.region
-  service_name          = "superserve-api"
-  service_account_email = module.iam.service_account_emails[local.api_sa_key]
-  image                 = "${local.region}-docker.pkg.dev/${local.project_id}/superserve/controlplane:replace-me"
-
-  env = {
-    API_PORT                    = "8080"
-    SUPABASE_URL                = var.supabase_url
-    SECRETS_SIGNING_KEY_ID      = "v1"
-    VMD_GRPC_ADDRESS            = format("%s:50051", module.sandbox_host.internal_ip)
-    ALLOW_EPHEMERAL_SEED        = "0"
-    DB_MAX_CONNS                = "12"
-    EDGE_PROXY_DOMAIN           = "sandbox.superserve.ai"
-    KMS_KEY_RESOURCE            = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
-    OTEL_ENVIRONMENT            = local.environment
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${module.sandbox_host.internal_ip}:4318"
-    OTEL_EXPORT_INTERVAL        = "15s"
-    OTEL_METRICS_ENABLED        = "true"
-    OTEL_SERVICE_NAME           = "sandbox-controlplane"
-  }
-
-  secrets = {
-    DATABASE_URL = {
-      secret = coalesce(var.database_url_secret_name, "database-url-${local.resource_suffix}")
-    }
-    INTERNAL_API_TOKEN = {
-      secret = coalesce(var.internal_api_token_secret_name, "internal-api-token-${local.resource_suffix}")
-    }
-    SANDBOX_ACCESS_TOKEN_SEED = {
-      secret = coalesce(var.sandbox_access_token_seed_secret_name, "sandbox-access-token-seed-${local.resource_suffix}")
-    }
-    SECRETS_SIGNING_KEY = {
-      secret = coalesce(var.secrets_signing_key_secret_name, "secretsproxy-signing-key-${local.resource_suffix}")
-    }
-    SENTRY_DSN = {
-      secret = coalesce(var.sentry_dsn_secret_name, "sentry-dsn")
-    }
-    SYSTEM_TEAM_ID = {
-      secret = coalesce(var.system_team_id_secret_name, "system-team-id-${local.resource_suffix}")
-    }
-    SLACK_QUOTA_ALERT_WEBHOOK = {
-      secret = "slack-quota-alert-webhook"
-    }
-    POSTHOG_KEY = {
-      secret = "posthog-project-key"
-    }
-  }
-  cpu_limit    = "2"
-  memory_limit = "1Gi"
-  # 0 matches the live service: this cell was scaled to idle after the us-east4
-  # cutover and is pending decommission. Declaring the live value keeps the plan
-  # a no-op instead of re-inflating the idle cell to 6 on the next apply.
-  min_instances     = 0
-  max_instances     = 10
-  startup_cpu_boost = true
-  cpu_idle          = true
-
-  vpc_connector = module.network.vpc_connector_id
-  vpc_egress    = "PRIVATE_RANGES_ONLY"
-  labels        = local.common_labels
-
-  depends_on = [
-    google_secret_manager_secret_iam_member.api_runtime_secrets,
-  ]
-}
-
-module "sandbox_host" {
-  source = "../../../modules/sandbox-host"
-
-  project_id    = local.project_id
-  environment   = local.environment
-  region        = local.region
-  zone          = local.zone
-  instance_name = "superserve-vmd-prod"
-  machine_type  = var.machine_type
-  subnet        = module.network.subnetwork_self_link
-  internal_ip   = "10.0.0.3"
-  tags          = ["superserve-vmd"]
-  labels = merge(local.common_labels, {
-    component               = "vmd"
-    sandbox_role            = "vmd"
-    "goog-ops-agent-policy" = "v2-template-1-7-0"
-  })
-
-  service_account_email = module.iam.service_account_emails[local.api_sa_key]
-  boot_disk_image       = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts"
-  can_ip_forward        = false
-  on_host_maintenance   = "TERMINATE"
-  metadata              = {}
-}
-
+# Production monitoring dashboards. These are fleet-wide (whole-fleet
+# operations/hosts/database/collector views spanning every region), not
+# us-central1-specific — they are rooted in this state only because us-central1
+# was historically the primary region. The host and control plane here are being
+# decommissioned, but the dashboards must survive, so this module stays. The
+# per-host CPU alert that used to live here was removed with the host it watched.
 module "observability" {
   source = "../../../modules/observability"
 
   project_id               = local.project_id
   environment              = local.environment
   notification_channel_ids = var.notification_channel_ids
-  compute_instance_cpu_alerts = {
-    sandbox_host = {
-      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / CPU saturation"
-      instance_name = module.sandbox_host.instance_name
-      instance_id   = module.sandbox_host.instance_id
-    }
-  }
-  labels = local.common_labels
+  labels                   = local.common_labels
   dashboards = {
     sandbox_operations = {
       display_name = "Sandbox Telemetry / Production Operations"

--- a/infra/envs/production/us-central1/outputs.tf
+++ b/infra/envs/production/us-central1/outputs.tf
@@ -3,11 +3,6 @@ output "network_contract" {
   value       = module.network.contract
 }
 
-output "sandbox_host_contract" {
-  description = "Rendered new-region sandbox host contract."
-  value       = module.sandbox_host.contract
-}
-
 output "deployment_config" {
   description = "Deployment identity for this environment."
   value = {


### PR DESCRIPTION
Draft — the destructive prerequisites below are executed manually alongside the merge. api.superserve.ai now serves from us-east4; the us-central1 control plane is idle (min=0, ~0 traffic) and its vmd host is drained (the DB host row points at us-east4).

## Terraform — removes (region-local, from `infra/envs/production/us-central1`)
- `module.api` — the `superserve-api` Cloud Run control plane
- `module.sandbox_host` — the `superserve-vmd-prod` host
- the `sandbox_host` CPU-saturation alert (the host it watched is gone)
- the now-dangling `sandbox_host` output + `imports.tf`

## Terraform — keeps
- `module.network` (shared VPC), `module.iam` (api-runner + github-actions SAs used by use4/usw), and the shared runtime-secret IAM.
- `module.observability` **dashboards** — the Production Operations/Fleet/Hosts/Database/Collector boards are **fleet-wide** (they span every region) and only rooted in this state historically. Deleting them here would remove the whole fleet's monitoring, so the module stays with just the dashboards; only the per-host alert is dropped.

## CD — stop targeting us-central1 (addresses Codex P1: retired deploy targets)
- `terraform-cd.yml`: drop the `Deploy API production/us-central1` job (Cloud Run deploy + traffic + /health + region smoke against the deleted service); rewire us-east4 to depend on the us-central1 **infra** apply. The us-central1 infra apply stays (it manages the shared VPC/IAM/dashboards).
- `deploy-api.yml`: drop the us-central1 Cloud Run service deploy/route/verify steps. The us-central1 image push stays — it is the shared Artifact Registry repo use4/usw pull from.
- `deploy-vmd.yml` / `deploy-otel-collector.yml`: drop the us-central1 host fan-out / collector steps.
- `environments.yaml`: drop the us-central1 production region entry.

Staging us-central1 is untouched — only the production primary is retired.

## Deletion protection (addresses Codex P1)
- Host: `module.sandbox_host` has `prevent_destroy = true`.
- CP: the api module sets `deletion_protection = true` (though the live service currently reports it **off**).

Rather than rely on a plain destroy, both are removed from state and deleted out-of-band, so the CD apply never attempts a guarded destroy:
1. `terraform state rm module.sandbox_host module.api`
2. `gcloud compute instances delete superserve-vmd-prod --zone us-central1-c` and `gcloud run services delete superserve-api --region us-central1`
3. Merge → terraform-cd applies the trimmed config: destroys only the host CPU alert, updates the dashboards in-place (`0 add, 5 change, 1 destroy` once the modules are out of state).

The boot disk is archived as the rollback path; reversible until the host is deleted.

## Follow-up (separate PR)
Release the host's static IP + its now-orphaned firewall rules.