### PR TITLE
boxd: cap sync exec output buffering

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2458,18 +2458,28 @@ components:
 
     ExecResult:
       type: object
-      description: Full output of a command run to completion via `POST /exec`.
+      description: Output of a command run to completion via `POST /exec`.
       required: [stdout, stderr, exit_code]
       properties:
         stdout:
           type: string
-          description: Complete standard output.
+          description: >
+            Standard output. Combined stdout/stderr is retained up to a
+            server-side cap (currently 8 MiB); see `truncated`.
         stderr:
           type: string
-          description: Complete standard error.
+          description: >
+            Standard error. Combined stdout/stderr is retained up to a
+            server-side cap (currently 8 MiB); see `truncated`.
         exit_code:
           type: integer
           description: Process exit code. A non-zero value is returned, not raised.
+        truncated:
+          type: boolean
+          description: >
+            Present and true when combined output exceeded the retention cap
+            and the tail was dropped. Use `POST /exec/stream` to receive
+            unbounded output.
 
     ExecStreamEvent:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -970,12 +970,12 @@ paths:
       summary: Run a command and wait for it to finish
       description: |
         Runs a command to completion and returns its output in a single
-        response, retained up to a server-side cap (currently 8 MiB combined;
-        see `truncated`). For live or unbounded output use `POST /exec/stream`
-        (Server-Sent Events) or `GET /exec/connect` (WebSocket). A non-zero
-        exit code is returned in the body, not as an HTTP error. The sandbox
-        must be `running`; a paused sandbox returns `503`. Activate it first
-        with `POST /sandboxes/{sandbox_id}/activate` (the SDKs do this
+        response, retained up to a server-side cap (see `truncated`). For live
+        or unbounded output use `POST /exec/stream` (Server-Sent Events) or
+        `GET /exec/connect` (WebSocket). A non-zero exit code is returned in
+        the body, not as an HTTP error. The sandbox must be `running`; a
+        paused sandbox returns `503`. Activate it first with
+        `POST /sandboxes/{sandbox_id}/activate` (the SDKs do this
         automatically).
       security:
         - accessToken: []
@@ -987,9 +987,7 @@ paths:
               $ref: "#/components/schemas/ExecRequest"
       responses:
         "200":
-          description: >
-            The command finished; output (up to the retention cap) and exit
-            code.
+          description: The command finished; output and exit code.
           content:
             application/json:
               schema:
@@ -2467,23 +2465,19 @@ components:
       properties:
         stdout:
           type: string
-          description: >
-            Standard output. Combined stdout/stderr is retained up to a
-            server-side cap (currently 8 MiB); see `truncated`.
+          description: Standard output; see `truncated`.
         stderr:
           type: string
-          description: >
-            Standard error. Combined stdout/stderr is retained up to a
-            server-side cap (currently 8 MiB); see `truncated`.
+          description: Standard error; see `truncated`.
         exit_code:
           type: integer
           description: Process exit code. A non-zero value is returned, not raised.
         truncated:
           type: boolean
           description: >
-            Present and true when combined output exceeded the retention cap
-            and the tail was dropped. Use `POST /exec/stream` to receive
-            unbounded output.
+            Present and true when combined stdout/stderr exceeded the
+            server-side retention cap (currently 8 MiB) and the tail was
+            dropped. Use `POST /exec/stream` for unbounded output.
 
     ExecStreamEvent:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -969,12 +969,14 @@ paths:
       tags: [Exec]
       summary: Run a command and wait for it to finish
       description: |
-        Runs a command to completion and returns its full output in a single
-        response. For live output use `POST /exec/stream` (Server-Sent Events)
-        or `GET /exec/connect` (WebSocket). A non-zero exit code is returned in
-        the body, not as an HTTP error. The sandbox must be `running`; a paused
-        sandbox returns `503`. Activate it first with
-        `POST /sandboxes/{sandbox_id}/activate` (the SDKs do this automatically).
+        Runs a command to completion and returns its output in a single
+        response, retained up to a server-side cap (currently 8 MiB combined;
+        see `truncated`). For live or unbounded output use `POST /exec/stream`
+        (Server-Sent Events) or `GET /exec/connect` (WebSocket). A non-zero
+        exit code is returned in the body, not as an HTTP error. The sandbox
+        must be `running`; a paused sandbox returns `503`. Activate it first
+        with `POST /sandboxes/{sandbox_id}/activate` (the SDKs do this
+        automatically).
       security:
         - accessToken: []
       requestBody:
@@ -985,7 +987,9 @@ paths:
               $ref: "#/components/schemas/ExecRequest"
       responses:
         "200":
-          description: The command finished; full output and exit code.
+          description: >
+            The command finished; output (up to the retention cap) and exit
+            code.
           content:
             application/json:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2477,7 +2477,8 @@ components:
           description: >
             Present and true when combined stdout/stderr exceeded the
             server-side retention cap (currently 8 MiB) and the tail was
-            dropped. Use `POST /exec/stream` for unbounded output.
+            dropped; a notice explaining the cut is also appended to `stderr`.
+            Use `POST /exec/stream` for unbounded output.
 
     ExecStreamEvent:
       type: object

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -139,9 +139,14 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		tSpawn    time.Time
 	)
 	// appendCapped retains the longest prefix whose encoded cost fits the
-	// shared budget, dropping the rest. Callers hold mu.
+	// shared budget. The first dropped rune ends retention for good — a
+	// cheaper rune in a later event must not splice past the gap, so each
+	// stream stays a prefix of what the command wrote. Callers hold mu.
 	budget := maxSyncExecOutputBytes
 	appendCapped := func(dst, b []byte) []byte {
+		if truncated {
+			return dst
+		}
 		i := 0
 		for i < len(b) {
 			cost, size := jsonRuneCost(b[i:])

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -39,7 +39,7 @@ func jsonRuneCost(b []byte) (cost, size int) {
 	switch {
 	case r == utf8.RuneError && size <= 1:
 		return 6, 1
-	case r == '"' || r == '\\' || r == '\n' || r == '\r' || r == '\t':
+	case r == '"' || r == '\\' || r == '\b' || r == '\f' || r == '\n' || r == '\r' || r == '\t':
 		return 2, size
 	case r < 0x20 || r == '<' || r == '>' || r == '&' || r == '\u2028' || r == '\u2029':
 		return 6, size

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
@@ -26,21 +27,24 @@ var sseKeepaliveInterval = 15 * time.Second
 // var, not const, so tests can shrink it.
 var maxSyncExecOutputBytes = 8 << 20
 
-// byteJSONCost is an upper bound on how many bytes one input byte occupies
-// inside an encoding/json string (HTML escaping on): quotes and backslashes
-// become two, control and HTML-significant bytes become \u00XX, and non-ASCII
-// bytes cost at most three (worst case invalid UTF-8 → U+FFFD). Overcounts
-// never undercounts, so the encoded body stays within budget.
-func byteJSONCost(c byte) int {
+// jsonRuneCost returns how many bytes the rune starting b occupies inside an
+// encoding/json string (HTML escaping on) and how many input bytes it spans:
+// backslash-escapable characters cost two, characters the encoder writes as
+// \uXXXX cost six — including each invalid UTF-8 byte, which encodes as
+// \ufffd — and everything else passes through at its own width. A rune split
+// across output chunks is charged as invalid bytes: an overcount, never an
+// undercount, so the encoded body stays within budget.
+func jsonRuneCost(b []byte) (cost, size int) {
+	r, size := utf8.DecodeRune(b)
 	switch {
-	case c == '"' || c == '\\':
-		return 2
-	case c < 0x20 || c == '<' || c == '>' || c == '&':
-		return 6
-	case c >= 0x80:
-		return 3
+	case r == utf8.RuneError && size <= 1:
+		return 6, 1
+	case r == '"' || r == '\\' || r == '\n' || r == '\r' || r == '\t':
+		return 2, size
+	case r < 0x20 || r == '<' || r == '>' || r == '&' || r == '\u2028' || r == '\u2029':
+		return 6, size
 	default:
-		return 1
+		return size, size
 	}
 }
 
@@ -140,12 +144,12 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	appendCapped := func(dst, b []byte) []byte {
 		i := 0
 		for i < len(b) {
-			cost := byteJSONCost(b[i])
+			cost, size := jsonRuneCost(b[i:])
 			if cost > budget {
 				break
 			}
 			budget -= cost
-			i++
+			i += size
 		}
 		if i < len(b) {
 			truncated = true

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -16,6 +16,15 @@ import (
 // var, not const, so tests can shorten it.
 var sseKeepaliveInterval = 15 * time.Second
 
+// Combined stdout+stderr retained by the sync exec handler, which buffers the
+// whole result into one JSON reply — unbounded, a single chatty command can
+// exhaust the guest's RAM, and clients bound how much of a buffered reply they
+// read anyway. Output past the cap is still drained (a full pipe would block
+// the child) but dropped, and the reply is flagged truncated; streaming exec
+// forwards instead of holding, so it needs no cap.
+// var, not const, so tests can shrink it.
+var maxSyncExecOutputBytes = 8 << 20
+
 // CodeInvalidArgument → 400, everything else → 500.
 func writeRunError(w http.ResponseWriter, err error) {
 	var ce *connect.Error
@@ -48,6 +57,9 @@ type execResponse struct {
 	Stdout   string `json:"stdout"`
 	Stderr   string `json:"stderr"`
 	ExitCode int32  `json:"exit_code"`
+	// Truncated reports that combined output exceeded the sync buffer cap
+	// and the tail was dropped; stream the command instead for full output.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 func (r *execRequest) toStartRequest() *pb.StartRequest {
@@ -96,12 +108,27 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	// are not collected off the guest.
 	tRecv := time.Now()
 	var (
-		mu       sync.Mutex
-		stdout   []byte
-		stderr   []byte
-		exitCode int32
-		tSpawn   time.Time
+		mu        sync.Mutex
+		stdout    []byte
+		stderr    []byte
+		truncated bool
+		exitCode  int32
+		tSpawn    time.Time
 	)
+	// appendCapped retains at most maxSyncExecOutputBytes across both
+	// streams, dropping the rest. Callers hold mu.
+	appendCapped := func(dst, b []byte) []byte {
+		remaining := maxSyncExecOutputBytes - len(stdout) - len(stderr)
+		if remaining <= 0 {
+			truncated = true
+			return dst
+		}
+		if len(b) > remaining {
+			b = b[:remaining]
+			truncated = true
+		}
+		return append(dst, b...)
+	}
 	emit := func(ev *pb.ProcessEvent) error {
 		mu.Lock()
 		defer mu.Unlock()
@@ -109,11 +136,11 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		case *pb.ProcessEvent_Data:
 			switch out := x.Data.Output.(type) {
 			case *pb.DataEvent_Stdout:
-				stdout = append(stdout, out.Stdout...)
+				stdout = appendCapped(stdout, out.Stdout)
 			case *pb.DataEvent_Stderr:
-				stderr = append(stderr, out.Stderr...)
+				stderr = appendCapped(stderr, out.Stderr)
 			case *pb.DataEvent_PtyData:
-				stdout = append(stdout, out.PtyData...)
+				stdout = appendCapped(stdout, out.PtyData)
 			}
 		case *pb.ProcessEvent_Start:
 			if tSpawn.IsZero() {
@@ -136,9 +163,10 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(execResponse{
-		Stdout:   string(stdout),
-		Stderr:   string(stderr),
-		ExitCode: exitCode,
+		Stdout:    string(stdout),
+		Stderr:    string(stderr),
+		ExitCode:  exitCode,
+		Truncated: truncated,
 	})
 }
 

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -184,6 +184,15 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The marker rides in stderr so every consumer sees why the output ends
+	// early, not only clients that read the structured flag. Appended past
+	// the budget; its fixed size keeps the reply bounded.
+	if truncated {
+		stderr = append(stderr, fmt.Sprintf(
+			"\n[superserve] output truncated: combined stdout/stderr exceeded the sync exec limit (%d bytes); use /exec/stream or redirect output to a file for full output\n",
+			maxSyncExecOutputBytes)...)
+	}
+
 	if !tSpawn.IsZero() {
 		w.Header().Set("X-Boxd-Spawn-Ms", fmt.Sprintf("%d", tSpawn.Sub(tRecv).Milliseconds()))
 		w.Header().Set("X-Boxd-Run-Ms", fmt.Sprintf("%d", time.Since(tSpawn).Milliseconds()))

--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -16,14 +16,33 @@ import (
 // var, not const, so tests can shorten it.
 var sseKeepaliveInterval = 15 * time.Second
 
-// Combined stdout+stderr retained by the sync exec handler, which buffers the
-// whole result into one JSON reply — unbounded, a single chatty command can
-// exhaust the guest's RAM, and clients bound how much of a buffered reply they
-// read anyway. Output past the cap is still drained (a full pipe would block
-// the child) but dropped, and the reply is flagged truncated; streaming exec
-// forwards instead of holding, so it needs no cap.
+// Budget for the sync exec handler's buffered stdout+stderr, measured in
+// JSON-encoded bytes so the reply body stays bounded regardless of content —
+// unbounded, a single chatty command can exhaust the guest's RAM, and clients
+// bound how much of a buffered reply they read anyway. Output past the cap is
+// still drained (a full pipe would block the child) but dropped, and the
+// reply is flagged truncated; streaming exec forwards instead of holding, so
+// it needs no cap.
 // var, not const, so tests can shrink it.
 var maxSyncExecOutputBytes = 8 << 20
+
+// byteJSONCost is an upper bound on how many bytes one input byte occupies
+// inside an encoding/json string (HTML escaping on): quotes and backslashes
+// become two, control and HTML-significant bytes become \u00XX, and non-ASCII
+// bytes cost at most three (worst case invalid UTF-8 → U+FFFD). Overcounts
+// never undercounts, so the encoded body stays within budget.
+func byteJSONCost(c byte) int {
+	switch {
+	case c == '"' || c == '\\':
+		return 2
+	case c < 0x20 || c == '<' || c == '>' || c == '&':
+		return 6
+	case c >= 0x80:
+		return 3
+	default:
+		return 1
+	}
+}
 
 // CodeInvalidArgument → 400, everything else → 500.
 func writeRunError(w http.ResponseWriter, err error) {
@@ -115,19 +134,23 @@ func (s *processService) handleExec(w http.ResponseWriter, r *http.Request) {
 		exitCode  int32
 		tSpawn    time.Time
 	)
-	// appendCapped retains at most maxSyncExecOutputBytes across both
-	// streams, dropping the rest. Callers hold mu.
+	// appendCapped retains the longest prefix whose encoded cost fits the
+	// shared budget, dropping the rest. Callers hold mu.
+	budget := maxSyncExecOutputBytes
 	appendCapped := func(dst, b []byte) []byte {
-		remaining := maxSyncExecOutputBytes - len(stdout) - len(stderr)
-		if remaining <= 0 {
-			truncated = true
-			return dst
+		i := 0
+		for i < len(b) {
+			cost := byteJSONCost(b[i])
+			if cost > budget {
+				break
+			}
+			budget -= cost
+			i++
 		}
-		if len(b) > remaining {
-			b = b[:remaining]
+		if i < len(b) {
 			truncated = true
 		}
-		return append(dst, b...)
+		return append(dst, b[:i]...)
 	}
 	emit := func(ev *pb.ProcessEvent) error {
 		mu.Lock()

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -50,6 +50,38 @@ func TestHandleExec_Success(t *testing.T) {
 	}
 }
 
+func TestHandleExec_OutputCapped(t *testing.T) {
+	old := maxSyncExecOutputBytes
+	maxSyncExecOutputBytes = 16
+	defer func() { maxSyncExecOutputBytes = old }()
+
+	s := newProcessService()
+	// 64 bytes of stdout against a 16-byte cap; the command must still run
+	// to completion (drained, not blocked) and exit 0.
+	body := `{"command":"/bin/sh","args":["-c","printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'"],"working_dir":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp execResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v; body: %s", err, w.Body.String())
+	}
+	if len(resp.Stdout) != 16 {
+		t.Errorf("stdout length = %d, want 16 (capped)", len(resp.Stdout))
+	}
+	if !resp.Truncated {
+		t.Error("truncated = false, want true")
+	}
+	if resp.ExitCode != 0 {
+		t.Errorf("exit_code = %d, want 0", resp.ExitCode)
+	}
+}
+
 func TestHandleExec_NonzeroExit(t *testing.T) {
 	s := newProcessService()
 	body := `{"command":"/bin/sh","args":["-c","exit 7"],"working_dir":"/tmp"}`

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func newProcessService() *processService {
@@ -105,6 +106,35 @@ func TestHandleExec_OutputCapCountsEncodedSize(t *testing.T) {
 	}
 	if len(resp.Stdout) != 2 {
 		t.Errorf("stdout length = %d, want 2 (two 6-byte escapes fit a 16-byte budget)", len(resp.Stdout))
+	}
+	if !resp.Truncated {
+		t.Error("truncated = false, want true")
+	}
+}
+
+func TestHandleExec_OutputCapChargesInvalidUTF8(t *testing.T) {
+	old := maxSyncExecOutputBytes
+	maxSyncExecOutputBytes = 16
+	defer func() { maxSyncExecOutputBytes = old }()
+
+	s := newProcessService()
+	// Each invalid byte encodes as a six-byte replacement-rune escape, so a
+	// 16-byte encoded budget retains only two of the four 0xff bytes.
+	body := `{"command":"/bin/sh","args":["-c","printf '\\377\\377\\377\\377'"],"working_dir":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp execResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v; body: %s", err, w.Body.String())
+	}
+	if want := strings.Repeat(string(utf8.RuneError), 2); resp.Stdout != want {
+		t.Errorf("stdout = %q, want %q (two replacement runes)", resp.Stdout, want)
 	}
 	if !resp.Truncated {
 		t.Error("truncated = false, want true")

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -78,6 +78,9 @@ func TestHandleExec_OutputCapped(t *testing.T) {
 	if !resp.Truncated {
 		t.Error("truncated = false, want true")
 	}
+	if !strings.Contains(resp.Stderr, "output truncated") {
+		t.Errorf("stderr = %q, want the truncation marker", resp.Stderr)
+	}
 	if resp.ExitCode != 0 {
 		t.Errorf("exit_code = %d, want 0", resp.ExitCode)
 	}

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -144,6 +144,36 @@ func TestHandleExec_OutputCapChargesInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestHandleExec_NoRetentionAfterFirstDrop(t *testing.T) {
+	old := maxSyncExecOutputBytes
+	maxSyncExecOutputBytes = 2
+	defer func() { maxSyncExecOutputBytes = old }()
+
+	s := newProcessService()
+	// Three separate writes: 'a' fits (budget 1 left), the newline costs 2
+	// and is dropped, and the trailing 'x' would fit the leftover budget but
+	// must not — retained output stays a prefix, never a splice.
+	body := `{"command":"/bin/sh","args":["-c","printf a; sleep 0.3; printf '\\n'; sleep 0.3; printf x"],"working_dir":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp execResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v; body: %s", err, w.Body.String())
+	}
+	if resp.Stdout != "a" {
+		t.Errorf("stdout = %q, want %q (no bytes retained past the first drop)", resp.Stdout, "a")
+	}
+	if !resp.Truncated {
+		t.Error("truncated = false, want true")
+	}
+}
+
 func TestHandleExec_NonzeroExit(t *testing.T) {
 	s := newProcessService()
 	body := `{"command":"/bin/sh","args":["-c","exit 7"],"working_dir":"/tmp"}`

--- a/cmd/boxd/exec_http_test.go
+++ b/cmd/boxd/exec_http_test.go
@@ -82,6 +82,35 @@ func TestHandleExec_OutputCapped(t *testing.T) {
 	}
 }
 
+func TestHandleExec_OutputCapCountsEncodedSize(t *testing.T) {
+	old := maxSyncExecOutputBytes
+	maxSyncExecOutputBytes = 16
+	defer func() { maxSyncExecOutputBytes = old }()
+
+	s := newProcessService()
+	// NUL bytes encode as six-byte \u0000 escapes, so a 16-byte encoded
+	// budget retains only two of the four despite 4 < 16 raw bytes.
+	body := `{"command":"/bin/sh","args":["-c","head -c 4 /dev/zero"],"working_dir":"/tmp"}`
+	req := httptest.NewRequest(http.MethodPost, "/exec", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	s.handleExec(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp execResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v; body: %s", err, w.Body.String())
+	}
+	if len(resp.Stdout) != 2 {
+		t.Errorf("stdout length = %d, want 2 (two 6-byte escapes fit a 16-byte budget)", len(resp.Stdout))
+	}
+	if !resp.Truncated {
+		t.Error("truncated = false, want true")
+	}
+}
+
 func TestHandleExec_NonzeroExit(t *testing.T) {
 	s := newProcessService()
 	body := `{"command":"/bin/sh","args":["-c","exit 7"],"working_dir":"/tmp"}`


### PR DESCRIPTION
The sync `/exec` handler buffered the command's entire stdout/stderr in memory to build its single JSON reply, with no bound. A command that prints enough output grows that buffer (with append-doubling spikes) until the guest runs out of memory, killing boxd — and with it the whole sandbox — instead of just that request.

Cap combined retained stdout+stderr at 8 MiB. Output past the cap is still drained (a full pipe would block the child) but dropped, and the response carries `truncated: true` so callers know to use the streaming endpoint for large output. Streaming exec is unchanged — it forwards output instead of holding it.