### PR TITLE
fix(boxd): handle file close errors during HTTP upload

### DIFF
--- a/cmd/boxd/files_test.go
+++ b/cmd/boxd/files_test.go
@@ -774,3 +774,30 @@ func TestFileUpload_Success(t *testing.T) {
 	}
 }
 
+type enospcReader struct{}
+
+func (enospcReader) Read(p []byte) (int, error) {
+	return 0, syscall.ENOSPC
+}
+
+func (enospcReader) Close() error {
+	return nil
+}
+
+func TestFileUpload_StorageFull(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "partial.txt")
+	req := httptest.NewRequest(http.MethodPost, "/files?path="+url.QueryEscape(p), enospcReader{})
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+
+	if w.Code != http.StatusInsufficientStorage {
+		t.Fatalf("status = %d, want 507 (Insufficient Storage); body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "sandbox_storage_full") {
+		t.Errorf("body = %q, want code sandbox_storage_full", w.Body.String())
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("partial file %s still exists; want it to be removed on ENOSPC", p)
+	}
+}

--- a/cmd/boxd/files_test.go
+++ b/cmd/boxd/files_test.go
@@ -755,3 +755,22 @@ func TestServeDirAsZip_AbortsOnCanceledContext(t *testing.T) {
 		t.Fatalf("zip walk wrote %d entries after the context was canceled; want 0 (aborted)", len(zr.File))
 	}
 }
+
+func TestFileUpload_Success(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "upload.txt")
+	req := httptest.NewRequest(http.MethodPost, "/files?path="+url.QueryEscape(p), strings.NewReader("uploaded data"))
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	content, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if string(content) != "uploaded data" {
+		t.Errorf("content = %q, want %q", string(content), "uploaded data")
+	}
+}
+

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1419,7 +1419,10 @@ func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
 	}
 
 	written, err := io.Copy(f, r.Body)
-	f.Close()
+	closeErr := f.Close()
+	if err == nil {
+		err = closeErr
+	}
 	if err != nil {
 		// Remove the partial file — a truncated upload is never useful
 		// to the caller. This handles both ENOSPC (disk full) and


### PR DESCRIPTION
Closes #291

## Summary

- Capture return error from `f.Close()` in `cmd/boxd/main.go` (`handleFileUpload`).
- Add unit test `TestFileUpload_Success` in `cmd/boxd/files_test.go`.

## Why

When uploading files to a sandbox via `POST /files`, `boxd` streams data using `io.Copy(f, r.Body)` and closes the file descriptor with `f.Close()`. Because POSIX/Linux file writes are buffered in kernel page cache, disk space exhaustion (`syscall.ENOSPC`) or write-back errors during buffer flushing occur when `f.Close()` is invoked. Discarding `f.Close()`'s error allowed `handleFileUpload` to return `200 OK` to the client despite disk write failures, skipping cleanup of the truncated file and failing to return `507 Insufficient Storage` (`writeStorageFull`). Capturing `closeErr` ensures write-back errors trigger proper file removal and surface the correct storage error status.

## Test Plan

- [x] Build verification: `go test ./cmd/boxd` passed
- [x] Unit tests pass: `go test -v ./cmd/boxd` passed
- [x] Full test suite passes: `go test ./internal/... ./cmd/...` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @meAmitPatil @pavitrabhalla