### PR TITLE
cd: codify CONTROL_PLANE_URL/DATABASE_URL/INTERNAL_API_TOKEN for vmd deploys

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -189,6 +189,12 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
           INTERNAL_API_TOKEN: ${{ secrets.PROD_USW_INTERNAL_API_TOKEN }}
         run: |
+          # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
+          # filter and fan out to every VMD_LABEL match — which would push
+          # usw's DATABASE_URL/CONTROL_PLANE_URL/INTERNAL_API_TOKEN onto the
+          # use4 primary host below instead of just skipping usw. This must
+          # abort before the fail-closed checks below, not run unscoped.
+          : "${GCP_REGION:?GCP_REGION_USW is unset — refusing an unscoped usw fan-out}"
           # Same fail-closed reasoning as the use4 step above — see its comment.
           : "${CONTROL_PLANE_URL:?CONTROL_PLANE_URL_USW is unset — refusing to deploy without it}"
           : "${DATABASE_URL:?DATABASE_URL_USWEST is unset — refusing to deploy without it}"

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -155,6 +155,15 @@ jobs:
           # filter and fan out to every VMD_LABEL match. use4 is the permanent
           # primary, so a missing GCP_REGION_USE4 must abort, not run unscoped.
           : "${GCP_REGION:?GCP_REGION_USE4 is unset — refusing an unscoped use4 primary fan-out}"
+          # deploy-vmd.py treats an empty CONTROL_PLANE_URL/DATABASE_URL/
+          # INTERNAL_API_TOKEN as "skip, leave the host's existing value alone" —
+          # the right behavior for staging/unprovisioned hosts, but silently
+          # deploying-and-reporting-success while these are unset on a
+          # production host is exactly the failure mode this workflow exists
+          # to prevent. Fail closed rather than skip.
+          : "${CONTROL_PLANE_URL:?CONTROL_PLANE_URL_PROD is unset — refusing to deploy without it}"
+          : "${DATABASE_URL:?DATABASE_URL_PROD is unset — refusing to deploy without it}"
+          : "${INTERNAL_API_TOKEN:?PROD_INTERNAL_API_TOKEN is unset — refusing to deploy without it}"
           python3 .github/workflows/scripts/deploy-vmd.py
 
       # The usw cell deploys as a step in this job — not a separate job —
@@ -180,4 +189,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
           INTERNAL_API_TOKEN: ${{ secrets.PROD_USW_INTERNAL_API_TOKEN }}
         run: |
+          # Same fail-closed reasoning as the use4 step above — see its comment.
+          : "${CONTROL_PLANE_URL:?CONTROL_PLANE_URL_USW is unset — refusing to deploy without it}"
+          : "${DATABASE_URL:?DATABASE_URL_USWEST is unset — refusing to deploy without it}"
+          : "${INTERNAL_API_TOKEN:?PROD_USW_INTERNAL_API_TOKEN is unset — refusing to deploy without it}"
           python3 .github/workflows/scripts/deploy-vmd.py

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -146,6 +146,10 @@ jobs:
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # use4 is the "use" cell's Supabase + control plane.
+          CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_PROD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          INTERNAL_API_TOKEN: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
         run: |
           # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
           # filter and fan out to every VMD_LABEL match. use4 is the permanent
@@ -170,5 +174,10 @@ jobs:
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # usw is its own cell — separate Supabase project + control plane
+          # from the "use" cell above.
+          CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_USW }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
+          INTERNAL_API_TOKEN: ${{ secrets.PROD_USW_INTERNAL_API_TOKEN }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -237,7 +237,7 @@ def main() -> int:
                 ROOTFS=""
                 for env_file in /etc/sandbox/vmd.env; do
                     if [ -f "$env_file" ]; then
-                        candidate=$(grep "^BASE_ROOTFS_PATH=" "$env_file" | head -1 | cut -d= -f2) || true
+                        candidate=$(sudo grep "^BASE_ROOTFS_PATH=" "$env_file" | head -1 | cut -d= -f2) || true
                         if [ -n "$candidate" ]; then
                             ROOTFS="$candidate"
                             break

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -26,6 +26,14 @@ Env vars:
                        (secretsproxy authenticates callers with the same token
                        the control plane presents). Hosts previously had these
                        provisioned out-of-band via Packer/manual staging.
+  DATABASE_URL         optional — this host's Postgres connection string,
+                       sourced from CI secrets / Secret Manager (never
+                       hardcode). Upserted into vmd.env when set; empty = skip
+                       (same convention as CONTROL_PLANE_URL). Without it the
+                       reconciler silently falls back to BoltDB-only drift
+                       detection and never writes its audit trail — no error,
+                       just quiet degradation, so this is easy to miss if the
+                       value is ever lost from a host's env file.
   VMD_DNS_REDIRECT_PORT optional — local resolver port vmd REDIRECTs guest :53
                        to via its SANDBOX_DNS_REDIRECT nat chain. Empty = skip
                        (like CONTROL_PLANE_URL). Do NOT default this fleet-wide:
@@ -101,6 +109,7 @@ def main() -> int:
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
+    database_url = os.environ.get("DATABASE_URL", "")
     # Empty = skip, so a fleet-wide deploy never writes a redirect to a host
     # whose resolver isn't on this port. Set per host/region to match unbound.
     dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "")
@@ -118,6 +127,8 @@ def main() -> int:
     q_token = shlex.quote(internal_api_token)
     q_iat_line = shlex.quote(f"INTERNAL_API_TOKEN={internal_api_token}")
     q_dat_line = shlex.quote(f"DAEMON_AUTH_TOKEN={internal_api_token}")
+    q_db = shlex.quote(database_url)
+    q_db_line = shlex.quote(f"DATABASE_URL={database_url}")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -333,6 +344,19 @@ def main() -> int:
                     sudo sed -i '/^DAEMON_AUTH_TOKEN=/d' /etc/sandbox/secretsproxy.env
                     echo {q_dat_line} | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
                 fi
+            fi
+
+            # Upsert this host's DB connection string. Sourced from CI secrets /
+            # Secret Manager — never hardcoded. Empty = leave existing value
+            # alone: losing this silently degrades the reconciler to
+            # BoltDB-only mode (no error, just a quiet fallback), so an empty
+            # value here must never overwrite a working one.
+            if [ -n {q_db} ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/vmd.env
+                sudo chmod 0600 /etc/sandbox/vmd.env
+                sudo sed -i '/^DATABASE_URL=/d' /etc/sandbox/vmd.env
+                echo {q_db_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
             # Stop before starting the socket unit: on the first deploy of

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -357,6 +357,16 @@ def main() -> int:
                 sudo chmod 0600 /etc/sandbox/vmd.env
                 sudo sed -i '/^DATABASE_URL=/d' /etc/sandbox/vmd.env
                 echo {q_db_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                # secretsproxy reads its own DATABASE_URL from its own env file
+                # (buildAuditSink fails startup without it, unless
+                # SECRETSPROXY_AUDIT_DISABLED=true) — only upsert into an
+                # EXISTING file, same reason as CONTROL_PLANE_URL/DAEMON_AUTH_TOKEN
+                # above: never create a partial secretsproxy.env here.
+                if [ -f /etc/sandbox/secretsproxy.env ]; then
+                    sudo chmod 0600 /etc/sandbox/secretsproxy.env
+                    sudo sed -i '/^DATABASE_URL=/d' /etc/sandbox/secretsproxy.env
+                    echo {q_db_line} | sudo tee -a /etc/sandbox/secretsproxy.env > /dev/null
+                fi
             fi
 
             # Stop before starting the socket unit: on the first deploy of


### PR DESCRIPTION
## Summary

`CONTROL_PLANE_URL`, `DATABASE_URL`, and `INTERNAL_API_TOKEN` in a vmd host's `/etc/sandbox/vmd.env` were never set by any code path — purely hand-staged once per host. On `superserve-vmd-use4` all three ended up blank after the us-east4 cutover: heartbeat silently never started, and the reconciler silently fell back to BoltDB-only mode (no DB audit trail, but it kept tripping the auto-fail rate limiter every pass since that check is in-memory and DB-independent).

This wires all three explicitly per region in `deploy-vmd.yml`, reusing secrets that already exist (`DATABASE_URL_PROD`, `DATABASE_URL_USWEST`, `PROD_INTERNAL_API_TOKEN`, `PROD_USW_INTERNAL_API_TOKEN`), and adds `DATABASE_URL` upsert support to `deploy-vmd.py` (CD already had upsert logic for the other two, just never called with a value). Two new repo variables hold the actual URLs: `CONTROL_PLANE_URL_PROD` (`https://api.superserve.ai`, shared by use4 + the legacy us-central1 host) and `CONTROL_PLANE_URL_USW` (pulled from the working usw2 host's existing config, not guessed).

## Technical decisions / tradeoffs

- Reused existing GH secrets rather than introducing new ones — `DATABASE_URL_PROD`/`DATABASE_URL_USWEST` already back the Supabase migration step in `cd.yml`, and the `INTERNAL_API_TOKEN` secrets already existed under their current names.
- `DATABASE_URL` upsert is treated as sensitive (created with `chmod 0600`, matches the `INTERNAL_API_TOKEN` handling) and only upserts on a non-empty value, so a CD run without the secret set can never wipe a working value — same "empty = skip" convention as the existing vars.
- Left the underlying `superserve-api-usw2` Cloud Run default URL as-is for `CONTROL_PLANE_URL_USW` rather than standing up a custom domain for that cell — that's a separate, larger change and out of scope here.

## Testing

- Applied this exact fix by hand on `superserve-vmd-use4` (same env file, same values) and confirmed via logs (`"reconciler DB connection ready"`, `"heartbeat started"`) and the `host`/`reconciler_log` tables that heartbeat and DB-backed reconciliation both recovered, with the running vmd restart reattaching all VMs cleanly (0 stale).
- `deploy-vmd.py` syntax-checked (`python3 -m py_compile`); the upsert logic itself is unchanged in shape from the existing `CONTROL_PLANE_URL`/`INTERNAL_API_TOKEN` blocks it mirrors.
- Have not run this through an actual CD `deploy-vmd` workflow execution end-to-end — next merge to `main` touching a vmd-tracked path (or manual `workflow_dispatch`) will be the first real exercise of this code path.