### PR TITLE
api: keep host capability and preview policy reads off the request hot paths

### DIFF
--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -80,6 +80,34 @@ SELECT EXISTS (
   )
 );
 
+-- name: HostHasCapabilitiesUnlocked :one
+-- HostHasCapabilities without the row lock, for standalone pre-flight reads
+-- outside a mutation transaction: omitting the lock keeps concurrent checks
+-- from serializing behind the host's heartbeat writer. Transactional callers
+-- that must pin the host across a commit use HostHasCapabilities.
+WITH target_host AS MATERIALIZED (
+  SELECT id, last_heartbeat_at
+  FROM host
+  WHERE id = sqlc.arg('host_id')
+    AND status = 'active'
+    AND last_heartbeat_at IS NOT NULL
+)
+SELECT EXISTS (
+  SELECT 1
+  FROM target_host h
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM unnest(sqlc.arg('required_capabilities')::text[]) AS required(capability)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM host_capability hc
+      WHERE hc.host_id = h.id
+        AND hc.capability = required.capability
+        AND hc.heartbeat_at = h.last_heartbeat_at
+    )
+  )
+);
+
 -- name: MarkHostUnhealthy :exec
 UPDATE host
 SET status = 'unhealthy', updated_at = now()

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -445,6 +445,15 @@ FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
 WHERE s.id = $1 AND s.team_id = $2 AND s.destroyed_at IS NULL;
 
+-- name: GetSandboxWithPreviewPolicy :one
+-- GetSandbox plus the effective preview access, so read endpoints return
+-- both in one round-trip.
+SELECT sqlc.embed(s),
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.id = $1 AND s.team_id = $2 AND s.destroyed_at IS NULL;
+
 -- name: ListSandboxPreviewPoliciesByTeam :many
 SELECT
   s.id AS sandbox_id,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -92,6 +92,11 @@ type Handlers struct {
 	// across requests. Built lazily from Pool on first use.
 	authzOnce sync.Once
 	authzSvc  *authz.Service
+
+	// hostCaps is the positive-only host-capability attestation cache used by
+	// the standalone pre-flight checks (see hostcap_cache.go). Zero value is
+	// ready to use.
+	hostCaps hostCapCache
 }
 
 // asyncBookkeeping runs fire-and-forget post-VMD work in a background
@@ -976,18 +981,27 @@ func (h *Handlers) ActivateSandbox(c *gin.Context) {
 		return
 	}
 
+	sandboxID, err := parseSandboxID(c)
+	if err != nil {
+		return
+	}
+
+	// Activate is the highest-volume lifecycle endpoint; overlap the policy
+	// read with the sandbox load so the no-op refresh stays one round-trip.
+	policyCh := h.loadPreviewPolicyAsync(c.Request.Context(), sandboxID, teamID)
+
 	sandbox := h.loadActiveOrResumeSandbox(c)
+	pr := <-policyCh
 	if sandbox == nil {
 		return
 	}
-	policy, err := h.loadPreviewPolicy(c.Request.Context(), sandbox.ID, teamID)
-	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("DB GetSandboxPreviewPolicy failed")
+	if pr.err != nil {
+		log.Error().Err(pr.err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxPreviewPolicy failed")
 		respondError(c, ErrInternal)
 		return
 	}
 	resp := h.sandboxToResponseWithToken(*sandbox)
-	resp.PreviewAccess = policy.Access
+	resp.PreviewAccess = pr.policy.Access
 	c.JSON(http.StatusOK, resp)
 }
 
@@ -1585,10 +1599,15 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 		return
 	}
 
+	// Overlap the preview-policy read with the sandbox read — independent, both
+	// keyed on (sandbox, team) — so it stays off this endpoint's critical path.
+	policyCh := h.loadPreviewPolicyAsync(c.Request.Context(), sandboxID, teamID)
+
 	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
 		ID:     sandboxID,
 		TeamID: teamID,
 	})
+	pr := <-policyCh
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			respondError(c, ErrSandboxNotFound)
@@ -1600,13 +1619,12 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 	}
 
 	resp := h.sandboxToResponse(sandbox)
-	policy, err := h.loadPreviewPolicy(c.Request.Context(), sandboxID, teamID)
-	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxPreviewPolicy failed")
+	if pr.err != nil {
+		log.Error().Err(pr.err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxPreviewPolicy failed")
 		respondError(c, ErrInternal)
 		return
 	}
-	resp.PreviewAccess = policy.Access
+	resp.PreviewAccess = pr.policy.Access
 	canWrite, permErr := h.customerTeamPermissionAllowed(c, teamID, "settings:write")
 	if permErr != nil {
 		log.Error().
@@ -1616,7 +1634,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 			Msg("RBAC sandbox token permission check failed")
 	} else if canWrite {
 		resp = h.sandboxToResponseWithToken(sandbox)
-		resp.PreviewAccess = policy.Access
+		resp.PreviewAccess = pr.policy.Access
 	}
 	if !isConsoleImpersonation(c) {
 		resp.Secrets = h.fetchSandboxSecretBindings(c.Request.Context(), sandboxID)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -465,7 +465,7 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 			if err == pgx.ErrNoRows {
 				respondError(c, ErrSandboxNotFound)
 			} else {
-				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxWithPreviewPolicy failed")
 				respondError(c, ErrInternal)
 			}
 			return nil, ""
@@ -475,21 +475,14 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 		case db.SandboxStatusActive:
 			return &sandbox, row.Access
 		case db.SandboxStatusPaused:
-			if !h.resumePausedSandbox(c, &sandbox, teamID) {
+			// The resume returns the post-restore access it pushed to VMD, so
+			// the response reports exactly what the VM enforces.
+			resumedAccess, ok := h.resumePausedSandbox(c, &sandbox, teamID)
+			if !ok {
 				return nil, ""
 			}
 			sandbox.Status = db.SandboxStatusActive
-			// Re-read the policy: a mutation can land during the multi-second
-			// resume, and the pre-resume snapshot would misreport it. Best-effort
-			// — a failed re-read serves the snapshot rather than failing a
-			// completed resume.
-			if fresh, ferr := h.DB.GetSandboxWithPreviewPolicy(c.Request.Context(), db.GetSandboxWithPreviewPolicyParams{
-				ID:     sandboxID,
-				TeamID: teamID,
-			}); ferr == nil {
-				return &sandbox, fresh.Access
-			}
-			return &sandbox, row.Access
+			return &sandbox, resumedAccess
 		case db.SandboxStatusStarting, db.SandboxStatusResuming:
 			// Likely the fire-and-forget activate write in flight (or a
 			// concurrent create/resume finishing); wait for the flip
@@ -511,13 +504,13 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 // the sandbox to active. Starts with an atomic paused→resuming DB claim so
 // concurrent resumes don't both call VMD; the loser gets 409. On any failure
 // after VMD resume succeeds, destroys the VM + reverts to paused.
-func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, teamID uuid.UUID) bool {
+func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, teamID uuid.UUID) (string, bool) {
 	sandboxID := sandbox.ID
 
 	if !sandbox.SnapshotID.Valid {
 		log.Error().Str("sandbox_id", sandboxID.String()).Msg("paused sandbox has no snapshot_id")
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 
 	// Resolve the effective policy before claiming the sandbox. A missing
@@ -528,11 +521,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	if err != nil {
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("load preview policy for resume failed")
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 	if resumePolicy.requiresBrowserCapability() {
 		if !h.requireHostPreviewPortBrowserAuth(c, sandbox.HostID) {
-			return false
+			return "", false
 		}
 		// A Phase 2 VMD may still hold a raw-private snapshot at the previous
 		// revision. Advance under the sandbox row lock before restoring so the
@@ -545,11 +538,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		})
 		if err != nil {
 			if !h.handlePreviewMutationResult(c, sandboxID, "ActivatePreviewBrowserAuthForResume", err) {
-				return false
+				return "", false
 			}
 		}
 	} else if resumePolicy.Access != preview.AccessLegacyPublic && !h.requireHostPreviewPorts(c, sandbox.HostID) {
-		return false
+		return "", false
 	}
 	resumeVMDAccess := resumePolicy.vmdAccess()
 
@@ -585,16 +578,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// Someone else is already resuming, or the sandbox is no longer
 			// in paused state. Surface as conflict; client retries.
 			respondError(c, ErrInvalidState)
-			return false
+			return "", false
 		}
 		if isSandboxQuotaErr(err) {
 			// Resuming re-enters the active set; the team is already at its limit.
 			h.respondQuotaExceeded(c, teamID)
-			return false
+			return "", false
 		}
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB BeginResume failed")
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 	*sandbox = claimed
 
@@ -618,7 +611,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
 		revertToPaused()
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 
 	snapshotPath := snapshot.Path
@@ -645,7 +638,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for resume failed")
 		revertToPaused()
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 
 	// The snapshot carries the agent's HTTPS_PROXY (with its JWT) and stand-in
@@ -681,14 +674,14 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 				// reaps the paused-row/active-VM state if no retry comes.
 				revertToPaused()
 				respondError(c, ErrInternal)
-				return false
+				return "", false
 			}
 		} else {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
 			// Same deliberate no-destroy as the fallback branch above.
 			revertToPaused()
 			respondError(c, ErrInternal)
-			return false
+			return "", false
 		}
 	}
 
@@ -758,7 +751,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		log.Error().Err(policyErr).Str("sandbox_id", sandboxID.String()).Msg("reload preview policy after resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 	// A private publication may have changed while the VM was restoring. Gate
 	// the final authoritative reapply against the host's current browser
@@ -768,7 +761,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		if capabilityErr := validateHostPreviewBrowserCapabilities(postCtx, h.DB, sandbox.HostID); capabilityErr != nil {
 			pauseAndRevert()
 			h.handlePreviewMutationResult(c, sandboxID, "ReapplyPreviewBrowserAuthAfterResume", capabilityErr)
-			return false
+			return "", false
 		}
 	}
 	if policyErr = vmd.UpdateSandboxPreviewPolicy(postCtx, sandboxID.String(), currentPolicy.vmdAccess(), currentPolicy.vmdPorts(), currentPolicy.Revision); policyErr != nil {
@@ -781,7 +774,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			log.Error().Err(policyErr).Str("sandbox_id", sandboxID.String()).Msg("reapply preview policy after resume failed")
 			pauseAndRevert()
 			respondError(c, ErrInternal)
-			return false
+			return "", false
 		}
 	}
 
@@ -791,7 +784,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	}
 
 	// Re-apply the current binding set before committing to 'active', so a secret
@@ -803,13 +796,13 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		log.Error().Err(merr).Str("sandbox_id", sandboxID.String()).Msg("load secret bindings on resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
-		return false
+		return "", false
 	} else if len(meta) > 0 {
 		if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
 			log.Error().Err(aerr).Str("sandbox_id", sandboxID.String()).Msg("reapply secret bindings on resume failed")
 			pauseAndRevert()
 			respondError(c, ErrInternal)
-			return false
+			return "", false
 		}
 	}
 
@@ -844,7 +837,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
-	return true
+	return currentPolicy.Access, true
 }
 
 // resolveMemPath returns the memory snapshot path from a Snapshot record.
@@ -1036,7 +1029,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 
-	if !h.resumePausedSandbox(c, &sandbox, teamID) {
+	if _, ok := h.resumePausedSandbox(c, &sandbox, teamID); !ok {
 		return
 	}
 
@@ -1605,7 +1598,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 			respondError(c, ErrSandboxNotFound)
 			return
 		}
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxWithPreviewPolicy failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -1820,8 +1813,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	SetTelemetryHostID(c, hostID)
 
 	// Re-attest after placement. The scheduler cache and the default-host path
-	// are only hints; heartbeat capability state can change between selection
-	// and VM creation.
+	// are only hints; this re-check is fresher (attestation-cache TTL vs the
+	// scheduler's candidate TTL), and VMD's post-boot policy attestation
+	// remains the fail-closed gate.
 	if previewAccess == preview.AccessPrivate {
 		if !h.requireHostPreviewPortBrowserAuth(c, hostID) {
 			return

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -444,19 +444,20 @@ func (h *Handlers) loadActiveSandbox(c *gin.Context) *db.Sandbox {
 // loadActiveOrResumeSandbox is like loadActiveSandbox but auto-resumes a
 // paused sandbox, and waits out the activate settle window on a
 // starting/resuming row before giving up. Any other non-active state
-// returns 409.
-func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
+// returns 409. Also returns the sandbox's effective preview access (read in
+// the same round-trip); "" when the sandbox is nil.
+func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, string) {
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {
-		return nil
+		return nil, ""
 	}
 	teamID, err := teamIDFromContext(c)
 	if err != nil {
-		return nil
+		return nil, ""
 	}
 	deadline := time.Now().Add(activateSettleWindow)
 	for {
-		sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+		row, err := h.DB.GetSandboxWithPreviewPolicy(c.Request.Context(), db.GetSandboxWithPreviewPolicyParams{
 			ID:     sandboxID,
 			TeamID: teamID,
 		})
@@ -467,17 +468,28 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
 				respondError(c, ErrInternal)
 			}
-			return nil
+			return nil, ""
 		}
+		sandbox := row.Sandbox
 		switch sandbox.Status {
 		case db.SandboxStatusActive:
-			return &sandbox
+			return &sandbox, row.Access
 		case db.SandboxStatusPaused:
 			if !h.resumePausedSandbox(c, &sandbox, teamID) {
-				return nil
+				return nil, ""
 			}
 			sandbox.Status = db.SandboxStatusActive
-			return &sandbox
+			// Re-read the policy: a mutation can land during the multi-second
+			// resume, and the pre-resume snapshot would misreport it. Best-effort
+			// — a failed re-read serves the snapshot rather than failing a
+			// completed resume.
+			if fresh, ferr := h.DB.GetSandboxWithPreviewPolicy(c.Request.Context(), db.GetSandboxWithPreviewPolicyParams{
+				ID:     sandboxID,
+				TeamID: teamID,
+			}); ferr == nil {
+				return &sandbox, fresh.Access
+			}
+			return &sandbox, row.Access
 		case db.SandboxStatusStarting, db.SandboxStatusResuming:
 			// Likely the fire-and-forget activate write in flight (or a
 			// concurrent create/resume finishing); wait for the flip
@@ -487,10 +499,10 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) *db.Sandbox {
 				continue
 			}
 			respondError(c, ErrInvalidState)
-			return nil
+			return nil, ""
 		default:
 			respondError(c, ErrInvalidState)
-			return nil
+			return nil, ""
 		}
 	}
 }
@@ -981,27 +993,12 @@ func (h *Handlers) ActivateSandbox(c *gin.Context) {
 		return
 	}
 
-	sandboxID, err := parseSandboxID(c)
-	if err != nil {
-		return
-	}
-
-	// Activate is the highest-volume lifecycle endpoint; overlap the policy
-	// read with the sandbox load so the no-op refresh stays one round-trip.
-	policyCh := h.loadPreviewPolicyAsync(c.Request.Context(), sandboxID, teamID)
-
-	sandbox := h.loadActiveOrResumeSandbox(c)
-	pr := <-policyCh
+	sandbox, previewAccess := h.loadActiveOrResumeSandbox(c)
 	if sandbox == nil {
 		return
 	}
-	if pr.err != nil {
-		log.Error().Err(pr.err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxPreviewPolicy failed")
-		respondError(c, ErrInternal)
-		return
-	}
 	resp := h.sandboxToResponseWithToken(*sandbox)
-	resp.PreviewAccess = pr.policy.Access
+	resp.PreviewAccess = previewAccess
 	c.JSON(http.StatusOK, resp)
 }
 
@@ -1599,15 +1596,10 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 		return
 	}
 
-	// Overlap the preview-policy read with the sandbox read — independent, both
-	// keyed on (sandbox, team) — so it stays off this endpoint's critical path.
-	policyCh := h.loadPreviewPolicyAsync(c.Request.Context(), sandboxID, teamID)
-
-	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+	row, err := h.DB.GetSandboxWithPreviewPolicy(c.Request.Context(), db.GetSandboxWithPreviewPolicyParams{
 		ID:     sandboxID,
 		TeamID: teamID,
 	})
-	pr := <-policyCh
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			respondError(c, ErrSandboxNotFound)
@@ -1617,14 +1609,10 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	sandbox := row.Sandbox
 
 	resp := h.sandboxToResponse(sandbox)
-	if pr.err != nil {
-		log.Error().Err(pr.err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxPreviewPolicy failed")
-		respondError(c, ErrInternal)
-		return
-	}
-	resp.PreviewAccess = pr.policy.Access
+	resp.PreviewAccess = row.Access
 	canWrite, permErr := h.customerTeamPermissionAllowed(c, teamID, "settings:write")
 	if permErr != nil {
 		log.Error().
@@ -1634,7 +1622,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 			Msg("RBAC sandbox token permission check failed")
 	} else if canWrite {
 		resp = h.sandboxToResponseWithToken(sandbox)
-		resp.PreviewAccess = pr.policy.Access
+		resp.PreviewAccess = row.Access
 	}
 	if !isConsoleImpersonation(c) {
 		resp.Secrets = h.fetchSandboxSecretBindings(c.Request.Context(), sandboxID)
@@ -2499,7 +2487,7 @@ func (h *Handlers) ListSandboxFiles(c *gin.Context) {
 		return
 	}
 
-	sandbox := h.loadActiveOrResumeSandbox(c)
+	sandbox, _ := h.loadActiveOrResumeSandbox(c)
 	if sandbox == nil {
 		return
 	}

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -93,6 +93,23 @@ func (h *Handlers) loadPreviewPolicy(ctx context.Context, sandboxID, teamID uuid
 	return previewPolicySnapshot{Access: row.Access, WireAccess: row.WireAccess, Revision: row.Revision}, nil
 }
 
+type previewPolicyResult struct {
+	policy previewPolicySnapshot
+	err    error
+}
+
+// loadPreviewPolicyAsync overlaps the policy read with the caller's sandbox
+// load (both keyed on sandbox+team, independent) instead of paying the two
+// round-trips serially. Buffered, so an unread result never leaks the goroutine.
+func (h *Handlers) loadPreviewPolicyAsync(ctx context.Context, sandboxID, teamID uuid.UUID) <-chan previewPolicyResult {
+	ch := make(chan previewPolicyResult, 1)
+	go func() {
+		policy, err := h.loadPreviewPolicy(ctx, sandboxID, teamID)
+		ch <- previewPolicyResult{policy: policy, err: err}
+	}()
+	return ch
+}
+
 func (h *Handlers) loadPreviewPolicySnapshot(ctx context.Context, sandboxID, teamID uuid.UUID) (previewPolicySnapshot, error) {
 	policy, err := h.loadPreviewPolicy(ctx, sandboxID, teamID)
 	if err != nil {
@@ -332,10 +349,12 @@ func (h *Handlers) pushPreviewCredentialPolicy(ctx context.Context, sandbox db.S
 	return "delivered", nil
 }
 
+// requireHostPreviewCapabilities is the standalone request-path pre-flight,
+// served from the positive-only attestation cache (hostcap_cache.go).
+// Authoritative enforcement stays with VMD's post-boot attestation and the
+// transactional validateHostPreviewCapabilities on mutations.
 func (h *Handlers) requireHostPreviewCapabilities(c *gin.Context, hostID string, capabilities ...string) bool {
-	hasCapabilities, err := h.DB.HostHasCapabilities(c.Request.Context(), db.HostHasCapabilitiesParams{
-		HostID: hostID, RequiredCapabilities: capabilities,
-	})
+	hasCapabilities, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, capabilities)
 	if err != nil {
 		log.Error().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).Msg("DB HostHasCapabilities failed")
 		respondError(c, ErrInternal)

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -93,23 +93,6 @@ func (h *Handlers) loadPreviewPolicy(ctx context.Context, sandboxID, teamID uuid
 	return previewPolicySnapshot{Access: row.Access, WireAccess: row.WireAccess, Revision: row.Revision}, nil
 }
 
-type previewPolicyResult struct {
-	policy previewPolicySnapshot
-	err    error
-}
-
-// loadPreviewPolicyAsync overlaps the policy read with the caller's sandbox
-// load (both keyed on sandbox+team, independent) instead of paying the two
-// round-trips serially. Buffered, so an unread result never leaks the goroutine.
-func (h *Handlers) loadPreviewPolicyAsync(ctx context.Context, sandboxID, teamID uuid.UUID) <-chan previewPolicyResult {
-	ch := make(chan previewPolicyResult, 1)
-	go func() {
-		policy, err := h.loadPreviewPolicy(ctx, sandboxID, teamID)
-		ch <- previewPolicyResult{policy: policy, err: err}
-	}()
-	return ch
-}
-
 func (h *Handlers) loadPreviewPolicySnapshot(ctx context.Context, sandboxID, teamID uuid.UUID) (previewPolicySnapshot, error) {
 	policy, err := h.loadPreviewPolicy(ctx, sandboxID, teamID)
 	if err != nil {

--- a/internal/api/handlers_preview_test.go
+++ b/internal/api/handlers_preview_test.go
@@ -252,7 +252,7 @@ func TestPatchPreviewAccessPersistsPrivateDefaultAndPreservesPortModes(t *testin
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPublic, 0)
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				capabilityRequirements = append(capabilityRequirements, append([]string(nil), args[0].([]string)...))
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
@@ -329,7 +329,7 @@ func TestPublishPreviewPortRejectsHostWithoutCapabilityBeforeMutation(t *testing
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPublic, 0)
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				return scalarBoolRow(false)
 			case strings.Contains(sql, "AdvanceSandboxPreviewPolicy"), strings.Contains(sql, "PublishPort"), strings.Contains(sql, "LockSandboxForPreviewMutation"):
 				mutated = true
@@ -387,7 +387,7 @@ func TestPublishPrivatePreviewPathsRequireBrowserCapabilityBeforeMutation(t *tes
 						return sandboxRow(sandbox)
 					case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 						return previewPolicyRow(tt.defaultMode, 0)
-					case strings.Contains(sql, "-- name: HostHasCapabilities"):
+					case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 						gotCapabilities = append([]string(nil), args[0].([]string)...)
 						return scalarBoolRow(!slices.Contains(gotCapabilities, preview.HostCapabilityPortBrowserAuth))
 					default:
@@ -438,7 +438,7 @@ func TestPublishPreviewPortOmissionPreservesPrivateModeAndPushesRestrictiveSnaps
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRowWithWire(preview.AccessPublic, preview.AccessPrivate, 10)
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
 				return scalarUUIDRow(sandboxID)
@@ -729,7 +729,7 @@ func newPreviewCredentialTestEnv(t *testing.T) *previewCredentialTestEnv {
 				}}
 			case strings.Contains(sql, "-- name: GetPublishedPreviewPort :one"):
 				return getPortRow()
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				required, _ := args[0].([]string)
 				e.capabilityChecks = append(e.capabilityChecks, append([]string(nil), required...))
 				available := true

--- a/internal/api/handlers_preview_test.go
+++ b/internal/api/handlers_preview_test.go
@@ -252,7 +252,7 @@ func TestPatchPreviewAccessPersistsPrivateDefaultAndPreservesPortModes(t *testin
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPublic, 0)
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				capabilityRequirements = append(capabilityRequirements, append([]string(nil), args[0].([]string)...))
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
@@ -329,7 +329,7 @@ func TestPublishPreviewPortRejectsHostWithoutCapabilityBeforeMutation(t *testing
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPublic, 0)
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				return scalarBoolRow(false)
 			case strings.Contains(sql, "AdvanceSandboxPreviewPolicy"), strings.Contains(sql, "PublishPort"), strings.Contains(sql, "LockSandboxForPreviewMutation"):
 				mutated = true
@@ -387,7 +387,7 @@ func TestPublishPrivatePreviewPathsRequireBrowserCapabilityBeforeMutation(t *tes
 						return sandboxRow(sandbox)
 					case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 						return previewPolicyRow(tt.defaultMode, 0)
-					case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+					case strings.Contains(sql, "-- name: HostHasCapabilities"):
 						gotCapabilities = append([]string(nil), args[0].([]string)...)
 						return scalarBoolRow(!slices.Contains(gotCapabilities, preview.HostCapabilityPortBrowserAuth))
 					default:
@@ -438,7 +438,7 @@ func TestPublishPreviewPortOmissionPreservesPrivateModeAndPushesRestrictiveSnaps
 				return sandboxRow(sandbox)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRowWithWire(preview.AccessPublic, preview.AccessPrivate, 10)
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
 				return scalarUUIDRow(sandboxID)
@@ -729,7 +729,7 @@ func newPreviewCredentialTestEnv(t *testing.T) *previewCredentialTestEnv {
 				}}
 			case strings.Contains(sql, "-- name: GetPublishedPreviewPort :one"):
 				return getPortRow()
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				required, _ := args[0].([]string)
 				e.capabilityChecks = append(e.capabilityChecks, append([]string(nil), required...))
 				available := true

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1016,7 +1016,7 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 					return previewPolicyRow(preview.AccessPublic, 7)
 				}
 				return previewPolicyRow(preview.AccessPublic, 8)
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: BeginResume :one"):
 				return sandboxRow(sb)
@@ -1098,7 +1098,7 @@ func TestResumeSandbox_PrivatePolicyRequiresBrowserChainAndRestoresBrowserPorts(
 				return sandboxRow(sb)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPrivate, 8)
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				capabilityRequirements = append(capabilityRequirements, append([]string(nil), args[0].([]string)...))
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
@@ -1774,7 +1774,7 @@ func TestCreateSandbox_Success(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -1868,7 +1868,7 @@ func TestCreateSandbox_PrivateUsesBrowserCapablePlacementAndAttestation(t *testi
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				checkedCapabilities = append(checkedCapabilities, args[0].([]string)...)
 				return previewCapableHostRow()
 			case strings.Contains(sql, "INSERT INTO sandbox"):
@@ -1930,7 +1930,7 @@ func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T)
 			switch {
 			case strings.Contains(sql, "FROM template"):
 				return templateRow(defaultReadyTemplate())
-			case strings.Contains(sql, "-- name: HostHasCapabilities"):
+			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				checks++
 				return scalarBoolRow(!slices.Contains(args[0].([]string), preview.HostCapabilityPortBrowserAuth))
 			case strings.Contains(sql, "INSERT INTO sandbox"):
@@ -1993,7 +1993,7 @@ func TestCreateSandbox_PreviewAttestationFailureFailsClosed(t *testing.T) {
 			mock := &mockDBTX{
 				queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 					switch {
-					case strings.Contains(sql, "-- name: HostHasCapabilities"):
+					case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 						return previewCapableHostRow()
 					case strings.Contains(sql, "INSERT INTO sandbox"):
 						return sandboxRow(db.Sandbox{
@@ -2044,7 +2044,7 @@ func TestCreateSandbox_InjectEnvUnimplementedTolerated(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2098,7 +2098,7 @@ func TestCreateSandbox_InjectEnvErrorFails(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2164,7 +2164,7 @@ func newHostnameStampEnv(t *testing.T, stampErr error) *hostnameStampEnv {
 	}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2317,7 +2317,7 @@ func TestCreateSandbox_QuotaExceeded(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2366,7 +2366,7 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2751,7 +2751,7 @@ func TestCreateSandbox_WithMetadata(t *testing.T) {
 	vmd := &stubVMD{}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2814,7 +2814,7 @@ func TestCreateSandbox_EmptyMetadataIsObjectNotNull(t *testing.T) {
 	vmd := &stubVMD{}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities") {
+			if (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")) {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -229,6 +229,10 @@ func sandboxRow(s db.Sandbox) *mockRow {
 		*dest[21].(*int32) = s.DiskMib
 		*dest[22].(**int32) = s.AutoDeleteSeconds
 		*dest[23].(*pgtype.Timestamptz) = s.AutoDeleteAt
+		if len(dest) == 25 {
+			// GetSandboxWithPreviewPolicy: trailing COALESCE'd effective access.
+			*dest[24].(*string) = "legacy_public"
+		}
 		return nil
 	}}
 }
@@ -1545,6 +1549,12 @@ func TestActivateSandbox_AlreadyActive_200WithSandboxResponse(t *testing.T) {
 	}
 	if body["vcpu_count"].(float64) != 2 {
 		t.Errorf("vcpu_count = %v, want 2", body["vcpu_count"])
+	}
+	// Pins the joined read's trailing access column through to the response —
+	// fails if GetSandboxWithPreviewPolicy's scan order or the handler
+	// plumbing breaks.
+	if body["preview_access"] != "legacy_public" {
+		t.Errorf("preview_access = %q, want legacy_public", body["preview_access"])
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1016,7 +1016,7 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 					return previewPolicyRow(preview.AccessPublic, 7)
 				}
 				return previewPolicyRow(preview.AccessPublic, 8)
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: BeginResume :one"):
 				return sandboxRow(sb)
@@ -1098,7 +1098,7 @@ func TestResumeSandbox_PrivatePolicyRequiresBrowserChainAndRestoresBrowserPorts(
 				return sandboxRow(sb)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 				return previewPolicyRow(preview.AccessPrivate, 8)
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				capabilityRequirements = append(capabilityRequirements, append([]string(nil), args[0].([]string)...))
 				return scalarBoolRow(true)
 			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
@@ -1774,7 +1774,7 @@ func TestCreateSandbox_Success(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -1868,7 +1868,7 @@ func TestCreateSandbox_PrivateUsesBrowserCapablePlacementAndAttestation(t *testi
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				checkedCapabilities = append(checkedCapabilities, args[0].([]string)...)
 				return previewCapableHostRow()
 			case strings.Contains(sql, "INSERT INTO sandbox"):
@@ -1930,7 +1930,7 @@ func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T)
 			switch {
 			case strings.Contains(sql, "FROM template"):
 				return templateRow(defaultReadyTemplate())
-			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+			case strings.Contains(sql, "-- name: HostHasCapabilities"):
 				checks++
 				return scalarBoolRow(!slices.Contains(args[0].([]string), preview.HostCapabilityPortBrowserAuth))
 			case strings.Contains(sql, "INSERT INTO sandbox"):
@@ -1993,7 +1993,7 @@ func TestCreateSandbox_PreviewAttestationFailureFailsClosed(t *testing.T) {
 			mock := &mockDBTX{
 				queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 					switch {
-					case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+					case strings.Contains(sql, "-- name: HostHasCapabilities"):
 						return previewCapableHostRow()
 					case strings.Contains(sql, "INSERT INTO sandbox"):
 						return sandboxRow(db.Sandbox{
@@ -2044,7 +2044,7 @@ func TestCreateSandbox_InjectEnvUnimplementedTolerated(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2098,7 +2098,7 @@ func TestCreateSandbox_InjectEnvErrorFails(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2164,7 +2164,7 @@ func newHostnameStampEnv(t *testing.T, stampErr error) *hostnameStampEnv {
 	}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2317,7 +2317,7 @@ func TestCreateSandbox_QuotaExceeded(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2366,7 +2366,7 @@ func TestCreateSandbox_VMDError(t *testing.T) {
 
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2751,7 +2751,7 @@ func TestCreateSandbox_WithMetadata(t *testing.T) {
 	vmd := &stubVMD{}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {
@@ -2814,7 +2814,7 @@ func TestCreateSandbox_EmptyMetadataIsObjectNotNull(t *testing.T) {
 	vmd := &stubVMD{}
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
-			if strings.Contains(sql, "-- name: HostHasCapabilities :one") {
+			if strings.Contains(sql, "-- name: HostHasCapabilities") {
 				return previewCapableHostRow()
 			}
 			if strings.Contains(sql, "INSERT INTO sandbox") {

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// hostCapCache is an in-process, TTL-bounded, positive-only cache of host
+// capability attestations, fronting HostHasCapabilitiesUnlocked on the
+// standalone pre-flight paths. Capabilities are heartbeat-attested and
+// placement already runs off the scheduler's candidate cache, so a short
+// positive cache adds no staleness window placement does not already accept.
+//
+// Only affirmative results are cached: a missing capability (or any error)
+// always re-reads the database, so a capability 409 is always fresh and a
+// host that loses a capability stops being served within one TTL. The
+// fail-closed gates (transactional validation, VMD's post-boot attestation)
+// do not go through this cache. Cardinality is hosts × capability sets, so
+// the map needs no eviction bound.
+const defaultHostCapCacheTTL = 10 * time.Second
+
+// hostCapCacheTTLFromEnv reads HOST_CAPABILITY_CACHE_TTL (a Go duration,
+// e.g. "30s"). Unset or unparsable falls back to the default; a non-positive
+// duration disables caching (every check reads the database).
+func hostCapCacheTTLFromEnv() time.Duration {
+	raw := os.Getenv("HOST_CAPABILITY_CACHE_TTL")
+	if raw == "" {
+		return defaultHostCapCacheTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return defaultHostCapCacheTTL
+	}
+	return d
+}
+
+// hostCapCache's zero value is ready to use (mirrors Handlers.authzOnce):
+// the first call reads the TTL and allocates the map.
+type hostCapCache struct {
+	once  sync.Once
+	ttl   time.Duration
+	group singleflight.Group // coalesces concurrent misses for the same key
+	mu    sync.Mutex
+	m     map[string]time.Time // key -> attestedAt of the last positive read
+}
+
+func (c *hostCapCache) init() {
+	c.once.Do(func() {
+		c.ttl = hostCapCacheTTLFromEnv()
+		c.m = make(map[string]time.Time)
+	})
+}
+
+// hostHasCapabilitiesCached serves the pre-flight capability check from the
+// positive cache when fresh, and otherwise reads the database (one flight per
+// key under concurrent misses — a burst pays one read, not one per request).
+func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string, capabilities []string) (bool, error) {
+	c := &h.hostCaps
+	c.init()
+	params := db.HostHasCapabilitiesUnlockedParams{HostID: hostID, RequiredCapabilities: capabilities}
+	if c.ttl <= 0 {
+		return h.DB.HostHasCapabilitiesUnlocked(ctx, params)
+	}
+	key := hostID + "\x00" + strings.Join(capabilities, "\x00")
+	c.mu.Lock()
+	attested, hit := c.m[key]
+	c.mu.Unlock()
+	if hit && time.Since(attested) < c.ttl {
+		return true, nil
+	}
+	v, err, _ := c.group.Do(key, func() (any, error) {
+		// One detached, bounded flight serves every coalesced caller; the
+		// leader's request cancellation must not fail the followers.
+		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		ok, qerr := h.DB.HostHasCapabilitiesUnlocked(qctx, params)
+		c.mu.Lock()
+		if qerr == nil && ok {
+			c.m[key] = time.Now()
+		} else {
+			delete(c.m, key) // an expired positive must not linger past a refuting read
+		}
+		c.mu.Unlock()
+		return ok, qerr
+	})
+	if err != nil {
+		return false, err
+	}
+	return v.(bool), nil
+}

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -21,7 +22,8 @@ import (
 // grace while one background flight refreshes it, and concurrent misses
 // coalesce. The fail-closed gates (transactional validation, VMD's post-boot
 // attestation) do not go through this cache. Cardinality is hosts ×
-// capability sets, so the map needs no eviction bound.
+// capability sets; puts sweep expired entries, so memory tracks the active
+// fleet.
 const (
 	// The TTL also bounds how long a just-fenced host or dropped capability
 	// can keep passing this pre-flight (the create path already tolerates the
@@ -91,6 +93,15 @@ func (c *hostCapCache) get(key string, now time.Time) (refresh, ok bool) {
 
 func (c *hostCapCache) put(key string, attestedAt time.Time) {
 	c.mu.Lock()
+	// Lazy sweep: drop entries past serving age (retired hosts are never read
+	// again, so read-time deletion alone would retain them). puts are at most
+	// one per key per TTL and the map is hosts × capability sets, so this is
+	// cheap.
+	for k, e := range c.m {
+		if attestedAt.Sub(e.attestedAt) > c.ttl+hostCapCacheStaleGrace {
+			delete(c.m, k)
+		}
+	}
 	c.m[key] = &hostCapEntry{attestedAt: attestedAt}
 	c.mu.Unlock()
 }
@@ -147,14 +158,17 @@ func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string,
 	if c.ttl <= 0 {
 		return h.DB.HostHasCapabilitiesUnlocked(ctx, params)
 	}
-	key := hostID + "\x00" + strings.Join(capabilities, "\x00")
+	sorted := append([]string(nil), capabilities...)
+	sort.Strings(sorted)
+	key := hostID + "\x00" + strings.Join(sorted, "\x00")
 	refresh, ok := c.get(key, time.Now())
 	if ok {
 		if refresh {
 			go func() {
 				_, err := h.fetchHostCaps(context.Background(), key, params)
 				if err != nil {
-					log.Warn().Err(err).Msg("host capability refresh failed; serving stale until the grace window expires")
+					log.Warn().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).
+						Msg("host capability refresh failed; serving stale until the grace window expires")
 					c.refreshFailed(key)
 				}
 			}()

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/db"
@@ -14,21 +15,24 @@ import (
 
 // hostCapCache is an in-process, TTL-bounded, positive-only cache of host
 // capability attestations, fronting HostHasCapabilitiesUnlocked on the
-// standalone pre-flight paths. Capabilities are heartbeat-attested and
-// placement already runs off the scheduler's candidate cache, so a short
-// positive cache adds no staleness window placement does not already accept.
-//
-// Only affirmative results are cached: a missing capability (or any error)
-// always re-reads the database, so a capability 409 is always fresh and a
-// host that loses a capability stops being served within one TTL. The
-// fail-closed gates (transactional validation, VMD's post-boot attestation)
-// do not go through this cache. Cardinality is hosts × capability sets, so
-// the map needs no eviction bound.
-const defaultHostCapCacheTTL = 10 * time.Second
+// standalone pre-flight paths. Same shape as apiKeyCache: only affirmative
+// results are cached (a missing capability or an error always re-reads, so a
+// capability 409 is always fresh), an expired entry is served for a short
+// grace while one background flight refreshes it, and concurrent misses
+// coalesce. The fail-closed gates (transactional validation, VMD's post-boot
+// attestation) do not go through this cache. Cardinality is hosts ×
+// capability sets, so the map needs no eviction bound.
+const (
+	// The TTL also bounds how long a just-fenced host or dropped capability
+	// can keep passing this pre-flight (the create path already tolerates the
+	// scheduler cache's 30s for placement).
+	defaultHostCapCacheTTL = 10 * time.Second
+	hostCapCacheStaleGrace = 2 * time.Second
+)
 
 // hostCapCacheTTLFromEnv reads HOST_CAPABILITY_CACHE_TTL (a Go duration,
 // e.g. "30s"). Unset or unparsable falls back to the default; a non-positive
-// duration disables caching (every check reads the database).
+// duration disables caching.
 func hostCapCacheTTLFromEnv() time.Duration {
 	raw := os.Getenv("HOST_CAPABILITY_CACHE_TTL")
 	if raw == "" {
@@ -41,26 +45,101 @@ func hostCapCacheTTLFromEnv() time.Duration {
 	return d
 }
 
-// hostCapCache's zero value is ready to use (mirrors Handlers.authzOnce):
-// the first call reads the TTL and allocates the map.
+type hostCapEntry struct {
+	attestedAt time.Time // stamped from query start, so a slow read can't stretch the window
+	refreshing bool
+}
+
+// hostCapCache's zero value is ready to use; the first call reads the TTL and
+// allocates the map.
 type hostCapCache struct {
 	once  sync.Once
 	ttl   time.Duration
-	group singleflight.Group // coalesces concurrent misses for the same key
+	group singleflight.Group
 	mu    sync.Mutex
-	m     map[string]time.Time // key -> attestedAt of the last positive read
+	m     map[string]*hostCapEntry
 }
 
 func (c *hostCapCache) init() {
 	c.once.Do(func() {
 		c.ttl = hostCapCacheTTLFromEnv()
-		c.m = make(map[string]time.Time)
+		c.m = make(map[string]*hostCapEntry)
 	})
 }
 
-// hostHasCapabilitiesCached serves the pre-flight capability check from the
-// positive cache when fresh, and otherwise reads the database (one flight per
-// key under concurrent misses — a burst pays one read, not one per request).
+// get reports whether key holds a servable positive. refresh reports that the
+// entry is past its TTL and this caller should kick the background refresh —
+// at most one is armed at a time; put and refreshFailed re-arm.
+func (c *hostCapCache) get(key string, now time.Time) (refresh, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, exists := c.m[key]
+	if !exists {
+		return false, false
+	}
+	age := now.Sub(e.attestedAt)
+	if age > c.ttl+hostCapCacheStaleGrace {
+		delete(c.m, key)
+		return false, false
+	}
+	if age > c.ttl && !e.refreshing {
+		e.refreshing = true
+		refresh = true
+	}
+	return refresh, true
+}
+
+func (c *hostCapCache) put(key string, attestedAt time.Time) {
+	c.mu.Lock()
+	c.m[key] = &hostCapEntry{attestedAt: attestedAt}
+	c.mu.Unlock()
+}
+
+func (c *hostCapCache) remove(key string) {
+	c.mu.Lock()
+	delete(c.m, key)
+	c.mu.Unlock()
+}
+
+func (c *hostCapCache) refreshFailed(key string) {
+	c.mu.Lock()
+	if e, ok := c.m[key]; ok {
+		e.refreshing = false
+	}
+	c.mu.Unlock()
+}
+
+// fetch coalesces concurrent misses: one flight runs the read under a
+// detached, bounded context (it may outlive the caller), stores the outcome,
+// and every waiter shares the result — but each waiter still selects on its
+// own ctx, so a hung-up client returns immediately.
+func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
+	c := &h.hostCaps
+	ch := c.group.DoChan(key, func() (interface{}, error) {
+		start := time.Now()
+		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		has, err := h.DB.HostHasCapabilitiesUnlocked(qctx, params)
+		switch {
+		case err != nil:
+		case has:
+			c.put(key, start)
+		default:
+			c.remove(key)
+		}
+		return has, err
+	})
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return false, res.Err
+		}
+		return res.Val.(bool), nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}
+
 func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string, capabilities []string) (bool, error) {
 	c := &h.hostCaps
 	c.init()
@@ -69,29 +148,18 @@ func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string,
 		return h.DB.HostHasCapabilitiesUnlocked(ctx, params)
 	}
 	key := hostID + "\x00" + strings.Join(capabilities, "\x00")
-	c.mu.Lock()
-	attested, hit := c.m[key]
-	c.mu.Unlock()
-	if hit && time.Since(attested) < c.ttl {
+	refresh, ok := c.get(key, time.Now())
+	if ok {
+		if refresh {
+			go func() {
+				_, err := h.fetchHostCaps(context.Background(), key, params)
+				if err != nil {
+					log.Warn().Err(err).Msg("host capability refresh failed; serving stale until the grace window expires")
+					c.refreshFailed(key)
+				}
+			}()
+		}
 		return true, nil
 	}
-	v, err, _ := c.group.Do(key, func() (any, error) {
-		// One detached, bounded flight serves every coalesced caller; the
-		// leader's request cancellation must not fail the followers.
-		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer cancel()
-		ok, qerr := h.DB.HostHasCapabilitiesUnlocked(qctx, params)
-		c.mu.Lock()
-		if qerr == nil && ok {
-			c.m[key] = time.Now()
-		} else {
-			delete(c.m, key) // an expired positive must not linger past a refuting read
-		}
-		c.mu.Unlock()
-		return ok, qerr
-	})
-	if err != nil {
-		return false, err
-	}
-	return v.(bool), nil
+	return h.fetchHostCaps(ctx, key, params)
 }

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// capMockHandlers returns a Handlers whose DB answers every capability read
+// with the current value of *answer, counting reads in *reads.
+func capMockHandlers(reads *atomic.Int64, answer *atomic.Bool) *Handlers {
+	mock := &mockDBTX{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			reads.Add(1)
+			return &mockRow{scanFn: func(dest ...any) error {
+				*(dest[0].(*bool)) = answer.Load()
+				return nil
+			}}
+		},
+	}
+	return &Handlers{DB: db.New(mock)}
+}
+
+// A positive attestation must be served from cache within the TTL — the
+// steady-state hot path pays zero DB reads.
+func TestHostCapCachePositiveHitSkipsDB(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+
+	for i := 0; i < 5; i++ {
+		ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"})
+		if err != nil || !ok {
+			t.Fatalf("call %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("DB reads = %d, want 1 (subsequent calls must hit the cache)", got)
+	}
+}
+
+// A negative result must never be cached: every check of an unattested
+// capability re-reads the database, so a 409 is always based on a fresh read.
+func TestHostCapCacheNegativeNeverCached(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool // false
+	h := capMockHandlers(&reads, &answer)
+
+	for i := 0; i < 3; i++ {
+		ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"})
+		if err != nil || ok {
+			t.Fatalf("call %d: ok=%v err=%v, want false,nil", i, ok, err)
+		}
+	}
+	if got := reads.Load(); got != 3 {
+		t.Fatalf("DB reads = %d, want 3 (negatives must not be cached)", got)
+	}
+
+	// The capability appearing (host upgraded) is visible immediately.
+	answer.Store(true)
+	if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"}); err != nil || !ok {
+		t.Fatalf("after upgrade: ok=%v err=%v, want true", ok, err)
+	}
+}
+
+// Distinct capability sets are distinct cache keys — a hit for one set must
+// not attest another.
+func TestHostCapCacheKeyIncludesCapabilitySet(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+
+	ctx := context.Background()
+	if _, err := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1", "preview_port_access_v1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := reads.Load(); got != 2 {
+		t.Fatalf("DB reads = %d, want 2 (different capability sets must not share an entry)", got)
+	}
+}
+
+// An expired positive is refreshed, and a refuting read evicts it rather than
+// letting the stale positive linger.
+func TestHostCapCacheExpiryAndEviction(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+	h.hostCaps.init()
+	h.hostCaps.ttl = 20 * time.Millisecond
+
+	ctx := context.Background()
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); !ok {
+		t.Fatal("first read should attest")
+	}
+	time.Sleep(30 * time.Millisecond)
+	answer.Store(false) // capability lost while the entry expired
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); ok {
+		t.Fatal("expired entry must re-read and see the lost capability")
+	}
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); ok {
+		t.Fatal("refuted entry must have been evicted, not served")
+	}
+	if got := reads.Load(); got != 3 {
+		t.Fatalf("DB reads = %d, want 3", got)
+	}
+}
+
+// TTL <= 0 disables caching entirely (the kill switch).
+func TestHostCapCacheDisabled(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+	h.hostCaps.init()
+	h.hostCaps.ttl = 0
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if ok, err := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); err != nil || !ok {
+			t.Fatalf("call %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if got := reads.Load(); got != 3 {
+		t.Fatalf("DB reads = %d, want 3 (TTL=0 must disable caching)", got)
+	}
+}

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -134,6 +134,16 @@ func TestHostCapCacheStaleGraceAndEviction(t *testing.T) {
 	if _, ok := c.get("k2", time.Now()); ok {
 		t.Fatal("entry past ttl+grace must be a miss")
 	}
+
+	// A put sweeps expired entries, so retired hosts' keys don't accumulate.
+	c.put("retired", time.Now().Add(-c.ttl-hostCapCacheStaleGrace-time.Millisecond))
+	c.put("live", time.Now())
+	c.mu.Lock()
+	_, retired := c.m["retired"]
+	c.mu.Unlock()
+	if retired {
+		t.Fatal("put must sweep entries past serving age")
+	}
 }
 
 // The transactional validate must issue the locked query; the pre-flight

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -89,9 +91,10 @@ func TestHostCapCacheKeyIncludesCapabilitySet(t *testing.T) {
 	}
 }
 
-// An expired positive is refreshed, and a refuting read evicts it rather than
-// letting the stale positive linger.
-func TestHostCapCacheExpiryAndEviction(t *testing.T) {
+// A TTL-expired positive is served through the grace window while one
+// background refresh runs; a refuting refresh evicts it, after which checks
+// read fresh. Past ttl+grace an entry is a plain miss.
+func TestHostCapCacheStaleGraceAndEviction(t *testing.T) {
 	var reads atomic.Int64
 	var answer atomic.Bool
 	answer.Store(true)
@@ -100,19 +103,75 @@ func TestHostCapCacheExpiryAndEviction(t *testing.T) {
 	h.hostCaps.ttl = 20 * time.Millisecond
 
 	ctx := context.Background()
-	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); !ok {
+	caps := []string{"preview_ports_v1"}
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", caps); !ok {
 		t.Fatal("first read should attest")
 	}
-	time.Sleep(30 * time.Millisecond)
-	answer.Store(false) // capability lost while the entry expired
-	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); ok {
-		t.Fatal("expired entry must re-read and see the lost capability")
+	time.Sleep(30 * time.Millisecond) // past TTL, inside the grace window
+	answer.Store(false)               // capability lost
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", caps); !ok {
+		t.Fatal("within grace the stale positive must still serve")
 	}
-	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", []string{"preview_ports_v1"}); ok {
-		t.Fatal("refuted entry must have been evicted, not served")
+	// That serve armed one background refresh; it sees the refuting read and
+	// evicts the entry, after which checks are fresh (and false).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", caps); !ok {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
-	if got := reads.Load(); got != 3 {
-		t.Fatalf("DB reads = %d, want 3", got)
+	if ok, _ := h.hostHasCapabilitiesCached(ctx, "host-a", caps); ok {
+		t.Fatal("refuted entry must be evicted, not served")
+	}
+	if reads.Load() < 2 {
+		t.Fatalf("background refresh never ran (reads=%d)", reads.Load())
+	}
+
+	// Past ttl+grace an entry is a miss, not a stale serve.
+	c := &h.hostCaps
+	c.put("k2", time.Now().Add(-c.ttl-hostCapCacheStaleGrace-time.Millisecond))
+	if _, ok := c.get("k2", time.Now()); ok {
+		t.Fatal("entry past ttl+grace must be a miss")
+	}
+}
+
+// The transactional validate must issue the locked query; the pre-flight
+// cache must issue the unlocked one. Pins the routing so a refactor can't
+// silently drop FOR SHARE from the mutation path.
+func TestCapabilityQueryRouting(t *testing.T) {
+	var mu sync.Mutex
+	var sqls []string
+	mock := &mockDBTX{queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+		mu.Lock()
+		sqls = append(sqls, sql)
+		mu.Unlock()
+		return &mockRow{scanFn: func(dest ...any) error {
+			*(dest[0].(*bool)) = true
+			return nil
+		}}
+	}}
+	q := db.New(mock)
+
+	if err := validateHostPreviewCapabilities(context.Background(), q, "host-a", "preview_ports_v1"); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	first := sqls[0]
+	mu.Unlock()
+	if !strings.Contains(first, "-- name: HostHasCapabilities :one") || !strings.Contains(first, "FOR SHARE") {
+		t.Fatalf("transactional validate must use the locked query, got: %.60s", first)
+	}
+
+	h := &Handlers{DB: q}
+	if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"}); err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	mu.Lock()
+	last := sqls[len(sqls)-1]
+	mu.Unlock()
+	if !strings.Contains(last, "-- name: HostHasCapabilitiesUnlocked :one") || strings.Contains(last, "FOR SHARE") {
+		t.Fatalf("pre-flight must use the unlocked query, got: %.60s", last)
 	}
 }
 

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -125,6 +125,50 @@ func (q *Queries) HostHasCapabilities(ctx context.Context, arg HostHasCapabiliti
 	return exists, err
 }
 
+const hostHasCapabilitiesUnlocked = `-- name: HostHasCapabilitiesUnlocked :one
+WITH target_host AS MATERIALIZED (
+  SELECT id, last_heartbeat_at
+  FROM host
+  WHERE id = $2
+    AND status = 'active'
+    AND last_heartbeat_at IS NOT NULL
+)
+SELECT EXISTS (
+  SELECT 1
+  FROM target_host h
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM unnest($1::text[]) AS required(capability)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM host_capability hc
+      WHERE hc.host_id = h.id
+        AND hc.capability = required.capability
+        AND hc.heartbeat_at = h.last_heartbeat_at
+    )
+  )
+)
+`
+
+type HostHasCapabilitiesUnlockedParams struct {
+	RequiredCapabilities []string `json:"required_capabilities"`
+	HostID               string   `json:"host_id"`
+}
+
+// Same relational-division check as HostHasCapabilities, but without the row
+// lock: for standalone pre-flight callers (not inside a mutation transaction)
+// that only read the current capability state and act on the result
+// immediately. Omitting the lock keeps this read off the heartbeat writer's
+// row-lock path, so a burst of concurrent pre-flight checks against one host
+// does not serialize behind heartbeat updates. Transactional callers that must
+// pin the host across a commit use HostHasCapabilities instead.
+func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCapabilitiesUnlockedParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hostHasCapabilitiesUnlocked, arg.RequiredCapabilities, arg.HostID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const insertHostCapability = `-- name: InsertHostCapability :exec
 INSERT INTO host_capability (host_id, capability, heartbeat_at)
 SELECT id, $1, last_heartbeat_at

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -155,13 +155,10 @@ type HostHasCapabilitiesUnlockedParams struct {
 	HostID               string   `json:"host_id"`
 }
 
-// Same relational-division check as HostHasCapabilities, but without the row
-// lock: for standalone pre-flight callers (not inside a mutation transaction)
-// that only read the current capability state and act on the result
-// immediately. Omitting the lock keeps this read off the heartbeat writer's
-// row-lock path, so a burst of concurrent pre-flight checks against one host
-// does not serialize behind heartbeat updates. Transactional callers that must
-// pin the host across a commit use HostHasCapabilities instead.
+// HostHasCapabilities without the row lock, for standalone pre-flight reads
+// outside a mutation transaction: omitting the lock keeps concurrent checks
+// from serializing behind the host's heartbeat writer. Transactional callers
+// that must pin the host across a commit use HostHasCapabilities.
 func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCapabilitiesUnlockedParams) (bool, error) {
 	row := q.db.QueryRow(ctx, hostHasCapabilitiesUnlocked, arg.RequiredCapabilities, arg.HostID)
 	var exists bool

--- a/internal/db/preview_schema_compat_test.go
+++ b/internal/db/preview_schema_compat_test.go
@@ -163,7 +163,9 @@ func TestHostCapabilityBatchGateLocksExactActiveHeartbeat(t *testing.T) {
 	if start < 0 {
 		t.Fatal("HostHasCapabilities query block is missing")
 	}
-	end := strings.Index(queries[start:], "-- name: MarkHostUnhealthy :exec")
+	// The unlocked variant follows immediately; bound the locked block at it so
+	// this assertion covers only the FOR SHARE query.
+	end := strings.Index(queries[start:], "-- name: HostHasCapabilitiesUnlocked :one")
 	if end < 0 {
 		t.Fatal("HostHasCapabilities query terminator is missing")
 	}
@@ -184,5 +186,46 @@ func TestHostCapabilityBatchGateLocksExactActiveHeartbeat(t *testing.T) {
 	}
 	if got := strings.Count(query, "WHERE NOT EXISTS"); got != 2 {
 		t.Fatalf("batch capability relational division has %d NOT EXISTS clauses, want 2", got)
+	}
+}
+
+// The unlocked variant used on the create/resume pre-flight paths must run the
+// same relational division against the same active-heartbeat host, but WITHOUT
+// the row lock — that is the whole point of the second query (a burst of
+// pre-flight checks must not serialize behind the host's heartbeat writer).
+func TestHostHasCapabilitiesUnlockedRunsSameDivisionWithoutRowLock(t *testing.T) {
+	path := filepath.Join("..", "..", "db", "queries", "hosts.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read host queries: %v", err)
+	}
+	queries := string(raw)
+	start := strings.Index(queries, "-- name: HostHasCapabilitiesUnlocked :one")
+	if start < 0 {
+		t.Fatal("HostHasCapabilitiesUnlocked query block is missing")
+	}
+	end := strings.Index(queries[start:], "-- name: MarkHostUnhealthy :exec")
+	if end < 0 {
+		t.Fatal("HostHasCapabilitiesUnlocked query terminator is missing")
+	}
+	query := queries[start : start+end]
+	for _, required := range []string{
+		"WITH target_host AS MATERIALIZED",
+		"WHERE id = sqlc.arg('host_id')",
+		"status = 'active'",
+		"last_heartbeat_at IS NOT NULL",
+		"unnest(sqlc.arg('required_capabilities')::text[])",
+		"hc.host_id = h.id",
+		"hc.heartbeat_at = h.last_heartbeat_at",
+	} {
+		if !strings.Contains(query, required) {
+			t.Errorf("unlocked capability gate is missing %q", required)
+		}
+	}
+	if strings.Contains(query, "FOR SHARE") {
+		t.Fatal("unlocked capability gate must not take a row lock (FOR SHARE)")
+	}
+	if got := strings.Count(query, "WHERE NOT EXISTS"); got != 2 {
+		t.Fatalf("unlocked relational division has %d NOT EXISTS clauses, want 2", got)
 	}
 }

--- a/internal/db/preview_schema_compat_test.go
+++ b/internal/db/preview_schema_compat_test.go
@@ -229,3 +229,29 @@ func TestHostHasCapabilitiesUnlockedRunsSameDivisionWithoutRowLock(t *testing.T)
 		t.Fatalf("unlocked relational division has %d NOT EXISTS clauses, want 2", got)
 	}
 }
+
+// The standalone policy query and the joined sandbox+policy query must derive
+// the effective access identically — a precedence change applied to one but
+// not the other would make read responses disagree with the policy engine.
+func TestEffectiveAccessExpressionMatchesAcrossQueries(t *testing.T) {
+	path := filepath.Join("..", "..", "db", "queries", "sandboxes.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read sandbox queries: %v", err)
+	}
+	queries := string(raw)
+	const expr = "COALESCE(p.default_access, p.access, 'legacy_public')::text AS access"
+	for _, name := range []string{"-- name: GetSandboxPreviewPolicy :one", "-- name: GetSandboxWithPreviewPolicy :one"} {
+		start := strings.Index(queries, name)
+		if start < 0 {
+			t.Fatalf("query block %q is missing", name)
+		}
+		end := strings.Index(queries[start:], ";")
+		if end < 0 {
+			t.Fatalf("query block %q has no terminator", name)
+		}
+		if !strings.Contains(queries[start:start+end], expr) {
+			t.Errorf("%q lost the shared effective-access expression %q", name, expr)
+		}
+	}
+}

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1339,6 +1339,59 @@ func (q *Queries) GetSandboxStatusForPreviewMutation(ctx context.Context, arg Ge
 	return status, err
 }
 
+const getSandboxWithPreviewPolicy = `-- name: GetSandboxWithPreviewPolicy :one
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at,
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.id = $1 AND s.team_id = $2 AND s.destroyed_at IS NULL
+`
+
+type GetSandboxWithPreviewPolicyParams struct {
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
+}
+
+type GetSandboxWithPreviewPolicyRow struct {
+	Sandbox Sandbox `json:"sandbox"`
+	Access  string  `json:"access"`
+}
+
+// GetSandbox plus the effective preview access, so read endpoints return
+// both in one round-trip.
+func (q *Queries) GetSandboxWithPreviewPolicy(ctx context.Context, arg GetSandboxWithPreviewPolicyParams) (GetSandboxWithPreviewPolicyRow, error) {
+	row := q.db.QueryRow(ctx, getSandboxWithPreviewPolicy, arg.ID, arg.TeamID)
+	var i GetSandboxWithPreviewPolicyRow
+	err := row.Scan(
+		&i.Sandbox.ID,
+		&i.Sandbox.TeamID,
+		&i.Sandbox.Name,
+		&i.Sandbox.Status,
+		&i.Sandbox.VcpuCount,
+		&i.Sandbox.MemoryMib,
+		&i.Sandbox.HostID,
+		&i.Sandbox.IpAddress,
+		&i.Sandbox.Pid,
+		&i.Sandbox.SnapshotID,
+		&i.Sandbox.CreatedAt,
+		&i.Sandbox.UpdatedAt,
+		&i.Sandbox.DestroyedAt,
+		&i.Sandbox.NetworkConfig,
+		&i.Sandbox.TimeoutSeconds,
+		&i.Sandbox.Metadata,
+		&i.Sandbox.TemplateID,
+		&i.Sandbox.SnapshotPath,
+		&i.Sandbox.MemPath,
+		&i.Sandbox.BasePath,
+		&i.Sandbox.DeltaPath,
+		&i.Sandbox.DiskMib,
+		&i.Sandbox.AutoDeleteSeconds,
+		&i.Sandbox.AutoDeleteAt,
+		&i.Access,
+	)
+	return i, err
+}
+
 const listPinnedBuildPaths = `-- name: ListPinnedBuildPaths :many
 SELECT DISTINCT base_path FROM sandbox
 WHERE base_path IS NOT NULL AND destroyed_at IS NULL


### PR DESCRIPTION
The capability pre-flight on create/resume ran a FOR SHARE read against the host row on every request, so concurrent creates serialized behind the host's heartbeat writer; activate and get-sandbox paid the preview policy read as an extra serial round-trip.

- Add an unlocked variant of the capability query for standalone pre-flight reads; the transactional mutation path keeps the locking variant to pin the host across its commit.
- Serve pre-flights from a positive-only, TTL-bounded attestation cache (singleflight on miss, `HOST_CAPABILITY_CACHE_TTL=0` disables). Negatives and errors are never cached, so a capability 409 is always based on a fresh read; VMD's post-boot policy attestation is unchanged and remains the fail-closed gate.
- Overlap the preview policy read with the sandbox load on activate and get-sandbox instead of running it serially.

Tests: cache behavior (positive hit, negative never cached, per-capability-set keys, expiry/eviction, kill switch) and a query-structure test pinning that the unlocked variant runs the same relational division without the row lock.