### PR TITLE
fix(billing): harden platform billing boundary coverage

### DIFF
--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -165,34 +165,34 @@ WITH compute AS (
     SELECT
         COALESCE(SUM(
             EXTRACT(EPOCH FROM (
-                LEAST(COALESCE(i.ended_at, now()), sqlc.arg(hour_end))
+                LEAST(COALESCE(i.ended_at, billing_request_now()), sqlc.arg(hour_end))
                 - GREATEST(i.started_at, sqlc.arg(hour_start))
             )) * i.vcpu_count
         ), 0)::numeric AS vcpu_seconds,
         COALESCE(SUM(
             EXTRACT(EPOCH FROM (
-                LEAST(COALESCE(i.ended_at, now()), sqlc.arg(hour_end))
+                LEAST(COALESCE(i.ended_at, billing_request_now()), sqlc.arg(hour_end))
                 - GREATEST(i.started_at, sqlc.arg(hour_start))
             )) * i.memory_mib
         ), 0)::numeric AS memory_mib_seconds
     FROM sandbox_compute_billing_interval i
     WHERE i.team_id = sqlc.arg(team_id)
       AND i.started_at < sqlc.arg(hour_end)
-      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
-      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
+      AND sqlc.arg(hour_start) < LEAST(billing_request_now(), sqlc.arg(hour_end))
+      AND COALESCE(i.ended_at, LEAST(billing_request_now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
 ),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
-            LEAST(COALESCE(i.ended_at, now()), sqlc.arg(hour_end))
+            LEAST(COALESCE(i.ended_at, billing_request_now()), sqlc.arg(hour_end))
             - GREATEST(i.started_at, sqlc.arg(hour_start))
         )) * i.disk_mib
     ), 0)::numeric AS storage_mib_seconds
     FROM sandbox_storage_interval i
     WHERE i.team_id = sqlc.arg(team_id)
       AND i.started_at < sqlc.arg(hour_end)
-      AND sqlc.arg(hour_start) < LEAST(now(), sqlc.arg(hour_end))
-      AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
+      AND sqlc.arg(hour_start) < LEAST(billing_request_now(), sqlc.arg(hour_end))
+      AND COALESCE(i.ended_at, LEAST(billing_request_now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
 ),
 usage AS (
     SELECT

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -78,6 +78,7 @@ type Handlers struct {
 	Analytics *analytics.Client // when set, emits product-usage events; nil is a no-op
 	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
 	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
+	Now       func() time.Time  // when set, returns the current UTC time for testable handlers
 
 	// asyncMu/asyncCond/asyncCount track fire-and-forget bookkeeping goroutines
 	// (ActivateSandbox, FinalizePause) so tests can wait for quiescence;

--- a/internal/api/handlers_platform_billing.go
+++ b/internal/api/handlers_platform_billing.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
@@ -110,16 +112,22 @@ func (h *Handlers) ListPlatformBilling(c *gin.Context) {
 	}
 
 	var payload json.RawMessage
-	if err := h.Pool.QueryRow(
-		c.Request.Context(),
-		platformBillingQueryForSort(params.SortBy),
-		params.Search,
-		params.SortBy,
-		params.SortDir,
-		params.Limit,
-		params.Offset,
-	).Scan(&payload); err != nil {
-		log.Error().Err(err).Msg("platform billing query failed")
+	var queryErr error
+	if h.Now != nil {
+		payload, queryErr = h.queryPlatformBillingWithClock(c.Request.Context(), platformBillingQueryForSort(params.SortBy), params.Search, params.SortBy, params.SortDir, params.Limit, params.Offset)
+	} else {
+		queryErr = h.Pool.QueryRow(
+			c.Request.Context(),
+			platformBillingQueryForSort(params.SortBy),
+			params.Search,
+			params.SortBy,
+			params.SortDir,
+			params.Limit,
+			params.Offset,
+		).Scan(&payload)
+	}
+	if queryErr != nil {
+		log.Error().Err(queryErr).Msg("platform billing query failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -127,6 +135,35 @@ func (h *Handlers) ListPlatformBilling(c *gin.Context) {
 	c.Header("Cache-Control", "private, no-store")
 	c.Header("Vary", "Authorization, X-Actor-User-Id")
 	c.Data(http.StatusOK, "application/json; charset=utf-8", payload)
+}
+
+func (h *Handlers) queryPlatformBillingWithClock(ctx context.Context, query, search, sortBy, sortDir string, limit, offset int64) (json.RawMessage, error) {
+	conn, err := h.Pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Release()
+
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if _, err := tx.Exec(ctx, `SELECT set_config('superserve.billing_now', $1, true)`, h.Now().UTC().Format(time.RFC3339Nano)); err != nil {
+		return nil, err
+	}
+
+	var payload json.RawMessage
+	if err := tx.QueryRow(ctx, query, search, sortBy, sortDir, limit, offset).Scan(&payload); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return payload, nil
 }
 
 func platformBillingQueryForSort(sortBy string) string {
@@ -140,7 +177,7 @@ func platformBillingQueryForSort(sortBy string) string {
 
 const platformBillingChargesQuery = `
 WITH request_time AS (
-	SELECT now() AS calculated_at
+	SELECT billing_request_now() AS calculated_at
 ),
 team_periods AS (
 	SELECT
@@ -395,7 +432,7 @@ SELECT jsonb_build_object(
 
 const platformBillingMetadataQuery = `
 WITH request_time AS (
-	SELECT now() AS calculated_at
+	SELECT billing_request_now() AS calculated_at
 ),
 team_periods AS (
 	SELECT

--- a/internal/billing/summary_test.go
+++ b/internal/billing/summary_test.go
@@ -56,6 +56,88 @@ func TestValidateSummaryPricingRatesRejectsUnsupportedResource(t *testing.T) {
 	}
 }
 
+func TestCurrentBillingPeriodBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		now       time.Time
+		wantStart time.Time
+		wantEnd   time.Time
+	}{
+		{
+			name:      "utc month start",
+			now:       time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "utc month end",
+			now:       time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC),
+			wantStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "one nanosecond before utc month rollover",
+			now:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Add(-time.Nanosecond),
+			wantStart: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "exact utc month rollover",
+			now:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "one nanosecond after utc month rollover",
+			now:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Add(time.Nanosecond),
+			wantStart: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "utc year end",
+			now:       time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
+			wantStart: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "leap year february end",
+			now:       time.Date(2024, 2, 29, 23, 59, 59, 999999999, time.UTC),
+			wantStart: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "utc year start",
+			now:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "non-utc input normalizes to utc month end",
+			now:       time.Date(2026, 1, 31, 23, 30, 0, 0, time.FixedZone("UTC-2", -2*3600)),
+			wantStart: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "non-utc input crosses into previous year in utc",
+			now:       time.Date(2026, 1, 1, 0, 30, 0, 0, time.FixedZone("UTC+2", 2*3600)),
+			wantStart: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStart, gotEnd := CurrentBillingPeriod(tc.now)
+			if !gotStart.Equal(tc.wantStart) {
+				t.Fatalf("period start = %s, want %s", gotStart, tc.wantStart)
+			}
+			if !gotEnd.Equal(tc.wantEnd) {
+				t.Fatalf("period end = %s, want %s", gotEnd, tc.wantEnd)
+			}
+		})
+	}
+}
+
 func numericFromFloat64(t *testing.T, v float64) pgtype.Numeric {
 	t.Helper()
 	var n pgtype.Numeric

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -1343,34 +1343,34 @@ WITH compute AS (
     SELECT
         COALESCE(SUM(
             EXTRACT(EPOCH FROM (
-                LEAST(COALESCE(i.ended_at, now()), $1)
+                LEAST(COALESCE(i.ended_at, billing_request_now()), $1)
                 - GREATEST(i.started_at, $2)
             )) * i.vcpu_count
         ), 0)::numeric AS vcpu_seconds,
         COALESCE(SUM(
             EXTRACT(EPOCH FROM (
-                LEAST(COALESCE(i.ended_at, now()), $1)
+                LEAST(COALESCE(i.ended_at, billing_request_now()), $1)
                 - GREATEST(i.started_at, $2)
             )) * i.memory_mib
         ), 0)::numeric AS memory_mib_seconds
     FROM sandbox_compute_billing_interval i
     WHERE i.team_id = $3
       AND i.started_at < $1
-      AND $2 < LEAST(now(), $1)
-      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
+      AND $2 < LEAST(billing_request_now(), $1)
+      AND COALESCE(i.ended_at, LEAST(billing_request_now(), $1)) > $2
 ),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
-            LEAST(COALESCE(i.ended_at, now()), $1)
+            LEAST(COALESCE(i.ended_at, billing_request_now()), $1)
             - GREATEST(i.started_at, $2)
         )) * i.disk_mib
     ), 0)::numeric AS storage_mib_seconds
     FROM sandbox_storage_interval i
     WHERE i.team_id = $3
       AND i.started_at < $1
-      AND $2 < LEAST(now(), $1)
-      AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
+      AND $2 < LEAST(billing_request_now(), $1)
+      AND COALESCE(i.ended_at, LEAST(billing_request_now(), $1)) > $2
 ),
 usage AS (
     SELECT

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1221,6 +1221,10 @@ func waitBookkeeping() {
 }
 
 func newRouter(t *testing.T) *gin.Engine {
+	return newRouterWithNow(t, nil)
+}
+
+func newRouterWithNow(t *testing.T, now func() time.Time) *gin.Engine {
 	t.Helper()
 	cfg := &config.Config{
 		Port:          "0",
@@ -1230,6 +1234,9 @@ func newRouter(t *testing.T) *gin.Engine {
 	}
 	h := api.NewHandlers(&stubVMD{}, testQueries, cfg)
 	h.Pool = testPool
+	if now != nil {
+		h.Now = now
+	}
 	registerTestHandlers(h)
 	return api.SetupRouter(t.Context(), h, testPool)
 }
@@ -2680,7 +2687,8 @@ func TestIntegration_TenantUsageDashboardEnabledByDefaultForNewTeams(t *testing.
 func TestIntegration_HourlyRollupBoundsOpenIntervalsAtNow(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
-	r := newRouter(t)
+	fixedNow := time.Date(2026, 8, 4, 12, 30, 0, 0, time.UTC)
+	r := newRouterWithNow(t, func() time.Time { return fixedNow })
 
 	if _, err := testPool.Exec(ctx, `
 		INSERT INTO team_feature_flag (team_id, key, enabled)
@@ -2696,12 +2704,9 @@ func TestIntegration_HourlyRollupBoundsOpenIntervalsAtNow(t *testing.T) {
 	}
 	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
 
-	hourStart := time.Now().UTC().Truncate(time.Hour)
+	hourStart := fixedNow.Truncate(time.Hour)
 	hourEnd := hourStart.Add(time.Hour)
-	startedAt := time.Now().UTC().Add(-5 * time.Minute)
-	if startedAt.Before(hourStart) {
-		startedAt = hourStart
-	}
+	startedAt := hourStart
 
 	if _, err := testPool.Exec(ctx, `
 		UPDATE sandbox_compute_billing_interval
@@ -2720,7 +2725,17 @@ func TestIntegration_HourlyRollupBoundsOpenIntervalsAtNow(t *testing.T) {
 		t.Fatalf("set storage interval: %v", err)
 	}
 
-	row, err := testQueries.UpsertTeamBillingUsageHour(ctx, db.UpsertTeamBillingUsageHourParams{
+	tx, err := testPool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tx.Rollback(ctx)
+	})
+	if _, err := tx.Exec(ctx, `SELECT set_config('superserve.billing_now', $1, true)`, fixedNow.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("set billing clock: %v", err)
+	}
+	row, err := db.New(tx).UpsertTeamBillingUsageHour(ctx, db.UpsertTeamBillingUsageHourParams{
 		TeamID:    teamID,
 		HourStart: pgtype.Timestamptz{Time: hourStart, Valid: true},
 		HourEnd:   pgtype.Timestamptz{Time: hourEnd, Valid: true},
@@ -3968,6 +3983,68 @@ func TestIntegration_BillingPeriodFinalizationUsesPeriodPricingAndUsageUnits(t *
 	if got := numericFloat64(t, result.Period.NetInvoiceAmountUsd); math.Abs(got-wantCurrent) > 1e-9 {
 		t.Fatalf("net invoice = %v, want %v", got, wantCurrent)
 	}
+}
+
+func TestIntegration_BillingPeriodFinalizationPreservesMonthBoundaryPeriodBounds(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+
+	planKey := "month-boundary-finalization-" + uuid.New().String()
+	periodStart := time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rateEffectiveFrom := periodStart.Add(-time.Hour)
+
+	insertPricingPlanForTest(t, ctx, planKey, true)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+		VALUES
+			($1, 'vcpu', 'second', 0.000011, $2),
+			($1, 'memory_gib', 'second', 0.0000045, $2),
+			($1, 'storage_gib', 'second', 0.00000003, $2)
+	`, planKey, rateEffectiveFrom); err != nil {
+		t.Fatalf("insert month-boundary pricing rates: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_pricing_plan (team_id, plan_key, effective_from)
+		VALUES ($1, $2, $3)
+	`, teamID, planKey, rateEffectiveFrom); err != nil {
+		t.Fatalf("assign month-boundary pricing plan: %v", err)
+	}
+
+	rates, err := testQueries.ListActivePricingRatesForTeamCurrent(ctx, teamID)
+	if err != nil {
+		t.Fatalf("list pricing rates: %v", err)
+	}
+	planRates, err := billing.ValidateSummaryPricingRates(rates)
+	if err != nil {
+		t.Fatalf("validate pricing rates: %v", err)
+	}
+	vcpuRate := numericFloat64(t, planRates["vcpu"].PriceUsd)
+
+	vcpuSeconds := 100000.0
+	gross := vcpuSeconds * vcpuRate
+	scenario := setupBillingFinalizationScenarioAt(t, ctx, teamID, periodStart, periodEnd, vcpuSeconds, []billingFinalizationGrantSpec{
+		{amountUsd: gross * 0.5},
+	})
+
+	result, err := billing.FinalizeTeamBillingPeriodWithCredits(ctx, testPool, teamID, scenario.periodStart, scenario.periodEnd)
+	if err != nil {
+		t.Fatalf("finalize billing period: %v", err)
+	}
+
+	wantGrantRemaining, wantLedgerAmounts := expectedBillingFinalizationConsumption([]billingFinalizationGrantSpec{
+		{amountUsd: gross * 0.5},
+	}, scenario.grantIDs, scenario.periodEnd, scenario.grossCharges)
+	assertBillingFinalizationState(
+		t,
+		teamID,
+		scenario.periodStart,
+		scenario.periodEnd,
+		result,
+		result.Charges.CreditsAppliedUSD,
+		wantGrantRemaining,
+		wantLedgerAmounts,
+	)
 }
 
 func TestIntegration_BillingPeriodFinalizationRoundsFinancialValuesAtMicroBoundary(t *testing.T) {

--- a/internal/integration/platform_billing_test.go
+++ b/internal/integration/platform_billing_test.go
@@ -137,7 +137,8 @@ func TestPlatformBillingPaginationTotalsAndPartialFailures(t *testing.T) {
 func TestPlatformBillingUsesCurrentPeriodLedgerToReconstructOpeningBalance(t *testing.T) {
 	ctx := context.Background()
 	teamID, ownerKey := seedTeamAndKey(t)
-	r := newInternalRouter(t)
+	fixedNow := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	r := newInternalRouterWithNow(t, func() time.Time { return fixedNow })
 
 	cw := do(r, "POST", "/sandboxes", ownerKey, `{"name":"platform-billing-ledger"}`)
 	if cw.Code != http.StatusCreated {
@@ -154,8 +155,7 @@ func TestPlatformBillingUsesCurrentPeriodLedgerToReconstructOpeningBalance(t *te
 		t.Fatalf("clear seeded storage billing interval: %v", err)
 	}
 
-	now := time.Now().UTC().Truncate(time.Second)
-	periodStart, periodEnd := billing.CurrentBillingPeriod(now)
+	periodStart, periodEnd := billing.CurrentBillingPeriod(fixedNow)
 	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
 		TeamID:      teamID,
 		PeriodStart: periodStart,
@@ -237,4 +237,271 @@ func TestPlatformBillingUsesCurrentPeriodLedgerToReconstructOpeningBalance(t *te
 	if got := row.Summary["credits_remaining_usd"].(float64); got < -0.000001 || got > 0.000001 {
 		t.Fatalf("credits_remaining_usd = %v, want 0", got)
 	}
+}
+
+func seedPlatformBillingRatesForTest(t *testing.T, ctx context.Context, teamID uuid.UUID, planKey string, effectiveFrom time.Time) {
+	t.Helper()
+
+	insertPricingPlanForTest(t, ctx, planKey, true)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO pricing_rate (plan_key, resource, unit, price_usd, effective_from)
+		VALUES
+			($1, 'vcpu', 'second', 0.000011, $2),
+			($1, 'memory_gib', 'second', 0.0000045, $2),
+			($1, 'storage_gib', 'second', 0.00000003, $2)
+	`, planKey, effectiveFrom); err != nil {
+		t.Fatalf("insert platform billing pricing rates: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_pricing_plan (team_id, plan_key, effective_from)
+		VALUES ($1, $2, $3)
+	`, teamID, planKey, effectiveFrom); err != nil {
+		t.Fatalf("assign platform billing pricing plan: %v", err)
+	}
+}
+
+func TestPlatformBillingUsesHalfOpenMonthBoundaryForUsage(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	fixedNow := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	r := newInternalRouterWithNow(t, func() time.Time { return fixedNow })
+
+	cw := do(r, "POST", "/sandboxes", ownerKey, `{"name":"platform-billing-month-boundary"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: expected 201, got %d: %s", cw.Code, cw.Body.String())
+	}
+	sandboxID, err := uuid.Parse(mustJSON(t, cw)["id"].(string))
+	if err != nil {
+		t.Fatalf("parse sandbox id: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_compute_billing_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded compute billing interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_storage_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded storage billing interval: %v", err)
+	}
+
+	periodStart, periodEnd := billing.CurrentBillingPeriod(fixedNow)
+	seedPlatformBillingRatesForTest(t, ctx, teamID, "platform-billing-half-open-"+uuid.NewString(), periodStart.Add(-time.Hour))
+
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_compute_billing_interval (
+			sandbox_id, team_id, vcpu_count, memory_mib, started_at, ended_at, end_reason
+		)
+		VALUES
+			($1, $2, 2, 2048, $3, $4, 'paused'),
+			($1, $2, 2, 2048, $4, $5, 'paused')
+	`, sandboxID, teamID, periodStart.Add(-time.Hour), periodStart, periodStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed month-boundary compute intervals: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_storage_interval (
+			sandbox_id, team_id, disk_mib, started_at, ended_at, end_reason
+		)
+		VALUES
+			($1, $2, 10240, $3, $4, 'deleted'),
+			($1, $2, 10240, $4, $5, 'deleted')
+	`, sandboxID, teamID, periodStart.Add(-time.Hour), periodStart, periodStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed month-boundary storage intervals: %v", err)
+	}
+
+	var grantID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason, created_at, updated_at)
+		VALUES ($1, 0.060000, 0.020000, 'month boundary opening balance', $2, $2)
+		RETURNING id
+	`, teamID, periodStart.Add(-time.Hour)).Scan(&grantID); err != nil {
+		t.Fatalf("seed credit grant: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_ledger (
+			team_id, grant_id, billing_period_start, billing_period_end, amount_usd, reason
+		)
+		VALUES ($1, $2, $3, $4, 0.040000, 'billing period finalization credit application')
+	`, teamID, grantID, periodStart, periodEnd); err != nil {
+		t.Fatalf("seed july credit ledger: %v", err)
+	}
+
+	actorID := seedPlatformAdminProfile(t)
+	resp := doInternal(
+		r,
+		http.MethodGet,
+		fmt.Sprintf("/internal/billing?search=%s&sort=team_name&order=asc", teamID.String()),
+		actorID.String(),
+		"",
+	)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("platform billing response: %d %s", resp.Code, resp.Body.String())
+	}
+
+	body := decodePlatformBilling(t, resp.Body.Bytes())
+	if len(body.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(body.Rows))
+	}
+	row := body.Rows[0]
+	if row.TeamID != teamID.String() {
+		t.Fatalf("team_id = %s, want %s", row.TeamID, teamID)
+	}
+	if row.Error != nil {
+		t.Fatalf("unexpected billing error: %+v", row.Error)
+	}
+	if row.Summary == nil {
+		t.Fatal("summary missing")
+	}
+
+	billingPeriod, ok := row.Summary["billing_period"].(map[string]any)
+	if !ok {
+		t.Fatalf("billing_period = %T, want map", row.Summary["billing_period"])
+	}
+	start, err := time.Parse(time.RFC3339Nano, billingPeriod["start"].(string))
+	if err != nil {
+		t.Fatalf("parse billing_period.start: %v", err)
+	}
+	if !start.Equal(periodStart) {
+		t.Fatalf("billing_period.start = %s, want %s", start, periodStart)
+	}
+	end, err := time.Parse(time.RFC3339Nano, billingPeriod["end"].(string))
+	if err != nil {
+		t.Fatalf("parse billing_period.end: %v", err)
+	}
+	if !end.Equal(periodEnd) {
+		t.Fatalf("billing_period.end = %s, want %s", end, periodEnd)
+	}
+
+	want := billing.CalculateSummaryCharges(
+		2*3600,
+		2*3600,
+		10*3600,
+		0.000011,
+		0.0000045,
+		0.00000003,
+		0.060000,
+	)
+	assertFloatNear(t, row.Summary["current_charges_usd"].(float64), want.CurrentChargesUSD)
+	assertFloatNear(t, row.Summary["credits_applied_usd"].(float64), want.CreditsAppliedUSD)
+	assertFloatNear(t, row.Summary["credits_remaining_usd"].(float64), want.CreditsRemainingUSD)
+}
+
+func TestPlatformBillingUsesExactMonthBoundaryAtRollover(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	fixedNow := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	r := newInternalRouterWithNow(t, func() time.Time { return fixedNow })
+
+	cw := do(r, "POST", "/sandboxes", ownerKey, `{"name":"platform-billing-month-rollover"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: expected 201, got %d: %s", cw.Code, cw.Body.String())
+	}
+	sandboxID, err := uuid.Parse(mustJSON(t, cw)["id"].(string))
+	if err != nil {
+		t.Fatalf("parse sandbox id: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_compute_billing_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded compute billing interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_storage_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded storage billing interval: %v", err)
+	}
+
+	periodStart, periodEnd := billing.CurrentBillingPeriod(fixedNow)
+	seedPlatformBillingRatesForTest(t, ctx, teamID, "platform-billing-rollover-"+uuid.NewString(), periodStart.Add(-time.Hour))
+
+	// One interval ends exactly at the boundary, one starts exactly at the
+	// boundary, and one ledger row belongs to the previous month.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_compute_billing_interval (
+			sandbox_id, team_id, vcpu_count, memory_mib, started_at, ended_at, end_reason
+		)
+		VALUES
+			($1, $2, 2, 2048, $3, $4, 'paused'),
+			($1, $2, 2, 2048, $4, $5, 'paused')
+	`, sandboxID, teamID, periodStart.Add(-time.Hour), periodStart, periodStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed rollover compute intervals: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO sandbox_storage_interval (
+			sandbox_id, team_id, disk_mib, started_at, ended_at, end_reason
+		)
+		VALUES
+			($1, $2, 10240, $3, $4, 'deleted'),
+			($1, $2, 10240, $4, $5, 'deleted')
+	`, sandboxID, teamID, periodStart.Add(-time.Hour), periodStart, periodStart.Add(time.Hour)); err != nil {
+		t.Fatalf("seed rollover storage intervals: %v", err)
+	}
+
+	var grantID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason, created_at, updated_at)
+		VALUES ($1, 0.060000, 0.020000, 'month rollover opening balance', $2, $2)
+		RETURNING id
+	`, teamID, periodStart.Add(-time.Hour)).Scan(&grantID); err != nil {
+		t.Fatalf("seed credit grant: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_ledger (
+			team_id, grant_id, billing_period_start, billing_period_end, amount_usd, reason
+		)
+		VALUES ($1, $2, $3, $4, 0.040000, 'billing period finalization credit application')
+	`, teamID, grantID, periodStart.AddDate(0, -1, 0), periodStart); err != nil {
+		t.Fatalf("seed july credit ledger: %v", err)
+	}
+
+	actorID := seedPlatformAdminProfile(t)
+	resp := doInternal(
+		r,
+		http.MethodGet,
+		fmt.Sprintf("/internal/billing?search=%s&sort=team_name&order=asc", teamID.String()),
+		actorID.String(),
+		"",
+	)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("platform billing response: %d %s", resp.Code, resp.Body.String())
+	}
+
+	body := decodePlatformBilling(t, resp.Body.Bytes())
+	if len(body.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(body.Rows))
+	}
+	row := body.Rows[0]
+	if row.TeamID != teamID.String() {
+		t.Fatalf("team_id = %s, want %s", row.TeamID, teamID)
+	}
+	if row.Error != nil {
+		t.Fatalf("unexpected billing error: %+v", row.Error)
+	}
+	if row.Summary == nil {
+		t.Fatal("summary missing")
+	}
+
+	billingPeriod, ok := row.Summary["billing_period"].(map[string]any)
+	if !ok {
+		t.Fatalf("billing_period = %T, want map", row.Summary["billing_period"])
+	}
+	start, err := time.Parse(time.RFC3339Nano, billingPeriod["start"].(string))
+	if err != nil {
+		t.Fatalf("parse billing_period.start: %v", err)
+	}
+	if !start.Equal(periodStart) {
+		t.Fatalf("billing_period.start = %s, want %s", start, periodStart)
+	}
+	end, err := time.Parse(time.RFC3339Nano, billingPeriod["end"].(string))
+	if err != nil {
+		t.Fatalf("parse billing_period.end: %v", err)
+	}
+	if !end.Equal(periodEnd) {
+		t.Fatalf("billing_period.end = %s, want %s", end, periodEnd)
+	}
+
+	want := billing.CalculateSummaryCharges(
+		0,
+		0,
+		0,
+		0.000011,
+		0.0000045,
+		0.00000003,
+		0.020000,
+	)
+	assertFloatNear(t, row.Summary["current_charges_usd"].(float64), want.CurrentChargesUSD)
+	assertFloatNear(t, row.Summary["credits_applied_usd"].(float64), want.CreditsAppliedUSD)
+	assertFloatNear(t, row.Summary["credits_remaining_usd"].(float64), want.CreditsRemainingUSD)
 }

--- a/internal/integration/rbac_phase2b_test.go
+++ b/internal/integration/rbac_phase2b_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -21,9 +22,13 @@ import (
 const internalRBACToken = "integration-rbac-phase2b-token"
 
 func newInternalRouter(t *testing.T) *gin.Engine {
+	return newInternalRouterWithNow(t, nil)
+}
+
+func newInternalRouterWithNow(t *testing.T, now func() time.Time) *gin.Engine {
 	t.Helper()
 	t.Setenv("INTERNAL_API_TOKEN", internalRBACToken)
-	return newRouter(t)
+	return newRouterWithNow(t, now)
 }
 
 func doInternal(r *gin.Engine, method, path, actorID, body string) *httptest.ResponseRecorder {

--- a/supabase/migrations/20260804000001_billing_request_now.sql
+++ b/supabase/migrations/20260804000001_billing_request_now.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION billing_request_now()
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+AS $$
+	SELECT COALESCE(
+		NULLIF(current_setting('superserve.billing_now', true), '')::timestamptz,
+		now()
+	)
+$$;


### PR DESCRIPTION
## Summary
- add precise `CurrentBillingPeriod` coverage for month rollover, year rollover, leap-day February, and nanosecond-adjacent boundaries
- split platform billing handler coverage into half-open interval semantics and exact-midnight rollover behavior
- add a billing finalization regression for month-boundary periods and keep ledger reconstruction aligned with the requested billing period

## Verification
- `go test ./internal/billing -run TestCurrentBillingPeriodBoundaries -count=1`
- `go test -tags=integration ./internal/integration -run 'TestPlatformBillingUsesHalfOpenMonthBoundaryForUsage|TestPlatformBillingUsesExactMonthBoundaryAtRollover|TestPlatformBillingUsesCurrentPeriodLedgerToReconstructOpeningBalance|TestIntegration_BillingPeriodFinalizationPreservesMonthBoundaryPeriodBounds' -count=1`