### PR TITLE
fix(build): remove obsolete seed-apikey target and align dev setup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,12 @@ git commit -s -m "your commit message"
 ## Development setup
 
 ```bash
-# Prerequisites: Go 1.25+, Docker
-docker compose up -d db
+# Prerequisites: Go 1.25+, Docker, golangci-lint
+export DATABASE_URL='postgres://postgres:postgres@localhost:5432/sandbox_test?sslmode=disable'
+export ALLOW_EPHEMERAL_SEED=1
+
+make db-up
+make db-wait
 make migrate-up
 make run-controlplane
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-.PHONY: build run test test-integration lint clean generate migrate image validate-boot deploy smoke-test seed-apikey seed-templates up down
+.PHONY: build run test test-integration lint clean generate migrate migrate-up image validate-boot deploy smoke-test seed-templates up down
 
 # Binary names
 CONTROLPLANE_BIN := bin/controlplane
 VMD_BIN := bin/vmd
-SEED_APIKEY_BIN := bin/seed-apikey
 SEED_TEMPLATES_BIN := bin/seed-templates
 BOXD_BIN := bin/boxd
 PROXY_BIN := bin/proxy
@@ -13,16 +12,13 @@ LDFLAGS := -ldflags "-s -w"
 
 ## Build
 
-build: build-controlplane build-vmd build-seed-apikey build-boxd build-proxy
+build: build-controlplane build-vmd build-seed-templates build-boxd build-proxy
 
 build-controlplane:
 	go build $(LDFLAGS) -o $(CONTROLPLANE_BIN) ./cmd/controlplane
 
 build-vmd:
 	go build $(LDFLAGS) -o $(VMD_BIN) ./cmd/vmd
-
-build-seed-apikey:
-	go build $(LDFLAGS) -o $(SEED_APIKEY_BIN) ./cmd/seed-apikey
 
 build-seed-templates:
 	go build $(LDFLAGS) -o $(SEED_TEMPLATES_BIN) ./cmd/seed-templates
@@ -85,8 +81,8 @@ db-reset: db-down db-up
 db-wait:
 	until docker exec $(DB_CONTAINER) pg_isready -U postgres -d sandbox_test; do sleep 1; done
 
-seed-apikey:
-	go run ./cmd/seed-apikey
+migrate: migrate-local
+migrate-up: migrate-local
 
 migrate-local:
 	for f in $$(ls supabase/migrations/*.sql | sort); do psql "$(DATABASE_URL)" -f $$f; done

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-seed-templates:
 # Seed the 5 curated public templates. Requires DATABASE_URL + SYSTEM_TEAM_ID
 # in the environment. Idempotent — safe to run repeatedly.
 seed-templates: build-seed-templates
-	$(SEED_TEMPLATES_BIN) --dir superserve_templates
+	DATABASE_URL="$(DATABASE_URL)" $(SEED_TEMPLATES_BIN) --dir superserve_templates
 
 build-boxd:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BOXD_BIN) ./cmd/boxd

--- a/README.md
+++ b/README.md
@@ -93,9 +93,11 @@ export ALLOW_EPHEMERAL_SEED=1
 
 make db-up
 make db-wait        # wait for postgres to accept connections
-make migrate-local  # apply supabase/migrations/ before first run
+make migrate-up     # apply supabase/migrations/ before first run (alias for migrate-local)
 make run-controlplane
 ```
+
+If port 5432 is already bound on your host, override `DB_PORT` (e.g., `DB_PORT=5433 make db-reset db-wait`).
 
 `ALLOW_EPHEMERAL_SEED=1` is for local development only. Production must set `SANDBOX_ACCESS_TOKEN_SEED` explicitly.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,6 @@ services:
     environment:
       API_PORT: "8080"
       VMD_GRPC_ADDRESS: host.docker.internal:50051
+      DATABASE_URL: ${DATABASE_URL:-postgres://postgres:postgres@host.docker.internal:5432/sandbox_test?sslmode=disable}
+      ALLOW_EPHEMERAL_SEED: "1"
+


### PR DESCRIPTION
## Summary

- Remove orphan `seed-apikey` / `build-seed-apikey` targets from `Makefile` so `make build` succeeds out-of-the-box
- Add `migrate:` and `migrate-up:` target aliases in `Makefile`
- Update `CONTRIBUTING.md` and `README.md` to reflect actual working database commands
- Add environment variable fallbacks in `docker-compose.yml`

## Why

Running `make build` failed out-of-the-box because it attempted to compile `./cmd/seed-apikey`, a binary directory that was removed prior to open-sourcing. Furthermore, `CONTRIBUTING.md` instructed developers to run `docker compose up -d db` and `make migrate-up`, both of which failed because `docker-compose.yml` lacked a `db` service and `Makefile` lacked a `migrate-up` rule. This fix cleans up stale targets, adds convenience aliases, and updates documentation so developer setup succeeds seamlessly.

## Test Plan

- [x] Build verification: `make clean && make build` passed
- [x] Unit tests pass: `make test-short` passed
- [x] Migration verification: `DB_PORT=5433 make migrate-up` passed
- [x] Integration tests pass: `DB_PORT=5433 make test-integration` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @pavitrabhalla  @meAmitPatil
