### PR TITLE
vmd: skip the systemd linger query for provably-fresh unit launches

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1103,7 +1103,7 @@ func (m *Manager) ResumeVM(ctx context.Context, vmID, snapshotPath, memPath stri
 	}
 
 	tFcStart := time.Now()
-	pid, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace)
+	pid, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace, false)
 	if err != nil {
 		return nil, fmt.Errorf("start firecracker for restore: %w", err)
 	}
@@ -1298,7 +1298,7 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 	// way out. Safe because the VM is paused (no live FC to disrupt), but it must
 	// not run concurrently with a resume of the same sandbox — fine for the
 	// debug/staging use this endpoint is gated to.
-	if _, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace); err != nil {
+	if _, err := m.startFirecrackerViaSystemd(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, inst.Namespace, false); err != nil {
 		return "", fmt.Errorf("start firecracker for verify: %w", err)
 	}
 	defer func() { _ = stopUnitWithBudget(context.Background(), systemdUnitName(vmID)) }()
@@ -1628,6 +1628,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 	}
 
+	// Sampled before this attempt creates the rundir: a pre-existing rundir
+	// means a prior attempt on this host reached start.sh (and possibly
+	// started the unit) even if it died before persisting any state, so the
+	// unit name is not provably fresh.
+	_, rdErr := os.Stat(filepath.Join(m.cfg.RunDir, vmID))
+	priorRunDir := rdErr == nil
+
 	m.mu.Lock()
 	_, inPlace := m.vms[vmID]
 	if inPlace {
@@ -1650,6 +1657,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	m.vms[vmID] = inst
 	m.mu.Unlock()
+
+	// A provably-fresh unit name — no known instance (lazyReattach already
+	// folded BoltDB into the map) and no prior rundir — cannot be lingering,
+	// so the launch may skip the systemd linger query. Retry attempts inside
+	// the loop keep the same answer: they only proceed after the unit is
+	// confirmed dead.
+	freshUnit := !inPlace && !priorRunDir
 
 	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
 	// Failure cleanup must not delete an overlay this attempt didn't create:
@@ -1740,7 +1754,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		inst.mu.Unlock()
 
 		var startErr error
-		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName)
+		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, freshUnit)
 		if startErr != nil {
 			if !inPlace {
 				m.netMgr.CleanupVM(vmID)
@@ -2873,7 +2887,7 @@ func fcStartScript(netNS, launcherNSPath, setupCmds, fcBin, socketPath, vmID str
 // as a standalone systemd unit. The VM survives VMD restarts because systemd
 // owns the process, not VMD. Non-empty basePath switches the start script to
 // the dual-symlink overlay layout.
-func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPath, perVMRootfs, basePath, netNS string) (int, error) {
+func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPath, perVMRootfs, basePath, netNS string, freshUnit bool) (int, error) {
 	tPrestart := time.Now()
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
 		return 0, fmt.Errorf("mkdir socket dir: %w", err)
@@ -2922,9 +2936,12 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	// the restart job clears at fork, before the socket exists, so no
 	// at-timeout probe can tell a just-replaced unit from a stalled fresh
 	// one. Timed separately: it is a per-launch systemd round trip, and
-	// concurrent launches serialize on the shared D-Bus connection.
+	// concurrent launches serialize on the shared D-Bus connection — which
+	// is why a provably-fresh unit (freshUnit) skips the query: a unit that
+	// never existed reads NotLoaded, i.e. not lingering, so the answer is
+	// known without the round trip.
 	tLinger := time.Now()
-	replacingLive := unitLingering(ctx, systemdUnitName(vmID))
+	replacingLive := !freshUnit && unitLingering(ctx, systemdUnitName(vmID))
 	lingerCheckMs := time.Since(tLinger).Milliseconds()
 
 	tStartUnit := time.Now()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1631,9 +1631,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// Sampled before this attempt creates the rundir: a pre-existing rundir
 	// means a prior attempt on this host reached start.sh (and possibly
 	// started the unit) even if it died before persisting any state, so the
-	// unit name is not provably fresh.
+	// unit name is not provably fresh. Only a definitive not-exist proves
+	// absence — any other stat error reads as prior.
 	_, rdErr := os.Stat(filepath.Join(m.cfg.RunDir, vmID))
-	priorRunDir := rdErr == nil
+	priorRunDir := !errors.Is(rdErr, os.ErrNotExist)
 
 	m.mu.Lock()
 	_, inPlace := m.vms[vmID]
@@ -1659,11 +1660,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	m.mu.Unlock()
 
 	// A provably-fresh unit name — no known instance (lazyReattach already
-	// folded BoltDB into the map) and no prior rundir — cannot be lingering,
-	// so the launch may skip the systemd linger query. Cleared before any
-	// retry: once an attempt has started the unit, the name is no longer
-	// fresh.
-	freshUnit := !inPlace && !priorRunDir
+	// folded BoltDB into the map), no prior rundir, and no stop attempt this
+	// process could still be winding down from — cannot be lingering, so the
+	// launch may skip the systemd linger query. The winding-down term covers
+	// cleanup paths that delete the other evidence after an unconfirmed stop
+	// (destroy, reattach stale-cleanup, recording VMs). Only the first
+	// attempt qualifies: any retry follows a start of the same unit name.
+	freshUnit := !inPlace && !priorRunDir && !unitMaybeWindingDown(systemdUnitName(vmID))
 
 	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
 	// Failure cleanup must not delete an overlay this attempt didn't create:
@@ -1754,7 +1757,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		inst.mu.Unlock()
 
 		var startErr error
-		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, freshUnit)
+		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, freshUnit && attempt == 1)
 		if startErr != nil {
 			if !inPlace {
 				m.netMgr.CleanupVM(vmID)
@@ -1888,10 +1891,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
 			Msg("restore failed with tap0 busy — retrying with a fresh slot")
-		// This attempt started the unit, so the name is no longer fresh: the
-		// dead-check above reads a deactivating unit as dead, and the next
-		// launch must budget for replacing a unit still in its stop phase.
-		freshUnit = false
 		// Full teardown, not recycle: a fast recycle could return this same busy
 		// slot to the pool and the next attempt could re-claim it.
 		m.netMgr.TeardownVM(vmID)
@@ -2983,6 +2982,7 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 		Str("vm_id", vmID).
 		Int64("prestart_ms", tStartUnit.Sub(tPrestart).Milliseconds()).
 		Int64("linger_check_ms", lingerCheckMs).
+		Bool("linger_skipped", freshUnit).
 		Int64("start_unit_ms", tStartUnitDone.Sub(tStartUnit).Milliseconds()).
 		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds()).
 		Msg("fc startup phases")

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -235,6 +235,13 @@ type Manager struct {
 	// the launcher path.
 	launcherBuilt atomic.Bool
 
+	// orphanScanDone gates the fresh-unit linger skip: it is set only after
+	// startup reattach successfully listed active units and registered the
+	// BoltDB-missing ones as unconfirmed stops. Until then (or forever, if
+	// the listing failed) a predecessor-era unit could be alive with no
+	// bookkeeping, so every launch must run the linger query.
+	orphanScanDone atomic.Bool
+
 	// presenceConverged mirrors the on-disk converged marker: every layered
 	// overlay on this host has a presence side-car, so strict enforcement can
 	// engage (in "auto" mode) without affecting anything that exists. Set at
@@ -1667,10 +1674,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// (destroy, reattach stale-cleanup). Build VMs never qualify: their
 	// deterministic reused IDs are exempt from persistence and invisible to
 	// the reconciler, so no bookkeeping can ever rule out a prior unit.
+	// orphanScanDone gates everything: until startup reattach has listed
+	// active units, a predecessor-era orphan may exist with no bookkeeping.
 	// Only the first attempt qualifies: any retry follows a start of the
 	// same unit name.
-	freshUnit := !inPlace && !priorRunDir && !isBuildVM(vmID) &&
-		!unitMaybeWindingDown(systemdUnitName(vmID))
+	freshUnit := m.orphanScanDone.Load() && !inPlace && !priorRunDir &&
+		!isBuildVM(vmID) && !unitMaybeWindingDown(systemdUnitName(vmID))
 
 	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
 	// Failure cleanup must not delete an overlay this attempt didn't create:
@@ -2085,6 +2094,10 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 				m.log.Warn().Str("vm_id", id).Msg("orphan systemd unit detected (not in BoltDB) — will be handled by reconciler")
 			}
 		}
+		// Orphans are accounted for — fresh-unit launches may skip the
+		// linger query from here on. Stays unset on listing failure: an
+		// unobserved orphan can't be ruled out by anything else.
+		m.orphanScanDone.Store(true)
 	}
 
 	// No broad re-sweep here. Startup already swept once before StartPool filled

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2077,6 +2077,11 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 	} else {
 		for _, id := range activeIDs {
 			if !knownIDs[id] {
+				// Registered as an unconfirmed stop so a same-ID launch never
+				// reads this orphan as fresh: without a control-plane DB the
+				// reconciler never stops BoltDB-missing units, so this
+				// observation may be the only bookkeeping the unit gets.
+				recordUnitStop(systemdUnitName(id))
 				m.log.Warn().Str("vm_id", id).Msg("orphan systemd unit detected (not in BoltDB) — will be handled by reconciler")
 			}
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1664,9 +1664,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// process could still be winding down from — cannot be lingering, so the
 	// launch may skip the systemd linger query. The winding-down term covers
 	// cleanup paths that delete the other evidence after an unconfirmed stop
-	// (destroy, reattach stale-cleanup, recording VMs). Only the first
-	// attempt qualifies: any retry follows a start of the same unit name.
-	freshUnit := !inPlace && !priorRunDir && !unitMaybeWindingDown(systemdUnitName(vmID))
+	// (destroy, reattach stale-cleanup). Build VMs never qualify: their
+	// deterministic reused IDs are exempt from persistence and invisible to
+	// the reconciler, so no bookkeeping can ever rule out a prior unit.
+	// Only the first attempt qualifies: any retry follows a start of the
+	// same unit name.
+	freshUnit := !inPlace && !priorRunDir && !isBuildVM(vmID) &&
+		!unitMaybeWindingDown(systemdUnitName(vmID))
 
 	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
 	// Failure cleanup must not delete an overlay this attempt didn't create:

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2943,10 +2943,9 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	// the restart job clears at fork, before the socket exists, so no
 	// at-timeout probe can tell a just-replaced unit from a stalled fresh
 	// one. Timed separately: it is a per-launch systemd round trip, and
-	// concurrent launches serialize on the shared D-Bus connection — which
-	// is why a provably-fresh unit (freshUnit) skips the query: a unit that
-	// never existed reads NotLoaded, i.e. not lingering, so the answer is
-	// known without the round trip.
+	// concurrent launches serialize on the shared D-Bus connection. A
+	// fresh unit skips it with the identical outcome: never-existed reads
+	// NotLoaded, i.e. not lingering.
 	tLinger := time.Now()
 	replacingLive := !freshUnit && unitLingering(ctx, systemdUnitName(vmID))
 	lingerCheckMs := time.Since(tLinger).Milliseconds()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1660,9 +1660,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	// A provably-fresh unit name — no known instance (lazyReattach already
 	// folded BoltDB into the map) and no prior rundir — cannot be lingering,
-	// so the launch may skip the systemd linger query. Retry attempts inside
-	// the loop keep the same answer: they only proceed after the unit is
-	// confirmed dead.
+	// so the launch may skip the systemd linger query. Cleared before any
+	// retry: once an attempt has started the unit, the name is no longer
+	// fresh.
 	freshUnit := !inPlace && !priorRunDir
 
 	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
@@ -1888,6 +1888,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
 			Msg("restore failed with tap0 busy — retrying with a fresh slot")
+		// This attempt started the unit, so the name is no longer fresh: the
+		// dead-check above reads a deactivating unit as dead, and the next
+		// launch must budget for replacing a unit still in its stop phase.
+		freshUnit = false
 		// Full teardown, not recycle: a fast recycle could return this same busy
 		// slot to the pool and the next attempt could re-claim it.
 		m.netMgr.TeardownVM(vmID)

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -311,7 +311,11 @@ func unitDefinitelyDead(ctx context.Context, unit string) bool {
 }
 
 // listActiveFirecrackerUnits returns the sandbox IDs of all running
-// firecracker@ units. Used during startup reattach.
+// firecracker@ units. Used during startup reattach. It lists
+// ActiveState=active only — a unit mid-deactivating is invisible here, which
+// is why processSettleWindow independently blankets the post-start period:
+// the scan catches indefinitely-alive orphans, the clock covers wind-downs
+// the scan can't see.
 func listActiveFirecrackerUnits(ctx context.Context) ([]string, error) {
 	var units []sddbus.UnitStatus
 	if err, ok := sdbusDo(func(c *sddbus.Conn) error {

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
@@ -60,9 +62,63 @@ const stopJobWaitCap = 35 * time.Second
 // otherwise queue every other stop on the host behind it indefinitely.
 const stopEnqueueCap = 5 * time.Second
 
+// recentUnitStops records every unit this process attempted to stop, keyed by
+// unit name. It lets the launch path tell "unit never existed" from "the
+// unit's other evidence was deleted while it may still be winding down":
+// cleanup paths remove a VM's rundir and records after a stop that can settle
+// while the unit is still deactivating (unitDefinitelyDead reads deactivating
+// as dead; lingeringState does not). Recorded on entry — even a failed
+// enqueue may have created a stop job.
+var recentUnitStops sync.Map // unit name -> time.Time of the stop attempt
+
+// vmProcessStart anchors the young-process guard in unitMaybeWindingDown:
+// units outlive the daemon, so stops issued by a previous vmd process are
+// invisible to recentUnitStops. Variable for tests.
+var vmProcessStart = time.Now()
+
+// unitStopSettleWindow generously covers a unit's worst-case wind-down after
+// a stop attempt: the stop job's TimeoutStopSec, ExecStopPost, and the kill
+// escalation. A false "maybe winding down" only costs one linger query.
+const unitStopSettleWindow = 60 * time.Second
+
+var stopsSinceSweep atomic.Int64
+
+func recordUnitStop(unit string) {
+	recentUnitStops.Store(unit, time.Now())
+	// Amortized prune so the map stays bounded on a host that stops many
+	// distinct units between launches that would read (and prune) them.
+	if stopsSinceSweep.Add(1)%4096 == 0 {
+		now := time.Now()
+		recentUnitStops.Range(func(k, v any) bool {
+			if now.Sub(v.(time.Time)) > unitStopSettleWindow {
+				recentUnitStops.Delete(k)
+			}
+			return true
+		})
+	}
+}
+
+// unitMaybeWindingDown reports whether a unit could still be in a stop phase
+// that this process's own bookkeeping cannot rule out: it was stopped
+// recently, or the process is too young to have observed a stop issued by
+// its predecessor.
+func unitMaybeWindingDown(unit string) bool {
+	if time.Since(vmProcessStart) < unitStopSettleWindow {
+		return true
+	}
+	if v, ok := recentUnitStops.Load(unit); ok {
+		if time.Since(v.(time.Time)) < unitStopSettleWindow {
+			return true
+		}
+		recentUnitStops.Delete(unit)
+	}
+	return false
+}
+
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
 // unit is a no-op. Blocks until the stop job completes.
 func stopUnit(ctx context.Context, unit string) error {
+	recordUnitStop(unit)
 	// Buffered channel: the library's dispatcher does one blocking send;
 	// buffer 1 keeps an abandoned wait from wedging every job on the
 	// connection. Non-nil ch also serializes concurrent stops on the

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -183,6 +183,7 @@ func settleExpiredStopWait(ctx context.Context, unit string, ch <-chan string, w
 	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 	defer cancel()
 	if unitDefinitelyDead(cctx, unit) {
+		confirmUnitStopped(unit) // definitively dead == systemd confirms down
 		return nil
 	}
 	return waitErr

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	sddbus "github.com/coreos/go-systemd/v22/dbus"
@@ -62,57 +61,51 @@ const stopJobWaitCap = 35 * time.Second
 // otherwise queue every other stop on the host behind it indefinitely.
 const stopEnqueueCap = 5 * time.Second
 
-// recentUnitStops records every unit this process attempted to stop, keyed by
-// unit name. It lets the launch path tell "unit never existed" from "the
-// unit's other evidence was deleted while it may still be winding down":
-// cleanup paths remove a VM's rundir and records after a stop that can settle
-// while the unit is still deactivating (unitDefinitelyDead reads deactivating
-// as dead; lingeringState does not). Recorded on entry — even a failed
-// enqueue may have created a stop job.
-var recentUnitStops sync.Map // unit name -> time.Time of the stop attempt
+// recentUnitStops records units this process attempted to stop without yet
+// confirming them stopped. It lets the launch path tell "unit never existed"
+// from "the unit's other evidence was deleted while it may still be alive":
+// cleanup paths remove a VM's rundir and records after a stop that can fail
+// outright (unit keeps running indefinitely) or settle while the unit is
+// still deactivating (unitDefinitelyDead reads deactivating as dead;
+// lingeringState does not). Recorded on entry to stopUnit; cleared ONLY when
+// systemd confirms the unit down — never by clock, because an unaccepted
+// stop job bounds nothing.
+var recentUnitStops sync.Map // unit name -> struct{}
 
 // vmProcessStart anchors the young-process guard in unitMaybeWindingDown:
 // units outlive the daemon, so stops issued by a previous vmd process are
 // invisible to recentUnitStops. Variable for tests.
 var vmProcessStart = time.Now()
 
-// unitStopSettleWindow generously covers a unit's worst-case wind-down after
-// a stop attempt: the stop job's TimeoutStopSec, ExecStopPost, and the kill
-// escalation. A false "maybe winding down" only costs one linger query.
-const unitStopSettleWindow = 60 * time.Second
-
-var stopsSinceSweep atomic.Int64
+// processSettleWindow is how long after process start every unit reads as
+// maybe-winding-down. It must outlast the reconciler's first orphan-unit
+// sweep (interval + grace + one stop cycle): that sweep re-records any
+// still-live predecessor-era unit into recentUnitStops, after which the
+// registry carries the knowledge forward. A false "maybe" only costs one
+// linger query per launch.
+const processSettleWindow = 3 * time.Minute
 
 func recordUnitStop(unit string) {
-	recentUnitStops.Store(unit, time.Now())
-	// Amortized prune so the map stays bounded on a host that stops many
-	// distinct units between launches that would read (and prune) them.
-	if stopsSinceSweep.Add(1)%4096 == 0 {
-		now := time.Now()
-		recentUnitStops.Range(func(k, v any) bool {
-			if now.Sub(v.(time.Time)) > unitStopSettleWindow {
-				recentUnitStops.Delete(k)
-			}
-			return true
-		})
-	}
+	recentUnitStops.Store(unit, struct{}{})
 }
 
-// unitMaybeWindingDown reports whether a unit could still be in a stop phase
-// that this process's own bookkeeping cannot rule out: it was stopped
-// recently, or the process is too young to have observed a stop issued by
-// its predecessor.
+// confirmUnitStopped clears a unit's stop record on a systemd-confirmed
+// outcome: stop job done/skipped, unit not loaded, or a successful
+// synchronous systemctl stop.
+func confirmUnitStopped(unit string) {
+	recentUnitStops.Delete(unit)
+}
+
+// unitMaybeWindingDown reports whether a unit could still be alive from a
+// stop this process's own bookkeeping cannot rule out: an unconfirmed stop
+// attempt, or a process too young for the reconciler to have re-observed
+// stops issued by its predecessor.
 func unitMaybeWindingDown(unit string) bool {
-	if time.Since(vmProcessStart) < unitStopSettleWindow {
+	if time.Since(vmProcessStart) < processSettleWindow {
 		return true
 	}
-	if v, ok := recentUnitStops.Load(unit); ok {
-		if time.Since(v.(time.Time)) < unitStopSettleWindow {
-			return true
-		}
-		recentUnitStops.Delete(unit)
-	}
-	return false
+	_, ok := recentUnitStops.Load(unit)
+	return ok
 }
 
 // stopUnit stops a systemd unit. Idempotent — stopping an already-stopped
@@ -136,6 +129,7 @@ func stopUnit(ctx context.Context, unit string) error {
 	if enqueued {
 		if err != nil {
 			if sdbusNotLoaded(err) {
+				confirmUnitStopped(unit)
 				return nil // not loaded == already stopped
 			}
 			return fmt.Errorf("stop unit %s: %w", unit, err)
@@ -161,6 +155,7 @@ func stopUnit(ctx context.Context, unit string) error {
 	if err != nil {
 		return fmt.Errorf("systemctl stop %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 	}
+	confirmUnitStopped(unit) // synchronous stop returned success
 	return nil
 }
 
@@ -168,6 +163,7 @@ func stopJobResult(unit, res string) error {
 	if res != "done" && res != "skipped" {
 		return fmt.Errorf("stop unit %s: job result %q", unit, res)
 	}
+	confirmUnitStopped(unit) // systemd reports the stop job completed
 	return nil
 }
 

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -182,11 +182,62 @@ func settleExpiredStopWait(ctx context.Context, unit string, ch <-chan string, w
 	}
 	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 	defer cancel()
-	if unitDefinitelyDead(cctx, unit) {
-		confirmUnitStopped(unit) // definitively dead == systemd confirms down
+	// One authoritative ActiveState read decides both the reported outcome and
+	// whether the stop marker may be cleared. A unit still "deactivating" is
+	// dead to unitDefinitelyDead but its socket can still be held, so its stop
+	// is reported complete YET the marker is retained — otherwise a same-ID
+	// relaunch after the settle window would read as fresh, skip the linger
+	// query, and race the winding-down unit's socket. Only a conclusively-down
+	// state clears the marker; an inconclusive read confirms nothing.
+	state, notLoaded, ok := unitActiveStateRaw(cctx, unit)
+	stopConfirmed, clearMarker := classifyStopSettle(state, notLoaded, ok)
+	if clearMarker {
+		confirmUnitStopped(unit)
+	}
+	if stopConfirmed {
 		return nil
 	}
 	return waitErr
+}
+
+// unitActiveStateRaw returns a unit's ActiveState string (e.g. "active",
+// "deactivating", "inactive", "failed") via D-Bus, falling back to systemctl.
+// notLoaded is true for a unit systemd does not know; ok is false only when the
+// state cannot be determined at all (inconclusive — the caller must fail safe).
+func unitActiveStateRaw(ctx context.Context, unit string) (state string, notLoaded, ok bool) {
+	if val, nl, handled := sdbusUnitProperty(ctx, unit, "", "ActiveState"); handled {
+		if nl {
+			return "", true, true
+		}
+		if s, isStr := val.(string); isStr && s != "" {
+			return s, false, true
+		}
+	}
+	out, err := exec.CommandContext(ctx, "systemctl", "show", "--property=ActiveState", "--value", unit).Output()
+	if err != nil {
+		return "", false, false
+	}
+	return strings.TrimSpace(string(out)), false, true
+}
+
+// classifyStopSettle maps a post-stop ActiveState read to the settle outcome.
+// stopConfirmed reports the stop as complete (report success rather than the
+// wait error); clearMarker allows clearing the recentUnitStops entry. Only a
+// fully-down unit (inactive/failed/not-loaded) clears the marker — a unit still
+// deactivating or activating counts as stop-complete but KEEPS the marker
+// because its socket may still linger, and an inconclusive read (ok=false) or a
+// still-up unit confirms nothing.
+func classifyStopSettle(state string, notLoaded, ok bool) (stopConfirmed, clearMarker bool) {
+	if !ok {
+		return false, false
+	}
+	if notLoaded || state == "inactive" || state == "failed" {
+		return true, true
+	}
+	if state == "deactivating" || state == "activating" {
+		return true, false
+	}
+	return false, false // active, reloading, or any other still-up state
 }
 
 // unitFailureSummary returns a one-line summary of a unit's

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -67,9 +67,9 @@ const stopEnqueueCap = 5 * time.Second
 // cleanup paths remove a VM's rundir and records after a stop that can fail
 // outright (unit keeps running indefinitely) or settle while the unit is
 // still deactivating (unitDefinitelyDead reads deactivating as dead;
-// lingeringState does not). Recorded on entry to stopUnit; cleared ONLY when
-// systemd confirms the unit down — never by clock, because an unaccepted
-// stop job bounds nothing.
+// lingeringState does not). Recorded on entry to stopUnit and for orphan
+// units observed at startup reattach; cleared ONLY when systemd confirms the
+// unit down — never by clock, because an unaccepted stop job bounds nothing.
 var recentUnitStops sync.Map // unit name -> struct{}
 
 // vmProcessStart anchors the young-process guard in unitMaybeWindingDown:

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 // A job result buffered at deadline-time must win over the wait error — the
@@ -34,5 +35,35 @@ func TestLingeringState(t *testing.T) {
 		if lingeringState(s) {
 			t.Errorf("%s should not linger", s)
 		}
+	}
+}
+
+func TestUnitMaybeWindingDown(t *testing.T) {
+	origStart := vmProcessStart
+	defer func() { vmProcessStart = origStart }()
+
+	// A young process cannot rule out stops issued by its predecessor.
+	vmProcessStart = time.Now()
+	if !unitMaybeWindingDown("young.service") {
+		t.Error("young process should report maybe-winding-down for any unit")
+	}
+
+	vmProcessStart = time.Now().Add(-2 * unitStopSettleWindow)
+	if unitMaybeWindingDown("never-stopped.service") {
+		t.Error("never-stopped unit on a settled process should be clear")
+	}
+
+	recordUnitStop("stopped.service")
+	if !unitMaybeWindingDown("stopped.service") {
+		t.Error("recently stopped unit should report maybe-winding-down")
+	}
+
+	// An expired entry reads clear and is pruned.
+	recentUnitStops.Store("old-stop.service", time.Now().Add(-2*unitStopSettleWindow))
+	if unitMaybeWindingDown("old-stop.service") {
+		t.Error("stop older than the settle window should be clear")
+	}
+	if _, ok := recentUnitStops.Load("old-stop.service"); ok {
+		t.Error("expired entry should be pruned on read")
 	}
 }

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -25,6 +25,34 @@ func TestSettleExpiredStopWait_DrainsBufferedResult(t *testing.T) {
 	}
 }
 
+// The settle path may clear the stop marker only when the unit is CONCLUSIVELY
+// down. A still-deactivating unit reports its stop complete but must KEEP the
+// marker — clearing it would let a same-ID relaunch skip the linger query and
+// race the winding-down socket.
+func TestClassifyStopSettle(t *testing.T) {
+	cases := []struct {
+		state               string
+		notLoaded, ok       bool
+		wantStop, wantClear bool
+	}{
+		{"inactive", false, true, true, true},
+		{"failed", false, true, true, true},
+		{"", true, true, true, true}, // not-loaded == gone
+		{"deactivating", false, true, true, false}, // stop done, marker RETAINED
+		{"activating", false, true, true, false},
+		{"active", false, true, false, false},
+		{"reloading", false, true, false, false},
+		{"inactive", false, false, false, false}, // inconclusive read confirms nothing
+	}
+	for _, c := range cases {
+		stop, clear := classifyStopSettle(c.state, c.notLoaded, c.ok)
+		if stop != c.wantStop || clear != c.wantClear {
+			t.Errorf("classifyStopSettle(%q, notLoaded=%v, ok=%v) = (stop=%v, clear=%v), want (stop=%v, clear=%v)",
+				c.state, c.notLoaded, c.ok, stop, clear, c.wantStop, c.wantClear)
+		}
+	}
+}
+
 func TestLingeringState(t *testing.T) {
 	for _, s := range []string{"active", "activating", "deactivating"} {
 		if !lingeringState(s) {

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -82,3 +82,16 @@ func TestStopJobResultConfirmsStop(t *testing.T) {
 		t.Error("done job result should clear the stop record")
 	}
 }
+
+// processSettleWindow backstops the deactivating units the startup orphan
+// scan cannot see (it lists active only). That holds only while the window
+// outlasts the reconciler's first orphan sweep plus one stop cycle; this
+// pins the inequality so a constant bump elsewhere fails here instead of
+// silently shrinking the guard.
+func TestProcessSettleWindowCoversOrphanSweep(t *testing.T) {
+	cfg := DefaultReconcilerConfig()
+	if min := cfg.Interval + cfg.GracePeriod + stopJobWaitCap; processSettleWindow <= min {
+		t.Fatalf("processSettleWindow %v must exceed reconciler interval+grace+stop cap %v",
+			processSettleWindow, min)
+	}
+}

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -48,22 +48,37 @@ func TestUnitMaybeWindingDown(t *testing.T) {
 		t.Error("young process should report maybe-winding-down for any unit")
 	}
 
-	vmProcessStart = time.Now().Add(-2 * unitStopSettleWindow)
+	vmProcessStart = time.Now().Add(-2 * processSettleWindow)
 	if unitMaybeWindingDown("never-stopped.service") {
 		t.Error("never-stopped unit on a settled process should be clear")
 	}
 
+	// An unconfirmed stop blocks freshness until systemd confirms — no
+	// clock-based expiry.
 	recordUnitStop("stopped.service")
 	if !unitMaybeWindingDown("stopped.service") {
-		t.Error("recently stopped unit should report maybe-winding-down")
+		t.Error("unconfirmed stop should report maybe-winding-down")
 	}
+	confirmUnitStopped("stopped.service")
+	if unitMaybeWindingDown("stopped.service") {
+		t.Error("confirmed stop should clear the record")
+	}
+}
 
-	// An expired entry reads clear and is pruned.
-	recentUnitStops.Store("old-stop.service", time.Now().Add(-2*unitStopSettleWindow))
-	if unitMaybeWindingDown("old-stop.service") {
-		t.Error("stop older than the settle window should be clear")
+// stopJobResult is a confirmation point: a completed job clears the stop
+// record, a failed one keeps it.
+func TestStopJobResultConfirmsStop(t *testing.T) {
+	recordUnitStop("job.service")
+	if err := stopJobResult("job.service", "failed"); err == nil {
+		t.Fatal("failed job result should error")
 	}
-	if _, ok := recentUnitStops.Load("old-stop.service"); ok {
-		t.Error("expired entry should be pruned on read")
+	if _, ok := recentUnitStops.Load("job.service"); !ok {
+		t.Error("failed job result must keep the stop record")
+	}
+	if err := stopJobResult("job.service", "done"); err != nil {
+		t.Fatalf("done job result should succeed: %v", err)
+	}
+	if _, ok := recentUnitStops.Load("job.service"); ok {
+		t.Error("done job result should clear the stop record")
 	}
 }


### PR DESCRIPTION
Before starting a VM's unit, the launch path asks systemd whether a unit with the same name is still winding down (the answer widens the socket budget for the stop phase). For a brand-new VM the unit name has never existed, so the query always answers not-lingering — but it still costs a systemd round trip per launch, and concurrent launches serialize those round trips on the shared D-Bus connection.

This skips the query when the unit name is provably fresh: no known instance for the vmID (BoltDB already folded into the in-memory map at entry) and no pre-existing rundir. The rundir check covers the daemon-crash window — a prior attempt that wrote start.sh and possibly started the unit before dying leaves its rundir behind, so such a vmID never classifies as fresh even with no persisted state.

Paths that can genuinely be replacing a live or winding-down unit keep the query: resume, snapshot verify, retried creates (a failed attempt leaves its instance in the map), and in-loop retries (which already require the unit to be confirmed dead before proceeding).

No behavior change for any skipped case: a never-existed unit reads NotLoaded, which the query already mapped to not-lingering.