### PR TITLE
fix(terraform): add required GCP compute labels

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -5,32 +5,49 @@ Terraform skeleton layout for Superserve GCP adoption.
 - `modules/` defines resource-area contracts
 - `envs/` wires those contracts into staging, production, and a greenfield new-region target
 
-Production roots configure a shared Compute Engine CPU alert for each
-Terraform-managed sandbox host. The alert fires when the 60-second mean CPU
-utilization is above 80% for 15 minutes, with a 15-minute notification rate
-limit and 30-minute auto-close. Notifications are sent to the existing
+The current Terraform-managed Compute Engine inventory for Vanta is:
+
+| Environment | Region | Instance | Status |
+| --- | --- | --- | --- |
+| staging | us-central1 | `superserve-vmd-staging` | Managed by Terraform |
+| production | us-west2 | `superserve-vmd-usw2` | Managed by Terraform |
+| production | us-east4 | `superserve-vmd-use4` | Managed by Terraform |
+| production | us-central1 | none | Decommissioned, no Terraform-managed instance remains |
+
+Each live instance is managed through the shared `sandbox-host` module and
+receives the required labels on the actual instance label map:
+
+- `environment`
+- `managed_by`
+- `region`
+- `owner`
+- `project`
+- `dataclassification`
+- `application`
+
+Role-specific labels such as `component`, `sandbox_role`, `sandbox_status`,
+and `goog-ops-agent-policy` remain instance-specific where needed. No
+non-Terraform Compute Engine instances are documented in this repository, so
+there are no remaining exceptions to track here.
+
+The production roots still configure a shared Compute Engine CPU alert for
+each Terraform-managed sandbox host. The alert fires when the 60-second mean
+CPU utilization is above 80% for 15 minutes, with a 15-minute notification
+rate limit and 30-minute auto-close. Notifications are sent to the existing
 monitored Cloud Monitoring channel names supplied through
 `TF_VAR_notification_channel_ids`; the channel and its Slack credential are
 owned outside this repository.
 
-The current production host inventory is:
-
-| Region | Instance | Alert policy key |
-| --- | --- | --- |
-| us-central1 | `superserve-vmd-prod` | `sandbox_host` |
-| us-east4 | `superserve-vmd-use4` | `sandbox_host` |
-| us-west2 | `superserve-vmd-usw2` | `sandbox_host` |
-
 Before the first apply, the infrastructure owner must compare this inventory
-with the Vanta finding and run read-only checks such as
+with any Vanta finding and run read-only checks such as
 `gcloud monitoring policies list --project PROJECT_ID` filtered for each
 instance name. If an existing policy covers a host, import or correct that
 policy instead of creating a duplicate. The owner must also verify the
 configured channel with `gcloud monitoring channels describe CHANNEL_ID`; this
 checks channel ownership and delivery configuration without exposing a Slack
 webhook credential. The reusable module contains one policy per instance only
-because the instance-ID filter keeps each host's Vanta evidence and response
-path unambiguous.
+because the instance-ID filter keeps each host's evidence and response path
+unambiguous.
 
 For an existing matching policy, use its full Monitoring policy name with
 `terraform import module.observability.google_monitoring_alert_policy.compute_instance_cpu[\"sandbox_host\"] POLICY_NAME`

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -32,6 +32,13 @@ locals {
     managed_by  = "terraform"
     region      = local.region
   }
+
+  sandbox_host_labels = merge(local.common_labels, {
+    owner              = "platform"
+    project            = "sandbox"
+    dataclassification = "confidential"
+    application        = "sandbox-host"
+  })
 }
 
 module "network" {
@@ -244,7 +251,7 @@ module "sandbox_host" {
   # this stays a no-op adoption: sandbox_status is still "provisioning" live;
   # flipping it to "ready" (to match the deployment-registry selector) is a
   # separate, intentional change, not part of this import PR.
-  labels = merge(local.common_labels, {
+  labels = merge(local.sandbox_host_labels, {
     component               = "vmd"
     sandbox_role            = "vmd"
     sandbox_status          = "provisioning"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -35,6 +35,13 @@ locals {
     region      = local.region
   }
 
+  sandbox_host_labels = merge(local.common_labels, {
+    owner              = "platform"
+    project            = "sandbox"
+    dataclassification = "confidential"
+    application        = "sandbox-host"
+  })
+
   api_service_account_email = "superserve-api-runner@${local.project_id}.iam.gserviceaccount.com"
 }
 module "network" {
@@ -186,7 +193,7 @@ module "sandbox_host" {
   subnet        = module.network.subnetwork_self_link
   internal_ip   = "10.1.0.2"
   tags          = ["vmd-usw2"]
-  labels = merge(local.common_labels, {
+  labels = merge(local.sandbox_host_labels, {
     component    = "vmd"
     sandbox_role = "vmd"
   })

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -32,6 +32,13 @@ locals {
     region      = local.region
   }
 
+  sandbox_host_labels = merge(local.common_labels, {
+    owner              = "platform"
+    project            = "sandbox"
+    dataclassification = "confidential"
+    application        = "sandbox-host"
+  })
+
   staging_otlp_endpoint = "http://10.0.0.2:4318"
 }
 
@@ -224,7 +231,7 @@ module "sandbox_host" {
   internal_ip = "10.0.0.2"
   tags        = ["superserve-vmd"]
 
-  labels = merge(local.common_labels, {
+  labels = merge(local.sandbox_host_labels, {
     component    = "vmd"
     sandbox_role = "vmd"
   })


### PR DESCRIPTION
## Summary
- Add the required Compute Engine labels on each Terraform-managed sandbox host instance
- Keep role-specific labels on the host modules without using provider-wide defaults
- Update the infra inventory to reflect the live host set and the decommissioned us-central1 production host

## Notes
- This is a direct implementation of the required GCP Compute Engine labels for Vanta compliance
- Required labels are applied at the instance label map level so the values match each host's actual role

## Validation
- `terraform fmt` on the edited `.tf` files
- `terraform init -backend=false -input=false` in `infra/envs/staging/us-central1`
- `terraform validate` is still blocked here by the Google provider plugin handshake in this sandbox