### PR TITLE
fix(api): give each DB call in cleanupExpiredRevocations its own timeout

### DIFF
--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -114,9 +114,9 @@ func (h *Handlers) sweepOrphanedIntervals(ctx context.Context) {
 // cleanupExpiredRevocations deletes sandbox_revocation and revoked_proxy_token
 // rows past their TTL — once no live JWT can carry them, the entries are moot.
 func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
-	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	n, err := h.DB.DeleteExpiredSandboxRevocations(queryCtx)
+	revokeCtx, revokeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer revokeCancel()
+	n, err := h.DB.DeleteExpiredSandboxRevocations(revokeCtx)
 	if err != nil {
 		log.Warn().Err(err).Msg("reaper: cleanup revocations failed")
 		return
@@ -125,7 +125,9 @@ func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
 		log.Info().Int64("reaped", n).Msg("reaper: deleted expired sandbox revocations")
 	}
 
-	tn, err := h.DB.DeleteExpiredRevokedProxyTokens(queryCtx)
+	tokenCtx, tokenCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer tokenCancel()
+	tn, err := h.DB.DeleteExpiredRevokedProxyTokens(tokenCtx)
 	if err != nil {
 		log.Warn().Err(err).Msg("reaper: cleanup revoked proxy tokens failed")
 		return

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -366,3 +366,53 @@ func TestReaper_LoopRunsImmediately(t *testing.T) {
 	}
 	t.Fatal("reaper did not run immediately on startup")
 }
+
+// TestCleanupExpiredRevocations_IndependentTimeouts verifies that the two DB
+// calls in cleanupExpiredRevocations each receive their own deadline rather
+// than sharing a single context. If they shared one context and the first
+// call ran for nearly the full budget, the second would get a near-zero
+// deadline and fail with DeadlineExceeded. With independent contexts the
+// second call always has a fresh 5-second budget.
+func TestCleanupExpiredRevocations_IndependentTimeouts(t *testing.T) {
+	const budget = 5 * time.Second
+
+	var firstDeadline, secondDeadline time.Time
+	var callCount int32
+
+	mock := &reaperMockDBTX{
+		execFn: func(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			n := atomic.AddInt32(&callCount, 1)
+			dl, ok := ctx.Deadline()
+			if !ok {
+				t.Errorf("call %d: context has no deadline", n)
+				return pgconn.CommandTag{}, nil
+			}
+			switch n {
+			case 1:
+				firstDeadline = dl
+			case 2:
+				secondDeadline = dl
+			}
+			return pgconn.CommandTag{}, nil
+		},
+	}
+	h := &Handlers{DB: db.New(mock)}
+	h.cleanupExpiredRevocations(context.Background())
+
+	if atomic.LoadInt32(&callCount) != 2 {
+		t.Fatalf("expected 2 DB exec calls, got %d", callCount)
+	}
+
+	// Each deadline must be approximately `budget` from now, not from the
+	// start of the function. A shared context would give the second call a
+	// deadline close to the first's, meaning it started from the same origin.
+	// With independent contexts both deadlines are >= budget - small delta.
+	const slack = time.Second
+	now := time.Now()
+	if d := firstDeadline.Sub(now); d < budget-slack {
+		t.Errorf("first call deadline too soon: %v remaining (want >= %v)", d, budget-slack)
+	}
+	if d := secondDeadline.Sub(now); d < budget-slack {
+		t.Errorf("second call deadline too soon: %v remaining (want >= %v)", d, budget-slack)
+	}
+}

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -415,4 +415,7 @@ func TestCleanupExpiredRevocations_IndependentTimeouts(t *testing.T) {
 	if d := secondDeadline.Sub(now); d < budget-slack {
 		t.Errorf("second call deadline too soon: %v remaining (want >= %v)", d, budget-slack)
 	}
+	if !secondDeadline.After(firstDeadline) {
+		t.Errorf("second deadline (%v) must be strictly after first deadline (%v)", secondDeadline, firstDeadline)
+	}
 }


### PR DESCRIPTION
## Summary

- Give `DeleteExpiredSandboxRevocations` and `DeleteExpiredRevokedProxyTokens` independent 5-second timeout contexts (`revokeCtx` and `tokenCtx`) in `cleanupExpiredRevocations`.
- Add unit test `TestCleanupExpiredRevocations_IndependentTimeouts` in `internal/api/reaper_test.go`.

## Why

Both DB cleanup operations previously shared a single 5-second timeout context. If `DeleteExpiredSandboxRevocations` consumed most of the 5-second budget (e.g., under DB contention), `DeleteExpiredRevokedProxyTokens` received a near-zero remaining deadline and failed with `DeadlineExceeded`. Providing independent contexts ensures neither cleanup step starves the other regardless of execution duration.

## Test Plan

- [x] Build verification: `go build ./internal/api/` passed
- [x] Unit tests pass: `go test ./internal/api/ -short -run 'TestCleanupExpiredRevocations' -v` passed
- [x] Short test suite pass: `make test-short` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @meAmitPatil @pavitrabhalla