### PR TITLE
api: retry a deadline-exceeded vmd boot once on create and resume

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -209,11 +209,12 @@ module "api_cert_lb" {
   cloud_run_service = module.api.service_name
   domain            = "api.superserve.ai"
 
-  # Must exceed the API's worst-case boot envelope (two vmd attempts plus
-  # margin), or the LB 504s while the control plane is still working and a
-  # late success races the client's error. Cloud Run's own 300s service
-  # timeout remains the outer ceiling.
-  backend_timeout_sec = 90
+  # Must exceed the API's worst-case create/resume envelope — two vmd boot
+  # attempts plus one more vmd-timeout of synchronous post-boot work (env
+  # inject, secret rebinding, network rules) — or the LB 504s while the
+  # control plane is still working and a late success races the client's
+  # error. Cloud Run's own 300s service timeout remains the outer ceiling.
+  backend_timeout_sec = 120
 
   dns_authorization_name     = "api-superserve-dnsauth"
   certificate_name           = "api-superserve-cert"

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -209,6 +209,12 @@ module "api_cert_lb" {
   cloud_run_service = module.api.service_name
   domain            = "api.superserve.ai"
 
+  # Must exceed the API's worst-case boot envelope (two vmd attempts plus
+  # margin), or the LB 504s while the control plane is still working and a
+  # late success races the client's error. Cloud Run's own 300s service
+  # timeout remains the outer ceiling.
+  backend_timeout_sec = 90
+
   dns_authorization_name     = "api-superserve-dnsauth"
   certificate_name           = "api-superserve-cert"
   certificate_map_name       = "api-superserve-certmap"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -192,30 +192,31 @@ func (h *Handlers) vmdForHost(ctx context.Context, hostID string) (VMDClient, er
 // vmdTimeout is the default deadline for VMD gRPC calls.
 const vmdTimeout = 30 * time.Second
 
-// retryBootOnDeadline runs one vmd boot call under vmdTimeout and, when the
-// attempt dies on DeadlineExceeded with the caller's context still alive,
-// runs exactly one more under a fresh vmdTimeout — worst case 2×vmdTimeout
-// for a caller that waits. This is the layer above the dial-site
-// Unavailable retry (retryUnavailableUnaryInterceptor absorbs a restarting
-// daemon; this absorbs the boot that then runs into its deadline). The
-// daemon serializes same-ID boots and recognizes a completed prior attempt,
-// so the retry either adopts the VM the first attempt brought up or boots
-// cleanly — never a double boot. A dead caller skips the retry: a boot
-// landing after the client gave up would activate a sandbox the caller
-// believes failed. (pauseWithRetry deliberately differs on both points —
-// any-error retry, detached context — because a late pause reconciles
-// state instead of surprising the caller.)
-func retryBootOnDeadline(parent context.Context, sandboxID string, boot func(context.Context) (string, uint32, uint32, error)) (ip string, vcpu, memMiB uint32, retried bool, err error) {
+// retryTransientBoot runs one vmd boot call under vmdTimeout and, when the
+// attempt dies on a transient — DeadlineExceeded, or Unavailable that
+// outlived the dial-site interceptor's window — with the caller's context
+// still alive, runs exactly one more under a fresh vmdTimeout; worst case
+// 2×vmdTimeout for a caller that waits (the API LB's backend timeout is
+// sized above that envelope). The daemon serializes same-ID boots and
+// recognizes a completed prior attempt, so the retry either adopts the VM
+// the first attempt brought up or boots cleanly — never a double boot; at
+// most one retry per boot and the daemon's restore semaphore bound the
+// added load. A dead caller skips the retry: a boot landing after the
+// client gave up would activate a sandbox the caller believes failed.
+// (pauseWithRetry deliberately differs on both points — any-error retry,
+// detached context — because a late pause reconciles state instead of
+// surprising the caller.)
+func retryTransientBoot(parent context.Context, sandboxID string, boot func(context.Context) (string, uint32, uint32, error)) (ip string, vcpu, memMiB uint32, retried bool, err error) {
 	attempt := func() (string, uint32, uint32, error) {
 		ctx, cancel := context.WithTimeout(parent, vmdTimeout)
 		defer cancel()
 		return boot(ctx)
 	}
 	ip, vcpu, memMiB, err = attempt()
-	if err == nil || !isVMDDeadline(err) || parent.Err() != nil {
+	if err == nil || !(isVMDDeadline(err) || isVMDUnavailable(err)) || parent.Err() != nil {
 		return ip, vcpu, memMiB, false, err
 	}
-	log.Warn().Str("sandbox_id", sandboxID).Msg("vmd boot hit deadline — retrying once")
+	log.Warn().Str("sandbox_id", sandboxID).Msg("vmd boot hit a transient — retrying once")
 	ip, vcpu, memMiB, err = attempt()
 	return ip, vcpu, memMiB, true, err
 }
@@ -606,7 +607,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// no matter which path it walks.
 	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdTimeout)
 	defer bootCancel()
-	ipAddress, actualVcpu, actualMemMiB, _, err := retryBootOnDeadline(bootCtx, sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
 		return vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath)
 	})
 	if err != nil {
@@ -1837,7 +1838,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// InjectSandboxEnv pushes the env again together with the JWT minted
 	// against the now-known source IP.
 	tVmdStart := time.Now()
-	ipAddress, actualVcpu, actualMemMiB, vmdRetried, vmdErr := retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+	ipAddress, actualVcpu, actualMemMiB, vmdRetried, vmdErr := retryTransientBoot(c.Request.Context(), sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
 		return vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
 	})
 	tVmdEnd := time.Now()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -624,12 +624,17 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			fcancel()
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
+				// Deliberately no destroy for a boot that may land late: the
+				// row reverts to paused, so a follow-up resume on this ID
+				// adopts the live VM (instant resume), and the reconciler
+				// reaps the paused-row/active-VM state if no retry comes.
 				revertToPaused()
 				respondError(c, ErrInternal)
 				return false
 			}
 		} else {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
+			// Same deliberate no-destroy as the fallback branch above.
 			revertToPaused()
 			respondError(c, ErrInternal)
 			return false

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -192,30 +192,32 @@ func (h *Handlers) vmdForHost(ctx context.Context, hostID string) (VMDClient, er
 // vmdTimeout is the default deadline for VMD gRPC calls.
 const vmdTimeout = 30 * time.Second
 
-// vmdRetryTimeout is the second-attempt budget in retryBootOnDeadline —
-// tighter than vmdTimeout so the combined worst case stays within the
-// client's patience.
-const vmdRetryTimeout = 20 * time.Second
-
 // retryBootOnDeadline runs one vmd boot call under vmdTimeout and, when the
-// attempt dies on DeadlineExceeded with the request still alive, runs exactly
-// one more under vmdRetryTimeout. A deadline here is transient host pressure
-// (typically a deploy-window restart); the daemon serializes same-ID boots
-// and recognizes a completed prior attempt, so the retry either adopts the
-// VM the first attempt brought up or boots cleanly — never a double boot.
-// A dead request skips the retry: a boot landing after the client gave up
-// would activate a sandbox the caller believes failed.
-func retryBootOnDeadline(parent context.Context, sandboxID string, boot func(context.Context) error) error {
-	ctx, cancel := context.WithTimeout(parent, vmdTimeout)
-	err := boot(ctx)
-	cancel()
+// attempt dies on DeadlineExceeded with the caller's context still alive,
+// runs exactly one more under a fresh vmdTimeout — worst case 2×vmdTimeout
+// for a caller that waits. This is the layer above the dial-site
+// Unavailable retry (retryUnavailableUnaryInterceptor absorbs a restarting
+// daemon; this absorbs the boot that then runs into its deadline). The
+// daemon serializes same-ID boots and recognizes a completed prior attempt,
+// so the retry either adopts the VM the first attempt brought up or boots
+// cleanly — never a double boot. A dead caller skips the retry: a boot
+// landing after the client gave up would activate a sandbox the caller
+// believes failed. (pauseWithRetry deliberately differs on both points —
+// any-error retry, detached context — because a late pause reconciles
+// state instead of surprising the caller.)
+func retryBootOnDeadline(parent context.Context, sandboxID string, boot func(context.Context) (string, uint32, uint32, error)) (ip string, vcpu, memMiB uint32, retried bool, err error) {
+	attempt := func() (string, uint32, uint32, error) {
+		ctx, cancel := context.WithTimeout(parent, vmdTimeout)
+		defer cancel()
+		return boot(ctx)
+	}
+	ip, vcpu, memMiB, err = attempt()
 	if err == nil || !isVMDDeadline(err) || parent.Err() != nil {
-		return err
+		return ip, vcpu, memMiB, false, err
 	}
 	log.Warn().Str("sandbox_id", sandboxID).Msg("vmd boot hit deadline — retrying once")
-	rctx, rcancel := context.WithTimeout(parent, vmdRetryTimeout)
-	defer rcancel()
-	return boot(rctx)
+	ip, vcpu, memMiB, err = attempt()
+	return ip, vcpu, memMiB, true, err
 }
 
 // asyncTimeout is the deadline for fire-and-forget DB writes.
@@ -597,12 +599,15 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// The snapshot carries the agent's HTTPS_PROXY (with its JWT) and stand-in
 	// tokens as they were at pause; the current binding set is re-applied below
 	// once the VM is up, so a mutation made while paused takes effect.
-	var ipAddress string
-	var actualVcpu, actualMemMiB uint32
-	err = retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
-		var rerr error
-		ipAddress, actualVcpu, actualMemMiB, rerr = vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath)
-		return rerr
+	//
+	// One clock for the whole boot sequence: ResumeInstance, its deadline
+	// retry, and the stateless fallback all draw down the same 2×vmdTimeout
+	// budget, so a resume holds the row mid-transition for a bounded window
+	// no matter which path it walks.
+	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdTimeout)
+	defer bootCancel()
+	ipAddress, actualVcpu, actualMemMiB, _, err := retryBootOnDeadline(bootCtx, sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+		return vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath)
 	})
 	if err != nil {
 		if isVMDNotFound(err) {
@@ -611,11 +616,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
 			// because resume is supposed to preserve whatever envs the sandbox
 			// already has baked into the snapshot — not inject new ones.
-			err = retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
-				var rerr error
-				ipAddress, actualVcpu, actualMemMiB, rerr = vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
-				return rerr
-			})
+			// Single attempt under whatever remains of the sequence budget:
+			// the fallback is already the second recovery layer.
+			fctx, fcancel := context.WithTimeout(bootCtx, vmdTimeout)
+			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(fctx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
+			fcancel()
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
 				revertToPaused()
@@ -1832,12 +1837,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// InjectSandboxEnv pushes the env again together with the JWT minted
 	// against the now-known source IP.
 	tVmdStart := time.Now()
-	var ipAddress string
-	var actualVcpu, actualMemMiB uint32
-	vmdErr := retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
-		var err error
-		ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
-		return err
+	ipAddress, actualVcpu, actualMemMiB, vmdRetried, vmdErr := retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+		return vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
 	})
 	tVmdEnd := time.Now()
 
@@ -1892,6 +1893,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// records the create failure metric from the HTTP status, so avoid
 		// emitting a second request-scoped transition here.
 		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Msg("VMD create/resume failed")
+		// A cancelled attempt can still complete on the host just after the
+		// deadline; best-effort destroy so a booted VM can't idle against a
+		// failed row until the reconciler sweeps it.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
+		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
+		cleanupCancel()
 		failCtx, failCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), asyncTimeout)
 		defer failCancel()
 		if err := h.DB.UpdateSandboxStatus(failCtx, db.UpdateSandboxStatusParams{
@@ -2103,6 +2110,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		Int64("lookup_ms", tLookupDone.Sub(tStart).Milliseconds()).
 		Int64("sched_ms", tVmdStart.Sub(tLookupDone).Milliseconds()).
 		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
+		Bool("vmd_retried", vmdRetried).
 		Int64("insert_ms", tInsertEnd.Sub(tInsertStart).Milliseconds()).
 		Int64("insert_wait_after_vmd_ms", tInsertReceive.Sub(tVmdEnd).Milliseconds()).
 		Int64("post_ms", tPostDone.Sub(tInsertReceive).Milliseconds()).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -192,6 +192,32 @@ func (h *Handlers) vmdForHost(ctx context.Context, hostID string) (VMDClient, er
 // vmdTimeout is the default deadline for VMD gRPC calls.
 const vmdTimeout = 30 * time.Second
 
+// vmdRetryTimeout is the second-attempt budget in retryBootOnDeadline —
+// tighter than vmdTimeout so the combined worst case stays within the
+// client's patience.
+const vmdRetryTimeout = 20 * time.Second
+
+// retryBootOnDeadline runs one vmd boot call under vmdTimeout and, when the
+// attempt dies on DeadlineExceeded with the request still alive, runs exactly
+// one more under vmdRetryTimeout. A deadline here is transient host pressure
+// (typically a deploy-window restart); the daemon serializes same-ID boots
+// and recognizes a completed prior attempt, so the retry either adopts the
+// VM the first attempt brought up or boots cleanly — never a double boot.
+// A dead request skips the retry: a boot landing after the client gave up
+// would activate a sandbox the caller believes failed.
+func retryBootOnDeadline(parent context.Context, sandboxID string, boot func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(parent, vmdTimeout)
+	err := boot(ctx)
+	cancel()
+	if err == nil || !isVMDDeadline(err) || parent.Err() != nil {
+		return err
+	}
+	log.Warn().Str("sandbox_id", sandboxID).Msg("vmd boot hit deadline — retrying once")
+	rctx, rcancel := context.WithTimeout(parent, vmdRetryTimeout)
+	defer rcancel()
+	return boot(rctx)
+}
+
 // asyncTimeout is the deadline for fire-and-forget DB writes.
 const asyncTimeout = 5 * time.Second
 
@@ -568,12 +594,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		return false
 	}
 
-	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-	defer vmdCancel()
 	// The snapshot carries the agent's HTTPS_PROXY (with its JWT) and stand-in
 	// tokens as they were at pause; the current binding set is re-applied below
 	// once the VM is up, so a mutation made while paused takes effect.
-	ipAddress, actualVcpu, actualMemMiB, err := vmd.ResumeInstance(vmdCtx, sandboxID.String(), snapshotPath, memPath)
+	var ipAddress string
+	var actualVcpu, actualMemMiB uint32
+	err = retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
+		var rerr error
+		ipAddress, actualVcpu, actualMemMiB, rerr = vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath)
+		return rerr
+	})
 	if err != nil {
 		if isVMDNotFound(err) {
 			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).
@@ -581,7 +611,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
 			// because resume is supposed to preserve whatever envs the sandbox
 			// already has baked into the snapshot — not inject new ones.
-			ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
+			err = retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
+				var rerr error
+				ipAddress, actualVcpu, actualMemMiB, rerr = vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), nil)
+				return rerr
+			})
 			if err != nil {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
 				revertToPaused()
@@ -1788,12 +1822,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	}()
 
 	// Boot the VM synchronously — the client gets a response only after
-	// the sandbox is fully running and ready to use. This call is still
-	// scoped to the request context so that if the client hangs up, the
-	// boot is cancelled and VMD cleans up.
-	vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
-	defer vmdCancel()
-
+	// the sandbox is fully running and ready to use. The boot is still
+	// scoped to the request context so that if the client hangs up, it is
+	// cancelled and VMD cleans up.
 	envVarsToShip := mergeEnvVarsWithSecrets(req.EnvVars, secretMeta)
 
 	// Phase 1: RestoreSnapshot boots the VM with the caller's env vars and
@@ -1801,7 +1832,13 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// InjectSandboxEnv pushes the env again together with the JWT minted
 	// against the now-known source IP.
 	tVmdStart := time.Now()
-	ipAddress, actualVcpu, actualMemMiB, vmdErr := vmd.RestoreSnapshot(vmdCtx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
+	var ipAddress string
+	var actualVcpu, actualMemMiB uint32
+	vmdErr := retryBootOnDeadline(c.Request.Context(), sandboxID.String(), func(ctx context.Context) error {
+		var err error
+		ipAddress, actualVcpu, actualMemMiB, err = vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), req.EnvVars)
+		return err
+	})
 	tVmdEnd := time.Now()
 
 	// Wait for the parallel INSERT to complete — its result determines

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -347,11 +347,14 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 		return
 	}
 
-	vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
 	// Reaper rollback resume: brings the VM back up after a pause-DB-write
-	// failure, before the customer ever sees the transition.
-	_, _, _, err := vmd.ResumeInstance(vmdCtx, sbx.ID.String(), snapshotPath, memPath)
-	vmdCancel()
+	// failure, before the customer ever sees the transition. Same deadline
+	// retry as the user-facing boots — the background ctx never reads dead,
+	// which is right: a rollback landing late still beats marking the
+	// sandbox failed.
+	_, _, _, _, err := retryBootOnDeadline(ctx, sbx.ID.String(), func(rctx context.Context) (string, uint32, uint32, error) {
+		return vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath)
+	})
 	if err != nil {
 		rl.Error().Err(err).Msg("reaper: rollback resume failed")
 		h.markSandboxFailed(ctx, sbx, "rollback resume failed after pause DB error", rl)

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -352,7 +352,7 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	// retry as the user-facing boots — the background ctx never reads dead,
 	// which is right: a rollback landing late still beats marking the
 	// sandbox failed.
-	_, _, _, _, err := retryBootOnDeadline(ctx, sbx.ID.String(), func(rctx context.Context) (string, uint32, uint32, error) {
+	_, _, _, _, err := retryTransientBoot(ctx, sbx.ID.String(), func(rctx context.Context) (string, uint32, uint32, error) {
 		return vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath)
 	})
 	if err != nil {

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -357,6 +357,14 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	})
 	if err != nil {
 		rl.Error().Err(err).Msg("reaper: rollback resume failed")
+		// failed is terminal — nothing will resume this ID again, so a boot
+		// that landed after the deadline would idle against the failed row
+		// until the reconciler sweeps it. Best-effort destroy now (mirrors
+		// the create path). Unlike the resume handler's error branches,
+		// there is no adopt-on-retry self-heal here to preserve.
+		dctx, dcancel := context.WithTimeout(context.WithoutCancel(ctx), vmdTimeout)
+		_ = vmd.DestroyInstance(dctx, sbx.ID.String(), true)
+		dcancel()
 		h.markSandboxFailed(ctx, sbx, "rollback resume failed after pause DB error", rl)
 		return
 	}

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -54,6 +54,16 @@ func isVMDNotFound(err error) bool {
 // indicating a snapshot/mem file is missing on disk. The caller maps
 // this to a 503 with `host_state_missing` rather than a generic 500 so
 // users understand it's a service-side issue not a bad request.
+// isVMDDeadline returns true when a vmd call died on its deadline — either
+// the gRPC status or the local context error, both of which map to
+// codes.DeadlineExceeded through status.Code.
+func isVMDDeadline(err error) bool {
+	if err == nil {
+		return false
+	}
+	return status.Code(err) == codes.DeadlineExceeded
+}
+
 func isVMDFileMissing(err error) bool {
 	if err == nil {
 		return false

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -50,20 +51,23 @@ func isVMDNotFound(err error) bool {
 	return status.Code(err) == codes.NotFound
 }
 
-// isVMDFileMissing returns true when vmd returned a FailedPrecondition
-// indicating a snapshot/mem file is missing on disk. The caller maps
-// this to a 503 with `host_state_missing` rather than a generic 500 so
-// users understand it's a service-side issue not a bad request.
-// isVMDDeadline returns true when a vmd call died on its deadline — either
-// the gRPC status or the local context error, both of which map to
-// codes.DeadlineExceeded through status.Code.
+// isVMDDeadline returns true when a vmd call died on its deadline. Two
+// distinct surfaces: a gRPC status (which status.Code resolves even through
+// fmt.Errorf wrapping), and a plain context.DeadlineExceeded — which
+// status.Code does NOT map (it reads as Unknown) and which the dial-site
+// Unavailable-retry interceptor returns when its window expires mid-backoff.
 func isVMDDeadline(err error) bool {
 	if err == nil {
 		return false
 	}
-	return status.Code(err) == codes.DeadlineExceeded
+	return status.Code(err) == codes.DeadlineExceeded ||
+		errors.Is(err, context.DeadlineExceeded)
 }
 
+// isVMDFileMissing returns true when vmd returned a FailedPrecondition
+// indicating a snapshot/mem file is missing on disk. The caller maps
+// this to a 503 with `host_state_missing` rather than a generic 500 so
+// users understand it's a service-side issue not a bad request.
 func isVMDFileMissing(err error) bool {
 	if err == nil {
 		return false

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -64,6 +64,16 @@ func isVMDDeadline(err error) bool {
 		errors.Is(err, context.DeadlineExceeded)
 }
 
+// isVMDUnavailable returns true when the daemon was unreachable for the
+// whole of the dial-site interceptor's retry window — the shape a vmd
+// restart longer than that window surfaces as.
+func isVMDUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	return status.Code(err) == codes.Unavailable
+}
+
 // isVMDFileMissing returns true when vmd returned a FailedPrecondition
 // indicating a snapshot/mem file is missing on disk. The caller maps
 // this to a 503 with `host_state_missing` rather than a generic 500 so

--- a/internal/api/vmd_retry_test.go
+++ b/internal/api/vmd_retry_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -10,66 +11,83 @@ import (
 )
 
 func TestRetryBootOnDeadline(t *testing.T) {
-	deadline := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	grpcDeadline := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	// The dial-site interceptor's expired-window shape: a wrapped plain
+	// context error, which status.Code reads as Unknown.
+	wrappedCtxDeadline := fmt.Errorf("%w (last attempt: %v)", context.DeadlineExceeded, grpcDeadline)
 	other := errors.New("boom")
+
+	boot := func(results []error, calls *int) func(context.Context) (string, uint32, uint32, error) {
+		return func(context.Context) (string, uint32, uint32, error) {
+			err := results[*calls]
+			*calls++
+			if err != nil {
+				return "", 0, 0, err
+			}
+			return "10.0.0.9", 2, 512, nil
+		}
+	}
 
 	t.Run("success first try", func(t *testing.T) {
 		calls := 0
-		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
-			calls++
-			return nil
-		})
-		if err != nil || calls != 1 {
-			t.Fatalf("err=%v calls=%d, want nil/1", err, calls)
+		ip, vcpu, mem, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{nil}, &calls))
+		if err != nil || retried || calls != 1 || ip != "10.0.0.9" || vcpu != 2 || mem != 512 {
+			t.Fatalf("got ip=%q vcpu=%d mem=%d retried=%v err=%v calls=%d", ip, vcpu, mem, retried, err, calls)
 		}
 	})
 
 	t.Run("non-deadline error is not retried", func(t *testing.T) {
 		calls := 0
-		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
-			calls++
-			return other
-		})
-		if !errors.Is(err, other) || calls != 1 {
-			t.Fatalf("err=%v calls=%d, want boom/1", err, calls)
+		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{other}, &calls))
+		if !errors.Is(err, other) || retried || calls != 1 {
+			t.Fatalf("err=%v retried=%v calls=%d, want boom/false/1", err, retried, calls)
 		}
 	})
 
-	t.Run("deadline retried once then succeeds", func(t *testing.T) {
+	t.Run("grpc deadline retried once then succeeds with attempt-2 outputs", func(t *testing.T) {
 		calls := 0
-		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
-			calls++
-			if calls == 1 {
-				return deadline
-			}
-			return nil
-		})
-		if err != nil || calls != 2 {
-			t.Fatalf("err=%v calls=%d, want nil/2", err, calls)
+		ip, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{grpcDeadline, nil}, &calls))
+		if err != nil || !retried || calls != 2 || ip != "10.0.0.9" {
+			t.Fatalf("got ip=%q retried=%v err=%v calls=%d", ip, retried, err, calls)
+		}
+	})
+
+	t.Run("wrapped context deadline from the interceptor is retried", func(t *testing.T) {
+		calls := 0
+		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{wrappedCtxDeadline, nil}, &calls))
+		if err != nil || !retried || calls != 2 {
+			t.Fatalf("err=%v retried=%v calls=%d, want nil/true/2", err, retried, calls)
 		}
 	})
 
 	t.Run("deadline twice returns the second error", func(t *testing.T) {
 		calls := 0
-		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
-			calls++
-			return deadline
-		})
-		if !isVMDDeadline(err) || calls != 2 {
-			t.Fatalf("err=%v calls=%d, want deadline/2", err, calls)
+		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{grpcDeadline, grpcDeadline}, &calls))
+		if !isVMDDeadline(err) || !retried || calls != 2 {
+			t.Fatalf("err=%v retried=%v calls=%d, want deadline/true/2", err, retried, calls)
 		}
 	})
 
-	t.Run("dead request skips the retry", func(t *testing.T) {
+	t.Run("dead caller skips the retry", func(t *testing.T) {
 		parent, cancel := context.WithCancel(context.Background())
 		cancel()
 		calls := 0
-		err := retryBootOnDeadline(parent, "sb", func(context.Context) error {
-			calls++
-			return deadline
-		})
-		if !isVMDDeadline(err) || calls != 1 {
-			t.Fatalf("err=%v calls=%d, want deadline/1", err, calls)
+		_, _, _, retried, err := retryBootOnDeadline(parent, "sb", boot([]error{grpcDeadline, nil}, &calls))
+		if !isVMDDeadline(err) || retried || calls != 1 {
+			t.Fatalf("err=%v retried=%v calls=%d, want deadline/false/1", err, retried, calls)
 		}
 	})
+}
+
+func TestIsVMDDeadline(t *testing.T) {
+	if !isVMDDeadline(status.Error(codes.DeadlineExceeded, "x")) {
+		t.Error("grpc deadline status should classify")
+	}
+	if !isVMDDeadline(fmt.Errorf("wrap: %w", context.DeadlineExceeded)) {
+		t.Error("wrapped context deadline should classify")
+	}
+	if isVMDDeadline(nil) || isVMDDeadline(errors.New("boom")) ||
+		isVMDDeadline(status.Error(codes.Unavailable, "x")) || isVMDDeadline(context.Canceled) {
+		t.Error("nil, plain, Unavailable, and Canceled must not classify")
+	}
 }

--- a/internal/api/vmd_retry_test.go
+++ b/internal/api/vmd_retry_test.go
@@ -30,7 +30,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("success first try", func(t *testing.T) {
 		calls := 0
-		ip, vcpu, mem, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{nil}, &calls))
+		ip, vcpu, mem, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{nil}, &calls))
 		if err != nil || retried || calls != 1 || ip != "10.0.0.9" || vcpu != 2 || mem != 512 {
 			t.Fatalf("got ip=%q vcpu=%d mem=%d retried=%v err=%v calls=%d", ip, vcpu, mem, retried, err, calls)
 		}
@@ -38,7 +38,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("non-deadline error is not retried", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{other}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{other}, &calls))
 		if !errors.Is(err, other) || retried || calls != 1 {
 			t.Fatalf("err=%v retried=%v calls=%d, want boom/false/1", err, retried, calls)
 		}
@@ -46,7 +46,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("grpc deadline retried once then succeeds with attempt-2 outputs", func(t *testing.T) {
 		calls := 0
-		ip, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{grpcDeadline, nil}, &calls))
+		ip, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{grpcDeadline, nil}, &calls))
 		if err != nil || !retried || calls != 2 || ip != "10.0.0.9" {
 			t.Fatalf("got ip=%q retried=%v err=%v calls=%d", ip, retried, err, calls)
 		}
@@ -54,7 +54,15 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("wrapped context deadline from the interceptor is retried", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{wrappedCtxDeadline, nil}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{wrappedCtxDeadline, nil}, &calls))
+		if err != nil || !retried || calls != 2 {
+			t.Fatalf("err=%v retried=%v calls=%d, want nil/true/2", err, retried, calls)
+		}
+	})
+
+	t.Run("unavailable that outlived the interceptor window is retried", func(t *testing.T) {
+		calls := 0
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{status.Error(codes.Unavailable, "connection refused"), nil}, &calls))
 		if err != nil || !retried || calls != 2 {
 			t.Fatalf("err=%v retried=%v calls=%d, want nil/true/2", err, retried, calls)
 		}
@@ -62,7 +70,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("deadline twice returns the second error", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryBootOnDeadline(context.Background(), "sb", boot([]error{grpcDeadline, grpcDeadline}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{grpcDeadline, grpcDeadline}, &calls))
 		if !isVMDDeadline(err) || !retried || calls != 2 {
 			t.Fatalf("err=%v retried=%v calls=%d, want deadline/true/2", err, retried, calls)
 		}
@@ -72,7 +80,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 		parent, cancel := context.WithCancel(context.Background())
 		cancel()
 		calls := 0
-		_, _, _, retried, err := retryBootOnDeadline(parent, "sb", boot([]error{grpcDeadline, nil}, &calls))
+		_, _, _, retried, err := retryTransientBoot(parent, "sb", boot([]error{grpcDeadline, nil}, &calls))
 		if !isVMDDeadline(err) || retried || calls != 1 {
 			t.Fatalf("err=%v retried=%v calls=%d, want deadline/false/1", err, retried, calls)
 		}

--- a/internal/api/vmd_retry_test.go
+++ b/internal/api/vmd_retry_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRetryBootOnDeadline(t *testing.T) {
+	deadline := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	other := errors.New("boom")
+
+	t.Run("success first try", func(t *testing.T) {
+		calls := 0
+		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
+			calls++
+			return nil
+		})
+		if err != nil || calls != 1 {
+			t.Fatalf("err=%v calls=%d, want nil/1", err, calls)
+		}
+	})
+
+	t.Run("non-deadline error is not retried", func(t *testing.T) {
+		calls := 0
+		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
+			calls++
+			return other
+		})
+		if !errors.Is(err, other) || calls != 1 {
+			t.Fatalf("err=%v calls=%d, want boom/1", err, calls)
+		}
+	})
+
+	t.Run("deadline retried once then succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
+			calls++
+			if calls == 1 {
+				return deadline
+			}
+			return nil
+		})
+		if err != nil || calls != 2 {
+			t.Fatalf("err=%v calls=%d, want nil/2", err, calls)
+		}
+	})
+
+	t.Run("deadline twice returns the second error", func(t *testing.T) {
+		calls := 0
+		err := retryBootOnDeadline(context.Background(), "sb", func(context.Context) error {
+			calls++
+			return deadline
+		})
+		if !isVMDDeadline(err) || calls != 2 {
+			t.Fatalf("err=%v calls=%d, want deadline/2", err, calls)
+		}
+	})
+
+	t.Run("dead request skips the retry", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := retryBootOnDeadline(parent, "sb", func(context.Context) error {
+			calls++
+			return deadline
+		})
+		if !isVMDDeadline(err) || calls != 1 {
+			t.Fatalf("err=%v calls=%d, want deadline/1", err, calls)
+		}
+	})
+}


### PR DESCRIPTION
A create or resume whose vmd boot call dies on a transient — DeadlineExceeded, or Unavailable that outlived the vmd client's dial-site retry window — previously failed the request outright even though the daemon may be seconds from healthy. The daemon already serializes same-ID boots and recognizes a completed prior attempt (a retried boot either adopts the VM the first attempt brought up or boots cleanly), so the control plane can safely retry.

This wraps the boot calls (create RestoreSnapshot, ResumeInstance and its stateless fallback, and the reaper's pause-rollback resume) in a helper that retries exactly once on those transients, under a fresh budget. The resume sequence runs under one shared clock so the worst-case hold stays bounded. A request whose own context is already dead never retries — a boot landing after the client gave up would activate a sandbox the caller believes failed. Where a late-landing boot has no self-heal path (create's failed row, the reaper's terminal fail) a best-effort destroy follows; the resume error branches deliberately skip it, since a follow-up resume adopts the live VM and the reconciler reaps the paused-row/active-VM state otherwise.

Every other error code is a real answer and still fails fast. The API load balancer's backend timeout is raised to cover the full boot-plus-postwork envelope so a slow-but-successful path can't be cut off mid-flight.