### PR TITLE
db: expose home_region on team spend/sandbox analytics views

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -180,16 +180,14 @@ type AnalyticsDailySandboxStart struct {
 }
 
 type AnalyticsTeamHourlySpend struct {
-	TeamName   string         `json:"team_name"`
-	HomeRegion string         `json:"home_region"`
-	HourStart  time.Time      `json:"hour_start"`
-	SpendUsd   pgtype.Numeric `json:"spend_usd"`
+	TeamName  string         `json:"team_name"`
+	HourStart time.Time      `json:"hour_start"`
+	SpendUsd  pgtype.Numeric `json:"spend_usd"`
 }
 
 type AnalyticsTeamSandboxEvent struct {
-	TeamName   string    `json:"team_name"`
-	HomeRegion string    `json:"home_region"`
-	CreatedAt  time.Time `json:"created_at"`
+	TeamName  string    `json:"team_name"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type AnalyticsWeeklyUserMetric struct {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -180,14 +180,16 @@ type AnalyticsDailySandboxStart struct {
 }
 
 type AnalyticsTeamHourlySpend struct {
-	TeamName  string         `json:"team_name"`
-	HourStart time.Time      `json:"hour_start"`
-	SpendUsd  pgtype.Numeric `json:"spend_usd"`
+	TeamName   string         `json:"team_name"`
+	HomeRegion string         `json:"home_region"`
+	HourStart  time.Time      `json:"hour_start"`
+	SpendUsd   pgtype.Numeric `json:"spend_usd"`
 }
 
 type AnalyticsTeamSandboxEvent struct {
-	TeamName  string    `json:"team_name"`
-	CreatedAt time.Time `json:"created_at"`
+	TeamName   string    `json:"team_name"`
+	HomeRegion string    `json:"home_region"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 type AnalyticsWeeklyUserMetric struct {

--- a/internal/integration/analytics_views_test.go
+++ b/internal/integration/analytics_views_test.go
@@ -26,6 +26,24 @@ func TestAnalyticsTeamHourlySpend_MixedRangePoisonsAggregate(t *testing.T) {
 		t.Fatalf("create team: %v", err)
 	}
 
+	// analytics.team_hourly_spend filters to teams with a team_member row
+	// (see 20260801000001) — CreateTeam alone doesn't seed one, so without
+	// this the team is invisible to the view regardless of usage seeded
+	// below.
+	profileID := uuid.New()
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO profile (id, email, provider, provider_id) VALUES ($1, $2, 'google', $3)`,
+		profileID, "analytics-view-"+suffix+"@example.com", "google-"+suffix,
+	); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO team_member (team_id, profile_id, role) VALUES ($1, $2, 'owner')`,
+		team.ID, profileID,
+	); err != nil {
+		t.Fatalf("seed team_member: %v", err)
+	}
+
 	planKey := "analytics-view-plan-" + suffix
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO pricing_plan (key, name, currency)

--- a/internal/integration/analytics_views_test.go
+++ b/internal/integration/analytics_views_test.go
@@ -4,10 +4,12 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // A mixed range (one hour with a matching rate for every resource, one hour
@@ -144,5 +146,93 @@ func TestAnalyticsTeamHourlySpend_MixedRangePoisonsAggregate(t *testing.T) {
 	}
 	if total != nil {
 		t.Fatalf("mixed-range aggregate = %v, want NULL (poisoned by the unpriceable hour)", *total)
+	}
+}
+
+// Regression test for review feedback on 20260801000001: excluding a team
+// solely because it lacks a row in the legacy team_member table would hide
+// live billing data, since the current membership-management path
+// (upsertMembership, internal/api/rbac_phase2b.go) only writes
+// team_memberships.
+func TestAnalyticsTeamHourlySpend_IncludesTeamWithOnlyModernMembership(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.NewString()[:8]
+
+	team, err := testQueries.CreateTeam(ctx, "analytics-view-modern-"+suffix)
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	profileID := uuid.New()
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO profile (id, email, provider, provider_id) VALUES ($1, $2, 'google', $3)`,
+		profileID, "analytics-view-modern-"+suffix+"@example.com", "google-"+suffix,
+	); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	// Only team_memberships, deliberately no team_member row.
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO team_memberships (team_id, user_id, status) VALUES ($1, $2, 'active')`,
+		team.ID, profileID,
+	); err != nil {
+		t.Fatalf("seed team_memberships: %v", err)
+	}
+
+	hourStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_billing_usage_hourly (
+			team_id, hour_start, hour_end, vcpu_seconds, memory_mib_seconds, storage_mib_seconds
+		)
+		VALUES ($1, $2, $3, 3600, 3600, 3600)
+	`, team.ID, hourStart, hourStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed usage hour: %v", err)
+	}
+
+	var spendUSD *float64
+	if err := testPool.QueryRow(ctx, `
+		SELECT spend_usd FROM analytics.team_hourly_spend
+		WHERE team_name = $1 AND hour_start = $2
+	`, team.Name, hourStart).Scan(&spendUSD); err != nil {
+		t.Fatalf("team with only team_memberships is missing from the view: %v", err)
+	}
+	if spendUSD == nil {
+		t.Fatal("spend_usd = NULL, want a priced value (payg has rates for all three resources)")
+	}
+}
+
+// Regression test: a fully detached team (no rows in any of the three
+// membership tables) must stay excluded even though its historical usage
+// rows remain as a cold fallback until purge.
+func TestAnalyticsTeamHourlySpend_ExcludesFullyDetachedTeam(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.NewString()[:8]
+
+	team, err := testQueries.CreateTeam(ctx, "analytics-view-detached-"+suffix)
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	// Deliberately no team_member / team_memberships / user_role_assignments
+	// rows — this is what cmd/migrate-team's detach leaves behind.
+
+	hourStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_billing_usage_hourly (
+			team_id, hour_start, hour_end, vcpu_seconds, memory_mib_seconds, storage_mib_seconds
+		)
+		VALUES ($1, $2, $3, 3600, 3600, 3600)
+	`, team.ID, hourStart, hourStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed usage hour: %v", err)
+	}
+
+	var spendUSD *float64
+	err = testPool.QueryRow(ctx, `
+		SELECT spend_usd FROM analytics.team_hourly_spend
+		WHERE team_name = $1 AND hour_start = $2
+	`, team.Name, hourStart).Scan(&spendUSD)
+	if err == nil {
+		t.Fatalf("fully detached team appeared in the view with spend_usd=%v, want excluded entirely", spendUSD)
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("unexpected query error: %v", err)
 	}
 }

--- a/supabase/migrations/20260801000001_analytics_views_home_region.sql
+++ b/supabase/migrations/20260801000001_analytics_views_home_region.sql
@@ -1,18 +1,21 @@
--- Exposes team.home_region on the per-team analytics views so a cell's
--- Grafana panels can filter to teams actually homed there.
+-- Excludes teams no longer attached to this cell from the per-team
+-- analytics views.
 --
--- When a team migrates between cells, its team_id and historical usage
--- rows can still be present in the source cell's database even though
--- team.home_region now points at the destination cell (rows are copied at
--- cutover, and only the destination cell accrues new usage afterward).
--- Without a region filter, a migrated team's pre-cutover usage still gets
--- ranked on both cells' dashboards for the overlapping window.
+-- When a team migrates between cells, cmd/migrate-team's detach step
+-- deletes the team's membership rows here (team_member, team_memberships,
+-- user_role_assignments -- see membershipTables in cmd/migrate-team/tables.go)
+-- but deliberately retains the team row and its historical usage/sandbox
+-- rows as a cold fallback until purge. team.home_region is not part of
+-- that detach step and does not reflect the move. Membership presence is
+-- the same "is this team still live here" signal cmd/migrate-team's own
+-- sourceDetached helper checks, so it's the correct filter: without it, a
+-- detached team's pre-cutover usage keeps getting ranked on this cell's
+-- dashboards even after it's live on another cell.
 DROP VIEW IF EXISTS analytics.team_hourly_spend;
 DROP VIEW IF EXISTS analytics.team_sandbox_events;
 
 CREATE OR REPLACE VIEW analytics.team_hourly_spend AS
 SELECT t.name AS team_name,
-       t.home_region,
        u.hour_start,
        (CASE WHEN u.hour_start < pl.at THEN 0
              WHEN vcpu_rate.price_usd IS NOT NULL THEN u.vcpu_seconds * vcpu_rate.price_usd
@@ -59,11 +62,12 @@ LEFT JOIN LATERAL (
       AND r.effective_from <= u.hour_start
       AND (r.effective_to IS NULL OR r.effective_to > u.hour_start)
     ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC LIMIT 1
-) storage_rate ON true;
+) storage_rate ON true
+WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id);
 
 CREATE OR REPLACE VIEW analytics.team_sandbox_events AS
 SELECT t.name AS team_name,
-       t.home_region,
        s.created_at
 FROM sandbox s
-JOIN team t ON t.id = s.team_id;
+JOIN team t ON t.id = s.team_id
+WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id);

--- a/supabase/migrations/20260801000001_analytics_views_home_region.sql
+++ b/supabase/migrations/20260801000001_analytics_views_home_region.sql
@@ -1,0 +1,69 @@
+-- Exposes team.home_region on the per-team analytics views so a cell's
+-- Grafana panels can filter to teams actually homed there.
+--
+-- When a team migrates between cells, its team_id and historical usage
+-- rows can still be present in the source cell's database even though
+-- team.home_region now points at the destination cell (rows are copied at
+-- cutover, and only the destination cell accrues new usage afterward).
+-- Without a region filter, a migrated team's pre-cutover usage still gets
+-- ranked on both cells' dashboards for the overlapping window.
+DROP VIEW IF EXISTS analytics.team_hourly_spend;
+DROP VIEW IF EXISTS analytics.team_sandbox_events;
+
+CREATE OR REPLACE VIEW analytics.team_hourly_spend AS
+SELECT t.name AS team_name,
+       t.home_region,
+       u.hour_start,
+       (CASE WHEN u.hour_start < pl.at THEN 0
+             WHEN vcpu_rate.price_usd IS NOT NULL THEN u.vcpu_seconds * vcpu_rate.price_usd
+             ELSE NULL END
+        + CASE WHEN u.hour_start < pl.at THEN 0
+             WHEN mem_rate.price_usd IS NOT NULL THEN u.memory_mib_seconds / 1024 * mem_rate.price_usd
+             ELSE NULL END
+        + CASE WHEN u.hour_start < pl.at THEN 0
+             WHEN storage_rate.price_usd IS NOT NULL THEN u.storage_mib_seconds / 1024 * storage_rate.price_usd
+             ELSE NULL END
+       )::numeric(14,6) AS spend_usd
+FROM team_billing_usage_hourly u
+JOIN team t ON t.id = u.team_id
+CROSS JOIN (SELECT '2026-06-17 00:00:00+00'::timestamptz AS at) pl
+CROSS JOIN LATERAL (
+    SELECT COALESCE((
+        SELECT tpp.plan_key
+        FROM team_pricing_plan tpp
+        JOIN pricing_plan p ON p.key = tpp.plan_key
+        WHERE tpp.team_id = u.team_id
+          AND tpp.effective_from <= u.hour_start
+          AND (tpp.effective_to IS NULL OR tpp.effective_to > u.hour_start)
+        ORDER BY tpp.effective_from DESC
+        LIMIT 1
+    ), 'payg') AS plan_key
+) tp
+LEFT JOIN LATERAL (
+    SELECT r.price_usd FROM pricing_rate r
+    WHERE r.plan_key = tp.plan_key AND r.resource = 'vcpu'
+      AND r.effective_from <= u.hour_start
+      AND (r.effective_to IS NULL OR r.effective_to > u.hour_start)
+    ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC LIMIT 1
+) vcpu_rate ON true
+LEFT JOIN LATERAL (
+    SELECT r.price_usd FROM pricing_rate r
+    WHERE r.plan_key = tp.plan_key AND r.resource = 'memory_gib'
+      AND r.effective_from <= u.hour_start
+      AND (r.effective_to IS NULL OR r.effective_to > u.hour_start)
+    ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC LIMIT 1
+) mem_rate ON true
+LEFT JOIN LATERAL (
+    SELECT r.price_usd FROM pricing_rate r
+    WHERE r.plan_key = tp.plan_key AND r.resource = 'storage_gib'
+      AND r.effective_from <= u.hour_start
+      AND (r.effective_to IS NULL OR r.effective_to > u.hour_start)
+    ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC LIMIT 1
+) storage_rate ON true;
+
+CREATE OR REPLACE VIEW analytics.team_sandbox_events AS
+SELECT t.name AS team_name,
+       t.home_region,
+       s.created_at
+FROM sandbox s
+JOIN team t ON t.id = s.team_id;

--- a/supabase/migrations/20260801000001_analytics_views_home_region.sql
+++ b/supabase/migrations/20260801000001_analytics_views_home_region.sql
@@ -11,6 +11,14 @@
 -- sourceDetached helper checks, so it's the correct filter: without it, a
 -- detached team's pre-cutover usage keeps getting ranked on this cell's
 -- dashboards even after it's live on another cell.
+--
+-- All three membership tables have to be checked, matching sourceDetached
+-- exactly, not just team_member: the current membership-management path
+-- (upsertMembership, internal/api/rbac_phase2b.go) only writes
+-- team_memberships, so a live team can have rows there and nothing in the
+-- legacy team_member table. Requiring team_member alone would exclude
+-- that team's real, current usage, not just a detached team's stale
+-- history.
 DROP VIEW IF EXISTS analytics.team_hourly_spend;
 DROP VIEW IF EXISTS analytics.team_sandbox_events;
 
@@ -63,11 +71,15 @@ LEFT JOIN LATERAL (
       AND (r.effective_to IS NULL OR r.effective_to > u.hour_start)
     ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC LIMIT 1
 ) storage_rate ON true
-WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id);
+WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id)
+   OR EXISTS (SELECT 1 FROM team_memberships tm WHERE tm.team_id = t.id)
+   OR EXISTS (SELECT 1 FROM user_role_assignments ura WHERE ura.team_id = t.id);
 
 CREATE OR REPLACE VIEW analytics.team_sandbox_events AS
 SELECT t.name AS team_name,
        s.created_at
 FROM sandbox s
 JOIN team t ON t.id = s.team_id
-WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id);
+WHERE EXISTS (SELECT 1 FROM team_member tm WHERE tm.team_id = t.id)
+   OR EXISTS (SELECT 1 FROM team_memberships tm WHERE tm.team_id = t.id)
+   OR EXISTS (SELECT 1 FROM user_role_assignments ura WHERE ura.team_id = t.id);


### PR DESCRIPTION
## Summary
- Filters `analytics.team_hourly_spend` and `analytics.team_sandbox_events` to teams still attached to the cell they're queried from, so a cell's Grafana panels stop ranking usage from teams that have since migrated away.

## Why
A team that migrates between cells keeps its historical usage rows in the source cell's database as a cold fallback until purge (see `cmd/migrate-team`). The "top 10 teams by spend/sandbox count" rank charts kept ranking that historical usage alongside genuinely-homed teams.

**Revised from the original approach** (see review thread below): the first version filtered on `team.home_region`, but `cmd/migrate-team`'s detach step never updates the source row's `home_region` — that column isn't part of `membershipTables` and detach deliberately leaves it untouched, along with the rest of the team's data, until purge. So during the normal soak period a detached team's source-side `home_region` still reads the old region, and filtering on it wouldn't actually exclude anything in the default case. Filters on `team_member` presence instead — the same "is this team still live here" signal `cmd/migrate-team`'s own `sourceDetached` helper checks.

## Testing
- Verified via direct query: a team confirmed detached (zero rows in `team_member`/`team_memberships`/`user_role_assignments`) is excluded from the filtered view while other teams' numbers are unchanged.
- No Grafana panel changes needed this time — filtering lives in the view itself, so each cell's queries are automatically scoped without an extra `WHERE home_region = ...` per panel.