### PR TITLE
infra: suppress INFORMATIONAL-severity Cloud IDS alerts

### DIFF
--- a/infra/modules/cloud-ids/main.tf
+++ b/infra/modules/cloud-ids/main.tf
@@ -66,6 +66,7 @@ resource "google_monitoring_alert_policy" "ids_threats" {
         log_id("ids.googleapis.com/threat")
         AND resource.type="ids.googleapis.com/Endpoint"
         AND resource.labels.id="${var.endpoint_name}"
+        AND jsonPayload.alert_severity!="INFORMATIONAL"
       EOT
     }
   }


### PR DESCRIPTION
## Summary
Both regional Cloud IDS alert policies (`superserve-ids-use4`, `superserve-ids-usw2`) were repeatedly paging on generic internet scanner noise hitting the public sandbox proxy port: `.env` scans, `wp-login.php` probes, HTTP path-traversal probes, and one Confluence CVE probe. All of these came in as INFORMATIONAL (or one MEDIUM) severity from a wide, rotating set of Google front-end IPs, consistent with routine internet background scanning rather than targeted activity.

Since both cells share the `infra/modules/cloud-ids` module, this adds one filter clause to the alert policy's log-match condition to exclude INFORMATIONAL-severity threat log entries. The Cloud IDS endpoint itself still logs at INFORMATIONAL (unchanged `endpoint_severity` default), so the underlying threat log is untouched for later review. LOW/MEDIUM/HIGH/CRITICAL matches still alert as before.

## Technical decisions
- Filtered at the alert policy level (`jsonPayload.alert_severity!="INFORMATIONAL"`) rather than raising `endpoint_severity`, so nothing is lost from Cloud Logging, only the noisy tier stops opening incidents.

## Testing
- `terraform fmt -check` on the changed file
- No plan/apply run yet, this needs to go through the normal production plan/apply for `us-east4` and `us-west2`