### PR TITLE
fix(infra): tune cloud ids alert routing

### DIFF
--- a/infra/CLOUD_IDS.md
+++ b/infra/CLOUD_IDS.md
@@ -35,9 +35,18 @@ Cloud Monitoring notification channels.
   coverage here.
 - The shared Private Service Access prerequisite for Cloud IDS is managed
   outside this repository and must be confirmed before the first apply.
-- Threat findings are surfaced through a log-based Cloud Monitoring alert so
-  notifications can reuse the existing monitored destination without adding a
-  webhook secret to Terraform state.
+- Threat findings are surfaced through log-based Cloud Monitoring alert
+  policies so notifications can reuse the existing monitored destination
+  without adding a webhook secret to Terraform state.
+- INFORMATIONAL and LOW findings remain in Cloud Logging only and are not sent
+  to the incident channel.
+- MEDIUM findings map to an `ERROR` alert policy.
+- HIGH and CRITICAL findings map to a `CRITICAL` alert policy.
+- The log-based policies extract the IDS severity, threat name, threat ID,
+  URI or filename, source IP address, destination IP address, and destination
+  port so Slack notifications carry the useful threat context directly.
+- MEDIUM and HIGH/CRITICAL findings use the shared
+  `TF_VAR_notification_channel_ids` list.
 
 ## Cost estimate
 
@@ -70,6 +79,13 @@ outside this repo before the first Cloud IDS apply; do not create them here.
 After the endpoints are live, locate a real IDS threat log in Cloud Logging and
 confirm the alert policy matches the same `logName`, `resource.type`, and
 `resource.labels.id` values before relying on notification delivery.
+Confirm the notification severity in Slack matches the alert policy severity
+for the matching band:
+
+- `ERROR` for MEDIUM
+- `CRITICAL` for HIGH and CRITICAL
+Also confirm that INFORMATIONAL and LOW findings continue to appear in
+Cloud Logging without generating incident notifications.
 
 ## Rollback
 

--- a/infra/modules/cloud-ids/main.tf
+++ b/infra/modules/cloud-ids/main.tf
@@ -2,6 +2,30 @@ terraform {
   required_version = ">= 1.5.0"
 }
 
+moved {
+  from = google_monitoring_alert_policy.ids_threats
+  to   = google_monitoring_alert_policy.ids_high_critical
+}
+
+locals {
+  ids_log_filter = <<-EOT
+    log_id("ids.googleapis.com/threat")
+    AND resource.type="ids.googleapis.com/Endpoint"
+    AND resource.labels.id="${var.endpoint_name}"
+  EOT
+
+  ids_label_extractors = {
+    ids_severity           = "EXTRACT(jsonPayload.alert_severity)"
+    threat_name            = "EXTRACT(jsonPayload.name)"
+    threat_id              = "EXTRACT(jsonPayload.threat_id)"
+    uri_or_filename        = "EXTRACT(jsonPayload.uri_or_filename)"
+    source_ip_address      = "EXTRACT(jsonPayload.source_ip_address)"
+    destination_ip_address = "EXTRACT(jsonPayload.destination_ip_address)"
+    destination_port       = "EXTRACT(jsonPayload.destination_port)"
+  }
+
+}
+
 resource "google_cloud_ids_endpoint" "this" {
   project     = var.project_id
   name        = var.endpoint_name
@@ -35,17 +59,18 @@ resource "google_compute_packet_mirroring" "this" {
   }
 }
 
-resource "google_monitoring_alert_policy" "ids_threats" {
+resource "google_monitoring_alert_policy" "ids_medium" {
   project               = var.project_id
-  display_name          = "Security / ${var.endpoint_name} / Cloud IDS threats"
+  display_name          = "Security / ${var.endpoint_name} / Cloud IDS MEDIUM threats"
   combiner              = "OR"
   enabled               = true
+  severity              = "ERROR"
   notification_channels = var.notification_channel_ids
 
   lifecycle {
     precondition {
       condition     = length(var.notification_channel_ids) > 0
-      error_message = "notification_channel_ids must contain an existing monitored channel for Cloud IDS alerts"
+      error_message = "notification_channel_ids must contain an existing monitored channel for Cloud IDS MEDIUM alerts"
     }
     precondition {
       condition = alltrue([
@@ -59,15 +84,11 @@ resource "google_monitoring_alert_policy" "ids_threats" {
   }
 
   conditions {
-    display_name = "${var.endpoint_name} threat log"
+    display_name = "${var.endpoint_name} MEDIUM threat log"
 
     condition_matched_log {
-      filter = <<-EOT
-        log_id("ids.googleapis.com/threat")
-        AND resource.type="ids.googleapis.com/Endpoint"
-        AND resource.labels.id="${var.endpoint_name}"
-        AND jsonPayload.alert_severity!="INFORMATIONAL"
-      EOT
+      filter           = "${local.ids_log_filter}\nAND jsonPayload.alert_severity=\"MEDIUM\""
+      label_extractors = local.ids_label_extractors
     }
   }
 
@@ -79,10 +100,19 @@ resource "google_monitoring_alert_policy" "ids_threats" {
   }
 
   documentation {
+    subject   = "Cloud IDS MEDIUM: $${log.extracted_label.ids_severity} $${log.extracted_label.threat_name}"
     content   = <<-EOT
-      Cloud IDS reported a threat on ${var.endpoint_name}.
+      Cloud IDS reported a MEDIUM threat on ${var.endpoint_name}.
 
-      Owner: Infrastructure Operations. Response: review the threat log in Cloud Logging, inspect the mirrored source and destination traffic, confirm whether the finding is expected, and record the remediation or suppression decision before closing the incident.
+      IDS severity: $${log.extracted_label.ids_severity}
+      Threat name: $${log.extracted_label.threat_name}
+      Threat ID: $${log.extracted_label.threat_id}
+      Source IP: $${log.extracted_label.source_ip_address}
+      Destination IP: $${log.extracted_label.destination_ip_address}
+      Destination port: $${log.extracted_label.destination_port}
+      URI or filename: $${log.extracted_label.uri_or_filename}
+
+      This policy routes MEDIUM findings with an error-severity incident so responders can triage them separately from LOW findings.
     EOT
     mime_type = "text/markdown"
   }
@@ -91,5 +121,78 @@ resource "google_monitoring_alert_policy" "ids_threats" {
     alert_type = "cloud_ids_threat_activity"
     endpoint   = var.endpoint_name
     managed_by = "terraform"
+    severity   = "medium"
+  })
+}
+
+resource "google_monitoring_alert_policy" "ids_high_critical" {
+  project               = var.project_id
+  display_name          = "Security / ${var.endpoint_name} / Cloud IDS HIGH and CRITICAL threats"
+  combiner              = "OR"
+  enabled               = true
+  severity              = "CRITICAL"
+  notification_channels = var.notification_channel_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(var.notification_channel_ids) > 0
+      error_message = "notification_channel_ids must contain an existing monitored channel for Cloud IDS HIGH and CRITICAL alerts"
+    }
+    precondition {
+      condition = alltrue([
+        for channel_id in var.notification_channel_ids : can(regex(
+          "^projects/${var.project_id}/notificationChannels/[0-9]+$",
+          channel_id
+        ))
+      ])
+      error_message = "notification_channel_ids must reference monitored channels in the configured project using full resource names"
+    }
+  }
+
+  conditions {
+    display_name = "${var.endpoint_name} HIGH and CRITICAL threat log"
+
+    condition_matched_log {
+      filter           = <<-EOT
+        ${local.ids_log_filter}
+        AND (
+          jsonPayload.alert_severity="HIGH"
+          OR jsonPayload.alert_severity="CRITICAL"
+        )
+      EOT
+      label_extractors = local.ids_label_extractors
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+    auto_close = "1800s"
+  }
+
+  documentation {
+    subject   = "Cloud IDS HIGH/CRITICAL: $${log.extracted_label.ids_severity} $${log.extracted_label.threat_name}"
+    content   = <<-EOT
+      Cloud IDS reported a HIGH or CRITICAL threat on ${var.endpoint_name}.
+
+      IDS severity: $${log.extracted_label.ids_severity}
+      Threat name: $${log.extracted_label.threat_name}
+      Threat ID: $${log.extracted_label.threat_id}
+      Source IP: $${log.extracted_label.source_ip_address}
+      Destination IP: $${log.extracted_label.destination_ip_address}
+      Destination port: $${log.extracted_label.destination_port}
+      URI or filename: $${log.extracted_label.uri_or_filename}
+
+      This policy keeps the highest-severity findings on the immediate response path.
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type = "cloud_ids_threat_activity"
+    endpoint   = var.endpoint_name
+    managed_by = "terraform"
+    severity   = "high_critical"
   })
 }

--- a/infra/modules/cloud-ids/outputs.tf
+++ b/infra/modules/cloud-ids/outputs.tf
@@ -14,6 +14,14 @@ output "packet_mirroring_name" {
 }
 
 output "alert_policy_name" {
-  description = "Cloud IDS alert policy name."
-  value       = google_monitoring_alert_policy.ids_threats.name
+  description = "Compatibility alias for the pre-split singular Cloud IDS policy name; points at the HIGH and CRITICAL policy."
+  value       = google_monitoring_alert_policy.ids_high_critical.name
+}
+
+output "alert_policy_names" {
+  description = "Cloud IDS alert policy names keyed by severity band."
+  value = {
+    medium        = google_monitoring_alert_policy.ids_medium.name
+    high_critical = google_monitoring_alert_policy.ids_high_critical.name
+  }
 }


### PR DESCRIPTION
This PR updates Cloud IDS alerting so:

- INFORMATIONAL and LOW findings stay in Cloud Logging only
- MEDIUM findings notify through the shared incident channels with Monitoring severity `ERROR`
- HIGH and CRITICAL findings notify through the shared incident channels with Monitoring severity `CRITICAL`
- alert documentation includes extracted severity and threat fields
- the existing HIGH/CRITICAL policy identity is preserved with a Terraform `moved` block

Testing:

- `terraform fmt -recursive infra`
- `terraform -chdir=infra/envs/production/us-west2 init -backend=false -input=false`
- `terraform -chdir=infra/envs/production/us-east4 init -backend=false -input=false`

Notes:

- provider-backed `terraform validate` / `terraform plan` were not completed in this sandbox
fixes SS-277