### PR TITLE
infra: raise east control-plane DB pool to 15 conns per instance

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -165,7 +165,7 @@ module "api" {
     SUPABASE_URL           = var.supabase_url
     SECRETS_SIGNING_KEY_ID = "v1"
     ALLOW_EPHEMERAL_SEED   = "0"
-    DB_MAX_CONNS           = "12"
+    DB_MAX_CONNS           = "15"
     VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
     # OTEL_* is intentionally omitted here: the live service has no OTEL env, so


### PR DESCRIPTION
Aligns the control plane's client-side connection ceiling with the transaction pooler's server pool: at the steady instance count the per-instance limit of 12 underfills the pooler's server pool, making the client side the binding constraint on concurrent sandbox inserts. 15 per instance matches the pools at steady state.

Headroom checks: at the observed max scale-out the client count stays well under the pooler's client limit, and the pooler's server pool (the bound the quota margin keys on — see the comment at the pool setup in cmd/controlplane/main.go) is unchanged, so no margin change is needed. East only; the west cell's pooler is separately sized and unchanged.

Rolls a new Cloud Run revision on apply — instances recycle gradually, standard env-change rollout.