### PR TITLE
DB: add saved snapshot expand and host-admission guard

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -90,7 +90,7 @@ WITH tpl AS (
   SELECT ins.id, (@secret_ids::uuid[])[i], (@env_keys::text[])[i], (@proxy_tokens::text[])[i]
   FROM ins, generate_subscripts(@secret_ids::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at
+SELECT ins.*
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id;
 

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -1,8 +1,8 @@
 -- name: CreateSandbox :one
 -- ID is supplied by the caller (generated in Go via uuid.New()) rather
--- than defaulted in SQL, so the caller can parallelize this INSERT with
--- the VMD CreateVM call — both need the same sandbox_id and generating
--- it client-side lets them run concurrently instead of strictly serially.
+-- than defaulted in SQL, so the committed row and later VMD operations
+-- share one stable sandbox_id. Callers must wait for this statement before
+-- starting VMD: its triggers own quota and final host admission.
 -- template_id is optional (NULL when sandbox is not derived from a template).
 -- snapshot_path / mem_path / base_path / delta_path pin the sandbox to a
 -- specific build's artifacts so a later template rebuild can't corrupt it.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -56,6 +56,17 @@ both VMD and proxy below the policy generation required by live strict
 sandboxes; drain or move those sandboxes first. The same rule applies to the
 earlier publication, per-port-access, and header-token capability boundaries.
 
+### Saved-snapshot rollback safety
+
+The saved-snapshot database expand migrations are leave-forward: do not run a
+destructive down migration when rolling application code back. Before routing
+API traffic to a revision from before the DB-first sandbox-create change, first
+return every `draining` host to `active` and verify that state has converged.
+Those older revisions can start VMD in parallel with the sandbox INSERT, so a
+database host-admission rejection could otherwise race a VM launch. If any
+draining host cannot be explicitly returned to `active`, do not roll the API
+back that far.
+
 ## Host selection
 
 Do not deploy to a host merely because it exists. Host deployment jobs should only target hosts that are explicitly marked ready for that environment/region.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1833,18 +1833,14 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return
 	}
 
-	// Generate the sandbox ID in Go so the DB INSERT and the VMD call
-	// can run in parallel — both need the same ID and neither needs to
-	// wait on the other. This hides the ~10-20ms INSERT roundtrip behind
-	// VMD's ~100-200ms create latency, shaving that much off the p50.
+	// Generate the sandbox ID in Go so the committed DB row and every later
+	// VMD operation share one stable identity. The INSERT must finish before
+	// RestoreSnapshot: besides quota enforcement, its database triggers own
+	// the final host-admission decision and must be able to reject a launch
+	// without causing any VMD side effect.
 	sandboxID := uuid.New()
 
 	insertCtx := context.WithoutCancel(c.Request.Context())
-	type insertResult struct {
-		sandbox db.Sandbox
-		err     error
-	}
-	insertCh := make(chan insertResult, 1)
 	// runInsert performs the quota-safe sandbox + preview-policy statement.
 	// Closure captures sandboxID/teamID/req/templateID/hostID/metadataJSON.
 	runInsert := func(q *db.Queries) (db.Sandbox, error) {
@@ -1958,14 +1954,34 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return db.Sandbox(row), err
 	}
 
-	var tInsertStart, tInsertEnd time.Time
-	go func() {
-		tInsertStart = time.Now()
-		// Quota is enforced by the sandbox_quota_on_insert trigger.
-		sb, err := insertWithBindings()
-		tInsertEnd = time.Now()
-		insertCh <- insertResult{sandbox: sb, err: err}
-	}()
+	tInsertStart := time.Now()
+	// Quota and cross-version host admission are enforced by INSERT triggers.
+	// Waiting for the statement to return also confirms that the autocommit
+	// transaction completed before a VM can start on the selected host.
+	sandbox, dbErr := insertWithBindings()
+	tInsertEnd := time.Now()
+
+	// 0 rows from CreateSandboxFromTemplate = template deleted mid-create.
+	templateRace := templateID.Valid && errors.Is(dbErr, pgx.ErrNoRows)
+
+	// Per-team sandbox count cap; raised by sandbox_quota_on_insert trigger.
+	quotaExceeded := isSandboxQuotaErr(dbErr)
+
+	if dbErr != nil {
+		// No VMD RPC has run yet, so an admission, quota, or template-race
+		// rejection needs no orphan cleanup and cannot perturb the host.
+		log.Error().Err(dbErr).Str("sandbox_id", sandboxID.String()).Msg("CreateSandbox: INSERT failed before VMD restore")
+		if templateRace {
+			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
+			return
+		}
+		if quotaExceeded {
+			h.respondQuotaExceeded(c, teamID)
+			return
+		}
+		respondError(c, ErrInternal)
+		return
+	}
 
 	// Boot the VM synchronously — the client gets a response only after
 	// the sandbox is fully running and ready to use. The boot is still
@@ -1983,60 +1999,14 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	})
 	tVmdEnd := time.Now()
 
-	// Wait for the parallel INSERT to complete — its result determines
-	// how we handle a VMD failure (mark row failed vs. nothing to mark).
-	insertRes := <-insertCh
-	tInsertReceive := time.Now()
-	sandbox := insertRes.sandbox
-	dbErr := insertRes.err
-
-	// 0 rows from CreateSandboxFromTemplate = template deleted mid-create.
-	templateRace := templateID.Valid && errors.Is(dbErr, pgx.ErrNoRows)
-
-	// Per-team sandbox count cap; raised by sandbox_quota_on_insert trigger.
-	quotaExceeded := isSandboxQuotaErr(dbErr)
-
-	switch {
-	case dbErr != nil && vmdErr != nil:
-		// Both failed — nothing persisted, nothing to clean up.
-		log.Error().Err(dbErr).AnErr("vmd_err", vmdErr).Msg("CreateSandbox: DB and VMD both failed")
-		if templateRace {
-			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
-			return
-		}
-		if quotaExceeded {
-			h.respondQuotaExceeded(c, teamID)
-			return
-		}
-		respondError(c, ErrInternal)
-		return
-	case dbErr != nil:
-		// DB insert failed but VMD succeeded — destroy the orphan VM so
-		// it doesn't linger on the host. Use a detached context so client
-		// disconnect doesn't leak the VM.
-		log.Error().Err(dbErr).Str("sandbox_id", sandboxID.String()).Msg("CreateSandbox: INSERT failed, destroying orphan VM")
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
-		cleanupCancel()
-		if templateRace {
-			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
-			return
-		}
-		if quotaExceeded {
-			h.respondQuotaExceeded(c, teamID)
-			return
-		}
-		respondError(c, ErrInternal)
-		return
-	case vmdErr != nil:
-		// VMD failed but DB row exists — mark it failed so the reaper
-		// doesn't leave it stuck in "starting". The request middleware
-		// records the create failure metric from the HTTP status, so avoid
-		// emitting a second request-scoped transition here.
+	if vmdErr != nil {
+		// The DB row was committed before boot. Mark it failed so the reaper
+		// doesn't leave it stuck in "starting", and best-effort destroy in
+		// case a cancelled/timed-out attempt completed on the host just after
+		// the client returned. The request middleware records the create
+		// failure metric from the HTTP status, so avoid emitting a second
+		// request-scoped transition here.
 		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Msg("VMD create/resume failed")
-		// A cancelled attempt can still complete on the host just after the
-		// deadline; best-effort destroy so a booted VM can't idle against a
-		// failed row until the reconciler sweeps it.
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
 		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
 		cleanupCancel()
@@ -2263,12 +2233,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		Str("sandbox_id", sandbox.ID.String()).
 		Int64("auth_ms", c.GetInt64("auth_ms")).
 		Int64("lookup_ms", tLookupDone.Sub(tStart).Milliseconds()).
-		Int64("sched_ms", tVmdStart.Sub(tLookupDone).Milliseconds()).
+		Int64("sched_ms", tInsertStart.Sub(tLookupDone).Milliseconds()).
 		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
 		Bool("vmd_retried", vmdRetried).
 		Int64("insert_ms", tInsertEnd.Sub(tInsertStart).Milliseconds()).
-		Int64("insert_wait_after_vmd_ms", tInsertReceive.Sub(tVmdEnd).Milliseconds()).
-		Int64("post_ms", tPostDone.Sub(tInsertReceive).Milliseconds()).
+		Int64("insert_wait_after_vmd_ms", 0).
+		Int64("post_ms", tPostDone.Sub(tVmdEnd).Milliseconds()).
 		Int64("total_ms", tPostDone.Sub(tStart).Milliseconds()).
 		Msg("CreateSandbox phases")
 	c.JSON(http.StatusCreated, resp)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1757,10 +1757,14 @@ func TestCreateSandbox_Success(t *testing.T) {
 	var attested bool
 	var insertedSandboxID, policySandboxID uuid.UUID
 	var insertedPolicyAccess string
+	var insertCommitted atomic.Bool
 	scheduler := &stubScheduler{hostID: "public-host"}
 	var policyInsertedAtomically bool
 	vmd := &stubVMD{
 		restorePolicyFn: func(access string, ports map[int32]vmdclient.PortPolicy, revision int64) {
+			if !insertCommitted.Load() {
+				t.Error("RestoreSnapshot ran before the sandbox INSERT completed")
+			}
 			restoredAccess, restoredPorts, restoredRevision = access, ports, revision
 		},
 		updatePreviewFn: func(_ context.Context, _ string, access string, ports map[int32]vmdclient.PortPolicy, revision int64) error {
@@ -1786,11 +1790,20 @@ func TestCreateSandbox_Success(t *testing.T) {
 						insertedPolicyAccess = access
 					}
 				}
-				return sandboxRow(db.Sandbox{
+				row := sandboxRow(db.Sandbox{
 					ID: sandboxID, TeamID: teamID, Name: "my-sandbox",
 					Status: db.SandboxStatusStarting, VcpuCount: 2, MemoryMib: 512,
 					CreatedAt: time.Now(),
 				})
+				return &mockRow{scanFn: func(dest ...any) error {
+					if err := row.Scan(dest...); err != nil {
+						return err
+					}
+					// QueryRow.Scan returning is the point at which the handler
+					// has observed the successful autocommit statement.
+					insertCommitted.Store(true)
+					return nil
+				}}
 			}
 			if strings.Contains(sql, "FROM template") {
 				return templateRow(defaultReadyTemplate())
@@ -1826,6 +1839,9 @@ func TestCreateSandbox_Success(t *testing.T) {
 	}
 	if !attested {
 		t.Error("create did not attest the live VMD after restore")
+	}
+	if !insertCommitted.Load() {
+		t.Error("successful create did not commit its sandbox row")
 	}
 	if insertedSandboxID == uuid.Nil || !policyInsertedAtomically || policySandboxID != insertedSandboxID || insertedPolicyAccess != preview.AccessPublic {
 		t.Errorf("inserted policy = (sandbox=%s access=%q), want sandbox=%s access=%q", policySandboxID, insertedPolicyAccess, insertedSandboxID, preview.AccessPublic)
@@ -2304,15 +2320,19 @@ func TestCreateSandbox_MissingTeamID(t *testing.T) {
 
 func TestCreateSandbox_QuotaExceeded(t *testing.T) {
 	teamID := uuid.New()
-	vmd := &stubVMD{}
-
-	// SS001 is what the sandbox_quota_on_insert trigger raises on over-quota.
-	var destroyCalled bool
-	vmd.destroyFn = func(_ context.Context, _ string, _ bool) error {
-		destroyCalled = true
-		return nil
+	var restoreCalls, destroyCalls atomic.Int32
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			restoreCalls.Add(1)
+			return "10.0.0.1", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyCalls.Add(1)
+			return nil
+		},
 	}
 
+	// SS001 is what the sandbox_quota_on_insert trigger raises on over-quota.
 	quotaErr := &pgconn.PgError{Code: "SS001", Message: "sandbox quota exceeded"}
 
 	mock := &mockDBTX{
@@ -2347,8 +2367,61 @@ func TestCreateSandbox_QuotaExceeded(t *testing.T) {
 	if errObj["code"] != "too_many_sandboxes" {
 		t.Errorf("error code = %v, want too_many_sandboxes", errObj["code"])
 	}
-	if !destroyCalled {
-		t.Error("orphan VM was not destroyed after quota rejection")
+	if got := restoreCalls.Load(); got != 0 {
+		t.Errorf("RestoreSnapshot calls = %d, want 0 after quota rejection", got)
+	}
+	if got := destroyCalls.Load(); got != 0 {
+		t.Errorf("DestroyInstance calls = %d, want 0 when no VM was started", got)
+	}
+}
+
+func TestCreateSandbox_HostAdmissionErrorHasNoVMDSideEffects(t *testing.T) {
+	teamID := uuid.New()
+	var restoreCalls, destroyCalls atomic.Int32
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			restoreCalls.Add(1)
+			return "10.0.0.1", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyCalls.Add(1)
+			return nil
+		},
+	}
+	admissionErr := &pgconn.PgError{
+		Code:    "SS006",
+		Message: "host admission denied for sandbox on host draining-host",
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+				return previewCapableHostRow()
+			case strings.Contains(sql, "INSERT INTO sandbox"):
+				return errorRow(admissionErr)
+			case strings.Contains(sql, "FROM template"):
+				return templateRow(defaultReadyTemplate())
+			default:
+				return errorRow(fmt.Errorf("unexpected query after admission rejection: %s", sql))
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.CommandTag{}, fmt.Errorf("unexpected exec after admission rejection: %s", sql)
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"rejected"}`))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	if got := restoreCalls.Load(); got != 0 {
+		t.Errorf("RestoreSnapshot calls = %d, want 0 after host admission rejection", got)
+	}
+	if got := destroyCalls.Load(); got != 0 {
+		t.Errorf("DestroyInstance calls = %d, want 0 when no VM was started", got)
 	}
 }
 
@@ -2358,9 +2431,14 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 
 	// With the superserve/base default, CreateSandbox routes through
 	// RestoreSnapshot. Fail it to exercise the VMD-error branch.
+	var destroyed, markedFailed, clearedBindings atomic.Bool
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "", fmt.Errorf("vmd unreachable")
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed.Store(true)
+			return nil
 		},
 	}
 
@@ -2380,7 +2458,16 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 			}
 			return activityRow()
 		},
-		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			switch {
+			case strings.Contains(sql, "SET status = $2"):
+				if got := args[1]; got != db.SandboxStatusFailed {
+					t.Errorf("compensating status = %v, want failed", got)
+				}
+				markedFailed.Store(true)
+			case strings.Contains(sql, "DELETE FROM sandbox_secret"):
+				clearedBindings.Store(true)
+			}
 			return pgconn.NewCommandTag("UPDATE 1"), nil
 		},
 	}
@@ -2392,6 +2479,10 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 	// Creation is synchronous — VMD error returns 500.
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !destroyed.Load() || !markedFailed.Load() || !clearedBindings.Load() {
+		t.Errorf("VMD failure compensation: destroyed=%v marked_failed=%v cleared_bindings=%v, want all true",
+			destroyed.Load(), markedFailed.Load(), clearedBindings.Load())
 	}
 }
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -61,6 +61,136 @@ func (ns NullSandboxStatus) Value() (driver.Value, error) {
 	return string(ns.SandboxStatus), nil
 }
 
+type SnapshotKind string
+
+const (
+	SnapshotKindRuntimeCheckpoint SnapshotKind = "runtime_checkpoint"
+	SnapshotKindSaved             SnapshotKind = "saved"
+)
+
+func (e *SnapshotKind) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = SnapshotKind(s)
+	case string:
+		*e = SnapshotKind(s)
+	default:
+		return fmt.Errorf("unsupported scan type for SnapshotKind: %T", src)
+	}
+	return nil
+}
+
+type NullSnapshotKind struct {
+	SnapshotKind SnapshotKind `json:"snapshot_kind"`
+	Valid        bool         `json:"valid"` // Valid is true if SnapshotKind is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullSnapshotKind) Scan(value interface{}) error {
+	if value == nil {
+		ns.SnapshotKind, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.SnapshotKind.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullSnapshotKind) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.SnapshotKind), nil
+}
+
+type SnapshotStatus string
+
+const (
+	SnapshotStatusCreating    SnapshotStatus = "creating"
+	SnapshotStatusReady       SnapshotStatus = "ready"
+	SnapshotStatusUnavailable SnapshotStatus = "unavailable"
+	SnapshotStatusFailed      SnapshotStatus = "failed"
+	SnapshotStatusDeleting    SnapshotStatus = "deleting"
+)
+
+func (e *SnapshotStatus) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = SnapshotStatus(s)
+	case string:
+		*e = SnapshotStatus(s)
+	default:
+		return fmt.Errorf("unsupported scan type for SnapshotStatus: %T", src)
+	}
+	return nil
+}
+
+type NullSnapshotStatus struct {
+	SnapshotStatus SnapshotStatus `json:"snapshot_status"`
+	Valid          bool           `json:"valid"` // Valid is true if SnapshotStatus is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullSnapshotStatus) Scan(value interface{}) error {
+	if value == nil {
+		ns.SnapshotStatus, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.SnapshotStatus.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullSnapshotStatus) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.SnapshotStatus), nil
+}
+
+type SnapshotStorageLayerKind string
+
+const (
+	SnapshotStorageLayerKindSavedSnapshot     SnapshotStorageLayerKind = "saved_snapshot"
+	SnapshotStorageLayerKindSandboxGeneration SnapshotStorageLayerKind = "sandbox_generation"
+	SnapshotStorageLayerKindSandboxWritable   SnapshotStorageLayerKind = "sandbox_writable"
+)
+
+func (e *SnapshotStorageLayerKind) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = SnapshotStorageLayerKind(s)
+	case string:
+		*e = SnapshotStorageLayerKind(s)
+	default:
+		return fmt.Errorf("unsupported scan type for SnapshotStorageLayerKind: %T", src)
+	}
+	return nil
+}
+
+type NullSnapshotStorageLayerKind struct {
+	SnapshotStorageLayerKind SnapshotStorageLayerKind `json:"snapshot_storage_layer_kind"`
+	Valid                    bool                     `json:"valid"` // Valid is true if SnapshotStorageLayerKind is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullSnapshotStorageLayerKind) Scan(value interface{}) error {
+	if value == nil {
+		ns.SnapshotStorageLayerKind, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.SnapshotStorageLayerKind.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullSnapshotStorageLayerKind) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.SnapshotStorageLayerKind), nil
+}
+
 type TemplateBuildStatus string
 
 const (
@@ -434,15 +564,19 @@ type Sandbox struct {
 	// Auto-pause timeout in seconds, evaluated against the current active session (re-armed on each resume). NULL = no timeout. Settable at create and via PATCH. The reaper pauses the sandbox on expiry; it does not delete it.
 	TimeoutSeconds *int32 `json:"timeout_seconds"`
 	// User-supplied flat string→string tags attached at creation. Immutable. Filterable on list endpoints via jsonb @> containment. Always non-null; an absent value is the empty object {}, never NULL.
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 type SandboxActiveInterval struct {
@@ -542,14 +676,69 @@ type Secret struct {
 }
 
 type Snapshot struct {
-	ID        uuid.UUID `json:"id"`
-	SandboxID uuid.UUID `json:"sandbox_id"`
-	TeamID    uuid.UUID `json:"team_id"`
-	Path      string    `json:"path"`
-	SizeBytes int64     `json:"size_bytes"`
-	Trigger   string    `json:"trigger"`
-	CreatedAt time.Time `json:"created_at"`
-	MemPath   *string   `json:"mem_path"`
+	ID                   uuid.UUID          `json:"id"`
+	SandboxID            uuid.UUID          `json:"sandbox_id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Path                 string             `json:"path"`
+	SizeBytes            int64              `json:"size_bytes"`
+	Trigger              string             `json:"trigger"`
+	CreatedAt            time.Time          `json:"created_at"`
+	MemPath              *string            `json:"mem_path"`
+	Kind                 SnapshotKind       `json:"kind"`
+	Status               SnapshotStatus     `json:"status"`
+	Name                 *string            `json:"name"`
+	IdempotencyKey       *string            `json:"idempotency_key"`
+	ParentSnapshotID     pgtype.UUID        `json:"parent_snapshot_id"`
+	SourceStatus         NullSandboxStatus  `json:"source_status"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	TemplateSnapshotPath *string            `json:"template_snapshot_path"`
+	TemplateMemPath      *string            `json:"template_mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	HostID               *string            `json:"host_id"`
+	VcpuCount            *int32             `json:"vcpu_count"`
+	MemoryMib            *int32             `json:"memory_mib"`
+	DiskMib              *int32             `json:"disk_mib"`
+	ManifestPath         *string            `json:"manifest_path"`
+	ManifestDigest       *string            `json:"manifest_digest"`
+	ArtifactMetadata     []byte             `json:"artifact_metadata"`
+	LogicalSizeBytes     int64              `json:"logical_size_bytes"`
+	ExclusiveSizeBytes   int64              `json:"exclusive_size_bytes"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	SecretBindings       []byte             `json:"secret_bindings"`
+	SecretEnvKeys        []byte             `json:"secret_env_keys"`
+	FailureReason        *string            `json:"failure_reason"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	FinalizedAt          pgtype.Timestamptz `json:"finalized_at"`
+	DeletedAt            pgtype.Timestamptz `json:"deleted_at"`
+}
+
+type SnapshotStorageLayer struct {
+	ID                         int64                    `json:"id"`
+	TeamID                     uuid.UUID                `json:"team_id"`
+	Kind                       SnapshotStorageLayerKind `json:"kind"`
+	OwnerSnapshotID            pgtype.UUID              `json:"owner_snapshot_id"`
+	OwnerSandboxID             pgtype.UUID              `json:"owner_sandbox_id"`
+	RetainedLogicalSizeBytes   int64                    `json:"retained_logical_size_bytes"`
+	CurrentLogicalSizeBytes    int64                    `json:"current_logical_size_bytes"`
+	RetainedExclusiveSizeBytes int64                    `json:"retained_exclusive_size_bytes"`
+	CurrentExclusiveSizeBytes  int64                    `json:"current_exclusive_size_bytes"`
+	ShadowOnly                 bool                     `json:"shadow_only"`
+	CreatedAt                  time.Time                `json:"created_at"`
+	UpdatedAt                  time.Time                `json:"updated_at"`
+	EndedAt                    pgtype.Timestamptz       `json:"ended_at"`
+}
+
+type SnapshotStorageReference struct {
+	ID         int64              `json:"id"`
+	LayerID    int64              `json:"layer_id"`
+	TeamID     uuid.UUID          `json:"team_id"`
+	SnapshotID pgtype.UUID        `json:"snapshot_id"`
+	SandboxID  pgtype.UUID        `json:"sandbox_id"`
+	CreatedAt  time.Time          `json:"created_at"`
+	ReleasedAt pgtype.Timestamptz `json:"released_at"`
 }
 
 type Team struct {
@@ -564,11 +753,15 @@ type Team struct {
 	MaxTemplates         *int32    `json:"max_templates"`
 	MaxSandboxes         int32     `json:"max_sandboxes"`
 	// Frozen at the sharded-counter migration; read team_active_sandbox_counts instead.
-	ActiveSandboxCount    int32  `json:"active_sandbox_count"`
-	CredentialStoreKind   string `json:"credential_store_kind"`
-	CredentialStoreConfig []byte `json:"credential_store_config"`
-	UnmatchedHostPolicy   string `json:"unmatched_host_policy"`
-	HomeRegion            string `json:"home_region"`
+	ActiveSandboxCount        int32  `json:"active_sandbox_count"`
+	CredentialStoreKind       string `json:"credential_store_kind"`
+	CredentialStoreConfig     []byte `json:"credential_store_config"`
+	UnmatchedHostPolicy       string `json:"unmatched_host_policy"`
+	HomeRegion                string `json:"home_region"`
+	MaxSnapshots              int32  `json:"max_snapshots"`
+	MaxSnapshotsPerSandbox    int32  `json:"max_snapshots_per_sandbox"`
+	SnapshotStorageQuotaBytes *int64 `json:"snapshot_storage_quota_bytes"`
+	SnapshotStorageBytes      int64  `json:"snapshot_storage_bytes"`
 }
 
 type TeamActiveSandboxCount struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -580,9 +580,9 @@ type CreateSandboxRow struct {
 }
 
 // ID is supplied by the caller (generated in Go via uuid.New()) rather
-// than defaulted in SQL, so the caller can parallelize this INSERT with
-// the VMD CreateVM call — both need the same sandbox_id and generating
-// it client-side lets them run concurrently instead of strictly serially.
+// than defaulted in SQL, so the committed row and later VMD operations
+// share one stable sandbox_id. Callers must wait for this statement before
+// starting VMD: its triggers own quota and final host admission.
 // template_id is optional (NULL when sandbox is not derived from a template).
 // snapshot_path / mem_path / base_path / delta_path pin the sandbox to a
 // specific build's artifacts so a later template rebuild can't corrupt it.

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -110,7 +110,7 @@ WITH paused AS (
     AND sandbox.team_id = $2
     AND sandbox.destroyed_at IS NULL
     AND sandbox.status = 'active'
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 ),
 closed_interval AS (
   UPDATE sandbox_active_interval
@@ -126,7 +126,7 @@ closed_billing_compute AS (
     AND ended_at IS NULL
   RETURNING sandbox_id
 )
-SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at
+SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at, p.source_snapshot_id, p.snapshot_operation_id, p.snapshot_operation_started_at, p.secret_env_keys
 FROM paused p
 LEFT JOIN closed_interval ci ON ci.sandbox_id = p.id
 `
@@ -137,30 +137,34 @@ type BeginPauseParams struct {
 }
 
 type BeginPauseRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	ID                         uuid.UUID          `json:"id"`
+	TeamID                     uuid.UUID          `json:"team_id"`
+	Name                       string             `json:"name"`
+	Status                     SandboxStatus      `json:"status"`
+	VcpuCount                  int32              `json:"vcpu_count"`
+	MemoryMib                  int32              `json:"memory_mib"`
+	HostID                     string             `json:"host_id"`
+	IpAddress                  *netip.Addr        `json:"ip_address"`
+	Pid                        *int32             `json:"pid"`
+	SnapshotID                 pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt                  time.Time          `json:"created_at"`
+	UpdatedAt                  time.Time          `json:"updated_at"`
+	DestroyedAt                pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig              []byte             `json:"network_config"`
+	TimeoutSeconds             *int32             `json:"timeout_seconds"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 // Atomic ownership + state check + transition to 'pausing' AND close of any
@@ -201,6 +205,10 @@ func (q *Queries) BeginPause(ctx context.Context, arg BeginPauseParams) (BeginPa
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -209,7 +217,7 @@ const beginResume = `-- name: BeginResume :one
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 `
 
 type BeginResumeParams struct {
@@ -249,6 +257,10 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -504,13 +516,13 @@ const createSandbox = `-- name: CreateSandbox :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.source_snapshot_id, ins.snapshot_operation_id, ins.snapshot_operation_started_at, ins.secret_env_keys FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -537,30 +549,34 @@ type CreateSandboxParams struct {
 }
 
 type CreateSandboxRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	ID                         uuid.UUID          `json:"id"`
+	TeamID                     uuid.UUID          `json:"team_id"`
+	Name                       string             `json:"name"`
+	Status                     SandboxStatus      `json:"status"`
+	VcpuCount                  int32              `json:"vcpu_count"`
+	MemoryMib                  int32              `json:"memory_mib"`
+	HostID                     string             `json:"host_id"`
+	IpAddress                  *netip.Addr        `json:"ip_address"`
+	Pid                        *int32             `json:"pid"`
+	SnapshotID                 pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt                  time.Time          `json:"created_at"`
+	UpdatedAt                  time.Time          `json:"updated_at"`
+	DestroyedAt                pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig              []byte             `json:"network_config"`
+	TimeoutSeconds             *int32             `json:"timeout_seconds"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 // ID is supplied by the caller (generated in Go via uuid.New()) rather
@@ -621,6 +637,10 @@ func (q *Queries) CreateSandbox(ctx context.Context, arg CreateSandboxParams) (C
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -635,13 +655,13 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
   SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib, $20 FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $21::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.source_snapshot_id, ins.snapshot_operation_id, ins.snapshot_operation_started_at, ins.secret_env_keys FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -670,30 +690,34 @@ type CreateSandboxFromTemplateParams struct {
 }
 
 type CreateSandboxFromTemplateRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	ID                         uuid.UUID          `json:"id"`
+	TeamID                     uuid.UUID          `json:"team_id"`
+	Name                       string             `json:"name"`
+	Status                     SandboxStatus      `json:"status"`
+	VcpuCount                  int32              `json:"vcpu_count"`
+	MemoryMib                  int32              `json:"memory_mib"`
+	HostID                     string             `json:"host_id"`
+	IpAddress                  *netip.Addr        `json:"ip_address"`
+	Pid                        *int32             `json:"pid"`
+	SnapshotID                 pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt                  time.Time          `json:"created_at"`
+	UpdatedAt                  time.Time          `json:"updated_at"`
+	DestroyedAt                pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig              []byte             `json:"network_config"`
+	TimeoutSeconds             *int32             `json:"timeout_seconds"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 // CreateSandbox variant that holds FOR KEY SHARE on the template row
@@ -750,6 +774,10 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -764,7 +792,7 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
   SELECT $4, $2, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, tpl_id, $15, $16, $17, $18, disk_mib, $19 FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $20::text, 0 FROM ins
@@ -774,7 +802,7 @@ WITH tpl AS (
   SELECT ins.id, ($21::uuid[])[i], ($22::text[])[i], ($23::text[])[i]
   FROM ins, generate_subscripts($21::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.source_snapshot_id, ins.snapshot_operation_id, ins.snapshot_operation_started_at, ins.secret_env_keys
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
@@ -806,30 +834,34 @@ type CreateSandboxFromTemplateWithSecretsParams struct {
 }
 
 type CreateSandboxFromTemplateWithSecretsRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	ID                         uuid.UUID          `json:"id"`
+	TeamID                     uuid.UUID          `json:"team_id"`
+	Name                       string             `json:"name"`
+	Status                     SandboxStatus      `json:"status"`
+	VcpuCount                  int32              `json:"vcpu_count"`
+	MemoryMib                  int32              `json:"memory_mib"`
+	HostID                     string             `json:"host_id"`
+	IpAddress                  *netip.Addr        `json:"ip_address"`
+	Pid                        *int32             `json:"pid"`
+	SnapshotID                 pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt                  time.Time          `json:"created_at"`
+	UpdatedAt                  time.Time          `json:"updated_at"`
+	DestroyedAt                pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig              []byte             `json:"network_config"`
+	TimeoutSeconds             *int32             `json:"timeout_seconds"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 // CreateSandboxFromTemplate plus secret bindings in one statement (see
@@ -888,6 +920,10 @@ func (q *Queries) CreateSandboxFromTemplateWithSecrets(ctx context.Context, arg 
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -896,7 +932,7 @@ const createSandboxWithSecrets = `-- name: CreateSandboxWithSecrets :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
@@ -906,7 +942,7 @@ WITH ins AS (
   SELECT ins.id, ($20::uuid[])[i], ($21::text[])[i], ($22::text[])[i]
   FROM ins, generate_subscripts($20::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.source_snapshot_id, ins.snapshot_operation_id, ins.snapshot_operation_started_at, ins.secret_env_keys FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -936,30 +972,34 @@ type CreateSandboxWithSecretsParams struct {
 }
 
 type CreateSandboxWithSecretsRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	ID                         uuid.UUID          `json:"id"`
+	TeamID                     uuid.UUID          `json:"team_id"`
+	Name                       string             `json:"name"`
+	Status                     SandboxStatus      `json:"status"`
+	VcpuCount                  int32              `json:"vcpu_count"`
+	MemoryMib                  int32              `json:"memory_mib"`
+	HostID                     string             `json:"host_id"`
+	IpAddress                  *netip.Addr        `json:"ip_address"`
+	Pid                        *int32             `json:"pid"`
+	SnapshotID                 pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt                  time.Time          `json:"created_at"`
+	UpdatedAt                  time.Time          `json:"updated_at"`
+	DestroyedAt                pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig              []byte             `json:"network_config"`
+	TimeoutSeconds             *int32             `json:"timeout_seconds"`
+	Metadata                   []byte             `json:"metadata"`
+	TemplateID                 pgtype.UUID        `json:"template_id"`
+	SnapshotPath               *string            `json:"snapshot_path"`
+	MemPath                    *string            `json:"mem_path"`
+	BasePath                   *string            `json:"base_path"`
+	DeltaPath                  *string            `json:"delta_path"`
+	DiskMib                    int32              `json:"disk_mib"`
+	AutoDeleteSeconds          *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt               pgtype.Timestamptz `json:"auto_delete_at"`
+	SourceSnapshotID           pgtype.UUID        `json:"source_snapshot_id"`
+	SnapshotOperationID        pgtype.UUID        `json:"snapshot_operation_id"`
+	SnapshotOperationStartedAt pgtype.Timestamptz `json:"snapshot_operation_started_at"`
+	SecretEnvKeys              []byte             `json:"secret_env_keys"`
 }
 
 // CreateSandbox plus its strict preview policy and secret bindings in ONE
@@ -1018,6 +1058,10 @@ func (q *Queries) CreateSandboxWithSecrets(ctx context.Context, arg CreateSandbo
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -1213,7 +1257,7 @@ func (q *Queries) GetPublishedPreviewPort(ctx context.Context, arg GetPublishedP
 }
 
 const getSandbox = `-- name: GetSandbox :one
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
 `
 
@@ -1250,6 +1294,10 @@ func (q *Queries) GetSandbox(ctx context.Context, arg GetSandboxParams) (Sandbox
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.SourceSnapshotID,
+		&i.SnapshotOperationID,
+		&i.SnapshotOperationStartedAt,
+		&i.SecretEnvKeys,
 	)
 	return i, err
 }
@@ -1479,7 +1527,7 @@ func (q *Queries) ListSandboxPreviewPoliciesByTeam(ctx context.Context, teamID u
 }
 
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, snap.path AS snapshot_path
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.source_snapshot_id, s.snapshot_operation_id, s.snapshot_operation_started_at, s.secret_env_keys, snap.path AS snapshot_path
 FROM sandbox s
 LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL
@@ -1526,6 +1574,10 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 			&i.Sandbox.DiskMib,
 			&i.Sandbox.AutoDeleteSeconds,
 			&i.Sandbox.AutoDeleteAt,
+			&i.Sandbox.SourceSnapshotID,
+			&i.Sandbox.SnapshotOperationID,
+			&i.Sandbox.SnapshotOperationStartedAt,
+			&i.Sandbox.SecretEnvKeys,
 			&i.SnapshotPath,
 		); err != nil {
 			return nil, err
@@ -1539,7 +1591,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 }
 
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, source_snapshot_id, snapshot_operation_id, snapshot_operation_started_at, secret_env_keys FROM sandbox
 WHERE team_id = $1
   AND destroyed_at IS NULL
   AND metadata @> $2
@@ -1621,6 +1673,10 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 			&i.DiskMib,
 			&i.AutoDeleteSeconds,
 			&i.AutoDeleteAt,
+			&i.SourceSnapshotID,
+			&i.SnapshotOperationID,
+			&i.SnapshotOperationStartedAt,
+			&i.SecretEnvKeys,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/saved_snapshot_expand_compat_test.go
+++ b/internal/db/saved_snapshot_expand_compat_test.go
@@ -19,8 +19,8 @@ func readSavedSnapshotExpandSQL(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("find expand migrations: %v", err)
 	}
-	if len(paths) != 8 {
-		t.Fatalf("found %d expand migrations, want 8", len(paths))
+	if len(paths) != 9 {
+		t.Fatalf("found %d expand migrations, want 9", len(paths))
 	}
 
 	var sql strings.Builder
@@ -79,6 +79,17 @@ func TestSavedSnapshotExpandPreservesLegacyPauseCompatibility(t *testing.T) {
 	}
 	if !strings.Contains(sql, "deleted saved snapshot cannot be resurrected") {
 		t.Fatal("expand migration does not enforce monotonic logical deletion")
+	}
+	if !strings.Contains(sql, "FOR SHARE") ||
+		!strings.Contains(sql, "trg_sandbox_host_admission_insert") ||
+		!strings.Contains(sql, "trg_template_build_host_admission") {
+		t.Fatal("expand migration does not enforce cross-version host admission")
+	}
+	if !strings.Contains(sql, "IF NOT EXISTS (SELECT 1 FROM public.host)") {
+		t.Fatal("expand migration does not constrain legacy host fallback to an empty registry")
+	}
+	if !strings.Contains(sql, "USING ERRCODE = 'SS006'") {
+		t.Fatal("expand migration does not expose unavailable hosts through the saved-host error contract")
 	}
 }
 

--- a/internal/db/saved_snapshot_expand_compat_test.go
+++ b/internal/db/saved_snapshot_expand_compat_test.go
@@ -66,6 +66,9 @@ func TestSavedSnapshotExpandPreservesLegacyPauseCompatibility(t *testing.T) {
 	if !strings.Contains(sql, "CREATE TRIGGER trg_remember_sandbox_secret_env_key") {
 		t.Fatal("expand migration does not preserve secret scrub history for legacy writers")
 	}
+	if !strings.Contains(sql, "jsonb_array_elements_text(s.secret_env_keys)") {
+		t.Fatal("secret-history backfill does not merge concurrently recorded trigger history")
+	}
 	if !strings.Contains(sql, "deleted saved snapshot cannot be resurrected") {
 		t.Fatal("expand migration does not enforce monotonic logical deletion")
 	}

--- a/internal/db/saved_snapshot_expand_compat_test.go
+++ b/internal/db/saved_snapshot_expand_compat_test.go
@@ -66,7 +66,15 @@ func TestSavedSnapshotExpandPreservesLegacyPauseCompatibility(t *testing.T) {
 	if !strings.Contains(sql, "CREATE TRIGGER trg_remember_sandbox_secret_env_key") {
 		t.Fatal("expand migration does not preserve secret scrub history for legacy writers")
 	}
-	if !strings.Contains(sql, "jsonb_array_elements_text(s.secret_env_keys)") {
+	backfillPath := filepath.Join(
+		"..", "..", "supabase", "migrations",
+		"20260729000004_saved_snapshot_secret_history.sql",
+	)
+	backfill, err := os.ReadFile(backfillPath)
+	if err != nil {
+		t.Fatalf("read secret-history backfill: %v", err)
+	}
+	if !strings.Contains(string(backfill), "jsonb_array_elements_text(merged.keys)") {
 		t.Fatal("secret-history backfill does not merge concurrently recorded trigger history")
 	}
 	if !strings.Contains(sql, "deleted saved snapshot cannot be resurrected") {

--- a/internal/db/saved_snapshot_expand_compat_test.go
+++ b/internal/db/saved_snapshot_expand_compat_test.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readSavedSnapshotExpandSQL(t *testing.T) string {
+	t.Helper()
+
+	pattern := filepath.Join(
+		"..", "..", "supabase", "migrations",
+		"2026072900000*_saved_snapshot*.sql",
+	)
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("find expand migrations: %v", err)
+	}
+	if len(paths) != 8 {
+		t.Fatalf("found %d expand migrations, want 8", len(paths))
+	}
+
+	var sql strings.Builder
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read expand migration %s: %v", path, err)
+		}
+		sql.Write(raw)
+		sql.WriteByte('\n')
+	}
+	return sql.String()
+}
+
+func TestSavedSnapshotExpandPreservesLegacyPauseCompatibility(t *testing.T) {
+	sql := readSavedSnapshotExpandSQL(t)
+
+	dropsLegacyIndex := regexp.MustCompile(
+		`(?is)DROP\s+INDEX(?:\s+IF\s+EXISTS)?\s+(?:public\.)?snapshot_sandbox_unique\b`,
+	)
+	if dropsLegacyIndex.MatchString(sql) {
+		t.Fatal("expand migration drops snapshot_sandbox_unique before old FinalizePause writers are retired")
+	}
+	if strings.Contains(sql, "CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique") {
+		t.Fatal("expand migration builds a hot-table index before the pre-contract maintenance gate")
+	}
+	if !strings.Contains(sql, "SET LOCAL lock_timeout = '5s'") {
+		t.Fatal("expand migration does not bound lock acquisition time")
+	}
+	if !strings.Contains(sql, "SET LOCAL statement_timeout = '30s'") {
+		t.Fatal("expand migration does not bound hot-table lock duration")
+	}
+	if !strings.Contains(sql, "expand requires the legacy non-partial snapshot_sandbox_unique index") {
+		t.Fatal("expand migration does not verify its legacy conflict target")
+	}
+	if !strings.Contains(sql, "'sandbox_snapshots_v1',\n    false,") {
+		t.Fatal("expand migration does not keep saved snapshots disabled by default")
+	}
+	if !strings.Contains(sql, "ON CONFLICT (key) DO UPDATE") ||
+		!strings.Contains(sql, "WHERE key = 'sandbox_snapshots_v1'\n  AND enabled") {
+		t.Fatal("expand migration does not disable existing global and team feature flags")
+	}
+	if !strings.Contains(sql, "CREATE TRIGGER trg_remember_sandbox_secret_env_key") {
+		t.Fatal("expand migration does not preserve secret scrub history for legacy writers")
+	}
+	if !strings.Contains(sql, "deleted saved snapshot cannot be resurrected") {
+		t.Fatal("expand migration does not enforce monotonic logical deletion")
+	}
+}
+
+func TestSavedSnapshotExpandProtectsInternalLedgerWithRLS(t *testing.T) {
+	sql := readSavedSnapshotExpandSQL(t)
+
+	for _, table := range []string{
+		"snapshot_storage_layer",
+		"snapshot_storage_reference",
+	} {
+		if !strings.Contains(sql, "CREATE TABLE "+table) {
+			t.Errorf("expand migration does not create %s", table)
+		}
+		if !strings.Contains(sql, "ALTER TABLE public."+table+" ENABLE ROW LEVEL SECURITY") {
+			t.Errorf("expand migration does not enable RLS on %s", table)
+		}
+	}
+}

--- a/internal/db/snapshots.sql.go
+++ b/internal/db/snapshots.sql.go
@@ -14,7 +14,7 @@ import (
 const createSnapshot = `-- name: CreateSnapshot :one
 INSERT INTO snapshot (sandbox_id, team_id, path, mem_path, size_bytes, trigger)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path
+RETURNING id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path, kind, status, name, idempotency_key, parent_snapshot_id, source_status, template_id, template_snapshot_path, template_mem_path, base_path, delta_path, host_id, vcpu_count, memory_mib, disk_mib, manifest_path, manifest_digest, artifact_metadata, logical_size_bytes, exclusive_size_bytes, network_config, timeout_seconds, auto_delete_seconds, secret_bindings, secret_env_keys, failure_reason, updated_at, finalized_at, deleted_at
 `
 
 type CreateSnapshotParams struct {
@@ -45,6 +45,35 @@ func (q *Queries) CreateSnapshot(ctx context.Context, arg CreateSnapshotParams) 
 		&i.Trigger,
 		&i.CreatedAt,
 		&i.MemPath,
+		&i.Kind,
+		&i.Status,
+		&i.Name,
+		&i.IdempotencyKey,
+		&i.ParentSnapshotID,
+		&i.SourceStatus,
+		&i.TemplateID,
+		&i.TemplateSnapshotPath,
+		&i.TemplateMemPath,
+		&i.BasePath,
+		&i.DeltaPath,
+		&i.HostID,
+		&i.VcpuCount,
+		&i.MemoryMib,
+		&i.DiskMib,
+		&i.ManifestPath,
+		&i.ManifestDigest,
+		&i.ArtifactMetadata,
+		&i.LogicalSizeBytes,
+		&i.ExclusiveSizeBytes,
+		&i.NetworkConfig,
+		&i.TimeoutSeconds,
+		&i.AutoDeleteSeconds,
+		&i.SecretBindings,
+		&i.SecretEnvKeys,
+		&i.FailureReason,
+		&i.UpdatedAt,
+		&i.FinalizedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -83,7 +112,7 @@ func (q *Queries) DeleteSnapshotsOfDestroyedSandboxes(ctx context.Context) (int6
 }
 
 const getSnapshot = `-- name: GetSnapshot :one
-SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path FROM snapshot
+SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path, kind, status, name, idempotency_key, parent_snapshot_id, source_status, template_id, template_snapshot_path, template_mem_path, base_path, delta_path, host_id, vcpu_count, memory_mib, disk_mib, manifest_path, manifest_digest, artifact_metadata, logical_size_bytes, exclusive_size_bytes, network_config, timeout_seconds, auto_delete_seconds, secret_bindings, secret_env_keys, failure_reason, updated_at, finalized_at, deleted_at FROM snapshot
 WHERE id = $1 AND team_id = $2
 `
 
@@ -108,12 +137,41 @@ func (q *Queries) GetSnapshot(ctx context.Context, arg GetSnapshotParams) (Snaps
 		&i.Trigger,
 		&i.CreatedAt,
 		&i.MemPath,
+		&i.Kind,
+		&i.Status,
+		&i.Name,
+		&i.IdempotencyKey,
+		&i.ParentSnapshotID,
+		&i.SourceStatus,
+		&i.TemplateID,
+		&i.TemplateSnapshotPath,
+		&i.TemplateMemPath,
+		&i.BasePath,
+		&i.DeltaPath,
+		&i.HostID,
+		&i.VcpuCount,
+		&i.MemoryMib,
+		&i.DiskMib,
+		&i.ManifestPath,
+		&i.ManifestDigest,
+		&i.ArtifactMetadata,
+		&i.LogicalSizeBytes,
+		&i.ExclusiveSizeBytes,
+		&i.NetworkConfig,
+		&i.TimeoutSeconds,
+		&i.AutoDeleteSeconds,
+		&i.SecretBindings,
+		&i.SecretEnvKeys,
+		&i.FailureReason,
+		&i.UpdatedAt,
+		&i.FinalizedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const getSnapshotByID = `-- name: GetSnapshotByID :one
-SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path FROM snapshot
+SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path, kind, status, name, idempotency_key, parent_snapshot_id, source_status, template_id, template_snapshot_path, template_mem_path, base_path, delta_path, host_id, vcpu_count, memory_mib, disk_mib, manifest_path, manifest_digest, artifact_metadata, logical_size_bytes, exclusive_size_bytes, network_config, timeout_seconds, auto_delete_seconds, secret_bindings, secret_env_keys, failure_reason, updated_at, finalized_at, deleted_at FROM snapshot
 WHERE id = $1
 `
 
@@ -131,12 +189,41 @@ func (q *Queries) GetSnapshotByID(ctx context.Context, id uuid.UUID) (Snapshot, 
 		&i.Trigger,
 		&i.CreatedAt,
 		&i.MemPath,
+		&i.Kind,
+		&i.Status,
+		&i.Name,
+		&i.IdempotencyKey,
+		&i.ParentSnapshotID,
+		&i.SourceStatus,
+		&i.TemplateID,
+		&i.TemplateSnapshotPath,
+		&i.TemplateMemPath,
+		&i.BasePath,
+		&i.DeltaPath,
+		&i.HostID,
+		&i.VcpuCount,
+		&i.MemoryMib,
+		&i.DiskMib,
+		&i.ManifestPath,
+		&i.ManifestDigest,
+		&i.ArtifactMetadata,
+		&i.LogicalSizeBytes,
+		&i.ExclusiveSizeBytes,
+		&i.NetworkConfig,
+		&i.TimeoutSeconds,
+		&i.AutoDeleteSeconds,
+		&i.SecretBindings,
+		&i.SecretEnvKeys,
+		&i.FailureReason,
+		&i.UpdatedAt,
+		&i.FinalizedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const listSnapshotsBySandbox = `-- name: ListSnapshotsBySandbox :many
-SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path FROM snapshot
+SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path, kind, status, name, idempotency_key, parent_snapshot_id, source_status, template_id, template_snapshot_path, template_mem_path, base_path, delta_path, host_id, vcpu_count, memory_mib, disk_mib, manifest_path, manifest_digest, artifact_metadata, logical_size_bytes, exclusive_size_bytes, network_config, timeout_seconds, auto_delete_seconds, secret_bindings, secret_env_keys, failure_reason, updated_at, finalized_at, deleted_at FROM snapshot
 WHERE sandbox_id = $1
 ORDER BY created_at DESC
 `
@@ -159,6 +246,35 @@ func (q *Queries) ListSnapshotsBySandbox(ctx context.Context, sandboxID uuid.UUI
 			&i.Trigger,
 			&i.CreatedAt,
 			&i.MemPath,
+			&i.Kind,
+			&i.Status,
+			&i.Name,
+			&i.IdempotencyKey,
+			&i.ParentSnapshotID,
+			&i.SourceStatus,
+			&i.TemplateID,
+			&i.TemplateSnapshotPath,
+			&i.TemplateMemPath,
+			&i.BasePath,
+			&i.DeltaPath,
+			&i.HostID,
+			&i.VcpuCount,
+			&i.MemoryMib,
+			&i.DiskMib,
+			&i.ManifestPath,
+			&i.ManifestDigest,
+			&i.ArtifactMetadata,
+			&i.LogicalSizeBytes,
+			&i.ExclusiveSizeBytes,
+			&i.NetworkConfig,
+			&i.TimeoutSeconds,
+			&i.AutoDeleteSeconds,
+			&i.SecretBindings,
+			&i.SecretEnvKeys,
+			&i.FailureReason,
+			&i.UpdatedAt,
+			&i.FinalizedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -171,7 +287,7 @@ func (q *Queries) ListSnapshotsBySandbox(ctx context.Context, sandboxID uuid.UUI
 }
 
 const listSnapshotsByTeam = `-- name: ListSnapshotsByTeam :many
-SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path FROM snapshot
+SELECT id, sandbox_id, team_id, path, size_bytes, trigger, created_at, mem_path, kind, status, name, idempotency_key, parent_snapshot_id, source_status, template_id, template_snapshot_path, template_mem_path, base_path, delta_path, host_id, vcpu_count, memory_mib, disk_mib, manifest_path, manifest_digest, artifact_metadata, logical_size_bytes, exclusive_size_bytes, network_config, timeout_seconds, auto_delete_seconds, secret_bindings, secret_env_keys, failure_reason, updated_at, finalized_at, deleted_at FROM snapshot
 WHERE team_id = $1
 ORDER BY created_at DESC
 `
@@ -194,6 +310,35 @@ func (q *Queries) ListSnapshotsByTeam(ctx context.Context, teamID uuid.UUID) ([]
 			&i.Trigger,
 			&i.CreatedAt,
 			&i.MemPath,
+			&i.Kind,
+			&i.Status,
+			&i.Name,
+			&i.IdempotencyKey,
+			&i.ParentSnapshotID,
+			&i.SourceStatus,
+			&i.TemplateID,
+			&i.TemplateSnapshotPath,
+			&i.TemplateMemPath,
+			&i.BasePath,
+			&i.DeltaPath,
+			&i.HostID,
+			&i.VcpuCount,
+			&i.MemoryMib,
+			&i.DiskMib,
+			&i.ManifestPath,
+			&i.ManifestDigest,
+			&i.ArtifactMetadata,
+			&i.LogicalSizeBytes,
+			&i.ExclusiveSizeBytes,
+			&i.NetworkConfig,
+			&i.TimeoutSeconds,
+			&i.AutoDeleteSeconds,
+			&i.SecretBindings,
+			&i.SecretEnvKeys,
+			&i.FailureReason,
+			&i.UpdatedAt,
+			&i.FinalizedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/teams.sql.go
+++ b/internal/db/teams.sql.go
@@ -14,7 +14,7 @@ import (
 const createTeam = `-- name: CreateTeam :one
 INSERT INTO team (name)
 VALUES ($1)
-RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region, max_snapshots, max_snapshots_per_sandbox, snapshot_storage_quota_bytes, snapshot_storage_bytes
 `
 
 func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
@@ -36,6 +36,10 @@ func (q *Queries) CreateTeam(ctx context.Context, name string) (Team, error) {
 		&i.CredentialStoreConfig,
 		&i.UnmatchedHostPolicy,
 		&i.HomeRegion,
+		&i.MaxSnapshots,
+		&i.MaxSnapshotsPerSandbox,
+		&i.SnapshotStorageQuotaBytes,
+		&i.SnapshotStorageBytes,
 	)
 	return i, err
 }
@@ -51,7 +55,7 @@ func (q *Queries) DeleteTeam(ctx context.Context, id uuid.UUID) error {
 }
 
 const getTeam = `-- name: GetTeam :one
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region, max_snapshots, max_snapshots_per_sandbox, snapshot_storage_quota_bytes, snapshot_storage_bytes FROM team
 WHERE id = $1
 `
 
@@ -74,6 +78,10 @@ func (q *Queries) GetTeam(ctx context.Context, id uuid.UUID) (Team, error) {
 		&i.CredentialStoreConfig,
 		&i.UnmatchedHostPolicy,
 		&i.HomeRegion,
+		&i.MaxSnapshots,
+		&i.MaxSnapshotsPerSandbox,
+		&i.SnapshotStorageQuotaBytes,
+		&i.SnapshotStorageBytes,
 	)
 	return i, err
 }
@@ -91,7 +99,7 @@ func (q *Queries) GetTeamBuildConcurrency(ctx context.Context, id uuid.UUID) (in
 }
 
 const getTeamByName = `-- name: GetTeamByName :one
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region, max_snapshots, max_snapshots_per_sandbox, snapshot_storage_quota_bytes, snapshot_storage_bytes FROM team
 WHERE name = $1
 `
 
@@ -114,12 +122,16 @@ func (q *Queries) GetTeamByName(ctx context.Context, name string) (Team, error) 
 		&i.CredentialStoreConfig,
 		&i.UnmatchedHostPolicy,
 		&i.HomeRegion,
+		&i.MaxSnapshots,
+		&i.MaxSnapshotsPerSandbox,
+		&i.SnapshotStorageQuotaBytes,
+		&i.SnapshotStorageBytes,
 	)
 	return i, err
 }
 
 const listTeams = `-- name: ListTeams :many
-SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region FROM team
+SELECT id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region, max_snapshots, max_snapshots_per_sandbox, snapshot_storage_quota_bytes, snapshot_storage_bytes FROM team
 ORDER BY created_at DESC
 `
 
@@ -148,6 +160,10 @@ func (q *Queries) ListTeams(ctx context.Context) ([]Team, error) {
 			&i.CredentialStoreConfig,
 			&i.UnmatchedHostPolicy,
 			&i.HomeRegion,
+			&i.MaxSnapshots,
+			&i.MaxSnapshotsPerSandbox,
+			&i.SnapshotStorageQuotaBytes,
+			&i.SnapshotStorageBytes,
 		); err != nil {
 			return nil, err
 		}
@@ -163,7 +179,7 @@ const updateTeamName = `-- name: UpdateTeamName :one
 UPDATE team
 SET name = $2, updated_at = now()
 WHERE id = $1
-RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region
+RETURNING id, name, created_at, updated_at, build_concurrency, max_template_vcpu, max_template_memory_mib, max_template_disk_mib, max_templates, max_sandboxes, active_sandbox_count, credential_store_kind, credential_store_config, unmatched_host_policy, home_region, max_snapshots, max_snapshots_per_sandbox, snapshot_storage_quota_bytes, snapshot_storage_bytes
 `
 
 type UpdateTeamNameParams struct {
@@ -190,6 +206,10 @@ func (q *Queries) UpdateTeamName(ctx context.Context, arg UpdateTeamNameParams) 
 		&i.CredentialStoreConfig,
 		&i.UnmatchedHostPolicy,
 		&i.HomeRegion,
+		&i.MaxSnapshots,
+		&i.MaxSnapshotsPerSandbox,
+		&i.SnapshotStorageQuotaBytes,
+		&i.SnapshotStorageBytes,
 	)
 	return i, err
 }

--- a/internal/integration/host_admission_test.go
+++ b/internal/integration/host_admission_test.go
@@ -1,0 +1,341 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func insertHostAdmissionHost(t *testing.T, tx pgx.Tx, status string) string {
+	t.Helper()
+
+	hostID := "admission-" + status + "-" + uuid.NewString()
+	if _, err := tx.Exec(context.Background(), `
+		INSERT INTO host (
+		    id, vmd_addr, proxy_addr, region, status,
+		    capacity_memory_mib, capacity_vcpus
+		)
+		VALUES ($1, '127.0.0.1:1', '127.0.0.1:2', 'test', $2, 1024, 1)
+	`, hostID, status); err != nil {
+		t.Fatalf("insert %s host: %v", status, err)
+	}
+	return hostID
+}
+
+func insertHostAdmissionSandbox(
+	t *testing.T,
+	tx pgx.Tx,
+	hostID string,
+	status string,
+) uuid.UUID {
+	t.Helper()
+
+	sandboxID := uuid.New()
+	if _, err := tx.Exec(context.Background(), `
+		INSERT INTO sandbox (id, team_id, name, status, host_id)
+		VALUES ($1, $2, $3, $4::sandbox_status, $5)
+	`, sandboxID, testSystemTeamID, "host-admission-"+uuid.NewString(), status, hostID); err != nil {
+		t.Fatalf("insert %s sandbox: %v", status, err)
+	}
+	return sandboxID
+}
+
+func requireHostAdmissionRejection(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("host admission unexpectedly succeeded")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		t.Fatalf("host admission error = %T %v, want PostgreSQL error", err, err)
+	}
+	if pgErr.Code != "SS006" {
+		t.Fatalf("host admission SQLSTATE = %s, want SS006: %v", pgErr.Code, err)
+	}
+	if !strings.Contains(pgErr.Message, "host admission denied") {
+		t.Fatalf("host admission message = %q, want admission denial", pgErr.Message)
+	}
+}
+
+func TestHostAdmissionAllowsActiveHostAndLifecycleCompletion(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	hostID := insertHostAdmissionHost(t, tx, "active")
+	startingID := insertHostAdmissionSandbox(t, tx, hostID, "starting")
+	resumingID := insertHostAdmissionSandbox(t, tx, hostID, "paused")
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE sandbox
+		SET status = 'resuming'
+		WHERE id = $1
+	`, resumingID); err != nil {
+		t.Fatalf("admit resume on active host: %v", err)
+	}
+
+	var templateID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		SELECT id
+		FROM template
+		WHERE team_id = $1
+		ORDER BY created_at
+		LIMIT 1
+	`, testSystemTeamID).Scan(&templateID); err != nil {
+		t.Fatalf("find template: %v", err)
+	}
+	var buildID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO template_build (
+		    template_id, team_id, build_spec_hash
+		)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, templateID, testSystemTeamID, uuid.NewString()).Scan(&buildID); err != nil {
+		t.Fatalf("insert pending template build: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE template_build
+		SET status = 'building',
+		    vmd_host_id = $2,
+		    vmd_build_vm_id = $3
+		WHERE id = $1 AND status = 'pending'
+	`, buildID, hostID, "build-"+uuid.NewString()); err != nil {
+		t.Fatalf("dispatch template build on active host: %v", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE host SET status = 'draining' WHERE id = $1
+	`, hostID); err != nil {
+		t.Fatalf("drain admitted host: %v", err)
+	}
+
+	// These are bookkeeping completions for launches admitted while the host
+	// was active. A later drain must not strand either row in a transitional
+	// state.
+	for _, sandboxID := range []uuid.UUID{startingID, resumingID} {
+		if _, err := tx.Exec(ctx, `
+			UPDATE sandbox SET status = 'active' WHERE id = $1
+		`, sandboxID); err != nil {
+			t.Fatalf("complete admitted sandbox %s after drain: %v", sandboxID, err)
+		}
+	}
+}
+
+func TestHostAdmissionSerializesWithHostDrain(t *testing.T) {
+	ctx := context.Background()
+	hostID := "admission-lock-" + uuid.NewString()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO host (
+		    id, vmd_addr, proxy_addr, region, status,
+		    capacity_memory_mib, capacity_vcpus
+		)
+		VALUES ($1, '127.0.0.1:1', '127.0.0.1:2', 'test', 'active', 1024, 1)
+	`, hostID); err != nil {
+		t.Fatalf("insert active host: %v", err)
+	}
+
+	sandboxID := uuid.New()
+	defer func() {
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM sandbox WHERE id = $1`, sandboxID)
+		_, _ = testPool.Exec(context.Background(), `DELETE FROM host WHERE id = $1`, hostID)
+	}()
+
+	admissionTx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin admission: %v", err)
+	}
+	defer admissionTx.Rollback(ctx)
+	if _, err := admissionTx.Exec(ctx, `
+		INSERT INTO sandbox (id, team_id, name, status, host_id)
+		VALUES ($1, $2, $3, 'starting', $4)
+	`, sandboxID, testSystemTeamID, "serialized-"+uuid.NewString(), hostID); err != nil {
+		t.Fatalf("admit sandbox: %v", err)
+	}
+
+	drainTx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin drain: %v", err)
+	}
+	defer drainTx.Rollback(ctx)
+	if _, err := drainTx.Exec(ctx, `SET LOCAL lock_timeout = '100ms'`); err != nil {
+		t.Fatalf("set drain lock timeout: %v", err)
+	}
+	_, err = drainTx.Exec(ctx, `
+		UPDATE host SET status = 'draining' WHERE id = $1
+	`, hostID)
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "55P03" {
+		t.Fatalf("concurrent drain error = %v, want lock timeout 55P03", err)
+	}
+	if err := drainTx.Rollback(ctx); err != nil {
+		t.Fatalf("rollback blocked drain: %v", err)
+	}
+
+	if err := admissionTx.Commit(ctx); err != nil {
+		t.Fatalf("commit admission: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE host SET status = 'draining' WHERE id = $1
+	`, hostID); err != nil {
+		t.Fatalf("drain after admission commit: %v", err)
+	}
+}
+
+func TestHostAdmissionRejectsUnavailableSandboxInsert(t *testing.T) {
+	for _, status := range []string{"draining", "unhealthy"} {
+		t.Run(status, func(t *testing.T) {
+			ctx := context.Background()
+			tx, err := testPool.Begin(ctx)
+			if err != nil {
+				t.Fatalf("begin: %v", err)
+			}
+			defer tx.Rollback(ctx)
+
+			hostID := insertHostAdmissionHost(t, tx, status)
+			_, err = tx.Exec(ctx, `
+				INSERT INTO sandbox (id, team_id, name, status, host_id)
+				VALUES ($1, $2, $3, 'starting', $4)
+			`, uuid.New(), testSystemTeamID, "rejected-"+uuid.NewString(), hostID)
+			requireHostAdmissionRejection(t, err)
+		})
+	}
+}
+
+func TestHostAdmissionTriggerRunsForNonOwnerWithoutFunctionExecute(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	role := "host_admission_app_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	quotedRole := pgx.Identifier{role}.Sanitize()
+	if _, err := tx.Exec(ctx, "CREATE ROLE "+quotedRole+" NOLOGIN BYPASSRLS"); err != nil {
+		t.Fatalf("create app role: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "GRANT USAGE ON SCHEMA public TO "+quotedRole); err != nil {
+		t.Fatalf("grant schema usage: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "GRANT INSERT ON sandbox TO "+quotedRole); err != nil {
+		t.Fatalf("grant sandbox insert: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE "+quotedRole); err != nil {
+		t.Fatalf("assume app role: %v", err)
+	}
+
+	// Trigger functions are intentionally not executable by PUBLIC. PostgreSQL
+	// invokes them through the trigger, and their SECURITY DEFINER owner can
+	// still call the private admission helper.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO sandbox (id, team_id, name, status, host_id)
+		VALUES ($1, $2, $3, 'starting', $4)
+	`, uuid.New(), testSystemTeamID, "non-owner-"+uuid.NewString(), "missing-host")
+	requireHostAdmissionRejection(t, err)
+}
+
+func TestHostAdmissionAllowsLegacyFallbackOnlyWithEmptyHostTable(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Isolate the compatibility condition from the suite's seeded default
+	// host. The rollback restores every host and capability row.
+	if _, err := tx.Exec(ctx, `LOCK TABLE host IN ACCESS EXCLUSIVE MODE`); err != nil {
+		t.Fatalf("lock host registry: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM host`); err != nil {
+		t.Fatalf("empty host registry: %v", err)
+	}
+	insertHostAdmissionSandbox(t, tx, "legacy-default", "starting")
+}
+
+func TestHostAdmissionRejectsResumeOnDrainingHost(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	hostID := insertHostAdmissionHost(t, tx, "draining")
+	sandboxID := insertHostAdmissionSandbox(t, tx, hostID, "paused")
+	_, err = tx.Exec(ctx, `
+		UPDATE sandbox SET status = 'resuming' WHERE id = $1
+	`, sandboxID)
+	requireHostAdmissionRejection(t, err)
+}
+
+func TestHostAdmissionRejectsLiveSandboxHostChange(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	activeHostID := insertHostAdmissionHost(t, tx, "active")
+	drainingHostID := insertHostAdmissionHost(t, tx, "draining")
+	sandboxID := insertHostAdmissionSandbox(t, tx, activeHostID, "active")
+
+	_, err = tx.Exec(ctx, `
+		UPDATE sandbox SET host_id = $2 WHERE id = $1
+	`, sandboxID, drainingHostID)
+	requireHostAdmissionRejection(t, err)
+}
+
+func TestHostAdmissionRejectsTemplateDispatchOnDrainingHost(t *testing.T) {
+	ctx := context.Background()
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	hostID := insertHostAdmissionHost(t, tx, "draining")
+	var templateID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		SELECT id
+		FROM template
+		WHERE team_id = $1
+		ORDER BY created_at
+		LIMIT 1
+	`, testSystemTeamID).Scan(&templateID); err != nil {
+		t.Fatalf("find template: %v", err)
+	}
+
+	var buildID uuid.UUID
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO template_build (
+		    template_id, team_id, build_spec_hash
+		)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, templateID, testSystemTeamID, uuid.NewString()).Scan(&buildID); err != nil {
+		t.Fatalf("insert pending template build: %v", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE template_build
+		SET status = 'building',
+		    vmd_host_id = $2,
+		    vmd_build_vm_id = $3
+		WHERE id = $1 AND status = 'pending'
+	`, buildID, hostID, "build-"+uuid.NewString())
+	requireHostAdmissionRejection(t, err)
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -4398,8 +4398,8 @@ func TestIntegration_DeleteStaleTransitionalSandbox(t *testing.T) {
 	insert := func(updatedAt time.Time) uuid.UUID {
 		id := uuid.New()
 		if _, err := testPool.Exec(ctx,
-			`INSERT INTO sandbox (id, team_id, name, status, host_id, updated_at) VALUES ($1,$2,$3,'resuming','host-1',$4)`,
-			id, teamID, "wedged", updatedAt); err != nil {
+			`INSERT INTO sandbox (id, team_id, name, status, host_id, updated_at) VALUES ($1,$2,$3,'resuming',$4,$5)`,
+			id, teamID, "wedged", testDefaultHostID, updatedAt); err != nil {
 			t.Fatalf("insert: %v", err)
 		}
 		return id

--- a/internal/integration/pagination_test.go
+++ b/internal/integration/pagination_test.go
@@ -17,13 +17,14 @@ import (
 func insertSandboxAt(t *testing.T, teamID uuid.UUID, name, status string, createdAt time.Time) uuid.UUID {
 	t.Helper()
 	id := uuid.New()
-	// host_id is NOT NULL (migration 20260410000001); supply a placeholder like
-	// the other integration sandbox inserts do. created_at is set explicitly so
-	// the sort assertions are deterministic.
+	// host_id is NOT NULL (migration 20260410000001). Use TestMain's active
+	// registered host so this fixture follows the same admission invariant as
+	// application-created sandboxes. created_at is explicit for deterministic
+	// sort assertions.
 	if _, err := testPool.Exec(context.Background(),
 		`INSERT INTO sandbox (id, team_id, name, status, host_id, created_at)
-		 VALUES ($1, $2, $3, $4::sandbox_status, 'test-host', $5)`,
-		id, teamID, name, status, createdAt,
+		 VALUES ($1, $2, $3, $4::sandbox_status, $5, $6)`,
+		id, teamID, name, status, testDefaultHostID, createdAt,
 	); err != nil {
 		t.Fatalf("insert sandbox %q: %v", name, err)
 	}

--- a/internal/integration/saved_snapshot_expand_test.go
+++ b/internal/integration/saved_snapshot_expand_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -172,6 +173,151 @@ func TestSavedSnapshotExpandTracksLegacySecretHistory(t *testing.T) {
 		t.Fatalf("legacy detach secret: %v", err)
 	}
 	assertSandboxSecretHistory(t, ctx, sandboxID, []string{"LEGACY_TOKEN"})
+}
+
+func TestSavedSnapshotSecretBackfillPreservesConcurrentTriggerWrite(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	router := newRouter(t)
+
+	response := do(router, http.MethodPost, "/sandboxes", apiKey, `{"name":"concurrent-secret-backfill"}`)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: %d %s", response.Code, response.Body.String())
+	}
+	sandboxID := mustJSON(t, response)["id"].(string)
+
+	insertSecret := func(name string) uuid.UUID {
+		t.Helper()
+		var secretID uuid.UUID
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO secret (
+			    team_id, name, auth_type, hosts, ciphertext, encrypted_dek, kek_id
+			)
+			VALUES ($1, $2, 'bearer', ARRAY['example.com'], '\x01', '\x02', 'test-kek')
+			RETURNING id
+		`, teamID, name+"-"+uuid.NewString()[:8]).Scan(&secretID); err != nil {
+			t.Fatalf("create %s secret: %v", name, err)
+		}
+		return secretID
+	}
+
+	initialSecretID := insertSecret("initial")
+	concurrentSecretID := insertSecret("concurrent")
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_secret (sandbox_id, secret_id, env_key)
+		VALUES ($1, $2, 'INITIAL_TOKEN')
+	`, sandboxID, initialSecretID); err != nil {
+		t.Fatalf("attach initial secret: %v", err)
+	}
+	// Model the expand window after the sandbox column exists but before the
+	// active-binding backfill has populated it.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET secret_env_keys = '[]'::jsonb
+		WHERE id = $1
+	`, sandboxID); err != nil {
+		t.Fatalf("clear pre-backfill secret history: %v", err)
+	}
+
+	triggerTx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin concurrent trigger transaction: %v", err)
+	}
+	defer triggerTx.Rollback(ctx)
+	if _, err := triggerTx.Exec(ctx, `
+		INSERT INTO sandbox_secret (sandbox_id, secret_id, env_key)
+		VALUES ($1, $2, 'CONCURRENT_TOKEN')
+	`, sandboxID, concurrentSecretID); err != nil {
+		t.Fatalf("attach concurrent secret: %v", err)
+	}
+
+	backfillConn, err := testPool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire backfill connection: %v", err)
+	}
+	defer backfillConn.Release()
+
+	var backfillPID int32
+	if err := backfillConn.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&backfillPID); err != nil {
+		t.Fatalf("read backfill backend pid: %v", err)
+	}
+
+	backfillDone := make(chan error, 1)
+	go func() {
+		_, execErr := backfillConn.Exec(ctx, `
+			UPDATE sandbox s
+			SET secret_env_keys = (
+			        SELECT COALESCE(
+			            jsonb_agg(history.env_key ORDER BY history.env_key),
+			            '[]'::jsonb
+			        )
+			        FROM (
+			            SELECT jsonb_array_elements_text(s.secret_env_keys) AS env_key
+			            UNION
+			            SELECT jsonb_array_elements_text(merged.keys) AS env_key
+			        ) history
+			    ),
+			    updated_at = now()
+			FROM (
+			    SELECT source.sandbox_id,
+			           jsonb_agg(source.env_key ORDER BY source.env_key) AS keys
+			    FROM (
+			        SELECT existing.id AS sandbox_id,
+			               jsonb_array_elements_text(existing.secret_env_keys) AS env_key
+			        FROM sandbox existing
+			        UNION
+			        SELECT binding.sandbox_id, binding.env_key
+			        FROM sandbox_secret binding
+			    ) source
+			    GROUP BY source.sandbox_id
+			) merged
+			WHERE s.id = merged.sandbox_id
+			  AND s.secret_env_keys IS DISTINCT FROM merged.keys
+		`)
+		backfillDone <- execErr
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var waiting bool
+		if err := testPool.QueryRow(ctx, `
+			SELECT COALESCE(
+			    (SELECT wait_event_type = 'Lock'
+			     FROM pg_stat_activity
+			     WHERE pid = $1),
+			    false
+			)
+		`, backfillPID).Scan(&waiting); err != nil {
+			t.Fatalf("inspect blocked backfill: %v", err)
+		}
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("backfill did not block behind the concurrent trigger writer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := triggerTx.Commit(ctx); err != nil {
+		t.Fatalf("commit concurrent trigger transaction: %v", err)
+	}
+
+	select {
+	case err := <-backfillDone:
+		if err != nil {
+			t.Fatalf("run concurrent secret-history backfill: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("backfill did not finish after the concurrent trigger committed")
+	}
+
+	assertSandboxSecretHistory(
+		t,
+		ctx,
+		sandboxID,
+		[]string{"CONCURRENT_TOKEN", "INITIAL_TOKEN"},
+	)
 }
 
 func assertSandboxSecretHistory(t *testing.T, ctx context.Context, sandboxID string, want []string) {

--- a/internal/integration/saved_snapshot_expand_test.go
+++ b/internal/integration/saved_snapshot_expand_test.go
@@ -1,0 +1,345 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+func TestSavedSnapshotExpandRolloutGuards(t *testing.T) {
+	ctx := context.Background()
+
+	var unique, valid, ready, partial bool
+	err := testPool.QueryRow(ctx, `
+		SELECT i.indisunique,
+		       i.indisvalid,
+		       i.indisready,
+		       i.indpred IS NOT NULL
+		FROM pg_index i
+		JOIN pg_class idx ON idx.oid = i.indexrelid
+		JOIN pg_namespace ns ON ns.oid = idx.relnamespace
+		WHERE ns.nspname = 'public'
+		  AND idx.relname = 'snapshot_sandbox_unique'
+		  AND i.indrelid = 'public.snapshot'::regclass
+	`).Scan(&unique, &valid, &ready, &partial)
+	if err != nil {
+		t.Fatalf("inspect snapshot_sandbox_unique: %v", err)
+	}
+	if !unique || !valid || !ready || partial {
+		t.Error("legacy snapshot_sandbox_unique is not a ready, valid, non-partial unique index")
+	}
+
+	constraints := []string{
+		"snapshot_name_valid",
+		"snapshot_idempotency_key_valid",
+		"snapshot_vcpu_positive",
+		"snapshot_memory_positive",
+		"snapshot_disk_positive",
+		"snapshot_logical_size_non_negative",
+		"snapshot_exclusive_size_non_negative",
+		"snapshot_artifact_metadata_object",
+		"snapshot_secret_bindings_array",
+		"snapshot_secret_env_keys_array",
+		"snapshot_runtime_shape",
+		"snapshot_saved_source_shape",
+		"snapshot_ready_artifact_shape",
+		"snapshot_deleted_state",
+		"snapshot_template_id_fk",
+		"snapshot_parent_team_fk",
+		"snapshot_source_sandbox_team_fk",
+		"team_max_snapshots_positive",
+		"team_max_snapshots_per_sandbox_positive",
+		"team_snapshot_storage_quota_non_negative",
+		"team_snapshot_storage_non_negative",
+		"sandbox_source_snapshot_team_fk",
+		"sandbox_snapshot_operation_team_fk",
+		"sandbox_snapshot_operation_pair",
+		"sandbox_secret_env_keys_array",
+	}
+	var validated int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM pg_constraint
+		WHERE conname = ANY($1::text[])
+		  AND convalidated
+	`, constraints).Scan(&validated); err != nil {
+		t.Fatalf("inspect validated expand constraints: %v", err)
+	}
+	if validated != len(constraints) {
+		t.Errorf("validated expand constraints = %d, want %d", validated, len(constraints))
+	}
+
+	var globalEnabled bool
+	if err := testPool.QueryRow(ctx, `
+		SELECT enabled
+		FROM feature_flag
+		WHERE key = 'sandbox_snapshots_v1'
+	`).Scan(&globalEnabled); err != nil {
+		t.Fatalf("read global saved-snapshot feature flag: %v", err)
+	}
+	if globalEnabled {
+		t.Error("global saved-snapshot feature flag is enabled during expand")
+	}
+
+	var enabledTeamOverrides int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM team_feature_flag
+		WHERE key = 'sandbox_snapshots_v1'
+		  AND enabled
+	`).Scan(&enabledTeamOverrides); err != nil {
+		t.Fatalf("count enabled team saved-snapshot overrides: %v", err)
+	}
+	if enabledTeamOverrides != 0 {
+		t.Errorf("enabled saved-snapshot team overrides = %d, want 0", enabledTeamOverrides)
+	}
+
+	rows, err := testPool.Query(ctx, `
+		SELECT c.relname, c.relrowsecurity
+		FROM pg_class c
+		JOIN pg_namespace ns ON ns.oid = c.relnamespace
+		WHERE ns.nspname = 'public'
+		  AND c.relname = ANY (
+		      ARRAY['snapshot_storage_layer', 'snapshot_storage_reference']
+		  )
+		ORDER BY c.relname
+	`)
+	if err != nil {
+		t.Fatalf("inspect saved-snapshot ledger RLS: %v", err)
+	}
+	defer rows.Close()
+
+	seen := 0
+	for rows.Next() {
+		var table string
+		var enabled bool
+		if err := rows.Scan(&table, &enabled); err != nil {
+			t.Fatalf("scan saved-snapshot ledger RLS: %v", err)
+		}
+		seen++
+		if !enabled {
+			t.Errorf("RLS is disabled on %s", table)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate saved-snapshot ledger RLS: %v", err)
+	}
+	if seen != 2 {
+		t.Errorf("found %d saved-snapshot ledger tables, want 2", seen)
+	}
+}
+
+func TestSavedSnapshotExpandTracksLegacySecretHistory(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	router := newRouter(t)
+
+	response := do(router, http.MethodPost, "/sandboxes", apiKey, `{"name":"legacy-secret-history"}`)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: %d %s", response.Code, response.Body.String())
+	}
+	sandboxID := mustJSON(t, response)["id"].(string)
+
+	var secretID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO secret (
+		    team_id, name, auth_type, hosts, ciphertext, encrypted_dek, kek_id
+		)
+		VALUES ($1, $2, 'bearer', ARRAY['example.com'], '\x01', '\x02', 'test-kek')
+		RETURNING id
+	`, teamID, "legacy-secret-"+uuid.NewString()[:8]).Scan(&secretID); err != nil {
+		t.Fatalf("create secret: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_secret (sandbox_id, secret_id, env_key)
+		VALUES ($1, $2, 'LEGACY_TOKEN')
+	`, sandboxID, secretID); err != nil {
+		t.Fatalf("legacy attach secret: %v", err)
+	}
+	assertSandboxSecretHistory(t, ctx, sandboxID, []string{"LEGACY_TOKEN"})
+
+	if _, err := testPool.Exec(ctx, `
+		DELETE FROM sandbox_secret
+		WHERE sandbox_id = $1 AND env_key = 'LEGACY_TOKEN'
+	`, sandboxID); err != nil {
+		t.Fatalf("legacy detach secret: %v", err)
+	}
+	assertSandboxSecretHistory(t, ctx, sandboxID, []string{"LEGACY_TOKEN"})
+}
+
+func assertSandboxSecretHistory(t *testing.T, ctx context.Context, sandboxID string, want []string) {
+	t.Helper()
+
+	var raw []byte
+	if err := testPool.QueryRow(ctx, `
+		SELECT secret_env_keys
+		FROM sandbox
+		WHERE id = $1
+	`, sandboxID).Scan(&raw); err != nil {
+		t.Fatalf("read sandbox secret history: %v", err)
+	}
+	var got []string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode sandbox secret history: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sandbox secret history = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sandbox secret history = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestSavedSnapshotExpandLedgerRLSBlocksUnprivilegedReads(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	router := newRouter(t)
+
+	response := do(router, http.MethodPost, "/sandboxes", apiKey, `{"name":"ledger-rls"}`)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: %d %s", response.Code, response.Body.String())
+	}
+	sandboxID := mustJSON(t, response)["id"].(string)
+
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin RLS test transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var layerID int64
+	if err := tx.QueryRow(ctx, `
+		INSERT INTO snapshot_storage_layer (
+		    team_id, kind, owner_sandbox_id
+		)
+		VALUES ($1, 'sandbox_writable', $2)
+		RETURNING id
+	`, teamID, sandboxID).Scan(&layerID); err != nil {
+		t.Fatalf("seed ledger layer: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO snapshot_storage_reference (
+		    layer_id, team_id, sandbox_id
+		)
+		VALUES ($1, $2, $3)
+	`, layerID, teamID, sandboxID); err != nil {
+		t.Fatalf("seed ledger reference: %v", err)
+	}
+
+	role := "snapshot_rls_" + uuid.NewString()
+	quotedRole := pgx.Identifier{role}.Sanitize()
+	if _, err := tx.Exec(ctx, "CREATE ROLE "+quotedRole+" NOLOGIN"); err != nil {
+		t.Fatalf("create restricted role: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "GRANT USAGE ON SCHEMA public TO "+quotedRole); err != nil {
+		t.Fatalf("grant schema usage: %v", err)
+	}
+	if _, err := tx.Exec(ctx,
+		"GRANT SELECT ON snapshot_storage_layer, snapshot_storage_reference TO "+quotedRole,
+	); err != nil {
+		t.Fatalf("grant ledger select: %v", err)
+	}
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE "+quotedRole); err != nil {
+		t.Fatalf("assume restricted role: %v", err)
+	}
+
+	for _, table := range []string{
+		"snapshot_storage_layer",
+		"snapshot_storage_reference",
+	} {
+		var visible int
+		query := "SELECT count(*) FROM " + pgx.Identifier{table}.Sanitize()
+		if err := tx.QueryRow(ctx, query).Scan(&visible); err != nil {
+			t.Fatalf("restricted select from %s: %v", table, err)
+		}
+		if visible != 0 {
+			t.Errorf("restricted role can see %d rows in %s, want 0", visible, table)
+		}
+	}
+}
+
+func TestSavedSnapshotExpandDoesNotResurrectDeletedSnapshots(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	router := newRouter(t)
+
+	response := do(router, http.MethodPost, "/sandboxes", apiKey, `{"name":"snapshot-delete-guard"}`)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: %d %s", response.Code, response.Body.String())
+	}
+	sandboxID := mustJSON(t, response)["id"].(string)
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team
+		SET snapshot_storage_quota_bytes = 1048576
+		WHERE id = $1
+	`, teamID); err != nil {
+		t.Fatalf("provision snapshot storage quota: %v", err)
+	}
+
+	var snapshotID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO snapshot (
+		    sandbox_id, team_id, path, trigger, kind, status, name,
+		    source_status, host_id, vcpu_count, memory_mib, disk_mib
+		)
+		VALUES (
+		    $1, $2, '/pending', 'manual', 'saved', 'creating', 'delete-guard',
+		    'active', $3, 1, 1024, 4096
+		)
+		RETURNING id
+	`, sandboxID, teamID, testDefaultHostID).Scan(&snapshotID); err != nil {
+		t.Fatalf("create saved snapshot row: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE snapshot
+		SET status = 'ready',
+		    path = '/snapshots/delete-guard/vmstate.snap',
+		    mem_path = '/snapshots/delete-guard/mem.snap',
+		    manifest_path = '/snapshots/delete-guard/manifest.json',
+		    manifest_digest = repeat('a', 64),
+		    logical_size_bytes = 1024,
+		    exclusive_size_bytes = 1024,
+		    finalized_at = now()
+		WHERE id = $1
+	`, snapshotID); err != nil {
+		t.Fatalf("finalize saved snapshot row: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE snapshot
+		SET status = 'deleting', deleted_at = now()
+		WHERE id = $1
+	`, snapshotID); err != nil {
+		t.Fatalf("logically delete saved snapshot row: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE snapshot
+		SET deleted_at = NULL
+		WHERE id = $1
+	`, snapshotID); err == nil {
+		t.Fatal("resurrecting a logically deleted saved snapshot succeeded")
+	}
+
+	var stillDeleted bool
+	if err := testPool.QueryRow(ctx, `
+		SELECT deleted_at IS NOT NULL
+		FROM snapshot
+		WHERE id = $1
+	`, snapshotID).Scan(&stillDeleted); err != nil {
+		t.Fatalf("read deleted snapshot state: %v", err)
+	}
+	if !stillDeleted {
+		t.Fatal("failed resurrection attempt cleared deleted_at")
+	}
+}

--- a/supabase/migrations/20260729000001_saved_snapshot_columns.sql
+++ b/supabase/migrations/20260729000001_saved_snapshot_columns.sql
@@ -1,0 +1,73 @@
+-- Expand the snapshot row shape in a short metadata-only transaction.
+-- PostgreSQL 16 stores constant defaults in the catalog, so existing rows are
+-- not rewritten while the ACCESS EXCLUSIVE lock is held.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- Old control planes finalize pause checkpoints with ON CONFLICT (sandbox_id).
+-- Refuse to expand a drifted database unless the exact legacy conflict target
+-- remains available for those writers.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class idx ON idx.oid = i.indexrelid
+        JOIN pg_namespace ns ON ns.oid = idx.relnamespace
+        WHERE ns.nspname = 'public'
+          AND idx.relname = 'snapshot_sandbox_unique'
+          AND i.indrelid = 'public.snapshot'::regclass
+          AND i.indisunique
+          AND i.indisvalid
+          AND i.indisready
+          AND i.indimmediate
+          AND i.indpred IS NULL
+          AND i.indnkeyatts = 1
+          AND pg_get_indexdef(i.indexrelid, 1, true) = 'sandbox_id'
+    ) THEN
+        RAISE EXCEPTION
+            'expand requires the legacy non-partial snapshot_sandbox_unique index';
+    END IF;
+END;
+$$;
+
+CREATE TYPE snapshot_kind AS ENUM ('runtime_checkpoint', 'saved');
+CREATE TYPE snapshot_status AS ENUM (
+    'creating', 'ready', 'unavailable', 'failed', 'deleting'
+);
+
+ALTER TABLE snapshot
+    ADD COLUMN kind snapshot_kind NOT NULL DEFAULT 'runtime_checkpoint',
+    ADD COLUMN status snapshot_status NOT NULL DEFAULT 'ready',
+    ADD COLUMN name text,
+    ADD COLUMN idempotency_key text,
+    ADD COLUMN parent_snapshot_id uuid,
+    ADD COLUMN source_status sandbox_status,
+    ADD COLUMN template_id uuid,
+    ADD COLUMN template_snapshot_path text,
+    ADD COLUMN template_mem_path text,
+    ADD COLUMN base_path text,
+    ADD COLUMN delta_path text,
+    ADD COLUMN host_id text,
+    ADD COLUMN vcpu_count integer,
+    ADD COLUMN memory_mib integer,
+    ADD COLUMN disk_mib integer,
+    ADD COLUMN manifest_path text,
+    ADD COLUMN manifest_digest text,
+    ADD COLUMN artifact_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN logical_size_bytes bigint NOT NULL DEFAULT 0,
+    ADD COLUMN exclusive_size_bytes bigint NOT NULL DEFAULT 0,
+    ADD COLUMN network_config jsonb,
+    ADD COLUMN timeout_seconds integer,
+    ADD COLUMN auto_delete_seconds integer,
+    ADD COLUMN secret_bindings jsonb NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN secret_env_keys jsonb NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN failure_reason text,
+    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN finalized_at timestamptz,
+    ADD COLUMN deleted_at timestamptz;
+
+COMMIT;

--- a/supabase/migrations/20260729000002_saved_snapshot_team_columns.sql
+++ b/supabase/migrations/20260729000002_saved_snapshot_team_columns.sql
@@ -1,0 +1,34 @@
+-- Add team limits separately so no snapshot lock is retained while waiting on
+-- the team catalog change. Keep every feature override dark during expand.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE team
+    ADD COLUMN max_snapshots integer NOT NULL DEFAULT 100,
+    ADD COLUMN max_snapshots_per_sandbox integer NOT NULL DEFAULT 20,
+    ADD COLUMN snapshot_storage_quota_bytes bigint,
+    ADD COLUMN snapshot_storage_bytes bigint NOT NULL DEFAULT 0;
+
+INSERT INTO feature_flag (key, enabled, description)
+VALUES (
+    'sandbox_snapshots_v1',
+    false,
+    'Allow a team to capture immutable saved snapshots and create sandboxes from them.'
+)
+ON CONFLICT (key) DO UPDATE
+SET enabled = false,
+    description = EXCLUDED.description,
+    updated_at = now();
+
+-- A team override wins over the global flag, so reset any residue from an
+-- earlier manual experiment before the new code is deployed.
+UPDATE team_feature_flag
+SET enabled = false,
+    updated_at = now()
+WHERE key = 'sandbox_snapshots_v1'
+  AND enabled;
+
+COMMIT;

--- a/supabase/migrations/20260729000003_saved_snapshot_sandbox_columns.sql
+++ b/supabase/migrations/20260729000003_saved_snapshot_sandbox_columns.sql
@@ -1,0 +1,57 @@
+-- Add sandbox lineage columns and install history maintenance atomically.
+-- Taking a trigger lock on sandbox_secret closes the rolling-writer gap:
+-- changes committed before this transaction are visible to the later
+-- backfill, while changes after it are recorded by the trigger.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE sandbox
+    ADD COLUMN source_snapshot_id uuid,
+    ADD COLUMN snapshot_operation_id uuid,
+    ADD COLUMN snapshot_operation_started_at timestamptz,
+    ADD COLUMN secret_env_keys jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE OR REPLACE FUNCTION remember_sandbox_secret_env_key() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    binding_sandbox_id uuid;
+    binding_env_key text;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        binding_sandbox_id := OLD.sandbox_id;
+        binding_env_key := OLD.env_key;
+    ELSE
+        binding_sandbox_id := NEW.sandbox_id;
+        binding_env_key := NEW.env_key;
+    END IF;
+
+    UPDATE sandbox s
+    SET secret_env_keys = (
+            SELECT jsonb_agg(keys.env_key ORDER BY keys.env_key)
+            FROM (
+                SELECT jsonb_array_elements_text(s.secret_env_keys) AS env_key
+                UNION
+                SELECT binding_env_key
+            ) keys
+        ),
+        updated_at = now()
+    WHERE s.id = binding_sandbox_id
+      AND NOT s.secret_env_keys ? binding_env_key;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_remember_sandbox_secret_env_key
+    AFTER INSERT OR DELETE ON sandbox_secret
+    FOR EACH ROW
+    EXECUTE FUNCTION remember_sandbox_secret_env_key();
+
+COMMIT;

--- a/supabase/migrations/20260729000004_saved_snapshot_secret_history.sql
+++ b/supabase/migrations/20260729000004_saved_snapshot_secret_history.sql
@@ -7,7 +7,20 @@ SET LOCAL lock_timeout = '5s';
 SET LOCAL statement_timeout = '2min';
 
 UPDATE sandbox s
-SET secret_env_keys = merged.keys,
+SET secret_env_keys = (
+        SELECT COALESCE(
+            jsonb_agg(history.env_key ORDER BY history.env_key),
+            '[]'::jsonb
+        )
+        FROM (
+            -- Re-read the target row during EvalPlanQual after any concurrent
+            -- trigger writer commits, rather than replacing it with the
+            -- statement-snapshot aggregate below.
+            SELECT jsonb_array_elements_text(s.secret_env_keys) AS env_key
+            UNION
+            SELECT jsonb_array_elements_text(merged.keys) AS env_key
+        ) history
+    ),
     updated_at = now()
 FROM (
     SELECT source.sandbox_id,

--- a/supabase/migrations/20260729000004_saved_snapshot_secret_history.sql
+++ b/supabase/migrations/20260729000004_saved_snapshot_secret_history.sql
@@ -1,0 +1,28 @@
+-- Backfill active bindings without overwriting keys captured by the rolling
+-- writer trigger between the column migration and this statement.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '2min';
+
+UPDATE sandbox s
+SET secret_env_keys = merged.keys,
+    updated_at = now()
+FROM (
+    SELECT source.sandbox_id,
+           jsonb_agg(source.env_key ORDER BY source.env_key) AS keys
+    FROM (
+        SELECT existing.id AS sandbox_id,
+               jsonb_array_elements_text(existing.secret_env_keys) AS env_key
+        FROM sandbox existing
+        UNION
+        SELECT binding.sandbox_id, binding.env_key
+        FROM sandbox_secret binding
+    ) source
+    GROUP BY source.sandbox_id
+) merged
+WHERE s.id = merged.sandbox_id
+  AND s.secret_env_keys IS DISTINCT FROM merged.keys;
+
+COMMIT;

--- a/supabase/migrations/20260729000005_saved_snapshot_identity_index.sql
+++ b/supabase/migrations/20260729000005_saved_snapshot_identity_index.sql
@@ -1,0 +1,14 @@
+-- Supabase CLI applies every migration transactionally, so CONCURRENTLY is
+-- unavailable. Isolate the one hot-table index required by expand's composite
+-- foreign keys, bound its write-blocking window, and measure it in staging
+-- before production approval.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE UNIQUE INDEX snapshot_id_team_unique_idx
+    ON snapshot (id, team_id);
+
+COMMIT;

--- a/supabase/migrations/20260729000006_saved_snapshot_schema.sql
+++ b/supabase/migrations/20260729000006_saved_snapshot_schema.sql
@@ -1,0 +1,1037 @@
+-- Immutable saved-snapshot constraints, accounting objects, and functions.
+-- Hot-table columns and the supporting identity index are installed by the
+-- preceding short, independently recorded migrations.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE snapshot
+    ADD CONSTRAINT snapshot_id_team_unique
+        UNIQUE USING INDEX snapshot_id_team_unique_idx,
+    ADD CONSTRAINT snapshot_name_valid
+        CHECK (name IS NULL OR char_length(name) BETWEEN 1 AND 64)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_idempotency_key_valid
+        CHECK (idempotency_key IS NULL
+               OR char_length(idempotency_key) BETWEEN 1 AND 255)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_vcpu_positive
+        CHECK (vcpu_count IS NULL OR vcpu_count > 0)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_memory_positive
+        CHECK (memory_mib IS NULL OR memory_mib > 0)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_disk_positive
+        CHECK (disk_mib IS NULL OR disk_mib > 0)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_logical_size_non_negative
+        CHECK (logical_size_bytes >= 0)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_exclusive_size_non_negative
+        CHECK (exclusive_size_bytes >= 0)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_artifact_metadata_object
+        CHECK (jsonb_typeof(artifact_metadata) = 'object')
+        NOT VALID,
+    ADD CONSTRAINT snapshot_secret_bindings_array
+        CHECK (jsonb_typeof(secret_bindings) = 'array')
+        NOT VALID,
+    ADD CONSTRAINT snapshot_secret_env_keys_array
+        CHECK (jsonb_typeof(secret_env_keys) = 'array'
+               AND jsonb_array_length(secret_env_keys) <= 256)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_runtime_shape
+        CHECK (kind <> 'runtime_checkpoint'
+               OR (status = 'ready'
+                   AND parent_snapshot_id IS NULL
+                   AND idempotency_key IS NULL
+                   AND deleted_at IS NULL))
+        NOT VALID,
+    ADD CONSTRAINT snapshot_saved_source_shape
+        CHECK (kind <> 'saved'
+               OR (source_status IN ('active', 'paused')
+                   AND host_id IS NOT NULL
+                   AND host_id <> ''
+                   AND vcpu_count IS NOT NULL
+                   AND memory_mib IS NOT NULL
+                   AND disk_mib IS NOT NULL))
+        NOT VALID,
+    ADD CONSTRAINT snapshot_ready_artifact_shape
+        CHECK (kind <> 'saved' OR status <> 'ready'
+               OR (path <> ''
+                   AND mem_path IS NOT NULL
+                   AND mem_path <> ''
+                   AND manifest_path IS NOT NULL
+                   AND manifest_path <> ''
+                   AND manifest_digest ~ '^[0-9a-f]{64}$'))
+        NOT VALID,
+    ADD CONSTRAINT snapshot_deleted_state
+        CHECK (deleted_at IS NULL OR status = 'deleting')
+        NOT VALID,
+    ADD CONSTRAINT snapshot_template_id_fk
+        FOREIGN KEY (template_id)
+        REFERENCES template(id)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_parent_team_fk
+        FOREIGN KEY (parent_snapshot_id, team_id)
+        REFERENCES snapshot(id, team_id)
+        NOT VALID,
+    ADD CONSTRAINT snapshot_source_sandbox_team_fk
+        FOREIGN KEY (sandbox_id, team_id)
+        REFERENCES sandbox(id, team_id)
+        NOT VALID;
+
+ALTER TABLE team
+    ADD CONSTRAINT team_max_snapshots_positive
+        CHECK (max_snapshots > 0)
+        NOT VALID,
+    ADD CONSTRAINT team_max_snapshots_per_sandbox_positive
+        CHECK (max_snapshots_per_sandbox > 0)
+        NOT VALID,
+    ADD CONSTRAINT team_snapshot_storage_quota_non_negative
+        CHECK (snapshot_storage_quota_bytes IS NULL
+               OR snapshot_storage_quota_bytes >= 0)
+        NOT VALID,
+    ADD CONSTRAINT team_snapshot_storage_non_negative
+        CHECK (snapshot_storage_bytes >= 0)
+        NOT VALID;
+
+ALTER TABLE sandbox
+    ADD CONSTRAINT sandbox_source_snapshot_team_fk
+        FOREIGN KEY (source_snapshot_id, team_id)
+        REFERENCES snapshot(id, team_id)
+        NOT VALID,
+    ADD CONSTRAINT sandbox_snapshot_operation_team_fk
+        FOREIGN KEY (snapshot_operation_id, team_id)
+        REFERENCES snapshot(id, team_id)
+        DEFERRABLE INITIALLY DEFERRED
+        NOT VALID,
+    ADD CONSTRAINT sandbox_snapshot_operation_pair
+        CHECK ((snapshot_operation_id IS NULL)
+               = (snapshot_operation_started_at IS NULL))
+        NOT VALID,
+    ADD CONSTRAINT sandbox_secret_env_keys_array
+        CHECK (jsonb_typeof(secret_env_keys) = 'array'
+               AND jsonb_array_length(secret_env_keys) <= 256)
+        NOT VALID;
+
+-- Count admission is serialized on the team row. Creating, ready,
+-- unavailable, and deleting rows consume the count until logical deletion;
+-- failed captures do not prevent a retry with a new idempotency key.
+CREATE OR REPLACE FUNCTION saved_snapshot_quota_on_insert() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    team_count bigint;
+    source_count bigint;
+    team_limit integer;
+    source_limit integer;
+    storage_limit bigint;
+    storage_usage bigint;
+BEGIN
+    IF NEW.kind <> 'saved'
+       OR NEW.deleted_at IS NOT NULL
+       OR NEW.status = 'failed' THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT max_snapshots, max_snapshots_per_sandbox,
+           snapshot_storage_quota_bytes, snapshot_storage_bytes
+    INTO team_limit, source_limit, storage_limit, storage_usage
+    FROM team
+    WHERE id = NEW.team_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'team % does not exist', NEW.team_id;
+    END IF;
+
+    -- Let a concurrent idempotent retry reach the unique constraint instead
+    -- of being misreported as a quota error. The handler adopts the committed
+    -- row after that unique violation.
+    IF NEW.idempotency_key IS NOT NULL AND EXISTS (
+        SELECT 1 FROM snapshot existing
+        WHERE existing.team_id = NEW.team_id
+          AND existing.sandbox_id = NEW.sandbox_id
+          AND existing.kind = 'saved'
+          AND existing.idempotency_key = NEW.idempotency_key
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    IF storage_limit IS NULL THEN
+        RAISE EXCEPTION 'saved snapshot storage quota is not provisioned'
+            USING ERRCODE = 'SS004';
+    END IF;
+
+    -- Reject before host capture when the team has no remaining byte of
+    -- provisioned capacity. Finalization still admits the artifact's actual
+    -- exclusive size for teams that have some capacity left.
+    IF storage_usage >= storage_limit THEN
+        RAISE EXCEPTION 'saved snapshot storage quota exhausted (usage=%, max=%)',
+                        storage_usage, storage_limit
+            USING ERRCODE = 'SS005';
+    END IF;
+
+    SELECT count(*) INTO team_count
+    FROM snapshot
+    WHERE team_id = NEW.team_id
+      AND kind = 'saved'
+      AND deleted_at IS NULL
+      AND status <> 'failed';
+
+    IF team_count >= team_limit THEN
+        RAISE EXCEPTION 'saved snapshot team quota exceeded (count=%, max=%)',
+                        team_count, team_limit
+            USING ERRCODE = 'SS002';
+    END IF;
+
+    SELECT count(*) INTO source_count
+    FROM snapshot
+    WHERE sandbox_id = NEW.sandbox_id
+      AND kind = 'saved'
+      AND deleted_at IS NULL
+      AND status <> 'failed';
+
+    IF source_count >= source_limit THEN
+        RAISE EXCEPTION 'saved snapshot source quota exceeded (count=%, max=%)',
+                        source_count, source_limit
+            USING ERRCODE = 'SS003';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Saved snapshot identity, lineage, captured policy, and committed artifacts
+-- are immutable. Only the forward lifecycle and its diagnostic timestamps may
+-- change after insert.
+CREATE OR REPLACE FUNCTION saved_snapshot_immutable_on_update() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.kind IS DISTINCT FROM NEW.kind THEN
+        RAISE EXCEPTION 'snapshot kind is immutable' USING ERRCODE = '23514';
+    END IF;
+
+    IF OLD.kind <> 'saved' THEN
+        RETURN NEW;
+    END IF;
+
+    IF OLD.id IS DISTINCT FROM NEW.id
+       OR OLD.sandbox_id IS DISTINCT FROM NEW.sandbox_id
+       OR OLD.team_id IS DISTINCT FROM NEW.team_id
+       OR OLD.name IS DISTINCT FROM NEW.name
+       OR OLD.idempotency_key IS DISTINCT FROM NEW.idempotency_key
+       OR OLD.parent_snapshot_id IS DISTINCT FROM NEW.parent_snapshot_id
+       OR OLD.source_status IS DISTINCT FROM NEW.source_status
+       OR OLD.template_id IS DISTINCT FROM NEW.template_id
+       OR OLD.template_snapshot_path IS DISTINCT FROM NEW.template_snapshot_path
+       OR OLD.template_mem_path IS DISTINCT FROM NEW.template_mem_path
+       OR OLD.base_path IS DISTINCT FROM NEW.base_path
+       OR OLD.delta_path IS DISTINCT FROM NEW.delta_path
+       OR OLD.host_id IS DISTINCT FROM NEW.host_id
+       OR OLD.vcpu_count IS DISTINCT FROM NEW.vcpu_count
+       OR OLD.memory_mib IS DISTINCT FROM NEW.memory_mib
+       OR OLD.disk_mib IS DISTINCT FROM NEW.disk_mib
+       OR OLD.network_config IS DISTINCT FROM NEW.network_config
+       OR OLD.timeout_seconds IS DISTINCT FROM NEW.timeout_seconds
+       OR OLD.auto_delete_seconds IS DISTINCT FROM NEW.auto_delete_seconds
+       OR OLD.secret_bindings IS DISTINCT FROM NEW.secret_bindings
+       OR OLD.secret_env_keys IS DISTINCT FROM NEW.secret_env_keys
+       OR OLD.trigger IS DISTINCT FROM NEW.trigger
+       OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'saved snapshot captured fields are immutable'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF (OLD.path IS DISTINCT FROM NEW.path
+        OR OLD.mem_path IS DISTINCT FROM NEW.mem_path
+        OR OLD.size_bytes IS DISTINCT FROM NEW.size_bytes
+        OR OLD.manifest_path IS DISTINCT FROM NEW.manifest_path
+        OR OLD.manifest_digest IS DISTINCT FROM NEW.manifest_digest
+        OR OLD.artifact_metadata IS DISTINCT FROM NEW.artifact_metadata
+        OR OLD.logical_size_bytes IS DISTINCT FROM NEW.logical_size_bytes
+        OR OLD.exclusive_size_bytes IS DISTINCT FROM NEW.exclusive_size_bytes)
+       AND NOT (OLD.status = 'creating' AND NEW.status IN ('ready', 'deleting')) THEN
+        RAISE EXCEPTION 'saved snapshot artifacts are immutable after commit'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF OLD.finalized_at IS NOT NULL
+       AND NEW.finalized_at IS DISTINCT FROM OLD.finalized_at THEN
+        RAISE EXCEPTION 'saved snapshot finalization timestamp is immutable'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF OLD.deleted_at IS NOT NULL
+       AND NEW.deleted_at IS DISTINCT FROM OLD.deleted_at THEN
+        RAISE EXCEPTION 'deleted saved snapshot cannot be resurrected'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF NOT (
+        OLD.status = NEW.status
+        OR (OLD.status = 'creating' AND NEW.status IN ('ready', 'failed', 'deleting'))
+        OR (OLD.status = 'ready' AND NEW.status IN ('unavailable', 'deleting'))
+        OR (OLD.status IN ('unavailable', 'failed') AND NEW.status = 'deleting')
+    ) THEN
+        RAISE EXCEPTION 'invalid saved snapshot status transition: % -> %',
+                        OLD.status, NEW.status
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Shadow-only layer ownership and references. This is intentionally separate
+-- from invoice/export tables. One layer is charged once to its team while any
+-- sandbox or snapshot reference remains; fan-out copies references, not bytes.
+CREATE TYPE snapshot_storage_layer_kind AS ENUM (
+    'saved_snapshot', 'sandbox_generation', 'sandbox_writable'
+);
+
+CREATE TABLE snapshot_storage_layer (
+    id bigserial PRIMARY KEY,
+    team_id uuid NOT NULL REFERENCES team(id),
+    kind snapshot_storage_layer_kind NOT NULL,
+    owner_snapshot_id uuid,
+    owner_sandbox_id uuid,
+    retained_logical_size_bytes bigint NOT NULL DEFAULT 0,
+    current_logical_size_bytes bigint NOT NULL DEFAULT 0,
+    retained_exclusive_size_bytes bigint NOT NULL DEFAULT 0,
+    current_exclusive_size_bytes bigint NOT NULL DEFAULT 0,
+    shadow_only boolean NOT NULL DEFAULT true,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    ended_at timestamptz,
+    CONSTRAINT snapshot_storage_layer_id_team_unique UNIQUE (id, team_id),
+    CONSTRAINT snapshot_storage_layer_one_owner CHECK (
+        (owner_snapshot_id IS NOT NULL)::integer
+        + (owner_sandbox_id IS NOT NULL)::integer = 1
+    ),
+    CONSTRAINT snapshot_storage_layer_kind_owner CHECK (
+        (kind = 'saved_snapshot' AND owner_snapshot_id IS NOT NULL)
+        OR (kind IN ('sandbox_generation', 'sandbox_writable')
+            AND owner_sandbox_id IS NOT NULL)
+    ),
+    CONSTRAINT snapshot_storage_layer_sizes_non_negative CHECK (
+        retained_logical_size_bytes >= 0
+        AND current_logical_size_bytes >= 0
+        AND retained_exclusive_size_bytes >= 0
+        AND current_exclusive_size_bytes >= 0
+    ),
+    CONSTRAINT snapshot_storage_layer_snapshot_team_fk
+        FOREIGN KEY (owner_snapshot_id, team_id)
+        REFERENCES snapshot(id, team_id),
+    CONSTRAINT snapshot_storage_layer_sandbox_team_fk
+        FOREIGN KEY (owner_sandbox_id, team_id)
+        REFERENCES sandbox(id, team_id)
+);
+
+CREATE UNIQUE INDEX snapshot_storage_layer_snapshot_owner_unique
+    ON snapshot_storage_layer (owner_snapshot_id)
+    WHERE owner_snapshot_id IS NOT NULL;
+-- A sandbox has exactly one mutable current generation, but may own many
+-- immutable sealed generations retained by different snapshots/descendants.
+CREATE UNIQUE INDEX snapshot_storage_layer_sandbox_current_owner_unique
+    ON snapshot_storage_layer (owner_sandbox_id)
+    WHERE owner_sandbox_id IS NOT NULL
+      AND kind = 'sandbox_writable'
+      AND ended_at IS NULL;
+CREATE INDEX snapshot_storage_layer_team_active
+    ON snapshot_storage_layer (team_id, id)
+    WHERE ended_at IS NULL;
+
+CREATE TABLE snapshot_storage_reference (
+    id bigserial PRIMARY KEY,
+    layer_id bigint NOT NULL,
+    team_id uuid NOT NULL REFERENCES team(id),
+    snapshot_id uuid,
+    sandbox_id uuid,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    released_at timestamptz,
+    CONSTRAINT snapshot_storage_reference_one_resource CHECK (
+        (snapshot_id IS NOT NULL)::integer
+        + (sandbox_id IS NOT NULL)::integer = 1
+    ),
+    CONSTRAINT snapshot_storage_reference_layer_team_fk
+        FOREIGN KEY (layer_id, team_id)
+        REFERENCES snapshot_storage_layer(id, team_id),
+    CONSTRAINT snapshot_storage_reference_snapshot_team_fk
+        FOREIGN KEY (snapshot_id, team_id)
+        REFERENCES snapshot(id, team_id),
+    CONSTRAINT snapshot_storage_reference_sandbox_team_fk
+        FOREIGN KEY (sandbox_id, team_id)
+        REFERENCES sandbox(id, team_id)
+);
+
+-- These are internal accounting tables in Supabase's API-exposed public
+-- schema. With RLS enabled and no client policies, only the privileged
+-- backend role can read or mutate the storage ledger.
+ALTER TABLE public.snapshot_storage_layer ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.snapshot_storage_reference ENABLE ROW LEVEL SECURITY;
+
+CREATE UNIQUE INDEX snapshot_storage_reference_snapshot_active_unique
+    ON snapshot_storage_reference (layer_id, snapshot_id)
+    WHERE snapshot_id IS NOT NULL AND released_at IS NULL;
+CREATE UNIQUE INDEX snapshot_storage_reference_sandbox_active_unique
+    ON snapshot_storage_reference (layer_id, sandbox_id)
+    WHERE sandbox_id IS NOT NULL AND released_at IS NULL;
+CREATE INDEX snapshot_storage_reference_layer_active
+    ON snapshot_storage_reference (layer_id)
+    WHERE released_at IS NULL;
+
+CREATE OR REPLACE FUNCTION snapshot_storage_layer_usage_on_write() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    old_bytes bigint := 0;
+    new_bytes bigint := 0;
+    delta_bytes bigint;
+    total_bytes bigint;
+    quota_bytes bigint;
+    owner_team_id uuid;
+BEGIN
+    IF TG_OP <> 'INSERT' AND OLD.ended_at IS NULL THEN
+        old_bytes := OLD.retained_exclusive_size_bytes
+                     + OLD.current_exclusive_size_bytes;
+    END IF;
+
+    IF TG_OP <> 'DELETE' AND NEW.ended_at IS NULL THEN
+        new_bytes := NEW.retained_exclusive_size_bytes
+                     + NEW.current_exclusive_size_bytes;
+    END IF;
+
+    delta_bytes := new_bytes - old_bytes;
+    IF delta_bytes = 0 THEN
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    owner_team_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.team_id ELSE NEW.team_id END;
+
+    UPDATE team
+    SET snapshot_storage_bytes = snapshot_storage_bytes + delta_bytes
+    WHERE id = owner_team_id
+    RETURNING snapshot_storage_bytes, snapshot_storage_quota_bytes
+    INTO total_bytes, quota_bytes;
+
+    -- Sandbox writes already exist by measurement time and cleanup artifacts
+    -- may already exist after failed admission, so only a ready saved-snapshot
+    -- layer is allowed to reject the transaction on quota.
+    IF TG_OP <> 'DELETE'
+       AND delta_bytes > 0
+       AND NEW.kind = 'saved_snapshot'
+       AND EXISTS (
+           SELECT 1 FROM snapshot s
+           WHERE s.id = NEW.owner_snapshot_id
+             AND s.team_id = NEW.team_id
+             AND s.status = 'ready'
+             AND s.deleted_at IS NULL
+       ) THEN
+        IF quota_bytes IS NULL THEN
+            RAISE EXCEPTION 'saved snapshot storage quota is not provisioned'
+                USING ERRCODE = 'SS004';
+        END IF;
+
+        IF total_bytes > quota_bytes THEN
+            RAISE EXCEPTION 'saved snapshot storage quota exceeded (usage=%, max=%)',
+                            total_bytes, quota_bytes
+                USING ERRCODE = 'SS005';
+        END IF;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_snapshot_storage_layer_usage_on_write
+    BEFORE INSERT OR UPDATE OR DELETE ON snapshot_storage_layer
+    FOR EACH ROW
+    EXECUTE FUNCTION snapshot_storage_layer_usage_on_write();
+
+-- Fold sealed source generations back into their live owner's mutable row
+-- once no snapshot or descendant sandbox references them. Their extents become
+-- source-exclusive again when the final external reflink disappears, so a
+-- later full-inode FIEMAP measurement must replace this combined current value
+-- rather than be added beside the old retained row. Callers may scope by one
+-- owner (pause/capture reconciliation), a set of layers whose references were
+-- just released (lifecycle triggers), or both. Requiring one scope prevents an
+-- accidental team-wide sweep.
+CREATE OR REPLACE FUNCTION snapshot_storage_fold_owner_only_generations(
+    requested_team_id uuid,
+    requested_owner_sandbox_id uuid DEFAULT NULL,
+    candidate_layer_ids bigint[] DEFAULT NULL
+) RETURNS bigint
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    generation snapshot_storage_layer%ROWTYPE;
+    current_layer_id bigint;
+    active_ref_count bigint;
+    owner_ref_count bigint;
+    affected_count bigint;
+    folded_count bigint := 0;
+BEGIN
+    IF requested_owner_sandbox_id IS NULL
+       AND candidate_layer_ids IS NULL THEN
+        RETURN 0;
+    END IF;
+    IF candidate_layer_ids IS NOT NULL
+       AND cardinality(candidate_layer_ids) = 0 THEN
+        RETURN 0;
+    END IF;
+
+    -- Capture finalization takes the same sandbox row lock before sealing its
+    -- writable generation. Lock every candidate owner in a stable order so a
+    -- capture either publishes its new reference first or observes the fully
+    -- folded current row; it can never observe a half-folded generation.
+    PERFORM owner.id
+    FROM sandbox owner
+    WHERE owner.team_id = requested_team_id
+      AND owner.destroyed_at IS NULL
+      AND (requested_owner_sandbox_id IS NULL
+           OR owner.id = requested_owner_sandbox_id)
+      AND EXISTS (
+          SELECT 1
+          FROM snapshot_storage_layer layer
+          WHERE layer.team_id = requested_team_id
+            AND layer.owner_sandbox_id = owner.id
+            AND layer.kind = 'sandbox_generation'
+            AND layer.ended_at IS NULL
+            AND (candidate_layer_ids IS NULL
+                 OR layer.id = ANY(candidate_layer_ids))
+      )
+    ORDER BY owner.id
+    FOR UPDATE;
+
+    -- Lock candidate layers by ID. The active-reference predicate is checked
+    -- again after their reference rows are locked; missing live owners/current
+    -- rows are deliberately left retained (fail closed) rather than dropped.
+    FOR generation IN
+        SELECT layer.*
+        FROM snapshot_storage_layer layer
+        JOIN sandbox owner
+          ON owner.id = layer.owner_sandbox_id
+         AND owner.team_id = layer.team_id
+        WHERE layer.team_id = requested_team_id
+          AND layer.kind = 'sandbox_generation'
+          AND layer.ended_at IS NULL
+          AND owner.destroyed_at IS NULL
+          AND (requested_owner_sandbox_id IS NULL
+               OR layer.owner_sandbox_id = requested_owner_sandbox_id)
+          AND (candidate_layer_ids IS NULL
+               OR layer.id = ANY(candidate_layer_ids))
+        ORDER BY layer.id
+        FOR UPDATE OF layer
+    LOOP
+        SELECT current.id
+        INTO current_layer_id
+        FROM snapshot_storage_layer current
+        WHERE current.team_id = requested_team_id
+          AND current.owner_sandbox_id = generation.owner_sandbox_id
+          AND current.kind = 'sandbox_writable'
+          AND current.ended_at IS NULL
+        FOR UPDATE;
+        IF current_layer_id IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        PERFORM ref.id
+        FROM snapshot_storage_reference ref
+        WHERE ref.layer_id = generation.id
+          AND ref.team_id = requested_team_id
+          AND ref.released_at IS NULL
+        ORDER BY ref.id
+        FOR UPDATE;
+
+        SELECT count(*),
+               count(*) FILTER (
+                   WHERE ref.snapshot_id IS NULL
+                     AND ref.sandbox_id = generation.owner_sandbox_id
+               )
+        INTO active_ref_count, owner_ref_count
+        FROM snapshot_storage_reference ref
+        WHERE ref.layer_id = generation.id
+          AND ref.team_id = requested_team_id
+          AND ref.released_at IS NULL;
+        IF active_ref_count <> 1 OR owner_ref_count <> 1 THEN
+            CONTINUE;
+        END IF;
+
+        UPDATE snapshot_storage_layer current
+        SET current_logical_size_bytes =
+                current.current_logical_size_bytes
+                + generation.retained_logical_size_bytes
+                + generation.current_logical_size_bytes,
+            current_exclusive_size_bytes =
+                current.current_exclusive_size_bytes
+                + generation.retained_exclusive_size_bytes
+                + generation.current_exclusive_size_bytes,
+            updated_at = now()
+        WHERE current.id = current_layer_id
+          AND current.team_id = requested_team_id
+          AND current.kind = 'sandbox_writable'
+          AND current.ended_at IS NULL;
+        GET DIAGNOSTICS affected_count = ROW_COUNT;
+        IF affected_count <> 1 THEN
+            RAISE EXCEPTION 'owner-only generation has no live writable layer'
+                USING ERRCODE = '23514';
+        END IF;
+
+        UPDATE snapshot_storage_reference ref
+        SET released_at = now()
+        WHERE ref.layer_id = generation.id
+          AND ref.team_id = requested_team_id
+          AND ref.snapshot_id IS NULL
+          AND ref.sandbox_id = generation.owner_sandbox_id
+          AND ref.released_at IS NULL;
+        GET DIAGNOSTICS affected_count = ROW_COUNT;
+        IF affected_count <> 1 THEN
+            RAISE EXCEPTION 'owner-only generation reference changed during fold'
+                USING ERRCODE = '23514';
+        END IF;
+
+        UPDATE snapshot_storage_layer layer
+        SET ended_at = now(), updated_at = now()
+        WHERE layer.id = generation.id
+          AND layer.team_id = requested_team_id
+          AND layer.kind = 'sandbox_generation'
+          AND layer.ended_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM snapshot_storage_reference ref
+              WHERE ref.layer_id = layer.id
+                AND ref.team_id = layer.team_id
+                AND ref.released_at IS NULL
+          );
+        GET DIAGNOSTICS affected_count = ROW_COUNT;
+        IF affected_count <> 1 THEN
+            RAISE EXCEPTION 'owner-only generation gained a reference during fold'
+                USING ERRCODE = '23514';
+        END IF;
+
+        folded_count := folded_count + 1;
+    END LOOP;
+    RETURN folded_count;
+END;
+$$;
+
+-- Reconcile a stable VMD full-inode measurement in one database transaction.
+-- PL/pgSQL sequencing is intentional: an owner-only fold updates the current
+-- row before the authoritative replacement, which PostgreSQL does not allow a
+-- data-modifying CTE and its outer UPDATE to do to the same tuple.
+CREATE OR REPLACE FUNCTION snapshot_storage_reconcile_writable_usage(
+    requested_team_id uuid,
+    requested_sandbox_id uuid,
+    measured_logical_size_bytes bigint,
+    measured_exclusive_size_bytes bigint
+) RETURNS bigint
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    affected_count bigint;
+BEGIN
+    IF measured_logical_size_bytes < 0
+       OR measured_exclusive_size_bytes < 0 THEN
+        RAISE EXCEPTION 'writable-layer measurements must be non-negative'
+            USING ERRCODE = '23514';
+    END IF;
+
+    PERFORM sandbox.id
+    FROM sandbox
+    WHERE sandbox.id = requested_sandbox_id
+      AND sandbox.team_id = requested_team_id
+      AND sandbox.destroyed_at IS NULL
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN 0;
+    END IF;
+
+    PERFORM snapshot_storage_fold_owner_only_generations(
+        requested_team_id, requested_sandbox_id, NULL
+    );
+
+    UPDATE snapshot_storage_layer layer
+    SET current_logical_size_bytes = measured_logical_size_bytes,
+        current_exclusive_size_bytes = measured_exclusive_size_bytes,
+        updated_at = now()
+    WHERE layer.owner_sandbox_id = requested_sandbox_id
+      AND layer.team_id = requested_team_id
+      AND layer.kind = 'sandbox_writable'
+      AND layer.ended_at IS NULL;
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+    RETURN affected_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION snapshot_storage_snapshot_lifecycle() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    source_layer_id bigint;
+    snapshot_layer_id bigint;
+    source_logical bigint;
+    source_exclusive bigint;
+    source_current_logical bigint := 0;
+    source_current_exclusive bigint := 0;
+    source_remaining_logical bigint := 0;
+    source_remaining_exclusive bigint := 0;
+    team_usage bigint;
+    team_quota bigint;
+    released_layer_ids bigint[];
+BEGIN
+    IF OLD.status = 'creating'
+       AND NEW.status IN ('ready', 'deleting')
+       AND NEW.finalized_at IS NOT NULL THEN
+        source_logical := COALESCE(
+            (NEW.artifact_metadata ->> 'source_logical_size_bytes')::bigint,
+            0
+        );
+        source_exclusive := COALESCE(
+            (NEW.artifact_metadata ->> 'source_exclusive_size_bytes')::bigint,
+            0
+        );
+
+        -- A ready branch seals the source's current writable generation into
+        -- its own immutable row. Snapshot references must never point at the
+        -- replacement mutable row: otherwise later source writes would be
+        -- charged and retained by an older snapshot that cannot reference
+        -- those bytes. Cleanup-only artifacts never retain source generations
+        -- because their reflinks are about to be discarded.
+        IF NEW.status = 'ready' THEN
+            -- Defensive repair for a final-reference release performed by an
+            -- older writer: fold any owner-only generations before sealing the
+            -- current row. The source lock held by finalization serializes this
+            -- with lifecycle folding.
+            PERFORM snapshot_storage_fold_owner_only_generations(
+                NEW.team_id, NEW.sandbox_id, NULL
+            );
+
+            SELECT layer.id,
+                   layer.current_logical_size_bytes,
+                   layer.current_exclusive_size_bytes
+            INTO source_layer_id,
+                 source_current_logical,
+                 source_current_exclusive
+            FROM snapshot_storage_layer layer
+            WHERE layer.owner_sandbox_id = NEW.sandbox_id
+              AND layer.team_id = NEW.team_id
+              AND layer.kind = 'sandbox_writable'
+              AND layer.ended_at IS NULL
+            FOR UPDATE;
+
+            IF source_layer_id IS NULL THEN
+                INSERT INTO snapshot_storage_layer (
+                    team_id, kind, owner_sandbox_id,
+                    retained_logical_size_bytes,
+                    retained_exclusive_size_bytes
+                ) VALUES (
+                    NEW.team_id, 'sandbox_generation', NEW.sandbox_id,
+                    source_logical, source_exclusive
+                )
+                RETURNING id INTO source_layer_id;
+            ELSE
+                -- The VMD source fields describe only bytes that this capture
+                -- actually retained through reflink sharing. A prior writable
+                -- measurement may also include source-only vmstate, sidecars,
+                -- or copied-delta bytes. Carry that non-retained remainder into
+                -- the replacement current generation instead of making it
+                -- disappear until the next pause measurement.
+                source_remaining_logical := GREATEST(
+                    source_current_logical - source_logical, 0
+                );
+                source_remaining_exclusive := GREATEST(
+                    source_current_exclusive - source_exclusive, 0
+                );
+                UPDATE snapshot_storage_layer
+                SET kind = 'sandbox_generation',
+                    retained_logical_size_bytes = source_logical,
+                    retained_exclusive_size_bytes = source_exclusive,
+                    current_logical_size_bytes = 0,
+                    current_exclusive_size_bytes = 0,
+                    updated_at = now()
+                WHERE id = source_layer_id;
+            END IF;
+
+            INSERT INTO snapshot_storage_reference (
+                layer_id, team_id, sandbox_id
+            ) VALUES (source_layer_id, NEW.team_id, NEW.sandbox_id)
+            ON CONFLICT (layer_id, sandbox_id)
+                WHERE sandbox_id IS NOT NULL AND released_at IS NULL
+            DO NOTHING;
+        END IF;
+
+        INSERT INTO snapshot_storage_layer (
+            team_id, kind, owner_snapshot_id,
+            retained_logical_size_bytes,
+            retained_exclusive_size_bytes
+        ) VALUES (
+            NEW.team_id, 'saved_snapshot', NEW.id,
+            NEW.logical_size_bytes, NEW.exclusive_size_bytes
+        )
+        ON CONFLICT (owner_snapshot_id)
+            WHERE owner_snapshot_id IS NOT NULL
+        DO UPDATE SET
+            retained_logical_size_bytes = EXCLUDED.retained_logical_size_bytes,
+            retained_exclusive_size_bytes = EXCLUDED.retained_exclusive_size_bytes,
+            ended_at = NULL,
+            updated_at = now()
+        RETURNING id INTO snapshot_layer_id;
+
+        INSERT INTO snapshot_storage_reference (
+            layer_id, team_id, snapshot_id
+        ) VALUES (snapshot_layer_id, NEW.team_id, NEW.id)
+        ON CONFLICT (layer_id, snapshot_id)
+            WHERE snapshot_id IS NOT NULL AND released_at IS NULL
+        DO NOTHING;
+
+        IF NEW.status = 'ready' THEN
+            -- The source sandbox already references every immutable ancestor
+            -- it needs. Copy that reference set to the new snapshot, including
+            -- the source writable generation retained above.
+            INSERT INTO snapshot_storage_reference (
+                layer_id, team_id, snapshot_id
+            )
+            SELECT ref.layer_id, NEW.team_id, NEW.id
+            FROM snapshot_storage_reference ref
+            WHERE ref.sandbox_id = NEW.sandbox_id
+              AND ref.team_id = NEW.team_id
+              AND ref.released_at IS NULL
+            ON CONFLICT (layer_id, snapshot_id)
+                WHERE snapshot_id IS NOT NULL AND released_at IS NULL
+            DO NOTHING;
+
+            -- Start a new mutable generation only after copying the source's
+            -- sealed/ancestor reference set to the snapshot. This row is
+            -- referenced by the source sandbox alone until the next capture
+            -- seals it.
+            INSERT INTO snapshot_storage_layer (
+                team_id, kind, owner_sandbox_id,
+                current_logical_size_bytes,
+                current_exclusive_size_bytes
+            ) VALUES (
+                NEW.team_id, 'sandbox_writable', NEW.sandbox_id,
+                source_remaining_logical, source_remaining_exclusive
+            )
+            RETURNING id INTO source_layer_id;
+
+            INSERT INTO snapshot_storage_reference (
+                layer_id, team_id, sandbox_id
+            ) VALUES (source_layer_id, NEW.team_id, NEW.sandbox_id);
+
+            SELECT snapshot_storage_bytes, snapshot_storage_quota_bytes
+            INTO team_usage, team_quota
+            FROM team
+            WHERE id = NEW.team_id
+            FOR UPDATE;
+            IF team_quota IS NULL THEN
+                RAISE EXCEPTION 'saved snapshot storage quota is not provisioned'
+                    USING ERRCODE = 'SS004';
+            END IF;
+            IF team_usage > team_quota THEN
+                RAISE EXCEPTION 'saved snapshot storage quota exceeded (usage=%, max=%)',
+                                team_usage, team_quota
+                    USING ERRCODE = 'SS005';
+            END IF;
+        END IF;
+    END IF;
+
+    IF OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL THEN
+        SELECT array_agg(DISTINCT ref.layer_id ORDER BY ref.layer_id)
+        INTO released_layer_ids
+        FROM snapshot_storage_reference ref
+        WHERE ref.snapshot_id = NEW.id
+          AND ref.team_id = NEW.team_id
+          AND ref.released_at IS NULL;
+
+        -- Acquire owner -> generation -> reference locks before releasing the
+        -- target refs. Calling the fold once while those refs are still active
+        -- normally makes no change, but establishes the same lock order used by
+        -- concurrent capture finalization and prevents a source/ref deadlock.
+        PERFORM snapshot_storage_fold_owner_only_generations(
+            NEW.team_id, NULL, released_layer_ids
+        );
+
+        UPDATE snapshot_storage_reference
+        SET released_at = now()
+        WHERE snapshot_id = NEW.id
+          AND team_id = NEW.team_id
+          AND released_at IS NULL;
+
+        PERFORM snapshot_storage_fold_owner_only_generations(
+            NEW.team_id, NULL, released_layer_ids
+        );
+
+        UPDATE snapshot_storage_layer layer
+        SET ended_at = now(), updated_at = now()
+        WHERE layer.team_id = NEW.team_id
+          AND layer.ended_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM snapshot_storage_reference ref
+              WHERE ref.layer_id = layer.id AND ref.released_at IS NULL
+          );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION snapshot_storage_sandbox_lifecycle() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    writable_layer_id bigint;
+    released_layer_ids bigint[];
+BEGIN
+    -- A fork's lineage is part of its immutable restore identity. The only
+    -- supported mutation is releasing the pin after host teardown has made
+    -- the sandbox terminal; otherwise the reference ledger could diverge
+    -- from source_snapshot_id.
+    IF TG_OP = 'UPDATE'
+       AND OLD.source_snapshot_id IS DISTINCT FROM NEW.source_snapshot_id
+       AND NOT (
+           OLD.source_snapshot_id IS NOT NULL
+           AND NEW.source_snapshot_id IS NULL
+           AND NEW.destroyed_at IS NOT NULL
+       ) THEN
+        RAISE EXCEPTION 'sandbox source snapshot is immutable while live'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF TG_OP = 'INSERT' AND NEW.source_snapshot_id IS NOT NULL THEN
+        INSERT INTO snapshot_storage_layer (
+            team_id, kind, owner_sandbox_id
+        ) VALUES (
+            NEW.team_id, 'sandbox_writable', NEW.id
+        )
+        RETURNING id INTO writable_layer_id;
+
+        INSERT INTO snapshot_storage_reference (
+            layer_id, team_id, sandbox_id
+        ) VALUES (writable_layer_id, NEW.team_id, NEW.id)
+        ON CONFLICT (layer_id, sandbox_id)
+            WHERE sandbox_id IS NOT NULL AND released_at IS NULL
+        DO NOTHING;
+
+        INSERT INTO snapshot_storage_reference (
+            layer_id, team_id, sandbox_id
+        )
+        SELECT ref.layer_id, NEW.team_id, NEW.id
+        FROM snapshot_storage_reference ref
+        WHERE ref.snapshot_id = NEW.source_snapshot_id
+          AND ref.team_id = NEW.team_id
+          AND ref.released_at IS NULL
+        ON CONFLICT (layer_id, sandbox_id)
+            WHERE sandbox_id IS NOT NULL AND released_at IS NULL
+        DO NOTHING;
+    END IF;
+
+    IF TG_OP = 'UPDATE' AND (
+        (OLD.destroyed_at IS NULL AND NEW.destroyed_at IS NOT NULL
+         AND NEW.source_snapshot_id IS NULL)
+        OR (OLD.source_snapshot_id IS NOT NULL
+            AND NEW.source_snapshot_id IS NULL
+            AND NEW.destroyed_at IS NOT NULL)
+    ) THEN
+        SELECT array_agg(DISTINCT ref.layer_id ORDER BY ref.layer_id)
+        INTO released_layer_ids
+        FROM snapshot_storage_reference ref
+        WHERE ref.sandbox_id = NEW.id
+          AND ref.team_id = NEW.team_id
+          AND ref.released_at IS NULL;
+
+        -- Establish source-first locking before reference release; see the
+        -- equivalent saved-snapshot lifecycle path above.
+        PERFORM snapshot_storage_fold_owner_only_generations(
+            NEW.team_id, NULL, released_layer_ids
+        );
+
+        UPDATE snapshot_storage_reference
+        SET released_at = now()
+        WHERE sandbox_id = NEW.id
+          AND team_id = NEW.team_id
+          AND released_at IS NULL;
+
+        PERFORM snapshot_storage_fold_owner_only_generations(
+            NEW.team_id, NULL, released_layer_ids
+        );
+
+        UPDATE snapshot_storage_layer layer
+        SET ended_at = now(), updated_at = now()
+        WHERE layer.team_id = NEW.team_id
+          AND layer.ended_at IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM snapshot_storage_reference ref
+              WHERE ref.layer_id = layer.id AND ref.released_at IS NULL
+          );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- Saved-snapshot forks are pinned to the artifact host. Serialize their
+-- admission on that host row and account for both active and starting VMs so
+-- a concurrent fan-out cannot overcommit stale capacity. This intentionally
+-- guards the V1 host-local fork path; the general scheduler may adopt the same
+-- resource-weighted admission in a later migration.
+CREATE OR REPLACE FUNCTION admit_saved_snapshot_host(
+    requested_host_id text,
+    requested_vcpus integer,
+    requested_memory_mib integer
+) RETURNS boolean
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    max_vcpus bigint;
+    max_memory_mib bigint;
+    used_vcpus bigint;
+    used_memory_mib bigint;
+BEGIN
+    SELECT capacity_vcpus, capacity_memory_mib
+    INTO max_vcpus, max_memory_mib
+    FROM host
+    WHERE id = requested_host_id
+      AND status = 'active'
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'saved snapshot host % is unavailable', requested_host_id
+            USING ERRCODE = 'SS006';
+    END IF;
+
+    SELECT COALESCE(sum(vcpu_count), 0), COALESCE(sum(memory_mib), 0)
+    INTO used_vcpus, used_memory_mib
+    FROM sandbox
+    WHERE host_id = requested_host_id
+      -- Starting/restoring and resuming admissions are serialized on the host
+      -- row. Pausing remains physically resident until VMD confirms the pause,
+      -- so it cannot free capacity early.
+      -- A live failed row may represent an ambiguous teardown whose host
+      -- process could not be proven dead. Count it until destroyed_at is set
+      -- so saved-snapshot admission cannot overcommit an orphaned VM.
+      AND status IN ('active', 'starting', 'resuming', 'pausing', 'failed')
+      AND destroyed_at IS NULL;
+
+    IF used_vcpus + requested_vcpus > max_vcpus
+       OR used_memory_mib + requested_memory_mib > max_memory_mib THEN
+        RAISE EXCEPTION
+            'saved snapshot host capacity exhausted (vcpus=%+%/%, memory_mib=%+%/%)',
+            used_vcpus, requested_vcpus, max_vcpus,
+            used_memory_mib, requested_memory_mib, max_memory_mib
+            USING ERRCODE = 'SS006';
+    END IF;
+
+    RETURN true;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260729000007_saved_snapshot_triggers.sql
+++ b/supabase/migrations/20260729000007_saved_snapshot_triggers.sql
@@ -1,0 +1,39 @@
+-- Install hot-table triggers in a short catalog-only transaction after all
+-- referenced functions and ledger tables exist.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE TRIGGER trg_saved_snapshot_quota_on_insert
+    BEFORE INSERT ON snapshot
+    FOR EACH ROW
+    EXECUTE FUNCTION saved_snapshot_quota_on_insert();
+
+CREATE TRIGGER trg_saved_snapshot_immutable_on_update
+    BEFORE UPDATE ON snapshot
+    FOR EACH ROW
+    EXECUTE FUNCTION saved_snapshot_immutable_on_update();
+
+CREATE TRIGGER trg_snapshot_storage_snapshot_lifecycle
+    AFTER UPDATE ON snapshot
+    FOR EACH ROW
+    WHEN (OLD.kind = 'saved')
+    EXECUTE FUNCTION snapshot_storage_snapshot_lifecycle();
+
+CREATE TRIGGER trg_snapshot_storage_sandbox_insert
+    AFTER INSERT ON sandbox
+    FOR EACH ROW
+    EXECUTE FUNCTION snapshot_storage_sandbox_lifecycle();
+
+-- PostgreSQL runs same-kind triggers in name order. This storage trigger must
+-- acquire any ancestor-owner sandbox locks before trg_sandbox_quota_on_update
+-- acquires the team row; capture finalization uses the same sandbox -> team
+-- order. The numeric prefix makes that lock order explicit and deadlock-free.
+CREATE TRIGGER trg_00_snapshot_storage_sandbox_update
+    AFTER UPDATE ON sandbox
+    FOR EACH ROW
+    EXECUTE FUNCTION snapshot_storage_sandbox_lifecycle();
+
+COMMIT;

--- a/supabase/migrations/20260729000008_saved_snapshot_validate.sql
+++ b/supabase/migrations/20260729000008_saved_snapshot_validate.sql
@@ -1,0 +1,37 @@
+-- Validate pre-existing rows under PostgreSQL's weaker validation locks.
+-- NOT VALID constraints already protect every row written after migration 6.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '2min';
+
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_name_valid;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_idempotency_key_valid;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_vcpu_positive;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_memory_positive;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_disk_positive;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_logical_size_non_negative;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_exclusive_size_non_negative;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_artifact_metadata_object;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_secret_bindings_array;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_secret_env_keys_array;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_runtime_shape;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_saved_source_shape;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_ready_artifact_shape;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_deleted_state;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_template_id_fk;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_parent_team_fk;
+ALTER TABLE snapshot VALIDATE CONSTRAINT snapshot_source_sandbox_team_fk;
+
+ALTER TABLE team VALIDATE CONSTRAINT team_max_snapshots_positive;
+ALTER TABLE team VALIDATE CONSTRAINT team_max_snapshots_per_sandbox_positive;
+ALTER TABLE team VALIDATE CONSTRAINT team_snapshot_storage_quota_non_negative;
+ALTER TABLE team VALIDATE CONSTRAINT team_snapshot_storage_non_negative;
+
+ALTER TABLE sandbox VALIDATE CONSTRAINT sandbox_source_snapshot_team_fk;
+ALTER TABLE sandbox VALIDATE CONSTRAINT sandbox_snapshot_operation_team_fk;
+ALTER TABLE sandbox VALIDATE CONSTRAINT sandbox_snapshot_operation_pair;
+ALTER TABLE sandbox VALIDATE CONSTRAINT sandbox_secret_env_keys_array;
+
+COMMIT;

--- a/supabase/migrations/20260729000009_saved_snapshot_host_admission.sql
+++ b/supabase/migrations/20260729000009_saved_snapshot_host_admission.sql
@@ -1,0 +1,122 @@
+-- Keep host admission safe across control-plane rollbacks. A pre-drain-aware
+-- binary can still issue the legacy sandbox/build SQL, so enforce the final
+-- launch decision at the database boundary shared by every binary version.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE FUNCTION public.require_active_host_admission(
+    requested_host_id text,
+    workload_kind text
+) RETURNS void
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+AS $$
+BEGIN
+    -- FOR SHARE serializes admission with the UPDATE that marks a host
+    -- draining/unhealthy. If admission wins, the status update waits for the
+    -- launch transaction to commit; if the status update wins, this predicate
+    -- is rechecked after the wait and admission is rejected.
+    PERFORM 1
+    FROM public.host h
+    WHERE h.id = requested_host_id
+      AND h.status = 'active'
+    FOR SHARE;
+
+    IF FOUND THEN
+        RETURN;
+    END IF;
+
+    -- Before the first host row is registered, legacy single-host
+    -- installations route through their configured/default VMD without a
+    -- registry entry. Retain only that whole-table-empty compatibility path:
+    -- once any host is registered, missing and unavailable hosts fail closed.
+    IF NOT EXISTS (SELECT 1 FROM public.host) THEN
+        RETURN;
+    END IF;
+
+    RAISE EXCEPTION
+        'host admission denied for % on host %: host is missing or not active',
+        workload_kind,
+        requested_host_id
+        USING ERRCODE = 'SS006';
+END;
+$$;
+
+CREATE FUNCTION public.enforce_sandbox_host_admission() RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status IN ('starting', 'active', 'resuming') THEN
+            PERFORM public.require_active_host_admission(
+                NEW.host_id,
+                'sandbox'
+            );
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    -- A paused -> resuming transition owns a new launch attempt. A host move
+    -- while already in a live launch state does too. Deliberately do not
+    -- re-admit same-host starting/resuming -> active: that write completes a
+    -- launch already admitted before a later drain began.
+    IF (OLD.status = 'paused' AND NEW.status = 'resuming')
+       OR (
+           NEW.host_id IS DISTINCT FROM OLD.host_id
+           AND NEW.status IN ('starting', 'active', 'resuming')
+       )
+    THEN
+        PERFORM public.require_active_host_admission(
+            NEW.host_id,
+            'sandbox'
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_host_admission_insert
+    BEFORE INSERT ON public.sandbox
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_sandbox_host_admission();
+
+CREATE TRIGGER trg_sandbox_host_admission_update
+    BEFORE UPDATE OF status, host_id ON public.sandbox
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_sandbox_host_admission();
+
+CREATE FUNCTION public.enforce_template_build_host_admission() RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+AS $$
+BEGIN
+    IF OLD.status = 'pending' AND NEW.status = 'building' THEN
+        PERFORM public.require_active_host_admission(
+            NEW.vmd_host_id,
+            'template build'
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_template_build_host_admission
+    BEFORE UPDATE OF status, vmd_host_id ON public.template_build
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_template_build_host_admission();
+
+-- These functions are trigger internals, not an application-callable API.
+REVOKE ALL ON FUNCTION public.require_active_host_admission(text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.enforce_sandbox_host_admission() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.enforce_template_build_host_admission() FROM PUBLIC;
+
+COMMIT;


### PR DESCRIPTION
## Stack

**1 of 4** for saved snapshots and independent forks. This is the additive expand and rolling-deploy safety layer; later PRs add VMD/storage, the control plane/API, then indexes/contracts/canary rollout. Part of #221.

## What changes

- Adds saved-snapshot identity, lifecycle, lineage, quota, and storage-ledger schema.
- Keeps `sandbox_snapshots_v1` globally disabled and clears any enabled team override.
- Preserves the legacy non-partial `snapshot_sandbox_unique` index so old pause writers remain compatible.
- Preserves secret scrub history for rolling old writers with a database trigger plus a concurrency-safe, merge-only backfill.
- Enables RLS on internal storage-ledger tables with no client-visible policies.
- Splits hot-table changes into bounded migrations, adds constraints `NOT VALID`, and validates them separately.
- Defers nonessential hot-table indexes until the pre-contract maintenance gate while the feature is dark.
- Adds a database-owned active-host admission guard for new launches, resumes, host moves, and template builds. It serializes with host drain/status updates and fails closed with `SS006`.
- Makes ordinary/template sandbox creation commit the trigger-backed DB admission before any VMD restore, preventing a rejected insert from leaving an untracked VM during mixed-version rollout.

## Rollback posture

Rollback to this PR (or a later stack revision) is safe: VMD launch cannot run before the database admission succeeds. Database rollback is intentionally **leave-forward**—the expand changes are additive, and removing columns/types after a mixed-version deploy would be riskier than leaving the dark schema in place. The legacy runtime identity index remains in place.

Before routing traffic to any **pre-PR1** API revision, first return every `draining` host to `active` and verify convergence. Those older binaries launch VMD and perform the INSERT in parallel; if a host cannot be reactivated, do not roll back that far. This is recorded in `deploy/README.md`.

## Validation

- `go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0 generate`
- Full current integration and migrate-team suites with `-race`
- Full integration suite from a binary compiled at the exact `main` base, run against the expanded schema
- Real-Postgres host-admission coverage for active/draining/unhealthy/missing hosts, resume/template/host-move paths, lock serialization, and non-owner trigger execution
- Regression proving `SS006`, quota, and template-race INSERT failures make zero VMD restore/destroy calls
- Lock-orchestrated regression proving a concurrent legacy secret attach cannot be overwritten by the history backfill
- Focused `-race` tests for db/API/control-plane and `go vet`
- Linux builds for controlplane, vmd, boxd, template-builder, and secretsproxy
- Post-fix migration rehearsal on 100k sandboxes, 100k runtime snapshots, and 50k secret bindings: ~3.4s total; concurrency-safe secret-history backfill 2.76s; required composite index 0.13s; each catalog-only lock step <0.06s

## Pre-production gates

- Run the data preflight queries in staging (secret-history cardinality and team/lineage consistency).
- Confirm the manually repaired `20260716000001` migration-history state is absent/clean in staging.
- Repeat the timing rehearsal with staging row counts and monitor lock waits.
- Keep the feature flag dark through PRs 1–3.