### PR TITLE
infra: drop the invalid LB backend timeout override

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -209,13 +209,6 @@ module "api_cert_lb" {
   cloud_run_service = module.api.service_name
   domain            = "api.superserve.ai"
 
-  # Must exceed the API's worst-case create/resume envelope — two vmd boot
-  # attempts plus one more vmd-timeout of synchronous post-boot work (env
-  # inject, secret rebinding, network rules) — or the LB 504s while the
-  # control plane is still working and a late success races the client's
-  # error. Cloud Run's own 300s service timeout remains the outer ceiling.
-  backend_timeout_sec = 120
-
   dns_authorization_name     = "api-superserve-dnsauth"
   certificate_name           = "api-superserve-cert"
   certificate_map_name       = "api-superserve-certmap"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -196,8 +196,9 @@ const vmdTimeout = 30 * time.Second
 // attempt dies on a transient — DeadlineExceeded, or Unavailable that
 // outlived the dial-site interceptor's window — with the caller's context
 // still alive, runs exactly one more under a fresh vmdTimeout; worst case
-// 2×vmdTimeout for a caller that waits (the API LB's backend timeout is
-// sized above that envelope). The daemon serializes same-ID boots and
+// 2×vmdTimeout for a caller that waits, which stays under Cloud Run's 300s
+// request timeout (the real ceiling; a serverless backend has no LB-level
+// timeout). The daemon serializes same-ID boots and
 // recognizes a completed prior attempt, so the retry either adopts the VM
 // the first attempt brought up or boots cleanly — never a double boot; at
 // most one retry per boot and the daemon's restore semaphore bound the


### PR DESCRIPTION
The us-east4 LB backend fronts Cloud Run through a serverless network endpoint group, and GCP does not allow setting timeout_sec on such a backend — so the recently added backend_timeout_sec override failed to apply ("Timeout sec is not supported for a backend service with Serverless network endpoint groups") and left the terraform run red.

The override was also unnecessary: request duration for a serverless backend is governed by Cloud Run's own request timeout (300s), which already sits well above the control plane's worst-case boot-plus-retry envelope. Removing the override returns east to a zero-change plan (matching west, which never had it) and greens the run. The boot-retry code is unaffected and already deployed; its comment is corrected to name Cloud Run's timeout as the real ceiling.