### PR TITLE
feat(observability): add Grafana monitoring service accounts

### DIFF
--- a/infra/envs/production/us-central1/main.tf
+++ b/infra/envs/production/us-central1/main.tf
@@ -97,12 +97,29 @@ module "iam" {
       account_id   = "superserve-api-runner"
       display_name = "Superserve API Cloud Run Service Account"
     }
+    grafana_monitoring = {
+      account_id   = "grafana-monitoring"
+      display_name = "Grafana Monitoring"
+    }
   }
   project_bindings = {
     production_host_metric_writer = {
       role = "roles/monitoring.metricWriter"
       members = [
         "serviceAccount:${local.api_service_account_email}"
+      ]
+    }
+    grafana_monitoring_viewer = {
+      role = "roles/monitoring.viewer"
+      members = [
+        "serviceAccount:grafana-monitoring@${local.project_id}.iam.gserviceaccount.com"
+      ]
+    }
+
+    grafana_browser = {
+      role = "roles/browser"
+      members = [
+        "serviceAccount:grafana-monitoring@${local.project_id}.iam.gserviceaccount.com"
       ]
     }
   }

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -107,6 +107,10 @@ module "iam" {
       account_id   = "superserve-github-actions"
       display_name = "GitHub Actions CI/CD Service Account"
     }
+    grafana_monitoring = {
+      account_id   = "grafana-monitoring"
+      display_name = "Grafana Monitoring"
+    }
   }
   project_bindings = {
     staging_host_collector_metric_writer = {
@@ -120,6 +124,19 @@ module "iam" {
     cd_network_admin = {
       role    = "roles/compute.networkAdmin"
       members = ["serviceAccount:superserve-github-actions@${local.project_id}.iam.gserviceaccount.com"]
+    }
+    grafana_monitoring_viewer = {
+      role = "roles/monitoring.viewer"
+      members = [
+        "serviceAccount:grafana-monitoring@${local.project_id}.iam.gserviceaccount.com"
+      ]
+    }
+
+    grafana_browser = {
+      role = "roles/browser"
+      members = [
+        "serviceAccount:grafana-monitoring@${local.project_id}.iam.gserviceaccount.com"
+      ]
     }
   }
   labels = local.common_labels


### PR DESCRIPTION
## Summary

Add dedicated Grafana Cloud monitoring service accounts for staging and production.

- create a Grafana monitoring service account in each environment
- grant `roles/monitoring.viewer` so Grafana can query Cloud Monitoring and Managed Service for Prometheus metrics
- grant `roles/browser` so Grafana can discover the configured GCP projects

## Notes

This change only creates read-only observability identities. It does not switch any running workload to a new service account.

## Validation

- Terraform formatting and validation
- Terraform plan for staging and production
- Apply through the environment GitHub Actions workflow, since local user credentials may not have permission to update project IAM policies