### PR TITLE
vmd, boxd, proxy: per-request phase timing for launch prestart and the exec data path

### DIFF
--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -90,11 +90,17 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// tRecv..tSpawn covers decode + spawn queueing + fork; the Start event
+	// marks the moment the process exists. Returned as response headers so
+	// the data-plane proxy can log the guest-side split — boxd's own logs
+	// are not collected off the guest.
+	tRecv := time.Now()
 	var (
 		mu       sync.Mutex
 		stdout   []byte
 		stderr   []byte
 		exitCode int32
+		tSpawn   time.Time
 	)
 	emit := func(ev *pb.ProcessEvent) error {
 		mu.Lock()
@@ -109,6 +115,10 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 			case *pb.DataEvent_PtyData:
 				stdout = append(stdout, out.PtyData...)
 			}
+		case *pb.ProcessEvent_Start:
+			if tSpawn.IsZero() {
+				tSpawn = time.Now()
+			}
 		case *pb.ProcessEvent_End:
 			exitCode = x.End.ExitCode
 		}
@@ -120,6 +130,10 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !tSpawn.IsZero() {
+		w.Header().Set("X-Boxd-Spawn-Ms", fmt.Sprintf("%d", tSpawn.Sub(tRecv).Milliseconds()))
+		w.Header().Set("X-Boxd-Run-Ms", fmt.Sprintf("%d", time.Since(tSpawn).Milliseconds()))
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(execResponse{
 		Stdout:   string(stdout),

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -43,6 +43,11 @@ func TestHandleExec_Success(t *testing.T) {
 	if resp.ExitCode != 0 {
 		t.Errorf("exit_code = %d, want 0", resp.ExitCode)
 	}
+	for _, hdr := range []string{"X-Boxd-Spawn-Ms", "X-Boxd-Run-Ms"} {
+		if w.Header().Get(hdr) == "" {
+			t.Errorf("missing timing header %s", hdr)
+		}
+	}
 }
 
 func TestHandleExec_NonzeroExit(t *testing.T) {

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -79,8 +80,8 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 	var (
 		upstreamStatus int
 		ttfbMs         int64 = -1
-		boxdSpawnMs          = ""
-		boxdRunMs            = ""
+		boxdSpawnMs    int64 = -1
+		boxdRunMs      int64 = -1
 	)
 
 	rp := &httputil.ReverseProxy{
@@ -104,8 +105,8 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		ModifyResponse: func(resp *http.Response) error {
 			ttfbMs = time.Since(tStart).Milliseconds()
 			upstreamStatus = resp.StatusCode
-			boxdSpawnMs = resp.Header.Get("X-Boxd-Spawn-Ms")
-			boxdRunMs = resp.Header.Get("X-Boxd-Run-Ms")
+			boxdSpawnMs = headerMs(resp, "X-Boxd-Spawn-Ms")
+			boxdRunMs = headerMs(resp, "X-Boxd-Run-Ms")
 			return nil
 		},
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
@@ -128,7 +129,22 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		Int64("auth_ms", tAuthDone.Sub(tStart).Milliseconds()).
 		Int64("upstream_ttfb_ms", ttfbMs).
 		Int64("total_ms", time.Since(tStart).Milliseconds()).
-		Str("boxd_spawn_ms", boxdSpawnMs).
-		Str("boxd_run_ms", boxdRunMs).
+		Int64("boxd_spawn_ms", boxdSpawnMs).
+		Int64("boxd_run_ms", boxdRunMs).
 		Msg("exec phases")
+}
+
+// headerMs parses a millisecond timing header; -1 means absent or unparseable
+// (an old boxd, or a non-exec error response), keeping the field numeric so
+// it aggregates with the other *_ms fields.
+func headerMs(resp *http.Response, name string) int64 {
+	v := resp.Header.Get(name)
+	if v == "" {
+		return -1
+	}
+	ms, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return ms
 }

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -82,6 +82,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		ttfbMs         int64 = -1
 		boxdSpawnMs    int64 = -1
 		boxdRunMs      int64 = -1
+		tProxy         time.Time
 	)
 
 	rp := &httputil.ReverseProxy{
@@ -103,7 +104,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		// -1: stream each chunk as it arrives — required for SSE.
 		FlushInterval: -1,
 		ModifyResponse: func(resp *http.Response) error {
-			ttfbMs = time.Since(tStart).Milliseconds()
+			ttfbMs = time.Since(tProxy).Milliseconds()
 			upstreamStatus = resp.StatusCode
 			boxdSpawnMs = headerMs(resp, "X-Boxd-Spawn-Ms")
 			boxdRunMs = headerMs(resp, "X-Boxd-Run-Ms")
@@ -120,6 +121,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 			http.Error(rw, "sandbox unreachable", http.StatusBadGateway)
 		},
 	}
+	tProxy = time.Now()
 	rp.ServeHTTP(w, r)
 
 	h.log.Info().

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -72,10 +72,10 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 	}
 
 	// Per-request phase fields, mirroring the create path's phase log:
-	// aggregate them for burst percentiles or read one line for a single
-	// create→exec flow. upstream_ttfb spans dial + request + boxd's whole
-	// run for the sync path (boxd buffers to completion), so the guest-side
-	// headers are what split it further.
+	// aggregate across requests or read one line for a single create→exec
+	// flow. upstream_ttfb spans dial + request + boxd's whole run for the
+	// sync path (boxd buffers to completion), so the guest-side headers
+	// are what split it further.
 	var (
 		upstreamStatus int
 		ttfbMs         int64 = -1

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 const (
@@ -44,6 +45,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	tStart := time.Now()
 
 	token := r.Header.Get(accessTokenHeader)
 	if token == "" {
@@ -60,6 +62,7 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		fail.write(w)
 		return
 	}
+	tAuthDone := time.Now()
 	h.captureUsage(instanceID, "command_run", info)
 
 	transport := h.transports.get(instanceID, info)
@@ -67,6 +70,18 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		Scheme: "http",
 		Host:   fmt.Sprintf("%s:%d", info.VMIP, boxdPort),
 	}
+
+	// Per-request phase fields, mirroring the create path's phase log:
+	// aggregate them for burst percentiles or read one line for a single
+	// create→exec flow. upstream_ttfb spans dial + request + boxd's whole
+	// run for the sync path (boxd buffers to completion), so the guest-side
+	// headers are what split it further.
+	var (
+		upstreamStatus int
+		ttfbMs         int64 = -1
+		boxdSpawnMs          = ""
+		boxdRunMs            = ""
+	)
 
 	rp := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
@@ -86,6 +101,13 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		Transport: transport,
 		// -1: stream each chunk as it arrives — required for SSE.
 		FlushInterval: -1,
+		ModifyResponse: func(resp *http.Response) error {
+			ttfbMs = time.Since(tStart).Milliseconds()
+			upstreamStatus = resp.StatusCode
+			boxdSpawnMs = resp.Header.Get("X-Boxd-Spawn-Ms")
+			boxdRunMs = resp.Header.Get("X-Boxd-Run-Ms")
+			return nil
+		},
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
 			h.log.Error().Err(proxyErr).
 				Str("instance", instanceID).
@@ -98,4 +120,15 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 		},
 	}
 	rp.ServeHTTP(w, r)
+
+	h.log.Info().
+		Str("sandbox_id", instanceID).
+		Bool("streaming", streaming).
+		Int("status", upstreamStatus).
+		Int64("auth_ms", tAuthDone.Sub(tStart).Milliseconds()).
+		Int64("upstream_ttfb_ms", ttfbMs).
+		Int64("total_ms", time.Since(tStart).Milliseconds()).
+		Str("boxd_spawn_ms", boxdSpawnMs).
+		Str("boxd_run_ms", boxdRunMs).
+		Msg("exec phases")
 }

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -117,6 +117,9 @@ func (h *Handler) serveExecCommon(w http.ResponseWriter, r *http.Request, instan
 				Bool("streaming", streaming).
 				Msg("exec: upstream error")
 			h.resolver.Invalidate(instanceID)
+			// ModifyResponse never ran; record what the client actually got
+			// so unreachable-sandbox 502s show up in status-based queries.
+			upstreamStatus = http.StatusBadGateway
 			rw.Header().Set("Retry-After", "2")
 			http.Error(rw, "sandbox unreachable", http.StatusBadGateway)
 		},

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1005,6 +1005,7 @@ func fileExists(path string) bool {
 // ResumeVM restores a paused VM from its snapshot using a mount namespace.
 func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath string) (*VMInstance, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	tEntry := time.Now()
 
 	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate resume
 	// waits, then is recognized as a retry rather than relaunching.
@@ -1091,6 +1092,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	vmDir := filepath.Join(m.cfg.RunDir, rundirKey)
 	socketPath := filepath.Join(vmDir, "firecracker.sock")
 
+	tSlot := time.Now()
 	var netInfo *network.VMNetInfo
 	if inst.Namespace != "" {
 		var nsErr error
@@ -1100,10 +1102,12 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		}
 	}
 
+	tFcStart := time.Now()
 	pid, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("start firecracker for restore: %w", err)
 	}
+	tFcDone := time.Now()
 
 	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
 	// A base is needed only when memPath is itself a diff overlay. Keying on memPath
@@ -1127,6 +1131,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
 		}
 	}
+	tRestore := time.Now()
 	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo)
 	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
@@ -1161,7 +1166,17 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	inst.mu.Unlock()
 
 	m.persistState(inst)
-	log.Info().Int("pid", pid).Msg("VM resumed from snapshot")
+	// Resume-side phase parity with the create path's "restoring snapshot"
+	// line; wait_boxd_ms arrives async on the probe log below. prep spans
+	// the op-lock wait plus the precondition gates, so a duplicate-resume
+	// queue shows up here rather than hiding in the total.
+	log.Info().Int("pid", pid).
+		Int64("prep_ms", tSlot.Sub(tEntry).Milliseconds()).
+		Int64("ensure_slot_ms", tFcStart.Sub(tSlot).Milliseconds()).
+		Int64("fc_start_ms", tFcDone.Sub(tFcStart).Milliseconds()).
+		Int64("restore_ms", time.Since(tRestore).Milliseconds()).
+		Int64("total_ms", time.Since(tEntry).Milliseconds()).
+		Msg("VM resumed from snapshot")
 
 	// Telemetry only: measure how long boxd takes to become reachable after
 	// the vCPUs resume. Detached — status is already running and the probe

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2858,6 +2858,7 @@ func fcStartScript(netNS, launcherNSPath, setupCmds, fcBin, socketPath, vmID str
 // owns the process, not VMD. Non-empty basePath switches the start script to
 // the dual-symlink overlay layout.
 func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPath, perVMRootfs, basePath, netNS string) (int, error) {
+	tPrestart := time.Now()
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
 		return 0, fmt.Errorf("mkdir socket dir: %w", err)
 	}
@@ -2892,8 +2893,11 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	// it needs a bigger socket budget. Decided up front: with Type=simple
 	// the restart job clears at fork, before the socket exists, so no
 	// at-timeout probe can tell a just-replaced unit from a stalled fresh
-	// one.
+	// one. Timed separately: it is a per-launch systemd round trip, and
+	// concurrent launches serialize on the shared D-Bus connection.
+	tLinger := time.Now()
 	replacingLive := unitLingering(ctx, systemdUnitName(vmID))
+	lingerCheckMs := time.Since(tLinger).Milliseconds()
 
 	tStartUnit := time.Now()
 	if err := restartUnit(ctx, systemdUnitName(vmID)); err != nil {
@@ -2928,6 +2932,8 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 
 	m.log.Info().
 		Str("vm_id", vmID).
+		Int64("prestart_ms", tStartUnit.Sub(tPrestart).Milliseconds()).
+		Int64("linger_check_ms", lingerCheckMs).
 		Int64("start_unit_ms", tStartUnitDone.Sub(tStartUnit).Milliseconds()).
 		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds()).
 		Msg("fc startup phases")

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1133,6 +1133,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 	tRestore := time.Now()
 	dirtyTracked, err := m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo)
+	tRestoreDone := time.Now()
 	if err != nil {
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
@@ -1174,7 +1175,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 		Int64("prep_ms", tSlot.Sub(tEntry).Milliseconds()).
 		Int64("ensure_slot_ms", tFcStart.Sub(tSlot).Milliseconds()).
 		Int64("fc_start_ms", tFcDone.Sub(tFcStart).Milliseconds()).
-		Int64("restore_ms", time.Since(tRestore).Milliseconds()).
+		Int64("restore_ms", tRestoreDone.Sub(tRestore).Milliseconds()).
 		Int64("total_ms", time.Since(tEntry).Milliseconds()).
 		Msg("VM resumed from snapshot")
 


### PR DESCRIPTION
Two measurement gaps closed, both with per-request structured fields so single (sequential) operations read individually and bursts aggregate into percentiles:

**vmd launch prestart.** The span between entering the systemd launch path and the unit start had no timer — script setup plus the per-launch lingering-unit systemd query, which serializes on the shared D-Bus connection under concurrent launches. `fc startup phases` now carries `prestart_ms` and `linger_check_ms` alongside the existing fields.

**The exec data path.** Nothing timed an exec after create returned. Now:
- boxd's sync `/exec` returns `X-Boxd-Spawn-Ms` (request received → process forked, via the Start event it already receives) and `X-Boxd-Run-Ms` (fork → exit) as response headers — boxd's own logs never leave the guest, headers ride back for free. The SSE stream path writes its headers before running and is unchanged.
- the data-plane proxy logs one `exec phases` line per request: `auth_ms`, `upstream_ttfb_ms`, `total_ms`, upstream status, and the boxd header values — splitting proxy-side network from guest-side spawn/run.

No behavior changes; timing only. New boxd ships with the next deploy (injected at restore, no template rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)