### PR TITLE
Release: gate saved snapshots for staging canary

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,10 @@ on:
     paths:
       - 'supabase/migrations/**'
 
+concurrency:
+  group: cd-migrate
+  cancel-in-progress: false
+
 jobs:
   migrate-staging:
     name: Migrate Staging
@@ -36,6 +40,25 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
+
+      - name: Ensure PostgreSQL client is available
+        run: |
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+
+      # These hot-table indexes must be built one at a time outside the
+      # transactional Supabase migration. The script also verifies their exact
+      # table, btree, uniqueness, key, predicate, and catalog state contract.
+      - name: Prebuild and verify saved-snapshot indexes in staging
+        run: >-
+          psql
+          --dbname="$DATABASE_URL"
+          --no-psqlrc
+          --file=scripts/prebuild-saved-snapshot-indexes.sql
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
 
       - name: Push migrations to staging
         run: supabase db push --db-url "$DATABASE_URL"
@@ -55,7 +78,35 @@ jobs:
         with:
           version: latest
 
-      - name: Push migrations to production
+      - name: Ensure PostgreSQL client is available
+        run: |
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+
+      # Prebuild and verify both production cells before either cell crosses
+      # the contract migration. A failure leaves both databases on the
+      # leave-forward expand schema with the feature dark.
+      - name: Prebuild and verify saved-snapshot indexes in production primary
+        run: >-
+          psql
+          --dbname="$DATABASE_URL"
+          --no-psqlrc
+          --file=scripts/prebuild-saved-snapshot-indexes.sql
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+
+      - name: Prebuild and verify saved-snapshot indexes in production usw
+        run: >-
+          psql
+          --dbname="$DATABASE_URL"
+          --no-psqlrc
+          --file=scripts/prebuild-saved-snapshot-indexes.sql
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
+
+      - name: Push migrations to production primary
         run: supabase db push --db-url "$DATABASE_URL"
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Run integration tests
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/sandbox_test?sslmode=disable
-        run: go test -v -tags integration -count=1 -race -timeout 10m ./internal/integration/ ./cmd/migrate-team/
+        # Both package TestMain functions reset and migrate the same disposable
+        # database. Keep package execution sequential so their schema setup
+        # cannot race the bounded migration locks.
+        run: go test -p 1 -v -tags integration -count=1 -race -timeout 10m ./internal/integration/ ./cmd/migrate-team/
 
   build:
     name: Build

--- a/.github/workflows/snapshot-canary.yml
+++ b/.github/workflows/snapshot-canary.yml
@@ -1,0 +1,737 @@
+name: Saved Snapshot Staging Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type RUN_STAGING_SNAPSHOT_CANARY'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: saved-snapshot-staging-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Exact-main saved snapshot canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: staging
+    env:
+      API_BASE_URL: https://api-staging.superserve.ai
+      SANDBOX_BASE_URL: https://staging-sandbox.superserve.ai
+      API_KEY: ${{ secrets.STAGING_INTERNAL_API_TOKEN }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL_STAGING }}
+      SNAPSHOT_TEAM_ID: ${{ secrets.SYSTEM_TEAM_ID_STAGING }}
+      SNAPSHOT_CANARY_MAIN_SHA: ${{ github.sha }}
+      CANARY_QUOTA_HEADROOM_BYTES: '21474836480'
+      PGCONNECT_TIMEOUT: '10'
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Validate exact-main staging intent
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [[ "$CONFIRM" != "RUN_STAGING_SNAPSHOT_CANARY" ]]; then
+            echo "Refusing to run. Re-dispatch with the exact confirmation phrase." >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "The staging ship gate may only be dispatched from main, got ${GITHUB_REF}." >&2
+            exit 1
+          fi
+          for name in API_KEY DATABASE_URL SNAPSHOT_TEAM_ID GH_TOKEN; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Required staging secret/environment value is missing: ${name}" >&2
+              exit 1
+            fi
+          done
+          if [[ ! "$SNAPSHOT_TEAM_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+            echo "SYSTEM_TEAM_ID_STAGING is not a UUID." >&2
+            exit 1
+          fi
+          remote_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)"
+          if [[ "$remote_main" != "$SNAPSHOT_CANARY_MAIN_SHA" ]]; then
+            echo "main moved from ${SNAPSHOT_CANARY_MAIN_SHA} to ${remote_main}; re-dispatch the canary." >&2
+            exit 1
+          fi
+          bash -n scripts/smoke-test-snapshots.sh
+          bash -n scripts/restart-staging-snapshot-services.sh
+
+      - name: Enable one team, run strict canary, and restore prior state
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          PRIOR_STATE=""
+          restore_rollout_state() {
+            local original_result=$?
+            local exact_restored=0
+            local dark_asserted=0
+            local failsafe_dark=0
+            local attempt
+            local flag_exists quota_is_null prior_enabled prior_created_at prior_updated_at prior_quota
+
+            trap - EXIT INT TERM
+            force_team_dark_once() {
+              PGCONNECT_TIMEOUT=3 psql "$DATABASE_URL" \
+                --no-psqlrc \
+                --quiet \
+                --set=ON_ERROR_STOP=1 \
+                --set=team_id="$SNAPSHOT_TEAM_ID" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '2s';
+          SET LOCAL statement_timeout = '5s';
+          UPDATE public.team_feature_flag
+          SET enabled = false,
+              updated_at = now()
+          WHERE team_id = :'team_id'::uuid
+            AND key = 'sandbox_snapshots_v1'
+            AND enabled;
+          SELECT NOT EXISTS (
+            SELECT 1
+            FROM public.team_feature_flag
+            WHERE team_id = :'team_id'::uuid
+              AND key = 'sandbox_snapshots_v1'
+              AND enabled
+          ) AS team_dark
+          \gset
+          \if :team_dark
+          COMMIT;
+          \else
+          ROLLBACK;
+          SELECT 1 / 0; -- ON_ERROR_STOP makes the cleanup fail closed.
+          \endif
+          SQL
+            }
+
+            # First cleanup action: force the team dark within cancellation
+            # grace, before parsing state or attempting exact restoration.
+            set +e
+            for attempt in 1 2 3; do
+              if force_team_dark_once; then
+                failsafe_dark=1
+                break
+              fi
+              echo "::warning::Priority team-disable attempt ${attempt}/3 failed." >&2
+              sleep "$((attempt * 2))"
+            done
+            set -e
+
+            if [[ -z "$PRIOR_STATE" ]]; then
+              if (( failsafe_dark == 0 )); then
+                echo "::error::CRITICAL: cleanup had no prior state and could not force ${SNAPSHOT_TEAM_ID} dark." >&2
+                exit 1
+              fi
+              echo "::warning::Cleanup had no captured quota state; the canary team was forced dark but quota restoration could not be verified." >&2
+              if (( original_result == 0 )); then
+                exit 1
+              fi
+              exit "$original_result"
+            fi
+
+            if ! jq -e '
+              type == "object"
+              and has("quota")
+              and has("flag")
+              and (.flag == null or (
+                .flag.enabled == false
+                and (.flag.created_at | type) == "string"
+                and (.flag.updated_at | type) == "string"
+              ))
+            ' >/dev/null <<<"$PRIOR_STATE"; then
+              if (( failsafe_dark == 0 )); then
+                echo "::error::CRITICAL: captured state is malformed and the canary team could not be forced dark." >&2
+              else
+                echo "::error::Captured state is malformed; the team is dark but exact quota/row restoration is impossible." >&2
+              fi
+              exit 1
+            fi
+
+            flag_exists="$(jq -r '(.flag != null)' <<<"$PRIOR_STATE")"
+            quota_is_null="$(jq -r '(.quota == null)' <<<"$PRIOR_STATE")"
+            prior_enabled="$(jq -r '.flag.enabled // false' <<<"$PRIOR_STATE")"
+            prior_created_at="$(jq -r '.flag.created_at // "1970-01-01T00:00:00Z"' <<<"$PRIOR_STATE")"
+            prior_updated_at="$(jq -r '.flag.updated_at // "1970-01-01T00:00:00Z"' <<<"$PRIOR_STATE")"
+            prior_quota="$(jq -r '.quota // 0' <<<"$PRIOR_STATE")"
+
+            restore_exact_once() {
+              psql "$DATABASE_URL" \
+                --no-psqlrc \
+                --quiet \
+                --set=ON_ERROR_STOP=1 \
+                --set=team_id="$SNAPSHOT_TEAM_ID" \
+                --set=flag_exists="$flag_exists" \
+                --set=quota_is_null="$quota_is_null" \
+                --set=prior_enabled="$prior_enabled" \
+                --set=prior_created_at="$prior_created_at" \
+                --set=prior_updated_at="$prior_updated_at" \
+                --set=prior_quota="$prior_quota" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '5s';
+          SET LOCAL statement_timeout = '30s';
+          LOCK TABLE public.feature_flag, public.team_feature_flag
+            IN SHARE ROW EXCLUSIVE MODE;
+          LOCK TABLE public.team IN ROW EXCLUSIVE MODE;
+
+          \if :flag_exists
+          INSERT INTO public.team_feature_flag (
+            team_id, key, enabled, created_at, updated_at
+          )
+          VALUES (
+            :'team_id'::uuid,
+            'sandbox_snapshots_v1',
+            :'prior_enabled'::boolean,
+            :'prior_created_at'::timestamptz,
+            :'prior_updated_at'::timestamptz
+          )
+          ON CONFLICT (team_id, key) DO UPDATE
+          SET enabled = EXCLUDED.enabled,
+              created_at = EXCLUDED.created_at,
+              updated_at = EXCLUDED.updated_at;
+          \else
+          DELETE FROM public.team_feature_flag
+          WHERE team_id = :'team_id'::uuid
+            AND key = 'sandbox_snapshots_v1';
+          \endif
+
+          \if :quota_is_null
+          UPDATE public.team
+          SET snapshot_storage_quota_bytes = NULL
+          WHERE id = :'team_id'::uuid;
+          \else
+          UPDATE public.team
+          SET snapshot_storage_quota_bytes = :'prior_quota'::bigint
+          WHERE id = :'team_id'::uuid;
+          \endif
+
+          SELECT (
+            (
+              :'flag_exists'::boolean
+              AND EXISTS (
+                SELECT 1
+                FROM public.team_feature_flag
+                WHERE team_id = :'team_id'::uuid
+                  AND key = 'sandbox_snapshots_v1'
+                  AND enabled = :'prior_enabled'::boolean
+                  AND created_at = :'prior_created_at'::timestamptz
+                  AND updated_at = :'prior_updated_at'::timestamptz
+              )
+            )
+            OR (
+              NOT :'flag_exists'::boolean
+              AND NOT EXISTS (
+                SELECT 1
+                FROM public.team_feature_flag
+                WHERE team_id = :'team_id'::uuid
+                  AND key = 'sandbox_snapshots_v1'
+              )
+            )
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM public.team
+            WHERE id = :'team_id'::uuid
+              AND (
+                (
+                  :'quota_is_null'::boolean
+                  AND snapshot_storage_quota_bytes IS NULL
+                )
+                OR (
+                  NOT :'quota_is_null'::boolean
+                  AND snapshot_storage_quota_bytes = :'prior_quota'::bigint
+                )
+              )
+          ) AS restore_ok
+          \gset
+          \if :restore_ok
+          COMMIT;
+          \else
+          ROLLBACK;
+          \echo 'Exact canary-team flag/quota restoration failed.'
+          SELECT 1 / 0; -- ON_ERROR_STOP makes the exact restore fail closed.
+          \endif
+          SQL
+            }
+
+            assert_fully_dark_once() {
+              local observed
+              observed="$(psql "$DATABASE_URL" \
+                --no-psqlrc --quiet --set=ON_ERROR_STOP=1 \
+                --tuples-only --no-align \
+                --set=team_id="$SNAPSHOT_TEAM_ID" \
+                --set=flag_exists="$flag_exists" \
+                --set=quota_is_null="$quota_is_null" \
+                --set=prior_enabled="$prior_enabled" \
+                --set=prior_created_at="$prior_created_at" \
+                --set=prior_updated_at="$prior_updated_at" \
+                --set=prior_quota="$prior_quota" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '5s';
+          SET LOCAL statement_timeout = '30s';
+          LOCK TABLE public.feature_flag, public.team_feature_flag IN SHARE MODE;
+          LOCK TABLE public.team IN SHARE MODE;
+          SELECT (
+            EXISTS (
+              SELECT 1
+              FROM public.feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND NOT enabled
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.team_feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND enabled
+            )
+            AND (
+              (
+                :'flag_exists'::boolean
+                AND EXISTS (
+                  SELECT 1
+                  FROM public.team_feature_flag
+                  WHERE team_id = :'team_id'::uuid
+                    AND key = 'sandbox_snapshots_v1'
+                    AND enabled = :'prior_enabled'::boolean
+                    AND created_at = :'prior_created_at'::timestamptz
+                    AND updated_at = :'prior_updated_at'::timestamptz
+                )
+              )
+              OR (
+                NOT :'flag_exists'::boolean
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM public.team_feature_flag
+                  WHERE team_id = :'team_id'::uuid
+                    AND key = 'sandbox_snapshots_v1'
+                )
+              )
+            )
+            AND EXISTS (
+              SELECT 1
+              FROM public.team
+              WHERE id = :'team_id'::uuid
+                AND (
+                  (
+                    :'quota_is_null'::boolean
+                    AND snapshot_storage_quota_bytes IS NULL
+                  )
+                  OR (
+                    NOT :'quota_is_null'::boolean
+                    AND snapshot_storage_quota_bytes = :'prior_quota'::bigint
+                  )
+                )
+            )
+          )::text;
+          COMMIT;
+          SQL
+              )" || return 1
+              [[ "$observed" == "true" ]]
+            }
+
+            set +e
+            for attempt in 1 2 3 4 5; do
+              if restore_exact_once; then
+                exact_restored=1
+                break
+              fi
+              echo "::warning::Exact saved-snapshot rollout-state restore attempt ${attempt}/5 failed." >&2
+              sleep "$((attempt * 2))"
+            done
+
+            if (( exact_restored == 0 )); then
+              echo "::error::EXACT RESTORE FAILED. Forcing the canary team's saved-snapshot flag dark; quota may remain elevated and requires operator repair." >&2
+              failsafe_dark=0
+              for attempt in 1 2 3 4 5; do
+                if force_team_dark_once; then
+                  failsafe_dark=1
+                  break
+                fi
+                echo "::warning::Fail-safe team-disable attempt ${attempt}/5 failed." >&2
+                sleep "$((attempt * 2))"
+              done
+              if (( failsafe_dark == 0 )); then
+                echo "::error::CRITICAL: could not force the canary team feature flag dark. Disable sandbox_snapshots_v1 for ${SNAPSHOT_TEAM_ID} immediately." >&2
+              else
+                echo "::error::Fail-safe disabled the canary team, but exact flag/quota restoration did not complete. Operator repair is required." >&2
+              fi
+              exit 1
+            fi
+
+            for attempt in 1 2 3; do
+              if assert_fully_dark_once; then
+                dark_asserted=1
+                break
+              fi
+              echo "::warning::Post-restore global dark-state assertion attempt ${attempt}/3 failed." >&2
+              sleep "$((attempt * 2))"
+            done
+            set -e
+
+            if (( dark_asserted == 0 )); then
+              echo "::error::Post-restore sign-off failed: the global flag is not false, an enabled team override exists, or the database could not be verified. Global state was not mutated." >&2
+              exit 1
+            fi
+            echo "Restored the canary team's exact prior feature-flag row and snapshot quota."
+            exit "$original_result"
+          }
+          trap restore_rollout_state EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          # First capture prior state without mutation. The trap can now restore
+          # the exact quota/row before a later transaction is allowed to enable
+          # anything, including if cancellation lands just after that COMMIT.
+          PRIOR_STATE="$(psql "$DATABASE_URL" \
+            --no-psqlrc \
+            --quiet \
+            --tuples-only \
+            --no-align \
+            --set=ON_ERROR_STOP=1 \
+            --set=team_id="$SNAPSHOT_TEAM_ID" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '5s';
+          SET LOCAL statement_timeout = '30s';
+          LOCK TABLE public.feature_flag, public.team_feature_flag
+            IN SHARE ROW EXCLUSIVE MODE;
+          LOCK TABLE public.team IN ROW EXCLUSIVE MODE;
+          LOCK TABLE public.sandbox IN SHARE MODE;
+          LOCK TABLE public.snapshot IN SHARE MODE;
+
+          SELECT
+            EXISTS (
+              SELECT 1
+              FROM public.feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND NOT enabled
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.team_feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND enabled
+            )
+            AND EXISTS (
+              SELECT 1 FROM public.team WHERE id = :'team_id'::uuid
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.snapshot
+              WHERE team_id = :'team_id'::uuid
+                AND kind = 'saved'
+                AND deleted_at IS NULL
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.sandbox
+              WHERE team_id = :'team_id'::uuid
+                AND (
+                  source_snapshot_id IS NOT NULL
+                  OR snapshot_operation_id IS NOT NULL
+                  OR snapshot_operation_started_at IS NOT NULL
+                )
+            ) AS gate_ok
+          \gset
+
+          \if :gate_ok
+          SELECT jsonb_build_object(
+            'quota', t.snapshot_storage_quota_bytes,
+            'flag', (
+              SELECT jsonb_build_object(
+                'enabled', tff.enabled,
+                'created_at', tff.created_at,
+                'updated_at', tff.updated_at
+              )
+              FROM public.team_feature_flag tff
+              WHERE tff.team_id = t.id
+                AND tff.key = 'sandbox_snapshots_v1'
+            )
+          )::text
+          FROM public.team t
+          WHERE t.id = :'team_id'::uuid;
+          COMMIT;
+          \else
+          ROLLBACK;
+          \warn 'Saved-snapshot canary preflight failed: global flag, team overrides, team existence, or zero-residue invariant is unsafe.'
+          SELECT 1 / 0; -- ON_ERROR_STOP makes preflight fail closed.
+          \endif
+          SQL
+          )"
+
+          if ! jq -e '
+            type == "object"
+            and has("quota")
+            and has("flag")
+            and (.flag == null or (
+              .flag.enabled == false
+              and (.flag.created_at | type) == "string"
+              and (.flag.updated_at | type) == "string"
+            ))
+          ' >/dev/null <<<"$PRIOR_STATE"; then
+            echo "Could not capture a valid pre-canary rollout state." >&2
+            exit 1
+          fi
+
+          prior_flag_exists="$(jq -r '(.flag != null)' <<<"$PRIOR_STATE")"
+          prior_quota_is_null="$(jq -r '(.quota == null)' <<<"$PRIOR_STATE")"
+          prior_enabled="$(jq -r '.flag.enabled // false' <<<"$PRIOR_STATE")"
+          prior_created_at="$(jq -r '.flag.created_at // "1970-01-01T00:00:00Z"' <<<"$PRIOR_STATE")"
+          prior_updated_at="$(jq -r '.flag.updated_at // "1970-01-01T00:00:00Z"' <<<"$PRIOR_STATE")"
+          prior_quota="$(jq -r '.quota // 0' <<<"$PRIOR_STATE")"
+
+          # Re-lock and compare-and-set against the captured row/quota. A
+          # concurrent rollout/configuration change aborts without mutation.
+          psql "$DATABASE_URL" \
+            --no-psqlrc \
+            --quiet \
+            --set=ON_ERROR_STOP=1 \
+            --set=team_id="$SNAPSHOT_TEAM_ID" \
+            --set=headroom="$CANARY_QUOTA_HEADROOM_BYTES" \
+            --set=flag_exists="$prior_flag_exists" \
+            --set=quota_is_null="$prior_quota_is_null" \
+            --set=prior_enabled="$prior_enabled" \
+            --set=prior_created_at="$prior_created_at" \
+            --set=prior_updated_at="$prior_updated_at" \
+            --set=prior_quota="$prior_quota" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '5s';
+          SET LOCAL statement_timeout = '30s';
+          LOCK TABLE public.feature_flag, public.team_feature_flag
+            IN SHARE ROW EXCLUSIVE MODE;
+          LOCK TABLE public.team IN ROW EXCLUSIVE MODE;
+          LOCK TABLE public.sandbox IN SHARE MODE;
+          LOCK TABLE public.snapshot IN SHARE MODE;
+
+          SELECT EXISTS (
+            SELECT 1
+            FROM public.feature_flag
+            WHERE key = 'sandbox_snapshots_v1'
+              AND NOT enabled
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.team_feature_flag
+            WHERE key = 'sandbox_snapshots_v1'
+              AND enabled
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.snapshot
+            WHERE team_id = :'team_id'::uuid
+              AND kind = 'saved'
+              AND deleted_at IS NULL
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.sandbox
+            WHERE team_id = :'team_id'::uuid
+              AND (
+                source_snapshot_id IS NOT NULL
+                OR snapshot_operation_id IS NOT NULL
+                OR snapshot_operation_started_at IS NOT NULL
+              )
+          )
+          AND (
+            (
+              :'flag_exists'::boolean
+              AND EXISTS (
+                SELECT 1
+                FROM public.team_feature_flag
+                WHERE team_id = :'team_id'::uuid
+                  AND key = 'sandbox_snapshots_v1'
+                  AND enabled = :'prior_enabled'::boolean
+                  AND created_at = :'prior_created_at'::timestamptz
+                  AND updated_at = :'prior_updated_at'::timestamptz
+              )
+            )
+            OR (
+              NOT :'flag_exists'::boolean
+              AND NOT EXISTS (
+                SELECT 1
+                FROM public.team_feature_flag
+                WHERE team_id = :'team_id'::uuid
+                  AND key = 'sandbox_snapshots_v1'
+              )
+            )
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM public.team
+            WHERE id = :'team_id'::uuid
+              AND (
+                (
+                  :'quota_is_null'::boolean
+                  AND snapshot_storage_quota_bytes IS NULL
+                )
+                OR (
+                  NOT :'quota_is_null'::boolean
+                  AND snapshot_storage_quota_bytes = :'prior_quota'::bigint
+                )
+              )
+          ) AS cas_ok
+          \gset
+
+          \if :cas_ok
+          INSERT INTO public.team_feature_flag (team_id, key, enabled)
+          VALUES (:'team_id'::uuid, 'sandbox_snapshots_v1', true)
+          ON CONFLICT (team_id, key) DO UPDATE
+          SET enabled = true,
+              updated_at = now();
+
+          UPDATE public.team
+          SET snapshot_storage_quota_bytes = GREATEST(
+            COALESCE(snapshot_storage_quota_bytes, 0),
+            snapshot_storage_bytes + :'headroom'::bigint
+          )
+          WHERE id = :'team_id'::uuid;
+
+          SELECT EXISTS (
+            SELECT 1
+            FROM public.feature_flag
+            WHERE key = 'sandbox_snapshots_v1'
+              AND NOT enabled
+          )
+          AND (
+            SELECT count(*) = 1
+            FROM public.team_feature_flag
+            WHERE key = 'sandbox_snapshots_v1'
+              AND enabled
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM public.team_feature_flag
+            WHERE key = 'sandbox_snapshots_v1'
+              AND enabled
+              AND team_id = :'team_id'::uuid
+          ) AS enable_ok
+          \gset
+          \if :enable_ok
+          COMMIT;
+          \else
+          ROLLBACK;
+          \warn 'Failed to establish exactly one enabled team override.'
+          SELECT 1 / 0; -- ON_ERROR_STOP makes enable fail closed.
+          \endif
+          \else
+          ROLLBACK;
+          \warn 'Saved-snapshot canary state changed after capture; refusing enable.'
+          SELECT 1 / 0; -- ON_ERROR_STOP makes the CAS fail closed.
+          \endif
+          SQL
+
+          chmod +x \
+            scripts/smoke-test-snapshots.sh \
+            scripts/restart-staging-snapshot-services.sh
+
+          RUN_SNAPSHOT_CANARY=1 \
+          REQUIRE_SNAPSHOT_RESTART_HOOK=1 \
+          SKIP_SNAPSHOT_SECRET_CHECKS=0 \
+          SNAPSHOT_RESTART_HOOK="$GITHUB_WORKSPACE/scripts/restart-staging-snapshot-services.sh" \
+          SNAPSHOT_SHADOW_DATABASE_URL="$DATABASE_URL" \
+          ./scripts/smoke-test-snapshots.sh
+
+          final_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)"
+          if [[ "$final_main" != "$SNAPSHOT_CANARY_MAIN_SHA" ]]; then
+            echo "::error::main moved to ${final_main} after the final restart; refusing stale/mixed-deploy canary sign-off for ${SNAPSHOT_CANARY_MAIN_SHA}." >&2
+            exit 1
+          fi
+          echo "Final canary sign-off remains pinned to main ${SNAPSHOT_CANARY_MAIN_SHA}."
+
+      - name: Always enforce dark rollout state
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          : "${DATABASE_URL:?DATABASE_URL_STAGING is required}"
+          : "${SNAPSHOT_TEAM_ID:?SYSTEM_TEAM_ID_STAGING is required}"
+
+          force_dark() {
+            PGCONNECT_TIMEOUT=3 psql "$DATABASE_URL" \
+              --no-psqlrc --quiet --set=ON_ERROR_STOP=1 \
+              --set=team_id="$SNAPSHOT_TEAM_ID" <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '2s';
+          SET LOCAL statement_timeout = '5s';
+          UPDATE public.team_feature_flag
+          SET enabled = false,
+              updated_at = now()
+          WHERE team_id = :'team_id'::uuid
+            AND key = 'sandbox_snapshots_v1'
+            AND enabled;
+          COMMIT;
+          SQL
+          }
+
+          assert_dark() {
+            local observed
+            observed="$(psql "$DATABASE_URL" \
+              --no-psqlrc --quiet --set=ON_ERROR_STOP=1 \
+              --tuples-only --no-align <<'SQL'
+          BEGIN;
+          SET LOCAL lock_timeout = '5s';
+          SET LOCAL statement_timeout = '30s';
+          LOCK TABLE public.feature_flag, public.team_feature_flag IN SHARE MODE;
+          SELECT (
+            EXISTS (
+              SELECT 1
+              FROM public.feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND NOT enabled
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.team_feature_flag
+              WHERE key = 'sandbox_snapshots_v1'
+                AND enabled
+            )
+          )::text;
+          COMMIT;
+          SQL
+            )" || return 1
+            [[ "$observed" == "true" ]]
+          }
+
+          forced=0
+          for attempt in 1 2 3 4 5; do
+            if force_dark; then
+              forced=1
+              break
+            fi
+            echo "::warning::Always-cleanup team-disable attempt ${attempt}/5 failed." >&2
+            sleep "$((attempt * 2))"
+          done
+          if (( forced == 0 )); then
+            echo "::error::CRITICAL: always-cleanup could not force ${SNAPSHOT_TEAM_ID} dark." >&2
+            exit 1
+          fi
+
+          asserted=0
+          for attempt in 1 2 3; do
+            if assert_dark; then
+              asserted=1
+              break
+            fi
+            echo "::warning::Always-cleanup global dark assertion attempt ${attempt}/3 failed." >&2
+            sleep "$((attempt * 2))"
+          done
+          if (( asserted == 0 )); then
+            echo "::error::Global saved-snapshot flag is not false, an enabled team override remains, or dark state could not be verified. Global state was not mutated." >&2
+            exit 1
+          fi
+          echo "Confirmed global saved-snapshot flag false and zero enabled team overrides."

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test-short:
 	go test ./... -short -count=1
 
 test-integration: db-reset db-wait
-	DATABASE_URL="$(DATABASE_URL)" go test -tags integration ./internal/integration/ ./cmd/migrate-team/ -v -count=1 -timeout 10m
+	DATABASE_URL="$(DATABASE_URL)" go test -p 1 -tags integration ./internal/integration/ ./cmd/migrate-team/ -v -count=1 -timeout 10m
 
 ## Lint
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -16,10 +16,12 @@ info:
 
     | Endpoint | What it does |
     |----------|-------------|
-    | `POST /sandboxes` | Create a new sandbox (optionally `from_template`) |
+    | `POST /sandboxes` | Create a new sandbox from a template or saved snapshot |
     | `PATCH /sandboxes/:id` | Partially update a running sandbox (e.g. network rules) |
     | `POST /sandboxes/:id/pause` | Snapshot full state, suspend the VM |
     | `POST /sandboxes/:id/resume` | Restore from snapshot, continue where it left off |
+    | `POST /sandboxes/:id/snapshots` | Create a named or unnamed immutable saved snapshot |
+    | `GET /snapshots` | List immutable saved snapshots |
     | `DELETE /sandboxes/:id` | Delete sandbox and all resources |
 
     ## Sandbox environment
@@ -28,7 +30,9 @@ info:
     1 vCPU, 1 GB RAM, 4 GB disk, with Python 3.12, Node.js 22, npm, git, curl,
     and build-essential pre-installed). Callers can override with any template
     name (e.g. `superserve/python-3.11`, `superserve/node-22`) or a team-owned template UUID
-    via the `from_template` field on `POST /sandboxes`.
+    via the `from_template` field on `POST /sandboxes`. A ready immutable
+    saved snapshot can instead be forked into any number of independent
+    sandboxes with `from_snapshot`.
 
     ## Files and commands
 
@@ -479,10 +483,33 @@ paths:
       tags: [Sandboxes]
       summary: Create a new sandbox
       description: |
-        Creates a sandbox from a template (defaults to `superserve/base` when
-        `from_template` is omitted). When the request returns successfully,
-        the sandbox is ready to use — you can run commands against it
-        immediately.
+        Creates a sandbox from either a template or an immutable saved
+        snapshot. When both source fields are omitted, the sandbox defaults to
+        `superserve/base`. `from_template` and `from_snapshot` cannot be sent
+        together.
+
+        `from_snapshot` accepts only a saved snapshot belonging to the
+        authenticated team whose status is `ready`. The replaceable runtime
+        checkpoint created by `POST /sandboxes/{sandbox_id}/pause` is not a
+        reusable saved snapshot and is never accepted here. A fork inherits the
+        saved VM resource shape and captured memory/disk state, but receives a
+        new sandbox identity, access token, network identity, and writable
+        layers.
+
+        Omitted `timeout_seconds` and `auto_delete_seconds` inherit the captured
+        values; explicit `null` clears them. Omitted `network` and `secrets`
+        inherit captured configuration, while an object is a full replacement
+        (`secrets: {}` clears all bindings). JSON `null` is invalid for
+        `from_template`, `from_snapshot`, `network`, and `secrets`.
+
+        Preview publication is intentionally child-local. A fork starts with
+        no published preview ports and never inherits source preview tokens or
+        publications. `preview_access` selects the child default. With
+        `private`, every port remains closed until it is explicitly published
+        and a new child-scoped token is minted.
+
+        When the request returns successfully, the sandbox is ready to use —
+        you can run commands against it immediately.
 
         New sandboxes use strict preview routing: only ports explicitly
         published through `/sandboxes/{sandbox_id}/preview-ports` are reachable.
@@ -498,17 +525,53 @@ paths:
               $ref: "#/components/schemas/CreateSandboxRequest"
       responses:
         "201":
-          description: Sandbox created
+          description: |
+            Sandbox created. When the request used `from_snapshot`, the
+            response includes `source_snapshot_id` equal to that saved
+            snapshot ID; template-rooted sandboxes omit the field.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/SandboxResponse"
         "400":
-          $ref: "#/components/responses/BadRequest"
+          description: |
+            Invalid request. Sending both `from_template` and `from_snapshot`,
+            sending JSON `null` for a non-nullable inheritance field, or using
+            an invalid snapshot ID returns `bad_request`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: |
+            The caller cannot create the requested sandbox. `error.code` is:
+            - `feature_disabled` when `from_snapshot` was used but saved
+              snapshots are not enabled for the team.
+            - `forbidden` when the caller lacks sandbox write permission.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: |
+            Requested source not found. A missing or cross-team saved snapshot
+            uses error code `snapshot_not_found`; a missing template uses the
+            template lookup's existing not-found code.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "409":
-          $ref: "#/components/responses/Conflict"
+          description: |
+            A `from_snapshot` request uses `snapshot_not_ready` when the saved
+            snapshot is transitional or failed. Other create conflicts use the
+            existing conflict envelope.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "429":
           description: |
             Rate-limited or quota reached. The `error.code` distinguishes:
@@ -516,6 +579,25 @@ paths:
             - `too_many_sandboxes` — team has reached its active sandbox count
               limit (paused sandboxes do not count; pause or delete a sandbox to
               free a slot, or contact support to raise the cap).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          $ref: "#/components/responses/SnapshotUnavailable"
+        "503":
+          description: |
+            Required host capacity is temporarily unavailable. A
+            `from_snapshot` request uses `snapshot_host_unavailable` and never
+            falls back to a host without the exact artifacts. Template-rooted
+            creation may use `service_unavailable` when no host can be
+            scheduled. Snapshot-host failures include `Retry-After`.
+          headers:
+            Retry-After:
+              description: Delay in seconds before retrying, when provided.
+              schema:
+                type: integer
+                minimum: 1
           content:
             application/json:
               schema:
@@ -551,6 +633,13 @@ paths:
       operationId: deleteSandbox
       tags: [Sandboxes]
       summary: Delete a sandbox
+      description: |
+        Deletes a sandbox that has no saved snapshots. The initial snapshot
+        canary has no cascade option: if saved snapshots originate from this
+        sandbox, the request returns `409 sandbox_has_snapshots` with dependency
+        counts and IDs. Delete the dependent leaf snapshots first. A sandbox
+        in a live lifecycle transition may instead return the existing generic
+        `409 conflict`; retry after the transition completes.
       security:
         - apiKey: []
       responses:
@@ -558,6 +647,18 @@ paths:
           description: Sandbox deleted
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            The sandbox owns saved snapshots or is in a lifecycle transition.
+            Dependency blocks use `sandbox_has_snapshots` and include counts;
+            transitional-state blocks use the existing `conflict` code. No
+            resources are deleted.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/DependencyConflictError"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":
@@ -854,9 +955,11 @@ paths:
       tags: [Sandboxes]
       summary: Pause a running sandbox
       description: |
-        Snapshots the sandbox's full state (memory + disk), suspends the VM,
-        and transitions to `paused`. Resume it later to continue exactly where
-        it left off — same memory, same running processes, same files.
+        Creates or replaces the sandbox's internal runtime checkpoint (memory
+        and disk), suspends the VM, and transitions to `paused`. Resume it later
+        to continue exactly where it left off — same memory, same running
+        processes, same files. This checkpoint restores only this sandbox; it
+        is not an immutable saved snapshot and cannot be used to create forks.
       security:
         - apiKey: []
       responses:
@@ -880,8 +983,9 @@ paths:
       tags: [Sandboxes]
       summary: Resume a paused sandbox
       description: |
-        Restores the sandbox from its paused snapshot. Transitions back to
-        `active` with all state intact — same memory, same processes, same files.
+        Restores the sandbox from its replaceable runtime checkpoint. Transitions
+        back to `active` with all state intact — same memory, same processes,
+        same files. This does not read or mutate user-addressable saved snapshots.
       security:
         - apiKey: []
       responses:
@@ -903,6 +1007,243 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          $ref: "#/components/responses/SandboxResumeHostUnavailable"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /sandboxes/{sandbox_id}/snapshots:
+    parameters:
+      - $ref: "#/components/parameters/SandboxId"
+
+    post:
+      operationId: createSnapshot
+      tags: [Snapshots]
+      summary: Create an immutable saved snapshot
+      description: |
+        Captures the sandbox's memory, process state, and disk state as a
+        durable saved snapshot. The source may be `active` or `paused`. An
+        active source may be briefly frozen and is returned to its prior state
+        before this request completes; a paused source remains paused and its
+        runtime resume checkpoint is not consumed or replaced.
+
+        This operation is synchronous. A `201` response always contains a
+        durable snapshot with status `ready`; partial captures are never
+        exposed as ready. The snapshot is immutable and can be passed as
+        `from_snapshot` to multiple concurrent `POST /sandboxes` requests.
+
+        The optional `name` is a non-unique human-readable label. Omit the body
+        or send `{}` for an unnamed snapshot. Supplying the same
+        `Idempotency-Key` for the same team and operation returns the
+        originally created snapshot instead of capturing another one.
+      security:
+        - apiKey: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        description: Omit the body or send `{}` to create an unnamed snapshot.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSnapshotRequest"
+      responses:
+        "201":
+          description: Saved snapshot created and ready for use
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/SnapshotFeatureDisabled"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: |
+            The capture cannot proceed. `error.code` is one of:
+            - `snapshot_source_state_invalid` — the sandbox cannot be captured
+              in its current lifecycle/VM state; wait for any pause, resume,
+              snapshot, or delete transition to finish before retrying.
+            - `snapshot_not_ready` — a prior request with the same idempotency
+              key is failed, deleting, or awaiting reconciliation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "410":
+          description: |
+            Required artifacts are permanently unavailable. `error.code` is
+            one of:
+            - `snapshot_unavailable` — the saved snapshot associated with an
+              idempotency key can no longer be used.
+            - `snapshot_artifacts_missing` — the source VM's committed memory
+              or disk artifacts are missing or corrupt.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: |
+            Rate-limited or snapshot quota reached. `error.code` is one of:
+            - `rate_limited` — request rate exceeded.
+            - `too_many_snapshots` — a per-sandbox or per-team snapshot-count
+              limit was reached.
+            - `snapshot_storage_quota_exceeded` — the team's exclusive saved
+              snapshot storage quota was reached.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/SnapshotQuotaError"
+        "503":
+          $ref: "#/components/responses/SnapshotHostUnavailable"
+        "500":
+          description: |
+            Internal capture failure. `error.code` is
+            `snapshot_source_failed` when VMD committed or attempted the
+            capture but could not return the source sandbox to its prior
+            running state; the source is reconciled to `failed`.
+            `snapshot_chain_invalid` means VMD returned a committed artifact
+            set that failed integrity validation. Other unexpected failures
+            use the normal internal error envelope.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /snapshots:
+    get:
+      operationId: listSnapshots
+      tags: [Snapshots]
+      summary: List saved snapshots
+      description: |
+        Returns only immutable saved snapshots belonging to the authenticated
+        team, ordered newest first. Named and unnamed snapshots are both
+        included; runtime pause checkpoints are never included. Use
+        `sandbox_id` to restrict results to snapshots captured directly from
+        one source sandbox. Placement hosts, artifact paths, manifests, and
+        secret material are never returned.
+      security:
+        - apiKey: []
+      parameters:
+        - name: sandbox_id
+          in: query
+          required: false
+          description: Filter by the sandbox from which the snapshot was captured.
+          schema:
+            $ref: "#/components/schemas/PublicSandboxId"
+        - $ref: "#/components/parameters/PageLimit"
+        - $ref: "#/components/parameters/PageOffset"
+      responses:
+        "200":
+          description: Saved snapshots belonging to the authenticated team
+          headers:
+            X-Total-Count:
+              $ref: "#/components/headers/TotalCount"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SnapshotResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /snapshots/{snapshot_id}:
+    parameters:
+      - $ref: "#/components/parameters/SnapshotId"
+
+    get:
+      operationId: getSnapshot
+      tags: [Snapshots]
+      summary: Get a saved snapshot
+      description: |
+        Returns public saved-snapshot metadata and dependency counts. The
+        `parent_snapshot_id` records direct lineage when the source sandbox was
+        itself forked from a saved snapshot. Host placement, filesystem paths,
+        manifests, layer addresses, and secret material are never exposed.
+      security:
+        - apiKey: []
+      responses:
+        "200":
+          description: Saved snapshot metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SnapshotNotFound"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+    delete:
+      operationId: deleteSnapshot
+      tags: [Snapshots]
+      summary: Delete a leaf saved snapshot
+      description: |
+        Deletes a saved snapshot only when no live sandbox or saved snapshot
+        depends on it. The initial canary deliberately has no cascade option
+        and does not reparent descendants. Delete dependent resources
+        leaf-first before retrying an intermediate snapshot.
+
+        Host cleanup is attempted before returning `204`; a transient host
+        failure returns retryable `503` while retaining the durable deletion
+        claim. Shared ancestor layers remain until their final reference
+        disappears, so success does not imply that every physical byte in the
+        reconstructed snapshot was removed.
+      security:
+        - apiKey: []
+      responses:
+        "204":
+          description: Saved snapshot deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/SnapshotNotFound"
+        "409":
+          description: |
+            The snapshot cannot currently be deleted. `error.code` is one of:
+            - `snapshot_has_dependents` — one or more sandboxes or saved
+              snapshots depend on it; the response includes dependency details.
+            - `snapshot_not_ready` — the snapshot cannot enter the deleting
+              state. A `creating` leaf is cancellable and enters the same
+              durable cleanup queue as any other deletion.
+            No resources are deleted for a dependency conflict.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/Error"
+                  - $ref: "#/components/schemas/DependencyConflictError"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "503":
+          $ref: "#/components/responses/SnapshotHostUnavailable"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -939,6 +1280,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          $ref: "#/components/responses/SandboxResumeHostUnavailable"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -2043,6 +2386,28 @@ components:
         $ref: "#/components/schemas/PublicSandboxId"
       description: The unique identifier of the sandbox.
 
+    SnapshotId:
+      name: snapshot_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: The unique identifier of an immutable saved snapshot.
+
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Caller-generated key used to safely retry a mutation without creating
+        another resource. Keys are scoped to the authenticated team and
+        operation.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+
     PreviewPort:
       name: port
       in: path
@@ -2247,6 +2612,11 @@ components:
     CreateSandboxRequest:
       type: object
       required: [name]
+      not:
+        properties:
+          from_template: {}
+          from_snapshot: {}
+        required: [from_template, from_snapshot]
       properties:
         name:
           type: string
@@ -2263,31 +2633,50 @@ components:
             (curated templates use the `superserve/` name prefix). The template's
             vCPU, memory, and disk values are inherited by the sandbox —
             they cannot be overridden per-sandbox because the snapshot
-            dictates VM shape. When omitted, defaults to `superserve/base`.
+            dictates VM shape. When both source fields are omitted, defaults
+            to `superserve/base`. Mutually exclusive with `from_snapshot`.
+            JSON `null` is invalid.
+        from_snapshot:
+          type: string
+          format: uuid
+          description: |
+            Create an independent sandbox from this immutable saved snapshot.
+            The snapshot must belong to the authenticated team and have status
+            `ready`; creating from a runtime pause checkpoint, a transitional
+            snapshot, or an unavailable snapshot is rejected. Resource shape,
+            memory, disk, network policy, secret bindings, and lifecycle
+            defaults are captured from the snapshot. The new sandbox receives
+            its own identity, writable layers, network identity, access token,
+            preview policy, and preview credentials. Mutually exclusive with
+            `from_template`; JSON `null` is invalid.
         timeout_seconds:
-          type: integer
+          type: [integer, "null"]
           format: int32
           minimum: 1
           maximum: 604800
-          description: >
+          description: |
             Optional auto-pause timeout in seconds. The sandbox is paused
             once its current active session has run this long; each resume
-            starts a fresh window. When unset, the sandbox stays active
-            until explicitly paused. Also settable later via
-            `PATCH /sandboxes/{sandbox_id}`. Maximum 604800 (7 days).
+            starts a fresh window. When omitted for `from_snapshot`, inherits
+            the snapshot-time value; explicit `null` disables the inherited
+            timeout. For template/default creation, omitted or `null` means the
+            sandbox stays active until explicitly paused. Also settable later
+            via `PATCH /sandboxes/{sandbox_id}`. Maximum 604800 (7 days).
         auto_delete_seconds:
-          type: integer
+          type: [integer, "null"]
           format: int32
           minimum: 0
           maximum: 2592000
-          description: >
+          description: |
             Optional garbage-collection window for paused sandboxes, in
             seconds. Once the sandbox has been continuously paused for this
             long it is deleted automatically. The window arms each time the
             sandbox pauses and is cancelled by resume, so a sandbox in use is
             never eligible. `0` deletes the sandbox as soon as it pauses.
-            When unset, paused sandboxes are kept until explicitly deleted.
-            Also settable later via `PATCH /sandboxes/{sandbox_id}`.
+            When omitted for `from_snapshot`, inherits the snapshot-time value;
+            explicit `null` disables the inherited window. For template/default
+            creation, omitted or `null` keeps paused sandboxes until explicitly
+            deleted. Also settable later via `PATCH /sandboxes/{sandbox_id}`.
             Maximum 2592000 (30 days).
         metadata:
           type: object
@@ -2310,7 +2699,8 @@ components:
 
             Metadata can be updated after creation via `PATCH /sandboxes/:id`.
             Filter sandboxes by metadata via the `metadata.{key}` query
-            parameter on `GET /sandboxes`.
+            parameter on `GET /sandboxes`. User metadata is never inherited
+            from a saved snapshot; omitted metadata starts as `{}`.
           example:
             env: prod
             owner: agent-7
@@ -2322,13 +2712,19 @@ components:
             Environment variables injected into every process inside the
             sandbox (terminal sessions, exec calls). Merged on top of any
             defaults set by the template's `env` build steps — caller keys
-            win on conflict. Survive pause/resume.
+            win on conflict. For `from_snapshot`, these values become defaults
+            for processes started after restore; already-running cloned
+            processes retain their captured environments. Survive pause/resume.
           example:
             OPENAI_API_KEY: sk-...
             DEBUG: "1"
             run_id: 7f3c-21
         network:
           $ref: "#/components/schemas/NetworkConfig"
+          description: |
+            Egress policy for the sandbox. When omitted for `from_snapshot`,
+            inherits the snapshot-time policy. When present, this object is a
+            full replacement rather than a merge. JSON `null` is invalid.
         secrets:
           type: object
           additionalProperties:
@@ -2338,7 +2734,13 @@ components:
             sandbox. Keys are env-var names; values are secret names from
             `POST /secrets`. The agent never sees the real value: it sees a
             proxy token in env, and the in-host enforcement daemon swaps the
-            token for the real credential at egress.
+            token for the real credential at egress. When omitted for
+            `from_snapshot`, the captured binding definitions are inherited
+            with fresh child-specific tokens. When present, the object is a
+            full replacement; `{}` removes every captured binding. JSON `null`
+            is invalid. Because a saved snapshot clones full process memory,
+            replacing bindings cannot scrub secret bytes that a captured
+            process had already read.
           example:
             ANTHROPIC_API_KEY: anthropic-prod
             GITHUB_TOKEN: ghp-readonly
@@ -2348,11 +2750,124 @@ components:
           default: public
           description: |
             Default access for newly published preview ports. New sandboxes
-            default to `public`; `private` ports stay closed with 401 until
-            preview-token authentication is introduced. Both modes are strict:
-            only explicitly published ports are reachable.
+            and saved-snapshot forks default to `public`. Both modes are strict:
+            only explicitly published ports are reachable. A fork never
+            inherits its source's published-port rows, token generations, or
+            credentials, so it starts with zero published ports. Choosing
+            `private` keeps each later-published private port closed with `401`
+            until a child-scoped preview token is minted.
             `legacy_public` is reserved for sandboxes created before explicit
             publication and cannot be selected through the API.
+
+    CreateSnapshotRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: |
+            Optional human-readable label. Labels are not unique; use `id` as
+            the stable identity of a saved snapshot. Omit `name` for an unnamed
+            snapshot; JSON `null` is invalid.
+
+    SnapshotResponse:
+      type: object
+      description: |
+        Public metadata for an immutable saved snapshot. This resource is
+        distinct from a sandbox's replaceable runtime pause checkpoint. Host
+        identity, filesystem paths, manifests, layer addresses, captured
+        environment values, and secret material are intentionally opaque.
+      required:
+        - id
+        - status
+        - sandbox_id
+        - vcpu_count
+        - memory_mib
+        - disk_mib
+        - logical_size_bytes
+        - exclusive_size_bytes
+        - child_sandbox_count
+        - child_snapshot_count
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Stable ID accepted by `CreateSandboxRequest.from_snapshot`.
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: Optional, non-unique human-readable label.
+        status:
+          type: string
+          enum: [creating, ready, unavailable, failed, deleting]
+          description: |
+            Saved-snapshot lifecycle state. Only `ready` snapshots can create
+            sandboxes. `unavailable` means committed host artifacts are
+            permanently missing or corrupt; metadata and deletion remain
+            available, but fork attempts return `410 snapshot_unavailable`.
+        sandbox_id:
+          $ref: "#/components/schemas/PublicSandboxId"
+          description: Sandbox from which this saved snapshot was captured.
+        parent_snapshot_id:
+          type: [string, "null"]
+          format: uuid
+          description: |
+            Direct lineage edge: the saved snapshot from which the source
+            sandbox was originally created. Absent or null for a
+            template-rooted source sandbox.
+        vcpu_count:
+          type: integer
+          format: int32
+          minimum: 1
+          description: vCPU count inherited by sandboxes created from this snapshot.
+        memory_mib:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Memory size inherited by sandboxes created from this snapshot.
+        disk_mib:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Disk capacity inherited by sandboxes created from this snapshot.
+        logical_size_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Logical bytes represented by the reconstructable memory and disk
+            state, including shared ancestor layers.
+        exclusive_size_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Allocated bytes introduced by this saved snapshot after excluding
+            shared ancestor layers. Shared bytes are attributed to the team
+            once rather than once per fork.
+        child_sandbox_count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Number of live sandboxes created directly from this snapshot.
+        child_snapshot_count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Number of direct descendant saved snapshots.
+        created_at:
+          type: string
+          format: date-time
+          description: Time the saved-snapshot record was created.
+        updated_at:
+          type: string
+          format: date-time
+          description: Time the saved-snapshot status or metadata last changed.
 
     ActivityResponse:
       description: One audit-log activity row returned by the activity list endpoint.
@@ -2433,7 +2948,20 @@ components:
         snapshot_id:
           type: string
           format: uuid
-          description: ID of the latest snapshot (present after a pause).
+          deprecated: true
+          description: |
+            Deprecated ID of the replaceable runtime checkpoint used only to
+            resume this same paused sandbox. It is not a saved snapshot, is not
+            returned by `/snapshots`, and must not be passed as
+            `from_snapshot`. Clients should not persist or otherwise use it.
+        source_snapshot_id:
+          type: string
+          format: uuid
+          description: |
+            Immutable saved snapshot from which this sandbox was created.
+            Absent when the sandbox was created from a template. Unlike the
+            deprecated `snapshot_id`, this is a reusable saved-snapshot ID and
+            records the fork's direct lineage edge.
         created_at:
           type: string
           format: date-time
@@ -3680,12 +4208,125 @@ components:
           items:
             $ref: "#/components/schemas/TeamRoleAssignment"
 
+    DependencyConflictDetails:
+      type: object
+      description: |
+        Team-scoped resources that currently block a non-cascading delete.
+        Counts cover all known blockers. ID arrays contain stable public IDs
+        when returned; clients must use the counts rather than assuming an
+        omitted or truncated array means zero dependencies.
+      required: [sandbox_count, snapshot_count]
+      properties:
+        sandbox_count:
+          type: integer
+          format: int64
+          minimum: 0
+        snapshot_count:
+          type: integer
+          format: int64
+          minimum: 0
+        sandbox_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicSandboxId"
+          description: Stable IDs of blocking sandboxes included in this response.
+        snapshot_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Stable IDs of blocking saved snapshots included in this response.
+
+    DependencyConflictError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message, dependencies]
+          properties:
+            code:
+              type: string
+              enum:
+                [snapshot_has_dependents, sandbox_has_snapshots, template_has_dependents]
+            message:
+              type: string
+            dependencies:
+              $ref: "#/components/schemas/DependencyConflictDetails"
+
+    SnapshotQuotaDetails:
+      type: object
+      description: Team and source usage at the point snapshot admission failed.
+      required:
+        - snapshot_count
+        - max_snapshots
+        - source_snapshot_count
+        - max_snapshots_per_sandbox
+        - storage_bytes
+        - storage_quota_bytes
+      properties:
+        snapshot_count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Current saved-snapshot count for the team.
+        max_snapshots:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Maximum saved-snapshot count for the team.
+        source_snapshot_count:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Current saved-snapshot count for the source sandbox.
+        max_snapshots_per_sandbox:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Maximum saved-snapshot count for one source sandbox.
+        storage_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Current team-attributed exclusive saved-snapshot bytes.
+        storage_quota_bytes:
+          type: [integer, "null"]
+          format: int64
+          minimum: 0
+          description: |
+            Team exclusive-storage limit. Null means no pilot quota has been
+            provisioned, so saved-snapshot capture remains unavailable.
+
+    SnapshotQuotaError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message, quota]
+          properties:
+            code:
+              type: string
+              enum: [too_many_snapshots, snapshot_storage_quota_exceeded]
+            message:
+              type: string
+            quota:
+              $ref: "#/components/schemas/SnapshotQuotaDetails"
+
     Error:
       type: object
       description: |
         Error envelope. `error.code` is a stable, machine-readable identifier
         (e.g. `bad_request`, `not_found`, `conflict`, `rate_limited`,
         `too_many_builds`, `too_many_templates`, `too_many_sandboxes`,
+        `feature_disabled`, `snapshot_not_found`, `snapshot_not_ready`,
+        `too_many_snapshots`, `snapshot_storage_quota_exceeded`,
+        `snapshot_source_state_invalid`, `snapshot_source_failed`,
+        `snapshot_secret_unavailable`, `snapshot_host_unavailable`,
+        `snapshot_unavailable`, `snapshot_artifacts_missing`,
+        `snapshot_chain_invalid`, `snapshot_has_dependents`,
+        `sandbox_has_snapshots`,
         `image_pull_failed`, `step_failed`, `snapshot_failed`,
         `start_cmd_failed`, `ready_cmd_failed`, `build_failed`).
         `error.message` is human-readable and may change between releases;
@@ -3718,12 +4359,40 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    SnapshotFeatureDisabled:
+      description: |
+        The caller cannot create the saved snapshot. The response uses
+        `feature_disabled` when saved snapshots are not enabled for the team,
+        or `forbidden` when the caller lacks sandbox write permission. Normal
+        template sandbox creation and runtime pause/resume are unaffected by
+        the saved-snapshot feature gate.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: feature_disabled
+              message: Saved snapshots are not enabled for this team.
     NotFound:
       description: Resource not found
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    SnapshotNotFound:
+      description: |
+        Saved snapshot not found. The response uses error code
+        `snapshot_not_found`; unknown and cross-team IDs are deliberately
+        indistinguishable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: snapshot_not_found
+              message: Snapshot not found.
     Conflict:
       description: Operation conflicts with the resource's current state
       content:
@@ -3745,6 +4414,75 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    SnapshotHostUnavailable:
+      description: |
+        The host holding the exact source or saved-snapshot artifacts is
+        temporarily unreachable, unhealthy, or at operation capacity. The
+        response uses error code `snapshot_host_unavailable`; durable capture
+        or deletion state is retained so the operation can be retried after the
+        indicated delay. A ready snapshot stays ready on a fork failure. The
+        platform never silently schedules the request on a host without the
+        artifacts.
+      headers:
+        Retry-After:
+          description: Delay in seconds before retrying the request.
+          schema:
+            type: integer
+            minimum: 1
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: snapshot_host_unavailable
+              message: The saved snapshot host is temporarily unavailable.
+    SandboxResumeHostUnavailable:
+      description: |
+        The sandbox's assigned host is temporarily unavailable, or a
+        snapshot-derived sandbox cannot currently reacquire capacity on the
+        host holding its exact saved-snapshot artifacts. `error.code` is
+        `sandbox_host_unavailable` for assigned-host admission failures and
+        `snapshot_host_unavailable` for saved-snapshot capacity failures.
+        Both conditions are retryable; the platform never silently schedules
+        the sandbox on a host without its required runtime or snapshot state.
+      headers:
+        Retry-After:
+          description: Delay in seconds before retrying the request.
+          schema:
+            type: integer
+            minimum: 1
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            assignedHost:
+              summary: Assigned sandbox host is unavailable
+              value:
+                error:
+                  code: sandbox_host_unavailable
+                  message: The sandbox host is temporarily unavailable.
+            snapshotCapacity:
+              summary: Saved-snapshot host lacks operation capacity
+              value:
+                error:
+                  code: snapshot_host_unavailable
+                  message: The snapshot host has insufficient capacity.
+    SnapshotUnavailable:
+      description: |
+        The committed artifacts needed to restore this saved snapshot are
+        permanently missing, corrupt, or otherwise unusable. The response uses
+        error code `snapshot_unavailable`. The snapshot remains inspectable and
+        deletable, but cannot create new sandboxes.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error:
+              code: snapshot_unavailable
+              message: Snapshot artifacts are missing or corrupt.
     StorageFull:
       description: >
         The sandbox has run out of disk space. Response body uses error code

--- a/cmd/controlplane/main_test.go
+++ b/cmd/controlplane/main_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -102,13 +104,124 @@ func TestRetryUnavailableStopsOnContextCancel(t *testing.T) {
 // embedded nil interface.
 type fakeVMDClient struct {
 	vmdpb.VMDaemonClient
-	opens   int
-	opensFn func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error)
+	opens            int
+	opensFn          func(call int) (vmdpb.VMDaemon_StreamBuildLogsClient, error)
+	capabilitiesFn   func() (*vmdpb.GetCapabilitiesResponse, error)
+	createSnapshotFn func() (*vmdpb.CreateSnapshotResponse, error)
+}
+
+func (f *fakeVMDClient) GetCapabilities(context.Context, *vmdpb.GetCapabilitiesRequest, ...grpc.CallOption) (*vmdpb.GetCapabilitiesResponse, error) {
+	return f.capabilitiesFn()
+}
+
+func (f *fakeVMDClient) CreateSnapshot(context.Context, *vmdpb.CreateSnapshotRequest, ...grpc.CallOption) (*vmdpb.CreateSnapshotResponse, error) {
+	return f.createSnapshotFn()
 }
 
 func (f *fakeVMDClient) StreamBuildLogs(ctx context.Context, req *vmdpb.StreamBuildLogsRequest, opts ...grpc.CallOption) (vmdpb.VMDaemon_StreamBuildLogsClient, error) {
 	f.opens++
 	return f.opensFn(f.opens)
+}
+
+func TestGRPCVMDClientSavedSnapshotCapabilityFailsClosedOnOldVMD(t *testing.T) {
+	fake := &fakeVMDClient{capabilitiesFn: func() (*vmdpb.GetCapabilitiesResponse, error) {
+		return nil, grpcstatus.Error(grpccodes.Unimplemented, "unknown method GetCapabilities")
+	}}
+	err := (&grpcVMDClient{client: fake}).CheckSavedSnapshotSupport(context.Background())
+	if grpcstatus.Code(err) != grpccodes.Unimplemented {
+		t.Fatalf("capability error code = %s, want Unimplemented: %v", grpcstatus.Code(err), err)
+	}
+}
+
+func TestGRPCVMDClientSavedSnapshotCapabilityRequiresAdvertisement(t *testing.T) {
+	fake := &fakeVMDClient{capabilitiesFn: func() (*vmdpb.GetCapabilitiesResponse, error) {
+		return &vmdpb.GetCapabilitiesResponse{}, nil
+	}}
+	err := (&grpcVMDClient{client: fake}).CheckSavedSnapshotSupport(context.Background())
+	if grpcstatus.Code(err) != grpccodes.Unimplemented {
+		t.Fatalf("capability error code = %s, want Unimplemented: %v", grpcstatus.Code(err), err)
+	}
+}
+
+func TestGRPCVMDClientMissingSavedSnapshotArtifactsAreRetryable(t *testing.T) {
+	fake := &fakeVMDClient{createSnapshotFn: func() (*vmdpb.CreateSnapshotResponse, error) {
+		return &vmdpb.CreateSnapshotResponse{}, nil
+	}}
+	_, err := (&grpcVMDClient{client: fake}).CreateSavedSnapshot(context.Background(), "source", "snapshot")
+	if grpcstatus.Code(err) != grpccodes.Unavailable {
+		t.Fatalf("missing artifact error code = %s, want Unavailable: %v", grpcstatus.Code(err), err)
+	}
+}
+
+func TestGRPCVMDClientSanitizesSavedSnapshotErrorsFromOlderVMD(t *testing.T) {
+	const hostPath = "/var/lib/superserve/private/snapshots/source/snapshot/manifest.json"
+	st, err := grpcstatus.New(grpccodes.DataLoss, "read "+hostPath+": input/output error").WithDetails(&errdetails.ErrorInfo{
+		Reason: vmdclient.SavedSnapshotSourceResumeFailureReason,
+		Domain: "vmd.superserve.ai",
+		Metadata: map[string]string{
+			"artifact_path": hostPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("attach VMD error details: %v", err)
+	}
+	fake := &fakeVMDClient{createSnapshotFn: func() (*vmdpb.CreateSnapshotResponse, error) {
+		return nil, st.Err()
+	}}
+
+	_, err = (&grpcVMDClient{client: fake}).CreateSavedSnapshot(context.Background(), "source", "snapshot")
+	if grpcstatus.Code(err) != grpccodes.DataLoss {
+		t.Fatalf("code = %s, want DataLoss (%v)", grpcstatus.Code(err), err)
+	}
+	if !vmdclient.GRPCErrorHasReason(err, vmdclient.SavedSnapshotSourceResumeFailureReason) {
+		t.Fatalf("stable error reason was not preserved: %v", err)
+	}
+	if strings.Contains(err.Error(), hostPath) || strings.Contains(err.Error(), "artifact_path") {
+		t.Fatalf("control-plane boundary exposed host artifact path: %v", err)
+	}
+}
+
+func TestGRPCVMDClientRejectsInvalidSavedSnapshotMetadata(t *testing.T) {
+	validResponse := func() *vmdpb.CreateSnapshotResponse {
+		return &vmdpb.CreateSnapshotResponse{
+			Artifacts: &vmdpb.SavedSnapshotArtifacts{
+				SchemaVersion:  1,
+				ManifestPath:   "/snapshots/saved/manifest.json",
+				ManifestDigest: strings.Repeat("a", 64),
+				SnapshotPath:   "/snapshots/saved/vmstate.snap",
+				MemFilePath:    "/snapshots/saved/mem.snap",
+				DiskFullPath:   "/snapshots/saved/rootfs.ext4",
+			},
+			ResourceLimits: &vmdpb.ResourceLimits{VcpuCount: 2, MemoryMib: 2048, DiskSizeMib: 8192},
+			SourceState:    "running",
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*vmdpb.CreateSnapshotResponse)
+	}{
+		{name: "logical", mutate: func(resp *vmdpb.CreateSnapshotResponse) { resp.LogicalSizeBytes = -1 }},
+		{name: "exclusive", mutate: func(resp *vmdpb.CreateSnapshotResponse) { resp.ExclusiveSizeBytes = -1 }},
+		{name: "source logical", mutate: func(resp *vmdpb.CreateSnapshotResponse) { resp.SourceLogicalSizeBytes = -1 }},
+		{name: "source exclusive", mutate: func(resp *vmdpb.CreateSnapshotResponse) { resp.SourceExclusiveSizeBytes = -1 }},
+		{name: "uppercase manifest digest", mutate: func(resp *vmdpb.CreateSnapshotResponse) {
+			resp.Artifacts.ManifestDigest = strings.Repeat("A", 64)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := validResponse()
+			tt.mutate(resp)
+			fake := &fakeVMDClient{createSnapshotFn: func() (*vmdpb.CreateSnapshotResponse, error) {
+				return resp, nil
+			}}
+			_, err := (&grpcVMDClient{client: fake}).CreateSavedSnapshot(context.Background(), "source", "snapshot")
+			if grpcstatus.Code(err) != grpccodes.Unavailable {
+				t.Fatalf("invalid metadata error code = %s, want Unavailable: %v", grpcstatus.Code(err), err)
+			}
+		})
+	}
 }
 
 // fakeLogStream serves the given events, then errAfter (or io.EOF).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,6 +67,119 @@ database host-admission rejection could otherwise race a VM launch. If any
 draining host cannot be explicitly returned to `active`, do not roll the API
 back that far.
 
+The saved-snapshot contract migration
+`20260729000011_saved_snapshot_contract.sql` makes the PR3 saved-snapshot
+control-plane release the application rollback floor. It drops the legacy
+non-partial `snapshot_sandbox_unique` conflict target after installing the
+replacement partial runtime-checkpoint index. A pre-PR3 control plane still
+uses `ON CONFLICT (sandbox_id)` without that predicate and cannot finalize
+pauses after the contract. Once migration 11 is recorded in an environment,
+do not deploy or roll API workers below PR3. Database rollback remains
+leave-forward; restoring the legacy index is not an approved rollback path.
+
+Keep the global `sandbox_snapshots_v1` flag and every team override disabled
+through the index and contract rollout. Before migration 11, verify that the
+environment contains:
+
+- zero `snapshot` rows with `kind = 'saved'`;
+- zero sandboxes with `source_snapshot_id` set;
+- zero sandboxes with `snapshot_operation_id` or
+  `snapshot_operation_started_at` set.
+
+The contract migration takes bounded write locks and rechecks those conditions
+atomically before dropping the legacy index. A failed check is a safe stop:
+leave the schema expanded, keep the feature dark, remove the residue or drift,
+and retry the migration.
+
+#### Saved-snapshot index prebuild
+
+The 10 hot-table indexes are built outside the Supabase migration transaction:
+
+```sh
+psql \
+  --dbname="$DATABASE_URL" \
+  --no-psqlrc \
+  --file=scripts/prebuild-saved-snapshot-indexes.sql
+```
+
+The script issues sequential `CREATE INDEX CONCURRENTLY` statements, then
+checks the exact public table, btree access method, uniqueness, key order,
+predicate, full definition, and `valid`/`ready`/`live` catalog state. CD runs
+and verifies it in this order:
+
+1. staging prebuild, then staging migrations;
+2. production-primary prebuild;
+3. production-usw prebuild;
+4. production-primary migrations;
+5. production-usw migrations.
+
+The workflow-wide `cd-migrate` concurrency group prevents overlapping CD runs.
+The prebuild and recovery scripts also share a stable session advisory lock,
+so a manual psql invocation cannot overlap another cooperative index session
+on the same database. Do not run migration 10 against a populated `snapshot`
+or `sandbox` table by another path: it intentionally refuses to build a
+missing index transactionally. Its ordinary `CREATE INDEX` fallback is only
+for an empty local or CI schema reset.
+
+If a canceled concurrent build leaves an invalid index, inspect the failed
+workflow and run the operator-only recovery script against that exact
+environment:
+
+```sh
+psql \
+  --dbname="$DATABASE_URL" \
+  --no-psqlrc \
+  --file=scripts/recover-saved-snapshot-indexes.sql
+```
+
+Recovery drops only invalid remnants through sequential
+`DROP INDEX CONCURRENTLY` commands. It never drops a valid-but-drifted index
+and CD never invokes it automatically. After recovery, rerun the prebuild,
+verify all 10 indexes, and only then retry migrations.
+
+#### Saved-snapshot staging canary
+
+Run the staging canary only after PR3 is live on every traffic-serving API
+revision and VMD host, and after migrations 10/11 have completed. The global
+flag and all team overrides must still be disabled.
+
+Before the first canary, mark the exact staging VMD host `draining` through the
+approved operator path and wait for the drain/reconciliation workers to report
+no remaining Firecracker processes. Then activate the allowlisted XFS device
+once:
+
+```sh
+gh workflow run deploy-vmd.yml \
+  --ref main \
+  -f environment=staging \
+  -f activate_staging_snapshot_storage=true \
+  -f staging_snapshot_storage_device=/dev/disk/by-id/google-superserve-sandbox-data
+```
+
+The setup refuses to migrate storage while a Firecracker process is active.
+After activation succeeds, return the host to `active`, wait for a current
+saved-snapshot capability heartbeat, and dispatch the strict canary from the
+current `main` commit:
+
+```sh
+gh workflow run snapshot-canary.yml \
+  --ref main \
+  -f confirm=RUN_STAGING_SNAPSHOT_CANARY
+```
+
+The canary refuses a moving or non-`main` ref, a globally enabled flag, any
+enabled team override, rollout residue, missing secrets, or missing shadow
+ledger access. It temporarily enables only the staging system team, verifies
+idempotent capture, active/paused snapshots, N-way and nested forks, private
+preview policy, secret-token freshness, restricted egress, dependency-safe
+deletion, accounting, and two exact-release API/VMD restarts. Its trap and
+always-run cleanup force the team dark and restore the prior team flag/quota.
+
+Staging sign-off requires both the canary step and its final dark-state cleanup
+to be green. Confirm the global flag is still false and there are zero enabled
+team overrides afterward. This rollout does not enable saved snapshots in
+production.
+
 ## Host selection
 
 Do not deploy to a host merely because it exists. Host deployment jobs should only target hosts that are explicitly marked ready for that environment/region.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/preview"
 	"github.com/superserve-ai/sandbox/internal/secrets"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -1225,6 +1226,7 @@ func (h *Handlers) respondSandboxSnapshotDependencyConflict(c *gin.Context, sand
 	if count == 0 {
 		return false
 	}
+	RecordSavedSnapshotOutcome(c.Request.Context(), telemetry.SavedSnapshotOperationDelete, telemetry.SavedSnapshotOutcomeDependencyBlocked, telemetryHostID(c))
 	h.capture(c, "sandbox_delete_blocked", map[string]any{
 		"sandbox_id":     sandboxID.String(),
 		"snapshot_count": count,

--- a/internal/api/handlers_sandbox_secret_test.go
+++ b/internal/api/handlers_sandbox_secret_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/secrets"
@@ -565,6 +566,46 @@ func TestDetachSandboxSecret_BadStatus_Conflict(t *testing.T) {
 		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
 	}
 	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock), Encryptor: noopEncryptor{}, Signer: newTestSigner(t, "v1")}
+	w := httptest.NewRecorder()
+	setupSecretRouter(h, teamID.String()).ServeHTTP(w, detachReq(sandboxID.String(), "ANTHROPIC_API_KEY"))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAttachSandboxSecret_SnapshotOperation_Conflict(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	operationID := uuid.New()
+	sb := db.Sandbox{
+		ID:                  sandboxID,
+		TeamID:              teamID,
+		Status:              db.SandboxStatusActive,
+		SnapshotOperationID: pgtype.UUID{Bytes: operationID, Valid: true},
+	}
+	mock := &mockDBTX{queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) }}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock), Encryptor: noopEncryptor{}, Signer: newTestSigner(t, "v1")}
+	w := httptest.NewRecorder()
+	setupSecretRouter(h, teamID.String()).ServeHTTP(w, attachReq(sandboxID.String(), `{"env_key":"ANTHROPIC_API_KEY","secret_name":"anthropic-prod"}`))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDetachSandboxSecret_SnapshotOperation_Conflict(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	operationID := uuid.New()
+	sb := db.Sandbox{
+		ID:                  sandboxID,
+		TeamID:              teamID,
+		Status:              db.SandboxStatusPaused,
+		SnapshotOperationID: pgtype.UUID{Bytes: operationID, Valid: true},
+	}
+	mock := &mockDBTX{queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) }}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
 	w := httptest.NewRecorder()
 	setupSecretRouter(h, teamID.String()).ServeHTTP(w, detachReq(sandboxID.String(), "ANTHROPIC_API_KEY"))
 

--- a/internal/api/handlers_snapshot.go
+++ b/internal/api/handlers_snapshot.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -585,6 +586,7 @@ func (h *Handlers) CreateSnapshot(c *gin.Context) {
 	}
 	if err := validateSavedSnapshotArtifacts(saved, artifacts); err != nil {
 		log.Error().Err(err).Str("snapshot_id", saved.ID.String()).Msg("VMD returned invalid saved snapshot manifest")
+		RecordSavedSnapshotOutcome(c.Request.Context(), telemetry.SavedSnapshotOperationCapture, telemetry.SavedSnapshotOutcomeArtifactCorrupt, savedSnapshotHostID(saved))
 		h.capture(c, "snapshot_artifact_corrupt", map[string]any{
 			"snapshot_id": saved.ID.String(),
 			"sandbox_id":  saved.SandboxID.String(),
@@ -813,6 +815,7 @@ func (h *Handlers) respondSavedSnapshotCaptureError(c *gin.Context, saved db.Sna
 	}
 	grpcCode := status.Code(err)
 	if grpcCode == codes.NotFound || grpcCode == codes.DataLoss {
+		RecordSavedSnapshotOutcome(c.Request.Context(), telemetry.SavedSnapshotOperationCapture, telemetry.SavedSnapshotOutcomeArtifactCorrupt, savedSnapshotHostID(saved))
 		h.capture(c, "snapshot_artifact_corrupt", map[string]any{
 			"snapshot_id": saved.ID.String(),
 			"sandbox_id":  saved.SandboxID.String(),
@@ -939,8 +942,14 @@ func (h *Handlers) deleteCapturedSnapshotBestEffort(reqCtx context.Context, vmd 
 	defer cancel()
 	if err := vmd.DeleteSavedSnapshot(ctx, saved.SandboxID.String(), saved.ID.String()); err != nil && !isVMDNotFound(err) {
 		log.Warn().Err(vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationDelete, err)).Str("snapshot_id", saved.ID.String()).Msg("cleanup captured saved snapshot")
+		outcome := telemetry.SavedSnapshotOutcomeError
+		if transientSavedSnapshotAPIError(err) {
+			outcome = telemetry.SavedSnapshotOutcomeRetry
+		}
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, outcome, savedSnapshotHostID(saved))
 		return err
 	}
+	RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeSuccess, savedSnapshotHostID(saved))
 	return nil
 }
 
@@ -966,7 +975,21 @@ func (h *Handlers) queueSavedSnapshotCleanup(reqCtx context.Context, saved db.Sn
 		ExclusiveSizeBytes: exclusiveSize,
 		FailureReason:      &reason,
 	})
+	if err == nil {
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeQueued, savedSnapshotHostID(saved))
+	} else {
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeError, savedSnapshotHostID(saved))
+	}
 	return err
+}
+
+func transientSavedSnapshotAPIError(err error) bool {
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded, codes.Unavailable, codes.Aborted, codes.ResourceExhausted, codes.Unimplemented:
+		return true
+	default:
+		return false
+	}
 }
 
 func savedSnapshotQuotaCode(err error) string {
@@ -1193,12 +1216,14 @@ func (h *Handlers) DeleteSavedSnapshot(c *gin.Context) {
 	}
 	if snapshot.HostID == nil || *snapshot.HostID == "" {
 		log.Error().Str("snapshot_id", snapshotID.String()).Msg("saved snapshot has no host")
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeError, "")
 		respondError(c, ErrInternal)
 		return
 	}
 	SetTelemetryHostID(c, *snapshot.HostID)
 	vmd, ok := h.snapshotVMDForHost(c, *snapshot.HostID, false)
 	if !ok {
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, *snapshot.HostID)
 		return
 	}
 	vmdCtx, cancel := context.WithTimeout(ctx, vmdTimeout)
@@ -1207,10 +1232,12 @@ func (h *Handlers) DeleteSavedSnapshot(c *gin.Context) {
 	if err != nil && !isVMDNotFound(err) {
 		switch status.Code(err) {
 		case codes.Canceled, codes.DeadlineExceeded, codes.Unavailable, codes.Aborted, codes.ResourceExhausted, codes.Unimplemented:
+			RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, *snapshot.HostID)
 			c.Header("Retry-After", "5")
 			respondErrorMsg(c, "snapshot_host_unavailable", "The snapshot host is temporarily unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeError, *snapshot.HostID)
 		log.Error().Err(vmdclient.SanitizeSavedSnapshotError(vmdclient.SavedSnapshotOperationDelete, err)).Str("snapshot_id", snapshotID.String()).Msg("VMD DeleteSavedSnapshot")
 		respondError(c, ErrInternal)
 		return
@@ -1220,25 +1247,31 @@ func (h *Handlers) DeleteSavedSnapshot(c *gin.Context) {
 			current, getErr := h.DB.GetSavedSnapshotForDelete(ctx, db.GetSavedSnapshotForDeleteParams{SnapshotID: snapshotID, TeamID: teamID})
 			switch {
 			case errors.Is(getErr, pgx.ErrNoRows):
+				RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeSuccess, *snapshot.HostID)
 				snapshotNotFound(c, getErr)
 				return
 			case getErr != nil:
 				log.Error().Err(getErr).Str("snapshot_id", snapshotID.String()).Msg("DB re-read saved snapshot after delete finalize race")
+				RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, *snapshot.HostID)
 				respondError(c, ErrInternal)
 				return
 			case current.DeletedAt.Valid:
+				RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeSuccess, *snapshot.HostID)
 				c.Status(http.StatusNoContent)
 				return
 			default:
 				log.Error().Str("snapshot_id", snapshotID.String()).Str("status", string(current.Status)).Msg("saved snapshot delete finalize returned no row without a tombstone")
+				RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeError, *snapshot.HostID)
 				respondError(c, ErrInternal)
 				return
 			}
 		}
 		log.Error().Err(err).Str("snapshot_id", snapshotID.String()).Msg("DB FinalizeSavedSnapshotDelete")
+		RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, *snapshot.HostID)
 		respondError(c, ErrInternal)
 		return
 	}
+	RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeSuccess, *snapshot.HostID)
 	h.capture(c, "snapshot_deleted", map[string]any{"snapshot_id": snapshotID.String()})
 	c.Status(http.StatusNoContent)
 }
@@ -1256,6 +1289,7 @@ func (h *Handlers) respondSnapshotDependencyConflict(c *gin.Context, snapshotID,
 		respondErrorMsg(c, "snapshot_not_ready", "Snapshot cannot be deleted in its current state", http.StatusConflict)
 		return
 	}
+	RecordSavedSnapshotOutcome(c.Request.Context(), telemetry.SavedSnapshotOperationDelete, telemetry.SavedSnapshotOutcomeDependencyBlocked, telemetryHostID(c))
 	h.capture(c, "snapshot_delete_blocked", map[string]any{
 		"snapshot_id":    snapshotID.String(),
 		"sandbox_count":  deps.ChildSandboxCount,

--- a/internal/api/handlers_snapshot_fork.go
+++ b/internal/api/handlers_snapshot_fork.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -620,6 +621,7 @@ func (h *Handlers) cleanupFailedSavedSnapshotForkWithTimeouts(
 		}
 		revokeCancel()
 		markFailed()
+		RecordSavedSnapshotOutcome(detachedCtx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeError, sandbox.HostID)
 		return
 	}
 
@@ -639,6 +641,11 @@ func (h *Handlers) cleanupFailedSavedSnapshotForkWithTimeouts(
 		// user-deletable; soft-deleting it here would let the parent snapshot be
 		// reclaimed underneath a VM whose teardown outcome is unknown.
 		markFailed()
+		outcome := telemetry.SavedSnapshotOutcomeError
+		if transientSavedSnapshotAPIError(destroyErr) {
+			outcome = telemetry.SavedSnapshotOutcomeRetry
+		}
+		RecordSavedSnapshotOutcome(detachedCtx, telemetry.SavedSnapshotOperationCleanup, outcome, sandbox.HostID)
 		return
 	}
 
@@ -657,10 +664,12 @@ func (h *Handlers) cleanupFailedSavedSnapshotForkWithTimeouts(
 		if errors.Is(err, pgx.ErrNoRows) {
 			// A concurrent lifecycle owner won the claim. Its cleanup path owns
 			// bindings and the pin; both remain protected by durable revocation.
+			RecordSavedSnapshotOutcome(detachedCtx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, sandbox.HostID)
 			return
 		}
 		log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("soft-delete failed saved-snapshot fork")
 		markFailed()
+		RecordSavedSnapshotOutcome(detachedCtx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeRetry, sandbox.HostID)
 		return
 	}
 
@@ -682,6 +691,7 @@ func (h *Handlers) cleanupFailedSavedSnapshotForkWithTimeouts(
 			log.Warn().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("release compensated fork snapshot pin")
 		}
 	}
+	RecordSavedSnapshotOutcome(detachedCtx, telemetry.SavedSnapshotOperationCleanup, telemetry.SavedSnapshotOutcomeSuccess, sandbox.HostID)
 }
 
 func (h *Handlers) markFailedSnapshotFork(ctx context.Context, sandbox db.Sandbox) {
@@ -720,6 +730,7 @@ func (h *Handlers) markSavedSnapshotUnavailable(c *gin.Context, saved db.Snapsho
 		}
 		return
 	}
+	RecordSavedSnapshotOutcome(ctx, telemetry.SavedSnapshotOperationRestore, telemetry.SavedSnapshotOutcomeUnavailable, savedSnapshotHostID(saved))
 	h.capture(c, "snapshot_unavailable", map[string]any{
 		"snapshot_id": saved.ID.String(),
 		"reason":      reason,

--- a/internal/api/handlers_snapshot_fork_safety_test.go
+++ b/internal/api/handlers_snapshot_fork_safety_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+type forkSecretIDRows struct {
+	ids []uuid.UUID
+	idx int
+}
+
+func (r *forkSecretIDRows) Close()                                       {}
+func (r *forkSecretIDRows) Err() error                                   { return nil }
+func (r *forkSecretIDRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *forkSecretIDRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *forkSecretIDRows) Next() bool {
+	if r.idx >= len(r.ids) {
+		return false
+	}
+	r.idx++
+	return true
+}
+func (r *forkSecretIDRows) Scan(dest ...any) error {
+	*dest[0].(*uuid.UUID) = r.ids[r.idx-1]
+	return nil
+}
+func (r *forkSecretIDRows) Values() ([]any, error) { return nil, nil }
+func (r *forkSecretIDRows) RawValues() [][]byte    { return nil }
+func (r *forkSecretIDRows) Conn() *pgx.Conn        { return nil }
+
+func forkUUIDRow(id uuid.UUID) pgx.Row {
+	return &mockRow{scanFn: func(dest ...any) error {
+		*dest[0].(*uuid.UUID) = id
+		return nil
+	}}
+}
+
+func TestFailedForkCleanupRevocationPersistenceFailureFailsClosed(t *testing.T) {
+	snapshotID := uuid.New()
+	sandbox := db.Sandbox{
+		ID:               uuid.New(),
+		TeamID:           uuid.New(),
+		SourceSnapshotID: pgtype.UUID{Bytes: snapshotID, Valid: true},
+	}
+	revocationErr := errors.New("revocation store unavailable")
+	var (
+		destroyCalled       bool
+		directRevokeCalled  bool
+		markedFailed        bool
+		bindingsDeleted     bool
+		pinReleaseAttempted bool
+	)
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "ReleaseDestroyedSandboxSnapshotPin") {
+				pinReleaseAttempted = true
+			}
+			return notFoundRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			switch {
+			case strings.Contains(sql, "UpsertSandboxRevocation"):
+				return pgconn.CommandTag{}, revocationErr
+			case strings.Contains(sql, "MarkSandboxFailedInTeam"):
+				markedFailed = true
+				return pgconn.NewCommandTag("UPDATE 1"), nil
+			case strings.Contains(sql, "DeleteSandboxSecrets"):
+				bindingsDeleted = true
+				return pgconn.NewCommandTag("DELETE 1"), nil
+			default:
+				t.Fatalf("unexpected DB exec during fail-closed cleanup: %s", sql)
+				return pgconn.CommandTag{}, nil
+			}
+		},
+	}
+	vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{
+		revokeSandboxFn: func(_ context.Context, gotID string) error {
+			if gotID != sandbox.ID.String() {
+				t.Errorf("direct revoke sandbox ID = %q, want %q", gotID, sandbox.ID)
+			}
+			directRevokeCalled = true
+			return nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyCalled = true
+			return nil
+		},
+	}}
+
+	(&Handlers{DB: db.New(mock)}).cleanupFailedSavedSnapshotFork(context.Background(), vmd, sandbox)
+
+	if !directRevokeCalled {
+		t.Fatal("direct sandbox revocation was not attempted after persistence failure")
+	}
+	if !markedFailed {
+		t.Fatal("failed fork was not retained and marked failed")
+	}
+	if destroyCalled {
+		t.Fatal("host teardown ran without a durable revocation")
+	}
+	if bindingsDeleted {
+		t.Fatal("secret bindings were deleted without a durable revocation")
+	}
+	if pinReleaseAttempted {
+		t.Fatal("snapshot dependency pin was released without a durable revocation")
+	}
+}
+
+func TestLockSavedSnapshotForkSecretsDeduplicatesIDsAndReportsMissingEnvKeys(t *testing.T) {
+	teamID := uuid.New()
+	availableID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	missingID := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	bindings := []db.AddSandboxSecretParams{
+		{SecretID: missingID, EnvKey: "SECOND_TOKEN"},
+		{SecretID: availableID, EnvKey: "AVAILABLE_TOKEN"},
+		{SecretID: missingID, EnvKey: "FIRST_TOKEN"},
+	}
+	meta := []SecretBindingMeta{
+		{SecretID: missingID, EnvKey: "SECOND_TOKEN"},
+		{SecretID: availableID, EnvKey: "AVAILABLE_TOKEN"},
+		{SecretID: missingID, EnvKey: "FIRST_TOKEN"},
+	}
+	var lockedArgs []uuid.UUID
+	mock := &mockDBTX{
+		queryFn: func(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+			if !strings.Contains(sql, "LockActiveTeamSecretIDs") {
+				t.Fatalf("unexpected DB query: %s", sql)
+			}
+			if got := args[0].(uuid.UUID); got != teamID {
+				t.Errorf("lock team ID = %s, want %s", got, teamID)
+			}
+			lockedArgs = append([]uuid.UUID(nil), args[1].([]uuid.UUID)...)
+			return &forkSecretIDRows{ids: []uuid.UUID{availableID}}, nil
+		},
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			t.Fatalf("unexpected DB row query: %s", sql)
+			return notFoundRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			t.Fatalf("unexpected DB exec: %s", sql)
+			return pgconn.CommandTag{}, nil
+		},
+	}
+
+	err := lockSavedSnapshotForkSecrets(context.Background(), db.New(mock), teamID, bindings, meta)
+	var unavailable *savedSnapshotSecretUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("lock error = %v, want savedSnapshotSecretUnavailableError", err)
+	}
+	if want := []uuid.UUID{availableID, missingID}; !slices.Equal(lockedArgs, want) {
+		t.Fatalf("locked secret IDs = %v, want deduplicated deterministic IDs %v", lockedArgs, want)
+	}
+	if want := []string{"FIRST_TOKEN", "SECOND_TOKEN"}; !slices.Equal(unavailable.EnvKeys, want) {
+		t.Fatalf("missing env keys = %v, want %v", unavailable.EnvKeys, want)
+	}
+}
+
+func TestCreateSandboxFromSavedSnapshotActivationFailureCompensatesBeforeTeardown(t *testing.T) {
+	teamID := uuid.New()
+	sourceID := uuid.New()
+	snapshotID := uuid.New()
+	hostID := "host-a"
+	manifestPath := "/var/lib/superserve/snapshots/saved/" + sourceID.String() + "/" + snapshotID.String() + "/manifest.json"
+	manifestDigest := strings.Repeat("b", 64)
+	vcpu, memoryMiB, diskMiB := int32(2), int32(2048), int32(8192)
+	saved := db.Snapshot{
+		ID:             snapshotID,
+		SandboxID:      sourceID,
+		TeamID:         teamID,
+		Kind:           db.SnapshotKindSaved,
+		Status:         db.SnapshotStatusReady,
+		Trigger:        "api",
+		HostID:         &hostID,
+		ManifestPath:   &manifestPath,
+		ManifestDigest: &manifestDigest,
+		VcpuCount:      &vcpu,
+		MemoryMib:      &memoryMiB,
+		DiskMib:        &diskMiB,
+		SecretBindings: []byte(`[]`),
+		CreatedAt:      time.Now().Add(-time.Minute),
+		UpdatedAt:      time.Now(),
+	}
+	activationErr := errors.New("activation write failed")
+	var (
+		child       db.Sandbox
+		events      []string
+		bindingsNil bool
+		pinReleased bool
+	)
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "IsFeatureEnabledForTeam"):
+				return boolRow(true)
+			case strings.Contains(sql, "GetSavedSnapshot"):
+				return savedSnapshotRow(saved)
+			case strings.Contains(sql, "HostHasCapabilities"):
+				return boolRow(true)
+			case strings.Contains(sql, "CreateSandboxFromSnapshot"):
+				child = db.Sandbox{
+					ID:               args[2].(uuid.UUID),
+					TeamID:           teamID,
+					Name:             "forked",
+					Status:           db.SandboxStatusStarting,
+					VcpuCount:        vcpu,
+					MemoryMib:        memoryMiB,
+					DiskMib:          diskMiB,
+					HostID:           hostID,
+					SourceSnapshotID: pgtype.UUID{Bytes: snapshotID, Valid: true},
+					CreatedAt:        time.Now(),
+					UpdatedAt:        time.Now(),
+				}
+				return sandboxRow(child)
+			case strings.Contains(sql, "ReleaseDestroyedSandboxSnapshotPin"):
+				events = append(events, "release-pin")
+				pinReleased = true
+				return forkUUIDRow(child.ID)
+			case strings.Contains(sql, "DestroySandbox"):
+				events = append(events, "soft-delete")
+				return forkUUIDRow(child.ID)
+			default:
+				t.Fatalf("unexpected DB row query: %s", sql)
+				return notFoundRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			switch {
+			case strings.Contains(sql, "ActivateSandbox"):
+				events = append(events, "activate")
+				return pgconn.CommandTag{}, activationErr
+			case strings.Contains(sql, "UpsertSandboxRevocation"):
+				events = append(events, "persist-revocation")
+				return pgconn.NewCommandTag("INSERT 1"), nil
+			case strings.Contains(sql, "DeleteSandboxSecrets"):
+				events = append(events, "delete-bindings")
+				bindingsNil = true
+				return pgconn.NewCommandTag("DELETE 0"), nil
+			case strings.Contains(sql, "MarkSandboxFailedInTeam"):
+				t.Fatal("successfully compensated fork should not be marked failed")
+				return pgconn.CommandTag{}, nil
+			default:
+				t.Fatalf("unexpected DB exec: %s", sql)
+				return pgconn.CommandTag{}, nil
+			}
+		},
+	}
+	vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{
+		revokeSandboxFn: func(_ context.Context, gotID string) error {
+			if gotID != child.ID.String() {
+				t.Errorf("direct revoke sandbox ID = %q, want %q", gotID, child.ID)
+			}
+			events = append(events, "direct-revoke")
+			return nil
+		},
+		destroyFn: func(_ context.Context, gotID string, force bool) error {
+			if gotID != child.ID.String() || !force {
+				t.Errorf("teardown = (%q, %v), want (%q, true)", gotID, force, child.ID)
+			}
+			events = append(events, "host-teardown")
+			return nil
+		},
+	}}
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+
+	w := httptest.NewRecorder()
+	body := `{"name":"forked","from_snapshot":"` + snapshotID.String() + `"}`
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body)))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	if got := errorCode(parseJSON(t, w)); got != "internal_error" {
+		t.Fatalf("error code = %q, want internal_error", got)
+	}
+	wantEvents := []string{
+		"activate",
+		"persist-revocation",
+		"direct-revoke",
+		"host-teardown",
+		"soft-delete",
+		"delete-bindings",
+		"release-pin",
+	}
+	if !slices.Equal(events, wantEvents) {
+		t.Fatalf("compensation events = %v, want %v", events, wantEvents)
+	}
+	if !bindingsNil || !pinReleased {
+		t.Fatalf("completed compensation bindings_deleted=%v pin_released=%v, want both true", bindingsNil, pinReleased)
+	}
+}

--- a/internal/api/handlers_snapshot_fork_test.go
+++ b/internal/api/handlers_snapshot_fork_test.go
@@ -1,0 +1,551 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+type stubSavedSnapshotVMD struct {
+	*stubVMD
+	checkSavedFn   func(context.Context) error
+	createSavedFn  func(context.Context, string, string) (vmdclient.SavedSnapshotArtifacts, error)
+	restoreSavedFn func(context.Context, string, string, string, string, string, vmdclient.SavedSnapshotNetwork, []string, string, map[int32]vmdclient.PortPolicy, int64) (string, uint32, uint32, error)
+	deleteSavedFn  func(context.Context, string, string) error
+	measureSavedFn func(context.Context, string) (int64, int64, error)
+}
+
+func (s *stubSavedSnapshotVMD) CheckSavedSnapshotSupport(ctx context.Context) error {
+	if s.checkSavedFn != nil {
+		return s.checkSavedFn(ctx)
+	}
+	return nil
+}
+
+func (s *stubSavedSnapshotVMD) CreateSavedSnapshot(ctx context.Context, sourceID, snapshotID string) (vmdclient.SavedSnapshotArtifacts, error) {
+	if s.createSavedFn != nil {
+		return s.createSavedFn(ctx, sourceID, snapshotID)
+	}
+	return vmdclient.SavedSnapshotArtifacts{}, nil
+}
+
+func (s *stubSavedSnapshotVMD) RestoreSavedSnapshot(
+	ctx context.Context,
+	instanceID, manifestPath, manifestDigest, teamID, ownerID string,
+	network vmdclient.SavedSnapshotNetwork,
+	clearEnvKeys []string,
+	previewAccess string,
+	previewPorts map[int32]vmdclient.PortPolicy,
+	previewPolicyRevision int64,
+) (string, uint32, uint32, error) {
+	if s.restoreSavedFn != nil {
+		return s.restoreSavedFn(
+			ctx, instanceID, manifestPath, manifestDigest, teamID, ownerID,
+			network, clearEnvKeys, previewAccess, previewPorts, previewPolicyRevision,
+		)
+	}
+	return "10.0.0.8", 2, 2048, nil
+}
+
+func (s *stubSavedSnapshotVMD) DeleteSavedSnapshot(ctx context.Context, sourceID, snapshotID string) error {
+	if s.deleteSavedFn != nil {
+		return s.deleteSavedFn(ctx, sourceID, snapshotID)
+	}
+	return nil
+}
+
+func (s *stubSavedSnapshotVMD) MeasureSandboxWritableLayer(ctx context.Context, instanceID string) (int64, int64, error) {
+	if s.measureSavedFn != nil {
+		return s.measureSavedFn(ctx, instanceID)
+	}
+	return 0, 0, nil
+}
+
+func TestCreateSandboxRequestRejectsExplicitNullInheritanceFields(t *testing.T) {
+	for _, field := range []string{"from_template", "from_snapshot", "network", "secrets"} {
+		t.Run(field, func(t *testing.T) {
+			var req createSandboxRequest
+			body := []byte(`{"name":"sandbox","` + field + `":null}`)
+			if err := json.Unmarshal(body, &req); err == nil {
+				t.Fatalf("explicit null %s was accepted", field)
+			}
+		})
+	}
+
+	var omitted createSandboxRequest
+	if err := json.Unmarshal([]byte(`{"name":"sandbox"}`), &omitted); err != nil {
+		t.Fatalf("omitted inheritance fields should remain valid: %v", err)
+	}
+}
+
+func TestCapturedSnapshotSecretEnvKeysScrubsProxyDefaultsAfterSecretUse(t *testing.T) {
+	keys := capturedSnapshotSecretEnvKeys(nil, []string{"DETACHED_TOKEN"})
+	if !slices.Contains(keys, "DETACHED_TOKEN") {
+		t.Error("detached secret env key was not retained for scrubbing")
+	}
+	if keys := capturedSnapshotSecretEnvKeys(nil, nil); len(keys) != 0 {
+		t.Errorf("source with no secret history clears unrelated env defaults: %v", keys)
+	}
+	for _, want := range capturedSecretProxyEnvKeys {
+		if !slices.Contains(keys, want) {
+			t.Errorf("proxy default %q was not scrubbed without active bindings", want)
+		}
+	}
+}
+
+func TestSnapshotVMDForHostFailsClosedWhenCapabilityRPCIsUnimplemented(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	checks := 0
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		checkSavedFn: func(context.Context) error {
+			checks++
+			return status.Error(codes.Unimplemented, "unknown method GetCapabilities")
+		},
+	}
+	h := &Handlers{VMD: vmd}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes/example/snapshots", nil)
+
+	client, ok := h.snapshotVMDForHost(c, "host-a", true)
+	if ok || client != nil {
+		t.Fatal("old VMD unexpectedly passed saved snapshot capability check")
+	}
+	if checks != 1 {
+		t.Fatalf("capability checks = %d, want 1", checks)
+	}
+	if w.Code != http.StatusServiceUnavailable || w.Header().Get("Retry-After") != "5" {
+		t.Fatalf("response = %d retry-after=%q, want 503 and 5", w.Code, w.Header().Get("Retry-After"))
+	}
+}
+
+func TestSnapshotVMDForHostLogDoesNotExposeHostArtifactPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const hostPath = "/var/lib/superserve/private/snapshots/source/snapshot/manifest.json"
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		checkSavedFn: func(context.Context) error {
+			return status.Error(codes.Unavailable, "stat "+hostPath+": input/output error")
+		},
+	}
+	var output bytes.Buffer
+	previousLogger := log.Logger
+	log.Logger = zerolog.New(&output)
+	defer func() { log.Logger = previousLogger }()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes/example/snapshots", nil)
+	client, ok := (&Handlers{VMD: vmd}).snapshotVMDForHost(c, "host-a", true)
+	if ok || client != nil {
+		t.Fatal("failed capability check unexpectedly returned a client")
+	}
+	if strings.Contains(output.String(), hostPath) {
+		t.Fatalf("API log exposed host artifact path: %s", output.String())
+	}
+	if !strings.Contains(output.String(), "saved snapshot capability check failed") {
+		t.Fatalf("API log lost safe operation context: %s", output.String())
+	}
+}
+
+func TestSavedSnapshotOperationsMapUnimplementedVMDToHostUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldVMDErr := status.Error(codes.Unimplemented, "unknown saved snapshot operation")
+
+	t.Run("capture", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes/example/snapshots", nil)
+		(&Handlers{}).respondSavedSnapshotCaptureError(c, db.Snapshot{}, &stubSavedSnapshotVMD{stubVMD: &stubVMD{}}, oldVMDErr)
+		if w.Code != http.StatusServiceUnavailable || w.Header().Get("Retry-After") != "5" {
+			t.Fatalf("capture response = %d retry-after=%q, want 503 and 5", w.Code, w.Header().Get("Retry-After"))
+		}
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+		if !(&Handlers{}).respondSavedSnapshotRestoreError(c, db.Snapshot{}, oldVMDErr) {
+			t.Fatal("Unimplemented restore was not handled")
+		}
+		if w.Code != http.StatusServiceUnavailable || w.Header().Get("Retry-After") != "5" {
+			t.Fatalf("restore response = %d retry-after=%q, want 503 and 5", w.Code, w.Header().Get("Retry-After"))
+		}
+	})
+}
+
+func TestSavedSnapshotForkCapacityErrorIncludesRetryAfter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+	(&Handlers{}).respondSavedSnapshotForkInsertError(c, db.Snapshot{}, &pgconn.PgError{
+		Code: savedSnapshotHostCapacityErrCode,
+	})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusServiceUnavailable, w.Body.String())
+	}
+	if got := w.Header().Get("Retry-After"); got != "5" {
+		t.Fatalf("Retry-After = %q, want 5", got)
+	}
+}
+
+func savedSnapshotRow(s db.Snapshot) pgx.Row {
+	return &mockRow{scanFn: func(dest ...any) error {
+		*dest[0].(*uuid.UUID) = s.ID
+		*dest[1].(*uuid.UUID) = s.SandboxID
+		*dest[2].(*uuid.UUID) = s.TeamID
+		*dest[3].(*string) = s.Path
+		*dest[4].(*int64) = s.SizeBytes
+		*dest[5].(*string) = s.Trigger
+		*dest[6].(*time.Time) = s.CreatedAt
+		*dest[7].(**string) = s.MemPath
+		*dest[8].(*db.SnapshotKind) = s.Kind
+		*dest[9].(*db.SnapshotStatus) = s.Status
+		*dest[10].(**string) = s.Name
+		*dest[11].(**string) = s.IdempotencyKey
+		*dest[12].(*pgtype.UUID) = s.ParentSnapshotID
+		*dest[13].(*db.NullSandboxStatus) = s.SourceStatus
+		*dest[14].(*pgtype.UUID) = s.TemplateID
+		*dest[15].(**string) = s.TemplateSnapshotPath
+		*dest[16].(**string) = s.TemplateMemPath
+		*dest[17].(**string) = s.BasePath
+		*dest[18].(**string) = s.DeltaPath
+		*dest[19].(**string) = s.HostID
+		*dest[20].(**int32) = s.VcpuCount
+		*dest[21].(**int32) = s.MemoryMib
+		*dest[22].(**int32) = s.DiskMib
+		*dest[23].(**string) = s.ManifestPath
+		*dest[24].(**string) = s.ManifestDigest
+		*dest[25].(*[]byte) = s.ArtifactMetadata
+		*dest[26].(*int64) = s.LogicalSizeBytes
+		*dest[27].(*int64) = s.ExclusiveSizeBytes
+		*dest[28].(*[]byte) = s.NetworkConfig
+		*dest[29].(**int32) = s.TimeoutSeconds
+		*dest[30].(**int32) = s.AutoDeleteSeconds
+		*dest[31].(*[]byte) = s.SecretBindings
+		*dest[32].(*[]byte) = s.SecretEnvKeys
+		*dest[33].(**string) = s.FailureReason
+		*dest[34].(*time.Time) = s.UpdatedAt
+		*dest[35].(*pgtype.Timestamptz) = s.FinalizedAt
+		*dest[36].(*pgtype.Timestamptz) = s.DeletedAt
+		return nil
+	}}
+}
+
+func TestCreateSandboxFromSavedSnapshot_InheritsPoliciesAndReturnsLineage(t *testing.T) {
+	teamID := uuid.New()
+	sourceID := uuid.New()
+	snapshotID := uuid.New()
+	hostID := "host-a"
+	manifestPath := "/var/lib/superserve/snapshots/saved/" + sourceID.String() + "/" + snapshotID.String() + "/manifest.json"
+	manifestDigest := strings.Repeat("a", 64)
+	vcpu, memoryMiB, diskMiB := int32(2), int32(2048), int32(8192)
+	timeout, autoDelete := int32(900), int32(3600)
+	networkJSON := []byte(`{"egress":{"allowed_cidrs":["10.0.0.0/8"],"denied_cidrs":["10.4.0.0/16"],"allowed_domains":["api.example.com"]}}`)
+	saved := db.Snapshot{
+		ID:                snapshotID,
+		SandboxID:         sourceID,
+		TeamID:            teamID,
+		Kind:              db.SnapshotKindSaved,
+		Status:            db.SnapshotStatusReady,
+		Trigger:           "api",
+		HostID:            &hostID,
+		ManifestPath:      &manifestPath,
+		ManifestDigest:    &manifestDigest,
+		VcpuCount:         &vcpu,
+		MemoryMib:         &memoryMiB,
+		DiskMib:           &diskMiB,
+		TimeoutSeconds:    &timeout,
+		AutoDeleteSeconds: &autoDelete,
+		NetworkConfig:     networkJSON,
+		SecretBindings:    []byte(`[]`),
+		CreatedAt:         time.Now().Add(-time.Minute),
+		UpdatedAt:         time.Now(),
+	}
+
+	var insertedID uuid.UUID
+	var insertedSandbox db.Sandbox
+	var insertArgs []any
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "feature_enabled") && !strings.Contains(sql, "WITH snap AS"):
+				return boolRow(true)
+			case strings.Contains(sql, "HostHasCapabilities"):
+				return boolRow(true)
+			case strings.Contains(sql, "WITH snap AS"):
+				insertArgs = append([]any(nil), args...)
+				insertedID = args[2].(uuid.UUID)
+				insertedSandbox = db.Sandbox{
+					ID:                insertedID,
+					TeamID:            teamID,
+					Name:              "forked",
+					Status:            db.SandboxStatusStarting,
+					VcpuCount:         vcpu,
+					MemoryMib:         memoryMiB,
+					DiskMib:           diskMiB,
+					HostID:            hostID,
+					TimeoutSeconds:    &timeout,
+					AutoDeleteSeconds: &autoDelete,
+					NetworkConfig:     networkJSON,
+					Metadata:          []byte(`{"run":"test"}`),
+					SourceSnapshotID:  pgtype.UUID{Bytes: snapshotID, Valid: true},
+					CreatedAt:         time.Now(),
+				}
+				return sandboxRow(insertedSandbox)
+			case strings.Contains(sql, "FROM sandbox") && strings.Contains(sql, "destroyed_at IS NULL"):
+				insertedSandbox.Status = db.SandboxStatusActive
+				addr := netip.MustParseAddr("10.0.0.8")
+				insertedSandbox.IpAddress = &addr
+				return sandboxRow(insertedSandbox)
+			case strings.Contains(sql, "kind = 'saved'"):
+				return savedSnapshotRow(saved)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	var restoredNetwork vmdclient.SavedSnapshotNetwork
+	var restoredManifest string
+	var restoredManifestDigest string
+	var restoredID string
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		restoreSavedFn: func(_ context.Context, instanceID, manifest, digest, gotTeamID, _ string, network vmdclient.SavedSnapshotNetwork, clear []string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64) (string, uint32, uint32, error) {
+			restoredID = instanceID
+			restoredManifest = manifest
+			restoredManifestDigest = digest
+			restoredNetwork = network
+			if gotTeamID != teamID.String() {
+				t.Errorf("team ID = %q, want %q", gotTeamID, teamID)
+			}
+			if len(clear) != 0 {
+				t.Errorf("clear env keys = %v, want none for snapshot without secret history", clear)
+			}
+			if previewAccess != preview.AccessPublic || previewPorts != nil || previewPolicyRevision != 0 {
+				t.Errorf("preview policy = (%q, %#v, %d), want public/nil/0", previewAccess, previewPorts, previewPolicyRevision)
+			}
+			return "10.0.0.8", uint32(vcpu), uint32(memoryMiB), nil
+		},
+	}
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+
+	w := httptest.NewRecorder()
+	body := `{"name":"forked","from_snapshot":"` + snapshotID.String() + `","metadata":{"run":"test"},"env_vars":{"RUN_ID":"child"}}`
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body)))
+	h.WaitAsyncBookkeeping()
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+	if restoredID != insertedID.String() || restoredManifest != manifestPath {
+		t.Fatalf("restore = (%q, %q), want (%q, %q)", restoredID, restoredManifest, insertedID, manifestPath)
+	}
+	if restoredManifestDigest != manifestDigest {
+		t.Fatalf("restore manifest digest = %q, want %q", restoredManifestDigest, manifestDigest)
+	}
+	wantNetwork := vmdclient.SavedSnapshotNetwork{
+		AllowedCIDRs:   []string{"10.0.0.0/8"},
+		DeniedCIDRs:    []string{"10.4.0.0/16"},
+		AllowedDomains: []string{"api.example.com"},
+	}
+	if !reflect.DeepEqual(restoredNetwork, wantNetwork) {
+		t.Errorf("restore network = %#v, want %#v", restoredNetwork, wantNetwork)
+	}
+	if len(insertArgs) != 15 {
+		t.Fatalf("fork insert args = %d, want 15", len(insertArgs))
+	}
+	if inherited, _ := insertArgs[7].(bool); !inherited {
+		t.Error("timeout policy was not inherited")
+	}
+	if inherited, _ := insertArgs[10].(bool); !inherited {
+		t.Error("auto-delete policy was not inherited")
+	}
+	if inherited, _ := insertArgs[12].(bool); !inherited {
+		t.Error("network policy was not inherited")
+	}
+	if got := insertArgs[0].(uuid.UUID); got != snapshotID {
+		t.Errorf("source snapshot insert arg = %s, want %s", got, snapshotID)
+	}
+	if got := insertArgs[14].(string); got != preview.AccessPublic {
+		t.Errorf("preview access insert arg = %q, want %q", got, preview.AccessPublic)
+	}
+
+	var response sandboxResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.SourceSnapshotID == nil || *response.SourceSnapshotID != snapshotID {
+		t.Errorf("source_snapshot_id = %v, want %s", response.SourceSnapshotID, snapshotID)
+	}
+	if response.TimeoutSeconds == nil || *response.TimeoutSeconds != timeout {
+		t.Errorf("timeout_seconds = %v, want %d", response.TimeoutSeconds, timeout)
+	}
+	if response.Metadata["run"] != "test" {
+		t.Errorf("metadata = %#v, want request metadata", response.Metadata)
+	}
+}
+
+func TestCapturedSnapshotSecretEnvKeysScrubsTokensAndProxyIdentity(t *testing.T) {
+	bindings := []savedSnapshotSecretBinding{
+		{EnvKey: "Z_TOKEN", SecretID: uuid.New()},
+		{EnvKey: "A_TOKEN", SecretID: uuid.New()},
+	}
+	got := capturedSnapshotSecretEnvKeys(bindings, nil)
+	want := []string{
+		"A_TOKEN",
+		"CURL_CA_BUNDLE",
+		"HTTPS_PROXY",
+		"NODE_EXTRA_CA_CERTS",
+		"REQUESTS_CA_BUNDLE",
+		"SSL_CERT_DIR",
+		"SSL_CERT_FILE",
+		"Z_TOKEN",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("clear env keys = %v, want %v", got, want)
+	}
+}
+
+func TestSavedSnapshotReadyForFork_UnavailableIsGone(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+	if savedSnapshotReadyForFork(c, db.Snapshot{Status: db.SnapshotStatusUnavailable}) {
+		t.Fatal("unavailable snapshot unexpectedly accepted")
+	}
+	if w.Code != http.StatusGone {
+		t.Fatalf("status = %d, want 410; body: %s", w.Code, w.Body.String())
+	}
+	if got := errorCode(parseJSON(t, w)); got != "snapshot_unavailable" {
+		t.Fatalf("error code = %q, want snapshot_unavailable", got)
+	}
+}
+
+func TestCapSandboxIDsUsesPublicIDFormat(t *testing.T) {
+	t.Setenv("SANDBOX_ID_REGION", "use")
+	first := uuid.MustParse("1b4e28ba-2fa1-11d2-883f-0016d3cca427")
+	second := uuid.MustParse("2b4e28ba-2fa1-11d2-883f-0016d3cca427")
+
+	got := capSandboxIDs([]uuid.UUID{first, second}, 1)
+	want := []string{"sb-use-" + first.String()}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("capSandboxIDs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFailedForkCleanupRetainsDependencyWhenHostTeardownFails(t *testing.T) {
+	sandbox := db.Sandbox{ID: uuid.New(), TeamID: uuid.New()}
+	var destroyClaimed bool
+	var markedFailed bool
+	var revocationPersisted bool
+	var revokeDelivered bool
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			destroyClaimed = true
+			return notFoundRow()
+		},
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "INSERT INTO sandbox_revocation") {
+				revocationPersisted = true
+			}
+			if strings.Contains(sql, "SET status = 'failed'") {
+				markedFailed = true
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+	vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{
+		destroyFn: func(context.Context, string, bool) error {
+			if !revocationPersisted || !revokeDelivered {
+				t.Fatal("host teardown ran before durable and direct revocation")
+			}
+			return status.Error(codes.Unavailable, "host unavailable")
+		},
+		revokeSandboxFn: func(context.Context, string) error {
+			revokeDelivered = true
+			return nil
+		},
+	}}
+
+	(&Handlers{DB: db.New(mock)}).cleanupFailedSavedSnapshotFork(context.Background(), vmd, sandbox)
+
+	if destroyClaimed {
+		t.Fatal("sandbox was soft-deleted while host teardown outcome was unknown")
+	}
+	if !markedFailed {
+		t.Fatal("orphaned fork was not retained as a failed, dependency-pinning row")
+	}
+	if !revocationPersisted || !revokeDelivered {
+		t.Fatal("failed fork was not revoked before compensation")
+	}
+}
+
+func TestQueueSavedSnapshotCleanupPersistsNonNegativeArtifactUsage(t *testing.T) {
+	saved := db.Snapshot{
+		ID:        uuid.New(),
+		SandboxID: uuid.New(),
+		TeamID:    uuid.New(),
+		Kind:      db.SnapshotKindSaved,
+		Status:    db.SnapshotStatusDeleting,
+		Trigger:   "api",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	var gotArgs []any
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+		if !strings.Contains(sql, "SET status = 'deleting'") {
+			t.Fatalf("unexpected query: %s", sql)
+		}
+		gotArgs = append([]any(nil), args...)
+		return savedSnapshotRow(saved)
+	}}
+	h := &Handlers{DB: db.New(mock)}
+	err := h.queueSavedSnapshotCleanup(context.Background(), saved, vmdclient.SavedSnapshotArtifacts{
+		SnapshotPath:       "/saved/vmstate.snap",
+		MemPath:            "/saved/mem.snap",
+		ManifestPath:       "/saved/manifest.json",
+		LogicalSizeBytes:   -1,
+		ExclusiveSizeBytes: -2,
+	}, []byte(`{"schema_version":1}`), "artifact_validation_failed")
+	if err != nil {
+		t.Fatalf("queue cleanup: %v", err)
+	}
+	if len(gotArgs) != 10 {
+		t.Fatalf("queue args = %d, want 10", len(gotArgs))
+	}
+	if gotArgs[4] != int64(0) || gotArgs[8] != int64(0) {
+		t.Fatalf("queued sizes = logical %v exclusive %v, want non-negative zeros", gotArgs[4], gotArgs[8])
+	}
+}

--- a/internal/api/handlers_snapshot_observability_test.go
+++ b/internal/api/handlers_snapshot_observability_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+type savedSnapshotOutcomeRecorder struct {
+	outcomes []telemetry.SavedSnapshotOutcome
+}
+
+func (*savedSnapshotOutcomeRecorder) RecordSandboxTransition(context.Context, telemetry.SandboxTransition) {
+}
+func (*savedSnapshotOutcomeRecorder) RecordVMDCall(context.Context, telemetry.VMDCall) {}
+func (r *savedSnapshotOutcomeRecorder) RecordSavedSnapshotOutcome(_ context.Context, outcome telemetry.SavedSnapshotOutcome) {
+	r.outcomes = append(r.outcomes, outcome)
+}
+func (*savedSnapshotOutcomeRecorder) RecordHostCapacity(context.Context, telemetry.HostCapacity) {}
+func (*savedSnapshotOutcomeRecorder) RecordDBPoolStats(context.Context, telemetry.DBPoolStats)   {}
+
+func useSavedSnapshotOutcomeRecorder(t *testing.T) *savedSnapshotOutcomeRecorder {
+	t.Helper()
+	recorder := &savedSnapshotOutcomeRecorder{}
+	SetTelemetryRecorder(recorder)
+	t.Cleanup(func() { SetTelemetryRecorder(nil) })
+	return recorder
+}
+
+func TestSnapshotDependencyConflictRecordsBoundedOutcome(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := useSavedSnapshotOutcomeRecorder(t)
+	snapshotID, teamID := uuid.New(), uuid.New()
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+		if !strings.Contains(sql, "-- name: GetSavedSnapshotDependencyCounts :one") {
+			t.Fatalf("unexpected row query: %s", sql)
+		}
+		return &mockRow{scanFn: func(dest ...any) error {
+			*dest[0].(*int64) = 2
+			*dest[1].(*int64) = 1
+			return nil
+		}}
+	}}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/snapshots/"+snapshotID.String(), nil)
+	SetTelemetryHostID(c, "host-a")
+	(&Handlers{DB: db.New(mock)}).respondSnapshotDependencyConflict(c, snapshotID, teamID)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+	if len(recorder.outcomes) != 1 {
+		t.Fatalf("outcomes = %+v, want one dependency block", recorder.outcomes)
+	}
+	got := recorder.outcomes[0]
+	if got.Operation != telemetry.SavedSnapshotOperationDelete || got.Outcome != telemetry.SavedSnapshotOutcomeDependencyBlocked || got.HostID != "host-a" {
+		t.Fatalf("outcome = %+v", got)
+	}
+}
+
+func TestMarkSavedSnapshotUnavailableRecordsOnlyCommittedTransition(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := useSavedSnapshotOutcomeRecorder(t)
+	hostID := "host-a"
+	saved := db.Snapshot{
+		ID: uuid.New(), SandboxID: uuid.New(), TeamID: uuid.New(),
+		Kind: db.SnapshotKindSaved, Status: db.SnapshotStatusReady, HostID: &hostID,
+		Trigger: "api", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	call := 0
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+		if !strings.Contains(sql, "-- name: MarkSavedSnapshotUnavailable :one") {
+			t.Fatalf("unexpected row query: %s", sql)
+		}
+		call++
+		if call == 2 {
+			return notFoundRow()
+		}
+		updated := saved
+		updated.Status = db.SnapshotStatusUnavailable
+		return savedSnapshotRow(updated)
+	}}
+	h := &Handlers{DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+	h.markSavedSnapshotUnavailable(c, saved, "artifact_restore_failed")
+	h.markSavedSnapshotUnavailable(c, saved, "artifact_restore_failed")
+
+	if len(recorder.outcomes) != 1 {
+		t.Fatalf("outcomes = %+v, want only the committed ready->unavailable transition", recorder.outcomes)
+	}
+	got := recorder.outcomes[0]
+	if got.Operation != telemetry.SavedSnapshotOperationRestore || got.Outcome != telemetry.SavedSnapshotOutcomeUnavailable || got.HostID != hostID {
+		t.Fatalf("outcome = %+v", got)
+	}
+}
+
+func TestCapturedSnapshotCleanupRecordsRetryAndSuccess(t *testing.T) {
+	recorder := useSavedSnapshotOutcomeRecorder(t)
+	hostID := "host-a"
+	saved := db.Snapshot{ID: uuid.New(), SandboxID: uuid.New(), HostID: &hostID}
+	deleteErr := status.Error(codes.Unavailable, "delete failed")
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		deleteSavedFn: func(context.Context, string, string) error {
+			return deleteErr
+		},
+	}
+	h := &Handlers{}
+
+	if err := h.deleteCapturedSnapshotBestEffort(context.Background(), vmd, saved); status.Code(err) != codes.Unavailable {
+		t.Fatalf("cleanup error = %v, want %v", err, deleteErr)
+	}
+	vmd.deleteSavedFn = func(context.Context, string, string) error { return nil }
+	if err := h.deleteCapturedSnapshotBestEffort(context.Background(), vmd, saved); err != nil {
+		t.Fatalf("cleanup success: %v", err)
+	}
+
+	if len(recorder.outcomes) != 2 {
+		t.Fatalf("outcomes = %+v, want retry then success", recorder.outcomes)
+	}
+	if recorder.outcomes[0].Outcome != telemetry.SavedSnapshotOutcomeRetry || recorder.outcomes[1].Outcome != telemetry.SavedSnapshotOutcomeSuccess {
+		t.Fatalf("cleanup outcomes = %+v", recorder.outcomes)
+	}
+	for _, outcome := range recorder.outcomes {
+		if outcome.Operation != telemetry.SavedSnapshotOperationCleanup || outcome.HostID != hostID {
+			t.Fatalf("cleanup outcome dimensions = %+v", outcome)
+		}
+	}
+}

--- a/internal/api/handlers_snapshot_race_test.go
+++ b/internal/api/handlers_snapshot_race_test.go
@@ -1,0 +1,286 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+func TestFailSavedSnapshotAndSourceRequiresDurableFallbackProofBeforeDestroy(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		fallbackOK  bool
+		wantDestroy bool
+	}{
+		{name: "fallback transition commits", fallbackOK: true, wantDestroy: true},
+		{name: "fallback transition returns no proof", fallbackOK: false, wantDestroy: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID, sourceID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+			hostID := "snapshot-host"
+			saved := db.Snapshot{
+				ID: snapshotID, SandboxID: sourceID, TeamID: teamID,
+				Kind: db.SnapshotKindSaved, Status: db.SnapshotStatusCreating, HostID: &hostID,
+			}
+			var revocationPersisted, fallbackAttempted bool
+			mock := &mockDBTX{
+				queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+					switch {
+					case strings.Contains(sql, "-- name: FailSavedSnapshotAndSource :one"):
+						return notFoundRow()
+					case strings.Contains(sql, "-- name: FailSavedSnapshotSourceAfterRevocation :one"):
+						fallbackAttempted = true
+						if tt.fallbackOK {
+							return uuidRow(sourceID)
+						}
+						return notFoundRow()
+					default:
+						t.Fatalf("unexpected DB row query: %s", sql)
+						return notFoundRow()
+					}
+				},
+				execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+					if !strings.Contains(sql, "-- name: UpsertSandboxRevocation :exec") {
+						t.Fatalf("unexpected DB exec: %s", sql)
+					}
+					revocationPersisted = true
+					return pgconn.NewCommandTag("INSERT 0 1"), nil
+				},
+			}
+			var revoked, destroyed bool
+			vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{
+				revokeSandboxFn: func(context.Context, string) error {
+					revoked = true
+					return nil
+				},
+				destroyFn: func(context.Context, string, bool) error {
+					destroyed = true
+					return nil
+				},
+			}}
+
+			(&Handlers{DB: db.New(mock)}).failSavedSnapshotAndSource(context.Background(), saved, vmd, "source_resume_failed")
+
+			if !revocationPersisted || !fallbackAttempted || !revoked {
+				t.Fatalf("fallback actions = revocation:%t transition:%t direct-revoke:%t, want all true", revocationPersisted, fallbackAttempted, revoked)
+			}
+			if destroyed != tt.wantDestroy {
+				t.Fatalf("host destroy = %t, want %t", destroyed, tt.wantDestroy)
+			}
+		})
+	}
+}
+
+func TestDeleteSavedSnapshotReturnsNoContentForExistingTombstone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	teamID, sourceID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+	hostID := "snapshot-host"
+	tombstone := db.Snapshot{
+		ID: snapshotID, SandboxID: sourceID, TeamID: teamID,
+		Kind: db.SnapshotKindSaved, Status: db.SnapshotStatusDeleting, HostID: &hostID,
+		DeletedAt: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if !strings.Contains(sql, "-- name: GetSavedSnapshotForDelete :one") {
+				t.Fatalf("unexpected DB row query: %s", sql)
+			}
+			return savedSnapshotRow(tombstone)
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			t.Fatalf("unexpected DB exec: %s", sql)
+			return pgconn.CommandTag{}, nil
+		},
+	}
+	deleteCalled := false
+	vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{}, deleteSavedFn: func(context.Context, string, string) error {
+		deleteCalled = true
+		return nil
+	}}
+
+	w := httptest.NewRecorder()
+	savedSnapshotDeleteTestRouter(&Handlers{DB: db.New(mock), VMD: vmd}, teamID).ServeHTTP(w,
+		httptest.NewRequest(http.MethodDelete, "/snapshots/"+snapshotID.String(), nil))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
+	}
+	if deleteCalled {
+		t.Fatal("tombstoned snapshot invoked host cleanup")
+	}
+}
+
+func TestDeleteSavedSnapshotAdoptsConcurrentDeletingClaim(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	teamID, sourceID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+	hostID := "snapshot-host"
+	ready := db.Snapshot{
+		ID: snapshotID, SandboxID: sourceID, TeamID: teamID,
+		Kind: db.SnapshotKindSaved, Status: db.SnapshotStatusReady, HostID: &hostID,
+	}
+	deleting := ready
+	deleting.Status = db.SnapshotStatusDeleting
+	deleted := deleting
+	deleted.DeletedAt = pgtype.Timestamptz{Time: time.Now(), Valid: true}
+	lookupCalls := 0
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: GetSavedSnapshotForDelete :one"):
+				lookupCalls++
+				if lookupCalls == 1 {
+					return savedSnapshotRow(ready)
+				}
+				return savedSnapshotRow(deleting)
+			case strings.Contains(sql, "-- name: ClaimDeleteSavedSnapshotIfLeaf :one"):
+				return notFoundRow()
+			case strings.Contains(sql, "-- name: FinalizeSavedSnapshotDelete :one"):
+				return savedSnapshotRow(deleted)
+			default:
+				t.Fatalf("unexpected DB row query: %s", sql)
+				return notFoundRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			t.Fatalf("unexpected DB exec: %s", sql)
+			return pgconn.CommandTag{}, nil
+		},
+	}
+	deleteCalls := 0
+	vmd := &stubSavedSnapshotVMD{stubVMD: &stubVMD{}, deleteSavedFn: func(_ context.Context, gotSourceID, gotSnapshotID string) error {
+		deleteCalls++
+		if gotSourceID != sourceID.String() || gotSnapshotID != snapshotID.String() {
+			t.Fatalf("host delete identity = (%s, %s), want (%s, %s)", gotSourceID, gotSnapshotID, sourceID, snapshotID)
+		}
+		return nil
+	}}
+
+	w := httptest.NewRecorder()
+	savedSnapshotDeleteTestRouter(&Handlers{DB: db.New(mock), VMD: vmd}, teamID).ServeHTTP(w,
+		httptest.NewRequest(http.MethodDelete, "/snapshots/"+snapshotID.String(), nil))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
+	}
+	if lookupCalls != 2 || deleteCalls != 1 {
+		t.Fatalf("race adoption calls = lookups:%d host-deletes:%d, want 2 and 1", lookupCalls, deleteCalls)
+	}
+}
+
+func TestCreateSnapshotAdoptsSameKeyWinnerAfterAdmissionNoRows(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	teamID, sourceID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+	hostID := "snapshot-host"
+	idempotencyKey := "same-request"
+	vcpu, memoryMiB, diskMiB := int32(2), int32(2048), int32(8192)
+	source := db.Sandbox{
+		ID: sourceID, TeamID: teamID, Status: db.SandboxStatusActive,
+		HostID: hostID, VcpuCount: vcpu, MemoryMib: memoryMiB, DiskMib: diskMiB,
+	}
+	winnerSource := source
+	winnerSource.SnapshotOperationID = pgtype.UUID{Bytes: snapshotID, Valid: true}
+	winner := db.Snapshot{
+		ID: snapshotID, SandboxID: sourceID, TeamID: teamID,
+		Kind: db.SnapshotKindSaved, Status: db.SnapshotStatusCreating,
+		IdempotencyKey: &idempotencyKey, HostID: &hostID,
+		VcpuCount: &vcpu, MemoryMib: &memoryMiB, DiskMib: &diskMiB,
+		SourceStatus: db.NullSandboxStatus{SandboxStatus: db.SandboxStatusActive, Valid: true},
+	}
+	getSandboxCalls, idempotencyLookups, beginCalls := 0, 0, 0
+	quota := int64(1 << 50)
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: IsFeatureEnabledForTeam :one"):
+				return boolRow(true)
+			case strings.Contains(sql, "-- name: GetSandbox :one"):
+				getSandboxCalls++
+				if getSandboxCalls == 1 {
+					return sandboxRow(source)
+				}
+				return sandboxRow(winnerSource)
+			case strings.Contains(sql, "-- name: GetSavedSnapshotByIdempotencyKey :one"):
+				idempotencyLookups++
+				if idempotencyLookups == 1 {
+					return notFoundRow()
+				}
+				return savedSnapshotRow(winner)
+			case strings.Contains(sql, "-- name: GetSavedSnapshotQuotaUsage :one"):
+				return &mockRow{scanFn: func(dest ...any) error {
+					*dest[0].(*int32) = 100
+					*dest[1].(*int32) = 100
+					*dest[2].(**int64) = &quota
+					*dest[3].(*int64) = 0
+					*dest[4].(*int64) = 0
+					return nil
+				}}
+			case strings.Contains(sql, "-- name: BeginSavedSnapshot :one"):
+				beginCalls++
+				return notFoundRow()
+			default:
+				t.Fatalf("unexpected DB row query: %s", sql)
+				return notFoundRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			t.Fatalf("unexpected DB exec: %s", sql)
+			return pgconn.CommandTag{}, nil
+		},
+	}
+	var capturedSnapshotID string
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		createSavedFn: func(_ context.Context, gotSourceID, gotSnapshotID string) (vmdclient.SavedSnapshotArtifacts, error) {
+			if gotSourceID != sourceID.String() {
+				t.Fatalf("capture source = %s, want %s", gotSourceID, sourceID)
+			}
+			capturedSnapshotID = gotSnapshotID
+			return vmdclient.SavedSnapshotArtifacts{}, status.Error(codes.Unavailable, "host retry")
+		},
+	}
+	h := &Handlers{DB: db.New(mock), VMD: vmd}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("team_id", teamID.String())
+		c.Next()
+	})
+	r.POST("/sandboxes/:sandbox_id/snapshots", h.CreateSnapshot)
+	req := httptest.NewRequest(http.MethodPost, "/sandboxes/"+sourceID.String()+"/snapshots", strings.NewReader(`{}`))
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 after adopted host retry; body: %s", w.Code, w.Body.String())
+	}
+	if capturedSnapshotID != snapshotID.String() {
+		t.Fatalf("captured snapshot ID = %q, want adopted winner %s", capturedSnapshotID, snapshotID)
+	}
+	if getSandboxCalls != 2 || idempotencyLookups != 2 || beginCalls != 1 {
+		t.Fatalf("admission-race calls = source:%d key:%d begin:%d, want 2/2/1", getSandboxCalls, idempotencyLookups, beginCalls)
+	}
+}
+
+func savedSnapshotDeleteTestRouter(h *Handlers, teamID uuid.UUID) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("team_id", teamID.String())
+		c.Next()
+	})
+	r.DELETE("/snapshots/:snapshot_id", h.DeleteSavedSnapshot)
+	return r
+}

--- a/internal/api/handlers_snapshot_security_test.go
+++ b/internal/api/handlers_snapshot_security_test.go
@@ -1,0 +1,546 @@
+package api
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
+)
+
+func TestSavedSnapshotFeatureDisabledStopsCaptureAndForkBeforeResourceLookup(t *testing.T) {
+	teamID := uuid.New()
+	sourceID := uuid.New()
+	snapshotID := uuid.New()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		router func(*Handlers) http.Handler
+	}{
+		{
+			name:   "capture",
+			method: http.MethodPost,
+			path:   "/sandboxes/" + sourceID.String() + "/snapshots",
+			body:   `{}`,
+			router: func(h *Handlers) http.Handler {
+				gin.SetMode(gin.TestMode)
+				r := gin.New()
+				r.Use(func(c *gin.Context) {
+					c.Set("team_id", teamID.String())
+					c.Next()
+				})
+				r.POST("/sandboxes/:sandbox_id/snapshots", h.CreateSnapshot)
+				return r
+			},
+		},
+		{
+			name:   "fork",
+			method: http.MethodPost,
+			path:   "/sandboxes",
+			body:   `{"name":"fork","from_snapshot":"` + snapshotID.String() + `"}`,
+			router: func(h *Handlers) http.Handler {
+				return setupTestRouter(h, teamID.String())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featureLookups := 0
+			dbtx := &mockDBTX{
+				queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+					if !strings.Contains(sql, "-- name: IsFeatureEnabledForTeam :one") {
+						t.Errorf("unexpected DB query after disabled feature gate: %s", firstSQLLine(sql))
+						return errorRow(fmt.Errorf("unexpected query"))
+					}
+					featureLookups++
+					assertSnapshotFeatureArgs(t, args, teamID)
+					return boolRow(false)
+				},
+				execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+					t.Errorf("unexpected DB write after disabled feature gate: %s", firstSQLLine(sql))
+					return pgconn.CommandTag{}, fmt.Errorf("unexpected exec")
+				},
+			}
+			vmdCalls := 0
+			h := &Handlers{
+				DB:  db.New(dbtx),
+				VMD: snapshotVMDRecordingUnexpectedCalls(t, &vmdCalls),
+			}
+
+			w := httptest.NewRecorder()
+			tc.router(h).ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body)))
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body: %s", w.Code, w.Body.String())
+			}
+			if got := errorCode(parseJSON(t, w)); got != "feature_disabled" {
+				t.Fatalf("error code = %q, want feature_disabled", got)
+			}
+			if featureLookups != 1 {
+				t.Fatalf("feature lookups = %d, want 1", featureLookups)
+			}
+			if vmdCalls != 0 {
+				t.Fatalf("VMD calls = %d, want 0", vmdCalls)
+			}
+		})
+	}
+}
+
+func TestSavedSnapshotCrossTeamOperationsAreIndistinguishableFromMissing(t *testing.T) {
+	callerTeamID := uuid.New()
+	foreignSnapshotID := uuid.New()
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		lookupName string
+		router     func(*Handlers) http.Handler
+	}{
+		{
+			name:       "get",
+			method:     http.MethodGet,
+			path:       "/snapshots/" + foreignSnapshotID.String(),
+			lookupName: "-- name: GetSavedSnapshot :one",
+			router: func(h *Handlers) http.Handler {
+				gin.SetMode(gin.TestMode)
+				r := gin.New()
+				r.Use(func(c *gin.Context) {
+					c.Set("team_id", callerTeamID.String())
+					c.Next()
+				})
+				r.GET("/snapshots/:snapshot_id", h.GetSnapshot)
+				return r
+			},
+		},
+		{
+			name:       "delete",
+			method:     http.MethodDelete,
+			path:       "/snapshots/" + foreignSnapshotID.String(),
+			lookupName: "-- name: GetSavedSnapshotForDelete :one",
+			router: func(h *Handlers) http.Handler {
+				return savedSnapshotDeleteTestRouter(h, callerTeamID)
+			},
+		},
+		{
+			name:       "fork",
+			method:     http.MethodPost,
+			path:       "/sandboxes",
+			body:       `{"name":"fork","from_snapshot":"` + foreignSnapshotID.String() + `"}`,
+			lookupName: "-- name: GetSavedSnapshot :one",
+			router: func(h *Handlers) http.Handler {
+				return setupTestRouter(h, callerTeamID.String())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookups := 0
+			dbtx := &mockDBTX{
+				queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+					if strings.Contains(sql, "-- name: IsFeatureEnabledForTeam :one") {
+						if tc.name != "fork" {
+							t.Errorf("unexpected feature lookup for %s", tc.name)
+						}
+						assertSnapshotFeatureArgs(t, args, callerTeamID)
+						return boolRow(true)
+					}
+					if !strings.Contains(sql, tc.lookupName) {
+						t.Errorf("unexpected DB query: %s", firstSQLLine(sql))
+						return errorRow(fmt.Errorf("unexpected query"))
+					}
+					lookups++
+					assertTeamScopedSnapshotArgs(t, args, foreignSnapshotID, callerTeamID)
+					// The database predicate filters the row owned by another team.
+					return notFoundRow()
+				},
+				execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+					t.Errorf("unexpected DB write for cross-team %s: %s", tc.name, firstSQLLine(sql))
+					return pgconn.CommandTag{}, fmt.Errorf("unexpected exec")
+				},
+			}
+			vmdCalls := 0
+			h := &Handlers{
+				DB:  db.New(dbtx),
+				VMD: snapshotVMDRecordingUnexpectedCalls(t, &vmdCalls),
+			}
+
+			w := httptest.NewRecorder()
+			var body *strings.Reader
+			if tc.body == "" {
+				body = strings.NewReader("")
+			} else {
+				body = strings.NewReader(tc.body)
+			}
+			tc.router(h).ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, body))
+
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+			}
+			if got := errorCode(parseJSON(t, w)); got != "snapshot_not_found" {
+				t.Fatalf("error code = %q, want snapshot_not_found", got)
+			}
+			if lookups != 1 {
+				t.Fatalf("team-scoped snapshot lookups = %d, want 1", lookups)
+			}
+			if vmdCalls != 0 {
+				t.Fatalf("VMD calls = %d, want 0", vmdCalls)
+			}
+		})
+	}
+}
+
+func TestSavedSnapshotForkInheritanceMintsUniqueChildCredentials(t *testing.T) {
+	teamID := uuid.New()
+	sourceID := uuid.New()
+	snapshotID := uuid.New()
+	secretID := uuid.New()
+	provider := "openai"
+	const envKey = "OPENAI_API_KEY"
+	const sourceProxyToken = "sk-proj-source-sandbox-token"
+
+	hostID := "host-a"
+	manifestPath := "/var/lib/superserve/snapshots/saved/" + sourceID.String() + "/" + snapshotID.String() + "/manifest.json"
+	manifestDigest := strings.Repeat("a", 64)
+	vcpu, memoryMiB, diskMiB := int32(2), int32(2048), int32(8192)
+	saved := db.Snapshot{
+		ID:             snapshotID,
+		SandboxID:      sourceID,
+		TeamID:         teamID,
+		Kind:           db.SnapshotKindSaved,
+		Status:         db.SnapshotStatusReady,
+		Trigger:        "api",
+		HostID:         &hostID,
+		ManifestPath:   &manifestPath,
+		ManifestDigest: &manifestDigest,
+		VcpuCount:      &vcpu,
+		MemoryMib:      &memoryMiB,
+		DiskMib:        &diskMiB,
+		SecretBindings: []byte(`[{"env_key":"` + envKey + `","secret_id":"` + secretID.String() + `","secret_name":"openai"}]`),
+		SecretEnvKeys:  []byte(`["` + envKey + `"]`),
+		CreatedAt:      time.Now().Add(-time.Minute),
+		UpdatedAt:      time.Now(),
+	}
+	secret := db.Secret{
+		ID:               secretID,
+		TeamID:           teamID,
+		Name:             "openai",
+		AuthType:         "bearer",
+		AuthConfig:       []byte(`{}`),
+		ProviderShortcut: &provider,
+		Hosts:            []string{"api.openai.com"},
+	}
+
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+	signer, err := NewSecretsSigner(base64.StdEncoding.EncodeToString(seed), "snapshot-fork-test")
+	if err != nil {
+		t.Fatalf("create secrets signer: %v", err)
+	}
+
+	var mu sync.Mutex
+	inserted := make([]uuid.UUID, 0, 2)
+	insertedSandboxes := make(map[uuid.UUID]db.Sandbox)
+	persistedTokens := make(map[uuid.UUID]string)
+	injectedTokens := make(map[uuid.UUID]string)
+	injectedJWTs := make(map[uuid.UUID]string)
+	restoredIPs := make(map[uuid.UUID]string)
+	activityDone := make(chan struct{}, 2)
+
+	dbtx := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: IsFeatureEnabledForTeam :one"):
+				assertSnapshotFeatureArgs(t, args, teamID)
+				return boolRow(true)
+			case strings.Contains(sql, "-- name: GetSavedSnapshot :one"):
+				assertTeamScopedSnapshotArgs(t, args, snapshotID, teamID)
+				return savedSnapshotRow(saved)
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+				return boolRow(true)
+			case strings.Contains(sql, "-- name: GetSecretByID :one"):
+				if len(args) != 2 || args[0] != secretID || args[1] != teamID {
+					t.Errorf("GetSecretByID args = %#v, want [%s %s]", args, secretID, teamID)
+				}
+				return secretRow(secret)
+			case strings.Contains(sql, "-- name: CreateSandboxFromSnapshot :one"):
+				childID, ok := args[2].(uuid.UUID)
+				if !ok {
+					t.Errorf("fork child ID arg = %T, want uuid.UUID", args[2])
+					return errorRow(fmt.Errorf("invalid child id"))
+				}
+				sandbox := db.Sandbox{
+					ID:               childID,
+					TeamID:           teamID,
+					Name:             args[3].(string),
+					Status:           db.SandboxStatusStarting,
+					VcpuCount:        vcpu,
+					MemoryMib:        memoryMiB,
+					DiskMib:          diskMiB,
+					HostID:           hostID,
+					Metadata:         []byte(`{}`),
+					SourceSnapshotID: pgtype.UUID{Bytes: snapshotID, Valid: true},
+					CreatedAt:        time.Now(),
+					UpdatedAt:        time.Now(),
+				}
+				mu.Lock()
+				inserted = append(inserted, childID)
+				insertedSandboxes[childID] = sandbox
+				mu.Unlock()
+				return sandboxRow(sandbox)
+			case strings.Contains(sql, "-- name: GetSandbox :one"):
+				childID := args[0].(uuid.UUID)
+				if args[1] != teamID {
+					t.Errorf("GetSandbox team arg = %v, want %s", args[1], teamID)
+				}
+				mu.Lock()
+				sandbox := insertedSandboxes[childID]
+				ip := restoredIPs[childID]
+				mu.Unlock()
+				sandbox.Status = db.SandboxStatusActive
+				addr := netip.MustParseAddr(ip)
+				sandbox.IpAddress = &addr
+				return sandboxRow(sandbox)
+			case strings.Contains(sql, "-- name: CreateActivity :one"):
+				activityDone <- struct{}{}
+				return activityRow()
+			default:
+				t.Errorf("unexpected DB query during inherited-secret fork: %s", firstSQLLine(sql))
+				return errorRow(fmt.Errorf("unexpected query"))
+			}
+		},
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			switch {
+			case strings.Contains(sql, "-- name: AddSandboxSecrets :exec"):
+				childID := args[0].(uuid.UUID)
+				secretIDs := args[1].([]uuid.UUID)
+				envKeys := args[2].([]string)
+				proxyTokens := args[3].([]string)
+				if len(secretIDs) != 1 || secretIDs[0] != secretID || len(envKeys) != 1 || envKeys[0] != envKey || len(proxyTokens) != 1 {
+					t.Errorf("persisted inherited binding = ids:%v env:%v tokens:%d", secretIDs, envKeys, len(proxyTokens))
+				} else {
+					mu.Lock()
+					persistedTokens[childID] = proxyTokens[0]
+					mu.Unlock()
+				}
+				return pgconn.NewCommandTag("UPDATE 1"), nil
+			case strings.Contains(sql, "-- name: ActivateSandbox :exec"):
+				if args[4] != teamID {
+					t.Errorf("ActivateSandbox team arg = %v, want %s", args[4], teamID)
+				}
+				return pgconn.NewCommandTag("UPDATE 1"), nil
+			default:
+				t.Errorf("unexpected DB write during inherited-secret fork: %s", firstSQLLine(sql))
+				return pgconn.CommandTag{}, fmt.Errorf("unexpected exec")
+			}
+		},
+	}
+
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{
+			injectEnvFn: func(_ context.Context, id string, env map[string]string, secretsJWT string) error {
+				childID, err := uuid.Parse(id)
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				injectedTokens[childID] = env[envKey]
+				injectedJWTs[childID] = secretsJWT
+				mu.Unlock()
+				return nil
+			},
+		},
+		checkSavedFn: func(context.Context) error { return nil },
+		restoreSavedFn: func(_ context.Context, id, _, _, gotTeamID, _ string, _ vmdclient.SavedSnapshotNetwork, clearEnvKeys []string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64) (string, uint32, uint32, error) {
+			if gotTeamID != teamID.String() {
+				t.Errorf("restore team ID = %q, want %q", gotTeamID, teamID)
+			}
+			if previewAccess != preview.AccessPublic || previewPorts != nil || previewPolicyRevision != 0 {
+				t.Errorf("restore preview policy = (%q, %#v, %d), want public/nil/0", previewAccess, previewPorts, previewPolicyRevision)
+			}
+			// The captured guest is assumed to contain sourceProxyToken under
+			// envKey. The restore boundary must scrub that captured value before
+			// the freshly minted child credential is injected below.
+			if !slices.Contains(clearEnvKeys, envKey) {
+				t.Errorf("restore clear env keys = %v, want captured key %q", clearEnvKeys, envKey)
+			}
+			childID, err := uuid.Parse(id)
+			if err != nil {
+				return "", 0, 0, err
+			}
+			mu.Lock()
+			ip := fmt.Sprintf("10.0.0.%d", len(restoredIPs)+8)
+			restoredIPs[childID] = ip
+			mu.Unlock()
+			return ip, uint32(vcpu), uint32(memoryMiB), nil
+		},
+	}
+	h := &Handlers{DB: db.New(dbtx), VMD: vmd, Signer: signer}
+	router := setupTestRouter(h, teamID.String())
+
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		body := `{"name":"fork-` + fmt.Sprint(i+1) + `","from_snapshot":"` + snapshotID.String() + `"}`
+		router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/sandboxes", strings.NewReader(body)))
+		if w.Code != http.StatusCreated {
+			t.Fatalf("fork %d status = %d, want 201; body: %s", i+1, w.Code, w.Body.String())
+		}
+		select {
+		case <-activityDone:
+		case <-time.After(time.Second):
+			t.Fatalf("fork %d activity bookkeeping did not finish", i+1)
+		}
+	}
+
+	mu.Lock()
+	children := append([]uuid.UUID(nil), inserted...)
+	persisted := cloneStringMapByUUID(persistedTokens)
+	injected := cloneStringMapByUUID(injectedTokens)
+	jwtByChild := cloneStringMapByUUID(injectedJWTs)
+	mu.Unlock()
+
+	if len(children) != 2 {
+		t.Fatalf("inserted children = %d, want 2", len(children))
+	}
+	if children[0] == children[1] {
+		t.Fatalf("sibling forks reused child ID %s", children[0])
+	}
+	for _, childID := range children {
+		token := injected[childID]
+		if token == "" {
+			t.Fatalf("child %s received an empty inherited proxy token", childID)
+		}
+		if token == sourceProxyToken {
+			t.Fatalf("child %s reused the source sandbox proxy token", childID)
+		}
+		if persisted[childID] != token {
+			t.Fatalf("child %s persisted token %q, injected %q", childID, persisted[childID], token)
+		}
+
+		claims := &SecretsClaims{}
+		parsed, err := jwt.ParseWithClaims(jwtByChild[childID], claims, func(token *jwt.Token) (any, error) {
+			if token.Method.Alg() != jwt.SigningMethodEdDSA.Alg() {
+				return nil, fmt.Errorf("unexpected signing method %s", token.Method.Alg())
+			}
+			return signer.PublicKey(), nil
+		})
+		if err != nil || !parsed.Valid {
+			t.Fatalf("verify child %s secrets JWT: valid=%v err=%v", childID, parsed != nil && parsed.Valid, err)
+		}
+		if claims.Subject != childID.String() {
+			t.Errorf("JWT subject = %q, want child %s", claims.Subject, childID)
+		}
+		if claims.TeamID != teamID.String() {
+			t.Errorf("JWT team = %q, want %s", claims.TeamID, teamID)
+		}
+		if len(claims.Bindings) != 1 || claims.Bindings[0].ProxyToken != token || claims.Bindings[0].SecretID != secretID.String() || claims.Bindings[0].EnvKey != envKey {
+			t.Errorf("JWT binding for child %s = %#v", childID, claims.Bindings)
+		}
+	}
+	if injected[children[0]] == injected[children[1]] {
+		t.Fatalf("sibling forks reused proxy token %q", injected[children[0]])
+	}
+}
+
+func assertSnapshotFeatureArgs(t *testing.T, args []any, teamID uuid.UUID) {
+	t.Helper()
+	if len(args) != 2 {
+		t.Errorf("feature lookup args = %d, want 2", len(args))
+		return
+	}
+	if args[0] != "sandbox_snapshots_v1" {
+		t.Errorf("feature key = %v, want sandbox_snapshots_v1", args[0])
+	}
+	gotTeam, ok := args[1].(pgtype.UUID)
+	if !ok || !gotTeam.Valid || uuid.UUID(gotTeam.Bytes) != teamID {
+		t.Errorf("feature team = %#v, want %s", args[1], teamID)
+	}
+}
+
+func assertTeamScopedSnapshotArgs(t *testing.T, args []any, snapshotID, teamID uuid.UUID) {
+	t.Helper()
+	if len(args) != 2 {
+		t.Errorf("snapshot lookup args = %d, want 2", len(args))
+		return
+	}
+	if args[0] != snapshotID || args[1] != teamID {
+		t.Errorf("snapshot lookup args = %#v, want [%s %s]", args, snapshotID, teamID)
+	}
+}
+
+func snapshotVMDRecordingUnexpectedCalls(t *testing.T, calls *int) *stubSavedSnapshotVMD {
+	t.Helper()
+	record := func(op string) {
+		(*calls)++
+		t.Errorf("unexpected VMD %s call", op)
+	}
+	return &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{
+			injectEnvFn: func(context.Context, string, map[string]string, string) error {
+				record("InjectSandboxEnv")
+				return fmt.Errorf("unexpected VMD call")
+			},
+		},
+		checkSavedFn: func(context.Context) error {
+			record("CheckSavedSnapshotSupport")
+			return fmt.Errorf("unexpected VMD call")
+		},
+		createSavedFn: func(context.Context, string, string) (vmdclient.SavedSnapshotArtifacts, error) {
+			record("CreateSavedSnapshot")
+			return vmdclient.SavedSnapshotArtifacts{}, fmt.Errorf("unexpected VMD call")
+		},
+		restoreSavedFn: func(context.Context, string, string, string, string, string, vmdclient.SavedSnapshotNetwork, []string, string, map[int32]vmdclient.PortPolicy, int64) (string, uint32, uint32, error) {
+			record("RestoreSavedSnapshot")
+			return "", 0, 0, fmt.Errorf("unexpected VMD call")
+		},
+		deleteSavedFn: func(context.Context, string, string) error {
+			record("DeleteSavedSnapshot")
+			return fmt.Errorf("unexpected VMD call")
+		},
+		measureSavedFn: func(context.Context, string) (int64, int64, error) {
+			record("MeasureSandboxWritableLayer")
+			return 0, 0, fmt.Errorf("unexpected VMD call")
+		},
+	}
+}
+
+func firstSQLLine(sql string) string {
+	if i := strings.IndexByte(sql, '\n'); i >= 0 {
+		return sql[:i]
+	}
+	return sql
+}
+
+func cloneStringMapByUUID(in map[uuid.UUID]string) map[uuid.UUID]string {
+	out := make(map[uuid.UUID]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/internal/api/handlers_snapshot_storage_test.go
+++ b/internal/api/handlers_snapshot_storage_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+func TestRecordSandboxWritableLayerUsagePersistsMeasuredGeneration(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	var gotArgs []any
+	dbtx := &mockDBTX{execFn: func(ctx context.Context, _ string, args ...any) (pgconn.CommandTag, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("shadow accounting DB write has no bounded deadline")
+		}
+		gotArgs = append([]any(nil), args...)
+		return pgconn.NewCommandTag("UPDATE 1"), nil
+	}}
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		measureSavedFn: func(ctx context.Context, instanceID string) (int64, int64, error) {
+			if _, ok := ctx.Deadline(); !ok {
+				t.Fatal("writable-layer measurement has no bounded deadline")
+			}
+			if instanceID != sandboxID.String() {
+				t.Fatalf("measured sandbox = %s, want %s", instanceID, sandboxID)
+			}
+			return 8192, 4096, nil
+		},
+	}
+	h := &Handlers{DB: db.New(dbtx)}
+
+	h.recordSandboxWritableLayerUsage(context.Background(), vmd, sandboxID, teamID)
+
+	if len(gotArgs) != 4 {
+		t.Fatalf("storage update args = %v, want 4", gotArgs)
+	}
+	if gotArgs[0] != teamID {
+		t.Fatalf("storage team arg = %#v, want %s", gotArgs[0], teamID)
+	}
+	if gotArgs[1] != sandboxID {
+		t.Fatalf("storage sandbox arg = %#v, want %s", gotArgs[1], sandboxID)
+	}
+	if gotArgs[2] != int64(8192) || gotArgs[3] != int64(4096) {
+		t.Fatalf("storage size args = %v, want logical=8192 exclusive=4096", gotArgs[2:])
+	}
+}
+
+func TestRecordSandboxWritableLayerUsageRejectsNegativeMeasurement(t *testing.T) {
+	dbtx := &mockDBTX{execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+		t.Fatal("negative measurement reached the storage ledger")
+		return pgconn.CommandTag{}, nil
+	}}
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: &stubVMD{},
+		measureSavedFn: func(context.Context, string) (int64, int64, error) {
+			return 1, -1, nil
+		},
+	}
+	h := &Handlers{DB: db.New(dbtx)}
+
+	h.recordSandboxWritableLayerUsage(context.Background(), vmd, uuid.New(), uuid.New())
+}

--- a/internal/api/handlers_template.go
+++ b/internal/api/handlers_template.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -719,6 +720,7 @@ func (h *Handlers) DeleteTemplate(c *gin.Context) {
 	if !res.Deleted {
 		switch {
 		case res.LiveCount > 0 || res.SnapshotCount > 0:
+			RecordSavedSnapshotOutcome(c.Request.Context(), telemetry.SavedSnapshotOperationDelete, telemetry.SavedSnapshotOutcomeDependencyBlocked, telemetryHostID(c))
 			h.capture(c, "template_delete_blocked", map[string]any{
 				"template_id":    tplID.String(),
 				"sandbox_count":  res.LiveCount,

--- a/internal/api/handlers_template_test.go
+++ b/internal/api/handlers_template_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
 // These tests cover the purely-functional helpers in handlers_template.go
@@ -449,5 +450,52 @@ func TestTemplateCache_MidFlightInvalidationVetoesStore(t *testing.T) {
 	}
 	if _, ok := templateCache.Load(key); !ok {
 		t.Fatal("expected the entry to be cached once no invalidation raced the flight")
+	}
+}
+
+func TestDeleteTemplate_SavedSnapshotDependencyConflict(t *testing.T) {
+	recorder := useSavedSnapshotOutcomeRecorder(t)
+	templateID := uuid.New()
+	teamID := uuid.New()
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+		if strings.Contains(sql, "snapshot_count") && strings.Contains(sql, "SoftDeleteTemplateIfUnused") {
+			return &mockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*bool) = true
+				*dest[1].(*int64) = 0
+				*dest[2].(*int64) = 2
+				*dest[3].(*int64) = 0
+				*dest[4].(*bool) = false
+				return nil
+			}}
+		}
+		return notFoundRow()
+	}}
+
+	h := &Handlers{DB: db.New(mock), VMD: &stubVMD{}}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("team_id", teamID.String())
+		c.Next()
+	})
+	r.DELETE("/templates/:template_id", h.DeleteTemplate)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/templates/"+templateID.String(), nil))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(t, w)
+	errorBody, _ := body["error"].(map[string]any)
+	if got := errorBody["code"]; got != "template_has_dependents" {
+		t.Fatalf("error code = %v, want template_has_dependents", got)
+	}
+	dependencies, _ := errorBody["dependencies"].(map[string]any)
+	if got := dependencies["snapshot_count"]; got != float64(2) {
+		t.Errorf("snapshot_count = %v, want 2", got)
+	}
+	if len(recorder.outcomes) != 1 || recorder.outcomes[0].Operation != telemetry.SavedSnapshotOperationDelete ||
+		recorder.outcomes[0].Outcome != telemetry.SavedSnapshotOutcomeDependencyBlocked {
+		t.Fatalf("dependency-block telemetry = %+v", recorder.outcomes)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -40,6 +41,7 @@ type stubVMD struct {
 	updateNetworkFn  func(ctx context.Context, id string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
 	updatePreviewFn  func(ctx context.Context, id, access string, ports map[int32]vmdclient.PortPolicy, revision int64) error
 	injectEnvFn      func(ctx context.Context, id string, envVars map[string]string, secretsJWT string) error
+	revokeSandboxFn  func(ctx context.Context, id string) error
 	listDirFn        func(ctx context.Context, id, path string) ([]vmdclient.DirEntry, error)
 }
 
@@ -120,8 +122,13 @@ func (s *stubVMD) UpdateSandboxPreviewPolicy(ctx context.Context, id, access str
 	}
 	return nil
 }
-func (s *stubVMD) InvalidateSecret(_ context.Context, _ string) error       { return nil }
-func (s *stubVMD) RevokeSandbox(_ context.Context, _ string) error          { return nil }
+func (s *stubVMD) InvalidateSecret(_ context.Context, _ string) error { return nil }
+func (s *stubVMD) RevokeSandbox(ctx context.Context, id string) error {
+	if s.revokeSandboxFn != nil {
+		return s.revokeSandboxFn(ctx, id)
+	}
+	return nil
+}
 func (s *stubVMD) InvalidateSandboxRules(_ context.Context, _ string) error { return nil }
 func (s *stubVMD) InjectSandboxEnv(ctx context.Context, id string, envVars map[string]string, secretsJWT string) error {
 	if s.injectEnvFn != nil {
@@ -372,6 +379,10 @@ func setupTestRouter(h *Handlers, teamID string) *gin.Engine {
 
 func deleteRequest(sandboxID string) *http.Request {
 	return httptest.NewRequest(http.MethodDelete, "/sandboxes/"+sandboxID, nil)
+}
+
+func patchRequest(sandboxID, body string) *http.Request {
+	return httptest.NewRequest(http.MethodPatch, "/sandboxes/"+sandboxID, strings.NewReader(body))
 }
 
 func parseJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
@@ -3187,5 +3198,129 @@ func TestPauseWithRetry_NotFoundIsTerminal(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("NotFound must not be retried, got %d calls", calls)
+	}
+}
+
+func TestPatchSandbox_SnapshotOperationRejectsCapturedPolicyChanges(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	operationID := uuid.New()
+	sb := db.Sandbox{
+		ID:                  sandboxID,
+		TeamID:              teamID,
+		Status:              db.SandboxStatusActive,
+		SnapshotOperationID: pgtype.UUID{Bytes: operationID, Valid: true},
+	}
+
+	for name, body := range map[string]string{
+		"network":     `{"network":{"allow_out":["192.0.2.0/24"]}}`,
+		"timeout":     `{"timeout_seconds":600}`,
+		"auto_delete": `{"auto_delete_seconds":3600}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var networkCalled bool
+			mock := &mockDBTX{
+				queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+				execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+					return pgconn.NewCommandTag("UPDATE 0"), nil
+				},
+			}
+			h := &Handlers{
+				VMD: &stubVMD{updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
+					networkCalled = true
+					return nil
+				}},
+				DB: db.New(mock),
+			}
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set("team_id", teamID.String())
+				c.Next()
+			})
+			r.PATCH("/sandboxes/:sandbox_id", h.PatchSandbox)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, patchRequest(sandboxID.String(), body))
+
+			if w.Code != http.StatusConflict {
+				t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+			}
+			if networkCalled {
+				t.Error("network policy must not be pushed while snapshot capture is in progress")
+			}
+		})
+	}
+}
+
+func TestDeleteSandbox_SavedSnapshots_ReturnsDependencyConflict(t *testing.T) {
+	recorder := useSavedSnapshotOutcomeRecorder(t)
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
+
+	var destroyCalled bool
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error {
+		destroyCalled = true
+		return nil
+	}}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return notFoundRow()
+			case strings.Contains(sql, "saved_snapshot_count"):
+				return &mockRow{scanFn: func(dest ...any) error {
+					*dest[0].(*int64) = int64(len(snapshotIDs))
+					return nil
+				}}
+			default:
+				return sandboxRow(sb)
+			}
+		},
+		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+			if strings.Contains(sql, "kind = 'saved'") {
+				rows := make([]func(...any) error, 0, len(snapshotIDs))
+				for _, id := range snapshotIDs {
+					id := id
+					rows = append(rows, func(dest ...any) error {
+						*dest[0].(*uuid.UUID) = id
+						return nil
+					})
+				}
+				return &scanRows{rows: rows}, nil
+			}
+			return &scanRows{}, nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	body := parseJSON(t, w)
+	errorBody, _ := body["error"].(map[string]any)
+	if got := errorBody["code"]; got != "sandbox_has_snapshots" {
+		t.Fatalf("error code = %v, want sandbox_has_snapshots", got)
+	}
+	dependencies, _ := errorBody["dependencies"].(map[string]any)
+	if got := dependencies["sandbox_count"]; got != float64(0) {
+		t.Errorf("sandbox_count = %v, want 0", got)
+	}
+	if got := dependencies["snapshot_count"]; got != float64(len(snapshotIDs)) {
+		t.Errorf("snapshot_count = %v, want %d", got, len(snapshotIDs))
+	}
+	if ids, _ := dependencies["snapshot_ids"].([]any); len(ids) != len(snapshotIDs) {
+		t.Errorf("snapshot_ids length = %d, want %d", len(ids), len(snapshotIDs))
+	}
+	if destroyCalled {
+		t.Error("must not tear down a source sandbox while saved snapshots pin it")
+	}
+	if len(recorder.outcomes) != 1 || recorder.outcomes[0].Operation != telemetry.SavedSnapshotOperationDelete ||
+		recorder.outcomes[0].Outcome != telemetry.SavedSnapshotOutcomeDependencyBlocked {
+		t.Fatalf("dependency-block telemetry = %+v", recorder.outcomes)
 	}
 }

--- a/internal/api/openapi_sync_test.go
+++ b/internal/api/openapi_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -18,16 +19,6 @@ var dataPlaneSpecPaths = map[string]bool{
 	"/exec":         true,
 	"/exec/stream":  true,
 	"/exec/connect": true,
-}
-
-// deferredContractOps are routes introduced in this stacked control-plane
-// change whose OpenAPI contract ships in the immediately following PR.
-// Remove these exceptions when that contract lands.
-var deferredContractOps = map[string]bool{
-	"POST /sandboxes/{sandbox_id}/snapshots": true,
-	"GET /snapshots":                         true,
-	"GET /snapshots/{snapshot_id}":           true,
-	"DELETE /snapshots/{snapshot_id}":        true,
 }
 
 // TestOpenAPISpecMatchesRoutes fails if a registered route is missing from
@@ -54,7 +45,7 @@ func TestOpenAPISpecMatchesRoutes(t *testing.T) {
 
 	// Every control-plane route must be documented.
 	for op := range routeOps {
-		if !specOps[op] && !deferredContractOps[op] {
+		if !specOps[op] {
 			t.Errorf("route %q is registered but missing from api/openapi.yaml — add it to the spec", op)
 		}
 	}
@@ -69,6 +60,208 @@ func TestOpenAPISpecMatchesRoutes(t *testing.T) {
 			t.Errorf("operation %q is in api/openapi.yaml but has no control-plane route — remove it from the spec or implement it", op)
 		}
 	}
+}
+
+// TestOpenAPISavedSnapshotContract protects the public distinction between a
+// sandbox's replaceable pause checkpoint and immutable, reusable saved
+// snapshots. Route parity alone cannot catch schema regressions such as making
+// inherited lifecycle fields non-nullable or dropping fork lineage.
+func TestOpenAPISavedSnapshotContract(t *testing.T) {
+	doc := loadSpecDocument(t)
+
+	t.Run("routes", func(t *testing.T) {
+		want := map[string]map[string]string{
+			"/sandboxes/{sandbox_id}/snapshots": {"post": "createSnapshot"},
+			"/snapshots":                        {"get": "listSnapshots"},
+			"/snapshots/{snapshot_id}":          {"get": "getSnapshot", "delete": "deleteSnapshot"},
+		}
+		for path, methods := range want {
+			for method, operationID := range methods {
+				op := specObjectAt(t, doc, "paths", path, method)
+				if got := op["operationId"]; got != operationID {
+					t.Errorf("%s %s operationId = %v, want %q", strings.ToUpper(method), path, got, operationID)
+				}
+			}
+		}
+		for path := range specObjectAt(t, doc, "paths") {
+			if strings.Contains(strings.ToLower(path), "cascade") {
+				t.Errorf("initial snapshot canary must not publish a cascade endpoint: %s", path)
+			}
+		}
+	})
+
+	t.Run("fork source and response lineage", func(t *testing.T) {
+		create := specObjectAt(t, doc, "components", "schemas", "CreateSandboxRequest")
+		properties := specObjectAt(t, create, "properties")
+		fromSnapshot := specObjectAt(t, properties, "from_snapshot")
+		if got := fromSnapshot["format"]; got != "uuid" {
+			t.Errorf("CreateSandboxRequest.from_snapshot format = %v, want uuid", got)
+		}
+
+		excludedTogether := stringSet(t, specObjectAt(t, create, "not")["required"], "CreateSandboxRequest.not.required")
+		if !reflect.DeepEqual(excludedTogether, map[string]bool{"from_snapshot": true, "from_template": true}) {
+			t.Errorf("mutually excluded source fields = %v", excludedTogether)
+		}
+
+		listItem := specObjectAt(t, doc, "components", "schemas", "SandboxListItem")
+		itemProperties := specObjectAt(t, listItem, "properties")
+		checkpoint := specObjectAt(t, itemProperties, "snapshot_id")
+		if checkpoint["deprecated"] != true {
+			t.Errorf("SandboxListItem.snapshot_id must remain deprecated; got %v", checkpoint["deprecated"])
+		}
+		lineage := specObjectAt(t, itemProperties, "source_snapshot_id")
+		if got := lineage["format"]; got != "uuid" {
+			t.Errorf("SandboxListItem.source_snapshot_id format = %v, want uuid", got)
+		}
+
+		createResponse := specObjectAt(t, doc, "paths", "/sandboxes", "post", "responses", "201", "content", "application/json", "schema")
+		if got := createResponse["$ref"]; got != "#/components/schemas/SandboxResponse" {
+			t.Errorf("POST /sandboxes 201 schema = %v, want SandboxResponse", got)
+		}
+		responseAllOf := specListAt(t, specObjectAt(t, doc, "components", "schemas", "SandboxResponse"), "allOf")
+		if !listHasRef(responseAllOf, "#/components/schemas/SandboxListItem") {
+			t.Error("SandboxResponse must include SandboxListItem so source_snapshot_id is returned after a fork")
+		}
+	})
+
+	t.Run("nullable lifecycle inheritance", func(t *testing.T) {
+		properties := specObjectAt(t, doc, "components", "schemas", "CreateSandboxRequest", "properties")
+		for _, field := range []string{"timeout_seconds", "auto_delete_seconds"} {
+			schema := specObjectAt(t, properties, field)
+			gotTypes := stringSet(t, schema["type"], "CreateSandboxRequest."+field+".type")
+			wantTypes := map[string]bool{"integer": true, "null": true}
+			if !reflect.DeepEqual(gotTypes, wantTypes) {
+				t.Errorf("CreateSandboxRequest.%s types = %v, want integer|null", field, gotTypes)
+			}
+			description, _ := schema["description"].(string)
+			if !strings.Contains(description, "inherits") || !strings.Contains(description, "explicit `null` disables") {
+				t.Errorf("CreateSandboxRequest.%s must document omitted=inherit and null=disable", field)
+			}
+		}
+	})
+
+	t.Run("replacement and private preview isolation", func(t *testing.T) {
+		properties := specObjectAt(t, doc, "components", "schemas", "CreateSandboxRequest", "properties")
+		for _, field := range []string{"network", "secrets"} {
+			description, _ := specObjectAt(t, properties, field)["description"].(string)
+			description = strings.Join(strings.Fields(description), " ")
+			if !strings.Contains(description, "inherit") || !strings.Contains(description, "full replacement") || !strings.Contains(description, "JSON `null` is invalid") {
+				t.Errorf("CreateSandboxRequest.%s must document omitted=inherit, object=replace, and null=invalid", field)
+			}
+		}
+		previewDescription, _ := specObjectAt(t, properties, "preview_access")["description"].(string)
+		previewDescription = strings.Join(strings.Fields(previewDescription), " ")
+		for _, phrase := range []string{"zero published ports", "never inherits", "child-scoped preview token"} {
+			if !strings.Contains(previewDescription, phrase) {
+				t.Errorf("CreateSandboxRequest.preview_access is missing %q", phrase)
+			}
+		}
+	})
+
+	t.Run("saved snapshot response is complete and host opaque", func(t *testing.T) {
+		snapshot := specObjectAt(t, doc, "components", "schemas", "SnapshotResponse")
+		required := stringSet(t, snapshot["required"], "SnapshotResponse.required")
+		for _, field := range []string{
+			"id", "status", "sandbox_id", "vcpu_count", "memory_mib", "disk_mib",
+			"logical_size_bytes", "exclusive_size_bytes", "child_sandbox_count",
+			"child_snapshot_count", "created_at", "updated_at",
+		} {
+			if !required[field] {
+				t.Errorf("SnapshotResponse.required is missing %q", field)
+			}
+		}
+
+		properties := specObjectAt(t, snapshot, "properties")
+		for _, internal := range []string{
+			"host_id", "path", "mem_path", "manifest_path", "manifest_digest",
+			"artifact_metadata", "secret_bindings", "failure_reason",
+		} {
+			if _, exposed := properties[internal]; exposed {
+				t.Errorf("SnapshotResponse exposes host/internal field %q", internal)
+			}
+		}
+
+		statuses := stringSet(t, specObjectAt(t, properties, "status")["enum"], "SnapshotResponse.status.enum")
+		wantStatuses := map[string]bool{
+			"creating": true, "ready": true, "unavailable": true, "failed": true, "deleting": true,
+		}
+		if !reflect.DeepEqual(statuses, wantStatuses) {
+			t.Errorf("SnapshotResponse statuses = %v, want %v", statuses, wantStatuses)
+		}
+	})
+
+	t.Run("delete is retryable but non cascading", func(t *testing.T) {
+		pathItem := specObjectAt(t, doc, "paths", "/snapshots/{snapshot_id}")
+		deleteOp := specObjectAt(t, pathItem, "delete")
+		responses := specObjectAt(t, deleteOp, "responses")
+		unavailable := specObjectAt(t, responses, "503")
+		if got := unavailable["$ref"]; got != "#/components/responses/SnapshotHostUnavailable" {
+			t.Errorf("DELETE /snapshots/{snapshot_id} 503 = %v, want SnapshotHostUnavailable", got)
+		}
+		conflictSchema := specObjectAt(t, responses, "409", "content", "application/json", "schema")
+		if !listHasRef(specListAt(t, conflictSchema, "anyOf"), "#/components/schemas/DependencyConflictError") {
+			t.Error("snapshot delete 409 must document snapshot_has_dependents details")
+		}
+		if operationHasParameter(pathItem, "cascade") || operationHasParameter(deleteOp, "cascade") {
+			t.Error("initial snapshot delete must not accept a cascade parameter")
+		}
+
+		hostUnavailable := specObjectAt(t, doc, "components", "responses", "SnapshotHostUnavailable")
+		_ = specObjectAt(t, hostUnavailable, "headers", "Retry-After")
+		captureResponses := specObjectAt(t, doc, "paths", "/sandboxes/{sandbox_id}/snapshots", "post", "responses")
+		if _, ok := captureResponses["410"]; !ok {
+			t.Error("snapshot capture must document permanent artifact loss as 410")
+		}
+	})
+
+	t.Run("snapshot-derived resume capacity is retryable", func(t *testing.T) {
+		for _, path := range []string{
+			"/sandboxes/{sandbox_id}/resume",
+			"/sandboxes/{sandbox_id}/activate",
+		} {
+			unavailable := specObjectAt(t, doc, "paths", path, "post", "responses", "503")
+			if got := unavailable["$ref"]; got != "#/components/responses/SandboxResumeHostUnavailable" {
+				t.Errorf("POST %s 503 = %v, want SandboxResumeHostUnavailable", path, got)
+			}
+		}
+
+		resumeUnavailable := specObjectAt(t, doc, "components", "responses", "SandboxResumeHostUnavailable")
+		description, ok := resumeUnavailable["description"].(string)
+		if !ok {
+			t.Fatal("SandboxResumeHostUnavailable.description must be a string")
+		}
+		for _, code := range []string{"sandbox_host_unavailable", "snapshot_host_unavailable"} {
+			if !strings.Contains(description, code) {
+				t.Errorf("SandboxResumeHostUnavailable.description must document %q", code)
+			}
+		}
+	})
+
+	t.Run("snapshot authorization and terminal capture failure", func(t *testing.T) {
+		for _, operation := range []struct {
+			path, method string
+		}{
+			{path: "/snapshots", method: "get"},
+			{path: "/snapshots/{snapshot_id}", method: "get"},
+			{path: "/snapshots/{snapshot_id}", method: "delete"},
+		} {
+			responses := specObjectAt(t, doc, "paths", operation.path, operation.method, "responses")
+			forbidden := specObjectAt(t, responses, "403")
+			if got := forbidden["$ref"]; got != "#/components/responses/Forbidden" {
+				t.Errorf("%s %s 403 = %v, want Forbidden", strings.ToUpper(operation.method), operation.path, got)
+			}
+		}
+
+		capture500 := specObjectAt(t, doc, "paths", "/sandboxes/{sandbox_id}/snapshots", "post", "responses", "500")
+		description, _ := capture500["description"].(string)
+		if !strings.Contains(description, "snapshot_source_failed") {
+			t.Error("snapshot capture 500 must document snapshot_source_failed")
+		}
+		errorDescription, _ := specObjectAt(t, doc, "components", "schemas", "Error")["description"].(string)
+		if !strings.Contains(errorDescription, "snapshot_source_failed") {
+			t.Error("Error code catalog must include snapshot_source_failed")
+		}
+	})
 }
 
 func TestOpenAPIPreviewTokenIsDocumentedAsARequestCredential(t *testing.T) {
@@ -118,6 +311,100 @@ func loadSpecOps(t *testing.T) map[string]bool {
 		}
 	}
 	return ops
+}
+
+func loadSpecDocument(t *testing.T) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	return doc
+}
+
+func specObjectAt(t *testing.T, root map[string]any, keys ...string) map[string]any {
+	t.Helper()
+	var current any = root
+	path := "#"
+	for _, key := range keys {
+		object, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("%s is %T, want object while looking up %q", path, current, key)
+		}
+		var found bool
+		current, found = object[key]
+		path += "/" + key
+		if !found {
+			t.Fatalf("missing OpenAPI value %s", path)
+		}
+	}
+	object, ok := current.(map[string]any)
+	if !ok {
+		t.Fatalf("%s is %T, want object", path, current)
+	}
+	return object
+}
+
+func specListAt(t *testing.T, root map[string]any, key string) []any {
+	t.Helper()
+	value, ok := root[key]
+	if !ok {
+		t.Fatalf("missing OpenAPI list %q", key)
+	}
+	list, ok := value.([]any)
+	if !ok {
+		t.Fatalf("OpenAPI value %q is %T, want list", key, value)
+	}
+	return list
+}
+
+func stringSet(t *testing.T, value any, path string) map[string]bool {
+	t.Helper()
+	list, ok := value.([]any)
+	if !ok {
+		t.Fatalf("%s is %T, want string list", path, value)
+	}
+	out := make(map[string]bool, len(list))
+	for i, raw := range list {
+		s, ok := raw.(string)
+		if !ok {
+			t.Fatalf("%s[%d] is %T, want string", path, i, raw)
+		}
+		out[s] = true
+	}
+	return out
+}
+
+func listHasRef(list []any, want string) bool {
+	for _, item := range list {
+		object, ok := item.(map[string]any)
+		if ok && object["$ref"] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func operationHasParameter(operation map[string]any, name string) bool {
+	raw, ok := operation["parameters"]
+	if !ok {
+		return false
+	}
+	parameters, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, parameter := range parameters {
+		object, ok := parameter.(map[string]any)
+		if ok && object["name"] == name {
+			return true
+		}
+	}
+	return false
 }
 
 // ginPathToOpenAPI rewrites gin's ":param" segments into OpenAPI's "{param}" form.

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -356,3 +356,40 @@ func TestReaper_LoopRunsImmediately(t *testing.T) {
 	}
 	t.Fatal("reaper did not run immediately on startup")
 }
+
+func TestReaper_MeasuresShadowUsageBeforeFinalizingPause(t *testing.T) {
+	row := expiredRow("sbx-accounted")
+	var events []string
+	dbtx := &reaperMockDBTX{
+		queryFn: func(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+			return newStubRows([]db.ClaimExpiredSandboxesRow{row}), nil
+		},
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "upserted AS") {
+				events = append(events, "finalize")
+				return finalizePauseRow(uuid.New())
+			}
+			return activityRow()
+		},
+	}
+	base := &stubVMD{pauseFn: func(_ context.Context, _ string, _ string) (string, string, error) {
+		return "/snapshots/vmstate.snap", "/snapshots/mem.snap", nil
+	}}
+	vmd := &stubSavedSnapshotVMD{
+		stubVMD: base,
+		measureSavedFn: func(_ context.Context, instanceID string) (int64, int64, error) {
+			events = append(events, "measure")
+			if instanceID != row.ID.String() {
+				t.Fatalf("measured sandbox = %s, want %s", instanceID, row.ID)
+			}
+			return 2048, 1024, nil
+		},
+	}
+	h := &Handlers{VMD: vmd, DB: db.New(dbtx)}
+
+	h.reapOnce(context.Background(), 10, 1)
+
+	if got, want := strings.Join(events, ","), "measure,finalize"; got != want {
+		t.Fatalf("pause accounting order = %q, want %q", got, want)
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -658,6 +658,15 @@ type SandboxStorageInterval struct {
 	EndReason *string            `json:"end_reason"`
 }
 
+type SavedSnapshotExpectedIndex struct {
+	IndexName  string   `json:"index_name"`
+	TableName  string   `json:"table_name"`
+	IsUnique   bool     `json:"is_unique"`
+	KeyColumns []string `json:"key_columns"`
+	Predicate  string   `json:"predicate"`
+	Definition string   `json:"definition"`
+}
+
 type Secret struct {
 	ID               uuid.UUID          `json:"id"`
 	TeamID           uuid.UUID          `json:"team_id"`

--- a/internal/db/saved_snapshot_index_contract_test.go
+++ b/internal/db/saved_snapshot_index_contract_test.go
@@ -1,0 +1,204 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var savedSnapshotContractIndexNames = []string{
+	"snapshot_sandbox_runtime_unique",
+	"snapshot_team_source_idempotency_unique",
+	"idx_snapshot_team_saved_created",
+	"idx_snapshot_source_saved_created",
+	"idx_snapshot_parent_saved",
+	"idx_snapshot_saved_host",
+	"idx_snapshot_saved_reconcile",
+	"idx_sandbox_source_snapshot_pin",
+	"idx_sandbox_destroyed_snapshot_pin",
+	"idx_sandbox_snapshot_operation",
+}
+
+func readRepositoryFile(t *testing.T, parts ...string) string {
+	t.Helper()
+
+	path := filepath.Join(append([]string{"..", ".."}, parts...)...)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+func TestSavedSnapshotIndexPrebuildContract(t *testing.T) {
+	prebuild := readRepositoryFile(
+		t,
+		"scripts",
+		"prebuild-saved-snapshot-indexes.sql",
+	)
+
+	if strings.Contains(prebuild, "\nBEGIN;") {
+		t.Fatal("concurrent index prebuild must not run in a transaction")
+	}
+	concurrentBuild := regexp.MustCompile(
+		`(?m)^CREATE (?:UNIQUE )?INDEX CONCURRENTLY IF NOT EXISTS `,
+	)
+	if got := len(concurrentBuild.FindAllString(prebuild, -1)); got != 10 {
+		t.Fatalf("concurrent index builds = %d, want 10", got)
+	}
+	for _, indexName := range savedSnapshotContractIndexNames {
+		if !strings.Contains(prebuild, indexName) {
+			t.Errorf("prebuild is missing %s", indexName)
+		}
+	}
+	for _, required := range []string{
+		"pg_advisory_lock(20819, 20260729)",
+		"pg_advisory_unlock(20819, 20260729)",
+		"catalog.indisvalid",
+		"catalog.indisready",
+		"catalog.indislive",
+		"actual_access_method <> 'btree'",
+		"actual_keys IS DISTINCT FROM expected.key_columns",
+		"actual_predicate IS DISTINCT FROM expected.predicate",
+		"actual_definition IS DISTINCT FROM expected.definition",
+	} {
+		if !strings.Contains(prebuild, required) {
+			t.Errorf("prebuild is missing exact catalog guard %q", required)
+		}
+	}
+}
+
+func TestSavedSnapshotIndexRecoveryIsInvalidOnly(t *testing.T) {
+	recovery := readRepositoryFile(
+		t,
+		"scripts",
+		"recover-saved-snapshot-indexes.sql",
+	)
+
+	for _, required := range []string{
+		"pg_advisory_lock(20819, 20260729)",
+		"pg_advisory_unlock(20819, 20260729)",
+		"\\gexec",
+		"AND NOT catalog.indisvalid",
+		"indexed_table.relname = expected.table_name",
+		"pg_get_indexdef(catalog.indexrelid) = expected.definition",
+		"refusing recovery:",
+	} {
+		if !strings.Contains(recovery, required) {
+			t.Errorf("recovery is missing invalid-only guard %q", required)
+		}
+	}
+	if strings.Contains(recovery, "DROP INDEX public.") {
+		t.Fatal("recovery contains an unconditional literal DROP INDEX")
+	}
+}
+
+func TestSavedSnapshotIndexMigrationHasFreshResetOnlyFallback(t *testing.T) {
+	migration := readRepositoryFile(
+		t,
+		"supabase",
+		"migrations",
+		"20260729000010_saved_snapshot_indexes.sql",
+	)
+
+	for _, indexName := range savedSnapshotContractIndexNames {
+		if !strings.Contains(migration, indexName) {
+			t.Errorf("index migration is missing %s", indexName)
+		}
+	}
+	for _, required := range []string{
+		"pg_advisory_xact_lock(20819, 20260729)",
+		"EXISTS (SELECT 1 FROM public.snapshot LIMIT 1)",
+		"EXISTS (SELECT 1 FROM public.sandbox LIMIT 1)",
+		"LOCK TABLE public.sandbox, public.snapshot IN SHARE MODE",
+		"IF tables_are_populated AND missing_indexes IS NOT NULL",
+		"require concurrent prebuild of all saved-snapshot indexes",
+		"IF NOT tables_are_populated THEN",
+		"EXECUTE expected.definition",
+		"actual_valid",
+		"actual_ready",
+		"actual_live",
+		"actual_keys IS DISTINCT FROM expected.key_columns",
+		"actual_predicate IS DISTINCT FROM expected.predicate",
+		"actual_definition IS DISTINCT FROM expected.definition",
+	} {
+		if !strings.Contains(migration, required) {
+			t.Errorf("index migration is missing guard %q", required)
+		}
+	}
+}
+
+func TestSavedSnapshotContractMigrationIsDarkAtomicAndBounded(t *testing.T) {
+	migration := readRepositoryFile(
+		t,
+		"supabase",
+		"migrations",
+		"20260729000011_saved_snapshot_contract.sql",
+	)
+
+	for _, required := range []string{
+		"SET LOCAL lock_timeout = '5s'",
+		"SET LOCAL statement_timeout = '30s'",
+		"pg_advisory_xact_lock(20819, 20260729)",
+		"LOCK TABLE public.feature_flag, public.team_feature_flag",
+		"LOCK TABLE public.sandbox IN SHARE ROW EXCLUSIVE MODE",
+		"LOCK TABLE public.snapshot IN ACCESS EXCLUSIVE MODE",
+		"key = 'sandbox_snapshots_v1'",
+		"AND NOT enabled",
+		"WHERE kind = 'saved'",
+		"WHERE source_snapshot_id IS NOT NULL",
+		"WHERE snapshot_operation_id IS NOT NULL",
+		"pg_get_expr(",
+		"pg_get_indexdef(catalog.indexrelid)",
+	} {
+		if !strings.Contains(migration, required) {
+			t.Errorf("contract migration is missing guard %q", required)
+		}
+	}
+
+	dropLast := regexp.MustCompile(
+		`(?s)DROP INDEX public\.snapshot_sandbox_unique;\s*COMMIT;\s*$`,
+	)
+	if !dropLast.MatchString(migration) {
+		t.Fatal("legacy index drop is not the final operation before COMMIT")
+	}
+}
+
+func TestMigrationCDPrebuildsEveryDatabaseBeforePush(t *testing.T) {
+	workflow := readRepositoryFile(t, ".github", "workflows", "cd.yml")
+
+	for _, required := range []string{
+		"group: cd-migrate",
+		"cancel-in-progress: false",
+		"scripts/prebuild-saved-snapshot-indexes.sql",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("migration CD is missing %q", required)
+		}
+	}
+	if strings.Contains(workflow, "recover-saved-snapshot-indexes.sql") {
+		t.Fatal("migration CD must never invoke index recovery automatically")
+	}
+
+	orderedSteps := []string{
+		"Prebuild and verify saved-snapshot indexes in staging",
+		"Push migrations to staging",
+		"Prebuild and verify saved-snapshot indexes in production primary",
+		"Prebuild and verify saved-snapshot indexes in production usw",
+		"Push migrations to production primary",
+		"Push migrations to usw cell",
+	}
+	lastPosition := -1
+	for _, step := range orderedSteps {
+		position := strings.Index(workflow, step)
+		if position < 0 {
+			t.Fatalf("migration CD is missing step %q", step)
+		}
+		if position <= lastPosition {
+			t.Fatalf("migration CD step %q is out of order", step)
+		}
+		lastPosition = position
+	}
+}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -79,6 +79,10 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "migration failed: %v\n", err)
 		os.Exit(1)
 	}
+	if err := verifySavedSnapshotContractStartsDark(ctx, testPool); err != nil {
+		fmt.Fprintf(os.Stderr, "saved-snapshot contract initial state: %v\n", err)
+		os.Exit(1)
+	}
 
 	testQueries = db.New(testPool)
 
@@ -92,6 +96,36 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
+}
+
+func verifySavedSnapshotContractStartsDark(ctx context.Context, pool *pgxpool.Pool) error {
+	var (
+		globalEnabled        bool
+		enabledTeamOverrides int
+	)
+	if err := pool.QueryRow(ctx, `
+		SELECT
+		    COALESCE((
+		        SELECT enabled
+		        FROM feature_flag
+		        WHERE key = 'sandbox_snapshots_v1'
+		    ), true),
+		    (
+		        SELECT count(*)
+		        FROM team_feature_flag
+		        WHERE key = 'sandbox_snapshots_v1'
+		          AND enabled
+		    )
+	`).Scan(&globalEnabled, &enabledTeamOverrides); err != nil {
+		return fmt.Errorf("inspect feature flags: %w", err)
+	}
+	if globalEnabled {
+		return errors.New("global sandbox_snapshots_v1 flag is enabled or missing")
+	}
+	if enabledTeamOverrides != 0 {
+		return fmt.Errorf("found %d enabled team overrides", enabledTeamOverrides)
+	}
+	return nil
 }
 
 func resetTestSchema(ctx context.Context, pool *pgxpool.Pool) error {

--- a/internal/integration/saved_snapshot_db_safety_test.go
+++ b/internal/integration/saved_snapshot_db_safety_test.go
@@ -1,0 +1,1171 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/preview"
+)
+
+type savedSnapshotForkFixture struct {
+	teamID     uuid.UUID
+	snapshotID uuid.UUID
+	forkID     uuid.UUID
+}
+
+// seedSavedSnapshotTestHost satisfies the same host-admission invariant as
+// production: every sandbox that can mutate host-local snapshot artifacts must
+// belong to an active host row. Keep this scoped to the snapshot fixtures so a
+// synthetic host cannot affect unrelated scheduler tests.
+func seedSavedSnapshotTestHost(t *testing.T) {
+	t.Helper()
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO host (
+			id, vmd_addr, proxy_addr, region,
+			capacity_memory_mib, capacity_vcpus, status
+		) VALUES (
+			'snapshot-host', '127.0.0.1:1', '127.0.0.1:2', 'test',
+			65536, 64, 'active'
+		)
+		ON CONFLICT (id) DO UPDATE
+		SET status = 'active', updated_at = now()
+	`); err != nil {
+		t.Fatalf("seed snapshot test host: %v", err)
+	}
+}
+
+func seedSavedSnapshotForkFixture(t *testing.T, destroyed bool) savedSnapshotForkFixture {
+	t.Helper()
+	seedSavedSnapshotTestHost(t)
+
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-db-safety-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team
+		SET snapshot_storage_quota_bytes = 1073741824
+		WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("provision snapshot storage quota: %v", err)
+	}
+
+	sourceID := uuid.New()
+	snapshotID := uuid.New()
+	forkID := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'active', $4, 2, 2048, 8192)
+	`, sourceID, team.ID, "snapshot-source-"+sourceID.String(), "snapshot-host"); err != nil {
+		t.Fatalf("insert source sandbox: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO snapshot (
+			id, sandbox_id, team_id, path, mem_path, size_bytes, trigger,
+			kind, status, source_status, host_id, vcpu_count, memory_mib,
+			disk_mib, manifest_path, manifest_digest
+		) VALUES (
+			$1, $2, $3, $4, $5, 0, 'manual', 'saved', 'ready', 'active',
+			$6, 2, 2048, 8192, $7, repeat('a', 64)
+		)
+	`, snapshotID, sourceID, team.ID, "/saved/"+snapshotID.String()+"/disk",
+		"/saved/"+snapshotID.String()+"/memory", "snapshot-host",
+		"/saved/"+snapshotID.String()+"/manifest.json"); err != nil {
+		t.Fatalf("insert saved snapshot: %v", err)
+	}
+
+	status := "starting"
+	var destroyedAt any
+	if destroyed {
+		status = "deleted"
+		destroyedAt = time.Now().Add(-time.Minute)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib,
+			disk_mib, base_path, source_snapshot_id, destroyed_at
+		) VALUES ($1, $2, $3, $4, $5, 2, 2048, 8192, $6, $7, $8)
+	`, forkID, team.ID, "snapshot-fork-"+forkID.String(), status,
+		"snapshot-host", "/saved/base", snapshotID, destroyedAt); err != nil {
+		t.Fatalf("insert snapshot fork: %v", err)
+	}
+
+	return savedSnapshotForkFixture{
+		teamID:     team.ID,
+		snapshotID: snapshotID,
+		forkID:     forkID,
+	}
+}
+
+func TestIntegration_DestroyedForkPinsSavedSnapshotUntilRelease(t *testing.T) {
+	ctx := context.Background()
+	fixture := seedSavedSnapshotForkFixture(t, true)
+
+	deps, err := testQueries.GetSavedSnapshotDependencyCounts(ctx, db.GetSavedSnapshotDependencyCountsParams{
+		SnapshotID: fixture.snapshotID,
+		TeamID:     fixture.teamID,
+	})
+	if err != nil {
+		t.Fatalf("GetSavedSnapshotDependencyCounts: %v", err)
+	}
+	if deps.ChildSandboxCount != 1 {
+		t.Fatalf("child sandbox count = %d, want 1 while destroyed fork is pinned", deps.ChildSandboxCount)
+	}
+
+	childIDs, err := testQueries.ListSavedSnapshotChildSandboxIDs(ctx, db.ListSavedSnapshotChildSandboxIDsParams{
+		SnapshotID: pgtype.UUID{Bytes: fixture.snapshotID, Valid: true},
+		TeamID:     fixture.teamID,
+	})
+	if err != nil {
+		t.Fatalf("ListSavedSnapshotChildSandboxIDs: %v", err)
+	}
+	if len(childIDs) != 1 || childIDs[0] != fixture.forkID {
+		t.Fatalf("child sandbox IDs = %v, want [%s]", childIDs, fixture.forkID)
+	}
+
+	if _, err := testQueries.ClaimDeleteSavedSnapshotIfLeaf(ctx, db.ClaimDeleteSavedSnapshotIfLeafParams{
+		SnapshotID: fixture.snapshotID,
+		TeamID:     fixture.teamID,
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("delete claim with pending fork teardown error = %v, want pgx.ErrNoRows", err)
+	}
+
+	pending, err := testQueries.ListDestroyedSnapshotForksPendingPinRelease(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListDestroyedSnapshotForksPendingPinRelease: %v", err)
+	}
+	var queued *db.ListDestroyedSnapshotForksPendingPinReleaseRow
+	for i := range pending {
+		if pending[i].ID == fixture.forkID {
+			queued = &pending[i]
+			break
+		}
+	}
+	if queued == nil {
+		t.Fatalf("destroyed fork %s missing from pending pin-release queue", fixture.forkID)
+	}
+	if queued.TeamID != fixture.teamID || queued.HostID != "snapshot-host" ||
+		queued.BasePath == nil || *queued.BasePath != "/saved/base" ||
+		!queued.SourceSnapshotID.Valid || queued.SourceSnapshotID.Bytes != fixture.snapshotID {
+		t.Fatalf("pending teardown row = %+v, want exact host and snapshot lineage", *queued)
+	}
+
+	otherTeam, err := testQueries.CreateTeam(ctx, "snapshot-db-other-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam(other): %v", err)
+	}
+	if _, err := testQueries.ReleaseDestroyedSandboxSnapshotPin(ctx, db.ReleaseDestroyedSandboxSnapshotPinParams{
+		SandboxID:        fixture.forkID,
+		TeamID:           otherTeam.ID,
+		SourceSnapshotID: queued.SourceSnapshotID,
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("cross-team pin release error = %v, want pgx.ErrNoRows", err)
+	}
+
+	if releasedID, err := testQueries.ReleaseDestroyedSandboxSnapshotPin(ctx, db.ReleaseDestroyedSandboxSnapshotPinParams{
+		SandboxID:        fixture.forkID,
+		TeamID:           fixture.teamID,
+		SourceSnapshotID: queued.SourceSnapshotID,
+	}); err != nil {
+		t.Fatalf("ReleaseDestroyedSandboxSnapshotPin: %v", err)
+	} else if releasedID != fixture.forkID {
+		t.Fatalf("released sandbox ID = %s, want %s", releasedID, fixture.forkID)
+	}
+
+	deps, err = testQueries.GetSavedSnapshotDependencyCounts(ctx, db.GetSavedSnapshotDependencyCountsParams{
+		SnapshotID: fixture.snapshotID,
+		TeamID:     fixture.teamID,
+	})
+	if err != nil {
+		t.Fatalf("GetSavedSnapshotDependencyCounts after release: %v", err)
+	}
+	if deps.ChildSandboxCount != 0 {
+		t.Fatalf("child sandbox count after release = %d, want 0", deps.ChildSandboxCount)
+	}
+	if _, err := testQueries.ClaimDeleteSavedSnapshotIfLeaf(ctx, db.ClaimDeleteSavedSnapshotIfLeafParams{
+		SnapshotID: fixture.snapshotID,
+		TeamID:     fixture.teamID,
+	}); err != nil {
+		t.Fatalf("leaf delete claim after host teardown release: %v", err)
+	}
+}
+
+func TestIntegration_LiveForkCannotRewriteSnapshotLineage(t *testing.T) {
+	ctx := context.Background()
+	fixture := seedSavedSnapshotForkFixture(t, false)
+
+	_, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET source_snapshot_id = NULL, updated_at = now()
+		WHERE id = $1 AND team_id = $2
+	`, fixture.forkID, fixture.teamID)
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "23514" {
+		t.Fatalf("live lineage rewrite error = %v, want PostgreSQL code 23514", err)
+	}
+
+	var sourceSnapshotID pgtype.UUID
+	if err := testPool.QueryRow(ctx, `
+		SELECT source_snapshot_id FROM sandbox
+		WHERE id = $1 AND team_id = $2
+	`, fixture.forkID, fixture.teamID).Scan(&sourceSnapshotID); err != nil {
+		t.Fatalf("read fork lineage after rejected rewrite: %v", err)
+	}
+	if !sourceSnapshotID.Valid || sourceSnapshotID.Bytes != fixture.snapshotID {
+		t.Fatalf("source_snapshot_id = %v, want %s", sourceSnapshotID, fixture.snapshotID)
+	}
+}
+
+func TestIntegration_SnapshotForkActivationSkipsLegacyStorageInterval(t *testing.T) {
+	ctx := context.Background()
+	fixture := seedSavedSnapshotForkFixture(t, false)
+	normalID := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'starting', $4, 1, 1024, 4096)
+	`, normalID, fixture.teamID, "normal-sandbox-"+normalID.String(), "snapshot-host"); err != nil {
+		t.Fatalf("insert normal sandbox: %v", err)
+	}
+
+	for _, sandboxID := range []uuid.UUID{fixture.forkID, normalID} {
+		if err := testQueries.ActivateSandbox(ctx, db.ActivateSandboxParams{
+			ID:        sandboxID,
+			VcpuCount: 2,
+			MemoryMib: 2048,
+			TeamID:    fixture.teamID,
+			ActorID:   pgtype.UUID{},
+		}); err != nil {
+			t.Fatalf("ActivateSandbox(%s): %v", sandboxID, err)
+		}
+	}
+
+	if open := countOpenComputeBillingIntervals(t, ctx, fixture.forkID); open != 1 {
+		t.Fatalf("fork compute billing intervals = %d, want 1", open)
+	}
+	if open := countOpenStorageIntervals(t, ctx, fixture.forkID); open != 0 {
+		t.Fatalf("fork legacy full-disk storage intervals = %d, want 0", open)
+	}
+	if open := countOpenStorageIntervals(t, ctx, normalID); open != 1 {
+		t.Fatalf("normal sandbox storage intervals = %d, want 1", open)
+	}
+
+	if _, err := testQueries.ReleaseDestroyedSandboxSnapshotPin(ctx, db.ReleaseDestroyedSandboxSnapshotPinParams{
+		SandboxID: fixture.forkID,
+		TeamID:    fixture.teamID,
+		SourceSnapshotID: pgtype.UUID{
+			Bytes: fixture.snapshotID,
+			Valid: true,
+		},
+	}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("live fork pin release error = %v, want pgx.ErrNoRows", err)
+	}
+}
+
+func TestIntegration_BeginSavedSnapshotRejectsExhaustedStorageQuota(t *testing.T) {
+	seedSavedSnapshotTestHost(t)
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-quota-full-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team
+		SET snapshot_storage_quota_bytes = 4096,
+		    snapshot_storage_bytes = 4096
+		WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("configure exhausted snapshot quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable saved snapshots: %v", err)
+	}
+
+	sourceID := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (id, team_id, name, status, host_id)
+		VALUES ($1, $2, $3, 'active', $4)
+	`, sourceID, team.ID, "quota-source-"+sourceID.String(), "snapshot-host"); err != nil {
+		t.Fatalf("insert source sandbox: %v", err)
+	}
+
+	snapshotID := uuid.New()
+	_, err = testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: snapshotID,
+		Trigger:    "manual",
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+	})
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "SS005" {
+		t.Fatalf("BeginSavedSnapshot error = %v, want PostgreSQL code SS005", err)
+	}
+
+	var operationID pgtype.UUID
+	if err := testPool.QueryRow(ctx, `
+		SELECT snapshot_operation_id FROM sandbox WHERE id = $1
+	`, sourceID).Scan(&operationID); err != nil {
+		t.Fatalf("read source operation claim: %v", err)
+	}
+	if operationID.Valid {
+		t.Fatalf("source operation claim survived rejected admission: %s", operationID.Bytes)
+	}
+	var snapshotCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT count(*) FROM snapshot WHERE id = $1
+	`, snapshotID).Scan(&snapshotCount); err != nil {
+		t.Fatalf("count rejected snapshot: %v", err)
+	}
+	if snapshotCount != 0 {
+		t.Fatalf("saved snapshot rows after rejected admission = %d, want 0", snapshotCount)
+	}
+}
+
+func TestIntegration_LockActiveTeamSecretIDsFiltersAndOrders(t *testing.T) {
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-secret-lock-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	otherTeam, err := testQueries.CreateTeam(ctx, "snapshot-secret-lock-other-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam(other): %v", err)
+	}
+
+	activeIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	deletedID := uuid.New()
+	otherTeamID := uuid.New()
+	for _, fixture := range []struct {
+		id        uuid.UUID
+		teamID    uuid.UUID
+		name      string
+		deletedAt any
+	}{
+		{id: activeIDs[0], teamID: team.ID, name: "active-a"},
+		{id: activeIDs[1], teamID: team.ID, name: "active-b"},
+		{id: deletedID, teamID: team.ID, name: "deleted", deletedAt: time.Now()},
+		{id: otherTeamID, teamID: otherTeam.ID, name: "other-team"},
+	} {
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO secret (
+				id, team_id, name, auth_type, hosts, ciphertext,
+				encrypted_dek, kek_id, deleted_at
+			) VALUES (
+				$1, $2, $3, 'bearer', ARRAY['api.example.test'],
+				decode('01', 'hex'), decode('02', 'hex'), 'test-kek', $4
+			)
+		`, fixture.id, fixture.teamID, fixture.name, fixture.deletedAt); err != nil {
+			t.Fatalf("insert secret %s: %v", fixture.name, err)
+		}
+	}
+
+	candidates := []uuid.UUID{otherTeamID, activeIDs[1], deletedID, activeIDs[0]}
+	locked, err := testQueries.LockActiveTeamSecretIDs(ctx, db.LockActiveTeamSecretIDsParams{
+		TeamID:    team.ID,
+		SecretIds: candidates,
+	})
+	if err != nil {
+		t.Fatalf("LockActiveTeamSecretIDs: %v", err)
+	}
+	sort.Slice(activeIDs, func(i, j int) bool {
+		return activeIDs[i].String() < activeIDs[j].String()
+	})
+	if len(locked) != len(activeIDs) {
+		t.Fatalf("locked secret IDs = %v, want %v", locked, activeIDs)
+	}
+	for i := range activeIDs {
+		if locked[i] != activeIDs[i] {
+			t.Fatalf("locked secret IDs = %v, want ordered %v", locked, activeIDs)
+		}
+	}
+}
+
+func TestIntegration_UpsertSandboxRevocationNeverShortensExpiry(t *testing.T) {
+	ctx := context.Background()
+	sandboxID := uuid.New()
+	longExpiry := time.Now().UTC().Truncate(time.Microsecond).Add(2 * time.Hour)
+	shortExpiry := longExpiry.Add(-time.Hour)
+
+	for _, expiresAt := range []time.Time{longExpiry, shortExpiry} {
+		if err := testQueries.UpsertSandboxRevocation(ctx, db.UpsertSandboxRevocationParams{
+			SandboxID: sandboxID,
+			ExpiresAt: expiresAt,
+		}); err != nil {
+			t.Fatalf("UpsertSandboxRevocation(%s): %v", expiresAt, err)
+		}
+	}
+	var stored time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT expires_at FROM sandbox_revocation WHERE sandbox_id = $1
+	`, sandboxID).Scan(&stored); err != nil {
+		t.Fatalf("read sandbox revocation: %v", err)
+	}
+	if !stored.Equal(longExpiry) {
+		t.Fatalf("revocation expiry after older retry = %s, want %s", stored, longExpiry)
+	}
+
+	laterExpiry := longExpiry.Add(time.Hour)
+	if err := testQueries.UpsertSandboxRevocation(ctx, db.UpsertSandboxRevocationParams{
+		SandboxID: sandboxID,
+		ExpiresAt: laterExpiry,
+	}); err != nil {
+		t.Fatalf("UpsertSandboxRevocation(later): %v", err)
+	}
+	if err := testPool.QueryRow(ctx, `
+		SELECT expires_at FROM sandbox_revocation WHERE sandbox_id = $1
+	`, sandboxID).Scan(&stored); err != nil {
+		t.Fatalf("read extended sandbox revocation: %v", err)
+	}
+	if !stored.Equal(laterExpiry) {
+		t.Fatalf("extended revocation expiry = %s, want %s", stored, laterExpiry)
+	}
+}
+
+func TestIntegration_FailSavedSnapshotAndSourcePersistsRevocationAtomically(t *testing.T) {
+	seedSavedSnapshotTestHost(t)
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-source-failure-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1`, team.ID); err != nil {
+		t.Fatalf("configure snapshot quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable snapshot feature: %v", err)
+	}
+
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'active', 'snapshot-host', 2, 2048, 8192)
+	`, sourceID, team.ID, "source-"+sourceID.String()); err != nil {
+		t.Fatalf("insert source sandbox: %v", err)
+	}
+	if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: snapshotID,
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+		Trigger:    "manual",
+	}); err != nil {
+		t.Fatalf("BeginSavedSnapshot: %v", err)
+	}
+
+	expiresAt := time.Now().UTC().Truncate(time.Microsecond).Add(90 * 24 * time.Hour)
+	reason := "source_resume_failed"
+	if _, err := testQueries.FailSavedSnapshotAndSource(ctx, db.FailSavedSnapshotAndSourceParams{
+		SnapshotID:          snapshotID,
+		TeamID:              team.ID,
+		RevocationExpiresAt: expiresAt,
+		FailureReason:       &reason,
+	}); err != nil {
+		t.Fatalf("FailSavedSnapshotAndSource: %v", err)
+	}
+
+	var sourceStatus, snapshotStatus string
+	var operationID pgtype.UUID
+	var storedExpiry time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT source.status, source.snapshot_operation_id, snap.status, revoke.expires_at
+		FROM sandbox source
+		JOIN snapshot snap ON snap.id = $2 AND snap.sandbox_id = source.id
+		JOIN sandbox_revocation revoke ON revoke.sandbox_id = source.id
+		WHERE source.id = $1
+	`, sourceID, snapshotID).Scan(&sourceStatus, &operationID, &snapshotStatus, &storedExpiry); err != nil {
+		t.Fatalf("read terminal state: %v", err)
+	}
+	if sourceStatus != "failed" || snapshotStatus != "failed" || operationID.Valid || !storedExpiry.Equal(expiresAt) {
+		t.Fatalf("terminal state source=%s snapshot=%s operation=%v expiry=%s, want failed/failed/empty/%s",
+			sourceStatus, snapshotStatus, operationID, storedExpiry, expiresAt)
+	}
+}
+
+func TestIntegration_FinalizeSavedSnapshotEnforcesActualLayerQuotaAtomically(t *testing.T) {
+	seedSavedSnapshotTestHost(t)
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-finalize-quota-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team SET snapshot_storage_quota_bytes = 149 WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("configure snapshot quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable snapshot feature: %v", err)
+	}
+
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'active', $4, 2, 2048, 8192)
+	`, sourceID, team.ID, "finalize-quota-source-"+sourceID.String(), "snapshot-host"); err != nil {
+		t.Fatalf("insert source sandbox: %v", err)
+	}
+	if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: snapshotID,
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+		Trigger:    "manual",
+	}); err != nil {
+		t.Fatalf("BeginSavedSnapshot: %v", err)
+	}
+
+	digest := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	_, err = testQueries.FinalizeSavedSnapshot(ctx, db.FinalizeSavedSnapshotParams{
+		SnapshotID:         snapshotID,
+		TeamID:             team.ID,
+		Path:               "/saved/disk",
+		MemPath:            "/saved/memory",
+		LogicalSizeBytes:   1000,
+		ManifestPath:       "/saved/manifest.json",
+		ManifestDigest:     &digest,
+		ArtifactMetadata:   []byte(`{"schema_version":1,"source_logical_size_bytes":500,"source_exclusive_size_bytes":50}`),
+		ExclusiveSizeBytes: 100,
+	})
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "SS005" {
+		t.Fatalf("FinalizeSavedSnapshot error = %v, want PostgreSQL code SS005", err)
+	}
+
+	usage, err := testQueries.GetTeamSnapshotLayerUsage(ctx, team.ID)
+	if err != nil {
+		t.Fatalf("GetTeamSnapshotLayerUsage: %v", err)
+	}
+	if usage.ExclusiveSizeBytes != 0 || usage.ActiveLayerCount != 0 {
+		t.Fatalf("rolled-back layer usage = %+v, want zero", usage)
+	}
+	var counter int64
+	var status string
+	if err := testPool.QueryRow(ctx, `
+		SELECT t.snapshot_storage_bytes, s.status
+		FROM team t
+		JOIN snapshot s ON s.team_id = t.id AND s.id = $2
+		WHERE t.id = $1
+	`, team.ID, snapshotID).Scan(&counter, &status); err != nil {
+		t.Fatalf("read rolled-back quota state: %v", err)
+	}
+	if counter != 0 || status != "creating" {
+		t.Fatalf("rolled-back quota state counter=%d status=%s, want 0/creating", counter, status)
+	}
+}
+
+func TestIntegration_SavedSnapshotForkAdmissionSerializesHostCapacity(t *testing.T) {
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-host-capacity-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	hostID := "snapshot-capacity-" + uuid.NewString()
+	if _, err := testPool.Exec(ctx, `UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1`, team.ID); err != nil {
+		t.Fatalf("configure snapshot quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO host (id, vmd_addr, proxy_addr, region, capacity_memory_mib, capacity_vcpus)
+		VALUES ($1, '127.0.0.1:1', '127.0.0.1:2', 'test', 2048, 2)
+	`, hostID); err != nil {
+		t.Fatalf("configure capacity host: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable snapshot feature: %v", err)
+	}
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib)
+		VALUES ($1, $2, $3, 'paused', $4, 2, 2048, 8192)
+	`, sourceID, team.ID, "source-"+sourceID.String(), hostID); err != nil {
+		t.Fatalf("seed capacity source: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO snapshot (
+			id, sandbox_id, team_id, path, mem_path, size_bytes, trigger,
+			kind, status, source_status, host_id, vcpu_count, memory_mib,
+			disk_mib, manifest_path, manifest_digest
+		) VALUES ($1, $2, $3, '/saved/disk', '/saved/memory', 0, 'manual',
+			'saved', 'ready', 'paused', $4, 2, 2048, 8192, '/saved/manifest.json', repeat('b', 64))
+	`, snapshotID, sourceID, team.ID, hostID); err != nil {
+		t.Fatalf("seed capacity snapshot: %v", err)
+	}
+
+	create := func(id uuid.UUID) error {
+		_, err := testQueries.CreateSandboxFromSnapshot(ctx, db.CreateSandboxFromSnapshotParams{
+			ID:                       id,
+			TeamID:                   team.ID,
+			Name:                     "fork-" + id.String(),
+			Status:                   db.SandboxStatusStarting,
+			InheritTimeoutSeconds:    true,
+			Metadata:                 []byte(`{}`),
+			InheritAutoDeleteSeconds: true,
+			InheritNetworkConfig:     true,
+			SourceSnapshotID:         snapshotID,
+			PreviewAccess:            preview.AccessPublic,
+		})
+		return err
+	}
+	if err := create(uuid.New()); err != nil {
+		t.Fatalf("first capacity admission: %v", err)
+	}
+	err = create(uuid.New())
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "SS006" {
+		t.Fatalf("second capacity admission error = %v, want SS006", err)
+	}
+}
+
+func TestIntegration_SavedSnapshotLayerLedgerCountsSharedLayersOnce(t *testing.T) {
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-layer-ledger-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	hostID := "snapshot-layer-ledger-" + uuid.NewString()
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("configure layer-ledger team: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable layer-ledger feature: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO host (
+			id, vmd_addr, proxy_addr, region,
+			capacity_memory_mib, capacity_vcpus
+		) VALUES ($1, '127.0.0.1:1', '127.0.0.1:2', 'test', 65536, 64)
+	`, hostID); err != nil {
+		t.Fatalf("configure layer-ledger fixture: %v", err)
+	}
+
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id,
+			vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'active', $4, 2, 2048, 8192)
+	`, sourceID, team.ID, "layer-source-"+sourceID.String(), hostID); err != nil {
+		t.Fatalf("insert source: %v", err)
+	}
+	if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: snapshotID,
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+		Trigger:    "manual",
+	}); err != nil {
+		t.Fatalf("BeginSavedSnapshot: %v", err)
+	}
+	digest := "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	if _, err := testQueries.FinalizeSavedSnapshot(ctx, db.FinalizeSavedSnapshotParams{
+		SnapshotID:         snapshotID,
+		TeamID:             team.ID,
+		Path:               "/saved/disk",
+		MemPath:            "/saved/memory",
+		LogicalSizeBytes:   1000,
+		ManifestPath:       "/saved/manifest.json",
+		ManifestDigest:     &digest,
+		ArtifactMetadata:   []byte(`{"schema_version":1,"source_logical_size_bytes":500,"source_exclusive_size_bytes":50}`),
+		ExclusiveSizeBytes: 100,
+	}); err != nil {
+		t.Fatalf("FinalizeSavedSnapshot: %v", err)
+	}
+
+	assertUsage := func(wantLogical, wantExclusive, wantLayers int64) {
+		t.Helper()
+		usage, err := testQueries.GetTeamSnapshotLayerUsage(ctx, team.ID)
+		if err != nil {
+			t.Fatalf("GetTeamSnapshotLayerUsage: %v", err)
+		}
+		if usage.LogicalSizeBytes != wantLogical || usage.ExclusiveSizeBytes != wantExclusive || usage.ActiveLayerCount != wantLayers {
+			t.Fatalf("layer usage = %+v, want logical=%d exclusive=%d layers=%d", usage, wantLogical, wantExclusive, wantLayers)
+		}
+		var counter int64
+		if err := testPool.QueryRow(ctx, `SELECT snapshot_storage_bytes FROM team WHERE id = $1`, team.ID).Scan(&counter); err != nil {
+			t.Fatalf("read team shadow counter: %v", err)
+		}
+		if counter != wantExclusive {
+			t.Fatalf("team shadow counter = %d, want %d", counter, wantExclusive)
+		}
+	}
+	assertUsage(1500, 150, 3)
+
+	// The source's measured current layer includes both bytes a future capture
+	// can retain by reflink and source-only bytes such as copied sidecars.
+	if _, err := testQueries.RecordSandboxWritableLayerUsage(ctx, db.RecordSandboxWritableLayerUsageParams{
+		LogicalSizeBytes:   300,
+		ExclusiveSizeBytes: 75,
+		SandboxID:          sourceID,
+		TeamID:             team.ID,
+	}); err != nil {
+		t.Fatalf("RecordSandboxWritableLayerUsage(source): %v", err)
+	}
+	assertUsage(1800, 225, 3)
+
+	secondSnapshotID := uuid.New()
+	if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: secondSnapshotID,
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+		Trigger:    "manual",
+	}); err != nil {
+		t.Fatalf("BeginSavedSnapshot(second): %v", err)
+	}
+	secondDigest := "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	if _, err := testQueries.FinalizeSavedSnapshot(ctx, db.FinalizeSavedSnapshotParams{
+		SnapshotID:         secondSnapshotID,
+		TeamID:             team.ID,
+		Path:               "/saved/disk-2",
+		MemPath:            "/saved/memory-2",
+		LogicalSizeBytes:   100,
+		ManifestPath:       "/saved/manifest-2.json",
+		ManifestDigest:     &secondDigest,
+		ArtifactMetadata:   []byte(`{"schema_version":1,"source_logical_size_bytes":200,"source_exclusive_size_bytes":50}`),
+		ExclusiveSizeBytes: 10,
+	}); err != nil {
+		t.Fatalf("FinalizeSavedSnapshot(second): %v", err)
+	}
+	// The second capture seals 200/50, retains the 100/25 source-only
+	// remainder in a fresh current row, and adds its own 100/10 layer.
+	assertUsage(1900, 235, 5)
+
+	forkIDs := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	for _, forkID := range forkIDs {
+		if _, err := testQueries.CreateSandboxFromSnapshot(ctx, db.CreateSandboxFromSnapshotParams{
+			ID:                       forkID,
+			TeamID:                   team.ID,
+			Name:                     "layer-fork-" + forkID.String(),
+			Status:                   db.SandboxStatusStarting,
+			InheritTimeoutSeconds:    true,
+			Metadata:                 []byte(`{}`),
+			InheritAutoDeleteSeconds: true,
+			InheritNetworkConfig:     true,
+			SourceSnapshotID:         snapshotID,
+			PreviewAccess:            preview.AccessPublic,
+		}); err != nil {
+			t.Fatalf("CreateSandboxFromSnapshot(%s): %v", forkID, err)
+		}
+	}
+	assertUsage(1900, 235, 8)
+
+	layers, err := testQueries.ListSnapshotStorageLayersForTeam(ctx, team.ID)
+	if err != nil {
+		t.Fatalf("ListSnapshotStorageLayersForTeam: %v", err)
+	}
+	var snapshotLayerID, sourceCurrentLayerID int64
+	var sourceGenerationCount int
+	for _, layer := range layers {
+		if layer.Kind == db.SnapshotStorageLayerKindSavedSnapshot && layer.OwnerSnapshotID.Valid && layer.OwnerSnapshotID.Bytes == snapshotID {
+			snapshotLayerID = layer.ID
+		}
+		if layer.OwnerSandboxID.Valid && layer.OwnerSandboxID.Bytes == sourceID {
+			switch layer.Kind {
+			case db.SnapshotStorageLayerKindSandboxGeneration:
+				sourceGenerationCount++
+			case db.SnapshotStorageLayerKindSandboxWritable:
+				sourceCurrentLayerID = layer.ID
+				if layer.CurrentLogicalSizeBytes != 100 || layer.CurrentExclusiveSizeBytes != 25 {
+					t.Fatalf("replacement source current layer = %+v, want current logical=100 exclusive=25", layer)
+				}
+			}
+		}
+	}
+	if snapshotLayerID == 0 {
+		t.Fatal("saved-snapshot layer was not created")
+	}
+	if sourceGenerationCount != 2 || sourceCurrentLayerID == 0 {
+		t.Fatalf("source layers generation_count=%d current=%d, want 2 generations and one current", sourceGenerationCount, sourceCurrentLayerID)
+	}
+	refs, err := testQueries.GetSnapshotStorageReferenceCounts(ctx, db.GetSnapshotStorageReferenceCountsParams{
+		LayerID: snapshotLayerID,
+		TeamID:  team.ID,
+	})
+	if err != nil {
+		t.Fatalf("GetSnapshotStorageReferenceCounts: %v", err)
+	}
+	if refs.SnapshotReferenceCount != 1 || refs.SandboxReferenceCount != 3 {
+		t.Fatalf("snapshot layer refs = %+v, want snapshot=1 sandbox=3", refs)
+	}
+	currentRefs, err := testQueries.GetSnapshotStorageReferenceCounts(ctx, db.GetSnapshotStorageReferenceCountsParams{
+		LayerID: sourceCurrentLayerID,
+		TeamID:  team.ID,
+	})
+	if err != nil {
+		t.Fatalf("GetSnapshotStorageReferenceCounts(source current): %v", err)
+	}
+	if currentRefs.SnapshotReferenceCount != 0 || currentRefs.SandboxReferenceCount != 1 {
+		t.Fatalf("source current refs = %+v, want snapshot=0 sandbox=1", currentRefs)
+	}
+
+	if _, err := testQueries.RecordSandboxWritableLayerUsage(ctx, db.RecordSandboxWritableLayerUsageParams{
+		LogicalSizeBytes:   250,
+		ExclusiveSizeBytes: 25,
+		SandboxID:          forkIDs[0],
+		TeamID:             team.ID,
+	}); err != nil {
+		t.Fatalf("RecordSandboxWritableLayerUsage: %v", err)
+	}
+	assertUsage(2150, 260, 8)
+
+	for _, forkID := range forkIDs {
+		if _, err := testPool.Exec(ctx, `
+			UPDATE sandbox
+			SET status = 'deleted', destroyed_at = now(), updated_at = now()
+			WHERE id = $1 AND team_id = $2
+		`, forkID, team.ID); err != nil {
+			t.Fatalf("soft-delete fork %s: %v", forkID, err)
+		}
+		if _, err := testQueries.ReleaseDestroyedSandboxSnapshotPin(ctx, db.ReleaseDestroyedSandboxSnapshotPinParams{
+			SandboxID: forkID,
+			TeamID:    team.ID,
+			SourceSnapshotID: pgtype.UUID{
+				Bytes: snapshotID,
+				Valid: true,
+			},
+		}); err != nil {
+			t.Fatalf("ReleaseDestroyedSandboxSnapshotPin(%s): %v", forkID, err)
+		}
+	}
+	assertUsage(1900, 235, 5)
+
+	// Source-only remainder lives only in the replacement mutable generation.
+	// Releasing the source must drop those 25 exclusive bytes even while older
+	// snapshots still pin both sealed generations.
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET status = 'deleted', destroyed_at = now(), updated_at = now()
+		WHERE id = $1 AND team_id = $2
+	`, sourceID, team.ID); err != nil {
+		t.Fatalf("soft-delete source: %v", err)
+	}
+	assertUsage(1800, 210, 4)
+
+	if _, err := testQueries.ClaimDeleteSavedSnapshotIfLeaf(ctx, db.ClaimDeleteSavedSnapshotIfLeafParams{
+		SnapshotID: snapshotID,
+		TeamID:     team.ID,
+	}); err != nil {
+		t.Fatalf("ClaimDeleteSavedSnapshotIfLeaf: %v", err)
+	}
+	if _, err := testQueries.FinalizeSavedSnapshotDelete(ctx, db.FinalizeSavedSnapshotDeleteParams{
+		SnapshotID: snapshotID,
+		TeamID:     team.ID,
+	}); err != nil {
+		t.Fatalf("FinalizeSavedSnapshotDelete: %v", err)
+	}
+	// The second snapshot still pins both source generations, but not the first
+	// snapshot's own artifact layer.
+	assertUsage(800, 110, 3)
+
+	if _, err := testQueries.ClaimDeleteSavedSnapshotIfLeaf(ctx, db.ClaimDeleteSavedSnapshotIfLeafParams{
+		SnapshotID: secondSnapshotID,
+		TeamID:     team.ID,
+	}); err != nil {
+		t.Fatalf("ClaimDeleteSavedSnapshotIfLeaf(second): %v", err)
+	}
+	if _, err := testQueries.FinalizeSavedSnapshotDelete(ctx, db.FinalizeSavedSnapshotDeleteParams{
+		SnapshotID: secondSnapshotID,
+		TeamID:     team.ID,
+	}); err != nil {
+		t.Fatalf("FinalizeSavedSnapshotDelete(second): %v", err)
+	}
+	assertUsage(0, 0, 0)
+}
+
+func TestIntegration_WritableMeasurementCollapsesOwnerOnlySourceGenerations(t *testing.T) {
+	seedSavedSnapshotTestHost(t)
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-generation-collapse-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("configure snapshot quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable snapshot feature: %v", err)
+	}
+
+	sourceID := uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id,
+			vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'paused', 'snapshot-host', 2, 2048, 8192)
+	`, sourceID, team.ID, "generation-collapse-source-"+sourceID.String()); err != nil {
+		t.Fatalf("insert source: %v", err)
+	}
+
+	finalize := func(snapshotID uuid.UUID, logical, exclusive, sourceLogical, sourceExclusive int64, digest string) {
+		t.Helper()
+		if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+			SnapshotID: snapshotID,
+			SandboxID:  sourceID,
+			TeamID:     team.ID,
+			Trigger:    "manual",
+		}); err != nil {
+			t.Fatalf("BeginSavedSnapshot(%s): %v", snapshotID, err)
+		}
+		metadata := []byte(fmt.Sprintf(
+			`{"schema_version":1,"source_logical_size_bytes":%d,"source_exclusive_size_bytes":%d}`,
+			sourceLogical, sourceExclusive,
+		))
+		if _, err := testQueries.FinalizeSavedSnapshot(ctx, db.FinalizeSavedSnapshotParams{
+			SnapshotID:         snapshotID,
+			TeamID:             team.ID,
+			Path:               "/saved/" + snapshotID.String() + "/disk",
+			MemPath:            "/saved/" + snapshotID.String() + "/memory",
+			LogicalSizeBytes:   logical,
+			ManifestPath:       "/saved/" + snapshotID.String() + "/manifest.json",
+			ManifestDigest:     &digest,
+			ArtifactMetadata:   metadata,
+			ExclusiveSizeBytes: exclusive,
+		}); err != nil {
+			t.Fatalf("FinalizeSavedSnapshot(%s): %v", snapshotID, err)
+		}
+	}
+	remove := func(snapshotID uuid.UUID) {
+		t.Helper()
+		if _, err := testQueries.ClaimDeleteSavedSnapshotIfLeaf(ctx, db.ClaimDeleteSavedSnapshotIfLeafParams{
+			SnapshotID: snapshotID,
+			TeamID:     team.ID,
+		}); err != nil {
+			t.Fatalf("ClaimDeleteSavedSnapshotIfLeaf(%s): %v", snapshotID, err)
+		}
+		if _, err := testQueries.FinalizeSavedSnapshotDelete(ctx, db.FinalizeSavedSnapshotDeleteParams{
+			SnapshotID: snapshotID,
+			TeamID:     team.ID,
+		}); err != nil {
+			t.Fatalf("FinalizeSavedSnapshotDelete(%s): %v", snapshotID, err)
+		}
+	}
+	assertUsage := func(wantLogical, wantExclusive, wantLayers int64) {
+		t.Helper()
+		usage, err := testQueries.GetTeamSnapshotLayerUsage(ctx, team.ID)
+		if err != nil {
+			t.Fatalf("GetTeamSnapshotLayerUsage: %v", err)
+		}
+		if usage.LogicalSizeBytes != wantLogical || usage.ExclusiveSizeBytes != wantExclusive || usage.ActiveLayerCount != wantLayers {
+			t.Fatalf("layer usage = %+v, want logical=%d exclusive=%d layers=%d", usage, wantLogical, wantExclusive, wantLayers)
+		}
+		var counter int64
+		if err := testPool.QueryRow(ctx, `SELECT snapshot_storage_bytes FROM team WHERE id = $1`, team.ID).Scan(&counter); err != nil {
+			t.Fatalf("read team shadow counter: %v", err)
+		}
+		if counter != wantExclusive {
+			t.Fatalf("team shadow counter = %d, want %d", counter, wantExclusive)
+		}
+	}
+
+	firstSnapshotID := uuid.New()
+	finalize(firstSnapshotID, 100, 10, 400, 40, strings.Repeat("a", 64))
+	if _, err := testQueries.RecordSandboxWritableLayerUsage(ctx, db.RecordSandboxWritableLayerUsageParams{
+		LogicalSizeBytes:   200,
+		ExclusiveSizeBytes: 20,
+		SandboxID:          sourceID,
+		TeamID:             team.ID,
+	}); err != nil {
+		t.Fatalf("RecordSandboxWritableLayerUsage(initial): %v", err)
+	}
+
+	secondSnapshotID := uuid.New()
+	finalize(secondSnapshotID, 70, 7, 150, 15, strings.Repeat("b", 64))
+	assertUsage(770, 77, 5)
+
+	// Removing one clone must not collapse either source generation: the second
+	// snapshot still references both, so its physical reflinks still exclude
+	// those extents from VMD's writable measurement.
+	remove(firstSnapshotID)
+	if _, err := testQueries.RecordSandboxWritableLayerUsage(ctx, db.RecordSandboxWritableLayerUsageParams{
+		LogicalSizeBytes:   50,
+		ExclusiveSizeBytes: 5,
+		SandboxID:          sourceID,
+		TeamID:             team.ID,
+	}); err != nil {
+		t.Fatalf("RecordSandboxWritableLayerUsage(shared generations): %v", err)
+	}
+	assertUsage(670, 67, 4)
+
+	// Once the final clone is removed, both sealed generations have only their
+	// owner-source references. The deletion transaction folds their 55 retained
+	// bytes into the current row and retires both rows without changing the team
+	// total. This closes the window in which an immediate recapture could seal R
+	// a second time before another pause measurement.
+	remove(secondSnapshotID)
+	assertUsage(600, 60, 1)
+
+	thirdSnapshotID := uuid.New()
+	finalize(thirdSnapshotID, 20, 2, 600, 60, strings.Repeat("c", 64))
+	assertUsage(620, 62, 3)
+	remove(thirdSnapshotID)
+	assertUsage(600, 60, 1)
+
+	// Simulate an owner-only generation left by an older control-plane writer.
+	// Pause reconciliation is the defensive repair: it first folds the stale
+	// generation transactionally, then replaces current with VMD's authoritative
+	// full-inode result. The intermediate fold cannot leak into the team counter.
+	var legacyGenerationID int64
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO snapshot_storage_layer (
+			team_id, kind, owner_sandbox_id,
+			retained_logical_size_bytes, retained_exclusive_size_bytes
+		) VALUES ($1, 'sandbox_generation', $2, 100, 10)
+		RETURNING id
+	`, team.ID, sourceID).Scan(&legacyGenerationID); err != nil {
+		t.Fatalf("insert legacy owner-only generation: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO snapshot_storage_reference (layer_id, team_id, sandbox_id)
+		VALUES ($1, $2, $3)
+	`, legacyGenerationID, team.ID, sourceID); err != nil {
+		t.Fatalf("insert legacy owner-only reference: %v", err)
+	}
+	assertUsage(700, 70, 2)
+	if _, err := testQueries.RecordSandboxWritableLayerUsage(ctx, db.RecordSandboxWritableLayerUsageParams{
+		LogicalSizeBytes:   600,
+		ExclusiveSizeBytes: 60,
+		SandboxID:          sourceID,
+		TeamID:             team.ID,
+	}); err != nil {
+		t.Fatalf("RecordSandboxWritableLayerUsage(legacy owner-only generation): %v", err)
+	}
+	assertUsage(600, 60, 1)
+
+	var activeGenerations, activeGenerationRefs int64
+	if err := testPool.QueryRow(ctx, `
+		SELECT
+			count(DISTINCT layer.id) FILTER (WHERE layer.ended_at IS NULL),
+			count(ref.id) FILTER (WHERE ref.released_at IS NULL)
+		FROM snapshot_storage_layer layer
+		LEFT JOIN snapshot_storage_reference ref ON ref.layer_id = layer.id
+		WHERE layer.team_id = $1
+		  AND layer.owner_sandbox_id = $2
+		  AND layer.kind = 'sandbox_generation'
+	`, team.ID, sourceID).Scan(&activeGenerations, &activeGenerationRefs); err != nil {
+		t.Fatalf("read collapsed generations: %v", err)
+	}
+	if activeGenerations != 0 || activeGenerationRefs != 0 {
+		t.Fatalf("active generations=%d active refs=%d, want 0/0", activeGenerations, activeGenerationRefs)
+	}
+
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET status = 'deleted', destroyed_at = now(), updated_at = now()
+		WHERE id = $1 AND team_id = $2
+	`, sourceID, team.ID); err != nil {
+		t.Fatalf("delete reconciled source: %v", err)
+	}
+	assertUsage(0, 0, 0)
+}
+
+func TestIntegration_SavedSnapshotForkResumeSerializesHostCapacity(t *testing.T) {
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-resume-capacity-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	hostID := "snapshot-resume-capacity-" + uuid.NewString()
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1
+	`, team.ID); err != nil {
+		t.Fatalf("configure resume-capacity team: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO host (id, vmd_addr, proxy_addr, region, capacity_memory_mib, capacity_vcpus)
+		VALUES ($1, '127.0.0.1:1', '127.0.0.1:2', 'test', 2048, 2)
+	`, hostID); err != nil {
+		t.Fatalf("configure resume-capacity fixture: %v", err)
+	}
+
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib)
+		VALUES ($1, $2, $3, 'paused', $4, 2, 2048, 8192)
+	`, sourceID, team.ID, "resume-source-"+sourceID.String(), hostID); err != nil {
+		t.Fatalf("seed resume source: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO snapshot (
+			id, sandbox_id, team_id, path, mem_path, size_bytes, trigger,
+			kind, status, source_status, host_id, vcpu_count, memory_mib,
+			disk_mib, manifest_path, manifest_digest
+		) VALUES ($1, $2, $3, '/saved/disk', '/saved/memory', 0, 'manual',
+			'saved', 'ready', 'paused', $4, 2, 2048, 8192,
+			'/saved/manifest.json', repeat('d', 64))
+	`, snapshotID, sourceID, team.ID, hostID); err != nil {
+		t.Fatalf("seed resume snapshot: %v", err)
+	}
+
+	forkIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	for _, forkID := range forkIDs {
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO sandbox (
+				id, team_id, name, status, host_id, vcpu_count,
+				memory_mib, disk_mib, source_snapshot_id
+			) VALUES ($1, $2, $3, 'paused', $4, 2, 2048, 8192, $5)
+		`, forkID, team.ID, "resume-fork-"+forkID.String(), hostID, snapshotID); err != nil {
+			t.Fatalf("seed paused fork: %v", err)
+		}
+	}
+	if _, err := testQueries.BeginResume(ctx, db.BeginResumeParams{ID: forkIDs[0], TeamID: team.ID}); err != nil {
+		t.Fatalf("first BeginResume: %v", err)
+	}
+	_, err = testQueries.BeginResume(ctx, db.BeginResumeParams{ID: forkIDs[1], TeamID: team.ID})
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "SS006" {
+		t.Fatalf("second BeginResume error = %v, want SS006", err)
+	}
+	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{ID: forkIDs[0], TeamID: team.ID}); err != nil {
+		t.Fatalf("RevertResumeToPaused: %v", err)
+	}
+	if _, err := testQueries.BeginResume(ctx, db.BeginResumeParams{ID: forkIDs[1], TeamID: team.ID}); err != nil {
+		t.Fatalf("BeginResume after capacity release: %v", err)
+	}
+	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{ID: forkIDs[1], TeamID: team.ID}); err != nil {
+		t.Fatalf("RevertResumeToPaused(second): %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox SET status = 'failed', updated_at = now()
+		WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
+	`, forkIDs[0], team.ID); err != nil {
+		t.Fatalf("mark ambiguous live fork failed: %v", err)
+	}
+	_, err = testQueries.BeginResume(ctx, db.BeginResumeParams{ID: forkIDs[1], TeamID: team.ID})
+	if !errors.As(err, &pgErr) || pgErr.Code != "SS006" {
+		t.Fatalf("resume beside live failed fork error = %v, want SS006", err)
+	}
+}

--- a/internal/integration/saved_snapshot_expand_test.go
+++ b/internal/integration/saved_snapshot_expand_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,27 +14,197 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func TestSavedSnapshotExpandRolloutGuards(t *testing.T) {
+func TestSavedSnapshotContractRolloutGuards(t *testing.T) {
 	ctx := context.Background()
 
-	var unique, valid, ready, partial bool
-	err := testPool.QueryRow(ctx, `
-		SELECT i.indisunique,
-		       i.indisvalid,
-		       i.indisready,
-		       i.indpred IS NOT NULL
-		FROM pg_index i
-		JOIN pg_class idx ON idx.oid = i.indexrelid
-		JOIN pg_namespace ns ON ns.oid = idx.relnamespace
-		WHERE ns.nspname = 'public'
-		  AND idx.relname = 'snapshot_sandbox_unique'
-		  AND i.indrelid = 'public.snapshot'::regclass
-	`).Scan(&unique, &valid, &ready, &partial)
-	if err != nil {
-		t.Fatalf("inspect snapshot_sandbox_unique: %v", err)
+	expectedIndexes := []struct {
+		name       string
+		table      string
+		unique     bool
+		keys       []string
+		predicate  string
+		definition string
+	}{
+		{
+			name:       "snapshot_sandbox_runtime_unique",
+			table:      "snapshot",
+			unique:     true,
+			keys:       []string{"sandbox_id"},
+			predicate:  "(kind = 'runtime_checkpoint'::snapshot_kind)",
+			definition: "CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique ON public.snapshot USING btree (sandbox_id) WHERE (kind = 'runtime_checkpoint'::snapshot_kind)",
+		},
+		{
+			name:       "snapshot_team_source_idempotency_unique",
+			table:      "snapshot",
+			unique:     true,
+			keys:       []string{"team_id", "sandbox_id", "idempotency_key"},
+			predicate:  "((kind = 'saved'::snapshot_kind) AND (idempotency_key IS NOT NULL))",
+			definition: "CREATE UNIQUE INDEX snapshot_team_source_idempotency_unique ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key) WHERE ((kind = 'saved'::snapshot_kind) AND (idempotency_key IS NOT NULL))",
+		},
+		{
+			name:       "idx_snapshot_team_saved_created",
+			table:      "snapshot",
+			keys:       []string{"team_id", "created_at", "id"},
+			predicate:  "((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+			definition: "CREATE INDEX idx_snapshot_team_saved_created ON public.snapshot USING btree (team_id, created_at DESC, id DESC) WHERE ((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+		},
+		{
+			name:       "idx_snapshot_source_saved_created",
+			table:      "snapshot",
+			keys:       []string{"sandbox_id", "created_at", "id"},
+			predicate:  "((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+			definition: "CREATE INDEX idx_snapshot_source_saved_created ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC) WHERE ((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+		},
+		{
+			name:       "idx_snapshot_parent_saved",
+			table:      "snapshot",
+			keys:       []string{"parent_snapshot_id"},
+			predicate:  "((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+			definition: "CREATE INDEX idx_snapshot_parent_saved ON public.snapshot USING btree (parent_snapshot_id) WHERE ((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+		},
+		{
+			name:       "idx_snapshot_saved_host",
+			table:      "snapshot",
+			keys:       []string{"host_id", "status"},
+			predicate:  "((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+			definition: "CREATE INDEX idx_snapshot_saved_host ON public.snapshot USING btree (host_id, status) WHERE ((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL))",
+		},
+		{
+			name:      "idx_snapshot_saved_reconcile",
+			table:     "snapshot",
+			keys:      []string{"status", "updated_at", "id"},
+			predicate: "((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY['creating'::snapshot_status, 'deleting'::snapshot_status])))",
+			definition: "CREATE INDEX idx_snapshot_saved_reconcile ON public.snapshot USING btree (status, updated_at, id) " +
+				"WHERE ((kind = 'saved'::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY['creating'::snapshot_status, 'deleting'::snapshot_status])))",
+		},
+		{
+			name:       "idx_sandbox_source_snapshot_pin",
+			table:      "sandbox",
+			keys:       []string{"source_snapshot_id"},
+			predicate:  "(source_snapshot_id IS NOT NULL)",
+			definition: "CREATE INDEX idx_sandbox_source_snapshot_pin ON public.sandbox USING btree (source_snapshot_id) WHERE (source_snapshot_id IS NOT NULL)",
+		},
+		{
+			name:       "idx_sandbox_destroyed_snapshot_pin",
+			table:      "sandbox",
+			keys:       []string{"destroyed_at", "id"},
+			predicate:  "((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))",
+			definition: "CREATE INDEX idx_sandbox_destroyed_snapshot_pin ON public.sandbox USING btree (destroyed_at, id) WHERE ((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))",
+		},
+		{
+			name:       "idx_sandbox_snapshot_operation",
+			table:      "sandbox",
+			keys:       []string{"snapshot_operation_started_at"},
+			predicate:  "((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))",
+			definition: "CREATE INDEX idx_sandbox_snapshot_operation ON public.sandbox USING btree (snapshot_operation_started_at) WHERE ((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))",
+		},
 	}
-	if !unique || !valid || !ready || partial {
-		t.Error("legacy snapshot_sandbox_unique is not a ready, valid, non-partial unique index")
+
+	for _, expected := range expectedIndexes {
+		var (
+			table, accessMethod, predicate, definition string
+			unique, valid, ready, live, immediate      bool
+			keyCount, attributeCount                   int16
+			keys                                       []string
+			hasExpressions                             bool
+		)
+		err := testPool.QueryRow(ctx, `
+			SELECT indexed_table.relname,
+			       access_method.amname,
+			       catalog.indisunique,
+			       catalog.indisvalid,
+			       catalog.indisready,
+			       catalog.indislive,
+			       catalog.indimmediate,
+			       catalog.indnkeyatts,
+			       catalog.indnatts,
+			       ARRAY(
+			           SELECT pg_get_indexdef(
+			                      catalog.indexrelid,
+			                      key_position,
+			                      true
+			                  )
+			           FROM generate_series(
+			                    1,
+			                    catalog.indnkeyatts
+			                ) AS key_position
+			           ORDER BY key_position
+			       ),
+			       pg_get_expr(catalog.indpred, catalog.indrelid, false),
+			       pg_get_indexdef(catalog.indexrelid),
+			       catalog.indexprs IS NOT NULL
+			FROM pg_index catalog
+			JOIN pg_class index_object
+			  ON index_object.oid = catalog.indexrelid
+			JOIN pg_namespace index_namespace
+			  ON index_namespace.oid = index_object.relnamespace
+			JOIN pg_class indexed_table
+			  ON indexed_table.oid = catalog.indrelid
+			JOIN pg_namespace table_namespace
+			  ON table_namespace.oid = indexed_table.relnamespace
+			JOIN pg_am access_method
+			  ON access_method.oid = index_object.relam
+			WHERE index_namespace.nspname = 'public'
+			  AND table_namespace.nspname = 'public'
+			  AND index_object.relkind = 'i'
+			  AND index_object.relname = $1
+		`, expected.name).Scan(
+			&table,
+			&accessMethod,
+			&unique,
+			&valid,
+			&ready,
+			&live,
+			&immediate,
+			&keyCount,
+			&attributeCount,
+			&keys,
+			&predicate,
+			&definition,
+			&hasExpressions,
+		)
+		if err != nil {
+			t.Fatalf("inspect %s: %v", expected.name, err)
+		}
+		if table != expected.table ||
+			accessMethod != "btree" ||
+			unique != expected.unique ||
+			!valid ||
+			!ready ||
+			!live ||
+			!immediate ||
+			int(keyCount) != len(expected.keys) ||
+			attributeCount != keyCount ||
+			!slices.Equal(keys, expected.keys) ||
+			predicate != expected.predicate ||
+			definition != expected.definition ||
+			hasExpressions {
+			t.Errorf(
+				"%s catalog contract mismatch: table=%q access=%q unique=%v valid=%v ready=%v live=%v immediate=%v keys=%v predicate=%q definition=%q expressions=%v",
+				expected.name,
+				table,
+				accessMethod,
+				unique,
+				valid,
+				ready,
+				live,
+				immediate,
+				keys,
+				predicate,
+				definition,
+				hasExpressions,
+			)
+		}
+	}
+
+	var legacyIndexExists bool
+	if err := testPool.QueryRow(ctx, `
+		SELECT to_regclass('public.snapshot_sandbox_unique') IS NOT NULL
+	`).Scan(&legacyIndexExists); err != nil {
+		t.Fatalf("inspect legacy snapshot_sandbox_unique: %v", err)
+	}
+	if legacyIndexExists {
+		t.Error("legacy snapshot_sandbox_unique still exists after contract")
 	}
 
 	constraints := []string{
@@ -86,19 +257,6 @@ func TestSavedSnapshotExpandRolloutGuards(t *testing.T) {
 	}
 	if globalEnabled {
 		t.Error("global saved-snapshot feature flag is enabled during expand")
-	}
-
-	var enabledTeamOverrides int
-	if err := testPool.QueryRow(ctx, `
-		SELECT count(*)
-		FROM team_feature_flag
-		WHERE key = 'sandbox_snapshots_v1'
-		  AND enabled
-	`).Scan(&enabledTeamOverrides); err != nil {
-		t.Fatalf("count enabled team saved-snapshot overrides: %v", err)
-	}
-	if enabledTeamOverrides != 0 {
-		t.Errorf("enabled saved-snapshot team overrides = %d, want 0", enabledTeamOverrides)
 	}
 
 	rows, err := testPool.Query(ctx, `

--- a/internal/integration/saved_snapshot_source_fallback_test.go
+++ b/internal/integration/saved_snapshot_source_fallback_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+func TestIntegration_FailSavedSnapshotSourceAfterRevocationClearsHeldClaimAndClosesUsage(t *testing.T) {
+	seedSavedSnapshotTestHost(t)
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "snapshot-source-fallback-"+uuid.NewString())
+	if err != nil {
+		t.Fatalf("CreateTeam: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE team SET snapshot_storage_quota_bytes = 1073741824 WHERE id = $1`, team.ID); err != nil {
+		t.Fatalf("configure snapshot storage quota: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'sandbox_snapshots_v1', true)
+	`, team.ID); err != nil {
+		t.Fatalf("enable saved snapshots: %v", err)
+	}
+
+	sourceID, snapshotID := uuid.New(), uuid.New()
+	startedAt := time.Now().UTC().Add(-time.Minute)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox (
+			id, team_id, name, status, host_id, vcpu_count, memory_mib, disk_mib
+		) VALUES ($1, $2, $3, 'active', 'snapshot-host', 2, 2048, 8192)
+	`, sourceID, team.ID, "source-"+sourceID.String()); err != nil {
+		t.Fatalf("seed active source: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_active_interval (sandbox_id, team_id, started_at)
+		VALUES ($1, $2, $3)
+	`, sourceID, team.ID, startedAt); err != nil {
+		t.Fatalf("seed active interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_compute_billing_interval (
+			sandbox_id, team_id, vcpu_count, memory_mib, started_at
+		) VALUES ($1, $2, 2, 2048, $3)
+	`, sourceID, team.ID, startedAt); err != nil {
+		t.Fatalf("seed compute interval: %v", err)
+	}
+	if _, err := testQueries.BeginSavedSnapshot(ctx, db.BeginSavedSnapshotParams{
+		SnapshotID: snapshotID,
+		SandboxID:  sourceID,
+		TeamID:     team.ID,
+		Trigger:    "manual",
+	}); err != nil {
+		t.Fatalf("BeginSavedSnapshot: %v", err)
+	}
+	if err := testQueries.UpsertSandboxRevocation(ctx, db.UpsertSandboxRevocationParams{
+		SandboxID: sourceID,
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("UpsertSandboxRevocation: %v", err)
+	}
+
+	reason := "source_resume_failed"
+	for attempt := 1; attempt <= 2; attempt++ {
+		gotSourceID, err := testQueries.FailSavedSnapshotSourceAfterRevocation(ctx, db.FailSavedSnapshotSourceAfterRevocationParams{
+			SnapshotID:    snapshotID,
+			TeamID:        team.ID,
+			FailureReason: &reason,
+		})
+		if err != nil {
+			t.Fatalf("FailSavedSnapshotSourceAfterRevocation attempt %d: %v", attempt, err)
+		}
+		if gotSourceID != sourceID {
+			t.Fatalf("fallback source ID = %s, want %s", gotSourceID, sourceID)
+		}
+	}
+
+	var sourceStatus, snapshotStatus string
+	var failureReason *string
+	var operationID pgtype.UUID
+	var activeEndedAt, computeEndedAt pgtype.Timestamptz
+	var activeReason, computeReason *string
+	if err := testPool.QueryRow(ctx, `
+		SELECT source.status, source.snapshot_operation_id,
+		       snap.status, snap.failure_reason,
+		       active.ended_at, active.end_reason,
+		       compute.ended_at, compute.end_reason
+		FROM sandbox source
+		JOIN snapshot snap ON snap.id = $2 AND snap.sandbox_id = source.id
+		JOIN sandbox_active_interval active ON active.sandbox_id = source.id
+		JOIN sandbox_compute_billing_interval compute ON compute.sandbox_id = source.id
+		WHERE source.id = $1
+	`, sourceID, snapshotID).Scan(
+		&sourceStatus, &operationID, &snapshotStatus, &failureReason,
+		&activeEndedAt, &activeReason, &computeEndedAt, &computeReason,
+	); err != nil {
+		t.Fatalf("read fallback terminal state: %v", err)
+	}
+	if sourceStatus != "failed" || snapshotStatus != "failed" || operationID.Valid {
+		t.Fatalf("terminal state source=%s snapshot=%s operation=%v, want failed/failed/empty", sourceStatus, snapshotStatus, operationID)
+	}
+	if failureReason == nil || *failureReason != reason {
+		t.Fatalf("snapshot failure reason = %v, want %q", failureReason, reason)
+	}
+	if !activeEndedAt.Valid || activeReason == nil || *activeReason != "failed" {
+		t.Fatalf("active interval closure = (%v, %v), want ended/failed", activeEndedAt, activeReason)
+	}
+	if !computeEndedAt.Valid || computeReason == nil || *computeReason != "failed" {
+		t.Fatalf("compute interval closure = (%v, %v), want ended/failed", computeEndedAt, computeReason)
+	}
+}

--- a/internal/supervisor/saved_snapshot_observability_test.go
+++ b/internal/supervisor/saved_snapshot_observability_test.go
@@ -1,0 +1,84 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+type supervisorSnapshotOutcomeRecorder struct {
+	outcomes []telemetry.SavedSnapshotOutcome
+}
+
+func (*supervisorSnapshotOutcomeRecorder) RecordSandboxTransition(context.Context, telemetry.SandboxTransition) {
+}
+func (*supervisorSnapshotOutcomeRecorder) RecordVMDCall(context.Context, telemetry.VMDCall) {}
+func (r *supervisorSnapshotOutcomeRecorder) RecordSavedSnapshotOutcome(_ context.Context, outcome telemetry.SavedSnapshotOutcome) {
+	r.outcomes = append(r.outcomes, outcome)
+}
+func (*supervisorSnapshotOutcomeRecorder) RecordHostCapacity(context.Context, telemetry.HostCapacity) {
+}
+func (*supervisorSnapshotOutcomeRecorder) RecordDBPoolStats(context.Context, telemetry.DBPoolStats) {}
+
+func TestSavedSnapshotSupervisorRecordsCleanupRetry(t *testing.T) {
+	row := savedSnapshotFixture()
+	row.Status = db.SnapshotStatusDeleting
+	store := &fakeSavedSnapshotStore{deleting: []db.Snapshot{row}}
+	client := &fakeSavedSnapshotClient{deleteErr: status.Error(codes.Unavailable, "host restarting")}
+	recorder := &supervisorSnapshotOutcomeRecorder{}
+	var hosts []string
+	s := testSavedSnapshotSupervisor(store, client, &hosts).WithTelemetry(recorder)
+
+	s.tick(context.Background())
+
+	if len(recorder.outcomes) != 1 {
+		t.Fatalf("outcomes = %+v, want one cleanup retry", recorder.outcomes)
+	}
+	got := recorder.outcomes[0]
+	if got.Operation != telemetry.SavedSnapshotOperationCleanup || got.Outcome != telemetry.SavedSnapshotOutcomeRetry || got.HostID != "host-a" {
+		t.Fatalf("cleanup retry = %+v", got)
+	}
+}
+
+func TestSavedSnapshotSupervisorRecordsCorruptionAndQueuedCleanup(t *testing.T) {
+	row := savedSnapshotFixture()
+	store := &fakeSavedSnapshotStore{creating: []db.Snapshot{row}}
+	artifacts := savedSnapshotArtifactsFixture()
+	artifacts.SchemaVersion = 0
+	client := &fakeSavedSnapshotClient{
+		createArtifacts: artifacts,
+		deleteErr:       status.Error(codes.Unavailable, "host cleanup unavailable"),
+	}
+	recorder := &supervisorSnapshotOutcomeRecorder{}
+	var hosts []string
+	s := testSavedSnapshotSupervisor(store, client, &hosts).WithTelemetry(recorder)
+
+	s.tick(context.Background())
+
+	want := []string{
+		telemetry.SavedSnapshotOutcomeArtifactCorrupt,
+		telemetry.SavedSnapshotOutcomeRetry,
+		telemetry.SavedSnapshotOutcomeQueued,
+	}
+	if len(recorder.outcomes) != len(want) {
+		t.Fatalf("outcomes = %+v, want %v", recorder.outcomes, want)
+	}
+	for i, outcome := range recorder.outcomes {
+		if outcome.Outcome != want[i] || outcome.HostID != "host-a" {
+			t.Fatalf("outcome[%d] = %+v, want outcome=%s host=host-a", i, outcome, want[i])
+		}
+	}
+	if recorder.outcomes[0].Operation != telemetry.SavedSnapshotOperationCapture {
+		t.Fatalf("corruption operation = %q, want capture", recorder.outcomes[0].Operation)
+	}
+	for _, outcome := range recorder.outcomes[1:] {
+		if outcome.Operation != telemetry.SavedSnapshotOperationCleanup {
+			t.Fatalf("cleanup operation = %q", outcome.Operation)
+		}
+	}
+}

--- a/scripts/prebuild-saved-snapshot-indexes.sql
+++ b/scripts/prebuild-saved-snapshot-indexes.sql
@@ -1,0 +1,327 @@
+\set ON_ERROR_STOP on
+
+-- Build the saved-snapshot contract indexes outside Supabase's migration
+-- transaction. CREATE INDEX CONCURRENTLY must be the only command in its
+-- transaction, so keep these statements sequential and run this file with
+-- psql before 20260729000010_saved_snapshot_indexes.sql.
+SET lock_timeout = '5s';
+SET statement_timeout = '30min';
+
+-- Serialize CD and operator invocations on this database. Session-level
+-- ownership spans every autocommit transaction required by CONCURRENTLY and
+-- is also released automatically if psql exits on an error.
+SELECT pg_advisory_lock(20819, 20260729);
+
+CREATE TEMP TABLE saved_snapshot_expected_index (
+    index_name text PRIMARY KEY,
+    table_name text NOT NULL,
+    is_unique boolean NOT NULL,
+    key_columns text[] NOT NULL,
+    predicate text NOT NULL,
+    definition text NOT NULL
+);
+
+INSERT INTO saved_snapshot_expected_index (
+    index_name,
+    table_name,
+    is_unique,
+    key_columns,
+    predicate,
+    definition
+)
+VALUES
+(
+    'snapshot_sandbox_runtime_unique',
+    'snapshot',
+    true,
+    ARRAY['sandbox_id'],
+    '(kind = ''runtime_checkpoint''::snapshot_kind)',
+    'CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique ON public.snapshot USING btree (sandbox_id) WHERE (kind = ''runtime_checkpoint''::snapshot_kind)'
+),
+(
+    'snapshot_team_source_idempotency_unique',
+    'snapshot',
+    true,
+    ARRAY['team_id', 'sandbox_id', 'idempotency_key'],
+    '((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))',
+    'CREATE UNIQUE INDEX snapshot_team_source_idempotency_unique ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key) WHERE ((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))'
+),
+(
+    'idx_snapshot_team_saved_created',
+    'snapshot',
+    false,
+    ARRAY['team_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_team_saved_created ON public.snapshot USING btree (team_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_source_saved_created',
+    'snapshot',
+    false,
+    ARRAY['sandbox_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_source_saved_created ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_parent_saved',
+    'snapshot',
+    false,
+    ARRAY['parent_snapshot_id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_parent_saved ON public.snapshot USING btree (parent_snapshot_id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_host',
+    'snapshot',
+    false,
+    ARRAY['host_id', 'status'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_saved_host ON public.snapshot USING btree (host_id, status) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_reconcile',
+    'snapshot',
+    false,
+    ARRAY['status', 'updated_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))',
+    'CREATE INDEX idx_snapshot_saved_reconcile ON public.snapshot USING btree (status, updated_at, id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))'
+),
+(
+    'idx_sandbox_source_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['source_snapshot_id'],
+    '(source_snapshot_id IS NOT NULL)',
+    'CREATE INDEX idx_sandbox_source_snapshot_pin ON public.sandbox USING btree (source_snapshot_id) WHERE (source_snapshot_id IS NOT NULL)'
+),
+(
+    'idx_sandbox_destroyed_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['destroyed_at', 'id'],
+    '((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))',
+    'CREATE INDEX idx_sandbox_destroyed_snapshot_pin ON public.sandbox USING btree (destroyed_at, id) WHERE ((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))'
+),
+(
+    'idx_sandbox_snapshot_operation',
+    'sandbox',
+    false,
+    ARRAY['snapshot_operation_started_at'],
+    '((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))',
+    'CREATE INDEX idx_sandbox_snapshot_operation ON public.sandbox USING btree (snapshot_operation_started_at) WHERE ((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))'
+);
+
+CREATE FUNCTION pg_temp.require_saved_snapshot_index(
+    requested_index_name text,
+    required boolean
+) RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected saved_snapshot_expected_index%ROWTYPE;
+    index_oid oid;
+    actual_table_schema text;
+    actual_table_name text;
+    actual_access_method text;
+    actual_relkind "char";
+    actual_unique boolean;
+    actual_valid boolean;
+    actual_ready boolean;
+    actual_live boolean;
+    actual_immediate boolean;
+    actual_key_count smallint;
+    actual_attribute_count smallint;
+    actual_keys text[];
+    actual_predicate text;
+    actual_definition text;
+    has_expressions boolean;
+BEGIN
+    SELECT *
+    INTO STRICT expected
+    FROM saved_snapshot_expected_index
+    WHERE index_name = requested_index_name;
+
+    SELECT object.oid, object.relkind
+    INTO index_oid, actual_relkind
+    FROM pg_class object
+    JOIN pg_namespace object_namespace
+      ON object_namespace.oid = object.relnamespace
+    WHERE object_namespace.nspname = 'public'
+      AND object.relname = requested_index_name;
+
+    IF index_oid IS NULL THEN
+        IF required THEN
+            RAISE EXCEPTION
+                'required saved-snapshot index public.% is missing',
+                requested_index_name;
+        END IF;
+        RETURN;
+    END IF;
+
+    IF actual_relkind <> 'i' THEN
+        RAISE EXCEPTION
+            'public.% exists but is not a regular index (relkind=%)',
+            requested_index_name,
+            actual_relkind;
+    END IF;
+
+    SELECT table_namespace.nspname,
+           indexed_table.relname,
+           access_method.amname,
+           catalog.indisunique,
+           catalog.indisvalid,
+           catalog.indisready,
+           catalog.indislive,
+           catalog.indimmediate,
+           catalog.indnkeyatts,
+           catalog.indnatts,
+           ARRAY(
+               SELECT pg_get_indexdef(
+                          catalog.indexrelid,
+                          key_position,
+                          true
+                      )
+               FROM generate_series(
+                        1,
+                        catalog.indnkeyatts
+                    ) AS key_position
+               ORDER BY key_position
+           ),
+           pg_get_expr(catalog.indpred, catalog.indrelid, false),
+           pg_get_indexdef(catalog.indexrelid),
+           catalog.indexprs IS NOT NULL
+    INTO actual_table_schema,
+         actual_table_name,
+         actual_access_method,
+         actual_unique,
+         actual_valid,
+         actual_ready,
+         actual_live,
+         actual_immediate,
+         actual_key_count,
+         actual_attribute_count,
+         actual_keys,
+         actual_predicate,
+         actual_definition,
+         has_expressions
+    FROM pg_index catalog
+    JOIN pg_class indexed_table
+      ON indexed_table.oid = catalog.indrelid
+    JOIN pg_namespace table_namespace
+      ON table_namespace.oid = indexed_table.relnamespace
+    JOIN pg_class index_object
+      ON index_object.oid = catalog.indexrelid
+    JOIN pg_am access_method
+      ON access_method.oid = index_object.relam
+    WHERE catalog.indexrelid = index_oid;
+
+    IF NOT FOUND
+       OR actual_table_schema <> 'public'
+       OR actual_table_name <> expected.table_name
+       OR actual_access_method <> 'btree'
+       OR actual_unique IS DISTINCT FROM expected.is_unique
+       OR NOT actual_valid
+       OR NOT actual_ready
+       OR NOT actual_live
+       OR NOT actual_immediate
+       OR actual_key_count <> cardinality(expected.key_columns)
+       OR actual_attribute_count <> actual_key_count
+       OR actual_keys IS DISTINCT FROM expected.key_columns
+       OR actual_predicate IS DISTINCT FROM expected.predicate
+       OR actual_definition IS DISTINCT FROM expected.definition
+       OR has_expressions
+    THEN
+        RAISE EXCEPTION
+            'saved-snapshot index public.% does not match the required valid/ready/live btree definition (actual=%)',
+            requested_index_name,
+            COALESCE(actual_definition, '<not an index>');
+    END IF;
+END;
+$$;
+
+-- Fail before mutating anything if a same-named object is invalid or drifted.
+DO $$
+DECLARE
+    expected record;
+BEGIN
+    FOR expected IN
+        SELECT index_name
+        FROM saved_snapshot_expected_index
+        ORDER BY index_name
+    LOOP
+        PERFORM pg_temp.require_saved_snapshot_index(
+            expected.index_name,
+            false
+        );
+    END LOOP;
+END;
+$$;
+
+\echo 'Building saved-snapshot indexes concurrently and sequentially'
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS snapshot_sandbox_runtime_unique
+    ON public.snapshot USING btree (sandbox_id)
+    WHERE kind = 'runtime_checkpoint';
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS snapshot_team_source_idempotency_unique
+    ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key)
+    WHERE kind = 'saved' AND idempotency_key IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshot_team_saved_created
+    ON public.snapshot USING btree (team_id, created_at DESC, id DESC)
+    WHERE kind = 'saved' AND deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshot_source_saved_created
+    ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC)
+    WHERE kind = 'saved' AND deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshot_parent_saved
+    ON public.snapshot USING btree (parent_snapshot_id)
+    WHERE kind = 'saved' AND deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshot_saved_host
+    ON public.snapshot USING btree (host_id, status)
+    WHERE kind = 'saved' AND deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshot_saved_reconcile
+    ON public.snapshot USING btree (status, updated_at, id)
+    WHERE kind = 'saved'
+      AND deleted_at IS NULL
+      AND status IN ('creating', 'deleting');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_source_snapshot_pin
+    ON public.sandbox USING btree (source_snapshot_id)
+    WHERE source_snapshot_id IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_destroyed_snapshot_pin
+    ON public.sandbox USING btree (destroyed_at, id)
+    WHERE source_snapshot_id IS NOT NULL
+      AND destroyed_at IS NOT NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_snapshot_operation
+    ON public.sandbox USING btree (snapshot_operation_started_at)
+    WHERE snapshot_operation_id IS NOT NULL
+      AND destroyed_at IS NULL;
+
+-- Verify every catalog property again. IF NOT EXISTS is not a definition
+-- check, and a canceled concurrent build can leave an invalid index behind.
+DO $$
+DECLARE
+    expected record;
+BEGIN
+    FOR expected IN
+        SELECT index_name
+        FROM saved_snapshot_expected_index
+        ORDER BY index_name
+    LOOP
+        PERFORM pg_temp.require_saved_snapshot_index(
+            expected.index_name,
+            true
+        );
+    END LOOP;
+END;
+$$;
+
+\echo 'All 10 saved-snapshot indexes are exact, valid, ready, and live'
+
+SELECT pg_advisory_unlock(20819, 20260729);

--- a/scripts/recover-saved-snapshot-indexes.sql
+++ b/scripts/recover-saved-snapshot-indexes.sql
@@ -1,0 +1,259 @@
+\set ON_ERROR_STOP on
+
+-- Operator-only recovery after a canceled CREATE INDEX CONCURRENTLY. This
+-- deliberately drops only invalid remnants. It never replaces a valid,
+-- same-named index and is never invoked automatically by CD.
+SET lock_timeout = '5s';
+SET statement_timeout = '30min';
+
+SELECT pg_advisory_lock(20819, 20260729);
+
+CREATE TEMP TABLE saved_snapshot_expected_index (
+    index_name text PRIMARY KEY,
+    table_name text NOT NULL,
+    is_unique boolean NOT NULL,
+    key_columns text[] NOT NULL,
+    predicate text NOT NULL,
+    definition text NOT NULL
+);
+
+INSERT INTO saved_snapshot_expected_index (
+    index_name,
+    table_name,
+    is_unique,
+    key_columns,
+    predicate,
+    definition
+)
+VALUES
+(
+    'snapshot_sandbox_runtime_unique',
+    'snapshot',
+    true,
+    ARRAY['sandbox_id'],
+    '(kind = ''runtime_checkpoint''::snapshot_kind)',
+    'CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique ON public.snapshot USING btree (sandbox_id) WHERE (kind = ''runtime_checkpoint''::snapshot_kind)'
+),
+(
+    'snapshot_team_source_idempotency_unique',
+    'snapshot',
+    true,
+    ARRAY['team_id', 'sandbox_id', 'idempotency_key'],
+    '((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))',
+    'CREATE UNIQUE INDEX snapshot_team_source_idempotency_unique ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key) WHERE ((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))'
+),
+(
+    'idx_snapshot_team_saved_created',
+    'snapshot',
+    false,
+    ARRAY['team_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_team_saved_created ON public.snapshot USING btree (team_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_source_saved_created',
+    'snapshot',
+    false,
+    ARRAY['sandbox_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_source_saved_created ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_parent_saved',
+    'snapshot',
+    false,
+    ARRAY['parent_snapshot_id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_parent_saved ON public.snapshot USING btree (parent_snapshot_id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_host',
+    'snapshot',
+    false,
+    ARRAY['host_id', 'status'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_saved_host ON public.snapshot USING btree (host_id, status) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_reconcile',
+    'snapshot',
+    false,
+    ARRAY['status', 'updated_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))',
+    'CREATE INDEX idx_snapshot_saved_reconcile ON public.snapshot USING btree (status, updated_at, id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))'
+),
+(
+    'idx_sandbox_source_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['source_snapshot_id'],
+    '(source_snapshot_id IS NOT NULL)',
+    'CREATE INDEX idx_sandbox_source_snapshot_pin ON public.sandbox USING btree (source_snapshot_id) WHERE (source_snapshot_id IS NOT NULL)'
+),
+(
+    'idx_sandbox_destroyed_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['destroyed_at', 'id'],
+    '((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))',
+    'CREATE INDEX idx_sandbox_destroyed_snapshot_pin ON public.sandbox USING btree (destroyed_at, id) WHERE ((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))'
+),
+(
+    'idx_sandbox_snapshot_operation',
+    'sandbox',
+    false,
+    ARRAY['snapshot_operation_started_at'],
+    '((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))',
+    'CREATE INDEX idx_sandbox_snapshot_operation ON public.sandbox USING btree (snapshot_operation_started_at) WHERE ((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))'
+);
+
+-- A recovery target must be the exact expected index except for its invalid
+-- catalog state. Refuse valid-but-drifted indexes, wrong-table objects, and
+-- invalid indexes with a different key or predicate.
+DO $$
+DECLARE
+    expected record;
+    index_oid oid;
+    index_relkind "char";
+BEGIN
+    FOR expected IN
+        SELECT *
+        FROM saved_snapshot_expected_index
+        ORDER BY index_name
+    LOOP
+        index_oid := NULL;
+        index_relkind := NULL;
+
+        SELECT object.oid, object.relkind
+        INTO index_oid, index_relkind
+        FROM pg_class object
+        JOIN pg_namespace object_namespace
+          ON object_namespace.oid = object.relnamespace
+        WHERE object_namespace.nspname = 'public'
+          AND object.relname = expected.index_name;
+
+        IF index_oid IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF index_relkind <> 'i' OR NOT EXISTS (
+            SELECT 1
+            FROM pg_index catalog
+            JOIN pg_class indexed_table
+              ON indexed_table.oid = catalog.indrelid
+            JOIN pg_namespace table_namespace
+              ON table_namespace.oid = indexed_table.relnamespace
+            JOIN pg_class index_object
+              ON index_object.oid = catalog.indexrelid
+            JOIN pg_am access_method
+              ON access_method.oid = index_object.relam
+            WHERE catalog.indexrelid = index_oid
+              AND table_namespace.nspname = 'public'
+              AND indexed_table.relname = expected.table_name
+              AND access_method.amname = 'btree'
+              AND catalog.indisunique = expected.is_unique
+              AND catalog.indimmediate
+              AND catalog.indnkeyatts =
+                  cardinality(expected.key_columns)
+              AND catalog.indnatts = catalog.indnkeyatts
+              AND catalog.indexprs IS NULL
+              AND ARRAY(
+                      SELECT pg_get_indexdef(
+                                 catalog.indexrelid,
+                                 key_position,
+                                 true
+                             )
+                      FROM generate_series(
+                               1,
+                               catalog.indnkeyatts
+                           ) AS key_position
+                      ORDER BY key_position
+                  ) = expected.key_columns
+              AND pg_get_expr(
+                      catalog.indpred,
+                      catalog.indrelid,
+                      false
+                  ) = expected.predicate
+              AND pg_get_indexdef(catalog.indexrelid) =
+                  expected.definition
+        ) THEN
+            RAISE EXCEPTION
+                'refusing recovery: public.% is not the exact expected saved-snapshot index',
+                expected.index_name;
+        END IF;
+    END LOOP;
+END;
+$$;
+
+\echo 'Dropping invalid saved-snapshot index remnants, if any'
+
+SELECT format(
+           'DROP INDEX CONCURRENTLY IF EXISTS %I.%I;',
+           index_namespace.nspname,
+           index_object.relname
+       )
+FROM pg_index catalog
+JOIN pg_class index_object
+  ON index_object.oid = catalog.indexrelid
+JOIN pg_namespace index_namespace
+  ON index_namespace.oid = index_object.relnamespace
+JOIN saved_snapshot_expected_index expected
+  ON expected.index_name = index_object.relname
+JOIN pg_class indexed_table
+  ON indexed_table.oid = catalog.indrelid
+JOIN pg_namespace table_namespace
+  ON table_namespace.oid = indexed_table.relnamespace
+JOIN pg_am access_method
+  ON access_method.oid = index_object.relam
+WHERE index_namespace.nspname = 'public'
+  AND index_object.relkind = 'i'
+  AND table_namespace.nspname = 'public'
+  AND indexed_table.relname = expected.table_name
+  AND access_method.amname = 'btree'
+  AND catalog.indisunique = expected.is_unique
+  AND catalog.indimmediate
+  AND catalog.indnkeyatts = cardinality(expected.key_columns)
+  AND catalog.indnatts = catalog.indnkeyatts
+  AND catalog.indexprs IS NULL
+  AND ARRAY(
+          SELECT pg_get_indexdef(
+                     catalog.indexrelid,
+                     key_position,
+                     true
+                 )
+          FROM generate_series(
+                   1,
+                   catalog.indnkeyatts
+               ) AS key_position
+          ORDER BY key_position
+      ) = expected.key_columns
+  AND pg_get_expr(catalog.indpred, catalog.indrelid, false) =
+      expected.predicate
+  AND pg_get_indexdef(catalog.indexrelid) = expected.definition
+  AND NOT catalog.indisvalid
+ORDER BY index_object.relname
+\gexec
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_index catalog
+        JOIN pg_class index_object
+          ON index_object.oid = catalog.indexrelid
+        JOIN pg_namespace index_namespace
+          ON index_namespace.oid = index_object.relnamespace
+        JOIN saved_snapshot_expected_index expected
+          ON expected.index_name = index_object.relname
+        WHERE index_namespace.nspname = 'public'
+          AND NOT catalog.indisvalid
+    ) THEN
+        RAISE EXCEPTION
+            'saved-snapshot recovery left an invalid index remnant';
+    END IF;
+END;
+$$;
+
+\echo 'Invalid remnants removed; rerun prebuild-saved-snapshot-indexes.sql'
+
+SELECT pg_advisory_unlock(20819, 20260729);

--- a/scripts/restart-staging-snapshot-services.sh
+++ b/scripts/restart-staging-snapshot-services.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Restart both staging saved-snapshot service tiers at the exact main commit
+# under canary. The caller blocks until both workflow runs conclude.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: SNAPSHOT_CANARY_MAIN_SHA=<40-hex-main-sha> \
+  ./scripts/restart-staging-snapshot-services.sh \
+  <after-active-capture|after-paused-capture> <sandbox_id> <snapshot_id>
+
+Required:
+  SNAPSHOT_CANARY_MAIN_SHA  Exact origin/main commit being tested.
+  GH_TOKEN                  Token with Actions write/read access.
+
+Optional:
+  GITHUB_REPOSITORY         owner/repo; inferred with `gh repo view` otherwise.
+  SNAPSHOT_RESTART_RUN_TIMEOUT_S        Defaults to 3600.
+  SNAPSHOT_RESTART_POLL_INTERVAL_S      Defaults to 10.
+USAGE
+}
+
+if [[ "$#" -ne 3 ]]; then
+  usage
+  exit 2
+fi
+
+phase="$1"
+sandbox_id="$2"
+snapshot_id="$3"
+case "$phase" in
+  after-active-capture|after-paused-capture) ;;
+  *)
+    echo "unsupported restart phase: ${phase}" >&2
+    exit 2
+    ;;
+esac
+
+: "${SNAPSHOT_CANARY_MAIN_SHA:?SNAPSHOT_CANARY_MAIN_SHA is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+if [[ ! "$SNAPSHOT_CANARY_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "SNAPSHOT_CANARY_MAIN_SHA must be a lowercase 40-character commit SHA" >&2
+  exit 2
+fi
+for value in "$sandbox_id" "$snapshot_id"; do
+  if [[ ! "$value" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    echo "restart hook received a non-UUID resource id: ${value}" >&2
+    exit 2
+  fi
+done
+
+for tool in gh jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "required tool not found: ${tool}" >&2
+    exit 1
+  fi
+done
+
+run_timeout="${SNAPSHOT_RESTART_RUN_TIMEOUT_S:-3600}"
+poll_interval="${SNAPSHOT_RESTART_POLL_INTERVAL_S:-10}"
+for pair in \
+  "SNAPSHOT_RESTART_RUN_TIMEOUT_S:${run_timeout}" \
+  "SNAPSHOT_RESTART_POLL_INTERVAL_S:${poll_interval}"; do
+  name="${pair%%:*}"
+  value="${pair#*:}"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer, got: ${value}" >&2
+    exit 2
+  fi
+done
+
+repository="${GITHUB_REPOSITORY:-}"
+if [[ -z "$repository" ]]; then
+  repository="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+if [[ ! "$repository" =~ ^[^/]+/[^/]+$ ]]; then
+  echo "could not determine a valid GitHub owner/repository: ${repository}" >&2
+  exit 2
+fi
+
+main_sha() {
+  gh api "repos/${repository}/git/ref/heads/main" --jq .object.sha
+}
+
+assert_main_sha() {
+  local observed
+  observed="$(main_sha)"
+  if [[ "$observed" != "$SNAPSHOT_CANARY_MAIN_SHA" ]]; then
+    echo "origin/main moved to ${observed}; refusing to restart or sign off stale ${SNAPSHOT_CANARY_MAIN_SHA}" >&2
+    return 1
+  fi
+}
+
+dispatch_staging_workflow() {
+  local workflow="$1"
+  local inputs_json="$2"
+  local payload response run_id run_url
+
+  # The dispatch API only accepts a branch/tag. The 2026-03-10 response binds
+  # this invocation to its exact child run, eliminating ambiguous run-list
+  # discovery (including same-SHA production dispatches).
+  assert_main_sha
+  payload="$(jq -cn \
+    --arg ref main \
+    --argjson inputs "$inputs_json" \
+    '{ref: $ref, inputs: $inputs, return_run_details: true}')"
+  response="$(gh api \
+    --method POST \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2026-03-10' \
+    "repos/${repository}/actions/workflows/${workflow}/dispatches" \
+    --input - <<<"$payload")" || return 1
+  run_id="$(jq -er '
+    .workflow_run_id
+    | select(type == "number" or type == "string")
+    | tostring
+    | select(test("^[1-9][0-9]*$"))
+  ' <<<"$response")" || {
+    echo "${workflow} dispatch did not return workflow_run_id; refusing ambiguous run discovery" >&2
+    return 1
+  }
+  run_url="$(jq -er '.run_url | strings | select(length > 0)' <<<"$response")" || {
+    echo "${workflow} dispatch did not return run_url; refusing ambiguous run discovery" >&2
+    return 1
+  }
+  echo "${workflow} dispatched as run ${run_id}: ${run_url}" >&2
+  printf '%s' "$run_id"
+}
+
+wait_for_run() {
+  local workflow="$1"
+  local run_id="$2"
+  local deadline=$((SECONDS + run_timeout))
+  local view status conclusion head_sha url
+
+  while (( SECONDS < deadline )); do
+    if ! view="$(gh run view "$run_id" \
+      --repo "$repository" \
+      --json status,conclusion,headSha,url)"; then
+      sleep "$poll_interval"
+      continue
+    fi
+    status="$(jq -r .status <<<"$view")"
+    conclusion="$(jq -r '.conclusion // ""' <<<"$view")"
+    head_sha="$(jq -r .headSha <<<"$view")"
+    url="$(jq -r .url <<<"$view")"
+    if [[ "$head_sha" != "$SNAPSHOT_CANARY_MAIN_SHA" ]]; then
+      echo "${workflow} run ${run_id} uses ${head_sha}, want exact ${SNAPSHOT_CANARY_MAIN_SHA}: ${url}" >&2
+      return 1
+    fi
+    if [[ "$status" == "completed" ]]; then
+      if [[ "$conclusion" == "success" ]]; then
+        echo "${workflow} run ${run_id} succeeded at ${head_sha}: ${url}"
+        return 0
+      fi
+      echo "${workflow} run ${run_id} concluded ${conclusion:-unknown}: ${url}" >&2
+      return 1
+    fi
+    sleep "$poll_interval"
+  done
+
+  echo "timed out waiting for ${workflow} run ${run_id}" >&2
+  return 1
+}
+
+assert_main_sha
+echo "Dispatching exact-main staging restarts for ${phase} (${sandbox_id}/${snapshot_id})"
+# GitHub's workflow-dispatch API accepts a branch or tag, not a raw commit SHA.
+# Dispatch `main`, bind directly to the returned run IDs, then require both
+# runs' headSha to equal the canary SHA. Any missing direct ID or main movement
+# fails closed; there is deliberately no run-list fallback.
+api_inputs="$(jq -cn '{environment: "staging"}')"
+vmd_inputs="$(jq -cn '{environment: "staging", activate_staging_snapshot_storage: false}')"
+api_run_id="$(dispatch_staging_workflow deploy-api.yml "$api_inputs")"
+vmd_run_id="$(dispatch_staging_workflow deploy-vmd.yml "$vmd_inputs")"
+assert_main_sha
+
+set +e
+wait_for_run deploy-api.yml "$api_run_id" &
+api_wait_pid=$!
+wait_for_run deploy-vmd.yml "$vmd_run_id" &
+vmd_wait_pid=$!
+wait "$api_wait_pid"
+api_result=$?
+wait "$vmd_wait_pid"
+vmd_result=$?
+set -e
+
+if (( api_result != 0 || vmd_result != 0 )); then
+  echo "staging restart failed: deploy-api=${api_result}, deploy-vmd=${vmd_result}" >&2
+  exit 1
+fi
+
+assert_main_sha
+echo "Both staging service tiers restarted successfully at ${SNAPSHOT_CANARY_MAIN_SHA}"

--- a/scripts/smoke-test-snapshots.sh
+++ b/scripts/smoke-test-snapshots.sh
@@ -1,0 +1,1523 @@
+#!/usr/bin/env bash
+# End-to-end canary for immutable saved snapshots.
+#
+# This script is intentionally not part of the default regional smoke test.
+# The target team must have sandbox_snapshots_v1 enabled, a provisioned
+# snapshot-storage quota, and capacity for one source plus four active forks.
+# This is a staging ship gate, not a degraded lifecycle smoke. It requires
+# secret write access, direct shadow-ledger verification, and a restart hook.
+# EXIT cleanup always forces the canary team's feature override off before
+# deleting resources; the orchestrating workflow restores the exact prior row
+# and quota after this process returns.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: RUN_SNAPSHOT_CANARY=1 API_BASE_URL=https://api.example.test \
+  SANDBOX_BASE_URL=https://sandbox.example.test API_KEY=... \
+  SNAPSHOT_RESTART_HOOK=./restart-staging-snapshot-services.sh \
+  ./scripts/smoke-test-snapshots.sh
+
+Required environment variables:
+  RUN_SNAPSHOT_CANARY  Must be exactly 1. Prevents accidental production runs.
+  API_BASE_URL         Control-plane API base URL.
+  SANDBOX_BASE_URL     Data-plane base URL used by /exec.
+  API_KEY              Team API key used as X-API-Key.
+  SNAPSHOT_RESTART_HOOK
+                       Executable invoked after each capture to restart the
+                       staging control plane and VMD at the exact tested SHA.
+  SNAPSHOT_SHADOW_DATABASE_URL
+                       PostgreSQL URL used to verify the shadow storage ledger.
+  SNAPSHOT_TEAM_ID     UUID for the otherwise-quiescent canary team.
+
+Optional environment variables:
+  SANDBOX_TEMPLATE     Source template. Defaults to superserve/base.
+  API_TIMEOUT_S        Timeout for create/capture API calls. Defaults to 180.
+  EXEC_TIMEOUT_S       Timeout requested for each sandbox command. Defaults to 30.
+  POLL_TIMEOUT_S       Lifecycle polling timeout. Defaults to 300.
+  POLL_INTERVAL_S      Seconds between lifecycle polls. Defaults to 3.
+  CANARY_EGRESS_TEST_URL
+                       Public URL used to prove that the source's deny-all
+                       egress policy is inherited by every fork. Defaults to
+                       https://example.com.
+
+The restart hook is invoked as:
+  HOOK <phase> <sandbox_id> <snapshot_id>
+where phase is `after-active-capture` or `after-paused-capture`. It must
+return only after both staging services are ready for API traffic.
+USAGE
+}
+
+if [[ "${RUN_SNAPSHOT_CANARY:-}" != "1" ]]; then
+  usage
+  exit 2
+fi
+
+: "${API_BASE_URL:?API_BASE_URL is required}"
+: "${SANDBOX_BASE_URL:?SANDBOX_BASE_URL is required}"
+: "${API_KEY:?API_KEY is required}"
+: "${SNAPSHOT_RESTART_HOOK:?SNAPSHOT_RESTART_HOOK is required}"
+: "${SNAPSHOT_SHADOW_DATABASE_URL:?SNAPSHOT_SHADOW_DATABASE_URL is required}"
+: "${SNAPSHOT_TEAM_ID:?SNAPSHOT_TEAM_ID is required}"
+
+normalize_url() {
+  case "$1" in
+    http://*|https://*) printf '%s' "$1" ;;
+    *) printf 'https://%s' "$1" ;;
+  esac
+}
+
+require_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required tool not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${name} must be a positive integer, got: ${value}" >&2
+    exit 2
+  fi
+}
+
+require_boolean() {
+  local name="$1"
+  local value="$2"
+  if [[ "$value" != "0" && "$value" != "1" ]]; then
+    echo "${name} must be 0 or 1, got: ${value}" >&2
+    exit 2
+  fi
+}
+
+require_tool curl
+require_tool jq
+require_tool base64
+
+SANDBOX_TEMPLATE="${SANDBOX_TEMPLATE:-superserve/base}"
+API_TIMEOUT_S="${API_TIMEOUT_S:-180}"
+EXEC_TIMEOUT_S="${EXEC_TIMEOUT_S:-30}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-300}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-3}"
+SNAPSHOT_RESTART_HOOK="${SNAPSHOT_RESTART_HOOK:-}"
+REQUIRE_SNAPSHOT_RESTART_HOOK="${REQUIRE_SNAPSHOT_RESTART_HOOK:-1}"
+SKIP_SNAPSHOT_SECRET_CHECKS="${SKIP_SNAPSHOT_SECRET_CHECKS:-0}"
+CANARY_EGRESS_TEST_URL="${CANARY_EGRESS_TEST_URL:-https://example.com}"
+SNAPSHOT_SHADOW_DATABASE_URL="${SNAPSHOT_SHADOW_DATABASE_URL:-}"
+SNAPSHOT_TEAM_ID="${SNAPSHOT_TEAM_ID:-}"
+
+require_positive_integer API_TIMEOUT_S "$API_TIMEOUT_S"
+require_positive_integer EXEC_TIMEOUT_S "$EXEC_TIMEOUT_S"
+require_positive_integer POLL_TIMEOUT_S "$POLL_TIMEOUT_S"
+require_positive_integer POLL_INTERVAL_S "$POLL_INTERVAL_S"
+require_boolean REQUIRE_SNAPSHOT_RESTART_HOOK "$REQUIRE_SNAPSHOT_RESTART_HOOK"
+require_boolean SKIP_SNAPSHOT_SECRET_CHECKS "$SKIP_SNAPSHOT_SECRET_CHECKS"
+
+if [[ "$REQUIRE_SNAPSHOT_RESTART_HOOK" != "1" ]]; then
+  echo "REQUIRE_SNAPSHOT_RESTART_HOOK must remain 1; restart recovery is a required ship gate" >&2
+  exit 2
+fi
+if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" != "0" ]]; then
+  echo "SKIP_SNAPSHOT_SECRET_CHECKS must remain 0; degraded canaries are not accepted for staging sign-off" >&2
+  exit 2
+fi
+
+case "$CANARY_EGRESS_TEST_URL" in
+  http://*|https://*) ;;
+  *)
+    echo "CANARY_EGRESS_TEST_URL must use http:// or https://" >&2
+    exit 2
+    ;;
+esac
+if [[ "$CANARY_EGRESS_TEST_URL" == *"'"* || "$CANARY_EGRESS_TEST_URL" =~ [[:space:]] ]]; then
+  echo "CANARY_EGRESS_TEST_URL must not contain single quotes or whitespace" >&2
+  exit 2
+fi
+
+if [[ ! -x "$SNAPSHOT_RESTART_HOOK" ]]; then
+  echo "SNAPSHOT_RESTART_HOOK must name an executable file: ${SNAPSHOT_RESTART_HOOK}" >&2
+  exit 2
+fi
+if [[ ! "$SNAPSHOT_TEAM_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  echo "SNAPSHOT_TEAM_ID must be a UUID" >&2
+  exit 2
+fi
+require_tool psql
+
+API_BASE_URL="$(normalize_url "${API_BASE_URL%/}")"
+SANDBOX_BASE_URL="$(normalize_url "${SANDBOX_BASE_URL%/}")"
+
+RUN_ID="$(date +%s)-$$"
+SOURCE_NAME="snapshot-canary-source-${RUN_ID}"
+SNAPSHOT_NAME="snapshot-canary-${RUN_ID}"
+PAUSED_SNAPSHOT_NAME="snapshot-canary-paused-${RUN_ID}"
+STATE_PATH="/tmp/superserve-snapshot-canary-${RUN_ID}"
+SOURCE_MARKER="snapshot-canary-source-${RUN_ID}"
+SOURCE_MUTATED_MARKER="snapshot-canary-source-mutated-${RUN_ID}"
+MEMORY_MARKER="snapshot-canary-memory-${RUN_ID}"
+SOURCE_MEMORY_MARKER="snapshot-canary-memory-source-${RUN_ID}"
+MEMORY_REQUEST_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.request"
+MEMORY_RESPONSE_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.response"
+MEMORY_INPUT_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.input"
+MEMORY_PID_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.pid"
+MEMORY_SERVER_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.sh"
+MEMORY_LOG_PATH="/tmp/superserve-snapshot-memory-${RUN_ID}.log"
+IDEMPOTENCY_KEY="snapshot-canary-capture-${RUN_ID}"
+PAUSED_IDEMPOTENCY_KEY="snapshot-canary-paused-capture-${RUN_ID}"
+SECRET_NAME="snapshot-canary-secret-${RUN_ID}"
+SECRET_VALUE="snapshot-canary-value-${RUN_ID}"
+SECRET_CREATED=0
+SOURCE_SECRET_TOKEN=""
+
+SOURCE_ID=""
+SOURCE_TOKEN=""
+SNAPSHOT_ID=""
+SNAPSHOT_EXCLUSIVE_BYTES=""
+PAUSED_SNAPSHOT_ID=""
+PAUSED_SNAPSHOT_EXCLUSIVE_BYTES=""
+NESTED_FORK_ID=""
+NESTED_FORK_TOKEN=""
+FORK_IDS=("" "" "")
+FORK_TOKENS=("" "" "")
+FORK_SECRET_TOKENS=("" "" "")
+FORK_FILE_MARKERS=(
+  "snapshot-canary-fork-1-${RUN_ID}"
+  "snapshot-canary-fork-2-${RUN_ID}"
+  "snapshot-canary-fork-3-${RUN_ID}"
+)
+FORK_MEMORY_MARKERS=(
+  "snapshot-canary-memory-fork-1-${RUN_ID}"
+  "snapshot-canary-memory-fork-2-${RUN_ID}"
+  "snapshot-canary-memory-fork-3-${RUN_ID}"
+)
+BACKGROUND_PIDS=()
+TEMP_DIR="$(mktemp -d)"
+SHADOW_STORAGE_BASELINE=""
+SHADOW_STORAGE_AFTER_ROOT=""
+SHADOW_STORAGE_AFTER_SOURCE_PAUSE=""
+SHADOW_STORAGE_BEFORE_PAUSED_SNAPSHOT=""
+SHADOW_STORAGE_AFTER_PAUSED=""
+SHADOW_STORAGE_BEFORE_DELETE=""
+SHADOW_STORAGE_BEFORE_PAUSED_DELETE=""
+SHADOW_STORAGE_AFTER_PAUSED_DELETE=""
+SHADOW_STORAGE_BEFORE_ROOT_DELETE=""
+
+api_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local idempotency_key="${4:-}"
+  local output status rc
+  output="$(mktemp "${TEMP_DIR}/api-response.XXXXXX")"
+  local args=(
+    --silent --show-error --location
+    --connect-timeout 15
+    --max-time "$API_TIMEOUT_S"
+    --output "$output"
+    --write-out '%{http_code}'
+    --request "$method"
+    --header "X-API-Key: ${API_KEY}"
+  )
+  if [[ -n "$idempotency_key" ]]; then
+    args+=(--header "Idempotency-Key: ${idempotency_key}")
+  fi
+  if [[ -n "$body" ]]; then
+    args+=(
+      --header 'Content-Type: application/json'
+      --data "$body"
+    )
+  fi
+
+  if status="$(curl "${args[@]}" "${API_BASE_URL}${path}")"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if (( rc != 0 )); then
+    echo "curl failed for ${method} ${path} (exit ${rc})" >&2
+    if [[ -s "$output" ]]; then
+      cat "$output" >&2
+      echo >&2
+    fi
+    rm -f "$output"
+    return "$rc"
+  fi
+
+  printf '%s\n' "$status"
+  cat "$output"
+  rm -f "$output"
+}
+
+exec_request() {
+  local sandbox_id="$1"
+  local access_token="$2"
+  local command="$3"
+  local output status rc body
+  output="$(mktemp "${TEMP_DIR}/exec-response.XXXXXX")"
+  body="$(jq -cn \
+    --arg command "$command" \
+    --argjson timeout_s "$EXEC_TIMEOUT_S" \
+    '{command: $command, timeout_s: $timeout_s}')"
+
+  if status="$(curl --silent --show-error --location \
+    --connect-timeout 15 \
+    --max-time "$((EXEC_TIMEOUT_S + 15))" \
+    --output "$output" \
+    --write-out '%{http_code}' \
+    --request POST \
+    --header "X-Access-Token: ${access_token}" \
+    --header "X-Superserve-Sandbox-Id: ${sandbox_id}" \
+    --header 'Content-Type: application/json' \
+    --data "$body" \
+    "${SANDBOX_BASE_URL}/exec")"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if (( rc != 0 )); then
+    echo "curl failed for sandbox ${sandbox_id} /exec (exit ${rc})" >&2
+    if [[ -s "$output" ]]; then
+      cat "$output" >&2
+      echo >&2
+    fi
+    rm -f "$output"
+    return "$rc"
+  fi
+
+  printf '%s\n' "$status"
+  cat "$output"
+  rm -f "$output"
+}
+
+response_status() {
+  head -n 1 <<<"$1"
+}
+
+response_body() {
+  tail -n +2 <<<"$1"
+}
+
+fatal() {
+  echo "snapshot canary failed: $*" >&2
+  exit 1
+}
+
+expect_status() {
+  local actual="$1"
+  local expected="$2"
+  local body="$3"
+  local operation="$4"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "${operation}: expected HTTP ${expected}, got ${actual}" >&2
+    if [[ -n "$body" ]]; then
+      echo "$body" >&2
+    fi
+    exit 1
+  fi
+}
+
+expect_dependency_conflict() {
+  local body="$1"
+  local expected_code="$2"
+  local expected_sandbox_count="$3"
+  local expected_snapshot_count="$4"
+  local operation="$5"
+  local code sandbox_count snapshot_count
+
+  code="$(jq -r '.error.code // empty' <<<"$body")"
+  sandbox_count="$(jq -er '.error.dependencies.sandbox_count | numbers' <<<"$body")" ||
+    fatal "${operation}: dependency response omitted sandbox_count: ${body}"
+  snapshot_count="$(jq -er '.error.dependencies.snapshot_count | numbers' <<<"$body")" ||
+    fatal "${operation}: dependency response omitted snapshot_count: ${body}"
+  if [[ "$code" != "$expected_code" ||
+        "$sandbox_count" != "$expected_sandbox_count" ||
+        "$snapshot_count" != "$expected_snapshot_count" ]]; then
+    fatal "${operation}: got code=${code:-<none>} sandbox_count=${sandbox_count} snapshot_count=${snapshot_count}; want ${expected_code}/${expected_sandbox_count}/${expected_snapshot_count}: ${body}"
+  fi
+  echo "${operation}: dependency contract passed"
+}
+
+wait_for_sandbox_status() {
+  local sandbox_id="$1"
+  local wanted="$2"
+  local deadline=$((SECONDS + POLL_TIMEOUT_S))
+  local response status body current
+
+  while (( SECONDS < deadline )); do
+    if ! response="$(api_request GET "/sandboxes/${sandbox_id}")"; then
+      sleep "$POLL_INTERVAL_S"
+      continue
+    fi
+    status="$(response_status "$response")"
+    body="$(response_body "$response")"
+    if [[ "$status" != "200" ]]; then
+      case "$status" in
+        429|500|502|503|504)
+          sleep "$POLL_INTERVAL_S"
+          continue
+          ;;
+        *) fatal "get sandbox ${sandbox_id}: expected HTTP 200, got ${status}: ${body}" ;;
+      esac
+    fi
+    current="$(jq -r '.status // empty' <<<"$body")"
+    if [[ "$current" == "$wanted" ]]; then
+      return 0
+    fi
+    if [[ "$current" == "failed" || "$current" == "deleted" ]]; then
+      fatal "sandbox ${sandbox_id} reached terminal status ${current} while waiting for ${wanted}"
+    fi
+    sleep "$POLL_INTERVAL_S"
+  done
+
+  fatal "sandbox ${sandbox_id} did not reach ${wanted} within ${POLL_TIMEOUT_S}s"
+}
+
+wait_for_snapshot_ready() {
+  local snapshot_id="$1"
+  local expected_source_id="$2"
+  local expected_parent_id="${3:-}"
+  local deadline=$((SECONDS + POLL_TIMEOUT_S))
+  local response status body current source_id parent_id
+
+  while (( SECONDS < deadline )); do
+    if ! response="$(api_request GET "/snapshots/${snapshot_id}")"; then
+      sleep "$POLL_INTERVAL_S"
+      continue
+    fi
+    status="$(response_status "$response")"
+    body="$(response_body "$response")"
+    if [[ "$status" != "200" ]]; then
+      case "$status" in
+        429|500|502|503|504)
+          sleep "$POLL_INTERVAL_S"
+          continue
+          ;;
+        *) fatal "get snapshot ${snapshot_id}: expected HTTP 200, got ${status}: ${body}" ;;
+      esac
+    fi
+    current="$(jq -r '.status // empty' <<<"$body")"
+    source_id="$(jq -r '.sandbox_id // empty' <<<"$body")"
+    parent_id="$(jq -r '.parent_snapshot_id // empty' <<<"$body")"
+    if [[ "$current" == "ready" ]]; then
+      if [[ "$source_id" != "$expected_source_id" ]]; then
+        fatal "snapshot ${snapshot_id} source is ${source_id}, want ${expected_source_id}"
+      fi
+      if [[ "$parent_id" != "$expected_parent_id" ]]; then
+        fatal "snapshot ${snapshot_id} parent is ${parent_id:-<none>}, want ${expected_parent_id:-<none>}"
+      fi
+      return 0
+    fi
+    if [[ "$current" == "failed" || "$current" == "unavailable" || "$current" == "deleting" ]]; then
+      fatal "snapshot ${snapshot_id} reached terminal status ${current} while waiting for ready"
+    fi
+    sleep "$POLL_INTERVAL_S"
+  done
+
+  fatal "snapshot ${snapshot_id} did not remain ready within ${POLL_TIMEOUT_S}s"
+}
+
+pause_sandbox() {
+  local sandbox_id="$1"
+  local label="$2"
+  local response status body
+
+  if ! response="$(api_request POST "/sandboxes/${sandbox_id}/pause")"; then
+    fatal "${label}: pause request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 204 "$body" "pause ${label}"
+  wait_for_sandbox_status "$sandbox_id" paused
+}
+
+RESUMED_TOKEN=""
+resume_sandbox() {
+  local sandbox_id="$1"
+  local label="$2"
+  local response status body
+
+  if ! response="$(api_request POST "/sandboxes/${sandbox_id}/resume")"; then
+    fatal "${label}: resume request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 200 "$body" "resume ${label}"
+  RESUMED_TOKEN="$(jq -r '.access_token // empty' <<<"$body")"
+  if [[ -z "$RESUMED_TOKEN" ]]; then
+    fatal "${label}: resume response omitted access_token: ${body}"
+  fi
+  wait_for_sandbox_status "$sandbox_id" active
+}
+
+run_restart_hook() {
+  local phase="$1"
+  local sandbox_id="$2"
+  local snapshot_id="$3"
+
+  if [[ -z "$SNAPSHOT_RESTART_HOOK" ]]; then
+    echo "Restart hook skipped for ${phase}; set SNAPSHOT_RESTART_HOOK to exercise infrastructure restarts"
+    return 0
+  fi
+  echo "Running staging restart hook for ${phase}"
+  if ! "$SNAPSHOT_RESTART_HOOK" "$phase" "$sandbox_id" "$snapshot_id"; then
+    fatal "restart hook failed for ${phase}"
+  fi
+}
+
+shadow_scalar() {
+  local query="$1"
+  local description="$2"
+  local value
+  if [[ -z "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+    return 1
+  fi
+  value="$(psql "$SNAPSHOT_SHADOW_DATABASE_URL" \
+    --no-psqlrc --set=ON_ERROR_STOP=1 --tuples-only --no-align \
+    --command "$query")" || fatal "could not query ${description}"
+  value="${value//$'\n'/}"
+  value="${value//[[:space:]]/}"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fatal "${description} returned an invalid value: ${value:-<empty>}"
+  fi
+  printf '%s' "$value"
+}
+
+shadow_storage_bytes() {
+  shadow_scalar \
+    "SELECT snapshot_storage_bytes::text FROM team WHERE id = '${SNAPSHOT_TEAM_ID}'::uuid" \
+    "team shadow snapshot-storage usage"
+}
+
+shadow_layer_total_bytes() {
+  shadow_scalar \
+    "SELECT COALESCE(sum(retained_exclusive_size_bytes + current_exclusive_size_bytes), 0)::text FROM snapshot_storage_layer WHERE team_id = '${SNAPSHOT_TEAM_ID}'::uuid AND ended_at IS NULL" \
+    "active snapshot-storage layer usage"
+}
+
+shadow_snapshot_layer_bytes() {
+  local snapshot_id="$1"
+  if [[ ! "$snapshot_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    fatal "snapshot API returned a non-UUID id: ${snapshot_id}"
+  fi
+  shadow_scalar \
+    "SELECT (retained_exclusive_size_bytes + current_exclusive_size_bytes)::text FROM snapshot_storage_layer WHERE team_id = '${SNAPSHOT_TEAM_ID}'::uuid AND owner_snapshot_id = '${snapshot_id}'::uuid AND ended_at IS NULL" \
+    "saved snapshot layer usage for ${snapshot_id}"
+}
+
+assert_shadow_storage_bytes() {
+  local expected="$1"
+  local phase="$2"
+  local actual
+  if [[ -z "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+    return 0
+  fi
+  actual="$(shadow_storage_bytes)"
+  if [[ "$actual" != "$expected" ]]; then
+    fatal "${phase}: team shadow storage is ${actual} bytes, want ${expected}"
+  fi
+  echo "${phase}: team shadow storage is ${actual} bytes"
+}
+
+assert_shadow_storage_at_least() {
+  local minimum="$1"
+  local phase="$2"
+  local actual
+  if [[ -z "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+    return 0
+  fi
+  actual="$(shadow_storage_bytes)"
+  if (( actual < minimum )); then
+    fatal "${phase}: team shadow storage is ${actual} bytes, want at least ${minimum}"
+  fi
+  echo "${phase}: team shadow storage is ${actual} bytes (minimum ${minimum})"
+}
+
+assert_shadow_ledger_consistent() {
+  local phase="$1"
+  local counter layer_total
+  if [[ -z "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+    return 0
+  fi
+  counter="$(shadow_storage_bytes)"
+  layer_total="$(shadow_layer_total_bytes)"
+  if [[ "$counter" != "$layer_total" ]]; then
+    fatal "${phase}: team counter is ${counter} bytes but active layers sum to ${layer_total}"
+  fi
+  echo "${phase}: shadow counter matches active-layer total (${counter} bytes)"
+}
+
+assert_shadow_snapshot_layer_bytes() {
+  local snapshot_id="$1"
+  local expected="$2"
+  local phase="$3"
+  local actual
+  if [[ -z "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+    return 0
+  fi
+  actual="$(shadow_snapshot_layer_bytes "$snapshot_id")"
+  if [[ "$actual" != "$expected" ]]; then
+    fatal "${phase}: snapshot layer is ${actual} bytes, want ${expected}"
+  fi
+  echo "${phase}: saved-snapshot layer is ${actual} bytes"
+}
+
+exec_expect_stdout() {
+  local label="$1"
+  local sandbox_id="$2"
+  local access_token="$3"
+  local command="$4"
+  local expected="$5"
+  local response status body exit_code stdout
+
+  if ! response="$(exec_request "$sandbox_id" "$access_token" "$command")"; then
+    fatal "${label}: /exec request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 200 "$body" "${label}"
+  if ! exit_code="$(jq -er '.exit_code' <<<"$body")"; then
+    fatal "${label}: exec response omitted exit_code: ${body}"
+  fi
+  stdout="$(jq -r '.stdout // empty' <<<"$body")"
+  if [[ "$exit_code" != "0" || "$stdout" != "$expected" ]]; then
+    echo "${label}: expected exit 0 and stdout ${expected}" >&2
+    echo "$body" >&2
+    exit 1
+  fi
+  echo "${label}: passed"
+}
+
+EXEC_STDOUT=""
+exec_read_stdout() {
+  local label="$1"
+  local sandbox_id="$2"
+  local access_token="$3"
+  local command="$4"
+  local response status body exit_code
+
+  if ! response="$(exec_request "$sandbox_id" "$access_token" "$command")"; then
+    fatal "${label}: /exec request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 200 "$body" "$label"
+  if ! exit_code="$(jq -er '.exit_code' <<<"$body")"; then
+    fatal "${label}: exec response omitted exit_code: ${body}"
+  fi
+  if [[ "$exit_code" != "0" ]]; then
+    fatal "${label}: expected exit 0: ${body}"
+  fi
+  EXEC_STDOUT="$(jq -r '.stdout // empty' <<<"$body")"
+  echo "${label}: passed"
+}
+
+exec_expect_blocked_egress() {
+  local label="$1"
+  local sandbox_id="$2"
+  local access_token="$3"
+  exec_expect_stdout \
+    "$label" \
+    "$sandbox_id" \
+    "$access_token" \
+    "if curl --silent --show-error --fail --connect-timeout 3 --max-time 5 '${CANARY_EGRESS_TEST_URL}' >/dev/null 2>&1; then printf allowed; else printf blocked; fi" \
+    blocked
+}
+
+exec_expect_access_token_rejected() {
+  local label="$1"
+  local sandbox_id="$2"
+  local wrong_access_token="$3"
+  local response status body
+
+  if ! response="$(exec_request "$sandbox_id" "$wrong_access_token" 'printf should-not-run')"; then
+    fatal "${label}: /exec request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  case "$status" in
+    401|403) echo "${label}: passed" ;;
+    *) fatal "${label}: expected HTTP 401/403, got ${status}: ${body}" ;;
+  esac
+}
+
+memory_request_command() {
+  local request="$1"
+  printf '%s' "printf '%s\\n' '${request}' > '${MEMORY_REQUEST_PATH}'; cat '${MEMORY_RESPONSE_PATH}'"
+}
+
+exec_expect_memory() {
+  local label="$1"
+  local sandbox_id="$2"
+  local access_token="$3"
+  local expected="$4"
+  exec_expect_stdout \
+    "$label" \
+    "$sandbox_id" \
+    "$access_token" \
+    "$(memory_request_command GET)" \
+    "$expected"
+}
+
+exec_set_memory() {
+  local label="$1"
+  local sandbox_id="$2"
+  local access_token="$3"
+  local value="$4"
+  exec_expect_stdout \
+    "$label" \
+    "$sandbox_id" \
+    "$access_token" \
+    "$(memory_request_command "SET ${value}")" \
+    "$value"
+}
+
+start_memory_process() {
+  local server_code server_b64 command
+  server_code="$(printf '%s\n' \
+    '#!/bin/sh' \
+    'set -eu' \
+    'request_path=$1' \
+    'response_path=$2' \
+    'marker_path=$3' \
+    'pid_path=$4' \
+    'marker=$(cat "$marker_path")' \
+    'rm -f "$marker_path"' \
+    'mkfifo "$request_path" "$response_path"' \
+    'printf "%s" "$$" > "$pid_path"' \
+    'while true; do' \
+    '    request=' \
+    '    IFS= read -r request < "$request_path" || true' \
+    '    case "$request" in' \
+    '        "SET "*) marker=${request#SET } ;;' \
+    '    esac' \
+    '    printf "%s" "$marker" > "$response_path"' \
+    'done')"
+  server_b64="$(printf '%s' "$server_code" | base64 | tr -d '\n')"
+  command="set -eu; rm -f '${MEMORY_REQUEST_PATH}' '${MEMORY_RESPONSE_PATH}' '${MEMORY_PID_PATH}' '${MEMORY_INPUT_PATH}'; printf '%s' '${MEMORY_MARKER}' > '${MEMORY_INPUT_PATH}'; printf '%s' '${server_b64}' | base64 -d > '${MEMORY_SERVER_PATH}'; nohup sh '${MEMORY_SERVER_PATH}' '${MEMORY_REQUEST_PATH}' '${MEMORY_RESPONSE_PATH}' '${MEMORY_INPUT_PATH}' '${MEMORY_PID_PATH}' </dev/null >'${MEMORY_LOG_PATH}' 2>&1 & i=0; while { [ ! -p '${MEMORY_REQUEST_PATH}' ] || [ ! -p '${MEMORY_RESPONSE_PATH}' ]; } && [ \"\$i\" -lt 100 ]; do i=\$((i + 1)); sleep 0.1; done; if [ ! -p '${MEMORY_REQUEST_PATH}' ] || [ ! -p '${MEMORY_RESPONSE_PATH}' ] || [ ! -s '${MEMORY_PID_PATH}' ]; then cat '${MEMORY_LOG_PATH}' >&2 || true; exit 1; fi; pid=\$(cat '${MEMORY_PID_PATH}'); if ! kill -0 \"\$pid\"; then cat '${MEMORY_LOG_PATH}' >&2 || true; exit 1; fi; $(memory_request_command GET)"
+  exec_expect_stdout \
+    "start source in-memory process" \
+    "$SOURCE_ID" \
+    "$SOURCE_TOKEN" \
+    "$command" \
+    "$MEMORY_MARKER"
+}
+
+best_effort_delete() {
+  local resource="$1"
+  local id="$2"
+  local path status attempt
+  case "$resource" in
+    sandbox) path="/sandboxes/${id}" ;;
+    snapshot) path="/snapshots/${id}" ;;
+    secret) path="/secrets/${id}" ;;
+    *) return 0 ;;
+  esac
+
+  for attempt in 1 2 3; do
+    status="$(curl --silent --show-error \
+      --connect-timeout 10 \
+      --max-time 30 \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --request DELETE \
+      --header "X-API-Key: ${API_KEY}" \
+      "${API_BASE_URL}${path}" 2>/dev/null || true)"
+    if [[ "$status" == "204" || "$status" == "404" ]]; then
+      echo "cleanup: deleted ${resource} ${id}"
+      return 0
+    fi
+    sleep "$attempt"
+  done
+  echo "cleanup: could not delete ${resource} ${id} (last HTTP status: ${status:-curl-error})" >&2
+}
+
+force_canary_team_dark() {
+  local observed
+  observed="$(PGCONNECT_TIMEOUT=3 psql "$SNAPSHOT_SHADOW_DATABASE_URL" \
+    --no-psqlrc --quiet --tuples-only --no-align \
+    --set=ON_ERROR_STOP=1 \
+    --set=team_id="$SNAPSHOT_TEAM_ID" <<'SQL'
+BEGIN;
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '5s';
+UPDATE public.team_feature_flag
+SET enabled = false,
+    updated_at = now()
+WHERE team_id = :'team_id'::uuid
+  AND key = 'sandbox_snapshots_v1'
+  AND enabled;
+SELECT NOT EXISTS (
+  SELECT 1
+  FROM public.team_feature_flag
+  WHERE team_id = :'team_id'::uuid
+    AND key = 'sandbox_snapshots_v1'
+    AND enabled
+)::text;
+COMMIT;
+SQL
+  )" || return 1
+  [[ "$observed" == "true" ]]
+}
+
+cleanup() {
+  local exit_code=$?
+  local pid response status body id
+  local darkened=0 attempt
+  local recovered_forks=()
+  local recovered_nested_forks=()
+  local recovered_sources=()
+  local recovered_root_snapshots=()
+  local recovered_paused_snapshots=()
+
+  trap - EXIT INT TERM
+  set +e
+  # Bash 3.2 treats an initialized-but-empty array expansion as unbound under
+  # nounset. Cleanup is best-effort, so disable nounset before walking arrays.
+  set +u
+
+  # Disable snapshot creation before any potentially slow API cleanup. This is
+  # deliberately the first side effect in EXIT handling: cancellation grace
+  # must make the rollout dark even if host/API cleanup later stalls.
+  for attempt in 1 2 3; do
+    if force_canary_team_dark; then
+      darkened=1
+      break
+    fi
+    echo "cleanup: priority team-disable attempt ${attempt}/3 failed" >&2
+    sleep "$attempt"
+  done
+  if (( darkened == 0 )); then
+    echo "cleanup: CRITICAL: could not force sandbox_snapshots_v1 dark for ${SNAPSHOT_TEAM_ID}; skipping slow resource cleanup so the outer workflow can retry immediately" >&2
+    rm -rf "$TEMP_DIR"
+    exit 1
+  fi
+  echo "cleanup: canary team feature flag is dark"
+
+  # Let any in-flight fork request finish before discovering tagged resources.
+  for pid in "${BACKGROUND_PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  response="$(api_request GET "/sandboxes?metadata.snapshot_canary_run_id=${RUN_ID}" 2>/dev/null)"
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  if [[ "$status" == "200" ]] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$body"; then
+    while IFS= read -r id; do
+      [[ -n "$id" ]] && recovered_forks+=("$id")
+    done <<<"$(jq -r '.[] | select(.metadata.snapshot_canary_role == "fork") | .id' <<<"$body")"
+    while IFS= read -r id; do
+      [[ -n "$id" ]] && recovered_nested_forks+=("$id")
+    done <<<"$(jq -r '.[] | select(.metadata.snapshot_canary_role == "nested-fork") | .id' <<<"$body")"
+    while IFS= read -r id; do
+      [[ -n "$id" ]] && recovered_sources+=("$id")
+    done <<<"$(jq -r '.[] | select(.metadata.snapshot_canary_role == "source") | .id' <<<"$body")"
+  fi
+
+  # Delete the deepest branch first. Fork 1 owns PAUSED_SNAPSHOT_ID, so that
+  # snapshot must be gone before the first-level forks can be deleted.
+  for id in "$NESTED_FORK_ID" "${recovered_nested_forks[@]}"; do
+    [[ -n "$id" ]] && best_effort_delete sandbox "$id"
+  done
+
+  response="$(api_request GET '/snapshots?limit=100' 2>/dev/null)"
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  if [[ "$status" == "200" ]] && jq -e 'type == "array"' >/dev/null 2>&1 <<<"$body"; then
+    while IFS= read -r id; do
+      [[ -n "$id" ]] && recovered_root_snapshots+=("$id")
+    done <<<"$(jq -r --arg name "$SNAPSHOT_NAME" '.[] | select(.name == $name) | .id' <<<"$body")"
+    while IFS= read -r id; do
+      [[ -n "$id" ]] && recovered_paused_snapshots+=("$id")
+    done <<<"$(jq -r --arg name "$PAUSED_SNAPSHOT_NAME" '.[] | select(.name == $name) | .id' <<<"$body")"
+  fi
+
+  [[ -n "$PAUSED_SNAPSHOT_ID" ]] && best_effort_delete snapshot "$PAUSED_SNAPSHOT_ID"
+  for id in "${recovered_paused_snapshots[@]}"; do
+    [[ -n "$id" && "$id" != "$PAUSED_SNAPSHOT_ID" ]] && best_effort_delete snapshot "$id"
+  done
+
+  for id in "${FORK_IDS[@]}" "${recovered_forks[@]}"; do
+    [[ -n "$id" ]] && best_effort_delete sandbox "$id"
+  done
+
+  [[ -n "$SNAPSHOT_ID" ]] && best_effort_delete snapshot "$SNAPSHOT_ID"
+  for id in "${recovered_root_snapshots[@]}"; do
+    [[ -n "$id" && "$id" != "$SNAPSHOT_ID" ]] && best_effort_delete snapshot "$id"
+  done
+
+  [[ -n "$SOURCE_ID" ]] && best_effort_delete sandbox "$SOURCE_ID"
+  for id in "${recovered_sources[@]}"; do
+    [[ -n "$id" && "$id" != "$SOURCE_ID" ]] && best_effort_delete sandbox "$id"
+  done
+
+  if [[ "$SECRET_CREATED" == "1" ]]; then
+    best_effort_delete secret "$SECRET_NAME"
+  fi
+
+  rm -rf "$TEMP_DIR"
+  exit "$exit_code"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+SHADOW_STORAGE_BASELINE="$(shadow_storage_bytes)"
+echo "Initial team shadow snapshot storage: ${SHADOW_STORAGE_BASELINE} bytes"
+
+source_secrets='{}'
+if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" == "0" ]]; then
+  echo "Creating canary secret binding ${SECRET_NAME}"
+  secret_body="$(jq -cn \
+    --arg name "$SECRET_NAME" \
+    --arg value "$SECRET_VALUE" \
+    '{name: $name, value: $value, provider: "openai"}')"
+  if ! response="$(api_request POST /secrets "$secret_body")"; then
+    fatal "canary secret create request failed"
+  fi
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 201 "$body" "create canary secret"
+  SECRET_CREATED=1
+  source_secrets="$(jq -cn --arg secret_name "$SECRET_NAME" '{SNAPSHOT_CANARY_SECRET: $secret_name}')"
+fi
+
+echo "Creating active source sandbox ${SOURCE_NAME}"
+source_body="$(jq -cn \
+  --arg name "$SOURCE_NAME" \
+  --arg template "$SANDBOX_TEMPLATE" \
+  --arg run_id "$RUN_ID" \
+  --argjson source_secrets "$source_secrets" \
+  '{
+    name: $name,
+    from_template: $template,
+    timeout_seconds: 1800,
+    network: {
+      allow_out: [],
+      deny_out: ["0.0.0.0/0"]
+    },
+    metadata: {
+      snapshot_canary: "true",
+      snapshot_canary_role: "source",
+      snapshot_canary_run_id: $run_id
+    }
+  } + if ($source_secrets | length) > 0 then {secrets: $source_secrets} else {} end')"
+if ! response="$(api_request POST /sandboxes "$source_body")"; then
+  fatal "source sandbox create request failed"
+fi
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 201 "$body" "create source sandbox"
+SOURCE_ID="$(jq -r '.id // empty' <<<"$body")"
+SOURCE_TOKEN="$(jq -r '.access_token // empty' <<<"$body")"
+if [[ -z "$SOURCE_ID" || -z "$SOURCE_TOKEN" ]]; then
+  fatal "source create response omitted id or access_token: ${body}"
+fi
+if ! jq -e '.network.deny_out | index("0.0.0.0/0") != null' >/dev/null <<<"$body"; then
+  fatal "source response omitted the deny-all egress policy: ${body}"
+fi
+wait_for_sandbox_status "$SOURCE_ID" active
+
+if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" == "0" ]]; then
+  exec_read_stdout \
+    "read source secret proxy token" \
+    "$SOURCE_ID" \
+    "$SOURCE_TOKEN" \
+    'test -n "$SNAPSHOT_CANARY_SECRET" && printf "%s" "$SNAPSHOT_CANARY_SECRET"'
+  SOURCE_SECRET_TOKEN="$EXEC_STDOUT"
+  if [[ -z "$SOURCE_SECRET_TOKEN" || "$SOURCE_SECRET_TOKEN" == "$SECRET_VALUE" ]]; then
+    fatal "source did not receive an opaque proxy token for its secret binding"
+  fi
+fi
+exec_expect_blocked_egress \
+  "source deny-all egress policy" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN"
+
+write_source_command="printf '%s' '${SOURCE_MARKER}' > '${STATE_PATH}'"
+exec_expect_stdout \
+  "write source state" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "${write_source_command} && cat '${STATE_PATH}'" \
+  "$SOURCE_MARKER"
+start_memory_process
+
+echo "Capturing active source sandbox ${SOURCE_ID}"
+snapshot_body="$(jq -cn --arg name "$SNAPSHOT_NAME" '{name: $name}')"
+if ! response="$(api_request POST "/sandboxes/${SOURCE_ID}/snapshots" "$snapshot_body" "$IDEMPOTENCY_KEY")"; then
+  fatal "saved snapshot capture request failed"
+fi
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 201 "$body" "capture saved snapshot"
+SNAPSHOT_ID="$(jq -r '.id // empty' <<<"$body")"
+snapshot_status="$(jq -r '.status // empty' <<<"$body")"
+snapshot_source_id="$(jq -r '.sandbox_id // empty' <<<"$body")"
+if [[ -z "$SNAPSHOT_ID" || "$snapshot_status" != "ready" || "$snapshot_source_id" != "$SOURCE_ID" ]]; then
+  fatal "capture response did not describe a ready snapshot of the source: ${body}"
+fi
+if ! SNAPSHOT_EXCLUSIVE_BYTES="$(jq -er '.exclusive_size_bytes | numbers' <<<"$body")" ||
+   ! snapshot_logical_bytes="$(jq -er '.logical_size_bytes | numbers' <<<"$body")"; then
+  fatal "capture response omitted layer-byte observability: ${body}"
+fi
+if (( SNAPSHOT_EXCLUSIVE_BYTES < 0 || snapshot_logical_bytes < 0 )); then
+  fatal "capture returned invalid logical/exclusive byte accounting: ${body}"
+fi
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  # The ledger retains both the source's newly shared generation and the
+  # snapshot-owned layer. Source bytes are host-private metadata, so observe
+  # the committed counter instead of deriving it only from the public
+  # snapshot.exclusive_size_bytes field.
+  SHADOW_STORAGE_AFTER_ROOT="$(shadow_storage_bytes)"
+  assert_shadow_storage_at_least "$((SHADOW_STORAGE_BASELINE + SNAPSHOT_EXCLUSIVE_BYTES))" "active snapshot commit"
+  assert_shadow_snapshot_layer_bytes "$SNAPSHOT_ID" "$SNAPSHOT_EXCLUSIVE_BYTES" "active snapshot commit"
+  assert_shadow_ledger_consistent "active snapshot commit"
+fi
+
+echo "Retrying active capture with the same Idempotency-Key"
+if ! response="$(api_request POST "/sandboxes/${SOURCE_ID}/snapshots" "$snapshot_body" "$IDEMPOTENCY_KEY")"; then
+  fatal "idempotent saved snapshot retry failed"
+fi
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 201 "$body" "retry saved snapshot capture"
+retry_snapshot_id="$(jq -r '.id // empty' <<<"$body")"
+retry_exclusive_bytes="$(jq -er '.exclusive_size_bytes | numbers' <<<"$body")" ||
+  fatal "idempotent retry omitted exclusive byte accounting: ${body}"
+retry_logical_bytes="$(jq -er '.logical_size_bytes | numbers' <<<"$body")" ||
+  fatal "idempotent retry omitted logical byte accounting: ${body}"
+if [[ "$retry_snapshot_id" != "$SNAPSHOT_ID" ||
+      "$retry_exclusive_bytes" != "$SNAPSHOT_EXCLUSIVE_BYTES" ||
+      "$retry_logical_bytes" != "$snapshot_logical_bytes" ]]; then
+  fatal "idempotent retry changed snapshot identity or byte accounting: ${body}"
+fi
+assert_shadow_storage_bytes "$SHADOW_STORAGE_AFTER_ROOT" "idempotent capture retry"
+assert_shadow_snapshot_layer_bytes "$SNAPSHOT_ID" "$SNAPSHOT_EXCLUSIVE_BYTES" "idempotent capture retry"
+assert_shadow_ledger_consistent "idempotent capture retry"
+
+echo "Proving the source cannot be deleted while its saved snapshot exists"
+response="$(api_request DELETE "/sandboxes/${SOURCE_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 409 "$body" "delete source with saved snapshot"
+expect_dependency_conflict "$body" sandbox_has_snapshots 0 1 "delete source with saved snapshot"
+if ! jq -e --arg snapshot_id "$SNAPSHOT_ID" \
+  '.error.dependencies.snapshot_ids | index($snapshot_id) != null' >/dev/null <<<"$body"; then
+  fatal "source dependency response omitted saved snapshot ${SNAPSHOT_ID}: ${body}"
+fi
+
+# Active capture must return the source to active and leave it usable.
+wait_for_sandbox_status "$SOURCE_ID" active
+exec_expect_stdout \
+  "source after active capture" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "cat '${STATE_PATH}'" \
+  "$SOURCE_MARKER"
+exec_expect_memory \
+  "source live process after active capture" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "$MEMORY_MARKER"
+
+run_restart_hook after-active-capture "$SOURCE_ID" "$SNAPSHOT_ID"
+wait_for_snapshot_ready "$SNAPSHOT_ID" "$SOURCE_ID"
+wait_for_sandbox_status "$SOURCE_ID" active
+exec_expect_stdout \
+  "source file after active-capture restart hook" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "cat '${STATE_PATH}'" \
+  "$SOURCE_MARKER"
+exec_expect_memory \
+  "source live process after active-capture restart hook" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "$MEMORY_MARKER"
+
+echo "Creating three forks concurrently from snapshot ${SNAPSHOT_ID}"
+for i in 0 1 2; do
+  fork_preview_access=""
+  if (( i == 0 )); then
+    fork_preview_access="private"
+  fi
+  fork_body="$(jq -cn \
+    --arg name "snapshot-canary-fork-$((i + 1))-${RUN_ID}" \
+    --arg snapshot_id "$SNAPSHOT_ID" \
+    --arg run_id "$RUN_ID" \
+    --arg fork_index "$((i + 1))" \
+    --arg preview_access "$fork_preview_access" \
+    '{
+      name: $name,
+      from_snapshot: $snapshot_id,
+      metadata: {
+        snapshot_canary: "true",
+        snapshot_canary_role: "fork",
+        snapshot_canary_run_id: $run_id,
+        snapshot_canary_fork_index: $fork_index
+      }
+    } + if $preview_access != "" then {preview_access: $preview_access} else {} end')"
+  api_request POST /sandboxes "$fork_body" >"${TEMP_DIR}/fork-${i}.response" &
+  BACKGROUND_PIDS+=("$!")
+done
+
+fork_request_failed=0
+for pid in "${BACKGROUND_PIDS[@]}"; do
+  if ! wait "$pid"; then
+    fork_request_failed=1
+  fi
+done
+BACKGROUND_PIDS=()
+
+for i in 0 1 2; do
+  fork_response_file="${TEMP_DIR}/fork-${i}.response"
+  if [[ ! -s "$fork_response_file" ]]; then
+    echo "fork $((i + 1)): request returned no response" >&2
+    fork_request_failed=1
+    continue
+  fi
+  response="$(<"$fork_response_file")"
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  if [[ "$status" != "201" ]]; then
+    echo "fork $((i + 1)): expected HTTP 201, got ${status}" >&2
+    echo "$body" >&2
+    fork_request_failed=1
+    continue
+  fi
+  FORK_IDS[$i]="$(jq -r '.id // empty' <<<"$body")"
+  FORK_TOKENS[$i]="$(jq -r '.access_token // empty' <<<"$body")"
+  fork_source_snapshot="$(jq -r '.source_snapshot_id // empty' <<<"$body")"
+  if [[ -z "${FORK_IDS[$i]}" || -z "${FORK_TOKENS[$i]}" || "$fork_source_snapshot" != "$SNAPSHOT_ID" ]]; then
+    echo "fork $((i + 1)): response omitted identity/token/lineage" >&2
+    echo "$body" >&2
+    fork_request_failed=1
+  fi
+  if (( i == 0 )) && [[ "$(jq -r '.preview_access // empty' <<<"$body")" != "private" ]]; then
+    echo "fork 1: explicit private preview_access was not preserved" >&2
+    echo "$body" >&2
+    fork_request_failed=1
+  fi
+  if ! jq -e '.network.deny_out | index("0.0.0.0/0") != null' >/dev/null <<<"$body"; then
+    echo "fork $((i + 1)): response omitted inherited deny-all egress policy" >&2
+    echo "$body" >&2
+    fork_request_failed=1
+  fi
+done
+if (( fork_request_failed != 0 )); then
+  fatal "one or more concurrent fork creates failed"
+fi
+
+# Fan-out references the same immutable layers. Creating three forks must not
+# mutate either the public snapshot measurement or the team shadow counter.
+response="$(api_request GET "/snapshots/${SNAPSHOT_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 200 "$body" "read snapshot after fan-out"
+fanout_exclusive_bytes="$(jq -er '.exclusive_size_bytes | numbers' <<<"$body")" ||
+  fatal "snapshot read omitted exclusive byte accounting: ${body}"
+if [[ "$fanout_exclusive_bytes" != "$SNAPSHOT_EXCLUSIVE_BYTES" ]]; then
+  fatal "fan-out changed shared-layer exclusive bytes from ${SNAPSHOT_EXCLUSIVE_BYTES} to ${fanout_exclusive_bytes}"
+fi
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  assert_shadow_storage_bytes "$SHADOW_STORAGE_AFTER_ROOT" "three-fork fan-out"
+  assert_shadow_ledger_consistent "three-fork fan-out"
+fi
+
+for i in 0 1 2; do
+  wait_for_sandbox_status "${FORK_IDS[$i]}" active
+  if (( i == 0 )); then
+    response="$(api_request GET "/sandboxes/${FORK_IDS[$i]}")"
+    status="$(response_status "$response")"
+    body="$(response_body "$response")"
+    expect_status "$status" 200 "$body" "read explicit private fork"
+    if [[ "$(jq -r '.preview_access // empty' <<<"$body")" != "private" ]]; then
+      fatal "fork 1 lost explicit private preview_access after restore: ${body}"
+    fi
+  fi
+  if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" == "0" ]]; then
+    exec_read_stdout \
+      "fork $((i + 1)) fresh secret proxy token" \
+      "${FORK_IDS[$i]}" \
+      "${FORK_TOKENS[$i]}" \
+      'test -n "$SNAPSHOT_CANARY_SECRET" && printf "%s" "$SNAPSHOT_CANARY_SECRET"'
+    FORK_SECRET_TOKENS[$i]="$EXEC_STDOUT"
+    if [[ -z "${FORK_SECRET_TOKENS[$i]}" ||
+          "${FORK_SECRET_TOKENS[$i]}" == "$SOURCE_SECRET_TOKEN" ||
+          "${FORK_SECRET_TOKENS[$i]}" == "$SECRET_VALUE" ]]; then
+      fatal "fork $((i + 1)) reused a source/plaintext secret credential"
+    fi
+    for previous in 0 1 2; do
+      if (( previous < i )) && [[ "${FORK_SECRET_TOKENS[$i]}" == "${FORK_SECRET_TOKENS[$previous]}" ]]; then
+        fatal "fork $((i + 1)) reused fork $((previous + 1))'s secret proxy token"
+      fi
+    done
+  fi
+  exec_expect_access_token_rejected \
+    "fork $((i + 1)) rejects source access token" \
+    "${FORK_IDS[$i]}" \
+    "$SOURCE_TOKEN"
+  exec_expect_blocked_egress \
+    "fork $((i + 1)) inherited deny-all egress policy" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}"
+  exec_expect_stdout \
+    "fork $((i + 1)) restored source state" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "cat '${STATE_PATH}'" \
+    "$SOURCE_MARKER"
+  exec_expect_memory \
+    "fork $((i + 1)) restored live process state" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "$MEMORY_MARKER"
+done
+
+echo "Mutating source and every fork independently"
+exec_expect_stdout \
+  "source file mutation" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "printf '%s' '${SOURCE_MUTATED_MARKER}' > '${STATE_PATH}' && cat '${STATE_PATH}'" \
+  "$SOURCE_MUTATED_MARKER"
+exec_set_memory \
+  "source in-memory mutation" \
+  "$SOURCE_ID" \
+  "$SOURCE_TOKEN" \
+  "$SOURCE_MEMORY_MARKER"
+
+for i in 0 1 2; do
+  exec_expect_stdout \
+    "fork $((i + 1)) file mutation" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "printf '%s' '${FORK_FILE_MARKERS[$i]}' > '${STATE_PATH}' && cat '${STATE_PATH}'" \
+    "${FORK_FILE_MARKERS[$i]}"
+  exec_set_memory \
+    "fork $((i + 1)) in-memory mutation" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "${FORK_MEMORY_MARKERS[$i]}"
+done
+
+exec_expect_stdout "source file isolation" "$SOURCE_ID" "$SOURCE_TOKEN" "cat '${STATE_PATH}'" "$SOURCE_MUTATED_MARKER"
+exec_expect_memory "source memory isolation" "$SOURCE_ID" "$SOURCE_TOKEN" "$SOURCE_MEMORY_MARKER"
+for i in 0 1 2; do
+  exec_expect_stdout \
+    "fork $((i + 1)) file isolation" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "cat '${STATE_PATH}'" \
+    "${FORK_FILE_MARKERS[$i]}"
+  exec_expect_memory \
+    "fork $((i + 1)) memory isolation" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "${FORK_MEMORY_MARKERS[$i]}"
+done
+
+echo "Pausing and resuming the original source"
+pause_sandbox "$SOURCE_ID" source
+resume_sandbox "$SOURCE_ID" source
+SOURCE_TOKEN="$RESUMED_TOKEN"
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_AFTER_SOURCE_PAUSE="$(shadow_storage_bytes)"
+  if (( SHADOW_STORAGE_AFTER_SOURCE_PAUSE < SHADOW_STORAGE_AFTER_ROOT )); then
+    fatal "source pause measurement reduced shadow storage from ${SHADOW_STORAGE_AFTER_ROOT} to ${SHADOW_STORAGE_AFTER_SOURCE_PAUSE}"
+  fi
+  assert_shadow_ledger_consistent "source pause-time writable measurement"
+fi
+exec_expect_stdout "source file after pause/resume" "$SOURCE_ID" "$SOURCE_TOKEN" "cat '${STATE_PATH}'" "$SOURCE_MUTATED_MARKER"
+exec_expect_memory "source process after pause/resume" "$SOURCE_ID" "$SOURCE_TOKEN" "$SOURCE_MEMORY_MARKER"
+
+echo "Capturing a saved snapshot while fork 1 is paused"
+pause_sandbox "${FORK_IDS[0]}" "fork 1"
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_BEFORE_PAUSED_SNAPSHOT="$(shadow_storage_bytes)"
+  if (( SHADOW_STORAGE_BEFORE_PAUSED_SNAPSHOT < SHADOW_STORAGE_AFTER_SOURCE_PAUSE )); then
+    fatal "fork pause measurement reduced shadow storage from ${SHADOW_STORAGE_AFTER_SOURCE_PAUSE} to ${SHADOW_STORAGE_BEFORE_PAUSED_SNAPSHOT}"
+  fi
+  assert_shadow_ledger_consistent "fork 1 pause-time writable measurement"
+fi
+paused_snapshot_body="$(jq -cn --arg name "$PAUSED_SNAPSHOT_NAME" '{name: $name}')"
+if ! response="$(api_request POST "/sandboxes/${FORK_IDS[0]}/snapshots" "$paused_snapshot_body" "$PAUSED_IDEMPOTENCY_KEY")"; then
+  fatal "paused-source saved snapshot capture request failed"
+fi
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 201 "$body" "capture paused-source saved snapshot"
+PAUSED_SNAPSHOT_ID="$(jq -r '.id // empty' <<<"$body")"
+paused_snapshot_status="$(jq -r '.status // empty' <<<"$body")"
+paused_snapshot_source_id="$(jq -r '.sandbox_id // empty' <<<"$body")"
+paused_snapshot_parent_id="$(jq -r '.parent_snapshot_id // empty' <<<"$body")"
+if [[ -z "$PAUSED_SNAPSHOT_ID" || "$paused_snapshot_status" != "ready" ||
+      "$paused_snapshot_source_id" != "${FORK_IDS[0]}" || "$paused_snapshot_parent_id" != "$SNAPSHOT_ID" ]]; then
+  fatal "paused capture response has incorrect state or lineage: ${body}"
+fi
+if ! PAUSED_SNAPSHOT_EXCLUSIVE_BYTES="$(jq -er '.exclusive_size_bytes | numbers' <<<"$body")" ||
+   ! paused_snapshot_logical_bytes="$(jq -er '.logical_size_bytes | numbers' <<<"$body")"; then
+  fatal "paused capture response omitted layer-byte accounting: ${body}"
+fi
+if (( PAUSED_SNAPSHOT_EXCLUSIVE_BYTES < 0 || paused_snapshot_logical_bytes < 0 )); then
+  fatal "paused capture returned invalid logical/exclusive byte accounting: ${body}"
+fi
+wait_for_sandbox_status "${FORK_IDS[0]}" paused
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  # Sealing fork 1 transfers its already measured current generation into
+  # retained bytes without charging it twice; only the new snapshot-owned
+  # layer should increase the observed team counter.
+  SHADOW_STORAGE_AFTER_PAUSED=$((SHADOW_STORAGE_BEFORE_PAUSED_SNAPSHOT + PAUSED_SNAPSHOT_EXCLUSIVE_BYTES))
+  assert_shadow_storage_bytes "$SHADOW_STORAGE_AFTER_PAUSED" "paused snapshot commit"
+  assert_shadow_snapshot_layer_bytes "$PAUSED_SNAPSHOT_ID" "$PAUSED_SNAPSHOT_EXCLUSIVE_BYTES" "paused snapshot commit"
+  assert_shadow_ledger_consistent "paused snapshot commit"
+fi
+
+run_restart_hook after-paused-capture "${FORK_IDS[0]}" "$PAUSED_SNAPSHOT_ID"
+wait_for_snapshot_ready "$PAUSED_SNAPSHOT_ID" "${FORK_IDS[0]}" "$SNAPSHOT_ID"
+wait_for_sandbox_status "${FORK_IDS[0]}" paused
+resume_sandbox "${FORK_IDS[0]}" "fork 1 after paused capture"
+FORK_TOKENS[0]="$RESUMED_TOKEN"
+exec_expect_stdout \
+  "fork 1 file after paused capture/resume" \
+  "${FORK_IDS[0]}" \
+  "${FORK_TOKENS[0]}" \
+  "cat '${STATE_PATH}'" \
+  "${FORK_FILE_MARKERS[0]}"
+exec_expect_memory \
+  "fork 1 process after paused capture/resume" \
+  "${FORK_IDS[0]}" \
+  "${FORK_TOKENS[0]}" \
+  "${FORK_MEMORY_MARKERS[0]}"
+
+echo "Creating a nested fork from paused-source snapshot ${PAUSED_SNAPSHOT_ID}"
+nested_body="$(jq -cn \
+  --arg name "snapshot-canary-nested-${RUN_ID}" \
+  --arg snapshot_id "$PAUSED_SNAPSHOT_ID" \
+  --arg run_id "$RUN_ID" \
+  '{
+    name: $name,
+    from_snapshot: $snapshot_id,
+    metadata: {
+      snapshot_canary: "true",
+      snapshot_canary_role: "nested-fork",
+      snapshot_canary_run_id: $run_id
+    }
+  }')"
+if ! response="$(api_request POST /sandboxes "$nested_body")"; then
+  fatal "nested fork create request failed"
+fi
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 201 "$body" "create nested fork"
+NESTED_FORK_ID="$(jq -r '.id // empty' <<<"$body")"
+NESTED_FORK_TOKEN="$(jq -r '.access_token // empty' <<<"$body")"
+nested_source_snapshot="$(jq -r '.source_snapshot_id // empty' <<<"$body")"
+if [[ -z "$NESTED_FORK_ID" || -z "$NESTED_FORK_TOKEN" || "$nested_source_snapshot" != "$PAUSED_SNAPSHOT_ID" ]]; then
+  fatal "nested fork response omitted identity/token/lineage: ${body}"
+fi
+if ! jq -e '.network.deny_out | index("0.0.0.0/0") != null' >/dev/null <<<"$body"; then
+  fatal "nested fork response omitted inherited deny-all egress policy: ${body}"
+fi
+wait_for_sandbox_status "$NESTED_FORK_ID" active
+if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" == "0" ]]; then
+  exec_read_stdout \
+    "nested fork fresh secret proxy token" \
+    "$NESTED_FORK_ID" \
+    "$NESTED_FORK_TOKEN" \
+    'test -n "$SNAPSHOT_CANARY_SECRET" && printf "%s" "$SNAPSHOT_CANARY_SECRET"'
+  NESTED_SECRET_TOKEN="$EXEC_STDOUT"
+  if [[ -z "$NESTED_SECRET_TOKEN" || "$NESTED_SECRET_TOKEN" == "$SOURCE_SECRET_TOKEN" ||
+        "$NESTED_SECRET_TOKEN" == "${FORK_SECRET_TOKENS[0]}" || "$NESTED_SECRET_TOKEN" == "$SECRET_VALUE" ]]; then
+    fatal "nested fork reused an ancestor/plaintext secret credential"
+  fi
+fi
+exec_expect_access_token_rejected \
+  "nested fork rejects parent access token" \
+  "$NESTED_FORK_ID" \
+  "${FORK_TOKENS[0]}"
+exec_expect_blocked_egress \
+  "nested fork inherited deny-all egress policy" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN"
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  assert_shadow_storage_bytes "$SHADOW_STORAGE_AFTER_PAUSED" "nested-fork fan-out"
+  assert_shadow_ledger_consistent "nested-fork fan-out"
+fi
+
+echo "Proving the root snapshot cannot be deleted with child sandboxes and snapshots"
+response="$(api_request DELETE "/snapshots/${SNAPSHOT_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 409 "$body" "delete root snapshot with descendants"
+expect_dependency_conflict "$body" snapshot_has_dependents 3 1 "delete root snapshot with descendants"
+if ! jq -e --arg snapshot_id "$PAUSED_SNAPSHOT_ID" \
+  '.error.dependencies.snapshot_ids | index($snapshot_id) != null' >/dev/null <<<"$body"; then
+  fatal "root dependency response omitted child snapshot ${PAUSED_SNAPSHOT_ID}: ${body}"
+fi
+for id in "${FORK_IDS[@]}"; do
+  if ! jq -e --arg sandbox_id "$id" \
+    '.error.dependencies.sandbox_ids | index($sandbox_id) != null' >/dev/null <<<"$body"; then
+    fatal "root dependency response omitted child sandbox ${id}: ${body}"
+  fi
+done
+
+exec_expect_stdout \
+  "nested fork restored fork 1 file state" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "cat '${STATE_PATH}'" \
+  "${FORK_FILE_MARKERS[0]}"
+exec_expect_memory \
+  "nested fork restored fork 1 in-memory state" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "${FORK_MEMORY_MARKERS[0]}"
+
+NESTED_FILE_MARKER="snapshot-canary-nested-${RUN_ID}"
+NESTED_MEMORY_MARKER="snapshot-canary-memory-nested-${RUN_ID}"
+exec_expect_stdout \
+  "nested fork file mutation" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "printf '%s' '${NESTED_FILE_MARKER}' > '${STATE_PATH}' && cat '${STATE_PATH}'" \
+  "$NESTED_FILE_MARKER"
+exec_set_memory \
+  "nested fork in-memory mutation" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "$NESTED_MEMORY_MARKER"
+exec_expect_stdout \
+  "fork 1 remains isolated from nested fork" \
+  "${FORK_IDS[0]}" \
+  "${FORK_TOKENS[0]}" \
+  "cat '${STATE_PATH}'" \
+  "${FORK_FILE_MARKERS[0]}"
+exec_expect_memory \
+  "fork 1 memory remains isolated from nested fork" \
+  "${FORK_IDS[0]}" \
+  "${FORK_TOKENS[0]}" \
+  "${FORK_MEMORY_MARKERS[0]}"
+
+echo "Pausing and resuming every remaining fork"
+for i in 1 2; do
+  pause_sandbox "${FORK_IDS[$i]}" "fork $((i + 1))"
+  resume_sandbox "${FORK_IDS[$i]}" "fork $((i + 1))"
+  FORK_TOKENS[$i]="$RESUMED_TOKEN"
+  exec_expect_stdout \
+    "fork $((i + 1)) file after pause/resume" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "cat '${STATE_PATH}'" \
+    "${FORK_FILE_MARKERS[$i]}"
+  exec_expect_memory \
+    "fork $((i + 1)) process after pause/resume" \
+    "${FORK_IDS[$i]}" \
+    "${FORK_TOKENS[$i]}" \
+    "${FORK_MEMORY_MARKERS[$i]}"
+done
+pause_sandbox "$NESTED_FORK_ID" "nested fork"
+resume_sandbox "$NESTED_FORK_ID" "nested fork"
+NESTED_FORK_TOKEN="$RESUMED_TOKEN"
+exec_expect_stdout \
+  "nested fork file after pause/resume" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "cat '${STATE_PATH}'" \
+  "$NESTED_FILE_MARKER"
+exec_expect_memory \
+  "nested fork process after pause/resume" \
+  "$NESTED_FORK_ID" \
+  "$NESTED_FORK_TOKEN" \
+  "$NESTED_MEMORY_MARKER"
+
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_BEFORE_DELETE="$(shadow_storage_bytes)"
+  if (( SHADOW_STORAGE_BEFORE_DELETE < SHADOW_STORAGE_AFTER_PAUSED )); then
+    fatal "pause-time fork measurements reduced shadow storage from ${SHADOW_STORAGE_AFTER_PAUSED} to ${SHADOW_STORAGE_BEFORE_DELETE}"
+  fi
+  assert_shadow_ledger_consistent "all fork pause-time writable measurements"
+fi
+
+echo "Deleting the nested branch, first-level forks, snapshots, and source"
+response="$(api_request DELETE "/sandboxes/${NESTED_FORK_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 204 "$body" "delete nested fork"
+NESTED_FORK_ID=""
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_BEFORE_PAUSED_DELETE="$(shadow_storage_bytes)"
+  if (( SHADOW_STORAGE_BEFORE_PAUSED_DELETE > SHADOW_STORAGE_BEFORE_DELETE )); then
+    fatal "nested-fork deletion increased shadow storage from ${SHADOW_STORAGE_BEFORE_DELETE} to ${SHADOW_STORAGE_BEFORE_PAUSED_DELETE}"
+  fi
+  assert_shadow_ledger_consistent "nested-fork layer release"
+fi
+
+response="$(api_request DELETE "/snapshots/${PAUSED_SNAPSHOT_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 204 "$body" "delete paused-source snapshot"
+PAUSED_SNAPSHOT_ID=""
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_AFTER_PAUSED_DELETE=$((SHADOW_STORAGE_BEFORE_PAUSED_DELETE - PAUSED_SNAPSHOT_EXCLUSIVE_BYTES))
+  if (( SHADOW_STORAGE_AFTER_PAUSED_DELETE < 0 )); then
+    fatal "paused snapshot deletion accounting underflow"
+  fi
+  assert_shadow_storage_bytes "$SHADOW_STORAGE_AFTER_PAUSED_DELETE" "paused snapshot deletion"
+  assert_shadow_ledger_consistent "paused snapshot deletion"
+fi
+
+for i in 0 1 2; do
+  response="$(api_request DELETE "/sandboxes/${FORK_IDS[$i]}")"
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 204 "$body" "delete fork $((i + 1))"
+  FORK_IDS[$i]=""
+done
+
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  SHADOW_STORAGE_BEFORE_ROOT_DELETE="$(shadow_storage_bytes)"
+  if (( SHADOW_STORAGE_BEFORE_ROOT_DELETE > SHADOW_STORAGE_AFTER_PAUSED_DELETE )); then
+    fatal "first-level fork deletion increased shadow storage from ${SHADOW_STORAGE_AFTER_PAUSED_DELETE} to ${SHADOW_STORAGE_BEFORE_ROOT_DELETE}"
+  fi
+  assert_shadow_ledger_consistent "first-level fork layer release"
+fi
+
+response="$(api_request DELETE "/snapshots/${SNAPSHOT_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 204 "$body" "delete saved snapshot"
+SNAPSHOT_ID=""
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  root_delete_expected=$((SHADOW_STORAGE_BEFORE_ROOT_DELETE - SNAPSHOT_EXCLUSIVE_BYTES))
+  if (( root_delete_expected < 0 )); then
+    fatal "root snapshot deletion accounting underflow"
+  fi
+  assert_shadow_storage_bytes "$root_delete_expected" "root snapshot deletion"
+  assert_shadow_ledger_consistent "root snapshot deletion"
+fi
+
+response="$(api_request DELETE "/sandboxes/${SOURCE_ID}")"
+status="$(response_status "$response")"
+body="$(response_body "$response")"
+expect_status "$status" 204 "$body" "delete source sandbox"
+SOURCE_ID=""
+if [[ -n "$SNAPSHOT_SHADOW_DATABASE_URL" ]]; then
+  # The source retains its own writable generation after its snapshots are
+  # deleted. Releasing the source is the final reference and must restore the
+  # team's pre-canary shadow usage.
+  assert_shadow_storage_bytes "$SHADOW_STORAGE_BASELINE" "source final-reference deletion"
+  assert_shadow_ledger_consistent "source final-reference deletion"
+fi
+
+if [[ "$SKIP_SNAPSHOT_SECRET_CHECKS" == "0" ]]; then
+  response="$(api_request DELETE "/secrets/${SECRET_NAME}")"
+  status="$(response_status "$response")"
+  body="$(response_body "$response")"
+  expect_status "$status" 204 "$body" "delete canary secret"
+  SECRET_CREATED=0
+fi
+
+echo "Saved-snapshot staging canary passed: exact-SHA restart recovery, idempotent byte accounting, private preview policy, mandatory shadow-ledger and secret checks, live process/memory capture, inherited restricted egress, active and paused sources, nested lineage, four independent forks, pause/resume, and dependency-safe deletion"

--- a/supabase/migrations/20260729000010_saved_snapshot_indexes.sql
+++ b/supabase/migrations/20260729000010_saved_snapshot_indexes.sql
@@ -1,0 +1,333 @@
+-- Adopt the concurrently prebuilt saved-snapshot indexes. Production and
+-- staging tables must never fall back to transactional CREATE INDEX; only an
+-- empty database created by a fresh reset may build them in this migration.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- Cooperate with manual/CD prebuild and recovery sessions on this database.
+SELECT pg_advisory_xact_lock(20819, 20260729);
+
+CREATE TEMP TABLE saved_snapshot_expected_index (
+    index_name text PRIMARY KEY,
+    table_name text NOT NULL,
+    is_unique boolean NOT NULL,
+    key_columns text[] NOT NULL,
+    predicate text NOT NULL,
+    definition text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO saved_snapshot_expected_index (
+    index_name,
+    table_name,
+    is_unique,
+    key_columns,
+    predicate,
+    definition
+)
+VALUES
+(
+    'snapshot_sandbox_runtime_unique',
+    'snapshot',
+    true,
+    ARRAY['sandbox_id'],
+    '(kind = ''runtime_checkpoint''::snapshot_kind)',
+    'CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique ON public.snapshot USING btree (sandbox_id) WHERE (kind = ''runtime_checkpoint''::snapshot_kind)'
+),
+(
+    'snapshot_team_source_idempotency_unique',
+    'snapshot',
+    true,
+    ARRAY['team_id', 'sandbox_id', 'idempotency_key'],
+    '((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))',
+    'CREATE UNIQUE INDEX snapshot_team_source_idempotency_unique ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key) WHERE ((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))'
+),
+(
+    'idx_snapshot_team_saved_created',
+    'snapshot',
+    false,
+    ARRAY['team_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_team_saved_created ON public.snapshot USING btree (team_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_source_saved_created',
+    'snapshot',
+    false,
+    ARRAY['sandbox_id', 'created_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_source_saved_created ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_parent_saved',
+    'snapshot',
+    false,
+    ARRAY['parent_snapshot_id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_parent_saved ON public.snapshot USING btree (parent_snapshot_id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_host',
+    'snapshot',
+    false,
+    ARRAY['host_id', 'status'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+    'CREATE INDEX idx_snapshot_saved_host ON public.snapshot USING btree (host_id, status) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+),
+(
+    'idx_snapshot_saved_reconcile',
+    'snapshot',
+    false,
+    ARRAY['status', 'updated_at', 'id'],
+    '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))',
+    'CREATE INDEX idx_snapshot_saved_reconcile ON public.snapshot USING btree (status, updated_at, id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))'
+),
+(
+    'idx_sandbox_source_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['source_snapshot_id'],
+    '(source_snapshot_id IS NOT NULL)',
+    'CREATE INDEX idx_sandbox_source_snapshot_pin ON public.sandbox USING btree (source_snapshot_id) WHERE (source_snapshot_id IS NOT NULL)'
+),
+(
+    'idx_sandbox_destroyed_snapshot_pin',
+    'sandbox',
+    false,
+    ARRAY['destroyed_at', 'id'],
+    '((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))',
+    'CREATE INDEX idx_sandbox_destroyed_snapshot_pin ON public.sandbox USING btree (destroyed_at, id) WHERE ((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))'
+),
+(
+    'idx_sandbox_snapshot_operation',
+    'sandbox',
+    false,
+    ARRAY['snapshot_operation_started_at'],
+    '((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))',
+    'CREATE INDEX idx_sandbox_snapshot_operation ON public.sandbox USING btree (snapshot_operation_started_at) WHERE ((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))'
+);
+
+CREATE FUNCTION pg_temp.require_saved_snapshot_index(
+    requested_index_name text,
+    required boolean
+) RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected saved_snapshot_expected_index%ROWTYPE;
+    index_oid oid;
+    actual_table_schema text;
+    actual_table_name text;
+    actual_access_method text;
+    actual_relkind "char";
+    actual_unique boolean;
+    actual_valid boolean;
+    actual_ready boolean;
+    actual_live boolean;
+    actual_immediate boolean;
+    actual_key_count smallint;
+    actual_attribute_count smallint;
+    actual_keys text[];
+    actual_predicate text;
+    actual_definition text;
+    has_expressions boolean;
+BEGIN
+    SELECT *
+    INTO STRICT expected
+    FROM saved_snapshot_expected_index
+    WHERE index_name = requested_index_name;
+
+    SELECT object.oid, object.relkind
+    INTO index_oid, actual_relkind
+    FROM pg_class object
+    JOIN pg_namespace object_namespace
+      ON object_namespace.oid = object.relnamespace
+    WHERE object_namespace.nspname = 'public'
+      AND object.relname = requested_index_name;
+
+    IF index_oid IS NULL THEN
+        IF required THEN
+            RAISE EXCEPTION
+                'required saved-snapshot index public.% is missing',
+                requested_index_name;
+        END IF;
+        RETURN;
+    END IF;
+
+    IF actual_relkind <> 'i' THEN
+        RAISE EXCEPTION
+            'public.% exists but is not a regular index (relkind=%)',
+            requested_index_name,
+            actual_relkind;
+    END IF;
+
+    SELECT table_namespace.nspname,
+           indexed_table.relname,
+           access_method.amname,
+           catalog.indisunique,
+           catalog.indisvalid,
+           catalog.indisready,
+           catalog.indislive,
+           catalog.indimmediate,
+           catalog.indnkeyatts,
+           catalog.indnatts,
+           ARRAY(
+               SELECT pg_get_indexdef(
+                          catalog.indexrelid,
+                          key_position,
+                          true
+                      )
+               FROM generate_series(
+                        1,
+                        catalog.indnkeyatts
+                    ) AS key_position
+               ORDER BY key_position
+           ),
+           pg_get_expr(catalog.indpred, catalog.indrelid, false),
+           pg_get_indexdef(catalog.indexrelid),
+           catalog.indexprs IS NOT NULL
+    INTO actual_table_schema,
+         actual_table_name,
+         actual_access_method,
+         actual_unique,
+         actual_valid,
+         actual_ready,
+         actual_live,
+         actual_immediate,
+         actual_key_count,
+         actual_attribute_count,
+         actual_keys,
+         actual_predicate,
+         actual_definition,
+         has_expressions
+    FROM pg_index catalog
+    JOIN pg_class indexed_table
+      ON indexed_table.oid = catalog.indrelid
+    JOIN pg_namespace table_namespace
+      ON table_namespace.oid = indexed_table.relnamespace
+    JOIN pg_class index_object
+      ON index_object.oid = catalog.indexrelid
+    JOIN pg_am access_method
+      ON access_method.oid = index_object.relam
+    WHERE catalog.indexrelid = index_oid;
+
+    IF NOT FOUND
+       OR actual_table_schema <> 'public'
+       OR actual_table_name <> expected.table_name
+       OR actual_access_method <> 'btree'
+       OR actual_unique IS DISTINCT FROM expected.is_unique
+       OR NOT actual_valid
+       OR NOT actual_ready
+       OR NOT actual_live
+       OR NOT actual_immediate
+       OR actual_key_count <> cardinality(expected.key_columns)
+       OR actual_attribute_count <> actual_key_count
+       OR actual_keys IS DISTINCT FROM expected.key_columns
+       OR actual_predicate IS DISTINCT FROM expected.predicate
+       OR actual_definition IS DISTINCT FROM expected.definition
+       OR has_expressions
+    THEN
+        RAISE EXCEPTION
+            'saved-snapshot index public.% does not match the required valid/ready/live btree definition (actual=%)',
+            requested_index_name,
+            COALESCE(actual_definition, '<not an index>');
+    END IF;
+END;
+$$;
+
+-- Reject drifted and invalid same-named objects before deciding whether the
+-- fresh-reset fallback is allowed.
+DO $$
+DECLARE
+    expected record;
+BEGIN
+    FOR expected IN
+        SELECT index_name
+        FROM saved_snapshot_expected_index
+        ORDER BY index_name
+    LOOP
+        PERFORM pg_temp.require_saved_snapshot_index(
+            expected.index_name,
+            false
+        );
+    END LOOP;
+END;
+$$;
+
+DO $$
+DECLARE
+    tables_are_populated boolean;
+    missing_indexes text;
+    expected record;
+BEGIN
+    tables_are_populated :=
+        EXISTS (SELECT 1 FROM public.snapshot LIMIT 1)
+        OR EXISTS (SELECT 1 FROM public.sandbox LIMIT 1);
+
+    -- A fresh reset has no concurrent application writers. Still close the
+    -- theoretical check/build race before using ordinary CREATE INDEX: once
+    -- both tables are write-locked, recheck emptiness under that lock.
+    IF NOT tables_are_populated THEN
+        LOCK TABLE public.sandbox, public.snapshot IN SHARE MODE;
+        tables_are_populated :=
+            EXISTS (SELECT 1 FROM public.snapshot LIMIT 1)
+            OR EXISTS (SELECT 1 FROM public.sandbox LIMIT 1);
+    END IF;
+
+    SELECT string_agg(index_name, ', ' ORDER BY index_name)
+    INTO missing_indexes
+    FROM saved_snapshot_expected_index expected_index
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM pg_class index_object
+        JOIN pg_namespace index_namespace
+          ON index_namespace.oid = index_object.relnamespace
+        WHERE index_namespace.nspname = 'public'
+          AND index_object.relname = expected_index.index_name
+    );
+
+    IF tables_are_populated AND missing_indexes IS NOT NULL THEN
+        RAISE EXCEPTION
+            'populated snapshot/sandbox tables require concurrent prebuild of all saved-snapshot indexes; missing: %',
+            missing_indexes
+            USING HINT =
+                'Run scripts/prebuild-saved-snapshot-indexes.sql with psql, then retry this migration.';
+    END IF;
+
+    -- The ordinary build path exists only so local/CI schema resets can apply
+    -- the complete migration history to an empty database.
+    IF NOT tables_are_populated THEN
+        FOR expected IN
+            SELECT *
+            FROM saved_snapshot_expected_index
+            ORDER BY index_name
+        LOOP
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_class index_object
+                JOIN pg_namespace index_namespace
+                  ON index_namespace.oid = index_object.relnamespace
+                WHERE index_namespace.nspname = 'public'
+                  AND index_object.relname = expected.index_name
+            ) THEN
+                EXECUTE expected.definition;
+            END IF;
+        END LOOP;
+    END IF;
+
+    FOR expected IN
+        SELECT index_name
+        FROM saved_snapshot_expected_index
+        ORDER BY index_name
+    LOOP
+        PERFORM pg_temp.require_saved_snapshot_index(
+            expected.index_name,
+            true
+        );
+    END LOOP;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260729000011_saved_snapshot_contract.sql
+++ b/supabase/migrations/20260729000011_saved_snapshot_contract.sql
@@ -1,0 +1,277 @@
+-- Retire the legacy non-partial pause-checkpoint conflict target only after
+-- every saved-snapshot index is installed and the feature has remained dark.
+-- This establishes the PR3 control-plane release as the application rollback
+-- floor: older writers use ON CONFLICT (sandbox_id) without the new predicate.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+SELECT pg_advisory_xact_lock(20819, 20260729);
+
+-- Close enable/write TOCTOU windows around the final contract check. The lock
+-- order follows request handling: feature gates, sandbox lineage/operation
+-- state, then the snapshot row/index changed by pause finalization.
+LOCK TABLE public.feature_flag, public.team_feature_flag
+    IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.sandbox IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.snapshot IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+DECLARE
+    saved_snapshot_count bigint;
+    fork_count bigint;
+    operation_count bigint;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.feature_flag
+        WHERE key = 'sandbox_snapshots_v1'
+          AND NOT enabled
+    ) THEN
+        RAISE EXCEPTION
+            'saved-snapshot contract requires the global feature flag to exist and remain disabled';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.team_feature_flag
+        WHERE key = 'sandbox_snapshots_v1'
+          AND enabled
+    ) THEN
+        RAISE EXCEPTION
+            'saved-snapshot contract requires every team override to remain disabled';
+    END IF;
+
+    SELECT count(*)
+    INTO saved_snapshot_count
+    FROM public.snapshot
+    WHERE kind = 'saved';
+
+    SELECT count(*)
+    INTO fork_count
+    FROM public.sandbox
+    WHERE source_snapshot_id IS NOT NULL;
+
+    SELECT count(*)
+    INTO operation_count
+    FROM public.sandbox
+    WHERE snapshot_operation_id IS NOT NULL
+       OR snapshot_operation_started_at IS NOT NULL;
+
+    IF saved_snapshot_count <> 0
+       OR fork_count <> 0
+       OR operation_count <> 0
+    THEN
+        RAISE EXCEPTION
+            'saved-snapshot contract requires zero rollout residue (saved snapshots=%, forks=%, operations=%)',
+            saved_snapshot_count,
+            fork_count,
+            operation_count;
+    END IF;
+END;
+$$;
+
+-- Repeat migration 10's detailed table/access-method/unique/key/predicate and
+-- full-definition checks under the write locks. The contract must never
+-- retire the legacy target after index drift or damage.
+DO $$
+DECLARE
+    expected record;
+BEGIN
+    FOR expected IN
+        SELECT *
+        FROM (
+            VALUES
+            (
+                'snapshot_sandbox_runtime_unique',
+                'snapshot',
+                true,
+                ARRAY['sandbox_id']::text[],
+                '(kind = ''runtime_checkpoint''::snapshot_kind)',
+                'CREATE UNIQUE INDEX snapshot_sandbox_runtime_unique ON public.snapshot USING btree (sandbox_id) WHERE (kind = ''runtime_checkpoint''::snapshot_kind)'
+            ),
+            (
+                'snapshot_team_source_idempotency_unique',
+                'snapshot',
+                true,
+                ARRAY['team_id', 'sandbox_id', 'idempotency_key']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))',
+                'CREATE UNIQUE INDEX snapshot_team_source_idempotency_unique ON public.snapshot USING btree (team_id, sandbox_id, idempotency_key) WHERE ((kind = ''saved''::snapshot_kind) AND (idempotency_key IS NOT NULL))'
+            ),
+            (
+                'idx_snapshot_team_saved_created',
+                'snapshot',
+                false,
+                ARRAY['team_id', 'created_at', 'id']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+                'CREATE INDEX idx_snapshot_team_saved_created ON public.snapshot USING btree (team_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+            ),
+            (
+                'idx_snapshot_source_saved_created',
+                'snapshot',
+                false,
+                ARRAY['sandbox_id', 'created_at', 'id']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+                'CREATE INDEX idx_snapshot_source_saved_created ON public.snapshot USING btree (sandbox_id, created_at DESC, id DESC) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+            ),
+            (
+                'idx_snapshot_parent_saved',
+                'snapshot',
+                false,
+                ARRAY['parent_snapshot_id']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+                'CREATE INDEX idx_snapshot_parent_saved ON public.snapshot USING btree (parent_snapshot_id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+            ),
+            (
+                'idx_snapshot_saved_host',
+                'snapshot',
+                false,
+                ARRAY['host_id', 'status']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))',
+                'CREATE INDEX idx_snapshot_saved_host ON public.snapshot USING btree (host_id, status) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL))'
+            ),
+            (
+                'idx_snapshot_saved_reconcile',
+                'snapshot',
+                false,
+                ARRAY['status', 'updated_at', 'id']::text[],
+                '((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))',
+                'CREATE INDEX idx_snapshot_saved_reconcile ON public.snapshot USING btree (status, updated_at, id) WHERE ((kind = ''saved''::snapshot_kind) AND (deleted_at IS NULL) AND (status = ANY (ARRAY[''creating''::snapshot_status, ''deleting''::snapshot_status])))'
+            ),
+            (
+                'idx_sandbox_source_snapshot_pin',
+                'sandbox',
+                false,
+                ARRAY['source_snapshot_id']::text[],
+                '(source_snapshot_id IS NOT NULL)',
+                'CREATE INDEX idx_sandbox_source_snapshot_pin ON public.sandbox USING btree (source_snapshot_id) WHERE (source_snapshot_id IS NOT NULL)'
+            ),
+            (
+                'idx_sandbox_destroyed_snapshot_pin',
+                'sandbox',
+                false,
+                ARRAY['destroyed_at', 'id']::text[],
+                '((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))',
+                'CREATE INDEX idx_sandbox_destroyed_snapshot_pin ON public.sandbox USING btree (destroyed_at, id) WHERE ((source_snapshot_id IS NOT NULL) AND (destroyed_at IS NOT NULL))'
+            ),
+            (
+                'idx_sandbox_snapshot_operation',
+                'sandbox',
+                false,
+                ARRAY['snapshot_operation_started_at']::text[],
+                '((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))',
+                'CREATE INDEX idx_sandbox_snapshot_operation ON public.sandbox USING btree (snapshot_operation_started_at) WHERE ((snapshot_operation_id IS NOT NULL) AND (destroyed_at IS NULL))'
+            )
+        ) required(
+            index_name,
+            table_name,
+            is_unique,
+            key_columns,
+            predicate,
+            definition
+        )
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_index catalog
+            JOIN pg_class index_object
+              ON index_object.oid = catalog.indexrelid
+            JOIN pg_namespace index_namespace
+              ON index_namespace.oid = index_object.relnamespace
+            JOIN pg_class indexed_table
+              ON indexed_table.oid = catalog.indrelid
+            JOIN pg_namespace table_namespace
+              ON table_namespace.oid = indexed_table.relnamespace
+            JOIN pg_am access_method
+              ON access_method.oid = index_object.relam
+            WHERE index_namespace.nspname = 'public'
+              AND index_object.relname = expected.index_name
+              AND index_object.relkind = 'i'
+              AND table_namespace.nspname = 'public'
+              AND indexed_table.relname = expected.table_name
+              AND access_method.amname = 'btree'
+              AND catalog.indisunique = expected.is_unique
+              AND catalog.indisvalid
+              AND catalog.indisready
+              AND catalog.indislive
+              AND catalog.indimmediate
+              AND catalog.indnkeyatts =
+                  cardinality(expected.key_columns)
+              AND catalog.indnatts = catalog.indnkeyatts
+              AND catalog.indexprs IS NULL
+              AND ARRAY(
+                      SELECT pg_get_indexdef(
+                                 catalog.indexrelid,
+                                 key_position,
+                                 true
+                             )
+                      FROM generate_series(
+                               1,
+                               catalog.indnkeyatts
+                           ) AS key_position
+                      ORDER BY key_position
+                  ) = expected.key_columns
+              AND pg_get_expr(
+                      catalog.indpred,
+                      catalog.indrelid,
+                      false
+                  ) = expected.predicate
+              AND pg_get_indexdef(catalog.indexrelid) =
+                  expected.definition
+        ) THEN
+            RAISE EXCEPTION
+                'saved-snapshot contract index public.% is missing, invalid, or drifted',
+                expected.index_name;
+        END IF;
+    END LOOP;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_index catalog
+        JOIN pg_class index_object
+          ON index_object.oid = catalog.indexrelid
+        JOIN pg_namespace index_namespace
+          ON index_namespace.oid = index_object.relnamespace
+        JOIN pg_class indexed_table
+          ON indexed_table.oid = catalog.indrelid
+        JOIN pg_namespace table_namespace
+          ON table_namespace.oid = indexed_table.relnamespace
+        JOIN pg_am access_method
+          ON access_method.oid = index_object.relam
+        WHERE index_namespace.nspname = 'public'
+          AND index_object.relname = 'snapshot_sandbox_unique'
+          AND index_object.relkind = 'i'
+          AND table_namespace.nspname = 'public'
+          AND indexed_table.relname = 'snapshot'
+          AND access_method.amname = 'btree'
+          AND catalog.indisunique
+          AND catalog.indisvalid
+          AND catalog.indisready
+          AND catalog.indislive
+          AND catalog.indimmediate
+          AND catalog.indnkeyatts = 1
+          AND catalog.indnatts = 1
+          AND catalog.indexprs IS NULL
+          AND catalog.indpred IS NULL
+          AND pg_get_indexdef(
+                  catalog.indexrelid,
+                  1,
+                  true
+              ) = 'sandbox_id'
+          AND pg_get_indexdef(catalog.indexrelid) =
+              'CREATE UNIQUE INDEX snapshot_sandbox_unique ON public.snapshot USING btree (sandbox_id)'
+    ) THEN
+        RAISE EXCEPTION
+            'saved-snapshot contract requires the exact legacy snapshot_sandbox_unique conflict target';
+    END IF;
+END;
+$$;
+
+-- Keep this as the final operation in the bounded transaction. If the lock,
+-- dark-feature check, residue check, or catalog contract fails, PostgreSQL
+-- preserves the legacy writer target atomically.
+DROP INDEX public.snapshot_sandbox_unique;
+
+COMMIT;


### PR DESCRIPTION
## Stack

Stack 4/4. Depends on #286.

- #284 — database expand and host-admission safety
- #285 — immutable VMD capture/restore/delete
- #286 — saved-snapshot control plane
- This PR — contract indexes, public API contract, regression coverage, and staging ship gate

## What this ships

- Prebuilds and verifies the exact 10-index saved-snapshot contract with sequential `CREATE INDEX CONCURRENTLY`; manual recovery is invalid-index-only and fail-closed.
- Adds bounded migrations `20260729000010` and `20260729000011`. Migration 11 requires the feature globally dark, zero enabled team overrides, zero saved/fork/operation residue, exact index definitions, and drops the legacy pause index atomically and last.
- Publishes the named snapshot/fork OpenAPI contract, including direct lineage, nullable inheritance rules, host/path opacity, dependency conflicts, retryable host errors, and private preview isolation.
- Adds bounded saved-snapshot telemetry without snapshot IDs, host paths, or raw errors.
- Restores the full saved-snapshot database/API/security/race/observability regression suite.
- Adds a strict staging-only canary: one temporary team override, exact-main API/VMD restart binding, idempotent capture/accounting, active and paused capture, three independent forks plus nested fork, memory/files/private-preview/secret/network isolation, dependency-safe deletion, and fail-safe dark cleanup.

## Rollout gates

- Keep `sandbox_snapshots_v1` globally disabled and all team overrides disabled while merging/deploying.
- PR3 must already be serving every traffic cell before migration 11 runs. After migration 11, PR3 is the application rollback floor because the legacy `snapshot_sandbox_unique` conflict target is gone.
- Drain the staging VMD host and confirm no Firecracker processes before the one-time allowlisted XFS activation.
- Run `snapshot-canary.yml` only from the current `main` SHA after all four PRs are merged and deployed. The workflow temporarily enables only the staging system team and must finish with global dark plus zero enabled overrides.
- This PR does not enable saved snapshots in production.

## Rollback

Database changes are leave-forward. Turn the team gate off first, drain/clean up snapshot workloads, and roll application/VMD code back only within the documented compatibility floor. Never recreate the legacy index once named snapshots or forks exist.

## Validation

- PostgreSQL 16: fresh history, populated prebuild/adoption, dark/residue contract refusal, exact invalid-index recovery, valid/wrong-table drift refusal, and advisory-lock overlap timeout.
- `go test -p 1 -tags integration -count=1 -race -timeout 10m ./internal/integration ./cmd/migrate-team`
- `go test -count=1 -race ./cmd/controlplane ./internal/api ./internal/db ./internal/supervisor`
- `go vet ./cmd/controlplane ./internal/api ./internal/db ./internal/supervisor`
- Bash syntax, YAML parse, actionlint, OpenAPI sync tests, SQLC generation check, and `git diff --check`.
- Canary harness fault tests: exact dispatch success/missing-ID fail-closed and disposable-PostgreSQL state restoration for absent, null, false, failure, and pre-enabled override cases.
- Exact-head CI at `5c653e221d9850a5b5b60e13c5d50207bea09b35`: https://github.com/superserve-ai/sandbox/actions/runs/30471382451 ✅