### PR TITLE
deploy: enable the backup uploader on the production cells

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -195,6 +195,9 @@ jobs:
           CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_USW }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_USWEST }}
           INTERNAL_API_TOKEN: ${{ secrets.PROD_USW_INTERNAL_API_TOKEN }}
+          # Enables the pause-backup uploader for the cell (validated on
+          # staging first; the bucket is create-only for hosts).
+          BACKUP_BUCKET: superserve-artifact-backup-usw2
         run: |
           # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
           # filter and fan out to every VMD_LABEL match — which would push


### PR DESCRIPTION
## Summary

Turns on the pause-backup uploader for the production cells (use4 and usw2) by passing each cell's backup bucket through the vmd deploy, following staging validation. Part of the sandbox durability effort.

## Technical decisions

One line per cell by design: the uploader, journal, and staging machinery shipped dark and activate purely on this env var. The buckets and create-only host IAM have been live since the storage module merged.

## Testing

Staging cell soaking against its bucket since the uploader merged; this PR should merge only after that soak is verified (uploader enabled, generations landing with manifests, dedupe on re-pause, no errors).