### PR TITLE
VMD: add saved snapshot data plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Run unit tests
         run: go test -v -short -count=1 -race ./...
 
+      - name: Validate VMD deployment scripts
+        run: |
+          bash -n scripts/setup-sandbox-data-disk.sh
+          python3 -m unittest discover -s .github/workflows/scripts -p 'test_deploy_vmd.py' -v
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -8,6 +8,10 @@
 
 name: Deploy VMD
 
+concurrency:
+  group: deploy-vmd-hosts
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -18,6 +22,15 @@ on:
         options:
           - staging
           - production
+      activate_staging_snapshot_storage:
+        description: 'Manually migrate staging runtime/snapshots to the attached XFS disk'
+        required: false
+        default: false
+        type: boolean
+      staging_snapshot_storage_device:
+        description: 'Required with activation: /dev/disk/by-id/google-superserve-sandbox-data'
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -26,22 +39,28 @@ on:
       - 'cmd/template-builder/**'
       - 'cmd/secretsproxy/**'
       - 'internal/vm/**'
+      - 'internal/vmdclient/**'
       - 'internal/network/**'
       - 'internal/builder/**'
       - 'internal/db/**'
       - 'internal/secretsproxy/**'
+      - 'proto/vmd.proto'
+      - 'proto/vmdpb/**'
       - 'deploy/superserve-vmd.service'
       - 'deploy/superserve-vmd.socket'
       - 'deploy/superserve-secretsproxy.service'
       - 'deploy/firecracker@.service'
       - 'deploy/firecracker-netns@.service'
       - 'deploy/sandboxes.slice'
+      - 'deploy/sandbox-data-disk.service'
       - 'scripts/fc-cleanup'
+      - 'scripts/setup-sandbox-data-disk.sh'
       # The workflow + its deploy script must self-trigger (as deploy-otel does),
       # or a new cell/step lands without ever running until an unrelated vmd
       # asset changes — leaving that host on stale binaries.
       - '.github/workflows/deploy-vmd.yml'
       - '.github/workflows/scripts/deploy-vmd.py'
+      - '.github/workflows/scripts/test_deploy_vmd.py'
 
 jobs:
   deploy-staging:
@@ -89,8 +108,23 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VMD_SERVICE: ${{ vars.VMD_SERVICE }}
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
+          SNAPSHOT_STORAGE_ACTIVATION: ${{ github.event_name == 'workflow_dispatch' && inputs.activate_staging_snapshot_storage && 'true' || 'false' }}
+          SANDBOX_DATA_DISK_DEVICE: ${{ inputs.staging_snapshot_storage_device || '' }}
           SHA: ${{ github.sha }}
         run: |
+          if [[ "$SNAPSHOT_STORAGE_ACTIVATION" == "true" ]]; then
+            if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+              echo "Snapshot storage activation is manual-only." >&2
+              exit 1
+            fi
+            : "${SANDBOX_DATA_DISK_DEVICE:?staging_snapshot_storage_device is required when activation is enabled}"
+            if [[ "$SANDBOX_DATA_DISK_DEVICE" != "/dev/disk/by-id/google-superserve-sandbox-data" ]]; then
+              echo "Refusing any staging snapshot device except /dev/disk/by-id/google-superserve-sandbox-data." >&2
+              exit 1
+            fi
+          else
+            unset SANDBOX_DATA_DISK_DEVICE
+          fi
           python3 .github/workflows/scripts/deploy-vmd.py
 
   deploy-production:

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -14,6 +14,12 @@ Env vars:
   VMD_LABEL            required — gcloud instances list label filter (e.g. component=vmd)
   VMD_SERVICE          required — systemd unit name for vmd (e.g. superserve-vmd)
   VMD_INSTALL_DIR      required — bin install dir on the host (e.g. /usr/local/bin)
+  SANDBOX_DATA_DISK_DEVICE
+                       optional exact staging path
+                       /dev/disk/by-id/google-superserve-sandbox-data. When
+                       supplied, perform the manual first activation. Omit it
+                       for ordinary deploys; authoritative hosts are still
+                       refreshed and verified automatically.
   SHA                  required — commit SHA (only first 8 chars used)
   SENTRY_DSN           optional — upserted into /etc/sandbox/vmd.env when set
   CONTROL_PLANE_URL    optional — control-plane base URL (e.g.
@@ -95,8 +101,28 @@ BUNDLE_FILES = [
     "deploy/firecracker@.service",
     "deploy/firecracker-netns@.service",
     "deploy/sandboxes.slice",
+    "deploy/sandbox-data-disk.service",
     "scripts/fc-cleanup",
+    "scripts/setup-sandbox-data-disk.sh",
 ]
+
+STAGING_DATA_DISK_DEVICE = (
+    "/dev/disk/by-id/google-superserve-sandbox-data"
+)
+
+
+def optional_data_disk_device(environ=None):
+    """Return the one allowlisted staging data device when configured."""
+    environ = os.environ if environ is None else environ
+    value = environ.get("SANDBOX_DATA_DISK_DEVICE", "").strip()
+    if not value:
+        return ""
+    if value != STAGING_DATA_DISK_DEVICE:
+        raise ValueError(
+            "SANDBOX_DATA_DISK_DEVICE must be exactly "
+            f"{STAGING_DATA_DISK_DEVICE!r}, got {value!r}"
+        )
+    return value
 
 
 def main() -> int:
@@ -113,6 +139,7 @@ def main() -> int:
     # Empty = skip, so a fleet-wide deploy never writes a redirect to a host
     # whose resolver isn't on this port. Set per host/region to match unbound.
     dns_redirect_port = os.environ.get("VMD_DNS_REDIRECT_PORT", "")
+    data_disk_device = optional_data_disk_device()
 
     # Pre-quote every value injected into the remote shell script. These come
     # from CI secrets / Secret Manager and must be treated as arbitrary text:
@@ -129,6 +156,7 @@ def main() -> int:
     q_dat_line = shlex.quote(f"DAEMON_AUTH_TOKEN={internal_api_token}")
     q_db = shlex.quote(database_url)
     q_db_line = shlex.quote(f"DATABASE_URL={database_url}")
+    q_data_disk_device = shlex.quote(data_disk_device)
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -173,6 +201,156 @@ def main() -> int:
 
     bundle_remote = f"/tmp/deploy-bundle-{sha}.tar.gz"
     extract_dir = f"/tmp/deploy-{sha}"
+    data_disk_setup_call = textwrap.dedent(f"""
+        DATA_DISK_AUTHORITY_MARKER=/etc/sandbox/data-disk-authoritative
+        DATA_DISK_CONFIG_FILE=/etc/sandbox/data-disk.env
+        DATA_DISK_EXPECTED_DEVICE={shlex.quote(STAGING_DATA_DISK_DEVICE)}
+        DATA_DISK_REQUESTED_DEVICE={q_data_disk_device}
+        DATA_DISK_HAD_AUTHORITY=0
+        DATA_DISK_HAD_CONFIG=0
+        DATA_DISK_SETUP_ATTEMPTED=0
+        DATA_DISK_SETUP_RC=0
+        DATA_DISK_VMD_WAS_ACTIVE=0
+
+        sudo test -f "$DATA_DISK_AUTHORITY_MARKER" && DATA_DISK_HAD_AUTHORITY=1
+        sudo test -f "$DATA_DISK_CONFIG_FILE" && DATA_DISK_HAD_CONFIG=1
+        if sudo systemctl is-active --quiet {service}; then
+            DATA_DISK_VMD_WAS_ACTIVE=1
+        fi
+
+        install_data_disk_assets() {{
+            sudo install -m 0755 {extract_dir}/scripts/setup-sandbox-data-disk.sh /usr/local/bin/setup-sandbox-data-disk.sh
+            sudo install -m 0644 {extract_dir}/deploy/sandbox-data-disk.service /etc/systemd/system/sandbox-data-disk.service
+            sudo systemctl daemon-reload
+        }}
+
+        show_data_disk_diagnostics() {{
+            echo "sandbox-data-disk.service diagnostics:" >&2
+            sudo systemctl status --no-pager sandbox-data-disk.service >&2 || true
+            sudo journalctl -u sandbox-data-disk.service --no-pager -n 160 >&2 || true
+        }}
+
+        if [ -n "$DATA_DISK_REQUESTED_DEVICE" ]; then
+            if [ "$DATA_DISK_REQUESTED_DEVICE" != "$DATA_DISK_EXPECTED_DEVICE" ]; then
+                echo "ERROR: refusing non-allowlisted snapshot storage device: $DATA_DISK_REQUESTED_DEVICE" >&2
+                exit 1
+            fi
+
+            if [ "$DATA_DISK_HAD_AUTHORITY" != 1 ]; then
+                # Do this before installing either asset: every possible
+                # pre-authority exit must leave boot-time retries disabled.
+                sudo systemctl disable --quiet sandbox-data-disk.service || true
+            fi
+            install_data_disk_assets
+            if [ "$DATA_DISK_HAD_AUTHORITY" = 1 ]; then
+                # The host is already authoritative. Never restart its required
+                # oneshot; refresh the assets and verify the live bind mounts.
+                DATA_DISK_SETUP_ATTEMPTED=1
+                sudo /usr/local/bin/setup-sandbox-data-disk.sh --verify-only || DATA_DISK_SETUP_RC=$?
+            else
+                # A first activation is manual-only. Clear any stale enablement
+                # left by an older failed rollout before writing configuration,
+                # so a pre-authority failure cannot retry automatically at boot.
+                sudo install -d -m 0755 /etc/sandbox
+                DATA_DISK_CONFIG_TMP=$(sudo mktemp /etc/sandbox/.data-disk.env.XXXXXX)
+                trap 'sudo rm -f "$DATA_DISK_CONFIG_TMP"' EXIT
+                printf '%s\\n' "SANDBOX_DATA_DISK_DEVICE=$DATA_DISK_EXPECTED_DEVICE" | sudo tee "$DATA_DISK_CONFIG_TMP" > /dev/null
+                sudo chown root:root "$DATA_DISK_CONFIG_TMP"
+                sudo chmod 0644 "$DATA_DISK_CONFIG_TMP"
+                sudo mv -f "$DATA_DISK_CONFIG_TMP" "$DATA_DISK_CONFIG_FILE"
+                DATA_DISK_CONFIG_TMP=
+                trap - EXIT
+
+                if ! command -v mkfs.xfs >/dev/null 2>&1 || ! command -v xfs_info >/dev/null 2>&1; then
+                    if ! command -v apt-get >/dev/null 2>&1; then
+                        echo "ERROR: xfsprogs is required for staging snapshot storage" >&2
+                        DATA_DISK_SETUP_RC=1
+                    else
+                        sudo apt-get update -qq || DATA_DISK_SETUP_RC=$?
+                        if [ "$DATA_DISK_SETUP_RC" = 0 ]; then
+                            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq xfsprogs || DATA_DISK_SETUP_RC=$?
+                        fi
+                    fi
+                fi
+
+                DATA_DISK_SETUP_ATTEMPTED=1
+                if [ "$DATA_DISK_SETUP_RC" = 0 ]; then
+                    sudo systemctl start sandbox-data-disk.service || DATA_DISK_SETUP_RC=$?
+                fi
+            fi
+        elif [ "$DATA_DISK_HAD_AUTHORITY" = 1 ]; then
+            # Ordinary push deploy: authoritative storage must receive the
+            # updated verifier/unit before VMD is restarted.
+            install_data_disk_assets
+            DATA_DISK_SETUP_ATTEMPTED=1
+            sudo /usr/local/bin/setup-sandbox-data-disk.sh --verify-only || DATA_DISK_SETUP_RC=$?
+        elif [ "$DATA_DISK_HAD_CONFIG" = 1 ]; then
+            # Configuration without authority is residue from an interrupted
+            # or failed first activation. Do not turn a push into an implicit
+            # retry; clear the boot trigger and require another explicit input.
+            echo "Removing pre-authority snapshot storage configuration; activation remains manual-only" >&2
+            sudo systemctl disable --quiet sandbox-data-disk.service || true
+            sudo rm -f "$DATA_DISK_CONFIG_FILE"
+            sudo systemctl daemon-reload
+        else
+            # Defensive cleanup for a legacy pre-authority rollout that left
+            # only an enablement symlink behind.
+            sudo systemctl disable --quiet sandbox-data-disk.service || true
+        fi
+
+        if [ "$DATA_DISK_SETUP_ATTEMPTED" = 1 ] && [ "$DATA_DISK_SETUP_RC" = 0 ]; then
+            if ! sudo test -f "$DATA_DISK_AUTHORITY_MARKER" || ! sudo test -f "$DATA_DISK_CONFIG_FILE"; then
+                echo "ERROR: snapshot storage setup returned success without durable authority and configuration" >&2
+                DATA_DISK_SETUP_RC=1
+            else
+                # Enable boot-time execution only after the first activation
+                # has succeeded. Authoritative mid-commit failures are still
+                # protected by the Requires= drop-ins written by the setup
+                # script before it records the authority marker.
+                sudo systemctl enable --quiet sandbox-data-disk.service || DATA_DISK_SETUP_RC=$?
+            fi
+        fi
+
+        if [ "$DATA_DISK_SETUP_RC" != 0 ]; then
+            show_data_disk_diagnostics
+            if sudo test -f "$DATA_DISK_AUTHORITY_MARKER"; then
+                # Defense in depth: verify-only and authoritative setup errors
+                # also stop these listeners internally.
+                sudo systemctl stop superserve-vmd.socket {service} || true
+                echo "Data-disk verification failed after authority; the VMD control plane remains stopped" >&2
+            else
+                # No authority was recorded, so the original filesystem remains
+                # canonical. Remove both automatic retry mechanisms.
+                sudo systemctl disable --quiet sandbox-data-disk.service || true
+                sudo rm -f "$DATA_DISK_CONFIG_FILE"
+                sudo systemctl daemon-reload
+                if [ "$DATA_DISK_VMD_WAS_ACTIVE" = 1 ]; then
+                    for attempt in $(seq 1 30); do
+                        sudo systemctl is-active --quiet {service} && break
+                        sleep 1
+                    done
+                    if sudo systemctl is-active --quiet {service}; then
+                        echo "Data-disk setup failed before authority; {service} recovered on the original storage" >&2
+                    else
+                        echo "ERROR: {service} did not recover after the pre-authority setup failure" >&2
+                    fi
+                fi
+            fi
+            exit "$DATA_DISK_SETUP_RC"
+        fi
+
+        if [ "$DATA_DISK_SETUP_ATTEMPTED" = 1 ] && [ "$DATA_DISK_VMD_WAS_ACTIVE" = 1 ]; then
+            for attempt in $(seq 1 60); do
+                sudo systemctl is-active --quiet {service} && break
+                sleep 1
+            done
+            sudo systemctl is-active --quiet {service} || (
+                echo "ERROR: {service} did not recover after the data-disk operation" >&2
+                sudo systemctl status --no-pager {service} >&2 || true
+                exit 1
+            )
+        fi
+    """).strip()
 
     def deploy(inst):
         name, zone = inst["name"], inst["zone"]
@@ -197,6 +375,11 @@ def main() -> int:
             sudo rm -rf {extract_dir}
             mkdir -p {extract_dir}
             tar xzf {bundle_remote} -C {extract_dir}
+
+            # First activation is explicit and manual. Once the authority
+            # marker exists, every deploy refreshes and verifies the storage
+            # gate before replacing any VMD runtime assets.
+            {data_disk_setup_call}
 
             # Install vmd + template-builder binaries.
             sudo install -m 0755 {extract_dir}/bin/vmd {install_dir}/vmd

--- a/.github/workflows/scripts/test_deploy_vmd.py
+++ b/.github/workflows/scripts/test_deploy_vmd.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""Focused tests for the optional staging data-disk deployment path.
+
+The setup-script tests execute a transformed temporary copy with command
+shims.  They exercise the real validation/refusal flow without root access,
+mounts, or block devices; the repository script itself is never modified.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPLOY_SCRIPT = Path(__file__).with_name("deploy-vmd.py")
+SETUP_SCRIPT = REPO_ROOT / "scripts" / "setup-sandbox-data-disk.sh"
+
+
+def load_deploy_module():
+    spec = importlib.util.spec_from_file_location("deploy_vmd", DEPLOY_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+deploy_vmd = load_deploy_module()
+
+
+class DeployVmdDataDiskTests(unittest.TestCase):
+    def render_remote_script(self, data_disk_device=""):
+        ssh_commands = []
+
+        def fake_subprocess_run(command, *args, **kwargs):
+            if command[:4] == ["gcloud", "compute", "instances", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="staging-vmd,us-central1-a\n",
+                    stderr="",
+                )
+            if command[:3] == ["gcloud", "compute", "ssh"]:
+                ssh_commands.append(command[command.index("--command") + 1])
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            self.fail(f"unexpected subprocess.run command: {command!r}")
+
+        environ = {
+            "GCP_PROJECT": "test-project",
+            "GCP_REGION": "us-central1",
+            "VMD_LABEL": "component=vmd",
+            "VMD_SERVICE": "superserve-vmd",
+            "VMD_INSTALL_DIR": "/usr/local/bin",
+            "SHA": "0123456789abcdef",
+        }
+        if data_disk_device:
+            environ["SANDBOX_DATA_DISK_DEVICE"] = data_disk_device
+
+        with mock.patch.dict(deploy_vmd.os.environ, environ, clear=True), mock.patch.object(
+            deploy_vmd, "run_or_die"
+        ), mock.patch.object(
+            deploy_vmd.subprocess, "run", side_effect=fake_subprocess_run
+        ), mock.patch.object(
+            deploy_vmd.os.path, "getsize", return_value=123
+        ):
+            self.assertEqual(deploy_vmd.main(), 0)
+
+        self.assertEqual(len(ssh_commands), 1)
+        return ssh_commands[0]
+
+    def test_data_disk_device_validation(self):
+        valid = deploy_vmd.STAGING_DATA_DISK_DEVICE
+        self.assertEqual(
+            deploy_vmd.optional_data_disk_device(
+                {"SANDBOX_DATA_DISK_DEVICE": f"  {valid}  "}
+            ),
+            valid,
+        )
+        self.assertEqual(deploy_vmd.optional_data_disk_device({}), "")
+
+        invalid_values = (
+            "/dev/sdb",
+            "/dev/disk/by-id/scsi-superserve-sandbox-data",
+            "/dev/disk/by-id/google-other-data-disk",
+            "/dev/disk/by-id/google-data/partition",
+            "/dev/disk/by-id/google-data; reboot",
+            "/dev/disk/by-id/google-data $(id)",
+        )
+        for value in invalid_values:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                deploy_vmd.optional_data_disk_device(
+                    {"SANDBOX_DATA_DISK_DEVICE": value}
+                )
+
+    def test_bundle_and_staging_install_wiring(self):
+        expected_bundle_files = {
+            "deploy/sandbox-data-disk.service",
+            "scripts/setup-sandbox-data-disk.sh",
+        }
+        self.assertTrue(expected_bundle_files.issubset(deploy_vmd.BUNDLE_FILES))
+        for relative_path in expected_bundle_files:
+            self.assertTrue((REPO_ROOT / relative_path).is_file(), relative_path)
+
+        device = deploy_vmd.STAGING_DATA_DISK_DEVICE
+        remote_script = self.render_remote_script(device)
+        expected_fragments = (
+            "sudo install -m 0755 /tmp/deploy-01234567/scripts/setup-sandbox-data-disk.sh /usr/local/bin/setup-sandbox-data-disk.sh",
+            "sudo install -m 0644 /tmp/deploy-01234567/deploy/sandbox-data-disk.service /etc/systemd/system/sandbox-data-disk.service",
+            f"DATA_DISK_EXPECTED_DEVICE={device}",
+            f"DATA_DISK_REQUESTED_DEVICE={device}",
+            'printf \'%s\\n\' "SANDBOX_DATA_DISK_DEVICE=$DATA_DISK_EXPECTED_DEVICE"',
+            "sudo /usr/local/bin/setup-sandbox-data-disk.sh --verify-only",
+            "sudo systemctl start sandbox-data-disk.service",
+            "sudo systemctl enable --quiet sandbox-data-disk.service",
+            "sudo systemctl disable --quiet sandbox-data-disk.service",
+            'sudo rm -f "$DATA_DISK_CONFIG_FILE"',
+            "sudo journalctl -u sandbox-data-disk.service --no-pager -n 160",
+        )
+        for fragment in expected_fragments:
+            self.assertIn(fragment, remote_script)
+        self.assertEqual(
+            remote_script.count(
+                "sudo systemctl enable --quiet sandbox-data-disk.service"
+            ),
+            1,
+        )
+        self.assertNotIn("restart sandbox-data-disk.service", remote_script)
+        self.assertNotIn(
+            "tee /etc/systemd/system/superserve-vmd.service.d", remote_script
+        )
+
+        first_start = remote_script.index(
+            "sudo systemctl start sandbox-data-disk.service"
+        )
+        requested_branch = remote_script.index(
+            'if [ -n "$DATA_DISK_REQUESTED_DEVICE" ]; then'
+        )
+        remote_allowlist = remote_script.index(
+            'if [ "$DATA_DISK_REQUESTED_DEVICE" != '
+            '"$DATA_DISK_EXPECTED_DEVICE" ]',
+            requested_branch,
+        )
+        pre_authority_disable = remote_script.index(
+            "sudo systemctl disable --quiet sandbox-data-disk.service",
+            remote_allowlist,
+        )
+        first_asset_install_call = remote_script.index(
+            "\n    install_data_disk_assets\n",
+            pre_authority_disable,
+        )
+        durable_postcondition = remote_script.index(
+            'if ! sudo test -f "$DATA_DISK_AUTHORITY_MARKER"'
+        )
+        first_enable = remote_script.index(
+            "sudo systemctl enable --quiet sandbox-data-disk.service"
+        )
+        self.assertLess(remote_allowlist, pre_authority_disable)
+        self.assertLess(pre_authority_disable, first_asset_install_call)
+        self.assertLess(first_start, durable_postcondition)
+        self.assertLess(durable_postcondition, first_enable)
+        self.assertLess(
+            remote_script.index("install_data_disk_assets"),
+            remote_script.index("# Install vmd + template-builder binaries"),
+        )
+
+    def test_omitted_device_only_reconciles_authoritative_hosts(self):
+        remote_script = self.render_remote_script()
+        self.assertIn("DATA_DISK_REQUESTED_DEVICE=''", remote_script)
+        authority_branch = remote_script.index(
+            'elif [ "$DATA_DISK_HAD_AUTHORITY" = 1 ]; then'
+        )
+        stale_config_branch = remote_script.index(
+            'elif [ "$DATA_DISK_HAD_CONFIG" = 1 ]; then',
+            authority_branch,
+        )
+        authoritative_reconcile = remote_script[
+            authority_branch:stale_config_branch
+        ]
+        self.assertIn("install_data_disk_assets", authoritative_reconcile)
+        self.assertIn(
+            "setup-sandbox-data-disk.sh --verify-only",
+            authoritative_reconcile,
+        )
+        self.assertNotIn(
+            "systemctl start sandbox-data-disk.service",
+            authoritative_reconcile,
+        )
+        stale_config_cleanup = remote_script[
+            stale_config_branch:remote_script.index(
+                'if [ "$DATA_DISK_SETUP_ATTEMPTED" = 1 ]',
+                stale_config_branch,
+            )
+        ]
+        self.assertIn(
+            "systemctl disable --quiet sandbox-data-disk.service",
+            stale_config_cleanup,
+        )
+        self.assertIn('rm -f "$DATA_DISK_CONFIG_FILE"', stale_config_cleanup)
+        self.assertNotIn("restart sandbox-data-disk.service", remote_script)
+
+    def test_workflow_activation_is_manual_opt_in_and_staging_only(self):
+        workflow = (REPO_ROOT / ".github/workflows/deploy-vmd.yml").read_text()
+        self.assertEqual(
+            workflow.count("\n          SANDBOX_DATA_DISK_DEVICE:"),
+            1,
+        )
+        staging_job = workflow.index("deploy-staging:")
+        production_job = workflow.index("deploy-production:")
+        device_setting = workflow.index("SANDBOX_DATA_DISK_DEVICE:")
+        self.assertLess(staging_job, device_setting)
+        self.assertLess(device_setting, production_job)
+        self.assertIn("activate_staging_snapshot_storage:", workflow)
+        self.assertIn("staging_snapshot_storage_device:", workflow)
+        self.assertIn("default: false", workflow)
+        self.assertIn(
+            "github.event_name == 'workflow_dispatch' && "
+            "inputs.activate_staging_snapshot_storage",
+            workflow,
+        )
+        self.assertIn(
+            "staging_snapshot_storage_device is required when activation is enabled",
+            workflow,
+        )
+        exact_guard = workflow.index(
+            'if [[ "$SANDBOX_DATA_DISK_DEVICE" != '
+            '"/dev/disk/by-id/google-superserve-sandbox-data" ]]'
+        )
+        deploy_call = workflow.index(
+            "python3 .github/workflows/scripts/deploy-vmd.py",
+            exact_guard,
+        )
+        self.assertLess(exact_guard, deploy_call)
+        self.assertIn("unset SANDBOX_DATA_DISK_DEVICE", workflow)
+
+    def test_workflow_tracks_saved_snapshot_deploy_inputs(self):
+        workflow = (REPO_ROOT / ".github/workflows/deploy-vmd.yml").read_text()
+        expected_paths = (
+            "'proto/vmd.proto'",
+            "'proto/vmdpb/**'",
+            "'internal/vmdclient/**'",
+            "'deploy/sandbox-data-disk.service'",
+            "'scripts/setup-sandbox-data-disk.sh'",
+            "'.github/workflows/scripts/test_deploy_vmd.py'",
+        )
+        for path in expected_paths:
+            with self.subTest(path=path):
+                self.assertIn(path, workflow)
+
+
+class SetupSandboxDataDiskTests(unittest.TestCase):
+    def write_shim(self, shim_dir, name, body):
+        path = shim_dir / name
+        path.write_text("#!/bin/sh\nset -eu\n" + body)
+        path.chmod(0o755)
+
+    def make_harness(self, root, allow_regular_device=False):
+        source = SETUP_SCRIPT.read_text()
+        vmd_env = str(root / "vmd.env")
+        lock_root = str(root / "lock")
+        self.assertEqual(source.count("/etc/sandbox/vmd.env"), 4)
+        self.assertEqual(source.count("/run/lock"), 2)
+        source = source.replace("/etc/sandbox/vmd.env", vmd_env)
+        source = source.replace("/run/lock", lock_root)
+        replacements = {
+            "readonly CONFIG_FILE=/etc/sandbox/data-disk.env": (
+                f"readonly CONFIG_FILE={shlex.quote(str(root / 'data-disk.env'))}"
+            ),
+            "readonly AUTHORITY_MARKER=/etc/sandbox/data-disk-authoritative": (
+                f"readonly AUTHORITY_MARKER={shlex.quote(str(root / 'data-disk-authoritative'))}"
+            ),
+            "readonly MOUNT_ROOT=/mnt/sandbox-data": (
+                f"readonly MOUNT_ROOT={shlex.quote(str(root / 'mount'))}"
+            ),
+            "readonly CANON_RUNDIR=/var/lib/sandbox/rundir": (
+                f"readonly CANON_RUNDIR={shlex.quote(str(root / 'canonical-rundir'))}"
+            ),
+            "readonly CANON_SNAPSHOTS=/var/lib/sandbox/snapshots": (
+                f"readonly CANON_SNAPSHOTS={shlex.quote(str(root / 'canonical-snapshots'))}"
+            ),
+            '[[ "$EUID" -eq 0 ]] || fail "must run as root"': (
+                ": # root check disabled only in this temporary test copy"
+            ),
+        }
+        if allow_regular_device:
+            replacements.update(
+                {
+                    "readonly EXPECTED_DEVICE=/dev/disk/by-id/google-superserve-sandbox-data": (
+                        'readonly EXPECTED_DEVICE="${TEST_DEVICE_PATH:-/dev/disk/by-id/google-superserve-sandbox-data}"'
+                    ),
+                    '[[ -b "$resolved_device" ]] || fail "configured path is not a block device: $configured_device"': (
+                        '[[ -f "$resolved_device" ]] || fail "configured path is not a block device: $configured_device"'
+                    ),
+                }
+            )
+
+        for original, replacement in replacements.items():
+            self.assertIn(original, source, f"test harness target drifted: {original}")
+            source = source.replace(original, replacement, 1)
+
+        harness = root / "setup-sandbox-data-disk.test.sh"
+        harness.write_text(source)
+        harness.chmod(0o755)
+        return harness
+
+    def make_shims(self, root):
+        shim_dir = root / "shims"
+        shim_dir.mkdir()
+        self.write_shim(
+            shim_dir,
+            "findmnt",
+            """if [ "$*" = "-n -T / -o SOURCE" ]; then
+    printf '%s\\n' "$TEST_ROOT_DEVICE"
+    exit 0
+fi
+exit 98
+""",
+        )
+        self.write_shim(
+            shim_dir,
+            "lsblk",
+            """case "$*" in
+    *PKNAME*) exit 0 ;;
+    *"-o TYPE"*) printf '%s\\n' disk ;;
+    *"-o NAME"*) printf '%s\\n' fake-data-disk ;;
+    *) exit 97 ;;
+esac
+""",
+        )
+        self.write_shim(
+            shim_dir,
+            "systemctl",
+            """if [ "${1:-}" = list-units ]; then
+    printf '%s\\n' 'firecracker@test-sandbox.service loaded active running test'
+    exit 0
+fi
+if [ "${1:-}" = stop ]; then
+    printf '%s\\n' "$0 $*" >> "$TEST_MUTATION_LOG"
+    exit 0
+fi
+exit 96
+""",
+        )
+        self.write_shim(shim_dir, "flock", "exit 0\n")
+        self.write_shim(shim_dir, "mountpoint", "exit 1\n")
+        mutation_body = """printf '%s\\n' "$0 $*" >> "$TEST_MUTATION_LOG"
+exit 95
+"""
+        for command in (
+            "blkid",
+            "mkdir",
+            "mkfs.xfs",
+            "mount",
+            "umount",
+            "wipefs",
+            "xfs_info",
+        ):
+            self.write_shim(shim_dir, command, mutation_body)
+        return shim_dir
+
+    def run_harness(self, root, harness, shim_dir, extra_env=None, args=()):
+        root_device = root / "root-device"
+        root_device.touch(exist_ok=True)
+        (root / "vmd.env").touch(exist_ok=True)
+        mutation_log = root / "mutations.log"
+        env = os.environ.copy()
+        env.pop("SANDBOX_DATA_DISK_DEVICE", None)
+        env.update(
+            {
+                "PATH": f"{shim_dir}{os.pathsep}{env['PATH']}",
+                "TEST_ROOT_DEVICE": str(root_device),
+                "TEST_MUTATION_LOG": str(mutation_log),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+        result = subprocess.run(
+            [shutil.which("bash") or "bash", str(harness), *args],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        return result, mutation_log
+
+    def test_missing_device_config_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness = self.make_harness(root)
+            shims = self.make_shims(root)
+            result, mutation_log = self.run_harness(root, harness, shims)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "SANDBOX_DATA_DISK_DEVICE is not configured", result.stderr
+            )
+            self.assertFalse(mutation_log.exists())
+
+    def test_config_file_rejects_unknown_and_duplicate_assignments(self):
+        invalid_contents = (
+            "OTHER=value\n",
+            "SANDBOX_DATA_DISK_DEVICE=/dev/disk/by-id/google-one\n"
+            "SANDBOX_DATA_DISK_DEVICE=/dev/disk/by-id/google-two\n",
+        )
+        for contents in invalid_contents:
+            with self.subTest(contents=contents), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                harness = self.make_harness(root)
+                shims = self.make_shims(root)
+                (root / "data-disk.env").write_text(contents)
+                result, mutation_log = self.run_harness(root, harness, shims)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("data-disk.env", result.stderr)
+                self.assertFalse(mutation_log.exists())
+
+    def test_non_allowlisted_device_is_rejected_before_host_mutation(self):
+        invalid_devices = (
+            "/tmp/not-a-stable-device",
+            "/dev/disk/by-id/google-other-data-disk",
+        )
+        for invalid_device in invalid_devices:
+            with self.subTest(device=invalid_device), tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                harness = self.make_harness(root)
+                shims = self.make_shims(root)
+                result, mutation_log = self.run_harness(
+                    root,
+                    harness,
+                    shims,
+                    {"SANDBOX_DATA_DISK_DEVICE": invalid_device},
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "device must be exactly "
+                    "/dev/disk/by-id/google-superserve-sandbox-data",
+                    result.stderr,
+                )
+                self.assertFalse(mutation_log.exists())
+
+    def test_exact_device_guard_precedes_filesystem_formatting(self):
+        source = SETUP_SCRIPT.read_text()
+        exact_guard = source.index(
+            '[[ "$configured_device" == "$EXPECTED_DEVICE" ]]'
+        )
+        format_call = source.index("mkfs.xfs -m crc=1,reflink=1", exact_guard)
+        self.assertLess(exact_guard, format_call)
+
+    def test_active_firecracker_refuses_migration_before_host_mutation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness = self.make_harness(root, allow_regular_device=True)
+            shims = self.make_shims(root)
+            data_device = root / "data-device"
+            data_device.touch()
+            result, mutation_log = self.run_harness(
+                root,
+                harness,
+                shims,
+                {
+                    "SANDBOX_DATA_DISK_DEVICE": str(data_device),
+                    "TEST_DEVICE_PATH": str(data_device),
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "data disk is not mounted and Firecracker is running; drain the host before setup",
+                result.stderr,
+            )
+            self.assertIn("firecracker@test-sandbox.service", result.stderr)
+            self.assertFalse(mutation_log.exists())
+
+    def test_verify_only_ready_path_returns_before_service_mutation(self):
+        source = SETUP_SCRIPT.read_text()
+        ready_check = source.index('if [[ -f "$ACTIVATION_MARKER" ]] &&')
+        ready_return = source.index("return 0", ready_check)
+        verify_only_guard = source.index(
+            '(( verify_only == 0 )) || fail "data-disk verification requested',
+            ready_return,
+        )
+        first_service_stop = source.index(
+            'systemctl stop "$VMD_SOCKET" ||', verify_only_guard
+        )
+
+        self.assertLess(ready_check, ready_return)
+        self.assertLess(ready_return, verify_only_guard)
+        self.assertLess(verify_only_guard, first_service_stop)
+
+    def test_failed_direct_verification_stops_vmd_control_plane(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            harness = self.make_harness(root, allow_regular_device=True)
+            shims = self.make_shims(root)
+            data_device = root / "data-device"
+            data_device.touch()
+            result, mutation_log = self.run_harness(
+                root,
+                harness,
+                shims,
+                {
+                    "SANDBOX_DATA_DISK_DEVICE": str(data_device),
+                    "TEST_DEVICE_PATH": str(data_device),
+                },
+                ("--verify-only",),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("verify-only mode requires an existing", result.stderr)
+            self.assertIn(
+                "systemctl stop superserve-vmd.socket superserve-vmd.service",
+                mutation_log.read_text(),
+            )
+
+    def test_authority_gate_is_durable_before_atomic_commit(self):
+        source = SETUP_SCRIPT.read_text()
+        migration_block = source.index('if [[ ! -e "$DATA_ROOT" ]]')
+        dependency_install = source.index(
+            "install_fail_closed_dependencies", migration_block
+        )
+        authority_assignment = source.index(
+            "data_authoritative=1", dependency_install
+        )
+        authority_marker = source.index("write_authority_marker", authority_assignment)
+        atomic_commit = source.index('mv -- "$migration_tmp" "$DATA_ROOT"')
+
+        self.assertLess(dependency_install, authority_assignment)
+        self.assertLess(authority_assignment, authority_marker)
+        self.assertLess(authority_marker, atomic_commit)
+
+    def test_authoritative_cleanup_stops_runtime(self):
+        source = SETUP_SCRIPT.read_text()
+        cleanup = source.index("cleanup() {")
+        cleanup_end = source.index("trap cleanup EXIT RETURN", cleanup)
+        cleanup_source = source[cleanup:cleanup_end]
+
+        self.assertIn("stop_vmd_control_plane_fail_closed", cleanup_source)
+        self.assertIn("data_authoritative == 0", cleanup_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -86,6 +86,9 @@ jobs:
     name: Apply staging/us-central1
     runs-on: ubuntu-latest
     needs: [wait-for-migrations]
+    concurrency:
+      group: terraform-staging-us-central1
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/terraform-rollout-staging.yml
+++ b/.github/workflows/terraform-rollout-staging.yml
@@ -1,5 +1,9 @@
 name: Terraform Rollout Staging
 
+concurrency:
+  group: terraform-staging-us-central1
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,12 +11,23 @@ on:
         description: 'Type apply to apply staging Terraform and run smoke validation'
         required: true
         type: string
+      allow_non_main:
+        description: 'Allow an explicitly selected feature branch to update staging'
+        required: false
+        default: false
+        type: boolean
+      snapshot_storage_only:
+        description: 'Target only the saved-snapshot data disk and attachment'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   staging:
     name: Apply staging us-central1
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || inputs.allow_non_main
+    environment: staging
     permissions:
       contents: read
       id-token: write
@@ -23,8 +38,10 @@ jobs:
       SANDBOX_BASE_URL: https://staging-sandbox.superserve.ai
     steps:
       - name: Confirm rollout
+        env:
+          CONFIRM: ${{ inputs.confirm }}
         run: |
-          if [[ "${{ inputs.confirm }}" != "apply" ]]; then
+          if [[ "$CONFIRM" != "apply" ]]; then
             echo "Refusing to run. Re-run with confirm=apply."
             exit 1
           fi
@@ -48,13 +65,30 @@ jobs:
           command -v curl
 
       - name: Terraform apply staging/us-central1
+        env:
+          SNAPSHOT_STORAGE_ONLY: ${{ inputs.snapshot_storage_only }}
         run: |
           set -euo pipefail
           echo "## Terraform rollout: staging/us-central1" >> "$GITHUB_STEP_SUMMARY"
           cd infra/envs/staging/us-central1
           terraform init -input=false
           terraform validate
-          terraform plan -input=false -out=tfplan
+          target_args=()
+          if [[ "$SNAPSHOT_STORAGE_ONLY" == "true" ]]; then
+            target_args+=(
+              -target=google_compute_disk.sandbox_data
+              -target=google_compute_attached_disk.sandbox_data
+            )
+            echo "Targeted rollout: saved-snapshot storage only." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          terraform plan -input=false -out=tfplan "${target_args[@]}"
+          terraform show -json tfplan > tfplan.json
+          destructive=$(jq '[.resource_changes[]? | select(.change.actions | index("delete"))] | length' tfplan.json)
+          if [[ "$destructive" != "0" ]]; then
+            echo "::error::Refusing a staging plan with $destructive delete/replace action(s)."
+            jq -r '.resource_changes[]? | select(.change.actions | index("delete")) | "\(.address): \(.change.actions | join(","))"' tfplan.json
+            exit 1
+          fi
           terraform apply -input=false -auto-approve tfplan
 
       - name: Smoke test staging/us-central1

--- a/deploy/sandbox-data-disk.service
+++ b/deploy/sandbox-data-disk.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prepare persistent XFS storage for sandbox runtime and snapshots
+After=local-fs.target
+Before=superserve-vmd.service firecracker@.service
+RefuseManualStop=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/etc/sandbox/data-disk.env
+ExecStart=/usr/local/bin/setup-sandbox-data-disk.sh
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -256,10 +256,10 @@ module "sandbox_host" {
       # Ensure IP forwarding
       sysctl -w net.ipv4.ip_forward=1
 
-      # Clean stale state from previous run
+      # Clean stale process and network state from the previous run. Runtime
+      # and snapshot trees are persistent data and must survive host restarts.
       pkill -9 firecracker 2>/dev/null || true
       for ns in $(ip netns list 2>/dev/null | awk '{print $1}'); do ip netns del $ns 2>/dev/null; done
-      rm -rf /var/lib/superserve/snapshots/* /var/lib/superserve/rundir/*
 
       # Start VMD
       systemctl start superserve-vmd

--- a/infra/modules/sandbox-host/main.tf
+++ b/infra/modules/sandbox-host/main.tf
@@ -66,6 +66,9 @@ resource "google_compute_instance" "this" {
 
     ignore_changes = [
       advanced_machine_features,
+      # Standalone google_compute_attached_disk resources own this block;
+      # the provider requires the instance resource to ignore it.
+      attached_disk,
       boot_disk,
       metadata,
       network_interface[0].access_config,

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -623,7 +623,7 @@ func (m *Manager) Forget(vmID string) {
 // and the in-namespace nftables Firewall handle is reattached so the
 // customer's subsequent UpdateFirewallRules calls apply to the existing
 // kernel state.
-func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
+func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string, egress *EgressRules) error {
 	idx, ok := slotFromNamespace(namespace)
 	if !ok {
 		return fmt.Errorf("reattach %s: cannot parse slot from namespace %q", vmID, namespace)
@@ -676,6 +676,14 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		_ = prev.Firewall.Close()
 	}
 	m.registerEgress(vmID, info)
+	if m.egressProxy != nil && egress != nil {
+		applied := *egress
+		applied.AllowedCIDRs = append([]string(nil), egress.AllowedCIDRs...)
+		applied.DeniedCIDRs = append([]string(nil), egress.DeniedCIDRs...)
+		applied.AllowedDomains = append([]string(nil), egress.AllowedDomains...)
+		applied.SandboxID = vmID
+		m.egressProxy.SetRules(hostIP, &applied)
+	}
 
 	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
 	return nil

--- a/internal/vm/build_cleanup.go
+++ b/internal/vm/build_cleanup.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"syscall"
 	"time"
 )
 
@@ -112,7 +111,7 @@ func killOrphanFirecracker(buildVMID string) int {
 		if !firecrackerCmdlineMatches(cmdline, buildVMID) {
 			continue
 		}
-		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
+		if matched, err := killExactVMFirecrackerPID(pid, buildVMID, 500*time.Millisecond); err == nil && matched {
 			killed++
 		}
 	}
@@ -124,9 +123,14 @@ func killOrphanFirecracker(buildVMID string) int {
 // Only firecracker matches — never another process that happens to mention the
 // id in its args.
 func firecrackerCmdlineMatches(cmdline []byte, vmID string) bool {
-	if !bytes.Contains(cmdline, []byte("--id\x00"+vmID+"\x00")) {
+	args := bytes.Split(cmdline, []byte{0})
+	if len(args) == 0 || filepath.Base(string(args[0])) != "firecracker" {
 		return false
 	}
-	return bytes.HasPrefix(cmdline, []byte("firecracker")) ||
-		bytes.Contains(cmdline, []byte("/firecracker\x00"))
+	for i := 1; i+1 < len(args); i++ {
+		if string(args[i]) == "--id" && string(args[i+1]) == vmID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/vm/extent_usage_linux.go
+++ b/internal/vm/extent_usage_linux.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	fsIOCFiemap          = 0xC020660B
+	fiemapFlagSync       = 0x00000001
+	fiemapExtentLast     = 0x00000001
+	fiemapExtentUnknown  = 0x00000002
+	fiemapExtentDelalloc = 0x00000004
+	fiemapExtentShared   = 0x00002000
+	fiemapBatchExtents   = 256
+)
+
+type fiemapHeader struct {
+	Start         uint64
+	Length        uint64
+	Flags         uint32
+	MappedExtents uint32
+	ExtentCount   uint32
+	Reserved      uint32
+}
+
+type fiemapExtent struct {
+	Logical    uint64
+	Physical   uint64
+	Length     uint64
+	Reserved64 [2]uint64
+	Flags      uint32
+	Reserved   [3]uint32
+}
+
+func savedSnapshotExtentAccountingSupported() bool { return true }
+
+// exclusiveFileBytes returns allocated data extents that are not currently
+// shared by filesystem CoW. Unlike st_blocks, FIEMAP's SHARED flag lets the
+// shadow ledger exclude immutable bases referenced by many forks while still
+// counting blocks dirtied into an otherwise-reflinked child.
+func exclusiveFileBytes(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	headerSize := int(unsafe.Sizeof(fiemapHeader{}))
+	extentSize := int(unsafe.Sizeof(fiemapExtent{}))
+	buf := make([]byte, headerSize+fiemapBatchExtents*extentSize)
+	var start uint64
+	var total uint64
+	for {
+		clear(buf)
+		header := (*fiemapHeader)(unsafe.Pointer(&buf[0]))
+		header.Start = start
+		header.Length = math.MaxUint64 - start
+		header.Flags = fiemapFlagSync
+		header.ExtentCount = fiemapBatchExtents
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), fsIOCFiemap, uintptr(unsafe.Pointer(&buf[0])))
+		if errno != 0 {
+			return 0, fmt.Errorf("FIEMAP %s: %w", path, errno)
+		}
+		if header.MappedExtents == 0 {
+			break
+		}
+		if header.MappedExtents > fiemapBatchExtents {
+			return 0, fmt.Errorf("FIEMAP %s returned invalid extent count %d", path, header.MappedExtents)
+		}
+
+		last := false
+		for i := uint32(0); i < header.MappedExtents; i++ {
+			offset := headerSize + int(i)*extentSize
+			extent := (*fiemapExtent)(unsafe.Pointer(&buf[offset]))
+			if extent.Length == 0 {
+				return 0, fmt.Errorf("FIEMAP %s returned a zero-length extent", path)
+			}
+			if extent.Flags&(fiemapExtentUnknown|fiemapExtentDelalloc) != 0 {
+				return 0, fmt.Errorf("FIEMAP %s returned unresolved extent flags %#x", path, extent.Flags)
+			}
+			if extent.Flags&fiemapExtentShared == 0 {
+				if math.MaxUint64-total < extent.Length {
+					return 0, errors.New("exclusive extent byte count overflow")
+				}
+				total += extent.Length
+			}
+			next := extent.Logical + extent.Length
+			if next <= start {
+				return 0, fmt.Errorf("FIEMAP %s did not advance", path)
+			}
+			start = next
+			last = extent.Flags&fiemapExtentLast != 0
+		}
+		if last {
+			break
+		}
+	}
+	if total > math.MaxInt64 {
+		return 0, errors.New("exclusive extent byte count exceeds int64")
+	}
+	return int64(total), nil
+}

--- a/internal/vm/extent_usage_linux_test.go
+++ b/internal/vm/extent_usage_linux_test.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package vm
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExclusiveFileBytesSeparatesSharedAndCOWExtents(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	clone := filepath.Join(dir, "clone")
+	if err := os.WriteFile(source, bytes.Repeat([]byte{0x5a}, 2<<20), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := reflinkImmutableFileContext(context.Background(), source, clone); err != nil {
+		t.Skipf("test filesystem has no reflink support: %v", err)
+	}
+	if got, err := exclusiveFileBytes(clone); err != nil {
+		t.Fatal(err)
+	} else if got != 0 {
+		t.Fatalf("fresh reflink exclusive bytes = %d, want 0", got)
+	}
+
+	f, err := os.OpenFile(clone, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xa5}, 4096), 0); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := exclusiveFileBytes(clone); err != nil {
+		t.Fatal(err)
+	} else if got < 4096 || got >= 2<<20 {
+		t.Fatalf("COW clone exclusive bytes = %d, want a positive strict subset", got)
+	}
+}

--- a/internal/vm/extent_usage_other.go
+++ b/internal/vm/extent_usage_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package vm
+
+func savedSnapshotExtentAccountingSupported() bool { return false }
+
+// Non-Linux builds are development-only. They retain allocated-block
+// accounting so unit helpers remain portable; production capability probing
+// requires Linux FIEMAP semantics.
+func exclusiveFileBytes(path string) (int64, error) {
+	return allocatedFileBytes(path)
+}

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -38,6 +38,13 @@ func isTornSnapshotErr(err error) bool {
 // zero holes), so the caller must use a Full/previous snapshot instead.
 var ErrLayeredInvalidSnapshot = errors.New("layered restore overlay/base pairing is invalid")
 
+// ErrSnapshotLoadRejected marks a Firecracker 400 from /snapshot/load. For a
+// saved snapshot this is a deterministic artifact rejection (for example an
+// unreadable/corrupt vmstate or memory image), rather than a transport failure
+// talking to the local daemon. The saved-snapshot boundary maps it to DataLoss;
+// connection and server failures remain retryable host errors.
+var ErrSnapshotLoadRejected = errors.New("firecracker rejected snapshot load")
+
 // layeredInvalidMarker is the exact substring the forked Firecracker embeds in its
 // error for an invalid layered restore (the GuestMemoryFromUffdError::LayeredInvalid
 // display text). Named so a fork message change is updated here, not missed at runtime.
@@ -45,6 +52,20 @@ const layeredInvalidMarker = "overlay/base pairing is invalid"
 
 func isLayeredInvalidErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), layeredInvalidMarker)
+}
+
+func wrapSnapshotLoadError(operation string, err error) error {
+	if isTornSnapshotErr(err) {
+		return fmt.Errorf("%s: %w: %v", operation, ErrTornSnapshot, err)
+	}
+	if isLayeredInvalidErr(err) {
+		return fmt.Errorf("%s: %w: %v", operation, ErrLayeredInvalidSnapshot, err)
+	}
+	var rejected *operations.LoadSnapshotBadRequest
+	if errors.As(err, &rejected) {
+		return fmt.Errorf("%s: %w: %v", operation, ErrSnapshotLoadRejected, err)
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }
 
 // Firecracker's tap-attach failure when a previous owner still holds the
@@ -99,12 +120,16 @@ type FirecrackerConfig struct {
 func newFCClient(socketPath string) *fcclient.Firecracker {
 	transport := httptransport.New(fcclient.DefaultHost, fcclient.DefaultBasePath, fcclient.DefaultSchemes)
 	transport.Transport = &http.Transport{
-		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-			addr, err := net.ResolveUnixAddr("unix", socketPath)
-			if err != nil {
-				return nil, err
-			}
-			return net.DialUnix("unix", nil, addr)
+		// A Firecracker process accepts only a small, fixed number of API
+		// connections. Each helper in this file creates a short-lived client;
+		// retaining its HTTP/1.1 idle connection therefore exhausts that limit
+		// after enough lifecycle operations and makes every later request fail
+		// with "Too many open connections". Unix-socket dials are local and
+		// cheap, so close every connection when its request completes.
+		DisableKeepAlives: true,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
 		},
 	}
 	c := fcclient.NewHTTPClient(strfmt.NewFormats())
@@ -286,11 +311,21 @@ const (
 // containing dirty blocks — required to create sandboxes from this template.
 // mode=SnapshotFlatten bakes those deltas into base.ext4 (see SnapshotMode).
 func CreateSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string, mode SnapshotMode) error {
+	return CreateSnapshotContext(context.Background(), socketPath, snapshotPath, memPath, blockDeltaDir, mode)
+}
+
+// CreateSnapshotContext is CreateSnapshot with a caller-owned deadline. Saved
+// snapshot capture uses it so a wedged Firecracker API cannot hold the per-VM
+// operation lock forever. Legacy callers retain the background-context wrapper
+// above until their lifecycle contracts grow explicit deadlines.
+func CreateSnapshotContext(ctx context.Context, socketPath, snapshotPath, memPath, blockDeltaDir string, mode SnapshotMode) error {
 	if mode == SnapshotFlatten && blockDeltaDir == "" {
 		return fmt.Errorf("SnapshotFlatten requires non-empty blockDeltaDir")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	fc := newFCClient(socketPath)
-	ctx := context.Background()
 
 	// Pause the VM.
 	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
@@ -327,8 +362,14 @@ func CreateSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string, mod
 //   - layered overlay: memPath is fresh/sparse, so it ends up holding only the
 //     changed pages — restored over a separate base, never loaded standalone.
 func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
+	return CreateDiffSnapshotContext(context.Background(), socketPath, snapshotPath, memPath)
+}
+
+func CreateDiffSnapshotContext(ctx context.Context, socketPath, snapshotPath, memPath string) error {
 	fc := newFCClient(socketPath)
-	ctx := context.Background()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
 		Context: ctx,
@@ -353,14 +394,43 @@ func CreateDiffSnapshot(socketPath, snapshotPath, memPath string) error {
 // UnpauseVM resumes a paused VM's vCPUs. Used after CreateSnapshot to make
 // snapshot creation non-destructive.
 func UnpauseVM(socketPath string) error {
+	return UnpauseVMContext(context.Background(), socketPath)
+}
+
+// UnpauseVMContext resumes vCPUs with a caller-owned deadline. In particular,
+// saved capture invokes this with a fresh recovery context even when its main
+// capture context has expired, so cancellation never skips the source cleanup.
+func UnpauseVMContext(ctx context.Context, socketPath string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	fc := newFCClient(socketPath)
 	if _, err := fc.Operations.PatchVM(&operations.PatchVMParams{
-		Context: context.Background(),
+		Context: ctx,
 		Body:    &models.VM{State: strPtr(models.VMStateResumed)},
 	}); err != nil {
 		return fmt.Errorf("unpause VM: %w", err)
 	}
 	return nil
+}
+
+// FirecrackerVMStateContext reads the authoritative VMM state. It is used to
+// resolve an ambiguous PATCH /vm outcome: the daemon may have resumed vCPUs
+// and then lost the HTTP response, in which case retrying or failing the source
+// based on the transport error alone would be incorrect.
+func FirecrackerVMStateContext(ctx context.Context, socketPath string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fc := newFCClient(socketPath)
+	resp, err := fc.Operations.DescribeInstance(&operations.DescribeInstanceParams{Context: ctx})
+	if err != nil {
+		return "", fmt.Errorf("describe VM state: %w", err)
+	}
+	if resp == nil || resp.Payload == nil || resp.Payload.State == nil || *resp.Payload.State == "" {
+		return "", errors.New("describe VM state returned no state")
+	}
+	return *resp.Payload.State, nil
 }
 
 // LoadSnapshotNoResume loads a snapshot but leaves the vCPUs paused — used to
@@ -387,10 +457,7 @@ func LoadSnapshotNoResume(socketPath, snapshotPath, memPath, ifaceID, tapDevice,
 			BlockDeltaDir:    blockDeltaDir,
 		},
 	}); err != nil {
-		if isTornSnapshotErr(err) {
-			return fmt.Errorf("load snapshot (no-resume): %w: %v", ErrTornSnapshot, err)
-		}
-		return fmt.Errorf("load snapshot (no-resume): %w", err)
+		return wrapSnapshotLoadError("load snapshot (no-resume)", err)
 	}
 	return nil
 }
@@ -430,10 +497,7 @@ func RestoreSnapshot(socketPath, snapshotPath, memPath, blockDeltaDir string) er
 			BlockDeltaDir:    blockDeltaDir,
 		},
 	}); err != nil {
-		if isTornSnapshotErr(err) {
-			return fmt.Errorf("load snapshot: %w: %v", ErrTornSnapshot, err)
-		}
-		return fmt.Errorf("load snapshot: %w", err)
+		return wrapSnapshotLoadError("load snapshot", err)
 	}
 	return nil
 }
@@ -457,10 +521,7 @@ func RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, ifaceID, ta
 			BlockDeltaDir: blockDeltaDir,
 		},
 	}); err != nil {
-		if isTornSnapshotErr(err) {
-			return fmt.Errorf("load snapshot: %w: %v", ErrTornSnapshot, err)
-		}
-		return fmt.Errorf("load snapshot: %w", err)
+		return wrapSnapshotLoadError("load snapshot", err)
 	}
 	return nil
 }
@@ -506,13 +567,7 @@ func RestoreSnapshotUffdInternalWithOverrides(
 			BlockDeltaDir: blockDeltaDir,
 		},
 	}); err != nil {
-		if isTornSnapshotErr(err) {
-			return fmt.Errorf("load snapshot (uffd-internal): %w: %v", ErrTornSnapshot, err)
-		}
-		if isLayeredInvalidErr(err) {
-			return fmt.Errorf("load snapshot (uffd-internal): %w: %v", ErrLayeredInvalidSnapshot, err)
-		}
-		return fmt.Errorf("load snapshot (uffd-internal): %w", err)
+		return wrapSnapshotLoadError("load snapshot (uffd-internal)", err)
 	}
 	return nil
 }

--- a/internal/vm/firecracker_test.go
+++ b/internal/vm/firecracker_test.go
@@ -1,7 +1,9 @@
 package vm
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -9,9 +11,67 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/superserve-ai/sandbox/internal/vm/fc/client/operations"
 )
+
+// TestFCClientClosesConnections guards Firecracker's small API connection
+// budget. newFCClient is intentionally created per high-level operation, so a
+// keep-alive left behind by each client eventually makes the VMM reject every
+// request with "Too many open connections".
+func TestFCClientClosesConnections(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "fc.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+
+	var openConnections atomic.Int32
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/" {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"app_name":"Firecracker","id":"vm-1","state":"Running","vmm_version":"test"}`)
+		}),
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			switch state {
+			case http.StateNew:
+				openConnections.Add(1)
+			case http.StateHijacked, http.StateClosed:
+				openConnections.Add(-1)
+			}
+		},
+	}
+	go srv.Serve(ln)
+	defer srv.Close()
+	waitForUnixSocket(t, socketPath)
+
+	for i := 0; i < 20; i++ {
+		state, err := FirecrackerVMStateContext(context.Background(), socketPath)
+		if err != nil {
+			t.Fatalf("state probe %d: %v", i, err)
+		}
+		if state != "Running" {
+			t.Fatalf("state probe %d = %q, want Running", i, state)
+		}
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for openConnections.Load() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := openConnections.Load(); got != 0 {
+		t.Fatalf("Firecracker API connections still open after requests: %d", got)
+	}
+}
 
 // TestCreateSnapshot_FlattenFieldInJSONBody asserts that the Go-side enum
 // (SnapshotNormal/SnapshotFlatten) serializes the `flatten` field correctly
@@ -160,5 +220,17 @@ func TestIsLayeredInvalidErr(t *testing.T) {
 	}
 	if isLayeredInvalidErr(nil) {
 		t.Error("isLayeredInvalidErr(nil) = true, want false")
+	}
+}
+
+func TestWrapSnapshotLoadErrorMarksOnlyFirecrackerRejections(t *testing.T) {
+	rejected := wrapSnapshotLoadError("load snapshot", operations.NewLoadSnapshotBadRequest())
+	if !errors.Is(rejected, ErrSnapshotLoadRejected) {
+		t.Fatalf("Firecracker 400 was not marked as an artifact rejection: %v", rejected)
+	}
+
+	transport := wrapSnapshotLoadError("load snapshot", fmt.Errorf("dial unix: connection refused"))
+	if errors.Is(transport, ErrSnapshotLoadRejected) {
+		t.Fatalf("transport failure was misclassified as an artifact rejection: %v", transport)
 	}
 }

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -2,14 +2,19 @@ package vm
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"time"
 
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/builder"
 	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
@@ -32,6 +37,11 @@ func (a *GRPCAdapter) WithSecretsBroker(socketPath, sandboxProxyURL string) *GRP
 	a.secrets = NewSecretsBrokerClient(socketPath)
 	a.sandboxProxyURL = sandboxProxyURL
 	return a
+}
+
+func (a *GRPCAdapter) GetCapabilities(context.Context, *vmdpb.GetCapabilitiesRequest) (*vmdpb.GetCapabilitiesResponse, error) {
+	enabled := a != nil && a.mgr != nil && a.mgr.savedSnapshotsSupported()
+	return &vmdpb.GetCapabilitiesResponse{SavedSnapshotsV1: enabled}, nil
 }
 
 func (a *GRPCAdapter) DestroyVM(ctx context.Context, req *vmdpb.DestroyVMRequest) (*vmdpb.DestroyVMResponse, error) {
@@ -82,6 +92,61 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 }
 
 func (a *GRPCAdapter) CreateSnapshot(ctx context.Context, req *vmdpb.CreateSnapshotRequest) (*vmdpb.CreateSnapshotResponse, error) {
+	if req.GetSnapshotId() != "" {
+		saved, err := a.mgr.CreateSavedSnapshot(ctx, req.GetVmId(), req.GetSnapshotId())
+		if err != nil {
+			if errors.Is(err, ErrSavedSnapshotSourceResume) {
+				st := status.New(codes.Internal, "saved snapshot source failed to resume after capture")
+				withDetails, detailErr := st.WithDetails(&errdetails.ErrorInfo{
+					Reason: vmdclient.SavedSnapshotSourceResumeFailureReason,
+					Domain: "vmd.superserve.ai",
+				})
+				if detailErr == nil {
+					return nil, withDetails.Err()
+				}
+				return nil, st.Err()
+			}
+			if errors.Is(err, context.Canceled) {
+				return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationCapture, err)
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationCapture, err)
+			}
+			if status.Code(err) == codes.Unknown {
+				err = status.Error(codes.Unavailable, "saved snapshot host capture failed")
+			}
+			return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationCapture, err)
+		}
+		return &vmdpb.CreateSnapshotResponse{
+			VmId:          req.GetVmId(),
+			SnapshotId:    saved.SnapshotID,
+			SnapshotPath:  saved.Artifacts.SnapshotPath,
+			MemFilePath:   saved.Artifacts.MemFilePath,
+			CreatedAtUnix: saved.CreatedAt.Unix(),
+			Artifacts: &vmdpb.SavedSnapshotArtifacts{
+				SchemaVersion:   saved.SchemaVersion,
+				ManifestPath:    saved.Artifacts.ManifestPath,
+				SnapshotPath:    saved.Artifacts.SnapshotPath,
+				MemFilePath:     saved.Artifacts.MemFilePath,
+				MemoryBasePath:  saved.Artifacts.MemoryBasePath,
+				DiskBasePath:    saved.Artifacts.DiskBasePath,
+				DiskDeltaPath:   saved.Artifacts.DiskDeltaPath,
+				DiskOverlayPath: saved.Artifacts.DiskOverlayPath,
+				DiskFullPath:    saved.Artifacts.DiskFullPath,
+				ManifestDigest:  saved.ManifestDigest,
+			},
+			ResourceLimits: &vmdpb.ResourceLimits{
+				VcpuCount:   saved.Resources.VCPU,
+				MemoryMib:   saved.Resources.MemoryMiB,
+				DiskSizeMib: saved.Resources.DiskSizeMiB,
+			},
+			LogicalSizeBytes:         saved.LogicalSizeBytes,
+			ExclusiveSizeBytes:       saved.ExclusiveSizeBytes,
+			SourceLogicalSizeBytes:   saved.SourceLogicalSizeBytes,
+			SourceExclusiveSizeBytes: saved.SourceExclusiveSizeBytes,
+			SourceState:              saved.SourceState,
+		}, nil
+	}
 	snapshotPath, memPath, err := a.mgr.CreateVMSnapshot(ctx, req.GetVmId(), req.GetSnapshotDir())
 	if err != nil {
 		return nil, err
@@ -91,6 +156,114 @@ func (a *GRPCAdapter) CreateSnapshot(ctx context.Context, req *vmdpb.CreateSnaps
 		SnapshotPath:  snapshotPath,
 		MemFilePath:   memPath,
 		CreatedAtUnix: time.Now().Unix(),
+	}, nil
+}
+
+func (a *GRPCAdapter) RestoreSavedSnapshot(ctx context.Context, req *vmdpb.RestoreSavedSnapshotRequest) (*vmdpb.RestoreSavedSnapshotResponse, error) {
+	if len(req.GetExpectedManifestDigest()) != sha256.Size*2 {
+		return nil, status.Error(codes.InvalidArgument, "expected_manifest_digest must be a SHA-256 hex digest")
+	}
+	if _, err := hex.DecodeString(req.GetExpectedManifestDigest()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "expected_manifest_digest must be a SHA-256 hex digest")
+	}
+	clear := make(map[string]string, len(req.GetClearEnvKeys()))
+	for _, key := range req.GetClearEnvKeys() {
+		if key == "" {
+			return nil, status.Error(codes.InvalidArgument, "clear_env_keys cannot contain an empty key")
+		}
+		clear[key] = ""
+	}
+	var netCfg *network.Config
+	if nc := req.GetNetworkConfig(); nc != nil {
+		netCfg = &network.Config{
+			HostInterface: nc.GetHostInterface(),
+			SubnetCIDR:    nc.GetSubnetCidr(),
+			GatewayIP:     nc.GetGatewayIp(),
+			EnableNAT:     nc.GetEnableNat(),
+		}
+	}
+	var egress *network.EgressRules
+	if sandboxNetwork := req.GetSandboxNetwork(); sandboxNetwork != nil && sandboxNetwork.GetEgress() != nil {
+		rules := sandboxNetwork.GetEgress()
+		egress = &network.EgressRules{
+			AllowedCIDRs:   rules.GetAllowedCidrs(),
+			DeniedCIDRs:    rules.GetDeniedCidrs(),
+			AllowedDomains: rules.GetAllowedDomains(),
+			SandboxID:      req.GetVmId(),
+		}
+	}
+	if access := req.GetPreviewAccess(); access != "" && access != preview.AccessLegacyPublic && access != preview.AccessPublic && access != preview.AccessPrivate {
+		return nil, status.Errorf(codes.InvalidArgument, "preview_access must be empty, %q, %q or %q, got %q", preview.AccessLegacyPublic, preview.AccessPublic, preview.AccessPrivate, access)
+	}
+	previewPorts, err := previewPortsFromProto(req.GetPreviewPorts())
+	if err != nil {
+		return nil, err
+	}
+	if previewPortsContainTokenizedAccess(previewPorts) && req.GetPreviewPolicyRevision() <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "tokenized preview policy requires a positive preview_policy_revision")
+	}
+	inst, saved, err := a.mgr.RestoreSavedSnapshot(
+		ctx,
+		req.GetVmId(),
+		req.GetManifestPath(),
+		req.GetExpectedManifestDigest(),
+		netCfg,
+		egress,
+		req.GetTeamId(),
+		req.GetOwnerId(),
+		req.GetPreviewAccess(),
+		previewPorts,
+		req.GetPreviewPolicyRevision(),
+	)
+	if err != nil {
+		return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationRestore, err)
+	}
+
+	// boxd /init is additive, so overwrite captured source-specific secret
+	// token defaults with empty values before exposing the child. Fresh child
+	// values and HTTPS_PROXY are injected afterward through InjectSandboxEnv.
+	if len(clear) > 0 {
+		if err := postBoxdInit(ctx, inst.IP, clear, vmHostname(inst.ID)); err != nil {
+			// Do not leave a reachable child with captured boxd defaults after
+			// the security scrub failed. Control-plane cleanup remains idempotent.
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = a.mgr.DestroyVM(cleanupCtx, inst.ID, true)
+			cancel()
+			return nil, vmdclient.SanitizeSavedSnapshotError(
+				vmdclient.SavedSnapshotOperationRestore,
+				status.Errorf(codes.Internal, "clear captured env defaults: %v", err),
+			)
+		}
+	}
+
+	return &vmdpb.RestoreSavedSnapshotResponse{
+		VmId:       inst.ID,
+		SocketPath: inst.SocketPath,
+		IpAddress:  inst.IP,
+		Pid:        uint32(inst.PID),
+		ResourceLimits: &vmdpb.ResourceLimits{
+			VcpuCount:   saved.Resources.VCPU,
+			MemoryMib:   saved.Resources.MemoryMiB,
+			DiskSizeMib: saved.Resources.DiskSizeMiB,
+		},
+	}, nil
+}
+
+func (a *GRPCAdapter) DeleteSavedSnapshot(ctx context.Context, req *vmdpb.DeleteSavedSnapshotRequest) (*vmdpb.DeleteSavedSnapshotResponse, error) {
+	if err := a.mgr.DeleteSavedSnapshot(ctx, req.GetSourceVmId(), req.GetSnapshotId()); err != nil {
+		return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationDelete, err)
+	}
+	return &vmdpb.DeleteSavedSnapshotResponse{Deleted: true}, nil
+}
+
+func (a *GRPCAdapter) GetWritableLayerUsage(_ context.Context, req *vmdpb.GetWritableLayerUsageRequest) (*vmdpb.GetWritableLayerUsageResponse, error) {
+	logical, exclusive, err := a.mgr.SandboxWritableLayerUsage(req.GetVmId())
+	if err != nil {
+		return nil, vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationWritableLayerMeasurement, err)
+	}
+	return &vmdpb.GetWritableLayerUsageResponse{
+		LogicalSizeBytes:   logical,
+		ExclusiveSizeBytes: exclusive,
 	}, nil
 }
 
@@ -331,8 +504,15 @@ func (a *GRPCAdapter) UpdateSandboxNetwork(ctx context.Context, req *vmdpb.Updat
 	// This RPC reads netMgr state directly (below), which the background startup
 	// reattach may not have restored yet. Resolve the VM through getInstance first
 	// so it's reattached on demand (or NotFound if it's genuinely gone).
-	if _, err := a.mgr.getInstance(vmID); err != nil {
+	inst, err := a.mgr.getInstance(vmID)
+	if err != nil {
 		return nil, err
+	}
+	rules := &network.EgressRules{
+		AllowedCIDRs:   append([]string(nil), egress.GetAllowedCidrs()...),
+		DeniedCIDRs:    append([]string(nil), egress.GetDeniedCidrs()...),
+		AllowedDomains: append([]string(nil), egress.GetAllowedDomains()...),
+		SandboxID:      vmID,
 	}
 
 	// Update nftables rules (non-TCP traffic).
@@ -344,14 +524,14 @@ func (a *GRPCAdapter) UpdateSandboxNetwork(ctx context.Context, req *vmdpb.Updat
 	if a.mgr.egressProxy != nil {
 		netInfo := a.mgr.netMgr.GetVMNetInfo(vmID)
 		if netInfo != nil {
-			a.mgr.egressProxy.SetRules(netInfo.HostIP, &network.EgressRules{
-				AllowedCIDRs:   egress.GetAllowedCidrs(),
-				DeniedCIDRs:    egress.GetDeniedCidrs(),
-				AllowedDomains: egress.GetAllowedDomains(),
-				SandboxID:      vmID,
-			})
+			a.mgr.egressProxy.SetRules(netInfo.HostIP, rules)
 		}
 	}
+
+	inst.mu.Lock()
+	inst.Config.EgressPolicy = rules
+	inst.mu.Unlock()
+	a.mgr.persistState(inst)
 
 	return &vmdpb.UpdateSandboxNetworkResponse{VmId: vmID}, nil
 }

--- a/internal/vm/grpc_adapter_capabilities_test.go
+++ b/internal/vm/grpc_adapter_capabilities_test.go
@@ -1,0 +1,65 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/superserve-ai/sandbox/proto/vmdpb"
+)
+
+func TestGRPCAdapterAdvertisesSavedSnapshotsCapability(t *testing.T) {
+	mgr := &Manager{cfg: ManagerConfig{
+		SnapshotDir:                "/var/lib/sandbox/snapshots",
+		RunDir:                     "/run/sandbox",
+		UffdEnabled:                true,
+		ResumeUffdEnabled:          true,
+		IncrementalSnapshotEnabled: true,
+	}, savedSnapshotCapabilityProbe: func(context.Context) error { return nil }}
+	resp, err := NewGRPCAdapter(mgr).GetCapabilities(context.Background(), &vmdpb.GetCapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("GetCapabilities: %v", err)
+	}
+	if !resp.GetSavedSnapshotsV1() {
+		t.Fatal("saved_snapshots_v1 was not advertised")
+	}
+}
+
+func TestGRPCAdapterDoesNotAdvertiseSavedSnapshotsWithoutRequiredHostFeatures(t *testing.T) {
+	tests := []struct {
+		name string
+		mgr  *Manager
+	}{
+		{name: "nil manager"},
+		{name: "unconfigured", mgr: &Manager{}},
+		{name: "no incremental", mgr: &Manager{cfg: ManagerConfig{
+			SnapshotDir:       "/var/lib/sandbox/snapshots",
+			RunDir:            "/run/sandbox",
+			UffdEnabled:       true,
+			ResumeUffdEnabled: true,
+		}}},
+		{name: "reflink unsupported", mgr: &Manager{
+			cfg: ManagerConfig{
+				SnapshotDir:                "/var/lib/sandbox/snapshots",
+				RunDir:                     "/run/sandbox",
+				UffdEnabled:                true,
+				ResumeUffdEnabled:          true,
+				IncrementalSnapshotEnabled: true,
+			},
+			savedSnapshotCapabilityProbe: func(context.Context) error {
+				return errors.New("reflink is unavailable")
+			},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := (&GRPCAdapter{mgr: tt.mgr}).GetCapabilities(context.Background(), &vmdpb.GetCapabilitiesRequest{})
+			if err != nil {
+				t.Fatalf("GetCapabilities: %v", err)
+			}
+			if resp.GetSavedSnapshotsV1() {
+				t.Fatal("saved_snapshots_v1 advertised without required host features")
+			}
+		})
+	}
+}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -154,6 +154,14 @@ type VMConfig struct {
 	// DeltaDir hydrates a fresh per-VM overlay from <dir>/rootfs.delta on
 	// restore. Empty for in-place resume of an already-populated overlay.
 	DeltaDir string
+	// EgressPolicy, when non-nil, is installed after the network slot is
+	// allocated but before Firecracker starts. Saved-snapshot forks use this
+	// to preserve a restrictive source policy without an allow-all race.
+	EgressPolicy *network.EgressRules
+	// savedSnapshotRestore marks a restore that must always materialize a fresh
+	// child-owned disk. It is deliberately package-private and non-persistent:
+	// every retry reconstructs it from the immutable saved manifest.
+	savedSnapshotRestore bool
 }
 
 // ManagerConfig holds paths and settings for the VM manager.
@@ -247,6 +255,14 @@ type Manager struct {
 	log         zerolog.Logger
 	state       *StateStore // persistent local state (BoltDB); nil = no persistence
 
+	// savedSnapshotCapability is established by one real reflink probe across
+	// RunDir and SnapshotDir. The feature requires mandatory CoW branching, so
+	// configuration flags alone are not sufficient evidence that this host can
+	// safely advertise saved snapshots.
+	savedSnapshotCapabilityOnce  sync.Once
+	savedSnapshotCapability      bool
+	savedSnapshotCapabilityProbe func(context.Context) error // test seam; nil uses the host probe
+
 	// launcherReady gates the launcher launch path: false → launches use the
 	// legacy path. Set when the namespace is built/validated; kept in sync by
 	// revalidateLauncher.
@@ -292,17 +308,17 @@ type Manager struct {
 	buildsMu sync.RWMutex
 	builds   map[string]*buildRecord
 
-	// vmOpLocks serializes lifecycle operations (restore, resume, pause) for
+	// vmOpLocks serializes lifecycle operations (restore, resume, pause, and
+	// the destructive phase of destroy) for
 	// a single vmID, so a retry or a concurrent actor can't stomp an
 	// in-flight launch (kill a still-booting VM, re-diff a consumed dirty
 	// bitmap). Keyed by vmID → chan struct{}{} used as a capacity-1
 	// semaphore, so acquisition can honor the caller's context. Entries are
 	// never deleted: vmIDs are unique UUIDs so they don't collide, and
 	// deleting on destroy would let a same-vmID retry acquire a fresh lock
-	// and lose mutual exclusion. DestroyVM deliberately does NOT take these
-	// locks — it must interrupt a wedged op (a hung firecracker socket call
-	// holds the lock until destroy SIGKILLs the process), so blocking it
-	// would turn a recoverable wedge into a permanent hang.
+	// and lose mutual exclusion. DestroyVM first stops the exact process
+	// without the lock to interrupt a wedged socket operation, then acquires
+	// this lock and reconfirms process death before releasing resources.
 	vmOpLocks sync.Map
 }
 
@@ -440,18 +456,29 @@ const (
 	restoreCreateOverlay restoreDiskAction = iota // overlay clone of a template
 	restoreReuseOverlay                           // existing per-VM overlay (resume)
 	restoreLegacyResolve                          // legacy non-overlay path
+	restoreCloneOverlay                           // fresh clone of an immutable saved overlay
+	restoreCopyRootfs                             // fresh copy of an immutable saved legacy rootfs
 )
 
 // restorePlan is planRestore's output — pure decision, no I/O.
 type restorePlan struct {
 	action   restoreDiskAction
 	deltaDir string
+	source   string
 }
 
 // planRestore picks the disk action + delta_dir for a restore. createOverlay
 // requires ALL of {basePath, deltaDir, !inPlace} — anything missing means
 // we'd be cloning over an existing per-VM file, so fall back to reuse.
 func planRestore(basePath, deltaDir string, inPlace bool) restorePlan {
+	return planRestoreWithSource(basePath, deltaDir, "", inPlace)
+}
+
+// planRestoreWithSource extends planRestore for saved snapshots. sourcePath is
+// an immutable saved disk artifact: with a base it is a sparse overlay to clone;
+// without a base it is a complete legacy rootfs to copy. Normal restores pass
+// an empty sourcePath and retain the existing behavior.
+func planRestoreWithSource(basePath, deltaDir, sourcePath string, inPlace bool) restorePlan {
 	p := restorePlan{deltaDir: deltaDir}
 	if inPlace {
 		// fc's delta-apply truncates the overlay; force empty to stop a
@@ -459,6 +486,14 @@ func planRestore(basePath, deltaDir string, inPlace bool) restorePlan {
 		p.deltaDir = ""
 	}
 	switch {
+	case sourcePath != "" && basePath != "" && !inPlace:
+		p.action = restoreCloneOverlay
+		p.source = sourcePath
+		p.deltaDir = ""
+	case sourcePath != "" && basePath == "" && !inPlace:
+		p.action = restoreCopyRootfs
+		p.source = sourcePath
+		p.deltaDir = ""
 	case basePath != "" && deltaDir != "" && !inPlace:
 		p.action = restoreCreateOverlay
 	case basePath != "":
@@ -686,51 +721,41 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 		return status.Error(codes.InvalidArgument, "vm_id must be a valid per-VM identifier")
 	}
 
-	// A paused or post-restart VM may be absent from m.vms. Don't early-return on
-	// that: unit stop and rundir removal are derivable from vmID and must run, or
-	// destroying a paused sandbox leaks its rundir. Process/socket teardown needs
-	// the instance, so it's gated below. Destroy is idempotent.
-	inst, instErr := m.getInstance(vmID)
+	// Interrupt first, before waiting on the lifecycle lock. A wedged
+	// Firecracker socket call may hold that lock and only process death can make
+	// it return. No disk/network/state is released at this stage.
+	initial, initialErr := m.getInstance(vmID)
+	if initialErr != nil {
+		initial = nil
+	}
+	if _, err := m.stopVMProcessAndConfirm(ctx, vmID, initial); err != nil {
+		return status.Errorf(codes.Unavailable, "confirm VM teardown: %v", err)
+	}
 
-	// Stop the systemd unit if one exists — this is the path for sandbox
-	// VMs launched via startFirecrackerViaSystemd.
-	if err := stopUnit(ctx, systemdUnitName(vmID)); err != nil {
-		log.Warn().Err(err).Msg("systemctl stop failed (unit may not exist — trying PID-based kill)")
+	// Once the interrupted operation has unwound, own the lifecycle boundary.
+	// It may have started or persisted a replacement process after the first
+	// stop, so re-resolve and positively confirm death again under the lock.
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return err
+	}
+	defer unlockOp()
+
+	inst, instErr := m.getInstance(vmID)
+	tracked := inst
+	if instErr != nil {
+		tracked = nil
+	}
+	identity, err := m.stopVMProcessAndConfirm(ctx, vmID, tracked)
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "reconfirm VM teardown under lifecycle lock: %v", err)
 	}
 	removeUnitDropIn(vmID)
-
-	// Recover the PID, socket, and namespace to tear down. A tracked VM has them
-	// in memory; an untracked one (paused or post-restart, absent from m.vms) has
-	// them only in the record. Without the record fallback a cold-boot VM's
-	// Firecracker is never killed (stopUnit is a no-op for it) and its slot is
-	// never reclaimed (ns is "").
-	var pid int
-	var sockPath, ns string
-	if instErr == nil {
-		inst.mu.RLock()
-		pid = inst.PID
-		sockPath = inst.SocketPath
-		ns = inst.Namespace
-		inst.mu.RUnlock()
-	} else if m.state != nil {
-		if rec, err := m.state.Get(vmID); err == nil && rec != nil {
-			pid = rec.PID
-			sockPath = rec.SocketPath
-			ns = rec.Namespace
-		}
+	if identity.socketPath != "" {
+		_ = os.Remove(identity.socketPath)
 	}
 
-	// No-op for systemd VMs (stopUnit already killed them); the real kill for
-	// cold-boot VMs and record orphans. Identity-gated regardless of source —
-	// a paused VM's PID is stale whether it came from memory or the record.
-	if pidIsVMFirecracker(pid, vmID) {
-		sigkillPID(pid, 500*time.Millisecond)
-	}
-	if sockPath != "" {
-		_ = os.Remove(sockPath)
-	}
-
-	m.netMgr.CleanupVMOrNamespace(vmID, ns)
+	m.netMgr.CleanupVMOrNamespace(vmID, identity.namespace)
 
 	// Fall back to vmID when the instance is absent (RunDirID == vmID anyway).
 	rundirKey := vmID
@@ -742,6 +767,125 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) error 
 
 	log.Info().Msg("VM destroyed")
 	return nil
+}
+
+type stoppedVMProcessIdentity struct {
+	socketPath string
+	namespace  string
+}
+
+// stopVMProcessAndConfirm is the destructive safety boundary shared by normal
+// deletion and failed saved-snapshot source recovery. It stops only the exact
+// Firecracker process; callers decide whether to retain or remove the VM's
+// disk, network namespace, in-memory entry, and Bolt record.
+func (m *Manager) stopVMProcessAndConfirm(ctx context.Context, vmID string, inst *VMInstance) (stoppedVMProcessIdentity, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	log := m.log.With().Str("vm_id", vmID).Logger()
+	stopCtx, stopCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	if err := stopUnit(stopCtx, systemdUnitName(vmID)); err != nil {
+		log.Warn().Err(err).Msg("systemctl stop failed (unit may not exist — trying PID-based kill)")
+	}
+	stopCancel()
+
+	var identity stoppedVMProcessIdentity
+	var pid int
+	if inst != nil {
+		inst.mu.RLock()
+		pid = inst.PID
+		identity.socketPath = inst.SocketPath
+		identity.namespace = inst.Namespace
+		inst.mu.RUnlock()
+	} else if m.state != nil {
+		if rec, err := m.state.Get(vmID); err == nil && rec != nil {
+			pid = rec.PID
+			identity.socketPath = rec.SocketPath
+			identity.namespace = rec.Namespace
+		} else if err != nil {
+			return identity, fmt.Errorf("read VM state for teardown: %w", err)
+		}
+	}
+
+	if _, killErr := killExactVMFirecrackerPID(pid, vmID, 500*time.Millisecond); killErr != nil {
+		return identity, fmt.Errorf("stop tracked VM process: %w", killErr)
+	}
+	orphanPIDs, scanErr := vmFirecrackerPIDs(vmID)
+	if scanErr != nil {
+		return identity, fmt.Errorf("inspect VM processes: %w", scanErr)
+	}
+	for _, orphanPID := range orphanPIDs {
+		if _, killErr := killExactVMFirecrackerPID(orphanPID, vmID, 500*time.Millisecond); killErr != nil {
+			return identity, fmt.Errorf("stop scanned VM process: %w", killErr)
+		}
+	}
+
+	confirmCtx, confirmCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer confirmCancel()
+	if err := unitConfirmedInactive(confirmCtx, systemdUnitName(vmID)); err != nil {
+		return identity, fmt.Errorf("confirm VM unit teardown: %w", err)
+	}
+	remaining, scanErr := vmFirecrackerPIDs(vmID)
+	if scanErr != nil {
+		return identity, fmt.Errorf("confirm VM process teardown: %w", scanErr)
+	}
+	if len(remaining) > 0 {
+		return identity, fmt.Errorf("VM process teardown is incomplete for %s", vmID)
+	}
+	return identity, nil
+}
+
+// confirmSavedRestoreProcessStopped is the fail-closed teardown boundary for a
+// saved-snapshot restore that started (or may have started) Firecracker. A
+// failed confirmation deliberately retains the provisional VM, network, disk,
+// and Bolt record so the caller's compensation or the reconciler can retry
+// exact teardown; releasing any of them beneath an unproven process would turn
+// a retryable host failure into an orphan or cross-sandbox resource race.
+func (m *Manager) confirmSavedRestoreProcessStopped(vmID string, inst *VMInstance) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	_, err := m.stopVMProcessAndConfirm(ctx, vmID, inst)
+	cancel()
+	if err == nil {
+		return nil
+	}
+
+	if inst != nil {
+		inst.mu.Lock()
+		inst.Status = StatusError
+		inst.DirtyTracked = false
+		inst.mu.Unlock()
+		m.persistState(inst)
+	}
+	return err
+}
+
+// vmFirecrackerPIDs returns every /proc process whose exact argv identifies it
+// as Firecracker for vmID. Any unreadable numeric proc entry is inconclusive:
+// destroy must fail closed rather than release an artifact beneath a hidden
+// reader. Entries that disappear between directory scan and read are ignored.
+func vmFirecrackerPIDs(vmID string) ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("read /proc: %w", err)
+	}
+	var pids []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read process %d identity: %w", pid, err)
+		}
+		if firecrackerCmdlineMatches(cmdline, vmID) {
+			pids = append(pids, pid)
+		}
+	}
+	return pids, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1679,11 +1823,43 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	priorRunDir := !errors.Is(rdErr, os.ErrNotExist)
 
 	m.mu.Lock()
-	_, inPlace := m.vms[vmID]
-	if inPlace {
-		delete(m.vms, vmID)
+	priorTarget, targetExists := m.vms[vmID]
+	// A saved snapshot always creates a new child-owned disk. A prior failed
+	// attempt may still have an Error/Creating record after a daemon crash, but
+	// treating that as an in-place resume would reuse its partial target disk.
+	inPlace := targetExists && !resourceLimits.savedSnapshotRestore
+	if targetExists {
+		if resourceLimits.savedSnapshotRestore {
+			m.mu.Unlock()
+			if stopErr := m.confirmSavedRestoreProcessStopped(vmID, priorTarget); stopErr != nil {
+				return nil, status.Errorf(codes.Unavailable,
+					"prior saved snapshot restore process teardown is inconclusive: %v", stopErr)
+			}
+			removeUnitDropIn(vmID)
+			m.mu.Lock()
+		} else {
+			delete(m.vms, vmID)
+			m.mu.Unlock()
+			_ = stopUnit(ctx, systemdUnitName(vmID))
+			m.mu.Lock()
+		}
+	}
+	if resourceLimits.savedSnapshotRestore {
+		// Only forget a retained provisional target after exact process death was
+		// proven above. The per-VM operation lock excludes another restore; the
+		// pointer check avoids deleting a concurrently replaced entry.
+		if targetExists {
+			if current, ok := m.vms[vmID]; ok && current == priorTarget {
+				delete(m.vms, vmID)
+			}
+		}
 		m.mu.Unlock()
-		_ = stopUnit(ctx, systemdUnitName(vmID))
+		if targetExists && m.netMgr != nil {
+			m.netMgr.CleanupVM(vmID)
+		}
+		// Also handles an unrecorded partial disk left by a daemon/process crash.
+		m.cleanupRunDir(vmID)
+		m.deleteState(vmID)
 		m.mu.Lock()
 	}
 
@@ -1721,7 +1897,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	freshUnit := m.orphanScanDone.Load() && !inPlace && !priorRunDir &&
 		!isBuildVM(vmID) && !unitMaybeWindingDown(systemdUnitName(vmID))
 
-	plan := planRestore(resourceLimits.BasePath, resourceLimits.DeltaDir, inPlace)
+	plan := planRestoreWithSource(resourceLimits.BasePath, resourceLimits.DeltaDir, resourceLimits.RootfsPath, inPlace)
 	// Failure cleanup must not delete an overlay this attempt didn't create:
 	// see cleanupRunDirKeepOverlay.
 	cleanupAfterRestoreFailure := func() {
@@ -1730,6 +1906,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		} else {
 			m.cleanupRunDir(vmID)
 		}
+	}
+	failRestoreTarget := func() {
+		if resourceLimits.savedSnapshotRestore {
+			// A retry must be planned as another fresh clone/copy, never as an
+			// in-place resume of a failed provisional child.
+			m.removeVM(vmID)
+			return
+		}
+		m.setStatus(vmID, StatusError)
 	}
 	var diskPath string
 	var diskErr error
@@ -1745,9 +1930,18 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 	case restoreLegacyResolve:
 		diskPath, diskErr = m.resolveRestoreDisk(ctx, vmID, snapshotPath)
+	case restoreCloneOverlay:
+		diskPath, diskErr = m.cloneSavedOverlay(ctx, vmID, plan.source)
+	case restoreCopyRootfs:
+		if resourceLimits.savedSnapshotRestore {
+			diskPath, diskErr = m.copySavedRootfs(ctx, vmID, plan.source)
+		} else {
+			diskPath, diskErr = m.copyRootfs(ctx, vmID, plan.source)
+		}
 	}
 	if diskErr != nil {
-		m.setStatus(vmID, StatusError)
+		cleanupAfterRestoreFailure()
+		failRestoreTarget()
 		return nil, diskErr
 	}
 	tDiskReady := time.Now()
@@ -1788,13 +1982,29 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			netInfo, netErr := m.netMgr.SetupVM(ctx, vmID, netCfg)
 			if netErr != nil {
 				cleanupAfterRestoreFailure()
-				m.setStatus(vmID, StatusError)
+				failRestoreTarget()
 				return nil, fmt.Errorf("setup network: %w", netErr)
 			}
 			tapDevice = netInfo.TAPDevice
 			macAddr = netInfo.MACAddress
 			hostIP = netInfo.HostIP
 			nsName = netInfo.Namespace
+		}
+		if resourceLimits.EgressPolicy != nil {
+			policy := resourceLimits.EgressPolicy
+			if err := m.netMgr.UpdateFirewallRules(vmID, policy.AllowedCIDRs, policy.DeniedCIDRs); err != nil {
+				if !inPlace {
+					m.netMgr.CleanupVM(vmID)
+				}
+				cleanupAfterRestoreFailure()
+				failRestoreTarget()
+				return nil, fmt.Errorf("install pre-restore egress firewall: %w", err)
+			}
+			if m.egressProxy != nil {
+				applied := *policy
+				applied.SandboxID = vmID
+				m.egressProxy.SetRules(hostIP, &applied)
+			}
 		}
 		tNetReady := time.Now()
 
@@ -1812,11 +2022,19 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		var startErr error
 		pid, startErr = m.startFirecrackerViaSystemd(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, freshUnit && attempt == 1)
 		if startErr != nil {
+			if resourceLimits.savedSnapshotRestore {
+				if stopErr := m.confirmSavedRestoreProcessStopped(vmID, inst); stopErr != nil {
+					return nil, status.Errorf(codes.Unavailable,
+						"saved snapshot restore start failed and process teardown is inconclusive (start error: %v): %v",
+						startErr, stopErr)
+				}
+				removeUnitDropIn(vmID)
+			}
 			if !inPlace {
 				m.netMgr.CleanupVM(vmID)
 			}
 			cleanupAfterRestoreFailure()
-			m.setStatus(vmID, StatusError)
+			failRestoreTarget()
 			return nil, fmt.Errorf("start firecracker: %w", startErr)
 		}
 		inst.mu.Lock()
@@ -1895,10 +2113,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				inst.mu.Unlock()
 			case isOverlayMemFile(memPath):
 				attemptErr = fmt.Errorf("layered overlay %q has no base sidecar; refusing standalone restore", memPath)
-			case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" && isTemplate:
+			case m.cfg.IncrementalSnapshotEnabled && canLayered && recordToPath == "" &&
+				(isTemplate || resourceLimits.savedSnapshotRestore):
 				armLayered = true
 				inst.mu.Lock()
-				inst.BaseMemPath = memPath // template mem file = the layered base
+				// A saved standalone memory image is immutable just like a
+				// template image. Treat it as the base so the child appends its
+				// next dirty set into one bounded overlay instead of taking a
+				// second full snapshot.
+				inst.BaseMemPath = memPath
 				inst.DirtyTracked = true
 				inst.mu.Unlock()
 			}
@@ -1929,18 +2152,27 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if inPlace || attempt >= maxRestoreAttempts || !isTapDeviceBusyErr(restoreErr) {
 			break
 		}
-		m.stopUnitDuringRestoreError(vmID)
-		// Retry only when the unit is affirmatively dead — an inconclusive
-		// answer reads as alive. Launches would replace a live leftover,
-		// but "not confirmed dead" means systemctl itself is struggling;
-		// kept conservative.
-		checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
-		checkCancel()
-		if !dead {
-			log.Warn().Int("attempt", attempt).
-				Msg("unit not confirmed dead after stop — not retrying restore")
-			break
+		if resourceLimits.savedSnapshotRestore {
+			if stopErr := m.confirmSavedRestoreProcessStopped(vmID, inst); stopErr != nil {
+				return nil, status.Errorf(codes.Unavailable,
+					"saved snapshot load retry process teardown is inconclusive (load error: %v): %v",
+					restoreErr, stopErr)
+			}
+			removeUnitDropIn(vmID)
+		} else {
+			m.stopUnitDuringRestoreError(vmID)
+			// Retry only when the unit is affirmatively dead — an inconclusive
+			// answer reads as alive. Launches would replace a live leftover,
+			// but "not confirmed dead" means systemctl itself is struggling;
+			// kept conservative.
+			checkCtx, checkCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			dead := unitDefinitelyDead(checkCtx, systemdUnitName(vmID))
+			checkCancel()
+			if !dead {
+				log.Warn().Int("attempt", attempt).
+					Msg("unit not confirmed dead after stop — not retrying restore")
+				break
+			}
 		}
 		log.Warn().Err(restoreErr).Int("attempt", attempt).
 			Msg("restore failed with tap0 busy — retrying with a fresh slot")
@@ -1955,7 +2187,16 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	if restoreErr != nil {
 		// Firecracker is already running; stop the unit before other
 		// cleanup or it leaks. See stopUnitDuringRestoreError comment.
-		m.stopUnitDuringRestoreError(vmID)
+		if resourceLimits.savedSnapshotRestore {
+			if stopErr := m.confirmSavedRestoreProcessStopped(vmID, inst); stopErr != nil {
+				return nil, status.Errorf(codes.Unavailable,
+					"saved snapshot load failed and process teardown is inconclusive (load error: %v): %v",
+					restoreErr, stopErr)
+			}
+			removeUnitDropIn(vmID)
+		} else {
+			m.stopUnitDuringRestoreError(vmID)
+		}
 		if !inPlace {
 			// A tap-busy slot is suspect — tear it down rather than recycle it,
 			// so it isn't handed to another create with the same bad tap.
@@ -1966,7 +2207,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			}
 		}
 		cleanupAfterRestoreFailure()
-		m.setStatus(vmID, StatusError)
+		failRestoreTarget()
 		// armLayered may have set DirtyTracked=true on inst before the restore call;
 		// clear it on failure so a lingering instance can't later take a Diff against a
 		// baseline that never loaded. (The VM is StatusError + unit stopped, so this is
@@ -2003,12 +2244,21 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// evicted) legitimately needs more than a warm same-host resume, and a
 	// timeout here is destructive — the error path below tears down the VM.
 	if err := m.waitForBoxd(ctx, hostIP, 30*time.Second); err != nil {
-		m.stopUnitDuringRestoreError(vmID)
+		if resourceLimits.savedSnapshotRestore {
+			if stopErr := m.confirmSavedRestoreProcessStopped(vmID, inst); stopErr != nil {
+				return nil, status.Errorf(codes.Unavailable,
+					"saved snapshot boxd readiness failed and process teardown is inconclusive (readiness error: %v): %v",
+					err, stopErr)
+			}
+			removeUnitDropIn(vmID)
+		} else {
+			m.stopUnitDuringRestoreError(vmID)
+		}
 		if !inPlace {
 			m.netMgr.CleanupVM(vmID)
 		}
 		cleanupAfterRestoreFailure()
-		m.setStatus(vmID, StatusError)
+		failRestoreTarget()
 		return nil, fmt.Errorf("boxd not ready after restore: %w", err)
 	}
 	tBoxdReady := time.Now()
@@ -2029,8 +2279,17 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	_, stillTracked := m.vms[vmID]
 	m.mu.RUnlock()
 	if !stillTracked {
+		if resourceLimits.savedSnapshotRestore {
+			if stopErr := m.confirmSavedRestoreProcessStopped(vmID, inst); stopErr != nil {
+				return nil, status.Errorf(codes.Unavailable,
+					"saved snapshot restore lost its lifecycle record and process teardown is inconclusive: %v",
+					stopErr)
+			}
+			removeUnitDropIn(vmID)
+		} else {
+			m.stopUnitDuringRestoreError(vmID)
+		}
 		m.deleteState(vmID)
-		m.stopUnitDuringRestoreError(vmID)
 		if !inPlace {
 			m.netMgr.CleanupVM(vmID)
 		}
@@ -2186,8 +2445,10 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			// PID, but only after verifying the PID still names this VM (a stale
 			// record PID may have been reused by an unrelated process). The wait
 			// lets the kernel release the tap fd before the netns teardown below.
-			if pidIsVMFirecracker(rec.PID, rec.ID) {
-				sigkillPID(rec.PID, 500*time.Millisecond)
+			if matched, killErr := killExactVMFirecrackerPID(rec.PID, rec.ID, 500*time.Millisecond); killErr != nil {
+				log.Error().Err(killErr).Int("pid", rec.PID).Msg("refusing stale-record cleanup without safe process teardown")
+				return nil, false
+			} else if matched {
 				log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
 			}
 			m.state.Delete(rec.ID)
@@ -2231,7 +2492,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	// idempotent, so a rare double restore (background pass and a request both
 	// reaching here) is harmless.
 	if inst.Namespace != "" && inst.IP != "" {
-		if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress); err != nil {
+		if err := m.netMgr.ReattachVM(rec.ID, inst.Namespace, inst.IP, inst.MACAddress, inst.Config.EgressPolicy); err != nil {
 			log.Error().Err(err).Msg("reattach: restore network state failed")
 		}
 	}
@@ -2850,12 +3111,67 @@ func (m *Manager) copyRootfs(ctx context.Context, dirName, srcRootfs string) (st
 	}
 
 	diskPath := filepath.Join(vmDir, "rootfs.ext4")
-	cmd := exec.CommandContext(ctx, "cp", "--reflink=auto", srcRootfs, diskPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", fmt.Errorf("copy rootfs: %s: %w", string(out), err)
+	if err := copyWritableDisk(ctx, "copy rootfs", srcRootfs, diskPath, "--reflink=auto"); err != nil {
+		return "", err
 	}
 
 	return diskPath, nil
+}
+
+// copySavedRootfs creates the fork's writable branch without duplicating the
+// immutable saved full-disk layer. Saved snapshots are feature-gated and fail
+// closed on hosts/filesystems that cannot provide reflink semantics.
+func (m *Manager) copySavedRootfs(ctx context.Context, dirName, srcRootfs string) (string, error) {
+	vmDir := filepath.Join(m.cfg.RunDir, dirName)
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir vm dir: %w", err)
+	}
+	diskPath := filepath.Join(vmDir, "rootfs.ext4")
+	if err := copyWritableDisk(ctx, "clone saved rootfs", srcRootfs, diskPath, "--reflink=always", "--sparse=auto"); err != nil {
+		return "", err
+	}
+	return diskPath, nil
+}
+
+// cloneSavedOverlay gives a fork a private writable overlay cloned from an
+// immutable saved overlay. Reflink is required so unchanged blocks stay
+// physically shared; this feature fails closed instead of duplicating bytes.
+func (m *Manager) cloneSavedOverlay(ctx context.Context, dirName, source string) (string, error) {
+	vmDir := filepath.Join(m.cfg.RunDir, dirName)
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir vm dir: %w", err)
+	}
+	dst := filepath.Join(vmDir, "overlay.ext4")
+	if err := copyWritableDisk(ctx, "clone saved overlay", source, dst, "--reflink=always", "--sparse=auto"); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// copyWritableDisk publishes the child disk only after cp and chmod both
+// succeed. A cancellation, ENOSPC, or process crash can leave the staging file
+// behind, but never a partially written destination that a retry could reuse.
+func copyWritableDisk(ctx context.Context, operation, source, destination string, cpOptions ...string) error {
+	staging := destination + ".restore-tmp"
+	for _, path := range []string{staging, destination} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("%s: remove stale target %q: %w", operation, path, err)
+		}
+	}
+	defer os.Remove(staging) // best-effort cleanup after every error path
+
+	args := append(append([]string(nil), cpOptions...), source, staging)
+	cmd := exec.CommandContext(ctx, "cp", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %s: %w", operation, string(out), err)
+	}
+	if err := os.Chmod(staging, 0o600); err != nil {
+		return fmt.Errorf("%s: make staged disk writable: %w", operation, err)
+	}
+	if err := os.Rename(staging, destination); err != nil {
+		return fmt.Errorf("%s: publish staged disk: %w", operation, err)
+	}
+	return nil
 }
 
 // createOverlay creates a sparse per-VM overlay file pre-sized to the base

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -448,6 +449,7 @@ func TestDeleteSnapshotFiles_BothEmpty_Rejected(t *testing.T) {
 // TestDestroyVM_AbsentInstance_CleansRundir: destroying a VM that's absent from
 // m.vms (e.g. a paused sandbox) must still remove its rundir, not leak it.
 func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
+	installInactiveSystemctl(t)
 	runDir := t.TempDir()
 	vmID := "11111111-1111-1111-1111-111111111111"
 	dir := filepath.Join(runDir, vmID)
@@ -479,6 +481,7 @@ func TestDestroyVM_AbsentInstance_CleansRundir(t *testing.T) {
 // TestDestroyVM_UnsafeVMID_Rejected: a non-path-safe or reserved vmID is
 // rejected before cleanup, so it can't escape RunDir or wipe shared dirs.
 func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
+	installInactiveSystemctl(t)
 	runDir := t.TempDir()
 	shared := []string{"keep", templateDirName, TemplatesDirName}
 	for _, name := range shared {
@@ -516,6 +519,73 @@ func TestDestroyVM_UnsafeVMID_Rejected(t *testing.T) {
 		if err != nil {
 			t.Errorf("DestroyVM(%q): want nil, got %v", vmID, err)
 		}
+	}
+}
+
+func installInactiveSystemctl(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := filepath.Join(binDir, "systemctl")
+	contents := []byte("#!/bin/sh\ncase \"$1\" in\n  stop) exit 0 ;;\n  is-active) echo inactive; exit 3 ;;\n  *) exit 0 ;;\nesac\n")
+	if err := os.WriteFile(script, contents, 0o755); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestUnitConfirmedInactiveRequiresAuthoritativeSystemdState(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		exit    int
+		wantErr bool
+	}{
+		{name: "inactive", output: "inactive", exit: 3},
+		{name: "failed", output: "failed", exit: 3},
+		{name: "unknown unit", output: "unknown", exit: 4},
+		{name: "active", output: "active", exit: 0, wantErr: true},
+		{name: "blank transport failure", exit: 1, wantErr: true},
+		{name: "bus failure", output: "Failed to connect to bus", exit: 1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			script := filepath.Join(binDir, "systemctl")
+			contents := "#!/bin/sh\nprintf '%s\\n' '" + tt.output + "'\nexit " + strconv.Itoa(tt.exit) + "\n"
+			if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			err := unitConfirmedInactive(context.Background(), "firecracker@test.service")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unitConfirmedInactive error = %v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFirecrackerCmdlineMatchesExactProcessIdentity(t *testing.T) {
+	vmID := "vm-123"
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		{name: "bare binary", cmdline: "firecracker\x00--id\x00vm-123\x00", want: true},
+		{name: "absolute binary", cmdline: "/usr/bin/firecracker\x00--id\x00vm-123\x00", want: true},
+		{name: "different program", cmdline: "sh\x00-c\x00firecracker --id vm-123\x00"},
+		{name: "prefixed binary", cmdline: "firecracker-wrapper\x00--id\x00vm-123\x00"},
+		{name: "prefixed absolute binary", cmdline: "/tmp/firecracker-malicious\x00--id\x00vm-123\x00"},
+		{name: "id substring", cmdline: "firecracker\x00--id\x00vm-1234\x00"},
+		{name: "combined id option", cmdline: "firecracker\x00--id=vm-123\x00"},
+		{name: "missing id flag", cmdline: "firecracker\x00vm-123\x00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firecrackerCmdlineMatches([]byte(tt.cmdline), vmID); got != tt.want {
+				t.Fatalf("firecrackerCmdlineMatches = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/vm/pidfd_linux.go
+++ b/internal/vm/pidfd_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// killExactVMFirecrackerPID binds the numeric PID to a pidfd before reading
+// identity. If the process exits and the PID is reused at any later point, the
+// signal still targets only the originally opened process description.
+func killExactVMFirecrackerPID(pid int, vmID string, wait time.Duration) (bool, error) {
+	if pid <= 0 || vmID == "" {
+		return false, nil
+	}
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if errors.Is(err, unix.ESRCH) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("pidfd_open(%d): %w", pid, err)
+	}
+	defer unix.Close(pidfd)
+
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read process %d identity: %w", pid, err)
+	}
+	if !firecrackerCmdlineMatches(cmdline, vmID) {
+		return false, nil
+	}
+
+	if err := unix.PidfdSendSignal(pidfd, unix.SIGKILL, nil, 0); err != nil && !errors.Is(err, unix.ESRCH) {
+		return true, fmt.Errorf("pidfd_send_signal(%d): %w", pid, err)
+	}
+	if wait > 0 {
+		timeoutMS := int(wait.Milliseconds())
+		if timeoutMS < 1 {
+			timeoutMS = 1
+		}
+		poll := []unix.PollFd{{Fd: int32(pidfd), Events: unix.POLLIN}}
+		if _, err := unix.Poll(poll, timeoutMS); err != nil && !errors.Is(err, unix.EINTR) {
+			return true, fmt.Errorf("poll pidfd %d: %w", pid, err)
+		}
+	}
+	return true, nil
+}

--- a/internal/vm/pidfd_other.go
+++ b/internal/vm/pidfd_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package vm
+
+import (
+	"fmt"
+	"time"
+)
+
+// Production VMD hosts are Linux. Refuse to perform an identity-sensitive
+// kill on platforms without pidfds rather than falling back to a racy numeric
+// PID signal.
+func killExactVMFirecrackerPID(pid int, vmID string, wait time.Duration) (bool, error) {
+	if pid <= 0 || vmID == "" || !pidIsVMFirecracker(pid, vmID) {
+		return false, nil
+	}
+	return true, fmt.Errorf("safe pidfd signalling is unavailable on this platform")
+}

--- a/internal/vm/saved_snapshot.go
+++ b/internal/vm/saved_snapshot.go
@@ -1,0 +1,1878 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/network"
+	"github.com/superserve-ai/sandbox/internal/presence"
+	"github.com/superserve-ai/sandbox/internal/vm/fc/models"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+const (
+	// SavedSnapshotsDirName is intentionally not a UUID. The disk-orphan
+	// reconciler scans UUID-named direct children of SnapshotDir, so keeping
+	// reusable snapshots in this separate tree prevents source-sandbox cleanup
+	// from quarantining artifacts still referenced by forks.
+	SavedSnapshotsDirName = "saved"
+
+	savedSnapshotSchemaVersion = 1
+	savedSnapshotManifestName  = "manifest.json"
+
+	diskArtifactBlockDelta = "block_delta"
+	diskArtifactOverlay    = "overlay"
+	diskArtifactFull       = "full"
+
+	savedSnapshotSourceRecoveryTimeout  = 30 * time.Second
+	savedSnapshotSourceRecoveryAttempts = 3
+	savedSnapshotSourceResumeFailedKey  = "saved_snapshot_source_resume_failed"
+)
+
+// ErrSavedSnapshotSourceResume marks the one capture failure that changes the
+// source's availability: Firecracker accepted the freeze/snapshot operation
+// but could not be returned to running. The gRPC adapter attaches a stable
+// machine-readable reason so the control plane can fail the source row rather
+// than release the capture claim while reporting it as active.
+var ErrSavedSnapshotSourceResume = errors.New("saved snapshot source failed to resume")
+
+// SavedSnapshotResources is the immutable VM shape recorded by a saved
+// snapshot. Firecracker snapshots cannot be restored at a different shape.
+type SavedSnapshotResources struct {
+	VCPU        uint32 `json:"vcpu_count"`
+	MemoryMiB   uint32 `json:"memory_mib"`
+	DiskSizeMiB uint32 `json:"disk_size_mib"`
+}
+
+// SavedSnapshotArtifacts is the VMD-internal artifact metadata returned to
+// the control plane. Paths must not be exposed by public API responses.
+type SavedSnapshotArtifacts struct {
+	ManifestPath    string
+	SnapshotPath    string
+	MemFilePath     string
+	MemoryBasePath  string
+	DiskBasePath    string
+	DiskDeltaPath   string
+	DiskOverlayPath string
+	DiskFullPath    string
+}
+
+// SavedSnapshot is the committed result of CreateSavedSnapshot.
+type SavedSnapshot struct {
+	SchemaVersion          uint32
+	SnapshotID             string
+	SourceVMID             string
+	SourceState            string
+	CreatedAt              time.Time
+	Resources              SavedSnapshotResources
+	Artifacts              SavedSnapshotArtifacts
+	LogicalSizeBytes       int64
+	ExclusiveSizeBytes     int64
+	SourceLogicalSizeBytes int64
+	// SourceExclusiveSizeBytes is the source-owned writable generation that
+	// became retained by this branch. The control-plane layer ledger transfers
+	// it from current writable usage to retained usage without charging the
+	// reflink again to this snapshot.
+	SourceExclusiveSizeBytes int64
+	ManifestDigest           string
+}
+
+// savedSnapshotManifest is the durable commit record. All owned artifact
+// paths resolve inside the manifest directory; base paths are immutable
+// references owned by an ancestor template/layer.
+type savedSnapshotManifest struct {
+	SchemaVersion        uint32                 `json:"schema_version"`
+	SnapshotID           string                 `json:"snapshot_id"`
+	SourceVMID           string                 `json:"source_vm_id"`
+	SourceState          string                 `json:"source_state"`
+	CreatedAt            time.Time              `json:"created_at"`
+	Resources            SavedSnapshotResources `json:"resources"`
+	VMStatePath          string                 `json:"vmstate_path"`
+	Memory               savedMemoryArtifact    `json:"memory"`
+	Disk                 savedDiskArtifact      `json:"disk"`
+	ArtifactSHA256       map[string]string      `json:"artifact_sha256"`
+	LogicalBytes         int64                  `json:"logical_size_bytes"`
+	ExclusiveBytes       int64                  `json:"exclusive_size_bytes"`
+	SourceLogicalBytes   int64                  `json:"source_logical_size_bytes"`
+	SourceExclusiveBytes int64                  `json:"source_exclusive_size_bytes"`
+
+	// sharedOwnedPaths are files physically branched from an existing immutable
+	// layer with a mandatory reflink. They are owned by this manifest (and are
+	// therefore removed with it), but their pre-existing extents are not new
+	// team storage. This capture-only field is deliberately absent from JSON.
+	sharedOwnedPaths      []string
+	artifactSizesMeasured bool
+}
+
+// savedSourceLayerUsage measures only source-owned extents that a committed
+// capture actually turns into shared immutable storage. Merely copying a
+// source file (for example vmstate.snap or a Firecracker block delta) does not
+// retain that source generation and therefore must not move its bytes into the
+// control-plane's retained source layer.
+type savedSourceLayerUsage struct {
+	logicalBytes   int64
+	exclusiveBytes int64
+	sources        map[string]savedSourceLayerFile
+	finalized      bool
+}
+
+type savedSourceLayerFile struct {
+	path            string
+	logicalBytes    int64
+	exclusiveBefore int64
+}
+
+// reflink branches one source-owned file and records its pre-branch exclusive
+// usage. finalize performs the after measurement only once all destination
+// mutations are complete: applying a dirty-memory delta can COW some extents
+// back out of the clone, and those bytes are not retained by the branch.
+func (u *savedSourceLayerUsage) reflink(ctx context.Context, src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	key := filepath.Clean(src)
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		key = fmt.Sprintf("%d:%d", st.Dev, st.Ino)
+	}
+	if u.sources == nil {
+		u.sources = make(map[string]savedSourceLayerFile)
+	}
+	if _, recorded := u.sources[key]; !recorded {
+		before, err := exclusiveFileBytes(src)
+		if err != nil {
+			return err
+		}
+		u.sources[key] = savedSourceLayerFile{
+			path:            src,
+			logicalBytes:    info.Size(),
+			exclusiveBefore: before,
+		}
+	}
+	return reflinkImmutableFileContext(ctx, src, dst)
+}
+
+// finalize records only extents that remain shared after every capture write.
+// Running captures call it before unpausing the source; paused captures call it
+// while the source process is confirmed dead.
+func (u *savedSourceLayerUsage) finalize() error {
+	if u.finalized {
+		return nil
+	}
+	var logical, exclusive int64
+	for _, source := range u.sources {
+		after, err := exclusiveFileBytes(source.path)
+		if err != nil {
+			return err
+		}
+		if after > source.exclusiveBefore {
+			return fmt.Errorf("source exclusive bytes grew across capture: before=%d after=%d", source.exclusiveBefore, after)
+		}
+		shared := source.exclusiveBefore - after
+		if shared == 0 {
+			continue
+		}
+		if shared > math.MaxInt64-exclusive {
+			return errors.New("retained source exclusive byte count overflow")
+		}
+		if source.logicalBytes > math.MaxInt64-logical {
+			return errors.New("retained source logical byte count overflow")
+		}
+		exclusive += shared
+		logical += source.logicalBytes
+	}
+	u.logicalBytes = logical
+	u.exclusiveBytes = exclusive
+	u.finalized = true
+	return nil
+}
+
+type savedMemoryArtifact struct {
+	Path     string `json:"path"`
+	BasePath string `json:"base_path,omitempty"`
+}
+
+type savedDiskArtifact struct {
+	Kind     string `json:"kind"`
+	BasePath string `json:"base_path,omitempty"`
+	Path     string `json:"path"`
+}
+
+func (s *savedSnapshotManifest) result(manifestPath string) (*SavedSnapshot, error) {
+	manifestDigest, err := sha256File(manifestPath)
+	if err != nil {
+		return nil, savedSnapshotArtifactIOError("hash saved snapshot manifest", err)
+	}
+	artifacts := SavedSnapshotArtifacts{
+		ManifestPath:   manifestPath,
+		SnapshotPath:   s.VMStatePath,
+		MemFilePath:    s.Memory.Path,
+		MemoryBasePath: s.Memory.BasePath,
+		DiskBasePath:   s.Disk.BasePath,
+	}
+	switch s.Disk.Kind {
+	case diskArtifactBlockDelta:
+		artifacts.DiskDeltaPath = s.Disk.Path
+	case diskArtifactOverlay:
+		artifacts.DiskOverlayPath = s.Disk.Path
+	case diskArtifactFull:
+		artifacts.DiskFullPath = s.Disk.Path
+	}
+	return &SavedSnapshot{
+		SchemaVersion:            s.SchemaVersion,
+		SnapshotID:               s.SnapshotID,
+		SourceVMID:               s.SourceVMID,
+		SourceState:              s.SourceState,
+		CreatedAt:                s.CreatedAt,
+		Resources:                s.Resources,
+		Artifacts:                artifacts,
+		LogicalSizeBytes:         s.LogicalBytes,
+		ExclusiveSizeBytes:       s.ExclusiveBytes,
+		SourceLogicalSizeBytes:   s.SourceLogicalBytes,
+		SourceExclusiveSizeBytes: s.SourceExclusiveBytes,
+		ManifestDigest:           manifestDigest,
+	}, nil
+}
+
+func (m *Manager) savedSnapshotDir(sourceVMID, snapshotID string) (string, error) {
+	if m.cfg.SnapshotDir == "" || !filepath.IsAbs(m.cfg.SnapshotDir) {
+		return "", status.Error(codes.FailedPrecondition, "snapshot_dir must be configured as an absolute path")
+	}
+	if !isLeafName(sourceVMID) || isReservedRunDirName(sourceVMID) {
+		return "", status.Error(codes.InvalidArgument, "source_vm_id must be a valid identifier")
+	}
+	if !isLeafName(snapshotID) {
+		return "", status.Error(codes.InvalidArgument, "snapshot_id must be a valid identifier")
+	}
+	return filepath.Join(m.cfg.SnapshotDir, SavedSnapshotsDirName, sourceVMID, snapshotID), nil
+}
+
+// CreateSavedSnapshot captures an immutable reusable snapshot. Active VMs are
+// frozen only while Firecracker writes a full memory image and disk delta, then
+// returned to running. Paused VMs are copied from their retained checkpoint and
+// never woken. The final directory rename is the commit point.
+func (m *Manager) CreateSavedSnapshot(ctx context.Context, sourceVMID, snapshotID string) (*SavedSnapshot, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	finalDir, err := m.savedSnapshotDir(sourceVMID, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+
+	unlock, err := m.lockVMOp(ctx, sourceVMID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	manifestPath := filepath.Join(finalDir, savedSnapshotManifestName)
+	if _, statErr := os.Stat(finalDir); statErr == nil {
+		manifest, loadErr := m.loadSavedSnapshotManifest(manifestPath)
+		if loadErr != nil {
+			if status.Code(loadErr) == codes.Unavailable {
+				return nil, loadErr
+			}
+			return nil, status.Errorf(codes.DataLoss,
+				"saved snapshot directory exists without a valid committed manifest: %v", loadErr)
+		}
+		if manifest.SourceVMID != sourceVMID || manifest.SnapshotID != snapshotID {
+			return nil, status.Error(codes.DataLoss, "saved snapshot manifest identity mismatch")
+		}
+		return manifest.result(manifestPath)
+	} else if !os.IsNotExist(statErr) {
+		return nil, fmt.Errorf("stat saved snapshot directory: %w", statErr)
+	}
+
+	inst, err := m.getInstance(sourceVMID)
+	if err != nil {
+		return nil, err
+	}
+	inst.mu.RLock()
+	state := inst.Status
+	sourceResumePreviouslyFailed := inst.Metadata != nil && inst.Metadata[savedSnapshotSourceResumeFailedKey] == "true"
+	sourceSnapshotPath := inst.SnapshotPath
+	sourceMemPath := inst.MemFilePath
+	sourceMemBasePath := inst.BaseMemPath
+	diskPath := inst.DiskPath
+	runDirID := inst.RunDirID
+	basePath := inst.Config.BasePath
+	resources := SavedSnapshotResources{
+		VCPU:        inst.Config.VCPU,
+		MemoryMiB:   inst.Config.MemoryMiB,
+		DiskSizeMiB: inst.Config.DiskSizeMiB,
+	}
+	inst.mu.RUnlock()
+	if sourceResumePreviouslyFailed {
+		return nil, ErrSavedSnapshotSourceResume
+	}
+
+	if state != StatusRunning && state != StatusPaused {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"vm %s cannot be snapshotted from state %s", sourceVMID, state)
+	}
+	if state == StatusPaused {
+		// PauseVM can preserve a valid checkpoint even when its final systemd
+		// stop is inconclusive. That is sufficient for retrying pause, but not
+		// for copying a supposedly immutable disk offline: a lingering reader/
+		// writer could tear the saved artifact. Require positive process death.
+		confirmCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		unitErr := unitConfirmedInactive(confirmCtx, systemdUnitName(sourceVMID))
+		cancel()
+		if unitErr != nil {
+			return nil, status.Errorf(codes.Unavailable, "paused source process state is inconclusive: %v", unitErr)
+		}
+		pids, scanErr := vmFirecrackerPIDs(sourceVMID)
+		if scanErr != nil {
+			return nil, status.Errorf(codes.Unavailable, "inspect paused source processes: %v", scanErr)
+		}
+		if len(pids) > 0 {
+			return nil, status.Error(codes.Unavailable, "paused source Firecracker process is still running")
+		}
+	}
+	if resources.VCPU == 0 || resources.MemoryMiB == 0 {
+		return nil, status.Error(codes.FailedPrecondition, "source VM resource shape is incomplete")
+	}
+	if runDirID == "" {
+		runDirID = sourceVMID
+	}
+	if diskPath == "" {
+		name := "rootfs.ext4"
+		if basePath != "" {
+			name = "overlay.ext4"
+		}
+		diskPath = filepath.Join(m.cfg.RunDir, runDirID, name)
+	}
+	if resources.DiskSizeMiB == 0 {
+		if info, statErr := os.Stat(diskPath); statErr == nil {
+			resources.DiskSizeMiB = uint32((info.Size() + (1 << 20) - 1) >> 20)
+		}
+	}
+
+	parentDir := filepath.Dir(finalDir)
+	savedRoot := filepath.Join(m.cfg.SnapshotDir, SavedSnapshotsDirName)
+	_, sourceDirStatErr := os.Stat(parentDir)
+	sourceDirWasMissing := os.IsNotExist(sourceDirStatErr)
+	if sourceDirStatErr != nil && !sourceDirWasMissing {
+		return nil, fmt.Errorf("stat saved snapshot source directory: %w", sourceDirStatErr)
+	}
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create saved snapshot parent: %w", err)
+	}
+	if err := ensureNoSymlinkDirs(savedRoot, parentDir); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "unsafe saved snapshot directory: %v", err)
+	}
+	if sourceDirWasMissing {
+		if err := fsyncDir(savedRoot); err != nil {
+			return nil, fmt.Errorf("fsync saved snapshot root after source directory create: %w", err)
+		}
+	}
+	// A host crash may leave the staging directory from this exact durable
+	// intent behind. The source VM operation lock serializes same-source
+	// captures, so these same-ID directories cannot belong to a live peer.
+	stalePattern := filepath.Join(parentDir, "."+snapshotID+".tmp-*")
+	if staleDirs, globErr := filepath.Glob(stalePattern); globErr != nil {
+		return nil, fmt.Errorf("find stale saved snapshot staging directories: %w", globErr)
+	} else {
+		for _, staleDir := range staleDirs {
+			if err := os.RemoveAll(staleDir); err != nil {
+				return nil, fmt.Errorf("remove stale saved snapshot staging directory: %w", err)
+			}
+		}
+	}
+	tmpDir := filepath.Join(parentDir, "."+snapshotID+".tmp-"+uuid.NewString())
+	if err := os.Mkdir(tmpDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create saved snapshot staging dir: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	createdAt := time.Now().UTC()
+	manifest := &savedSnapshotManifest{
+		SchemaVersion: savedSnapshotSchemaVersion,
+		SnapshotID:    snapshotID,
+		SourceVMID:    sourceVMID,
+		SourceState:   state.String(),
+		CreatedAt:     createdAt,
+		Resources:     resources,
+		VMStatePath:   filepath.Join(finalDir, "vmstate.snap"),
+		Memory: savedMemoryArtifact{
+			Path: filepath.Join(finalDir, "mem.snap"),
+		},
+	}
+	sourceLayer := &savedSourceLayerUsage{}
+
+	if state == StatusRunning {
+		err = m.captureRunningSavedSnapshot(ctx, inst, tmpDir, finalDir, diskPath, basePath, manifest, sourceLayer)
+	} else {
+		err = m.capturePausedSavedSnapshot(ctx, tmpDir, finalDir, sourceSnapshotPath, sourceMemPath, sourceMemBasePath, diskPath, basePath, manifest, sourceLayer)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := sourceLayer.finalize(); err != nil {
+		return nil, savedSnapshotCaptureCopyError("measure retained source layer", err)
+	}
+	manifest.SourceLogicalBytes = sourceLayer.logicalBytes
+	manifest.SourceExclusiveBytes = sourceLayer.exclusiveBytes
+	if err := populateSavedSnapshotDigests(tmpDir, finalDir, manifest); err != nil {
+		return nil, fmt.Errorf("digest saved snapshot artifacts: %w", err)
+	}
+
+	if !manifest.artifactSizesMeasured {
+		logical, exclusive, err := snapshotArtifactSizesWithShared(
+			tmpDir,
+			manifest.sharedOwnedPaths,
+			manifest.Memory.BasePath,
+			manifest.Disk.BasePath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("measure saved snapshot artifacts: %w", err)
+		}
+		manifest.LogicalBytes = logical
+		manifest.ExclusiveBytes = exclusive
+	}
+
+	if err := writeSavedSnapshotManifest(tmpDir, manifest); err != nil {
+		return nil, err
+	}
+	if err := makeSnapshotArtifactsReadOnly(tmpDir); err != nil {
+		return nil, err
+	}
+	if err := fsyncTree(tmpDir); err != nil {
+		return nil, fmt.Errorf("fsync saved snapshot artifacts: %w", err)
+	}
+
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		// Another daemon/process may have committed the same id after our first
+		// existence check. Treat an identical committed manifest as success.
+		if existing, loadErr := m.loadSavedSnapshotManifest(manifestPath); loadErr == nil &&
+			existing.SourceVMID == sourceVMID && existing.SnapshotID == snapshotID {
+			return existing.result(manifestPath)
+		}
+		return nil, fmt.Errorf("commit saved snapshot directory: %w", err)
+	}
+	committed = true
+	if err := fsyncDir(parentDir); err != nil {
+		return nil, fmt.Errorf("fsync saved snapshot parent: %w", err)
+	}
+	return manifest.result(manifestPath)
+}
+
+func (m *Manager) captureRunningSavedSnapshot(ctx context.Context, inst *VMInstance, tmpDir, finalDir, diskPath, basePath string, manifest *savedSnapshotManifest, sourceLayer *savedSourceLayerUsage) error {
+	tmpSnapshot := filepath.Join(tmpDir, "vmstate.snap")
+
+	inst.mu.RLock()
+	socketPath := inst.SocketPath
+	dirtyTracked := inst.DirtyTracked
+	sourceMemPath := inst.MemFilePath
+	sourceMemBasePath := inst.BaseMemPath
+	inst.mu.RUnlock()
+
+	incremental := m.cfg.IncrementalSnapshotEnabled && dirtyTracked && sourceMemPath != "" && fileExists(sourceMemPath)
+	var captureErr error
+	if incremental {
+		rawDelta := filepath.Join(tmpDir, "mem.capture.diff")
+		captureErr = CreateDiffSnapshotContext(ctx, socketPath, tmpSnapshot, rawDelta)
+		// A successful Diff consumes Firecracker's current dirty bitmap, and an
+		// HTTP error cannot prove the operation was not applied before its response
+		// was lost. Conservatively disarm after every attempted Diff. At worst a
+		// pre-emission failure makes the next capture Full; leaving it armed after
+		// an ambiguous success would silently omit consumed pages.
+		inst.mu.Lock()
+		inst.DirtyTracked = false
+		inst.mu.Unlock()
+		// DirtyTracked describes only the live Firecracker process and therefore
+		// defaults to false after restart, but persist the surrounding instance
+		// state now as the same durability boundary used by a successful Full.
+		m.persistState(inst)
+		if captureErr == nil {
+			// The saved branch below is intentionally separate from the source's
+			// runtime checkpoint, so that checkpoint is no longer a valid target for
+			// another in-place Diff. Disarm before materialization: ENOSPC, a torn
+			// presence sidecar, digest failure, or an interrupted manifest commit must
+			// all force the source's next pause/capture down the Full path rather than
+			// silently omit the pages consumed by this successful emission.
+			captureErr = materializeSavedMemoryBranch(ctx, tmpDir, finalDir, sourceMemPath, sourceMemBasePath, rawDelta, manifest, sourceLayer)
+		}
+	} else {
+		tmpMem := filepath.Join(tmpDir, "mem.snap")
+		blockDeltaDir := ""
+		if basePath != "" {
+			blockDeltaDir = tmpDir
+		}
+		captureErr = CreateSnapshotContext(ctx, socketPath, tmpSnapshot, tmpMem, blockDeltaDir, SnapshotNormal)
+		if captureErr == nil {
+			manifest.Memory.Path = filepath.Join(finalDir, "mem.snap")
+		}
+	}
+	if captureErr == nil {
+		if !incremental {
+			// A full snapshot resets Firecracker's dirty baseline. Persist this
+			// before unpausing so a failed unpause cannot leave stale diff state.
+			inst.mu.Lock()
+			inst.DirtyTracked = false
+			inst.mu.Unlock()
+			m.persistState(inst)
+		}
+
+		if basePath != "" {
+			delta := filepath.Join(tmpDir, "rootfs.delta")
+			if fileExists(delta) {
+				manifest.Disk = savedDiskArtifact{
+					Kind:     diskArtifactBlockDelta,
+					BasePath: basePath,
+					Path:     filepath.Join(finalDir, "rootfs.delta"),
+				}
+			} else {
+				// Older fork builds may accept block_delta_dir but not emit a
+				// delta. Branch the frozen overlay with mandatory COW sharing;
+				// silently making a physical copy would violate shadow billing.
+				overlay := filepath.Join(tmpDir, "rootfs.overlay")
+				if err := sourceLayer.reflink(ctx, diskPath, overlay); err != nil {
+					captureErr = savedSnapshotCaptureCopyError("reflink frozen disk overlay", err)
+				} else {
+					manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, overlay)
+					manifest.Disk = savedDiskArtifact{
+						Kind:     diskArtifactOverlay,
+						BasePath: basePath,
+						Path:     filepath.Join(finalDir, "rootfs.overlay"),
+					}
+				}
+			}
+		} else {
+			full := filepath.Join(tmpDir, "rootfs.ext4")
+			if err := sourceLayer.reflink(ctx, diskPath, full); err != nil {
+				captureErr = savedSnapshotCaptureCopyError("reflink frozen rootfs", err)
+			} else {
+				manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, full)
+				manifest.Disk = savedDiskArtifact{
+					Kind: diskArtifactFull,
+					Path: filepath.Join(finalDir, "rootfs.ext4"),
+				}
+			}
+		}
+	}
+	if captureErr == nil {
+		captureErr = sourceLayer.finalize()
+	}
+	if captureErr == nil {
+		// Measure while the source is still frozen. Once it resumes, a write can
+		// COW a shared extent away from the source and make the immutable clone
+		// look exclusive; charging that clone as well as the already-sealed
+		// source generation would double-count the same physical block.
+		manifest.LogicalBytes, manifest.ExclusiveBytes, captureErr = snapshotArtifactSizesWithShared(
+			tmpDir,
+			manifest.sharedOwnedPaths,
+			manifest.Memory.BasePath,
+			manifest.Disk.BasePath,
+		)
+		manifest.artifactSizesMeasured = captureErr == nil
+	}
+
+	// CreateSnapshot leaves vCPUs paused on success and can also fail after
+	// its pause call. Always attempt to restore the source's prior state.
+	unpauseErr := unpauseSavedSnapshotSource(socketPath)
+	if unpauseErr != nil {
+		inst.mu.Lock()
+		inst.Status = StatusError
+		inst.DirtyTracked = false
+		if inst.Metadata == nil {
+			inst.Metadata = make(map[string]string)
+		}
+		inst.Metadata[savedSnapshotSourceResumeFailedKey] = "true"
+		inst.mu.Unlock()
+		m.persistState(inst)
+		containCtx, containCancel := context.WithTimeout(context.Background(), savedSnapshotSourceRecoveryTimeout)
+		_, containErr := m.stopVMProcessAndConfirm(containCtx, inst.ID, inst)
+		containCancel()
+		sourceErr := fmt.Errorf("%w: %v", ErrSavedSnapshotSourceResume, unpauseErr)
+		if containErr != nil {
+			sourceErr = errors.Join(sourceErr, fmt.Errorf("stop failed snapshot source: %w", containErr))
+		}
+		if captureErr != nil {
+			return errors.Join(
+				fmt.Errorf("capture running VM: %w", captureErr),
+				sourceErr,
+			)
+		}
+		return sourceErr
+	}
+	if captureErr != nil {
+		return fmt.Errorf("capture running VM: %w", captureErr)
+	}
+	return nil
+}
+
+func materializeSavedMemoryBranch(ctx context.Context, tmpDir, finalDir, sourceMemPath, sourceMemBasePath, rawDelta string, manifest *savedSnapshotManifest, sourceLayer *savedSourceLayerUsage) error {
+	deltaPresence, err := presence.Read(rawDelta)
+	if err != nil {
+		return status.Errorf(codes.DataLoss, "dirty memory delta has no valid presence map: %v", err)
+	}
+
+	memName := "mem.snap"
+	target := filepath.Join(tmpDir, memName)
+	var priorPresence *presence.Bitmap
+	if sourceMemBasePath != "" {
+		memName = "mem.diff"
+		target = filepath.Join(tmpDir, memName)
+		if sourceMemPath == sourceMemBasePath {
+			baseInfo, statErr := os.Stat(sourceMemBasePath)
+			if statErr != nil {
+				return savedSnapshotCaptureCopyError("stat memory base", statErr)
+			}
+			if err := createSparseFile(target, baseInfo.Size()); err != nil {
+				return savedSnapshotCaptureCopyError("create saved memory overlay", err)
+			}
+			manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, target)
+		} else {
+			if err := sourceLayer.reflink(ctx, sourceMemPath, target); err != nil {
+				return savedSnapshotCaptureCopyError("reflink prior memory overlay", err)
+			}
+			manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, target)
+			prior, readErr := presence.Read(sourceMemPath)
+			if readErr != nil {
+				return status.Errorf(codes.DataLoss, "prior memory overlay has no valid presence map: %v", readErr)
+			}
+			priorPresence = &prior
+		}
+	} else {
+		if err := sourceLayer.reflink(ctx, sourceMemPath, target); err != nil {
+			return savedSnapshotCaptureCopyError("reflink prior full memory", err)
+		}
+		manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, target)
+	}
+
+	if err := applySparseFileContext(ctx, rawDelta, target); err != nil {
+		return savedSnapshotCaptureCopyError("apply dirty memory delta", err)
+	}
+	if sourceMemBasePath != "" {
+		bits := append([]uint64(nil), deltaPresence.Bits...)
+		if priorPresence != nil {
+			if priorPresence.PageSize != deltaPresence.PageSize || priorPresence.NPages != deltaPresence.NPages {
+				return status.Error(codes.DataLoss, "memory presence maps have incompatible shapes")
+			}
+			for i := range bits {
+				bits[i] |= priorPresence.Bits[i]
+			}
+		}
+		if err := presence.Write(target, deltaPresence.PageSize, deltaPresence.NPages, bits); err != nil {
+			return fmt.Errorf("write accumulated memory presence map: %w", err)
+		}
+		if err := os.WriteFile(target+".base", []byte(sourceMemBasePath+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write saved memory base record: %w", err)
+		}
+	}
+	_ = os.Remove(rawDelta)
+	_ = os.Remove(presence.SidecarPath(rawDelta))
+	manifest.Memory.Path = filepath.Join(finalDir, memName)
+	manifest.Memory.BasePath = sourceMemBasePath
+	return nil
+}
+
+func unpauseSavedSnapshotSource(socketPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), savedSnapshotSourceRecoveryTimeout)
+	defer cancel()
+	var errs []error
+	for attempt := 0; attempt < savedSnapshotSourceRecoveryAttempts; attempt++ {
+		if err := UnpauseVMContext(ctx, socketPath); err == nil {
+			return nil
+		} else {
+			errs = append(errs, err)
+		}
+		// PATCH /vm is not an idempotency receipt: Firecracker may apply the
+		// resume and lose its response. Resolve that ambiguity from GET / before
+		// declaring the source failed. The probe gets a detached recovery budget
+		// even when the preceding transport call consumed the outer deadline.
+		probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		state, probeErr := FirecrackerVMStateContext(probeCtx, socketPath)
+		probeCancel()
+		if probeErr == nil && state == models.InstanceInfoStateRunning {
+			return nil
+		}
+		if probeErr != nil {
+			errs = append(errs, probeErr)
+		} else if state != models.InstanceInfoStatePaused {
+			errs = append(errs, fmt.Errorf("source VM state after unpause attempt is %q", state))
+		}
+		if attempt+1 < savedSnapshotSourceRecoveryAttempts {
+			select {
+			case <-ctx.Done():
+				return errors.Join(append(errs, ctx.Err())...)
+			case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) capturePausedSavedSnapshot(ctx context.Context, tmpDir, finalDir, sourceSnapshotPath, sourceMemPath, sourceMemBasePath, diskPath, basePath string, manifest *savedSnapshotManifest, sourceLayer *savedSourceLayerUsage) error {
+	if sourceSnapshotPath == "" || sourceMemPath == "" {
+		return status.Error(codes.DataLoss, "paused source has no retained runtime checkpoint")
+	}
+	if err := copySparseFileContext(ctx, sourceSnapshotPath, filepath.Join(tmpDir, "vmstate.snap")); err != nil {
+		return savedSnapshotCaptureCopyError("copy paused VM state", err)
+	}
+
+	memoryOwnedBySource := sourceMemPath != sourceMemBasePath
+	memName := "mem.snap"
+	if isOverlayMemFile(sourceMemPath) {
+		memName = "mem.diff"
+		if sourceMemBasePath == "" {
+			if recorded, ok := readLayeredBase(sourceMemPath); ok {
+				sourceMemBasePath = recorded
+			}
+		}
+		if sourceMemBasePath == "" {
+			return status.Error(codes.FailedPrecondition, "paused layered memory checkpoint has no immutable base")
+		}
+	} else {
+		sourceMemBasePath = ""
+	}
+	ownedMemPath := filepath.Join(tmpDir, memName)
+	var memReflinkErr error
+	if memoryOwnedBySource {
+		memReflinkErr = sourceLayer.reflink(ctx, sourceMemPath, ownedMemPath)
+	} else {
+		memReflinkErr = reflinkImmutableFileContext(ctx, sourceMemPath, ownedMemPath)
+	}
+	if memReflinkErr != nil {
+		return savedSnapshotCaptureCopyError("reflink paused memory checkpoint", memReflinkErr)
+	}
+	manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, ownedMemPath)
+	manifest.Memory.Path = filepath.Join(finalDir, memName)
+	manifest.Memory.BasePath = sourceMemBasePath
+	if sourceMemBasePath != "" {
+		if err := os.WriteFile(filepath.Join(tmpDir, memName)+".base", []byte(sourceMemBasePath+"\n"), 0o600); err != nil {
+			return fmt.Errorf("write saved memory base record: %w", err)
+		}
+		presenceSrc := presence.SidecarPath(sourceMemPath)
+		if !fileExists(presenceSrc) {
+			return status.Error(codes.DataLoss, "paused layered memory checkpoint has no presence map")
+		}
+		if err := copySparseFileContext(ctx, presenceSrc, presence.SidecarPath(filepath.Join(tmpDir, memName))); err != nil {
+			return savedSnapshotCaptureCopyError("copy memory presence map", err)
+		}
+	}
+
+	if basePath != "" {
+		overlay := filepath.Join(tmpDir, "rootfs.overlay")
+		var diskReflinkErr error
+		if diskPath != basePath {
+			diskReflinkErr = sourceLayer.reflink(ctx, diskPath, overlay)
+		} else {
+			diskReflinkErr = reflinkImmutableFileContext(ctx, diskPath, overlay)
+		}
+		if diskReflinkErr != nil {
+			return savedSnapshotCaptureCopyError("reflink paused disk overlay", diskReflinkErr)
+		}
+		manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, overlay)
+		manifest.Disk = savedDiskArtifact{
+			Kind:     diskArtifactOverlay,
+			BasePath: basePath,
+			Path:     filepath.Join(finalDir, "rootfs.overlay"),
+		}
+	} else {
+		full := filepath.Join(tmpDir, "rootfs.ext4")
+		if err := sourceLayer.reflink(ctx, diskPath, full); err != nil {
+			return savedSnapshotCaptureCopyError("reflink paused rootfs", err)
+		}
+		manifest.sharedOwnedPaths = append(manifest.sharedOwnedPaths, full)
+		manifest.Disk = savedDiskArtifact{
+			Kind: diskArtifactFull,
+			Path: filepath.Join(finalDir, "rootfs.ext4"),
+		}
+	}
+	return nil
+}
+
+func savedSnapshotCaptureCopyError(operation string, err error) error {
+	if os.IsNotExist(err) {
+		return status.Errorf(codes.DataLoss, "%s: source artifact is missing", operation)
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Errorf(codes.Canceled, "%s: canceled", operation)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Errorf(codes.DeadlineExceeded, "%s: deadline exceeded", operation)
+	}
+	return status.Errorf(codes.Unavailable, "%s: host filesystem unavailable", operation)
+}
+
+// RestoreSavedSnapshot resolves a committed local manifest and restores it
+// using the existing snapshot loader. Disk metadata selects either delta
+// hydration, a sparse-overlay copy, or a complete legacy-rootfs copy; all
+// three create a new child-owned writable file.
+func (m *Manager) RestoreSavedSnapshot(
+	ctx context.Context,
+	vmID, manifestPath, expectedManifestDigest string,
+	netCfg *network.Config,
+	egress *network.EgressRules,
+	teamID, ownerID string,
+	previewAccess string,
+	previewPorts map[int32]PreviewPortPolicy,
+	previewPolicyRevision int64,
+) (*VMInstance, *SavedSnapshot, error) {
+	if len(expectedManifestDigest) != sha256.Size*2 {
+		return nil, nil, status.Error(codes.InvalidArgument, "expected manifest digest must be a SHA-256 hex digest")
+	}
+	if _, err := hex.DecodeString(expectedManifestDigest); err != nil {
+		return nil, nil, status.Error(codes.InvalidArgument, "expected manifest digest must be a SHA-256 hex digest")
+	}
+	manifest, err := m.loadSavedSnapshotManifest(manifestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	result, err := manifest.result(manifestPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !strings.EqualFold(result.ManifestDigest, expectedManifestDigest) {
+		return nil, nil, status.Error(codes.DataLoss, "saved snapshot manifest digest does not match the committed control-plane digest")
+	}
+	cfg, err := savedSnapshotVMConfig(manifest, egress)
+	if err != nil {
+		return nil, nil, err
+	}
+	inst, err := m.RestoreVMSnapshot(
+		ctx,
+		vmID,
+		manifest.VMStatePath,
+		manifest.Memory.Path,
+		cfg,
+		netCfg,
+		teamID,
+		ownerID,
+		previewAccess,
+		previewPorts,
+		previewPolicyRevision,
+	)
+	if err != nil {
+		return nil, nil, m.classifySavedSnapshotRestoreError(manifestPath, err)
+	}
+	return inst, result, nil
+}
+
+// classifySavedSnapshotRestoreError keeps deterministic artifact failures
+// distinct from host availability failures. Firecracker reports malformed
+// snapshot contents as a 400; transport, process, network, and local resource
+// failures reach this boundary as ordinary errors and remain retryable.
+func (m *Manager) classifySavedSnapshotRestoreError(manifestPath string, restoreErr error) error {
+	if restoreErr == nil {
+		return nil
+	}
+
+	// An artifact can disappear after the initial manifest validation but
+	// before/during disk or memory restore. Revalidate first so that race is
+	// still reported as stable DataLoss rather than a generic host failure.
+	if _, err := m.loadSavedSnapshotManifest(manifestPath); err != nil {
+		return err
+	}
+
+	if errors.Is(restoreErr, ErrSnapshotLoadRejected) && !isTapDeviceBusyErr(restoreErr) {
+		return status.Error(codes.DataLoss, "saved snapshot artifacts were rejected as invalid")
+	}
+
+	code := status.Code(restoreErr)
+	if code != codes.Unknown && code != codes.Internal {
+		return restoreErr
+	}
+	return status.Error(codes.Unavailable, "saved snapshot host restore failed")
+}
+
+func savedSnapshotVMConfig(manifest *savedSnapshotManifest, egress *network.EgressRules) (VMConfig, error) {
+	cfg := VMConfig{
+		VCPU:                 manifest.Resources.VCPU,
+		MemoryMiB:            manifest.Resources.MemoryMiB,
+		DiskSizeMiB:          manifest.Resources.DiskSizeMiB,
+		EgressPolicy:         egress,
+		savedSnapshotRestore: true,
+	}
+	switch manifest.Disk.Kind {
+	case diskArtifactBlockDelta:
+		cfg.BasePath = manifest.Disk.BasePath
+		cfg.DeltaDir = filepath.Dir(manifest.Disk.Path)
+	case diskArtifactOverlay:
+		cfg.BasePath = manifest.Disk.BasePath
+		cfg.RootfsPath = manifest.Disk.Path
+	case diskArtifactFull:
+		cfg.RootfsPath = manifest.Disk.Path
+	default:
+		return VMConfig{}, status.Errorf(codes.DataLoss, "unsupported saved disk artifact kind %q", manifest.Disk.Kind)
+	}
+	return cfg, nil
+}
+
+// DeleteSavedSnapshot removes one leaf artifact directory. Reference safety is
+// a control-plane responsibility; VMD constructs the path from validated ids
+// and never accepts a caller-provided delete path.
+func (m *Manager) DeleteSavedSnapshot(ctx context.Context, sourceVMID, snapshotID string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Serialize with capture/pause/resume/restore for the source. Without this
+	// lock a cancellation could observe no final directory, finalize its DB
+	// delete, and then let the still-running capture publish an unowned
+	// immutable directory after the durable cleanup record had disappeared.
+	unlock, err := m.lockVMOp(ctx, sourceVMID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	dir, err := m.savedSnapshotDir(sourceVMID, snapshotID)
+	if err != nil {
+		return err
+	}
+	root := filepath.Join(m.cfg.SnapshotDir, SavedSnapshotsDirName)
+	sourceDir := filepath.Dir(dir)
+	if _, statErr := os.Lstat(sourceDir); os.IsNotExist(statErr) {
+		return nil
+	} else if statErr != nil {
+		return fmt.Errorf("stat saved snapshot source directory: %w", statErr)
+	}
+	if err := ensureNoSymlinkDirs(root, sourceDir); err != nil {
+		return status.Errorf(codes.FailedPrecondition, "unsafe saved snapshot delete path: %v", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove saved snapshot artifacts: %w", err)
+	}
+	// Cancellation can race a daemon crash before the staging directory is
+	// atomically renamed into place. Once the durable DB intent is deleting,
+	// no later capture may adopt those bytes, so remove every exact same-ID
+	// staging directory under the same source lock as the committed path.
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("list saved snapshot staging artifacts: %w", err)
+	}
+	stagingPrefix := "." + snapshotID + ".tmp-"
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), stagingPrefix) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(sourceDir, entry.Name())); err != nil {
+			return fmt.Errorf("remove saved snapshot staging artifacts: %w", err)
+		}
+	}
+	// Persist removal of the snapshot entry in its direct parent. If that was
+	// the last snapshot, also persist removal of the now-empty source directory
+	// in the saved root.
+	if err := fsyncDir(sourceDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("fsync saved snapshot source directory: %w", err)
+	}
+	removedSourceDir := false
+	if err := os.Remove(sourceDir); err == nil {
+		removedSourceDir = true
+	} else if !os.IsNotExist(err) && !errors.Is(err, syscall.ENOTEMPTY) {
+		return fmt.Errorf("remove empty saved snapshot source directory: %w", err)
+	}
+	if removedSourceDir {
+		if err := fsyncDir(root); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("fsync saved snapshot root: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) loadSavedSnapshotManifest(manifestPath string) (*savedSnapshotManifest, error) {
+	dir, sourceVMID, snapshotID, err := m.validateSavedManifestPath(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Lstat(manifestPath)
+	if err != nil {
+		return nil, savedSnapshotArtifactIOError("stat saved snapshot manifest", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest is not a regular file")
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, savedSnapshotArtifactIOError("read saved snapshot manifest", err)
+	}
+	var manifest savedSnapshotManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, status.Errorf(codes.DataLoss, "decode saved snapshot manifest: %v", err)
+	}
+	if manifest.SchemaVersion != savedSnapshotSchemaVersion {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"unsupported saved snapshot schema version %d", manifest.SchemaVersion)
+	}
+	if manifest.SourceVMID != sourceVMID || manifest.SnapshotID != snapshotID {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest identity does not match its path")
+	}
+	if manifest.SourceState != StatusRunning.String() && manifest.SourceState != StatusPaused.String() {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest has an invalid source state")
+	}
+	if manifest.Resources.VCPU == 0 || manifest.Resources.MemoryMiB == 0 {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest has an incomplete resource shape")
+	}
+	if manifest.LogicalBytes < 0 || manifest.ExclusiveBytes < 0 || manifest.SourceLogicalBytes < 0 || manifest.SourceExclusiveBytes < 0 {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest has invalid storage accounting")
+	}
+
+	if err := validateOwnedArtifact(dir, manifest.VMStatePath, "vmstate.snap"); err != nil {
+		return nil, err
+	}
+	memName := filepath.Base(manifest.Memory.Path)
+	if memName != "mem.snap" && memName != "mem.diff" {
+		return nil, status.Error(codes.DataLoss, "saved snapshot manifest has an invalid memory artifact name")
+	}
+	if err := validateOwnedArtifact(dir, manifest.Memory.Path, memName); err != nil {
+		return nil, err
+	}
+	if memName == "mem.diff" && manifest.Memory.BasePath == "" {
+		return nil, status.Error(codes.DataLoss, "saved memory diff has no base")
+	}
+	if manifest.Memory.BasePath != "" {
+		if err := validateReferencedArtifact(manifest.Memory.BasePath); err != nil {
+			return nil, err
+		}
+		baseRecord := manifest.Memory.Path + ".base"
+		if err := validateOwnedArtifact(dir, baseRecord, memName+".base"); err != nil {
+			return nil, err
+		}
+		recorded, err := os.ReadFile(baseRecord)
+		if err != nil {
+			return nil, savedSnapshotArtifactIOError("read saved memory base record", err)
+		}
+		if strings.TrimSpace(string(recorded)) != manifest.Memory.BasePath {
+			return nil, status.Error(codes.DataLoss, "saved memory base record does not match manifest")
+		}
+		presencePath := presence.SidecarPath(manifest.Memory.Path)
+		if _, err := os.Lstat(presencePath); err == nil {
+			if err := validateOwnedArtifact(dir, presencePath, filepath.Base(presencePath)); err != nil {
+				return nil, err
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, savedSnapshotArtifactIOError("stat saved memory presence map", err)
+		}
+	}
+
+	var diskName string
+	switch manifest.Disk.Kind {
+	case diskArtifactBlockDelta:
+		diskName = "rootfs.delta"
+		if manifest.Disk.BasePath == "" {
+			return nil, status.Error(codes.DataLoss, "saved disk delta has no base")
+		}
+	case diskArtifactOverlay:
+		diskName = "rootfs.overlay"
+		if manifest.Disk.BasePath == "" {
+			return nil, status.Error(codes.DataLoss, "saved disk overlay has no base")
+		}
+	case diskArtifactFull:
+		diskName = "rootfs.ext4"
+		if manifest.Disk.BasePath != "" {
+			return nil, status.Error(codes.DataLoss, "saved full rootfs unexpectedly has a base")
+		}
+	default:
+		return nil, status.Errorf(codes.DataLoss, "saved snapshot manifest has invalid disk kind %q", manifest.Disk.Kind)
+	}
+	if err := validateOwnedArtifact(dir, manifest.Disk.Path, diskName); err != nil {
+		return nil, err
+	}
+	if manifest.Disk.BasePath != "" {
+		if err := validateReferencedArtifact(manifest.Disk.BasePath); err != nil {
+			return nil, err
+		}
+	}
+	if err := verifySavedSnapshotDigests(&manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+const (
+	digestVMState          = "vmstate"
+	digestMemory           = "memory"
+	digestMemoryBase       = "memory_base"
+	digestMemoryBaseRecord = "memory_base_record"
+	digestMemoryPresence   = "memory_presence"
+	digestDisk             = "disk"
+	digestDiskBase         = "disk_base"
+)
+
+func savedSnapshotDigestPaths(manifest *savedSnapshotManifest) (map[string]string, error) {
+	paths := map[string]string{
+		digestVMState: manifest.VMStatePath,
+		digestMemory:  manifest.Memory.Path,
+		digestDisk:    manifest.Disk.Path,
+	}
+	if manifest.Memory.BasePath != "" {
+		paths[digestMemoryBase] = manifest.Memory.BasePath
+		paths[digestMemoryBaseRecord] = manifest.Memory.Path + ".base"
+		paths[digestMemoryPresence] = presence.SidecarPath(manifest.Memory.Path)
+	}
+	if manifest.Disk.BasePath != "" {
+		paths[digestDiskBase] = manifest.Disk.BasePath
+	}
+	for key, path := range paths {
+		if path == "" {
+			return nil, fmt.Errorf("digest path %q is empty", key)
+		}
+	}
+	return paths, nil
+}
+
+func populateSavedSnapshotDigests(tmpDir, finalDir string, manifest *savedSnapshotManifest) error {
+	paths, err := savedSnapshotDigestPaths(manifest)
+	if err != nil {
+		return err
+	}
+	manifest.ArtifactSHA256 = make(map[string]string, len(paths))
+	for key, path := range paths {
+		capturePath := path
+		if rel, relErr := filepath.Rel(finalDir, path); relErr == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			capturePath = filepath.Join(tmpDir, rel)
+		}
+		digest, digestErr := sha256File(capturePath)
+		if digestErr != nil {
+			return fmt.Errorf("%s: %w", key, digestErr)
+		}
+		manifest.ArtifactSHA256[key] = digest
+	}
+	return nil
+}
+
+func verifySavedSnapshotDigests(manifest *savedSnapshotManifest) error {
+	paths, err := savedSnapshotDigestPaths(manifest)
+	if err != nil {
+		return status.Errorf(codes.DataLoss, "saved snapshot digest manifest is invalid: %v", err)
+	}
+	if len(manifest.ArtifactSHA256) != len(paths) {
+		return status.Error(codes.DataLoss, "saved snapshot digest manifest is incomplete")
+	}
+	for key, path := range paths {
+		want := manifest.ArtifactSHA256[key]
+		if len(want) != sha256.Size*2 {
+			return status.Errorf(codes.DataLoss, "saved snapshot digest %q is missing or malformed", key)
+		}
+		got, digestErr := sha256File(path)
+		if digestErr != nil {
+			return savedSnapshotArtifactIOError("hash saved snapshot artifact", digestErr)
+		}
+		if got != want {
+			return status.Errorf(codes.DataLoss, "saved snapshot artifact digest mismatch: %s", key)
+		}
+	}
+	return nil
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (m *Manager) validateSavedManifestPath(manifestPath string) (dir, sourceVMID, snapshotID string, err error) {
+	if m.cfg.SnapshotDir == "" || !filepath.IsAbs(m.cfg.SnapshotDir) {
+		return "", "", "", status.Error(codes.FailedPrecondition, "snapshot_dir must be configured as an absolute path")
+	}
+	if !filepath.IsAbs(manifestPath) || filepath.Clean(manifestPath) != manifestPath {
+		return "", "", "", status.Error(codes.InvalidArgument, "manifest_path must be a clean absolute path")
+	}
+	root := filepath.Join(filepath.Clean(m.cfg.SnapshotDir), SavedSnapshotsDirName)
+	rel, relErr := filepath.Rel(root, manifestPath)
+	if relErr != nil {
+		return "", "", "", status.Error(codes.InvalidArgument, "manifest_path is outside the saved snapshot root")
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) != 3 || parts[2] != savedSnapshotManifestName || !isLeafName(parts[0]) || !isLeafName(parts[1]) {
+		return "", "", "", status.Error(codes.InvalidArgument,
+			"manifest_path must have shape <snapshot_dir>/saved/<source_vm_id>/<snapshot_id>/manifest.json")
+	}
+	dir = filepath.Dir(manifestPath)
+	if pathErr := ensureNoSymlinkDirs(root, dir); pathErr != nil {
+		if os.IsNotExist(pathErr) {
+			return "", "", "", status.Error(codes.DataLoss, "saved snapshot artifact directory is missing on this host")
+		}
+		var fsErr *os.PathError
+		if errors.As(pathErr, &fsErr) {
+			return "", "", "", status.Error(codes.Unavailable, "inspect saved snapshot artifact directory failed")
+		}
+		return "", "", "", status.Error(codes.InvalidArgument, "manifest_path traverses an unsafe directory")
+	}
+	return dir, parts[0], parts[1], nil
+}
+
+func ensureNoSymlinkDirs(root, target string) error {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q is outside root %q", target, root)
+	}
+	paths := []string{root}
+	if rel != "." {
+		cur := root
+		for _, part := range strings.Split(rel, string(filepath.Separator)) {
+			cur = filepath.Join(cur, part)
+			paths = append(paths, cur)
+		}
+	}
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is not a real directory", path)
+		}
+	}
+	return nil
+}
+
+func validateOwnedArtifact(dir, path, name string) error {
+	if path != filepath.Join(dir, name) {
+		return status.Error(codes.DataLoss, "saved artifact path does not match manifest directory")
+	}
+	return validateReferencedArtifact(path)
+}
+
+func validateReferencedArtifact(path string) error {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return status.Error(codes.DataLoss, "saved artifact path is not a clean absolute path")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return savedSnapshotArtifactIOError("stat saved snapshot artifact", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return status.Error(codes.DataLoss, "saved artifact is not a regular non-symlink file")
+	}
+	return nil
+}
+
+// savedSnapshotArtifactIOError treats disappearance as corruption of the
+// committed immutable snapshot, while keeping all other host filesystem
+// failures retryable. The latter includes a temporarily unavailable mount,
+// permission/credential refresh, and transient device I/O errors.
+func savedSnapshotArtifactIOError(operation string, err error) error {
+	if os.IsNotExist(err) {
+		return status.Errorf(codes.DataLoss, "%s: artifact is missing", operation)
+	}
+	return status.Errorf(codes.Unavailable, "%s: host filesystem unavailable", operation)
+}
+
+func writeSavedSnapshotManifest(dir string, manifest *savedSnapshotManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode saved snapshot manifest: %w", err)
+	}
+	data = append(data, '\n')
+	tmp := filepath.Join(dir, savedSnapshotManifestName+".tmp")
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create saved snapshot manifest: %w", err)
+	}
+	if _, err = f.Write(data); err == nil {
+		err = f.Sync()
+	}
+	closeErr := f.Close()
+	if err != nil {
+		return fmt.Errorf("write saved snapshot manifest: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close saved snapshot manifest: %w", closeErr)
+	}
+	if err := os.Rename(tmp, filepath.Join(dir, savedSnapshotManifestName)); err != nil {
+		return fmt.Errorf("commit saved snapshot manifest: %w", err)
+	}
+	return fsyncDir(dir)
+}
+
+func makeSnapshotArtifactsReadOnly(dir string) error {
+	return filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if err := os.Chmod(path, 0o444); err != nil {
+			return fmt.Errorf("chmod saved artifact %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func fsyncTree(dir string) error {
+	if err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		syncErr := f.Sync()
+		closeErr := f.Close()
+		if syncErr != nil {
+			return syncErr
+		}
+		return closeErr
+	}); err != nil {
+		return err
+	}
+	return fsyncDir(dir)
+}
+
+func fsyncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
+func snapshotArtifactSizes(dir string, referencedPaths ...string) (logical, exclusive int64, err error) {
+	return snapshotArtifactSizesWithShared(dir, nil, referencedPaths...)
+}
+
+// snapshotArtifactSizesWithShared reports logical reconstruction size and the
+// allocated bytes newly introduced by this capture. FIEMAP distinguishes the
+// still-shared portions of a mandatory reflink from blocks COW-written into
+// that inode while a memory/disk delta was materialized.
+func snapshotArtifactSizesWithShared(dir string, sharedOwnedPaths []string, referencedPaths ...string) (logical, exclusive int64, err error) {
+	seen := make(map[string]struct{})
+	shared := make(map[string]struct{}, len(sharedOwnedPaths))
+	for _, path := range sharedOwnedPaths {
+		shared[filepath.Clean(path)] = struct{}{}
+	}
+	addLogical := func(path string, info os.FileInfo) {
+		key := filepath.Clean(path)
+		if st, ok := info.Sys().(*syscall.Stat_t); ok {
+			key = fmt.Sprintf("%d:%d", st.Dev, st.Ino)
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		logical += info.Size()
+	}
+	err = filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("saved artifact is not regular: %s", path)
+		}
+		addLogical(path, info)
+		if _, isShared := shared[filepath.Clean(path)]; isShared {
+			owned, usageErr := exclusiveFileBytes(path)
+			if usageErr != nil {
+				return usageErr
+			}
+			exclusive += owned
+		} else {
+			if st, ok := info.Sys().(*syscall.Stat_t); ok {
+				exclusive += st.Blocks * 512
+			} else {
+				exclusive += info.Size()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, path := range referencedPaths {
+		if path == "" {
+			continue
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return 0, 0, statErr
+		}
+		if !info.Mode().IsRegular() {
+			return 0, 0, fmt.Errorf("referenced snapshot base is not regular: %s", path)
+		}
+		addLogical(path, info)
+	}
+	return logical, exclusive, err
+}
+
+// reflinkImmutableFileContext creates a new inode whose existing extents stay
+// physically shared with src. --reflink=always is intentional: a transparent
+// byte-copy fallback would make deduplicated shadow usage dishonest. GNU cp
+// only permits reflink copies with sparse=auto; the clone still preserves the
+// source's holes and shared extents.
+func reflinkImmutableFileContext(ctx context.Context, src, dst string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(src); err != nil {
+		return err
+	} else if !info.Mode().IsRegular() {
+		return fmt.Errorf("source is not a regular file: %s", src)
+	}
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "cp", "--reflink=always", "--sparse=auto", "--", src, dst)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("mandatory reflink %s to %s: %s: %w", src, dst, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func (m *Manager) savedSnapshotsSupported() bool {
+	if m == nil || !filepath.IsAbs(m.cfg.SnapshotDir) || !filepath.IsAbs(m.cfg.RunDir) ||
+		!m.cfg.UffdEnabled || !m.cfg.ResumeUffdEnabled || !m.cfg.IncrementalSnapshotEnabled {
+		return false
+	}
+	if m.savedSnapshotCapabilityProbe == nil && !savedSnapshotExtentAccountingSupported() {
+		return false
+	}
+	m.savedSnapshotCapabilityOnce.Do(func() {
+		probe := m.savedSnapshotCapabilityProbe
+		if probe == nil {
+			probe = m.probeSavedSnapshotReflinks
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := probe(ctx); err != nil {
+			m.log.Warn().Err(vmdclient.SanitizeSavedSnapshotError(
+				vmdclient.SavedSnapshotOperationCapabilityCheck, err,
+			)).Msg("saved snapshots disabled: mandatory reflink probe failed")
+			return
+		}
+		m.savedSnapshotCapability = true
+	})
+	return m.savedSnapshotCapability
+}
+
+// probeSavedSnapshotReflinks verifies both CoW paths used by capture: paused
+// artifacts branch within SnapshotDir, while an active VM's writable disk
+// branches from RunDir into SnapshotDir. A non-empty source is intentional;
+// cloning an empty file can succeed without proving extent-sharing support.
+func (m *Manager) probeSavedSnapshotReflinks(ctx context.Context) error {
+	probeDir, err := os.MkdirTemp(m.cfg.SnapshotDir, ".saved-snapshot-reflink-probe-")
+	if err != nil {
+		return fmt.Errorf("create snapshot reflink probe dir: %w", err)
+	}
+	defer os.RemoveAll(probeDir)
+	probePayload := bytes.Repeat([]byte("superserve-saved-snapshot-reflink-capability\n"), 4096)
+
+	writeProbe := func(dir, pattern string) (string, error) {
+		f, createErr := os.CreateTemp(dir, pattern)
+		if createErr != nil {
+			return "", createErr
+		}
+		path := f.Name()
+		if _, writeErr := f.Write(probePayload); writeErr != nil {
+			_ = f.Close()
+			_ = os.Remove(path)
+			return "", writeErr
+		}
+		if syncErr := f.Sync(); syncErr != nil {
+			_ = f.Close()
+			_ = os.Remove(path)
+			return "", syncErr
+		}
+		if closeErr := f.Close(); closeErr != nil {
+			_ = os.Remove(path)
+			return "", closeErr
+		}
+		return path, nil
+	}
+	verifyClone := func(label, path string) error {
+		got, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("read %s clone: %w", label, readErr)
+		}
+		if !bytes.Equal(got, probePayload) {
+			return fmt.Errorf("%s clone content differs from its source", label)
+		}
+		exclusive, usageErr := exclusiveFileBytes(path)
+		if usageErr != nil {
+			return fmt.Errorf("measure %s clone extents: %w", label, usageErr)
+		}
+		if exclusive != 0 {
+			return fmt.Errorf("%s clone retained %d unshared bytes", label, exclusive)
+		}
+		return nil
+	}
+
+	runSource, err := writeProbe(m.cfg.RunDir, ".saved-snapshot-run-probe-")
+	if err != nil {
+		return fmt.Errorf("create run-dir reflink probe: %w", err)
+	}
+	defer os.Remove(runSource)
+	runClone := filepath.Join(probeDir, "from-run")
+	if err := reflinkImmutableFileContext(ctx, runSource, runClone); err != nil {
+		return fmt.Errorf("probe RunDir to SnapshotDir reflink: %w", err)
+	}
+	if err := verifyClone("RunDir to SnapshotDir", runClone); err != nil {
+		return fmt.Errorf("probe reflink extent accounting: %w", err)
+	}
+
+	snapshotSource, err := writeProbe(probeDir, "snapshot-source-")
+	if err != nil {
+		return fmt.Errorf("create snapshot-dir reflink probe: %w", err)
+	}
+	snapshotClone := filepath.Join(probeDir, "within-snapshot")
+	if err := reflinkImmutableFileContext(ctx, snapshotSource, snapshotClone); err != nil {
+		return fmt.Errorf("probe SnapshotDir reflink: %w", err)
+	}
+	if err := verifyClone("SnapshotDir", snapshotClone); err != nil {
+		return fmt.Errorf("probe snapshot reflink extent accounting: %w", err)
+	}
+	return nil
+}
+
+func allocatedFileBytes(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		return st.Blocks * 512, nil
+	}
+	return info.Size(), nil
+}
+
+func exclusivePathsBytes(paths ...string) (int64, error) {
+	seen := make(map[string]struct{}, len(paths))
+	var total int64
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, err
+		}
+		key := filepath.Clean(path)
+		if st, ok := info.Sys().(*syscall.Stat_t); ok {
+			key = fmt.Sprintf("%d:%d", st.Dev, st.Ino)
+		}
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		owned, err := exclusiveFileBytes(path)
+		if err != nil {
+			return 0, err
+		}
+		if owned > math.MaxInt64-total {
+			return 0, errors.New("source writable byte count overflow")
+		}
+		total += owned
+	}
+	return total, nil
+}
+
+func logicalPathsBytes(paths ...string) (int64, error) {
+	seen := make(map[string]struct{}, len(paths))
+	var total int64
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, err
+		}
+		key := filepath.Clean(path)
+		if st, ok := info.Sys().(*syscall.Stat_t); ok {
+			key = fmt.Sprintf("%d:%d", st.Dev, st.Ino)
+		}
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		if info.Size() > math.MaxInt64-total {
+			return 0, errors.New("writable layer logical byte count overflow")
+		}
+		total += info.Size()
+	}
+	return total, nil
+}
+
+// SandboxWritableLayerUsage measures the currently persisted sandbox-owned
+// generation. It is called after pause for shadow reconciliation; immutable
+// bases are either omitted explicitly or excluded by FIEMAP's SHARED flag.
+func (m *Manager) SandboxWritableLayerUsage(vmID string) (logical, exclusive int64, err error) {
+	if !isLeafName(vmID) || isReservedRunDirName(vmID) {
+		return 0, 0, status.Error(codes.InvalidArgument, "vm_id must be a valid per-VM identifier")
+	}
+	inst, err := m.getInstance(vmID)
+	if err != nil {
+		return 0, 0, err
+	}
+	inst.mu.RLock()
+	paths := []string{inst.DiskPath, inst.SnapshotPath}
+	if inst.MemFilePath != inst.BaseMemPath {
+		paths = append(paths, inst.MemFilePath)
+		if inst.MemFilePath != "" {
+			for _, sidecar := range []string{presence.SidecarPath(inst.MemFilePath), inst.MemFilePath + ".base"} {
+				if fileExists(sidecar) {
+					paths = append(paths, sidecar)
+				}
+			}
+		}
+	}
+	inst.mu.RUnlock()
+	logical, err = logicalPathsBytes(paths...)
+	if err != nil {
+		return 0, 0, savedSnapshotArtifactIOError("measure writable layer logical bytes", err)
+	}
+	exclusive, err = exclusivePathsBytes(paths...)
+	if err != nil {
+		return 0, 0, savedSnapshotArtifactIOError("measure writable layer exclusive bytes", err)
+	}
+	return logical, exclusive, nil
+}
+
+func createSparseFile(path string, size int64) (retErr error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); retErr == nil && closeErr != nil {
+			retErr = closeErr
+		}
+		if retErr != nil {
+			_ = os.Remove(path)
+		}
+	}()
+	if err := f.Truncate(size); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// applySparseFileContext overwrites only src's allocated extents in an
+// existing same-sized branch. It is used to fold a fresh Firecracker dirty
+// delta into a reflink without materializing clean pages.
+func applySparseFileContext(ctx context.Context, src, dst string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+	dstInfo, err := dstFile.Stat()
+	if err != nil {
+		return err
+	}
+	if srcInfo.Size() != dstInfo.Size() {
+		return fmt.Errorf("memory delta size %d does not match branch size %d", srcInfo.Size(), dstInfo.Size())
+	}
+	for offset := int64(0); offset < srcInfo.Size(); {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		data, seekErr := unix.Seek(int(srcFile.Fd()), offset, unix.SEEK_DATA)
+		if errors.Is(seekErr, syscall.ENXIO) {
+			break
+		}
+		if seekErr != nil {
+			return seekErr
+		}
+		hole, seekErr := unix.Seek(int(srcFile.Fd()), data, unix.SEEK_HOLE)
+		if seekErr != nil {
+			return seekErr
+		}
+		if hole > srcInfo.Size() {
+			hole = srcInfo.Size()
+		}
+		if hole <= data {
+			return fmt.Errorf("invalid sparse extent [%d,%d) in %s", data, hole, src)
+		}
+		if _, err := dstFile.Seek(data, io.SeekStart); err != nil {
+			return err
+		}
+		if err := copyNWithContext(ctx, dstFile, io.NewSectionReader(srcFile, data, hole-data), hole-data); err != nil {
+			return err
+		}
+		offset = hole
+	}
+	return dstFile.Sync()
+}
+
+// copySparseFile copies data extents into newly allocated blocks. It never
+// reflinks: the destination is an independently owned immutable artifact, so
+// its st_blocks value is a meaningful V1 exclusive-byte measurement.
+func copySparseFile(src, dst string) (retErr error) {
+	return copySparseFileContext(context.Background(), src, dst)
+}
+
+func copySparseFileContext(ctx context.Context, src, dst string) (retErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	lstat, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if !lstat.Mode().IsRegular() || lstat.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("source is not a regular non-symlink file: %s", src)
+	}
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	info, err := srcFile.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("source is not a regular file: %s", src)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := dstFile.Close(); retErr == nil && closeErr != nil {
+			retErr = closeErr
+		}
+		if retErr != nil {
+			_ = os.Remove(dst)
+		}
+	}()
+	if err := dstFile.Truncate(info.Size()); err != nil {
+		return err
+	}
+	if info.Size() == 0 {
+		return dstFile.Sync()
+	}
+
+	copyDense := func() error {
+		if _, err := srcFile.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		if _, err := dstFile.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		return copyNWithContext(ctx, dstFile, srcFile, info.Size())
+	}
+
+	offset := int64(0)
+	for offset < info.Size() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		data, seekErr := unix.Seek(int(srcFile.Fd()), offset, unix.SEEK_DATA)
+		if seekErr != nil {
+			if errors.Is(seekErr, syscall.ENXIO) {
+				break
+			}
+			if errors.Is(seekErr, syscall.EINVAL) || errors.Is(seekErr, syscall.ENOTSUP) {
+				if err := copyDense(); err != nil {
+					return err
+				}
+				return dstFile.Sync()
+			}
+			return seekErr
+		}
+		hole, seekErr := unix.Seek(int(srcFile.Fd()), data, unix.SEEK_HOLE)
+		if seekErr != nil {
+			return seekErr
+		}
+		if hole > info.Size() {
+			hole = info.Size()
+		}
+		if hole <= data {
+			return fmt.Errorf("invalid sparse extent [%d,%d) in %s", data, hole, src)
+		}
+		if _, err := dstFile.Seek(data, io.SeekStart); err != nil {
+			return err
+		}
+		if err := copyNWithContext(ctx, dstFile, io.NewSectionReader(srcFile, data, hole-data), hole-data); err != nil {
+			return err
+		}
+		offset = hole
+	}
+	return dstFile.Sync()
+}
+
+func copyNWithContext(ctx context.Context, dst io.Writer, src io.Reader, n int64) error {
+	buf := make([]byte, 1<<20)
+	for n > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		chunk := int64(len(buf))
+		if n < chunk {
+			chunk = n
+		}
+		written, err := io.CopyN(dst, src, chunk)
+		n -= written
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/vm/saved_snapshot_containment_linux_test.go
+++ b/internal/vm/saved_snapshot_containment_linux_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package vm
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSavedSnapshotFirecrackerHelperProcess(t *testing.T) {
+	if os.Getenv("SUPERSERVE_TEST_FIRECRACKER_HELPER") != "1" {
+		return
+	}
+	for {
+		time.Sleep(time.Minute)
+	}
+}
+
+func TestStopVMProcessAndConfirmKillsExactFirecrackerIdentity(t *testing.T) {
+	installInactiveSystemctl(t)
+	vmID := "saved-snapshot-containment-test"
+	cmd := exec.Command(os.Args[0], "-test.run=TestSavedSnapshotFirecrackerHelperProcess", "--", "--id", vmID)
+	cmd.Args[0] = "firecracker"
+	cmd.Env = append(os.Environ(), "SUPERSERVE_TEST_FIRECRACKER_HELPER=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for !pidIsVMFirecracker(cmd.Process.Pid, vmID) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !pidIsVMFirecracker(cmd.Process.Pid, vmID) {
+		t.Fatalf("helper pid %d never acquired exact Firecracker identity", cmd.Process.Pid)
+	}
+
+	mgr := &Manager{log: zerolog.Nop()}
+	inst := &VMInstance{ID: vmID, PID: cmd.Process.Pid}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err := mgr.stopVMProcessAndConfirm(ctx, vmID, inst)
+	cancel()
+	if err != nil {
+		t.Fatalf("stopVMProcessAndConfirm: %v", err)
+	}
+	if pidIsVMFirecracker(cmd.Process.Pid, vmID) {
+		t.Fatalf("exact Firecracker process %d remains after containment", cmd.Process.Pid)
+	}
+	if remaining, err := vmFirecrackerPIDs(vmID); err != nil {
+		t.Fatalf("scan remaining Firecracker processes: %v", err)
+	} else if len(remaining) != 0 {
+		t.Fatalf("remaining Firecracker pids: %v", remaining)
+	}
+}
+
+func TestSavedRestoreRetryRetainsTargetWhenProcessStopIsInconclusive(t *testing.T) {
+	binDir := t.TempDir()
+	systemctl := filepath.Join(binDir, "systemctl")
+	if err := os.WriteFile(systemctl, []byte(`#!/bin/sh
+case "$1" in
+  stop) echo synthetic-stop-failure >&2; exit 1 ;;
+  is-active) echo active; exit 0 ;;
+  *) exit 0 ;;
+esac
+`), 0o755); err != nil {
+		t.Fatalf("write fake systemctl: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	vmID := "saved-restore-inconclusive-test"
+	runDir := t.TempDir()
+	diskPath := filepath.Join(runDir, vmID, "rootfs.ext4")
+	if err := os.MkdirAll(filepath.Dir(diskPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(diskPath, []byte("retain-me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	snapshotPath := filepath.Join(t.TempDir(), "vmstate.snap")
+	memPath := filepath.Join(t.TempDir(), "mem.snap")
+	if err := os.WriteFile(snapshotPath, []byte("snapshot"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(memPath, []byte("memory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state store: %v", err)
+	}
+	defer state.Close()
+
+	inst := &VMInstance{
+		ID:        vmID,
+		Status:    StatusCreating,
+		RunDirID:  vmID,
+		DiskPath:  diskPath,
+		CreatedAt: time.Now(),
+	}
+	mgr := &Manager{
+		cfg:        ManagerConfig{RunDir: runDir},
+		log:        zerolog.Nop(),
+		state:      state,
+		vms:        map[string]*VMInstance{vmID: inst},
+		restoreSem: make(chan struct{}, 1),
+	}
+
+	_, err = mgr.RestoreVMSnapshot(context.Background(), vmID, snapshotPath, memPath, VMConfig{
+		RootfsPath:           diskPath,
+		savedSnapshotRestore: true,
+	}, nil, "team", "owner", "", nil, 0)
+	if err == nil {
+		t.Fatal("saved restore retry unexpectedly proceeded after inconclusive process stop")
+	}
+	if _, err := os.Stat(diskPath); err != nil {
+		t.Fatalf("inconclusive containment removed provisional disk: %v", err)
+	}
+	mgr.mu.RLock()
+	tracked := mgr.vms[vmID]
+	mgr.mu.RUnlock()
+	if tracked != inst {
+		t.Fatal("inconclusive containment removed provisional VM")
+	}
+	inst.mu.RLock()
+	statusAfter := inst.Status
+	inst.mu.RUnlock()
+	if statusAfter != StatusError {
+		t.Fatalf("provisional status = %s, want error", statusAfter)
+	}
+	record, err := state.Get(vmID)
+	if err != nil || record == nil || record.Status != StatusError {
+		t.Fatalf("persisted retained target = %+v, %v", record, err)
+	}
+}

--- a/internal/vm/saved_snapshot_test.go
+++ b/internal/vm/saved_snapshot_test.go
@@ -1,0 +1,1108 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/presence"
+	"github.com/superserve-ai/sandbox/internal/vm/fc/models"
+	"github.com/superserve-ai/sandbox/proto/vmdpb"
+)
+
+func writeSavedTestFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func requireSavedSnapshotTestReflink(t *testing.T, sourceDir, destinationDir string) {
+	t.Helper()
+	source := filepath.Join(sourceDir, ".saved-snapshot-test-reflink-source")
+	destination := filepath.Join(destinationDir, ".saved-snapshot-test-reflink-destination")
+	writeSavedTestFile(t, source, bytes.Repeat([]byte{0x5a}, 4096))
+	t.Cleanup(func() {
+		_ = os.Remove(source)
+		_ = os.Remove(destination)
+	})
+	if err := reflinkImmutableFileContext(context.Background(), source, destination); err != nil {
+		t.Skipf("test filesystem has no cross-directory reflink support: %v", err)
+	}
+}
+
+func savedTestManager(snapshotDir, runDir string, inst *VMInstance) *Manager {
+	return &Manager{
+		cfg: ManagerConfig{
+			SnapshotDir: snapshotDir,
+			RunDir:      runDir,
+		},
+		log: zerolog.Nop(),
+		vms: map[string]*VMInstance{inst.ID: inst},
+	}
+}
+
+func TestCreateSavedSnapshotPausedFullIsImmutableAndIdempotent(t *testing.T) {
+	installInactiveSystemctl(t)
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	requireSavedSnapshotTestReflink(t, runRoot, snapshotRoot)
+	vmID := "11111111-1111-1111-1111-111111111111"
+	snapshotID := "snap-111"
+	runtimeDir := filepath.Join(snapshotRoot, vmID)
+	vmstate := filepath.Join(runtimeDir, "vmstate.snap")
+	memory := filepath.Join(runtimeDir, "mem.snap")
+	disk := filepath.Join(runRoot, vmID, "rootfs.ext4")
+	writeSavedTestFile(t, vmstate, []byte("paused-vmstate"))
+	writeSavedTestFile(t, memory, []byte("paused-memory"))
+	writeSavedTestFile(t, disk, []byte("paused-disk"))
+
+	inst := &VMInstance{
+		ID:           vmID,
+		Status:       StatusPaused,
+		RunDirID:     vmID,
+		DiskPath:     disk,
+		SnapshotPath: vmstate,
+		MemFilePath:  memory,
+		Config: VMConfig{
+			VCPU:      2,
+			MemoryMiB: 2048,
+		},
+	}
+	mgr := savedTestManager(snapshotRoot, runRoot, inst)
+
+	got, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID)
+	if err != nil {
+		t.Fatalf("CreateSavedSnapshot: %v", err)
+	}
+	if got.SourceState != "paused" || inst.Status != StatusPaused {
+		t.Fatalf("source state changed: result=%q instance=%s", got.SourceState, inst.Status)
+	}
+	wantDir := filepath.Join(snapshotRoot, SavedSnapshotsDirName, vmID, snapshotID)
+	if filepath.Dir(got.Artifacts.ManifestPath) != wantDir {
+		t.Fatalf("manifest dir = %q, want %q", filepath.Dir(got.Artifacts.ManifestPath), wantDir)
+	}
+	if got.Artifacts.DiskFullPath == "" || got.Artifacts.DiskOverlayPath != "" || got.Artifacts.DiskDeltaPath != "" {
+		t.Fatalf("unexpected disk artifacts: %+v", got.Artifacts)
+	}
+	if got.Resources.DiskSizeMiB != 1 {
+		t.Fatalf("inferred disk size = %d MiB, want 1", got.Resources.DiskSizeMiB)
+	}
+	// vmstate is copied into a new inode, while memory and disk are reflinked.
+	// Only the latter seal source-owned extents into the shared branch.
+	wantSourceLogical := int64(len("paused-memory") + len("paused-disk"))
+	if got.SourceLogicalSizeBytes != wantSourceLogical || got.SourceExclusiveSizeBytes <= 0 {
+		t.Fatalf("source storage accounting = logical %d exclusive %d, want logical %d and positive exclusive bytes",
+			got.SourceLogicalSizeBytes, got.SourceExclusiveSizeBytes, wantSourceLogical)
+	}
+
+	// The committed copies do not share mutable bytes with the retained pause
+	// checkpoint. Changing the source after capture cannot change the snapshot.
+	writeSavedTestFile(t, vmstate, []byte("changed-vmstate"))
+	writeSavedTestFile(t, memory, []byte("changed-memory"))
+	writeSavedTestFile(t, disk, []byte("changed-disk"))
+	for path, want := range map[string]string{
+		got.Artifacts.SnapshotPath: "paused-vmstate",
+		got.Artifacts.MemFilePath:  "paused-memory",
+		got.Artifacts.DiskFullPath: "paused-disk",
+	} {
+		data, readErr := os.ReadFile(path)
+		if readErr != nil || string(data) != want {
+			t.Errorf("immutable artifact %s = %q, %v; want %q", path, data, readErr, want)
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			t.Errorf("stat immutable artifact %s: %v", path, statErr)
+		} else if info.Mode().Perm()&0o222 != 0 {
+			t.Errorf("artifact %s is writable: mode=%v", path, info.Mode())
+		}
+	}
+
+	// Lost-response retry returns the committed snapshot without consulting
+	// the now-mutated runtime checkpoint.
+	retry, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID)
+	if err != nil {
+		t.Fatalf("idempotent retry: %v", err)
+	}
+	if retry.CreatedAt != got.CreatedAt || retry.Artifacts.ManifestPath != got.Artifacts.ManifestPath {
+		t.Fatalf("retry created a different snapshot: first=%+v retry=%+v", got, retry)
+	}
+	protoResult, err := NewGRPCAdapter(mgr).CreateSnapshot(context.Background(), &vmdpb.CreateSnapshotRequest{
+		VmId:       vmID,
+		SnapshotId: snapshotID,
+	})
+	if err != nil {
+		t.Fatalf("gRPC idempotent retry: %v", err)
+	}
+	if protoResult.GetSourceLogicalSizeBytes() != got.SourceLogicalSizeBytes ||
+		protoResult.GetSourceExclusiveSizeBytes() != got.SourceExclusiveSizeBytes {
+		t.Fatalf("gRPC source storage accounting = logical %d exclusive %d, want logical %d exclusive %d",
+			protoResult.GetSourceLogicalSizeBytes(), protoResult.GetSourceExclusiveSizeBytes(),
+			got.SourceLogicalSizeBytes, got.SourceExclusiveSizeBytes)
+	}
+
+	if err := mgr.DeleteSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("DeleteSavedSnapshot: %v", err)
+	}
+	if _, err := os.Stat(wantDir); !os.IsNotExist(err) {
+		t.Fatalf("saved snapshot dir remains after delete: %v", err)
+	}
+	if err := mgr.DeleteSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("idempotent DeleteSavedSnapshot: %v", err)
+	}
+}
+
+func TestDeleteSavedSnapshotWaitsForSourceLifecycleOperation(t *testing.T) {
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	vmID := "12111111-1111-1111-1111-111111111111"
+	snapshotID := "snap-locked"
+	dir := filepath.Join(snapshotRoot, SavedSnapshotsDirName, vmID, snapshotID)
+	writeSavedTestFile(t, filepath.Join(dir, savedSnapshotManifestName), []byte(`{}`))
+	mgr := savedTestManager(snapshotRoot, runRoot, &VMInstance{ID: vmID})
+
+	unlock, err := mgr.lockVMOp(context.Background(), vmID)
+	if err != nil {
+		t.Fatalf("hold source lifecycle lock: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	err = mgr.DeleteSavedSnapshot(ctx, vmID, snapshotID)
+	cancel()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("delete while capture lock held = %v, want deadline exceeded", err)
+	}
+	if _, statErr := os.Stat(dir); statErr != nil {
+		t.Fatalf("timed-out delete touched saved directory: %v", statErr)
+	}
+
+	unlock()
+	if err := mgr.DeleteSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("delete after source operation completed: %v", err)
+	}
+}
+
+func TestDeleteSavedSnapshotRemovesMatchingStagingArtifacts(t *testing.T) {
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	vmID := "13111111-1111-1111-1111-111111111111"
+	snapshotID := "snap-cancelled"
+	sourceDir := filepath.Join(snapshotRoot, SavedSnapshotsDirName, vmID)
+	matching := filepath.Join(sourceDir, "."+snapshotID+".tmp-attempt")
+	unrelated := filepath.Join(sourceDir, ".another-snapshot.tmp-attempt")
+	writeSavedTestFile(t, filepath.Join(matching, "partial.mem"), []byte("partial"))
+	writeSavedTestFile(t, filepath.Join(unrelated, "partial.mem"), []byte("keep"))
+	mgr := savedTestManager(snapshotRoot, runRoot, &VMInstance{ID: vmID})
+
+	if err := mgr.DeleteSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("DeleteSavedSnapshot: %v", err)
+	}
+	if _, err := os.Stat(matching); !os.IsNotExist(err) {
+		t.Fatalf("matching staging directory remains: %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatalf("unrelated staging directory was removed: %v", err)
+	}
+}
+
+func TestCreateSavedSnapshotPausedLayeredCopiesSidecarsAndPlansFreshClone(t *testing.T) {
+	installInactiveSystemctl(t)
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	requireSavedSnapshotTestReflink(t, runRoot, snapshotRoot)
+	vmID := "22222222-2222-2222-2222-222222222222"
+	snapshotID := "snap-layered"
+	runtimeDir := filepath.Join(snapshotRoot, vmID)
+	vmstate := filepath.Join(runtimeDir, "vmstate.snap")
+	memory := filepath.Join(runtimeDir, "mem.diff")
+	memoryBase := filepath.Join(snapshotRoot, TemplatesDirName, "template-a", "build-a", "mem.snap")
+	diskBase := filepath.Join(runRoot, TemplatesDirName, "template-a", "build-a", "base.ext4")
+	disk := filepath.Join(runRoot, vmID, "overlay.ext4")
+	writeSavedTestFile(t, vmstate, []byte("state"))
+	writeSavedTestFile(t, memory, []byte("memory-diff"))
+	writeSavedTestFile(t, presence.SidecarPath(memory), []byte("presence"))
+	writeSavedTestFile(t, memoryBase, []byte("memory-base"))
+	writeSavedTestFile(t, diskBase, []byte("disk-base"))
+	writeSavedTestFile(t, disk, []byte("disk-overlay"))
+
+	inst := &VMInstance{
+		ID:           vmID,
+		Status:       StatusPaused,
+		RunDirID:     vmID,
+		DiskPath:     disk,
+		SnapshotPath: vmstate,
+		MemFilePath:  memory,
+		BaseMemPath:  memoryBase,
+		Config: VMConfig{
+			VCPU:        4,
+			MemoryMiB:   4096,
+			DiskSizeMiB: 8192,
+			BasePath:    diskBase,
+		},
+	}
+	mgr := savedTestManager(snapshotRoot, runRoot, inst)
+	got, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID)
+	if err != nil {
+		t.Fatalf("CreateSavedSnapshot: %v", err)
+	}
+	if got.Artifacts.MemoryBasePath != memoryBase || got.Artifacts.DiskBasePath != diskBase {
+		t.Fatalf("base references not retained: %+v", got.Artifacts)
+	}
+	if filepath.Base(got.Artifacts.MemFilePath) != "mem.diff" || got.Artifacts.DiskOverlayPath == "" {
+		t.Fatalf("layered artifacts not selected: %+v", got.Artifacts)
+	}
+	if got.SourceLogicalSizeBytes != int64(len("memory-diff")+len("disk-overlay")) || got.SourceExclusiveSizeBytes <= 0 {
+		t.Fatalf("retained source layer = logical %d exclusive %d; copied vmstate/sidecars must be excluded",
+			got.SourceLogicalSizeBytes, got.SourceExclusiveSizeBytes)
+	}
+	baseRecord, err := os.ReadFile(got.Artifacts.MemFilePath + ".base")
+	if err != nil || string(baseRecord) != memoryBase+"\n" {
+		t.Fatalf("memory base sidecar = %q, %v", baseRecord, err)
+	}
+	if data, err := os.ReadFile(presence.SidecarPath(got.Artifacts.MemFilePath)); err != nil || string(data) != "presence" {
+		t.Fatalf("memory presence sidecar = %q, %v", data, err)
+	}
+
+	manifest, err := mgr.loadSavedSnapshotManifest(got.Artifacts.ManifestPath)
+	if err != nil {
+		t.Fatalf("loadSavedSnapshotManifest: %v", err)
+	}
+	cfg, err := savedSnapshotVMConfig(manifest, nil)
+	if err != nil {
+		t.Fatalf("savedSnapshotVMConfig: %v", err)
+	}
+	if cfg.BasePath != diskBase || cfg.RootfsPath != got.Artifacts.DiskOverlayPath || cfg.DeltaDir != "" {
+		t.Fatalf("restore config = %+v", cfg)
+	}
+	plan := planRestoreWithSource(cfg.BasePath, cfg.DeltaDir, cfg.RootfsPath, false)
+	if plan.action != restoreCloneOverlay || plan.source != got.Artifacts.DiskOverlayPath {
+		t.Fatalf("restore plan = %+v, want fresh saved-overlay clone", plan)
+	}
+}
+
+func TestCreateSavedSnapshotRunningReturnsSourceToRunningAndUsesDelta(t *testing.T) {
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	vmID := "33333333-3333-3333-3333-333333333333"
+	snapshotID := "snap-running"
+	diskBase := filepath.Join(runRoot, TemplatesDirName, "template-a", "build-a", "base.ext4")
+	disk := filepath.Join(runRoot, vmID, "overlay.ext4")
+	writeSavedTestFile(t, diskBase, []byte("immutable-base"))
+	writeSavedTestFile(t, disk, []byte("live-overlay"))
+
+	socketPath := filepath.Join(t.TempDir(), "firecracker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+	var mu sync.Mutex
+	var patchStates []string
+	createCalls := 0
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/vm":
+			var body struct {
+				State string `json:"state"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			mu.Lock()
+			patchStates = append(patchStates, body.State)
+			mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPut && r.URL.Path == "/snapshot/create":
+			var body struct {
+				SnapshotPath  string `json:"snapshot_path"`
+				MemFilePath   string `json:"mem_file_path"`
+				BlockDeltaDir string `json:"block_delta_dir"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			createCalls++
+			mu.Unlock()
+			if err := os.WriteFile(body.SnapshotPath, []byte("vmstate"), 0o600); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if err := os.WriteFile(body.MemFilePath, []byte("memory"), 0o600); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if err := os.WriteFile(filepath.Join(body.BlockDeltaDir, "rootfs.delta"), []byte("delta"), 0o600); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			_, _ = io.WriteString(w, "unexpected request")
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+	waitForUnixSocket(t, socketPath)
+
+	inst := &VMInstance{
+		ID:         vmID,
+		Status:     StatusRunning,
+		SocketPath: socketPath,
+		DiskPath:   disk,
+		RunDirID:   vmID,
+		Config: VMConfig{
+			VCPU:        2,
+			MemoryMiB:   1024,
+			DiskSizeMiB: 4096,
+			BasePath:    diskBase,
+		},
+		DirtyTracked: true,
+	}
+	mgr := savedTestManager(snapshotRoot, runRoot, inst)
+	got, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID)
+	if err != nil {
+		t.Fatalf("CreateSavedSnapshot: %v", err)
+	}
+	if got.SourceState != "running" || inst.Status != StatusRunning || inst.DirtyTracked {
+		t.Fatalf("running source not restored cleanly: source=%q status=%s dirty=%v", got.SourceState, inst.Status, inst.DirtyTracked)
+	}
+	if got.Artifacts.DiskDeltaPath == "" || got.Artifacts.DiskOverlayPath != "" {
+		t.Fatalf("running overlay capture did not use block delta: %+v", got.Artifacts)
+	}
+	if got.SourceLogicalSizeBytes != 0 || got.SourceExclusiveSizeBytes != 0 {
+		t.Fatalf("block-delta capture retained unrelated source bytes: logical=%d exclusive=%d",
+			got.SourceLogicalSizeBytes, got.SourceExclusiveSizeBytes)
+	}
+	mu.Lock()
+	states := append([]string(nil), patchStates...)
+	calls := createCalls
+	mu.Unlock()
+	if len(states) != 2 || calls != 1 {
+		t.Fatalf("firecracker calls: patch states=%v creates=%d", states, calls)
+	}
+
+	if _, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("idempotent running retry: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if createCalls != 1 || len(patchStates) != 2 {
+		t.Fatalf("idempotent retry touched source: patch=%v creates=%d", patchStates, createCalls)
+	}
+}
+
+func TestSavedCaptureDisarmsConsumedDirtyBitmapBeforeMaterialization(t *testing.T) {
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	vmID := "34333333-3333-3333-3333-333333333333"
+	snapshotID := "snap-diff-materialization-retry"
+	diskBase := filepath.Join(runRoot, TemplatesDirName, "template-a", "build-a", "base.ext4")
+	disk := filepath.Join(runRoot, vmID, "overlay.ext4")
+	memoryBase := filepath.Join(snapshotRoot, TemplatesDirName, "template-a", "build-a", "mem.snap")
+	writeSavedTestFile(t, diskBase, []byte("immutable-disk-base"))
+	writeSavedTestFile(t, disk, []byte("live-overlay"))
+	writeSavedTestFile(t, memoryBase, make([]byte, 2*4096))
+
+	socketPath := filepath.Join(t.TempDir(), "firecracker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	var mu sync.Mutex
+	var snapshotTypes []string
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/vm":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPut && r.URL.Path == "/snapshot/create":
+			var body struct {
+				SnapshotPath  string `json:"snapshot_path"`
+				MemFilePath   string `json:"mem_file_path"`
+				SnapshotType  string `json:"snapshot_type"`
+				BlockDeltaDir string `json:"block_delta_dir"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			snapshotTypes = append(snapshotTypes, body.SnapshotType)
+			call := len(snapshotTypes)
+			mu.Unlock()
+			if err := os.WriteFile(body.SnapshotPath, []byte("vmstate"), 0o600); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if call == 1 {
+				// The Diff itself succeeds, consuming Firecracker's dirty bitmap,
+				// but its missing presence sidecar makes saved-branch
+				// materialization fail afterward.
+				if err := os.WriteFile(body.MemFilePath, make([]byte, 2*4096), 0o600); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			} else {
+				if err := os.WriteFile(body.MemFilePath, []byte("full-memory"), 0o600); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				if err := os.WriteFile(filepath.Join(body.BlockDeltaDir, "rootfs.delta"), []byte("disk-delta"), 0o600); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+	waitForUnixSocket(t, socketPath)
+
+	inst := &VMInstance{
+		ID:           vmID,
+		Status:       StatusRunning,
+		SocketPath:   socketPath,
+		DiskPath:     disk,
+		RunDirID:     vmID,
+		MemFilePath:  memoryBase,
+		BaseMemPath:  memoryBase,
+		DirtyTracked: true,
+		Config: VMConfig{
+			VCPU:        2,
+			MemoryMiB:   1024,
+			DiskSizeMiB: 4096,
+			BasePath:    diskBase,
+		},
+	}
+	mgr := savedTestManager(snapshotRoot, runRoot, inst)
+	mgr.cfg.IncrementalSnapshotEnabled = true
+	state, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state store: %v", err)
+	}
+	defer state.Close()
+	mgr.SetStateStore(state)
+
+	if _, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID); err == nil || !strings.Contains(err.Error(), "presence map") {
+		t.Fatalf("first capture error = %v, want post-Diff materialization failure", err)
+	}
+	inst.mu.RLock()
+	dirtyTracked := inst.DirtyTracked
+	inst.mu.RUnlock()
+	if dirtyTracked {
+		t.Fatal("successful Diff emission left source dirty tracking armed")
+	}
+	record, err := state.Get(vmID)
+	if err != nil || record == nil {
+		t.Fatalf("persisted source state = %+v, %v", record, err)
+	}
+	if recovered := toInstance(*record); recovered.DirtyTracked {
+		t.Fatal("restart recovery re-armed a consumed dirty bitmap")
+	}
+
+	if _, err := mgr.CreateSavedSnapshot(context.Background(), vmID, snapshotID); err != nil {
+		t.Fatalf("retry capture: %v", err)
+	}
+	mu.Lock()
+	gotTypes := append([]string(nil), snapshotTypes...)
+	mu.Unlock()
+	if len(gotTypes) != 2 || gotTypes[0] != models.SnapshotCreateParamsSnapshotTypeDiff || gotTypes[1] != models.SnapshotCreateParamsSnapshotTypeFull {
+		t.Fatalf("snapshot types = %v, want [Diff Full]", gotTypes)
+	}
+}
+
+func TestUnpauseSavedSnapshotSourceAcceptsErrorAfterResumeApplied(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "firecracker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	var mu sync.Mutex
+	state := models.InstanceInfoStatePaused
+	patchCalls := 0
+	describeCalls := 0
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/vm":
+			mu.Lock()
+			state = models.InstanceInfoStateRunning
+			patchCalls++
+			mu.Unlock()
+			// Model an applied command whose response was lost/failed. The
+			// caller must resolve the result from DescribeInstance.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"fault_message":"response lost after resume"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/":
+			mu.Lock()
+			describeCalls++
+			current := state
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"app_name":    "Firecracker",
+				"id":          "anonymous-instance",
+				"state":       current,
+				"vmm_version": "test",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+	waitForUnixSocket(t, socketPath)
+
+	if err := unpauseSavedSnapshotSource(socketPath); err != nil {
+		t.Fatalf("ambiguous unpause should be accepted after running-state proof: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if patchCalls != 1 || describeCalls != 1 {
+		t.Fatalf("calls: patch=%d describe=%d, want one of each", patchCalls, describeCalls)
+	}
+}
+
+func TestSnapshotArtifactSizesIncludesAndDeduplicatesReferencedBases(t *testing.T) {
+	owned := t.TempDir()
+	writeSavedTestFile(t, filepath.Join(owned, "a"), []byte("abc"))
+	writeSavedTestFile(t, filepath.Join(owned, "b"), []byte("12345"))
+	baseDir := t.TempDir()
+	base := filepath.Join(baseDir, "base")
+	alias := filepath.Join(baseDir, "alias")
+	writeSavedTestFile(t, base, []byte("1234567"))
+	if err := os.Link(base, alias); err != nil {
+		t.Fatalf("hardlink: %v", err)
+	}
+
+	logical, exclusive, err := snapshotArtifactSizes(owned, base, alias, base)
+	if err != nil {
+		t.Fatalf("snapshotArtifactSizes: %v", err)
+	}
+	if logical != 3+5+7 {
+		t.Fatalf("logical = %d, want 15 (referenced inode counted once)", logical)
+	}
+	_, ownedExclusive, err := snapshotArtifactSizes(owned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exclusive != ownedExclusive || exclusive <= 0 {
+		t.Fatalf("exclusive = %d, want owned-only allocated bytes %d", exclusive, ownedExclusive)
+	}
+}
+
+func TestSnapshotArtifactSizesDoesNotRebillReflinkOwnedPaths(t *testing.T) {
+	owned := t.TempDir()
+	source := filepath.Join(t.TempDir(), "source-layer")
+	shared := filepath.Join(owned, "shared-layer")
+	metadata := filepath.Join(owned, "vmstate")
+	writeSavedTestFile(t, source, bytes.Repeat([]byte{0x5a}, 8192))
+	if err := reflinkImmutableFileContext(context.Background(), source, shared); err != nil {
+		t.Skipf("test filesystem has no reflink support: %v", err)
+	}
+	writeSavedTestFile(t, metadata, []byte("state"))
+
+	logical, exclusive, err := snapshotArtifactSizesWithShared(owned, []string{shared})
+	if err != nil {
+		t.Fatalf("snapshotArtifactSizesWithShared: %v", err)
+	}
+	if logical != 8192+int64(len("state")) {
+		t.Fatalf("logical = %d, want %d", logical, 8192+len("state"))
+	}
+	_, metadataExclusive, err := snapshotArtifactSizes(filepath.Dir(metadata), shared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The comparison directory includes shared too, so derive the metadata's
+	// allocation directly through a one-file directory.
+	metadataOnly := t.TempDir()
+	writeSavedTestFile(t, filepath.Join(metadataOnly, "vmstate"), []byte("state"))
+	_, metadataExclusive, err = snapshotArtifactSizes(metadataOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exclusive != metadataExclusive {
+		t.Fatalf("exclusive = %d, want metadata-only allocated bytes %d", exclusive, metadataExclusive)
+	}
+}
+
+func TestSavedSourceLayerUsageCountsOnlyExtentsStillSharedAfterCaptureWrites(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	clone := filepath.Join(dir, "clone")
+	writeSavedTestFile(t, source, bytes.Repeat([]byte{0x5a}, 2<<20))
+	before, err := exclusiveFileBytes(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage := &savedSourceLayerUsage{}
+	if err := usage.reflink(context.Background(), source, clone); err != nil {
+		t.Skipf("test filesystem has no reflink support: %v", err)
+	}
+
+	// Model materializeSavedMemoryBranch overwriting a dirty page after the
+	// initial clone. That page is no longer retained from the source.
+	f, err := os.OpenFile(clone, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xa5}, 4096), 0); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := exclusiveFileBytes(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := usage.finalize(); err != nil {
+		t.Fatal(err)
+	}
+	wantExclusive := before - after
+	if usage.exclusiveBytes != wantExclusive {
+		t.Fatalf("retained exclusive bytes = %d, want before-after = %d-%d = %d",
+			usage.exclusiveBytes, before, after, wantExclusive)
+	}
+	wantLogical := int64(0)
+	if wantExclusive > 0 {
+		wantLogical = 2 << 20
+	}
+	if usage.logicalBytes != wantLogical {
+		t.Fatalf("retained logical bytes = %d, want %d", usage.logicalBytes, wantLogical)
+	}
+}
+
+func TestApplySparseFileOverwritesOnlyDirtyExtents(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	delta := filepath.Join(dir, "delta")
+	const page = int64(4096)
+	if err := createSparseFile(target, 3*page); err != nil {
+		t.Fatal(err)
+	}
+	if err := createSparseFile(delta, 3*page); err != nil {
+		t.Fatal(err)
+	}
+	targetFile, err := os.OpenFile(target, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := targetFile.WriteAt(bytes.Repeat([]byte{'A'}, int(page)), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := targetFile.WriteAt(bytes.Repeat([]byte{'C'}, int(page)), 2*page); err != nil {
+		t.Fatal(err)
+	}
+	if err := targetFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	deltaFile, err := os.OpenFile(delta, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := deltaFile.WriteAt(bytes.Repeat([]byte{'B'}, int(page)), page); err != nil {
+		t.Fatal(err)
+	}
+	if err := deltaFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := applySparseFileContext(context.Background(), delta, target); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []byte{'A', 'B', 'C'} {
+		if pageBytes := got[int64(i)*page : int64(i+1)*page]; !bytes.Equal(pageBytes, bytes.Repeat([]byte{want}, int(page))) {
+			t.Fatalf("page %d was not preserved/applied as %q", i, want)
+		}
+	}
+}
+
+func TestSavedSnapshotPathsRejectTraversalAndSymlinkParents(t *testing.T) {
+	root := t.TempDir()
+	mgr := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	if _, err := mgr.savedSnapshotDir("../escape", "snap"); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("source traversal code = %s, want InvalidArgument (%v)", status.Code(err), err)
+	}
+	if _, err := mgr.savedSnapshotDir("source", "../escape"); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("snapshot traversal code = %s, want InvalidArgument (%v)", status.Code(err), err)
+	}
+
+	outside := t.TempDir()
+	writeSavedTestFile(t, filepath.Join(outside, "snap", savedSnapshotManifestName), []byte(`{}`))
+	if err := os.MkdirAll(filepath.Join(root, SavedSnapshotsDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, SavedSnapshotsDirName, "source")); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(root, SavedSnapshotsDirName, "source", "snap", savedSnapshotManifestName)
+	if _, err := mgr.loadSavedSnapshotManifest(manifestPath); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("symlink parent code = %s, want InvalidArgument (%v)", status.Code(err), err)
+	}
+	if err := mgr.DeleteSavedSnapshot(context.Background(), "source", "snap"); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("symlink delete code = %s, want FailedPrecondition (%v)", status.Code(err), err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "snap", savedSnapshotManifestName)); err != nil {
+		t.Fatalf("unsafe delete touched symlink target: %v", err)
+	}
+}
+
+func TestSavedSnapshotVMConfigUsesImmutableDiskModes(t *testing.T) {
+	base := "/var/lib/sandbox/templates/t/base.ext4"
+	dir := "/var/lib/sandbox/snapshots/saved/source/snap"
+	cases := []struct {
+		name string
+		disk savedDiskArtifact
+		want restoreDiskAction
+	}{
+		{"block delta", savedDiskArtifact{Kind: diskArtifactBlockDelta, BasePath: base, Path: filepath.Join(dir, "rootfs.delta")}, restoreCreateOverlay},
+		{"saved overlay", savedDiskArtifact{Kind: diskArtifactOverlay, BasePath: base, Path: filepath.Join(dir, "rootfs.overlay")}, restoreCloneOverlay},
+		{"legacy full", savedDiskArtifact{Kind: diskArtifactFull, Path: filepath.Join(dir, "rootfs.ext4")}, restoreCopyRootfs},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := &savedSnapshotManifest{Resources: SavedSnapshotResources{VCPU: 2, MemoryMiB: 1024, DiskSizeMiB: 4096}, Disk: tc.disk}
+			cfg, err := savedSnapshotVMConfig(manifest, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan := planRestoreWithSource(cfg.BasePath, cfg.DeltaDir, cfg.RootfsPath, false)
+			if plan.action != tc.want {
+				t.Fatalf("plan action = %v, want %v (cfg=%+v)", plan.action, tc.want, cfg)
+			}
+		})
+	}
+}
+
+func writeSavedRestoreFixture(t *testing.T) (*Manager, string, *savedSnapshotManifest) {
+	t.Helper()
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	dir := filepath.Join(snapshotRoot, SavedSnapshotsDirName, "source-vm", "snapshot-1")
+	manifestPath := filepath.Join(dir, savedSnapshotManifestName)
+	manifest := &savedSnapshotManifest{
+		SchemaVersion: savedSnapshotSchemaVersion,
+		SnapshotID:    "snapshot-1",
+		SourceVMID:    "source-vm",
+		SourceState:   StatusPaused.String(),
+		CreatedAt:     time.Now().UTC(),
+		Resources: SavedSnapshotResources{
+			VCPU:        1,
+			MemoryMiB:   128,
+			DiskSizeMiB: 1,
+		},
+		VMStatePath: filepath.Join(dir, "vmstate.snap"),
+		Memory:      savedMemoryArtifact{Path: filepath.Join(dir, "mem.snap")},
+		Disk:        savedDiskArtifact{Kind: diskArtifactFull, Path: filepath.Join(dir, "rootfs.ext4")},
+	}
+	writeSavedTestFile(t, manifest.VMStatePath, []byte("vmstate"))
+	writeSavedTestFile(t, manifest.Memory.Path, []byte("memory"))
+	writeSavedTestFile(t, manifest.Disk.Path, []byte("disk"))
+	if err := populateSavedSnapshotDigests(dir, dir, manifest); err != nil {
+		t.Fatalf("populate digests: %v", err)
+	}
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSavedTestFile(t, manifestPath, encoded)
+	mgr := &Manager{
+		cfg: ManagerConfig{SnapshotDir: snapshotRoot, RunDir: runRoot},
+		log: zerolog.Nop(),
+		vms: make(map[string]*VMInstance),
+	}
+	return mgr, manifestPath, manifest
+}
+
+func TestRestoreSavedSnapshotClassifiesMissingAndCorruptArtifactsAsDataLoss(t *testing.T) {
+	t.Run("missing manifest", func(t *testing.T) {
+		snapshotRoot := t.TempDir()
+		mgr := &Manager{cfg: ManagerConfig{SnapshotDir: snapshotRoot}}
+		manifestPath := filepath.Join(snapshotRoot, SavedSnapshotsDirName, "source-vm", "snapshot-1", savedSnapshotManifestName)
+		_, _, err := mgr.RestoreSavedSnapshot(context.Background(), "child-vm", manifestPath, strings.Repeat("0", 64), nil, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.DataLoss {
+			t.Fatalf("missing manifest code = %s, want DataLoss (%v)", status.Code(err), err)
+		}
+	})
+
+	t.Run("corrupt manifest", func(t *testing.T) {
+		mgr, manifestPath, _ := writeSavedRestoreFixture(t)
+		digest, err := sha256File(manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeSavedTestFile(t, manifestPath, []byte("{not-json"))
+		_, _, err = mgr.RestoreSavedSnapshot(context.Background(), "child-vm", manifestPath, digest, nil, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.DataLoss {
+			t.Fatalf("corrupt manifest code = %s, want DataLoss (%v)", status.Code(err), err)
+		}
+	})
+
+	t.Run("missing owned artifact", func(t *testing.T) {
+		mgr, manifestPath, manifest := writeSavedRestoreFixture(t)
+		digest, err := sha256File(manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(manifest.VMStatePath); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = mgr.RestoreSavedSnapshot(context.Background(), "child-vm", manifestPath, digest, nil, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.DataLoss {
+			t.Fatalf("missing artifact code = %s, want DataLoss (%v)", status.Code(err), err)
+		}
+	})
+
+	t.Run("mutated owned artifact", func(t *testing.T) {
+		mgr, manifestPath, manifest := writeSavedRestoreFixture(t)
+		digest, err := sha256File(manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeSavedTestFile(t, manifest.Memory.Path, []byte("tampered-memory"))
+		_, _, err = mgr.RestoreSavedSnapshot(context.Background(), "child-vm", manifestPath, digest, nil, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.DataLoss || !strings.Contains(err.Error(), "digest mismatch") {
+			t.Fatalf("mutated artifact error = %v, want DataLoss digest mismatch", err)
+		}
+	})
+
+	t.Run("manifest differs from control-plane commit", func(t *testing.T) {
+		mgr, manifestPath, _ := writeSavedRestoreFixture(t)
+		_, _, err := mgr.RestoreSavedSnapshot(context.Background(), "child-vm", manifestPath, strings.Repeat("f", 64), nil, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.DataLoss || !strings.Contains(err.Error(), "control-plane digest") {
+			t.Fatalf("manifest commit mismatch error = %v, want DataLoss", err)
+		}
+		if _, exists := mgr.vms["child-vm"]; exists {
+			t.Fatal("manifest mismatch allocated a child VM")
+		}
+	})
+}
+
+func TestSavedSnapshotRestoreErrorClassification(t *testing.T) {
+	mgr, manifestPath, _ := writeSavedRestoreFixture(t)
+
+	rejected := mgr.classifySavedSnapshotRestoreError(manifestPath, fmt.Errorf("load failed: %w", ErrSnapshotLoadRejected))
+	if status.Code(rejected) != codes.DataLoss {
+		t.Fatalf("Firecracker rejection code = %s, want DataLoss (%v)", status.Code(rejected), rejected)
+	}
+
+	temporary := mgr.classifySavedSnapshotRestoreError(manifestPath, fmt.Errorf("dial local daemon: %w", syscall.ECONNREFUSED))
+	if status.Code(temporary) != codes.Unavailable {
+		t.Fatalf("temporary host error code = %s, want Unavailable (%v)", status.Code(temporary), temporary)
+	}
+
+	ioFailure := savedSnapshotArtifactIOError("read artifact", &os.PathError{Op: "read", Path: manifestPath, Err: syscall.EIO})
+	if status.Code(ioFailure) != codes.Unavailable {
+		t.Fatalf("temporary artifact I/O code = %s, want Unavailable (%v)", status.Code(ioFailure), ioFailure)
+	}
+}
+
+func TestSavedSnapshotGRPCBoundaryDoesNotExposeHostArtifactPaths(t *testing.T) {
+	t.Run("capture", func(t *testing.T) {
+		installInactiveSystemctl(t)
+		snapshotRoot := t.TempDir()
+		runRoot := t.TempDir()
+		privateRoot := filepath.Join(t.TempDir(), "host-private-artifacts")
+		missingVMState := filepath.Join(privateRoot, "source", "vmstate.snap")
+		memory := filepath.Join(privateRoot, "source", "mem.snap")
+		disk := filepath.Join(privateRoot, "source", "rootfs.ext4")
+		writeSavedTestFile(t, memory, []byte("memory"))
+		writeSavedTestFile(t, disk, []byte("disk"))
+
+		vmID := "source-private-path"
+		mgr := savedTestManager(snapshotRoot, runRoot, &VMInstance{
+			ID:           vmID,
+			Status:       StatusPaused,
+			SnapshotPath: missingVMState,
+			MemFilePath:  memory,
+			DiskPath:     disk,
+			Config:       VMConfig{VCPU: 1, MemoryMiB: 128, DiskSizeMiB: 1},
+		})
+		_, err := NewGRPCAdapter(mgr).CreateSnapshot(context.Background(), &vmdpb.CreateSnapshotRequest{
+			VmId:       vmID,
+			SnapshotId: "snapshot-private-path",
+		})
+		if status.Code(err) != codes.DataLoss {
+			t.Fatalf("capture code = %s, want DataLoss (%v)", status.Code(err), err)
+		}
+		if strings.Contains(err.Error(), privateRoot) || strings.Contains(err.Error(), missingVMState) {
+			t.Fatalf("capture RPC error exposed host artifact path: %v", err)
+		}
+		if !strings.Contains(err.Error(), "saved snapshot capture failed") {
+			t.Fatalf("capture RPC error lost safe operation context: %v", err)
+		}
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		mgr, manifestPath, manifest := writeSavedRestoreFixture(t)
+		privateArtifact := filepath.Join(t.TempDir(), "host-private-memory", "mem.snap")
+		manifest.Memory.Path = privateArtifact
+		encoded, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeSavedTestFile(t, manifestPath, encoded)
+		digest, err := sha256File(manifestPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = NewGRPCAdapter(mgr).RestoreSavedSnapshot(context.Background(), &vmdpb.RestoreSavedSnapshotRequest{
+			VmId:                   "child-private-path",
+			ManifestPath:           manifestPath,
+			ExpectedManifestDigest: digest,
+		})
+		if status.Code(err) != codes.DataLoss {
+			t.Fatalf("restore code = %s, want DataLoss (%v)", status.Code(err), err)
+		}
+		if strings.Contains(err.Error(), privateArtifact) || strings.Contains(err.Error(), manifestPath) {
+			t.Fatalf("restore RPC error exposed host artifact path: %v", err)
+		}
+		if !strings.Contains(err.Error(), "saved snapshot restore failed") {
+			t.Fatalf("restore RPC error lost safe operation context: %v", err)
+		}
+	})
+}
+
+func TestCreateSavedSnapshotExistingInvalidManifestIsDataLoss(t *testing.T) {
+	snapshotRoot := t.TempDir()
+	runRoot := t.TempDir()
+	sourceVMID := "source-vm"
+	snapshotID := "snapshot-1"
+	finalDir := filepath.Join(snapshotRoot, SavedSnapshotsDirName, sourceVMID, snapshotID)
+	writeSavedTestFile(t, filepath.Join(finalDir, savedSnapshotManifestName), []byte("{not-json"))
+	mgr := savedTestManager(snapshotRoot, runRoot, &VMInstance{ID: sourceVMID})
+
+	_, err := mgr.CreateSavedSnapshot(context.Background(), sourceVMID, snapshotID)
+	if status.Code(err) != codes.DataLoss {
+		t.Fatalf("existing invalid manifest code = %s, want DataLoss (%v)", status.Code(err), err)
+	}
+}
+
+func TestCopyWritableDiskFailureDoesNotPoisonRetry(t *testing.T) {
+	binDir := t.TempDir()
+	fakeCP := filepath.Join(binDir, "cp")
+	script := `#!/bin/sh
+prev=
+for arg in "$@"; do
+  src=$prev
+  dst=$arg
+  prev=$arg
+done
+if [ "$FAKE_CP_FAIL" = "1" ]; then
+  printf partial > "$dst"
+  echo synthetic-copy-failure >&2
+  exit 41
+fi
+exec /bin/cp "$src" "$dst"
+`
+	writeSavedTestFile(t, fakeCP, []byte(script))
+	if err := os.Chmod(fakeCP, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_CP_FAIL", "1")
+
+	runRoot := t.TempDir()
+	source := filepath.Join(t.TempDir(), "source.ext4")
+	writeSavedTestFile(t, source, []byte("complete-disk"))
+	mgr := &Manager{cfg: ManagerConfig{RunDir: runRoot}}
+	destination := filepath.Join(runRoot, "child-vm", "rootfs.ext4")
+	if _, err := mgr.copyRootfs(context.Background(), "child-vm", source); err == nil || !strings.Contains(err.Error(), "synthetic-copy-failure") {
+		t.Fatalf("first copy error = %v, want synthetic failure", err)
+	}
+	for _, path := range []string{destination, destination + ".restore-tmp"} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("failed copy left target artifact %q: %v", path, err)
+		}
+	}
+
+	t.Setenv("FAKE_CP_FAIL", "0")
+	got, err := mgr.copyRootfs(context.Background(), "child-vm", source)
+	if err != nil {
+		t.Fatalf("retry copy: %v", err)
+	}
+	data, err := os.ReadFile(got)
+	if err != nil || string(data) != "complete-disk" {
+		t.Fatalf("retry target = %q, %v; want complete disk", data, err)
+	}
+}
+
+func TestFailedSavedRestoreRemovesProvisionalTargetBeforeRetry(t *testing.T) {
+	binDir := t.TempDir()
+	fakeCP := filepath.Join(binDir, "cp")
+	writeSavedTestFile(t, fakeCP, []byte(`#!/bin/sh
+for arg in "$@"; do dst=$arg; done
+printf partial > "$dst"
+echo synthetic-copy-failure >&2
+exit 41
+`))
+	if err := os.Chmod(fakeCP, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	runRoot := t.TempDir()
+	source := filepath.Join(t.TempDir(), "source.ext4")
+	snapshot := filepath.Join(t.TempDir(), "vmstate.snap")
+	memory := filepath.Join(t.TempDir(), "mem.snap")
+	for path, contents := range map[string]string{source: "disk", snapshot: "state", memory: "memory"} {
+		writeSavedTestFile(t, path, []byte(contents))
+	}
+	mgr := &Manager{
+		cfg:        ManagerConfig{RunDir: runRoot},
+		log:        zerolog.Nop(),
+		vms:        make(map[string]*VMInstance),
+		restoreSem: make(chan struct{}, 1),
+	}
+	cfg := VMConfig{RootfsPath: source, savedSnapshotRestore: true}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		_, err := mgr.RestoreVMSnapshot(context.Background(), "child-vm", snapshot, memory, cfg, nil, "team", "owner", "", nil, 0)
+		if err == nil || !strings.Contains(err.Error(), "synthetic-copy-failure") {
+			t.Fatalf("attempt %d error = %v, want fresh copy failure", attempt, err)
+		}
+		mgr.mu.RLock()
+		_, tracked := mgr.vms["child-vm"]
+		mgr.mu.RUnlock()
+		if tracked {
+			t.Fatalf("attempt %d left provisional VM tracked", attempt)
+		}
+		if _, err := os.Stat(filepath.Join(runRoot, "child-vm")); !os.IsNotExist(err) {
+			t.Fatalf("attempt %d left partial target directory: %v", attempt, err)
+		}
+	}
+}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	bolt "go.etcd.io/bbolt"
+
+	"github.com/superserve-ai/sandbox/internal/network"
 )
 
 // State provides durable local persistence for VM instance metadata.
@@ -19,9 +21,10 @@ var (
 	previewPolicyBucketName = []byte("vm_preview_policies")
 )
 
-// persistedPreviewPolicy is stored separately from VMRecord so a rollback to
-// a VMD binary that predates preview policy fields can keep writing lifecycle
-// records without erasing the last policy enforced by newer binaries.
+// persistedPreviewPolicy is stored separately from VMRecord so a rollback can
+// keep writing lifecycle records without erasing fields introduced by newer
+// binaries. DiskSizeMiB and EgressPolicy intentionally share the established
+// sidecar: the current main binary preserves unknown JSON fields in it.
 type persistedPreviewPolicy struct {
 	Access              string
 	Ports               map[int32]bool
@@ -29,17 +32,21 @@ type persistedPreviewPolicy struct {
 	TokenVersions       map[int32]int64
 	Revision            int64
 	TokenPolicyRevision int64
+	DiskSizeMiB         uint32
+	EgressPolicy        *network.EgressRules
 	unknownFields       map[string]json.RawMessage
 }
 
 func (p *persistedPreviewPolicy) UnmarshalJSON(data []byte) error {
 	var known struct {
-		Access              string           `json:"access,omitempty"`
-		Ports               map[int32]bool   `json:"ports,omitempty"`
-		PortAccess          map[int32]string `json:"port_access,omitempty"`
-		TokenVersions       map[int32]int64  `json:"token_versions,omitempty"`
-		Revision            int64            `json:"revision,omitempty"`
-		TokenPolicyRevision int64            `json:"token_policy_revision,omitempty"`
+		Access              string               `json:"access,omitempty"`
+		Ports               map[int32]bool       `json:"ports,omitempty"`
+		PortAccess          map[int32]string     `json:"port_access,omitempty"`
+		TokenVersions       map[int32]int64      `json:"token_versions,omitempty"`
+		Revision            int64                `json:"revision,omitempty"`
+		TokenPolicyRevision int64                `json:"token_policy_revision,omitempty"`
+		DiskSizeMiB         uint32               `json:"disk_size_mib,omitempty"`
+		EgressPolicy        *network.EgressRules `json:"egress_policy,omitempty"`
 	}
 	if err := json.Unmarshal(data, &known); err != nil {
 		return err
@@ -54,6 +61,8 @@ func (p *persistedPreviewPolicy) UnmarshalJSON(data []byte) error {
 	delete(fields, "token_versions")
 	delete(fields, "revision")
 	delete(fields, "token_policy_revision")
+	delete(fields, "disk_size_mib")
+	delete(fields, "egress_policy")
 	if len(fields) == 0 {
 		fields = nil
 	}
@@ -64,6 +73,8 @@ func (p *persistedPreviewPolicy) UnmarshalJSON(data []byte) error {
 		TokenVersions:       known.TokenVersions,
 		Revision:            known.Revision,
 		TokenPolicyRevision: known.TokenPolicyRevision,
+		DiskSizeMiB:         known.DiskSizeMiB,
+		EgressPolicy:        known.EgressPolicy,
 		unknownFields:       fields,
 	}
 	return nil
@@ -71,7 +82,7 @@ func (p *persistedPreviewPolicy) UnmarshalJSON(data []byte) error {
 
 func (p persistedPreviewPolicy) MarshalJSON() ([]byte, error) {
 	p = p.normalizedTokenState()
-	fields := make(map[string]json.RawMessage, len(p.unknownFields)+6)
+	fields := make(map[string]json.RawMessage, len(p.unknownFields)+8)
 	for key, value := range p.unknownFields {
 		fields[key] = value
 	}
@@ -117,6 +128,20 @@ func (p persistedPreviewPolicy) MarshalJSON() ([]byte, error) {
 		}
 		fields["token_policy_revision"] = data
 	}
+	if p.DiskSizeMiB != 0 {
+		data, err := json.Marshal(p.DiskSizeMiB)
+		if err != nil {
+			return nil, err
+		}
+		fields["disk_size_mib"] = data
+	}
+	if p.EgressPolicy != nil {
+		data, err := json.Marshal(p.EgressPolicy)
+		if err != nil {
+			return nil, err
+		}
+		fields["egress_policy"] = data
+	}
 	return json.Marshal(fields)
 }
 
@@ -146,12 +171,18 @@ type VMRecord struct {
 	Metadata    map[string]string `json:"metadata,omitempty"`
 	VCPU        uint32            `json:"vcpu"`
 	MemoryMiB   uint32            `json:"memory_mib"`
+	DiskSizeMiB uint32            `json:"disk_size_mib,omitempty"`
 	// Persisted so overlay-mode sandboxes can be resumed correctly after a
 	// vmd restart (the start script needs basePath to wire up the
 	// dual-symlink mount namespace). DeltaDir is intentionally NOT
 	// persisted — it's only relevant at create-from-template; a resumed
 	// sandbox reuses its existing overlay file in place.
 	BasePath string `json:"base_path,omitempty"`
+	// EgressPolicy is the effective sandbox policy installed before boot. It
+	// must survive a VMD restart: nftables keeps CIDR rules in the namespace,
+	// but the in-process domain proxy otherwise comes back with an allow-all
+	// default until the control plane happens to issue another update.
+	EgressPolicy *network.EgressRules `json:"egress_policy,omitempty"`
 	// Persisted so usage attribution survives a vmd restart.
 	TeamID  string `json:"team_id,omitempty"`
 	OwnerID string `json:"owner_id,omitempty"`
@@ -237,7 +268,7 @@ func (s *StateStore) Close() error {
 
 // Put persists a VM record. Batched; the callback is idempotent so Batch's
 // retry-on-failure semantics are safe. The lifecycle record and authoritative
-// preview-policy sidecar are updated in the same transaction.
+// rollback-stable sidecar are updated in the same transaction.
 func (s *StateStore) Put(rec VMRecord) error {
 	return s.db.Batch(func(tx *bolt.Tx) error {
 		_, err := putRecord(tx, rec, false)
@@ -322,12 +353,27 @@ func putRecord(tx *bolt.Tx, incoming VMRecord, onlyIfPresent bool) (bool, error)
 			// Preserve fields introduced by later VMD versions even when this
 			// binary legitimately advances the fields it understands.
 			incomingPolicy.unknownFields = persistedPolicy.unknownFields
+			// A zero disk size and nil egress pointer mean an older lifecycle
+			// writer omitted these fields. Preserve the sidecar. A new writer
+			// can intentionally persist the default egress policy as a non-nil
+			// empty ruleset.
+			if incomingPolicy.DiskSizeMiB == 0 {
+				incomingPolicy.DiskSizeMiB = persistedPolicy.DiskSizeMiB
+			}
+			if incomingPolicy.EgressPolicy == nil && persistedPolicy.EgressPolicy != nil {
+				copy := cloneEgressRules(persistedPolicy.EgressPolicy)
+				incomingPolicy.EgressPolicy = &copy
+			}
 			// A policy revision identifies one immutable policy snapshot. Keeping
 			// the sidecar on equality also protects an initial strict revision-zero
 			// policy from an old lifecycle record with legacy zero values.
 			if persistedPolicy.Revision >= incomingPolicy.Revision {
-				persistedPolicy.applyTo(&incoming)
-				incomingPolicy = persistedPolicy
+				incomingPolicy.Access = persistedPolicy.Access
+				incomingPolicy.Ports = persistedPolicy.Ports
+				incomingPolicy.PortAccess = persistedPolicy.PortAccess
+				incomingPolicy.TokenVersions = persistedPolicy.TokenVersions
+				incomingPolicy.Revision = persistedPolicy.Revision
+				incomingPolicy.TokenPolicyRevision = persistedPolicy.TokenPolicyRevision
 			}
 		}
 	}
@@ -355,6 +401,11 @@ func putRecord(tx *bolt.Tx, incoming VMRecord, onlyIfPresent bool) (bool, error)
 
 func previewPolicyFromRecord(rec VMRecord) persistedPreviewPolicy {
 	ports := previewPortsFromRecord(rec.PreviewPorts, rec.PreviewPortAccess, rec.PreviewPortTokenVersions)
+	var egressPolicy *network.EgressRules
+	if rec.EgressPolicy != nil {
+		copy := cloneEgressRules(rec.EgressPolicy)
+		egressPolicy = &copy
+	}
 	return persistedPreviewPolicy{
 		Access:              restrictivePreviewAccess(rec.PreviewAccess, ports),
 		Ports:               previewPortsToRecord(ports),
@@ -362,12 +413,15 @@ func previewPolicyFromRecord(rec VMRecord) persistedPreviewPolicy {
 		TokenVersions:       previewPortTokenVersionsToRecord(ports),
 		Revision:            rec.PreviewPolicyRevision,
 		TokenPolicyRevision: rec.PreviewTokenPolicyRevision,
+		DiskSizeMiB:         rec.DiskSizeMiB,
+		EgressPolicy:        egressPolicy,
 	}.normalizedTokenState()
 }
 
 func (p persistedPreviewPolicy) isSet() bool {
 	return p.Access != "" || len(p.Ports) != 0 || len(p.PortAccess) != 0 ||
 		len(p.TokenVersions) != 0 || p.Revision != 0 || p.TokenPolicyRevision != 0 ||
+		p.DiskSizeMiB != 0 || p.EgressPolicy != nil ||
 		len(p.unknownFields) != 0
 }
 
@@ -380,6 +434,13 @@ func (p persistedPreviewPolicy) applyTo(rec *VMRecord) {
 	rec.PreviewPortTokenVersions = previewPortTokenVersionsToRecord(ports)
 	rec.PreviewPolicyRevision = p.Revision
 	rec.PreviewTokenPolicyRevision = p.TokenPolicyRevision
+	rec.DiskSizeMiB = p.DiskSizeMiB
+	if p.EgressPolicy == nil {
+		rec.EgressPolicy = nil
+	} else {
+		copy := cloneEgressRules(p.EgressPolicy)
+		rec.EgressPolicy = &copy
+	}
 }
 
 // normalizedTokenState makes the token sidecar self-invalidating across a
@@ -484,6 +545,11 @@ func toRecord(inst *VMInstance) VMRecord {
 // toRecordLocked snapshots an instance while its caller holds inst.mu. It is
 // used when a state write must be serialized with the in-memory mutation.
 func toRecordLocked(inst *VMInstance) VMRecord {
+	var egressPolicy *network.EgressRules
+	if inst.Config.EgressPolicy != nil {
+		copy := cloneEgressRules(inst.Config.EgressPolicy)
+		egressPolicy = &copy
+	}
 	return VMRecord{
 		ID:                         inst.ID,
 		PID:                        inst.PID,
@@ -503,7 +569,9 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
 		MemoryMiB:                  inst.Config.MemoryMiB,
+		DiskSizeMiB:                inst.Config.DiskSizeMiB,
 		BasePath:                   inst.Config.BasePath,
+		EgressPolicy:               egressPolicy,
 		TeamID:                     inst.TeamID,
 		OwnerID:                    inst.OwnerID,
 		PreviewAccess:              restrictivePreviewAccess(inst.PreviewAccess, inst.PreviewPorts),
@@ -569,6 +637,11 @@ func previewPortsFromRecord(in map[int32]bool, access map[int32]string, tokenVer
 func toInstance(rec VMRecord) *VMInstance {
 	ports := previewPortsFromRecord(rec.PreviewPorts, rec.PreviewPortAccess, rec.PreviewPortTokenVersions)
 	ports, tokenPolicyRevision := normalizePreviewTokenPolicy(ports, rec.PreviewPolicyRevision, rec.PreviewTokenPolicyRevision)
+	var egressPolicy *network.EgressRules
+	if rec.EgressPolicy != nil {
+		copy := cloneEgressRules(rec.EgressPolicy)
+		egressPolicy = &copy
+	}
 	return &VMInstance{
 		ID:                         rec.ID,
 		PID:                        rec.PID,
@@ -593,9 +666,23 @@ func toInstance(rec VMRecord) *VMInstance {
 		PreviewPolicyRevision:      rec.PreviewPolicyRevision,
 		PreviewTokenPolicyRevision: tokenPolicyRevision,
 		Config: VMConfig{
-			VCPU:      rec.VCPU,
-			MemoryMiB: rec.MemoryMiB,
-			BasePath:  rec.BasePath,
+			VCPU:         rec.VCPU,
+			MemoryMiB:    rec.MemoryMiB,
+			DiskSizeMiB:  rec.DiskSizeMiB,
+			BasePath:     rec.BasePath,
+			EgressPolicy: egressPolicy,
 		},
+	}
+}
+
+func cloneEgressRules(in *network.EgressRules) network.EgressRules {
+	if in == nil {
+		return network.EgressRules{}
+	}
+	return network.EgressRules{
+		AllowedCIDRs:   append([]string(nil), in.AllowedCIDRs...),
+		DeniedCIDRs:    append([]string(nil), in.DeniedCIDRs...),
+		AllowedDomains: append([]string(nil), in.AllowedDomains...),
+		SandboxID:      in.SandboxID,
 	}
 }

--- a/internal/vm/state_test.go
+++ b/internal/vm/state_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/preview"
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
@@ -987,6 +988,64 @@ func TestTokenPolicyNormalizationFailsClosed(t *testing.T) {
 	}, 10, 10)
 	if watermark != 0 || ports[3000].TokenVersion != 0 || ports[3001].TokenVersion != 0 {
 		t.Fatalf("malformed browser snapshot normalized to (%#v, %d), want all generations closed", ports, watermark)
+	}
+}
+
+func TestStateStorePreservesSavedRestoreFieldsAcrossOldLifecycleWrites(t *testing.T) {
+	s, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	rec := VMRecord{
+		ID:                    "vm-saved-restore-sidecar",
+		PID:                   10,
+		DiskSizeMiB:           4096,
+		EgressPolicy:          &network.EgressRules{DeniedCIDRs: []string{"0.0.0.0/0"}, SandboxID: "vm-saved-restore-sidecar"},
+		PreviewAccess:         preview.AccessPublic,
+		PreviewPolicyRevision: 3,
+	}
+	if err := s.Put(rec); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	// Model a rollback binary that knows neither disk_size_mib nor
+	// egress_policy: it rewrites only the primary lifecycle record and leaves
+	// the established sidecar bucket untouched.
+	overwritePrimaryVMRecord(t, s, VMRecord{ID: rec.ID, PID: 99})
+	got, err := s.Get(rec.ID)
+	if err != nil {
+		t.Fatalf("Get after old write: %v", err)
+	}
+	if got.PID != 99 {
+		t.Fatalf("lifecycle PID = %d, want old-writer update 99", got.PID)
+	}
+	if got.DiskSizeMiB != rec.DiskSizeMiB {
+		t.Fatalf("disk size = %d, want %d", got.DiskSizeMiB, rec.DiskSizeMiB)
+	}
+	if got.EgressPolicy == nil || len(got.EgressPolicy.DeniedCIDRs) != 1 ||
+		got.EgressPolicy.DeniedCIDRs[0] != "0.0.0.0/0" {
+		t.Fatalf("egress policy = %#v, want restrictive sidecar policy", got.EgressPolicy)
+	}
+
+	// A newer writer may legitimately advance preview policy while carrying an
+	// old lifecycle snapshot that omits the saved-restore fields. Those fields
+	// remain independently authoritative.
+	if err := s.Put(VMRecord{
+		ID:                    rec.ID,
+		PID:                   100,
+		PreviewAccess:         preview.AccessPublic,
+		PreviewPolicyRevision: 4,
+	}); err != nil {
+		t.Fatalf("Put after old lifecycle snapshot: %v", err)
+	}
+	got, err = s.Get(rec.ID)
+	if err != nil {
+		t.Fatalf("Get after rewritten sidecar: %v", err)
+	}
+	if got.PID != 100 || got.DiskSizeMiB != rec.DiskSizeMiB || got.EgressPolicy == nil {
+		t.Fatalf("record after rewrite = %#v, want lifecycle update plus saved fields", got)
 	}
 }
 

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -362,6 +362,24 @@ func unitDefinitelyDead(ctx context.Context, unit string) bool {
 	return errors.As(err, &exitErr)
 }
 
+// unitConfirmedInactive is the stronger destroy-time proof. It accepts only
+// systemctl's explicit terminal states; transport/bus errors are inconclusive
+// even when systemctl exits non-zero.
+func unitConfirmedInactive(ctx context.Context, unit string) error {
+	out, err := exec.CommandContext(ctx, "systemctl", "is-active", unit).CombinedOutput()
+	state := strings.TrimSpace(string(out))
+	switch state {
+	case "inactive", "failed", "unknown":
+		return nil
+	case "active", "activating", "deactivating", "reloading":
+		return fmt.Errorf("systemd unit %s is still %s", unit, state)
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return fmt.Errorf("could not confirm systemd unit %s inactive (state=%q): %w", unit, state, err)
+}
+
 // listActiveFirecrackerUnits returns the sandbox IDs of all running
 // firecracker@ units. Used during startup reattach. It lists
 // ActiveState=active only — a unit mid-deactivating is invisible here, which

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -5,6 +5,9 @@ package vmdclient
 
 import (
 	"context"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/status"
 )
 
 // PortPolicy is the control-plane representation of one published preview
@@ -13,6 +16,24 @@ import (
 type PortPolicy struct {
 	Access       string
 	TokenVersion int64
+}
+
+const SavedSnapshotSourceResumeFailureReason = "SAVED_SNAPSHOT_SOURCE_RESUME_FAILED"
+
+// GRPCErrorHasReason reads a stable ErrorInfo reason through wrapped gRPC
+// errors. Status codes alone cannot distinguish a corrupt snapshot from the
+// operationally different case where capture failed to return its source VM
+// to running.
+func GRPCErrorHasReason(err error, reason string) bool {
+	if err == nil {
+		return false
+	}
+	for _, detail := range status.Convert(err).Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok && info.GetReason() == reason {
+			return true
+		}
+	}
+	return false
 }
 
 // Client defines the subset of the VM daemon gRPC interface used by the
@@ -95,6 +116,71 @@ type Client interface {
 	// ctx is cancelled. Returns nil on clean close, an error on transport
 	// failure or gRPC NotFound (which callers surface as SSE 404).
 	StreamBuildLogs(ctx context.Context, buildVMID string, onEvent func(BuildLogEvent) error) error
+}
+
+// SavedSnapshotClient is the optional immutable-snapshot extension exposed by
+// VMDs that support sandbox_snapshots_v1. Keeping it separate from Client lets
+// the control plane roll out first: existing daemons continue serving the
+// pause/resume lifecycle, while feature-enabled requests fail closed until the
+// selected host advertises these methods.
+type SavedSnapshotClient interface {
+	// CheckSavedSnapshotSupport performs an explicit capability handshake with
+	// the remote VMD. Callers must invoke it before any saved-snapshot operation:
+	// an interface assertion only proves the local adapter is new enough, not
+	// that the daemon on the other side of its gRPC connection is compatible.
+	CheckSavedSnapshotSupport(ctx context.Context) error
+
+	// CreateSavedSnapshot captures sourceInstanceID into an immutable,
+	// committed artifact directory identified by snapshotID. The source may be
+	// active or paused and must be left in its original state.
+	CreateSavedSnapshot(ctx context.Context, sourceInstanceID, snapshotID string) (SavedSnapshotArtifacts, error)
+
+	// RestoreSavedSnapshot creates a new VM and writable disk overlay from a
+	// committed saved-snapshot manifest. Resource shape comes from the manifest
+	// and cannot be overridden.
+	RestoreSavedSnapshot(ctx context.Context, instanceID, manifestPath, manifestDigest, teamID, ownerID string, network SavedSnapshotNetwork, clearEnvKeys []string, previewAccess string, previewPorts map[int32]PortPolicy, previewPolicyRevision int64) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+
+	// DeleteSavedSnapshot removes one immutable saved-snapshot directory.
+	// Dependency safety is enforced in the database before this host call;
+	// VMD validates path ownership and treats an absent directory as success.
+	DeleteSavedSnapshot(ctx context.Context, sourceInstanceID, snapshotID string) error
+
+	// MeasureSandboxWritableLayer returns filesystem-authoritative shadow usage
+	// for the sandbox-owned persisted disk/memory generation. Shared reflink
+	// extents are excluded.
+	MeasureSandboxWritableLayer(ctx context.Context, instanceID string) (logicalBytes, exclusiveBytes int64, err error)
+}
+
+// SavedSnapshotArtifacts is the host-private capture result persisted by the
+// control plane. None of its path fields are exposed in public API responses.
+type SavedSnapshotArtifacts struct {
+	SchemaVersion            uint32
+	ManifestPath             string
+	ManifestDigest           string
+	SnapshotPath             string
+	MemPath                  string
+	MemoryBasePath           string
+	DiskBasePath             string
+	DiskDeltaPath            string
+	DiskOverlayPath          string
+	DiskFullPath             string
+	VCPU                     uint32
+	MemoryMiB                uint32
+	DiskMiB                  uint32
+	LogicalSizeBytes         int64
+	ExclusiveSizeBytes       int64
+	SourceLogicalSizeBytes   int64
+	SourceExclusiveSizeBytes int64
+	SourceState              string
+}
+
+// SavedSnapshotNetwork is the effective egress policy for a fork. Empty
+// slices mean the platform's default policy; callers must intentionally pass
+// either the captured policy or an explicit replacement.
+type SavedSnapshotNetwork struct {
+	AllowedCIDRs   []string
+	DeniedCIDRs    []string
+	AllowedDomains []string
 }
 
 // BuildTemplateInput mirrors vmdpb.BuildTemplateRequest at the client layer

--- a/internal/vmdclient/saved_snapshot_error.go
+++ b/internal/vmdclient/saved_snapshot_error.go
@@ -1,0 +1,101 @@
+package vmdclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SavedSnapshotOperation identifies the trusted operation context used when a
+// saved-snapshot error crosses an RPC or logging boundary. Keeping this as a
+// closed set prevents a caller-controlled filesystem path from becoming the
+// replacement error message.
+type SavedSnapshotOperation uint8
+
+const (
+	SavedSnapshotOperationUnknown SavedSnapshotOperation = iota
+	SavedSnapshotOperationHostResolution
+	SavedSnapshotOperationCapabilityCheck
+	SavedSnapshotOperationCapture
+	SavedSnapshotOperationRestore
+	SavedSnapshotOperationDelete
+	SavedSnapshotOperationWritableLayerMeasurement
+)
+
+func (o SavedSnapshotOperation) message() string {
+	switch o {
+	case SavedSnapshotOperationHostResolution:
+		return "saved snapshot host resolution failed"
+	case SavedSnapshotOperationCapabilityCheck:
+		return "saved snapshot capability check failed"
+	case SavedSnapshotOperationCapture:
+		return "saved snapshot capture failed"
+	case SavedSnapshotOperationRestore:
+		return "saved snapshot restore failed"
+	case SavedSnapshotOperationDelete:
+		return "saved snapshot artifact delete failed"
+	case SavedSnapshotOperationWritableLayerMeasurement:
+		return "sandbox writable-layer measurement failed"
+	default:
+		return "saved snapshot operation failed"
+	}
+}
+
+// SanitizeSavedSnapshotError returns an error safe for RPC responses and
+// structured logs. Host filesystem paths commonly enter errors through
+// os.PathError, Firecracker, or system utilities, so the original description
+// and ErrorInfo metadata are deliberately discarded. The gRPC code and safe
+// machine-readable ErrorInfo reason/domain remain available for control-flow
+// decisions such as source-resume containment.
+func SanitizeSavedSnapshotError(operation SavedSnapshotOperation, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	code := status.Code(err)
+	switch {
+	case errors.Is(err, context.Canceled):
+		code = codes.Canceled
+	case errors.Is(err, context.DeadlineExceeded):
+		code = codes.DeadlineExceeded
+	}
+	if code == codes.OK {
+		code = codes.Unknown
+	}
+
+	sanitized := status.New(code, operation.message())
+	for _, detail := range status.Convert(err).Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok || !safeErrorToken(info.GetReason(), 128) ||
+			(info.GetDomain() != "" && !safeErrorToken(info.GetDomain(), 253)) {
+			continue
+		}
+		withDetails, detailErr := sanitized.WithDetails(&errdetails.ErrorInfo{
+			Reason: info.GetReason(),
+			Domain: info.GetDomain(),
+		})
+		if detailErr == nil {
+			sanitized = withDetails
+		}
+		break
+	}
+	return sanitized.Err()
+}
+
+func safeErrorToken(value string, maxLen int) bool {
+	if value == "" || len(value) > maxLen || strings.ContainsAny(value, `/\\`) {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/vmdclient/saved_snapshot_error_test.go
+++ b/internal/vmdclient/saved_snapshot_error_test.go
@@ -1,0 +1,58 @@
+package vmdclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSanitizeSavedSnapshotErrorRemovesPathsAndPreservesClassification(t *testing.T) {
+	const hostPath = "/var/lib/superserve/private/snapshots/team/source/snapshot/mem.snap"
+	original, err := status.New(codes.DataLoss, "read "+hostPath+": input/output error").WithDetails(&errdetails.ErrorInfo{
+		Reason: SavedSnapshotSourceResumeFailureReason,
+		Domain: "vmd.superserve.ai",
+		Metadata: map[string]string{
+			"artifact_path": hostPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("attach error details: %v", err)
+	}
+
+	got := SanitizeSavedSnapshotError(
+		SavedSnapshotOperationCapture,
+		fmt.Errorf("gRPC CreateSnapshot(saved): %w", original.Err()),
+	)
+	if status.Code(got) != codes.DataLoss {
+		t.Fatalf("code = %s, want DataLoss (%v)", status.Code(got), got)
+	}
+	if !GRPCErrorHasReason(got, SavedSnapshotSourceResumeFailureReason) {
+		t.Fatalf("stable reason was not preserved: %v", got)
+	}
+	if strings.Contains(got.Error(), hostPath) || strings.Contains(got.Error(), "artifact_path") {
+		t.Fatalf("sanitized error exposed host artifact metadata: %v", got)
+	}
+	if !strings.Contains(got.Error(), "saved snapshot capture failed") {
+		t.Fatalf("sanitized error lost operation context: %v", got)
+	}
+	for _, detail := range status.Convert(got).Details() {
+		if info, ok := detail.(*errdetails.ErrorInfo); ok && len(info.GetMetadata()) != 0 {
+			t.Fatalf("sanitized ErrorInfo retained metadata: %+v", info.GetMetadata())
+		}
+	}
+}
+
+func TestSanitizeSavedSnapshotErrorMapsContextErrorsWithoutTheirText(t *testing.T) {
+	got := SanitizeSavedSnapshotError(SavedSnapshotOperationDelete, fmt.Errorf("remove /private/artifact: %w", context.DeadlineExceeded))
+	if status.Code(got) != codes.DeadlineExceeded {
+		t.Fatalf("code = %s, want DeadlineExceeded (%v)", status.Code(got), got)
+	}
+	if strings.Contains(got.Error(), "/private/artifact") {
+		t.Fatalf("sanitized context error exposed path: %v", got)
+	}
+}

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -6,6 +6,11 @@ option go_package = "github.com/superserve-ai/sandbox/proto/vmdpb";
 
 // VMDaemon manages Firecracker microVM lifecycles for the AgentBox platform.
 service VMDaemon {
+  // GetCapabilities reports optional data-plane features. Control planes must
+  // check the corresponding bit before using an optional RPC or overloaded
+  // request shape so a rolling deploy fails closed against an older VMD.
+  rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse);
+
   // DestroyVM terminates a running microVM and cleans up all associated resources.
   rpc DestroyVM(DestroyVMRequest) returns (DestroyVMResponse);
 
@@ -15,8 +20,24 @@ service VMDaemon {
   // ResumeVM restores a paused VM from its snapshot, optionally into a pre-warmed slot.
   rpc ResumeVM(ResumeVMRequest) returns (ResumeVMResponse);
 
-  // CreateSnapshot captures a point-in-time snapshot of a running VM.
+  // CreateSnapshot captures a point-in-time snapshot. A non-empty snapshot_id
+  // selects immutable saved-snapshot semantics for a running or paused VM;
+  // otherwise the legacy caller-selected-directory behavior is retained.
   rpc CreateSnapshot(CreateSnapshotRequest) returns (CreateSnapshotResponse);
+
+  // RestoreSavedSnapshot boots a new VM from an immutable saved-snapshot
+  // manifest. VMD resolves and validates every artifact locally and always
+  // creates a fresh writable disk layer for the new VM.
+  rpc RestoreSavedSnapshot(RestoreSavedSnapshotRequest) returns (RestoreSavedSnapshotResponse);
+
+  // DeleteSavedSnapshot removes one committed saved-snapshot artifact
+  // directory. The control plane must first prove the snapshot is a leaf.
+  // Path construction is local to VMD and the operation is idempotent.
+  rpc DeleteSavedSnapshot(DeleteSavedSnapshotRequest) returns (DeleteSavedSnapshotResponse);
+
+  // GetWritableLayerUsage measures the sandbox-owned persisted disk/memory
+  // generation with CoW-shared extents excluded. It is shadow accounting only.
+  rpc GetWritableLayerUsage(GetWritableLayerUsageRequest) returns (GetWritableLayerUsageResponse);
 
   // RestoreSnapshot boots a VM from a previously captured snapshot and
   // returns its source IP. The caller must follow with InjectSandboxEnv to
@@ -105,6 +126,17 @@ service VMDaemon {
   // events as they arrive. Closes when the build reaches a terminal
   // status. Used by the control plane to drive /builds/:id/logs SSE.
   rpc StreamBuildLogs(StreamBuildLogsRequest) returns (stream BuildLogEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+message GetCapabilitiesRequest {}
+
+message GetCapabilitiesResponse {
+  // Supports immutable saved-snapshot capture, restore, and delete semantics.
+  bool saved_snapshots_v1 = 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -303,7 +335,11 @@ message ResumeVMResponse {
 
 message CreateSnapshotRequest {
   string vm_id = 1;
+  // Legacy caller-selected output directory. Ignored when snapshot_id is set.
   string snapshot_dir = 2;
+  // Stable control-plane id for an immutable reusable snapshot. Retrying the
+  // same source VM + snapshot id returns the already-committed manifest.
+  string snapshot_id = 3;
 }
 
 message CreateSnapshotResponse {
@@ -311,6 +347,101 @@ message CreateSnapshotResponse {
   string snapshot_path = 2;
   string mem_file_path = 3;
   int64 created_at_unix = 4;
+  SavedSnapshotArtifacts artifacts = 5;
+  ResourceLimits resource_limits = 6;
+  // Apparent bytes required to reconstruct the state, including referenced
+  // immutable template/base files and deduplicating identical inodes.
+  int64 logical_size_bytes = 7;
+  // Allocated filesystem blocks owned by this saved snapshot. Shared base
+  // files are excluded, so fan-out does not multiply this value.
+  int64 exclusive_size_bytes = 8;
+  // Source lifecycle state restored before this RPC returned: "running" or
+  // "paused".
+  string source_state = 9;
+  string snapshot_id = 10;
+  // Source-owned unshared extents that became retained by this immutable
+  // branch. Shadow accounting transfers them into the source writable layer;
+  // they are not charged again as snapshot-exclusive reflink bytes.
+  int64 source_exclusive_size_bytes = 11;
+  int64 source_logical_size_bytes = 12;
+}
+
+// SavedSnapshotArtifacts identifies a committed local artifact set. These
+// paths are control-plane metadata only and must never be returned publicly.
+message SavedSnapshotArtifacts {
+  uint32 schema_version = 1;
+  string manifest_path = 2;
+  string snapshot_path = 3;
+  string mem_file_path = 4;
+  // Present only when mem_file_path is an immutable diff over another
+  // immutable memory image.
+  string memory_base_path = 5;
+  // Immutable disk base referenced by an overlay-mode snapshot.
+  string disk_base_path = 6;
+  // Firecracker block-delta artifact emitted for a running source.
+  string disk_delta_path = 7;
+  // Immutable sparse disk overlay copied from a paused source when no block
+  // delta can be emitted without changing its lifecycle state.
+  string disk_overlay_path = 8;
+  // Immutable complete rootfs for legacy non-overlay sources.
+  string disk_full_path = 9;
+  // sha256 of the exact committed manifest bytes, hex encoded.
+  string manifest_digest = 10;
+}
+
+// ---------------------------------------------------------------------------
+// RestoreSavedSnapshot / DeleteSavedSnapshot
+// ---------------------------------------------------------------------------
+
+message RestoreSavedSnapshotRequest {
+  string vm_id = 1;
+  string manifest_path = 2;
+  NetworkConfig network_config = 3;
+  string team_id = 4;
+  string owner_id = 5;
+  // Captured boxd defaults to overwrite with empty values before this RPC
+  // returns. Used for source-specific secret proxy-token variables; existing
+  // in-memory process environments are inherently part of the snapshot.
+  repeated string clear_env_keys = 6;
+  // Effective inherited or explicitly replaced egress policy. VMD installs
+  // it after allocating the child network and before starting Firecracker, so
+  // restored processes never observe a transient allow-all gap.
+  SandboxNetworkConfig sandbox_network = 7;
+  // SHA-256 of the committed manifest recorded by the control plane. VMD
+  // rejects a different manifest before allocating any child resources.
+  string expected_manifest_digest = 8;
+  // Numeric-port routing policy for the fork. Empty and "legacy_public"
+  // preserve all-port routing; "public" requires explicit membership.
+  string preview_access = 9;
+  repeated PreviewPort preview_ports = 10;
+  // Monotonic generation used to reject stale full-allowlist pushes.
+  int64 preview_policy_revision = 11;
+}
+
+message RestoreSavedSnapshotResponse {
+  string vm_id = 1;
+  string socket_path = 2;
+  string ip_address = 3;
+  uint32 pid = 4;
+  ResourceLimits resource_limits = 5;
+}
+
+message DeleteSavedSnapshotRequest {
+  string source_vm_id = 1;
+  string snapshot_id = 2;
+}
+
+message DeleteSavedSnapshotResponse {
+  bool deleted = 1;
+}
+
+message GetWritableLayerUsageRequest {
+  string vm_id = 1;
+}
+
+message GetWritableLayerUsageResponse {
+  int64 logical_size_bytes = 1;
+  int64 exclusive_size_bytes = 2;
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -79,6 +79,87 @@ func (VMStatus) EnumDescriptor() ([]byte, []int) {
 	return file_proto_vmd_proto_rawDescGZIP(), []int{0}
 }
 
+type GetCapabilitiesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCapabilitiesRequest) Reset() {
+	*x = GetCapabilitiesRequest{}
+	mi := &file_proto_vmd_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapabilitiesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapabilitiesRequest) ProtoMessage() {}
+
+func (x *GetCapabilitiesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapabilitiesRequest.ProtoReflect.Descriptor instead.
+func (*GetCapabilitiesRequest) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{0}
+}
+
+type GetCapabilitiesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Supports immutable saved-snapshot capture, restore, and delete semantics.
+	SavedSnapshotsV1 bool `protobuf:"varint,1,opt,name=saved_snapshots_v1,json=savedSnapshotsV1,proto3" json:"saved_snapshots_v1,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetCapabilitiesResponse) Reset() {
+	*x = GetCapabilitiesResponse{}
+	mi := &file_proto_vmd_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapabilitiesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapabilitiesResponse) ProtoMessage() {}
+
+func (x *GetCapabilitiesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapabilitiesResponse.ProtoReflect.Descriptor instead.
+func (*GetCapabilitiesResponse) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *GetCapabilitiesResponse) GetSavedSnapshotsV1() bool {
+	if x != nil {
+		return x.SavedSnapshotsV1
+	}
+	return false
+}
+
 type BuildTemplateRequest struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	TemplateId string                 `protobuf:"bytes,1,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"` // Key under which the snapshot is registered.
@@ -97,7 +178,7 @@ type BuildTemplateRequest struct {
 
 func (x *BuildTemplateRequest) Reset() {
 	*x = BuildTemplateRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[0]
+	mi := &file_proto_vmd_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -109,7 +190,7 @@ func (x *BuildTemplateRequest) String() string {
 func (*BuildTemplateRequest) ProtoMessage() {}
 
 func (x *BuildTemplateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[0]
+	mi := &file_proto_vmd_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -122,7 +203,7 @@ func (x *BuildTemplateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildTemplateRequest.ProtoReflect.Descriptor instead.
 func (*BuildTemplateRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{0}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *BuildTemplateRequest) GetTemplateId() string {
@@ -207,7 +288,7 @@ type BuildStep struct {
 
 func (x *BuildStep) Reset() {
 	*x = BuildStep{}
-	mi := &file_proto_vmd_proto_msgTypes[1]
+	mi := &file_proto_vmd_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -219,7 +300,7 @@ func (x *BuildStep) String() string {
 func (*BuildStep) ProtoMessage() {}
 
 func (x *BuildStep) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[1]
+	mi := &file_proto_vmd_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -232,7 +313,7 @@ func (x *BuildStep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildStep.ProtoReflect.Descriptor instead.
 func (*BuildStep) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{1}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *BuildStep) GetOp() isBuildStep_Op {
@@ -316,7 +397,7 @@ type BuildEnvOp struct {
 
 func (x *BuildEnvOp) Reset() {
 	*x = BuildEnvOp{}
-	mi := &file_proto_vmd_proto_msgTypes[2]
+	mi := &file_proto_vmd_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -328,7 +409,7 @@ func (x *BuildEnvOp) String() string {
 func (*BuildEnvOp) ProtoMessage() {}
 
 func (x *BuildEnvOp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[2]
+	mi := &file_proto_vmd_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -341,7 +422,7 @@ func (x *BuildEnvOp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildEnvOp.ProtoReflect.Descriptor instead.
 func (*BuildEnvOp) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{2}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *BuildEnvOp) GetKey() string {
@@ -368,7 +449,7 @@ type BuildUserOp struct {
 
 func (x *BuildUserOp) Reset() {
 	*x = BuildUserOp{}
-	mi := &file_proto_vmd_proto_msgTypes[3]
+	mi := &file_proto_vmd_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -380,7 +461,7 @@ func (x *BuildUserOp) String() string {
 func (*BuildUserOp) ProtoMessage() {}
 
 func (x *BuildUserOp) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[3]
+	mi := &file_proto_vmd_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -393,7 +474,7 @@ func (x *BuildUserOp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildUserOp.ProtoReflect.Descriptor instead.
 func (*BuildUserOp) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{3}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *BuildUserOp) GetName() string {
@@ -421,7 +502,7 @@ type BuildTemplateResponse struct {
 
 func (x *BuildTemplateResponse) Reset() {
 	*x = BuildTemplateResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[4]
+	mi := &file_proto_vmd_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -433,7 +514,7 @@ func (x *BuildTemplateResponse) String() string {
 func (*BuildTemplateResponse) ProtoMessage() {}
 
 func (x *BuildTemplateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[4]
+	mi := &file_proto_vmd_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -446,7 +527,7 @@ func (x *BuildTemplateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildTemplateResponse.ProtoReflect.Descriptor instead.
 func (*BuildTemplateResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{4}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *BuildTemplateResponse) GetBuildVmId() string {
@@ -465,7 +546,7 @@ type GetBuildStatusRequest struct {
 
 func (x *GetBuildStatusRequest) Reset() {
 	*x = GetBuildStatusRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[5]
+	mi := &file_proto_vmd_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -477,7 +558,7 @@ func (x *GetBuildStatusRequest) String() string {
 func (*GetBuildStatusRequest) ProtoMessage() {}
 
 func (x *GetBuildStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[5]
+	mi := &file_proto_vmd_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -490,7 +571,7 @@ func (x *GetBuildStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBuildStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetBuildStatusRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{5}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetBuildStatusRequest) GetBuildVmId() string {
@@ -528,7 +609,7 @@ type GetBuildStatusResponse struct {
 
 func (x *GetBuildStatusResponse) Reset() {
 	*x = GetBuildStatusResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[6]
+	mi := &file_proto_vmd_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -540,7 +621,7 @@ func (x *GetBuildStatusResponse) String() string {
 func (*GetBuildStatusResponse) ProtoMessage() {}
 
 func (x *GetBuildStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[6]
+	mi := &file_proto_vmd_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -553,7 +634,7 @@ func (x *GetBuildStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBuildStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetBuildStatusResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{6}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetBuildStatusResponse) GetStatus() string {
@@ -649,7 +730,7 @@ type CancelBuildRequest struct {
 
 func (x *CancelBuildRequest) Reset() {
 	*x = CancelBuildRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[7]
+	mi := &file_proto_vmd_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -661,7 +742,7 @@ func (x *CancelBuildRequest) String() string {
 func (*CancelBuildRequest) ProtoMessage() {}
 
 func (x *CancelBuildRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[7]
+	mi := &file_proto_vmd_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -674,7 +755,7 @@ func (x *CancelBuildRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelBuildRequest.ProtoReflect.Descriptor instead.
 func (*CancelBuildRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{7}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CancelBuildRequest) GetBuildVmId() string {
@@ -692,7 +773,7 @@ type CancelBuildResponse struct {
 
 func (x *CancelBuildResponse) Reset() {
 	*x = CancelBuildResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[8]
+	mi := &file_proto_vmd_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -704,7 +785,7 @@ func (x *CancelBuildResponse) String() string {
 func (*CancelBuildResponse) ProtoMessage() {}
 
 func (x *CancelBuildResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[8]
+	mi := &file_proto_vmd_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -717,7 +798,7 @@ func (x *CancelBuildResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelBuildResponse.ProtoReflect.Descriptor instead.
 func (*CancelBuildResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{8}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{10}
 }
 
 type StreamBuildLogsRequest struct {
@@ -729,7 +810,7 @@ type StreamBuildLogsRequest struct {
 
 func (x *StreamBuildLogsRequest) Reset() {
 	*x = StreamBuildLogsRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[9]
+	mi := &file_proto_vmd_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -741,7 +822,7 @@ func (x *StreamBuildLogsRequest) String() string {
 func (*StreamBuildLogsRequest) ProtoMessage() {}
 
 func (x *StreamBuildLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[9]
+	mi := &file_proto_vmd_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -754,7 +835,7 @@ func (x *StreamBuildLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamBuildLogsRequest.ProtoReflect.Descriptor instead.
 func (*StreamBuildLogsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{9}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *StreamBuildLogsRequest) GetBuildVmId() string {
@@ -782,7 +863,7 @@ type BuildLogEvent struct {
 
 func (x *BuildLogEvent) Reset() {
 	*x = BuildLogEvent{}
-	mi := &file_proto_vmd_proto_msgTypes[10]
+	mi := &file_proto_vmd_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -794,7 +875,7 @@ func (x *BuildLogEvent) String() string {
 func (*BuildLogEvent) ProtoMessage() {}
 
 func (x *BuildLogEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[10]
+	mi := &file_proto_vmd_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -807,7 +888,7 @@ func (x *BuildLogEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildLogEvent.ProtoReflect.Descriptor instead.
 func (*BuildLogEvent) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{10}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BuildLogEvent) GetTimestampUnix() int64 {
@@ -864,7 +945,7 @@ type ResourceLimits struct {
 
 func (x *ResourceLimits) Reset() {
 	*x = ResourceLimits{}
-	mi := &file_proto_vmd_proto_msgTypes[11]
+	mi := &file_proto_vmd_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -876,7 +957,7 @@ func (x *ResourceLimits) String() string {
 func (*ResourceLimits) ProtoMessage() {}
 
 func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[11]
+	mi := &file_proto_vmd_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -889,7 +970,7 @@ func (x *ResourceLimits) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceLimits.ProtoReflect.Descriptor instead.
 func (*ResourceLimits) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{11}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ResourceLimits) GetVcpuCount() uint32 {
@@ -932,7 +1013,7 @@ type NetworkConfig struct {
 
 func (x *NetworkConfig) Reset() {
 	*x = NetworkConfig{}
-	mi := &file_proto_vmd_proto_msgTypes[12]
+	mi := &file_proto_vmd_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -944,7 +1025,7 @@ func (x *NetworkConfig) String() string {
 func (*NetworkConfig) ProtoMessage() {}
 
 func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[12]
+	mi := &file_proto_vmd_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -957,7 +1038,7 @@ func (x *NetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NetworkConfig.ProtoReflect.Descriptor instead.
 func (*NetworkConfig) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{12}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *NetworkConfig) GetHostInterface() string {
@@ -998,7 +1079,7 @@ type SandboxNetworkConfig struct {
 
 func (x *SandboxNetworkConfig) Reset() {
 	*x = SandboxNetworkConfig{}
-	mi := &file_proto_vmd_proto_msgTypes[13]
+	mi := &file_proto_vmd_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1010,7 +1091,7 @@ func (x *SandboxNetworkConfig) String() string {
 func (*SandboxNetworkConfig) ProtoMessage() {}
 
 func (x *SandboxNetworkConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[13]
+	mi := &file_proto_vmd_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1023,7 +1104,7 @@ func (x *SandboxNetworkConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxNetworkConfig.ProtoReflect.Descriptor instead.
 func (*SandboxNetworkConfig) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{13}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *SandboxNetworkConfig) GetEgress() *SandboxNetworkEgressConfig {
@@ -1045,7 +1126,7 @@ type SandboxNetworkEgressConfig struct {
 
 func (x *SandboxNetworkEgressConfig) Reset() {
 	*x = SandboxNetworkEgressConfig{}
-	mi := &file_proto_vmd_proto_msgTypes[14]
+	mi := &file_proto_vmd_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1057,7 +1138,7 @@ func (x *SandboxNetworkEgressConfig) String() string {
 func (*SandboxNetworkEgressConfig) ProtoMessage() {}
 
 func (x *SandboxNetworkEgressConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[14]
+	mi := &file_proto_vmd_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1070,7 +1151,7 @@ func (x *SandboxNetworkEgressConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxNetworkEgressConfig.ProtoReflect.Descriptor instead.
 func (*SandboxNetworkEgressConfig) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{14}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SandboxNetworkEgressConfig) GetAllowedCidrs() []string {
@@ -1104,7 +1185,7 @@ type DestroyVMRequest struct {
 
 func (x *DestroyVMRequest) Reset() {
 	*x = DestroyVMRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[15]
+	mi := &file_proto_vmd_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1116,7 +1197,7 @@ func (x *DestroyVMRequest) String() string {
 func (*DestroyVMRequest) ProtoMessage() {}
 
 func (x *DestroyVMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[15]
+	mi := &file_proto_vmd_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1129,7 +1210,7 @@ func (x *DestroyVMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyVMRequest.ProtoReflect.Descriptor instead.
 func (*DestroyVMRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{15}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *DestroyVMRequest) GetVmId() string {
@@ -1156,7 +1237,7 @@ type DestroyVMResponse struct {
 
 func (x *DestroyVMResponse) Reset() {
 	*x = DestroyVMResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[16]
+	mi := &file_proto_vmd_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1168,7 +1249,7 @@ func (x *DestroyVMResponse) String() string {
 func (*DestroyVMResponse) ProtoMessage() {}
 
 func (x *DestroyVMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[16]
+	mi := &file_proto_vmd_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1181,7 +1262,7 @@ func (x *DestroyVMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroyVMResponse.ProtoReflect.Descriptor instead.
 func (*DestroyVMResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{16}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *DestroyVMResponse) GetVmId() string {
@@ -1208,7 +1289,7 @@ type PauseVMRequest struct {
 
 func (x *PauseVMRequest) Reset() {
 	*x = PauseVMRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[17]
+	mi := &file_proto_vmd_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1301,7 @@ func (x *PauseVMRequest) String() string {
 func (*PauseVMRequest) ProtoMessage() {}
 
 func (x *PauseVMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[17]
+	mi := &file_proto_vmd_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1314,7 @@ func (x *PauseVMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseVMRequest.ProtoReflect.Descriptor instead.
 func (*PauseVMRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{17}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PauseVMRequest) GetVmId() string {
@@ -1261,7 +1342,7 @@ type PauseVMResponse struct {
 
 func (x *PauseVMResponse) Reset() {
 	*x = PauseVMResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[18]
+	mi := &file_proto_vmd_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1273,7 +1354,7 @@ func (x *PauseVMResponse) String() string {
 func (*PauseVMResponse) ProtoMessage() {}
 
 func (x *PauseVMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[18]
+	mi := &file_proto_vmd_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1286,7 +1367,7 @@ func (x *PauseVMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseVMResponse.ProtoReflect.Descriptor instead.
 func (*PauseVMResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{18}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PauseVMResponse) GetVmId() string {
@@ -1323,7 +1404,7 @@ type ResumeVMRequest struct {
 
 func (x *ResumeVMRequest) Reset() {
 	*x = ResumeVMRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[19]
+	mi := &file_proto_vmd_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1335,7 +1416,7 @@ func (x *ResumeVMRequest) String() string {
 func (*ResumeVMRequest) ProtoMessage() {}
 
 func (x *ResumeVMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[19]
+	mi := &file_proto_vmd_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1348,7 +1429,7 @@ func (x *ResumeVMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeVMRequest.ProtoReflect.Descriptor instead.
 func (*ResumeVMRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{19}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ResumeVMRequest) GetVmId() string {
@@ -1399,7 +1480,7 @@ type ResumeVMResponse struct {
 
 func (x *ResumeVMResponse) Reset() {
 	*x = ResumeVMResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[20]
+	mi := &file_proto_vmd_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1411,7 +1492,7 @@ func (x *ResumeVMResponse) String() string {
 func (*ResumeVMResponse) ProtoMessage() {}
 
 func (x *ResumeVMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[20]
+	mi := &file_proto_vmd_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1424,7 +1505,7 @@ func (x *ResumeVMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeVMResponse.ProtoReflect.Descriptor instead.
 func (*ResumeVMResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{20}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ResumeVMResponse) GetVmId() string {
@@ -1463,16 +1544,20 @@ func (x *ResumeVMResponse) GetResourceLimits() *ResourceLimits {
 }
 
 type CreateSnapshotRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VmId          string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
-	SnapshotDir   string                 `protobuf:"bytes,2,opt,name=snapshot_dir,json=snapshotDir,proto3" json:"snapshot_dir,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	VmId  string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	// Legacy caller-selected output directory. Ignored when snapshot_id is set.
+	SnapshotDir string `protobuf:"bytes,2,opt,name=snapshot_dir,json=snapshotDir,proto3" json:"snapshot_dir,omitempty"`
+	// Stable control-plane id for an immutable reusable snapshot. Retrying the
+	// same source VM + snapshot id returns the already-committed manifest.
+	SnapshotId    string `protobuf:"bytes,3,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSnapshotRequest) Reset() {
 	*x = CreateSnapshotRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[21]
+	mi := &file_proto_vmd_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1484,7 +1569,7 @@ func (x *CreateSnapshotRequest) String() string {
 func (*CreateSnapshotRequest) ProtoMessage() {}
 
 func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[21]
+	mi := &file_proto_vmd_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1497,7 +1582,7 @@ func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{21}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *CreateSnapshotRequest) GetVmId() string {
@@ -1514,19 +1599,43 @@ func (x *CreateSnapshotRequest) GetSnapshotDir() string {
 	return ""
 }
 
+func (x *CreateSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
 type CreateSnapshotResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VmId          string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
-	SnapshotPath  string                 `protobuf:"bytes,2,opt,name=snapshot_path,json=snapshotPath,proto3" json:"snapshot_path,omitempty"`
-	MemFilePath   string                 `protobuf:"bytes,3,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
-	CreatedAtUnix int64                  `protobuf:"varint,4,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState  `protogen:"open.v1"`
+	VmId           string                  `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	SnapshotPath   string                  `protobuf:"bytes,2,opt,name=snapshot_path,json=snapshotPath,proto3" json:"snapshot_path,omitempty"`
+	MemFilePath    string                  `protobuf:"bytes,3,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
+	CreatedAtUnix  int64                   `protobuf:"varint,4,opt,name=created_at_unix,json=createdAtUnix,proto3" json:"created_at_unix,omitempty"`
+	Artifacts      *SavedSnapshotArtifacts `protobuf:"bytes,5,opt,name=artifacts,proto3" json:"artifacts,omitempty"`
+	ResourceLimits *ResourceLimits         `protobuf:"bytes,6,opt,name=resource_limits,json=resourceLimits,proto3" json:"resource_limits,omitempty"`
+	// Apparent bytes required to reconstruct the state, including referenced
+	// immutable template/base files and deduplicating identical inodes.
+	LogicalSizeBytes int64 `protobuf:"varint,7,opt,name=logical_size_bytes,json=logicalSizeBytes,proto3" json:"logical_size_bytes,omitempty"`
+	// Allocated filesystem blocks owned by this saved snapshot. Shared base
+	// files are excluded, so fan-out does not multiply this value.
+	ExclusiveSizeBytes int64 `protobuf:"varint,8,opt,name=exclusive_size_bytes,json=exclusiveSizeBytes,proto3" json:"exclusive_size_bytes,omitempty"`
+	// Source lifecycle state restored before this RPC returned: "running" or
+	// "paused".
+	SourceState string `protobuf:"bytes,9,opt,name=source_state,json=sourceState,proto3" json:"source_state,omitempty"`
+	SnapshotId  string `protobuf:"bytes,10,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	// Source-owned unshared extents that became retained by this immutable
+	// branch. Shadow accounting transfers them into the source writable layer;
+	// they are not charged again as snapshot-exclusive reflink bytes.
+	SourceExclusiveSizeBytes int64 `protobuf:"varint,11,opt,name=source_exclusive_size_bytes,json=sourceExclusiveSizeBytes,proto3" json:"source_exclusive_size_bytes,omitempty"`
+	SourceLogicalSizeBytes   int64 `protobuf:"varint,12,opt,name=source_logical_size_bytes,json=sourceLogicalSizeBytes,proto3" json:"source_logical_size_bytes,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *CreateSnapshotResponse) Reset() {
 	*x = CreateSnapshotResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[22]
+	mi := &file_proto_vmd_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1538,7 +1647,7 @@ func (x *CreateSnapshotResponse) String() string {
 func (*CreateSnapshotResponse) ProtoMessage() {}
 
 func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[22]
+	mi := &file_proto_vmd_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1551,7 +1660,7 @@ func (x *CreateSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{22}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *CreateSnapshotResponse) GetVmId() string {
@@ -1578,6 +1687,591 @@ func (x *CreateSnapshotResponse) GetMemFilePath() string {
 func (x *CreateSnapshotResponse) GetCreatedAtUnix() int64 {
 	if x != nil {
 		return x.CreatedAtUnix
+	}
+	return 0
+}
+
+func (x *CreateSnapshotResponse) GetArtifacts() *SavedSnapshotArtifacts {
+	if x != nil {
+		return x.Artifacts
+	}
+	return nil
+}
+
+func (x *CreateSnapshotResponse) GetResourceLimits() *ResourceLimits {
+	if x != nil {
+		return x.ResourceLimits
+	}
+	return nil
+}
+
+func (x *CreateSnapshotResponse) GetLogicalSizeBytes() int64 {
+	if x != nil {
+		return x.LogicalSizeBytes
+	}
+	return 0
+}
+
+func (x *CreateSnapshotResponse) GetExclusiveSizeBytes() int64 {
+	if x != nil {
+		return x.ExclusiveSizeBytes
+	}
+	return 0
+}
+
+func (x *CreateSnapshotResponse) GetSourceState() string {
+	if x != nil {
+		return x.SourceState
+	}
+	return ""
+}
+
+func (x *CreateSnapshotResponse) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *CreateSnapshotResponse) GetSourceExclusiveSizeBytes() int64 {
+	if x != nil {
+		return x.SourceExclusiveSizeBytes
+	}
+	return 0
+}
+
+func (x *CreateSnapshotResponse) GetSourceLogicalSizeBytes() int64 {
+	if x != nil {
+		return x.SourceLogicalSizeBytes
+	}
+	return 0
+}
+
+// SavedSnapshotArtifacts identifies a committed local artifact set. These
+// paths are control-plane metadata only and must never be returned publicly.
+type SavedSnapshotArtifacts struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SchemaVersion uint32                 `protobuf:"varint,1,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"`
+	ManifestPath  string                 `protobuf:"bytes,2,opt,name=manifest_path,json=manifestPath,proto3" json:"manifest_path,omitempty"`
+	SnapshotPath  string                 `protobuf:"bytes,3,opt,name=snapshot_path,json=snapshotPath,proto3" json:"snapshot_path,omitempty"`
+	MemFilePath   string                 `protobuf:"bytes,4,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
+	// Present only when mem_file_path is an immutable diff over another
+	// immutable memory image.
+	MemoryBasePath string `protobuf:"bytes,5,opt,name=memory_base_path,json=memoryBasePath,proto3" json:"memory_base_path,omitempty"`
+	// Immutable disk base referenced by an overlay-mode snapshot.
+	DiskBasePath string `protobuf:"bytes,6,opt,name=disk_base_path,json=diskBasePath,proto3" json:"disk_base_path,omitempty"`
+	// Firecracker block-delta artifact emitted for a running source.
+	DiskDeltaPath string `protobuf:"bytes,7,opt,name=disk_delta_path,json=diskDeltaPath,proto3" json:"disk_delta_path,omitempty"`
+	// Immutable sparse disk overlay copied from a paused source when no block
+	// delta can be emitted without changing its lifecycle state.
+	DiskOverlayPath string `protobuf:"bytes,8,opt,name=disk_overlay_path,json=diskOverlayPath,proto3" json:"disk_overlay_path,omitempty"`
+	// Immutable complete rootfs for legacy non-overlay sources.
+	DiskFullPath string `protobuf:"bytes,9,opt,name=disk_full_path,json=diskFullPath,proto3" json:"disk_full_path,omitempty"`
+	// sha256 of the exact committed manifest bytes, hex encoded.
+	ManifestDigest string `protobuf:"bytes,10,opt,name=manifest_digest,json=manifestDigest,proto3" json:"manifest_digest,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SavedSnapshotArtifacts) Reset() {
+	*x = SavedSnapshotArtifacts{}
+	mi := &file_proto_vmd_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SavedSnapshotArtifacts) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SavedSnapshotArtifacts) ProtoMessage() {}
+
+func (x *SavedSnapshotArtifacts) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SavedSnapshotArtifacts.ProtoReflect.Descriptor instead.
+func (*SavedSnapshotArtifacts) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *SavedSnapshotArtifacts) GetSchemaVersion() uint32 {
+	if x != nil {
+		return x.SchemaVersion
+	}
+	return 0
+}
+
+func (x *SavedSnapshotArtifacts) GetManifestPath() string {
+	if x != nil {
+		return x.ManifestPath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetSnapshotPath() string {
+	if x != nil {
+		return x.SnapshotPath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetMemFilePath() string {
+	if x != nil {
+		return x.MemFilePath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetMemoryBasePath() string {
+	if x != nil {
+		return x.MemoryBasePath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetDiskBasePath() string {
+	if x != nil {
+		return x.DiskBasePath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetDiskDeltaPath() string {
+	if x != nil {
+		return x.DiskDeltaPath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetDiskOverlayPath() string {
+	if x != nil {
+		return x.DiskOverlayPath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetDiskFullPath() string {
+	if x != nil {
+		return x.DiskFullPath
+	}
+	return ""
+}
+
+func (x *SavedSnapshotArtifacts) GetManifestDigest() string {
+	if x != nil {
+		return x.ManifestDigest
+	}
+	return ""
+}
+
+type RestoreSavedSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	VmId          string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	ManifestPath  string                 `protobuf:"bytes,2,opt,name=manifest_path,json=manifestPath,proto3" json:"manifest_path,omitempty"`
+	NetworkConfig *NetworkConfig         `protobuf:"bytes,3,opt,name=network_config,json=networkConfig,proto3" json:"network_config,omitempty"`
+	TeamId        string                 `protobuf:"bytes,4,opt,name=team_id,json=teamId,proto3" json:"team_id,omitempty"`
+	OwnerId       string                 `protobuf:"bytes,5,opt,name=owner_id,json=ownerId,proto3" json:"owner_id,omitempty"`
+	// Captured boxd defaults to overwrite with empty values before this RPC
+	// returns. Used for source-specific secret proxy-token variables; existing
+	// in-memory process environments are inherently part of the snapshot.
+	ClearEnvKeys []string `protobuf:"bytes,6,rep,name=clear_env_keys,json=clearEnvKeys,proto3" json:"clear_env_keys,omitempty"`
+	// Effective inherited or explicitly replaced egress policy. VMD installs
+	// it after allocating the child network and before starting Firecracker, so
+	// restored processes never observe a transient allow-all gap.
+	SandboxNetwork *SandboxNetworkConfig `protobuf:"bytes,7,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`
+	// SHA-256 of the committed manifest recorded by the control plane. VMD
+	// rejects a different manifest before allocating any child resources.
+	ExpectedManifestDigest string `protobuf:"bytes,8,opt,name=expected_manifest_digest,json=expectedManifestDigest,proto3" json:"expected_manifest_digest,omitempty"`
+	// Numeric-port routing policy for the fork. Empty and "legacy_public"
+	// preserve all-port routing; "public" requires explicit membership.
+	PreviewAccess string         `protobuf:"bytes,9,opt,name=preview_access,json=previewAccess,proto3" json:"preview_access,omitempty"`
+	PreviewPorts  []*PreviewPort `protobuf:"bytes,10,rep,name=preview_ports,json=previewPorts,proto3" json:"preview_ports,omitempty"`
+	// Monotonic generation used to reject stale full-allowlist pushes.
+	PreviewPolicyRevision int64 `protobuf:"varint,11,opt,name=preview_policy_revision,json=previewPolicyRevision,proto3" json:"preview_policy_revision,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *RestoreSavedSnapshotRequest) Reset() {
+	*x = RestoreSavedSnapshotRequest{}
+	mi := &file_proto_vmd_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSavedSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSavedSnapshotRequest) ProtoMessage() {}
+
+func (x *RestoreSavedSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSavedSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*RestoreSavedSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *RestoreSavedSnapshotRequest) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetManifestPath() string {
+	if x != nil {
+		return x.ManifestPath
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetNetworkConfig() *NetworkConfig {
+	if x != nil {
+		return x.NetworkConfig
+	}
+	return nil
+}
+
+func (x *RestoreSavedSnapshotRequest) GetTeamId() string {
+	if x != nil {
+		return x.TeamId
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetOwnerId() string {
+	if x != nil {
+		return x.OwnerId
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetClearEnvKeys() []string {
+	if x != nil {
+		return x.ClearEnvKeys
+	}
+	return nil
+}
+
+func (x *RestoreSavedSnapshotRequest) GetSandboxNetwork() *SandboxNetworkConfig {
+	if x != nil {
+		return x.SandboxNetwork
+	}
+	return nil
+}
+
+func (x *RestoreSavedSnapshotRequest) GetExpectedManifestDigest() string {
+	if x != nil {
+		return x.ExpectedManifestDigest
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetPreviewAccess() string {
+	if x != nil {
+		return x.PreviewAccess
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotRequest) GetPreviewPorts() []*PreviewPort {
+	if x != nil {
+		return x.PreviewPorts
+	}
+	return nil
+}
+
+func (x *RestoreSavedSnapshotRequest) GetPreviewPolicyRevision() int64 {
+	if x != nil {
+		return x.PreviewPolicyRevision
+	}
+	return 0
+}
+
+type RestoreSavedSnapshotResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	VmId           string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	SocketPath     string                 `protobuf:"bytes,2,opt,name=socket_path,json=socketPath,proto3" json:"socket_path,omitempty"`
+	IpAddress      string                 `protobuf:"bytes,3,opt,name=ip_address,json=ipAddress,proto3" json:"ip_address,omitempty"`
+	Pid            uint32                 `protobuf:"varint,4,opt,name=pid,proto3" json:"pid,omitempty"`
+	ResourceLimits *ResourceLimits        `protobuf:"bytes,5,opt,name=resource_limits,json=resourceLimits,proto3" json:"resource_limits,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RestoreSavedSnapshotResponse) Reset() {
+	*x = RestoreSavedSnapshotResponse{}
+	mi := &file_proto_vmd_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSavedSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSavedSnapshotResponse) ProtoMessage() {}
+
+func (x *RestoreSavedSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSavedSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*RestoreSavedSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *RestoreSavedSnapshotResponse) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotResponse) GetSocketPath() string {
+	if x != nil {
+		return x.SocketPath
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotResponse) GetIpAddress() string {
+	if x != nil {
+		return x.IpAddress
+	}
+	return ""
+}
+
+func (x *RestoreSavedSnapshotResponse) GetPid() uint32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *RestoreSavedSnapshotResponse) GetResourceLimits() *ResourceLimits {
+	if x != nil {
+		return x.ResourceLimits
+	}
+	return nil
+}
+
+type DeleteSavedSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SourceVmId    string                 `protobuf:"bytes,1,opt,name=source_vm_id,json=sourceVmId,proto3" json:"source_vm_id,omitempty"`
+	SnapshotId    string                 `protobuf:"bytes,2,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSavedSnapshotRequest) Reset() {
+	*x = DeleteSavedSnapshotRequest{}
+	mi := &file_proto_vmd_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSavedSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSavedSnapshotRequest) ProtoMessage() {}
+
+func (x *DeleteSavedSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSavedSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*DeleteSavedSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *DeleteSavedSnapshotRequest) GetSourceVmId() string {
+	if x != nil {
+		return x.SourceVmId
+	}
+	return ""
+}
+
+func (x *DeleteSavedSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type DeleteSavedSnapshotResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Deleted       bool                   `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSavedSnapshotResponse) Reset() {
+	*x = DeleteSavedSnapshotResponse{}
+	mi := &file_proto_vmd_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSavedSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSavedSnapshotResponse) ProtoMessage() {}
+
+func (x *DeleteSavedSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSavedSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*DeleteSavedSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *DeleteSavedSnapshotResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
+type GetWritableLayerUsageRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	VmId          string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWritableLayerUsageRequest) Reset() {
+	*x = GetWritableLayerUsageRequest{}
+	mi := &file_proto_vmd_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWritableLayerUsageRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWritableLayerUsageRequest) ProtoMessage() {}
+
+func (x *GetWritableLayerUsageRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWritableLayerUsageRequest.ProtoReflect.Descriptor instead.
+func (*GetWritableLayerUsageRequest) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *GetWritableLayerUsageRequest) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
+}
+
+type GetWritableLayerUsageResponse struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	LogicalSizeBytes   int64                  `protobuf:"varint,1,opt,name=logical_size_bytes,json=logicalSizeBytes,proto3" json:"logical_size_bytes,omitempty"`
+	ExclusiveSizeBytes int64                  `protobuf:"varint,2,opt,name=exclusive_size_bytes,json=exclusiveSizeBytes,proto3" json:"exclusive_size_bytes,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *GetWritableLayerUsageResponse) Reset() {
+	*x = GetWritableLayerUsageResponse{}
+	mi := &file_proto_vmd_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWritableLayerUsageResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWritableLayerUsageResponse) ProtoMessage() {}
+
+func (x *GetWritableLayerUsageResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_vmd_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWritableLayerUsageResponse.ProtoReflect.Descriptor instead.
+func (*GetWritableLayerUsageResponse) Descriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *GetWritableLayerUsageResponse) GetLogicalSizeBytes() int64 {
+	if x != nil {
+		return x.LogicalSizeBytes
+	}
+	return 0
+}
+
+func (x *GetWritableLayerUsageResponse) GetExclusiveSizeBytes() int64 {
+	if x != nil {
+		return x.ExclusiveSizeBytes
 	}
 	return 0
 }
@@ -1619,7 +2313,7 @@ type RestoreSnapshotRequest struct {
 
 func (x *RestoreSnapshotRequest) Reset() {
 	*x = RestoreSnapshotRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[23]
+	mi := &file_proto_vmd_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1631,7 +2325,7 @@ func (x *RestoreSnapshotRequest) String() string {
 func (*RestoreSnapshotRequest) ProtoMessage() {}
 
 func (x *RestoreSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[23]
+	mi := &file_proto_vmd_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1644,7 +2338,7 @@ func (x *RestoreSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*RestoreSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{23}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *RestoreSnapshotRequest) GetVmId() string {
@@ -1753,7 +2447,7 @@ type PreviewPort struct {
 
 func (x *PreviewPort) Reset() {
 	*x = PreviewPort{}
-	mi := &file_proto_vmd_proto_msgTypes[24]
+	mi := &file_proto_vmd_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1765,7 +2459,7 @@ func (x *PreviewPort) String() string {
 func (*PreviewPort) ProtoMessage() {}
 
 func (x *PreviewPort) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[24]
+	mi := &file_proto_vmd_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1778,7 +2472,7 @@ func (x *PreviewPort) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviewPort.ProtoReflect.Descriptor instead.
 func (*PreviewPort) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{24}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PreviewPort) GetPort() int32 {
@@ -1815,7 +2509,7 @@ type RestoreSnapshotResponse struct {
 
 func (x *RestoreSnapshotResponse) Reset() {
 	*x = RestoreSnapshotResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[25]
+	mi := &file_proto_vmd_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1827,7 +2521,7 @@ func (x *RestoreSnapshotResponse) String() string {
 func (*RestoreSnapshotResponse) ProtoMessage() {}
 
 func (x *RestoreSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[25]
+	mi := &file_proto_vmd_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1840,7 +2534,7 @@ func (x *RestoreSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestoreSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*RestoreSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{25}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *RestoreSnapshotResponse) GetVmId() string {
@@ -1892,7 +2586,7 @@ type InjectSandboxEnvRequest struct {
 
 func (x *InjectSandboxEnvRequest) Reset() {
 	*x = InjectSandboxEnvRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[26]
+	mi := &file_proto_vmd_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1904,7 +2598,7 @@ func (x *InjectSandboxEnvRequest) String() string {
 func (*InjectSandboxEnvRequest) ProtoMessage() {}
 
 func (x *InjectSandboxEnvRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[26]
+	mi := &file_proto_vmd_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1917,7 +2611,7 @@ func (x *InjectSandboxEnvRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InjectSandboxEnvRequest.ProtoReflect.Descriptor instead.
 func (*InjectSandboxEnvRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{26}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *InjectSandboxEnvRequest) GetVmId() string {
@@ -1950,7 +2644,7 @@ type InjectSandboxEnvResponse struct {
 
 func (x *InjectSandboxEnvResponse) Reset() {
 	*x = InjectSandboxEnvResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[27]
+	mi := &file_proto_vmd_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1962,7 +2656,7 @@ func (x *InjectSandboxEnvResponse) String() string {
 func (*InjectSandboxEnvResponse) ProtoMessage() {}
 
 func (x *InjectSandboxEnvResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[27]
+	mi := &file_proto_vmd_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1975,7 +2669,7 @@ func (x *InjectSandboxEnvResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InjectSandboxEnvResponse.ProtoReflect.Descriptor instead.
 func (*InjectSandboxEnvResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{27}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *InjectSandboxEnvResponse) GetVmId() string {
@@ -2001,7 +2695,7 @@ type DeleteSnapshotRequest struct {
 
 func (x *DeleteSnapshotRequest) Reset() {
 	*x = DeleteSnapshotRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[28]
+	mi := &file_proto_vmd_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2013,7 +2707,7 @@ func (x *DeleteSnapshotRequest) String() string {
 func (*DeleteSnapshotRequest) ProtoMessage() {}
 
 func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[28]
+	mi := &file_proto_vmd_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2026,7 +2720,7 @@ func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{28}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *DeleteSnapshotRequest) GetVmId() string {
@@ -2061,7 +2755,7 @@ type DeleteSnapshotResponse struct {
 
 func (x *DeleteSnapshotResponse) Reset() {
 	*x = DeleteSnapshotResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[29]
+	mi := &file_proto_vmd_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2073,7 +2767,7 @@ func (x *DeleteSnapshotResponse) String() string {
 func (*DeleteSnapshotResponse) ProtoMessage() {}
 
 func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[29]
+	mi := &file_proto_vmd_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2086,7 +2780,7 @@ func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{29}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DeleteSnapshotResponse) GetDeleted() bool {
@@ -2108,7 +2802,7 @@ type DeleteSandboxSnapshotsRequest struct {
 
 func (x *DeleteSandboxSnapshotsRequest) Reset() {
 	*x = DeleteSandboxSnapshotsRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[30]
+	mi := &file_proto_vmd_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2814,7 @@ func (x *DeleteSandboxSnapshotsRequest) String() string {
 func (*DeleteSandboxSnapshotsRequest) ProtoMessage() {}
 
 func (x *DeleteSandboxSnapshotsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[30]
+	mi := &file_proto_vmd_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2827,7 @@ func (x *DeleteSandboxSnapshotsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSandboxSnapshotsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteSandboxSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{30}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *DeleteSandboxSnapshotsRequest) GetVmId() string {
@@ -2153,7 +2847,7 @@ type DeleteSandboxSnapshotsResponse struct {
 
 func (x *DeleteSandboxSnapshotsResponse) Reset() {
 	*x = DeleteSandboxSnapshotsResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[31]
+	mi := &file_proto_vmd_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2165,7 +2859,7 @@ func (x *DeleteSandboxSnapshotsResponse) String() string {
 func (*DeleteSandboxSnapshotsResponse) ProtoMessage() {}
 
 func (x *DeleteSandboxSnapshotsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[31]
+	mi := &file_proto_vmd_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2178,7 +2872,7 @@ func (x *DeleteSandboxSnapshotsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteSandboxSnapshotsResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSandboxSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{31}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *DeleteSandboxSnapshotsResponse) GetDeleted() bool {
@@ -2197,7 +2891,7 @@ type DeleteTemplateArtifactsRequest struct {
 
 func (x *DeleteTemplateArtifactsRequest) Reset() {
 	*x = DeleteTemplateArtifactsRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[32]
+	mi := &file_proto_vmd_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2209,7 +2903,7 @@ func (x *DeleteTemplateArtifactsRequest) String() string {
 func (*DeleteTemplateArtifactsRequest) ProtoMessage() {}
 
 func (x *DeleteTemplateArtifactsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[32]
+	mi := &file_proto_vmd_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2222,7 +2916,7 @@ func (x *DeleteTemplateArtifactsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTemplateArtifactsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTemplateArtifactsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{32}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *DeleteTemplateArtifactsRequest) GetTemplateId() string {
@@ -2241,7 +2935,7 @@ type DeleteTemplateArtifactsResponse struct {
 
 func (x *DeleteTemplateArtifactsResponse) Reset() {
 	*x = DeleteTemplateArtifactsResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[33]
+	mi := &file_proto_vmd_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2253,7 +2947,7 @@ func (x *DeleteTemplateArtifactsResponse) String() string {
 func (*DeleteTemplateArtifactsResponse) ProtoMessage() {}
 
 func (x *DeleteTemplateArtifactsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[33]
+	mi := &file_proto_vmd_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2266,7 +2960,7 @@ func (x *DeleteTemplateArtifactsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTemplateArtifactsResponse.ProtoReflect.Descriptor instead.
 func (*DeleteTemplateArtifactsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{33}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *DeleteTemplateArtifactsResponse) GetDeleted() bool {
@@ -2286,7 +2980,7 @@ type DeleteBuildArtifactsRequest struct {
 
 func (x *DeleteBuildArtifactsRequest) Reset() {
 	*x = DeleteBuildArtifactsRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[34]
+	mi := &file_proto_vmd_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2298,7 +2992,7 @@ func (x *DeleteBuildArtifactsRequest) String() string {
 func (*DeleteBuildArtifactsRequest) ProtoMessage() {}
 
 func (x *DeleteBuildArtifactsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[34]
+	mi := &file_proto_vmd_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2311,7 +3005,7 @@ func (x *DeleteBuildArtifactsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteBuildArtifactsRequest.ProtoReflect.Descriptor instead.
 func (*DeleteBuildArtifactsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{34}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *DeleteBuildArtifactsRequest) GetTemplateId() string {
@@ -2337,7 +3031,7 @@ type DeleteBuildArtifactsResponse struct {
 
 func (x *DeleteBuildArtifactsResponse) Reset() {
 	*x = DeleteBuildArtifactsResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[35]
+	mi := &file_proto_vmd_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2349,7 +3043,7 @@ func (x *DeleteBuildArtifactsResponse) String() string {
 func (*DeleteBuildArtifactsResponse) ProtoMessage() {}
 
 func (x *DeleteBuildArtifactsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[35]
+	mi := &file_proto_vmd_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2362,7 +3056,7 @@ func (x *DeleteBuildArtifactsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteBuildArtifactsResponse.ProtoReflect.Descriptor instead.
 func (*DeleteBuildArtifactsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{35}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *DeleteBuildArtifactsResponse) GetDeleted() bool {
@@ -2380,7 +3074,7 @@ type ListBuildArtifactsRequest struct {
 
 func (x *ListBuildArtifactsRequest) Reset() {
 	*x = ListBuildArtifactsRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[36]
+	mi := &file_proto_vmd_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2392,7 +3086,7 @@ func (x *ListBuildArtifactsRequest) String() string {
 func (*ListBuildArtifactsRequest) ProtoMessage() {}
 
 func (x *ListBuildArtifactsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[36]
+	mi := &file_proto_vmd_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2405,7 +3099,7 @@ func (x *ListBuildArtifactsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBuildArtifactsRequest.ProtoReflect.Descriptor instead.
 func (*ListBuildArtifactsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{36}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{45}
 }
 
 type BuildArtifactEntry struct {
@@ -2419,7 +3113,7 @@ type BuildArtifactEntry struct {
 
 func (x *BuildArtifactEntry) Reset() {
 	*x = BuildArtifactEntry{}
-	mi := &file_proto_vmd_proto_msgTypes[37]
+	mi := &file_proto_vmd_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2431,7 +3125,7 @@ func (x *BuildArtifactEntry) String() string {
 func (*BuildArtifactEntry) ProtoMessage() {}
 
 func (x *BuildArtifactEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[37]
+	mi := &file_proto_vmd_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2444,7 +3138,7 @@ func (x *BuildArtifactEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BuildArtifactEntry.ProtoReflect.Descriptor instead.
 func (*BuildArtifactEntry) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{37}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *BuildArtifactEntry) GetTemplateId() string {
@@ -2477,7 +3171,7 @@ type ListBuildArtifactsResponse struct {
 
 func (x *ListBuildArtifactsResponse) Reset() {
 	*x = ListBuildArtifactsResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[38]
+	mi := &file_proto_vmd_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2489,7 +3183,7 @@ func (x *ListBuildArtifactsResponse) String() string {
 func (*ListBuildArtifactsResponse) ProtoMessage() {}
 
 func (x *ListBuildArtifactsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[38]
+	mi := &file_proto_vmd_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2502,7 +3196,7 @@ func (x *ListBuildArtifactsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBuildArtifactsResponse.ProtoReflect.Descriptor instead.
 func (*ListBuildArtifactsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{38}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ListBuildArtifactsResponse) GetEntries() []*BuildArtifactEntry {
@@ -2522,7 +3216,7 @@ type ListDirRequest struct {
 
 func (x *ListDirRequest) Reset() {
 	*x = ListDirRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[39]
+	mi := &file_proto_vmd_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2534,7 +3228,7 @@ func (x *ListDirRequest) String() string {
 func (*ListDirRequest) ProtoMessage() {}
 
 func (x *ListDirRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[39]
+	mi := &file_proto_vmd_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2547,7 +3241,7 @@ func (x *ListDirRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDirRequest.ProtoReflect.Descriptor instead.
 func (*ListDirRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{39}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ListDirRequest) GetVmId() string {
@@ -2573,7 +3267,7 @@ type ListDirResponse struct {
 
 func (x *ListDirResponse) Reset() {
 	*x = ListDirResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[40]
+	mi := &file_proto_vmd_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2585,7 +3279,7 @@ func (x *ListDirResponse) String() string {
 func (*ListDirResponse) ProtoMessage() {}
 
 func (x *ListDirResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[40]
+	mi := &file_proto_vmd_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2598,7 +3292,7 @@ func (x *ListDirResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDirResponse.ProtoReflect.Descriptor instead.
 func (*ListDirResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{40}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ListDirResponse) GetEntries() []*ListDirEntry {
@@ -2623,7 +3317,7 @@ type ListDirEntry struct {
 
 func (x *ListDirEntry) Reset() {
 	*x = ListDirEntry{}
-	mi := &file_proto_vmd_proto_msgTypes[41]
+	mi := &file_proto_vmd_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2635,7 +3329,7 @@ func (x *ListDirEntry) String() string {
 func (*ListDirEntry) ProtoMessage() {}
 
 func (x *ListDirEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[41]
+	mi := &file_proto_vmd_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2648,7 +3342,7 @@ func (x *ListDirEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDirEntry.ProtoReflect.Descriptor instead.
 func (*ListDirEntry) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{41}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ListDirEntry) GetName() string {
@@ -2688,7 +3382,7 @@ type GetVMInfoRequest struct {
 
 func (x *GetVMInfoRequest) Reset() {
 	*x = GetVMInfoRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[42]
+	mi := &file_proto_vmd_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2700,7 +3394,7 @@ func (x *GetVMInfoRequest) String() string {
 func (*GetVMInfoRequest) ProtoMessage() {}
 
 func (x *GetVMInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[42]
+	mi := &file_proto_vmd_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2713,7 +3407,7 @@ func (x *GetVMInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVMInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetVMInfoRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{42}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetVMInfoRequest) GetVmId() string {
@@ -2740,7 +3434,7 @@ type GetVMInfoResponse struct {
 
 func (x *GetVMInfoResponse) Reset() {
 	*x = GetVMInfoResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[43]
+	mi := &file_proto_vmd_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2752,7 +3446,7 @@ func (x *GetVMInfoResponse) String() string {
 func (*GetVMInfoResponse) ProtoMessage() {}
 
 func (x *GetVMInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[43]
+	mi := &file_proto_vmd_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2765,7 +3459,7 @@ func (x *GetVMInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVMInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetVMInfoResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{43}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetVMInfoResponse) GetVmId() string {
@@ -2841,7 +3535,7 @@ type SetupNetworkRequest struct {
 
 func (x *SetupNetworkRequest) Reset() {
 	*x = SetupNetworkRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[44]
+	mi := &file_proto_vmd_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2853,7 +3547,7 @@ func (x *SetupNetworkRequest) String() string {
 func (*SetupNetworkRequest) ProtoMessage() {}
 
 func (x *SetupNetworkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[44]
+	mi := &file_proto_vmd_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2866,7 +3560,7 @@ func (x *SetupNetworkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetupNetworkRequest.ProtoReflect.Descriptor instead.
 func (*SetupNetworkRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{44}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *SetupNetworkRequest) GetVmId() string {
@@ -2896,7 +3590,7 @@ type SetupNetworkResponse struct {
 
 func (x *SetupNetworkResponse) Reset() {
 	*x = SetupNetworkResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[45]
+	mi := &file_proto_vmd_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2908,7 +3602,7 @@ func (x *SetupNetworkResponse) String() string {
 func (*SetupNetworkResponse) ProtoMessage() {}
 
 func (x *SetupNetworkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[45]
+	mi := &file_proto_vmd_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2921,7 +3615,7 @@ func (x *SetupNetworkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetupNetworkResponse.ProtoReflect.Descriptor instead.
 func (*SetupNetworkResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{45}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *SetupNetworkResponse) GetVmId() string {
@@ -2969,7 +3663,7 @@ type UpdateSandboxNetworkRequest struct {
 
 func (x *UpdateSandboxNetworkRequest) Reset() {
 	*x = UpdateSandboxNetworkRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[46]
+	mi := &file_proto_vmd_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2981,7 +3675,7 @@ func (x *UpdateSandboxNetworkRequest) String() string {
 func (*UpdateSandboxNetworkRequest) ProtoMessage() {}
 
 func (x *UpdateSandboxNetworkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[46]
+	mi := &file_proto_vmd_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2994,7 +3688,7 @@ func (x *UpdateSandboxNetworkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSandboxNetworkRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSandboxNetworkRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{46}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *UpdateSandboxNetworkRequest) GetVmId() string {
@@ -3020,7 +3714,7 @@ type UpdateSandboxNetworkResponse struct {
 
 func (x *UpdateSandboxNetworkResponse) Reset() {
 	*x = UpdateSandboxNetworkResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[47]
+	mi := &file_proto_vmd_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3032,7 +3726,7 @@ func (x *UpdateSandboxNetworkResponse) String() string {
 func (*UpdateSandboxNetworkResponse) ProtoMessage() {}
 
 func (x *UpdateSandboxNetworkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[47]
+	mi := &file_proto_vmd_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3045,7 +3739,7 @@ func (x *UpdateSandboxNetworkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateSandboxNetworkResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSandboxNetworkResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{47}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *UpdateSandboxNetworkResponse) GetVmId() string {
@@ -3067,7 +3761,7 @@ type UpdateSandboxPreviewPolicyRequest struct {
 
 func (x *UpdateSandboxPreviewPolicyRequest) Reset() {
 	*x = UpdateSandboxPreviewPolicyRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[48]
+	mi := &file_proto_vmd_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3079,7 +3773,7 @@ func (x *UpdateSandboxPreviewPolicyRequest) String() string {
 func (*UpdateSandboxPreviewPolicyRequest) ProtoMessage() {}
 
 func (x *UpdateSandboxPreviewPolicyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[48]
+	mi := &file_proto_vmd_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3092,7 +3786,7 @@ func (x *UpdateSandboxPreviewPolicyRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UpdateSandboxPreviewPolicyRequest.ProtoReflect.Descriptor instead.
 func (*UpdateSandboxPreviewPolicyRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{48}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *UpdateSandboxPreviewPolicyRequest) GetVmId() string {
@@ -3132,7 +3826,7 @@ type UpdateSandboxPreviewPolicyResponse struct {
 
 func (x *UpdateSandboxPreviewPolicyResponse) Reset() {
 	*x = UpdateSandboxPreviewPolicyResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[49]
+	mi := &file_proto_vmd_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3144,7 +3838,7 @@ func (x *UpdateSandboxPreviewPolicyResponse) String() string {
 func (*UpdateSandboxPreviewPolicyResponse) ProtoMessage() {}
 
 func (x *UpdateSandboxPreviewPolicyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[49]
+	mi := &file_proto_vmd_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3157,7 +3851,7 @@ func (x *UpdateSandboxPreviewPolicyResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use UpdateSandboxPreviewPolicyResponse.ProtoReflect.Descriptor instead.
 func (*UpdateSandboxPreviewPolicyResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{49}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *UpdateSandboxPreviewPolicyResponse) GetVmId() string {
@@ -3176,7 +3870,7 @@ type InvalidateSecretRequest struct {
 
 func (x *InvalidateSecretRequest) Reset() {
 	*x = InvalidateSecretRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[50]
+	mi := &file_proto_vmd_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3188,7 +3882,7 @@ func (x *InvalidateSecretRequest) String() string {
 func (*InvalidateSecretRequest) ProtoMessage() {}
 
 func (x *InvalidateSecretRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[50]
+	mi := &file_proto_vmd_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3201,7 +3895,7 @@ func (x *InvalidateSecretRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateSecretRequest.ProtoReflect.Descriptor instead.
 func (*InvalidateSecretRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{50}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *InvalidateSecretRequest) GetSecretId() string {
@@ -3219,7 +3913,7 @@ type InvalidateSecretResponse struct {
 
 func (x *InvalidateSecretResponse) Reset() {
 	*x = InvalidateSecretResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[51]
+	mi := &file_proto_vmd_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3231,7 +3925,7 @@ func (x *InvalidateSecretResponse) String() string {
 func (*InvalidateSecretResponse) ProtoMessage() {}
 
 func (x *InvalidateSecretResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[51]
+	mi := &file_proto_vmd_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3244,7 +3938,7 @@ func (x *InvalidateSecretResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateSecretResponse.ProtoReflect.Descriptor instead.
 func (*InvalidateSecretResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{51}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{60}
 }
 
 type RevokeSandboxRequest struct {
@@ -3256,7 +3950,7 @@ type RevokeSandboxRequest struct {
 
 func (x *RevokeSandboxRequest) Reset() {
 	*x = RevokeSandboxRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[52]
+	mi := &file_proto_vmd_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3268,7 +3962,7 @@ func (x *RevokeSandboxRequest) String() string {
 func (*RevokeSandboxRequest) ProtoMessage() {}
 
 func (x *RevokeSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[52]
+	mi := &file_proto_vmd_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3281,7 +3975,7 @@ func (x *RevokeSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeSandboxRequest.ProtoReflect.Descriptor instead.
 func (*RevokeSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{52}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *RevokeSandboxRequest) GetSandboxId() string {
@@ -3299,7 +3993,7 @@ type RevokeSandboxResponse struct {
 
 func (x *RevokeSandboxResponse) Reset() {
 	*x = RevokeSandboxResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[53]
+	mi := &file_proto_vmd_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3311,7 +4005,7 @@ func (x *RevokeSandboxResponse) String() string {
 func (*RevokeSandboxResponse) ProtoMessage() {}
 
 func (x *RevokeSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[53]
+	mi := &file_proto_vmd_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3324,7 +4018,7 @@ func (x *RevokeSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeSandboxResponse.ProtoReflect.Descriptor instead.
 func (*RevokeSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{53}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{62}
 }
 
 type InvalidateSandboxRulesRequest struct {
@@ -3336,7 +4030,7 @@ type InvalidateSandboxRulesRequest struct {
 
 func (x *InvalidateSandboxRulesRequest) Reset() {
 	*x = InvalidateSandboxRulesRequest{}
-	mi := &file_proto_vmd_proto_msgTypes[54]
+	mi := &file_proto_vmd_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3348,7 +4042,7 @@ func (x *InvalidateSandboxRulesRequest) String() string {
 func (*InvalidateSandboxRulesRequest) ProtoMessage() {}
 
 func (x *InvalidateSandboxRulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[54]
+	mi := &file_proto_vmd_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3361,7 +4055,7 @@ func (x *InvalidateSandboxRulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateSandboxRulesRequest.ProtoReflect.Descriptor instead.
 func (*InvalidateSandboxRulesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{54}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *InvalidateSandboxRulesRequest) GetSandboxId() string {
@@ -3379,7 +4073,7 @@ type InvalidateSandboxRulesResponse struct {
 
 func (x *InvalidateSandboxRulesResponse) Reset() {
 	*x = InvalidateSandboxRulesResponse{}
-	mi := &file_proto_vmd_proto_msgTypes[55]
+	mi := &file_proto_vmd_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3391,7 +4085,7 @@ func (x *InvalidateSandboxRulesResponse) String() string {
 func (*InvalidateSandboxRulesResponse) ProtoMessage() {}
 
 func (x *InvalidateSandboxRulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_vmd_proto_msgTypes[55]
+	mi := &file_proto_vmd_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3404,14 +4098,17 @@ func (x *InvalidateSandboxRulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvalidateSandboxRulesResponse.ProtoReflect.Descriptor instead.
 func (*InvalidateSandboxRulesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{55}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{64}
 }
 
 var File_proto_vmd_proto protoreflect.FileDescriptor
 
 const file_proto_vmd_proto_rawDesc = "" +
 	"\n" +
-	"\x0fproto/vmd.proto\x12\x11superserve.vmd.v1\"\xa7\x02\n" +
+	"\x0fproto/vmd.proto\x12\x11superserve.vmd.v1\"\x18\n" +
+	"\x16GetCapabilitiesRequest\"G\n" +
+	"\x17GetCapabilitiesResponse\x12,\n" +
+	"\x12saved_snapshots_v1\x18\x01 \x01(\bR\x10savedSnapshotsV1\"\xa7\x02\n" +
 	"\x14BuildTemplateRequest\x12\x1f\n" +
 	"\vtemplate_id\x18\x01 \x01(\tR\n" +
 	"templateId\x12\x12\n" +
@@ -3521,15 +4218,72 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\n" +
 	"ip_address\x18\x03 \x01(\tR\tipAddress\x12\x10\n" +
 	"\x03pid\x18\x04 \x01(\rR\x03pid\x12J\n" +
-	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\"O\n" +
+	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\"p\n" +
 	"\x15CreateSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12!\n" +
-	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\x9e\x01\n" +
+	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\x12\x1f\n" +
+	"\vsnapshot_id\x18\x03 \x01(\tR\n" +
+	"snapshotId\"\xd1\x04\n" +
 	"\x16CreateSnapshotResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12&\n" +
-	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xc0\x05\n" +
+	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\x12G\n" +
+	"\tartifacts\x18\x05 \x01(\v2).superserve.vmd.v1.SavedSnapshotArtifactsR\tartifacts\x12J\n" +
+	"\x0fresource_limits\x18\x06 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12,\n" +
+	"\x12logical_size_bytes\x18\a \x01(\x03R\x10logicalSizeBytes\x120\n" +
+	"\x14exclusive_size_bytes\x18\b \x01(\x03R\x12exclusiveSizeBytes\x12!\n" +
+	"\fsource_state\x18\t \x01(\tR\vsourceState\x12\x1f\n" +
+	"\vsnapshot_id\x18\n" +
+	" \x01(\tR\n" +
+	"snapshotId\x12=\n" +
+	"\x1bsource_exclusive_size_bytes\x18\v \x01(\x03R\x18sourceExclusiveSizeBytes\x129\n" +
+	"\x19source_logical_size_bytes\x18\f \x01(\x03R\x16sourceLogicalSizeBytes\"\xa0\x03\n" +
+	"\x16SavedSnapshotArtifacts\x12%\n" +
+	"\x0eschema_version\x18\x01 \x01(\rR\rschemaVersion\x12#\n" +
+	"\rmanifest_path\x18\x02 \x01(\tR\fmanifestPath\x12#\n" +
+	"\rsnapshot_path\x18\x03 \x01(\tR\fsnapshotPath\x12\"\n" +
+	"\rmem_file_path\x18\x04 \x01(\tR\vmemFilePath\x12(\n" +
+	"\x10memory_base_path\x18\x05 \x01(\tR\x0ememoryBasePath\x12$\n" +
+	"\x0edisk_base_path\x18\x06 \x01(\tR\fdiskBasePath\x12&\n" +
+	"\x0fdisk_delta_path\x18\a \x01(\tR\rdiskDeltaPath\x12*\n" +
+	"\x11disk_overlay_path\x18\b \x01(\tR\x0fdiskOverlayPath\x12$\n" +
+	"\x0edisk_full_path\x18\t \x01(\tR\fdiskFullPath\x12'\n" +
+	"\x0fmanifest_digest\x18\n" +
+	" \x01(\tR\x0emanifestDigest\"\xaa\x04\n" +
+	"\x1bRestoreSavedSnapshotRequest\x12\x13\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
+	"\rmanifest_path\x18\x02 \x01(\tR\fmanifestPath\x12G\n" +
+	"\x0enetwork_config\x18\x03 \x01(\v2 .superserve.vmd.v1.NetworkConfigR\rnetworkConfig\x12\x17\n" +
+	"\ateam_id\x18\x04 \x01(\tR\x06teamId\x12\x19\n" +
+	"\bowner_id\x18\x05 \x01(\tR\aownerId\x12$\n" +
+	"\x0eclear_env_keys\x18\x06 \x03(\tR\fclearEnvKeys\x12P\n" +
+	"\x0fsandbox_network\x18\a \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x128\n" +
+	"\x18expected_manifest_digest\x18\b \x01(\tR\x16expectedManifestDigest\x12%\n" +
+	"\x0epreview_access\x18\t \x01(\tR\rpreviewAccess\x12C\n" +
+	"\rpreview_ports\x18\n" +
+	" \x03(\v2\x1e.superserve.vmd.v1.PreviewPortR\fpreviewPorts\x126\n" +
+	"\x17preview_policy_revision\x18\v \x01(\x03R\x15previewPolicyRevision\"\xd1\x01\n" +
+	"\x1cRestoreSavedSnapshotResponse\x12\x13\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
+	"\vsocket_path\x18\x02 \x01(\tR\n" +
+	"socketPath\x12\x1d\n" +
+	"\n" +
+	"ip_address\x18\x03 \x01(\tR\tipAddress\x12\x10\n" +
+	"\x03pid\x18\x04 \x01(\rR\x03pid\x12J\n" +
+	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\"_\n" +
+	"\x1aDeleteSavedSnapshotRequest\x12 \n" +
+	"\fsource_vm_id\x18\x01 \x01(\tR\n" +
+	"sourceVmId\x12\x1f\n" +
+	"\vsnapshot_id\x18\x02 \x01(\tR\n" +
+	"snapshotId\"7\n" +
+	"\x1bDeleteSavedSnapshotResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"3\n" +
+	"\x1cGetWritableLayerUsageRequest\x12\x13\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\"\x7f\n" +
+	"\x1dGetWritableLayerUsageResponse\x12,\n" +
+	"\x12logical_size_bytes\x18\x01 \x01(\x03R\x10logicalSizeBytes\x120\n" +
+	"\x14exclusive_size_bytes\x18\x02 \x01(\x03R\x12exclusiveSizeBytes\"\xc0\x05\n" +
 	"\x16RestoreSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
@@ -3668,12 +4422,16 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x11VM_STATUS_RUNNING\x10\x02\x12\x14\n" +
 	"\x10VM_STATUS_PAUSED\x10\x03\x12\x15\n" +
 	"\x11VM_STATUS_STOPPED\x10\x04\x12\x13\n" +
-	"\x0fVM_STATUS_ERROR\x10\x052\x87\x13\n" +
-	"\bVMDaemon\x12V\n" +
+	"\x0fVM_STATUS_ERROR\x10\x052\xdc\x16\n" +
+	"\bVMDaemon\x12h\n" +
+	"\x0fGetCapabilities\x12).superserve.vmd.v1.GetCapabilitiesRequest\x1a*.superserve.vmd.v1.GetCapabilitiesResponse\x12V\n" +
 	"\tDestroyVM\x12#.superserve.vmd.v1.DestroyVMRequest\x1a$.superserve.vmd.v1.DestroyVMResponse\x12P\n" +
 	"\aPauseVM\x12!.superserve.vmd.v1.PauseVMRequest\x1a\".superserve.vmd.v1.PauseVMResponse\x12S\n" +
 	"\bResumeVM\x12\".superserve.vmd.v1.ResumeVMRequest\x1a#.superserve.vmd.v1.ResumeVMResponse\x12e\n" +
-	"\x0eCreateSnapshot\x12(.superserve.vmd.v1.CreateSnapshotRequest\x1a).superserve.vmd.v1.CreateSnapshotResponse\x12h\n" +
+	"\x0eCreateSnapshot\x12(.superserve.vmd.v1.CreateSnapshotRequest\x1a).superserve.vmd.v1.CreateSnapshotResponse\x12w\n" +
+	"\x14RestoreSavedSnapshot\x12..superserve.vmd.v1.RestoreSavedSnapshotRequest\x1a/.superserve.vmd.v1.RestoreSavedSnapshotResponse\x12t\n" +
+	"\x13DeleteSavedSnapshot\x12-.superserve.vmd.v1.DeleteSavedSnapshotRequest\x1a..superserve.vmd.v1.DeleteSavedSnapshotResponse\x12z\n" +
+	"\x15GetWritableLayerUsage\x12/.superserve.vmd.v1.GetWritableLayerUsageRequest\x1a0.superserve.vmd.v1.GetWritableLayerUsageResponse\x12h\n" +
 	"\x0fRestoreSnapshot\x12).superserve.vmd.v1.RestoreSnapshotRequest\x1a*.superserve.vmd.v1.RestoreSnapshotResponse\x12k\n" +
 	"\x10InjectSandboxEnv\x12*.superserve.vmd.v1.InjectSandboxEnvRequest\x1a+.superserve.vmd.v1.InjectSandboxEnvResponse\x12e\n" +
 	"\x0eDeleteSnapshot\x12(.superserve.vmd.v1.DeleteSnapshotRequest\x1a).superserve.vmd.v1.DeleteSnapshotResponse\x12}\n" +
@@ -3707,143 +4465,166 @@ func file_proto_vmd_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_vmd_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_vmd_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
+var file_proto_vmd_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_proto_vmd_proto_goTypes = []any{
 	(VMStatus)(0),                              // 0: superserve.vmd.v1.VMStatus
-	(*BuildTemplateRequest)(nil),               // 1: superserve.vmd.v1.BuildTemplateRequest
-	(*BuildStep)(nil),                          // 2: superserve.vmd.v1.BuildStep
-	(*BuildEnvOp)(nil),                         // 3: superserve.vmd.v1.BuildEnvOp
-	(*BuildUserOp)(nil),                        // 4: superserve.vmd.v1.BuildUserOp
-	(*BuildTemplateResponse)(nil),              // 5: superserve.vmd.v1.BuildTemplateResponse
-	(*GetBuildStatusRequest)(nil),              // 6: superserve.vmd.v1.GetBuildStatusRequest
-	(*GetBuildStatusResponse)(nil),             // 7: superserve.vmd.v1.GetBuildStatusResponse
-	(*CancelBuildRequest)(nil),                 // 8: superserve.vmd.v1.CancelBuildRequest
-	(*CancelBuildResponse)(nil),                // 9: superserve.vmd.v1.CancelBuildResponse
-	(*StreamBuildLogsRequest)(nil),             // 10: superserve.vmd.v1.StreamBuildLogsRequest
-	(*BuildLogEvent)(nil),                      // 11: superserve.vmd.v1.BuildLogEvent
-	(*ResourceLimits)(nil),                     // 12: superserve.vmd.v1.ResourceLimits
-	(*NetworkConfig)(nil),                      // 13: superserve.vmd.v1.NetworkConfig
-	(*SandboxNetworkConfig)(nil),               // 14: superserve.vmd.v1.SandboxNetworkConfig
-	(*SandboxNetworkEgressConfig)(nil),         // 15: superserve.vmd.v1.SandboxNetworkEgressConfig
-	(*DestroyVMRequest)(nil),                   // 16: superserve.vmd.v1.DestroyVMRequest
-	(*DestroyVMResponse)(nil),                  // 17: superserve.vmd.v1.DestroyVMResponse
-	(*PauseVMRequest)(nil),                     // 18: superserve.vmd.v1.PauseVMRequest
-	(*PauseVMResponse)(nil),                    // 19: superserve.vmd.v1.PauseVMResponse
-	(*ResumeVMRequest)(nil),                    // 20: superserve.vmd.v1.ResumeVMRequest
-	(*ResumeVMResponse)(nil),                   // 21: superserve.vmd.v1.ResumeVMResponse
-	(*CreateSnapshotRequest)(nil),              // 22: superserve.vmd.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),             // 23: superserve.vmd.v1.CreateSnapshotResponse
-	(*RestoreSnapshotRequest)(nil),             // 24: superserve.vmd.v1.RestoreSnapshotRequest
-	(*PreviewPort)(nil),                        // 25: superserve.vmd.v1.PreviewPort
-	(*RestoreSnapshotResponse)(nil),            // 26: superserve.vmd.v1.RestoreSnapshotResponse
-	(*InjectSandboxEnvRequest)(nil),            // 27: superserve.vmd.v1.InjectSandboxEnvRequest
-	(*InjectSandboxEnvResponse)(nil),           // 28: superserve.vmd.v1.InjectSandboxEnvResponse
-	(*DeleteSnapshotRequest)(nil),              // 29: superserve.vmd.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),             // 30: superserve.vmd.v1.DeleteSnapshotResponse
-	(*DeleteSandboxSnapshotsRequest)(nil),      // 31: superserve.vmd.v1.DeleteSandboxSnapshotsRequest
-	(*DeleteSandboxSnapshotsResponse)(nil),     // 32: superserve.vmd.v1.DeleteSandboxSnapshotsResponse
-	(*DeleteTemplateArtifactsRequest)(nil),     // 33: superserve.vmd.v1.DeleteTemplateArtifactsRequest
-	(*DeleteTemplateArtifactsResponse)(nil),    // 34: superserve.vmd.v1.DeleteTemplateArtifactsResponse
-	(*DeleteBuildArtifactsRequest)(nil),        // 35: superserve.vmd.v1.DeleteBuildArtifactsRequest
-	(*DeleteBuildArtifactsResponse)(nil),       // 36: superserve.vmd.v1.DeleteBuildArtifactsResponse
-	(*ListBuildArtifactsRequest)(nil),          // 37: superserve.vmd.v1.ListBuildArtifactsRequest
-	(*BuildArtifactEntry)(nil),                 // 38: superserve.vmd.v1.BuildArtifactEntry
-	(*ListBuildArtifactsResponse)(nil),         // 39: superserve.vmd.v1.ListBuildArtifactsResponse
-	(*ListDirRequest)(nil),                     // 40: superserve.vmd.v1.ListDirRequest
-	(*ListDirResponse)(nil),                    // 41: superserve.vmd.v1.ListDirResponse
-	(*ListDirEntry)(nil),                       // 42: superserve.vmd.v1.ListDirEntry
-	(*GetVMInfoRequest)(nil),                   // 43: superserve.vmd.v1.GetVMInfoRequest
-	(*GetVMInfoResponse)(nil),                  // 44: superserve.vmd.v1.GetVMInfoResponse
-	(*SetupNetworkRequest)(nil),                // 45: superserve.vmd.v1.SetupNetworkRequest
-	(*SetupNetworkResponse)(nil),               // 46: superserve.vmd.v1.SetupNetworkResponse
-	(*UpdateSandboxNetworkRequest)(nil),        // 47: superserve.vmd.v1.UpdateSandboxNetworkRequest
-	(*UpdateSandboxNetworkResponse)(nil),       // 48: superserve.vmd.v1.UpdateSandboxNetworkResponse
-	(*UpdateSandboxPreviewPolicyRequest)(nil),  // 49: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
-	(*UpdateSandboxPreviewPolicyResponse)(nil), // 50: superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
-	(*InvalidateSecretRequest)(nil),            // 51: superserve.vmd.v1.InvalidateSecretRequest
-	(*InvalidateSecretResponse)(nil),           // 52: superserve.vmd.v1.InvalidateSecretResponse
-	(*RevokeSandboxRequest)(nil),               // 53: superserve.vmd.v1.RevokeSandboxRequest
-	(*RevokeSandboxResponse)(nil),              // 54: superserve.vmd.v1.RevokeSandboxResponse
-	(*InvalidateSandboxRulesRequest)(nil),      // 55: superserve.vmd.v1.InvalidateSandboxRulesRequest
-	(*InvalidateSandboxRulesResponse)(nil),     // 56: superserve.vmd.v1.InvalidateSandboxRulesResponse
-	nil,                                        // 57: superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
-	nil,                                        // 58: superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
-	nil,                                        // 59: superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
-	nil,                                        // 60: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	(*GetCapabilitiesRequest)(nil),             // 1: superserve.vmd.v1.GetCapabilitiesRequest
+	(*GetCapabilitiesResponse)(nil),            // 2: superserve.vmd.v1.GetCapabilitiesResponse
+	(*BuildTemplateRequest)(nil),               // 3: superserve.vmd.v1.BuildTemplateRequest
+	(*BuildStep)(nil),                          // 4: superserve.vmd.v1.BuildStep
+	(*BuildEnvOp)(nil),                         // 5: superserve.vmd.v1.BuildEnvOp
+	(*BuildUserOp)(nil),                        // 6: superserve.vmd.v1.BuildUserOp
+	(*BuildTemplateResponse)(nil),              // 7: superserve.vmd.v1.BuildTemplateResponse
+	(*GetBuildStatusRequest)(nil),              // 8: superserve.vmd.v1.GetBuildStatusRequest
+	(*GetBuildStatusResponse)(nil),             // 9: superserve.vmd.v1.GetBuildStatusResponse
+	(*CancelBuildRequest)(nil),                 // 10: superserve.vmd.v1.CancelBuildRequest
+	(*CancelBuildResponse)(nil),                // 11: superserve.vmd.v1.CancelBuildResponse
+	(*StreamBuildLogsRequest)(nil),             // 12: superserve.vmd.v1.StreamBuildLogsRequest
+	(*BuildLogEvent)(nil),                      // 13: superserve.vmd.v1.BuildLogEvent
+	(*ResourceLimits)(nil),                     // 14: superserve.vmd.v1.ResourceLimits
+	(*NetworkConfig)(nil),                      // 15: superserve.vmd.v1.NetworkConfig
+	(*SandboxNetworkConfig)(nil),               // 16: superserve.vmd.v1.SandboxNetworkConfig
+	(*SandboxNetworkEgressConfig)(nil),         // 17: superserve.vmd.v1.SandboxNetworkEgressConfig
+	(*DestroyVMRequest)(nil),                   // 18: superserve.vmd.v1.DestroyVMRequest
+	(*DestroyVMResponse)(nil),                  // 19: superserve.vmd.v1.DestroyVMResponse
+	(*PauseVMRequest)(nil),                     // 20: superserve.vmd.v1.PauseVMRequest
+	(*PauseVMResponse)(nil),                    // 21: superserve.vmd.v1.PauseVMResponse
+	(*ResumeVMRequest)(nil),                    // 22: superserve.vmd.v1.ResumeVMRequest
+	(*ResumeVMResponse)(nil),                   // 23: superserve.vmd.v1.ResumeVMResponse
+	(*CreateSnapshotRequest)(nil),              // 24: superserve.vmd.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),             // 25: superserve.vmd.v1.CreateSnapshotResponse
+	(*SavedSnapshotArtifacts)(nil),             // 26: superserve.vmd.v1.SavedSnapshotArtifacts
+	(*RestoreSavedSnapshotRequest)(nil),        // 27: superserve.vmd.v1.RestoreSavedSnapshotRequest
+	(*RestoreSavedSnapshotResponse)(nil),       // 28: superserve.vmd.v1.RestoreSavedSnapshotResponse
+	(*DeleteSavedSnapshotRequest)(nil),         // 29: superserve.vmd.v1.DeleteSavedSnapshotRequest
+	(*DeleteSavedSnapshotResponse)(nil),        // 30: superserve.vmd.v1.DeleteSavedSnapshotResponse
+	(*GetWritableLayerUsageRequest)(nil),       // 31: superserve.vmd.v1.GetWritableLayerUsageRequest
+	(*GetWritableLayerUsageResponse)(nil),      // 32: superserve.vmd.v1.GetWritableLayerUsageResponse
+	(*RestoreSnapshotRequest)(nil),             // 33: superserve.vmd.v1.RestoreSnapshotRequest
+	(*PreviewPort)(nil),                        // 34: superserve.vmd.v1.PreviewPort
+	(*RestoreSnapshotResponse)(nil),            // 35: superserve.vmd.v1.RestoreSnapshotResponse
+	(*InjectSandboxEnvRequest)(nil),            // 36: superserve.vmd.v1.InjectSandboxEnvRequest
+	(*InjectSandboxEnvResponse)(nil),           // 37: superserve.vmd.v1.InjectSandboxEnvResponse
+	(*DeleteSnapshotRequest)(nil),              // 38: superserve.vmd.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),             // 39: superserve.vmd.v1.DeleteSnapshotResponse
+	(*DeleteSandboxSnapshotsRequest)(nil),      // 40: superserve.vmd.v1.DeleteSandboxSnapshotsRequest
+	(*DeleteSandboxSnapshotsResponse)(nil),     // 41: superserve.vmd.v1.DeleteSandboxSnapshotsResponse
+	(*DeleteTemplateArtifactsRequest)(nil),     // 42: superserve.vmd.v1.DeleteTemplateArtifactsRequest
+	(*DeleteTemplateArtifactsResponse)(nil),    // 43: superserve.vmd.v1.DeleteTemplateArtifactsResponse
+	(*DeleteBuildArtifactsRequest)(nil),        // 44: superserve.vmd.v1.DeleteBuildArtifactsRequest
+	(*DeleteBuildArtifactsResponse)(nil),       // 45: superserve.vmd.v1.DeleteBuildArtifactsResponse
+	(*ListBuildArtifactsRequest)(nil),          // 46: superserve.vmd.v1.ListBuildArtifactsRequest
+	(*BuildArtifactEntry)(nil),                 // 47: superserve.vmd.v1.BuildArtifactEntry
+	(*ListBuildArtifactsResponse)(nil),         // 48: superserve.vmd.v1.ListBuildArtifactsResponse
+	(*ListDirRequest)(nil),                     // 49: superserve.vmd.v1.ListDirRequest
+	(*ListDirResponse)(nil),                    // 50: superserve.vmd.v1.ListDirResponse
+	(*ListDirEntry)(nil),                       // 51: superserve.vmd.v1.ListDirEntry
+	(*GetVMInfoRequest)(nil),                   // 52: superserve.vmd.v1.GetVMInfoRequest
+	(*GetVMInfoResponse)(nil),                  // 53: superserve.vmd.v1.GetVMInfoResponse
+	(*SetupNetworkRequest)(nil),                // 54: superserve.vmd.v1.SetupNetworkRequest
+	(*SetupNetworkResponse)(nil),               // 55: superserve.vmd.v1.SetupNetworkResponse
+	(*UpdateSandboxNetworkRequest)(nil),        // 56: superserve.vmd.v1.UpdateSandboxNetworkRequest
+	(*UpdateSandboxNetworkResponse)(nil),       // 57: superserve.vmd.v1.UpdateSandboxNetworkResponse
+	(*UpdateSandboxPreviewPolicyRequest)(nil),  // 58: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
+	(*UpdateSandboxPreviewPolicyResponse)(nil), // 59: superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
+	(*InvalidateSecretRequest)(nil),            // 60: superserve.vmd.v1.InvalidateSecretRequest
+	(*InvalidateSecretResponse)(nil),           // 61: superserve.vmd.v1.InvalidateSecretResponse
+	(*RevokeSandboxRequest)(nil),               // 62: superserve.vmd.v1.RevokeSandboxRequest
+	(*RevokeSandboxResponse)(nil),              // 63: superserve.vmd.v1.RevokeSandboxResponse
+	(*InvalidateSandboxRulesRequest)(nil),      // 64: superserve.vmd.v1.InvalidateSandboxRulesRequest
+	(*InvalidateSandboxRulesResponse)(nil),     // 65: superserve.vmd.v1.InvalidateSandboxRulesResponse
+	nil,                                        // 66: superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	nil,                                        // 67: superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
+	nil,                                        // 68: superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
+	nil,                                        // 69: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
 }
 var file_proto_vmd_proto_depIdxs = []int32{
-	2,  // 0: superserve.vmd.v1.BuildTemplateRequest.steps:type_name -> superserve.vmd.v1.BuildStep
-	3,  // 1: superserve.vmd.v1.BuildStep.env:type_name -> superserve.vmd.v1.BuildEnvOp
-	4,  // 2: superserve.vmd.v1.BuildStep.user:type_name -> superserve.vmd.v1.BuildUserOp
-	15, // 3: superserve.vmd.v1.SandboxNetworkConfig.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	14, // 4: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
-	57, // 5: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
-	12, // 6: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	12, // 7: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	13, // 8: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	58, // 9: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
-	25, // 10: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	12, // 11: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	59, // 12: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
-	38, // 13: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
-	42, // 14: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
-	0,  // 15: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
-	12, // 16: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	60, // 17: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
-	13, // 18: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	15, // 19: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	25, // 20: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	16, // 21: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
-	18, // 22: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
-	20, // 23: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
-	22, // 24: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
-	24, // 25: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
-	27, // 26: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
-	29, // 27: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
-	31, // 28: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
-	33, // 29: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
-	35, // 30: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
-	37, // 31: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
-	40, // 32: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
-	43, // 33: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
-	45, // 34: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
-	47, // 35: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
-	49, // 36: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
-	51, // 37: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
-	53, // 38: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
-	55, // 39: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
-	1,  // 40: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
-	6,  // 41: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
-	8,  // 42: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
-	10, // 43: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
-	17, // 44: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
-	19, // 45: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
-	21, // 46: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
-	23, // 47: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
-	26, // 48: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
-	28, // 49: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
-	30, // 50: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
-	32, // 51: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
-	34, // 52: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
-	36, // 53: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
-	39, // 54: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
-	41, // 55: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
-	44, // 56: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
-	46, // 57: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
-	48, // 58: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
-	50, // 59: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
-	52, // 60: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
-	54, // 61: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
-	56, // 62: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
-	5,  // 63: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
-	7,  // 64: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
-	9,  // 65: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
-	11, // 66: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
-	44, // [44:67] is the sub-list for method output_type
-	21, // [21:44] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	4,  // 0: superserve.vmd.v1.BuildTemplateRequest.steps:type_name -> superserve.vmd.v1.BuildStep
+	5,  // 1: superserve.vmd.v1.BuildStep.env:type_name -> superserve.vmd.v1.BuildEnvOp
+	6,  // 2: superserve.vmd.v1.BuildStep.user:type_name -> superserve.vmd.v1.BuildUserOp
+	17, // 3: superserve.vmd.v1.SandboxNetworkConfig.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	16, // 4: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
+	66, // 5: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	14, // 6: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	26, // 7: superserve.vmd.v1.CreateSnapshotResponse.artifacts:type_name -> superserve.vmd.v1.SavedSnapshotArtifacts
+	14, // 8: superserve.vmd.v1.CreateSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	15, // 9: superserve.vmd.v1.RestoreSavedSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	16, // 10: superserve.vmd.v1.RestoreSavedSnapshotRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
+	34, // 11: superserve.vmd.v1.RestoreSavedSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	14, // 12: superserve.vmd.v1.RestoreSavedSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	14, // 13: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	15, // 14: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	67, // 15: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
+	34, // 16: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	14, // 17: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	68, // 18: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
+	47, // 19: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
+	51, // 20: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
+	0,  // 21: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
+	14, // 22: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	69, // 23: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	15, // 24: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	17, // 25: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	34, // 26: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	1,  // 27: superserve.vmd.v1.VMDaemon.GetCapabilities:input_type -> superserve.vmd.v1.GetCapabilitiesRequest
+	18, // 28: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
+	20, // 29: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
+	22, // 30: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
+	24, // 31: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
+	27, // 32: superserve.vmd.v1.VMDaemon.RestoreSavedSnapshot:input_type -> superserve.vmd.v1.RestoreSavedSnapshotRequest
+	29, // 33: superserve.vmd.v1.VMDaemon.DeleteSavedSnapshot:input_type -> superserve.vmd.v1.DeleteSavedSnapshotRequest
+	31, // 34: superserve.vmd.v1.VMDaemon.GetWritableLayerUsage:input_type -> superserve.vmd.v1.GetWritableLayerUsageRequest
+	33, // 35: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
+	36, // 36: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
+	38, // 37: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
+	40, // 38: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
+	42, // 39: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
+	44, // 40: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
+	46, // 41: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
+	49, // 42: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
+	52, // 43: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
+	54, // 44: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
+	56, // 45: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
+	58, // 46: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
+	60, // 47: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
+	62, // 48: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
+	64, // 49: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
+	3,  // 50: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
+	8,  // 51: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
+	10, // 52: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
+	12, // 53: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
+	2,  // 54: superserve.vmd.v1.VMDaemon.GetCapabilities:output_type -> superserve.vmd.v1.GetCapabilitiesResponse
+	19, // 55: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
+	21, // 56: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
+	23, // 57: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
+	25, // 58: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
+	28, // 59: superserve.vmd.v1.VMDaemon.RestoreSavedSnapshot:output_type -> superserve.vmd.v1.RestoreSavedSnapshotResponse
+	30, // 60: superserve.vmd.v1.VMDaemon.DeleteSavedSnapshot:output_type -> superserve.vmd.v1.DeleteSavedSnapshotResponse
+	32, // 61: superserve.vmd.v1.VMDaemon.GetWritableLayerUsage:output_type -> superserve.vmd.v1.GetWritableLayerUsageResponse
+	35, // 62: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
+	37, // 63: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
+	39, // 64: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
+	41, // 65: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
+	43, // 66: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
+	45, // 67: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
+	48, // 68: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
+	50, // 69: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
+	53, // 70: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
+	55, // 71: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
+	57, // 72: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
+	59, // 73: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
+	61, // 74: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
+	63, // 75: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
+	65, // 76: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
+	7,  // 77: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
+	9,  // 78: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
+	11, // 79: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
+	13, // 80: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
+	54, // [54:81] is the sub-list for method output_type
+	27, // [27:54] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_proto_vmd_proto_init() }
@@ -3851,7 +4632,7 @@ func file_proto_vmd_proto_init() {
 	if File_proto_vmd_proto != nil {
 		return
 	}
-	file_proto_vmd_proto_msgTypes[1].OneofWrappers = []any{
+	file_proto_vmd_proto_msgTypes[3].OneofWrappers = []any{
 		(*BuildStep_Run)(nil),
 		(*BuildStep_Env)(nil),
 		(*BuildStep_Workdir)(nil),
@@ -3863,7 +4644,7 @@ func file_proto_vmd_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_vmd_proto_rawDesc), len(file_proto_vmd_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   60,
+			NumMessages:   69,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/vmdpb/vmd_grpc.pb.go
+++ b/proto/vmdpb/vmd_grpc.pb.go
@@ -19,10 +19,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	VMDaemon_GetCapabilities_FullMethodName            = "/superserve.vmd.v1.VMDaemon/GetCapabilities"
 	VMDaemon_DestroyVM_FullMethodName                  = "/superserve.vmd.v1.VMDaemon/DestroyVM"
 	VMDaemon_PauseVM_FullMethodName                    = "/superserve.vmd.v1.VMDaemon/PauseVM"
 	VMDaemon_ResumeVM_FullMethodName                   = "/superserve.vmd.v1.VMDaemon/ResumeVM"
 	VMDaemon_CreateSnapshot_FullMethodName             = "/superserve.vmd.v1.VMDaemon/CreateSnapshot"
+	VMDaemon_RestoreSavedSnapshot_FullMethodName       = "/superserve.vmd.v1.VMDaemon/RestoreSavedSnapshot"
+	VMDaemon_DeleteSavedSnapshot_FullMethodName        = "/superserve.vmd.v1.VMDaemon/DeleteSavedSnapshot"
+	VMDaemon_GetWritableLayerUsage_FullMethodName      = "/superserve.vmd.v1.VMDaemon/GetWritableLayerUsage"
 	VMDaemon_RestoreSnapshot_FullMethodName            = "/superserve.vmd.v1.VMDaemon/RestoreSnapshot"
 	VMDaemon_InjectSandboxEnv_FullMethodName           = "/superserve.vmd.v1.VMDaemon/InjectSandboxEnv"
 	VMDaemon_DeleteSnapshot_FullMethodName             = "/superserve.vmd.v1.VMDaemon/DeleteSnapshot"
@@ -50,14 +54,31 @@ const (
 //
 // VMDaemon manages Firecracker microVM lifecycles for the AgentBox platform.
 type VMDaemonClient interface {
+	// GetCapabilities reports optional data-plane features. Control planes must
+	// check the corresponding bit before using an optional RPC or overloaded
+	// request shape so a rolling deploy fails closed against an older VMD.
+	GetCapabilities(ctx context.Context, in *GetCapabilitiesRequest, opts ...grpc.CallOption) (*GetCapabilitiesResponse, error)
 	// DestroyVM terminates a running microVM and cleans up all associated resources.
 	DestroyVM(ctx context.Context, in *DestroyVMRequest, opts ...grpc.CallOption) (*DestroyVMResponse, error)
 	// PauseVM snapshots a running VM's state and suspends it (sleep).
 	PauseVM(ctx context.Context, in *PauseVMRequest, opts ...grpc.CallOption) (*PauseVMResponse, error)
 	// ResumeVM restores a paused VM from its snapshot, optionally into a pre-warmed slot.
 	ResumeVM(ctx context.Context, in *ResumeVMRequest, opts ...grpc.CallOption) (*ResumeVMResponse, error)
-	// CreateSnapshot captures a point-in-time snapshot of a running VM.
+	// CreateSnapshot captures a point-in-time snapshot. A non-empty snapshot_id
+	// selects immutable saved-snapshot semantics for a running or paused VM;
+	// otherwise the legacy caller-selected-directory behavior is retained.
 	CreateSnapshot(ctx context.Context, in *CreateSnapshotRequest, opts ...grpc.CallOption) (*CreateSnapshotResponse, error)
+	// RestoreSavedSnapshot boots a new VM from an immutable saved-snapshot
+	// manifest. VMD resolves and validates every artifact locally and always
+	// creates a fresh writable disk layer for the new VM.
+	RestoreSavedSnapshot(ctx context.Context, in *RestoreSavedSnapshotRequest, opts ...grpc.CallOption) (*RestoreSavedSnapshotResponse, error)
+	// DeleteSavedSnapshot removes one committed saved-snapshot artifact
+	// directory. The control plane must first prove the snapshot is a leaf.
+	// Path construction is local to VMD and the operation is idempotent.
+	DeleteSavedSnapshot(ctx context.Context, in *DeleteSavedSnapshotRequest, opts ...grpc.CallOption) (*DeleteSavedSnapshotResponse, error)
+	// GetWritableLayerUsage measures the sandbox-owned persisted disk/memory
+	// generation with CoW-shared extents excluded. It is shadow accounting only.
+	GetWritableLayerUsage(ctx context.Context, in *GetWritableLayerUsageRequest, opts ...grpc.CallOption) (*GetWritableLayerUsageResponse, error)
 	// RestoreSnapshot boots a VM from a previously captured snapshot and
 	// returns its source IP. The caller must follow with InjectSandboxEnv to
 	// push env vars (and the optional secrets JWT) into the running boxd.
@@ -137,6 +158,16 @@ func NewVMDaemonClient(cc grpc.ClientConnInterface) VMDaemonClient {
 	return &vMDaemonClient{cc}
 }
 
+func (c *vMDaemonClient) GetCapabilities(ctx context.Context, in *GetCapabilitiesRequest, opts ...grpc.CallOption) (*GetCapabilitiesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetCapabilitiesResponse)
+	err := c.cc.Invoke(ctx, VMDaemon_GetCapabilities_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *vMDaemonClient) DestroyVM(ctx context.Context, in *DestroyVMRequest, opts ...grpc.CallOption) (*DestroyVMResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DestroyVMResponse)
@@ -171,6 +202,36 @@ func (c *vMDaemonClient) CreateSnapshot(ctx context.Context, in *CreateSnapshotR
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateSnapshotResponse)
 	err := c.cc.Invoke(ctx, VMDaemon_CreateSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *vMDaemonClient) RestoreSavedSnapshot(ctx context.Context, in *RestoreSavedSnapshotRequest, opts ...grpc.CallOption) (*RestoreSavedSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RestoreSavedSnapshotResponse)
+	err := c.cc.Invoke(ctx, VMDaemon_RestoreSavedSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *vMDaemonClient) DeleteSavedSnapshot(ctx context.Context, in *DeleteSavedSnapshotRequest, opts ...grpc.CallOption) (*DeleteSavedSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteSavedSnapshotResponse)
+	err := c.cc.Invoke(ctx, VMDaemon_DeleteSavedSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *vMDaemonClient) GetWritableLayerUsage(ctx context.Context, in *GetWritableLayerUsageRequest, opts ...grpc.CallOption) (*GetWritableLayerUsageResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWritableLayerUsageResponse)
+	err := c.cc.Invoke(ctx, VMDaemon_GetWritableLayerUsage_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -382,14 +443,31 @@ type VMDaemon_StreamBuildLogsClient = grpc.ServerStreamingClient[BuildLogEvent]
 //
 // VMDaemon manages Firecracker microVM lifecycles for the AgentBox platform.
 type VMDaemonServer interface {
+	// GetCapabilities reports optional data-plane features. Control planes must
+	// check the corresponding bit before using an optional RPC or overloaded
+	// request shape so a rolling deploy fails closed against an older VMD.
+	GetCapabilities(context.Context, *GetCapabilitiesRequest) (*GetCapabilitiesResponse, error)
 	// DestroyVM terminates a running microVM and cleans up all associated resources.
 	DestroyVM(context.Context, *DestroyVMRequest) (*DestroyVMResponse, error)
 	// PauseVM snapshots a running VM's state and suspends it (sleep).
 	PauseVM(context.Context, *PauseVMRequest) (*PauseVMResponse, error)
 	// ResumeVM restores a paused VM from its snapshot, optionally into a pre-warmed slot.
 	ResumeVM(context.Context, *ResumeVMRequest) (*ResumeVMResponse, error)
-	// CreateSnapshot captures a point-in-time snapshot of a running VM.
+	// CreateSnapshot captures a point-in-time snapshot. A non-empty snapshot_id
+	// selects immutable saved-snapshot semantics for a running or paused VM;
+	// otherwise the legacy caller-selected-directory behavior is retained.
 	CreateSnapshot(context.Context, *CreateSnapshotRequest) (*CreateSnapshotResponse, error)
+	// RestoreSavedSnapshot boots a new VM from an immutable saved-snapshot
+	// manifest. VMD resolves and validates every artifact locally and always
+	// creates a fresh writable disk layer for the new VM.
+	RestoreSavedSnapshot(context.Context, *RestoreSavedSnapshotRequest) (*RestoreSavedSnapshotResponse, error)
+	// DeleteSavedSnapshot removes one committed saved-snapshot artifact
+	// directory. The control plane must first prove the snapshot is a leaf.
+	// Path construction is local to VMD and the operation is idempotent.
+	DeleteSavedSnapshot(context.Context, *DeleteSavedSnapshotRequest) (*DeleteSavedSnapshotResponse, error)
+	// GetWritableLayerUsage measures the sandbox-owned persisted disk/memory
+	// generation with CoW-shared extents excluded. It is shadow accounting only.
+	GetWritableLayerUsage(context.Context, *GetWritableLayerUsageRequest) (*GetWritableLayerUsageResponse, error)
 	// RestoreSnapshot boots a VM from a previously captured snapshot and
 	// returns its source IP. The caller must follow with InjectSandboxEnv to
 	// push env vars (and the optional secrets JWT) into the running boxd.
@@ -469,6 +547,9 @@ type VMDaemonServer interface {
 // pointer dereference when methods are called.
 type UnimplementedVMDaemonServer struct{}
 
+func (UnimplementedVMDaemonServer) GetCapabilities(context.Context, *GetCapabilitiesRequest) (*GetCapabilitiesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetCapabilities not implemented")
+}
 func (UnimplementedVMDaemonServer) DestroyVM(context.Context, *DestroyVMRequest) (*DestroyVMResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DestroyVM not implemented")
 }
@@ -480,6 +561,15 @@ func (UnimplementedVMDaemonServer) ResumeVM(context.Context, *ResumeVMRequest) (
 }
 func (UnimplementedVMDaemonServer) CreateSnapshot(context.Context, *CreateSnapshotRequest) (*CreateSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateSnapshot not implemented")
+}
+func (UnimplementedVMDaemonServer) RestoreSavedSnapshot(context.Context, *RestoreSavedSnapshotRequest) (*RestoreSavedSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RestoreSavedSnapshot not implemented")
+}
+func (UnimplementedVMDaemonServer) DeleteSavedSnapshot(context.Context, *DeleteSavedSnapshotRequest) (*DeleteSavedSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteSavedSnapshot not implemented")
+}
+func (UnimplementedVMDaemonServer) GetWritableLayerUsage(context.Context, *GetWritableLayerUsageRequest) (*GetWritableLayerUsageResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetWritableLayerUsage not implemented")
 }
 func (UnimplementedVMDaemonServer) RestoreSnapshot(context.Context, *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RestoreSnapshot not implemented")
@@ -559,6 +649,24 @@ func RegisterVMDaemonServer(s grpc.ServiceRegistrar, srv VMDaemonServer) {
 	s.RegisterService(&VMDaemon_ServiceDesc, srv)
 }
 
+func _VMDaemon_GetCapabilities_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCapabilitiesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VMDaemonServer).GetCapabilities(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VMDaemon_GetCapabilities_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VMDaemonServer).GetCapabilities(ctx, req.(*GetCapabilitiesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _VMDaemon_DestroyVM_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DestroyVMRequest)
 	if err := dec(in); err != nil {
@@ -627,6 +735,60 @@ func _VMDaemon_CreateSnapshot_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(VMDaemonServer).CreateSnapshot(ctx, req.(*CreateSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _VMDaemon_RestoreSavedSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RestoreSavedSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VMDaemonServer).RestoreSavedSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VMDaemon_RestoreSavedSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VMDaemonServer).RestoreSavedSnapshot(ctx, req.(*RestoreSavedSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _VMDaemon_DeleteSavedSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteSavedSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VMDaemonServer).DeleteSavedSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VMDaemon_DeleteSavedSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VMDaemonServer).DeleteSavedSnapshot(ctx, req.(*DeleteSavedSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _VMDaemon_GetWritableLayerUsage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWritableLayerUsageRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VMDaemonServer).GetWritableLayerUsage(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VMDaemon_GetWritableLayerUsage_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VMDaemonServer).GetWritableLayerUsage(ctx, req.(*GetWritableLayerUsageRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -974,6 +1136,10 @@ var VMDaemon_ServiceDesc = grpc.ServiceDesc{
 	HandlerType: (*VMDaemonServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "GetCapabilities",
+			Handler:    _VMDaemon_GetCapabilities_Handler,
+		},
+		{
 			MethodName: "DestroyVM",
 			Handler:    _VMDaemon_DestroyVM_Handler,
 		},
@@ -988,6 +1154,18 @@ var VMDaemon_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateSnapshot",
 			Handler:    _VMDaemon_CreateSnapshot_Handler,
+		},
+		{
+			MethodName: "RestoreSavedSnapshot",
+			Handler:    _VMDaemon_RestoreSavedSnapshot_Handler,
+		},
+		{
+			MethodName: "DeleteSavedSnapshot",
+			Handler:    _VMDaemon_DeleteSavedSnapshot_Handler,
+		},
+		{
+			MethodName: "GetWritableLayerUsage",
+			Handler:    _VMDaemon_GetWritableLayerUsage_Handler,
 		},
 		{
 			MethodName: "RestoreSnapshot",

--- a/scripts/setup-sandbox-data-disk.sh
+++ b/scripts/setup-sandbox-data-disk.sh
@@ -1,0 +1,518 @@
+#!/usr/bin/env bash
+# Prepare the persistent XFS data disk used by VMD's mutable runtime and
+# snapshot trees. The canonical /var/lib/sandbox paths remain unchanged: two
+# subdirectories from the XFS disk are bind-mounted over rundir and snapshots.
+#
+# The first run performs an atomic, one-time migration. It refuses to proceed
+# while any Firecracker unit is active and stops VMD/socket activation while
+# the copy and bind switch occur. Pre-commit failures restore the prior state;
+# post-commit failures keep the VMD control plane stopped for safe recovery.
+set -euo pipefail
+
+readonly CONFIG_FILE=/etc/sandbox/data-disk.env
+readonly EXPECTED_DEVICE=/dev/disk/by-id/google-superserve-sandbox-data
+readonly MOUNT_ROOT=/mnt/sandbox-data
+readonly DATA_ROOT="${MOUNT_ROOT}/data-v1"
+readonly MIGRATION_MARKER="${DATA_ROOT}/.migration-complete"
+readonly ACTIVATION_MARKER="${DATA_ROOT}/.activation-complete"
+readonly AUTHORITY_MARKER=/etc/sandbox/data-disk-authoritative
+readonly CANON_RUNDIR=/var/lib/sandbox/rundir
+readonly CANON_SNAPSHOTS=/var/lib/sandbox/snapshots
+readonly VMD_SERVICE=superserve-vmd.service
+readonly VMD_SOCKET=superserve-vmd.socket
+readonly DEVICE_WAIT_SECONDS=600
+
+log() {
+  printf 'setup-sandbox-data-disk: %s\n' "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  if [[ "${data_authoritative:-0}" == "1" ]]; then
+    log "ERROR: XFS data is authoritative; stopping the VMD control plane fail closed" >&2
+    stop_vmd_control_plane_fail_closed
+  fi
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command is missing: $1"
+}
+
+read_config_device() {
+  local file_value="" file_count=0 direct_value="${SANDBOX_DATA_DISK_DEVICE:-}"
+
+  if [[ -f "$CONFIG_FILE" ]]; then
+    file_count="$(awk '
+      /^[[:space:]]*(#|$)/ { next }
+      index($0, "SANDBOX_DATA_DISK_DEVICE=") == 1 { count++; next }
+      { invalid++ }
+      END {
+        if (invalid > 0) exit 2
+        print count + 0
+      }
+    ' "$CONFIG_FILE")" || fail "$CONFIG_FILE may contain only SANDBOX_DATA_DISK_DEVICE plus comments/blank lines"
+    [[ "$file_count" == "0" || "$file_count" == "1" ]] || fail "$CONFIG_FILE must contain exactly one SANDBOX_DATA_DISK_DEVICE assignment"
+    if [[ "$file_count" == "1" ]]; then
+      file_value="$(sed -n 's/^SANDBOX_DATA_DISK_DEVICE=//p' "$CONFIG_FILE")"
+    fi
+  fi
+
+  if [[ -n "$direct_value" && -n "$file_value" && "$direct_value" != "$file_value" ]]; then
+    fail "SANDBOX_DATA_DISK_DEVICE conflicts with $CONFIG_FILE"
+  fi
+
+  printf '%s' "${direct_value:-$file_value}"
+}
+
+active_firecracker_units() {
+  systemctl list-units \
+    --type=service \
+    --state=active,activating,deactivating,reloading \
+    --no-legend \
+    --plain \
+    'firecracker@*.service' 2>/dev/null | awk '{print $1}'
+}
+
+stop_vmd_control_plane_fail_closed() {
+  # Stop the listeners first so no new VM lifecycle work can enter while the
+  # host's authoritative storage is unavailable or inconsistent. Existing
+  # Firecracker processes intentionally survive VMD restarts; preserving them
+  # avoids turning a verifier/configuration failure into guest disk corruption.
+  systemctl stop "$VMD_SOCKET" "$VMD_SERVICE" >/dev/null 2>&1 || true
+}
+
+unit_active_state() {
+  systemctl show --property=ActiveState --value "$1" 2>/dev/null || printf 'unknown\n'
+}
+
+unit_should_restore() {
+  case "$(unit_active_state "$1")" in
+    active|activating|reloading) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+unit_is_quiescent() {
+  case "$(unit_active_state "$1")" in
+    inactive|failed) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+path_identity() {
+  stat -Lc '%d:%i' "$1"
+}
+
+mount_device_id() {
+  findmnt -n -T "$1" -o MAJ:MIN
+}
+
+mount_fstype() {
+  findmnt -n -T "$1" -o FSTYPE
+}
+
+verify_bind_mount() {
+  local canonical="$1" intended="$2" data_device_id="$3"
+  mountpoint -q "$canonical" || return 1
+  [[ "$(path_identity "$canonical")" == "$(path_identity "$intended")" ]] || return 1
+  [[ "$(mount_fstype "$canonical")" == "xfs" ]] || return 1
+  [[ "$(mount_device_id "$canonical")" == "$data_device_id" ]] || return 1
+}
+
+inventory_tree() {
+  local root="$1" output="$2"
+  (
+    cd "$root"
+    find . -xdev \
+      \( -type f -printf 'f\0%P\0%m\0%U\0%G\0%s\0' \
+      -o -type d -printf 'd\0%P\0%m\0%U\0%G\0' \
+      -o -type l -printf 'l\0%P\0%U\0%G\0%l\0' \
+      -o -printf 'o\0%P\0%y\0%m\0%U\0%G\0' \) |
+      LC_ALL=C sort -z
+  ) >"$output"
+}
+
+trees_match() {
+  local source="$1" destination="$2" source_inventory destination_inventory
+  local regular_files relative rc=0
+
+  source_inventory="$(mktemp)" || return 1
+  destination_inventory="$(mktemp)" || {
+    rm -f -- "$source_inventory"
+    return 1
+  }
+  regular_files="$(mktemp)" || {
+    rm -f -- "$source_inventory" "$destination_inventory"
+    return 1
+  }
+
+  inventory_tree "$source" "$source_inventory" || rc=1
+  (( rc != 0 )) || inventory_tree "$destination" "$destination_inventory" || rc=1
+  if (( rc != 0 )); then
+    rm -f -- "$source_inventory" "$destination_inventory" "$regular_files"
+    return 1
+  fi
+  if ! cmp -s "$source_inventory" "$destination_inventory"; then
+    rm -f -- "$source_inventory" "$destination_inventory" "$regular_files"
+    return 1
+  fi
+  rm -f -- "$source_inventory" "$destination_inventory"
+
+  (cd "$source" && find . -xdev -type f -print0 >"$regular_files") || {
+    rm -f -- "$regular_files"
+    return 1
+  }
+  while IFS= read -r -d '' relative; do
+    relative="${relative#./}"
+    if ! cmp -s -- "$source/$relative" "$destination/$relative"; then
+      rc=1
+      break
+    fi
+  done <"$regular_files"
+  rm -f -- "$regular_files"
+  return "$rc"
+}
+
+verify_reflinks() {
+  local run_dir="$1" snapshot_dir="$2" run_probe snapshot_probe_dir rc=0
+  run_probe="$(mktemp "$run_dir/.reflink-probe.XXXXXX")" || return 1
+  snapshot_probe_dir="$(mktemp -d "$snapshot_dir/.reflink-probe.XXXXXX")" || {
+    rm -f -- "$run_probe"
+    return 1
+  }
+  printf '%s\n' superserve-sandbox-data-reflink-probe >"$run_probe" || rc=1
+
+  if (( rc == 0 )); then
+    cp --reflink=always --sparse=always -- "$run_probe" "$snapshot_probe_dir/from-rundir" || rc=$?
+  fi
+  if (( rc == 0 )); then
+    cp --reflink=always --sparse=always -- "$snapshot_probe_dir/from-rundir" "$snapshot_probe_dir/within-snapshots" || rc=$?
+  fi
+  if (( rc == 0 )); then
+    cmp -s "$run_probe" "$snapshot_probe_dir/from-rundir" || rc=$?
+    cmp -s "$run_probe" "$snapshot_probe_dir/within-snapshots" || rc=$?
+  fi
+  rm -f -- "$run_probe"
+  rm -rf -- "$snapshot_probe_dir"
+  return "$rc"
+}
+
+install_fail_closed_dependencies() {
+  local target tmp
+  for target in \
+    /etc/systemd/system/superserve-vmd.service.d/sandbox-data-disk.conf \
+    /etc/systemd/system/superserve-vmd.socket.d/sandbox-data-disk.conf \
+    /etc/systemd/system/firecracker@.service.d/sandbox-data-disk.conf; do
+    install -d -m 0755 "$(dirname "$target")"
+    tmp="$(mktemp "${target}.XXXXXX")"
+    printf '%s\n' \
+      '[Unit]' \
+      'Requires=sandbox-data-disk.service' \
+      'After=sandbox-data-disk.service' >"$tmp"
+    chmod 0644 "$tmp"
+    if [[ -f "$target" ]] && cmp -s "$tmp" "$target"; then
+      rm -f -- "$tmp"
+    else
+      mv -f -- "$tmp" "$target"
+    fi
+  done
+  # The dependency files must reach stable storage before XFS can become the
+  # authoritative copy. After a crash, systemd must never start VMD without
+  # first running this data-disk unit.
+  sync
+  systemctl daemon-reload
+}
+
+write_authority_marker() {
+  local tmp
+
+  install -d -m 0755 "$(dirname "$AUTHORITY_MARKER")"
+  if [[ -f "$AUTHORITY_MARKER" ]] && grep -qxF 'data-v1' "$AUTHORITY_MARKER"; then
+    return 0
+  fi
+
+  tmp="$(mktemp "${AUTHORITY_MARKER}.XXXXXX")" || return 1
+  if ! printf '%s\n' data-v1 >"$tmp"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  chmod 0644 "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$AUTHORITY_MARKER" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  sync
+}
+
+main() {
+  local configured_device resolved_device root_source root_parent root_disk
+  local block_type child_count signatures fs_type mounted_targets
+  local device_id mount_id canonical_parent_id
+  local active_units vmd_was_active=0 socket_was_active=0
+  local migration_tmp=""
+  local created_rundir_bind=0 created_snapshots_bind=0
+  local data_authoritative=0 verify_only=0 run_dir snapshot_dir
+
+  cleanup() {
+    local rc=$? restore_failed=0
+    trap - EXIT RETURN INT TERM
+    set +e
+
+    if [[ -n "$migration_tmp" && -d "$migration_tmp" ]]; then
+      rm -rf -- "$migration_tmp"
+    fi
+
+    if (( rc != 0 && data_authoritative == 0 )); then
+      (( created_snapshots_bind == 1 )) && umount "$CANON_SNAPSHOTS"
+      (( created_rundir_bind == 1 )) && umount "$CANON_RUNDIR"
+    fi
+
+    if (( rc == 0 || data_authoritative == 0 )); then
+      if (( socket_was_active == 1 )); then
+        systemctl start --no-block "$VMD_SOCKET" || restore_failed=1
+      fi
+      if (( vmd_was_active == 1 )); then
+        systemctl start --no-block "$VMD_SERVICE" || restore_failed=1
+      fi
+    else
+      stop_vmd_control_plane_fail_closed
+      log "ERROR: XFS data is authoritative after commit; leaving the VMD control plane stopped for fail-closed recovery" >&2
+    fi
+    (( rc != 0 || restore_failed == 0 )) || rc=1
+    exit "$rc"
+  }
+
+  if [[ "${1:-}" == "--verify-only" ]]; then
+    verify_only=1
+    # Verification is used only after the storage unit has previously
+    # succeeded. Any failed check must therefore stop runtime consumers.
+    data_authoritative=1
+    shift
+  fi
+  [[ $# -eq 0 ]] || fail "usage: $0 [--verify-only]"
+
+  [[ "$EUID" -eq 0 ]] || fail "must run as root"
+
+  for command in awk blkid chmod cmp cp dirname find findmnt flock grep install lsblk mkdir mkfs.xfs mktemp mount mountpoint mv pgrep readlink rm sed seq sleep sort stat sync systemctl umount wipefs xfs_info; do
+    require_command "$command"
+  done
+
+  # RETURN handles successful/explicit returns while main's locals are still
+  # in scope; EXIT handles `exit`/errexit paths from inside main.
+  trap cleanup EXIT RETURN
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  install -d -m 0755 /run/lock
+  exec 9>/run/lock/sandbox-data-disk.lock
+  flock -n 9 || fail "another data-disk setup is already running"
+
+  if [[ -e "$AUTHORITY_MARKER" || -L "$AUTHORITY_MARKER" ]]; then
+    data_authoritative=1
+    [[ -f "$AUTHORITY_MARKER" && ! -L "$AUTHORITY_MARKER" ]] ||
+      fail "$AUTHORITY_MARKER must be a regular file"
+    grep -qxF 'data-v1' "$AUTHORITY_MARKER" ||
+      fail "$AUTHORITY_MARKER has unexpected contents"
+  fi
+
+  configured_device="$(read_config_device)"
+  [[ -n "$configured_device" ]] || fail "SANDBOX_DATA_DISK_DEVICE is not configured"
+  [[ "$configured_device" == "$EXPECTED_DEVICE" ]] ||
+    fail "device must be exactly $EXPECTED_DEVICE, got: $configured_device"
+  # On a main-branch rollout the VMD and Terraform workflows start in
+  # parallel. Give Terraform enough time to create and attach the first disk;
+  # later deploys return immediately because the stable by-id path exists.
+  for attempt in $(seq 1 "$DEVICE_WAIT_SECONDS"); do
+    [[ -e "$configured_device" ]] && break
+    sleep 1
+  done
+  [[ -e "$configured_device" ]] || fail "configured device did not appear within ${DEVICE_WAIT_SECONDS} seconds: $configured_device"
+
+  [[ -f /etc/sandbox/vmd.env ]] || fail "/etc/sandbox/vmd.env is missing"
+  run_dir="$(awk -F= '$1 == "RUN_DIR" {value = substr($0, index($0, "=") + 1)} END {print value}' /etc/sandbox/vmd.env | sed -e 's/^"//; s/"$//' -e "s/^'//; s/'$//")"
+  snapshot_dir="$(awk -F= '$1 == "SNAPSHOT_DIR" {value = substr($0, index($0, "=") + 1)} END {print value}' /etc/sandbox/vmd.env | sed -e 's/^"//; s/"$//' -e "s/^'//; s/'$//")"
+  run_dir="${run_dir:-$CANON_RUNDIR}"
+  snapshot_dir="${snapshot_dir:-$CANON_SNAPSHOTS}"
+  [[ "$run_dir" == "$CANON_RUNDIR" ]] || fail "RUN_DIR must remain $CANON_RUNDIR, got: $run_dir"
+  [[ "$snapshot_dir" == "$CANON_SNAPSHOTS" ]] || fail "SNAPSHOT_DIR must remain $CANON_SNAPSHOTS, got: $snapshot_dir"
+
+  resolved_device="$(readlink -f -- "$configured_device")"
+  [[ -b "$resolved_device" ]] || fail "configured path is not a block device: $configured_device"
+  block_type="$(lsblk -dn -o TYPE -- "$resolved_device" | awk 'NF {print; exit}')"
+  [[ "$block_type" == "disk" ]] || fail "configured device must be a whole disk, got TYPE=$block_type"
+  child_count="$(lsblk -nr -o NAME -- "$resolved_device" | awk 'END {print NR + 0}')"
+  [[ "$child_count" == "1" ]] || fail "configured device has partitions or child mappings; refusing to format/mount"
+
+  root_source="$(findmnt -n -T / -o SOURCE)"
+  root_parent="$(lsblk -no PKNAME -- "$root_source" 2>/dev/null | awk 'NF {print; exit}')"
+  if [[ -n "$root_parent" ]]; then
+    root_disk="$(readlink -f -- "/dev/$root_parent")"
+  else
+    root_disk="$(readlink -f -- "$root_source")"
+  fi
+  [[ "$resolved_device" != "$root_disk" ]] || fail "configured data device resolves to the root disk"
+
+  if (( verify_only == 1 )) && ! mountpoint -q "$MOUNT_ROOT"; then
+    fail "verify-only mode requires an existing $MOUNT_ROOT mount"
+  fi
+
+  if ! mountpoint -q "$MOUNT_ROOT"; then
+    active_units="$(active_firecracker_units)"
+    if [[ -n "$active_units" ]] || pgrep -x firecracker >/dev/null 2>&1; then
+      fail "the data disk is not mounted and Firecracker is running; drain the host before setup${active_units:+: $active_units}"
+    fi
+  fi
+
+  mkdir -p "$MOUNT_ROOT" "$CANON_RUNDIR" "$CANON_SNAPSHOTS"
+
+  if mountpoint -q "$MOUNT_ROOT"; then
+    mount_id="$(mount_device_id "$MOUNT_ROOT")"
+    device_id="$(lsblk -dn -o MAJ:MIN -- "$resolved_device" | awk 'NF {print; exit}')"
+    [[ "$mount_id" == "$device_id" ]] || fail "$MOUNT_ROOT is mounted from an unexpected device"
+    [[ "$(mount_fstype "$MOUNT_ROOT")" == "xfs" ]] || fail "$MOUNT_ROOT is not XFS"
+  else
+    mounted_targets="$(findmnt -rn -S "$resolved_device" -o TARGET 2>/dev/null || true)"
+    [[ -z "$mounted_targets" ]] || fail "configured device is already mounted elsewhere: $mounted_targets"
+
+    signatures="$(wipefs --noheadings --output TYPE -- "$resolved_device" 2>/dev/null | awk 'NF {print}')"
+    fs_type="$(blkid -s TYPE -o value -- "$resolved_device" 2>/dev/null || true)"
+    if [[ -z "$fs_type" ]]; then
+      [[ -z "$signatures" ]] || fail "blank-filesystem check found existing signatures: $signatures"
+      log "formatting blank data disk $configured_device as reflink-capable XFS"
+      mkfs.xfs -m crc=1,reflink=1 -- "$resolved_device"
+    else
+      [[ "$fs_type" == "xfs" ]] || fail "configured device already contains unsupported filesystem: $fs_type"
+      [[ "$(printf '%s\n' "$signatures" | awk 'NF {count++} END {print count + 0}')" == "1" ]] ||
+        fail "configured XFS device has multiple filesystem/partition signatures"
+    fi
+
+    mount -t xfs -o noatime,discard -- "$resolved_device" "$MOUNT_ROOT"
+  fi
+
+  xfs_info "$MOUNT_ROOT" | grep -Eq '(^|[[:space:]])reflink=1([[:space:]]|$)' ||
+    fail "$MOUNT_ROOT is XFS but reflink support is not enabled"
+  device_id="$(lsblk -dn -o MAJ:MIN -- "$resolved_device" | awk 'NF {print; exit}')"
+  [[ -n "$device_id" && "$(mount_device_id "$MOUNT_ROOT")" == "$device_id" ]] ||
+    fail "mounted data filesystem does not match the configured device"
+
+  canonical_parent_id="$(mount_device_id /var/lib/sandbox)"
+  [[ "$canonical_parent_id" != "$device_id" ]] ||
+    fail "the data disk must not cover all of /var/lib/sandbox"
+
+  if [[ -d "$DATA_ROOT" ]]; then
+    # A committed tree is authoritative even when activation did not finish.
+    # Mark that before any later validation can fail so cleanup never falls
+    # back to a divergent ext4 tree.
+    data_authoritative=1
+    [[ -f "$MIGRATION_MARKER" && -d "$DATA_ROOT/rundir" && -d "$DATA_ROOT/snapshots" ]] ||
+      fail "$DATA_ROOT exists without a complete migration marker and directory pair"
+    install_fail_closed_dependencies
+    write_authority_marker || fail "could not persist $AUTHORITY_MARKER"
+    if [[ -f "$ACTIVATION_MARKER" ]] &&
+      verify_bind_mount "$CANON_RUNDIR" "$DATA_ROOT/rundir" "$device_id" &&
+      verify_bind_mount "$CANON_SNAPSHOTS" "$DATA_ROOT/snapshots" "$device_id"; then
+      verify_reflinks "$CANON_RUNDIR" "$CANON_SNAPSHOTS" || fail "mandatory reflink verification failed"
+      log "data disk and canonical bind mounts are already ready"
+      return 0
+    fi
+  elif [[ -e "$DATA_ROOT" || -L "$DATA_ROOT" ]]; then
+    fail "$DATA_ROOT exists but is not a directory"
+  fi
+
+  (( verify_only == 0 )) || fail "data-disk verification requested, but the activated canonical XFS mounts are not ready"
+
+  if mountpoint -q "$CANON_RUNDIR" && ! verify_bind_mount "$CANON_RUNDIR" "$DATA_ROOT/rundir" "$device_id"; then
+    fail "$CANON_RUNDIR is already an unexpected mount"
+  fi
+  if mountpoint -q "$CANON_SNAPSHOTS" && ! verify_bind_mount "$CANON_SNAPSHOTS" "$DATA_ROOT/snapshots" "$device_id"; then
+    fail "$CANON_SNAPSHOTS is already an unexpected mount"
+  fi
+
+  active_units="$(active_firecracker_units)"
+  if [[ -n "$active_units" ]] || pgrep -x firecracker >/dev/null 2>&1; then
+    fail "active or transitional Firecracker processes must be paused/drained before migration or mount repair${active_units:+: $active_units}"
+  fi
+
+  # A migration that committed but did not activate is recoverable only while
+  # every still-unbound ext4 source tree exactly matches its XFS copy. A
+  # mismatch means the old location was written after commit; stay failed
+  # closed instead of guessing which copy is authoritative.
+  unit_should_restore "$VMD_SERVICE" && vmd_was_active=1 || true
+  unit_should_restore "$VMD_SOCKET" && socket_was_active=1 || true
+
+  # Stop both units unconditionally. Merely sampling `is-active` and stopping
+  # only that state misses activating/deactivating transitions and permits a
+  # writer to race the migration copy.
+  systemctl stop "$VMD_SOCKET" || fail "could not stop $VMD_SOCKET"
+  systemctl stop "$VMD_SERVICE" || fail "could not stop $VMD_SERVICE"
+  unit_is_quiescent "$VMD_SOCKET" || fail "$VMD_SOCKET did not become quiescent"
+  unit_is_quiescent "$VMD_SERVICE" || fail "$VMD_SERVICE did not become quiescent"
+
+  active_units="$(active_firecracker_units)"
+  if [[ -n "$active_units" ]] || pgrep -x firecracker >/dev/null 2>&1; then
+    fail "Firecracker became active while quiescing VMD; retry after draining the host"
+  fi
+
+  if [[ -d "$DATA_ROOT" && ! -f "$ACTIVATION_MARKER" ]]; then
+    if ! mountpoint -q "$CANON_RUNDIR" && ! trees_match "$CANON_RUNDIR" "$DATA_ROOT/rundir"; then
+      fail "incomplete migration: ext4 rundir diverged from committed XFS data"
+    fi
+    if ! mountpoint -q "$CANON_SNAPSHOTS" && ! trees_match "$CANON_SNAPSHOTS" "$DATA_ROOT/snapshots"; then
+      fail "incomplete migration: ext4 snapshots diverged from committed XFS data"
+    fi
+  fi
+
+  if [[ ! -e "$DATA_ROOT" ]]; then
+    migration_tmp="${MOUNT_ROOT}/.data-v1.migrate.$$"
+    [[ ! -e "$migration_tmp" ]] || fail "temporary migration path already exists: $migration_tmp"
+    mkdir -m 0700 "$migration_tmp"
+
+    log "copying existing rundir and snapshot trees to XFS"
+    cp -a --one-file-system --sparse=always --reflink=auto -- "$CANON_RUNDIR" "$migration_tmp/rundir"
+    cp -a --one-file-system --sparse=always --reflink=auto -- "$CANON_SNAPSHOTS" "$migration_tmp/snapshots"
+
+    trees_match "$CANON_RUNDIR" "$migration_tmp/rundir" || fail "rundir migration checksum/inventory does not match"
+    trees_match "$CANON_SNAPSHOTS" "$migration_tmp/snapshots" || fail "snapshot migration checksum/inventory does not match"
+    verify_reflinks "$migration_tmp/rundir" "$migration_tmp/snapshots" ||
+      fail "mandatory reflink verification failed inside the migration tree"
+
+    : >"$migration_tmp/.migration-complete"
+    # Persist the boot dependency and an out-of-filesystem authority marker
+    # before the atomic rename. Any crash from this point onward leaves the
+    # host gated on successful XFS recovery rather than booting against ext4.
+    install_fail_closed_dependencies
+    data_authoritative=1
+    write_authority_marker || fail "could not persist $AUTHORITY_MARKER"
+    sync
+    mv -- "$migration_tmp" "$DATA_ROOT"
+    migration_tmp=""
+    sync
+    log "one-time data migration committed"
+  fi
+
+  if ! mountpoint -q "$CANON_RUNDIR"; then
+    mount --bind "$DATA_ROOT/rundir" "$CANON_RUNDIR"
+    created_rundir_bind=1
+  fi
+  if ! mountpoint -q "$CANON_SNAPSHOTS"; then
+    mount --bind "$DATA_ROOT/snapshots" "$CANON_SNAPSHOTS"
+    created_snapshots_bind=1
+  fi
+
+  verify_bind_mount "$CANON_RUNDIR" "$DATA_ROOT/rundir" "$device_id" || fail "rundir bind mount verification failed"
+  verify_bind_mount "$CANON_SNAPSHOTS" "$DATA_ROOT/snapshots" "$device_id" || fail "snapshot bind mount verification failed"
+  [[ "$(mount_device_id "$CANON_RUNDIR")" == "$(mount_device_id "$CANON_SNAPSHOTS")" ]] ||
+    fail "rundir and snapshots do not share one filesystem"
+
+  verify_reflinks "$CANON_RUNDIR" "$CANON_SNAPSHOTS" || fail "canonical mandatory reflink verification failed"
+  : >"$ACTIVATION_MARKER"
+  sync
+
+  log "XFS migration, bind mounts, and mandatory reflink probes passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Stack

**2 of 4** for saved snapshots and independent forks. Depends on #284. This PR adds the data-plane primitives and dormant staging storage machinery; it does not expose the public API or enable the feature.

## What changes

- Adds VMD capability negotiation plus immutable saved-snapshot capture, restore, delete, and writable-layer accounting.
- Validates contained manifest/artifact paths and SHA-256 digests before allocating a child.
- Restores every fork onto a fresh writable layer and scrubs captured source-specific environment defaults before exposure.
- Carries current preview access, explicit published ports, preview revision, and egress policy through restore and restart.
- Adds pidfd-backed process containment, reflink/extent accounting, sparse-copy handling, and Firecracker API connection cleanup.
- Persists disk size and egress in the rollback-stable VMD sidecar without regressing current preview-policy persistence.
- Adds a fail-closed XFS setup unit/script for the existing staging disk and stops boot-time deletion of runtime/snapshot trees.

## Storage activation posture

First activation is **manual-only**, staging-only, defaults off, and accepts exactly `/dev/disk/by-id/google-superserve-sandbox-data`. Push deploys cannot format or migrate a disk. The unit is enabled only after successful authority commit; pre-authority failures remove automatic retry state. Once a host is authoritative, ordinary deploys update and verify the boot-critical storage gate.

Do not run first activation until PR3's declarative host-drain worker is deployed and the host is proven drained. No storage workflow or staging resource was changed while preparing this PR.

## Compatibility and rollback

- Existing CreateSnapshot/RestoreSnapshot callers retain legacy semantics.
- New control planes must pass the capability handshake before using optional RPCs.
- The current preview RPCs, launcher hardening, and fresh-unit linger optimization are preserved.
- Keep the feature dark until PR3 and the PR4 index/canary gate.
- After restrictive forks exist, VMD/storage rollback is drain-first: an older VMD preserves but cannot re-enforce restrictive domain egress after restart.
- Rollback to PR1 retains its DB-first host-admission guarantee; rollback to a pre-PR1 API follows the reactivation gate in `deploy/README.md`.

## Validation

- Pinned VMD protobuf regeneration (`protoc` 34.1, `protoc-gen-go` 1.36.11, `protoc-gen-go-grpc` 1.6.2)
- 14 storage/deploy regression tests, Python compile check, `bash -n`, and actionlint
- Terraform fmt plus staging init/validate in an isolated temporary copy
- Focused macOS race tests for vmdclient/db/API/control-plane
- Full integration suite with `-race`
- Linux test-binary compilation for `internal/vm` and `internal/network`
- Linux builds for all five binaries and Linux `go vet ./...`
- Exact rebased-head Linux CI: https://github.com/superserve-ai/sandbox/actions/runs/30466662415

The new VM/network race suite executes on GitHub's Linux runner; the existing `google/nftables` dependency is not macOS-buildable.