### PR TITLE
vmd: release a VM's slot only once its unit is terminal, and finish releases that were abandoned

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2587,7 +2587,14 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 				sigkillPID(rec.PID, 500*time.Millisecond)
 				log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
 			}
-			m.state.Delete(rec.ID)
+			// Delete-first, like markStale: freeing the slot while the record
+			// survives lets a later reattach of that record rebind a slot the
+			// pool has already handed to someone else. On failure keep both —
+			// the reconciler owns the retry.
+			if derr := m.state.Delete(rec.ID); derr != nil {
+				log.Error().Err(derr).Msg("failed to delete stale record; keeping its slot reserved")
+				return nil, false
+			}
 			// Free this record's namespace/slot directly instead of a broad
 			// re-sweep (which would also delete the warm pool's netns).
 			m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1892,6 +1892,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				// guest-dead, and the relaunch replaces the unit anyway.
 				// If-present, so a racing destroy's deletion still wins.
 				existing.mu.Lock()
+				existing.gen++
 				existing.Status = StatusError
 				existing.mu.Unlock()
 				// Best-effort: the returned error is the useful one, and an
@@ -2311,6 +2312,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// persist synchronously, serializing the very fsync the goroutine
 	// overlaps with the boxd wait.
 	inst.mu.Lock()
+	inst.gen++
 	inst.Status = StatusRunning
 	inst.Unverified = true
 	inst.mu.Unlock()
@@ -2378,6 +2380,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		return nil, fmt.Errorf("vm %s restored but its state could not be persisted", vmID)
 	}
 	inst.mu.Lock()
+	inst.gen++
 	inst.Unverified = false
 	inst.mu.Unlock()
 	// Persist-then-verify: checking AFTER the write leaves no window — a
@@ -2940,6 +2943,7 @@ func (m *Manager) handleVMError(vmID string, origErr error) error {
 		return status.Errorf(codes.NotFound, "vm %s is no longer running", vmID)
 	}
 	inst.mu.Lock()
+	inst.gen++
 	inst.Status = StatusStopped
 	inst.mu.Unlock()
 	delete(m.vms, vmID)
@@ -4061,6 +4065,7 @@ func (m *Manager) commitResumeState(inst *VMInstance) error {
 			// unit this teardown is stopping.
 			m.stopUnitDuringRestoreError(inst.ID)
 			inst.mu.Lock()
+			inst.gen++
 			inst.Status = StatusError
 			inst.DirtyTracked = false // unit stopped; a relaunch re-arms tracking
 			inst.mu.Unlock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -102,7 +102,14 @@ type VMInstance struct {
 	// fresh instances need no bump, and inspection ops (env inject,
 	// verification) must NOT bump, or they void retries for VMs they never
 	// touched.
+	//
+	// incarnation is a process-unique, non-owning identity, lazily stamped by
+	// incarnationID at the reconciler's first contact — episodes store this
+	// integer instead of the pointer, so drift bookkeeping can never root a
+	// removed instance, and a fresh instance at a reused address can never
+	// masquerade as its predecessor.
 	gen          uint64
+	incarnation  uint64
 	Config       VMConfig
 	RunDirID     string // Directory name under RunDir for this VM's files.
 	Namespace    string // Network namespace name.
@@ -3221,6 +3228,25 @@ func (m *Manager) getInstance(vmID string) (*VMInstance, error) {
 		return inst, nil
 	}
 	return nil, status.Errorf(codes.NotFound, "vm %s not found", vmID)
+}
+
+// incarnationCounter feeds VMInstance.incarnation; 0 is reserved for
+// "no instance".
+var incarnationCounter atomic.Uint64
+
+// incarnationID returns inst's process-unique identity, stamping it on first
+// use. Nil-safe: no instance is identity 0, which no stamped instance holds.
+func (inst *VMInstance) incarnationID() uint64 {
+	if inst == nil {
+		return 0
+	}
+	inst.mu.Lock()
+	if inst.incarnation == 0 {
+		inst.incarnation = incarnationCounter.Add(1)
+	}
+	v := inst.incarnation
+	inst.mu.Unlock()
+	return v
 }
 
 func (m *Manager) setStatus(vmID string, s VMStatus) {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3879,6 +3879,16 @@ var vmUnitDead = func(vmID string) bool {
 	return unitDefinitelyDead(ctx, systemdUnitName(vmID))
 }
 
+// vmUnitFullyDown reports a VM's unit in a TERMINAL state; swappable in tests.
+// Sites that release a record and its namespace need this claim, not
+// vmUnitDead — that one reads deactivating as dead, while the process may
+// still hold the tap device.
+var vmUnitFullyDown = func(vmID string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return unitFullyDown(ctx, systemdUnitName(vmID))
+}
+
 // adoptionBoxdReady is the boxd readiness gate for restore adoption and the
 // unverified relaunch (via verifyBoxdReady); a var for the same test seam
 // vmUnitDead uses.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2589,16 +2589,23 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			}
 			// Delete-first, like markStale: freeing the slot while the record
 			// survives lets a later reattach of that record rebind a slot the
-			// pool has already handed to someone else. On failure keep both —
-			// the reconciler owns the retry.
-			if derr := m.state.Delete(rec.ID); derr != nil {
-				log.Error().Err(derr).Msg("failed to delete stale record; keeping its slot reserved")
+			// pool has already handed to someone else.
+			if derr := m.state.Delete(rec.ID); derr == nil {
+				// Free this record's namespace/slot directly instead of a broad
+				// re-sweep (which would also delete the warm pool's netns).
+				m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
 				return nil, false
+			} else {
+				// Keep record AND slot — but returning unowned would strand
+				// them: with the DB row already failed, no drift rule matches
+				// a Running record behind a dead unit. Park as Error and fall
+				// through to the publish tail, so Drift 8's dead half owns the
+				// release through the deferred-retry machinery. In-memory
+				// only: the store just refused a delete, a Put would fare no
+				// better, and errorRecord reads the tracked instance first.
+				log.Error().Err(derr).Msg("failed to delete stale record; parking as error with its slot reserved")
+				rec.Status = StatusError
 			}
-			// Free this record's namespace/slot directly instead of a broad
-			// re-sweep (which would also delete the warm pool's netns).
-			m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
-			return nil, false
 		}
 		if rec.SocketPath != "" {
 			if _, statErr := os.Stat(rec.SocketPath); statErr != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -248,6 +248,12 @@ type Manager struct {
 	egressProxy *network.EgressProxy
 	log         zerolog.Logger
 	state       *StateStore // persistent local state (BoltDB); nil = no persistence
+	// onLifecycleClaim, when set, is invoked with the vmID whenever a
+	// lifecycle op acquires the vm-op lock. The reconciler wires it to void
+	// any release it deferred for that VM: the op now owns the instance, and
+	// a deferred reap decided against its predecessor must not outlive the
+	// claim — no matter what states the op drives the VM through afterwards.
+	onLifecycleClaim func(vmID string)
 	// backupEnqueue hands finalized pause manifests to the durability
 	// pipeline; nil when backup is disabled. See SetBackupEnqueue.
 	backupEnqueue func(backup.Task) error
@@ -430,6 +436,12 @@ func (m *Manager) lockVMOp(ctx context.Context, vmID string) (func(), error) {
 		if err := ctx.Err(); err != nil {
 			<-ch
 			return nil, err
+		}
+		// Every lifecycle op enters here (the reconciler deliberately uses
+		// tryLockVMOp instead), so this is the one place a claim on the VM
+		// is always visible — see onLifecycleClaim.
+		if m.onLifecycleClaim != nil {
+			m.onLifecycleClaim(vmID)
 		}
 		return func() { <-ch }, nil
 	case <-ctx.Done():

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -253,7 +253,9 @@ type Manager struct {
 	// any release it deferred for that VM: the op now owns the instance, and
 	// a deferred reap decided against its predecessor must not outlive the
 	// claim — no matter what states the op drives the VM through afterwards.
-	onLifecycleClaim func(vmID string)
+	// Atomic: the reconciler is constructed after the gRPC server is already
+	// serving, so the write races concurrent lockVMOp reads.
+	onLifecycleClaim atomic.Pointer[func(vmID string)]
 	// backupEnqueue hands finalized pause manifests to the durability
 	// pipeline; nil when backup is disabled. See SetBackupEnqueue.
 	backupEnqueue func(backup.Task) error
@@ -440,8 +442,8 @@ func (m *Manager) lockVMOp(ctx context.Context, vmID string) (func(), error) {
 		// Every lifecycle op enters here (the reconciler deliberately uses
 		// tryLockVMOp instead), so this is the one place a claim on the VM
 		// is always visible — see onLifecycleClaim.
-		if m.onLifecycleClaim != nil {
-			m.onLifecycleClaim(vmID)
+		if claim := m.onLifecycleClaim.Load(); claim != nil {
+			(*claim)(vmID)
 		}
 		return func() { <-ch }, nil
 	case <-ctx.Done():

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -87,15 +87,24 @@ func (s VMStatus) String() string {
 
 // VMInstance holds the runtime state of a single microVM.
 type VMInstance struct {
-	ID           string
-	PID          int
-	SocketPath   string
-	VsockPath    string
-	IP           string
-	TAPDevice    string
-	MACAddress   string
-	Status       VMStatus
-	Unverified   bool // Running persisted before boxd readiness (see VMRecord)
+	ID         string
+	PID        int
+	SocketPath string
+	VsockPath  string
+	IP         string
+	TAPDevice  string
+	MACAddress string
+	Status     VMStatus
+	Unverified bool // Running persisted before boxd readiness (see VMRecord)
+	// gen counts in-place lifecycle transitions (Status/Unverified writes on
+	// a tracked instance). The reconciler snapshots it when deferring a
+	// release: a changed gen proves a lifecycle op claimed the VM, no matter
+	// what state the op drove it back to. Fresh instances need no bump —
+	// pointer identity already voids across a replacement. Bump under
+	// inst.mu, at every in-place transition, and nowhere else: inspection
+	// ops (env inject, verification) must NOT bump, or they void retries
+	// for VMs they never touched.
+	gen          uint64
 	Config       VMConfig
 	RunDirID     string // Directory name under RunDir for this VM's files.
 	Namespace    string // Network namespace name.
@@ -248,14 +257,6 @@ type Manager struct {
 	egressProxy *network.EgressProxy
 	log         zerolog.Logger
 	state       *StateStore // persistent local state (BoltDB); nil = no persistence
-	// onLifecycleClaim, when set, is invoked with the vmID whenever a
-	// lifecycle op acquires the vm-op lock. The reconciler wires it to void
-	// any release it deferred for that VM: the op now owns the instance, and
-	// a deferred reap decided against its predecessor must not outlive the
-	// claim — no matter what states the op drives the VM through afterwards.
-	// Atomic: the reconciler is constructed after the gRPC server is already
-	// serving, so the write races concurrent lockVMOp reads.
-	onLifecycleClaim atomic.Pointer[func(vmID string)]
 	// backupEnqueue hands finalized pause manifests to the durability
 	// pipeline; nil when backup is disabled. See SetBackupEnqueue.
 	backupEnqueue func(backup.Task) error
@@ -438,12 +439,6 @@ func (m *Manager) lockVMOp(ctx context.Context, vmID string) (func(), error) {
 		if err := ctx.Err(); err != nil {
 			<-ch
 			return nil, err
-		}
-		// Every lifecycle op enters here (the reconciler deliberately uses
-		// tryLockVMOp instead), so this is the one place a claim on the VM
-		// is always visible — see onLifecycleClaim.
-		if claim := m.onLifecycleClaim.Load(); claim != nil {
-			(*claim)(vmID)
 		}
 		return func() { <-ch }, nil
 	case <-ctx.Done():
@@ -1057,6 +1052,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	stopCancel()
 
 	inst.mu.Lock()
+	inst.gen++
 	inst.Status = StatusPaused
 	inst.SnapshotPath = snapshotPath
 	inst.MemFilePath = memPath
@@ -1275,6 +1271,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			// VM that never came back. The marker stays set — readiness is
 			// still unproven, and the relaunch below reads it to verify.
 			existing.mu.Lock()
+			existing.gen++
 			existing.Status = StatusPaused
 			existing.mu.Unlock()
 			// The verdict has to be durable BEFORE relaunching: the relaunch
@@ -1431,6 +1428,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	}
 
 	inst.mu.Lock()
+	inst.gen++
 	inst.PID = pid
 	inst.SocketPath = socketPath
 	inst.Status = StatusRunning
@@ -3224,6 +3222,7 @@ func (m *Manager) setStatus(vmID string, s VMStatus) {
 		return
 	}
 	inst.mu.Lock()
+	inst.gen++
 	inst.Status = s
 	inst.mu.Unlock()
 	m.persistState(inst)
@@ -3430,6 +3429,7 @@ func (m *Manager) abortResumeLocked(vmID string) {
 	}
 	m.stopUnitDuringRestoreError(vmID)
 	inst.mu.Lock()
+	inst.gen++
 	inst.Status = StatusPaused
 	inst.DirtyTracked = false // FC process stopped; a fresh resume re-arms tracking.
 	inst.mu.Unlock()
@@ -4084,6 +4084,7 @@ func (m *Manager) commitVerifiedAdoption(existing *VMInstance) error {
 		return status.Errorf(codes.NotFound, "vm %s was destroyed during restore", existing.ID)
 	}
 	existing.mu.Lock()
+	existing.gen++
 	existing.Unverified = false
 	existing.mu.Unlock()
 	// Only a deletion aborts the adoption; an undurable clear is healed by

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3879,16 +3879,6 @@ var vmUnitDead = func(vmID string) bool {
 	return unitDefinitelyDead(ctx, systemdUnitName(vmID))
 }
 
-// vmUnitFullyDown reports a VM's unit in a TERMINAL state; swappable in tests.
-// Sites that release a record and its namespace need this claim, not
-// vmUnitDead — that one reads deactivating as dead, while the process may
-// still hold the tap device.
-var vmUnitFullyDown = func(vmID string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	return unitFullyDown(ctx, systemdUnitName(vmID))
-}
-
 // adoptionBoxdReady is the boxd readiness gate for restore adoption and the
 // unverified relaunch (via verifyBoxdReady); a var for the same test seam
 // vmUnitDead uses.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -97,13 +97,11 @@ type VMInstance struct {
 	Status     VMStatus
 	Unverified bool // Running persisted before boxd readiness (see VMRecord)
 	// gen counts in-place lifecycle transitions (Status/Unverified writes on
-	// a tracked instance). The reconciler snapshots it when deferring a
-	// release: a changed gen proves a lifecycle op claimed the VM, no matter
-	// what state the op drove it back to. Fresh instances need no bump —
-	// pointer identity already voids across a replacement. Bump under
-	// inst.mu, at every in-place transition, and nowhere else: inspection
-	// ops (env inject, verification) must NOT bump, or they void retries
-	// for VMs they never touched.
+	// a tracked instance); the reconciler's deferredRelease is its consumer.
+	// Bump under inst.mu, at every in-place transition, and nowhere else:
+	// fresh instances need no bump, and inspection ops (env inject,
+	// verification) must NOT bump, or they void retries for VMs they never
+	// touched.
 	gen          uint64
 	Config       VMConfig
 	RunDirID     string // Directory name under RunDir for this VM's files.

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2260,3 +2260,43 @@ func TestCommitResumeState_UndurableRunning_FailsResume(t *testing.T) {
 		t.Fatal("DirtyTracked must clear with the unit stopped")
 	}
 }
+
+// A startup sweep that cannot delete a stale record must not abandon it: with
+// the DB row already failed, no drift rule matches a Running record behind a
+// dead unit, so record and slot would be stranded until yet another restart.
+// Parking it as Error hands it to the error rules' deferred-retry machinery.
+func TestReattachRecord_StaleDeleteFails_ParksAsError(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return true } // unit conclusively gone
+	defer func() { vmUnitFullyDown = origDown }()
+
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := VMRecord{ID: "vm-1", Status: StatusRunning} // no namespace: skip netns bind
+	if err := store.Put(rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil { // the delete cannot land
+		t.Fatal(err)
+	}
+	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{}}
+
+	inst, ok := m.reattachRecord(context.Background(), rec, true)
+	if !ok || inst == nil {
+		t.Fatal("an unreleasable stale record must be parked, not abandoned")
+	}
+	inst.mu.RLock()
+	st := inst.Status
+	inst.mu.RUnlock()
+	if st != StatusError {
+		t.Fatalf("the parked record must read Error so the error rules own it, got %v", st)
+	}
+	m.mu.RLock()
+	_, tracked := m.vms["vm-1"]
+	m.mu.RUnlock()
+	if !tracked {
+		t.Fatal("the parked instance must be tracked, or no rule can find it")
+	}
+}

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -427,7 +427,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// dead-VM rule). Detach from the pass context, bounded.
 			persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			flipped := r.markFailedInDB(persistCtx, id, db.SandboxStatusActive)
-			releaseErr := r.markStale(persistCtx, id)
+			releaseErr := r.markStale(persistCtx, id, "")
 			if releaseErr != nil {
 				r.finalizeRelease(persistCtx, id, "", "", "empty Firecracker shell while DB said active", "fc_empty_shell", releaseErr)
 			}
@@ -469,7 +469,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_running_unit_missing").
 				Msg("dead Firecracker detected (no DB context)")
-			releaseErr := r.markStale(ctx, id)
+			releaseErr := r.markStale(ctx, id, "")
 			r.finalizeRelease(ctx, id, "", "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing", releaseErr)
 		}
 	}
@@ -514,7 +514,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
-			releaseErr := r.markStale(ctx, id)
+			releaseErr := r.markStale(ctx, id, "orphan:"+id)
 			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
 		}
 	}
@@ -573,7 +573,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			continue
 		}
 		removeUnitDropIn(id)
-		staleErr := r.markStale(ctx, id)
+		staleErr := r.markStale(ctx, id, "errunit:"+id)
 		unlockOp()
 		// Flip the DB row with the already-grace-qualified reap: Drift 1
 		// cleared its marker while the unit was active, so leaving the row
@@ -654,7 +654,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			unlockOp()
 			return
 		}
-		staleErr := r.markStale(ctx, id)
+		staleErr := r.markStale(ctx, id, "errdead:"+id)
 		unlockOp()
 		// Drift 1 skips Error records, so the row flip lands here (still
 		// compare-and-set: a relaunch may own the row by now).
@@ -779,13 +779,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
-			staleErr := r.markStale(ctx, id)
+			staleErr := r.markStale(ctx, id, "unverifiedorphan:"+id)
 			unlockOp()
 			if staleErr != nil {
 				// The unit is stopped but the record, its map entry and its slot
 				// survive, and no rule matches an inactive unit. Report the
 				// partial cleanup rather than an orphan_stop that did not happen.
-				r.tagPendingRelease(id, "unverifiedorphan:"+id)
 				r.writeAudit(ctx, id, "stale_cleanup_failed", "unit stopped but record not deleted", "unverified_orphan_abandoned")
 				continue
 			}
@@ -848,7 +847,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				}
 				removeUnitDropIn(id)
 			}
-			releaseErr := r.markStale(ctx, id)
+			releaseErr := r.markStale(ctx, id, "bolt-orphan:"+id)
 			r.finalizeRelease(ctx, id, "bolt-orphan:"+id, "stale_cleanup", "BoltDB entry with no DB row", "boltdb_present_db_missing", releaseErr)
 		}
 	}
@@ -1372,8 +1371,6 @@ func (r *Reconciler) refundAutoFailSlot() {
 // when the unit leaves the active set, so its retry waits out one more grace.
 func (r *Reconciler) finalizeErrorReap(ctx context.Context, vmID, marker, action, reason, driftKind string, staleErr error) {
 	if staleErr != nil {
-		// Same discipline as finalizeRelease — see pendingRelease's marker doc.
-		r.tagPendingRelease(vmID, marker)
 		r.writeAudit(ctx, vmID, "stale_cleanup_failed", reason+"; record not deleted", driftKind)
 		return
 	}
@@ -1389,7 +1386,7 @@ func (r *Reconciler) finalizeErrorReap(ctx context.Context, vmID, marker, action
 // before calling this must not report success on one: stopping the unit
 // retires the very condition their next pass matches on, so the record is
 // left for retryPendingReleases rather than another pass of the rule.
-func (r *Reconciler) markStale(ctx context.Context, vmID string) error {
+func (r *Reconciler) markStale(ctx context.Context, vmID, marker string) error {
 	// The release hands this VM's namespace, IP and tap device back to the
 	// pool, so it needs the terminal claim: a nil stopUnit only means the job
 	// finished, and absence from the active-unit snapshot is not terminal
@@ -1397,7 +1394,7 @@ func (r *Reconciler) markStale(ctx context.Context, vmID string) error {
 	// would claim a device the old process still owns. Fail-closed, so an
 	// inconclusive probe defers rather than releases.
 	if !unitFullyDownCtx(ctx, systemdUnitName(vmID)) {
-		r.notePendingRelease(vmID)
+		r.notePendingRelease(vmID, marker)
 		return errUnitNotTerminal
 	}
 
@@ -1413,7 +1410,7 @@ func (r *Reconciler) markStale(ctx context.Context, vmID string) error {
 	// failure here abandons the whole cleanup rather than half-applying it.
 	if err := r.mgr.state.Delete(vmID); err != nil {
 		// Recorded here, not per rule, so every caller inherits the retry.
-		r.notePendingRelease(vmID)
+		r.notePendingRelease(vmID, marker)
 		r.mgr.log.Error().Err(err).Str("vm_id", vmID).Msg("reconciler: failed to delete stale state")
 		return err
 	}
@@ -1454,7 +1451,6 @@ var errUnitNotTerminal = errors.New("unit not terminal; release deferred")
 // marker is for rules whose only marker markStale clears itself.
 func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, reason, driftKind string, releaseErr error) {
 	if releaseErr != nil {
-		r.tagPendingRelease(vmID, marker)
 		r.writeAudit(ctx, vmID, "release_deferred", reason+"; slot still held", driftKind)
 		return
 	}
@@ -1478,7 +1474,7 @@ type deferredRelease struct {
 	unverified bool
 }
 
-func (r *Reconciler) notePendingRelease(vmID string) {
+func (r *Reconciler) notePendingRelease(vmID, marker string) {
 	r.mgr.mu.RLock()
 	inst := r.mgr.vms[vmID]
 	r.mgr.mu.RUnlock()
@@ -1491,22 +1487,8 @@ func (r *Reconciler) notePendingRelease(vmID string) {
 	}
 	r.mu.Lock()
 	e := r.pendingRelease[vmID]
-	e.inst, e.status, e.unverified = inst, st, unv
+	e.inst, e.status, e.unverified, e.marker = inst, st, unv, marker
 	r.pendingRelease[vmID] = e
-	r.mu.Unlock()
-}
-
-// tagPendingRelease attaches the deferring rule's drift marker to an entry
-// notePendingRelease already recorded (markStale notes without rule context).
-func (r *Reconciler) tagPendingRelease(vmID, marker string) {
-	if marker == "" {
-		return
-	}
-	r.mu.Lock()
-	if e, ok := r.pendingRelease[vmID]; ok {
-		e.marker = marker
-		r.pendingRelease[vmID] = e
-	}
 	r.mu.Unlock()
 }
 
@@ -1574,7 +1556,7 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 			r.clearDrift(noted.marker)
 			continue
 		}
-		err := r.markStale(ctx, id)
+		err := r.markStale(ctx, id, noted.marker)
 		unlockOp()
 		if err != nil {
 			continue // still unreleasable; the entry survives for the next pass
@@ -1632,7 +1614,7 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 		log.Warn().Str("vm_id", id).Str("drift", "db_active_systemd_missing").
 			Msg("DB says active but VM is dead — marking failed")
 		flipped := r.markFailed(ctx, id, db.SandboxStatusActive)
-		staleErr := r.markStale(ctx, id)
+		staleErr := r.markStale(ctx, id, "")
 		unlockOp()
 		if staleErr != nil {
 			// The row is failed but the record and slot are still held, and

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -877,10 +877,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if errorRecord(id) {
 				continue
 			}
-			// The lock is taken before budget or the stop, and the in-memory
-			// record re-read under it: a create whose row insert is still in
-			// flight reads Running here, and killing it would be the stop-vs-
-			// relaunch race, not a reap.
+			// Same discipline as Drift 3; here the Running re-read also
+			// covers a create whose row insert is still in flight.
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
 				continue

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1549,7 +1549,13 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 			r.mu.Lock()
 			delete(r.pendingRelease, id)
 			r.mu.Unlock()
-			r.clearDrift(noted.marker) // see pendingRelease: voids retire the marker too
+			// Voids retire the episode's timestamps (see pendingRelease): the
+			// prefixed marker, and the bare id — Drift 1/2 grace under the bare
+			// id and defer with marker "", relying on markStale to clear it,
+			// which a void never runs. Leaving either hands its elapsed grace
+			// to the id's next episode.
+			r.clearDrift(id)
+			r.clearDrift(noted.marker)
 			continue
 		}
 		err := r.markStale(ctx, id)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -427,8 +427,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			log.Warn().Str("vm_id", id).Str("drift", "fc_empty_shell").
 				Msg("unit active but Firecracker holds no microVM — stopping the shell and marking failed")
 			err := stopUnit(ctx, systemdUnitName(id))
-			unlockOp()
 			if err != nil {
+				unlockOp()
 				// Leave the row untouched (a failed row behind a live
 				// unit would strand it). Refund the budget slot only when
 				// the stop provably never happened; an accepted-but-
@@ -449,7 +449,11 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// dead-VM rule). Detach from the pass context, bounded.
 			persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			flipped := r.markFailedInDB(persistCtx, id, db.SandboxStatusActive)
+			// Still under the vm-op lock: a resume winning the lock between
+			// the terminal probe and the cleanup would have its fresh record
+			// deleted and its live namespace reclaimed.
 			releaseErr := r.markStale(persistCtx, id, "")
+			unlockOp()
 			if releaseErr != nil {
 				r.finalizeRelease(persistCtx, id, "", "", "empty Firecracker shell while DB said active", "fc_empty_shell", releaseErr)
 			}
@@ -491,7 +495,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_running_unit_missing").
 				Msg("dead Firecracker detected (no DB context)")
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue // an op owns the VM; its claim voided any pending entry
+			}
 			releaseErr := r.markStale(ctx, id, "")
+			unlockOp()
 			r.finalizeRelease(ctx, id, "", "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing", releaseErr)
 		}
 	}
@@ -536,7 +545,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
 			releaseErr := r.markStale(ctx, id, "orphan:"+id)
+			unlockOp()
 			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
 		}
 	}
@@ -869,7 +883,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				}
 				removeUnitDropIn(id)
 			}
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
 			releaseErr := r.markStale(ctx, id, "bolt-orphan:"+id)
+			unlockOp()
 			r.finalizeRelease(ctx, id, "bolt-orphan:"+id, "stale_cleanup", "BoltDB entry with no DB row", "boltdb_present_db_missing", releaseErr)
 		}
 	}
@@ -1607,6 +1626,16 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 		// probe — a deactivating unit is absent from the active snapshot
 		// while its process may live on.
 		if errorRecord(id) {
+			continue
+		}
+		// A deferred release owns the release half of this reap (see
+		// hasPendingRelease) — but only the release: nobody else moves a
+		// stuck-active row off a dead VM, so the flip re-drives here,
+		// uncharged (same decision, already budgeted) and CAS-guarded.
+		if r.hasPendingRelease(id) {
+			if r.markFailed(ctx, id, db.SandboxStatusActive) {
+				r.writeAudit(ctx, id, "mark_failed", "VM dead while DB said active", "db_active_systemd_missing")
+			}
 			continue
 		}
 		if !r.gracePeriodElapsed(id, now) {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1254,15 +1254,30 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 type deferredRelease struct {
 	inst   *VMInstance
 	marker string
+	// Snapshot of the instance when the release was deferred. Pointer
+	// identity alone only detects REPLACEMENT ops (a fresh relaunch swaps
+	// the map entry); adoption clears Unverified and pause flips Status on
+	// the SAME object. A stale instance is by definition one nothing
+	// updates, so any observed mutation proves a lifecycle op claimed the
+	// VM and the reap decision is void.
+	status     VMStatus
+	unverified bool
 }
 
 func (r *Reconciler) notePendingRelease(vmID string) {
 	r.mgr.mu.RLock()
 	inst := r.mgr.vms[vmID]
 	r.mgr.mu.RUnlock()
+	var st VMStatus
+	var unv bool
+	if inst != nil {
+		inst.mu.RLock()
+		st, unv = inst.Status, inst.Unverified
+		inst.mu.RUnlock()
+	}
 	r.mu.Lock()
 	e := r.pendingRelease[vmID]
-	e.inst = inst
+	e.inst, e.status, e.unverified = inst, st, unv
 	r.pendingRelease[vmID] = e
 	r.mu.Unlock()
 }
@@ -1315,7 +1330,13 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 		r.mgr.mu.RLock()
 		cur := r.mgr.vms[id]
 		r.mgr.mu.RUnlock()
-		if cur != noted.inst {
+		mutated := false
+		if cur != nil && cur == noted.inst {
+			cur.mu.RLock()
+			mutated = cur.Status != noted.status || cur.Unverified != noted.unverified
+			cur.mu.RUnlock()
+		}
+		if cur != noted.inst || mutated {
 			unlockOp()
 			r.mu.Lock()
 			delete(r.pendingRelease, id)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -449,10 +449,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// dead-VM rule). Detach from the pass context, bounded.
 			persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			flipped := r.markFailedInDB(persistCtx, id, db.SandboxStatusActive)
-			// Still under the vm-op lock: a resume winning the lock between
-			// the terminal probe and the cleanup would have its fresh record
-			// deleted and its live namespace reclaimed.
-			releaseErr := r.markStale(persistCtx, id, "")
+			releaseErr := r.markStale(persistCtx, id, "") // under the lock, per its contract
+
 			unlockOp()
 			if releaseErr != nil {
 				r.finalizeRelease(persistCtx, id, "", "", "empty Firecracker shell while DB said active", "fc_empty_shell", releaseErr)
@@ -1427,6 +1425,10 @@ func (r *Reconciler) finalizeErrorReap(ctx context.Context, vmID, marker, action
 // before calling this must not report success on one: stopping the unit
 // retires the very condition their next pass matches on, so the record is
 // left for retryPendingReleases rather than another pass of the rule.
+//
+// Callers must hold vmID's vm-op lock across the call: a resume winning the
+// lock between the terminal probe and the cleanup would have its fresh
+// record deleted and its live namespace reclaimed.
 func (r *Reconciler) markStale(ctx context.Context, vmID, marker string) error {
 	// The release hands this VM's namespace, IP and tap device back to the
 	// pool, so it needs the terminal claim: a nil stopUnit only means the job

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -480,12 +480,18 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if r.hasPendingRelease(id) {
 				continue
 			}
-			if !r.gracePeriodElapsed(id, now) {
+			if !r.graceElapsedFor(id, id, now, r.cfg.GracePeriod) {
 				continue
 			}
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
 				continue // an op owns the VM; the generation voids any pending entry
+			}
+			// A resume-and-repause since the pass snapshot leaves the unit
+			// terminal again; only the episode tells the generations apart.
+			if !r.episodeStillCurrent(id, id) {
+				unlockOp()
+				continue
 			}
 			// No status re-check: this rule's target is a Running record whose
 			// unit is dead, and nothing flips that record when firecracker
@@ -1659,7 +1665,7 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 			}
 			continue
 		}
-		if !r.gracePeriodElapsed(id, now) {
+		if !r.graceElapsedFor(id, id, now, r.cfg.GracePeriod) {
 			continue
 		}
 		// Lock before spending budget, then re-probe the UNIT under it —
@@ -1667,9 +1673,15 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 		// firecracker dies out from under vmd, so a stale Running instance
 		// is the very state this rule cleans up. A resume that relaunched
 		// mid-pass owns a live unit again, which this probe sees; an
-		// inconclusive probe defers to the next pass.
+		// inconclusive probe defers to the next pass. The probe alone cannot
+		// see a resume-and-repause — the new generation's unit is terminal
+		// again — so the episode check guards the release.
 		unlockOp, ok := r.mgr.tryLockVMOp(id)
 		if !ok {
+			continue
+		}
+		if !r.episodeStillCurrent(id, id) {
+			unlockOp()
 			continue
 		}
 		if !unitFullyDownProbe(ctx, systemdUnitName(id)) {
@@ -1773,6 +1785,13 @@ func (r *Reconciler) failMissingSnapshots(ctx context.Context, log zerolog.Logge
 // — the rule must stop a genuinely stale orphan and must NOT stop a unit
 // whose generation was claimed since the pass snapshot.
 func (r *Reconciler) stopOrphanUnits(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool, errorRecord func(string) bool, now time.Time) {
+	// This rule's ONLY evidence that a unit is an orphan is its DB row being
+	// deleted/failed/absent. A nil map is a FAILED QUERY, not an empty host —
+	// treating it as absence would classify every active unit as an orphan
+	// and stop production VMs up to the budget on any DB blip. Fail closed.
+	if dbSandboxes == nil {
+		return
+	}
 	for id := range active {
 		sb, known := dbSandboxes[id]
 		deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -546,6 +546,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			r.clearDrift("errunit:" + id)
 			continue
 		}
+		// A prior pass already decided and charged this reap; its deferred
+		// release owns the id now (see hasPendingRelease).
+		if r.hasPendingRelease(id) {
+			unlockOp()
+			continue
+		}
 		if !r.consumeAutoFailBudget(id) {
 			unlockOp()
 			r.writeAudit(ctx, id, "budget_exhausted", "error_unit_stop suppressed by rate limit", "boltdb_error_unit_active")
@@ -615,6 +621,14 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		if r.mgr.instanceRunning(id) {
 			unlockOp()
 			r.clearDrift("errdead:" + id)
+			return
+		}
+		// A prior pass already decided and charged this reap (the deferral
+		// can arrive here when the active half's stop deferred, or when
+		// markStale's probe went inconclusive after this half's own probe
+		// passed); the retry owns it (see hasPendingRelease).
+		if r.hasPendingRelease(id) {
+			unlockOp()
 			return
 		}
 		// Absence from the active-only snapshot is not terminal — an
@@ -795,10 +809,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if _, ok := dbSandboxes[id]; ok {
 				continue
 			}
-			// A deferred release keeps a dead-unit id matching this rule
-			// forever; the retry owns it (see hasPendingRelease). A LIVE
-			// unit is a fresh decision and still gets stopped below.
-			if !active[id] && r.hasPendingRelease(id) {
+			// A deferred release owns this id (see hasPendingRelease) —
+			// unconditionally: the top-of-pass active snapshot can still read
+			// true for the unit a same-pass Drift 3 just stopped and deferred,
+			// and re-deciding here double-charges the budget. A genuinely
+			// relaunched VM costs one pass: the retry voids its entry.
+			if r.hasPendingRelease(id) {
 				continue
 			}
 			if !r.gracePeriodElapsed("bolt-orphan:"+id, now) {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -456,6 +456,11 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if errorRecord(id) {
 				continue
 			}
+			// A deferred release keeps this rule's predicate true; the retry
+			// owns it now (see hasPendingRelease).
+			if r.hasPendingRelease(id) {
+				continue
+			}
 			if !r.gracePeriodElapsed(id, now) {
 				continue
 			}
@@ -788,6 +793,12 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		// not for every bolted entry.
 		for id := range boltedIDs {
 			if _, ok := dbSandboxes[id]; ok {
+				continue
+			}
+			// A deferred release keeps a dead-unit id matching this rule
+			// forever; the retry owns it (see hasPendingRelease). A LIVE
+			// unit is a fresh decision and still gets stopped below.
+			if !active[id] && r.hasPendingRelease(id) {
 				continue
 			}
 			if !r.gracePeriodElapsed("bolt-orphan:"+id, now) {
@@ -1481,6 +1492,18 @@ func (r *Reconciler) tagPendingRelease(vmID, marker string) {
 		r.pendingRelease[vmID] = e
 	}
 	r.mu.Unlock()
+}
+
+// hasPendingRelease reports a reap already decided for vmID whose release is
+// deferred. Rules whose predicate a deferral preserves (a Running record
+// behind a dead unit) must stand aside for it: re-deciding every pass would
+// re-charge the auto-fail budget — one wedged record drains the host's whole
+// budget in minutes — and re-audit a decision retryPendingReleases already owns.
+func (r *Reconciler) hasPendingRelease(vmID string) bool {
+	r.mu.Lock()
+	_, ok := r.pendingRelease[vmID]
+	r.mu.Unlock()
+	return ok
 }
 
 func (r *Reconciler) pendingReleaseIDs() []string {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -120,7 +120,7 @@ type Reconciler struct {
 	// driftSeen tracks the first-seen timestamp for each drifted VM so
 	// we can enforce the grace period. Keyed by vmID.
 	mu          sync.Mutex
-	driftSeen   map[string]time.Time
+	driftSeen   map[string]driftEpisode
 	autoFailLog []time.Time // timestamps of recent auto-fail actions
 
 	// passCount counts completed reconcile passes, used to run the disk
@@ -160,7 +160,7 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 	r := &Reconciler{
 		mgr:            mgr,
 		cfg:            cfg,
-		driftSeen:      make(map[string]time.Time),
+		driftSeen:      make(map[string]driftEpisode),
 		pendingRelease: make(map[string]deferredRelease),
 		prevKeptLive:   -1,
 	}
@@ -505,63 +505,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	}
 
 	// Drift 3: systemd unit active, DB says deleted/failed/missing.
-	// `failed` catches restores whose forward-path cleanup didn't run
-	// (e.g., gRPC ctx fired mid-LoadSnapshot and our work continued
-	// after the caller gave up).
-	if dbSandboxes != nil {
-		for id := range active {
-			sb, known := dbSandboxes[id]
-			deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted
-			failed := known && sb.Sandbox.Status == db.SandboxStatusFailed
-			if known && !deleted && !failed {
-				continue
-			}
-			// Error records are Drift 8's (see Drift 1): its halves gate
-			// every record release on the terminal unit state, which this
-			// branch's stop does not.
-			if errorRecord(id) {
-				continue
-			}
-			if !r.gracePeriodElapsed("orphan:"+id, now) {
-				continue
-			}
-			// Lock before budget or the stop, so an in-flight create/resume
-			// (which holds it) is never killed mid-flight. No status re-check:
-			// an orphan that reached Running stays Running in memory until
-			// this rule stops it, so reading that as liveness would veto every
-			// reap — the Drift 1 mistake. A lifecycle op that COMPLETED since
-			// the pass snapshot is caught by the marker: its row moves and the
-			// next pass clears the drift before the grace re-elapses.
-			unlockOp, ok := r.mgr.tryLockVMOp(id)
-			if !ok {
-				continue
-			}
-			if !r.consumeAutoFailBudget(id) {
-				unlockOp()
-				r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "systemd_active_db_missing")
-				continue
-			}
-			reason := "systemd unit with no DB row"
-			kind := "systemd_active_db_missing"
-			if deleted {
-				reason = "systemd unit for soft-deleted sandbox"
-				kind = "systemd_active_db_deleted"
-			} else if failed {
-				reason = "systemd unit for failed sandbox"
-				kind = "systemd_active_db_failed"
-			}
-			log.Warn().Str("vm_id", id).Str("drift", kind).Msg("orphan systemd unit — stopping")
-			if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
-				unlockOp()
-				log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit")
-				continue
-			}
-			removeUnitDropIn(id)
-			releaseErr := r.markStale(ctx, id, "orphan:"+id)
-			unlockOp()
-			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
-		}
-	}
+	r.stopOrphanUnits(ctx, log, dbSandboxes, active, errorRecord, now)
 
 	// Drift 8: BoltDB record in Error but its systemd unit is still active.
 	// Reattach parks an unmanageable VM this way (unit alive, API socket
@@ -860,7 +804,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if r.hasPendingRelease(id) {
 				continue
 			}
-			if !r.gracePeriodElapsed("bolt-orphan:"+id, now) {
+			if !r.graceElapsedFor("bolt-orphan:"+id, id, now, r.cfg.GracePeriod) {
 				continue
 			}
 			rec, getErr := r.mgr.state.Get(id)
@@ -879,6 +823,10 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// re-check.
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
+				continue
+			}
+			if !r.episodeStillCurrent("bolt-orphan:"+id, id) {
+				unlockOp()
 				continue
 			}
 			// Only stopping a live unit is destructive; charge the budget there.
@@ -1259,14 +1207,34 @@ func (r *Reconciler) gracePeriodElapsed(key string, now time.Time) bool {
 // graceElapsed is gracePeriodElapsed with an explicit window, for drifts whose
 // safe wait differs from the default (see UnverifiedOrphanGrace).
 func (r *Reconciler) graceElapsed(key string, now time.Time, window time.Duration) bool {
+	return r.graceElapsedFor(key, "", now, window)
+}
+
+// graceElapsedFor is graceElapsed binding the episode to vmID's instance
+// identity and generation, so episodeStillCurrent can later tell a continuing
+// drift from a newly claimed generation. An empty vmID opens an unbound
+// episode (rules whose key is not a VM).
+func (r *Reconciler) graceElapsedFor(key, vmID string, now time.Time, window time.Duration) bool {
+	var inst *VMInstance
+	var gen uint64
+	if vmID != "" {
+		r.mgr.mu.RLock()
+		inst = r.mgr.vms[vmID]
+		r.mgr.mu.RUnlock()
+		if inst != nil {
+			inst.mu.RLock()
+			gen = inst.gen
+			inst.mu.RUnlock()
+		}
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	firstSeen, ok := r.driftSeen[key]
+	e, ok := r.driftSeen[key]
 	if !ok {
-		r.driftSeen[key] = now
+		r.driftSeen[key] = driftEpisode{at: now, inst: inst, gen: gen}
 		return false
 	}
-	return now.Sub(firstSeen) >= window
+	return now.Sub(e.at) >= window
 }
 
 // statPauseArtifact classifies a pause artifact for the missing-snapshot rule:
@@ -1280,6 +1248,47 @@ var statPauseArtifact = func(path string) (present, confirmedMissing bool) {
 		return true, false
 	}
 	return false, errors.Is(err, os.ErrNotExist)
+}
+
+// driftEpisode is one continuous observation of a drift. It carries the
+// instance identity and lifecycle generation seen when the episode opened:
+// a rule that destroys (stop, release) must confirm under the vm-op lock that
+// its evidence still describes the VM it evaluated. A lifecycle op completing
+// between the pass snapshot and the lock replaces the instance or advances
+// its generation — acting on the stale snapshot would stop the NEW unit, and
+// that destruction lands in this pass, not a later one.
+type driftEpisode struct {
+	at   time.Time
+	inst *VMInstance
+	gen  uint64
+}
+
+// episodeStillCurrent reports whether key's episode still describes vmID's
+// tracked instance. A changed identity or generation RESTARTS the episode —
+// the drift may well still hold for the new generation, but it must serve its
+// own grace period before anything destructive acts on it. Call under the
+// vm-op lock, before spending budget or stopping.
+func (r *Reconciler) episodeStillCurrent(key, vmID string) bool {
+	r.mgr.mu.RLock()
+	inst := r.mgr.vms[vmID]
+	r.mgr.mu.RUnlock()
+	var gen uint64
+	if inst != nil {
+		inst.mu.RLock()
+		gen = inst.gen
+		inst.mu.RUnlock()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.driftSeen[key]
+	if !ok {
+		return false
+	}
+	if e.inst == inst && e.gen == gen {
+		return true
+	}
+	r.driftSeen[key] = driftEpisode{at: time.Now(), inst: inst, gen: gen}
+	return false
 }
 
 // clearDrift removes a drift marker once the VM returns to a healthy state.
@@ -1490,6 +1499,9 @@ func (r *Reconciler) markStale(ctx context.Context, vmID, marker string) error {
 		Str("action", "mark_stale").Msg("reconciler: cleaned up stale VM record")
 	return nil
 }
+
+// stopUnitFn is the reap rules' destructive stop; a var for tests.
+var stopUnitFn = stopUnit
 
 // unitFullyDownCtx is markStale's terminal-unit oracle, bounded by the
 // caller's ctx so N wedged probes exhaust the pass deadline instead of
@@ -1753,5 +1765,69 @@ func (r *Reconciler) failMissingSnapshots(ctx context.Context, log zerolog.Logge
 		}
 		r.writeAudit(ctx, id, "mark_failed", "snapshot file missing", "paused_snapshot_missing")
 		r.clearDrift("paused:" + id)
+	}
+}
+
+// stopOrphanUnits is Drift 3's body: a live unit whose control-plane row is
+// deleted, failed or missing. Extracted so the lock/episode race is testable
+// — the rule must stop a genuinely stale orphan and must NOT stop a unit
+// whose generation was claimed since the pass snapshot.
+func (r *Reconciler) stopOrphanUnits(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool, errorRecord func(string) bool, now time.Time) {
+	for id := range active {
+		sb, known := dbSandboxes[id]
+		deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted
+		failed := known && sb.Sandbox.Status == db.SandboxStatusFailed
+		if known && !deleted && !failed {
+			continue
+		}
+		// Error records are Drift 8's (see Drift 1): its halves gate
+		// every record release on the terminal unit state, which this
+		// branch's stop does not.
+		if errorRecord(id) {
+			continue
+		}
+		if !r.graceElapsedFor("orphan:"+id, id, now, r.cfg.GracePeriod) {
+			continue
+		}
+		// Lock before budget or the stop, so an in-flight create/resume
+		// (which holds it) is never killed mid-flight — and confirm under
+		// the lock that the episode still describes the instance it was
+		// opened against. No status re-check: an orphan that reached
+		// Running stays Running in memory until this rule stops it, so
+		// reading that as liveness would veto every reap (the Drift 1
+		// mistake); identity+generation is what distinguishes a stale
+		// orphan from a generation claimed since the pass snapshot.
+		unlockOp, ok := r.mgr.tryLockVMOp(id)
+		if !ok {
+			continue
+		}
+		if !r.episodeStillCurrent("orphan:"+id, id) {
+			unlockOp()
+			continue
+		}
+		if !r.consumeAutoFailBudget(id) {
+			unlockOp()
+			r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "systemd_active_db_missing")
+			continue
+		}
+		reason := "systemd unit with no DB row"
+		kind := "systemd_active_db_missing"
+		if deleted {
+			reason = "systemd unit for soft-deleted sandbox"
+			kind = "systemd_active_db_deleted"
+		} else if failed {
+			reason = "systemd unit for failed sandbox"
+			kind = "systemd_active_db_failed"
+		}
+		log.Warn().Str("vm_id", id).Str("drift", kind).Msg("orphan systemd unit — stopping")
+		if err := stopUnitFn(ctx, systemdUnitName(id)); err != nil {
+			unlockOp()
+			log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit")
+			continue
+		}
+		removeUnitDropIn(id)
+		releaseErr := r.markStale(ctx, id, "orphan:"+id)
+		unlockOp()
+		r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
 	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -121,12 +121,10 @@ type Reconciler struct {
 	driftSeen   map[string]time.Time
 	autoFailLog []time.Time // timestamps of recent auto-fail actions
 
-	// pendingRelease holds VMs whose reap was already decided and whose unit
-	// was already stopped, but whose resource release did not complete. Every
-	// drift rule that reaps a live VM matches on an ACTIVE unit, which its own
-	// stop then retires — so once a release is abandoned, no rule ever looks at
-	// that VM again. This set is the only thing that remembers, and
-	// retryPendingReleases is where the decision gets finished.
+	// pendingRelease holds VMs whose reap was decided and whose unit was
+	// stopped, but whose resource release did not complete. Every drift rule
+	// that reaps a live VM matches on an ACTIVE unit, which its own stop then
+	// retires — so without this set, an abandoned release is never revisited.
 	pendingRelease map[string]struct{}
 
 	// passCount counts completed reconcile passes, used to run the disk
@@ -299,8 +297,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			log.Warn().Str("vm_id", id).Str("drift", "db_active_systemd_missing").
 				Msg("DB says active but VM is dead — marking failed")
 			r.markFailedInDB(ctx, id)
-			r.markStale(id)
-			r.writeAudit(ctx, id, "mark_failed", "VM dead while DB said active", "db_active_systemd_missing")
+			releaseErr := r.markStale(id)
+			r.finalizeRelease(ctx, id, "", "mark_failed", "VM dead while DB said active", "db_active_systemd_missing", releaseErr)
 		}
 	}
 
@@ -404,8 +402,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// dead-VM rule). Detach from the pass context, bounded.
 			persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			r.markFailedInDB(persistCtx, id)
-			r.markStale(id)
-			r.writeAudit(persistCtx, id, "mark_failed", "empty Firecracker shell while DB said active", "fc_empty_shell")
+			releaseErr := r.markStale(id)
+			r.finalizeRelease(persistCtx, id, "", "mark_failed", "empty Firecracker shell while DB said active", "fc_empty_shell", releaseErr)
 			persistCancel()
 		}
 	}
@@ -430,8 +428,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_running_unit_missing").
 				Msg("dead Firecracker detected (no DB context)")
-			r.markStale(id)
-			r.writeAudit(ctx, id, "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing")
+			releaseErr := r.markStale(id)
+			r.finalizeRelease(ctx, id, "", "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing", releaseErr)
 		}
 	}
 
@@ -469,9 +467,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
-			r.markStale(id)
-			r.writeAudit(ctx, id, "orphan_stop", reason, kind)
-			r.clearDrift("orphan:" + id)
+			releaseErr := r.markStale(id)
+			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
 		}
 	}
 
@@ -661,15 +658,13 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				}
 				removeUnitDropIn(id)
 			}
-			r.markStale(id)
-			r.writeAudit(ctx, id, "stale_cleanup", "BoltDB entry with no DB row", "boltdb_present_db_missing")
-			r.clearDrift("bolt-orphan:" + id)
+			releaseErr := r.markStale(id)
+			r.finalizeRelease(ctx, id, "bolt-orphan:"+id, "stale_cleanup", "BoltDB entry with no DB row", "boltdb_present_db_missing", releaseErr)
 		}
 	}
 
-	// Finish reaps whose release was abandoned earlier. Runs last so a
-	// deferral recorded by this pass is retried on the next one, giving a
-	// stopped unit time to reach a terminal state in between.
+	// Runs last so a deferral recorded by this pass is retried on the next
+	// one, giving a stopped unit time to reach a terminal state in between.
 	r.retryPendingReleases(ctx)
 
 	// Drift 6 (detect-only): per-sandbox dirs on disk with no live row. Runs
@@ -1160,12 +1155,11 @@ func (r *Reconciler) refundAutoFailSlot() {
 // left for the startup reattach sweep rather than another pass.
 func (r *Reconciler) markStale(vmID string) error {
 	// The release hands this VM's namespace, IP and tap device back to the
-	// pool, so it needs the terminal claim. A nil stopUnit only means the job
-	// finished — the unit can still be deactivating with Firecracker holding
-	// the tap, and absence from the active-unit snapshot is not terminal
-	// either. Releasing then lets the next VM claim a device the old process
-	// still owns. Fail-closed: an inconclusive probe defers rather than
-	// releases, and retryPendingReleases comes back once it settles.
+	// pool, so it needs the terminal claim: a nil stopUnit only means the job
+	// finished, and absence from the active-unit snapshot is not terminal
+	// either — either way Firecracker may still hold the tap, and the next VM
+	// would claim a device the old process still owns. Fail-closed, so an
+	// inconclusive probe defers rather than releases.
 	if !vmUnitFullyDown(vmID) {
 		r.notePendingRelease(vmID)
 		return errUnitNotTerminal
@@ -1182,9 +1176,7 @@ func (r *Reconciler) markStale(vmID string) error {
 	// cause ReattachAll to resurrect the stale record on next restart, so a
 	// failure here abandons the whole cleanup rather than half-applying it.
 	if err := r.mgr.state.Delete(vmID); err != nil {
-		// The caller's rule cannot come back for this: it matched a live unit
-		// and has already stopped it. Remember the unfinished release here so
-		// every caller inherits the retry, rather than each growing its own.
+		// Recorded here, not per rule, so every caller inherits the retry.
 		r.notePendingRelease(vmID)
 		r.mgr.log.Error().Err(err).Str("vm_id", vmID).Msg("reconciler: failed to delete stale state")
 		return err
@@ -1214,6 +1206,21 @@ func (r *Reconciler) markStale(vmID string) error {
 // later pass can release them safely.
 var errUnitNotTerminal = errors.New("unit not terminal; release deferred")
 
+// finalizeRelease records a reap's outcome. A deferred or failed release must
+// neither report success nor retire the drift marker: the record and its slot
+// are still held, and retryPendingReleases owns finishing the job. An empty
+// marker is for rules whose only marker markStale clears itself.
+func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, reason, driftKind string, releaseErr error) {
+	if releaseErr != nil {
+		r.writeAudit(ctx, vmID, "release_deferred", reason+"; slot still held", driftKind)
+		return
+	}
+	r.writeAudit(ctx, vmID, action, reason, driftKind)
+	if marker != "" {
+		r.clearDrift(marker)
+	}
+}
+
 func (r *Reconciler) notePendingRelease(vmID string) {
 	r.mu.Lock()
 	r.pendingRelease[vmID] = struct{}{}
@@ -1231,12 +1238,10 @@ func (r *Reconciler) pendingReleaseIDs() []string {
 }
 
 // retryPendingReleases finishes reaps whose resource release was abandoned.
-//
 // It takes no destructive decision of its own — the rule that stopped the unit
-// already made and budgeted that call, and this only completes it — so it
-// charges no auto-fail budget and waits out no grace period. Charging again
-// would let one broken store drain the host's whole budget and suppress
-// unrelated drift.
+// already made and budgeted that call — so it charges no budget and waits out
+// no grace: charging again would let one broken store drain the host's budget
+// and suppress unrelated drift.
 func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 	for _, id := range r.pendingReleaseIDs() {
 		// A relaunch between passes voids the reap: the record describes a live

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -169,7 +169,8 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 	// predecessor — at the lock, so no in-place state round-trip (pause and
 	// resume can return Status and Unverified to their noted values on the
 	// SAME instance) can ever masquerade as the unmutated stale original.
-	mgr.onLifecycleClaim = r.voidPendingRelease
+	claim := r.voidPendingRelease
+	mgr.onLifecycleClaim.Store(&claim)
 	return r
 }
 

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -800,6 +800,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		// not for every bolted entry.
 		for id := range boltedIDs {
 			if _, ok := dbSandboxes[id]; ok {
+				r.clearDrift("bolt-orphan:" + id) // healed; see Drift 3's twin
 				continue
 			}
 			// A deferred release owns this id (see hasPendingRelease) —
@@ -1797,6 +1798,10 @@ func (r *Reconciler) stopOrphanUnits(ctx context.Context, log zerolog.Logger, db
 		deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted
 		failed := known && sb.Sandbox.Status == db.SandboxStatusFailed
 		if known && !deleted && !failed {
+			// A healthy row heals the episode. Without this, a later orphan
+			// observation against the SAME generation (a row that flapped)
+			// inherits the old timestamp and acts without its grace.
+			r.clearDrift("orphan:" + id)
 			continue
 		}
 		// Error records are Drift 8's (see Drift 1): its halves gate

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -126,14 +126,20 @@ type Reconciler struct {
 	// that reaps a live VM matches on an ACTIVE unit, which its own stop then
 	// retires — so without this set, an abandoned release is never revisited.
 	//
-	// The value is the instance tracked when the release was deferred (nil for
-	// an untracked id). The retry proceeds only while m.vms still holds that
-	// EXACT object: any lifecycle op replaces or removes it, and that op owns
-	// cleanup from then on. Status is useless as this signal — nothing updates
-	// a record when firecracker dies out from under vmd, so a stale entry
-	// reads Running forever, and a relaunched-then-paused VM reads Paused —
-	// both indistinguishable by value from the states that must be released.
-	pendingRelease map[string]*VMInstance
+	// The entry holds the instance tracked when the release was deferred (nil
+	// for an untracked id). The retry proceeds only while m.vms still holds
+	// that EXACT object: any lifecycle op replaces or removes it, and that op
+	// owns cleanup from then on. Status is useless as this signal — nothing
+	// updates a record when firecracker dies out from under vmd, so a stale
+	// entry reads Running forever, and a relaunched-then-paused VM reads
+	// Paused — both indistinguishable by value from the states that must be
+	// released.
+	//
+	// marker is the originating rule's drift key, kept alive across the
+	// deferral: retiring the entry must retire that marker too, or a LATER
+	// episode of the same rule for the same id inherits the old timestamp and
+	// skips its grace period.
+	pendingRelease map[string]deferredRelease
 
 	// passCount counts completed reconcile passes, used to run the disk
 	// scan on a slower sub-cadence. Only touched from the single Run loop.
@@ -149,7 +155,7 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 		mgr:            mgr,
 		cfg:            cfg,
 		driftSeen:      make(map[string]time.Time),
-		pendingRelease: make(map[string]*VMInstance),
+		pendingRelease: make(map[string]deferredRelease),
 		prevKeptLive:   -1,
 	}
 }
@@ -305,7 +311,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			log.Warn().Str("vm_id", id).Str("drift", "db_active_systemd_missing").
 				Msg("DB says active but VM is dead — marking failed")
 			r.markFailedInDB(ctx, id)
-			releaseErr := r.markStale(id)
+			releaseErr := r.markStale(ctx, id)
 			r.finalizeRelease(ctx, id, "", "mark_failed", "VM dead while DB said active", "db_active_systemd_missing", releaseErr)
 		}
 	}
@@ -410,7 +416,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// dead-VM rule). Detach from the pass context, bounded.
 			persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			r.markFailedInDB(persistCtx, id)
-			releaseErr := r.markStale(id)
+			releaseErr := r.markStale(persistCtx, id)
 			r.finalizeRelease(persistCtx, id, "", "mark_failed", "empty Firecracker shell while DB said active", "fc_empty_shell", releaseErr)
 			persistCancel()
 		}
@@ -436,7 +442,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_running_unit_missing").
 				Msg("dead Firecracker detected (no DB context)")
-			releaseErr := r.markStale(id)
+			releaseErr := r.markStale(ctx, id)
 			r.finalizeRelease(ctx, id, "", "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing", releaseErr)
 		}
 	}
@@ -475,7 +481,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
-			releaseErr := r.markStale(id)
+			releaseErr := r.markStale(ctx, id)
 			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
 		}
 	}
@@ -583,12 +589,13 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				continue
 			}
 			removeUnitDropIn(id)
-			staleErr := r.markStale(id)
+			staleErr := r.markStale(ctx, id)
 			unlockOp()
 			if staleErr != nil {
 				// The unit is stopped but the record, its map entry and its slot
 				// survive, and no rule matches an inactive unit. Report the
 				// partial cleanup rather than an orphan_stop that did not happen.
+				r.tagPendingRelease(id, "unverifiedorphan:"+id)
 				r.writeAudit(ctx, id, "stale_cleanup_failed", "unit stopped but record not deleted", "unverified_orphan_abandoned")
 				continue
 			}
@@ -666,7 +673,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				}
 				removeUnitDropIn(id)
 			}
-			releaseErr := r.markStale(id)
+			releaseErr := r.markStale(ctx, id)
 			r.finalizeRelease(ctx, id, "bolt-orphan:"+id, "stale_cleanup", "BoltDB entry with no DB row", "boltdb_present_db_missing", releaseErr)
 		}
 	}
@@ -1161,14 +1168,14 @@ func (r *Reconciler) refundAutoFailSlot() {
 // before calling this must not report success on one: stopping the unit
 // retires the very condition their next pass matches on, so the record is
 // left for the startup reattach sweep rather than another pass.
-func (r *Reconciler) markStale(vmID string) error {
+func (r *Reconciler) markStale(ctx context.Context, vmID string) error {
 	// The release hands this VM's namespace, IP and tap device back to the
 	// pool, so it needs the terminal claim: a nil stopUnit only means the job
 	// finished, and absence from the active-unit snapshot is not terminal
 	// either — either way Firecracker may still hold the tap, and the next VM
 	// would claim a device the old process still owns. Fail-closed, so an
 	// inconclusive probe defers rather than releases.
-	if !vmUnitFullyDown(vmID) {
+	if !unitFullyDownCtx(ctx, systemdUnitName(vmID)) {
 		r.notePendingRelease(vmID)
 		return errUnitNotTerminal
 	}
@@ -1209,6 +1216,12 @@ func (r *Reconciler) markStale(vmID string) error {
 	return nil
 }
 
+// unitFullyDownCtx is markStale's terminal-unit oracle, bounded by the
+// caller's ctx so N wedged probes exhaust the pass deadline instead of
+// stacking 2s each past it; a var for tests. An expired ctx fails the probe,
+// which defers — the safe verdict.
+var unitFullyDownCtx = unitFullyDown
+
 // errUnitNotTerminal means the release was deferred, not that it failed: the
 // unit still has a process, so the record and its slot stay owned until a
 // later pass can release them safely.
@@ -1220,6 +1233,7 @@ var errUnitNotTerminal = errors.New("unit not terminal; release deferred")
 // marker is for rules whose only marker markStale clears itself.
 func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, reason, driftKind string, releaseErr error) {
 	if releaseErr != nil {
+		r.tagPendingRelease(vmID, marker)
 		r.writeAudit(ctx, vmID, "release_deferred", reason+"; slot still held", driftKind)
 		return
 	}
@@ -1229,12 +1243,33 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 	}
 }
 
+type deferredRelease struct {
+	inst   *VMInstance
+	marker string
+}
+
 func (r *Reconciler) notePendingRelease(vmID string) {
 	r.mgr.mu.RLock()
 	inst := r.mgr.vms[vmID]
 	r.mgr.mu.RUnlock()
 	r.mu.Lock()
-	r.pendingRelease[vmID] = inst
+	e := r.pendingRelease[vmID]
+	e.inst = inst
+	r.pendingRelease[vmID] = e
+	r.mu.Unlock()
+}
+
+// tagPendingRelease attaches the deferring rule's drift marker to an entry
+// notePendingRelease already recorded (markStale notes without rule context).
+func (r *Reconciler) tagPendingRelease(vmID, marker string) {
+	if marker == "" {
+		return
+	}
+	r.mu.Lock()
+	if e, ok := r.pendingRelease[vmID]; ok {
+		e.marker = marker
+		r.pendingRelease[vmID] = e
+	}
 	r.mu.Unlock()
 }
 
@@ -1255,9 +1290,9 @@ func (r *Reconciler) pendingReleaseIDs() []string {
 // and suppress unrelated drift.
 func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 	r.mu.Lock()
-	snapshot := make(map[string]*VMInstance, len(r.pendingRelease))
-	for id, inst := range r.pendingRelease {
-		snapshot[id] = inst
+	snapshot := make(map[string]deferredRelease, len(r.pendingRelease))
+	for id, e := range r.pendingRelease {
+		snapshot[id] = e
 	}
 	r.mu.Unlock()
 	for id, noted := range snapshot {
@@ -1272,18 +1307,22 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 		r.mgr.mu.RLock()
 		cur := r.mgr.vms[id]
 		r.mgr.mu.RUnlock()
-		if cur != noted {
+		if cur != noted.inst {
 			unlockOp()
 			r.mu.Lock()
 			delete(r.pendingRelease, id)
 			r.mu.Unlock()
+			// The deferral episode is over either way; a surviving marker
+			// would hand its stale timestamp to the id's next episode.
+			r.clearDrift(noted.marker)
 			continue
 		}
-		err := r.markStale(id)
+		err := r.markStale(ctx, id)
 		unlockOp()
 		if err != nil {
 			continue // still unreleasable; the entry survives for the next pass
 		}
+		r.clearDrift(noted.marker)
 		r.writeAudit(ctx, id, "stale_cleanup", "deferred release completed on a later pass", "release_retry")
 	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -138,13 +138,7 @@ type Reconciler struct {
 	// stopped, but whose resource release did not complete. Every drift rule
 	// that reaps a live VM matches on an ACTIVE unit, which its own stop then
 	// retires — so without this set, an abandoned release is never revisited.
-	//
-	// The entry holds the instance tracked when the release was deferred (nil
-	// for an untracked id). The retry proceeds only while m.vms still holds
-	// that EXACT object AND its snapshot is unmutated: any lifecycle op
-	// replaces the instance or mutates it in place, and that op owns cleanup
-	// from then on. Status alone is useless as this signal — nothing updates
-	// a record when firecracker dies out from under vmd.
+	// The void semantics live on deferredRelease.
 	//
 	// marker is the originating rule's drift key, kept alive across the
 	// deferral: retiring the entry — by completed release OR void — must
@@ -1351,10 +1345,7 @@ func (r *Reconciler) refundAutoFailSlot() {
 // when the unit leaves the active set, so its retry waits out one more grace.
 func (r *Reconciler) finalizeErrorReap(ctx context.Context, vmID, marker, action, reason, driftKind string, staleErr error) {
 	if staleErr != nil {
-		// Same discipline as finalizeRelease: the deferred entry must carry
-		// this rule's marker, or a completed retry retires the record while
-		// the errunit:/errdead: timestamp lives on to rob the id's next
-		// Error episode of its grace period.
+		// Same discipline as finalizeRelease — see pendingRelease's marker doc.
 		r.tagPendingRelease(vmID, marker)
 		r.writeAudit(ctx, vmID, "stale_cleanup_failed", reason+"; record not deleted", driftKind)
 		return
@@ -1446,15 +1437,16 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 	}
 }
 
+// deferredRelease is a reap decision awaiting its release. The retry proceeds
+// only while m.vms still holds the EXACT instance observed at deferral AND its
+// snapshot is unmutated: pointer identity alone only detects REPLACEMENT ops
+// (a fresh relaunch swaps the map entry), while adoption clears Unverified and
+// pause flips Status on the SAME object. A stale instance is by definition one
+// nothing updates, so any observed mutation proves a lifecycle op claimed the
+// VM — that op owns cleanup, and the reap decision is void.
 type deferredRelease struct {
-	inst   *VMInstance
-	marker string
-	// Snapshot of the instance when the release was deferred. Pointer
-	// identity alone only detects REPLACEMENT ops (a fresh relaunch swaps
-	// the map entry); adoption clears Unverified and pause flips Status on
-	// the SAME object. A stale instance is by definition one nothing
-	// updates, so any observed mutation proves a lifecycle op claimed the
-	// VM and the reap decision is void.
+	inst       *VMInstance
+	marker     string
 	status     VMStatus
 	unverified bool
 }
@@ -1518,11 +1510,8 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 		if !ok {
 			continue
 		}
-		// Identity AND an unmutated snapshot: the reap was decided against
-		// `noted`, and any lifecycle op since has either replaced the tracked
-		// instance or mutated it in place — that op owns cleanup now, and
-		// releasing under it would strand a relaunched VM or delete a
-		// legitimately re-paused record.
+		// Identity AND an unmutated snapshot decide the void — see
+		// deferredRelease for why either alone is insufficient.
 		r.mgr.mu.RLock()
 		cur := r.mgr.vms[id]
 		r.mgr.mu.RUnlock()

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -165,12 +165,6 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 		prevKeptLive:   -1,
 	}
 	r.markFailed = r.markFailedInDB
-	// A lifecycle op claiming a VM voids any release deferred against its
-	// predecessor — at the lock, so no in-place state round-trip (pause and
-	// resume can return Status and Unverified to their noted values on the
-	// SAME instance) can ever masquerade as the unmutated stale original.
-	claim := r.voidPendingRelease
-	mgr.onLifecycleClaim.Store(&claim)
 	return r
 }
 
@@ -1506,37 +1500,30 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 
 // deferredRelease is a reap decision awaiting its release. The retry proceeds
 // only while m.vms still holds the EXACT instance observed at deferral AND its
-// snapshot is unmutated: pointer identity alone only detects REPLACEMENT ops
-// (a fresh relaunch swaps the map entry), while adoption clears Unverified and
-// pause flips Status on the SAME object. A stale instance is by definition one
-// nothing updates, so any observed mutation proves a lifecycle op claimed the
-// VM — that op owns cleanup, and the reap decision is void.
-//
-// The snapshot cannot see a round-trip that returns both fields to their
-// noted values; onLifecycleClaim closes that class at the vm-op lock, voiding
-// the entry the moment any lifecycle op claims the instance. The comparison
-// below remains as the backstop for anything that mutates without the lock.
+// lifecycle generation is unchanged: pointer identity detects REPLACEMENT ops
+// (a fresh relaunch swaps the map entry), the generation detects in-place
+// claims — including a round-trip that drives the VM away and back to its
+// deferred-time state, which a value snapshot cannot see. A stale instance is
+// by definition one no lifecycle op touches, so it advances neither.
 type deferredRelease struct {
-	inst       *VMInstance
-	marker     string
-	status     VMStatus
-	unverified bool
+	inst   *VMInstance
+	marker string
+	gen    uint64
 }
 
 func (r *Reconciler) notePendingRelease(vmID, marker string) {
 	r.mgr.mu.RLock()
 	inst := r.mgr.vms[vmID]
 	r.mgr.mu.RUnlock()
-	var st VMStatus
-	var unv bool
+	var gen uint64
 	if inst != nil {
 		inst.mu.RLock()
-		st, unv = inst.Status, inst.Unverified
+		gen = inst.gen
 		inst.mu.RUnlock()
 	}
 	r.mu.Lock()
 	e := r.pendingRelease[vmID]
-	e.inst, e.status, e.unverified, e.marker = inst, st, unv, marker
+	e.inst, e.gen, e.marker = inst, gen, marker
 	r.pendingRelease[vmID] = e
 	r.mu.Unlock()
 }
@@ -1580,18 +1567,18 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 		if !ok {
 			continue
 		}
-		// Identity AND an unmutated snapshot decide the void — see
-		// deferredRelease for why either alone is insufficient.
+		// Identity AND an unchanged lifecycle generation decide the void —
+		// see deferredRelease for why either alone is insufficient.
 		r.mgr.mu.RLock()
 		cur := r.mgr.vms[id]
 		r.mgr.mu.RUnlock()
-		mutated := false
+		claimed := false
 		if cur != nil && cur == noted.inst {
 			cur.mu.RLock()
-			mutated = cur.Status != noted.status || cur.Unverified != noted.unverified
+			claimed = cur.gen != noted.gen
 			cur.mu.RUnlock()
 		}
-		if cur != noted.inst || mutated {
+		if cur != noted.inst || claimed {
 			// Voids retire the episode's timestamps (see pendingRelease): the
 			// prefixed marker, and the bare id — Drift 1/2 grace under the bare
 			// id and defer with marker "", relying on markStale to clear it,

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -463,6 +463,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	if dbSandboxes == nil {
 		for id, rec := range bolted {
 			if rec.Status != StatusRunning {
+				r.clearDrift(id) // predicate stopped matching; see the Drift 3 heal
 				continue
 			}
 			if active[id] {
@@ -1238,7 +1239,7 @@ func (r *Reconciler) graceElapsedFor(key, vmID string, now time.Time, window tim
 	defer r.mu.Unlock()
 	e, ok := r.driftSeen[key]
 	if !ok {
-		r.driftSeen[key] = driftEpisode{at: now, inst: inst, gen: gen}
+		r.driftSeen[key] = newDriftEpisode(now, inst, gen)
 		return false
 	}
 	return now.Sub(e.at) >= window
@@ -1265,9 +1266,15 @@ var statPauseArtifact = func(path string) (present, confirmedMissing bool) {
 // its generation — acting on the stale snapshot would stop the NEW unit, and
 // that destruction lands in this pass, not a later one.
 type driftEpisode struct {
-	at   time.Time
-	inst *VMInstance
-	gen  uint64
+	at time.Time
+	// inc is the instance's NON-OWNING incarnation identity (see
+	// VMInstance.incarnation): the episode must recognize its instance, not
+	// keep it alive — a pointer here would root the whole VMInstance graph in
+	// driftSeen for every episode whose predicate quietly stopped matching,
+	// since disappeared candidates are exactly the ones no loop revisits to
+	// clear.
+	inc uint64
+	gen uint64
 }
 
 // episodeStillCurrent reports whether key's episode still describes vmID's
@@ -1291,11 +1298,15 @@ func (r *Reconciler) episodeStillCurrent(key, vmID string) bool {
 	if !ok {
 		return false
 	}
-	if e.inst == inst && e.gen == gen {
+	if e.inc == inst.incarnationID() && e.gen == gen {
 		return true
 	}
-	r.driftSeen[key] = driftEpisode{at: time.Now(), inst: inst, gen: gen}
+	r.driftSeen[key] = newDriftEpisode(time.Now(), inst, gen)
 	return false
+}
+
+func newDriftEpisode(at time.Time, inst *VMInstance, gen uint64) driftEpisode {
+	return driftEpisode{at: at, inc: inst.incarnationID(), gen: gen}
 }
 
 // clearDrift removes a drift marker once the VM returns to a healthy state.
@@ -1643,6 +1654,9 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool, errorRecord func(string) bool, now time.Time) {
 	for id, sb := range dbSandboxes {
 		if sb.Sandbox.Status != db.SandboxStatusActive {
+			// The predicate stopped matching; retire the episode so a later
+			// recurrence serves its own grace (see the Drift 3 heal).
+			r.clearDrift(id)
 			continue
 		}
 		if active[id] {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -136,9 +136,17 @@ type Reconciler struct {
 	// released.
 	//
 	// marker is the originating rule's drift key, kept alive across the
-	// deferral: retiring the entry must retire that marker too, or a LATER
-	// episode of the same rule for the same id inherits the old timestamp and
-	// skips its grace period.
+	// deferral: retiring the entry — by completed release OR identity void —
+	// must retire that marker too, or a LATER episode of the same rule for
+	// the same id inherits the old timestamp and skips its grace period.
+	//
+	// The slot is single-marker by choice. Two accepted, fail-safe edges: a
+	// void racing a fresh episode of the same rule clears that episode's new
+	// timestamp (its grace restarts — delays the reap, favors adoption), and
+	// a second rule deferring the same id overwrites the first rule's marker
+	// (that sliver keeps the stale-timestamp bug). Episode-scoped markers
+	// would close both; neither failure is destructive, so they don't pay
+	// for the machinery.
 	pendingRelease map[string]deferredRelease
 
 	// passCount counts completed reconcile passes, used to run the disk
@@ -1312,9 +1320,7 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 			r.mu.Lock()
 			delete(r.pendingRelease, id)
 			r.mu.Unlock()
-			// The deferral episode is over either way; a surviving marker
-			// would hand its stale timestamp to the id's next episode.
-			r.clearDrift(noted.marker)
+			r.clearDrift(noted.marker) // see pendingRelease: voids retire the marker too
 			continue
 		}
 		err := r.markStale(ctx, id)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -125,7 +125,15 @@ type Reconciler struct {
 	// stopped, but whose resource release did not complete. Every drift rule
 	// that reaps a live VM matches on an ACTIVE unit, which its own stop then
 	// retires — so without this set, an abandoned release is never revisited.
-	pendingRelease map[string]struct{}
+	//
+	// The value is the instance tracked when the release was deferred (nil for
+	// an untracked id). The retry proceeds only while m.vms still holds that
+	// EXACT object: any lifecycle op replaces or removes it, and that op owns
+	// cleanup from then on. Status is useless as this signal — nothing updates
+	// a record when firecracker dies out from under vmd, so a stale entry
+	// reads Running forever, and a relaunched-then-paused VM reads Paused —
+	// both indistinguishable by value from the states that must be released.
+	pendingRelease map[string]*VMInstance
 
 	// passCount counts completed reconcile passes, used to run the disk
 	// scan on a slower sub-cadence. Only touched from the single Run loop.
@@ -141,7 +149,7 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 		mgr:            mgr,
 		cfg:            cfg,
 		driftSeen:      make(map[string]time.Time),
-		pendingRelease: make(map[string]struct{}),
+		pendingRelease: make(map[string]*VMInstance),
 		prevKeptLive:   -1,
 	}
 }
@@ -1222,8 +1230,11 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 }
 
 func (r *Reconciler) notePendingRelease(vmID string) {
+	r.mgr.mu.RLock()
+	inst := r.mgr.vms[vmID]
+	r.mgr.mu.RUnlock()
 	r.mu.Lock()
-	r.pendingRelease[vmID] = struct{}{}
+	r.pendingRelease[vmID] = inst
 	r.mu.Unlock()
 }
 
@@ -1243,20 +1254,25 @@ func (r *Reconciler) pendingReleaseIDs() []string {
 // no grace: charging again would let one broken store drain the host's budget
 // and suppress unrelated drift.
 func (r *Reconciler) retryPendingReleases(ctx context.Context) {
-	for _, id := range r.pendingReleaseIDs() {
-		// A relaunch between passes voids the reap: the record describes a live
-		// VM again, and releasing it would strand a running Firecracker.
-		if r.mgr.instanceRunning(id) {
-			r.mu.Lock()
-			delete(r.pendingRelease, id)
-			r.mu.Unlock()
-			continue
-		}
+	r.mu.Lock()
+	snapshot := make(map[string]*VMInstance, len(r.pendingRelease))
+	for id, inst := range r.pendingRelease {
+		snapshot[id] = inst
+	}
+	r.mu.Unlock()
+	for id, noted := range snapshot {
 		unlockOp, ok := r.mgr.tryLockVMOp(id)
 		if !ok {
 			continue
 		}
-		if r.mgr.instanceRunning(id) {
+		// Identity, not status: the reap was decided against `noted`, and any
+		// lifecycle op since has replaced or removed the tracked instance —
+		// that op owns cleanup now, and releasing under it would strand a
+		// relaunched VM or delete a legitimately re-paused record.
+		r.mgr.mu.RLock()
+		cur := r.mgr.vms[id]
+		r.mgr.mu.RUnlock()
+		if cur != noted {
 			unlockOp()
 			r.mu.Lock()
 			delete(r.pendingRelease, id)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -121,6 +121,14 @@ type Reconciler struct {
 	driftSeen   map[string]time.Time
 	autoFailLog []time.Time // timestamps of recent auto-fail actions
 
+	// pendingRelease holds VMs whose reap was already decided and whose unit
+	// was already stopped, but whose resource release did not complete. Every
+	// drift rule that reaps a live VM matches on an ACTIVE unit, which its own
+	// stop then retires — so once a release is abandoned, no rule ever looks at
+	// that VM again. This set is the only thing that remembers, and
+	// retryPendingReleases is where the decision gets finished.
+	pendingRelease map[string]struct{}
+
 	// passCount counts completed reconcile passes, used to run the disk
 	// scan on a slower sub-cadence. Only touched from the single Run loop.
 	passCount uint64
@@ -132,10 +140,11 @@ type Reconciler struct {
 // NewReconciler creates a reconciler bound to a Manager.
 func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 	return &Reconciler{
-		mgr:          mgr,
-		cfg:          cfg,
-		driftSeen:    make(map[string]time.Time),
-		prevKeptLive: -1,
+		mgr:            mgr,
+		cfg:            cfg,
+		driftSeen:      make(map[string]time.Time),
+		pendingRelease: make(map[string]struct{}),
+		prevKeptLive:   -1,
 	}
 }
 
@@ -658,6 +667,11 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		}
 	}
 
+	// Finish reaps whose release was abandoned earlier. Runs last so a
+	// deferral recorded by this pass is retried on the next one, giving a
+	// stopped unit time to reach a terminal state in between.
+	r.retryPendingReleases(ctx)
+
 	// Drift 6 (detect-only): per-sandbox dirs on disk with no live row. Runs
 	// on a slower sub-cadence so the filesystem walk doesn't ride every tick.
 	r.passCount++
@@ -1156,6 +1170,10 @@ func (r *Reconciler) markStale(vmID string) error {
 	// cause ReattachAll to resurrect the stale record on next restart, so a
 	// failure here abandons the whole cleanup rather than half-applying it.
 	if err := r.mgr.state.Delete(vmID); err != nil {
+		// The caller's rule cannot come back for this: it matched a live unit
+		// and has already stopped it. Remember the unfinished release here so
+		// every caller inherits the retry, rather than each growing its own.
+		r.notePendingRelease(vmID)
 		r.mgr.log.Error().Err(err).Str("vm_id", vmID).Msg("reconciler: failed to delete stale state")
 		return err
 	}
@@ -1171,9 +1189,63 @@ func (r *Reconciler) markStale(vmID string) error {
 
 	r.mu.Lock()
 	delete(r.driftSeen, vmID)
+	delete(r.pendingRelease, vmID)
 	r.mu.Unlock()
 
 	r.mgr.log.Warn().Str("component", "reconciler").Str("vm_id", vmID).
 		Str("action", "mark_stale").Msg("reconciler: cleaned up stale VM record")
 	return nil
+}
+
+func (r *Reconciler) notePendingRelease(vmID string) {
+	r.mu.Lock()
+	r.pendingRelease[vmID] = struct{}{}
+	r.mu.Unlock()
+}
+
+func (r *Reconciler) pendingReleaseIDs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ids := make([]string, 0, len(r.pendingRelease))
+	for id := range r.pendingRelease {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// retryPendingReleases finishes reaps whose resource release was abandoned.
+//
+// It takes no destructive decision of its own — the rule that stopped the unit
+// already made and budgeted that call, and this only completes it — so it
+// charges no auto-fail budget and waits out no grace period. Charging again
+// would let one broken store drain the host's whole budget and suppress
+// unrelated drift.
+func (r *Reconciler) retryPendingReleases(ctx context.Context) {
+	for _, id := range r.pendingReleaseIDs() {
+		// A relaunch between passes voids the reap: the record describes a live
+		// VM again, and releasing it would strand a running Firecracker.
+		if r.mgr.instanceRunning(id) {
+			r.mu.Lock()
+			delete(r.pendingRelease, id)
+			r.mu.Unlock()
+			continue
+		}
+		unlockOp, ok := r.mgr.tryLockVMOp(id)
+		if !ok {
+			continue
+		}
+		if r.mgr.instanceRunning(id) {
+			unlockOp()
+			r.mu.Lock()
+			delete(r.pendingRelease, id)
+			r.mu.Unlock()
+			continue
+		}
+		err := r.markStale(id)
+		unlockOp()
+		if err != nil {
+			continue // still unreleasable; the entry survives for the next pass
+		}
+		r.writeAudit(ctx, id, "stale_cleanup", "deferred release completed on a later pass", "release_retry")
+	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1159,6 +1159,18 @@ func (r *Reconciler) refundAutoFailSlot() {
 // retires the very condition their next pass matches on, so the record is
 // left for the startup reattach sweep rather than another pass.
 func (r *Reconciler) markStale(vmID string) error {
+	// The release hands this VM's namespace, IP and tap device back to the
+	// pool, so it needs the terminal claim. A nil stopUnit only means the job
+	// finished — the unit can still be deactivating with Firecracker holding
+	// the tap, and absence from the active-unit snapshot is not terminal
+	// either. Releasing then lets the next VM claim a device the old process
+	// still owns. Fail-closed: an inconclusive probe defers rather than
+	// releases, and retryPendingReleases comes back once it settles.
+	if !vmUnitFullyDown(vmID) {
+		r.notePendingRelease(vmID)
+		return errUnitNotTerminal
+	}
+
 	// Capture the namespace before deleting the record: a VM whose teardown
 	// didn't run (e.g. a vmd timeout mid-DELETE) would otherwise leak its slot.
 	var namespace string
@@ -1196,6 +1208,11 @@ func (r *Reconciler) markStale(vmID string) error {
 		Str("action", "mark_stale").Msg("reconciler: cleaned up stale VM record")
 	return nil
 }
+
+// errUnitNotTerminal means the release was deferred, not that it failed: the
+// unit still has a process, so the record and its slot stay owned until a
+// later pass can release them safely.
+var errUnitNotTerminal = errors.New("unit not terminal; release deferred")
 
 func (r *Reconciler) notePendingRelease(vmID string) {
 	r.mu.Lock()

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -165,7 +165,29 @@ func NewReconciler(mgr *Manager, cfg ReconcilerConfig) *Reconciler {
 		prevKeptLive:   -1,
 	}
 	r.markFailed = r.markFailedInDB
+	// A lifecycle op claiming a VM voids any release deferred against its
+	// predecessor — at the lock, so no in-place state round-trip (pause and
+	// resume can return Status and Unverified to their noted values on the
+	// SAME instance) can ever masquerade as the unmutated stale original.
+	mgr.onLifecycleClaim = r.voidPendingRelease
 	return r
+}
+
+// voidPendingRelease retires a deferred release and all of its episode
+// bookkeeping — entry, prefixed marker, bare-id grace. Shared by the retry's
+// own void exit and the lifecycle-claim hook.
+func (r *Reconciler) voidPendingRelease(vmID string) {
+	r.mu.Lock()
+	e, ok := r.pendingRelease[vmID]
+	if ok {
+		delete(r.pendingRelease, vmID)
+	}
+	r.mu.Unlock()
+	if !ok {
+		return
+	}
+	r.clearDrift(vmID)
+	r.clearDrift(e.marker)
 }
 
 // runTimeout bounds each reconciliation pass so a slow DB or stuck
@@ -1467,6 +1489,11 @@ func (r *Reconciler) finalizeRelease(ctx context.Context, vmID, marker, action, 
 // pause flips Status on the SAME object. A stale instance is by definition one
 // nothing updates, so any observed mutation proves a lifecycle op claimed the
 // VM — that op owns cleanup, and the reap decision is void.
+//
+// The snapshot cannot see a round-trip that returns both fields to their
+// noted values; onLifecycleClaim closes that class at the vm-op lock, voiding
+// the entry the moment any lifecycle op claims the instance. The comparison
+// below remains as the backstop for anything that mutates without the lock.
 type deferredRelease struct {
 	inst       *VMInstance
 	marker     string
@@ -1543,17 +1570,13 @@ func (r *Reconciler) retryPendingReleases(ctx context.Context) {
 			cur.mu.RUnlock()
 		}
 		if cur != noted.inst || mutated {
-			unlockOp()
-			r.mu.Lock()
-			delete(r.pendingRelease, id)
-			r.mu.Unlock()
 			// Voids retire the episode's timestamps (see pendingRelease): the
 			// prefixed marker, and the bare id — Drift 1/2 grace under the bare
 			// id and defer with marker "", relying on markStale to clear it,
 			// which a void never runs. Leaving either hands its elapsed grace
 			// to the id's next episode.
-			r.clearDrift(id)
-			r.clearDrift(noted.marker)
+			unlockOp()
+			r.voidPendingRelease(id)
 			continue
 		}
 		err := r.markStale(ctx, id, noted.marker)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -487,11 +487,11 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !ok {
 				continue // an op owns the VM; the generation voids any pending entry
 			}
-			if r.mgr.instanceRunning(id) {
-				unlockOp()
-				r.clearDrift(id)
-				continue
-			}
+			// No status re-check: this rule's target is a Running record whose
+			// unit is dead, and nothing flips that record when firecracker
+			// exits — reading Running as liveness would veto every reap (the
+			// mistake Drift 1 made). The lock excludes an in-flight op, and
+			// markStale's own terminal probe runs under it.
 			if !r.consumeAutoFailBudget(id) {
 				unlockOp()
 				continue
@@ -525,17 +525,15 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !r.gracePeriodElapsed("orphan:"+id, now) {
 				continue
 			}
-			// Drift 7's discipline, now covering the STOP too: the lock is
-			// taken before budget or destruction, and the in-memory record is
-			// re-read under it — a create/resume that began after the pass
-			// snapshot would otherwise have its fresh unit killed.
+			// Lock before budget or the stop, so an in-flight create/resume
+			// (which holds it) is never killed mid-flight. No status re-check:
+			// an orphan that reached Running stays Running in memory until
+			// this rule stops it, so reading that as liveness would veto every
+			// reap — the Drift 1 mistake. A lifecycle op that COMPLETED since
+			// the pass snapshot is caught by the marker: its row moves and the
+			// next pass clears the drift before the grace re-elapses.
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
-				continue
-			}
-			if r.mgr.instanceRunning(id) {
-				unlockOp()
-				r.clearDrift("orphan:" + id)
 				continue
 			}
 			if !r.consumeAutoFailBudget(id) {
@@ -877,15 +875,10 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if errorRecord(id) {
 				continue
 			}
-			// Same discipline as Drift 3; here the Running re-read also
-			// covers a create whose row insert is still in flight.
+			// Same discipline as Drift 3, and the same reason for no status
+			// re-check.
 			unlockOp, ok := r.mgr.tryLockVMOp(id)
 			if !ok {
-				continue
-			}
-			if r.mgr.instanceRunning(id) {
-				unlockOp()
-				r.clearDrift("bolt-orphan:" + id)
 				continue
 			}
 			// Only stopping a live unit is destructive; charge the budget there.

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1589,6 +1589,32 @@ func (r *Reconciler) hasPendingRelease(vmID string) bool {
 	return ok
 }
 
+// pendingReleaseCurrent reports whether id's deferred entry still describes
+// the tracked instance — same identity+generation verdict the retry uses.
+// Callers hold the vm-op lock; a false verdict means a lifecycle op claimed
+// the VM since the reap was decided, and the entry must be voided, not acted.
+func (r *Reconciler) pendingReleaseCurrent(id string) bool {
+	r.mu.Lock()
+	noted, ok := r.pendingRelease[id]
+	r.mu.Unlock()
+	if !ok {
+		return false
+	}
+	r.mgr.mu.RLock()
+	cur := r.mgr.vms[id]
+	r.mgr.mu.RUnlock()
+	if cur != noted.inst {
+		return false
+	}
+	if cur == nil {
+		return true
+	}
+	cur.mu.RLock()
+	same := cur.gen == noted.gen
+	cur.mu.RUnlock()
+	return same
+}
+
 func (r *Reconciler) pendingReleaseIDs() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1674,10 +1700,28 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 		// hasPendingRelease) — but only the release: nobody else moves a
 		// stuck-active row off a dead VM, so the flip re-drives here,
 		// uncharged (same decision, already budgeted) and CAS-guarded.
+		// Only for a reap that is still CURRENT and still a corpse, verified
+		// under the lock: a same-id relaunch can complete between the systemd
+		// snapshot (unit reads dead) and the DB snapshot (row reads Active),
+		// and the status-only CAS would happily fail the fresh generation.
 		if r.hasPendingRelease(id) {
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
+			if !r.pendingReleaseCurrent(id) {
+				unlockOp()
+				r.voidPendingRelease(id)
+				continue
+			}
+			if !unitFullyDownProbe(ctx, systemdUnitName(id)) {
+				unlockOp()
+				continue
+			}
 			if r.markFailed(ctx, id, db.SandboxStatusActive) {
 				r.writeAudit(ctx, id, "mark_failed", "VM dead while DB said active", "db_active_systemd_missing")
 			}
+			unlockOp()
 			continue
 		}
 		if !r.graceElapsedFor(id, id, now, r.cfg.GracePeriod) {

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -483,15 +483,21 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !r.gracePeriodElapsed(id, now) {
 				continue
 			}
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue // an op owns the VM; the generation voids any pending entry
+			}
+			if r.mgr.instanceRunning(id) {
+				unlockOp()
+				r.clearDrift(id)
+				continue
+			}
 			if !r.consumeAutoFailBudget(id) {
+				unlockOp()
 				continue
 			}
 			log.Warn().Str("vm_id", id).Str("drift", "boltdb_running_unit_missing").
 				Msg("dead Firecracker detected (no DB context)")
-			unlockOp, ok := r.mgr.tryLockVMOp(id)
-			if !ok {
-				continue // an op owns the VM; its claim voided any pending entry
-			}
 			releaseErr := r.markStale(ctx, id, "")
 			unlockOp()
 			r.finalizeRelease(ctx, id, "", "stale_cleanup", "VM dead, DB unavailable", "boltdb_running_unit_missing", releaseErr)
@@ -519,7 +525,21 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if !r.gracePeriodElapsed("orphan:"+id, now) {
 				continue
 			}
+			// Drift 7's discipline, now covering the STOP too: the lock is
+			// taken before budget or destruction, and the in-memory record is
+			// re-read under it — a create/resume that began after the pass
+			// snapshot would otherwise have its fresh unit killed.
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
+			if r.mgr.instanceRunning(id) {
+				unlockOp()
+				r.clearDrift("orphan:" + id)
+				continue
+			}
 			if !r.consumeAutoFailBudget(id) {
+				unlockOp()
 				r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "systemd_active_db_missing")
 				continue
 			}
@@ -534,14 +554,11 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			}
 			log.Warn().Str("vm_id", id).Str("drift", kind).Msg("orphan systemd unit — stopping")
 			if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
+				unlockOp()
 				log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit")
 				continue
 			}
 			removeUnitDropIn(id)
-			unlockOp, ok := r.mgr.tryLockVMOp(id)
-			if !ok {
-				continue
-			}
 			releaseErr := r.markStale(ctx, id, "orphan:"+id)
 			unlockOp()
 			r.finalizeRelease(ctx, id, "orphan:"+id, "orphan_stop", reason, kind, releaseErr)
@@ -860,25 +877,36 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			if errorRecord(id) {
 				continue
 			}
+			// The lock is taken before budget or the stop, and the in-memory
+			// record re-read under it: a create whose row insert is still in
+			// flight reads Running here, and killing it would be the stop-vs-
+			// relaunch race, not a reap.
+			unlockOp, ok := r.mgr.tryLockVMOp(id)
+			if !ok {
+				continue
+			}
+			if r.mgr.instanceRunning(id) {
+				unlockOp()
+				r.clearDrift("bolt-orphan:" + id)
+				continue
+			}
 			// Only stopping a live unit is destructive; charge the budget there.
 			// Gate on the fail-closed `active` snapshot (the pass bailed if systemctl
 			// couldn't be listed) so an inconclusive check never frees a live VM's slot.
 			if active[id] {
 				if !r.consumeAutoFailBudget(id) {
+					unlockOp()
 					r.writeAudit(ctx, id, "budget_exhausted", "orphan_stop suppressed by rate limit", "boltdb_present_db_missing")
 					continue
 				}
 				log.Warn().Str("vm_id", id).Str("drift", "boltdb_present_db_missing").
 					Msg("live orphan systemd unit with no DB row — stopping")
 				if err := stopUnit(ctx, systemdUnitName(id)); err != nil {
+					unlockOp()
 					log.Error().Err(err).Str("vm_id", id).Msg("failed to stop orphan unit from BoltDB — leaving for retry")
 					continue
 				}
 				removeUnitDropIn(id)
-			}
-			unlockOp, ok := r.mgr.tryLockVMOp(id)
-			if !ok {
-				continue
 			}
 			releaseErr := r.markStale(ctx, id, "bolt-orphan:"+id)
 			unlockOp()

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1351,6 +1351,11 @@ func (r *Reconciler) refundAutoFailSlot() {
 // when the unit leaves the active set, so its retry waits out one more grace.
 func (r *Reconciler) finalizeErrorReap(ctx context.Context, vmID, marker, action, reason, driftKind string, staleErr error) {
 	if staleErr != nil {
+		// Same discipline as finalizeRelease: the deferred entry must carry
+		// this rule's marker, or a completed retry retires the record while
+		// the errunit:/errdead: timestamp lives on to rob the id's next
+		// Error episode of its grace period.
+		r.tagPendingRelease(vmID, marker)
 		r.writeAudit(ctx, vmID, "stale_cleanup_failed", reason+"; record not deleted", driftKind)
 		return
 	}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1346,3 +1346,22 @@ func TestReapDeadActiveVMs_PendingReleaseRedrivesFlipUncharged(t *testing.T) {
 		t.Fatal("the release must stay owned by the retry")
 	}
 }
+
+// The reconciler is constructed while the gRPC server is already serving, so
+// the hook's publication must be race-free against concurrent lock
+// acquisitions — this test is the race detector's tripwire for a plain-field
+// regression.
+func TestLifecycleClaimHookPublicationIsRaceFree(t *testing.T) {
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 500; i++ {
+			if unlock, err := m.lockVMOp(context.Background(), "vm-race"); err == nil {
+				unlock()
+			}
+		}
+	}()
+	NewReconciler(m, DefaultReconcilerConfig()) // publishes the hook mid-traffic
+	<-done
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -453,7 +453,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 func TestFinalizeErrorReap_FailedDeleteKeepsMarker(t *testing.T) {
 	newRec := func() *Reconciler {
 		r := NewReconciler(&Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}, DefaultReconcilerConfig())
-		r.driftSeen["errdead:vm-1"] = time.Now()
+		r.driftSeen["errdead:vm-1"] = driftEpisode{at: time.Now()}
 		return r
 	}
 
@@ -584,7 +584,7 @@ func TestReapDeadActiveVMs_StaleRunningRecordDoesNotVetoReap(t *testing.T) {
 			vms: map[string]*VMInstance{id: {ID: id, Status: StatusRunning}},
 		}
 		r := NewReconciler(m, DefaultReconcilerConfig())
-		r.driftSeen[id] = time.Now().Add(-2 * r.cfg.GracePeriod)
+		r.driftSeen[id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
 
 		origProbe := unitFullyDownProbe
 		unitFullyDownProbe = func(context.Context, string) bool { return unitDown }
@@ -648,7 +648,7 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 		id := sbID.String()
 		m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
 		r := NewReconciler(m, DefaultReconcilerConfig())
-		r.driftSeen["paused:"+id] = time.Now().Add(-2 * r.cfg.GracePeriod)
+		r.driftSeen["paused:"+id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
 		flips := &[]string{}
 		r.markFailed = func(_ context.Context, vmID string, observed db.SandboxStatus) bool {
 			if observed != db.SandboxStatusPaused {
@@ -789,7 +789,7 @@ func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
 func TestFinalizeRelease_DeferralIsNotSuccess(t *testing.T) {
 	newRec := func() *Reconciler {
 		r := NewReconciler(&Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}, DefaultReconcilerConfig())
-		r.driftSeen["orphan:vm-1"] = time.Now()
+		r.driftSeen["orphan:vm-1"] = driftEpisode{at: time.Now()}
 		return r
 	}
 
@@ -971,7 +971,7 @@ func TestRetryPendingReleases_RetiresOriginMarker(t *testing.T) {
 		}
 		r := NewReconciler(m, DefaultReconcilerConfig())
 		marker := "unverifiedorphan:vm-1"
-		r.driftSeen[marker] = time.Now().Add(-2 * r.cfg.UnverifiedOrphanGrace)
+		r.driftSeen[marker] = driftEpisode{at: time.Now().Add(-2 * r.cfg.UnverifiedOrphanGrace)}
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -1112,7 +1112,7 @@ func TestFinalizeErrorReap_TagsDeferredRelease(t *testing.T) {
 	}
 	r := NewReconciler(m, DefaultReconcilerConfig())
 	marker := "errdead:vm-1"
-	r.driftSeen[marker] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	r.driftSeen[marker] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1217,7 +1217,7 @@ func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
 	}
 	r := NewReconciler(m, DefaultReconcilerConfig())
 	// The Drift 1/2 shape: grace elapsed under the bare id, then a deferral.
-	r.driftSeen["vm-1"] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	r.driftSeen["vm-1"] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
 	if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 		t.Fatal("non-terminal unit must defer")
 	}
@@ -1349,38 +1349,70 @@ func TestGenerationSeparatesClaimsFromLockTraffic(t *testing.T) {
 	})
 }
 
-// The Drift 1 mistake, re-checked for its siblings: a stale or orphaned VM
-// reads Running in memory until a rule stops it, so no reap rule may treat
-// cached Running as liveness. Pins the predicate direction for Drifts 2/3/5
-// by asserting the reap still happens for a Running-in-memory candidate.
-func TestReapRulesDoNotTrustCachedRunning(t *testing.T) {
-	stubUnitTerminal(t, true) // the unit is conclusively gone
-	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
-	if err != nil {
-		t.Fatal(err)
+// Drives Drift 3 itself — the earlier version of this test called markStale
+// directly and would have passed with the inverted guards still in runOnce.
+// Two directions: a genuinely stale orphan (Running in memory, as every
+// orphan is) must be stopped; a generation claimed since the pass snapshot
+// must not, even though the pass evidence still says orphan.
+func TestStopOrphanUnits_StaleVsClaimedGeneration(t *testing.T) {
+	newFixture := func(t *testing.T) (*Reconciler, string, *[]string) {
+		t.Helper()
+		stubUnitTerminal(t, true)
+		id := uuid.New().String()
+		inst := &VMInstance{ID: id, Status: StatusRunning} // orphans read Running
+		m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{id: inst}}
+		store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		m.state = store
+		if err := store.Put(VMRecord{ID: id, Status: StatusRunning}); err != nil {
+			t.Fatal(err)
+		}
+		r := NewReconciler(m, DefaultReconcilerConfig())
+		stopped := &[]string{}
+		orig := stopUnitFn
+		stopUnitFn = func(_ context.Context, unit string) error {
+			*stopped = append(*stopped, unit)
+			return nil
+		}
+		t.Cleanup(func() { stopUnitFn = orig })
+		return r, id, stopped
 	}
-	defer store.Close()
-	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
-		t.Fatal(err)
+	// The pass evidence: unit active, row absent (deleted/missing).
+	drive := func(r *Reconciler, id string) {
+		rows := map[string]db.ListSandboxesByHostRow{}
+		active := map[string]bool{id: true}
+		noErr := func(string) bool { return false }
+		now := time.Now()
+		r.stopOrphanUnits(context.Background(), zerolog.Nop(), rows, active, noErr, now)                          // opens the episode
+		r.stopOrphanUnits(context.Background(), zerolog.Nop(), rows, active, noErr, now.Add(2*r.cfg.GracePeriod)) // grace elapsed
 	}
-	m := &Manager{
-		log:   zerolog.Nop(),
-		state: store,
-		// The stale claim every reap candidate carries.
-		vms: map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning}},
-	}
-	r := NewReconciler(m, DefaultReconcilerConfig())
 
-	if err := r.markStale(context.Background(), "vm-1", ""); err != nil {
-		t.Fatalf("a dead unit's record must be released despite the Running claim: %v", err)
-	}
-	if rec, _ := store.Get("vm-1"); rec != nil {
-		t.Fatal("the stale record must be gone")
-	}
-	m.mu.RLock()
-	_, tracked := m.vms["vm-1"]
-	m.mu.RUnlock()
-	if tracked {
-		t.Fatal("the stale instance must be dropped")
-	}
+	t.Run("a stale orphan is stopped despite reading Running", func(t *testing.T) {
+		r, id, stopped := newFixture(t)
+		drive(r, id)
+		if len(*stopped) != 1 {
+			t.Fatalf("the stale orphan must be stopped, got %v", *stopped)
+		}
+	})
+
+	t.Run("a generation claimed since the snapshot is spared", func(t *testing.T) {
+		r, id, stopped := newFixture(t)
+		rows := map[string]db.ListSandboxesByHostRow{}
+		active := map[string]bool{id: true}
+		noErr := func(string) bool { return false }
+		now := time.Now()
+		r.stopOrphanUnits(context.Background(), zerolog.Nop(), rows, active, noErr, now) // episode opens
+		// A resume completes between the pass snapshot and the rule acting.
+		inst := r.mgr.vms[id]
+		inst.mu.Lock()
+		inst.gen++
+		inst.mu.Unlock()
+		r.stopOrphanUnits(context.Background(), zerolog.Nop(), rows, active, noErr, now.Add(2*r.cfg.GracePeriod))
+		if len(*stopped) != 0 {
+			t.Fatalf("a newly claimed generation must not be stopped, got %v", *stopped)
+		}
+	})
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -422,7 +422,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 		if err := st.Close(); err != nil { // the store is gone; the delete cannot land
 			t.Fatal(err)
 		}
-		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 			t.Fatal("an undeletable record must be reported, not reaped silently")
 		}
 		r.mgr.mu.RLock()
@@ -435,7 +435,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 
 	t.Run("success drops the instance", func(t *testing.T) {
 		r, _ := newRec(t)
-		if err := r.markStale(context.Background(), "vm-1"); err != nil {
+		if err := r.markStale(context.Background(), "vm-1", ""); err != nil {
 			t.Fatalf("markStale: %v", err)
 		}
 		r.mgr.mu.RLock()
@@ -505,7 +505,7 @@ func TestMarkStale_FailedDeleteRetriedOnLaterPass(t *testing.T) {
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.markStale(context.Background(), "vm-1"); err == nil {
+	if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 		t.Fatal("an undeletable record must report failure")
 	}
 	m.mu.RLock()
@@ -522,7 +522,7 @@ func TestMarkStale_FailedDeleteRetriedOnLaterPass(t *testing.T) {
 	}
 	defer reopened.Close()
 	m.state = reopened
-	if err := r.markStale(context.Background(), "vm-1"); err != nil {
+	if err := r.markStale(context.Background(), "vm-1", ""); err != nil {
 		t.Fatalf("retry must succeed once the store recovers: %v", err)
 	}
 	m.mu.RLock()
@@ -755,7 +755,7 @@ func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
 	r := NewReconciler(m, DefaultReconcilerConfig())
 
 	stubUnitTerminal(t, false) // unit still deactivating
-	if err := r.markStale(context.Background(), "vm-1"); !errors.Is(err, errUnitNotTerminal) {
+	if err := r.markStale(context.Background(), "vm-1", ""); !errors.Is(err, errUnitNotTerminal) {
 		t.Fatalf("a non-terminal unit must defer the release, got %v", err)
 	}
 	if rec, _ := store.Get("vm-1"); rec == nil {
@@ -847,7 +847,7 @@ func TestRetryPendingReleases(t *testing.T) {
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 			t.Fatal("an undeletable record must report failure")
 		}
 		return r, path
@@ -975,10 +975,9 @@ func TestRetryPendingReleases_RetiresOriginMarker(t *testing.T) {
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1", marker); err == nil {
 			t.Fatal("an undeletable record must report failure")
 		}
-		r.tagPendingRelease("vm-1", marker) // the deferring rule's keeper
 		return r, path, marker
 	}
 
@@ -1038,7 +1037,7 @@ func TestRetryPendingReleases_InPlaceAdoptionVoids(t *testing.T) {
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 			t.Fatal("an undeletable record must report failure")
 		}
 		return r
@@ -1115,7 +1114,7 @@ func TestFinalizeErrorReap_TagsDeferredRelease(t *testing.T) {
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
-	staleErr := r.markStale(context.Background(), "vm-1")
+	staleErr := r.markStale(context.Background(), "vm-1", marker)
 	if staleErr == nil {
 		t.Fatal("an undeletable record must report failure")
 	}
@@ -1166,7 +1165,7 @@ func TestHasPendingReleaseStandsAside(t *testing.T) {
 	if !r.consumeAutoFailBudget("vm-1") {
 		t.Fatal("first decision must have budget")
 	}
-	if err := r.markStale(context.Background(), "vm-1"); !errors.Is(err, errUnitNotTerminal) {
+	if err := r.markStale(context.Background(), "vm-1", ""); !errors.Is(err, errUnitNotTerminal) {
 		t.Fatalf("non-terminal unit must defer, got %v", err)
 	}
 	if !r.hasPendingRelease("vm-1") {
@@ -1217,7 +1216,7 @@ func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
 	r := NewReconciler(m, DefaultReconcilerConfig())
 	// The Drift 1/2 shape: grace elapsed under the bare id, then a deferral.
 	r.driftSeen["vm-1"] = time.Now().Add(-2 * r.cfg.GracePeriod)
-	if err := r.markStale(context.Background(), "vm-1"); err == nil {
+	if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 		t.Fatal("non-terminal unit must defer")
 	}
 

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -453,7 +453,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 func TestFinalizeErrorReap_FailedDeleteKeepsMarker(t *testing.T) {
 	newRec := func() *Reconciler {
 		r := NewReconciler(&Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}, DefaultReconcilerConfig())
-		r.driftSeen["errdead:vm-1"] = driftEpisode{at: time.Now()}
+		r.driftSeen["errdead:vm-1"] = newDriftEpisode(time.Now(), nil, 0)
 		return r
 	}
 
@@ -587,7 +587,7 @@ func TestReapDeadActiveVMs_StaleRunningRecordDoesNotVetoReap(t *testing.T) {
 		// Bind the pre-seeded episode to the instance, as graceElapsedFor
 		// does: an unbound seed reads as a different generation and the
 		// currentness check would (correctly) restart the episode.
-		r.driftSeen[id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod), inst: m.vms[id]}
+		r.driftSeen[id] = newDriftEpisode(time.Now().Add(-2*r.cfg.GracePeriod), m.vms[id], 0)
 
 		origProbe := unitFullyDownProbe
 		unitFullyDownProbe = func(context.Context, string) bool { return unitDown }
@@ -651,7 +651,7 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 		id := sbID.String()
 		m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
 		r := NewReconciler(m, DefaultReconcilerConfig())
-		r.driftSeen["paused:"+id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
+		r.driftSeen["paused:"+id] = newDriftEpisode(time.Now().Add(-2*r.cfg.GracePeriod), nil, 0)
 		flips := &[]string{}
 		r.markFailed = func(_ context.Context, vmID string, observed db.SandboxStatus) bool {
 			if observed != db.SandboxStatusPaused {
@@ -792,7 +792,7 @@ func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
 func TestFinalizeRelease_DeferralIsNotSuccess(t *testing.T) {
 	newRec := func() *Reconciler {
 		r := NewReconciler(&Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}, DefaultReconcilerConfig())
-		r.driftSeen["orphan:vm-1"] = driftEpisode{at: time.Now()}
+		r.driftSeen["orphan:vm-1"] = newDriftEpisode(time.Now(), nil, 0)
 		return r
 	}
 
@@ -974,7 +974,7 @@ func TestRetryPendingReleases_RetiresOriginMarker(t *testing.T) {
 		}
 		r := NewReconciler(m, DefaultReconcilerConfig())
 		marker := "unverifiedorphan:vm-1"
-		r.driftSeen[marker] = driftEpisode{at: time.Now().Add(-2 * r.cfg.UnverifiedOrphanGrace)}
+		r.driftSeen[marker] = newDriftEpisode(time.Now().Add(-2*r.cfg.UnverifiedOrphanGrace), nil, 0)
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -1115,7 +1115,7 @@ func TestFinalizeErrorReap_TagsDeferredRelease(t *testing.T) {
 	}
 	r := NewReconciler(m, DefaultReconcilerConfig())
 	marker := "errdead:vm-1"
-	r.driftSeen[marker] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
+	r.driftSeen[marker] = newDriftEpisode(time.Now().Add(-2*r.cfg.GracePeriod), nil, 0)
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -1220,7 +1220,7 @@ func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
 	}
 	r := NewReconciler(m, DefaultReconcilerConfig())
 	// The Drift 1/2 shape: grace elapsed under the bare id, then a deferral.
-	r.driftSeen["vm-1"] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
+	r.driftSeen["vm-1"] = newDriftEpisode(time.Now().Add(-2*r.cfg.GracePeriod), nil, 0)
 	if err := r.markStale(context.Background(), "vm-1", ""); err == nil {
 		t.Fatal("non-terminal unit must defer")
 	}
@@ -1535,5 +1535,28 @@ func TestStopOrphanUnits_HealThenRecurServesFreshGrace(t *testing.T) {
 	r.stopOrphanUnits(context.Background(), zerolog.Nop(), orphan, active, noErr, now.Add(5*r.cfg.GracePeriod))
 	if stopped != 1 {
 		t.Fatalf("the recurred orphan must be stopped once its own grace elapses, got %d", stopped)
+	}
+}
+
+// Episodes store a non-owning incarnation id, never the pointer: drift
+// bookkeeping must not root removed instances (disappeared candidates are
+// exactly the ones no loop revisits to clear), and a fresh instance — even
+// one reusing the old address — must never inherit its predecessor's episode.
+func TestDriftEpisodesUseNonOwningIdentity(t *testing.T) {
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+
+	instA := &VMInstance{ID: "vm-1", Status: StatusRunning}
+	m.vms["vm-1"] = instA
+	now := time.Now()
+	r.graceElapsedFor("vm-1", "vm-1", now, r.cfg.GracePeriod) // opens, bound to A
+	if !r.episodeStillCurrent("vm-1", "vm-1") {
+		t.Fatal("the episode must be current for the instance it opened against")
+	}
+
+	// A replacement instance with identical field values (gen included).
+	m.vms["vm-1"] = &VMInstance{ID: "vm-1", Status: StatusRunning}
+	if r.episodeStillCurrent("vm-1", "vm-1") {
+		t.Fatal("a replacement instance must never inherit its predecessor's episode")
 	}
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1055,7 +1055,9 @@ func TestRetryPendingReleases_InPlaceAdoptionVoids(t *testing.T) {
 		// place. Same object throughout — only the snapshot tells the story.
 		inst := r.mgr.vms["vm-1"]
 		inst.mu.Lock()
+		inst.gen++ // adoption's funnel bumps
 		inst.Unverified = false
+		inst.gen++ // pause's funnel bumps
 		inst.Status = StatusPaused
 		inst.mu.Unlock()
 		if err := reopened.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
@@ -1235,71 +1237,6 @@ func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
 	}
 }
 
-// The ABA the two-field snapshot cannot see: a lifecycle op can drive the
-// SAME instance away from and back to its noted (Status, Unverified) values
-// between passes. The claim hook closes the class at its choke point — every
-// lifecycle op acquires the vm-op lock, and acquiring it voids any release
-// deferred against the instance's predecessor.
-func TestLifecycleClaimVoidsPendingRelease(t *testing.T) {
-	stubUnitTerminal(t, false) // defer the release
-	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer store.Close()
-	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
-		t.Fatal(err)
-	}
-	inst := &VMInstance{ID: "vm-1", Status: StatusPaused}
-	m := &Manager{
-		log:   zerolog.Nop(),
-		state: store,
-		vms:   map[string]*VMInstance{"vm-1": inst},
-	}
-	r := NewReconciler(m, DefaultReconcilerConfig())
-	r.driftSeen["bolt-orphan:vm-1"] = time.Now().Add(-2 * r.cfg.GracePeriod)
-	if err := r.markStale(context.Background(), "vm-1", "bolt-orphan:vm-1"); err == nil {
-		t.Fatal("non-terminal unit must defer")
-	}
-
-	// A resume claims the VM, drives it Running, then a pause returns it to
-	// Paused — same pointer, both snapshot fields back to their noted values.
-	unlock, err := m.lockVMOp(context.Background(), "vm-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	inst.mu.Lock()
-	inst.Status = StatusRunning
-	inst.mu.Unlock()
-	unlock()
-	unlock2, err := m.lockVMOp(context.Background(), "vm-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	inst.mu.Lock()
-	inst.Status = StatusPaused
-	inst.mu.Unlock()
-	unlock2()
-
-	if r.hasPendingRelease("vm-1") {
-		t.Fatal("the claim must void the deferred release at the lock, not at state comparison")
-	}
-	r.mu.Lock()
-	_, kept := r.driftSeen["bolt-orphan:vm-1"]
-	r.mu.Unlock()
-	if kept {
-		t.Fatal("the void must retire the episode's marker")
-	}
-
-	// And the retry, running later with the unit now terminal, must not
-	// release the healthy re-paused VM.
-	stubUnitTerminal(t, true)
-	r.retryPendingReleases(context.Background())
-	if rec, _ := store.Get("vm-1"); rec == nil || rec.Status != StatusPaused {
-		t.Fatalf("the re-paused record must survive untouched, got %v", rec)
-	}
-}
-
 // A deferred release owns only the RELEASE half of Drift 1's reap: the row
 // flip re-drives uncharged (nobody else moves a stuck-active row off a dead
 // VM), and no second auto-fail slot is spent for the same decision.
@@ -1347,21 +1284,67 @@ func TestReapDeadActiveVMs_PendingReleaseRedrivesFlipUncharged(t *testing.T) {
 	}
 }
 
-// The reconciler is constructed while the gRPC server is already serving, so
-// the hook's publication must be race-free against concurrent lock
-// acquisitions — this test is the race detector's tripwire for a plain-field
-// regression.
-func TestLifecycleClaimHookPublicationIsRaceFree(t *testing.T) {
-	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for i := 0; i < 500; i++ {
-			if unlock, err := m.lockVMOp(context.Background(), "vm-race"); err == nil {
-				unlock()
-			}
+// The generation is what distinguishes a lifecycle claim from mere lock
+// traffic. Inspection ops (env inject, verification, PID persistence) take
+// the same vm-op lock but bump nothing — a delayed inject against a dead VM
+// must not erase the pending release and strand the record behind a Failed
+// row. And a full round-trip back to the deferred-time state — invisible to
+// any value snapshot — bumps twice, so the retry still voids.
+func TestGenerationSeparatesClaimsFromLockTraffic(t *testing.T) {
+	newRec := func(t *testing.T) (*Reconciler, *VMInstance, string) {
+		t.Helper()
+		stubUnitTerminal(t, false)
+		store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+		if err != nil {
+			t.Fatal(err)
 		}
-	}()
-	NewReconciler(m, DefaultReconcilerConfig()) // publishes the hook mid-traffic
-	<-done
+		t.Cleanup(func() { _ = store.Close() })
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+		inst := &VMInstance{ID: "vm-1", Status: StatusPaused}
+		m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": inst}}
+		r := NewReconciler(m, DefaultReconcilerConfig())
+		if err := r.markStale(context.Background(), "vm-1", "bolt-orphan:vm-1"); err == nil {
+			t.Fatal("non-terminal unit must defer")
+		}
+		return r, inst, "vm-1"
+	}
+
+	t.Run("an inspection op's lock does not void", func(t *testing.T) {
+		r, _, id := newRec(t)
+		unlock, err := r.mgr.lockVMOp(context.Background(), id) // inject-shaped: lock, no bump
+		if err != nil {
+			t.Fatal(err)
+		}
+		unlock()
+		stubUnitTerminal(t, true)
+		r.retryPendingReleases(context.Background())
+		if r.hasPendingRelease(id) {
+			t.Fatal("the retry must complete: no lifecycle op ever claimed the VM")
+		}
+		if rec, _ := r.mgr.state.Get(id); rec != nil {
+			t.Fatal("the stale record must be released despite intervening lock traffic")
+		}
+	})
+
+	t.Run("a round-trip back to the deferred state still voids", func(t *testing.T) {
+		r, inst, id := newRec(t)
+		inst.mu.Lock()
+		inst.gen++ // resume funnel
+		inst.Status = StatusRunning
+		inst.mu.Unlock()
+		inst.mu.Lock()
+		inst.gen++ // pause funnel: back to Paused, values identical to deferral time
+		inst.Status = StatusPaused
+		inst.mu.Unlock()
+		stubUnitTerminal(t, true)
+		r.retryPendingReleases(context.Background())
+		if rec, _ := r.mgr.state.Get(id); rec == nil {
+			t.Fatal("a claimed VM's record must survive the retry")
+		}
+		if r.hasPendingRelease(id) {
+			t.Fatal("the void must retire the entry")
+		}
+	})
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -396,6 +397,7 @@ func TestUnverifiedOrphanGrace(t *testing.T) {
 // unit first retire the condition their rule matches on, so a swallowed
 // failure would be reported as a completed reap and never revisited.
 func TestMarkStaleReportsDeleteFailure(t *testing.T) {
+	stubUnitTerminal(t, true)
 	newRec := func(t *testing.T) (*Reconciler, *StateStore) {
 		t.Helper()
 		st, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
@@ -449,6 +451,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 // stopped it, so without this the record and its network slot are held until
 // the next vmd restart.
 func TestRetryPendingReleases(t *testing.T) {
+	stubUnitTerminal(t, true)
 	newRec := func(t *testing.T) (*Reconciler, string) {
 		t.Helper()
 		path := filepath.Join(t.TempDir(), "vmd.db")
@@ -533,4 +536,60 @@ func TestRetryPendingReleases(t *testing.T) {
 			t.Fatal("a relaunched VM's record must survive")
 		}
 	})
+}
+
+// stubUnitTerminal swaps the terminal-state probe so release tests do not
+// depend on a live systemd.
+func stubUnitTerminal(t *testing.T, terminal bool) {
+	t.Helper()
+	orig := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return terminal }
+	t.Cleanup(func() { vmUnitFullyDown = orig })
+}
+
+// A release must not hand a VM's namespace, IP and tap device back to the pool
+// while its unit still has a process: the next VM would claim a device the old
+// Firecracker still owns. Deferring is safe because the retry comes back.
+func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusError, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusError}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+
+	stubUnitTerminal(t, false) // unit still deactivating
+	if err := r.markStale("vm-1"); !errors.Is(err, errUnitNotTerminal) {
+		t.Fatalf("a non-terminal unit must defer the release, got %v", err)
+	}
+	if rec, _ := store.Get("vm-1"); rec == nil {
+		t.Fatal("the record must survive a deferred release")
+	}
+	m.mu.RLock()
+	_, tracked := m.vms["vm-1"]
+	m.mu.RUnlock()
+	if !tracked {
+		t.Fatal("the instance and its slot must stay owned while the unit lives")
+	}
+	if got := r.pendingReleaseIDs(); len(got) != 1 || got[0] != "vm-1" {
+		t.Fatalf("a deferred release must be remembered for retry, got %v", got)
+	}
+
+	// The unit reaches a terminal state; the deferred release completes.
+	stubUnitTerminal(t, true)
+	r.retryPendingReleases(context.Background())
+	if rec, _ := store.Get("vm-1"); rec != nil {
+		t.Fatal("the retry must release once the unit is terminal")
+	}
+	if got := r.pendingReleaseIDs(); len(got) != 0 {
+		t.Fatalf("a completed release must be forgotten, got %v", got)
+	}
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1269,6 +1269,11 @@ func TestReapDeadActiveVMs_PendingReleaseRedrivesFlipUncharged(t *testing.T) {
 		flips++
 		return true // row moved active→failed
 	}
+	// The reap is still current and still a corpse — the one shape the
+	// uncharged flip re-drive exists for.
+	origProbe := unitFullyDownProbe
+	unitFullyDownProbe = func(context.Context, string) bool { return true }
+	t.Cleanup(func() { unitFullyDownProbe = origProbe })
 	rows := map[string]db.ListSandboxesByHostRow{
 		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
 	}
@@ -1558,5 +1563,54 @@ func TestDriftEpisodesUseNonOwningIdentity(t *testing.T) {
 	m.vms["vm-1"] = &VMInstance{ID: "vm-1", Status: StatusRunning}
 	if r.episodeStillCurrent("vm-1", "vm-1") {
 		t.Fatal("a replacement instance must never inherit its predecessor's episode")
+	}
+}
+
+// The reviewer's race: a same-id relaunch completes between the systemd
+// snapshot (unit reads dead) and the DB snapshot (row reads Active) while an
+// old generation's pending release survives. The flip shortcut must verify
+// the pending reap is still current and still a corpse before touching the
+// row — the status-only CAS would otherwise fail the fresh generation, and
+// the orphan rule would then stop its live unit.
+func TestReapDeadActiveVMs_StalePendingDoesNotFailFreshGeneration(t *testing.T) {
+	stubUnitTerminal(t, false) // defer the old generation's release
+	sbID := uuid.New()
+	id := sbID.String()
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	old := &VMInstance{ID: id, Status: StatusRunning}
+	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{id: old}}
+	if err := store.Put(VMRecord{ID: id, Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	if err := r.markStale(context.Background(), id, ""); err == nil {
+		t.Fatal("non-terminal unit must defer")
+	}
+	// The relaunch replaces the instance; its fresh unit is up, its row Active.
+	m.vms[id] = &VMInstance{ID: id, Status: StatusRunning}
+	origProbe := unitFullyDownProbe
+	unitFullyDownProbe = func(context.Context, string) bool { return false } // fresh unit alive
+	t.Cleanup(func() { unitFullyDownProbe = origProbe })
+	flips := 0
+	r.markFailed = func(context.Context, string, db.SandboxStatus) bool { flips++; return true }
+
+	rows := map[string]db.ListSandboxesByHostRow{
+		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+	}
+	// Stale systemd evidence: the pass snapshot predates the relaunch.
+	r.reapDeadActiveVMs(context.Background(), zerolog.Nop(), rows, map[string]bool{}, func(string) bool { return false }, time.Now())
+
+	if flips != 0 {
+		t.Fatalf("the fresh generation's row must not be failed, flipped %d times", flips)
+	}
+	if r.hasPendingRelease(id) {
+		t.Fatal("the stale entry must be voided, not left to ambush later passes")
+	}
+	if rec, _ := store.Get(id); rec == nil {
+		t.Fatal("the fresh generation's record must survive")
 	}
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -731,3 +731,81 @@ func TestRetryPendingReleases_RetiresOriginMarker(t *testing.T) {
 		}
 	})
 }
+
+// The in-place claim: adoption clears Unverified and pause flips Status on
+// the SAME tracked object, so pointer identity alone reads an adopted-then-
+// paused VM as the original reap target — and releases a healthy paused
+// record. Any observed mutation of the snapshot must void the entry.
+func TestRetryPendingReleases_InPlaceAdoptionVoids(t *testing.T) {
+	stubUnitTerminal(t, true)
+	path := ""
+	newRec := func(t *testing.T) *Reconciler {
+		t.Helper()
+		path = filepath.Join(t.TempDir(), "vmd.db")
+		store, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+		m := &Manager{
+			log:   zerolog.Nop(),
+			state: store,
+			vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning, Unverified: true}},
+		}
+		r := NewReconciler(m, DefaultReconcilerConfig())
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+			t.Fatal("an undeletable record must report failure")
+		}
+		return r
+	}
+
+	t.Run("adopted then paused, same pointer, is never released", func(t *testing.T) {
+		r := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+		// Adoption clears the marker in place; a later pause flips status in
+		// place. Same object throughout — only the snapshot tells the story.
+		inst := r.mgr.vms["vm-1"]
+		inst.mu.Lock()
+		inst.Unverified = false
+		inst.Status = StatusPaused
+		inst.mu.Unlock()
+		if err := reopened.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+
+		r.retryPendingReleases(context.Background())
+
+		if rec, _ := reopened.Get("vm-1"); rec == nil || rec.Status != StatusPaused {
+			t.Fatalf("the adopted VM's paused record must survive untouched, got %v", rec)
+		}
+		if got := r.pendingReleaseIDs(); len(got) != 0 {
+			t.Fatalf("the voided entry must be forgotten, got %v", got)
+		}
+	})
+
+	t.Run("an unmutated stale instance is still released", func(t *testing.T) {
+		r := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+
+		r.retryPendingReleases(context.Background())
+
+		if rec, _ := reopened.Get("vm-1"); rec != nil {
+			t.Fatal("a genuinely stale record must still be released")
+		}
+	})
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1140,3 +1140,57 @@ func TestFinalizeErrorReap_TagsDeferredRelease(t *testing.T) {
 		t.Fatal("a completed retry must retire the Drift 8 marker it was deferred under")
 	}
 }
+
+// A deferred release keeps its rule's predicate true (Running record, dead
+// unit), so without standing aside the rule re-decides every pass and one
+// wedged record drains the host's five-per-hour budget in minutes,
+// suppressing unrelated destructive reconciliation.
+func TestHasPendingReleaseStandsAside(t *testing.T) {
+	stubUnitTerminal(t, false) // the unit never reaches terminal: every release defers
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+
+	// The rule's first decision: charge once, defer the release.
+	if !r.consumeAutoFailBudget("vm-1") {
+		t.Fatal("first decision must have budget")
+	}
+	if err := r.markStale(context.Background(), "vm-1"); !errors.Is(err, errUnitNotTerminal) {
+		t.Fatalf("non-terminal unit must defer, got %v", err)
+	}
+	if !r.hasPendingRelease("vm-1") {
+		t.Fatal("a deferred release must be visible to the rules")
+	}
+
+	// Later passes: the retry re-drives the release without charging budget…
+	spent := len(r.autoFailLog)
+	for i := 0; i < 10; i++ {
+		r.retryPendingReleases(context.Background())
+	}
+	if len(r.autoFailLog) != spent {
+		t.Fatalf("the retry must never charge budget, spent %d more", len(r.autoFailLog)-spent)
+	}
+	if !r.hasPendingRelease("vm-1") {
+		t.Fatal("a still-deferred release must stay owned by the retry")
+	}
+	// …and the release completes once the unit lands, budget untouched.
+	stubUnitTerminal(t, true)
+	r.retryPendingReleases(context.Background())
+	if r.hasPendingRelease("vm-1") {
+		t.Fatal("the retry must complete once the unit is terminal")
+	}
+	if len(r.autoFailLog) != spent {
+		t.Fatal("completion must not charge budget either")
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -443,3 +443,94 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 		}
 	})
 }
+
+// A reap whose release fails is remembered and finished on a later pass. No
+// drift rule can do this: they all match on a live unit, and the reap already
+// stopped it, so without this the record and its network slot are held until
+// the next vmd restart.
+func TestRetryPendingReleases(t *testing.T) {
+	newRec := func(t *testing.T) (*Reconciler, string) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "vmd.db")
+		store, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusError, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+		m := &Manager{
+			log:   zerolog.Nop(),
+			state: store,
+			vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusError}},
+		}
+		r := NewReconciler(m, DefaultReconcilerConfig())
+		// Pass 1: the store refuses the delete, so the reap is left unfinished.
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.markStale("vm-1"); err == nil {
+			t.Fatal("an undeletable record must report failure")
+		}
+		return r, path
+	}
+
+	t.Run("failed release is remembered", func(t *testing.T) {
+		r, _ := newRec(t)
+		if got := r.pendingReleaseIDs(); len(got) != 1 || got[0] != "vm-1" {
+			t.Fatalf("an abandoned release must be remembered, got %v", got)
+		}
+	})
+
+	t.Run("later pass completes it", func(t *testing.T) {
+		r, path := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+
+		r.retryPendingReleases(context.Background())
+
+		if got := r.pendingReleaseIDs(); len(got) != 0 {
+			t.Fatalf("a completed release must be forgotten, got %v", got)
+		}
+		r.mgr.mu.RLock()
+		_, tracked := r.mgr.vms["vm-1"]
+		r.mgr.mu.RUnlock()
+		if tracked {
+			t.Fatal("the completed retry must drop the instance")
+		}
+		if rec, gerr := reopened.Get("vm-1"); gerr != nil || rec != nil {
+			t.Fatalf("the completed retry must delete the record, got rec=%v err=%v", rec, gerr)
+		}
+	})
+
+	t.Run("a relaunched VM voids the reap", func(t *testing.T) {
+		r, path := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+		// The sandbox came back between passes; the stale decision is void.
+		r.mgr.vms["vm-1"].Status = StatusRunning
+
+		r.retryPendingReleases(context.Background())
+
+		if got := r.pendingReleaseIDs(); len(got) != 0 {
+			t.Fatalf("a voided reap must be forgotten, got %v", got)
+		}
+		r.mgr.mu.RLock()
+		_, tracked := r.mgr.vms["vm-1"]
+		r.mgr.mu.RUnlock()
+		if !tracked {
+			t.Fatal("a relaunched VM must never be released by the retry")
+		}
+		if rec, _ := reopened.Get("vm-1"); rec == nil {
+			t.Fatal("a relaunched VM's record must survive")
+		}
+	})
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -421,7 +421,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 		if err := st.Close(); err != nil { // the store is gone; the delete cannot land
 			t.Fatal(err)
 		}
-		if err := r.markStale("vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1"); err == nil {
 			t.Fatal("an undeletable record must be reported, not reaped silently")
 		}
 		r.mgr.mu.RLock()
@@ -434,7 +434,7 @@ func TestMarkStaleReportsDeleteFailure(t *testing.T) {
 
 	t.Run("success drops the instance", func(t *testing.T) {
 		r, _ := newRec(t)
-		if err := r.markStale("vm-1"); err != nil {
+		if err := r.markStale(context.Background(), "vm-1"); err != nil {
 			t.Fatalf("markStale: %v", err)
 		}
 		r.mgr.mu.RLock()
@@ -475,7 +475,7 @@ func TestRetryPendingReleases(t *testing.T) {
 		if err := store.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if err := r.markStale("vm-1"); err == nil {
+		if err := r.markStale(context.Background(), "vm-1"); err == nil {
 			t.Fatal("an undeletable record must report failure")
 		}
 		return r, path
@@ -579,9 +579,9 @@ func TestRetryPendingReleases(t *testing.T) {
 // depend on a live systemd.
 func stubUnitTerminal(t *testing.T, terminal bool) {
 	t.Helper()
-	orig := vmUnitFullyDown
-	vmUnitFullyDown = func(string) bool { return terminal }
-	t.Cleanup(func() { vmUnitFullyDown = orig })
+	orig := unitFullyDownCtx
+	unitFullyDownCtx = func(context.Context, string) bool { return terminal }
+	t.Cleanup(func() { unitFullyDownCtx = orig })
 }
 
 // A release must not hand a VM's namespace, IP and tap device back to the pool
@@ -604,7 +604,7 @@ func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
 	r := NewReconciler(m, DefaultReconcilerConfig())
 
 	stubUnitTerminal(t, false) // unit still deactivating
-	if err := r.markStale("vm-1"); !errors.Is(err, errUnitNotTerminal) {
+	if err := r.markStale(context.Background(), "vm-1"); !errors.Is(err, errUnitNotTerminal) {
 		t.Fatalf("a non-terminal unit must defer the release, got %v", err)
 	}
 	if rec, _ := store.Get("vm-1"); rec == nil {
@@ -663,6 +663,71 @@ func TestFinalizeRelease_DeferralIsNotSuccess(t *testing.T) {
 		r.mu.Unlock()
 		if kept {
 			t.Fatal("a completed release must retire its marker")
+		}
+	})
+}
+
+// Retiring a deferred release must retire its originating drift marker too:
+// the deferring rule kept the marker alive on purpose, and a later episode of
+// the same rule for the same id would inherit its timestamp — an
+// unverified-orphan reap would then skip UnverifiedOrphanGrace entirely and
+// beat adoption to a brand-new crash window.
+func TestRetryPendingReleases_RetiresOriginMarker(t *testing.T) {
+	stubUnitTerminal(t, true)
+	newRec := func(t *testing.T) (*Reconciler, string, string) {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "vmd.db")
+		store, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+		m := &Manager{
+			log:   zerolog.Nop(),
+			state: store,
+			vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning, Unverified: true}},
+		}
+		r := NewReconciler(m, DefaultReconcilerConfig())
+		marker := "unverifiedorphan:vm-1"
+		r.driftSeen[marker] = time.Now().Add(-2 * r.cfg.UnverifiedOrphanGrace)
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.markStale(context.Background(), "vm-1"); err == nil {
+			t.Fatal("an undeletable record must report failure")
+		}
+		r.tagPendingRelease("vm-1", marker) // the deferring rule's keeper
+		return r, path, marker
+	}
+
+	t.Run("successful retry clears it", func(t *testing.T) {
+		r, path, marker := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+		r.retryPendingReleases(context.Background())
+		r.mu.Lock()
+		_, kept := r.driftSeen[marker]
+		r.mu.Unlock()
+		if kept {
+			t.Fatal("a completed release must retire the deferring rule's marker")
+		}
+	})
+
+	t.Run("identity void clears it", func(t *testing.T) {
+		r, _, marker := newRec(t)
+		r.mgr.vms["vm-1"] = &VMInstance{ID: "vm-1", Status: StatusRunning} // new generation
+		r.retryPendingReleases(context.Background())
+		r.mu.Lock()
+		_, kept := r.driftSeen[marker]
+		r.mu.Unlock()
+		if kept {
+			t.Fatal("a voided release must retire the old episode's marker")
 		}
 	})
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1491,3 +1491,49 @@ func TestReapDeadActiveVMs_RepauseABASpared(t *testing.T) {
 		t.Fatalf("the re-paused generation's record must survive, got %v", rec)
 	}
 }
+
+// A healthy row must heal the drift episode: without it, a later orphan
+// observation against the SAME generation (a row that flapped
+// deleted→active→deleted while the VM ran untouched) inherits the old
+// timestamp and stops the unit without serving its own grace.
+func TestStopOrphanUnits_HealThenRecurServesFreshGrace(t *testing.T) {
+	stubUnitTerminal(t, true)
+	sbID := uuid.New()
+	id := sbID.String()
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{id: {ID: id, Status: StatusRunning}}}
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	m.state = store
+	if err := store.Put(VMRecord{ID: id, Status: StatusRunning}); err != nil {
+		t.Fatal(err)
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	stopped := 0
+	orig := stopUnitFn
+	stopUnitFn = func(context.Context, string) error { stopped++; return nil }
+	t.Cleanup(func() { stopUnitFn = orig })
+
+	orphan := map[string]db.ListSandboxesByHostRow{} // row absent
+	healthy := map[string]db.ListSandboxesByHostRow{
+		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+	}
+	active := map[string]bool{id: true}
+	noErr := func(string) bool { return false }
+	now := time.Now()
+
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), orphan, active, noErr, now)  // opens
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), healthy, active, noErr, now) // heals
+	// Recurs later, same generation, at a time the ORIGINAL episode would
+	// have long satisfied: only a fresh grace may gate the stop.
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), orphan, active, noErr, now.Add(3*r.cfg.GracePeriod))
+	if stopped != 0 {
+		t.Fatalf("a recurrence after a heal must serve a fresh grace, stopped %d", stopped)
+	}
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), orphan, active, noErr, now.Add(5*r.cfg.GracePeriod))
+	if stopped != 1 {
+		t.Fatalf("the recurred orphan must be stopped once its own grace elapses, got %d", stopped)
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1194,3 +1194,44 @@ func TestHasPendingReleaseStandsAside(t *testing.T) {
 		t.Fatal("completion must not charge budget either")
 	}
 }
+
+// Drift 1/2 grace under the BARE vm id and defer with marker "" — a
+// successful markStale clears that id itself, but a void never runs
+// markStale. Without clearing it here, the elapsed timestamp survives the
+// void, and the relaunched VM's next death reaps instantly without grace.
+func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
+	stubUnitTerminal(t, false) // defer the release
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	// The Drift 1/2 shape: grace elapsed under the bare id, then a deferral.
+	r.driftSeen["vm-1"] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	if err := r.markStale(context.Background(), "vm-1"); err == nil {
+		t.Fatal("non-terminal unit must defer")
+	}
+
+	// A relaunch replaces the instance; the retry voids the stale decision.
+	r.mgr.vms["vm-1"] = &VMInstance{ID: "vm-1", Status: StatusRunning}
+	r.retryPendingReleases(context.Background())
+
+	if r.hasPendingRelease("vm-1") {
+		t.Fatal("the void must retire the entry")
+	}
+	r.mu.Lock()
+	_, kept := r.driftSeen["vm-1"]
+	r.mu.Unlock()
+	if kept {
+		t.Fatal("the void must retire the bare-id grace, or the relaunched VM's next death skips its waiting period")
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -593,3 +593,39 @@ func TestMarkStaleDefersWhileUnitNotTerminal(t *testing.T) {
 		t.Fatalf("a completed release must be forgotten, got %v", got)
 	}
 }
+
+// A deferred release must not be audited as a completed reap, and must not
+// retire the drift marker: the record and its slot are still held. The guard
+// makes deferral the COMMON outcome, so a rule that reported success here
+// would mislabel routine cleanups, not just rare store failures.
+func TestFinalizeRelease_DeferralIsNotSuccess(t *testing.T) {
+	newRec := func() *Reconciler {
+		r := NewReconciler(&Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}, DefaultReconcilerConfig())
+		r.driftSeen["orphan:vm-1"] = time.Now()
+		return r
+	}
+
+	t.Run("deferral keeps the marker", func(t *testing.T) {
+		r := newRec()
+		r.finalizeRelease(context.Background(), "vm-1", "orphan:vm-1", "orphan_stop",
+			"systemd unit with no DB row", "systemd_active_db_missing", errUnitNotTerminal)
+		r.mu.Lock()
+		_, kept := r.driftSeen["orphan:vm-1"]
+		r.mu.Unlock()
+		if !kept {
+			t.Fatal("a deferred release must keep its marker — the slot is still held")
+		}
+	})
+
+	t.Run("completion retires the marker", func(t *testing.T) {
+		r := newRec()
+		r.finalizeRelease(context.Background(), "vm-1", "orphan:vm-1", "orphan_stop",
+			"systemd unit with no DB row", "systemd_active_db_missing", nil)
+		r.mu.Lock()
+		_, kept := r.driftSeen["orphan:vm-1"]
+		r.mu.Unlock()
+		if kept {
+			t.Fatal("a completed release must retire its marker")
+		}
+	})
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1089,3 +1089,54 @@ func TestRetryPendingReleases_InPlaceAdoptionVoids(t *testing.T) {
 		}
 	})
 }
+
+// Drift 8's deferral must carry its marker into the pending release, like
+// every other deferring rule: a retry that completes without it retires the
+// record while the errdead: timestamp survives, robbing the id's next Error
+// episode of its grace period.
+func TestFinalizeErrorReap_TagsDeferredRelease(t *testing.T) {
+	stubUnitTerminal(t, true)
+	path := filepath.Join(t.TempDir(), "vmd.db")
+	store, err := OpenStateStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusError, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusError}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	marker := "errdead:vm-1"
+	r.driftSeen[marker] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	staleErr := r.markStale(context.Background(), "vm-1")
+	if staleErr == nil {
+		t.Fatal("an undeletable record must report failure")
+	}
+	r.finalizeErrorReap(context.Background(), "vm-1", marker, "stale_cleanup",
+		"error record with no unit", "boltdb_error_unit_missing", staleErr)
+
+	reopened, err := OpenStateStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	m.state = reopened
+	r.retryPendingReleases(context.Background())
+
+	if rec, _ := reopened.Get("vm-1"); rec != nil {
+		t.Fatal("the retry must complete the release")
+	}
+	r.mu.Lock()
+	_, kept := r.driftSeen[marker]
+	r.mu.Unlock()
+	if kept {
+		t.Fatal("a completed retry must retire the Drift 8 marker it was deferred under")
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1348,3 +1348,39 @@ func TestGenerationSeparatesClaimsFromLockTraffic(t *testing.T) {
 		}
 	})
 }
+
+// The Drift 1 mistake, re-checked for its siblings: a stale or orphaned VM
+// reads Running in memory until a rule stops it, so no reap rule may treat
+// cached Running as liveness. Pins the predicate direction for Drifts 2/3/5
+// by asserting the reap still happens for a Running-in-memory candidate.
+func TestReapRulesDoNotTrustCachedRunning(t *testing.T) {
+	stubUnitTerminal(t, true) // the unit is conclusively gone
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		// The stale claim every reap candidate carries.
+		vms: map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+
+	if err := r.markStale(context.Background(), "vm-1", ""); err != nil {
+		t.Fatalf("a dead unit's record must be released despite the Running claim: %v", err)
+	}
+	if rec, _ := store.Get("vm-1"); rec != nil {
+		t.Fatal("the stale record must be gone")
+	}
+	m.mu.RLock()
+	_, tracked := m.vms["vm-1"]
+	m.mu.RUnlock()
+	if tracked {
+		t.Fatal("the stale instance must be dropped")
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -459,13 +459,16 @@ func TestRetryPendingReleases(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusError, Namespace: "ns-1"}); err != nil {
+		// Running is the shape most reap sources leave behind — nothing
+		// updates a record when firecracker dies — and the shape the old
+		// status-keyed void silently discarded.
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Namespace: "ns-1"}); err != nil {
 			t.Fatal(err)
 		}
 		m := &Manager{
 			log:   zerolog.Nop(),
 			state: store,
-			vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusError}},
+			vms:   map[string]*VMInstance{"vm-1": {ID: "vm-1", Status: StatusRunning}},
 		}
 		r := NewReconciler(m, DefaultReconcilerConfig())
 		// Pass 1: the store refuses the delete, so the reap is left unfinished.
@@ -518,8 +521,9 @@ func TestRetryPendingReleases(t *testing.T) {
 		}
 		defer reopened.Close()
 		r.mgr.state = reopened
-		// The sandbox came back between passes; the stale decision is void.
-		r.mgr.vms["vm-1"].Status = StatusRunning
+		// A relaunch REPLACES the tracked instance — that pointer swap, not
+		// any status value, is what says a lifecycle op owns the VM now.
+		r.mgr.vms["vm-1"] = &VMInstance{ID: "vm-1", Status: StatusRunning}
 
 		r.retryPendingReleases(context.Background())
 
@@ -534,6 +538,39 @@ func TestRetryPendingReleases(t *testing.T) {
 		}
 		if rec, _ := reopened.Get("vm-1"); rec == nil {
 			t.Fatal("a relaunched VM's record must survive")
+		}
+	})
+	t.Run("a relaunched then re-paused VM is never released", func(t *testing.T) {
+		// The trap a unit-state void would fall into: the new generation
+		// paused, so its unit is terminal — exactly like the stale entry —
+		// and only instance identity tells them apart. Releasing here would
+		// delete a legitimately paused record and free its slot.
+		r, path := newRec(t)
+		reopened, err := OpenStateStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reopened.Close()
+		r.mgr.state = reopened
+		fresh := &VMInstance{ID: "vm-1", Status: StatusPaused}
+		r.mgr.vms["vm-1"] = fresh
+		if err := reopened.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
+			t.Fatal(err)
+		}
+
+		r.retryPendingReleases(context.Background())
+
+		if got := r.pendingReleaseIDs(); len(got) != 0 {
+			t.Fatalf("the voided entry must be forgotten, got %v", got)
+		}
+		if rec, _ := reopened.Get("vm-1"); rec == nil || rec.Status != StatusPaused {
+			t.Fatalf("the re-paused record must survive untouched, got %v", rec)
+		}
+		r.mgr.mu.RLock()
+		still := r.mgr.vms["vm-1"] == fresh
+		r.mgr.mu.RUnlock()
+		if !still {
+			t.Fatal("the new generation's instance must stay tracked")
 		}
 	})
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -584,7 +584,10 @@ func TestReapDeadActiveVMs_StaleRunningRecordDoesNotVetoReap(t *testing.T) {
 			vms: map[string]*VMInstance{id: {ID: id, Status: StatusRunning}},
 		}
 		r := NewReconciler(m, DefaultReconcilerConfig())
-		r.driftSeen[id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod)}
+		// Bind the pre-seeded episode to the instance, as graceElapsedFor
+		// does: an unbound seed reads as a different generation and the
+		// currentness check would (correctly) restart the episode.
+		r.driftSeen[id] = driftEpisode{at: time.Now().Add(-2 * r.cfg.GracePeriod), inst: m.vms[id]}
 
 		origProbe := unitFullyDownProbe
 		unitFullyDownProbe = func(context.Context, string) bool { return unitDown }
@@ -1415,4 +1418,76 @@ func TestStopOrphanUnits_StaleVsClaimedGeneration(t *testing.T) {
 			t.Fatalf("a newly claimed generation must not be stopped, got %v", *stopped)
 		}
 	})
+}
+
+// A nil dbSandboxes is a FAILED DB query, not an empty host. Treating absence
+// of evidence as evidence of orphanhood would stop every active production VM
+// on the host, up to the auto-fail budget, on any DB blip.
+func TestStopOrphanUnits_NilDBStopsNothing(t *testing.T) {
+	stubUnitTerminal(t, true)
+	id := uuid.New().String()
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{id: {ID: id, Status: StatusRunning}}}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	stopped := 0
+	orig := stopUnitFn
+	stopUnitFn = func(context.Context, string) error { stopped++; return nil }
+	t.Cleanup(func() { stopUnitFn = orig })
+
+	active := map[string]bool{id: true}
+	noErr := func(string) bool { return false }
+	now := time.Now()
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), nil, active, noErr, now)
+	r.stopOrphanUnits(context.Background(), zerolog.Nop(), nil, active, noErr, now.Add(2*r.cfg.GracePeriod))
+
+	if stopped != 0 {
+		t.Fatalf("a failed DB query must stop nothing, stopped %d units", stopped)
+	}
+}
+
+// Drift 1's terminal probe cannot distinguish a resume-and-repause from the
+// stale original — the new generation's unit is terminal again. Only the
+// episode's identity+generation binding spares the legitimate paused record.
+func TestReapDeadActiveVMs_RepauseABASpared(t *testing.T) {
+	stubUnitTerminal(t, true)
+	origProbe := unitFullyDownProbe
+	unitFullyDownProbe = func(context.Context, string) bool { return true }
+	t.Cleanup(func() { unitFullyDownProbe = origProbe })
+
+	sbID := uuid.New()
+	id := sbID.String()
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	inst := &VMInstance{ID: id, Status: StatusRunning}
+	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{id: inst}}
+	if err := store.Put(VMRecord{ID: id, Status: StatusRunning}); err != nil {
+		t.Fatal(err)
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	r.markFailed = func(context.Context, string, db.SandboxStatus) bool { return true }
+	rows := map[string]db.ListSandboxesByHostRow{
+		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+	}
+	noErr := func(string) bool { return false }
+	now := time.Now()
+
+	// Pass 1 opens the episode against the stale generation.
+	r.reapDeadActiveVMs(context.Background(), zerolog.Nop(), rows, map[string]bool{}, noErr, now)
+	// A resume claims and a pause re-parks the SAME instance; its unit is
+	// terminal again and its record legitimately Paused.
+	inst.mu.Lock()
+	inst.gen += 2
+	inst.Status = StatusPaused
+	inst.mu.Unlock()
+	if err := store.Put(VMRecord{ID: id, Status: StatusPaused}); err != nil {
+		t.Fatal(err)
+	}
+	// Pass 2 acts on the stale evidence.
+	r.reapDeadActiveVMs(context.Background(), zerolog.Nop(), rows, map[string]bool{}, noErr, now.Add(2*r.cfg.GracePeriod))
+
+	if rec, _ := store.Get(id); rec == nil || rec.Status != StatusPaused {
+		t.Fatalf("the re-paused generation's record must survive, got %v", rec)
+	}
 }

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1234,3 +1234,68 @@ func TestRetryPendingReleases_VoidClearsBareIDGrace(t *testing.T) {
 		t.Fatal("the void must retire the bare-id grace, or the relaunched VM's next death skips its waiting period")
 	}
 }
+
+// The ABA the two-field snapshot cannot see: a lifecycle op can drive the
+// SAME instance away from and back to its noted (Status, Unverified) values
+// between passes. The claim hook closes the class at its choke point — every
+// lifecycle op acquires the vm-op lock, and acquiring it voids any release
+// deferred against the instance's predecessor.
+func TestLifecycleClaimVoidsPendingRelease(t *testing.T) {
+	stubUnitTerminal(t, false) // defer the release
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusPaused, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	inst := &VMInstance{ID: "vm-1", Status: StatusPaused}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{"vm-1": inst},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	r.driftSeen["bolt-orphan:vm-1"] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	if err := r.markStale(context.Background(), "vm-1", "bolt-orphan:vm-1"); err == nil {
+		t.Fatal("non-terminal unit must defer")
+	}
+
+	// A resume claims the VM, drives it Running, then a pause returns it to
+	// Paused — same pointer, both snapshot fields back to their noted values.
+	unlock, err := m.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst.mu.Lock()
+	inst.Status = StatusRunning
+	inst.mu.Unlock()
+	unlock()
+	unlock2, err := m.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst.mu.Lock()
+	inst.Status = StatusPaused
+	inst.mu.Unlock()
+	unlock2()
+
+	if r.hasPendingRelease("vm-1") {
+		t.Fatal("the claim must void the deferred release at the lock, not at state comparison")
+	}
+	r.mu.Lock()
+	_, kept := r.driftSeen["bolt-orphan:vm-1"]
+	r.mu.Unlock()
+	if kept {
+		t.Fatal("the void must retire the episode's marker")
+	}
+
+	// And the retry, running later with the unit now terminal, must not
+	// release the healthy re-paused VM.
+	stubUnitTerminal(t, true)
+	r.retryPendingReleases(context.Background())
+	if rec, _ := store.Get("vm-1"); rec == nil || rec.Status != StatusPaused {
+		t.Fatalf("the re-paused record must survive untouched, got %v", rec)
+	}
+}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -1299,3 +1299,50 @@ func TestLifecycleClaimVoidsPendingRelease(t *testing.T) {
 		t.Fatalf("the re-paused record must survive untouched, got %v", rec)
 	}
 }
+
+// A deferred release owns only the RELEASE half of Drift 1's reap: the row
+// flip re-drives uncharged (nobody else moves a stuck-active row off a dead
+// VM), and no second auto-fail slot is spent for the same decision.
+func TestReapDeadActiveVMs_PendingReleaseRedrivesFlipUncharged(t *testing.T) {
+	stubUnitTerminal(t, false) // the release stays deferred
+	sbID := uuid.New()
+	id := sbID.String()
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.Put(VMRecord{ID: id, Status: StatusRunning, Namespace: "ns-1"}); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{
+		log:   zerolog.Nop(),
+		state: store,
+		vms:   map[string]*VMInstance{id: {ID: id, Status: StatusRunning}},
+	}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	if err := r.markStale(context.Background(), id, ""); err == nil {
+		t.Fatal("non-terminal unit must defer")
+	}
+	flips := 0
+	r.markFailed = func(_ context.Context, vmID string, observed db.SandboxStatus) bool {
+		flips++
+		return true // row moved active→failed
+	}
+	rows := map[string]db.ListSandboxesByHostRow{
+		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+	}
+
+	spent := len(r.autoFailLog)
+	r.reapDeadActiveVMs(context.Background(), zerolog.Nop(), rows, map[string]bool{}, func(string) bool { return false }, time.Now())
+
+	if flips != 1 {
+		t.Fatalf("the stuck-active row must be flipped exactly once, got %d", flips)
+	}
+	if len(r.autoFailLog) != spent {
+		t.Fatalf("re-driving an already-budgeted decision must not charge again, spent %d more", len(r.autoFailLog)-spent)
+	}
+	if !r.hasPendingRelease(id) {
+		t.Fatal("the release must stay owned by the retry")
+	}
+}


### PR DESCRIPTION
The reconciler releases a VM's namespace, IP and tap device when it reaps one.
That release could go wrong two ways, and nothing caught either.

**Too early.** A nil `stopUnit` only means the stop job finished, and absence
from the active-unit snapshot is not terminal — either way Firecracker may still
hold the tap, so the next VM can be launched onto a device the old process owns.

**Not at all.** A failed BoltDB delete abandons the release with the record and
its slot still held, and nothing revisits it: every rule that reaps a live VM
matches on an ACTIVE unit, which its own stop has already retired.

Six of the eight `markStale` call sites had one or both. Only Drift 8 gated on
`unitFullyDown`.

- `markStale` remembers an incomplete release; `retryPendingReleases` finishes it
  on a later pass. Recorded inside `markStale`, so every caller inherits it.
- `markStale` refuses to release while the unit still has a process, returning a
  deferral rather than a failure. Fail-closed.
- Callers route through `finalizeRelease`, so a deferral is no longer audited as
  a completed reap.

The guard is only safe with the retry: `unitFullyDown` is fail-closed, so without
something that revisits, a probe error would turn a rare corruption into a
permanent leak. Separate commits, but they land together.
