### PR TITLE
ci: revert the Blacksmith runner migration that rode in with an unrelated squash

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   migrate-staging:
     name: Migrate Staging
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
   migrate-prod:
     name: Migrate Production
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [migrate-staging]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +22,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16
@@ -52,7 +52,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +68,7 @@ jobs:
 
   vet:
     name: Vet
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -81,7 +81,7 @@ jobs:
 
   sqlc-check:
     name: sqlc Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +100,7 @@ jobs:
 
   migration-order:
     name: Migration Order
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       infra_changed: ${{ steps.changes.outputs.infra }}
     steps:
@@ -66,7 +66,7 @@ jobs:
   # deploy on the same-SHA migrate run. Pushes that touch no migrations
   # (the common case) pass through after one git diff.
   wait-for-migrations:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [detect-changes]
     if: github.event_name != 'push' || needs.detect-changes.outputs.infra_changed != 'true'
     permissions:
@@ -138,7 +138,7 @@ jobs:
           exit 1
 
   build-api-image:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [detect-changes, wait-for-migrations]
     if: github.event_name != 'push' || needs.detect-changes.outputs.infra_changed != 'true'
     permissions:
@@ -159,7 +159,7 @@ jobs:
           if-no-files-found: error
 
   deploy-staging:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     needs: [detect-changes, wait-for-migrations, build-api-image]
     if: github.event_name != 'push' || needs.detect-changes.outputs.infra_changed != 'true'
@@ -235,7 +235,7 @@ jobs:
   deploy-production:
     needs: [detect-changes, build-api-image, deploy-staging]
     if: (github.event_name == 'push' || github.event.inputs.environment == 'production') && (github.event_name != 'push' || needs.detect-changes.outputs.infra_changed != 'true')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: read

--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   deploy-staging:
     if: github.event_name == 'push' || github.event.inputs.environment == 'staging'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     permissions:
       contents: read
@@ -53,7 +53,7 @@ jobs:
 
   deploy-production:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: read

--- a/.github/workflows/deploy-proxy.yml
+++ b/.github/workflows/deploy-proxy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   deploy-staging:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     permissions:
       contents: read
@@ -76,7 +76,7 @@ jobs:
   deploy-production:
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
     needs: [deploy-staging]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: read

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -49,7 +49,7 @@ on:
 
 jobs:
   deploy-staging:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     permissions:
       contents: read
@@ -103,7 +103,7 @@ jobs:
   deploy-production:
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
     needs: [deploy-staging]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: read

--- a/.github/workflows/loop-pr-loop.yml
+++ b/.github/workflows/loop-pr-loop.yml
@@ -20,7 +20,7 @@ jobs:
   tick:
     # Fork PRs can't read repo secrets or write with the built-in token — skip them.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # Bound a stuck package/API/sandbox call; the loop's own review command times out after 20m.
     timeout-minutes: 30
     steps:

--- a/.github/workflows/seed-templates.yml
+++ b/.github/workflows/seed-templates.yml
@@ -64,7 +64,7 @@ concurrency:
 jobs:
   seed-staging:
     name: Seed Staging
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 45
     steps:
@@ -139,7 +139,7 @@ jobs:
   seed-prod:
     name: Seed Production
     if: github.event_name == 'push' || github.event.inputs.environment == 'production'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     # Two blocking seeder invocations (primary, then the usw cell), each with
     # the seeder's default 30-min build wait — 90 covers both plus slack.

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   wait-for-migrations:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -63,7 +63,7 @@ jobs:
 
   build-api-image:
     name: Build API image once
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [wait-for-migrations]
     permissions:
       contents: read
@@ -84,7 +84,7 @@ jobs:
 
   staging-us-central1-infra:
     name: Apply staging/us-central1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [wait-for-migrations]
     permissions:
       contents: read
@@ -122,7 +122,7 @@ jobs:
 
   staging-us-central1-api:
     name: Deploy API staging/us-central1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: staging
     needs: [build-api-image, staging-us-central1-infra]
     permissions:
@@ -203,7 +203,7 @@ jobs:
 
   production-us-central1-bootstrap:
     name: Bootstrap production/us-central1 project services
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [staging-us-central1-infra]
     permissions:
@@ -248,7 +248,7 @@ jobs:
 
   production-us-west2-infra:
     name: Apply production/us-west2
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [staging-us-central1-api, production-us-central1-bootstrap]
     permissions:
@@ -288,7 +288,7 @@ jobs:
 
   production-us-west2-api:
     name: Deploy API production/us-west2
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [build-api-image, production-us-west2-infra]
     permissions:
@@ -367,7 +367,7 @@ jobs:
 
   production-us-central1-infra:
     name: Apply production/us-central1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [production-us-west2-api]
     permissions:
@@ -418,7 +418,7 @@ jobs:
   # against that cell.
   production-us-east4-infra:
     name: Apply production/us-east4
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [staging-us-central1-api, production-us-central1-bootstrap]
     permissions:
@@ -452,7 +452,7 @@ jobs:
 
   production-us-east4-api:
     name: Deploy API production/us-east4
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment: production
     needs: [build-api-image, production-us-east4-infra]
     permissions:

--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   terraform-fmt:
     name: Terraform Fmt
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -26,7 +26,7 @@ jobs:
 
   terraform-validate:
     name: Terraform Validate
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   terraform-plan-summary:
     name: Terraform Plan Summary
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [terraform-fmt, terraform-validate]
     if: always()
     permissions:

--- a/.github/workflows/terraform-plans.yml
+++ b/.github/workflows/terraform-plans.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   terraform-plan:
     name: terraform-plan (${{ matrix.name }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -157,7 +157,7 @@ jobs:
 
   terraform-plan-summary:
     name: Terraform Plan Details
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [terraform-plan]
     if: always()
     permissions:

--- a/.github/workflows/terraform-rollout-production.yml
+++ b/.github/workflows/terraform-rollout-production.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   west2:
     name: Apply production us-west2
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && (inputs.target == 'west2' || inputs.target == 'all')
     environment: production
     permissions:
@@ -75,7 +75,7 @@ jobs:
 
   central1:
     name: Apply production us-central1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: ${{ always() && github.ref == 'refs/heads/main' && (inputs.target == 'central1' || inputs.target == 'all') && (needs.west2.result == 'success' || needs.west2.result == 'skipped') }}
     needs: [west2]
     environment: production

--- a/.github/workflows/terraform-rollout-staging.yml
+++ b/.github/workflows/terraform-rollout-staging.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   staging:
     name: Apply staging us-central1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read


### PR DESCRIPTION
The squash merge of the direct-spawn foundation PR also carried a bot-authored workflow migration (runs-on: ubuntu-latest → blacksmith-4vcpu-ubuntu-2404 across 13 workflow files) that was pushed onto that branch and was never part of its review. This restores every workflow file to its pre-merge state, byte-identical — no other changes. If the runner migration is wanted, it can land through its own reviewed PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/superserve-ai/codesmith/sandbox/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788650949&installation_model_id=431391&pr_number=334&repository=superserve-ai%2Fsandbox&return_to=https%3A%2F%2Fgithub.com%2Fsuperserve-ai%2Fsandbox%2Fpull%2F334&signature=478262c0d4c604175a5ddfee633534eeafa918e5ab1152c0e21f8f2f1a6d8a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->