### PR TITLE
backup: restore materializer and operator CLI

### DIFF
--- a/cmd/backup-restore/main.go
+++ b/cmd/backup-restore/main.go
@@ -5,6 +5,10 @@
 // operator entry point for the read path that lost-host recovery and
 // single-sandbox restore build on.
 //
+// A successful restore ends with a fsynced manifest.json completion marker
+// in the destination; a destination without the marker is a crashed or
+// interrupted restore and must not be consumed.
+//
 // Credentials come from application default credentials; run it under the
 // restore identity (object read access to the backup bucket).
 package main
@@ -17,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"cloud.google.com/go/storage"
 
@@ -30,7 +35,7 @@ func main() {
 	dest := flag.String("dest", "", "destination directory for restored artifacts")
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: backup-restore -bucket <bucket> -sandbox <id> -generation <gen> -dest <dir>")
-		fmt.Fprintln(os.Stderr, "       backup-restore -bucket <bucket> -sandbox <id>   (list restorable generations)")
+		fmt.Fprintln(os.Stderr, "       backup-restore -bucket <bucket> -sandbox <id>   (list restorable generations, newest first)")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -43,13 +48,22 @@ func main() {
 		fmt.Fprintln(os.Stderr, "-dest is required with -generation")
 		os.Exit(2)
 	}
+	if *generation == "" && *dest != "" {
+		fmt.Fprintln(os.Stderr, "-dest without -generation: refusing to guess; pass -generation to restore, or drop -dest to list")
+		os.Exit(2)
+	}
 
 	// A canceled context is how RestoreGeneration's all-or-nothing cleanup
 	// runs on SIGINT/SIGTERM: default signal handling would kill the process
-	// mid-write and leave a partial destination the fresh-directory check
-	// then rejects on retry.
+	// mid-write and leave a partial destination behind. After the first
+	// signal, stop() restores default handling so a second ^C force-kills
+	// instead of being swallowed by a cleanup that is itself stuck.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "storage client: %v\n", err)
@@ -69,12 +83,15 @@ func main() {
 			os.Exit(1)
 		}
 		for _, g := range generations {
-			fmt.Println(g)
+			fmt.Printf("%s  %s\n", g.Created.UTC().Format(time.RFC3339), g.Generation)
 		}
 		return
 	}
 
-	manifest, err := backup.RestoreGeneration(ctx, reader, *sandbox, *generation, *dest)
+	progress := func(format string, args ...any) {
+		fmt.Printf(format+"\n", args...)
+	}
+	manifest, err := backup.RestoreGeneration(ctx, reader, *sandbox, *generation, *dest, progress)
 	if err != nil {
 		if errors.Is(err, backup.ErrGenerationIncomplete) {
 			fmt.Fprintf(os.Stderr, "restore failed: %v\nthis generation was never completed and must not be restored from; pick another (omit -generation to list them)\n", err)
@@ -85,7 +102,6 @@ func main() {
 	}
 	var apparent, packed int64
 	for _, f := range manifest.Files {
-		fmt.Printf("verified %s: %d bytes apparent, %d packed, sha256 %s\n", f.Name, f.Size, f.PackedSize, f.SHA256)
 		apparent += f.Size
 		packed += f.PackedSize
 	}

--- a/cmd/backup-restore/main.go
+++ b/cmd/backup-restore/main.go
@@ -1,0 +1,87 @@
+// Command backup-restore materializes a sandbox backup generation from the
+// cell's backup bucket onto local disk: it fetches the generation manifest,
+// rebuilds each sparse artifact from its packed object, and verifies every
+// file's full apparent content against the manifest digest. It is the
+// operator entry point for the read path that lost-host recovery and
+// single-sandbox restore build on.
+//
+// Credentials come from application default credentials; run it under the
+// restore identity (object read access to the backup bucket).
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/superserve-ai/sandbox/internal/backup"
+)
+
+func main() {
+	bucket := flag.String("bucket", "", "backup bucket name")
+	sandbox := flag.String("sandbox", "", "sandbox id")
+	generation := flag.String("generation", "", "generation to restore; omit to list the sandbox's restorable generations")
+	dest := flag.String("dest", "", "destination directory for restored artifacts")
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: backup-restore -bucket <bucket> -sandbox <id> -generation <gen> -dest <dir>")
+		fmt.Fprintln(os.Stderr, "       backup-restore -bucket <bucket> -sandbox <id>   (list restorable generations)")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if *bucket == "" || *sandbox == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *generation != "" && *dest == "" {
+		fmt.Fprintln(os.Stderr, "-dest is required with -generation")
+		os.Exit(2)
+	}
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "storage client: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+	reader := backup.NewGCSReader(client, *bucket)
+
+	if *generation == "" {
+		generations, err := backup.ListGenerations(ctx, reader, *sandbox)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "list generations: %v\n", err)
+			os.Exit(1)
+		}
+		if len(generations) == 0 {
+			fmt.Fprintf(os.Stderr, "no restorable generations for sandbox %s\n", *sandbox)
+			os.Exit(1)
+		}
+		for _, g := range generations {
+			fmt.Println(g)
+		}
+		return
+	}
+
+	manifest, err := backup.RestoreGeneration(ctx, reader, *sandbox, *generation, *dest)
+	if err != nil {
+		if errors.Is(err, backup.ErrGenerationIncomplete) {
+			fmt.Fprintf(os.Stderr, "restore failed: %v\nthis generation was never completed and must not be restored from; pick another (omit -generation to list them)\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "restore failed: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	var apparent, packed int64
+	for _, f := range manifest.Files {
+		fmt.Printf("verified %s: %d bytes apparent, %d packed, sha256 %s\n", f.Name, f.Size, f.PackedSize, f.SHA256)
+		apparent += f.Size
+		packed += f.PackedSize
+	}
+	fmt.Printf("restored sandbox %s generation %s: %d files, %d bytes apparent (%d packed) into %s\n",
+		manifest.SandboxID, manifest.Generation, len(manifest.Files), apparent, packed, *dest)
+}

--- a/cmd/backup-restore/main.go
+++ b/cmd/backup-restore/main.go
@@ -15,6 +15,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"cloud.google.com/go/storage"
 
@@ -42,7 +44,12 @@ func main() {
 		os.Exit(2)
 	}
 
-	ctx := context.Background()
+	// A canceled context is how RestoreGeneration's all-or-nothing cleanup
+	// runs on SIGINT/SIGTERM: default signal handling would kill the process
+	// mid-write and leave a partial destination the fresh-directory check
+	// then rejects on retry.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "storage client: %v\n", err)

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -36,6 +36,12 @@ type TaskFile struct {
 	// identity is its bytes, not its path, so a rebuilt base at the same
 	// path yields a different generation.
 	BaseSHA256 string `json:"base_sha256,omitempty"`
+	// BaseStagedPath is where the uploader READS the base image when
+	// staging snapshotted it; BasePath itself never mutates after the
+	// generation key is computed, because it is key-covered and recorded
+	// in the manifest, and rewriting it post-key would make restore's
+	// key recomputation reject the generation.
+	BaseStagedPath string `json:"base_staged_path,omitempty"`
 	// Shared marks a content-addressed artifact stored once bucket-wide
 	// (under the bases/ prefix) rather than inside the generation: base
 	// images are multi-GB and common to every sandbox on the template,

--- a/internal/backup/layout.go
+++ b/internal/backup/layout.go
@@ -28,10 +28,15 @@ import (
 // bytes would dedupe onto a manifest pairing it with the wrong base
 // contents (the overlay digest cannot see this: holes hash as zeros, not
 // as base bytes).
+//
+// Size is in the key even though an honest digest already implies it:
+// restore trusts the recorded size as a resource bound (truncate target,
+// verification span), so a tampered manifest inflating it must fail the
+// key check rather than drive an effectively unbounded zero hash.
 func GenerationKey(files []TaskFile) string {
 	lines := make([]string, 0, len(files))
 	for _, f := range files {
-		lines = append(lines, f.Name+"="+f.SHA256+"="+f.BasePath+"="+f.BaseSHA256)
+		lines = append(lines, fmt.Sprintf("%s=%s=%d=%s=%s", f.Name, f.SHA256, f.Size, f.BasePath, f.BaseSHA256))
 	}
 	sort.Strings(lines)
 	h := sha256.New()

--- a/internal/backup/layout.go
+++ b/internal/backup/layout.go
@@ -33,11 +33,33 @@ import (
 // restore trusts the recorded size as a resource bound (truncate target,
 // verification span), so a tampered manifest inflating it must fail the
 // key check rather than drive an effectively unbounded zero hash.
+//
+// Uploads emit only this formula. Restore additionally accepts the
+// legacy formula below: generations uploaded before Size joined the key
+// exist in every bucket (and journal tasks carrying legacy keys survive
+// vmd upgrades), and a backup tier that cannot restore its own history
+// is not a backup tier. Legacy generations get their resource bounding
+// from the per-entry size cap in restore validation instead.
 func GenerationKey(files []TaskFile) string {
 	lines := make([]string, 0, len(files))
 	for _, f := range files {
 		lines = append(lines, fmt.Sprintf("%s=%s=%d=%s=%s", f.Name, f.SHA256, f.Size, f.BasePath, f.BaseSHA256))
 	}
+	return hashKeyLines(lines)
+}
+
+// generationKeyLegacy is the pre-Size derivation (name=sha=basePath=baseSHA),
+// kept ONLY so restore can verify generations uploaded under it. Nothing
+// may write new generations with this key.
+func generationKeyLegacy(files []TaskFile) string {
+	lines := make([]string, 0, len(files))
+	for _, f := range files {
+		lines = append(lines, f.Name+"="+f.SHA256+"="+f.BasePath+"="+f.BaseSHA256)
+	}
+	return hashKeyLines(lines)
+}
+
+func hashKeyLines(lines []string) string {
 	sort.Strings(lines)
 	h := sha256.New()
 	for _, l := range lines {

--- a/internal/backup/layout_test.go
+++ b/internal/backup/layout_test.go
@@ -52,6 +52,15 @@ func TestGenerationKey(t *testing.T) {
 	if rebased == k1 {
 		t.Fatal("changed base dependency did not change the generation key")
 	}
+	// Size is a restore-side resource bound, so it must be key-covered:
+	// a tampered manifest inflating it has to fail the key check.
+	resized := GenerationKey([]TaskFile{
+		{Name: "rootfs.ext4", SHA256: "aaaa", Size: 1 << 60},
+		base[1],
+	})
+	if resized == k1 {
+		t.Fatal("changed size did not change the generation key")
+	}
 	// A base rebuilt in place: same path, different bytes. The path
 	// cannot see it; the base content digest must.
 	rebuilt := GenerationKey([]TaskFile{

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -129,10 +128,19 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	if err := ensureFreshDir(destDir); err != nil {
 		return nil, err
 	}
+	// Pin the destination: every per-file open, verify, and cleanup below is
+	// relative to this directory descriptor, so a symlink swapped in for
+	// destDir (or planted inside it) after the freshness check cannot
+	// redirect writes elsewhere.
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return nil, fmt.Errorf("dest dir: %w", err)
+	}
+	defer root.Close()
 	var created []string
 	fail := func(err error) (*GenerationManifest, error) {
-		for _, p := range created {
-			os.Remove(p)
+		for _, name := range created {
+			root.Remove(name)
 		}
 		return nil, err
 	}
@@ -142,10 +150,9 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 		if err := validSegment(mf.Name); err != nil {
 			return fail(fmt.Errorf("manifest file name: %w", err))
 		}
-		dest := filepath.Join(destDir, mf.Name)
-		madeFile, err := restoreFile(ctx, r, sandboxID, generation, mf, dest)
+		madeFile, err := restoreFile(ctx, r, sandboxID, generation, mf, root)
 		if madeFile {
-			created = append(created, dest)
+			created = append(created, mf.Name)
 		}
 		if err != nil {
 			return fail(fmt.Errorf("restore %s: %w", mf.Name, err))
@@ -155,7 +162,7 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	// verification cannot leave earlier files implicitly blessed: either
 	// the whole set passes or the whole set is gone.
 	for _, mf := range manifest.Files {
-		if err := verifyFile(ctx, filepath.Join(destDir, mf.Name), mf); err != nil {
+		if err := verifyFile(ctx, root, mf); err != nil {
 			return fail(fmt.Errorf("verify %s: %w", mf.Name, err))
 		}
 	}
@@ -165,6 +172,12 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 // ensureFreshDir creates destDir (and parents) or accepts an existing but
 // empty directory. Anything else is refused; see RestoreGeneration.
 func ensureFreshDir(dir string) error {
+	// A symlink at dir itself would be followed by MkdirAll and everything
+	// after it, redirecting the restore to wherever it points. Require a
+	// real directory (or nothing) at the path.
+	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("dest dir: %w", err)
 	}
@@ -215,12 +228,13 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 // derived from the file name: the name embeds the packing fingerprint, so
 // this entry's extent table describes exactly the object it points at.
 //
-// The destination is opened O_EXCL: ensureFreshDir's emptiness check and
-// this open are separate operations, so exclusive creation is what
-// guarantees an existing file (or a symlink planted in between) is never
-// opened, truncated, or followed. madeFile reports whether this call
-// created dest, and only then may the caller's failure cleanup remove it.
-func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, dest string) (madeFile bool, _ error) {
+// The destination is opened O_EXCL relative to the pinned root:
+// ensureFreshDir's emptiness check and this open are separate operations,
+// so exclusive fd-relative creation is what guarantees an existing file
+// (or a symlink planted in between) is never opened, truncated, or
+// followed. madeFile reports whether this call created the file, and only
+// then may the caller's failure cleanup remove it.
+func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, root *os.Root) (madeFile bool, _ error) {
 	if mf.Object == "" {
 		return false, fmt.Errorf("manifest entry records no object name")
 	}
@@ -239,7 +253,7 @@ func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string
 		return false, err
 	}
 	defer rc.Close()
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	f, err := root.OpenFile(mf.Name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return false, err
 	}
@@ -284,9 +298,11 @@ func validExtents(mf ManifestFile) error {
 
 // verifyFile recomputes the full apparent digest of the rebuilt file with
 // the same logic the uploader used (hashApparent over the manifest's extent
-// table) and compares it to the manifest's recorded digest.
-func verifyFile(ctx context.Context, path string, mf ManifestFile) error {
-	f, err := os.Open(path)
+// table) and compares it to the manifest's recorded digest. The open is
+// relative to the pinned root so verification reads the file that was
+// written, not something swapped in at the path.
+func verifyFile(ctx context.Context, root *os.Root, mf ManifestFile) error {
+	f, err := root.Open(mf.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -143,8 +143,11 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 			return fail(fmt.Errorf("manifest file name: %w", err))
 		}
 		dest := filepath.Join(destDir, mf.Name)
-		created = append(created, dest)
-		if err := restoreFile(ctx, r, sandboxID, generation, mf, dest); err != nil {
+		madeFile, err := restoreFile(ctx, r, sandboxID, generation, mf, dest)
+		if madeFile {
+			created = append(created, dest)
+		}
+		if err != nil {
 			return fail(fmt.Errorf("restore %s: %w", mf.Name, err))
 		}
 	}
@@ -211,47 +214,54 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 // The object is fetched by the manifest entry's recorded Object name, never
 // derived from the file name: the name embeds the packing fingerprint, so
 // this entry's extent table describes exactly the object it points at.
-func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, dest string) error {
+//
+// The destination is opened O_EXCL: ensureFreshDir's emptiness check and
+// this open are separate operations, so exclusive creation is what
+// guarantees an existing file (or a symlink planted in between) is never
+// opened, truncated, or followed. madeFile reports whether this call
+// created dest, and only then may the caller's failure cleanup remove it.
+func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, dest string) (madeFile bool, _ error) {
 	if mf.Object == "" {
-		return fmt.Errorf("manifest entry records no object name")
+		return false, fmt.Errorf("manifest entry records no object name")
 	}
 	if err := validSegment(mf.Object); err != nil {
-		return fmt.Errorf("manifest object name: %w", err)
+		return false, fmt.Errorf("manifest object name: %w", err)
 	}
 	if err := validExtents(mf); err != nil {
-		return err
+		return false, err
 	}
 	object, err := SandboxObject(sandboxID, generation, mf.Object)
 	if err != nil {
-		return err
+		return false, err
 	}
 	rc, err := r.NewReader(ctx, object)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer rc.Close()
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
-		return err
+		return false, err
 	}
+	madeFile = true
 	defer f.Close()
 	for _, e := range mf.Extents {
 		if err := ctx.Err(); err != nil {
-			return err
+			return madeFile, err
 		}
 		if _, err := io.CopyN(io.NewOffsetWriter(f, e.Offset), rc, e.Length); err != nil {
-			return fmt.Errorf("extent at %d: %w", e.Offset, err)
+			return madeFile, fmt.Errorf("extent at %d: %w", e.Offset, err)
 		}
 	}
 	// The packed object must hold exactly the extent table's bytes; trailing
 	// data means object and manifest disagree.
 	if n, _ := io.CopyN(io.Discard, rc, 1); n != 0 {
-		return fmt.Errorf("packed object longer than extent table (%d bytes)", PackedSize(mf.Extents))
+		return madeFile, fmt.Errorf("packed object longer than extent table (%d bytes)", PackedSize(mf.Extents))
 	}
 	if err := f.Truncate(mf.Size); err != nil {
-		return err
+		return madeFile, err
 	}
-	return f.Close()
+	return madeFile, f.Close()
 }
 
 // validExtents rejects extent tables that could not have come from the

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -125,16 +126,9 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	if err != nil {
 		return nil, err
 	}
-	if err := ensureFreshDir(destDir); err != nil {
-		return nil, err
-	}
-	// Pin the destination: every per-file open, verify, and cleanup below is
-	// relative to this directory descriptor, so a symlink swapped in for
-	// destDir (or planted inside it) after the freshness check cannot
-	// redirect writes elsewhere.
-	root, err := os.OpenRoot(destDir)
+	root, err := openFreshDir(destDir)
 	if err != nil {
-		return nil, fmt.Errorf("dest dir: %w", err)
+		return nil, err
 	}
 	defer root.Close()
 	var created []string
@@ -169,26 +163,61 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	return manifest, nil
 }
 
-// ensureFreshDir creates destDir (and parents) or accepts an existing but
-// empty directory. Anything else is refused; see RestoreGeneration.
-func ensureFreshDir(dir string) error {
-	// A symlink at dir itself would be followed by MkdirAll and everything
-	// after it, redirecting the restore to wherever it points. Require a
-	// real directory (or nothing) at the path.
+// openFreshDir creates dir (and parents) if needed, requires it to be a
+// real, empty directory, and returns a Root pinned to it. Every per-file
+// open, verify, and cleanup in the restore runs relative to that pinned
+// descriptor.
+//
+// The leaf is checked through a Root on the parent: a symlink at dir must
+// never be followed, whether pre-planted (the plain Lstat and the pinned
+// re-check both refuse it) or swapped in concurrently. os.Root methods do
+// follow symlinks, but only confined within the root (absolute targets and
+// escapes error), so even a leaf link raced past the re-check cannot
+// anchor the restore outside dir's parent; and once the Root is open it
+// tracks the directory itself, unaffected by later renames at the path.
+func openFreshDir(dir string) (*os.Root, error) {
+	dir = filepath.Clean(dir)
 	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
+		return nil, fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("dest dir: %w", err)
+		return nil, fmt.Errorf("dest dir: %w", err)
 	}
-	entries, err := os.ReadDir(dir)
+	parent, err := os.OpenRoot(filepath.Dir(dir))
 	if err != nil {
-		return fmt.Errorf("dest dir: %w", err)
+		return nil, fmt.Errorf("dest dir parent: %w", err)
 	}
-	if len(entries) != 0 {
-		return fmt.Errorf("dest dir %s is not empty: restore refuses to overwrite existing content, use a fresh directory", dir)
+	defer parent.Close()
+	base := filepath.Base(dir)
+	fi, err := parent.Lstat(base)
+	if err != nil {
+		return nil, fmt.Errorf("dest dir: %w", err)
 	}
-	return nil
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
+	}
+	root, err := parent.OpenRoot(base)
+	if err != nil {
+		return nil, fmt.Errorf("dest dir: %w", err)
+	}
+	// Emptiness is checked through the pinned Root so it holds for the
+	// directory actually being written, not whatever the path resolves to.
+	d, err := root.Open(".")
+	if err != nil {
+		root.Close()
+		return nil, fmt.Errorf("dest dir: %w", err)
+	}
+	names, err := d.Readdirnames(1)
+	d.Close()
+	if err != nil && !errors.Is(err, io.EOF) {
+		root.Close()
+		return nil, fmt.Errorf("dest dir: %w", err)
+	}
+	if len(names) != 0 {
+		root.Close()
+		return nil, fmt.Errorf("dest dir %s is not empty: restore refuses to overwrite existing content, use a fresh directory", dir)
+	}
+	return root, nil
 }
 
 func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string) (*GenerationManifest, error) {
@@ -214,6 +243,19 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	if manifest.SandboxID != sandboxID || manifest.Generation != generation {
 		return nil, fmt.Errorf("manifest identity mismatch: %s records %s/%s, requested %s/%s",
 			object, manifest.SandboxID, manifest.Generation, sandboxID, generation)
+	}
+	// The manifest must also be self-authenticating: the generation prefix
+	// is the content address GenerationKey derives from the full file set,
+	// so the entries must reproduce it. A manifest with an entry dropped or
+	// a name, digest, or base dependency altered would otherwise pass the
+	// identity check and restore an incomplete or wrong file set with every
+	// remaining digest verifying.
+	files := make([]TaskFile, 0, len(manifest.Files))
+	for _, mf := range manifest.Files {
+		files = append(files, TaskFile{Name: mf.Name, SHA256: mf.SHA256, BasePath: mf.BasePath})
+	}
+	if key := GenerationKey(files); key != generation {
+		return nil, fmt.Errorf("manifest does not reproduce its generation key: file set derives %s, prefix is %s (entry dropped or altered)", key, generation)
 	}
 	return &manifest, nil
 }

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -231,19 +231,53 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 			object, manifest.SandboxID, manifest.Generation, sandboxID, generation)
 	}
 	// The manifest must also be self-authenticating: the generation prefix
-	// is the content address GenerationKey derives from the full file set,
-	// so the entries must reproduce it. A manifest with an entry dropped or
-	// a name, digest, or base dependency altered would otherwise pass the
-	// identity check and restore an incomplete or wrong file set with every
-	// remaining digest verifying.
+	// is the content address GenerationKey derives from the enqueued file
+	// set, so the entries must reproduce it. A manifest with an entry
+	// dropped or a name, digest, or base dependency altered would otherwise
+	// pass the identity check and restore an incomplete or wrong file set
+	// with every remaining digest verifying. Shared base entries are
+	// synthesized at upload time and excluded from the key; they are bound
+	// instead through the consistency-pair check below, whose BaseSHA256
+	// side IS key-covered.
 	files := make([]TaskFile, 0, len(manifest.Files))
+	baseDeps := map[string]bool{}
+	sharedEntries := map[string]bool{}
 	for _, mf := range manifest.Files {
-		files = append(files, TaskFile{Name: mf.Name, SHA256: mf.SHA256, BasePath: mf.BasePath})
+		if isSharedEntry(mf) {
+			sharedEntries[mf.SHA256] = true
+			continue
+		}
+		files = append(files, TaskFile{Name: mf.Name, SHA256: mf.SHA256, BasePath: mf.BasePath, BaseSHA256: mf.BaseSHA256})
+		if mf.BaseSHA256 != "" {
+			baseDeps[mf.BaseSHA256] = true
+		}
 	}
 	if key := GenerationKey(files); key != generation {
 		return nil, fmt.Errorf("manifest does not reproduce its generation key: file set derives %s, prefix is %s (entry dropped or altered)", key, generation)
 	}
+	// Consistency pair: an overlay's holes are backed by its base, so a
+	// declared base dependency without its shared entry is not restorable,
+	// and a shared entry no file depends on is not something this
+	// generation may vouch for.
+	for dep := range baseDeps {
+		if !sharedEntries[dep] {
+			return nil, fmt.Errorf("manifest declares base %s but carries no shared entry for it: consistency pair incomplete", dep)
+		}
+	}
+	for sha := range sharedEntries {
+		if !baseDeps[sha] {
+			return nil, fmt.Errorf("manifest carries shared object %s that no entry depends on", sha)
+		}
+	}
 	return &manifest, nil
+}
+
+// isSharedEntry reports whether a manifest entry points at a bucket-wide
+// shared object rather than one inside the generation prefix: shared
+// entries record the full object path, generation-local entries a single
+// name segment.
+func isSharedEntry(mf ManifestFile) bool {
+	return strings.Contains(mf.Object, "/")
 }
 
 // restoreFile streams a packed object into place: each extent's bytes land
@@ -266,15 +300,30 @@ func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string
 	if mf.Object == "" {
 		return false, fmt.Errorf("manifest entry records no object name")
 	}
-	if err := validSegment(mf.Object); err != nil {
-		return false, fmt.Errorf("manifest object name: %w", err)
-	}
 	if err := validExtents(mf); err != nil {
 		return false, err
 	}
-	object, err := SandboxObject(sandboxID, generation, mf.Object)
-	if err != nil {
-		return false, err
+	var object string
+	if isSharedEntry(mf) {
+		// Shared base objects live outside the generation prefix under a
+		// content-addressed name. Require the recorded path to embed this
+		// entry's digest: the digest chains back to a key-covered
+		// BaseSHA256, so a tampered manifest cannot point the pair at an
+		// arbitrary bucket object.
+		fp, ok := strings.CutPrefix(mf.Object, SharedBaseObject(mf.SHA256, ""))
+		if !ok || fp == "" || strings.ContainsAny(fp, "/\\") {
+			return false, fmt.Errorf("shared object name %q is not bound to digest %s", mf.Object, mf.SHA256)
+		}
+		object = mf.Object
+	} else {
+		if err := validSegment(mf.Object); err != nil {
+			return false, fmt.Errorf("manifest object name: %w", err)
+		}
+		var err error
+		object, err = SandboxObject(sandboxID, generation, mf.Object)
+		if err != nil {
+			return false, err
+		}
 	}
 	rc, err := r.NewReader(ctx, object)
 	if err != nil {

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -168,13 +168,12 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 // open, verify, and cleanup in the restore runs relative to that pinned
 // descriptor.
 //
-// The leaf is checked through a Root on the parent: a symlink at dir must
-// never be followed, whether pre-planted (the plain Lstat and the pinned
-// re-check both refuse it) or swapped in concurrently. os.Root methods do
-// follow symlinks, but only confined within the root (absolute targets and
-// escapes error), so even a leaf link raced past the re-check cannot
-// anchor the restore outside dir's parent; and once the Root is open it
-// tracks the directory itself, unaffected by later renames at the path.
+// A symlink at dir itself must never be followed, whether pre-planted
+// (the plain Lstat refuses it with a clear error) or swapped in
+// concurrently: openRootNoFollow makes the open itself reject a symlink
+// leaf, atomically in the kernel on linux, so there is no check-to-open
+// window. Once the Root is open it tracks the directory itself,
+// unaffected by later renames at the path.
 func openFreshDir(dir string) (*os.Root, error) {
 	dir = filepath.Clean(dir)
 	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
@@ -183,20 +182,7 @@ func openFreshDir(dir string) (*os.Root, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("dest dir: %w", err)
 	}
-	parent, err := os.OpenRoot(filepath.Dir(dir))
-	if err != nil {
-		return nil, fmt.Errorf("dest dir parent: %w", err)
-	}
-	defer parent.Close()
-	base := filepath.Base(dir)
-	fi, err := parent.Lstat(base)
-	if err != nil {
-		return nil, fmt.Errorf("dest dir: %w", err)
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
-	}
-	root, err := parent.OpenRoot(base)
+	root, err := openRootNoFollow(filepath.Dir(dir), filepath.Base(dir))
 	if err != nil {
 		return nil, fmt.Errorf("dest dir: %w", err)
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -200,11 +200,21 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 // size rematerializes trailing holes. Interior holes are simply never
 // written, so on filesystems with hole tracking the restored file is as
 // sparse as the original.
+//
+// The object is fetched by the manifest entry's recorded Object name, never
+// derived from the file name: the name embeds the packing fingerprint, so
+// this entry's extent table describes exactly the object it points at.
 func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, dest string) error {
+	if mf.Object == "" {
+		return fmt.Errorf("manifest entry records no object name")
+	}
+	if err := validSegment(mf.Object); err != nil {
+		return fmt.Errorf("manifest object name: %w", err)
+	}
 	if err := validExtents(mf); err != nil {
 		return err
 	}
-	object, err := SandboxObject(sandboxID, generation, mf.Name)
+	object, err := SandboxObject(sandboxID, generation, mf.Object)
 	if err != nil {
 		return err
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -1,0 +1,261 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+// ErrObjectNotFound reports a blob that does not exist in the store.
+// BlobReader implementations wrap it so callers can distinguish absence
+// from transport failure.
+var ErrObjectNotFound = errors.New("object not found")
+
+// ErrGenerationIncomplete reports a generation whose manifest object is
+// absent. The manifest is written last, so its absence means the uploader
+// never finished (or abandoned) this generation: some artifact objects may
+// exist under the prefix, but the set is unverified and must never be
+// restored from.
+var ErrGenerationIncomplete = errors.New("generation incomplete: manifest object absent")
+
+// BlobReader is the narrow read surface restore needs. It is the mirror of
+// BlobStore: the restore identity holds objectViewer and nothing else.
+type BlobReader interface {
+	// NewReader opens the named object for reading. An absent object yields
+	// an error wrapping ErrObjectNotFound.
+	NewReader(ctx context.Context, object string) (io.ReadCloser, error)
+}
+
+// BlobLister enumerates object names under a prefix. Kept separate from
+// BlobReader so RestoreGeneration does not demand list permission.
+type BlobLister interface {
+	List(ctx context.Context, prefix string) ([]string, error)
+}
+
+// GCSReader implements BlobReader and BlobLister against a bucket. The
+// caller supplies the client and thus the credentials; which identity may
+// read backups is a deployment concern, not a code one.
+type GCSReader struct {
+	bucket *storage.BucketHandle
+}
+
+// NewGCSReader builds a reader for the cell's backup bucket.
+func NewGCSReader(client *storage.Client, bucket string) *GCSReader {
+	return &GCSReader{bucket: client.Bucket(bucket)}
+}
+
+func (g *GCSReader) NewReader(ctx context.Context, object string) (io.ReadCloser, error) {
+	r, err := g.bucket.Object(object).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, fmt.Errorf("%s: %w", object, ErrObjectNotFound)
+		}
+		return nil, fmt.Errorf("open %s: %w", object, err)
+	}
+	return r, nil
+}
+
+func (g *GCSReader) List(ctx context.Context, prefix string) ([]string, error) {
+	it := g.bucket.Objects(ctx, &storage.Query{Prefix: prefix})
+	var names []string
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return names, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", prefix, err)
+		}
+		names = append(names, attrs.Name)
+	}
+}
+
+// ListGenerations returns the complete (manifest-bearing) generations of a
+// sandbox, sorted. Prefixes holding artifacts but no manifest are abandoned
+// or in-flight uploads and are deliberately omitted: they are not
+// restorable and listing them would only invite an operator to try.
+func ListGenerations(ctx context.Context, lister BlobLister, sandboxID string) ([]string, error) {
+	if err := validSegment(sandboxID); err != nil {
+		return nil, fmt.Errorf("sandbox id: %w", err)
+	}
+	prefix := fmt.Sprintf("%s/%s/", sandboxPrefix, sandboxID)
+	names, err := lister.List(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	var generations []string
+	for _, name := range names {
+		rest := strings.TrimPrefix(name, prefix)
+		gen, file, ok := strings.Cut(rest, "/")
+		if ok && file == ManifestObject {
+			generations = append(generations, gen)
+		}
+	}
+	sort.Strings(generations)
+	return generations, nil
+}
+
+// RestoreGeneration materializes one complete generation into destDir:
+// fetch the manifest, rebuild each sparse artifact from its packed object
+// and extent table, and verify every file's full apparent content against
+// the manifest digest. On success destDir holds exactly the manifest's
+// files, verified.
+//
+// Failure handling is all-or-nothing: any fetch, write, or digest failure
+// deletes every file this call created in destDir before returning. A
+// partially restored directory that looks plausible is the dangerous
+// outcome for a recovery tool; an empty one forces the operator (or the
+// calling recovery flow) to retry or pick another generation, never to
+// boot a half-verified sandbox.
+func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation, destDir string) (*GenerationManifest, error) {
+	manifest, err := fetchManifest(ctx, r, sandboxID, generation)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("dest dir: %w", err)
+	}
+	var created []string
+	fail := func(err error) (*GenerationManifest, error) {
+		for _, p := range created {
+			os.Remove(p)
+		}
+		return nil, err
+	}
+	for _, mf := range manifest.Files {
+		// The bucket is shared across the cell; never let a manifest name
+		// escape destDir.
+		if err := validSegment(mf.Name); err != nil {
+			return fail(fmt.Errorf("manifest file name: %w", err))
+		}
+		dest := filepath.Join(destDir, mf.Name)
+		created = append(created, dest)
+		if err := restoreFile(ctx, r, sandboxID, generation, mf, dest); err != nil {
+			return fail(fmt.Errorf("restore %s: %w", mf.Name, err))
+		}
+	}
+	// Verify after every file has materialized so an error part way through
+	// verification cannot leave earlier files implicitly blessed: either
+	// the whole set passes or the whole set is gone.
+	for _, mf := range manifest.Files {
+		if err := verifyFile(ctx, filepath.Join(destDir, mf.Name), mf); err != nil {
+			return fail(fmt.Errorf("verify %s: %w", mf.Name, err))
+		}
+	}
+	return manifest, nil
+}
+
+func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string) (*GenerationManifest, error) {
+	object, err := SandboxObject(sandboxID, generation, ManifestObject)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := r.NewReader(ctx, object)
+	if err != nil {
+		if errors.Is(err, ErrObjectNotFound) {
+			return nil, fmt.Errorf("%s/%s: %w", sandboxID, generation, ErrGenerationIncomplete)
+		}
+		return nil, err
+	}
+	defer rc.Close()
+	var manifest GenerationManifest
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", object, err)
+	}
+	return &manifest, nil
+}
+
+// restoreFile streams a packed object into place: each extent's bytes land
+// at their recorded apparent offset, then a final truncate to the apparent
+// size rematerializes trailing holes. Interior holes are simply never
+// written, so on filesystems with hole tracking the restored file is as
+// sparse as the original.
+func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string, mf ManifestFile, dest string) error {
+	if err := validExtents(mf); err != nil {
+		return err
+	}
+	object, err := SandboxObject(sandboxID, generation, mf.Name)
+	if err != nil {
+		return err
+	}
+	rc, err := r.NewReader(ctx, object)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, e := range mf.Extents {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, err := io.CopyN(io.NewOffsetWriter(f, e.Offset), rc, e.Length); err != nil {
+			return fmt.Errorf("extent at %d: %w", e.Offset, err)
+		}
+	}
+	// The packed object must hold exactly the extent table's bytes; trailing
+	// data means object and manifest disagree.
+	if n, _ := io.CopyN(io.Discard, rc, 1); n != 0 {
+		return fmt.Errorf("packed object longer than extent table (%d bytes)", PackedSize(mf.Extents))
+	}
+	if err := f.Truncate(mf.Size); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// validExtents rejects extent tables that could not have come from the
+// uploader: overlapping or out-of-order runs, or data past the apparent
+// size. The digest check would catch the resulting corruption anyway, but
+// failing on the malformed manifest gives a precise error instead.
+func validExtents(mf ManifestFile) error {
+	var pos int64
+	for _, e := range mf.Extents {
+		if e.Offset < pos || e.Length <= 0 {
+			return fmt.Errorf("malformed extent table at offset %d", e.Offset)
+		}
+		pos = e.Offset + e.Length
+	}
+	if pos > mf.Size {
+		return fmt.Errorf("extent table exceeds apparent size %d", mf.Size)
+	}
+	return nil
+}
+
+// verifyFile recomputes the full apparent digest of the rebuilt file with
+// the same logic the uploader used (hashApparent over the manifest's extent
+// table) and compares it to the manifest's recorded digest.
+func verifyFile(ctx context.Context, path string, mf ManifestFile) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if fi.Size() != mf.Size {
+		return fmt.Errorf("apparent size %d, manifest records %d", fi.Size(), mf.Size)
+	}
+	sum, err := hashApparent(ctx, f, mf.Extents, mf.Size)
+	if err != nil {
+		return err
+	}
+	if sum != mf.SHA256 {
+		return fmt.Errorf("sha256 mismatch: got %s, manifest records %s", sum, mf.SHA256)
+	}
+	return nil
+}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -107,8 +107,13 @@ func ListGenerations(ctx context.Context, lister BlobLister, sandboxID string) (
 // RestoreGeneration materializes one complete generation into destDir:
 // fetch the manifest, rebuild each sparse artifact from its packed object
 // and extent table, and verify every file's full apparent content against
-// the manifest digest. On success destDir holds exactly the manifest's
-// files, verified.
+// the manifest digest. destDir must be absent or an empty directory; on
+// success it holds exactly the manifest's files, verified.
+//
+// Requiring a fresh destination is deliberate: restoring over existing
+// content would truncate name-colliding files (and follow any symlinks
+// planted there), and the failure cleanup below would then delete what it
+// clobbered. A recovery tool must never destroy state it did not create.
 //
 // Failure handling is all-or-nothing: any fetch, write, or digest failure
 // deletes every file this call created in destDir before returning. A
@@ -121,8 +126,8 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(destDir, 0o755); err != nil {
-		return nil, fmt.Errorf("dest dir: %w", err)
+	if err := ensureFreshDir(destDir); err != nil {
+		return nil, err
 	}
 	var created []string
 	fail := func(err error) (*GenerationManifest, error) {
@@ -152,6 +157,22 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 		}
 	}
 	return manifest, nil
+}
+
+// ensureFreshDir creates destDir (and parents) or accepts an existing but
+// empty directory. Anything else is refused; see RestoreGeneration.
+func ensureFreshDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("dest dir: %w", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("dest dir: %w", err)
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("dest dir %s is not empty: restore refuses to overwrite existing content, use a fresh directory", dir)
+	}
+	return nil
 }
 
 func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string) (*GenerationManifest, error) {

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -164,7 +164,7 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 			progress(format, args...)
 		}
 	}
-	manifest, err := fetchManifest(ctx, r, sandboxID, generation)
+	manifest, err := fetchManifest(ctx, r, sandboxID, generation, report)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func openFreshDir(dir string) (*os.Root, error) {
 	return root, nil
 }
 
-func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string) (*GenerationManifest, error) {
+func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string, report ProgressFunc) (*GenerationManifest, error) {
 	object, err := SandboxObject(sandboxID, generation, ManifestObject)
 	if err != nil {
 		return nil, err
@@ -382,8 +382,19 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 			baseDeps[mf.BaseSHA256] = true
 		}
 	}
+	// Two accepted derivations: the current formula (Size in the key) and
+	// the legacy pre-Size formula. Buckets hold generations uploaded under
+	// the legacy formula, and refusing them would make history
+	// unrestorable; a legacy match loses key coverage of Size only, which
+	// the per-entry cap in validExtents bounds regardless of key version.
 	if key := GenerationKey(files); key != generation {
-		return nil, fmt.Errorf("manifest does not reproduce its generation key: file set derives %s, prefix is %s (entry dropped or altered)", key, generation)
+		if legacy := generationKeyLegacy(files); legacy == generation {
+			report("generation key verified via the legacy pre-size derivation")
+		} else {
+			return nil, fmt.Errorf("manifest does not reproduce its generation key: file set derives %s (legacy %s), prefix is %s (entry dropped or altered)", key, legacy, generation)
+		}
+	} else {
+		report("generation key verified via the current derivation")
 	}
 	// Consistency pair, exact in both directions: an overlay's holes are
 	// backed by its base, so a declared base dependency without its shared
@@ -513,12 +524,13 @@ func validExtents(mf ManifestFile) error {
 	if mf.Size < 0 {
 		return fmt.Errorf("negative apparent size %d", mf.Size)
 	}
-	// Generation-local sizes are covered by the generation key, but shared
-	// base entries are synthesized outside it, so their Size is bound only
-	// by this cap until the digest check, and the digest check itself costs
-	// a zero-hash proportional to Size. Fleet artifacts top out in the
-	// tens of GiB apparent; 16TiB is a physical-plausibility bound, not a
-	// tuning knob.
+	// The cap applies to every entry regardless of key version: shared
+	// base entries are synthesized outside the generation key, and legacy
+	// pre-size generations never covered Size at all, so for both the cap
+	// is the only bound before the digest check, and the digest check
+	// itself costs a zero-hash proportional to Size. Fleet artifacts top
+	// out in the tens of GiB apparent; 16TiB is a physical-plausibility
+	// bound, not a tuning knob.
 	if mf.Size > maxApparentSize {
 		return fmt.Errorf("apparent size %d exceeds the %d bound", mf.Size, int64(maxApparentSize))
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -324,25 +324,33 @@ func validExtents(mf ManifestFile) error {
 	return nil
 }
 
-// verifyFile recomputes the full apparent digest of the rebuilt file with
-// the same logic the uploader used (hashApparent over the manifest's extent
-// table) and compares it to the manifest's recorded digest. The open is
-// relative to the pinned root so verification reads the file that was
-// written, not something swapped in at the path.
+// verifyFile recomputes the full apparent digest of the rebuilt file and
+// compares it to the manifest's recorded digest. The open is relative to
+// the pinned root so verification reads the file that was written, not
+// something swapped in at the path.
+//
+// The extent geometry is derived from the restored file itself, never
+// taken from the manifest: hashing manifest-declared holes as synthetic
+// zeros would miss bytes written into a hole after materialization, and
+// verification would bless contents it never read. From the file's own
+// geometry, a hole hashed as zeros is genuinely a hole on disk (nothing
+// can hide there) and every data extent is read back. On filesystems
+// without hole tracking this degrades to hashing the complete file,
+// correct, just not compact.
 func verifyFile(ctx context.Context, root *os.Root, mf ManifestFile) error {
 	f, err := root.Open(mf.Name)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	fi, err := f.Stat()
+	extents, apparent, err := Extents(f)
 	if err != nil {
-		return err
+		return fmt.Errorf("extents: %w", err)
 	}
-	if fi.Size() != mf.Size {
-		return fmt.Errorf("apparent size %d, manifest records %d", fi.Size(), mf.Size)
+	if apparent != mf.Size {
+		return fmt.Errorf("apparent size %d, manifest records %d", apparent, mf.Size)
 	}
-	sum, err := hashApparent(ctx, f, mf.Extents, mf.Size)
+	sum, err := hashApparent(ctx, f, extents, apparent)
 	if err != nil {
 		return err
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -192,6 +192,13 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
 		return nil, fmt.Errorf("parse manifest %s: %w", object, err)
 	}
+	// The manifest records its own identity; a manifest copied or misplaced
+	// under another prefix could otherwise restore a different sandbox's
+	// generation with every digest passing.
+	if manifest.SandboxID != sandboxID || manifest.Generation != generation {
+		return nil, fmt.Errorf("manifest identity mismatch: %s records %s/%s, requested %s/%s",
+			object, manifest.SandboxID, manifest.Generation, sandboxID, generation)
+	}
 	return &manifest, nil
 }
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -226,6 +226,22 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	if err := syncRootDir(root); err != nil {
 		return fail(fmt.Errorf("sync dest dir: %w", err))
 	}
+	// The destination's own dirent lives in its PARENT: without syncing
+	// it, a freshly created destDir can vanish wholesale on power loss
+	// after success was reported, even though its contents were durable.
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return fail(fmt.Errorf("resolve dest for parent sync: %w", err))
+	}
+	if parent, err := os.Open(filepath.Dir(absDest)); err == nil {
+		serr := parent.Sync()
+		parent.Close()
+		if serr != nil {
+			return fail(fmt.Errorf("sync dest parent: %w", serr))
+		}
+	} else {
+		return fail(fmt.Errorf("open dest parent for sync: %w", err))
+	}
 	report("restore complete: %d files and completion marker durable", len(manifest.Files))
 	return manifest, nil
 }

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -35,10 +38,16 @@ type BlobReader interface {
 	NewReader(ctx context.Context, object string) (io.ReadCloser, error)
 }
 
-// BlobLister enumerates object names under a prefix. Kept separate from
+// BlobLister enumerates objects under a prefix. Kept separate from
 // BlobReader so RestoreGeneration does not demand list permission.
 type BlobLister interface {
-	List(ctx context.Context, prefix string) ([]string, error)
+	List(ctx context.Context, prefix string) ([]ObjectInfo, error)
+}
+
+// ObjectInfo describes one stored object as seen by a listing.
+type ObjectInfo struct {
+	Name    string
+	Created time.Time
 }
 
 // GCSReader implements BlobReader and BlobLister against a bucket. The
@@ -64,51 +73,70 @@ func (g *GCSReader) NewReader(ctx context.Context, object string) (io.ReadCloser
 	return r, nil
 }
 
-func (g *GCSReader) List(ctx context.Context, prefix string) ([]string, error) {
+func (g *GCSReader) List(ctx context.Context, prefix string) ([]ObjectInfo, error) {
 	it := g.bucket.Objects(ctx, &storage.Query{Prefix: prefix})
-	var names []string
+	var objects []ObjectInfo
 	for {
 		attrs, err := it.Next()
 		if errors.Is(err, iterator.Done) {
-			return names, nil
+			return objects, nil
 		}
 		if err != nil {
 			return nil, fmt.Errorf("list %s: %w", prefix, err)
 		}
-		names = append(names, attrs.Name)
+		objects = append(objects, ObjectInfo{Name: attrs.Name, Created: attrs.Created})
 	}
 }
 
-// ListGenerations returns the complete (manifest-bearing) generations of a
-// sandbox, sorted. Prefixes holding artifacts but no manifest are abandoned
-// or in-flight uploads and are deliberately omitted: they are not
-// restorable and listing them would only invite an operator to try.
-func ListGenerations(ctx context.Context, lister BlobLister, sandboxID string) ([]string, error) {
+// GenerationInfo identifies one restorable generation. Created is when
+// the manifest completion object was written: the moment the generation
+// became restorable, which is what an operator choosing between opaque
+// content-addressed keys under DR pressure actually needs to see.
+type GenerationInfo struct {
+	Generation string
+	Created    time.Time
+}
+
+// ListGenerations returns the complete (manifest-bearing) generations of
+// a sandbox, newest first. Prefixes holding artifacts but no manifest are
+// abandoned or in-flight uploads and are deliberately omitted: they are
+// not restorable and listing them would only invite an operator to try.
+func ListGenerations(ctx context.Context, lister BlobLister, sandboxID string) ([]GenerationInfo, error) {
 	if err := validSegment(sandboxID); err != nil {
 		return nil, fmt.Errorf("sandbox id: %w", err)
 	}
 	prefix := fmt.Sprintf("%s/%s/", sandboxPrefix, sandboxID)
-	names, err := lister.List(ctx, prefix)
+	objects, err := lister.List(ctx, prefix)
 	if err != nil {
 		return nil, err
 	}
-	var generations []string
-	for _, name := range names {
-		rest := strings.TrimPrefix(name, prefix)
+	var generations []GenerationInfo
+	for _, obj := range objects {
+		rest := strings.TrimPrefix(obj.Name, prefix)
 		gen, file, ok := strings.Cut(rest, "/")
 		if ok && file == ManifestObject {
-			generations = append(generations, gen)
+			generations = append(generations, GenerationInfo{Generation: gen, Created: obj.Created})
 		}
 	}
-	sort.Strings(generations)
+	sort.Slice(generations, func(i, j int) bool {
+		if !generations[i].Created.Equal(generations[j].Created) {
+			return generations[i].Created.After(generations[j].Created)
+		}
+		return generations[i].Generation < generations[j].Generation
+	})
 	return generations, nil
 }
+
+// ProgressFunc receives human-readable progress lines during a restore.
+// A nil ProgressFunc is silent.
+type ProgressFunc func(format string, args ...any)
 
 // RestoreGeneration materializes one complete generation into destDir:
 // fetch the manifest, rebuild each sparse artifact from its packed object
 // and extent table, and verify every file's full apparent content against
 // the manifest digest. destDir must be absent or an empty directory; on
-// success it holds exactly the manifest's files, verified.
+// success it holds exactly the manifest's files, verified and fsynced,
+// plus the completion marker described below.
 //
 // Requiring a fresh destination is deliberate: restoring over existing
 // content would truncate name-colliding files (and follow any symlinks
@@ -121,11 +149,26 @@ func ListGenerations(ctx context.Context, lister BlobLister, sandboxID string) (
 // outcome for a recovery tool; an empty one forces the operator (or the
 // calling recovery flow) to retry or pick another generation, never to
 // boot a half-verified sandbox.
-func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation, destDir string) (*GenerationManifest, error) {
+//
+// Completion marker: after every file verifies, the generation manifest
+// is written to destDir/manifest.json, fsynced, and the directory itself
+// is fsynced, mirroring the upload design where the manifest object is
+// written last. The marker is the completeness authority: a destination
+// without it is a crashed or interrupted restore regardless of which
+// artifact names happen to be present, and no consumer may treat such a
+// directory as restored. Artifact entries named manifest.json are
+// rejected up front so the marker can never collide.
+func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation, destDir string, progress ProgressFunc) (*GenerationManifest, error) {
+	report := func(format string, args ...any) {
+		if progress != nil {
+			progress(format, args...)
+		}
+	}
 	manifest, err := fetchManifest(ctx, r, sandboxID, generation)
 	if err != nil {
 		return nil, err
 	}
+	report("manifest %s/%s: %d files", sandboxID, generation, len(manifest.Files))
 	root, err := openFreshDir(destDir)
 	if err != nil {
 		return nil, err
@@ -133,8 +176,14 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 	defer root.Close()
 	var created []string
 	fail := func(err error) (*GenerationManifest, error) {
+		var cleanupErrs []string
 		for _, name := range created {
-			root.Remove(name)
+			if rerr := root.Remove(name); rerr != nil && !errors.Is(rerr, fs.ErrNotExist) {
+				cleanupErrs = append(cleanupErrs, rerr.Error())
+			}
+		}
+		if len(cleanupErrs) != 0 {
+			err = fmt.Errorf("%w (cleanup also failed, destination must not be reused: %s)", err, strings.Join(cleanupErrs, "; "))
 		}
 		return nil, err
 	}
@@ -144,6 +193,7 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 		if err := validSegment(mf.Name); err != nil {
 			return fail(fmt.Errorf("manifest file name: %w", err))
 		}
+		report("restoring %s (%d bytes packed, %d apparent)", mf.Name, mf.PackedSize, mf.Size)
 		madeFile, err := restoreFile(ctx, r, sandboxID, generation, mf, root)
 		if madeFile {
 			created = append(created, mf.Name)
@@ -159,8 +209,55 @@ func RestoreGeneration(ctx context.Context, r BlobReader, sandboxID, generation,
 		if err := verifyFile(ctx, root, mf); err != nil {
 			return fail(fmt.Errorf("verify %s: %w", mf.Name, err))
 		}
+		report("verified %s sha256 %s", mf.Name, mf.SHA256)
 	}
+	madeMarker, err := writeRestoreMarker(root, manifest)
+	if madeMarker {
+		created = append(created, ManifestObject)
+	}
+	if err != nil {
+		return fail(fmt.Errorf("completion marker: %w", err))
+	}
+	// Directory fsync makes the entries themselves durable; each file's
+	// contents were fsynced as it was restored. Without this, power loss
+	// after a reported success could leave a directory whose names are all
+	// present but whose data never reached disk, which a rerun would
+	// refuse as non-empty while looking complete.
+	if err := syncRootDir(root); err != nil {
+		return fail(fmt.Errorf("sync dest dir: %w", err))
+	}
+	report("restore complete: %d files and completion marker durable", len(manifest.Files))
 	return manifest, nil
+}
+
+// writeRestoreMarker writes the fsynced completion marker, last.
+func writeRestoreMarker(root *os.Root, manifest *GenerationManifest) (madeFile bool, _ error) {
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		return false, err
+	}
+	f, err := root.OpenFile(ManifestObject, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return false, err
+	}
+	madeFile = true
+	defer f.Close()
+	if _, err := f.Write(payload); err != nil {
+		return madeFile, err
+	}
+	if err := f.Sync(); err != nil {
+		return madeFile, err
+	}
+	return madeFile, f.Close()
+}
+
+func syncRootDir(root *os.Root) error {
+	d, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 // openFreshDir creates dir (and parents) if needed, requires it to be a
@@ -179,8 +276,22 @@ func openFreshDir(dir string) (*os.Root, error) {
 	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, fmt.Errorf("dest dir: %w", err)
+	// Mkdir on the leaf, never MkdirAll over the full path: MkdirAll
+	// re-resolves the whole path, so a symlink swapped in after the Lstat
+	// above would get directories created at its target (a side effect
+	// only, the no-follow open below still rejects the leaf, but a restore
+	// must not scribble directories elsewhere either). Mkdir on an
+	// existing leaf, symlink included, is EEXIST and creates nothing.
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			if perr := os.MkdirAll(filepath.Dir(dir), 0o755); perr != nil {
+				return nil, fmt.Errorf("dest dir parent: %w", perr)
+			}
+			err = os.Mkdir(dir, 0o755)
+		}
+		if err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("dest dir: %w", err)
+		}
 	}
 	root, err := openRootNoFollow(filepath.Dir(dir), filepath.Base(dir))
 	if err != nil {
@@ -220,7 +331,9 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	}
 	defer rc.Close()
 	var manifest GenerationManifest
-	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+	// Real manifests are kilobytes; the cap only bounds what a corrupt or
+	// hostile object can make this process buffer while decoding.
+	if err := json.NewDecoder(io.LimitReader(rc, maxManifestBytes)).Decode(&manifest); err != nil {
 		return nil, fmt.Errorf("parse manifest %s: %w", object, err)
 	}
 	// The manifest records its own identity; a manifest copied or misplaced
@@ -233,21 +346,38 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	// The manifest must also be self-authenticating: the generation prefix
 	// is the content address GenerationKey derives from the enqueued file
 	// set, so the entries must reproduce it. A manifest with an entry
-	// dropped or a name, digest, or base dependency altered would otherwise
-	// pass the identity check and restore an incomplete or wrong file set
-	// with every remaining digest verifying. Shared base entries are
-	// synthesized at upload time and excluded from the key; they are bound
-	// instead through the consistency-pair check below, whose BaseSHA256
-	// side IS key-covered.
+	// dropped or a name, digest, size, or base dependency altered would
+	// otherwise pass the identity check and restore an incomplete or wrong
+	// file set with every remaining digest verifying. Shared base entries
+	// are synthesized at upload time and excluded from the key; they are
+	// bound instead through the consistency-pair check below, whose
+	// BaseSHA256 side IS key-covered.
+	//
+	// Duplicates are rejected outright before any file is touched: a
+	// duplicated shared entry under a fresh name would otherwise restore
+	// and verify extra copies of a multi-GB base (silent disk exhaustion
+	// inside a "verified" restore), and duplicate names can never
+	// materialize under exclusive per-name creation.
 	files := make([]TaskFile, 0, len(manifest.Files))
 	baseDeps := map[string]bool{}
 	sharedEntries := map[string]bool{}
+	names := map[string]bool{}
 	for _, mf := range manifest.Files {
+		if mf.Name == ManifestObject {
+			return nil, fmt.Errorf("manifest entry named %q collides with the completion marker", mf.Name)
+		}
+		if names[mf.Name] {
+			return nil, fmt.Errorf("manifest lists file name %q twice", mf.Name)
+		}
+		names[mf.Name] = true
 		if isSharedEntry(mf) {
+			if sharedEntries[mf.SHA256] {
+				return nil, fmt.Errorf("manifest lists shared object %s twice", mf.SHA256)
+			}
 			sharedEntries[mf.SHA256] = true
 			continue
 		}
-		files = append(files, TaskFile{Name: mf.Name, SHA256: mf.SHA256, BasePath: mf.BasePath, BaseSHA256: mf.BaseSHA256})
+		files = append(files, TaskFile{Name: mf.Name, SHA256: mf.SHA256, Size: mf.Size, BasePath: mf.BasePath, BaseSHA256: mf.BaseSHA256})
 		if mf.BaseSHA256 != "" {
 			baseDeps[mf.BaseSHA256] = true
 		}
@@ -255,10 +385,10 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	if key := GenerationKey(files); key != generation {
 		return nil, fmt.Errorf("manifest does not reproduce its generation key: file set derives %s, prefix is %s (entry dropped or altered)", key, generation)
 	}
-	// Consistency pair: an overlay's holes are backed by its base, so a
-	// declared base dependency without its shared entry is not restorable,
-	// and a shared entry no file depends on is not something this
-	// generation may vouch for.
+	// Consistency pair, exact in both directions: an overlay's holes are
+	// backed by its base, so a declared base dependency without its shared
+	// entry is not restorable, and a shared entry no file depends on is
+	// not something this generation may vouch for.
 	for dep := range baseDeps {
 		if !sharedEntries[dep] {
 			return nil, fmt.Errorf("manifest declares base %s but carries no shared entry for it: consistency pair incomplete", dep)
@@ -271,6 +401,12 @@ func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation stri
 	}
 	return &manifest, nil
 }
+
+// maxManifestBytes bounds the manifest decode; see fetchManifest.
+const maxManifestBytes = 64 << 20
+
+// maxApparentSize bounds a single restored artifact; see validExtents.
+const maxApparentSize = int64(16) << 40
 
 // isSharedEntry reports whether a manifest entry points at a bucket-wide
 // shared object rather than one inside the generation prefix: shared
@@ -344,31 +480,63 @@ func restoreFile(ctx context.Context, r BlobReader, sandboxID, generation string
 			return madeFile, fmt.Errorf("extent at %d: %w", e.Offset, err)
 		}
 	}
-	// The packed object must hold exactly the extent table's bytes; trailing
-	// data means object and manifest disagree.
-	if n, _ := io.CopyN(io.Discard, rc, 1); n != 0 {
-		return madeFile, fmt.Errorf("packed object longer than extent table (%d bytes)", PackedSize(mf.Extents))
+	// The packed object must hold exactly the extent table's bytes;
+	// trailing data means object and manifest disagree. A transport error
+	// here is reported as such, not mistaken for a clean end of object.
+	switch n, err := io.CopyN(io.Discard, rc, 1); {
+	case n != 0:
+		extra, _ := io.Copy(io.Discard, rc)
+		return madeFile, fmt.Errorf("packed object is %d bytes, extent table describes %d", PackedSize(mf.Extents)+1+extra, PackedSize(mf.Extents))
+	case err != nil && !errors.Is(err, io.EOF):
+		return madeFile, fmt.Errorf("read past extents: %w", err)
 	}
 	if err := f.Truncate(mf.Size); err != nil {
+		return madeFile, err
+	}
+	// Contents must be on disk before the caller can report a verified
+	// restore; page-cache-only bytes would vanish in a power loss behind a
+	// complete-looking directory.
+	if err := f.Sync(); err != nil {
 		return madeFile, err
 	}
 	return madeFile, f.Close()
 }
 
 // validExtents rejects extent tables that could not have come from the
-// uploader: overlapping or out-of-order runs, or data past the apparent
-// size. The digest check would catch the resulting corruption anyway, but
-// failing on the malformed manifest gives a precise error instead.
+// uploader: negative fields, overlapping or out-of-order runs, offsets
+// that overflow int64, or data past the apparent size. The digest check
+// would catch most resulting corruption anyway, but the extent table
+// drives writes and truncation BEFORE any digest runs, so it must be
+// bounded on its own; and Offset+Length wrapping negative would otherwise
+// reset the monotonic cursor and re-admit anything.
 func validExtents(mf ManifestFile) error {
+	if mf.Size < 0 {
+		return fmt.Errorf("negative apparent size %d", mf.Size)
+	}
+	// Generation-local sizes are covered by the generation key, but shared
+	// base entries are synthesized outside it, so their Size is bound only
+	// by this cap until the digest check, and the digest check itself costs
+	// a zero-hash proportional to Size. Fleet artifacts top out in the
+	// tens of GiB apparent; 16TiB is a physical-plausibility bound, not a
+	// tuning knob.
+	if mf.Size > maxApparentSize {
+		return fmt.Errorf("apparent size %d exceeds the %d bound", mf.Size, int64(maxApparentSize))
+	}
 	var pos int64
 	for _, e := range mf.Extents {
-		if e.Offset < pos || e.Length <= 0 {
-			return fmt.Errorf("malformed extent table at offset %d", e.Offset)
+		if e.Offset < 0 || e.Length <= 0 {
+			return fmt.Errorf("malformed extent {offset %d, length %d}", e.Offset, e.Length)
+		}
+		if e.Offset < pos {
+			return fmt.Errorf("out-of-order or overlapping extent at offset %d", e.Offset)
+		}
+		if e.Length > math.MaxInt64-e.Offset {
+			return fmt.Errorf("extent {offset %d, length %d} overflows", e.Offset, e.Length)
 		}
 		pos = e.Offset + e.Length
 	}
 	if pos > mf.Size {
-		return fmt.Errorf("extent table exceeds apparent size %d", mf.Size)
+		return fmt.Errorf("extent table ends at %d, past apparent size %d", pos, mf.Size)
 	}
 	return nil
 }

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -276,22 +276,14 @@ func openFreshDir(dir string) (*os.Root, error) {
 	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return nil, fmt.Errorf("dest dir %s is a symlink: restore only writes into a real directory", dir)
 	}
-	// Mkdir on the leaf, never MkdirAll over the full path: MkdirAll
-	// re-resolves the whole path, so a symlink swapped in after the Lstat
-	// above would get directories created at its target (a side effect
-	// only, the no-follow open below still rejects the leaf, but a restore
-	// must not scribble directories elsewhere either). Mkdir on an
-	// existing leaf, symlink included, is EEXIST and creates nothing.
-	if err := os.Mkdir(dir, 0o755); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			if perr := os.MkdirAll(filepath.Dir(dir), 0o755); perr != nil {
-				return nil, fmt.Errorf("dest dir parent: %w", perr)
-			}
-			err = os.Mkdir(dir, 0o755)
-		}
-		if err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, fmt.Errorf("dest dir: %w", err)
-		}
+	// Creation must be as symlink-strict as the open: Mkdir and MkdirAll
+	// resolve ancestors normally, so a symlinked ancestor would get the
+	// destination created at its target even though the no-follow open
+	// below then rejects the path. On linux makeDirNoFollow walks and
+	// creates the hierarchy without following any symlink; elsewhere it
+	// falls back to portable creation with the weaker guarantee.
+	if err := makeDirNoFollow(dir); err != nil {
+		return nil, fmt.Errorf("dest dir: %w", err)
 	}
 	root, err := openRootNoFollow(filepath.Dir(dir), filepath.Base(dir))
 	if err != nil {
@@ -315,6 +307,26 @@ func openFreshDir(dir string) (*os.Root, error) {
 		return nil, fmt.Errorf("dest dir %s is not empty: restore refuses to overwrite existing content, use a fresh directory", dir)
 	}
 	return root, nil
+}
+
+// makeDirPortable creates dir and any missing parents with the standard
+// library primitives. Ancestor components are resolved normally, so a
+// symlinked ancestor IS followed: this is the weaker-guarantee path used
+// on platforms without a no-symlink traversal (and as the linux fallback
+// when openat2 is unavailable). Mkdir on an existing leaf, symlink
+// included, is EEXIST and creates nothing at the leaf itself.
+func makeDirPortable(dir string) error {
+	err := os.Mkdir(dir, 0o755)
+	if errors.Is(err, fs.ErrNotExist) {
+		if perr := os.MkdirAll(filepath.Dir(dir), 0o755); perr != nil {
+			return fmt.Errorf("parent: %w", perr)
+		}
+		err = os.Mkdir(dir, 0o755)
+	}
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		return err
+	}
+	return nil
 }
 
 func fetchManifest(ctx context.Context, r BlobReader, sandboxID, generation string, report ProgressFunc) (*GenerationManifest, error) {

--- a/internal/backup/restore_linux.go
+++ b/internal/backup/restore_linux.go
@@ -12,15 +12,63 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// openRootNoFollow opens base under parentPath as an os.Root without ever
-// following a symlink at the leaf. The kernel enforces it atomically:
-// openat with O_NOFOLLOW|O_DIRECTORY rejects a symlink (ELOOP) in the
-// same syscall that opens the directory, so there is no window between a
-// check and the open for a swap to slip through. The os.Root is then
-// bound to the already-open descriptor via /proc/self/fd, which the
-// kernel resolves to the open file description itself, not a fresh path
-// lookup that could race.
+// openRootNoFollow opens parentPath/base as an os.Root without following
+// a symlink anywhere in the path.
+//
+// The strong path is openat2 with RESOLVE_NO_SYMLINKS: the kernel refuses
+// a symlink in EVERY component of the path, atomically within the open
+// syscall, so neither the leaf nor an ancestor swapped for a symlink
+// between the caller's checks and this open can redirect the restore.
+// The os.Root is then bound to the already-open descriptor via
+// /proc/self/fd, which resolves to the open file description itself, not
+// a fresh path lookup.
+//
+// On kernels without openat2 (pre-5.6, ENOSYS) or seccomp policies that
+// deny it (older container runtimes report EPERM for filtered syscalls),
+// the fallback pins the parent with a plain directory open and rejects a
+// symlink leaf via openat O_NOFOLLOW. That protects the leaf atomically
+// but follows symlinks in ancestor components, a weaker guarantee;
+// production hosts run modern kernels, so the strong path is the
+// production path.
 func openRootNoFollow(parentPath, base string) (*os.Root, error) {
+	dir := filepath.Join(parentPath, base)
+	how := &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS,
+	}
+	var fd int
+	var err error
+	for {
+		fd, err = unix.Openat2(unix.AT_FDCWD, dir, how)
+		if err != unix.EINTR { //nolint:errorlint // raw errno from the syscall
+			break
+		}
+	}
+	switch {
+	case err == nil:
+		// fd stays open until OpenRoot returns so the /proc entry cannot
+		// dangle.
+		defer unix.Close(fd)
+		root, rerr := os.OpenRoot("/proc/self/fd/" + strconv.Itoa(fd))
+		if rerr != nil {
+			return nil, fmt.Errorf("bind root to %s: %w", dir, rerr)
+		}
+		return root, nil
+	case errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR):
+		return nil, fmt.Errorf("%s contains a symlink or non-directory component: restore only writes through real directories", dir)
+	case errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EPERM):
+		return openRootNoFollowFallback(parentPath, base)
+	default:
+		return nil, &os.PathError{Op: "openat2", Path: dir, Err: err}
+	}
+}
+
+// openRootNoFollowFallback is the pre-openat2 path: parent pinned by a
+// plain directory open, leaf opened openat O_NOFOLLOW so a symlink leaf
+// is rejected atomically. Ancestor components of parentPath are resolved
+// normally and CAN follow symlinks; see openRootNoFollow for why this
+// weaker guarantee is acceptable only as a fallback.
+func openRootNoFollowFallback(parentPath, base string) (*os.Root, error) {
 	pfd, err := unix.Open(parentPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: parentPath, Err: err}

--- a/internal/backup/restore_linux.go
+++ b/internal/backup/restore_linux.go
@@ -30,20 +30,82 @@ import (
 // but follows symlinks in ancestor components, a weaker guarantee;
 // production hosts run modern kernels, so the strong path is the
 // production path.
-func openRootNoFollow(parentPath, base string) (*os.Root, error) {
-	dir := filepath.Join(parentPath, base)
+// openat2NoSymlinks opens path as a directory, refusing symlinks in every
+// component, atomically in the kernel. EINTR is retried.
+func openat2NoSymlinks(path string) (int, error) {
 	how := &unix.OpenHow{
 		Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC,
 		Resolve: unix.RESOLVE_NO_SYMLINKS,
 	}
-	var fd int
-	var err error
 	for {
-		fd, err = unix.Openat2(unix.AT_FDCWD, dir, how)
+		fd, err := unix.Openat2(unix.AT_FDCWD, path, how)
 		if err != unix.EINTR { //nolint:errorlint // raw errno from the syscall
-			break
+			return fd, err
 		}
 	}
+}
+
+// makeDirNoFollow creates dir and any missing parents without following a
+// symlink in any component. The deepest existing ancestor is resolved
+// with one openat2(RESOLVE_NO_SYMLINKS) call, then each missing component
+// is created and entered fd-relative with Mkdirat plus openat O_NOFOLLOW,
+// holding the directory fd across each hop so no component can be swapped
+// mid-walk. Mkdir or MkdirAll here instead would resolve ancestors
+// normally and create the destination at a symlink target.
+//
+// Kernels without openat2 (and seccomp policies that filter it) fall back
+// to portable creation with its documented weaker guarantee, matching the
+// open-side fallback.
+func makeDirNoFollow(dir string) error {
+	dir = filepath.Clean(dir)
+	var missing []string
+	anc := dir
+	var fd int
+	for {
+		f, err := openat2NoSymlinks(anc)
+		if err == nil {
+			fd = f
+			break
+		}
+		switch {
+		case errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR):
+			return fmt.Errorf("%s contains a symlink or non-directory component: restore only writes through real directories", anc)
+		case errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EPERM):
+			return makeDirPortable(dir)
+		case !errors.Is(err, unix.ENOENT):
+			return &os.PathError{Op: "openat2", Path: anc, Err: err}
+		}
+		parent := filepath.Dir(anc)
+		if parent == anc {
+			return &os.PathError{Op: "openat2", Path: anc, Err: err}
+		}
+		missing = append([]string{filepath.Base(anc)}, missing...)
+		anc = parent
+	}
+	defer func() { unix.Close(fd) }()
+	for _, comp := range missing {
+		// EEXIST is tolerated (a concurrent restore may have made the same
+		// component); the O_NOFOLLOW open then decides whether whatever is
+		// there is a real directory.
+		if err := unix.Mkdirat(fd, comp, 0o755); err != nil && !errors.Is(err, unix.EEXIST) {
+			return &os.PathError{Op: "mkdirat", Path: comp, Err: err}
+		}
+		nfd, err := unix.Openat(fd, comp, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR) {
+				return fmt.Errorf("%s is a symlink or not a directory: restore only writes through real directories", comp)
+			}
+			return &os.PathError{Op: "openat", Path: comp, Err: err}
+		}
+		unix.Close(fd)
+		fd = nfd
+	}
+	return nil
+}
+
+func openRootNoFollow(parentPath, base string) (*os.Root, error) {
+	dir := filepath.Join(parentPath, base)
+	fd, err := openat2NoSymlinks(dir)
 	switch {
 	case err == nil:
 		// fd stays open until OpenRoot returns so the /proc entry cannot

--- a/internal/backup/restore_linux.go
+++ b/internal/backup/restore_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+// openRootNoFollow opens base under parentPath as an os.Root without ever
+// following a symlink at the leaf. The kernel enforces it atomically:
+// openat with O_NOFOLLOW|O_DIRECTORY rejects a symlink (ELOOP) in the
+// same syscall that opens the directory, so there is no window between a
+// check and the open for a swap to slip through. The os.Root is then
+// bound to the already-open descriptor via /proc/self/fd, which the
+// kernel resolves to the open file description itself, not a fresh path
+// lookup that could race.
+func openRootNoFollow(parentPath, base string) (*os.Root, error) {
+	pfd, err := unix.Open(parentPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: parentPath, Err: err}
+	}
+	defer unix.Close(pfd)
+	fd, err := unix.Openat(pfd, base, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		if errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENOTDIR) {
+			return nil, fmt.Errorf("%s is a symlink or not a directory: restore only writes into a real directory", filepath.Join(parentPath, base))
+		}
+		return nil, &os.PathError{Op: "openat", Path: filepath.Join(parentPath, base), Err: err}
+	}
+	// fd stays open until OpenRoot returns so the /proc entry cannot dangle.
+	defer unix.Close(fd)
+	root, err := os.OpenRoot("/proc/self/fd/" + strconv.Itoa(fd))
+	if err != nil {
+		return nil, fmt.Errorf("bind root to %s: %w", filepath.Join(parentPath, base), err)
+	}
+	return root, nil
+}

--- a/internal/backup/restore_linux_test.go
+++ b/internal/backup/restore_linux_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestOpenRootNoFollowRejectsSymlinkAncestor pins the openat2 path: with
+// RESOLVE_NO_SYMLINKS the kernel refuses a symlink in ANY component, so a
+// symlinked ancestor of the destination cannot redirect the restore. The
+// fallback path deliberately lacks this (leaf-only protection), so the
+// test skips where openat2 is unavailable.
+func TestOpenRootNoFollowRejectsSymlinkAncestor(t *testing.T) {
+	probe := &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS,
+	}
+	if fd, err := unix.Openat2(unix.AT_FDCWD, "/", probe); err != nil {
+		t.Skipf("openat2 unavailable, only the leaf guarantee applies: %v", err)
+	} else {
+		unix.Close(fd)
+	}
+
+	real := filepath.Join(t.TempDir(), "real")
+	if err := os.MkdirAll(filepath.Join(real, "dest"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	root, err := openRootNoFollow(link, "dest")
+	if err == nil {
+		root.Close()
+		t.Fatal("openRootNoFollow followed a symlink ancestor")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink component rejection", err)
+	}
+	// The real path still opens.
+	root, err = openRootNoFollow(real, "dest")
+	if err != nil {
+		t.Fatalf("real ancestor rejected: %v", err)
+	}
+	root.Close()
+}

--- a/internal/backup/restore_linux_test.go
+++ b/internal/backup/restore_linux_test.go
@@ -50,3 +50,53 @@ func TestOpenRootNoFollowRejectsSymlinkAncestor(t *testing.T) {
 	}
 	root.Close()
 }
+
+// TestMakeDirNoFollowRejectsSymlinkAncestor pins the creation side: a
+// missing destination leaf under a symlinked ancestor must fail WITHOUT
+// creating anything at the symlink target, where Mkdir/MkdirAll would
+// have created it before the protected open ever ran.
+func TestMakeDirNoFollowRejectsSymlinkAncestor(t *testing.T) {
+	probe := &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS,
+	}
+	if fd, err := unix.Openat2(unix.AT_FDCWD, "/", probe); err != nil {
+		t.Skipf("openat2 unavailable, only portable creation applies: %v", err)
+	} else {
+		unix.Close(fd)
+	}
+
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(link, "newdir")
+	if err := makeDirNoFollow(dest); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink component rejection", err)
+	}
+	entries, err := os.ReadDir(real)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("directory created at the symlink target: %d entries err=%v", len(entries), err)
+	}
+	// End to end: openFreshDir on the same path also refuses and creates
+	// nothing.
+	if _, err := openFreshDir(dest); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("openFreshDir err = %v, want symlink rejection", err)
+	}
+	entries, err = os.ReadDir(real)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("openFreshDir created at the symlink target: %d entries err=%v", len(entries), err)
+	}
+	// Deep creation through real components still works and the leaf
+	// opens through the pinned path.
+	deep := filepath.Join(real, "a", "b", "c")
+	if err := makeDirNoFollow(deep); err != nil {
+		t.Fatalf("deep creation: %v", err)
+	}
+	root, err := openRootNoFollow(filepath.Dir(deep), "c")
+	if err != nil {
+		t.Fatalf("open created leaf: %v", err)
+	}
+	root.Close()
+}

--- a/internal/backup/restore_other.go
+++ b/internal/backup/restore_other.go
@@ -15,6 +15,13 @@ import (
 // the parent; os.Root confinement still prevents anchoring outside it.
 // This is a weaker guarantee than linux, where the kernel rejects a
 // symlink leaf in the open syscall itself; production hosts are linux.
+// makeDirNoFollow on non-linux platforms is the portable creation: it
+// resolves ancestors normally and can follow ancestor symlinks, a weaker
+// guarantee than the linux no-symlink walk. Production hosts are linux.
+func makeDirNoFollow(dir string) error {
+	return makeDirPortable(dir)
+}
+
 func openRootNoFollow(parentPath, base string) (*os.Root, error) {
 	parent, err := os.OpenRoot(parentPath)
 	if err != nil {

--- a/internal/backup/restore_other.go
+++ b/internal/backup/restore_other.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+package backup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// openRootNoFollow on non-linux platforms approximates the atomic
+// no-follow open with an Lstat through a Root on the parent followed by
+// the confined OpenRoot. The check and the open are two operations, so a
+// symlink swapped in between them is followed if its target stays inside
+// the parent; os.Root confinement still prevents anchoring outside it.
+// This is a weaker guarantee than linux, where the kernel rejects a
+// symlink leaf in the open syscall itself; production hosts are linux.
+func openRootNoFollow(parentPath, base string) (*os.Root, error) {
+	parent, err := os.OpenRoot(parentPath)
+	if err != nil {
+		return nil, err
+	}
+	defer parent.Close()
+	fi, err := parent.Lstat(base)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s is a symlink or not a directory: restore only writes into a real directory", filepath.Join(parentPath, base))
+	}
+	return parent.OpenRoot(base)
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -1070,3 +1070,52 @@ func TestRestoreLegacyGenerationBoundsInflatedSize(t *testing.T) {
 		t.Fatalf("err = %v, want size bound rejection", err)
 	}
 }
+
+// A copy-fallback staged task uploads from staged snapshots while the
+// manifest records the pause-time BasePath identity: the generation key
+// recomputation at restore must accept it. This pins the contract that
+// staging never mutates key-covered fields.
+func TestRestoreValidatesStagedCopyFallbackGeneration(t *testing.T) {
+	dir := t.TempDir()
+	staging := filepath.Join(dir, "staging")
+	base := filepath.Join(dir, "base.ext4")
+	overlay := filepath.Join(dir, "overlay.ext4")
+	if err := os.WriteFile(base, []byte("base image bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlay, []byte("overlay bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseSum := sha256.Sum256([]byte("base image bytes"))
+	osum := sha256.Sum256([]byte("overlay bytes"))
+
+	files := []TaskFile{{
+		Name: "rootfs.ext4", Path: overlay,
+		SHA256: hex.EncodeToString(osum[:]), Size: int64(len("overlay bytes")),
+		BasePath: base, BaseSHA256: hex.EncodeToString(baseSum[:]),
+	}}
+	task := Task{
+		SandboxID: "sb", Generation: GenerationKey(files), Files: files,
+		EnqueuedAt: time.Unix(1, 0),
+	}
+	// Key computed, THEN staged: the copy-fallback ordering.
+	if err := StageTask(staging, &task); err != nil {
+		t.Fatal(err)
+	}
+
+	j, _ := testJournal(t)
+	store := newMemStore()
+	u := &Uploader{Journal: j, Store: store}
+	if completed, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
+		t.Fatalf("upload: completed=%v err=%v", completed, err)
+	}
+
+	dest := filepath.Join(dir, "restored")
+	if _, err := RestoreGeneration(context.Background(), &memBlobs{objects: store.objects}, "sb", task.Generation, dest, nil); err != nil {
+		t.Fatalf("restore of staged generation rejected: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "rootfs.ext4"))
+	if err != nil || string(got) != "overlay bytes" {
+		t.Fatalf("restored overlay = %q err=%v", got, err)
+	}
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,10 +26,16 @@ import (
 type memBlobs struct {
 	mu      sync.Mutex
 	objects map[string][]byte
+	created map[string]time.Time
+	clock   time.Time
 }
 
 func newMemBlobs() *memBlobs {
-	return &memBlobs{objects: map[string][]byte{}}
+	return &memBlobs{
+		objects: map[string][]byte{},
+		created: map[string]time.Time{},
+		clock:   time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC),
+	}
 }
 
 func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) (bool, error) {
@@ -41,6 +49,8 @@ func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) (bool, 
 		return false, err
 	}
 	m.objects[object] = data
+	m.clock = m.clock.Add(time.Minute)
+	m.created[object] = m.clock
 	return true, nil
 }
 
@@ -54,16 +64,16 @@ func (m *memBlobs) NewReader(_ context.Context, object string) (io.ReadCloser, e
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
-func (m *memBlobs) List(_ context.Context, prefix string) ([]string, error) {
+func (m *memBlobs) List(_ context.Context, prefix string) ([]ObjectInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var names []string
+	var objects []ObjectInfo
 	for name := range m.objects {
 		if strings.HasPrefix(name, prefix) {
-			names = append(names, name)
+			objects = append(objects, ObjectInfo{Name: name, Created: m.created[name]})
 		}
 	}
-	return names, nil
+	return objects, nil
 }
 
 // writeRestoreFixture builds the source artifacts: a genuinely sparse disk
@@ -141,7 +151,7 @@ func TestRestoreGenerationRoundTrip(t *testing.T) {
 	uploadFixture(t, store, task)
 
 	destDir := filepath.Join(t.TempDir(), "restored")
-	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
 	if err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -167,6 +177,24 @@ func TestRestoreGenerationRoundTrip(t *testing.T) {
 			t.Fatalf("digest for %s = %s, want %s", tf.Name, manifest.Files[i].SHA256, tf.SHA256)
 		}
 	}
+	// The completion marker is written last and is the completeness
+	// authority: it must exist, parse, and record this generation. The
+	// destination holds exactly the manifest's files plus the marker.
+	markerData, err := os.ReadFile(filepath.Join(destDir, ManifestObject))
+	if err != nil {
+		t.Fatalf("completion marker: %v", err)
+	}
+	var marker GenerationManifest
+	if err := json.Unmarshal(markerData, &marker); err != nil {
+		t.Fatalf("completion marker parse: %v", err)
+	}
+	if marker.SandboxID != task.SandboxID || marker.Generation != task.Generation {
+		t.Fatalf("marker identity = %s/%s", marker.SandboxID, marker.Generation)
+	}
+	entries, err := os.ReadDir(destDir)
+	if err != nil || len(entries) != len(task.Files)+1 {
+		t.Fatalf("dest entries = %d err=%v, want files plus marker", len(entries), err)
+	}
 }
 
 func TestRestoreGenerationFailsOnCorruptObject(t *testing.T) {
@@ -191,7 +219,7 @@ func TestRestoreGenerationFailsOnCorruptObject(t *testing.T) {
 	store.objects[object] = corrupted
 
 	destDir := filepath.Join(t.TempDir(), "restored")
-	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
 	if err == nil {
 		t.Fatal("restore of corrupted object succeeded")
 	}
@@ -213,7 +241,7 @@ func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
 	// leaves behind.
 	delete(store.objects, genObject(task, ManifestObject))
 
-	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
 	if !errors.Is(err, ErrGenerationIncomplete) {
 		t.Fatalf("err = %v, want ErrGenerationIncomplete", err)
 	}
@@ -230,7 +258,7 @@ func TestRestoreGenerationRejectsMisplacedManifest(t *testing.T) {
 	for name, data := range store.objects {
 		store.objects[strings.Replace(name, "sb-restore", "sb-victim", 1)] = data
 	}
-	_, err := RestoreGeneration(context.Background(), store, "sb-victim", task.Generation, filepath.Join(t.TempDir(), "restored"))
+	_, err := RestoreGeneration(context.Background(), store, "sb-victim", task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
 	if err == nil || !strings.Contains(err.Error(), "identity mismatch") {
 		t.Fatalf("err = %v, want manifest identity mismatch", err)
 	}
@@ -256,7 +284,7 @@ func TestRestoreGenerationRejectsManifestMissingEntries(t *testing.T) {
 	}
 	store.objects[manifestObject] = mutated
 
-	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
 	if err == nil || !strings.Contains(err.Error(), "generation key") {
 		t.Fatalf("err = %v, want generation key mismatch", err)
 	}
@@ -267,7 +295,7 @@ func TestVerifyFileDetectsDataWrittenIntoDeclaredHole(t *testing.T) {
 	store := newMemBlobs()
 	uploadFixture(t, store, task)
 	destDir := filepath.Join(t.TempDir(), "restored")
-	if _, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir); err != nil {
+	if _, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 	var manifest GenerationManifest
@@ -400,7 +428,7 @@ func TestRestoreGenerationRejectsEntryWithoutObject(t *testing.T) {
 	}
 	store.objects[manifestObject] = mutated
 
-	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
 	if err == nil || !strings.Contains(err.Error(), "no object name") {
 		t.Fatalf("err = %v, want rejection of entry without object name", err)
 	}
@@ -418,7 +446,7 @@ func TestRestoreGenerationRefusesPopulatedDest(t *testing.T) {
 	if err := os.WriteFile(existing, []byte("operator's earlier restore"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
 	if err == nil || !strings.Contains(err.Error(), "not empty") {
 		t.Fatalf("err = %v, want refusal of non-empty dest", err)
 	}
@@ -440,7 +468,7 @@ func TestRestoreGenerationRefusesSymlinkDest(t *testing.T) {
 	if err := os.Symlink(target, destDir); err != nil {
 		t.Fatal(err)
 	}
-	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
 	if err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("err = %v, want symlink refusal", err)
 	}
@@ -522,14 +550,14 @@ func TestRestoreGenerationRestoresSharedBasePair(t *testing.T) {
 	uploadFixture(t, store, task)
 
 	destDir := filepath.Join(t.TempDir(), "restored")
-	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
 	if err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 	if len(manifest.Files) != 3 {
 		t.Fatalf("manifest files = %d, want overlay+vmstate+base", len(manifest.Files))
 	}
-	got, err := os.ReadFile(filepath.Join(destDir, "base.ext4"))
+	got, err := os.ReadFile(filepath.Join(destDir, SharedBaseName(digestOf(baseData))))
 	if err != nil {
 		t.Fatalf("restored base: %v", err)
 	}
@@ -573,13 +601,13 @@ func TestRestoreGenerationRejectsMissingSharedBaseEntry(t *testing.T) {
 	}
 	store.objects[manifestObject] = mutated
 
-	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
 	if err == nil || !strings.Contains(err.Error(), "consistency pair") {
 		t.Fatalf("err = %v, want consistency pair incomplete", err)
 	}
 }
 
-func TestListGenerationsReportsOnlyComplete(t *testing.T) {
+func TestListGenerationsReportsOnlyCompleteNewestFirst(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()
 	uploadFixture(t, store, task)
@@ -587,12 +615,375 @@ func TestListGenerationsReportsOnlyComplete(t *testing.T) {
 	store.objects["sandboxes/sb-restore/gen-r2/overlay.ext4"] = []byte("partial")
 	// Another sandbox entirely.
 	store.objects["sandboxes/sb-other/gen-x/manifest.json"] = []byte("{}")
+	// An older and a newer complete generation: an operator under DR
+	// pressure needs the newest first, with its manifest creation time.
+	older := store.created[genObject(task, ManifestObject)].Add(-time.Hour)
+	newer := older.Add(2 * time.Hour)
+	store.objects["sandboxes/sb-restore/gen-older/manifest.json"] = []byte("{}")
+	store.created["sandboxes/sb-restore/gen-older/manifest.json"] = older
+	store.objects["sandboxes/sb-restore/gen-newer/manifest.json"] = []byte("{}")
+	store.created["sandboxes/sb-restore/gen-newer/manifest.json"] = newer
 
 	generations, err := ListGenerations(context.Background(), store, "sb-restore")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(generations) != 1 || generations[0] != task.Generation {
-		t.Fatalf("generations = %v, want [%s]", generations, task.Generation)
+	if len(generations) != 3 {
+		t.Fatalf("generations = %+v, want 3 complete", generations)
+	}
+	if generations[0].Generation != "gen-newer" || generations[1].Generation != task.Generation || generations[2].Generation != "gen-older" {
+		t.Fatalf("order = %+v, want newest first", generations)
+	}
+	if !generations[0].Created.Equal(newer) {
+		t.Fatalf("created = %v, want manifest object creation time %v", generations[0].Created, newer)
+	}
+}
+
+// rewriteManifest parses the stored manifest, applies mutate, and stores
+// it back: the tamper primitive for manifest-integrity tests.
+func rewriteManifest(t *testing.T, store *memBlobs, task Task, mutate func(*GenerationManifest)) {
+	t.Helper()
+	obj := genObject(task, ManifestObject)
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[obj], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	mutate(&manifest)
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.objects[obj] = data
+}
+
+// baseFixture writes a base image, binds the fixture overlay to it, and
+// returns the uploaded task plus the base bytes.
+func baseFixture(t *testing.T, fill byte) (Task, *memBlobs, []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base-image.ext4")
+	baseData := bytes.Repeat([]byte{fill}, 64<<10)
+	if err := os.WriteFile(basePath, baseData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := writeRestoreFixture(t, dir)
+	task.Files[0].BasePath = basePath
+	task.Files[0].BaseSHA256 = digestOf(baseData)
+	task.Generation = GenerationKey(task.Files)
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	return task, store, baseData
+}
+
+func TestRestoreTwoDistinctBasesRoundTrip(t *testing.T) {
+	// A generation with two overlays on two DIFFERENT bases: the shared
+	// entry names derive from the digests, so both bases must upload,
+	// restore to distinct files, and match byte for byte. A fixed name
+	// would make this generation complete-but-unrestorable.
+	dir := t.TempDir()
+	baseA := bytes.Repeat([]byte{0x33}, 96<<10)
+	baseB := bytes.Repeat([]byte{0x44}, 80<<10)
+	basePathA := filepath.Join(dir, "baseA.ext4")
+	basePathB := filepath.Join(dir, "baseB.ext4")
+	if err := os.WriteFile(basePathA, baseA, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(basePathB, baseB, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := writeRestoreFixture(t, dir)
+	overlay2 := filepath.Join(dir, "overlay2.ext4")
+	overlay2Data := bytes.Repeat([]byte{0x55}, 16<<10)
+	if err := os.WriteFile(overlay2, overlay2Data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task.Files[0].BasePath = basePathA
+	task.Files[0].BaseSHA256 = digestOf(baseA)
+	task.Files = append(task.Files, TaskFile{
+		Name: "overlay2.ext4", Path: overlay2, SHA256: digestOf(overlay2Data), Size: int64(len(overlay2Data)),
+		BasePath: basePathB, BaseSHA256: digestOf(baseB),
+	})
+	task.Generation = GenerationKey(task.Files)
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if len(manifest.Files) != 5 {
+		t.Fatalf("manifest files = %d, want 3 artifacts plus 2 bases", len(manifest.Files))
+	}
+	for _, want := range []struct {
+		name string
+		data []byte
+	}{
+		{SharedBaseName(digestOf(baseA)), baseA},
+		{SharedBaseName(digestOf(baseB)), baseB},
+	} {
+		got, err := os.ReadFile(filepath.Join(destDir, want.name))
+		if err != nil {
+			t.Fatalf("restored %s: %v", want.name, err)
+		}
+		if !bytes.Equal(got, want.data) {
+			t.Fatalf("restored %s differs from original", want.name)
+		}
+	}
+}
+
+func TestRestoreRejectsDuplicateSharedEntries(t *testing.T) {
+	task, store, _ := baseFixture(t, 0x66)
+	// Duplicate the shared base entry under a fresh name: without the
+	// duplicate check this restores and verifies an extra copy of the
+	// base, silent disk exhaustion inside a "verified" restore.
+	rewriteManifest(t, store, task, func(m *GenerationManifest) {
+		for _, mf := range m.Files {
+			if strings.HasPrefix(mf.Object, "bases/") {
+				dup := mf
+				dup.Name = "base-extra-copy.ext4"
+				m.Files = append(m.Files, dup)
+				return
+			}
+		}
+		t.Fatal("no shared entry in fixture manifest")
+	})
+	destDir := filepath.Join(t.TempDir(), "restored")
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
+	if err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Fatalf("err = %v, want duplicate shared entry rejection", err)
+	}
+	// Rejected before any file was restored: the destination was never
+	// even created.
+	if _, serr := os.Stat(destDir); !errors.Is(serr, fs.ErrNotExist) {
+		t.Fatalf("dest created despite pre-restore rejection: %v", serr)
+	}
+}
+
+func TestRestoreRejectsDuplicateNames(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	rewriteManifest(t, store, task, func(m *GenerationManifest) {
+		m.Files = append(m.Files, m.Files[1])
+	})
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
+	if err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Fatalf("err = %v, want duplicate name rejection", err)
+	}
+}
+
+func TestRestoreRejectsInflatedSize(t *testing.T) {
+	// Size is covered by the generation key: inflating it must fail the
+	// key check instead of driving an effectively unbounded zero hash
+	// during verification.
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	rewriteManifest(t, store, task, func(m *GenerationManifest) {
+		m.Files[0].Size = 1 << 60
+	})
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
+	if err == nil || !strings.Contains(err.Error(), "generation key") {
+		t.Fatalf("err = %v, want generation key mismatch for inflated size", err)
+	}
+}
+
+func TestValidExtentsRejectsMalformedTables(t *testing.T) {
+	bad := []ManifestFile{
+		// Offset+Length wraps negative and previously passed both checks.
+		{Size: 1 << 20, Extents: []Extent{{Offset: math.MaxInt64 - 10, Length: 100}}},
+		// First extent wraps, resetting the cursor so {0,50} passed ordering.
+		{Size: 1 << 20, Extents: []Extent{{Offset: 1 << 62, Length: 1 << 62}, {Offset: 0, Length: 50}}},
+		{Size: -1},
+		{Size: math.MaxInt64},
+		{Size: 100, Extents: []Extent{{Offset: -5, Length: 10}}},
+		{Size: 100, Extents: []Extent{{Offset: 0, Length: 0}}},
+		{Size: 100, Extents: []Extent{{Offset: 50, Length: 10}, {Offset: 40, Length: 10}}},
+		{Size: 100, Extents: []Extent{{Offset: 0, Length: 200}}},
+	}
+	for i, mf := range bad {
+		if err := validExtents(mf); err == nil {
+			t.Fatalf("case %d accepted: %+v", i, mf)
+		}
+	}
+	good := ManifestFile{Size: 200, Extents: []Extent{{Offset: 0, Length: 100}, {Offset: 150, Length: 50}}}
+	if err := validExtents(good); err != nil {
+		t.Fatalf("valid table rejected: %v", err)
+	}
+}
+
+func TestRestoreFailsOnTruncatedPackedObject(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	var object string
+	for name := range store.objects {
+		if strings.HasPrefix(name, genObject(task, "overlay.ext4.p")) {
+			object = name
+		}
+	}
+	if object == "" {
+		t.Fatal("packed overlay object not found")
+	}
+	store.objects[object] = store.objects[object][:len(store.objects[object])-5]
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
+	if err == nil || !strings.Contains(err.Error(), "extent at") {
+		t.Fatalf("err = %v, want mid-extent EOF failure", err)
+	}
+	entries, readErr := os.ReadDir(destDir)
+	if readErr == nil && len(entries) != 0 {
+		t.Fatalf("failed restore left %d files in dest", len(entries))
+	}
+}
+
+func TestRestoreRejectsUnboundSharedObjectName(t *testing.T) {
+	task, store, _ := baseFixture(t, 0x77)
+	otherSha := digestOf([]byte("a different base entirely"))
+	rewriteManifest(t, store, task, func(m *GenerationManifest) {
+		for i, mf := range m.Files {
+			if strings.HasPrefix(mf.Object, "bases/") {
+				// Same digest claim, object pointed elsewhere: the name
+				// must embed the entry's digest or fetching is refused.
+				m.Files[i].Object = SharedBaseObject(otherSha, "deadbeef1234")
+				return
+			}
+		}
+		t.Fatal("no shared entry in fixture manifest")
+	})
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
+	if err == nil || !strings.Contains(err.Error(), "not bound to digest") {
+		t.Fatalf("err = %v, want digest-binding rejection", err)
+	}
+}
+
+func TestRestoreRejectsUnreferencedSharedEntry(t *testing.T) {
+	task, store, _ := baseFixture(t, 0x88)
+	orphanSha := digestOf([]byte("orphan base"))
+	rewriteManifest(t, store, task, func(m *GenerationManifest) {
+		m.Files = append(m.Files, ManifestFile{
+			Name:   SharedBaseName(orphanSha),
+			Object: SharedBaseObject(orphanSha, "deadbeef1234"),
+			SHA256: orphanSha,
+			Size:   16,
+		})
+	})
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"), nil)
+	if err == nil || !strings.Contains(err.Error(), "no entry depends on") {
+		t.Fatalf("err = %v, want unreferenced shared entry rejection", err)
+	}
+}
+
+// cancelingBlobs cancels the restore context partway through: after the
+// configured number of NewReader calls, later calls cancel first.
+type cancelingBlobs struct {
+	*memBlobs
+	cancel context.CancelFunc
+	after  int
+	calls  int
+}
+
+func (c *cancelingBlobs) NewReader(ctx context.Context, object string) (io.ReadCloser, error) {
+	c.calls++
+	if c.calls > c.after {
+		c.cancel()
+	}
+	return c.memBlobs.NewReader(ctx, object)
+}
+
+func TestRestoreCancellationCleansUp(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Manifest is call 1, first artifact call 2; the context dies before
+	// the second artifact streams.
+	reader := &cancelingBlobs{memBlobs: store, cancel: cancel, after: 2}
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	_, err := RestoreGeneration(ctx, reader, task.SandboxID, task.Generation, destDir, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	entries, readErr := os.ReadDir(destDir)
+	if readErr == nil && len(entries) != 0 {
+		t.Fatalf("canceled restore left %d files in dest", len(entries))
+	}
+}
+
+func TestRestoreRejectsTraversalName(t *testing.T) {
+	// A hand-built manifest whose key genuinely covers a traversal name:
+	// the key check passes, so the name validation itself must refuse to
+	// let the entry escape the destination.
+	files := []TaskFile{{Name: "../evil", SHA256: digestOf([]byte("x")), Size: 1}}
+	gen := GenerationKey(files)
+	manifest := GenerationManifest{
+		SandboxID:  "sb-evil",
+		Generation: gen,
+		Files: []ManifestFile{{
+			Name: "../evil", Object: "evil.pdeadbeef1234", SHA256: digestOf([]byte("x")), Size: 1,
+			Extents: []Extent{{Offset: 0, Length: 1}},
+		}},
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newMemBlobs()
+	store.objects["sandboxes/sb-evil/"+gen+"/"+ManifestObject] = payload
+
+	parent := t.TempDir()
+	destDir := filepath.Join(parent, "restored")
+	_, err = RestoreGeneration(context.Background(), store, "sb-evil", gen, destDir, nil)
+	if err == nil || !strings.Contains(err.Error(), "manifest file name") {
+		t.Fatalf("err = %v, want traversal name rejection", err)
+	}
+	if _, serr := os.Stat(filepath.Join(parent, "evil")); !errors.Is(serr, fs.ErrNotExist) {
+		t.Fatal("traversal name escaped the destination")
+	}
+}
+
+func TestConcurrentRestoresSameDest(t *testing.T) {
+	// Two restores racing into one destination: exclusive per-name
+	// creation means exactly one wins, the loser removes nothing it did
+	// not create, and the surviving destination is complete and verified.
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	destDir := filepath.Join(t.TempDir(), "restored")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir, nil)
+		}(i)
+	}
+	wg.Wait()
+	winners := 0
+	for _, err := range errs {
+		if err == nil {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("winners = %d (errs %v), want exactly one", winners, errs)
+	}
+	// The surviving destination is complete: marker present, files intact.
+	if _, err := os.Stat(filepath.Join(destDir, ManifestObject)); err != nil {
+		t.Fatalf("completion marker missing after concurrent restore: %v", err)
+	}
+	orig, err := os.ReadFile(task.Files[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(destDir, task.Files[0].Name))
+	if err != nil || !bytes.Equal(orig, got) {
+		t.Fatalf("winner's restore incomplete: err=%v equal=%v", err, bytes.Equal(orig, got))
 	}
 }

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -275,6 +275,54 @@ func TestRestoreGenerationRefusesPopulatedDest(t *testing.T) {
 	}
 }
 
+func TestRestoreFileNeverOpensExistingDest(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects["sandboxes/sb-restore/gen-r1/manifest.json"], &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	// A file that appears between the emptiness check and the open (a
+	// concurrent restore, or a planted symlink): O_EXCL must refuse it,
+	// report the file as not created, and leave it untouched.
+	dest := filepath.Join(t.TempDir(), "overlay.ext4")
+	if err := os.WriteFile(dest, []byte("someone else's file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	madeFile, err := restoreFile(context.Background(), store, task.SandboxID, task.Generation, manifest.Files[0], dest)
+	if err == nil || !errors.Is(err, os.ErrExist) {
+		t.Fatalf("err = %v, want ErrExist", err)
+	}
+	if madeFile {
+		t.Fatal("restoreFile claims to have created a pre-existing file")
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || string(got) != "someone else's file" {
+		t.Fatalf("pre-existing file disturbed: %q err=%v", got, err)
+	}
+}
+
+func TestHashApparentHonorsCancellationMidExtent(t *testing.T) {
+	// A dense file is a single extent; cancellation must interrupt hashing
+	// inside it, not only at hole boundaries.
+	path := filepath.Join(t.TempDir(), "dense")
+	if err := os.WriteFile(path, bytes.Repeat([]byte{0xCC}, 4<<20), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := hashApparent(ctx, f, []Extent{{Offset: 0, Length: 4 << 20}}, 4<<20); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
 func TestListGenerationsReportsOnlyComplete(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -262,6 +262,48 @@ func TestRestoreGenerationRejectsManifestMissingEntries(t *testing.T) {
 	}
 }
 
+func TestVerifyFileDetectsDataWrittenIntoDeclaredHole(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	destDir := filepath.Join(t.TempDir(), "restored")
+	if _, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[genObject(task, ManifestObject)], &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bytes landing inside a manifest-declared hole (the fixture overlay is
+	// hole from 64KiB to 2MiB): verification must hash what is actually in
+	// the file, so this cannot pass as synthetic zeros.
+	f, err := os.OpenFile(filepath.Join(destDir, "overlay.ext4"), os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xEE}, 4096), 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	verr := verifyFile(context.Background(), root, manifest.Files[0])
+	if verr == nil || !strings.Contains(verr.Error(), "sha256 mismatch") {
+		t.Fatalf("err = %v, want sha256 mismatch for data written into a declared hole", verr)
+	}
+	// The untouched file still verifies against the same manifest entry.
+	if err := verifyFile(context.Background(), root, manifest.Files[1]); err != nil {
+		t.Fatalf("untouched file failed verification: %v", err)
+	}
+}
+
 func TestOpenRootNoFollowRejectsSymlinkLeaf(t *testing.T) {
 	// The leaf being a symlink at open time must be rejected by the open
 	// itself (kernel-atomic O_NOFOLLOW on linux; Lstat approximation

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -200,6 +200,28 @@ func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
 	}
 }
 
+func TestRestoreGenerationRefusesPopulatedDest(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// A reused recovery directory holding a name-colliding file: restore
+	// must refuse rather than truncate it (or delete it during cleanup).
+	destDir := t.TempDir()
+	existing := filepath.Join(destDir, "overlay.ext4")
+	if err := os.WriteFile(existing, []byte("operator's earlier restore"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	if err == nil || !strings.Contains(err.Error(), "not empty") {
+		t.Fatalf("err = %v, want refusal of non-empty dest", err)
+	}
+	got, readErr := os.ReadFile(existing)
+	if readErr != nil || string(got) != "operator's earlier restore" {
+		t.Fatalf("pre-existing file disturbed: %q err=%v", got, readErr)
+	}
+}
+
 func TestListGenerationsReportsOnlyComplete(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -504,24 +504,78 @@ func TestHashApparentHonorsCancellationMidExtent(t *testing.T) {
 	}
 }
 
-func TestHashApparentReportsTruncatedSource(t *testing.T) {
-	// The file shrank after its extent table was captured (a resume rewrote
-	// it): the short read must classify as ErrTruncatedSource so the
-	// generation is abandoned, not retried against a moving target.
-	path := filepath.Join(t.TempDir(), "shrunk")
-	if err := os.WriteFile(path, bytes.Repeat([]byte{0xDD}, 2<<20), 0o644); err != nil {
+func TestRestoreGenerationRestoresSharedBasePair(t *testing.T) {
+	// An overlay generation ships its base image as a bucket-wide shared
+	// object; restore must fetch and verify it as part of the consistency
+	// pair, since the overlay's holes are meaningless without it.
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base-image.ext4")
+	baseData := bytes.Repeat([]byte{0x11}, 128<<10)
+	if err := os.WriteFile(basePath, baseData, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	f, err := os.Open(path)
+	task := writeRestoreFixture(t, dir)
+	task.Files[0].BasePath = basePath
+	task.Files[0].BaseSHA256 = digestOf(baseData)
+	task.Generation = GenerationKey(task.Files)
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if len(manifest.Files) != 3 {
+		t.Fatalf("manifest files = %d, want overlay+vmstate+base", len(manifest.Files))
+	}
+	got, err := os.ReadFile(filepath.Join(destDir, "base.ext4"))
+	if err != nil {
+		t.Fatalf("restored base: %v", err)
+	}
+	if !bytes.Equal(got, baseData) {
+		t.Fatalf("restored base differs from original (%d vs %d bytes)", len(got), len(baseData))
+	}
+}
+
+func TestRestoreGenerationRejectsMissingSharedBaseEntry(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base-image.ext4")
+	baseData := bytes.Repeat([]byte{0x22}, 64<<10)
+	if err := os.WriteFile(basePath, baseData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := writeRestoreFixture(t, dir)
+	task.Files[0].BasePath = basePath
+	task.Files[0].BaseSHA256 = digestOf(baseData)
+	task.Generation = GenerationKey(task.Files)
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// Drop the shared base entry: the generation key still reproduces
+	// (base entries are synthesized outside it), so only the
+	// consistency-pair check catches the unrestorable manifest.
+	manifestObject := genObject(task, ManifestObject)
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[manifestObject], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	kept := manifest.Files[:0]
+	for _, mf := range manifest.Files {
+		if !strings.HasPrefix(mf.Object, "bases/") {
+			kept = append(kept, mf)
+		}
+	}
+	manifest.Files = kept
+	mutated, err := json.Marshal(manifest)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
-	if err := os.Truncate(path, 1<<20); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := hashApparent(context.Background(), f, []Extent{{Offset: 0, Length: 2 << 20}}, 2<<20); !errors.Is(err, ErrTruncatedSource) {
-		t.Fatalf("err = %v, want ErrTruncatedSource", err)
+	store.objects[manifestObject] = mutated
+
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	if err == nil || !strings.Contains(err.Error(), "consistency pair") {
+		t.Fatalf("err = %v, want consistency pair incomplete", err)
 	}
 }
 

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -275,6 +275,28 @@ func TestRestoreGenerationRefusesPopulatedDest(t *testing.T) {
 	}
 }
 
+func TestRestoreGenerationRefusesSymlinkDest(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// destDir itself is a pre-planted symlink: following it would redirect
+	// the restore outside the requested path.
+	target := t.TempDir()
+	destDir := filepath.Join(t.TempDir(), "dest")
+	if err := os.Symlink(target, destDir); err != nil {
+		t.Fatal(err)
+	}
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink refusal", err)
+	}
+	entries, readErr := os.ReadDir(target)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("symlink target written to: %d entries, err=%v", len(entries), readErr)
+	}
+}
+
 func TestRestoreFileNeverOpensExistingDest(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()
@@ -287,11 +309,17 @@ func TestRestoreFileNeverOpensExistingDest(t *testing.T) {
 	// A file that appears between the emptiness check and the open (a
 	// concurrent restore, or a planted symlink): O_EXCL must refuse it,
 	// report the file as not created, and leave it untouched.
-	dest := filepath.Join(t.TempDir(), "overlay.ext4")
+	destDir := t.TempDir()
+	dest := filepath.Join(destDir, "overlay.ext4")
 	if err := os.WriteFile(dest, []byte("someone else's file"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	madeFile, err := restoreFile(context.Background(), store, task.SandboxID, task.Generation, manifest.Files[0], dest)
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	madeFile, err := restoreFile(context.Background(), store, task.SandboxID, task.Generation, manifest.Files[0], root)
 	if err == nil || !errors.Is(err, os.ErrExist) {
 		t.Fatalf("err = %v, want ErrExist", err)
 	}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -1,0 +1,219 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// memBlobs is a map-backed store implementing both sides of the pipeline:
+// BlobStore for the uploader (create-only) and BlobReader plus BlobLister
+// for restore. It is deliberately separate from uploader_test.go's fixture
+// so the round-trip tests own their whole world.
+type memBlobs struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+}
+
+func newMemBlobs() *memBlobs {
+	return &memBlobs{objects: map[string][]byte{}}
+}
+
+func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.objects[object]; exists {
+		return nil // create-only dedupe
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.objects[object] = data
+	return nil
+}
+
+func (m *memBlobs) NewReader(_ context.Context, object string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.objects[object]
+	if !ok {
+		return nil, fmt.Errorf("%s: %w", object, ErrObjectNotFound)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *memBlobs) List(_ context.Context, prefix string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var names []string
+	for name := range m.objects {
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// writeRestoreFixture builds the source artifacts: a genuinely sparse disk
+// overlay (data runs separated by holes, trailing hole via Truncate) and a
+// small dense vmstate. Digests are of the full apparent content, matching
+// what the pause manifest records.
+func writeRestoreFixture(t *testing.T, dir string) Task {
+	t.Helper()
+	overlay := filepath.Join(dir, "overlay.ext4")
+	f, err := os.Create(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xAA}, 64<<10), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt(bytes.Repeat([]byte{0xBB}, 32<<10), 2<<20); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(4 << 20); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	vmstate := filepath.Join(dir, "vmstate.snap")
+	if err := os.WriteFile(vmstate, []byte("register file and device state"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := Task{
+		SandboxID:  "sb-restore",
+		Generation: "gen-r1",
+		Priority:   PriorityPause,
+		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
+	}
+	for _, name := range []string{"overlay.ext4", "vmstate.snap"} {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path) // full apparent content, holes as zeros
+		if err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(data)
+		task.Files = append(task.Files, TaskFile{
+			Name: name, Path: path, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(data)),
+		})
+	}
+	return task
+}
+
+// uploadFixture ships the task through the real Uploader into the store so
+// restore reads exactly what production writes: packed objects plus the
+// manifest completion object.
+func uploadFixture(t *testing.T, store *memBlobs, task Task) {
+	t.Helper()
+	u := &Uploader{Store: store}
+	completed, err := u.uploadTask(context.Background(), task)
+	if err != nil || !completed {
+		t.Fatalf("upload fixture: completed=%v err=%v", completed, err)
+	}
+}
+
+func TestRestoreGenerationRoundTrip(t *testing.T) {
+	srcDir := t.TempDir()
+	task := writeRestoreFixture(t, srcDir)
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	manifest, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if manifest.SandboxID != task.SandboxID || manifest.Generation != task.Generation {
+		t.Fatalf("manifest identity = %s/%s", manifest.SandboxID, manifest.Generation)
+	}
+	if len(manifest.Files) != len(task.Files) {
+		t.Fatalf("manifest files = %d, want %d", len(manifest.Files), len(task.Files))
+	}
+	for i, tf := range task.Files {
+		orig, err := os.ReadFile(tf.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(filepath.Join(destDir, tf.Name))
+		if err != nil {
+			t.Fatalf("restored %s: %v", tf.Name, err)
+		}
+		if !bytes.Equal(orig, got) {
+			t.Fatalf("restored %s differs from original (%d vs %d bytes)", tf.Name, len(got), len(orig))
+		}
+		if manifest.Files[i].SHA256 != tf.SHA256 {
+			t.Fatalf("digest for %s = %s, want %s", tf.Name, manifest.Files[i].SHA256, tf.SHA256)
+		}
+	}
+}
+
+func TestRestoreGenerationFailsOnCorruptObject(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// Flip one byte inside the packed overlay object: the rebuilt file's
+	// apparent digest can no longer match the manifest.
+	object := "sandboxes/sb-restore/gen-r1/overlay.ext4"
+	corrupted := bytes.Clone(store.objects[object])
+	corrupted[10] ^= 0xFF
+	store.objects[object] = corrupted
+
+	destDir := filepath.Join(t.TempDir(), "restored")
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, destDir)
+	if err == nil {
+		t.Fatal("restore of corrupted object succeeded")
+	}
+	if !strings.Contains(err.Error(), "overlay.ext4") || !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Fatalf("error does not name the corrupt file and cause: %v", err)
+	}
+	// All-or-nothing: nothing half-verified is left behind.
+	entries, readErr := os.ReadDir(destDir)
+	if readErr == nil && len(entries) != 0 {
+		t.Fatalf("failed restore left %d files in dest", len(entries))
+	}
+}
+
+func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	// Artifacts present, manifest gone: exactly what an interrupted upload
+	// leaves behind.
+	delete(store.objects, "sandboxes/sb-restore/gen-r1/manifest.json")
+
+	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	if !errors.Is(err, ErrGenerationIncomplete) {
+		t.Fatalf("err = %v, want ErrGenerationIncomplete", err)
+	}
+}
+
+func TestListGenerationsReportsOnlyComplete(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	// A second, incomplete generation: artifact object but no manifest.
+	store.objects["sandboxes/sb-restore/gen-r2/overlay.ext4"] = []byte("partial")
+	// Another sandbox entirely.
+	store.objects["sandboxes/sb-other/gen-x/manifest.json"] = []byte("{}")
+
+	generations, err := ListGenerations(context.Background(), store, "sb-restore")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 1 || generations[0] != "gen-r1" {
+		t.Fatalf("generations = %v, want [gen-r1]", generations)
+	}
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -323,6 +323,27 @@ func TestHashApparentHonorsCancellationMidExtent(t *testing.T) {
 	}
 }
 
+func TestHashApparentReportsTruncatedSource(t *testing.T) {
+	// The file shrank after its extent table was captured (a resume rewrote
+	// it): the short read must classify as ErrTruncatedSource so the
+	// generation is abandoned, not retried against a moving target.
+	path := filepath.Join(t.TempDir(), "shrunk")
+	if err := os.WriteFile(path, bytes.Repeat([]byte{0xDD}, 2<<20), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := os.Truncate(path, 1<<20); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hashApparent(context.Background(), f, []Extent{{Offset: 0, Length: 2 << 20}}, 2<<20); !errors.Is(err, ErrTruncatedSource) {
+		t.Fatalf("err = %v, want ErrTruncatedSource", err)
+	}
+}
+
 func TestListGenerationsReportsOnlyComplete(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -987,3 +987,84 @@ func TestConcurrentRestoresSameDest(t *testing.T) {
 		t.Fatalf("winner's restore incomplete: err=%v equal=%v", err, bytes.Equal(orig, got))
 	}
 }
+
+// legacyFixture re-homes an uploaded generation under the legacy pre-size
+// key: exactly what a bucket written before Size joined the key holds.
+func legacyFixture(t *testing.T, store *memBlobs, task Task) Task {
+	t.Helper()
+	legacy := task
+	legacy.Generation = generationKeyLegacy(task.Files)
+	oldPrefix := "sandboxes/" + task.SandboxID + "/" + task.Generation + "/"
+	newPrefix := "sandboxes/" + legacy.SandboxID + "/" + legacy.Generation + "/"
+	var names []string
+	for name := range store.objects {
+		if strings.HasPrefix(name, oldPrefix) {
+			names = append(names, name)
+		}
+	}
+	for _, name := range names {
+		store.objects[newPrefix+strings.TrimPrefix(name, oldPrefix)] = store.objects[name]
+		delete(store.objects, name)
+	}
+	rewriteManifest(t, store, legacy, func(m *GenerationManifest) {
+		m.Generation = legacy.Generation
+	})
+	return legacy
+}
+
+func TestRestoreAcceptsLegacyKeyGeneration(t *testing.T) {
+	// Buckets hold generations uploaded before Size joined the key, and
+	// journal tasks carrying legacy keys survive vmd upgrades: restore
+	// must verify them under the legacy derivation and say so.
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	legacy := legacyFixture(t, store, task)
+
+	var lines []string
+	progress := func(format string, args ...any) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	destDir := filepath.Join(t.TempDir(), "restored")
+	manifest, err := RestoreGeneration(context.Background(), store, legacy.SandboxID, legacy.Generation, destDir, progress)
+	if err != nil {
+		t.Fatalf("legacy restore: %v", err)
+	}
+	if manifest.Generation != legacy.Generation {
+		t.Fatalf("manifest generation = %s, want %s", manifest.Generation, legacy.Generation)
+	}
+	orig, err := os.ReadFile(task.Files[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(destDir, task.Files[0].Name))
+	if err != nil || !bytes.Equal(orig, got) {
+		t.Fatalf("legacy restore content mismatch: err=%v", err)
+	}
+	sawLegacy := false
+	for _, l := range lines {
+		if strings.Contains(l, "legacy") {
+			sawLegacy = true
+		}
+	}
+	if !sawLegacy {
+		t.Fatalf("progress never reported the legacy derivation: %q", lines)
+	}
+}
+
+func TestRestoreLegacyGenerationBoundsInflatedSize(t *testing.T) {
+	// A legacy key does not cover Size, so the per-entry cap is the only
+	// bound between a tampered size and an effectively unbounded zero
+	// hash during verification.
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	legacy := legacyFixture(t, store, task)
+	rewriteManifest(t, store, legacy, func(m *GenerationManifest) {
+		m.Files[0].Size = maxApparentSize + 1
+	})
+	_, err := RestoreGeneration(context.Background(), store, legacy.SandboxID, legacy.Generation, filepath.Join(t.TempDir(), "restored"), nil)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("err = %v, want size bound rejection", err)
+	}
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -165,8 +166,17 @@ func TestRestoreGenerationFailsOnCorruptObject(t *testing.T) {
 	uploadFixture(t, store, task)
 
 	// Flip one byte inside the packed overlay object: the rebuilt file's
-	// apparent digest can no longer match the manifest.
-	object := "sandboxes/sb-restore/gen-r1/overlay.ext4"
+	// apparent digest can no longer match the manifest. The object name
+	// embeds the packing fingerprint, so find it by its stem.
+	var object string
+	for name := range store.objects {
+		if strings.HasPrefix(name, "sandboxes/sb-restore/gen-r1/overlay.ext4.p") {
+			object = name
+		}
+	}
+	if object == "" {
+		t.Fatal("packed overlay object not found in store")
+	}
 	corrupted := bytes.Clone(store.objects[object])
 	corrupted[10] ^= 0xFF
 	store.objects[object] = corrupted
@@ -197,6 +207,32 @@ func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
 	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
 	if !errors.Is(err, ErrGenerationIncomplete) {
 		t.Fatalf("err = %v, want ErrGenerationIncomplete", err)
+	}
+}
+
+func TestRestoreGenerationRejectsEntryWithoutObject(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// A manifest entry without its recorded object name cannot be fetched
+	// safely: deriving the name from the file name would break the binding
+	// between extent table and packing.
+	manifestObject := "sandboxes/sb-restore/gen-r1/manifest.json"
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[manifestObject], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Files[0].Object = ""
+	mutated, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.objects[manifestObject] = mutated
+
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	if err == nil || !strings.Contains(err.Error(), "no object name") {
+		t.Fatalf("err = %v, want rejection of entry without object name", err)
 	}
 }
 

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -262,6 +262,42 @@ func TestRestoreGenerationRejectsManifestMissingEntries(t *testing.T) {
 	}
 }
 
+func TestOpenRootNoFollowRejectsSymlinkLeaf(t *testing.T) {
+	// The leaf being a symlink at open time must be rejected by the open
+	// itself (kernel-atomic O_NOFOLLOW on linux; Lstat approximation
+	// elsewhere), exactly the swap a raced check would miss.
+	parent := t.TempDir()
+	target := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(parent, "leaf")); err != nil {
+		t.Fatal(err)
+	}
+	root, err := openRootNoFollow(parent, "leaf")
+	if err == nil {
+		root.Close()
+		t.Fatal("openRootNoFollow followed a symlink leaf")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink rejection", err)
+	}
+	// A real directory leaf opens fine and the root is usable.
+	if err := os.Mkdir(filepath.Join(parent, "realdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root, err = openRootNoFollow(parent, "realdir")
+	if err != nil {
+		t.Fatalf("open real directory: %v", err)
+	}
+	defer root.Close()
+	f, err := root.OpenFile("probe", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		t.Fatalf("create through no-follow root: %v", err)
+	}
+	f.Close()
+	if _, err := os.Stat(filepath.Join(parent, "realdir", "probe")); err != nil {
+		t.Fatalf("probe file not in the opened directory: %v", err)
+	}
+}
+
 func TestRestoreRootPinsDirAcrossSwap(t *testing.T) {
 	// Once the destination Root is open it tracks the directory itself: a
 	// symlink swapped in at the path afterwards must not redirect writes,

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -30,18 +30,18 @@ func newMemBlobs() *memBlobs {
 	return &memBlobs{objects: map[string][]byte{}}
 }
 
-func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) error {
+func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, exists := m.objects[object]; exists {
-		return nil // create-only dedupe
+		return false, nil // create-only dedupe
 	}
 	data, err := io.ReadAll(r)
 	if err != nil {
-		return err
+		return false, err
 	}
 	m.objects[object] = data
-	return nil
+	return true, nil
 }
 
 func (m *memBlobs) NewReader(_ context.Context, object string) (io.ReadCloser, error) {
@@ -95,7 +95,6 @@ func writeRestoreFixture(t *testing.T, dir string) Task {
 	}
 	task := Task{
 		SandboxID:  "sb-restore",
-		Generation: "gen-r1",
 		Priority:   PriorityPause,
 		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC),
 	}
@@ -110,16 +109,26 @@ func writeRestoreFixture(t *testing.T, dir string) Task {
 			Name: name, Path: path, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(data)),
 		})
 	}
+	// The generation is its content address, exactly as the pause hook
+	// derives it; restore verifies the manifest reproduces this key.
+	task.Generation = GenerationKey(task.Files)
 	return task
+}
+
+// genObject names an object under the fixture task's generation prefix.
+func genObject(task Task, name string) string {
+	return "sandboxes/" + task.SandboxID + "/" + task.Generation + "/" + name
 }
 
 // uploadFixture ships the task through the real Uploader into the store so
 // restore reads exactly what production writes: packed objects plus the
-// manifest completion object.
+// manifest completion object. The uploader persists per-object
+// verification state, so it gets a real journal.
 func uploadFixture(t *testing.T, store *memBlobs, task Task) {
 	t.Helper()
-	u := &Uploader{Store: store}
-	completed, err := u.uploadTask(context.Background(), task)
+	j, _ := testJournal(t)
+	u := &Uploader{Journal: j, Store: store}
+	completed, err := u.uploadTask(context.Background(), &task)
 	if err != nil || !completed {
 		t.Fatalf("upload fixture: completed=%v err=%v", completed, err)
 	}
@@ -170,7 +179,7 @@ func TestRestoreGenerationFailsOnCorruptObject(t *testing.T) {
 	// embeds the packing fingerprint, so find it by its stem.
 	var object string
 	for name := range store.objects {
-		if strings.HasPrefix(name, "sandboxes/sb-restore/gen-r1/overlay.ext4.p") {
+		if strings.HasPrefix(name, genObject(task, "overlay.ext4.p")) {
 			object = name
 		}
 	}
@@ -202,7 +211,7 @@ func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
 	uploadFixture(t, store, task)
 	// Artifacts present, manifest gone: exactly what an interrupted upload
 	// leaves behind.
-	delete(store.objects, "sandboxes/sb-restore/gen-r1/manifest.json")
+	delete(store.objects, genObject(task, ManifestObject))
 
 	_, err := RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
 	if !errors.Is(err, ErrGenerationIncomplete) {
@@ -227,6 +236,72 @@ func TestRestoreGenerationRejectsMisplacedManifest(t *testing.T) {
 	}
 }
 
+func TestRestoreGenerationRejectsManifestMissingEntries(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// Drop one entry from the stored manifest: the identity fields still
+	// match and every remaining artifact verifies, so only recomputing the
+	// generation key from the file set catches the incomplete manifest.
+	manifestObject := genObject(task, ManifestObject)
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[manifestObject], &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Files = manifest.Files[:1]
+	mutated, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.objects[manifestObject] = mutated
+
+	_, err = RestoreGeneration(context.Background(), store, task.SandboxID, task.Generation, filepath.Join(t.TempDir(), "restored"))
+	if err == nil || !strings.Contains(err.Error(), "generation key") {
+		t.Fatalf("err = %v, want generation key mismatch", err)
+	}
+}
+
+func TestRestoreRootPinsDirAcrossSwap(t *testing.T) {
+	// Once the destination Root is open it tracks the directory itself: a
+	// symlink swapped in at the path afterwards must not redirect writes,
+	// and anything the swap points at must stay untouched.
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+	var manifest GenerationManifest
+	if err := json.Unmarshal(store.objects[genObject(task, ManifestObject)], &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	base := t.TempDir()
+	destDir := filepath.Join(base, "dest")
+	root, err := openFreshDir(destDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	moved := filepath.Join(base, "moved")
+	elsewhere := t.TempDir()
+	if err := os.Rename(destDir, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, destDir); err != nil {
+		t.Fatal(err)
+	}
+	madeFile, err := restoreFile(context.Background(), store, task.SandboxID, task.Generation, manifest.Files[1], root)
+	if err != nil || !madeFile {
+		t.Fatalf("restoreFile after dir swap: made=%v err=%v", madeFile, err)
+	}
+	if _, err := os.Stat(filepath.Join(moved, manifest.Files[1].Name)); err != nil {
+		t.Fatalf("file not written into the pinned directory: %v", err)
+	}
+	entries, err := os.ReadDir(elsewhere)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("symlink target written to: %d entries err=%v", len(entries), err)
+	}
+}
+
 func TestRestoreGenerationRejectsEntryWithoutObject(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()
@@ -235,7 +310,7 @@ func TestRestoreGenerationRejectsEntryWithoutObject(t *testing.T) {
 	// A manifest entry without its recorded object name cannot be fetched
 	// safely: deriving the name from the file name would break the binding
 	// between extent table and packing.
-	manifestObject := "sandboxes/sb-restore/gen-r1/manifest.json"
+	manifestObject := genObject(task, ManifestObject)
 	var manifest GenerationManifest
 	if err := json.Unmarshal(store.objects[manifestObject], &manifest); err != nil {
 		t.Fatal(err)
@@ -302,7 +377,7 @@ func TestRestoreFileNeverOpensExistingDest(t *testing.T) {
 	store := newMemBlobs()
 	uploadFixture(t, store, task)
 	var manifest GenerationManifest
-	if err := json.Unmarshal(store.objects["sandboxes/sb-restore/gen-r1/manifest.json"], &manifest); err != nil {
+	if err := json.Unmarshal(store.objects[genObject(task, ManifestObject)], &manifest); err != nil {
 		t.Fatal(err)
 	}
 
@@ -385,7 +460,7 @@ func TestListGenerationsReportsOnlyComplete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(generations) != 1 || generations[0] != "gen-r1" {
-		t.Fatalf("generations = %v, want [gen-r1]", generations)
+	if len(generations) != 1 || generations[0] != task.Generation {
+		t.Fatalf("generations = %v, want [%s]", generations, task.Generation)
 	}
 }

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -210,6 +210,23 @@ func TestRestoreGenerationMissingManifestIsIncomplete(t *testing.T) {
 	}
 }
 
+func TestRestoreGenerationRejectsMisplacedManifest(t *testing.T) {
+	task := writeRestoreFixture(t, t.TempDir())
+	store := newMemBlobs()
+	uploadFixture(t, store, task)
+
+	// Copy the whole generation under another sandbox's prefix, the way a
+	// bucket-side mistake would: every digest still verifies, so only the
+	// manifest's recorded identity can catch the misplacement.
+	for name, data := range store.objects {
+		store.objects[strings.Replace(name, "sb-restore", "sb-victim", 1)] = data
+	}
+	_, err := RestoreGeneration(context.Background(), store, "sb-victim", task.Generation, filepath.Join(t.TempDir(), "restored"))
+	if err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("err = %v, want manifest identity mismatch", err)
+	}
+}
+
 func TestRestoreGenerationRejectsEntryWithoutObject(t *testing.T) {
 	task := writeRestoreFixture(t, t.TempDir())
 	store := newMemBlobs()

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -38,6 +38,8 @@ func newMemBlobs() *memBlobs {
 	}
 }
 
+func (m *memBlobs) Identity() string { return "test-bucket" }
+
 func (m *memBlobs) Create(_ context.Context, object string, r io.Reader) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -113,7 +113,7 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 					return false, err
 				}
 			}
-			task.Files[i].BasePath = stagedBase
+			task.Files[i].BaseStagedPath = stagedBase
 		}
 	}
 	return all, nil

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -220,13 +220,19 @@ func (u *Uploader) flushNotifications() {
 // base image. Size comes from the live file: the digest check subsumes
 // it (a size change changes the digest).
 func baseTaskFile(file TaskFile) (TaskFile, error) {
-	fi, err := os.Stat(file.BasePath)
+	// Read from the staged snapshot when one exists; BasePath stays the
+	// recorded identity either way.
+	src := file.BasePath
+	if file.BaseStagedPath != "" {
+		src = file.BaseStagedPath
+	}
+	fi, err := os.Stat(src)
 	if err != nil {
 		return TaskFile{}, err
 	}
 	return TaskFile{
 		Name:   SharedBaseName(file.BaseSHA256),
-		Path:   file.BasePath,
+		Path:   src,
 		SHA256: file.BaseSHA256,
 		Size:   fi.Size(),
 		Shared: true,

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -206,12 +206,25 @@ func baseTaskFile(file TaskFile) (TaskFile, error) {
 		return TaskFile{}, err
 	}
 	return TaskFile{
-		Name:   "base.ext4",
+		Name:   SharedBaseName(file.BaseSHA256),
 		Path:   file.BasePath,
 		SHA256: file.BaseSHA256,
 		Size:   fi.Size(),
 		Shared: true,
 	}, nil
+}
+
+// SharedBaseName derives the manifest file name a shared base entry
+// restores to from its content digest. A fixed name would collide when a
+// generation depends on two different bases: the upload would succeed,
+// but restore's exclusive per-name creation could never materialize both
+// files, a complete-yet-unrestorable generation discovered only at
+// recovery time.
+func SharedBaseName(sha string) string {
+	if len(sha) > 12 {
+		sha = sha[:12]
+	}
+	return "base-" + sha + ".ext4"
 }
 
 // uploadTask ships every artifact of a generation, then its manifest

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -239,10 +239,11 @@ func baseTaskFile(file TaskFile) (TaskFile, error) {
 // but restore's exclusive per-name creation could never materialize both
 // files, a complete-yet-unrestorable generation discovered only at
 // recovery time.
+// SharedBaseName carries the FULL digest: distinct bases must map to
+// distinct restored file names unconditionally, and a truncated prefix
+// would let a (however unlikely) collision produce a generation that
+// uploads completely but is rejected at restore for duplicate names.
 func SharedBaseName(sha string) string {
-	if len(sha) > 12 {
-		sha = sha[:12]
-	}
 	return "base-" + sha + ".ext4"
 }
 

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -918,7 +918,7 @@ func TestOverlayGenerationUploadsSharedBase(t *testing.T) {
 	}
 	foundBase := false
 	for _, f := range gen.Files {
-		if f.Name == "base.ext4" && strings.HasPrefix(f.Object, "bases/"+baseSHA) {
+		if f.Name == SharedBaseName(baseSHA) && strings.HasPrefix(f.Object, "bases/"+baseSHA) {
 			foundBase = true
 		}
 	}

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -1064,8 +1064,11 @@ func TestStagedBaseSurvivesTemplateGC(t *testing.T) {
 	if err := StageTask(staging, &task); err != nil {
 		t.Fatal(err)
 	}
-	if task.Files[0].BasePath == base {
+	if task.Files[0].BaseStagedPath == "" {
 		t.Fatal("base path not staged")
+	}
+	if task.Files[0].BasePath != base {
+		t.Fatal("staging mutated the key-covered BasePath identity")
 	}
 	// Template GC deletes the original base and the sandbox artifacts.
 	if err := os.Remove(base); err != nil {

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -566,12 +566,13 @@ func (m *Manager) enqueueBackup(vmID string, manifest []ManifestEntry) (bool, bo
 	files := make([]backup.TaskFile, 0, len(manifest))
 	for _, e := range manifest {
 		files = append(files, backup.TaskFile{
-			Name:       e.FileName,
-			Path:       e.Path,
-			SHA256:     e.SHA256,
-			Size:       e.SizeBytes,
-			BasePath:   e.BasePath,
-			BaseSHA256: e.BaseSHA256,
+			Name:           e.FileName,
+			Path:           e.Path,
+			SHA256:         e.SHA256,
+			Size:           e.SizeBytes,
+			BasePath:       e.BasePath,
+			BaseStagedPath: e.BaseStagedPath,
+			BaseSHA256:     e.BaseSHA256,
 		})
 	}
 	if !pauseManifestComplete(manifest) {
@@ -677,7 +678,7 @@ func manifestWithTaskPaths(manifest []ManifestEntry, task backup.Task) []Manifes
 	for i, e := range out {
 		if f, ok := byName[e.FileName]; ok {
 			out[i].Path = f.Path
-			out[i].BasePath = f.BasePath
+			out[i].BaseStagedPath = f.BaseStagedPath
 		}
 	}
 	return out
@@ -691,7 +692,7 @@ func taskFullyStaged(root string, task backup.Task) bool {
 		if !strings.HasPrefix(f.Path, prefix) {
 			return false
 		}
-		if f.BasePath != "" && !strings.HasPrefix(f.BasePath, prefix) {
+		if f.BasePath != "" && !strings.HasPrefix(f.BaseStagedPath, prefix) {
 			return false
 		}
 	}
@@ -704,12 +705,13 @@ func rebuildTask(vmID string, manifest []ManifestEntry) backup.Task {
 	files := make([]backup.TaskFile, 0, len(manifest))
 	for _, e := range manifest {
 		files = append(files, backup.TaskFile{
-			Name:       e.FileName,
-			Path:       e.Path,
-			SHA256:     e.SHA256,
-			Size:       e.SizeBytes,
-			BasePath:   e.BasePath,
-			BaseSHA256: e.BaseSHA256,
+			Name:           e.FileName,
+			Path:           e.Path,
+			SHA256:         e.SHA256,
+			Size:           e.SizeBytes,
+			BasePath:       e.BasePath,
+			BaseStagedPath: e.BaseStagedPath,
+			BaseSHA256:     e.BaseSHA256,
 		})
 	}
 	return backup.Task{

--- a/internal/vm/manifest.go
+++ b/internal/vm/manifest.go
@@ -24,6 +24,9 @@ type ManifestEntry struct {
 	SizeBytes int64
 	SHA256    string
 	BasePath  string
+	// BaseStagedPath is the staged snapshot to READ the base from when
+	// staging captured one; BasePath remains the recorded identity.
+	BaseStagedPath string
 	// BaseSHA256 is the base file's content digest. The path alone is not
 	// an identity: a base rebuilt or restored with different bytes at the
 	// same path changes the effective filesystem under an unchanged


### PR DESCRIPTION
Stacks on #305 (backup uploader); retarget to main after it merges.

## Summary
The read path of the GCS backup tier: RestoreGeneration fetches a generation's manifest completion object, rebuilds each sparse artifact from its packed object and extent table, and verifies every file's full apparent content against the manifest digest. Plus cmd/backup-restore, the operator CLI that lost-host recovery and single-sandbox restore build on. Cold-boot integration into vmd is out of scope here.

## Technical decisions
- All-or-nothing materialization: any fetch, write, or digest failure deletes every file the call created in destDir. A partially restored directory that looks plausible is the dangerous outcome for a recovery tool, so nothing half-verified is ever left behind.
- Missing manifest is a distinct ErrGenerationIncomplete: the manifest is written last, so its absence means the upload never finished and the prefix must never be restored from. The CLI surfaces this with guidance to pick another generation.
- Verification reuses the uploader's hashApparent over the manifest's extent table, so upload and restore agree byte for byte on what the apparent content digest means. Sparse holes reappear via truncate to apparent size; interior holes are simply never written.
- BlobReader/BlobLister mirror BlobStore's narrowness: the restore identity needs objectViewer and nothing else, and RestoreGeneration itself does not demand list permission. ListGenerations reports only manifest-bearing (restorable) generations.
- Defensive manifest handling for the shared bucket: file names are segment-validated so a manifest cannot escape destDir, extent tables are sanity-checked, and a packed object longer than its extent table is an error.

## Testing
- Round trip through the real Uploader into a map-backed store fixture: a genuinely sparse overlay (WriteAt runs plus Truncate) and a dense vmstate restore byte-identical to the originals with digests verified.
- Corruption: a flipped byte in a stored packed object fails restore, names the file and cause, and leaves the dest dir empty.
- Missing manifest yields ErrGenerationIncomplete; ListGenerations omits incomplete generations and other sandboxes.
- gofmt, go test ./internal/backup/ -count=1, GOOS=linux go build ./..., GOOS=linux go vet on both packages.
