### PR TITLE
fix(terraform): add Vanta user-data labels to production hosts and backup buckets

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -252,10 +252,12 @@ module "sandbox_host" {
   # flipping it to "ready" (to match the deployment-registry selector) is a
   # separate, intentional change, not part of this import PR.
   labels = merge(local.sandbox_host_labels, {
-    component               = "vmd"
-    sandbox_role            = "vmd"
-    sandbox_status          = "provisioning"
-    "goog-ops-agent-policy" = "v2-template-1-7-0"
+    component                  = "vmd"
+    sandbox_role               = "vmd"
+    sandbox_status             = "provisioning"
+    "goog-ops-agent-policy"    = "v2-template-1-7-0"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"
   })
 
   service_account_email = data.google_service_account.api_runner.email
@@ -333,6 +335,8 @@ module "backup_storage" {
   ]
 
   labels = merge(local.common_labels, {
-    component = "backup"
+    component                  = "backup"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_snapshots_and_files"
   })
 }

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -194,8 +194,10 @@ module "sandbox_host" {
   internal_ip   = "10.1.0.2"
   tags          = ["vmd-usw2"]
   labels = merge(local.sandbox_host_labels, {
-    component    = "vmd"
-    sandbox_role = "vmd"
+    component                  = "vmd"
+    sandbox_role               = "vmd"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"
   })
 
   service_account_email = data.google_service_account.api_runner.email
@@ -247,6 +249,8 @@ module "backup_storage" {
   ]
 
   labels = merge(local.common_labels, {
-    component = "backup"
+    component                  = "backup"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_snapshots_and_files"
   })
 }


### PR DESCRIPTION
## Summary

- add `vanta-contains-user-data` and `vanta-user-data-stored` to the production sandbox Compute Engine hosts
- add the same labels to the production backup buckets
- leave staging unlabeled and do not touch the unmanaged migration bucket

## Verification

- ran `terraform fmt` on the edited Terraform files
- checked the diff with `git diff --check`
- rebased the branch onto `origin/main`