### PR TITLE
fix(api): use errors.Is for pgx.ErrNoRows in HostHeartbeat and internal/api handlers

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -485,7 +485,7 @@ func (h *Handlers) loadActiveSandbox(c *gin.Context) *db.Sandbox {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 		} else {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
@@ -521,7 +521,7 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 			TeamID: teamID,
 		})
 		if err != nil {
-			if err == pgx.ErrNoRows {
+			if errors.Is(err, pgx.ErrNoRows) {
 				respondError(c, ErrSandboxNotFound)
 			} else {
 				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandboxWithPreviewPolicy failed")
@@ -633,7 +633,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// Someone else is already resuming, or the sandbox is no longer
 			// in paused state. Surface as conflict; client retries.
 			respondError(c, ErrInvalidState)
@@ -1080,7 +1080,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 			return
 		}
@@ -1137,7 +1137,7 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 			return
 		}
@@ -1159,13 +1159,13 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 		RevocationExpiresAt:     time.Now().Add(SecretsJWTLifetime),
 		StaleTransitionalBefore: time.Now().Add(-staleTransitionGrace),
 	}); err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			// Not claimable from its current state. Re-read to tell a
 			// just-completed delete (idempotent) from a transitional state
 			// (resuming/pausing/starting) the caller should retry.
 			cur, gerr := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
 			switch {
-			case gerr == pgx.ErrNoRows:
+			case errors.Is(gerr, pgx.ErrNoRows):
 				c.Status(http.StatusNoContent)
 			case gerr != nil:
 				log.Error().Err(gerr).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox re-read failed")
@@ -1660,7 +1660,7 @@ func (h *Handlers) GetSandboxByID(c *gin.Context) {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 			return
 		}
@@ -2518,7 +2518,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 			// and FinalizePause (a rare race with DeleteSandbox). The VM is
 			// already stopped and its snapshot files are on disk — nothing to
 			// finalize for a sandbox that no longer exists.
-			if err == pgx.ErrNoRows {
+			if errors.Is(err, pgx.ErrNoRows) {
 				log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
 				return
 			}
@@ -2733,7 +2733,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 			return
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2406,7 +2406,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		TeamID: teamID,
 	})
 	if err != nil {
-		if err != pgx.ErrNoRows {
+		if !errors.Is(err, pgx.ErrNoRows) {
 			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB BeginPause failed")
 			respondError(c, ErrInternal)
 			return

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -191,7 +191,7 @@ type previewMutationFinalize func(*db.Queries, previewPolicySnapshot) (outcomeEr
 func (h *Handlers) applyPreviewMutationFinalized(ctx context.Context, sandboxID, teamID uuid.UUID, mutate func(*db.Queries) error, finalize previewMutationFinalize) (previewPolicySnapshot, error, error) {
 	run := func(q *db.Queries) (previewPolicySnapshot, error, error) {
 		if _, err := q.LockSandboxForPreviewMutation(ctx, db.LockSandboxForPreviewMutationParams{ID: sandboxID, TeamID: teamID}); err != nil {
-			if err == pgx.ErrNoRows {
+			if errors.Is(err, pgx.ErrNoRows) {
 				return previewPolicySnapshot{}, nil, ErrSandboxNotFound
 			}
 			return previewPolicySnapshot{}, nil, err
@@ -915,7 +915,7 @@ func (h *Handlers) pushAfterPreviewMutation(c *gin.Context, sandbox db.Sandbox, 
 
 func (h *Handlers) getTeamSandbox(c *gin.Context, sandboxID, teamID uuid.UUID) (db.Sandbox, bool) {
 	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		respondError(c, ErrSandboxNotFound)
 		return db.Sandbox{}, false
 	}

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -934,7 +934,7 @@ func (h *Handlers) GetSandboxEgressRules(c *gin.Context) {
 	}
 	row, err := h.DB.GetSandboxEgressContext(c.Request.Context(), sandboxID)
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			c.Status(http.StatusNotFound)
 			return
 		}

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -86,7 +87,7 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		}
 	}
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if errors.Is(err, pgx.ErrNoRows) {
 			respondErrorMsg(c, "not_found", "host not found", http.StatusNotFound)
 			return
 		}

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -123,3 +123,19 @@ func TestHostHeartbeatRejectsMalformedCapabilityBeforeDB(t *testing.T) {
 		t.Fatal("invalid heartbeat reached the database")
 	}
 }
+
+func TestHostHeartbeatWrappedErrNoRowsReturns404(t *testing.T) {
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return errorRow(fmt.Errorf("query update host heartbeat: %w", pgx.ErrNoRows))
+		},
+	}
+	h := &Handlers{DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/hosts/nonexistent-host/heartbeat", nil)
+	setupHostHeartbeatRouter(h).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Replace direct `err == pgx.ErrNoRows` equality comparisons across `internal/api/` handlers (`hosts.go:89`, `handlers_secret.go:937`, `handlers_preview.go:194,914`, `handlers.go`) with `errors.Is(err, pgx.ErrNoRows)`.
- Add unit test `TestHostHeartbeatWrappedErrNoRowsReturns404` in `internal/api/hosts_test.go` asserting a 404 response when `UpdateHostHeartbeat` returns an error wrapping `pgx.ErrNoRows`.

## Why

In `HostHeartbeat` and several handler functions across `internal/api/`, error checks against `pgx.ErrNoRows` used direct value equality (`==`). Utilizing `errors.Is(err, pgx.ErrNoRows)` aligns with codebase conventions (`middleware.go`) and safely handles error unwrapping if database errors are wrapped.

## Test Plan

- [x] Build verification: `go build ./internal/api/` passed
- [x] Unit tests pass: `go test ./internal/api/... -v -short` passed (including new test `TestHostHeartbeatWrappedErrNoRowsReturns404`)
- [x] Short test suite pass: `make test-short` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @meAmitPatil @pavitrabhalla
