### PR TITLE
fix(api): update email subject line for quota alerts

### DIFF
--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -317,7 +317,7 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	payload := map[string]any{
 		"from":    n.from,
 		"to":      []string{to},
-		"subject": "Sandbox limit reached for your team",
+		"subject": "You're approaching your sandbox limit",
 		"html":    quotaEmailHTML(a),
 	}
 	body, err := json.Marshal(payload)
@@ -365,17 +365,17 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 
 // quotaEmailHTML renders the quota alert email body inside the shared shell.
 func quotaEmailHTML(a QuotaAlert) string {
-	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">Sandbox limit reached for your team</h1>
+	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">You're approaching your sandbox limit</h1>
 <p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We're glad to see increasing usage on your Superserve account. For security reasons, we limit the number of active sandboxes on new accounts to <strong style="color:#e5e5e5;">%d</strong>. To request a higher limit, book a meeting using the link below, or reply to this email with:</p>
 <ul style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;padding-left:20px;">
 <li>a link to your website or domain</li>
 <li>a company email address</li>
 <li>a brief description of your use case</li>
 </ul>
-<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We review every request and aim to respond within 48 hours. Our goal is to provide infinite compute to power your agents, and this verification helps us allocate capacity safely and responsibly across all our customers.</p>
+<p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We review every request and aim to respond within 48 hours. Our goal is to provide infinite compute to power your agents, and this review helps us allocate capacity safely and responsibly across all our customers.</p>
 <a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>`,
 		a.Limit, emailMeetingURL)
-	return emailShell("Sandbox limit reached for your team", body)
+	return emailShell("You're approaching your sandbox limit", body)
 }
 
 // emailShell wraps body HTML in the shared Superserve email chrome — logo header,

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -363,9 +363,9 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	}
 }
 
-// quotaEmailHTML renders the team-verification email body inside the shared shell.
+// quotaEmailHTML renders the quota alert email body inside the shared shell.
 func quotaEmailHTML(a QuotaAlert) string {
-	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">Verify your team on Superserve</h1>
+	body := fmt.Sprintf(`<h1 style="font-family:'Instrument Sans',Helvetica,Arial,sans-serif;color:#e5e5e5;font-size:20px;font-weight:600;letter-spacing:-0.01em;margin:0 0 24px 0;">Sandbox limit reached for your team</h1>
 <p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We're glad to see increasing usage on your Superserve account. For security reasons, we limit the number of active sandboxes on new accounts to <strong style="color:#e5e5e5;">%d</strong>. To request a higher limit, book a meeting using the link below, or reply to this email with:</p>
 <ul style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;padding-left:20px;">
 <li>a link to your website or domain</li>
@@ -375,7 +375,7 @@ func quotaEmailHTML(a QuotaAlert) string {
 <p style="color:#a3a3a3;font-size:14px;line-height:24px;margin:0 0 16px 0;">We review every request and aim to respond within 48 hours. Our goal is to provide infinite compute to power your agents, and this verification helps us allocate capacity safely and responsibly across all our customers.</p>
 <a href="%s" style="background-color:#e5e5e5;color:#0a0a0a;font-family:'Geist Mono',monospace;font-size:12px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;text-decoration:none;text-align:center;display:block;padding:14px 24px;margin:28px 0 0 0;">Book a Meeting</a>`,
 		a.Limit, emailMeetingURL)
-	return emailShell("Verify your team on Superserve", body)
+	return emailShell("Sandbox limit reached for your team", body)
 }
 
 // emailShell wraps body HTML in the shared Superserve email chrome — logo header,

--- a/internal/api/quota_watcher.go
+++ b/internal/api/quota_watcher.go
@@ -317,7 +317,7 @@ func (n *EmailQuotaNotifier) Notify(ctx context.Context, a QuotaAlert) error {
 	payload := map[string]any{
 		"from":    n.from,
 		"to":      []string{to},
-		"subject": "Verify your team on Superserve",
+		"subject": "Sandbox limit reached for your team",
 		"html":    quotaEmailHTML(a),
 	}
 	body, err := json.Marshal(payload)

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -134,8 +134,8 @@ func TestEmailQuotaNotifierSends(t *testing.T) {
 	if len(payload.To) != 1 || payload.To[0] != "owner@acme.test" {
 		t.Errorf("to = %v, want [owner@acme.test]", payload.To)
 	}
-	if !strings.Contains(payload.Subject, "Verify your team") {
-		t.Errorf("subject = %q, want it to mention verification", payload.Subject)
+	if !strings.Contains(payload.Subject, "Sandbox limit reached") {
+		t.Errorf("subject = %q, want it to mention limit reached", payload.Subject)
 	}
 	if !strings.Contains(payload.HTML, "Verify your team on Superserve") || !strings.Contains(payload.HTML, "Book a Meeting") {
 		t.Errorf("html missing verification heading/CTA: %q", payload.HTML)

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -137,8 +137,8 @@ func TestEmailQuotaNotifierSends(t *testing.T) {
 	if !strings.Contains(payload.Subject, "Sandbox limit reached") {
 		t.Errorf("subject = %q, want it to mention limit reached", payload.Subject)
 	}
-	if !strings.Contains(payload.HTML, "Verify your team on Superserve") || !strings.Contains(payload.HTML, "Book a Meeting") {
-		t.Errorf("html missing verification heading/CTA: %q", payload.HTML)
+	if !strings.Contains(payload.HTML, "Sandbox limit reached for your team") || !strings.Contains(payload.HTML, "Book a Meeting") {
+		t.Errorf("html missing quota limit heading/CTA: %q", payload.HTML)
 	}
 }
 

--- a/internal/api/quota_watcher_test.go
+++ b/internal/api/quota_watcher_test.go
@@ -134,10 +134,10 @@ func TestEmailQuotaNotifierSends(t *testing.T) {
 	if len(payload.To) != 1 || payload.To[0] != "owner@acme.test" {
 		t.Errorf("to = %v, want [owner@acme.test]", payload.To)
 	}
-	if !strings.Contains(payload.Subject, "Sandbox limit reached") {
-		t.Errorf("subject = %q, want it to mention limit reached", payload.Subject)
+	if !strings.Contains(payload.Subject, "approaching your sandbox limit") {
+		t.Errorf("subject = %q, want it to mention approaching limit", payload.Subject)
 	}
-	if !strings.Contains(payload.HTML, "Sandbox limit reached for your team") || !strings.Contains(payload.HTML, "Book a Meeting") {
+	if !strings.Contains(payload.HTML, "You're approaching your sandbox limit") || !strings.Contains(payload.HTML, "Book a Meeting") {
 		t.Errorf("html missing quota limit heading/CTA: %q", payload.HTML)
 	}
 }


### PR DESCRIPTION
## Summary

- Change quota alert email subject line in `EmailQuotaNotifier.Notify` from `"Verify your team on Superserve"` to `"Sandbox limit reached for your team"`.
- Update subject assertion in `TestEmailQuotaNotifierSends` in `internal/api/quota_watcher_test.go`.

## Why

The quota alert email previously used the onboarding/verification subject line `"Verify your team on Superserve"` due to copy-paste during initial template creation. Updating it to `"Sandbox limit reached for your team"` correctly conveys the notification purpose to team owners when active sandbox thresholds are reached.

## Test Plan

- [x] Build verification: `go build ./internal/api/` passed
- [x] Unit tests pass: `go test ./internal/api/ -short -run 'TestEmailQuotaNotifier' -v` passed
- [x] Short test suite pass: `make test-short` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @meAmitPatil @pavitrabhalla