### PR TITLE
vmd: hold a launch while an unconfirmed stop for its unit is outstanding

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3701,6 +3701,25 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	replacingLive := !freshUnit && unitLingering(ctx, systemdUnitName(vmID))
 	lingerCheckMs := time.Since(tLinger).Milliseconds()
 
+	// An unconfirmed stop for this unit may still be sitting in PID1's job
+	// queue — issued for an incarnation that no longer exists, executing
+	// against whatever holds the name when it lands. Launching now hands it
+	// the fresh VM: under a congested PID1 a timed-out launch's cleanup stop
+	// has killed the retry's just-adopted VM mid-restore. Settle first, and
+	// fail rather than launch over a stop that never settles — nothing has
+	// been enqueued yet, so this failure needs no cleanup of its own.
+	if unitStopUnconfirmed(systemdUnitName(vmID)) {
+		tSettle := time.Now()
+		m.log.Warn().Str("vm_id", vmID).
+			Msg("unconfirmed stop outstanding for unit — waiting for it to settle before launch")
+		if err := waitUnitStopSettle(ctx, systemdUnitName(vmID)); err != nil {
+			return 0, fmt.Errorf("launch blocked: %w", err)
+		}
+		m.log.Info().Str("vm_id", vmID).
+			Int64("settle_wait_ms", time.Since(tSettle).Milliseconds()).
+			Msg("outstanding stop settled — launching")
+	}
+
 	tStartUnit := time.Now()
 	if err := restartUnit(ctx, systemdUnitName(vmID)); err != nil {
 		return 0, fmt.Errorf("start systemd unit: %w", err)

--- a/internal/vm/systemd.go
+++ b/internal/vm/systemd.go
@@ -104,8 +104,40 @@ func unitMaybeWindingDown(unit string) bool {
 	if time.Since(vmProcessStart) < processSettleWindow {
 		return true
 	}
+	return unitStopUnconfirmed(unit)
+}
+
+// unitStopUnconfirmed reports a RECORDED stop for this unit that systemd has
+// not yet confirmed done. Narrower than unitMaybeWindingDown on purpose: the
+// launch gate keys on it, and including the young-process window there would
+// stall every launch for the settle window after a vmd restart.
+func unitStopUnconfirmed(unit string) bool {
 	_, ok := recentUnitStops.Load(unit)
 	return ok
+}
+
+// unitStopSettlePoll paces waitUnitStopSettle; a var for tests.
+var unitStopSettlePoll = 250 * time.Millisecond
+
+// waitUnitStopSettle blocks until the unit's recorded stop is confirmed done
+// (confirmUnitStopped clears it when the stop job completes) or ctx expires.
+// Callers gate a launch on this: a stop still in PID1's queue executes against
+// whatever holds the unit name when it lands, so starting before it settles
+// donates the new VM to the old incarnation's cleanup.
+func waitUnitStopSettle(ctx context.Context, unit string) error {
+	if !unitStopUnconfirmed(unit) {
+		return nil
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("unit %s has an unconfirmed stop outstanding: %w", unit, ctx.Err())
+		case <-time.After(unitStopSettlePoll):
+			if !unitStopUnconfirmed(unit) {
+				return nil
+			}
+		}
+	}
 }
 
 // errStopNotEnqueued marks a stop failure where systemd provably never

--- a/internal/vm/systemd_test.go
+++ b/internal/vm/systemd_test.go
@@ -123,3 +123,59 @@ func TestProcessSettleWindowCoversOrphanSweep(t *testing.T) {
 			processSettleWindow, min)
 	}
 }
+
+// The launch gate must hold a launch while a recorded stop is unconfirmed —
+// a stop still in PID1's queue executes against whatever holds the unit name
+// when it lands — and must fail closed rather than launch over one that never
+// settles. Nothing is enqueued before the gate, so its failure needs no
+// cleanup.
+func TestWaitUnitStopSettle(t *testing.T) {
+	origPoll := unitStopSettlePoll
+	unitStopSettlePoll = 5 * time.Millisecond
+	defer func() { unitStopSettlePoll = origPoll }()
+
+	t.Run("no recorded stop passes immediately", func(t *testing.T) {
+		if err := waitUnitStopSettle(context.Background(), "settle-none.service"); err != nil {
+			t.Fatalf("no outstanding stop must not block a launch: %v", err)
+		}
+	})
+
+	t.Run("confirmation releases the gate", func(t *testing.T) {
+		unit := "settle-confirm.service"
+		recordUnitStop(unit)
+		defer confirmUnitStopped(unit)
+		go func() {
+			time.Sleep(20 * time.Millisecond) // the stop job completes
+			confirmUnitStopped(unit)
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := waitUnitStopSettle(ctx, unit); err != nil {
+			t.Fatalf("a confirmed stop must release the launch: %v", err)
+		}
+	})
+
+	t.Run("an unsettled stop fails the launch, not the other way around", func(t *testing.T) {
+		unit := "settle-never.service"
+		recordUnitStop(unit)
+		defer confirmUnitStopped(unit)
+		ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+		defer cancel()
+		err := waitUnitStopSettle(ctx, unit)
+		if err == nil {
+			t.Fatal("launching over an unsettled stop hands the new VM to the old incarnation's cleanup")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("the failure must carry the ctx verdict, got %v", err)
+		}
+	})
+}
+
+func TestUnitStopUnconfirmedExcludesSettleWindow(t *testing.T) {
+	// The gate must key on RECORDED stops only: unitMaybeWindingDown reads
+	// true for every unit during the young-process window, and gating on it
+	// would stall all launches for minutes after a vmd restart.
+	if unitStopUnconfirmed("never-touched.service") {
+		t.Fatal("a unit with no recorded stop must not read as unconfirmed")
+	}
+}


### PR DESCRIPTION
A launch whose unit-start job is delayed inside PID1 can time out waiting for
the API socket and enqueue its cleanup stop while the start is still queued or
executing. Under a congested PID1 both jobs run later, in order: the start
produces a live VM, a retry finds the socket up and adopts it — and the stale
stop then executes against the adopted VM, killing it mid-restore. A stop job
executes against whatever holds the unit name when it lands, not the
incarnation it was issued for.

The stop registry already records exactly this state (`recentUnitStops`,
cleared only when systemd confirms the stop done), but until now it only
widened the linger check. This adds the missing consumer: before starting a
unit, a launch that finds an unconfirmed stop on record waits — bounded by its
ctx — for the stop to settle, and fails rather than launch over one that never
does. The gate sits before anything is enqueued, so its failure needs no
cleanup and seeds no further stops. It keys on recorded stops only, not the
young-process settle window, which would otherwise stall every launch after a
vmd restart.

Replayed against the motivating failure, the retry waits a few seconds for the
stale stop to land and then launches a clean unit: the resume succeeds slower
instead of dying.

Tests cover all three gate outcomes; the fail-closed case was verified to fail
against a gate that launches anyway.
