### PR TITLE
db: add read-only grafana_readonly role for dashboard connections

### DIFF
--- a/supabase/migrations/20260730000001_grafana_readonly_role.sql
+++ b/supabase/migrations/20260730000001_grafana_readonly_role.sql
@@ -1,0 +1,24 @@
+-- Read-only Postgres role for the Grafana dashboard connection, kept
+-- distinct from the app's own database credentials (least privilege: no
+-- app secrets end up in Grafana, and this role can't write or see schemas
+-- outside public).
+--
+-- Idempotent: re-running on a database that already has this role is a
+-- no-op. The role is created with a random throwaway password — the actual
+-- password used for the Grafana connection is set out-of-band (dashboard
+-- SQL editor) and rotated independently of this migration, so no credential
+-- ever lands in git history.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'grafana_readonly') THEN
+        CREATE ROLE grafana_readonly WITH LOGIN
+            PASSWORD md5(random()::text || clock_timestamp()::text)
+            NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION;
+    END IF;
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO grafana_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_readonly;

--- a/supabase/migrations/20260730000002_grafana_readonly_role.sql
+++ b/supabase/migrations/20260730000002_grafana_readonly_role.sql
@@ -10,11 +10,14 @@
 -- ever lands in git history.
 
 DO $$
+DECLARE
+    throwaway_password text := md5(random()::text || clock_timestamp()::text);
 BEGIN
     IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'grafana_readonly') THEN
-        CREATE ROLE grafana_readonly WITH LOGIN
-            PASSWORD md5(random()::text || clock_timestamp()::text)
-            NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION;
+        EXECUTE format(
+            'CREATE ROLE grafana_readonly WITH LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION',
+            throwaway_password
+        );
     END IF;
 END
 $$;

--- a/supabase/migrations/20260730000002_grafana_readonly_role.sql
+++ b/supabase/migrations/20260730000002_grafana_readonly_role.sql
@@ -1,7 +1,14 @@
 -- Read-only Postgres role for the Grafana dashboard connection, kept
 -- distinct from the app's own database credentials (least privilege: no
 -- app secrets end up in Grafana, and this role can't write or see schemas
--- outside public).
+-- outside analytics).
+--
+-- Grants target the analytics schema, not public: every public base table
+-- has RLS enabled with no policy for this role, so a public grant would be
+-- silently unreadable. analytics views are the dedicated reporting surface
+-- (see 20260529000002_analytics_weekly_user_metrics.sql) and are not
+-- security_invoker, so they run with the view owner's privileges and stay
+-- readable through RLS.
 --
 -- Idempotent: re-running on a database that already has this role is a
 -- no-op. The role is created with a random throwaway password — the actual
@@ -22,6 +29,6 @@ BEGIN
 END
 $$;
 
-GRANT USAGE ON SCHEMA public TO grafana_readonly;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_readonly;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_readonly;
+GRANT USAGE ON SCHEMA analytics TO grafana_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO grafana_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT SELECT ON TABLES TO grafana_readonly;


### PR DESCRIPTION
## Summary
- Adds a `grafana_readonly` Postgres role via migration, scoped to `SELECT` on the `public` schema only — no write access, no other schemas, and distinct from the app's own DB credentials.
- Role is created with a random throwaway password at migration time so nothing ever lands in git history; the real password gets set per cell out-of-band and rotated independently.
- Rides the existing CD Migrate pipeline (staging → us-east → us-west), so it lands in every current cell without a manual step per cell, and any future cell inherits it once wired into `cd.yml`.

## Technical decisions
- `DO $$ ... IF NOT EXISTS $$` guard around `CREATE ROLE` makes the migration idempotent and safe to re-run.
- `GRANT` + `ALTER DEFAULT PRIVILEGES` cover both existing and future `public` tables.
- No `BYPASSRLS` — if RLS-protected tables need to be visible to this role, that's a separate, explicit follow-up grant.

## Testing
- Migration SQL validated locally against migration file conventions in `supabase/migrations/`.
- No functional/app code touched — this is schema-only, applied via `supabase db push` in CD Migrate.

## Manual step after merge (per cell)
In each project's Dashboard → SQL Editor, set the real password:
```sql
alter role grafana_readonly with password '<generated-password>';
```
Then wire the resulting connection string into the Grafana Postgres datasource.