### PR TITLE
fix(terraform): add cloud ids rollout

### DIFF
--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -201,11 +201,56 @@ jobs:
           scripts/smoke-test-region.sh staging us-central1
           echo "staging/us-central1 API deploy and smoke validation passed." >> "$GITHUB_STEP_SUMMARY"
 
+  production-us-central1-bootstrap:
+    name: Bootstrap production/us-central1 project services
+    runs-on: ubuntu-latest
+    environment: production
+    needs: [staging-us-central1-infra]
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TF_IN_AUTOMATION: 'true'
+      TF_VAR_notification_channel_ids: ${{ vars.TF_VAR_NOTIFICATION_CHANNEL_IDS || '[]' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Verify validation dependencies
+        run: |
+          set -euo pipefail
+          command -v jq
+          command -v curl
+
+      - name: Apply production/us-central1 project services
+        run: |
+          set -euo pipefail
+          echo "## Terraform rollout: production/us-central1 bootstrap" >> "$GITHUB_STEP_SUMMARY"
+          cd infra/envs/production/us-central1
+          terraform init -input=false
+          terraform validate
+          terraform plan -input=false \
+            -target=google_project_service.cloud_ids \
+            -target=google_project_service.compute \
+            -target=google_project_service.logging \
+            -target=google_project_service.monitoring \
+            -out=tfplan
+          terraform apply -input=false -auto-approve tfplan
+
   production-us-west2-infra:
     name: Apply production/us-west2
     runs-on: ubuntu-latest
     environment: production
-    needs: [staging-us-central1-api]
+    needs: [staging-us-central1-api, production-us-central1-bootstrap]
     permissions:
       contents: read
       id-token: write
@@ -375,7 +420,7 @@ jobs:
     name: Apply production/us-east4
     runs-on: ubuntu-latest
     environment: production
-    needs: [staging-us-central1-api]
+    needs: [staging-us-central1-api, production-us-central1-bootstrap]
     permissions:
       contents: read
       id-token: write

--- a/infra/CLOUD_IDS.md
+++ b/infra/CLOUD_IDS.md
@@ -1,0 +1,88 @@
+# Cloud IDS rollout
+
+This repository now models Cloud IDS as a combination of regional endpoint
+resources, packet mirroring, and log-based alerting that reuses the existing
+Cloud Monitoring notification channels.
+
+## Network disposition
+
+| Vanta-listed network | Disposition | Notes |
+| --- | --- | --- |
+| `superserve-production-vpc` | Active production VPC | Cloud IDS endpoints are deployed in `production/us-east4` and `production/us-west2`, mirroring the active VM host subnets in that shared VPC. |
+| `rayai-production-vpc` | Transitional legacy VPC | Still used by the existing Serverless VPC Access connector. Temporarily excluded from Vanta while connector migration and VPC retirement remain in progress. |
+| `default` | Temporarily retained with justification | The default VPC still hosts `prod-nat-router` in `us-west1`; Cloud IDS is not added until that router and the remaining default-network dependency are cleaned up or explicitly justified. |
+
+## Regional detail
+
+- `production/us-west2` creates the regional Cloud IDS endpoint, mirrors the
+  VM host subnet, and sends threat incidents to the existing monitored
+  channels. Cloud Run direct VPC egress is documented as not applicable to
+  Packet Mirroring.
+- `production/us-east4` creates the regional Cloud IDS endpoint, mirrors the
+  VM host subnet, and sends threat incidents to the existing monitored
+  channels. Cloud Run direct VPC egress is documented as not applicable to
+  Packet Mirroring.
+- `production/us-central1` remains the shared bootstrap networking root and
+  does not create a Cloud IDS endpoint.
+
+## Architecture
+
+- Cloud IDS runs per region because each endpoint is zonal and inspects traffic
+  from its own region.
+- Packet mirroring is limited to the production VM subnet in that region.
+- Cloud Run Direct VPC egress is not supported by Packet Mirroring, so that
+  traffic path is handled separately and is not claimed as packet-level IDS
+  coverage here.
+- The shared Private Service Access prerequisite for Cloud IDS is managed
+  outside this repository and must be confirmed before the first apply.
+- Threat findings are surfaced through a log-based Cloud Monitoring alert so
+  notifications can reuse the existing monitored destination without adding a
+  webhook secret to Terraform state.
+
+## Cost estimate
+
+Cloud IDS pricing is currently:
+
+- $1.50 per hour per running endpoint
+- $0.07 per GiB inspected by the endpoint
+- Packet Mirroring is included in the Cloud IDS per-GiB inspection price, so
+  there is no separate packet-mirroring charge
+
+For the current two active regional endpoints, the fixed monthly floor is about
+`2 * 24 * 30 * $1.50 = $2,160` before traffic-based charges.
+
+Additional indirect costs can come from Cloud Logging storage if the threat log
+volume grows enough to exceed the free allotment.
+
+## Validation
+
+Run these checks before any apply:
+
+```sh
+terraform fmt -check -recursive infra
+terraform -chdir=infra/envs/production/us-west2 plan -input=false -no-color
+terraform -chdir=infra/envs/production/us-east4 plan -input=false -no-color
+```
+
+Confirm the shared service-networking connection and reserved range exist
+outside this repo before the first Cloud IDS apply; do not create them here.
+
+After the endpoints are live, locate a real IDS threat log in Cloud Logging and
+confirm the alert policy matches the same `logName`, `resource.type`, and
+`resource.labels.id` values before relying on notification delivery.
+
+## Rollback
+
+1. Remove the regional IDS endpoint and packet mirroring resources first.
+2. Remove the log-based alert policy after the endpoints are gone.
+3. Keep the shared Private Service Access plumbing outside this repo unless a
+   separate bootstrap workflow owns its lifecycle, and remove it only after the
+   last endpoint is deleted and the VPC no longer needs Cloud IDS.
+4. Re-run the same plans to confirm Terraform only wants to remove the intended
+   objects.
+
+## Recheck
+
+After the plan is applied, re-run the two Cloud IDS Vanta checks and verify
+that the alert policy delivers to the monitored destination used by the other
+production infrastructure alerts.

--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -20,6 +20,30 @@ provider "google" {
   # impersonate_service_account = "terraform@rayai-dev.iam.gserviceaccount.com"
 }
 
+resource "google_project_service" "cloud_ids" {
+  project            = local.project_id
+  service            = "ids.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "compute" {
+  project            = local.project_id
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "logging" {
+  project            = local.project_id
+  service            = "logging.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "monitoring" {
+  project            = local.project_id
+  service            = "monitoring.googleapis.com"
+  disable_on_destroy = false
+}
+
 locals {
   project_id                = var.project_id
   environment               = var.environment

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -20,6 +20,12 @@ provider "google" {
 }
 
 locals {
+  cloud_ids_mirrored_subnet_self_links = [
+    module.network.subnetwork_self_link,
+  ]
+}
+
+locals {
   project_id             = var.project_id
   environment            = var.environment
   region                 = var.region
@@ -229,6 +235,19 @@ module "api_cert_lb" {
   # created it imperatively and its exact name was not captured. Correct this
   # value to match `gcloud compute network-endpoint-groups list` output first.
   neg_name = "superserve-api-use4-neg"
+}
+
+module "cloud_ids" {
+  source = "../../../modules/cloud-ids"
+
+  project_id                 = local.project_id
+  region                     = local.region
+  zone                       = local.zone
+  network_self_link          = module.network.network_self_link
+  endpoint_name              = "superserve-ids-${local.resource_suffix}"
+  mirrored_subnet_self_links = local.cloud_ids_mirrored_subnet_self_links
+  notification_channel_ids   = var.notification_channel_ids
+  labels                     = local.common_labels
 }
 
 module "sandbox_host" {

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -21,6 +21,12 @@ provider "google" {
 }
 
 locals {
+  cloud_ids_mirrored_subnet_self_links = [
+    module.network.subnetwork_self_link,
+  ]
+}
+
+locals {
   project_id             = var.project_id
   environment            = var.environment
   region                 = var.region
@@ -253,4 +259,17 @@ module "backup_storage" {
     "vanta-contains-user-data" = "true"
     "vanta-user-data-stored"   = "customer_sandbox_snapshots_and_files"
   })
+}
+
+module "cloud_ids" {
+  source = "../../../modules/cloud-ids"
+
+  project_id                 = local.project_id
+  region                     = local.region
+  zone                       = local.zone
+  network_self_link          = module.network.network_self_link
+  endpoint_name              = "superserve-ids-${local.resource_suffix}"
+  mirrored_subnet_self_links = local.cloud_ids_mirrored_subnet_self_links
+  notification_channel_ids   = var.notification_channel_ids
+  labels                     = local.common_labels
 }

--- a/infra/modules/cloud-ids/main.tf
+++ b/infra/modules/cloud-ids/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_version = ">= 1.5.0"
+}
+
+resource "google_cloud_ids_endpoint" "this" {
+  project     = var.project_id
+  name        = var.endpoint_name
+  network     = var.network_self_link
+  location    = var.zone
+  severity    = var.endpoint_severity
+  description = var.endpoint_description
+}
+
+resource "google_compute_packet_mirroring" "this" {
+  project = var.project_id
+  region  = var.region
+  name    = "${var.endpoint_name}-mirror"
+
+  network {
+    url = var.network_self_link
+  }
+
+  collector_ilb {
+    url = google_cloud_ids_endpoint.this.endpoint_forwarding_rule
+  }
+
+  mirrored_resources {
+    dynamic "subnetworks" {
+      for_each = var.mirrored_subnet_self_links
+
+      content {
+        url = subnetworks.value
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "ids_threats" {
+  project               = var.project_id
+  display_name          = "Security / ${var.endpoint_name} / Cloud IDS threats"
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.notification_channel_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(var.notification_channel_ids) > 0
+      error_message = "notification_channel_ids must contain an existing monitored channel for Cloud IDS alerts"
+    }
+    precondition {
+      condition = alltrue([
+        for channel_id in var.notification_channel_ids : can(regex(
+          "^projects/${var.project_id}/notificationChannels/[0-9]+$",
+          channel_id
+        ))
+      ])
+      error_message = "notification_channel_ids must reference monitored channels in the configured project using full resource names"
+    }
+  }
+
+  conditions {
+    display_name = "${var.endpoint_name} threat log"
+
+    condition_matched_log {
+      filter = <<-EOT
+        log_id("ids.googleapis.com/threat")
+        AND resource.type="ids.googleapis.com/Endpoint"
+        AND resource.labels.id="${var.endpoint_name}"
+      EOT
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content   = <<-EOT
+      Cloud IDS reported a threat on ${var.endpoint_name}.
+
+      Owner: Infrastructure Operations. Response: review the threat log in Cloud Logging, inspect the mirrored source and destination traffic, confirm whether the finding is expected, and record the remediation or suppression decision before closing the incident.
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type = "cloud_ids_threat_activity"
+    endpoint   = var.endpoint_name
+    managed_by = "terraform"
+  })
+}

--- a/infra/modules/cloud-ids/outputs.tf
+++ b/infra/modules/cloud-ids/outputs.tf
@@ -1,0 +1,19 @@
+output "endpoint_name" {
+  description = "Cloud IDS endpoint name."
+  value       = google_cloud_ids_endpoint.this.name
+}
+
+output "endpoint_forwarding_rule" {
+  description = "Cloud IDS endpoint forwarding rule."
+  value       = google_cloud_ids_endpoint.this.endpoint_forwarding_rule
+}
+
+output "packet_mirroring_name" {
+  description = "Packet mirroring policy name."
+  value       = google_compute_packet_mirroring.this.name
+}
+
+output "alert_policy_name" {
+  description = "Cloud IDS alert policy name."
+  value       = google_monitoring_alert_policy.ids_threats.name
+}

--- a/infra/modules/cloud-ids/variables.tf
+++ b/infra/modules/cloud-ids/variables.tf
@@ -1,0 +1,53 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = "Region that owns the packet mirroring policy."
+  type        = string
+}
+
+variable "zone" {
+  description = "Zonal Cloud IDS endpoint location."
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "VPC self link used by the IDS endpoint and packet mirroring policy."
+  type        = string
+}
+
+variable "endpoint_name" {
+  description = "Cloud IDS endpoint name."
+  type        = string
+}
+
+variable "mirrored_subnet_self_links" {
+  description = "Subnet self links mirrored into Cloud IDS."
+  type        = list(string)
+}
+
+variable "notification_channel_ids" {
+  description = "Existing Cloud Monitoring notification channel resource names."
+  type        = list(string)
+  default     = []
+}
+
+variable "endpoint_severity" {
+  description = "Minimum Cloud IDS severity to report."
+  type        = string
+  default     = "INFORMATIONAL"
+}
+
+variable "endpoint_description" {
+  description = "Optional Cloud IDS endpoint description."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Labels to apply to supported resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
fix(terraform): add cloud ids rollout

- Add Cloud IDS endpoints to `us-east4` and `us-west2`.
- Bootstrap the shared Cloud IDS project services from `us-central1` before the regional applies.
- Document the Cloud IDS rollout, validation steps, and Vanta network disposition.

Validation:
- `terraform fmt -check -recursive infra`
- `git diff --check`

Notes:
- The branch was trimmed to Cloud IDS-only changes.
- No unrelated rollout, IAM, or account changes remain in the diff.