### PR TITLE
Clean up orphaned us-central1 network + harden use4 deploys

### DIFF
--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -126,6 +126,11 @@ jobs:
           REQUIRE_DATA_PLANE: ${{ vars.REQUIRE_DATA_PLANE_PROD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          # Fail closed: an empty GCP_REGION makes deploy-proxy.py drop the region
+          # filter and apply the primary proxy env (prod domain + seed) to every
+          # VMD_LABEL match. use4 is the permanent primary, so a missing
+          # GCP_REGION_USE4 must abort, not run unscoped.
+          : "${GCP_REGION:?GCP_REGION_USE4 is unset — refusing an unscoped use4 primary proxy fan-out}"
           python3 .github/workflows/scripts/deploy-proxy.py
 
       # The usw cell deploys as a step in this job — not a separate job —

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -147,6 +147,10 @@ jobs:
           SHA: ${{ github.sha }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
+          # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
+          # filter and fan out to every VMD_LABEL match. use4 is the permanent
+          # primary, so a missing GCP_REGION_USE4 must abort, not run unscoped.
+          : "${GCP_REGION:?GCP_REGION_USE4 is unset — refusing an unscoped use4 primary fan-out}"
           python3 .github/workflows/scripts/deploy-vmd.py
 
       # The usw cell deploys as a step in this job — not a separate job —

--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -47,60 +47,18 @@ module "network" {
   create_network = var.create_network
   network_name   = var.network_name
 
-  subnet_name            = "superserve-prod-subnet"
-  subnet_cidr            = var.subnet_cidr
-  manage_public_ssh_deny = true
-  enable_iap_ssh         = true
-  iap_ssh_target_tags    = ["superserve-vmd"]
+  # The us-central1 primary control plane and vmd host are decommissioned. This
+  # root now keeps only its subnet in the shared superserve-production-vpc; the
+  # host's firewall rules, IAP-SSH allow, public-SSH deny, and the Cloud Run VPC
+  # connector (used only by the removed control plane) are all removed. The
+  # us-east4 cell owns its own equivalents in the same VPC.
+  subnet_name = "superserve-prod-subnet"
+  subnet_cidr = var.subnet_cidr
 
-  create_vpc_connector        = true
-  create_vpc_connector_subnet = false
-  vpc_connector_name          = "superserve-prod-conn"
-  vpc_connector_mode          = "ip_cidr_range"
-  vpc_connector_ip_cidr_range = var.connector_subnet_cidr
-  vpc_connector_machine_type  = "e2-micro"
-  vpc_connector_min_instances = 2
-  vpc_connector_max_instances = 10
-
-  firewall_rules = {
-    allow_internal = {
-      name          = "superserve-prod-allow-internal"
-      direction     = "INGRESS"
-      source_ranges = [var.subnet_cidr]
-      target_tags   = ["superserve-vmd"]
-      allow = [
-        {
-          protocol = "tcp"
-          ports    = ["5007", "5008", "50051"]
-        }
-      ]
-      description = "Allow private host-to-host sandbox control traffic only."
-    }
-    allow_otel_ingress = {
-      name          = "superserve-prod-allow-cr-to-host-otel"
-      direction     = "INGRESS"
-      source_ranges = [var.connector_subnet_cidr]
-      target_tags   = ["superserve-vmd"]
-      allow = [
-        {
-          protocol = "tcp"
-          ports    = ["4317", "4318"]
-        }
-      ]
-      description = "Allow Cloud Run connector traffic to host-local OTLP endpoints."
-    }
-    allow_vmd_grpc = {
-      name          = "superserve-prod-allow-cr-to-host-vmd"
-      direction     = "INGRESS"
-      source_ranges = [var.connector_subnet_cidr]
-      target_tags   = ["superserve-vmd"]
-      allow = [{
-        protocol = "tcp"
-        ports    = ["50051"]
-      }]
-      description = "Allow Cloud Run connector traffic to the host VMD gRPC endpoint."
-    }
-  }
+  manage_public_ssh_deny = false
+  enable_iap_ssh         = false
+  create_vpc_connector   = false
+  firewall_rules         = {}
 
   labels = local.common_labels
 }


### PR DESCRIPTION
Follow-up to the us-central1 primary decommission (#265). Two independent cleanups.

## 1. Remove orphaned us-central1 network resources
With the central control plane + vmd host gone, their footprint in the shared `superserve-production-vpc` is orphaned. Trims the network module to keep only the subnet and drop:
- the three `superserve-vmd` firewall rules (`allow_internal`, `allow_otel_ingress`, `allow_vmd_grpc`) — they target the deleted host tag
- the IAP-SSH allow + public-SSH deny rules (v4 + v6) for that host
- the Cloud Run VPC connector, which only the removed control plane used

Plan (verified against live state): `0 to add, 5 to change, 7 to destroy`. The 5 changes are the pre-existing dashboard `name`-field in-place noise; the 7 destroys are exactly the resources above. **The subnet and the shared VPC are untouched**, and us-east4 owns its own equivalents in the same VPC.

## 2. Fail closed on missing use4 region in vmd/proxy deploys
The use4 deploy steps are unguarded now (use4 is the permanent primary). But an empty `GCP_REGION_USE4` would make `deploy-vmd.py` / `deploy-proxy.py` drop the region filter and fan out to *every* `VMD_LABEL` match. Adds an explicit non-empty `GCP_REGION` check before each script so a missing primary-region variable aborts rather than running an unscoped rollout. (Addresses the two Codex P2s from #265.)

## Testing
- `terraform plan` on `production/us-central1` shows the destroy scope above, subnet retained.
- YAML lint + shell guard behavior verified (set → passes, empty → aborts).