### PR TITLE
Alert on GCE host maintenance notices and restart system events

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -40,6 +40,9 @@ on:
       - 'deploy/sandboxes.slice'
       - 'deploy/needrestart-superserve.conf'
       - 'deploy/apt-no-auto-upgrades.conf'
+      - 'deploy/maintenance-watch.sh'
+      - 'deploy/superserve-maintenance-watch.service'
+      - 'deploy/superserve-maintenance-watch.timer'
       - 'scripts/fc-cleanup'
       # The workflow + its deploy script must self-trigger (as deploy-otel does),
       # or a new cell/step lands without ever running until an unrelated vmd

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -97,6 +97,7 @@ jobs:
           # Staging validates the backup uploader first; the production
           # cells get their buckets after the staging soak.
           BACKUP_BUCKET: superserve-artifact-backup-staging-usc1
+          MAINTENANCE_ALERT_WEBHOOK: ${{ secrets.MAINTENANCE_ALERT_WEBHOOK }}
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py
 
@@ -158,6 +159,7 @@ jobs:
           CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_PROD }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           INTERNAL_API_TOKEN: ${{ secrets.PROD_INTERNAL_API_TOKEN }}
+          MAINTENANCE_ALERT_WEBHOOK: ${{ secrets.MAINTENANCE_ALERT_WEBHOOK }}
         run: |
           # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
           # filter and fan out to every VMD_LABEL match. use4 is the permanent
@@ -199,6 +201,7 @@ jobs:
           # Enables the pause-backup uploader for the cell (validated on
           # staging first; the bucket is create-only for hosts).
           BACKUP_BUCKET: superserve-artifact-backup-usw2
+          MAINTENANCE_ALERT_WEBHOOK: ${{ secrets.MAINTENANCE_ALERT_WEBHOOK }}
         run: |
           # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
           # filter and fan out to every VMD_LABEL match — which would push

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -101,6 +101,9 @@ BUNDLE_FILES = [
     "deploy/sandboxes.slice",
     "deploy/needrestart-superserve.conf",
     "deploy/apt-no-auto-upgrades.conf",
+    "deploy/maintenance-watch.sh",
+    "deploy/superserve-maintenance-watch.service",
+    "deploy/superserve-maintenance-watch.timer",
     "scripts/fc-cleanup",
 ]
 
@@ -138,6 +141,9 @@ def main() -> int:
     q_dat_line = shlex.quote(f"DAEMON_AUTH_TOKEN={internal_api_token}")
     q_db = shlex.quote(database_url)
     q_db_line = shlex.quote(f"DATABASE_URL={database_url}")
+    maintenance_webhook = os.environ.get("MAINTENANCE_ALERT_WEBHOOK", "")
+    q_webhook = shlex.quote(maintenance_webhook)
+    q_webhook_line = shlex.quote(f"MAINTENANCE_ALERT_WEBHOOK={maintenance_webhook}")
 
     # Build the deploy bundle once. Same artifact ships to every host;
     # building per-host would waste CI runner CPU.
@@ -226,8 +232,12 @@ def main() -> int:
             sudo install -m 0644 {extract_dir}/deploy/firecracker@.service /etc/systemd/system/firecracker@.service
             sudo install -m 0644 {extract_dir}/deploy/firecracker-netns@.service /etc/systemd/system/firecracker-netns@.service
             sudo install -m 0644 {extract_dir}/deploy/sandboxes.slice /etc/systemd/system/sandboxes.slice
+            sudo install -m 0755 {extract_dir}/deploy/maintenance-watch.sh {install_dir}/maintenance-watch
+            sudo install -m 0644 {extract_dir}/deploy/superserve-maintenance-watch.service /etc/systemd/system/superserve-maintenance-watch.service
+            sudo install -m 0644 {extract_dir}/deploy/superserve-maintenance-watch.timer /etc/systemd/system/superserve-maintenance-watch.timer
             sudo systemctl daemon-reload
             sudo systemctl enable --quiet superserve-vmd.socket
+            sudo systemctl enable --now --quiet superserve-maintenance-watch.timer
 
             sudo install -m 0755 {extract_dir}/scripts/fc-cleanup {install_dir}/fc-cleanup
 
@@ -304,6 +314,17 @@ def main() -> int:
             if [ -n {q_sentry} ]; then
                 sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
                 echo {q_sentry_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            fi
+
+            # Upsert the maintenance-watch webhook into its own env file so the
+            # watcher never sources vmd's tokens. Empty = skip: the watcher
+            # still runs and logs notices to the journal, it just can't page.
+            if [ -n {q_webhook} ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/maintenance-watch.env
+                sudo chmod 0600 /etc/sandbox/maintenance-watch.env
+                sudo sed -i '/^MAINTENANCE_ALERT_WEBHOOK=/d' /etc/sandbox/maintenance-watch.env
+                echo {q_webhook_line} | sudo tee -a /etc/sandbox/maintenance-watch.env > /dev/null
             fi
 
             # Upsert BACKUP_BUCKET (the cell's artifact backup bucket).

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -232,6 +232,18 @@ def main() -> int:
             sudo install -m 0644 {extract_dir}/deploy/firecracker@.service /etc/systemd/system/firecracker@.service
             sudo install -m 0644 {extract_dir}/deploy/firecracker-netns@.service /etc/systemd/system/firecracker-netns@.service
             sudo install -m 0644 {extract_dir}/deploy/sandboxes.slice /etc/systemd/system/sandboxes.slice
+            # Upsert the maintenance-watch webhook into its own env file so the
+            # watcher never sources vmd's tokens. Empty = skip: the watcher
+            # still runs and logs notices to the journal, it just can't page.
+            # Written BEFORE the timer is enabled below: an elapsed OnBootSec
+            # fires the watcher the moment `enable --now` runs.
+            if [ -n {q_webhook} ]; then
+                sudo install -d -m 0755 /etc/sandbox
+                sudo touch /etc/sandbox/maintenance-watch.env
+                sudo chmod 0600 /etc/sandbox/maintenance-watch.env
+                sudo sed -i '/^MAINTENANCE_ALERT_WEBHOOK=/d' /etc/sandbox/maintenance-watch.env
+                echo {q_webhook_line} | sudo tee -a /etc/sandbox/maintenance-watch.env > /dev/null
+            fi
             sudo install -m 0755 {extract_dir}/deploy/maintenance-watch.sh {install_dir}/maintenance-watch
             sudo install -m 0644 {extract_dir}/deploy/superserve-maintenance-watch.service /etc/systemd/system/superserve-maintenance-watch.service
             sudo install -m 0644 {extract_dir}/deploy/superserve-maintenance-watch.timer /etc/systemd/system/superserve-maintenance-watch.timer
@@ -314,17 +326,6 @@ def main() -> int:
             if [ -n {q_sentry} ]; then
                 sudo sed -i '/^SENTRY_DSN=/d' /etc/sandbox/vmd.env
                 echo {q_sentry_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
-            fi
-
-            # Upsert the maintenance-watch webhook into its own env file so the
-            # watcher never sources vmd's tokens. Empty = skip: the watcher
-            # still runs and logs notices to the journal, it just can't page.
-            if [ -n {q_webhook} ]; then
-                sudo install -d -m 0755 /etc/sandbox
-                sudo touch /etc/sandbox/maintenance-watch.env
-                sudo chmod 0600 /etc/sandbox/maintenance-watch.env
-                sudo sed -i '/^MAINTENANCE_ALERT_WEBHOOK=/d' /etc/sandbox/maintenance-watch.env
-                echo {q_webhook_line} | sudo tee -a /etc/sandbox/maintenance-watch.env > /dev/null
             fi
 
             # Upsert BACKUP_BUCKET (the cell's artifact backup bucket).

--- a/deploy/maintenance-watch.sh
+++ b/deploy/maintenance-watch.sh
@@ -7,7 +7,7 @@
 set -u
 
 # Overridable for tests only; production runs use the defaults.
-ENDPOINT="${MAINTENANCE_WATCH_ENDPOINT:-http://metadata.google.internal/computeMetadata/v1/instance/upcoming-maintenance}"
+ENDPOINT="${MAINTENANCE_WATCH_ENDPOINT:-http://metadata.google.internal/computeMetadata/v1/instance/upcoming-maintenance?alt=json}"
 STATE_FILE="${MAINTENANCE_WATCH_STATE:-/var/lib/sandbox/maintenance-notice}"
 
 tmp=$(mktemp)
@@ -15,12 +15,14 @@ trap 'rm -f "$tmp"' EXIT
 code=$(curl -s -o "$tmp" -w '%{http_code}' -H "Metadata-Flavor: Google" \
     --connect-timeout 5 --max-time 30 "$ENDPOINT") || code=000
 
+# Only a 200 decides: its body is either the literal NONE (nothing scheduled)
+# or the pending notice. Any other code is a transient metadata-server problem
+# — skip the poll rather than misread it as "notice cleared".
 case "$code" in
-200) notice=$(cat "$tmp") ;;
-# The endpoint 503s when no maintenance is scheduled — that's the healthy case.
-404 | 503) notice="" ;;
-# Anything else is a transient metadata-server problem: skip the poll rather
-# than misread it as "notice cleared".
+200)
+    notice=$(cat "$tmp")
+    [ "$notice" = "NONE" ] && notice=""
+    ;;
 *)
     echo "metadata server unreachable (http $code), skipping poll" >&2
     exit 0

--- a/deploy/maintenance-watch.sh
+++ b/deploy/maintenance-watch.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Watches the GCE metadata server for an upcoming host-maintenance notice.
+# Bare metal hosts cannot live-migrate: host maintenance terminates and
+# restarts the machine, so the advance notice is the only window to drain
+# the host first. Posts one webhook message when a notice appears, changes,
+# or clears; the notice is also logged to the journal either way.
+set -u
+
+# Overridable for tests only; production runs use the defaults.
+ENDPOINT="${MAINTENANCE_WATCH_ENDPOINT:-http://metadata.google.internal/computeMetadata/v1/instance/upcoming-maintenance}"
+STATE_FILE="${MAINTENANCE_WATCH_STATE:-/var/lib/sandbox/maintenance-notice}"
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+code=$(curl -s -o "$tmp" -w '%{http_code}' -H "Metadata-Flavor: Google" \
+    --connect-timeout 5 --max-time 30 "$ENDPOINT") || code=000
+
+case "$code" in
+200) notice=$(cat "$tmp") ;;
+# The endpoint 503s when no maintenance is scheduled — that's the healthy case.
+404 | 503) notice="" ;;
+# Anything else is a transient metadata-server problem: skip the poll rather
+# than misread it as "notice cleared".
+*)
+    echo "metadata server unreachable (http $code), skipping poll" >&2
+    exit 0
+    ;;
+esac
+
+prev=""
+[ -f "$STATE_FILE" ] && prev=$(cat "$STATE_FILE")
+[ "$notice" = "$prev" ] && exit 0
+
+host=$(hostname)
+if [ -n "$notice" ]; then
+    msg="GCE host maintenance notice on ${host}: ${notice}"
+else
+    msg="GCE host maintenance notice on ${host} cleared (window passed or maintenance completed)"
+fi
+echo "$msg"
+
+# State is only written after a successful delivery, so an unset webhook or a
+# failed POST re-fires on the next poll instead of dropping the notice.
+if [ -z "${MAINTENANCE_ALERT_WEBHOOK:-}" ]; then
+    echo "MAINTENANCE_ALERT_WEBHOOK is not set, notice logged to journal only" >&2
+    exit 1
+fi
+
+esc=$(printf '%s' "$msg" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+if ! curl -sf -X POST -H "Content-Type: application/json" \
+    -d "{\"text\":\"${esc}\"}" \
+    --connect-timeout 5 --max-time 30 "$MAINTENANCE_ALERT_WEBHOOK" >/dev/null; then
+    echo "webhook delivery failed, will retry next poll" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$STATE_FILE")"
+printf '%s' "$notice" >"$STATE_FILE"

--- a/deploy/superserve-maintenance-watch.service
+++ b/deploy/superserve-maintenance-watch.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=GCE host maintenance notice watcher
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/sandbox/maintenance-watch.env
+ExecStart=/usr/local/bin/maintenance-watch

--- a/deploy/superserve-maintenance-watch.timer
+++ b/deploy/superserve-maintenance-watch.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Poll for GCE host maintenance notices
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -341,6 +341,7 @@ module "observability" {
     sandbox_host = {
       display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"
       instance_name = module.sandbox_host.instance_name
+      instance_id   = module.sandbox_host.instance_id
     }
   }
   labels = local.common_labels

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -337,6 +337,12 @@ module "observability" {
       instance_id   = module.sandbox_host.instance_id
     }
   }
+  host_maintenance_event_alerts = {
+    sandbox_host = {
+      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"
+      instance_name = module.sandbox_host.instance_name
+    }
+  }
   labels = local.common_labels
 }
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -235,6 +235,7 @@ module "observability" {
     sandbox_host = {
       display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"
       instance_name = module.sandbox_host.instance_name
+      instance_id   = module.sandbox_host.instance_id
     }
   }
   labels = local.common_labels

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -231,6 +231,12 @@ module "observability" {
       instance_id   = module.sandbox_host.instance_id
     }
   }
+  host_maintenance_event_alerts = {
+    sandbox_host = {
+      display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"
+      instance_name = module.sandbox_host.instance_name
+    }
+  }
   labels = local.common_labels
 }
 

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -79,17 +79,84 @@ resource "google_monitoring_alert_policy" "compute_instance_cpu" {
   })
 }
 
+resource "google_monitoring_alert_policy" "host_maintenance_events" {
+  for_each = var.host_maintenance_event_alerts
+
+  project               = var.project_id
+  display_name          = each.value.display_name
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.notification_channel_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(var.notification_channel_ids) > 0
+      error_message = "notification_channel_ids must contain an existing monitored channel when host maintenance alerts are configured"
+    }
+    precondition {
+      condition = alltrue([
+        for channel_id in var.notification_channel_ids : can(regex(
+          "^projects/${var.project_id}/notificationChannels/[0-9]+$",
+          channel_id
+        ))
+      ])
+      error_message = "notification_channel_ids must reference monitored channels in the configured project using full resource names"
+    }
+  }
+
+  conditions {
+    display_name = "${each.value.instance_name} host maintenance system event"
+
+    condition_matched_log {
+      filter = <<-EOT
+        logName="projects/${var.project_id}/logs/cloudaudit.googleapis.com%2Fsystem_event"
+        resource.type="gce_instance"
+        protoPayload.resourceName=~"/instances/${each.value.instance_name}$"
+        protoPayload.methodName=~"(upcomingMaintenance|terminateOnHostMaintenance|hostError|automaticRestart)"
+      EOT
+    }
+  }
+
+  alert_strategy {
+    # Required on log-based policies; 5 min absorbs the notice/terminate/
+    # restart burst a single maintenance event produces.
+    notification_rate_limit {
+      period = "300s"
+    }
+    auto_close = "86400s"
+  }
+
+  documentation {
+    content = coalesce(each.value.documentation, <<-EOT
+      Compute Engine logged a host system event for ${each.value.instance_name}: an upcoming maintenance notice, a maintenance termination, a host error, or an automatic restart.
+
+      This instance is bare metal — host maintenance terminates and restarts it, taking every workload on it down. On an upcoming-maintenance notice, check `gcloud compute instances describe ${each.value.instance_name} --format="yaml(resourceStatus.upcomingMaintenance)"` for the window and whether it can be triggered early, and drain the host before the window starts. On a termination/restart event, verify the host and its services recovered.
+
+      Owner: Infrastructure Operations.
+    EOT
+    )
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type    = "host_maintenance_event"
+    instance_name = each.value.instance_name
+    managed_by    = "terraform"
+  })
+}
+
 locals {
   observability_contract = {
-    project_id                  = var.project_id
-    environment                 = var.environment
-    notification_email          = var.notification_email
-    notification_channel_ids    = var.notification_channel_ids
-    compute_instance_cpu_alerts = var.compute_instance_cpu_alerts
-    log_buckets                 = var.log_buckets
-    uptime_checks               = var.uptime_checks
-    alert_policies              = var.alert_policies
-    dashboards                  = var.dashboards
-    labels                      = var.labels
+    project_id                    = var.project_id
+    environment                   = var.environment
+    notification_email            = var.notification_email
+    notification_channel_ids      = var.notification_channel_ids
+    compute_instance_cpu_alerts   = var.compute_instance_cpu_alerts
+    host_maintenance_event_alerts = var.host_maintenance_event_alerts
+    log_buckets                   = var.log_buckets
+    uptime_checks                 = var.uptime_checks
+    alert_policies                = var.alert_policies
+    dashboards                    = var.dashboards
+    labels                        = var.labels
   }
 }

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -111,7 +111,7 @@ resource "google_monitoring_alert_policy" "host_maintenance_events" {
       filter = <<-EOT
         logName="projects/${var.project_id}/logs/cloudaudit.googleapis.com%2Fsystem_event"
         resource.type="gce_instance"
-        protoPayload.resourceName=~"/instances/${each.value.instance_name}$"
+        resource.labels.instance_id="${each.value.instance_id}"
         protoPayload.methodName=~"(upcomingMaintenance|terminateOnHostMaintenance|hostError|automaticRestart)"
       EOT
     }

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -33,6 +33,16 @@ variable "compute_instance_cpu_alerts" {
   default = {}
 }
 
+variable "host_maintenance_event_alerts" {
+  description = "Log-based alerts on GCE host maintenance / restart system events, keyed by logical name."
+  type = map(object({
+    display_name  = string
+    instance_name = string
+    documentation = optional(string, null)
+  }))
+  default = {}
+}
+
 variable "log_buckets" {
   description = "Logging bucket definitions keyed by logical name."
   type = map(object({

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -38,6 +38,7 @@ variable "host_maintenance_event_alerts" {
   type = map(object({
     display_name  = string
     instance_name = string
+    instance_id   = string
     documentation = optional(string, null)
   }))
   default = {}


### PR DESCRIPTION
Bare metal hosts can't live-migrate — host maintenance terminates and restarts them, and today nothing surfaces the advance notice or the restart itself.

- **On-host watcher** (script + systemd timer in the vmd deploy bundle): polls the metadata server's `upcoming-maintenance` endpoint and posts to a Slack webhook (`MAINTENANCE_ALERT_WEBHOOK` secret) when a notice appears, changes, or clears.
- **Log-based alert** (observability module, both production cells): fires on maintenance/termination/host-error/restart system events — the record for restarts that arrive with no notice.