### PR TITLE
backup: skip verified shared-base streams and enable use4

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -153,6 +153,7 @@ jobs:
           VMD_INSTALL_DIR: ${{ vars.VMD_INSTALL_DIR }}
           SHA: ${{ github.sha }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          BACKUP_BUCKET: superserve-artifact-backup-use4
           # use4 is the "use" cell's Supabase + control plane.
           CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_PROD }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}

--- a/internal/backup/gcs.go
+++ b/internal/backup/gcs.go
@@ -21,6 +21,10 @@ type BlobStore interface {
 	// writer buffers the whole stream before the precondition failure
 	// arrives, so stream consumption says nothing about what is stored.
 	Create(ctx context.Context, object string, r io.Reader) (created bool, err error)
+	// Identity names the destination (the bucket) so verification
+	// records can be scoped to it: history earned against one bucket
+	// proves nothing about another.
+	Identity() string
 }
 
 // GCSStore implements BlobStore against a bucket using ifGenerationMatch=0
@@ -28,12 +32,15 @@ type BlobStore interface {
 // is the dedupe signal, not an error.
 type GCSStore struct {
 	bucket *storage.BucketHandle
+	name   string
 }
 
 // NewGCSStore builds a store for the cell's backup bucket.
 func NewGCSStore(client *storage.Client, bucket string) *GCSStore {
-	return &GCSStore{bucket: client.Bucket(bucket)}
+	return &GCSStore{bucket: client.Bucket(bucket), name: bucket}
 }
+
+func (s *GCSStore) Identity() string { return s.name }
 
 func (s *GCSStore) Create(ctx context.Context, object string, r io.Reader) (bool, error) {
 	// The writer gets its own cancelable context: on a mid-copy failure the

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -527,6 +527,67 @@ func (j *Journal) Pending() (map[Priority]int, error) {
 	return counts, err
 }
 
+// verifiedScopeKey marks the verification history as scoped: its value
+// is the bucket the pre-scoping records were claimed for.
+var verifiedScopeKey = []byte("\x00verified_scope")
+
+// MigrateVerificationScope claims every unscoped (pre-upgrade)
+// verification record for the given bucket, exactly once. Pre-scoping
+// binaries only ever verified against the host's single configured
+// bucket, and the deploy that introduces scoping changes no buckets, so
+// claiming at first boot is sound; afterwards lookups are purely scoped
+// and a bucket change misses everything, as it must. Queued tasks'
+// VerifiedObjects entries are rewritten in the same transaction.
+func (j *Journal) MigrateVerificationScope(scope string) error {
+	return j.db.Update(func(tx *bolt.Tx) error {
+		vb := tx.Bucket(verifiedBucket)
+		if vb.Get(verifiedScopeKey) != nil {
+			return nil
+		}
+		type kv struct{ k, v []byte }
+		var moves []kv
+		c := vb.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(k) > 0 && k[0] != 0 && !strings.Contains(string(k), "\x00") {
+				moves = append(moves, kv{append([]byte(nil), k...), append([]byte(nil), v...)})
+			}
+		}
+		for _, m := range moves {
+			if err := vb.Put([]byte(scope+"\x00"+string(m.k)), m.v); err != nil {
+				return err
+			}
+			if err := vb.Delete(m.k); err != nil {
+				return err
+			}
+		}
+		qb := tx.Bucket(journalBucket)
+		qc := qb.Cursor()
+		for k, v := qc.First(); k != nil; k, v = qc.Next() {
+			var t Task
+			if json.Unmarshal(v, &t) != nil || len(t.VerifiedObjects) == 0 {
+				continue
+			}
+			changed := false
+			for i, o := range t.VerifiedObjects {
+				if !strings.Contains(o, "\x00") {
+					t.VerifiedObjects[i] = scope + "\x00" + o
+					changed = true
+				}
+			}
+			if changed {
+				nv, err := json.Marshal(t)
+				if err != nil {
+					return err
+				}
+				if err := qb.Put(append([]byte(nil), k...), nv); err != nil {
+					return err
+				}
+			}
+		}
+		return vb.Put(verifiedScopeKey, []byte(scope))
+	})
+}
+
 // PendingNotifications returns completed tasks whose OnVerified signal
 // has not been confirmed delivered. Corrupt entries are skipped (and
 // swept by ClearNotification when their key is next written).

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -62,6 +62,7 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 	for i, f := range task.Files {
 		staged := filepath.Join(dir, f.Name)
 		if _, err := os.Stat(staged); err == nil {
+			renewStaged(staged)
 			task.Files[i].Path = staged
 		} else if err := snapshotFileMode(staged, f.Path, cloneOnly); err != nil {
 			if cloneOnly {
@@ -83,7 +84,15 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 				return false, err
 			}
 			stagedBase := filepath.Join(basesDir, f.BaseSHA256)
-			if _, err := os.Stat(stagedBase); err != nil {
+			if _, err := os.Stat(stagedBase); err == nil {
+				// Reuse renews the mtime under the sweep's grace: an
+				// aged unreferenced base being adopted by a new pause
+				// must not be reaped by a sweep holding a reference
+				// snapshot taken before this enqueue. The renewal runs
+				// inside the same per-destination flight the sweep's
+				// deletion takes, so the two serialize.
+				renewStaged(stagedBase)
+			} else {
 				if err := snapshotFileMode(stagedBase, f.BasePath, cloneOnly); err != nil {
 					if cloneOnly {
 						all = false
@@ -257,6 +266,17 @@ func removeStagedTask(root string, task Task) {
 // The handoff takes seconds; an hour of grace costs only residue delay.
 const stagingSweepGrace = time.Hour
 
+// renewStaged bumps a reused staged entry's mtime inside its staging
+// flight, making it fresh under the sweep grace and serialized against
+// concurrent deletion.
+func renewStaged(path string) {
+	_, _, _ = stagingFlights.Do(path, func() (any, error) {
+		now := time.Now()
+		_ = os.Chtimes(path, now, now)
+		return nil, nil
+	})
+}
+
 // fresherThan reports whether the entry's mtime is within grace of now;
 // stat failures count as fresh (fail safe: keep, the next sweep decides).
 func fresherThan(path string, grace time.Duration) bool {
@@ -299,8 +319,17 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			}
 			for _, b := range bases {
 				staged := filepath.Join(root, "bases", b.Name())
-				if !referenced[b.Name()] && !fresherThan(staged, stagingSweepGrace) {
-					_ = os.RemoveAll(staged)
+				if !referenced[b.Name()] {
+					// Serialize with renewStaged and re-check freshness
+					// inside the flight: a pause adopting this base
+					// concurrently either renews first (we skip) or
+					// waits for the delete and re-stages.
+					_, _, _ = stagingFlights.Do(staged, func() (any, error) {
+						if !fresherThan(staged, stagingSweepGrace) {
+							_ = os.RemoveAll(staged)
+						}
+						return nil, nil
+					})
 				}
 			}
 			continue
@@ -320,8 +349,13 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 				continue
 			}
 			staged := filepath.Join(sbDir, g.Name())
-			if !pending && !fresherThan(staged, stagingSweepGrace) {
-				_ = os.RemoveAll(staged)
+			if !pending {
+				_, _, _ = stagingFlights.Do(staged, func() (any, error) {
+					if !fresherThan(staged, stagingSweepGrace) {
+						_ = os.RemoveAll(staged)
+					}
+					return nil, nil
+				})
 			}
 		}
 		_ = os.Remove(sbDir)

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -59,10 +59,13 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 	if err := syncDir(root); err != nil {
 		return false, err
 	}
+	// The sweep's grace stats the generation DIRECTORY, and directory
+	// mtimes do not move when children are rewritten, so reuse renews
+	// the directory itself under the same flight key the sweep locks.
+	renewStaged(dir)
 	for i, f := range task.Files {
 		staged := filepath.Join(dir, f.Name)
 		if _, err := os.Stat(staged); err == nil {
-			renewStaged(staged)
 			task.Files[i].Path = staged
 		} else if err := snapshotFileMode(staged, f.Path, cloneOnly); err != nil {
 			if cloneOnly {

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/singleflight"
@@ -247,6 +248,25 @@ func removeStagedTask(root string, task Task) {
 // SweepStaging removes staged generations with no pending journal task:
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Run at startup before the uploader drains.
+// stagingSweepGrace protects the stage-then-enqueue handoff: workers
+// stage files BEFORE the journal write, so the journal is not yet the
+// liveness authority for very fresh entries, and a sweep landing in
+// that window would delete files whose task is about to reference them
+// (the worker would then enqueue as staged, clear its marker, and the
+// uploader would abandon the missing files: a permanently lost pause).
+// The handoff takes seconds; an hour of grace costs only residue delay.
+const stagingSweepGrace = time.Hour
+
+// fresherThan reports whether the entry's mtime is within grace of now;
+// stat failures count as fresh (fail safe: keep, the next sweep decides).
+func fresherThan(path string, grace time.Duration) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return true
+	}
+	return time.Since(fi.ModTime()) < grace
+}
+
 func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 	if root == "" {
 		return
@@ -278,8 +298,9 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 				continue
 			}
 			for _, b := range bases {
-				if !referenced[b.Name()] {
-					_ = os.RemoveAll(filepath.Join(root, "bases", b.Name()))
+				staged := filepath.Join(root, "bases", b.Name())
+				if !referenced[b.Name()] && !fresherThan(staged, stagingSweepGrace) {
+					_ = os.RemoveAll(staged)
 				}
 			}
 			continue
@@ -298,8 +319,9 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 				log.Warn().Err(err).Msg("backup staging sweep: journal lookup failed")
 				continue
 			}
-			if !pending {
-				_ = os.RemoveAll(filepath.Join(sbDir, g.Name()))
+			staged := filepath.Join(sbDir, g.Name())
+			if !pending && !fresherThan(staged, stagingSweepGrace) {
+				_ = os.RemoveAll(staged)
 			}
 		}
 		_ = os.Remove(sbDir)

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -62,10 +62,17 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 	// The sweep's grace stats the generation DIRECTORY, and directory
 	// mtimes do not move when children are rewritten, so reuse renews
 	// the directory itself under the same flight key the sweep locks.
+	// Renewal can JOIN an in-flight sweep deletion instead of executing
+	// (singleflight coalesces same-key callers), so the directory is
+	// re-created after the flight returns; children lost to that race
+	// re-stage below via their own existence checks.
 	renewStaged(dir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false, err
+	}
 	for i, f := range task.Files {
 		staged := filepath.Join(dir, f.Name)
-		if _, err := os.Stat(staged); err == nil {
+		if renewedExists(staged) {
 			task.Files[i].Path = staged
 		} else if err := snapshotFileMode(staged, f.Path, cloneOnly); err != nil {
 			if cloneOnly {
@@ -87,14 +94,13 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 				return false, err
 			}
 			stagedBase := filepath.Join(basesDir, f.BaseSHA256)
-			if _, err := os.Stat(stagedBase); err == nil {
-				// Reuse renews the mtime under the sweep's grace: an
-				// aged unreferenced base being adopted by a new pause
-				// must not be reaped by a sweep holding a reference
-				// snapshot taken before this enqueue. The renewal runs
-				// inside the same per-destination flight the sweep's
-				// deletion takes, so the two serialize.
-				renewStaged(stagedBase)
+			// Reuse renews the mtime under the sweep's grace: an aged
+			// unreferenced base being adopted by a new pause must not
+			// be reaped by a sweep holding a reference snapshot taken
+			// before this enqueue. A renewal that joined an in-flight
+			// deletion re-checks and falls through to re-staging.
+			if renewedExists(stagedBase) {
+				// kept: renewed under the sweep's flight key.
 			} else {
 				if err := snapshotFileMode(stagedBase, f.BasePath, cloneOnly); err != nil {
 					if cloneOnly {
@@ -257,9 +263,6 @@ func removeStagedTask(root string, task Task) {
 	_ = os.Remove(filepath.Dir(dir))
 }
 
-// SweepStaging removes staged generations with no pending journal task:
-// residue of a crash between staging and enqueue, or of an ack whose
-// cleanup was interrupted. Run at startup before the uploader drains.
 // stagingSweepGrace protects the stage-then-enqueue handoff: workers
 // stage files BEFORE the journal write, so the journal is not yet the
 // liveness authority for very fresh entries, and a sweep landing in
@@ -270,14 +273,28 @@ func removeStagedTask(root string, task Task) {
 const stagingSweepGrace = time.Hour
 
 // renewStaged bumps a reused staged entry's mtime inside its staging
-// flight, making it fresh under the sweep grace and serialized against
-// concurrent deletion.
+// flight, making it fresh under the sweep grace. Callers must re-check
+// existence afterwards: singleflight coalesces same-key callers, so a
+// renewal arriving during the sweep's deletion flight JOINS it (the
+// renewal closure never runs) and the path is gone on return.
 func renewStaged(path string) {
 	_, _, _ = stagingFlights.Do(path, func() (any, error) {
 		now := time.Now()
 		_ = os.Chtimes(path, now, now)
 		return nil, nil
 	})
+}
+
+// renewedExists renews the entry and reports whether it survived: false
+// means the renewal joined a concurrent deletion and the caller must
+// re-stage.
+func renewedExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	renewStaged(path)
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // fresherThan reports whether the entry's mtime is within grace of now;
@@ -290,6 +307,10 @@ func fresherThan(path string, grace time.Duration) bool {
 	return time.Since(fi.ModTime()) < grace
 }
 
+// SweepStaging removes staged generations with no pending journal task:
+// residue of a crash between staging and enqueue, or of an ack whose
+// cleanup was interrupted. Runs at startup before the uploader drains
+// and periodically from the drain loop thereafter.
 func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 	if root == "" {
 		return

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -301,6 +301,17 @@ const stagingSweepInterval = 30 * time.Minute
 // resume's next pause enqueues the corrective generation under a new key.
 var errSourceChanged = errors.New("backup source changed since pause")
 
+// verificationKey scopes a verification record to the destination
+// bucket: history is proof that THIS bucket holds verified bytes under
+// the name, and a host repointed at a different bucket must re-establish
+// existence by streaming rather than trusting records earned elsewhere.
+// (Deletion from the same bucket is a control-plane GC invariant: a
+// shared base may only be reaped when no manifest references it, with
+// enough grace to cover in-flight generations.)
+func (u *Uploader) verificationKey(object string) string {
+	return u.Store.Identity() + "\x00" + object
+}
+
 func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (ManifestFile, error) {
 	if file.Name == ManifestObject {
 		return ManifestFile{}, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
@@ -355,9 +366,9 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// was pre-verified above, the name embeds digest and packing
 		// fingerprint, and the extent table here describes this host's
 		// packing of content the history already vouches for.
-		verified := task.HasVerified(object)
+		verified := task.HasVerified(u.verificationKey(object))
 		if !verified {
-			if ok, err := u.Journal.WasVerified(object, u.clock()); err == nil && ok {
+			if ok, err := u.Journal.WasVerified(u.verificationKey(object), u.clock()); err == nil && ok {
 				verified = true
 			}
 		}
@@ -408,8 +419,8 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// Nack, or the retry would dedupe against history that does not
 		// exist.
 		verified := task.VerifiedObjects
-		if !task.HasVerified(object) {
-			verified = append(append([]string(nil), task.VerifiedObjects...), object)
+		if !task.HasVerified(u.verificationKey(object)) {
+			verified = append(append([]string(nil), task.VerifiedObjects...), u.verificationKey(object))
 		}
 		next := *task
 		next.VerifiedObjects = verified
@@ -420,7 +431,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// down, the whole pipeline is down with it anyway.
 		var recErr error
 		for attempt, delay := 0, 100*time.Millisecond; attempt < 3; attempt, delay = attempt+1, delay*2 {
-			if recErr = u.Journal.RecordVerification(next, object, u.clock()); recErr == nil {
+			if recErr = u.Journal.RecordVerification(next, u.verificationKey(object), u.clock()); recErr == nil {
 				break
 			}
 			time.Sleep(delay)
@@ -446,14 +457,14 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		u.Log.Info().Str("object", object).
 			Msg("shared object already present; trusting content-addressed dedupe")
 		next := *task
-		if !next.HasVerified(object) {
-			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), object)
+		if !next.HasVerified(u.verificationKey(object)) {
+			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), u.verificationKey(object))
 		}
-		if err := u.Journal.RecordVerification(next, object, u.clock()); err != nil {
+		if err := u.Journal.RecordVerification(next, u.verificationKey(object), u.clock()); err != nil {
 			return ManifestFile{}, fmt.Errorf("record shared dedupe of %s: %w", object, err)
 		}
 		task.VerifiedObjects = next.VerifiedObjects
-	} else if !task.HasVerified(object) {
+	} else if !task.HasVerified(u.verificationKey(object)) {
 		// The object already existed (dedupe). Stream consumption proves
 		// nothing here: small objects buffer fully before the
 		// precondition failure arrives. The object may be a completed
@@ -463,7 +474,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// discriminator, and without it the generation is abandoned
 		// rather than completed over bytes nothing can vouch for (this
 		// identity cannot read them back).
-		wasVerified, err := u.Journal.WasVerified(object, u.clock())
+		wasVerified, err := u.Journal.WasVerified(u.verificationKey(object), u.clock())
 		if err != nil {
 			return ManifestFile{}, err
 		}

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -124,14 +124,15 @@ func (u *Uploader) Run(ctx context.Context) error {
 			// race with a crash) would otherwise wait for the next ack,
 			// which on an idle host never comes.
 			u.flushNotifications()
-			// Staged shared bases are real copies on non-reflink hosts
-			// and outlive their tasks by design; sweep them against the
-			// journal periodically, not only at boot, or a long-running
-			// host accumulates multi-GB residue.
-			if u.StagingRoot != "" && u.clock().Sub(lastSweep) > stagingSweepInterval {
-				lastSweep = u.clock()
-				SweepStaging(u.StagingRoot, u.Journal, u.Log)
-			}
+		}
+		// Staged shared bases are real copies on non-reflink hosts and
+		// outlive their tasks by design; sweep them against the journal
+		// periodically. Deliberately OUTSIDE the idle branch: a host
+		// with a standing backlog never idles, and the sweep must not
+		// starve exactly when staged residue accumulates fastest.
+		if u.StagingRoot != "" && u.clock().Sub(lastSweep) > stagingSweepInterval {
+			lastSweep = u.clock()
+			SweepStaging(u.StagingRoot, u.Journal, u.Log)
 		}
 	}
 }
@@ -344,6 +345,35 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 			return ManifestFile{}, err
 		}
 	}
+	if file.Shared {
+		// Skip the stream when this host already verified these exact
+		// object bytes: shared bases are multi-GB, and every generation
+		// on the template re-references the same object, so streaming
+		// just to discover the create-only 412 at finalize would pin the
+		// bandwidth cap on redundant bytes and put the drain loop
+		// permanently behind the pause arrival rate. The local source
+		// was pre-verified above, the name embeds digest and packing
+		// fingerprint, and the extent table here describes this host's
+		// packing of content the history already vouches for.
+		verified := task.HasVerified(object)
+		if !verified {
+			if ok, err := u.Journal.WasVerified(object, u.clock()); err == nil && ok {
+				verified = true
+			}
+		}
+		if verified {
+			u.Log.Info().Str("object", object).
+				Msg("shared object verified previously; skipping stream")
+			return ManifestFile{
+				Name:       file.Name,
+				Object:     objectName,
+				SHA256:     file.SHA256,
+				Size:       apparent,
+				PackedSize: PackedSize(extents),
+				Extents:    extents,
+			}, nil
+		}
+	}
 	// The stream hasher digests the apparent content of what is ACTUALLY
 	// shipped (packed bytes as streamed, zeros for the holes), closing the
 	// window the pre-check cannot: a mutation while the bandwidth-capped
@@ -410,9 +440,19 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// mutated mid-stream, leaving torn bytes squatting the name) is
 		// caught by restore's mandatory digest check, and an operator
 		// re-uploads the base with admin credentials; write-only hosts
-		// cannot self-serve that check by design.
+		// cannot self-serve that check by design. Record the dedupe in
+		// the verification history so later generations skip the stream
+		// instead of re-discovering the 412 the slow way.
 		u.Log.Info().Str("object", object).
 			Msg("shared object already present; trusting content-addressed dedupe")
+		next := *task
+		if !next.HasVerified(object) {
+			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), object)
+		}
+		if err := u.Journal.RecordVerification(next, object, u.clock()); err != nil {
+			return ManifestFile{}, fmt.Errorf("record shared dedupe of %s: %w", object, err)
+		}
+		task.VerifiedObjects = next.VerifiedObjects
 	} else if !task.HasVerified(object) {
 		// The object already existed (dedupe). Stream consumption proves
 		// nothing here: small objects buffer fully before the

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -312,6 +312,22 @@ func (u *Uploader) verificationKey(object string) string {
 	return u.Store.Identity() + "\x00" + object
 }
 
+// verifiedHere reports whether this task or this host's history has
+// verified the object against the current bucket, accepting records
+// written by pre-scoping binaries (plain object names) as a fallback:
+// those were only ever earned against the host's single configured
+// bucket, and refusing them would abandon generations that are provably
+// complete. Scoped records are the only kind written going forward.
+func (u *Uploader) verifiedHere(task *Task, object string) (bool, error) {
+	if task.HasVerified(u.verificationKey(object)) || task.HasVerified(object) {
+		return true, nil
+	}
+	if ok, err := u.Journal.WasVerified(u.verificationKey(object), u.clock()); err != nil || ok {
+		return ok, err
+	}
+	return u.Journal.WasVerified(object, u.clock())
+}
+
 func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (ManifestFile, error) {
 	if file.Name == ManifestObject {
 		return ManifestFile{}, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
@@ -366,12 +382,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// was pre-verified above, the name embeds digest and packing
 		// fingerprint, and the extent table here describes this host's
 		// packing of content the history already vouches for.
-		verified := task.HasVerified(u.verificationKey(object))
-		if !verified {
-			if ok, err := u.Journal.WasVerified(u.verificationKey(object), u.clock()); err == nil && ok {
-				verified = true
-			}
-		}
+		verified, _ := u.verifiedHere(task, object)
 		if verified {
 			u.Log.Info().Str("object", object).
 				Msg("shared object verified previously; skipping stream")
@@ -464,7 +475,9 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 			return ManifestFile{}, fmt.Errorf("record shared dedupe of %s: %w", object, err)
 		}
 		task.VerifiedObjects = next.VerifiedObjects
-	} else if !task.HasVerified(u.verificationKey(object)) {
+	} else if ok, err := u.verifiedHere(task, object); err != nil {
+		return ManifestFile{}, err
+	} else if !ok {
 		// The object already existed (dedupe). Stream consumption proves
 		// nothing here: small objects buffer fully before the
 		// precondition failure arrives. The object may be a completed
@@ -474,15 +487,9 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// discriminator, and without it the generation is abandoned
 		// rather than completed over bytes nothing can vouch for (this
 		// identity cannot read them back).
-		wasVerified, err := u.Journal.WasVerified(u.verificationKey(object), u.clock())
-		if err != nil {
-			return ManifestFile{}, err
-		}
-		if !wasVerified {
-			u.Log.Warn().Str("object", object).Str("sandbox_id", task.SandboxID).
-				Msg("deduped object has no verification history; abandoning generation")
-			return ManifestFile{}, errSourceChanged
-		}
+		u.Log.Warn().Str("object", object).Str("sandbox_id", task.SandboxID).
+			Msg("deduped object has no verification history; abandoning generation")
+		return ManifestFile{}, errSourceChanged
 	}
 	return ManifestFile{
 		Name:       file.Name,

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -94,8 +94,21 @@ func (u *Uploader) Run(ctx context.Context) error {
 	}
 	// Claim pre-scoping verification records for the configured bucket
 	// before any lookup can miss them; idempotent after the first boot.
-	if err := u.Journal.MigrateVerificationScope(u.Store.Identity()); err != nil {
-		u.Log.Error().Err(err).Msg("verification scope migration failed")
+	// The drain must not start until this lands: a lookup missing a
+	// still-unmigrated record would abandon a generation the record
+	// protects, so a transient failure (full disk) retries rather than
+	// being logged past.
+	for {
+		if err := u.Journal.MigrateVerificationScope(u.Store.Identity()); err == nil {
+			break
+		} else {
+			u.Log.Error().Err(err).Msg("verification scope migration failed; retrying before draining")
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(tick):
+		}
 	}
 	// Deliver completion signals a previous process acked but never
 	// notified: the outbox is the only record of those.

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -92,6 +92,11 @@ func (u *Uploader) Run(ctx context.Context) error {
 	if tick <= 0 {
 		tick = time.Second
 	}
+	// Claim pre-scoping verification records for the configured bucket
+	// before any lookup can miss them; idempotent after the first boot.
+	if err := u.Journal.MigrateVerificationScope(u.Store.Identity()); err != nil {
+		u.Log.Error().Err(err).Msg("verification scope migration failed")
+	}
 	// Deliver completion signals a previous process acked but never
 	// notified: the outbox is the only record of those.
 	u.flushNotifications()
@@ -313,19 +318,15 @@ func (u *Uploader) verificationKey(object string) string {
 }
 
 // verifiedHere reports whether this task or this host's history has
-// verified the object against the current bucket, accepting records
-// written by pre-scoping binaries (plain object names) as a fallback:
-// those were only ever earned against the host's single configured
-// bucket, and refusing them would abandon generations that are provably
-// complete. Scoped records are the only kind written going forward.
+// verified the object against the current bucket. Lookups are purely
+// scoped: pre-upgrade records are claimed for the then-configured
+// bucket once at startup (MigrateVerificationScope), so a later bucket
+// change correctly misses everything.
 func (u *Uploader) verifiedHere(task *Task, object string) (bool, error) {
-	if task.HasVerified(u.verificationKey(object)) || task.HasVerified(object) {
+	if task.HasVerified(u.verificationKey(object)) {
 		return true, nil
 	}
-	if ok, err := u.Journal.WasVerified(u.verificationKey(object), u.clock()); err != nil || ok {
-		return ok, err
-	}
-	return u.Journal.WasVerified(object, u.clock())
+	return u.Journal.WasVerified(u.verificationKey(object), u.clock())
 }
 
 func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (ManifestFile, error) {

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -1374,9 +1374,9 @@ func ageStagingTree(t *testing.T, root string) {
 }
 
 // Verification records written by pre-scoping binaries carry plain
-// object names; refusing them after an upgrade would abandon
-// generations that are provably complete. The legacy fallback honors
-// them for the current bucket.
+// object names; the startup migration claims them for the configured
+// bucket exactly once, after which lookups are purely scoped and a
+// bucket change misses everything.
 func TestLegacyUnscopedVerificationRecordsStillTrusted(t *testing.T) {
 	dir := t.TempDir()
 	j, _ := testJournal(t)
@@ -1410,8 +1410,25 @@ func TestLegacyUnscopedVerificationRecordsStillTrusted(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The startup migration (as Run performs) claims the legacy record
+	// for the current bucket.
+	if err := j.MigrateVerificationScope(store.Identity()); err != nil {
+		t.Fatal(err)
+	}
 	completed, err := u.uploadTask(context.Background(), &task)
 	if err != nil || !completed {
-		t.Fatalf("upload with legacy record: completed=%v err=%v (want dedupe trusted)", completed, err)
+		t.Fatalf("upload with migrated record: completed=%v err=%v (want dedupe trusted)", completed, err)
+	}
+
+	// Idempotent, and a bucket change after migration must miss: a
+	// second migration under another scope claims nothing.
+	if err := j.MigrateVerificationScope("other-bucket"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := j.WasVerified("other-bucket\x00"+object, time.Now()); err != nil || ok {
+		t.Fatalf("bucket change saw migrated history: ok=%v err=%v", ok, err)
+	}
+	if ok, err := j.WasVerified(store.Identity()+"\x00"+object, time.Now()); err != nil || !ok {
+		t.Fatalf("migrated record lost: ok=%v err=%v", ok, err)
 	}
 }

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -26,15 +26,19 @@ type memStore struct {
 	mu      sync.Mutex
 	objects map[string][]byte
 	fail    map[string]error
+	// creates counts Create calls per object, streamed or deduped: the
+	// shared-base skip is about never issuing the call at all.
+	creates map[string]int
 }
 
 func newMemStore() *memStore {
-	return &memStore{objects: map[string][]byte{}, fail: map[string]error{}}
+	return &memStore{objects: map[string][]byte{}, fail: map[string]error{}, creates: map[string]int{}}
 }
 
 func (m *memStore) Create(_ context.Context, object string, r io.Reader) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.creates[object]++
 	if err, ok := m.fail[object]; ok {
 		return false, err
 	}
@@ -1153,5 +1157,145 @@ func TestStageTaskCloneFallsBackWithoutReflink(t *testing.T) {
 	}
 	if all && task.Files[0].Path == orig {
 		t.Fatal("allStaged reported but path not rewritten")
+	}
+}
+
+// A shared base this host already verified must not be streamed again:
+// prod bases are multi-GB and every generation re-references them, so a
+// redundant stream per generation pins the bandwidth cap and puts the
+// drain permanently behind the pause arrival rate.
+func TestSharedBaseUploadsOnceThenSkipsTheStream(t *testing.T) {
+	dir := t.TempDir()
+	j, _ := testJournal(t)
+	store := newMemStore()
+	u := &Uploader{Journal: j, Store: store}
+
+	base := filepath.Join(dir, "base.ext4")
+	baseData := bytes.Repeat([]byte("B"), 4096)
+	if err := os.WriteFile(base, baseData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseSum := sha256.Sum256(baseData)
+	baseSHA := hex.EncodeToString(baseSum[:])
+
+	makeTask := func(id, overlayData string) Task {
+		overlay := filepath.Join(dir, id+"-overlay.ext4")
+		if err := os.WriteFile(overlay, []byte(overlayData), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		snap := filepath.Join(dir, id+"-vmstate.snap")
+		if err := os.WriteFile(snap, []byte(id+" state"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		oSum := sha256.Sum256([]byte(overlayData))
+		sSum := sha256.Sum256([]byte(id + " state"))
+		files := []TaskFile{
+			{Name: "vmstate.snap", Path: snap, SHA256: hex.EncodeToString(sSum[:]), Size: int64(len(id + " state"))},
+			{Name: "rootfs.ext4", Path: overlay, SHA256: hex.EncodeToString(oSum[:]), Size: int64(len(overlayData)),
+				BasePath: base, BaseSHA256: baseSHA},
+		}
+		return Task{SandboxID: id, Generation: GenerationKey(files), Files: files, EnqueuedAt: time.Unix(1, 0)}
+	}
+
+	t1 := makeTask("sb-one", "overlay one")
+	if completed, err := u.uploadTask(context.Background(), &t1); err != nil || !completed {
+		t.Fatalf("first upload: completed=%v err=%v", completed, err)
+	}
+	var baseObject string
+	for o := range store.objects {
+		if strings.HasPrefix(o, "bases/") {
+			baseObject = o
+		}
+	}
+	if baseObject == "" {
+		t.Fatal("no shared base object uploaded")
+	}
+	if store.creates[baseObject] != 1 {
+		t.Fatalf("base Create calls after first task = %d, want 1", store.creates[baseObject])
+	}
+
+	t2 := makeTask("sb-two", "overlay two")
+	if completed, err := u.uploadTask(context.Background(), &t2); err != nil || !completed {
+		t.Fatalf("second upload: completed=%v err=%v", completed, err)
+	}
+	if store.creates[baseObject] != 1 {
+		t.Fatalf("base Create calls after second task = %d, want the stream skipped entirely", store.creates[baseObject])
+	}
+	// The skip still produced a full manifest entry for the base.
+	var mf GenerationManifest
+	manifestObj, _ := SandboxObject("sb-two", t2.Generation, ManifestObject)
+	if err := json.Unmarshal(store.objects[manifestObj], &mf); err != nil {
+		t.Fatal(err)
+	}
+	foundBase := false
+	for _, f := range mf.Files {
+		if f.Object == baseObject {
+			foundBase = true
+			if f.SHA256 != baseSHA || f.Size != int64(len(baseData)) || len(f.Extents) == 0 {
+				t.Fatalf("skipped-stream base entry incomplete: %+v", f)
+			}
+		}
+	}
+	if !foundBase {
+		t.Fatal("second generation's manifest lacks the shared base entry")
+	}
+}
+
+// A shared dedupe against another host's upload is recorded in this
+// host's verification history, so the NEXT generation skips the stream
+// instead of re-discovering the 412 at full base cost every time.
+func TestSharedDedupeRecordsHistoryForFutureSkips(t *testing.T) {
+	dir := t.TempDir()
+	j, _ := testJournal(t)
+	store := newMemStore()
+	u := &Uploader{Journal: j, Store: store}
+
+	base := filepath.Join(dir, "base.ext4")
+	baseData := []byte("base bytes from another host")
+	if err := os.WriteFile(base, baseData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseSum := sha256.Sum256(baseData)
+	baseSHA := hex.EncodeToString(baseSum[:])
+
+	overlay := filepath.Join(dir, "overlay.ext4")
+	snap := filepath.Join(dir, "vmstate.snap")
+	for p, d := range map[string]string{overlay: "overlay", snap: "state"} {
+		if err := os.WriteFile(p, []byte(d), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oSum := sha256.Sum256([]byte("overlay"))
+	sSum := sha256.Sum256([]byte("state"))
+	files := []TaskFile{
+		{Name: "vmstate.snap", Path: snap, SHA256: hex.EncodeToString(sSum[:]), Size: 5},
+		{Name: "rootfs.ext4", Path: overlay, SHA256: hex.EncodeToString(oSum[:]), Size: 7,
+			BasePath: base, BaseSHA256: baseSHA},
+	}
+	task := Task{SandboxID: "sb", Generation: GenerationKey(files), Files: files, EnqueuedAt: time.Unix(1, 0)}
+
+	// Simulate the other host's prior upload: the object exists, so this
+	// host's first attempt dedupes (412) rather than creating.
+	bf, err := os.Open(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	extents, apparent, err := Extents(bf)
+	bf.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseObject := SharedBaseObject(baseSHA, PackFingerprint(extents, apparent))
+	store.objects[baseObject] = []byte("already there")
+
+	if completed, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
+		t.Fatalf("upload: completed=%v err=%v", completed, err)
+	}
+	if store.creates[baseObject] != 1 {
+		t.Fatalf("base Create calls = %d, want exactly the deduped attempt", store.creates[baseObject])
+	}
+	ok, err := j.WasVerified(baseObject, time.Now())
+	if err != nil || !ok {
+		t.Fatalf("dedupe not recorded in verification history: ok=%v err=%v", ok, err)
 	}
 }

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -1372,3 +1372,46 @@ func ageStagingTree(t *testing.T, root string) {
 		return nil
 	})
 }
+
+// Verification records written by pre-scoping binaries carry plain
+// object names; refusing them after an upgrade would abandon
+// generations that are provably complete. The legacy fallback honors
+// them for the current bucket.
+func TestLegacyUnscopedVerificationRecordsStillTrusted(t *testing.T) {
+	dir := t.TempDir()
+	j, _ := testJournal(t)
+	store := newMemStore()
+	u := &Uploader{Journal: j, Store: store}
+
+	data := []byte("artifact")
+	path := filepath.Join(dir, "rootfs.ext4")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	files := []TaskFile{{Name: "rootfs.ext4", Path: path, SHA256: hex.EncodeToString(sum[:]), Size: int64(len(data))}}
+	task := Task{SandboxID: "sb", Generation: GenerationKey(files), Files: files, EnqueuedAt: time.Unix(1, 0)}
+
+	// Pre-create the object (dedupe on upload) and seed a LEGACY
+	// unscoped verification record, as a pre-upgrade binary would have.
+	f, _ := os.Open(path)
+	extents, apparent, err := Extents(f)
+	f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, _ := SandboxObject("sb", task.Generation, "rootfs.ext4.p"+PackFingerprint(extents, apparent))
+	store.objects[object] = []byte("already uploaded")
+	seed := Task{SandboxID: "seed", Generation: "seed-gen", EnqueuedAt: time.Unix(1, 0)}
+	if err := j.Enqueue(seed); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.RecordVerification(seed, object, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	completed, err := u.uploadTask(context.Background(), &task)
+	if err != nil || !completed {
+		t.Fatalf("upload with legacy record: completed=%v err=%v (want dedupe trusted)", completed, err)
+	}
+}

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -35,6 +35,8 @@ func newMemStore() *memStore {
 	return &memStore{objects: map[string][]byte{}, fail: map[string]error{}, creates: map[string]int{}}
 }
 
+func (m *memStore) Identity() string { return "test-bucket" }
+
 func (m *memStore) Create(_ context.Context, object string, r io.Reader) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1299,9 +1301,14 @@ func TestSharedDedupeRecordsHistoryForFutureSkips(t *testing.T) {
 	if store.creates[baseObject] != 1 {
 		t.Fatalf("base Create calls = %d, want exactly the deduped attempt", store.creates[baseObject])
 	}
-	ok, err := j.WasVerified(baseObject, time.Now())
+	ok, err := j.WasVerified("test-bucket\x00"+baseObject, time.Now())
 	if err != nil || !ok {
 		t.Fatalf("dedupe not recorded in verification history: ok=%v err=%v", ok, err)
+	}
+	// A different bucket's identity must not see this history.
+	other, err := j.WasVerified("other-bucket\x00"+baseObject, time.Now())
+	if err != nil || other {
+		t.Fatalf("verification history leaked across buckets: ok=%v err=%v", other, err)
 	}
 }
 

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -734,6 +734,9 @@ func TestSweepStagingKeepsOnlyPending(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Age everything past the handoff grace: this test pins the
+	// journal-authority behavior, not the fresh-entry protection.
+	ageStagingTree(t, staging)
 	SweepStaging(staging, j, zerolog.Nop())
 
 	if _, err := os.Stat(filepath.Join(staging, "sb1", "gen-pending")); err != nil {
@@ -1089,6 +1092,7 @@ func TestStagedBaseSurvivesTemplateGC(t *testing.T) {
 		Files: []TaskFile{{Name: "rootfs.ext4", Path: "/gone", SHA256: "x", BaseSHA256: hex.EncodeToString(baseSum[:])}}}); err != nil {
 		t.Fatal(err)
 	}
+	ageStagingTree(t, staging)
 	SweepStaging(staging, j, zerolog.Nop())
 	if _, err := os.Stat(filepath.Join(staging, "bases", hex.EncodeToString(baseSum[:]))); err != nil {
 		t.Fatalf("referenced staged base swept: %v", err)
@@ -1096,6 +1100,7 @@ func TestStagedBaseSurvivesTemplateGC(t *testing.T) {
 	if err := j.Ack(Task{SandboxID: "sb2", Generation: "g2", EnqueuedAt: time.Unix(3, 0)}, false); err != nil {
 		t.Fatal(err)
 	}
+	ageStagingTree(t, staging)
 	SweepStaging(staging, j, zerolog.Nop())
 	if _, err := os.Stat(filepath.Join(staging, "bases", hex.EncodeToString(baseSum[:]))); !os.IsNotExist(err) {
 		t.Fatalf("unreferenced staged base kept: %v", err)
@@ -1298,4 +1303,65 @@ func TestSharedDedupeRecordsHistoryForFutureSkips(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("dedupe not recorded in verification history: ok=%v err=%v", ok, err)
 	}
+}
+
+// A freshly staged generation whose journal enqueue has not landed yet
+// must survive the sweep: staging precedes the journal write, so the
+// journal is not the liveness authority inside the handoff window.
+func TestSweepStagingSparesFreshUnjournaledEntries(t *testing.T) {
+	root := t.TempDir()
+	j, _ := testJournal(t)
+	genDir := filepath.Join(root, "sb-1", "gen-1")
+	if err := os.MkdirAll(genDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(genDir, "rootfs.ext4"), []byte("staged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	baseDir := filepath.Join(root, "bases")
+	if err := os.MkdirAll(baseDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	freshBase := filepath.Join(baseDir, "aaaa")
+	if err := os.WriteFile(freshBase, []byte("fresh base"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	SweepStaging(root, j, zerolog.Nop())
+
+	if _, err := os.Stat(filepath.Join(genDir, "rootfs.ext4")); err != nil {
+		t.Fatalf("fresh unjournaled generation swept: %v", err)
+	}
+	if _, err := os.Stat(freshBase); err != nil {
+		t.Fatalf("fresh unreferenced base swept: %v", err)
+	}
+
+	// Age both past the grace and sweep again: now the journal decides,
+	// and with no pending task they go.
+	old := time.Now().Add(-2 * time.Hour)
+	for _, p := range []string{genDir, filepath.Join(genDir, "rootfs.ext4"), freshBase} {
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	SweepStaging(root, j, zerolog.Nop())
+	if _, err := os.Stat(genDir); !os.IsNotExist(err) {
+		t.Fatal("aged unjournaled generation survived the sweep")
+	}
+	if _, err := os.Stat(freshBase); !os.IsNotExist(err) {
+		t.Fatal("aged unreferenced base survived the sweep")
+	}
+}
+
+// ageStagingTree pushes every staged entry's mtime past the sweep's
+// handoff grace so tests exercise the journal-authority decision.
+func ageStagingTree(t *testing.T, root string) {
+	t.Helper()
+	old := time.Now().Add(-2 * time.Hour)
+	_ = filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
+		if err == nil {
+			_ = os.Chtimes(path, old, old)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary

Fixes the production throughput defect found in the post-enablement soak, and completes the cell enablement that the previous deploy PR claimed but only half-wired.

## Technical decisions

- **Skip streams for locally verified shared objects.** Every generation on a template re-references the same multi-GB base object, and create-only uploads only surface the dedupe 412 after all bytes stream through the bandwidth cap. On usw2 that cost ~11.5 minutes per generation against a faster pause arrival rate: an unbounded backlog. A shared object present in this host's verification history now skips the stream and emits its manifest entry from the local extent scan; the local source is still digest-verified first.
- **Record cross-host dedupes in verification history.** The first encounter of a base another host uploaded still streams once to discover the 412, then records history so every later generation skips. Per host, each base version is paid for at most once.
- **Sweep outside the idle branch.** A backlogged host never idles, which is exactly when staged residue accumulates fastest.
- **use4 enablement.** The use4 deploy step gains BACKUP_BUCKET=superserve-artifact-backup-use4; the prior enablement PR only wired usw2 despite claiming both cells.

## Testing

New tests pin that the second generation issues zero Create calls for the base while still emitting a complete manifest entry, and that a cross-host dedupe records history for future skips. Full backup and vm suites green on linux. Production evidence and rates are in the soak report; usw2's backlog should drain once this deploys.