### PR TITLE
vmd: back up template build artifacts

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -513,7 +513,11 @@ func main() {
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
-		mgr.SetBackupCovered(journal.Covered)
+		mgr.SetBackupCovered(func(t backup.Task) (bool, error) {
+			// Coverage is per bucket: a completed generation elsewhere
+			// must not suppress uploading into this one.
+			return journal.Covered(bucket, t)
+		})
 		// The uploader must fully stop before the journal and GCS client
 		// close under it: a verification or Nack cut off mid-write leaves
 		// a finalized object the journal never recorded, which the

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -513,6 +513,7 @@ func main() {
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
+		mgr.SetBackupCovered(journal.Covered)
 		// The uploader must fully stop before the journal and GCS client
 		// close under it: a verification or Nack cut off mid-write leaves
 		// a finalized object the journal never recorded, which the
@@ -715,8 +716,11 @@ func main() {
 		}
 		// After the instance map is rebuilt: pauses that still owed their
 		// backup enqueue when the previous process exited get their
-		// rehash re-run (no-op when backup is disabled).
+		// rehash re-run, and completed template builds whose generation
+		// never reached the journal get reconciled from their stamped
+		// meta (both no-ops when backup is disabled).
 		mgr.RecoverPendingBackups(ctx, log)
+		mgr.RecoverTemplateBackups(ctx, log)
 	}()
 
 	// ---- Optional DB connection for the reconciler ----

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -157,6 +157,16 @@ func (t *Task) readyAt() time.Time {
 	return t.EnqueuedAt
 }
 
+// owner is the task's full owner identity: the sandbox id for pause
+// generations, the template/build pair for template builds. NUL-joined so
+// the pair can never alias a sandbox id or another template's pair.
+func (t *Task) owner() string {
+	if t.TemplateID != "" {
+		return t.TemplateID + "\x00" + t.BuildID
+	}
+	return t.SandboxID
+}
+
 // key orders the queue: priority, then READINESS time, then the owner
 // and generation for uniqueness. Readiness rather than enqueue time is
 // load-bearing for outage backlogs: deferred tasks sort behind runnable
@@ -164,10 +174,11 @@ func (t *Task) readyAt() time.Time {
 // priority instead of scanning every deferred entry on each drain and
 // idle tick. The owner segment is load-bearing too: generations are
 // content-addressed, so two untouched sandboxes cloned from one template
-// share a generation, and without the owner a same-tick enqueue would
-// collide keys and silently drop one sandbox's backup.
+// (or two template builds producing identical artifacts) share a
+// generation, and without the owner a same-tick enqueue would collide
+// keys and silently drop one owner's backup.
 func (t *Task) key() []byte {
-	return []byte(fmt.Sprintf("%d/%020d/%s/%s", t.Priority, t.readyAt().UnixNano(), t.SandboxID, t.Generation))
+	return []byte(fmt.Sprintf("%d/%020d/%s/%s", t.Priority, t.readyAt().UnixNano(), t.owner(), t.Generation))
 }
 
 // indexKey is the pending-generation identity for the dedupe index. The
@@ -175,11 +186,7 @@ func (t *Task) key() []byte {
 // tasks dedupe on their own identity and can never collide with a sandbox
 // task sharing a generation key.
 func (t *Task) indexKey() []byte {
-	owner := t.SandboxID
-	if t.TemplateID != "" {
-		owner = t.TemplateID + "\x00" + t.BuildID
-	}
-	return []byte(owner + "\x00" + t.Generation)
+	return []byte(t.owner() + "\x00" + t.Generation)
 }
 
 // Enqueue adds a task. A task for the same generation that is already

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -48,8 +48,14 @@ type TaskFile struct {
 // generation key is content-addressed, so re-running a task lands on the
 // same object names and the bucket's create-only precondition makes
 // duplicates a no-op.
+//
+// Exactly one owner is set: SandboxID for pause generations, TemplateID
+// (always with the BuildID that produced the artifacts) for template
+// builds. The owner picks the object prefix; see Task.objectName.
 type Task struct {
-	SandboxID  string     `json:"sandbox_id"`
+	SandboxID  string     `json:"sandbox_id,omitempty"`
+	TemplateID string     `json:"template_id,omitempty"`
+	BuildID    string     `json:"build_id,omitempty"`
 	Generation string     `json:"generation"`
 	Files      []TaskFile `json:"files"`
 	Priority   Priority   `json:"priority"`
@@ -164,9 +170,16 @@ func (t *Task) key() []byte {
 	return []byte(fmt.Sprintf("%d/%020d/%s/%s", t.Priority, t.readyAt().UnixNano(), t.SandboxID, t.Generation))
 }
 
-// indexKey is the pending-generation identity for the dedupe index.
+// indexKey is the pending-generation identity for the dedupe index. The
+// owner segment is the sandbox id or the template/build pair, so template
+// tasks dedupe on their own identity and can never collide with a sandbox
+// task sharing a generation key.
 func (t *Task) indexKey() []byte {
-	return []byte(t.SandboxID + "\x00" + t.Generation)
+	owner := t.SandboxID
+	if t.TemplateID != "" {
+		owner = t.TemplateID + "\x00" + t.BuildID
+	}
+	return []byte(owner + "\x00" + t.Generation)
 }
 
 // Enqueue adds a task. A task for the same generation that is already
@@ -174,8 +187,14 @@ func (t *Task) indexKey() []byte {
 // upload harmless, but there is no reason to do the work twice (idempotent
 // pause retries re-enqueue the identical generation).
 func (j *Journal) Enqueue(task Task) error {
-	if task.Generation == "" || task.SandboxID == "" {
-		return fmt.Errorf("task missing identity: %+v", task)
+	if task.Generation == "" {
+		return fmt.Errorf("task missing generation: %+v", task)
+	}
+	if (task.SandboxID == "") == (task.TemplateID == "") {
+		return fmt.Errorf("task must identify exactly one of sandbox or template: %+v", task)
+	}
+	if task.TemplateID != "" && task.BuildID == "" {
+		return fmt.Errorf("template task missing build id: %+v", task)
 	}
 	if task.EnqueuedAt.IsZero() {
 		task.EnqueuedAt = time.Now().UTC()

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -10,8 +10,12 @@ import (
 )
 
 // Priority orders upload work. Lower value uploads first: a pause or an
-// on-demand snapshot is user-visible durability; periodic checkpoints and
-// (later) memory-tier components are opportunistic and must never delay it.
+// on-demand snapshot is user-visible durability; template builds,
+// periodic checkpoints, and (later) memory-tier components are
+// recoverable or rebuildable and must never delay it. A multi-GiB
+// template upload at pause priority would head-of-line block every pause
+// backup for minutes at the bandwidth cap, and a pause is unique user
+// data while a template can be rebuilt.
 type Priority uint8
 
 const (
@@ -116,6 +120,13 @@ var (
 	// original task was acked. Entries carry a timestamp and are pruned
 	// lazily on ack.
 	verifiedBucket = []byte("backup_verified_objects")
+	// completionsBucket records owner+generation pairs whose generation
+	// fully reached the bucket (manifest object written, task acked as
+	// completed). Kept indefinitely: rows are tiny, and this record is
+	// what lets recovery sweeps distinguish "already durable, skip" from
+	// "never made it, reconcile", without which a swept owner would be
+	// re-uploaded on every pass after its task was acked away.
+	completionsBucket = []byte("backup_completed_generations")
 )
 
 // verifiedRetention bounds how long verification history is kept. Long
@@ -135,7 +146,7 @@ var pruneCursorKey = []byte("\x00prune_cursor")
 // caller owns the bolt DB; sharing vmd's state DB keeps one fsync domain.
 func NewJournal(db *bolt.DB) (*Journal, error) {
 	err := db.Update(func(tx *bolt.Tx) error {
-		for _, b := range [][]byte{journalBucket, indexBucket, verifiedBucket, outboxBucket} {
+		for _, b := range [][]byte{journalBucket, indexBucket, verifiedBucket, outboxBucket, completionsBucket} {
 			if _, err := tx.CreateBucketIfNotExists(b); err != nil {
 				return err
 			}
@@ -390,6 +401,31 @@ func (j *Journal) HasPending(sandboxID, generation string) (bool, error) {
 	return ok, err
 }
 
+// WasCompleted reports whether this task's owner+generation was ever
+// acked as completed (its generation fully verified in the bucket). Only
+// the task's identity fields (owner and Generation) are consulted.
+func (j *Journal) WasCompleted(task Task) (bool, error) {
+	var ok bool
+	err := j.db.View(func(tx *bolt.Tx) error {
+		ok = tx.Bucket(completionsBucket).Get(task.indexKey()) != nil
+		return nil
+	})
+	return ok, err
+}
+
+// Covered reports whether this task's owner+generation needs no new
+// enqueue: it is either still pending in the queue or already recorded
+// as completed. The recovery sweeps' gate.
+func (j *Journal) Covered(task Task) (bool, error) {
+	var ok bool
+	err := j.db.View(func(tx *bolt.Tx) error {
+		ok = tx.Bucket(indexBucket).Get(task.indexKey()) != nil ||
+			tx.Bucket(completionsBucket).Get(task.indexKey()) != nil
+		return nil
+	})
+	return ok, err
+}
+
 // WasVerified reports whether any task ever digest-verified this object
 // within the retention window.
 func (j *Journal) WasVerified(object string, now time.Time) (bool, error) {
@@ -411,12 +447,15 @@ func (j *Journal) WasVerified(object string, now time.Time) (bool, error) {
 
 // Ack removes a finished task. Called only after every object of the
 // generation is verified in the bucket (or the task was abandoned).
-// notify additionally records the task in the notification outbox within
-// the SAME transaction: the ack that makes the task's completion
-// otherwise unrecoverable is the last durable moment to remember that a
-// completion signal is still owed. Piggybacks a bounded lazy prune of
-// expired verification history.
-func (j *Journal) Ack(task Task, notify bool) error {
+// completed records the owner+generation in the durable completions
+// bucket within the SAME transaction: the ack deletes the queue row, so
+// this record is the only survivor telling recovery sweeps the
+// generation is already in the bucket. notify additionally records the
+// task in the notification outbox, likewise transactionally: the ack
+// that makes the task's completion otherwise unrecoverable is the last
+// durable moment to remember that a completion signal is still owed.
+// Piggybacks a bounded lazy prune of expired verification history.
+func (j *Journal) Ack(task Task, completed, notify bool) error {
 	now := time.Now()
 	return j.db.Update(func(tx *bolt.Tx) error {
 		if err := tx.Bucket(journalBucket).Delete(task.key()); err != nil {
@@ -424,6 +463,11 @@ func (j *Journal) Ack(task Task, notify bool) error {
 		}
 		if err := tx.Bucket(indexBucket).Delete(task.indexKey()); err != nil {
 			return err
+		}
+		if completed {
+			if err := tx.Bucket(completionsBucket).Put(task.indexKey(), []byte(fmt.Sprintf("%d", now.UnixNano()))); err != nil {
+				return err
+			}
 		}
 		if notify {
 			val, err := json.Marshal(task)

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -404,23 +404,32 @@ func (j *Journal) HasPending(sandboxID, generation string) (bool, error) {
 // WasCompleted reports whether this task's owner+generation was ever
 // acked as completed (its generation fully verified in the bucket). Only
 // the task's identity fields (owner and Generation) are consulted.
-func (j *Journal) WasCompleted(task Task) (bool, error) {
+// completionKey scopes a completion record to the destination bucket:
+// a completed generation in one bucket says nothing about another, and
+// an unscoped record would suppress re-upload after BACKUP_BUCKET
+// changes.
+func completionKey(scope string, task Task) []byte {
+	return append([]byte(scope+"\x00"), task.indexKey()...)
+}
+
+func (j *Journal) WasCompleted(scope string, task Task) (bool, error) {
 	var ok bool
 	err := j.db.View(func(tx *bolt.Tx) error {
-		ok = tx.Bucket(completionsBucket).Get(task.indexKey()) != nil
+		ok = tx.Bucket(completionsBucket).Get(completionKey(scope, task)) != nil
 		return nil
 	})
 	return ok, err
 }
 
 // Covered reports whether this task's owner+generation needs no new
-// enqueue: it is either still pending in the queue or already recorded
-// as completed. The recovery sweeps' gate.
-func (j *Journal) Covered(task Task) (bool, error) {
+// enqueue against the given bucket: it is either still pending in the
+// queue or already recorded as completed there. The recovery sweeps'
+// gate.
+func (j *Journal) Covered(scope string, task Task) (bool, error) {
 	var ok bool
 	err := j.db.View(func(tx *bolt.Tx) error {
 		ok = tx.Bucket(indexBucket).Get(task.indexKey()) != nil ||
-			tx.Bucket(completionsBucket).Get(task.indexKey()) != nil
+			tx.Bucket(completionsBucket).Get(completionKey(scope, task)) != nil
 		return nil
 	})
 	return ok, err
@@ -455,7 +464,8 @@ func (j *Journal) WasVerified(object string, now time.Time) (bool, error) {
 // that makes the task's completion otherwise unrecoverable is the last
 // durable moment to remember that a completion signal is still owed.
 // Piggybacks a bounded lazy prune of expired verification history.
-func (j *Journal) Ack(task Task, completed, notify bool) error {
+func (j *Journal) Ack(task Task, completedScope string, notify bool) error {
+	completed := completedScope != ""
 	now := time.Now()
 	return j.db.Update(func(tx *bolt.Tx) error {
 		if err := tx.Bucket(journalBucket).Delete(task.key()); err != nil {
@@ -465,7 +475,7 @@ func (j *Journal) Ack(task Task, completed, notify bool) error {
 			return err
 		}
 		if completed {
-			if err := tx.Bucket(completionsBucket).Put(task.indexKey(), []byte(fmt.Sprintf("%d", now.UnixNano()))); err != nil {
+			if err := tx.Bucket(completionsBucket).Put(completionKey(completedScope, task), []byte(fmt.Sprintf("%d", now.UnixNano()))); err != nil {
 				return err
 			}
 		}

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -49,7 +49,7 @@ func TestJournalPriorityAndFIFO(t *testing.T) {
 			break
 		}
 		got = append(got, task.Generation)
-		if err := j.Ack(task, false); err != nil {
+		if err := j.Ack(task, false, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -115,6 +115,48 @@ func TestJournalNackBackoffAndPersistence(t *testing.T) {
 	}
 }
 
+// Ack with completed=true leaves a durable owner+generation record that
+// survives the queue row's deletion: it is what recovery sweeps consult
+// to avoid re-uploading generations that already reached the bucket.
+func TestJournalRecordsCompletions(t *testing.T) {
+	j, _ := testJournal(t)
+	task := Task{TemplateID: "tpl", BuildID: "b1", Generation: "gen-1", EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if covered, err := j.Covered(task); err != nil || !covered {
+		t.Fatalf("pending task not covered: %v err=%v", covered, err)
+	}
+	if done, err := j.WasCompleted(task); err != nil || done {
+		t.Fatalf("WasCompleted before ack = %v err=%v", done, err)
+	}
+	if err := j.Ack(task, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if done, err := j.WasCompleted(task); err != nil || !done {
+		t.Fatalf("WasCompleted after completed ack = %v err=%v", done, err)
+	}
+	if covered, err := j.Covered(task); err != nil || !covered {
+		t.Fatalf("completed task not covered: %v err=%v", covered, err)
+	}
+
+	// An abandoned ack records nothing: the generation never became
+	// durable, so recovery must be free to retry it.
+	abandoned := Task{TemplateID: "tpl", BuildID: "b1", Generation: "gen-2", EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 1, 0, time.UTC)}
+	if err := j.Enqueue(abandoned); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Ack(abandoned, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if done, _ := j.WasCompleted(abandoned); done {
+		t.Fatal("abandoned ack recorded a completion")
+	}
+	if covered, _ := j.Covered(abandoned); covered {
+		t.Fatal("abandoned generation reported covered")
+	}
+}
+
 // Generations are content-addressed, so distinct owners can legitimately
 // share one generation. Queue keys must stay unique per owner even at the
 // same enqueue tick, or one owner's backup would be silently overwritten.
@@ -155,7 +197,7 @@ func TestJournalQueueKeysScopedByOwner(t *testing.T) {
 			break
 		}
 		owners[task.owner()] = true
-		if err := j.Ack(task, false); err != nil {
+		if err := j.Ack(task, false, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -115,6 +115,55 @@ func TestJournalNackBackoffAndPersistence(t *testing.T) {
 	}
 }
 
+// Generations are content-addressed, so distinct owners can legitimately
+// share one generation. Queue keys must stay unique per owner even at the
+// same enqueue tick, or one owner's backup would be silently overwritten.
+func TestJournalQueueKeysScopedByOwner(t *testing.T) {
+	j, _ := testJournal(t)
+	base := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{SandboxID: "sb-1", Generation: "shared-gen", Priority: PriorityPause, EnqueuedAt: base},
+		{TemplateID: "tpl-a", BuildID: "build-tpl-a", Generation: "shared-gen", Priority: PriorityPause, EnqueuedAt: base},
+		{TemplateID: "tpl-b", BuildID: "build-tpl-b", Generation: "shared-gen", Priority: PriorityPause, EnqueuedAt: base},
+	}
+
+	keys := make(map[string]int, len(tasks))
+	for i, task := range tasks {
+		k := string(task.key())
+		if prev, dup := keys[k]; dup {
+			t.Fatalf("tasks %d and %d collide on queue key %q", prev, i, k)
+		}
+		keys[k] = i
+		if err := j.Enqueue(task); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// All three survive as distinct pending entries and drain independently.
+	counts, err := j.Pending()
+	if err != nil || counts[PriorityPause] != 3 {
+		t.Fatalf("pending = %v err=%v, want 3 pause tasks", counts, err)
+	}
+	owners := make(map[string]bool, len(tasks))
+	now := base.Add(time.Minute)
+	for {
+		task, ok, err := j.Next(now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			break
+		}
+		owners[task.owner()] = true
+		if err := j.Ack(task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(owners) != 3 {
+		t.Fatalf("drained owners = %v, want 3 distinct owners", owners)
+	}
+}
+
 func TestJournalEnqueueRequiresExactlyOneOwner(t *testing.T) {
 	j, _ := testJournal(t)
 	cases := []struct {

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -155,7 +155,7 @@ func TestJournalQueueKeysScopedByOwner(t *testing.T) {
 			break
 		}
 		owners[task.owner()] = true
-		if err := j.Ack(task); err != nil {
+		if err := j.Ack(task, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -49,7 +49,7 @@ func TestJournalPriorityAndFIFO(t *testing.T) {
 			break
 		}
 		got = append(got, task.Generation)
-		if err := j.Ack(task, false, false); err != nil {
+		if err := j.Ack(task, "", false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -124,19 +124,19 @@ func TestJournalRecordsCompletions(t *testing.T) {
 	if err := j.Enqueue(task); err != nil {
 		t.Fatal(err)
 	}
-	if covered, err := j.Covered(task); err != nil || !covered {
+	if covered, err := j.Covered("test-bucket", task); err != nil || !covered {
 		t.Fatalf("pending task not covered: %v err=%v", covered, err)
 	}
-	if done, err := j.WasCompleted(task); err != nil || done {
+	if done, err := j.WasCompleted("test-bucket", task); err != nil || done {
 		t.Fatalf("WasCompleted before ack = %v err=%v", done, err)
 	}
-	if err := j.Ack(task, true, false); err != nil {
+	if err := j.Ack(task, "test-bucket", false); err != nil {
 		t.Fatal(err)
 	}
-	if done, err := j.WasCompleted(task); err != nil || !done {
+	if done, err := j.WasCompleted("test-bucket", task); err != nil || !done {
 		t.Fatalf("WasCompleted after completed ack = %v err=%v", done, err)
 	}
-	if covered, err := j.Covered(task); err != nil || !covered {
+	if covered, err := j.Covered("test-bucket", task); err != nil || !covered {
 		t.Fatalf("completed task not covered: %v err=%v", covered, err)
 	}
 
@@ -146,13 +146,13 @@ func TestJournalRecordsCompletions(t *testing.T) {
 	if err := j.Enqueue(abandoned); err != nil {
 		t.Fatal(err)
 	}
-	if err := j.Ack(abandoned, false, false); err != nil {
+	if err := j.Ack(abandoned, "", false); err != nil {
 		t.Fatal(err)
 	}
-	if done, _ := j.WasCompleted(abandoned); done {
+	if done, _ := j.WasCompleted("test-bucket", abandoned); done {
 		t.Fatal("abandoned ack recorded a completion")
 	}
-	if covered, _ := j.Covered(abandoned); covered {
+	if covered, _ := j.Covered("test-bucket", abandoned); covered {
 		t.Fatal("abandoned generation reported covered")
 	}
 }
@@ -197,7 +197,7 @@ func TestJournalQueueKeysScopedByOwner(t *testing.T) {
 			break
 		}
 		owners[task.owner()] = true
-		if err := j.Ack(task, false, false); err != nil {
+		if err := j.Ack(task, "", false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -114,3 +114,32 @@ func TestJournalNackBackoffAndPersistence(t *testing.T) {
 		t.Fatalf("pending = %v err=%v", counts, err)
 	}
 }
+
+func TestJournalEnqueueRequiresExactlyOneOwner(t *testing.T) {
+	j, _ := testJournal(t)
+	cases := []struct {
+		name    string
+		task    Task
+		wantErr bool
+	}{
+		{"sandbox task", Task{SandboxID: "sb", Generation: "g1"}, false},
+		{"template task", Task{TemplateID: "tpl", BuildID: "b1", Generation: "g2"}, false},
+		{"both owners", Task{SandboxID: "sb", TemplateID: "tpl", BuildID: "b1", Generation: "g3"}, true},
+		{"no owner", Task{Generation: "g4"}, true},
+		{"template without build id", Task{TemplateID: "tpl", Generation: "g5"}, true},
+		{"no generation", Task{SandboxID: "sb"}, true},
+	}
+	for _, tc := range cases {
+		err := j.Enqueue(tc.task)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("%s: err = %v, wantErr = %v", tc.name, err, tc.wantErr)
+		}
+	}
+	// Template tasks dedupe on their own identity like sandbox tasks do.
+	if err := j.Enqueue(Task{TemplateID: "tpl", BuildID: "b1", Generation: "g2"}); err != nil {
+		t.Fatal(err)
+	}
+	if counts, _ := j.Pending(); counts[PriorityBestEffort]+counts[PriorityCheckpoint]+counts[PriorityPause] != 2 {
+		t.Fatalf("pending after dedupe = %v", counts)
+	}
+}

--- a/internal/backup/layout.go
+++ b/internal/backup/layout.go
@@ -67,7 +67,6 @@ func SandboxObject(sandboxID, generation, fileName string) (string, error) {
 	return fmt.Sprintf("%s/%s/%s/%s", sandboxPrefix, sandboxID, generation, fileName), nil
 }
 
-// TemplateObject names an artifact object within a template build.
 // SharedBaseObject names a bucket-wide content-addressed base image
 // object: bases/<sha256>.p<fingerprint>. The digest addresses the bytes
 // and the fingerprint binds the extent table, so identical bases from
@@ -76,17 +75,26 @@ func SharedBaseObject(sha256, fingerprint string) string {
 	return "bases/" + sha256 + ".p" + fingerprint
 }
 
-func TemplateObject(templateID, buildID, fileName string) (string, error) {
+// TemplateObject names an artifact object within a template build
+// generation. The generation segment matters even though a finished build
+// is immutable: build ids are reusable (vmd defaults to build-<template>,
+// and a terminal build releases the id for the next rebuild), so without
+// it a rebuild would land on the previous build's prefix and create-only
+// dedupe would silently keep the stale objects.
+func TemplateObject(templateID, buildID, generation, fileName string) (string, error) {
 	if err := validSegment(templateID); err != nil {
 		return "", fmt.Errorf("template id: %w", err)
 	}
 	if err := validSegment(buildID); err != nil {
 		return "", fmt.Errorf("build id: %w", err)
 	}
+	if err := validSegment(generation); err != nil {
+		return "", fmt.Errorf("generation: %w", err)
+	}
 	if err := validSegment(fileName); err != nil {
 		return "", fmt.Errorf("file name: %w", err)
 	}
-	return fmt.Sprintf("%s/%s/%s/%s", templatePrefix, templateID, buildID, fileName), nil
+	return fmt.Sprintf("%s/%s/%s/%s/%s", templatePrefix, templateID, buildID, generation, fileName), nil
 }
 
 // validSegment rejects path traversal and separator injection in object-name

--- a/internal/backup/layout_test.go
+++ b/internal/backup/layout_test.go
@@ -7,8 +7,8 @@ func TestObjectNames(t *testing.T) {
 	if err != nil || got != "sandboxes/sb-123/abcd1234/overlay.ext4" {
 		t.Fatalf("sandbox object = %q err=%v", got, err)
 	}
-	got, err = TemplateObject("tpl-1", "build-9", "base.ext4")
-	if err != nil || got != "templates/tpl-1/build-9/base.ext4" {
+	got, err = TemplateObject("tpl-1", "build-9", "abcd1234", "base.ext4")
+	if err != nil || got != "templates/tpl-1/build-9/abcd1234/base.ext4" {
 		t.Fatalf("template object = %q err=%v", got, err)
 	}
 }

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -253,6 +253,14 @@ func removeStagedTask(root string, task Task) {
 	if root == "" || len(task.Files) == 0 {
 		return
 	}
+	// Template tasks are never staged (their artifacts are immutable on
+	// disk), and with an empty SandboxID the path math below would land
+	// on root/<generation> and the trailing Remove would target the
+	// staging root itself. Harmless today (recreated on demand) but a
+	// trap for any refactor that assumes the root persists.
+	if task.SandboxID == "" {
+		return
+	}
 	dir := filepath.Join(root, task.SandboxID, task.Generation)
 	if !strings.HasPrefix(dir, root+string(os.PathSeparator)) {
 		return

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -195,7 +195,11 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 			Str("generation", task.Generation).
 			Msg("template backup generation abandoned")
 	}
-	if err := u.Journal.Ack(task, completed, completed && u.OnVerified != nil); err != nil {
+	completedScope := ""
+	if completed {
+		completedScope = u.Store.Identity()
+	}
+	if err := u.Journal.Ack(task, completedScope, completed && u.OnVerified != nil); err != nil {
 		return true, err
 	}
 	removeStagedTask(u.StagingRoot, task)

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -181,12 +181,21 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 		// whatever deleted our sources. Leave the upgraded row for the
 		// next drain instead of acking it away.
 		if cur, ok, lerr := u.Journal.Load(task); lerr == nil && ok && cur.Staged {
-			u.Log.Info().Str("sandbox_id", task.SandboxID).
+			task.logOwner(u.Log.Info()).
 				Msg("abandoned mutable-path attempt; staged row retained for retry")
 			return true, nil
 		}
 	}
-	if err := u.Journal.Ack(task, completed && u.OnVerified != nil); err != nil {
+	if !completed && task.TemplateID != "" {
+		// Operator-visible by design: an abandoned template generation has
+		// no automatic corrective pause behind it the way a sandbox does;
+		// the recovery sweep re-reconciles from the on-host artifacts, but
+		// a template whose artifacts diverged from their stamps needs eyes.
+		task.logOwner(u.Log.Error()).
+			Str("generation", task.Generation).
+			Msg("template backup generation abandoned")
+	}
+	if err := u.Journal.Ack(task, completed, completed && u.OnVerified != nil); err != nil {
 		return true, err
 	}
 	removeStagedTask(u.StagingRoot, task)
@@ -209,8 +218,7 @@ func (u *Uploader) flushNotifications() {
 	for _, t := range pending {
 		u.OnVerified(t)
 		if err := u.Journal.ClearNotification(t); err != nil {
-			u.Log.Warn().Err(err).
-				Str("sandbox_id", t.SandboxID).
+			t.logOwner(u.Log.Warn().Err(err)).
 				Str("generation", t.Generation).
 				Msg("backup notification clear failed; will redeliver")
 		}
@@ -278,7 +286,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			bf, err := baseTaskFile(file)
 			if err != nil {
 				if os.IsNotExist(err) {
-					u.Log.Warn().Str("path", file.BasePath).Str("sandbox_id", task.SandboxID).
+					task.logOwner(u.Log.Warn().Str("path", file.BasePath)).
 						Msg("backup base image gone; abandoning generation")
 					return false, nil
 				}
@@ -287,7 +295,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			bmf, err := u.uploadFile(ctx, task, bf)
 			if err != nil {
 				if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
-					u.Log.Warn().Str("path", bf.Path).Str("sandbox_id", task.SandboxID).
+					task.logOwner(u.Log.Warn().Str("path", bf.Path)).
 						Msg("backup base image gone or rebuilt; abandoning generation")
 					return false, nil
 				}
@@ -318,7 +326,7 @@ const stagingSweepInterval = 30 * time.Minute
 // keep the content-addressed generation segment: build ids are reusable
 // across rebuilds of a template, so the generation is what stops a rebuild
 // from deduping against a previous build's objects (see TemplateObject).
-func (t Task) objectName(fileName string) (string, error) {
+func (t *Task) objectName(fileName string) (string, error) {
 	if t.TemplateID != "" {
 		return TemplateObject(t.TemplateID, t.BuildID, t.Generation, fileName)
 	}
@@ -326,7 +334,7 @@ func (t Task) objectName(fileName string) (string, error) {
 }
 
 // logOwner stamps the task's owning identity onto a log event.
-func (t Task) logOwner(e *zerolog.Event) *zerolog.Event {
+func (t *Task) logOwner(e *zerolog.Event) *zerolog.Event {
 	if t.TemplateID != "" {
 		return e.Str("template_id", t.TemplateID).Str("build_id", t.BuildID)
 	}
@@ -523,7 +531,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// discriminator, and without it the generation is abandoned
 		// rather than completed over bytes nothing can vouch for (this
 		// identity cannot read them back).
-		u.Log.Warn().Str("object", object).Str("sandbox_id", task.SandboxID).
+		task.logOwner(u.Log.Warn().Str("object", object)).
 			Msg("deduped object has no verification history; abandoning generation")
 		return ManifestFile{}, errSourceChanged
 	}

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -314,13 +314,13 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 // stagingSweepInterval paces the running staged-base sweep.
 const stagingSweepInterval = 30 * time.Minute
 
-// objectName routes an object into the task owner's prefix. Sandbox
-// generations are content-addressed under the generation key; template
-// builds are immutable per build id, so templates/<template>/<build>/ is
-// already a stable address and needs no generation segment.
+// objectName routes an object into the task owner's prefix. Both owners
+// keep the content-addressed generation segment: build ids are reusable
+// across rebuilds of a template, so the generation is what stops a rebuild
+// from deduping against a previous build's objects (see TemplateObject).
 func (t Task) objectName(fileName string) (string, error) {
 	if t.TemplateID != "" {
-		return TemplateObject(t.TemplateID, t.BuildID, fileName)
+		return TemplateObject(t.TemplateID, t.BuildID, t.Generation, fileName)
 	}
 	return SandboxObject(t.SandboxID, t.Generation, fileName)
 }

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -23,7 +23,9 @@ import (
 // extent tables. A generation without its manifest object is incomplete
 // and never restored from.
 type GenerationManifest struct {
-	SandboxID  string         `json:"sandbox_id"`
+	SandboxID  string         `json:"sandbox_id,omitempty"`
+	TemplateID string         `json:"template_id,omitempty"`
+	BuildID    string         `json:"build_id,omitempty"`
 	Generation string         `json:"generation"`
 	Files      []ManifestFile `json:"files"`
 	VMDVersion string         `json:"vmd_version,omitempty"`
@@ -164,8 +166,7 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 	}
 	completed, err := u.uploadTask(ctx, &task)
 	if err != nil {
-		u.Log.Warn().Err(err).
-			Str("sandbox_id", task.SandboxID).
+		task.logOwner(u.Log.Warn().Err(err)).
 			Str("generation", task.Generation).
 			Int("attempts", task.Attempts+1).
 			Msg("backup upload failed; will retry")
@@ -244,6 +245,8 @@ func baseTaskFile(file TaskFile) (TaskFile, error) {
 func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, _ error) {
 	gen := GenerationManifest{
 		SandboxID:  task.SandboxID,
+		TemplateID: task.TemplateID,
+		BuildID:    task.BuildID,
 		Generation: task.Generation,
 		VMDVersion: u.VMDVersion,
 	}
@@ -256,7 +259,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 				// upload (sandbox deleted or resumed, local GC won the
 				// race). Nothing valid to back up under this content
 				// address; the generation is abandoned, not retried.
-				u.Log.Warn().Str("path", file.Path).Str("sandbox_id", task.SandboxID).
+				task.logOwner(u.Log.Warn().Str("path", file.Path)).
 					Msg("backup source file gone; abandoning generation")
 				return false, nil
 			}
@@ -294,7 +297,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			gen.Files = append(gen.Files, bmf)
 		}
 	}
-	manifestObject, err := SandboxObject(task.SandboxID, task.Generation, ManifestObject)
+	manifestObject, err := task.objectName(ManifestObject)
 	if err != nil {
 		return false, err
 	}
@@ -310,6 +313,25 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 
 // stagingSweepInterval paces the running staged-base sweep.
 const stagingSweepInterval = 30 * time.Minute
+
+// objectName routes an object into the task owner's prefix. Sandbox
+// generations are content-addressed under the generation key; template
+// builds are immutable per build id, so templates/<template>/<build>/ is
+// already a stable address and needs no generation segment.
+func (t Task) objectName(fileName string) (string, error) {
+	if t.TemplateID != "" {
+		return TemplateObject(t.TemplateID, t.BuildID, fileName)
+	}
+	return SandboxObject(t.SandboxID, t.Generation, fileName)
+}
+
+// logOwner stamps the task's owning identity onto a log event.
+func (t Task) logOwner(e *zerolog.Event) *zerolog.Event {
+	if t.TemplateID != "" {
+		return e.Str("template_id", t.TemplateID).Str("build_id", t.BuildID)
+	}
+	return e.Str("sandbox_id", t.SandboxID)
+}
 
 // errSourceChanged marks a source file whose current content no longer
 // matches the digest recorded at pause time: the sandbox resumed and
@@ -381,7 +403,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		objectName = object
 	} else {
 		objectName = file.Name + ".p" + PackFingerprint(extents, apparent)
-		object, err = SandboxObject(task.SandboxID, task.Generation, objectName)
+		object, err = task.objectName(objectName)
 		if err != nil {
 			return ManifestFile{}, err
 		}
@@ -507,7 +529,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 	}
 	return ManifestFile{
 		Name:       file.Name,
-		Object:     objectName,
+		Object:     suffixedName,
 		SHA256:     file.SHA256,
 		BasePath:   file.BasePath,
 		BaseSHA256: file.BaseSHA256,

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -529,7 +529,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 	}
 	return ManifestFile{
 		Name:       file.Name,
-		Object:     suffixedName,
+		Object:     objectName,
 		SHA256:     file.SHA256,
 		BasePath:   file.BasePath,
 		BaseSHA256: file.BaseSHA256,

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -337,9 +337,9 @@ func TestUploaderRoutesTemplateTasks(t *testing.T) {
 		}
 	}
 
-	// Template artifacts land under templates/<template>/<build>/ with the
-	// fingerprint-suffixed object names, content intact.
-	prefix := "templates/tpl-1/build-tpl-1/"
+	// Template artifacts land under templates/<template>/<build>/<generation>/
+	// with the fingerprint-suffixed object names, content intact.
+	prefix := "templates/tpl-1/build-tpl-1/" + tpl.Generation + "/"
 	for _, f := range tpl.Files {
 		obj := prefix + packedName(t, f.Path, f.Name)
 		if got := string(store.objects[obj]); digestOf([]byte(got)) != f.SHA256 {

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -369,6 +369,67 @@ func TestUploaderRoutesTemplateTasks(t *testing.T) {
 	}
 }
 
+// A template build ships its base image as a regular member of its own
+// generation (the vm side enqueues it without a BaseSHA256 dependency), so
+// the uploader must ship it exactly once under the template prefix and
+// never also route it through the shared bases/ tree.
+func TestTemplateBaseShipsOnceInsideTheGeneration(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	u := &Uploader{Journal: j, Store: store}
+
+	dir := t.TempDir()
+	base := []byte("base image bytes")
+	basePath := filepath.Join(dir, "base.ext4")
+	if err := os.WriteFile(basePath, base, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := []TaskFile{{
+		Name:   "base.ext4",
+		Path:   basePath,
+		SHA256: digestOf(base),
+		Size:   int64(len(base)),
+	}}
+	task := Task{
+		TemplateID: "tpl-1",
+		BuildID:    "build-tpl-1",
+		Generation: GenerationKey(files),
+		Priority:   PriorityPause,
+		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 1, 0, time.UTC),
+		Files:      files,
+	}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := u.drainOne(context.Background(), task.EnqueuedAt.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix := "templates/tpl-1/build-tpl-1/" + task.Generation + "/"
+	baseObjects := 0
+	for obj := range store.objects {
+		if strings.HasPrefix(obj, "bases/") {
+			t.Fatalf("template base leaked into the shared prefix: %s", obj)
+		}
+		if strings.Contains(obj, "base.ext4") {
+			baseObjects++
+			if !strings.HasPrefix(obj, prefix) {
+				t.Fatalf("base object outside the template generation: %s", obj)
+			}
+		}
+	}
+	if baseObjects != 1 {
+		t.Fatalf("base.ext4 shipped %d times, want exactly 1 (objects: %v)", baseObjects, keysOf(store.objects))
+	}
+	var gen GenerationManifest
+	if err := json.Unmarshal(store.objects[prefix+ManifestObject], &gen); err != nil {
+		t.Fatalf("template manifest object: %v", err)
+	}
+	if len(gen.Files) != 1 || gen.Files[0].Name != "base.ext4" || gen.Files[0].BaseSHA256 != "" {
+		t.Fatalf("template manifest files = %+v, want one base.ext4 entry with no base dependency", gen.Files)
+	}
+}
+
 func keysOf(m map[string][]byte) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -430,6 +430,71 @@ func TestTemplateBaseShipsOnceInsideTheGeneration(t *testing.T) {
 	}
 }
 
+// A template task whose sources vanished acks cleanly: no journal
+// residue, no completion record (recovery may retry from the artifacts),
+// no verification hook, and the staging root untouched (template tasks
+// are never staged, and the empty-SandboxID path math must not walk the
+// cleanup onto the root itself).
+func TestTemplateTaskAbandonsCleanlyOnVanishedSource(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	staging := t.TempDir()
+	var verified []Task
+	u := &Uploader{Journal: j, Store: store, StagingRoot: staging, OnVerified: func(task Task) { verified = append(verified, task) }}
+
+	task := Task{
+		TemplateID: "tpl-1",
+		BuildID:    "build-tpl-1",
+		Generation: "gen-vanished",
+		Priority:   PriorityCheckpoint,
+		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 1, 0, time.UTC),
+		Files: []TaskFile{{
+			Name:   "mem.snap",
+			Path:   filepath.Join(t.TempDir(), "gone", "mem.snap"),
+			SHA256: digestOf([]byte("never written")),
+			Size:   13,
+		}},
+	}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	worked, err := u.drainOne(context.Background(), task.EnqueuedAt.Add(time.Minute))
+	if err != nil || !worked {
+		t.Fatalf("drain: worked=%v err=%v", worked, err)
+	}
+	if counts, _ := j.Pending(); counts[PriorityCheckpoint] != 0 {
+		t.Fatalf("journal residue after abandonment: %v", counts)
+	}
+	if done, _ := j.WasCompleted(task); done {
+		t.Fatal("abandoned template generation recorded as completed")
+	}
+	if len(verified) != 0 {
+		t.Fatalf("verification hook fired for an abandoned generation: %+v", verified)
+	}
+	if len(store.objects) != 0 {
+		t.Fatalf("abandoned generation shipped objects: %v", keysOf(store.objects))
+	}
+	if _, err := os.Stat(staging); err != nil {
+		t.Fatalf("staging root disturbed by template ack: %v", err)
+	}
+}
+
+// removeStagedTask must never resolve an empty SandboxID into the
+// staging root: root/<generation> plus the trailing parent Remove would
+// target the root itself.
+func TestRemoveStagedTaskIgnoresTemplateTasks(t *testing.T) {
+	root := t.TempDir()
+	removeStagedTask(root, Task{
+		TemplateID: "tpl-1",
+		BuildID:    "b1",
+		Generation: "gen",
+		Files:      []TaskFile{{Name: "mem.snap"}},
+	})
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("staging root removed for a template task: %v", err)
+	}
+}
+
 func keysOf(m map[string][]byte) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -655,7 +720,7 @@ func TestJournalPruneSweepsHistoryAcrossAcks(t *testing.T) {
 	task := Task{SandboxID: "sb", Generation: "g", Priority: PriorityPause,
 		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)}
 	for i := 0; i < 5; i++ {
-		if err := j.Ack(task, false); err != nil {
+		if err := j.Ack(task, false, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -686,7 +751,7 @@ func TestVerifiedNotificationSurvivesCrashBeforeDelivery(t *testing.T) {
 	}
 	// Simulate the first process: ack with notification owed, then crash
 	// before any delivery (no flush runs).
-	if err := j.Ack(task, true); err != nil {
+	if err := j.Ack(task, true, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -712,7 +777,7 @@ func TestAbandonedAckLeavesNoNotification(t *testing.T) {
 	if err := j.Enqueue(task); err != nil {
 		t.Fatal(err)
 	}
-	if err := j.Ack(task, false); err != nil {
+	if err := j.Ack(task, false, false); err != nil {
 		t.Fatal(err)
 	}
 	pending, err := j.PendingNotifications()
@@ -959,7 +1024,7 @@ func TestNextSkipsDeferredPriorityWithoutScanning(t *testing.T) {
 	// The nack re-keyed the row; ack through the same task state must
 	// clear it (index and queue agree on the new key).
 	nacked := got
-	if err := j.Ack(nacked, false); err != nil {
+	if err := j.Ack(nacked, false, false); err != nil {
 		t.Fatal(err)
 	}
 	if counts, _ := j.Pending(); counts[PriorityPause] != 0 {
@@ -1247,7 +1312,7 @@ func TestStagedBaseSurvivesTemplateGC(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(staging, "bases", hex.EncodeToString(baseSum[:]))); err != nil {
 		t.Fatalf("referenced staged base swept: %v", err)
 	}
-	if err := j.Ack(Task{SandboxID: "sb2", Generation: "g2", EnqueuedAt: time.Unix(3, 0)}, false); err != nil {
+	if err := j.Ack(Task{SandboxID: "sb2", Generation: "g2", EnqueuedAt: time.Unix(3, 0)}, false, false); err != nil {
 		t.Fatal(err)
 	}
 	ageStagingTree(t, staging)

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -282,6 +282,93 @@ func TestJournalEnqueueDedupesPendingGeneration(t *testing.T) {
 	}
 }
 
+func writeTemplateTask(t *testing.T, dir string) Task {
+	t.Helper()
+	contents := []struct{ name, data string }{
+		{"vmstate.snap", "tpl-state"},
+		{"mem.snap", "tpl-mem"},
+		{"rootfs.delta", "tpl-delta"},
+	}
+	files := make([]TaskFile, 0, len(contents))
+	for _, c := range contents {
+		path := filepath.Join(dir, c.name)
+		if err := os.WriteFile(path, []byte(c.data), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, TaskFile{
+			Name:   c.name,
+			Path:   path,
+			SHA256: digestOf([]byte(c.data)),
+			Size:   int64(len(c.data)),
+		})
+	}
+	return Task{
+		TemplateID: "tpl-1",
+		BuildID:    "build-tpl-1",
+		Generation: GenerationKey(files),
+		Priority:   PriorityPause,
+		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 1, 0, time.UTC),
+		Files:      files,
+	}
+}
+
+func TestUploaderRoutesTemplateTasks(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	var verified []Task
+	u := &Uploader{Journal: j, Store: store, OnVerified: func(task Task) { verified = append(verified, task) }}
+
+	// Mixed queue: a sandbox pause and a template build, both pause priority.
+	sandbox := writeTask(t, t.TempDir())
+	tpl := writeTemplateTask(t, t.TempDir())
+	for _, task := range []Task{sandbox, tpl} {
+		if err := j.Enqueue(task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := tpl.EnqueuedAt.Add(time.Minute)
+	for {
+		worked, err := u.drainOne(context.Background(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !worked {
+			break
+		}
+	}
+
+	// Template artifacts land under templates/<template>/<build>/ with the
+	// fingerprint-suffixed object names, content intact.
+	prefix := "templates/tpl-1/build-tpl-1/"
+	for _, f := range tpl.Files {
+		obj := prefix + packedName(t, f.Path, f.Name)
+		if got := string(store.objects[obj]); digestOf([]byte(got)) != f.SHA256 {
+			t.Fatalf("template object %s = %q", obj, got)
+		}
+	}
+	// Completion marker lives under the same prefix and carries the template identity.
+	var gen GenerationManifest
+	if err := json.Unmarshal(store.objects[prefix+ManifestObject], &gen); err != nil {
+		t.Fatalf("template manifest object: %v", err)
+	}
+	if gen.TemplateID != "tpl-1" || gen.BuildID != "build-tpl-1" || gen.SandboxID != "" {
+		t.Fatalf("template manifest identity = %+v", gen)
+	}
+	if gen.Generation != tpl.Generation || len(gen.Files) != len(tpl.Files) {
+		t.Fatalf("template manifest = %+v", gen)
+	}
+	// The sandbox task in the same queue drained to its own prefix.
+	if _, ok := store.objects["sandboxes/sb-1/gen-abc/"+ManifestObject]; !ok {
+		t.Fatal("sandbox manifest missing from mixed drain")
+	}
+	if len(verified) != 2 {
+		t.Fatalf("verified hooks = %+v", verified)
+	}
+	if counts, _ := j.Pending(); counts[PriorityPause] != 0 {
+		t.Fatalf("queue not drained: %v", counts)
+	}
+}
+
 func keysOf(m map[string][]byte) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -465,7 +465,7 @@ func TestTemplateTaskAbandonsCleanlyOnVanishedSource(t *testing.T) {
 	if counts, _ := j.Pending(); counts[PriorityCheckpoint] != 0 {
 		t.Fatalf("journal residue after abandonment: %v", counts)
 	}
-	if done, _ := j.WasCompleted(task); done {
+	if done, _ := j.WasCompleted("test-bucket", task); done {
 		t.Fatal("abandoned template generation recorded as completed")
 	}
 	if len(verified) != 0 {
@@ -720,7 +720,7 @@ func TestJournalPruneSweepsHistoryAcrossAcks(t *testing.T) {
 	task := Task{SandboxID: "sb", Generation: "g", Priority: PriorityPause,
 		EnqueuedAt: time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)}
 	for i := 0; i < 5; i++ {
-		if err := j.Ack(task, false, false); err != nil {
+		if err := j.Ack(task, "", false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -751,7 +751,7 @@ func TestVerifiedNotificationSurvivesCrashBeforeDelivery(t *testing.T) {
 	}
 	// Simulate the first process: ack with notification owed, then crash
 	// before any delivery (no flush runs).
-	if err := j.Ack(task, true, true); err != nil {
+	if err := j.Ack(task, "test-bucket", true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -777,7 +777,7 @@ func TestAbandonedAckLeavesNoNotification(t *testing.T) {
 	if err := j.Enqueue(task); err != nil {
 		t.Fatal(err)
 	}
-	if err := j.Ack(task, false, false); err != nil {
+	if err := j.Ack(task, "", false); err != nil {
 		t.Fatal(err)
 	}
 	pending, err := j.PendingNotifications()
@@ -1024,7 +1024,7 @@ func TestNextSkipsDeferredPriorityWithoutScanning(t *testing.T) {
 	// The nack re-keyed the row; ack through the same task state must
 	// clear it (index and queue agree on the new key).
 	nacked := got
-	if err := j.Ack(nacked, false, false); err != nil {
+	if err := j.Ack(nacked, "", false); err != nil {
 		t.Fatal(err)
 	}
 	if counts, _ := j.Pending(); counts[PriorityPause] != 0 {
@@ -1312,7 +1312,7 @@ func TestStagedBaseSurvivesTemplateGC(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(staging, "bases", hex.EncodeToString(baseSum[:]))); err != nil {
 		t.Fatalf("referenced staged base swept: %v", err)
 	}
-	if err := j.Ack(Task{SandboxID: "sb2", Generation: "g2", EnqueuedAt: time.Unix(3, 0)}, false, false); err != nil {
+	if err := j.Ack(Task{SandboxID: "sb2", Generation: "g2", EnqueuedAt: time.Unix(3, 0)}, "", false); err != nil {
 		t.Fatal(err)
 	}
 	ageStagingTree(t, staging)

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -29,6 +29,31 @@ func (m *Manager) SetBackupEnqueue(fn func(backup.Task) error) {
 	m.backupEnqueue = fn
 }
 
+// SetBackupCovered installs the journal's coverage probe: whether a
+// task's owner+generation is already pending in the queue or recorded as
+// completed. Recovery sweeps use it to skip work that is already
+// durable; nil (backup disabled, or older wiring) means "never covered",
+// which only costs idempotent re-enqueues the journal dedupes anyway.
+func (m *Manager) SetBackupCovered(fn func(backup.Task) (bool, error)) {
+	m.backupCovered = fn
+}
+
+// retryWithBackoff runs attempt with doubling delays until it succeeds
+// or enqueueRetryAttempts are exhausted, reporting whether it succeeded.
+// The first attempt is already behind the caller; this helper owns only
+// the retries, so it sleeps before every call.
+func retryWithBackoff(attempt func() bool) bool {
+	delay := time.Second
+	for i := 0; i < enqueueRetryAttempts; i++ {
+		time.Sleep(delay)
+		delay *= 2
+		if attempt() {
+			return true
+		}
+	}
+	return false
+}
+
 // pauseRehashBudget bounds the asynchronous rehash of a pause whose
 // synchronous hashing was skipped or partial. Generous by design: the
 // retry runs off the RPC path, where a large disk taking minutes is
@@ -275,6 +300,17 @@ func (m *Manager) rehashPendingBackup(ctx context.Context, pb PendingBackup, log
 // retries the remainder.
 const pendingRehashConcurrency = 2
 
+// ensureRehashSlots lazily creates the shared rehash bound. Both the
+// pause recovery and the template-build sweep route their hashing
+// through this one channel, so their combined disk pressure stays under
+// pendingRehashConcurrency no matter which recovery started first.
+func (m *Manager) ensureRehashSlots() chan struct{} {
+	m.rehashSlotsOnce.Do(func() {
+		m.rehashSlots = make(chan struct{}, pendingRehashConcurrency)
+	})
+	return m.rehashSlots
+}
+
 // pendingBackupSweepInterval paces retries of retained pending records:
 // a record kept on an inconclusive proof or transient failure must not
 // wait for the next process restart to try again.
@@ -291,7 +327,7 @@ func (m *Manager) RecoverPendingBackups(ctx context.Context, log zerolog.Logger)
 	if m.backupEnqueue == nil || m.state == nil {
 		return
 	}
-	m.rehashSlots = make(chan struct{}, pendingRehashConcurrency)
+	m.ensureRehashSlots()
 	m.runPendingBackups(ctx, log)
 	interval := m.pendingSweepInterval
 	if interval <= 0 {
@@ -383,25 +419,26 @@ func (m *Manager) finishPauseEnqueue(pb PendingBackup, manifest []ManifestEntry,
 // leaves the pending record for the next boot's recovery.
 func (m *Manager) retryEnqueue(pb PendingBackup, manifest []ManifestEntry, log zerolog.Logger) {
 	m.healPendingBackup(pb, log)
-	delay := time.Second
-	for attempt := 0; attempt < enqueueRetryAttempts; attempt++ {
-		time.Sleep(delay)
-		delay *= 2
-		if ok, staged := m.enqueueBackup(pb.VMID, manifest); ok {
-			if staged {
-				m.deletePendingBackupIf(pb, log)
-				return
-			}
-			// Journaled but from mutable paths: keep the marker so the
-			// sweep can upgrade the queued row, like every other path.
-			log.Warn().Str("vm_id", pb.VMID).
-				Msg("retry enqueued unstaged; keeping marker for staging upgrade")
-			m.healPendingBackup(pb, log)
-			return
-		}
+	var staged bool
+	enqueued := retryWithBackoff(func() bool {
+		ok, s := m.enqueueBackup(pb.VMID, manifest)
+		staged = s
+		return ok
+	})
+	if !enqueued {
+		log.Error().Str("vm_id", pb.VMID).
+			Msg("pause backup journal writes kept failing; pending record kept for recovery")
+		m.healPendingBackup(pb, log)
+		return
 	}
-	log.Error().Str("vm_id", pb.VMID).
-		Msg("pause backup journal writes kept failing; pending record kept for recovery")
+	if staged {
+		m.deletePendingBackupIf(pb, log)
+		return
+	}
+	// Journaled but from mutable paths: keep the marker so the
+	// sweep can upgrade the queued row, like every other path.
+	log.Warn().Str("vm_id", pb.VMID).
+		Msg("retry enqueued unstaged; keeping marker for staging upgrade")
 	m.healPendingBackup(pb, log)
 }
 
@@ -721,12 +758,13 @@ func rebuildTask(vmID string, manifest []ManifestEntry) backup.Task {
 }
 
 // enqueueTemplateBackup hands a completed template build's hashed artifact
-// set to the backup pipeline, reporting whether a task was enqueued. Same
-// contract as enqueueBackup: a nil hook (backup disabled) is a no-op, and
-// the enqueue is a local journal write that must never fail the build; the
-// caller owns retrying a failed write. Template builds ride the pause
-// priority: a finished build is user-visible durability exactly like a
-// pause, and build volume is far too low to starve the pause lane.
+// set to the backup pipeline, reporting whether the generation is covered
+// (enqueued now, still pending, or already completed). Same contract as
+// enqueueBackup: a nil hook (backup disabled) is a no-op, and the enqueue
+// is a local journal write that must never fail the build; the caller
+// owns retrying a failed write. Template builds ride the checkpoint
+// priority: a template is rebuildable, so a multi-GiB build upload must
+// never head-of-line block a pause generation, which is unique user data.
 func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []ManifestEntry) bool {
 	if m.backupEnqueue == nil || len(manifest) == 0 {
 		return false
@@ -746,13 +784,23 @@ func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []M
 			Size:   e.SizeBytes,
 		})
 	}
-	if err := m.backupEnqueue(backup.Task{
+	task := backup.Task{
 		TemplateID: templateID,
 		BuildID:    buildID,
 		Generation: backup.GenerationKey(files),
 		Files:      files,
-		Priority:   backup.PriorityPause,
-	}); err != nil {
+		Priority:   backup.PriorityCheckpoint,
+	}
+	// Already pending or already completed means nothing to do: recovery
+	// sweeps and repeated status-poll adoptions funnel through here, and
+	// without this gate an already-acked generation would be re-uploaded
+	// on every pass.
+	if m.backupCovered != nil {
+		if covered, err := m.backupCovered(task); err == nil && covered {
+			return true
+		}
+	}
+	if err := m.backupEnqueue(task); err != nil {
 		m.log.Error().Err(err).Str("template_id", templateID).Str("build_vm_id", buildID).
 			Msg("backup enqueue failed; build not journaled")
 		return false

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -733,6 +733,12 @@ func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []M
 	}
 	files := make([]backup.TaskFile, 0, len(manifest))
 	for _, e := range manifest {
+		// No BasePath/BaseSHA256, deliberately: the build's base image is
+		// already a REGULAR member of this artifact set (collectBuildManifest
+		// hashes it via extraPaths), so it ships inside the template's own
+		// generation. Declaring it a base dependency too would make the
+		// uploader also ship it as a shared bases/ object: the same bytes
+		// twice.
 		files = append(files, backup.TaskFile{
 			Name:   e.FileName,
 			Path:   e.Path,

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -721,14 +721,15 @@ func rebuildTask(vmID string, manifest []ManifestEntry) backup.Task {
 }
 
 // enqueueTemplateBackup hands a completed template build's hashed artifact
-// set to the backup pipeline. Same contract as enqueueBackup: a nil hook
-// (backup disabled) is a no-op, and the enqueue is a local journal write
-// that must never fail the build. Template builds ride the pause priority:
-// a finished build is user-visible durability exactly like a pause, and
-// build volume is far too low to starve the pause lane.
-func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []ManifestEntry) {
+// set to the backup pipeline, reporting whether a task was enqueued. Same
+// contract as enqueueBackup: a nil hook (backup disabled) is a no-op, and
+// the enqueue is a local journal write that must never fail the build; the
+// caller owns retrying a failed write. Template builds ride the pause
+// priority: a finished build is user-visible durability exactly like a
+// pause, and build volume is far too low to starve the pause lane.
+func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []ManifestEntry) bool {
 	if m.backupEnqueue == nil || len(manifest) == 0 {
-		return
+		return false
 	}
 	files := make([]backup.TaskFile, 0, len(manifest))
 	for _, e := range manifest {
@@ -739,11 +740,16 @@ func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []M
 			Size:   e.SizeBytes,
 		})
 	}
-	m.backupEnqueue(backup.Task{
+	if err := m.backupEnqueue(backup.Task{
 		TemplateID: templateID,
 		BuildID:    buildID,
 		Generation: backup.GenerationKey(files),
 		Files:      files,
 		Priority:   backup.PriorityPause,
-	})
+	}); err != nil {
+		m.log.Error().Err(err).Str("template_id", templateID).Str("build_vm_id", buildID).
+			Msg("backup enqueue failed; build not journaled")
+		return false
+	}
+	return true
 }

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -719,3 +719,31 @@ func rebuildTask(vmID string, manifest []ManifestEntry) backup.Task {
 		Priority:   backup.PriorityPause,
 	}
 }
+
+// enqueueTemplateBackup hands a completed template build's hashed artifact
+// set to the backup pipeline. Same contract as enqueueBackup: a nil hook
+// (backup disabled) is a no-op, and the enqueue is a local journal write
+// that must never fail the build. Template builds ride the pause priority:
+// a finished build is user-visible durability exactly like a pause, and
+// build volume is far too low to starve the pause lane.
+func (m *Manager) enqueueTemplateBackup(templateID, buildID string, manifest []ManifestEntry) {
+	if m.backupEnqueue == nil || len(manifest) == 0 {
+		return
+	}
+	files := make([]backup.TaskFile, 0, len(manifest))
+	for _, e := range manifest {
+		files = append(files, backup.TaskFile{
+			Name:   e.FileName,
+			Path:   e.Path,
+			SHA256: e.SHA256,
+			Size:   e.SizeBytes,
+		})
+	}
+	m.backupEnqueue(backup.Task{
+		TemplateID: templateID,
+		BuildID:    buildID,
+		Generation: backup.GenerationKey(files),
+		Files:      files,
+		Priority:   backup.PriorityPause,
+	})
+}

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -282,7 +282,37 @@ func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buil
 		SizeBytes: size,
 		SHA256:    sum,
 	})
-	m.enqueueTemplateBackup(templateID, buildVMID, entries)
+	if m.enqueueTemplateBackup(templateID, buildVMID, entries) {
+		return
+	}
+	// Only the journal write failed; the digests in hand describe the
+	// finished artifacts and are already stamped into build.meta.json, so
+	// the retry needs no rehash. Async so neither build completion nor a
+	// status poll ever blocks on journal recovery, mirroring the pause
+	// path's retryEnqueue. Unlike pause, no pending marker is persisted:
+	// the stamped meta IS the durable retry state, and the next process's
+	// adopted-build reconciliation rebuilds this exact task from it.
+	log.Warn().Msg("template backup journal write failed; retrying enqueue")
+	go m.retryTemplateEnqueue(templateID, buildVMID, entries, log)
+}
+
+// retryTemplateEnqueue re-attempts a template build's journal write with
+// bounded backoff. Exhausted retries leave recovery to the adopted-build
+// reconciliation after the next restart (the in-memory registry keeps
+// serving the build meanwhile, so within this process the gap is
+// log-and-monitoring surfaced, never silently closed).
+func (m *Manager) retryTemplateEnqueue(templateID, buildVMID string, entries []ManifestEntry, log zerolog.Logger) {
+	delay := time.Second
+	for attempt := 0; attempt < enqueueRetryAttempts; attempt++ {
+		time.Sleep(delay)
+		delay *= 2
+		if m.enqueueTemplateBackup(templateID, buildVMID, entries) {
+			log.Info().Int("attempt", attempt+1).Msg("template backup enqueued after retry")
+			return
+		}
+	}
+	log.Error().Str("template_id", templateID).Str("build_vm_id", buildVMID).
+		Msg("template backup journal writes kept failing; build stays unjournaled until restart reconciliation")
 }
 
 // readStampedBuildDigests returns the artifact digests writeBuildDigests

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -198,21 +198,33 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	// recorded above), stamp the digests into build.meta.json, and enqueue
 	// the build for backup. Best-effort by design: the artifacts on disk
 	// are valid regardless, so nothing in here fails the build.
-	m.backupBuildArtifacts(ctx, req.TemplateID, buildVMID, snapshotDir, log)
+	m.backupBuildArtifacts(ctx, req.TemplateID, buildVMID, snapshotDir, result.BasePath, log)
 
 	log.Info().Dur("total", time.Since(buildStart)).Msg("template build complete")
 	return result, nil
 }
 
-// backupBuildArtifacts makes a finished build's artifact directory durable:
-// hash the artifact set, record the digests into build.meta.json so the
-// on-host artifacts carry their integrity data the way pause artifacts do,
-// then enqueue the set (build.meta.json included) into the backup journal.
-func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir string, log zerolog.Logger) {
-	entries := collectBuildManifest(ctx, snapshotDir, log)
+// backupBuildArtifacts makes a finished build's artifact set durable: hash
+// the snapshot directory plus the base image build.meta.json references
+// (it lives in the run dir but the template is not restorable without it),
+// record the digests into build.meta.json so the on-host artifacts carry
+// their integrity data the way pause artifacts do, then enqueue the set
+// (build.meta.json included) into the backup journal.
+//
+// Fails closed on completeness: the manifest object's presence in the
+// bucket means "restorable", so a set missing even one artifact is never
+// enqueued. The build itself still succeeds; the gap is surfaced by the
+// warn log and coverage monitoring, never papered over.
+func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir, basePath string, log zerolog.Logger) {
+	entries, complete := collectBuildManifest(ctx, snapshotDir, []string{basePath}, log)
 	if len(entries) == 0 {
 		log.Warn().Str("dir", snapshotDir).
 			Msg("build manifest hashed no artifacts; build not enqueued for backup")
+		return
+	}
+	if !complete {
+		log.Warn().Str("dir", snapshotDir).
+			Msg("build artifact set hashed incompletely; build not enqueued for backup")
 		return
 	}
 	if err := writeBuildDigests(snapshotDir, entries); err != nil {
@@ -224,16 +236,17 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 	metaPath := filepath.Join(snapshotDir, buildMetaFilename)
 	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 	defer cancel()
-	if sum, size, err := hashFile(hctx, metaPath); err != nil {
-		log.Warn().Err(err).Msg("hashing build.meta.json failed; backed-up set omits it")
-	} else {
-		entries = append(entries, ManifestEntry{
-			FileName:  buildMetaFilename,
-			Path:      metaPath,
-			SizeBytes: size,
-			SHA256:    sum,
-		})
+	sum, size, err := hashFile(hctx, metaPath)
+	if err != nil {
+		log.Warn().Err(err).Msg("hashing build.meta.json failed; build not enqueued for backup")
+		return
 	}
+	entries = append(entries, ManifestEntry{
+		FileName:  buildMetaFilename,
+		Path:      metaPath,
+		SizeBytes: size,
+		SHA256:    sum,
+	})
 	m.enqueueTemplateBackup(templateID, buildVMID, entries)
 }
 

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/superserve-ai/sandbox/internal/builder"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 )
@@ -192,8 +194,47 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 		}
 	}
 
+	// Durability: hash the finished artifact set (access.log included when
+	// recorded above), stamp the digests into build.meta.json, and enqueue
+	// the build for backup. Best-effort by design: the artifacts on disk
+	// are valid regardless, so nothing in here fails the build.
+	m.backupBuildArtifacts(ctx, req.TemplateID, buildVMID, snapshotDir, log)
+
 	log.Info().Dur("total", time.Since(buildStart)).Msg("template build complete")
 	return result, nil
+}
+
+// backupBuildArtifacts makes a finished build's artifact directory durable:
+// hash the artifact set, record the digests into build.meta.json so the
+// on-host artifacts carry their integrity data the way pause artifacts do,
+// then enqueue the set (build.meta.json included) into the backup journal.
+func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir string, log zerolog.Logger) {
+	entries := collectBuildManifest(ctx, snapshotDir, log)
+	if len(entries) == 0 {
+		log.Warn().Str("dir", snapshotDir).
+			Msg("build manifest hashed no artifacts; build not enqueued for backup")
+		return
+	}
+	if err := writeBuildDigests(snapshotDir, entries); err != nil {
+		log.Warn().Err(err).Msg("recording artifact digests into build.meta.json failed")
+	}
+	// Hash build.meta.json last so the backed-up copy is the one carrying
+	// the digests it was just given; its own digest travels in the task
+	// (and the generation manifest), never inside itself.
+	metaPath := filepath.Join(snapshotDir, buildMetaFilename)
+	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	if sum, size, err := hashFile(hctx, metaPath); err != nil {
+		log.Warn().Err(err).Msg("hashing build.meta.json failed; backed-up set omits it")
+	} else {
+		entries = append(entries, ManifestEntry{
+			FileName:  buildMetaFilename,
+			Path:      metaPath,
+			SizeBytes: size,
+			SHA256:    sum,
+		})
+	}
+	m.enqueueTemplateBackup(templateID, buildVMID, entries)
 }
 
 // buildLogPipe parses NDJSON lines from template-builder's stdout and
@@ -247,9 +288,14 @@ func (p *buildLogPipe) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
+// buildMetaFilename is the metadata file template-builder writes into the
+// build's snapshot directory; vmd later stamps artifact digests into it
+// (writeBuildDigests).
+const buildMetaFilename = "build.meta.json"
+
 // readBuildMetaJSON reads the build.meta.json written by template-builder.
 func readBuildMetaJSON(snapshotDir string) (*BuildTemplateResult, error) {
-	data, err := os.ReadFile(filepath.Join(snapshotDir, "build.meta.json"))
+	data, err := os.ReadFile(filepath.Join(snapshotDir, buildMetaFilename))
 	if err != nil {
 		return nil, err
 	}
@@ -274,4 +320,69 @@ func readBuildMetaJSON(snapshotDir string) (*BuildTemplateResult, error) {
 		ResolvedDigest: meta.ResolvedDigest,
 		SizeBytes:      meta.SizeBytes,
 	}, nil
+}
+
+// buildArtifactDigest is one artifact's integrity record inside
+// build.meta.json's "artifacts" field.
+type buildArtifactDigest struct {
+	Name      string `json:"name"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// writeBuildDigests rewrites build.meta.json with an "artifacts" field
+// carrying the hashed artifact set. The document is edited as raw JSON so
+// every field template-builder wrote (including ones vmd does not model)
+// survives the round trip, and the replace is atomic so readers
+// (loadDurableBuild, the backup drain) never observe a torn file.
+func writeBuildDigests(snapshotDir string, entries []ManifestEntry) error {
+	path := filepath.Join(snapshotDir, buildMetaFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return fmt.Errorf("parse %s: %w", buildMetaFilename, err)
+	}
+	digests := make([]buildArtifactDigest, 0, len(entries))
+	for _, e := range entries {
+		digests = append(digests, buildArtifactDigest{
+			Name:      e.FileName,
+			SHA256:    e.SHA256,
+			SizeBytes: e.SizeBytes,
+		})
+	}
+	raw, err := json.Marshal(digests)
+	if err != nil {
+		return err
+	}
+	meta["artifacts"] = raw
+	out, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return err
+	}
+	if err := syncPath(tmp); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return syncPath(snapshotDir)
+}
+
+// syncPath fsyncs a file or directory by path.
+func syncPath(p string) error {
+	f, err := os.Open(p)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
 }

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -236,6 +236,27 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 			Msg("build artifact set hashed incompletely; build not enqueued for backup")
 		return
 	}
+	// Directory enumeration only proves what exists, not what should: an
+	// artifact that was never written (or already deleted) never reaches
+	// the hasher, so `complete` alone would bless the gap. Judge the set
+	// against the paths build.meta.json declares before publishing.
+	meta, err := readBuildMetaJSON(snapshotDir)
+	if err != nil {
+		log.Warn().Err(err).Msg("build manifest: reread build.meta.json failed; build not enqueued for backup")
+		return
+	}
+	hashed := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		hashed[e.FileName] = true
+	}
+	for _, p := range []string{meta.SnapshotPath, meta.MemFilePath, meta.RootfsPath, meta.BasePath, meta.DeltaPath} {
+		if p == "" || hashed[filepath.Base(p)] {
+			continue
+		}
+		log.Warn().Str("artifact", filepath.Base(p)).
+			Msg("required build artifact missing from hashed set; build not enqueued for backup")
+		return
+	}
 	if err := writeBuildDigests(snapshotDir, entries); err != nil {
 		log.Warn().Err(err).Msg("recording artifact digests into build.meta.json failed")
 	}

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -123,7 +123,14 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	if err != nil {
 		return nil, fmt.Errorf("reserve build network slot: %w", err)
 	}
-	defer m.netMgr.ReleaseSlot(buildVMID, slotIndex)
+	slotReleased := false
+	releaseSlot := func() {
+		if !slotReleased {
+			slotReleased = true
+			m.netMgr.ReleaseSlot(buildVMID, slotIndex)
+		}
+	}
+	defer releaseSlot()
 
 	cmd := exec.CommandContext(ctx, m.cfg.TemplateBuilderBin,
 		"--template-id", req.TemplateID,
@@ -194,11 +201,24 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 		}
 	}
 
+	// The subprocess is gone and the recording VM claims its own slot, so
+	// the build's ns-<idx>/veth-<idx> reservation guards nothing anymore.
+	// Release it before the hashing below: holding a network slot through
+	// minutes of disk reads would shrink sandbox capacity for no reason.
+	releaseSlot()
+
 	// Durability: hash the finished artifact set (access.log included when
 	// recorded above), stamp the digests into build.meta.json, and enqueue
 	// the build for backup. Best-effort by design: the artifacts on disk
 	// are valid regardless, so nothing in here fails the build.
-	m.backupBuildArtifacts(ctx, req.TemplateID, buildVMID, snapshotDir, result.BasePath, log)
+	//
+	// Deliberately synchronous: the build is reported ready only after its
+	// integrity record exists, at the cost of the completion (and any
+	// supervisor timeout budget) covering up to the hash budget for large
+	// artifact sets. The duration is logged so that tradeoff stays visible.
+	hashStart := time.Now()
+	m.backupBuildArtifacts(ctx, req.TemplateID, buildVMID, snapshotDir, result.BasePath, nil, log)
+	log.Info().Dur("backup_hash", time.Since(hashStart)).Msg("build backup pass finished")
 
 	log.Info().Dur("total", time.Since(buildStart)).Msg("template build complete")
 	return result, nil
@@ -214,14 +234,20 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 // Fails closed on completeness: the manifest object's presence in the
 // bucket means "restorable", so a set missing even one artifact is never
 // enqueued. The build itself still succeeds; the gap is surfaced by the
-// warn log and coverage monitoring, never papered over.
-func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir, basePath string, log zerolog.Logger) {
+// warn log and coverage monitoring, then retried by the template sweep.
+//
+// guard, when non-nil, is consulted before any mutation (the digest stamp
+// and the enqueue): reconcile workers run concurrently with new builds
+// that can reuse the same build id and directory, and a guard that
+// returns false drops the work silently because the newer build covers
+// itself. The completion path passes nil (it IS the newest build).
+func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir, basePath string, guard func() bool, log zerolog.Logger) {
 	// No enqueue hook means backup is disabled on this host (BACKUP_BUCKET
 	// unset). Bail before any hashing: the digests exist to feed the backup
 	// journal, and with no consumer the only effect would be delaying every
-	// successful build by up to buildHashBudget plus the metadata hash while
-	// the build's claimed network slot sits idle. Same gate as the pause
-	// path, just hoisted ahead of the hashing instead of inside the enqueue.
+	// successful build by up to buildHashBudget plus the metadata hash.
+	// Same gate as the pause path, just hoisted ahead of the hashing
+	// instead of inside the enqueue.
 	if m.backupEnqueue == nil {
 		return
 	}
@@ -249,7 +275,7 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 	for _, e := range entries {
 		hashed[e.FileName] = true
 	}
-	for _, p := range []string{meta.SnapshotPath, meta.MemFilePath, meta.RootfsPath, meta.BasePath, meta.DeltaPath} {
+	for _, p := range meta.declaredArtifactPaths() {
 		if p == "" || hashed[filepath.Base(p)] {
 			continue
 		}
@@ -257,17 +283,29 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 			Msg("required build artifact missing from hashed set; build not enqueued for backup")
 		return
 	}
+	if guard != nil && !guard() {
+		return
+	}
 	if err := writeBuildDigests(snapshotDir, entries); err != nil {
 		log.Warn().Err(err).Msg("recording artifact digests into build.meta.json failed")
 	}
-	m.finishBuildBackupEnqueue(ctx, templateID, buildVMID, snapshotDir, entries, log)
+	// The stamp above legitimately changed the meta's identity, so a
+	// guard pinning it would now always fail against our own write. From
+	// here the only rebuild-race signal left is an active registration.
+	postStamp := guard
+	if guard != nil {
+		postStamp = func() bool { return !m.buildActive(buildVMID) }
+	}
+	m.finishBuildBackupEnqueue(ctx, templateID, buildVMID, snapshotDir, entries, postStamp, log)
 }
 
 // finishBuildBackupEnqueue hashes build.meta.json last so the backed-up
 // copy is the one carrying the digests it was given by writeBuildDigests;
 // its own digest travels in the task (and the generation manifest), never
-// inside itself. Then the whole set goes to the journal.
-func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buildVMID, snapshotDir string, entries []ManifestEntry, log zerolog.Logger) {
+// inside itself. Then the whole set goes to the journal. guard has the
+// same contract as in backupBuildArtifacts: consulted right before the
+// enqueue, false drops the work silently.
+func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buildVMID, snapshotDir string, entries []ManifestEntry, guard func() bool, log zerolog.Logger) {
 	metaPath := filepath.Join(snapshotDir, buildMetaFilename)
 	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 	defer cancel()
@@ -282,6 +320,9 @@ func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buil
 		SizeBytes: size,
 		SHA256:    sum,
 	})
+	if guard != nil && !guard() {
+		return
+	}
 	if m.enqueueTemplateBackup(templateID, buildVMID, entries) {
 		return
 	}
@@ -290,29 +331,23 @@ func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buil
 	// the retry needs no rehash. Async so neither build completion nor a
 	// status poll ever blocks on journal recovery, mirroring the pause
 	// path's retryEnqueue. Unlike pause, no pending marker is persisted:
-	// the stamped meta IS the durable retry state, and the next process's
-	// adopted-build reconciliation rebuilds this exact task from it.
+	// the stamped meta IS the durable retry state, and the template sweep
+	// (this process or the next) rebuilds this exact task from it.
 	log.Warn().Msg("template backup journal write failed; retrying enqueue")
 	go m.retryTemplateEnqueue(templateID, buildVMID, entries, log)
 }
 
 // retryTemplateEnqueue re-attempts a template build's journal write with
-// bounded backoff. Exhausted retries leave recovery to the adopted-build
-// reconciliation after the next restart (the in-memory registry keeps
-// serving the build meanwhile, so within this process the gap is
-// log-and-monitoring surfaced, never silently closed).
+// bounded backoff. Exhausted retries are logged at error level and left
+// to the periodic template sweep, which re-reconciles every uncovered
+// ready build from its stamped meta, in this process and after restarts.
 func (m *Manager) retryTemplateEnqueue(templateID, buildVMID string, entries []ManifestEntry, log zerolog.Logger) {
-	delay := time.Second
-	for attempt := 0; attempt < enqueueRetryAttempts; attempt++ {
-		time.Sleep(delay)
-		delay *= 2
-		if m.enqueueTemplateBackup(templateID, buildVMID, entries) {
-			log.Info().Int("attempt", attempt+1).Msg("template backup enqueued after retry")
-			return
-		}
+	if retryWithBackoff(func() bool { return m.enqueueTemplateBackup(templateID, buildVMID, entries) }) {
+		log.Info().Msg("template backup enqueued after retry")
+		return
 	}
 	log.Error().Str("template_id", templateID).Str("build_vm_id", buildVMID).
-		Msg("template backup journal writes kept failing; build stays unjournaled until restart reconciliation")
+		Msg("template backup journal writes kept failing; template sweep owns the retry")
 }
 
 // readStampedBuildDigests returns the artifact digests writeBuildDigests
@@ -332,56 +367,120 @@ func readStampedBuildDigests(snapshotDir string) ([]buildArtifactDigest, error) 
 	return meta.Artifacts, nil
 }
 
+// buildActive reports whether a NON-terminal registration exists for this
+// build id: a new build is currently producing artifacts in the same
+// directory a reconcile worker would stamp.
+func (m *Manager) buildActive(buildVMID string) bool {
+	m.buildsMu.RLock()
+	defer m.buildsMu.RUnlock()
+	rec, ok := m.builds[buildVMID]
+	return ok && !rec.Status.IsTerminal()
+}
+
 // reconcileAdoptedBuildBackup re-enters an adopted completed build into the
 // backup pipeline. A vmd exit between template-builder writing
 // build.meta.json and the enqueue (a window as long as the hash budget)
 // leaves a durable, adoptable build with no journal record; without this,
-// such a template would stay unbacked until rebuilt. Runs once per build
-// per process, asynchronously, so adoption (a status read path) is never
-// serialized behind hash budgets.
+// such a template would stay unbacked until rebuilt. One in-flight worker
+// per build id, asynchronous so adoption (a status read path) is never
+// serialized behind hash budgets, and routed through the shared rehash
+// slots so a backlog of adopted builds cannot saturate disk bandwidth
+// (skipped workers are retried by the periodic template sweep).
+//
+// Rebuilds can legitimately reuse a build id (the default id is
+// build-<templateID>) and therefore the same directory. A worker that
+// raced such a rebuild must not stamp stale digests over the new build's
+// meta, so before any mutation it verifies no non-terminal registration
+// exists for the id AND that build.meta.json is still the exact file it
+// read (stat identity, the same pin the pause path uses for bases);
+// either failing drops the reconcile silently, because the newer build
+// covers its own backup.
 //
 // Two cases, keyed on whether writeBuildDigests already stamped the meta:
 //
 //   - no stamped digests: the crash predates hashing, so run the full
 //     pipeline (hash, stamp, enqueue) exactly as build completion would.
-//   - stamped digests: rebuild the task from the recorded digests instead
-//     of re-hashing multi-GiB artifacts on every restart. The journal
-//     dedupes by owner + generation so repeat adoptions are no-ops, and
-//     the uploader re-verifies streamed bytes against these digests, so a
-//     divergence between record and disk fails closed there.
+//   - stamped digests whose sizes still match the files on disk: rebuild
+//     the task from the record instead of re-hashing multi-GiB artifacts.
+//     The journal dedupes by owner + generation (and the completions
+//     record blocks re-uploads after ack), and the uploader re-verifies
+//     streamed bytes against these digests, so divergence fails closed.
+//   - stamped digests whose size does NOT match the disk (truncation,
+//     partial restore): the record is provably stale, so fall through to
+//     the full re-hash, which stamps fresh digests and enqueues a correct
+//     new generation instead of abandoning the stale one forever.
 func (m *Manager) reconcileAdoptedBuildBackup(snap BuildStatusSnapshot) {
 	if m.backupEnqueue == nil || snap.Status != BuildStatusReady || snap.Result == nil {
 		return
 	}
-	if _, already := m.adoptedBuildBackups.LoadOrStore(snap.BuildVMID, struct{}{}); already {
+	if _, busy := m.adoptedBuildBackups.LoadOrStore(snap.BuildVMID, struct{}{}); busy {
+		return
+	}
+	slots := m.ensureRehashSlots()
+	select {
+	case slots <- struct{}{}:
+	default:
+		// All rehash slots busy: drop this attempt rather than queueing
+		// unbounded hash work; the sweep retries uncovered builds.
+		m.adoptedBuildBackups.Delete(snap.BuildVMID)
 		return
 	}
 	templateID, buildVMID, res := snap.TemplateID, snap.BuildVMID, snap.Result
 	dir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID, buildVMID)
+	metaPath := filepath.Join(dir, buildMetaFilename)
 	log := m.log.With().Str("template_id", templateID).Str("build_vm_id", buildVMID).Logger()
 	go func() {
+		defer func() {
+			<-slots
+			m.adoptedBuildBackups.Delete(buildVMID)
+		}()
+		metaID, err := baseIdentity(metaPath)
+		if err != nil {
+			log.Warn().Err(err).Msg("adopted build meta unreadable; reconcile skipped")
+			return
+		}
+		guard := func() bool {
+			if m.buildActive(buildVMID) {
+				return false
+			}
+			cur, err := baseIdentity(metaPath)
+			return err == nil && cur == metaID
+		}
+		if !guard() {
+			return
+		}
 		stamped, err := readStampedBuildDigests(dir)
 		if err != nil || len(stamped) == 0 {
 			log.Info().Err(err).
 				Msg("adopted build has no stamped digests; running backup hashing")
-			m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, log)
+			m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
 			return
 		}
 		entries := make([]ManifestEntry, 0, len(stamped)+1)
 		for _, d := range stamped {
 			path := filepath.Join(dir, d.Name)
-			if _, statErr := os.Stat(path); statErr != nil {
+			fi, statErr := os.Stat(path)
+			if statErr != nil {
 				// The base image lives in the run dir, not the snapshot
 				// dir; anything else unresolvable means the stamp no
 				// longer matches the disk, so re-hash from scratch.
 				if res.BasePath != "" && d.Name == filepath.Base(res.BasePath) {
 					path = res.BasePath
-				} else {
+					fi, statErr = os.Stat(path)
+				}
+				if statErr != nil {
 					log.Warn().Str("artifact", d.Name).
 						Msg("stamped artifact not on disk; running backup hashing")
-					m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, log)
+					m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
 					return
 				}
+			}
+			if fi.Size() != d.SizeBytes {
+				log.Warn().Str("artifact", d.Name).
+					Int64("stamped", d.SizeBytes).Int64("on_disk", fi.Size()).
+					Msg("stamped artifact size diverged; running backup hashing")
+				m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
+				return
 			}
 			entries = append(entries, ManifestEntry{
 				FileName:  d.Name,
@@ -392,8 +491,73 @@ func (m *Manager) reconcileAdoptedBuildBackup(snap BuildStatusSnapshot) {
 		}
 		log.Info().Int("files", len(entries)).
 			Msg("adopted build re-enqueued for backup from stamped digests")
-		m.finishBuildBackupEnqueue(context.Background(), templateID, buildVMID, dir, entries, log)
+		m.finishBuildBackupEnqueue(context.Background(), templateID, buildVMID, dir, entries, guard, log)
 	}()
+}
+
+// RecoverTemplateBackups reconciles every ready on-disk build whose
+// current generation is neither pending in the journal nor recorded as
+// completed, then keeps sweeping periodically. This is the durable-retry
+// trigger the in-memory paths cannot provide: once a build's registry row
+// is terminal the supervisor stops polling, so exhausted enqueue retries,
+// process death during an async retry, or a fail-closed refusal at
+// completion would otherwise drop the template's backup with only a log.
+// Call alongside RecoverPendingBackups; no-op when backup is disabled.
+func (m *Manager) RecoverTemplateBackups(ctx context.Context, log zerolog.Logger) {
+	if m.backupEnqueue == nil {
+		return
+	}
+	m.runTemplateBackupSweep(log)
+	interval := m.pendingSweepInterval
+	if interval <= 0 {
+		interval = pendingBackupSweepInterval
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.runTemplateBackupSweep(log)
+			}
+		}
+	}()
+}
+
+// runTemplateBackupSweep scans SnapshotDir/templates/<tpl>/<build>/ for
+// adoptable completed builds and hands each to the reconcile flow, which
+// owns the covered check (via the enqueue), the rebuild-race guard, the
+// in-flight dedupe, and the shared hash bound.
+func (m *Manager) runTemplateBackupSweep(log zerolog.Logger) {
+	pattern := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, "*", "*", buildMetaFilename)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		log.Error().Err(err).Msg("template backup sweep: glob failed")
+		return
+	}
+	for _, metaPath := range matches {
+		dir := filepath.Dir(metaPath)
+		buildVMID := filepath.Base(dir)
+		templateID := filepath.Base(filepath.Dir(dir))
+		// An active rebuild owns the directory; its completion path owns
+		// the backup. Checked again under the reconcile guard, this early
+		// skip just avoids pointless worker churn.
+		if m.buildActive(buildVMID) {
+			continue
+		}
+		res, err := readBuildMetaJSON(dir)
+		if err != nil || !buildArtifactsPresent(res) {
+			continue // half-written or partially deleted build: not adoptable
+		}
+		m.reconcileAdoptedBuildBackup(BuildStatusSnapshot{
+			BuildVMID:  buildVMID,
+			TemplateID: templateID,
+			Status:     BuildStatusReady,
+			Result:     res,
+		})
+	}
 }
 
 // buildLogPipe parses NDJSON lines from template-builder's stdout and
@@ -481,6 +645,15 @@ func readBuildMetaJSON(snapshotDir string) (*BuildTemplateResult, error) {
 	}, nil
 }
 
+// declaredArtifactPaths lists every artifact file build.meta.json
+// declares (empty entries for modes that lack them). The single source
+// for both the adoption presence check and the backup completeness
+// check, so a future artifact field cannot be added to one and silently
+// escape the other.
+func (r *BuildTemplateResult) declaredArtifactPaths() []string {
+	return []string{r.SnapshotPath, r.MemFilePath, r.RootfsPath, r.BasePath, r.DeltaPath}
+}
+
 // buildArtifactDigest is one artifact's integrity record inside
 // build.meta.json's "artifacts" field.
 type buildArtifactDigest struct {
@@ -521,11 +694,27 @@ func writeBuildDigests(snapshotDir string, entries []ManifestEntry) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+	// Unique temp name (not a fixed <path>.tmp): a crash between write
+	// and rename leaves residue behind, and a fixed name would let the
+	// next stamping pass rename a STALE temp over a fresh meta. The
+	// pattern keeps the .tmp suffix so collectBuildManifest excludes any
+	// residue from the artifact set.
+	f, err := os.CreateTemp(snapshotDir, buildMetaFilename+".*.tmp")
+	if err != nil {
 		return err
 	}
-	if err := syncPath(tmp); err != nil {
+	tmp := f.Name()
+	if _, err := f.Write(out); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -216,6 +216,15 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 // enqueued. The build itself still succeeds; the gap is surfaced by the
 // warn log and coverage monitoring, never papered over.
 func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMID, snapshotDir, basePath string, log zerolog.Logger) {
+	// No enqueue hook means backup is disabled on this host (BACKUP_BUCKET
+	// unset). Bail before any hashing: the digests exist to feed the backup
+	// journal, and with no consumer the only effect would be delaying every
+	// successful build by up to buildHashBudget plus the metadata hash while
+	// the build's claimed network slot sits idle. Same gate as the pause
+	// path, just hoisted ahead of the hashing instead of inside the enqueue.
+	if m.backupEnqueue == nil {
+		return
+	}
 	entries, complete := collectBuildManifest(ctx, snapshotDir, []string{basePath}, log)
 	if len(entries) == 0 {
 		log.Warn().Str("dir", snapshotDir).

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -426,7 +426,15 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 	if m.backupEnqueue == nil || snap.Status != BuildStatusReady || snap.Result == nil {
 		return
 	}
-	if _, busy := m.adoptedBuildBackups.LoadOrStore(snap.BuildVMID, struct{}{}); busy {
+	// Keyed by template AND build id: build ids are reusable across
+	// templates, and a buildVMID-only key would let one template's
+	// in-flight reconcile permanently starve another's same-named build.
+	inflightKey := snap.TemplateID + "\x00" + snap.BuildVMID
+	handle := &reconcileHandle{done: make(chan struct{})}
+	rctx, rcancel := context.WithCancel(context.Background())
+	handle.cancel = rcancel
+	if _, busy := m.adoptedBuildBackups.LoadOrStore(inflightKey, handle); busy {
+		rcancel()
 		return
 	}
 	slots := m.ensureRehashSlots()
@@ -439,7 +447,9 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 			// All rehash slots busy: drop this attempt rather than
 			// queueing unbounded hash work; the sweep retries uncovered
 			// builds.
-			m.adoptedBuildBackups.Delete(snap.BuildVMID)
+			close(handle.done)
+			rcancel()
+			m.adoptedBuildBackups.Delete(inflightKey)
 			return
 		}
 	}
@@ -450,7 +460,9 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 	go func() {
 		defer func() {
 			<-slots
-			m.adoptedBuildBackups.Delete(buildVMID)
+			close(handle.done)
+			rcancel()
+			m.adoptedBuildBackups.Delete(inflightKey)
 		}()
 		metaID, err := baseIdentity(metaPath)
 		if err != nil {
@@ -458,6 +470,14 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 			return
 		}
 		guard := func() bool {
+			// A registration for this build id cancels rctx and AWAITS
+			// this goroutine's exit, so a guard that honors cancellation
+			// makes the check-and-write atomic with respect to rebuilds:
+			// no stamp or enqueue can land after a new build has been
+			// admitted for the same directory.
+			if rctx.Err() != nil {
+				return false
+			}
 			if m.buildActive(buildVMID) {
 				return false
 			}
@@ -471,7 +491,7 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 		if err != nil || len(stamped) == 0 {
 			log.Info().Err(err).
 				Msg("adopted build has no stamped digests; running backup hashing")
-			m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
+			m.backupBuildArtifacts(rctx, templateID, buildVMID, dir, res.BasePath, guard, log)
 			return
 		}
 		entries := make([]ManifestEntry, 0, len(stamped)+1)
@@ -489,7 +509,7 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 				if statErr != nil {
 					log.Warn().Str("artifact", d.Name).
 						Msg("stamped artifact not on disk; running backup hashing")
-					m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
+					m.backupBuildArtifacts(rctx, templateID, buildVMID, dir, res.BasePath, guard, log)
 					return
 				}
 			}
@@ -497,7 +517,7 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 				log.Warn().Str("artifact", d.Name).
 					Int64("stamped", d.SizeBytes).Int64("on_disk", fi.Size()).
 					Msg("stamped artifact size diverged; running backup hashing")
-				m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, guard, log)
+				m.backupBuildArtifacts(rctx, templateID, buildVMID, dir, res.BasePath, guard, log)
 				return
 			}
 			entries = append(entries, ManifestEntry{
@@ -509,8 +529,15 @@ func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, wait
 		}
 		log.Info().Int("files", len(entries)).
 			Msg("adopted build re-enqueued for backup from stamped digests")
-		m.finishBuildBackupEnqueue(context.Background(), templateID, buildVMID, dir, entries, guard, log)
+		m.finishBuildBackupEnqueue(rctx, templateID, buildVMID, dir, entries, guard, log)
 	}()
+}
+
+// reconcileHandle lets a rebuild registration cancel an in-flight
+// adoption reconcile for the same template+build and await its exit.
+type reconcileHandle struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 // RecoverTemplateBackups reconciles every ready on-disk build whose

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -260,9 +260,14 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 	if err := writeBuildDigests(snapshotDir, entries); err != nil {
 		log.Warn().Err(err).Msg("recording artifact digests into build.meta.json failed")
 	}
-	// Hash build.meta.json last so the backed-up copy is the one carrying
-	// the digests it was just given; its own digest travels in the task
-	// (and the generation manifest), never inside itself.
+	m.finishBuildBackupEnqueue(ctx, templateID, buildVMID, snapshotDir, entries, log)
+}
+
+// finishBuildBackupEnqueue hashes build.meta.json last so the backed-up
+// copy is the one carrying the digests it was given by writeBuildDigests;
+// its own digest travels in the task (and the generation manifest), never
+// inside itself. Then the whole set goes to the journal.
+func (m *Manager) finishBuildBackupEnqueue(ctx context.Context, templateID, buildVMID, snapshotDir string, entries []ManifestEntry, log zerolog.Logger) {
 	metaPath := filepath.Join(snapshotDir, buildMetaFilename)
 	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 	defer cancel()
@@ -278,6 +283,87 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 		SHA256:    sum,
 	})
 	m.enqueueTemplateBackup(templateID, buildVMID, entries)
+}
+
+// readStampedBuildDigests returns the artifact digests writeBuildDigests
+// previously stamped into build.meta.json; nil when the build never got
+// that far (crash before or during hashing).
+func readStampedBuildDigests(snapshotDir string) ([]buildArtifactDigest, error) {
+	data, err := os.ReadFile(filepath.Join(snapshotDir, buildMetaFilename))
+	if err != nil {
+		return nil, err
+	}
+	var meta struct {
+		Artifacts []buildArtifactDigest `json:"artifacts"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return meta.Artifacts, nil
+}
+
+// reconcileAdoptedBuildBackup re-enters an adopted completed build into the
+// backup pipeline. A vmd exit between template-builder writing
+// build.meta.json and the enqueue (a window as long as the hash budget)
+// leaves a durable, adoptable build with no journal record; without this,
+// such a template would stay unbacked until rebuilt. Runs once per build
+// per process, asynchronously, so adoption (a status read path) is never
+// serialized behind hash budgets.
+//
+// Two cases, keyed on whether writeBuildDigests already stamped the meta:
+//
+//   - no stamped digests: the crash predates hashing, so run the full
+//     pipeline (hash, stamp, enqueue) exactly as build completion would.
+//   - stamped digests: rebuild the task from the recorded digests instead
+//     of re-hashing multi-GiB artifacts on every restart. The journal
+//     dedupes by owner + generation so repeat adoptions are no-ops, and
+//     the uploader re-verifies streamed bytes against these digests, so a
+//     divergence between record and disk fails closed there.
+func (m *Manager) reconcileAdoptedBuildBackup(snap BuildStatusSnapshot) {
+	if m.backupEnqueue == nil || snap.Status != BuildStatusReady || snap.Result == nil {
+		return
+	}
+	if _, already := m.adoptedBuildBackups.LoadOrStore(snap.BuildVMID, struct{}{}); already {
+		return
+	}
+	templateID, buildVMID, res := snap.TemplateID, snap.BuildVMID, snap.Result
+	dir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID, buildVMID)
+	log := m.log.With().Str("template_id", templateID).Str("build_vm_id", buildVMID).Logger()
+	go func() {
+		stamped, err := readStampedBuildDigests(dir)
+		if err != nil || len(stamped) == 0 {
+			log.Info().Err(err).
+				Msg("adopted build has no stamped digests; running backup hashing")
+			m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, log)
+			return
+		}
+		entries := make([]ManifestEntry, 0, len(stamped)+1)
+		for _, d := range stamped {
+			path := filepath.Join(dir, d.Name)
+			if _, statErr := os.Stat(path); statErr != nil {
+				// The base image lives in the run dir, not the snapshot
+				// dir; anything else unresolvable means the stamp no
+				// longer matches the disk, so re-hash from scratch.
+				if res.BasePath != "" && d.Name == filepath.Base(res.BasePath) {
+					path = res.BasePath
+				} else {
+					log.Warn().Str("artifact", d.Name).
+						Msg("stamped artifact not on disk; running backup hashing")
+					m.backupBuildArtifacts(context.Background(), templateID, buildVMID, dir, res.BasePath, log)
+					return
+				}
+			}
+			entries = append(entries, ManifestEntry{
+				FileName:  d.Name,
+				Path:      path,
+				SizeBytes: d.SizeBytes,
+				SHA256:    d.SHA256,
+			})
+		}
+		log.Info().Int("files", len(entries)).
+			Msg("adopted build re-enqueued for backup from stamped digests")
+		m.finishBuildBackupEnqueue(context.Background(), templateID, buildVMID, dir, entries, log)
+	}()
 }
 
 // buildLogPipe parses NDJSON lines from template-builder's stdout and

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -410,6 +410,19 @@ func (m *Manager) buildActive(buildVMID string) bool {
 //     the full re-hash, which stamps fresh digests and enqueues a correct
 //     new generation instead of abandoning the stale one forever.
 func (m *Manager) reconcileAdoptedBuildBackup(snap BuildStatusSnapshot) {
+	m.reconcileAdoptedBuildBackupMode(snap, false)
+}
+
+// reconcileAdoptedBuildBackupMode reconciles with the caller's choice of
+// slot policy. The sweep passes waitForSlot=true: its glob order is
+// deterministic, so a non-blocking drop would let the same early-sorted
+// builds consume the slots every pass and starve a later build forever;
+// blocking guarantees every match is processed each sweep, still bounded
+// by the slot count (covered builds hold a slot for milliseconds). The
+// request-path caller keeps the non-blocking drop, since an API call
+// must not park behind multi-GB hash work; the sweep covers whatever it
+// drops.
+func (m *Manager) reconcileAdoptedBuildBackupMode(snap BuildStatusSnapshot, waitForSlot bool) {
 	if m.backupEnqueue == nil || snap.Status != BuildStatusReady || snap.Result == nil {
 		return
 	}
@@ -417,13 +430,18 @@ func (m *Manager) reconcileAdoptedBuildBackup(snap BuildStatusSnapshot) {
 		return
 	}
 	slots := m.ensureRehashSlots()
-	select {
-	case slots <- struct{}{}:
-	default:
-		// All rehash slots busy: drop this attempt rather than queueing
-		// unbounded hash work; the sweep retries uncovered builds.
-		m.adoptedBuildBackups.Delete(snap.BuildVMID)
-		return
+	if waitForSlot {
+		slots <- struct{}{}
+	} else {
+		select {
+		case slots <- struct{}{}:
+		default:
+			// All rehash slots busy: drop this attempt rather than
+			// queueing unbounded hash work; the sweep retries uncovered
+			// builds.
+			m.adoptedBuildBackups.Delete(snap.BuildVMID)
+			return
+		}
 	}
 	templateID, buildVMID, res := snap.TemplateID, snap.BuildVMID, snap.Result
 	dir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID, buildVMID)
@@ -551,12 +569,12 @@ func (m *Manager) runTemplateBackupSweep(log zerolog.Logger) {
 		if err != nil || !buildArtifactsPresent(res) {
 			continue // half-written or partially deleted build: not adoptable
 		}
-		m.reconcileAdoptedBuildBackup(BuildStatusSnapshot{
+		m.reconcileAdoptedBuildBackupMode(BuildStatusSnapshot{
 			BuildVMID:  buildVMID,
 			TemplateID: templateID,
 			Status:     BuildStatusReady,
 			Result:     res,
-		})
+		}, true)
 	}
 }
 

--- a/internal/vm/build_backup_recovery_test.go
+++ b/internal/vm/build_backup_recovery_test.go
@@ -1,0 +1,402 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/backup"
+)
+
+// adoptedSnapshot builds the BuildStatusSnapshot the sweep would hand to
+// the reconcile flow for a fixture directory.
+func adoptedSnapshot(t *testing.T, dir, templateID, buildVMID string) BuildStatusSnapshot {
+	t.Helper()
+	res, err := readBuildMetaJSON(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return BuildStatusSnapshot{
+		BuildVMID:  buildVMID,
+		TemplateID: templateID,
+		Status:     BuildStatusReady,
+		Result:     res,
+	}
+}
+
+// A reconcile worker racing a rebuild that reuses the same build id (the
+// default id is build-<templateID>) must not stamp stale digests over the
+// new build's meta or enqueue the old artifact set: the guard sees the
+// non-terminal registration and drops the work silently.
+func TestReconcileDropsWhenRebuildActive(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+	meta, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	// A new build for the same id is in flight.
+	if _, err := m.registerBuild("build-tpl", "tpl", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	m.reconcileAdoptedBuildBackup(adoptedSnapshot(t, dir, "tpl", "build-tpl"))
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case task := <-tasks:
+		t.Fatalf("reconcile enqueued despite an active rebuild: %+v", task)
+	default:
+	}
+	got, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, meta) {
+		t.Fatalf("reconcile stamped digests under an active rebuild:\n%s", got)
+	}
+}
+
+// The reconcile guard pins build.meta.json by stat identity; a rewrite
+// (what a completing rebuild does) must change that identity.
+func TestBuildMetaRewriteChangesIdentity(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildFixture(t, dir)
+	metaPath := filepath.Join(dir, buildMetaFilename)
+	before, err := baseIdentity(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeBuildDigests(dir, []ManifestEntry{{FileName: "mem.snap", SHA256: "aa", SizeBytes: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := baseIdentity(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Fatal("meta rewrite kept the same stat identity; the reconcile pin cannot see rebuilds")
+	}
+}
+
+// Stamped digests whose size no longer matches the disk are provably
+// stale (truncation, corruption): the reconcile must fall through to the
+// full re-hash and enqueue fresh digests instead of shipping a stamp the
+// uploader would abandon forever.
+func TestReconcileRehashesOnStampSizeDivergence(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	stamper := &Manager{}
+	stamper.SetBackupEnqueue(func(backup.Task) error { return nil })
+	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
+
+	// Truncate: different size than the stamp recorded.
+	truncated := []byte("short")
+	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), truncated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	m.reconcileAdoptedBuildBackup(adoptedSnapshot(t, dir, "tpl", "build-tpl"))
+	task := waitForTask(t, tasks)
+	want := sha256.Sum256(truncated)
+	var got string
+	for _, f := range task.Files {
+		if f.Name == "mem.snap" {
+			got = f.SHA256
+		}
+	}
+	if got != hex.EncodeToString(want[:]) {
+		t.Fatalf("mem.snap digest = %s, want fresh %s (stale stamp shipped)", got, hex.EncodeToString(want[:]))
+	}
+}
+
+// The sweep recovers a completed build whose enqueue never reached the
+// journal (retries exhausted or the process died mid-retry): the stamped
+// meta is the durable retry state, and the sweep rebuilds the exact task
+// from it.
+func TestTemplateSweepRecoversUnjournaledBuild(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	// Completion-time enqueue failed for good: stamps exist, no journal.
+	stamper := &Manager{}
+	stamper.SetBackupEnqueue(func(backup.Task) error { return errors.New("journal down") })
+	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
+	stamped, err := readStampedBuildDigests(dir)
+	if err != nil || len(stamped) == 0 {
+		t.Fatalf("fixture not stamped: %v err=%v", stamped, err)
+	}
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	m.runTemplateBackupSweep(zerolog.Nop())
+	task := waitForTask(t, tasks)
+	if task.TemplateID != "tpl" || task.BuildID != "build-tpl" {
+		t.Fatalf("task owner = %q/%q, want tpl/build-tpl", task.TemplateID, task.BuildID)
+	}
+	recorded := make(map[string]string, len(stamped))
+	for _, d := range stamped {
+		recorded[d.Name] = d.SHA256
+	}
+	for _, f := range task.Files {
+		if f.Name == buildMetaFilename {
+			continue
+		}
+		if recorded[f.Name] != f.SHA256 {
+			t.Fatalf("swept digest for %s = %s, want stamped %s", f.Name, f.SHA256, recorded[f.Name])
+		}
+	}
+}
+
+// A build whose generation is already covered (pending or completed in
+// the journal) is skipped by the sweep: no re-enqueue and no re-stamp.
+func TestTemplateSweepSkipsCoveredBuild(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	stamper := &Manager{}
+	stamper.SetBackupEnqueue(func(backup.Task) error { return nil })
+	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
+	meta, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	m.SetBackupCovered(func(backup.Task) (bool, error) { return true, nil })
+	m.runTemplateBackupSweep(zerolog.Nop())
+	time.Sleep(300 * time.Millisecond)
+	select {
+	case task := <-tasks:
+		t.Fatalf("sweep re-enqueued a covered generation: %+v", task)
+	default:
+	}
+	got, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, meta) {
+		t.Fatal("sweep re-stamped a covered build (re-hash happened)")
+	}
+}
+
+// Adopted-build hashing shares the pause recovery's bounded slots: with
+// every slot busy the reconcile is skipped (the sweep retries later), and
+// it proceeds once a slot frees.
+func TestReconcileHonorsRehashSlots(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	slots := m.ensureRehashSlots()
+	for i := 0; i < cap(slots); i++ {
+		slots <- struct{}{}
+	}
+	m.reconcileAdoptedBuildBackup(adoptedSnapshot(t, dir, "tpl", "build-tpl"))
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case task := <-tasks:
+		t.Fatalf("reconcile ran with all rehash slots busy: %+v", task)
+	default:
+	}
+	for i := 0; i < cap(slots); i++ {
+		<-slots
+	}
+	m.reconcileAdoptedBuildBackup(adoptedSnapshot(t, dir, "tpl", "build-tpl"))
+	waitForTask(t, tasks)
+}
+
+// Overlay-mode end to end: the base image lives outside the snapshot dir
+// (extraPaths), the declared-set check accepts the set, and the reconcile
+// cheap path resolves the base back to its run-dir location.
+func TestBackupBuildArtifactsOverlayFixture(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, TemplatesDirName, "tpl", "build-tpl")
+	runDir := filepath.Join(root, "run")
+	for _, d := range []string{dir, runDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := map[string]string{
+		filepath.Join(dir, "vmstate.snap"): "vm state",
+		filepath.Join(dir, "mem.snap"):     "memory image",
+		filepath.Join(dir, "rootfs.delta"): "delta bytes",
+		filepath.Join(runDir, "base.ext4"): "base image bytes",
+	}
+	for p, content := range files {
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	meta := fmt.Sprintf(`{"snapshot_path":%q,"mem_path":%q,"base_path":%q,"delta_path":%q,"size_bytes":1}`,
+		filepath.Join(dir, "vmstate.snap"), filepath.Join(dir, "mem.snap"),
+		filepath.Join(runDir, "base.ext4"), filepath.Join(dir, "rootfs.delta"))
+	if err := os.WriteFile(filepath.Join(dir, buildMetaFilename), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := make(chan backup.Task, 2)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, filepath.Join(runDir, "base.ext4"), nil, zerolog.Nop())
+	task := waitForTask(t, tasks)
+	var basePath string
+	for _, f := range task.Files {
+		if f.Name == "base.ext4" {
+			basePath = f.Path
+			if f.BaseSHA256 != "" || f.BasePath != "" {
+				t.Fatalf("template base carries a base dependency: %+v", f)
+			}
+		}
+	}
+	if basePath != filepath.Join(runDir, "base.ext4") {
+		t.Fatalf("base path = %q, want the run-dir base", basePath)
+	}
+
+	// Reconcile cheap path on a fresh manager: base.ext4 is not in the
+	// snapshot dir, so the stamped entry must resolve through the
+	// declared base path.
+	m2 := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m2.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
+	m2.reconcileAdoptedBuildBackup(adoptedSnapshot(t, dir, "tpl", "build-tpl"))
+	task2 := waitForTask(t, tasks)
+	basePath = ""
+	for _, f := range task2.Files {
+		if f.Name == "base.ext4" {
+			basePath = f.Path
+		}
+	}
+	if basePath != filepath.Join(runDir, "base.ext4") {
+		t.Fatalf("reconciled base path = %q, want the run-dir base", basePath)
+	}
+}
+
+// writeBuildDigests edits the document as raw JSON: every field
+// template-builder wrote survives, including ones vmd does not model.
+func TestWriteBuildDigestsPreservesUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	meta := []byte(`{"snapshot_path":"vmstate.snap","mem_path":"mem.snap","size_bytes":12,"builder_extra":"keepme"}`)
+	if err := os.WriteFile(filepath.Join(dir, buildMetaFilename), meta, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeBuildDigests(dir, []ManifestEntry{{FileName: "mem.snap", SHA256: "aa", SizeBytes: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	if string(out["builder_extra"]) != `"keepme"` {
+		t.Fatalf("unknown field lost across the digest stamp: %s", raw)
+	}
+	if _, ok := out["artifacts"]; !ok {
+		t.Fatal("artifacts field not stamped")
+	}
+	// No temp residue left behind by the atomic replace.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, de := range entries {
+		if de.Name() != buildMetaFilename {
+			t.Fatalf("unexpected residue in snapshot dir: %s", de.Name())
+		}
+	}
+}
+
+// Crash residue and reserved names never enter the artifact set: a torn
+// writeBuildDigests temp would be renamed away (dangling task path), and
+// a file named like the bucket's manifest object would collide with the
+// generation's completion marker.
+func TestCollectBuildManifestSkipsResidueAndReservedNames(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"mem.snap":                "memory image",
+		"build.meta.json.123.tmp": "torn residue",
+		backup.ManifestObject:     "squatter",
+		buildMetaFilename:         `{"mem_path":"mem.snap"}`,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, complete := collectBuildManifest(context.Background(), dir, nil, zerolog.Nop())
+	if !complete {
+		t.Fatal("skipping residue must not mark the set incomplete")
+	}
+	if len(entries) != 1 || entries[0].FileName != "mem.snap" {
+		t.Fatalf("entries = %+v, want only mem.snap", entries)
+	}
+}
+
+// Two different files sharing a basename cannot silently collapse into
+// one artifact: object names are basenames, so the set is ambiguous and
+// must fail closed.
+func TestCollectBuildManifestFlagsBasenameCollision(t *testing.T) {
+	dir := t.TempDir()
+	other := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "base.ext4"), []byte("copy in dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "base.ext4"), []byte("different file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, complete := collectBuildManifest(context.Background(), dir, []string{filepath.Join(other, "base.ext4")}, zerolog.Nop())
+	if complete {
+		t.Fatal("conflicting basenames must flip complete to false")
+	}
+	// The same path via extraPaths is the intentional dedupe, not a
+	// collision.
+	_, complete = collectBuildManifest(context.Background(), dir, []string{filepath.Join(dir, "base.ext4")}, zerolog.Nop())
+	if !complete {
+		t.Fatal("deduping the same path must stay complete")
+	}
+}

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -394,5 +395,99 @@ func TestSweepReconcileWaitsForSlotInsteadOfDropping(t *testing.T) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("blocking sweep reconcile never enqueued after slots freed")
+	}
+}
+
+// Registering a rebuild cancels an in-flight adoption reconcile for the
+// same template+build and waits for it to exit, so stale stamps can
+// never land after the new build is admitted.
+func TestRegisterBuildCancelsInFlightReconcile(t *testing.T) {
+	dir := t.TempDir()
+	writeAdoptableBuildFixture(t, dir, "tpl", "build-tpl")
+
+	// A hook that blocks keeps the reconcile in flight until cancelled.
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		entered <- struct{}{}
+		<-release
+		return nil
+	})
+	defer close(release)
+
+	res, err := readBuildMetaJSON(filepath.Join(dir, TemplatesDirName, "tpl", "build-tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.reconcileAdoptedBuildBackupMode(BuildStatusSnapshot{
+		BuildVMID: "build-tpl", TemplateID: "tpl", Status: BuildStatusReady, Result: res,
+	}, true)
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reconcile never reached the enqueue hook")
+	}
+
+	// Registration must cancel the reconcile and return once it exits.
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.registerBuild("build-tpl", "tpl", func() {})
+		done <- err
+	}()
+	// The blocked hook ignores cancellation, so release it shortly
+	// after the cancel lands to let the goroutine exit.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		release <- struct{}{}
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("registerBuild after reconcile exit: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("registerBuild never returned")
+	}
+}
+
+// In-flight reconcile keys carry the template: two templates reusing one
+// build id must not starve each other.
+func TestReconcileInFlightKeyIsTemplateScoped(t *testing.T) {
+	dir := t.TempDir()
+	writeAdoptableBuildFixture(t, dir, "tpl-a", "build-1")
+	writeAdoptableBuildFixture(t, dir, "tpl-b", "build-1")
+
+	var mu sync.Mutex
+	owners := map[string]bool{}
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		mu.Lock()
+		owners[task.TemplateID] = true
+		mu.Unlock()
+		return nil
+	})
+
+	for _, tpl := range []string{"tpl-a", "tpl-b"} {
+		res, err := readBuildMetaJSON(filepath.Join(dir, TemplatesDirName, tpl, "build-1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.reconcileAdoptedBuildBackupMode(BuildStatusSnapshot{
+			BuildVMID: "build-1", TemplateID: tpl, Status: BuildStatusReady, Result: res,
+		}, true)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		mu.Lock()
+		n := len(owners)
+		mu.Unlock()
+		if n == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("owners = %v, want both templates enqueued", owners)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -3,10 +3,14 @@ package vm
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -112,5 +116,166 @@ func TestBackupBuildArtifactsRefusesMissingDeclaredArtifact(t *testing.T) {
 
 	if len(tasks) != 0 {
 		t.Fatalf("enqueued %d tasks despite a missing declared artifact, want 0", len(tasks))
+	}
+}
+
+// writeAdoptableBuildFixture lays a completed build out under the templates
+// tree the way loadDurableBuild expects: snapshotRoot/templates/<tpl>/<build>/
+// with the artifacts and a build.meta.json whose declared paths are absolute
+// (adoption stats them). Returns the build dir.
+func writeAdoptableBuildFixture(t *testing.T, root, templateID, buildVMID string) string {
+	t.Helper()
+	dir := filepath.Join(root, TemplatesDirName, templateID, buildVMID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("memory image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vmstate.snap"), []byte("vm state"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := fmt.Sprintf(`{"snapshot_path":%q,"mem_path":%q,"size_bytes":12}`,
+		filepath.Join(dir, "vmstate.snap"), filepath.Join(dir, "mem.snap"))
+	if err := os.WriteFile(filepath.Join(dir, buildMetaFilename), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// waitForTask receives one enqueued task or fails the test.
+func waitForTask(t *testing.T, tasks <-chan backup.Task) backup.Task {
+	t.Helper()
+	select {
+	case task := <-tasks:
+		return task
+	case <-time.After(10 * time.Second):
+		t.Fatal("no backup task enqueued for adopted build")
+		return backup.Task{}
+	}
+}
+
+// A vmd exit after template-builder wrote build.meta.json but before the
+// backup enqueue leaves a durable build with no journal record and no
+// stamped digests. Adopting it via GetBuildStatus must rerun the full
+// hashing pipeline and enqueue the set.
+func TestAdoptedBuildWithoutStampedDigestsRerunsBackup(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	tasks := make(chan backup.Task, 2)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) { tasks <- task })
+
+	snap, ok := m.GetBuildStatus("build-tpl")
+	if !ok || snap.Status != BuildStatusReady {
+		t.Fatalf("adoption = %+v ok=%v, want ready", snap, ok)
+	}
+	task := waitForTask(t, tasks)
+	if task.TemplateID != "tpl" || task.BuildID != "build-tpl" {
+		t.Fatalf("task owner = %q/%q, want tpl/build-tpl", task.TemplateID, task.BuildID)
+	}
+	want := sha256.Sum256([]byte("memory image"))
+	var got string
+	for _, f := range task.Files {
+		if f.Name == "mem.snap" {
+			got = f.SHA256
+		}
+	}
+	if got != hex.EncodeToString(want[:]) {
+		t.Fatalf("mem.snap digest = %s, want freshly hashed %s", got, hex.EncodeToString(want[:]))
+	}
+	// The rerun also stamps the digests, so the next restart takes the
+	// cheap recorded-digest path.
+	stamped, err := readStampedBuildDigests(dir)
+	if err != nil || len(stamped) == 0 {
+		t.Fatalf("stamped digests after rerun = %v err=%v", stamped, err)
+	}
+}
+
+// A build whose digests were already stamped must be re-enqueued from the
+// record, not re-hashed: multi-GiB artifacts cannot be re-read on every
+// restart. Observable: mutate an artifact after stamping; the enqueued
+// digest still matches the stamp, proving no re-hash happened (the uploader
+// verifies bytes against the digest later and fails closed on divergence).
+func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+
+	// Stamp via the normal completion pipeline.
+	stamper := &Manager{}
+	stamper.SetBackupEnqueue(func(backup.Task) {})
+	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	stamped, err := readStampedBuildDigests(dir)
+	if err != nil || len(stamped) == 0 {
+		t.Fatalf("fixture not stamped: %v err=%v", stamped, err)
+	}
+	var recorded string
+	for _, d := range stamped {
+		if d.Name == "mem.snap" {
+			recorded = d.SHA256
+		}
+	}
+	if recorded == "" {
+		t.Fatal("mem.snap missing from stamped digests")
+	}
+
+	// Diverge the bytes on disk; a re-hash would notice, the record won't.
+	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("mutated bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks := make(chan backup.Task, 2)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	m.SetBackupEnqueue(func(task backup.Task) { tasks <- task })
+	if snap, ok := m.GetBuildStatus("build-tpl"); !ok || snap.Status != BuildStatusReady {
+		t.Fatalf("adoption = %+v ok=%v, want ready", snap, ok)
+	}
+	task := waitForTask(t, tasks)
+	var got string
+	for _, f := range task.Files {
+		if f.Name == "mem.snap" {
+			got = f.SHA256
+		}
+	}
+	if got != recorded {
+		t.Fatalf("mem.snap digest = %s, want recorded %s (artifact was re-hashed)", got, recorded)
+	}
+
+	// Repeat polls must not spawn another reconcile: the per-process guard
+	// is taken synchronously, so nothing new can ever land on the channel.
+	if _, ok := m.GetBuildStatus("build-tpl"); !ok {
+		t.Fatal("second adoption lookup failed")
+	}
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case extra := <-tasks:
+		t.Fatalf("second status poll enqueued another task: %+v", extra)
+	default:
+	}
+}
+
+// Backup disabled: adoption still reports the build ready but touches
+// nothing, mirroring the completion path's nil-hook gate.
+func TestAdoptedBuildWithoutHookDoesNothing(t *testing.T) {
+	root := t.TempDir()
+	dir := writeAdoptableBuildFixture(t, root, "tpl", "build-tpl")
+	meta, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
+	snap, ok := m.GetBuildStatus("build-tpl")
+	if !ok || snap.Status != BuildStatusReady {
+		t.Fatalf("adoption = %+v ok=%v, want ready", snap, ok)
+	}
+	time.Sleep(50 * time.Millisecond)
+	got, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, meta) {
+		t.Fatalf("build.meta.json rewritten with backup disabled:\n%s", got)
 	}
 }

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -21,6 +21,9 @@ func writeBuildFixture(t *testing.T, dir string) []byte {
 	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("memory image"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "vmstate.snap"), []byte("vm state"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	meta := []byte(`{"snapshot_path":"vmstate.snap","mem_path":"mem.snap","size_bytes":12}`)
 	if err := os.WriteFile(filepath.Join(dir, buildMetaFilename), meta, 0o644); err != nil {
 		t.Fatal(err)
@@ -72,8 +75,8 @@ func TestBackupBuildArtifactsHashesAndEnqueuesWithHook(t *testing.T) {
 	for _, f := range task.Files {
 		names[f.Name] = true
 	}
-	if !names["mem.snap"] || !names[buildMetaFilename] {
-		t.Fatalf("task files = %v, want mem.snap and %s", names, buildMetaFilename)
+	if !names["mem.snap"] || !names["vmstate.snap"] || !names[buildMetaFilename] {
+		t.Fatalf("task files = %v, want mem.snap, vmstate.snap and %s", names, buildMetaFilename)
 	}
 
 	raw, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
@@ -88,5 +91,26 @@ func TestBackupBuildArtifactsHashesAndEnqueuesWithHook(t *testing.T) {
 	}
 	if len(rewritten.Artifacts) == 0 {
 		t.Fatal("build.meta.json not stamped with artifact digests")
+	}
+}
+
+// A required artifact that is absent before enumeration never reaches the
+// hasher, so the hashed set looks internally complete while build.meta.json
+// knows better. The declared set is the completeness authority: a missing
+// declared artifact must keep the build out of the backup queue.
+func TestBackupBuildArtifactsRefusesMissingDeclaredArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildFixture(t, dir)
+	if err := os.Remove(filepath.Join(dir, "vmstate.snap")); err != nil {
+		t.Fatal(err)
+	}
+
+	var tasks []backup.Task
+	m := &Manager{}
+	m.SetBackupEnqueue(func(task backup.Task) { tasks = append(tasks, task) })
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+
+	if len(tasks) != 0 {
+		t.Fatalf("enqueued %d tasks despite a missing declared artifact, want 0", len(tasks))
 	}
 }

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -47,7 +47,7 @@ func TestBackupBuildArtifactsSkipsAllHashingWhenHookNil(t *testing.T) {
 	meta := writeBuildFixture(t, dir)
 
 	m := &Manager{} // no SetBackupEnqueue: backup disabled
-	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
 
 	got, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
 	if err != nil {
@@ -71,7 +71,7 @@ func TestBackupBuildArtifactsHashesAndEnqueuesWithHook(t *testing.T) {
 		tasks = append(tasks, task)
 		return nil
 	})
-	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
 
 	if len(tasks) != 1 {
 		t.Fatalf("enqueued %d tasks, want 1", len(tasks))
@@ -120,7 +120,7 @@ func TestBackupBuildArtifactsRefusesMissingDeclaredArtifact(t *testing.T) {
 		tasks = append(tasks, task)
 		return nil
 	})
-	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
 
 	if len(tasks) != 0 {
 		t.Fatalf("enqueued %d tasks despite a missing declared artifact, want 0", len(tasks))
@@ -216,7 +216,7 @@ func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
 	// Stamp via the normal completion pipeline.
 	stamper := &Manager{}
 	stamper.SetBackupEnqueue(func(backup.Task) error { return nil })
-	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
 	stamped, err := readStampedBuildDigests(dir)
 	if err != nil || len(stamped) == 0 {
 		t.Fatalf("fixture not stamped: %v err=%v", stamped, err)
@@ -231,17 +231,21 @@ func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
 		t.Fatal("mem.snap missing from stamped digests")
 	}
 
-	// Diverge the bytes on disk; a re-hash would notice, the record won't.
-	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("mutated bytes"), 0o644); err != nil {
+	// Diverge the bytes on disk at the SAME size (the size check guards
+	// truncation, not content); a re-hash would notice, the record won't.
+	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("MEMORY IMAGE"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	tasks := make(chan backup.Task, 2)
+	var covered atomic.Bool
 	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
 	m.SetBackupEnqueue(func(task backup.Task) error {
+		covered.Store(true) // journal now holds the generation
 		tasks <- task
 		return nil
 	})
+	m.SetBackupCovered(func(backup.Task) (bool, error) { return covered.Load(), nil })
 	if snap, ok := m.GetBuildStatus("build-tpl"); !ok || snap.Status != BuildStatusReady {
 		t.Fatalf("adoption = %+v ok=%v, want ready", snap, ok)
 	}
@@ -256,12 +260,12 @@ func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
 		t.Fatalf("mem.snap digest = %s, want recorded %s (artifact was re-hashed)", got, recorded)
 	}
 
-	// Repeat polls must not spawn another reconcile: the per-process guard
-	// is taken synchronously, so nothing new can ever land on the channel.
+	// Repeat polls re-run the reconcile but the covered check stops the
+	// re-enqueue: nothing new lands on the channel.
 	if _, ok := m.GetBuildStatus("build-tpl"); !ok {
 		t.Fatal("second adoption lookup failed")
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	select {
 	case extra := <-tasks:
 		t.Fatalf("second status poll enqueued another task: %+v", extra)
@@ -315,7 +319,7 @@ func TestBackupBuildArtifactsRetriesFailedEnqueue(t *testing.T) {
 	})
 
 	start := time.Now()
-	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", nil, zerolog.Nop())
 	if elapsed := time.Since(start); elapsed >= time.Second {
 		t.Fatalf("build path blocked %v on enqueue retry; retry must be async", elapsed)
 	}

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -1,0 +1,92 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/backup"
+)
+
+// writeBuildFixture lays out a minimal finished build: one artifact plus the
+// build.meta.json template-builder writes. Returns the meta bytes as written
+// so tests can assert the file was (or was not) rewritten with digests.
+func writeBuildFixture(t *testing.T, dir string) []byte {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "mem.snap"), []byte("memory image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := []byte(`{"snapshot_path":"vmstate.snap","mem_path":"mem.snap","size_bytes":12}`)
+	if err := os.WriteFile(filepath.Join(dir, buildMetaFilename), meta, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return meta
+}
+
+// A host without a backup hook installed (BACKUP_BUCKET unset) must not pay
+// for hashing at all: no artifact hashing, no digest stamping into
+// build.meta.json, no metadata hash. The digest rewrite is the observable:
+// whenever the hashing pipeline runs to completion it rewrites the meta file,
+// so an untouched file proves the pipeline never started.
+func TestBackupBuildArtifactsSkipsAllHashingWhenHookNil(t *testing.T) {
+	dir := t.TempDir()
+	meta := writeBuildFixture(t, dir)
+
+	m := &Manager{} // no SetBackupEnqueue: backup disabled
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+
+	got, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, meta) {
+		t.Fatalf("build.meta.json rewritten with backup disabled; hashing pipeline ran:\n%s", got)
+	}
+}
+
+// Contrast case proving the observable above is sensitive: with a hook
+// installed the same fixture gets hashed, build.meta.json gains the
+// artifacts field, and the task reaches the enqueue hook.
+func TestBackupBuildArtifactsHashesAndEnqueuesWithHook(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildFixture(t, dir)
+
+	var tasks []backup.Task
+	m := &Manager{}
+	m.SetBackupEnqueue(func(task backup.Task) { tasks = append(tasks, task) })
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+
+	if len(tasks) != 1 {
+		t.Fatalf("enqueued %d tasks, want 1", len(tasks))
+	}
+	task := tasks[0]
+	if task.TemplateID != "tpl" || task.BuildID != "build-tpl" {
+		t.Fatalf("task owner = %q/%q, want tpl/build-tpl", task.TemplateID, task.BuildID)
+	}
+	names := make(map[string]bool, len(task.Files))
+	for _, f := range task.Files {
+		names[f.Name] = true
+	}
+	if !names["mem.snap"] || !names[buildMetaFilename] {
+		t.Fatalf("task files = %v, want mem.snap and %s", names, buildMetaFilename)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, buildMetaFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rewritten struct {
+		Artifacts []buildArtifactDigest `json:"artifacts"`
+	}
+	if err := json.Unmarshal(raw, &rewritten); err != nil {
+		t.Fatal(err)
+	}
+	if len(rewritten.Artifacts) == 0 {
+		t.Fatal("build.meta.json not stamped with artifact digests")
+	}
+}

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -6,9 +6,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,7 +67,10 @@ func TestBackupBuildArtifactsHashesAndEnqueuesWithHook(t *testing.T) {
 
 	var tasks []backup.Task
 	m := &Manager{}
-	m.SetBackupEnqueue(func(task backup.Task) { tasks = append(tasks, task) })
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks = append(tasks, task)
+		return nil
+	})
 	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
 
 	if len(tasks) != 1 {
@@ -111,7 +116,10 @@ func TestBackupBuildArtifactsRefusesMissingDeclaredArtifact(t *testing.T) {
 
 	var tasks []backup.Task
 	m := &Manager{}
-	m.SetBackupEnqueue(func(task backup.Task) { tasks = append(tasks, task) })
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks = append(tasks, task)
+		return nil
+	})
 	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
 
 	if len(tasks) != 0 {
@@ -165,7 +173,10 @@ func TestAdoptedBuildWithoutStampedDigestsRerunsBackup(t *testing.T) {
 
 	tasks := make(chan backup.Task, 2)
 	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
-	m.SetBackupEnqueue(func(task backup.Task) { tasks <- task })
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
 
 	snap, ok := m.GetBuildStatus("build-tpl")
 	if !ok || snap.Status != BuildStatusReady {
@@ -204,7 +215,7 @@ func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
 
 	// Stamp via the normal completion pipeline.
 	stamper := &Manager{}
-	stamper.SetBackupEnqueue(func(backup.Task) {})
+	stamper.SetBackupEnqueue(func(backup.Task) error { return nil })
 	stamper.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
 	stamped, err := readStampedBuildDigests(dir)
 	if err != nil || len(stamped) == 0 {
@@ -227,7 +238,10 @@ func TestAdoptedBuildWithStampedDigestsEnqueuesWithoutRehash(t *testing.T) {
 
 	tasks := make(chan backup.Task, 2)
 	m := &Manager{cfg: ManagerConfig{SnapshotDir: root}}
-	m.SetBackupEnqueue(func(task backup.Task) { tasks <- task })
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		tasks <- task
+		return nil
+	})
 	if snap, ok := m.GetBuildStatus("build-tpl"); !ok || snap.Status != BuildStatusReady {
 		t.Fatalf("adoption = %+v ok=%v, want ready", snap, ok)
 	}
@@ -277,5 +291,59 @@ func TestAdoptedBuildWithoutHookDoesNothing(t *testing.T) {
 	}
 	if !bytes.Equal(got, meta) {
 		t.Fatalf("build.meta.json rewritten with backup disabled:\n%s", got)
+	}
+}
+
+// A journal write that fails transiently must not be swallowed: the
+// completion path returns without blocking (the retry backoff runs off
+// the build path) and the task is re-enqueued from the digests already in
+// hand, no rehash. The hook fails once, then succeeds; the delivered task
+// must carry the digests stamped during the original hash pass.
+func TestBackupBuildArtifactsRetriesFailedEnqueue(t *testing.T) {
+	dir := t.TempDir()
+	writeBuildFixture(t, dir)
+
+	var calls atomic.Int32
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{}
+	m.SetBackupEnqueue(func(task backup.Task) error {
+		if calls.Add(1) == 1 {
+			return errors.New("journal unavailable")
+		}
+		tasks <- task
+		return nil
+	})
+
+	start := time.Now()
+	m.backupBuildArtifacts(context.Background(), "tpl", "build-tpl", dir, "", zerolog.Nop())
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("build path blocked %v on enqueue retry; retry must be async", elapsed)
+	}
+
+	task := waitForTask(t, tasks)
+	if calls.Load() < 2 {
+		t.Fatalf("hook called %d times, want a retry after the failure", calls.Load())
+	}
+	if task.TemplateID != "tpl" || task.BuildID != "build-tpl" {
+		t.Fatalf("task owner = %q/%q, want tpl/build-tpl", task.TemplateID, task.BuildID)
+	}
+	// The retried task is rebuilt from the manifest in hand: its digests
+	// are exactly the ones stamped into build.meta.json by the original
+	// (only) hash pass.
+	stamped, err := readStampedBuildDigests(dir)
+	if err != nil || len(stamped) == 0 {
+		t.Fatalf("stamped digests = %v err=%v", stamped, err)
+	}
+	recorded := make(map[string]string, len(stamped))
+	for _, d := range stamped {
+		recorded[d.Name] = d.SHA256
+	}
+	for _, f := range task.Files {
+		if f.Name == buildMetaFilename {
+			continue
+		}
+		if recorded[f.Name] != f.SHA256 {
+			t.Fatalf("retried digest for %s = %s, want stamped %s", f.Name, f.SHA256, recorded[f.Name])
+		}
 	}
 }

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -351,3 +351,48 @@ func TestBackupBuildArtifactsRetriesFailedEnqueue(t *testing.T) {
 		}
 	}
 }
+
+// The sweep must process every match even when the rehash slots are
+// held: a non-blocking drop with deterministic glob order would let the
+// same early builds consume the slots each pass and starve a later
+// build forever. The sweep path blocks for a slot instead.
+func TestSweepReconcileWaitsForSlotInsteadOfDropping(t *testing.T) {
+	dir := t.TempDir()
+	writeAdoptableBuildFixture(t, dir, "tpl", "build-tpl")
+
+	tasks := make(chan backup.Task, 1)
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	m.SetBackupEnqueue(func(task backup.Task) error { tasks <- task; return nil })
+
+	// Occupy every rehash slot, then release them shortly after the
+	// sweep starts: a dropping implementation returns without ever
+	// enqueueing, a blocking one proceeds once slots free.
+	slots := m.ensureRehashSlots()
+	held := cap(slots)
+	for i := 0; i < held; i++ {
+		slots <- struct{}{}
+	}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		for i := 0; i < held; i++ {
+			<-slots
+		}
+	}()
+
+	res, err := readBuildMetaJSON(filepath.Join(dir, TemplatesDirName, "tpl", "build-tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.reconcileAdoptedBuildBackupMode(BuildStatusSnapshot{
+		BuildVMID: "build-tpl", TemplateID: "tpl", Status: BuildStatusReady, Result: res,
+	}, true)
+
+	select {
+	case task := <-tasks:
+		if task.TemplateID != "tpl" {
+			t.Fatalf("task owner = %q, want tpl", task.TemplateID)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("blocking sweep reconcile never enqueued after slots freed")
+	}
+}

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -204,7 +204,14 @@ func (m *Manager) GetBuildStatus(buildVMID string) (BuildStatusSnapshot, bool) {
 	}
 	m.buildsMu.RUnlock()
 	// Not in memory — consult durable artifacts on disk (no lock held).
-	return loadDurableBuild(m.cfg.SnapshotDir, buildVMID)
+	snap, ok := loadDurableBuild(m.cfg.SnapshotDir, buildVMID)
+	if ok {
+		// An adopted build finished under a previous vmd process, which may
+		// have exited before enqueueing it for backup; make sure the
+		// journal knows about it (idempotent, async).
+		m.reconcileAdoptedBuildBackup(snap)
+	}
+	return snap, ok
 }
 
 // loadDurableBuild adopts a completed build from its on-disk artifacts. To

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -241,7 +241,7 @@ func buildArtifactsPresent(r *BuildTemplateResult) bool {
 	if r == nil || r.SnapshotPath == "" || r.MemFilePath == "" {
 		return false
 	}
-	for _, p := range []string{r.SnapshotPath, r.MemFilePath, r.BasePath, r.DeltaPath, r.RootfsPath} {
+	for _, p := range r.declaredArtifactPaths() {
 		if p == "" {
 			continue
 		}

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -81,6 +81,21 @@ func (m *Manager) initBuildRegistry() {
 // unique buildVMID per BuildTemplate invocation.
 func (m *Manager) registerBuild(buildVMID, templateID string, cancel context.CancelFunc) (*buildRecord, error) {
 	m.initBuildRegistry()
+	// An adoption reconcile for this template+build may be mid-flight
+	// with stamped-metadata writes pending; cancel it and AWAIT its exit
+	// before admitting the new build, so a stale reconcile can never
+	// stamp or enqueue over the new build's metadata. Cancellation
+	// propagates into its hashing, so the wait is short; a reconcile
+	// that will not die refuses the registration rather than racing it.
+	if v, ok := m.adoptedBuildBackups.Load(templateID + "\x00" + buildVMID); ok {
+		h := v.(*reconcileHandle)
+		h.cancel()
+		select {
+		case <-h.done:
+		case <-time.After(30 * time.Second):
+			return nil, fmt.Errorf("build %s blocked on an unfinished backup reconcile", buildVMID)
+		}
+	}
 	m.buildsMu.Lock()
 	defer m.buildsMu.Unlock()
 	if existing, ok := m.builds[buildVMID]; ok && !existing.Status.IsTerminal() {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -264,6 +264,12 @@ type Manager struct {
 	pendingSweepInterval time.Duration
 	// rehashSlots bounds concurrent recovery/sweep rehash workers.
 	rehashSlots chan struct{}
+	// adoptedBuildBackups guards backup reconciliation of completed builds
+	// adopted from disk after a restart: one reconcile launch per build per
+	// process. Cross-process dedupe is the journal's job (owner +
+	// generation index); this map only keeps repeated status polls from
+	// spawning concurrent hash runs. See reconcileAdoptedBuildBackup.
+	adoptedBuildBackups sync.Map
 
 	// launcherReady gates the launcher launch path: false → launches use the
 	// legacy path. Set when the namespace is built/validated; kept in sync by

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -262,13 +262,21 @@ type Manager struct {
 	// pendingSweepInterval overrides the pending-backup sweep pace in
 	// tests; 0 means pendingBackupSweepInterval.
 	pendingSweepInterval time.Duration
-	// rehashSlots bounds concurrent recovery/sweep rehash workers.
-	rehashSlots chan struct{}
-	// adoptedBuildBackups guards backup reconciliation of completed builds
-	// adopted from disk after a restart: one reconcile launch per build per
-	// process. Cross-process dedupe is the journal's job (owner +
-	// generation index); this map only keeps repeated status polls from
-	// spawning concurrent hash runs. See reconcileAdoptedBuildBackup.
+	// rehashSlots bounds concurrent recovery/sweep rehash workers,
+	// shared by the pause recovery and the template-build sweep; created
+	// lazily via ensureRehashSlots.
+	rehashSlots     chan struct{}
+	rehashSlotsOnce sync.Once
+	// backupCovered probes the journal for whether an owner+generation is
+	// already pending or completed; nil means never covered. See
+	// SetBackupCovered.
+	backupCovered func(backup.Task) (bool, error)
+	// adoptedBuildBackups guards backup reconciliation of completed
+	// builds adopted from disk: one IN-FLIGHT reconcile per build id.
+	// Cross-process and cross-attempt dedupe is the journal's job (owner
+	// + generation index and the completions record); this map only keeps
+	// repeated status polls and overlapping sweeps from spawning
+	// concurrent workers for one build. See reconcileAdoptedBuildBackup.
 	adoptedBuildBackups sync.Map
 
 	// launcherReady gates the launcher launch path: false → launches use the

--- a/internal/vm/manifest.go
+++ b/internal/vm/manifest.go
@@ -8,12 +8,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/singleflight"
+
+	"github.com/superserve-ai/sandbox/internal/backup"
 )
 
 // ManifestEntry describes one durable artifact file finalized by a pause:
@@ -266,12 +269,21 @@ func collectBuildManifest(ctx context.Context, snapshotDir string, extraPaths []
 	start := time.Now()
 	complete = true
 	entries = make([]ManifestEntry, 0, len(dirEntries)+len(extraPaths))
-	seen := make(map[string]bool, len(dirEntries)+len(extraPaths))
+	seen := make(map[string]string, len(dirEntries)+len(extraPaths))
 	add := func(name, path string) {
-		if seen[name] {
+		if prev, dup := seen[name]; dup {
+			// Same path twice is the intentional dedupe (a base copied
+			// into the snapshot dir); two different files sharing a
+			// basename is ambiguity the artifact set must not paper
+			// over, since object names are basenames.
+			if prev != path {
+				log.Warn().Str("name", name).Str("kept", prev).Str("dropped", path).
+					Msg("build manifest: basename collision between artifacts")
+				complete = false
+			}
 			return
 		}
-		seen[name] = true
+		seen[name] = path
 		sum, size, err := hashFile(hctx, path)
 		if err != nil {
 			log.Warn().Err(err).Str("path", path).Msg("build manifest: hash failed")
@@ -287,6 +299,16 @@ func collectBuildManifest(ctx context.Context, snapshotDir string, extraPaths []
 	}
 	for _, de := range dirEntries {
 		if !de.Type().IsRegular() || de.Name() == buildMetaFilename {
+			continue
+		}
+		// Crash residue and reserved names are not artifacts: a *.tmp is
+		// a torn writeBuildDigests replacement that the next stamp will
+		// rename away (the enqueued path would dangle), and a file named
+		// like the bucket's manifest object would collide with the
+		// generation's completion marker and poison the task.
+		if strings.HasSuffix(de.Name(), ".tmp") || de.Name() == backup.ManifestObject {
+			log.Warn().Str("name", de.Name()).
+				Msg("build manifest: skipping non-artifact file")
 			continue
 		}
 		add(de.Name(), filepath.Join(snapshotDir, de.Name()))

--- a/internal/vm/manifest.go
+++ b/internal/vm/manifest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -39,6 +40,11 @@ const (
 	hashSafetyMargin = 3 * time.Second
 	// hashBudgetCap bounds hashing when the caller has no deadline.
 	hashBudgetCap = 60 * time.Second
+	// buildHashBudget bounds hashing a finished build's artifact set. Builds
+	// are not latency-critical the way pause is, so the budget is generous:
+	// it exists to keep a wedged disk from pinning the build worker forever,
+	// not to shave seconds off the pause RPC.
+	buildHashBudget = 10 * time.Minute
 )
 
 // hashFile streams path through sha256, returning the lowercase hex digest
@@ -232,4 +238,47 @@ func baseIdentity(path string) (string, error) {
 	// change is visible there.
 	return fmt.Sprintf("%s|%d|%d|%d|%d|%d",
 		path, st.Dev, st.Ino, fi.Size(), fi.ModTime().UnixNano(), st.Ctim.Nano()), nil
+}
+
+// collectBuildManifest hashes every artifact file in a completed build's
+// snapshot directory except build.meta.json, which the caller rewrites with
+// these digests afterwards and hashes separately. Detached from the
+// caller's cancellation like collectPauseManifest: a build that already
+// produced valid artifacts should get its integrity record even if the
+// caller gives up during finalize. A file that misses the budget or fails
+// to hash is skipped with a warning; the caller decides whether what
+// remains is worth enqueueing.
+func collectBuildManifest(ctx context.Context, snapshotDir string, log zerolog.Logger) []ManifestEntry {
+	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), buildHashBudget)
+	defer cancel()
+
+	dirEntries, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		log.Warn().Err(err).Str("dir", snapshotDir).Msg("build manifest: read artifact dir failed")
+		return nil
+	}
+	start := time.Now()
+	entries := make([]ManifestEntry, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		if !de.Type().IsRegular() || de.Name() == buildMetaFilename {
+			continue
+		}
+		path := filepath.Join(snapshotDir, de.Name())
+		sum, size, err := hashFile(hctx, path)
+		if err != nil {
+			log.Warn().Err(err).Str("path", path).Msg("build manifest: hash failed, entry skipped")
+			continue
+		}
+		entries = append(entries, ManifestEntry{
+			FileName:  de.Name(),
+			Path:      path,
+			SizeBytes: size,
+			SHA256:    sum,
+		})
+	}
+	log.Info().
+		Int("files", len(entries)).
+		Int64("manifest_hash_ms", time.Since(start).Milliseconds()).
+		Msg("build manifest computed")
+	return entries
 }

--- a/internal/vm/manifest.go
+++ b/internal/vm/manifest.go
@@ -242,43 +242,65 @@ func baseIdentity(path string) (string, error) {
 
 // collectBuildManifest hashes every artifact file in a completed build's
 // snapshot directory except build.meta.json, which the caller rewrites with
-// these digests afterwards and hashes separately. Detached from the
-// caller's cancellation like collectPauseManifest: a build that already
-// produced valid artifacts should get its integrity record even if the
-// caller gives up during finalize. A file that misses the budget or fails
-// to hash is skipped with a warning; the caller decides whether what
-// remains is worth enqueueing.
-func collectBuildManifest(ctx context.Context, snapshotDir string, log zerolog.Logger) []ManifestEntry {
+// these digests afterwards and hashes separately, plus any extraPaths that
+// live outside the directory (the overlay base image sits in the run dir
+// but is required to restore the template). Detached from the caller's
+// cancellation like collectPauseManifest: a build that already produced
+// valid artifacts should get its integrity record even if the caller gives
+// up during finalize.
+//
+// complete reports whether EVERY artifact hashed. A file that misses the
+// budget or fails to hash is skipped with a warning and flips complete to
+// false; callers building a durable generation must not publish a partial
+// set (the manifest object's presence means restorable), so they treat
+// !complete as "do not enqueue".
+func collectBuildManifest(ctx context.Context, snapshotDir string, extraPaths []string, log zerolog.Logger) (entries []ManifestEntry, complete bool) {
 	hctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), buildHashBudget)
 	defer cancel()
 
 	dirEntries, err := os.ReadDir(snapshotDir)
 	if err != nil {
 		log.Warn().Err(err).Str("dir", snapshotDir).Msg("build manifest: read artifact dir failed")
-		return nil
+		return nil, false
 	}
 	start := time.Now()
-	entries := make([]ManifestEntry, 0, len(dirEntries))
-	for _, de := range dirEntries {
-		if !de.Type().IsRegular() || de.Name() == buildMetaFilename {
-			continue
+	complete = true
+	entries = make([]ManifestEntry, 0, len(dirEntries)+len(extraPaths))
+	seen := make(map[string]bool, len(dirEntries)+len(extraPaths))
+	add := func(name, path string) {
+		if seen[name] {
+			return
 		}
-		path := filepath.Join(snapshotDir, de.Name())
+		seen[name] = true
 		sum, size, err := hashFile(hctx, path)
 		if err != nil {
-			log.Warn().Err(err).Str("path", path).Msg("build manifest: hash failed, entry skipped")
-			continue
+			log.Warn().Err(err).Str("path", path).Msg("build manifest: hash failed")
+			complete = false
+			return
 		}
 		entries = append(entries, ManifestEntry{
-			FileName:  de.Name(),
+			FileName:  name,
 			Path:      path,
 			SizeBytes: size,
 			SHA256:    sum,
 		})
 	}
+	for _, de := range dirEntries {
+		if !de.Type().IsRegular() || de.Name() == buildMetaFilename {
+			continue
+		}
+		add(de.Name(), filepath.Join(snapshotDir, de.Name()))
+	}
+	for _, p := range extraPaths {
+		if p == "" {
+			continue
+		}
+		add(filepath.Base(p), p)
+	}
 	log.Info().
 		Int("files", len(entries)).
+		Bool("complete", complete).
 		Int64("manifest_hash_ms", time.Since(start).Milliseconds()).
 		Msg("build manifest computed")
-	return entries
+	return entries, complete
 }


### PR DESCRIPTION
## Summary
When a template build completes, its artifact set (vmstate.snap, mem.snap, deltas, the run-dir base image, access.log, build.meta.json) becomes durable through the same backup pipeline as sandbox pauses. Part of the host-local artifact backup tier; stacks on the uploader PR and retargets to main after that merges.

## Technical decisions
- A backup task carries exactly one owner: SandboxID, or TemplateID+BuildID. The journal enforces the rule and the dedupe index keys on the full owner identity; the uploader routes template objects (manifest.json completion marker included) under templates/<template>/<build>/<generation>/. The generation segment mirrors the sandbox layout because build ids are reusable across rebuilds; without it a rebuild would dedupe against the previous build's objects.
- Hashing runs in the build finalize under a generous fixed budget (builds are not latency-critical), detached from caller cancellation like the pause manifest path. The overlay base referenced by build.meta.json lives in the run dir and is required for restore, so it joins the hashed set.
- Known tradeoff: that hashing is synchronous, so completion of a large build is delayed by up to the hash budget (the network slot is released first and the duration is logged), and a supervisor build timeout firing during that tail can cancel an otherwise valid build; accepted for now to keep "ready" meaning "integrity recorded", with the recovery sweep as the backstop.
- Completeness is enforced fail-closed: if any artifact (base image and build.meta.json included) fails to hash, nothing is enqueued, because the manifest object's presence in the bucket means restorable and a partial set must never look complete. The build itself still succeeds; gaps surface via warn logs.
- Digests are stamped into build.meta.json as an "artifacts" field by editing the raw JSON (template-builder's unmodeled fields survive) with an atomic tmp+rename+fsync replace. build.meta.json is hashed last so the backed-up copy carries the digests; its own digest travels in the task and generation manifest.
- A nil enqueue hook (backup disabled) is a no-op, matching the pause path.

## Testing
- go test ./internal/backup/ -count=1: new tests for template-task routing (fingerprint-suffixed objects and completion marker under the template generation prefix, mixed queue with a sandbox task drains fully) and the journal's exactly-one-owner validation plus template dedupe; existing tests untouched.
- GOOS=linux go build ./... and GOOS=linux go vet ./internal/backup/ ./internal/vm/ pass.
