### PR TITLE
vm: split wait_socket into chain and firecracker phases

### DIFF
--- a/internal/vm/directspawn_dispatch_linux.go
+++ b/internal/vm/directspawn_dispatch_linux.go
@@ -287,13 +287,19 @@ func (m *Manager) startFirecrackerDirect(ctx context.Context, vmID, socketPath, 
 	}
 	tSocketReady := time.Now()
 
-	m.log.Info().
+	ev := m.log.Info().
 		Str("vm_id", vmID).
 		Int64("prestart_ms", tStart.Sub(tPrestart).Milliseconds()).
 		Int64("spawn_ms", tSpawnDone.Sub(tStart).Milliseconds()).
 		Int64("wait_socket_ms", tSocketReady.Sub(tSpawnDone).Milliseconds()).
-		Bool("direct", true).
-		Msg("fc startup phases")
+		Bool("direct", true)
+	// chain_ms = fork return → the script's pre-exec stamp (nsenter/unshare/
+	// mounts); fc_socket_ms = Firecracker init plus our detection latency.
+	if ts, ok := readFCExecStamp(socketPath, tSpawnDone, tSocketReady); ok {
+		ev = ev.Int64("chain_ms", ts.Sub(tSpawnDone).Milliseconds()).
+			Int64("fc_socket_ms", tSocketReady.Sub(ts).Milliseconds())
+	}
+	ev.Msg("fc startup phases")
 
 	return pid, nil
 }

--- a/internal/vm/launcher_test.go
+++ b/internal/vm/launcher_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/superserve-ai/sandbox/internal/shellquote"
 )
@@ -33,6 +35,60 @@ func TestBuildLauncherNamespace_Integration(t *testing.T) {
 	// A rebuild over an existing pin must also succeed (stale-pin path).
 	if err := buildLauncherNamespace(ctx, pin); err != nil {
 		t.Fatalf("rebuild over existing pin: %v", err)
+	}
+}
+
+func TestFCStartScript_ExecStamp(t *testing.T) {
+	got := fcStartScript("ns-7", "", "SETUP",
+		"/usr/bin/firecracker", "/run/x/fc.sock", "vm-abc")
+	// The stamp path rides inside the doubly-quoted inner script, so assert on
+	// the stable fragments rather than the escaped quoting.
+	if !strings.Contains(got, "date +%s%N >") || !strings.Contains(got, "/run/x/fcexec.ts") {
+		t.Fatalf("script missing pre-exec stamp; got:\n%s", got)
+	}
+	// The stamp must precede the firecracker exec and follow the setup: a
+	// failed setup must not stamp, and the stamp must not run after exec.
+	idx := strings.Index(got, "fcexec.ts")
+	if execIdx := strings.Index(got, "/usr/bin/firecracker"); execIdx < idx {
+		t.Errorf("stamp must come before the firecracker exec; got:\n%s", got)
+	}
+	if setupIdx := strings.Index(got, "SETUP"); setupIdx > idx {
+		t.Errorf("stamp must come after setup commands; got:\n%s", got)
+	}
+	// A best-effort stamp: date failure must not break the && chain to exec.
+	if !strings.Contains(got, "|| true") {
+		t.Errorf("stamp must be best-effort (|| true); got:\n%s", got)
+	}
+}
+
+func TestReadFCExecStamp(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "fc.sock")
+	write := func(s string) {
+		if err := os.WriteFile(fcExecStampPath(socketPath), []byte(s), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := time.Now().Add(-time.Second)
+	after := time.Now().Add(time.Second)
+
+	if _, ok := readFCExecStamp(socketPath, before, after); ok {
+		t.Error("missing stamp file must read as absent")
+	}
+	write("garbage%N\n")
+	if _, ok := readFCExecStamp(socketPath, before, after); ok {
+		t.Error("unparsable stamp must read as absent")
+	}
+	// A stale stamp from a prior launch sits outside the window.
+	write(strconv.FormatInt(before.Add(-time.Hour).UnixNano(), 10))
+	if _, ok := readFCExecStamp(socketPath, before, after); ok {
+		t.Error("stale stamp outside the window must read as absent")
+	}
+	now := time.Now()
+	write(strconv.FormatInt(now.UnixNano(), 10) + "\n")
+	ts, ok := readFCExecStamp(socketPath, before, after)
+	if !ok || !ts.Equal(time.Unix(0, now.UnixNano())) {
+		t.Errorf("valid stamp: got (%v, %v), want (%v, true)", ts, ok, now)
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -4083,9 +4083,41 @@ func fcStartScript(netNS, launcherNSPath, setupCmds, fcBin, socketPath, vmID str
 	// Each value is single-quoted, then the whole inner script is single-quoted as
 	// the `sh -c` arg — two shellquote.Single layers, so a caller-influenced path
 	// (base_path, perVMRootfs) can't close a quote and inject shell as root.
-	inner := fmt.Sprintf("%s%s && exec %s --api-sock %s --id %s",
-		setupCmds, sysfs, shellquote.Single(fcBin), shellquote.Single(socketPath), shellquote.Single(vmID))
+	//
+	// The date stamp right before the exec splits wait_socket into shell-chain
+	// time and Firecracker-side time (see readFCExecStamp). Best-effort: a date
+	// without %N or an unwritable dir must never block the launch.
+	inner := fmt.Sprintf("%s%s && { date +%%s%%N >%s 2>/dev/null || true; } && exec %s --api-sock %s --id %s",
+		setupCmds, sysfs, shellquote.Single(fcExecStampPath(socketPath)),
+		shellquote.Single(fcBin), shellquote.Single(socketPath), shellquote.Single(vmID))
 	return fmt.Sprintf("#!/bin/sh\nexec %s unshare -m -- sh -c %s\n", prefix, shellquote.Single(inner))
+}
+
+// fcExecStampPath is the per-VM file the launch script writes (wall-clock
+// nanoseconds) immediately before exec'ing Firecracker.
+func fcExecStampPath(socketPath string) string {
+	return filepath.Join(filepath.Dir(socketPath), "fcexec.ts")
+}
+
+// readFCExecStamp returns the launch script's pre-exec timestamp, or false
+// when it is missing, unparsable (a shell whose date lacks %N), or outside
+// (notBefore, notAfter) — a stale stamp from a prior launch of the same VM
+// must not be attributed to this one. Wall clock on both sides: the script's
+// date and the phase timestamps compared against it.
+func readFCExecStamp(socketPath string, notBefore, notAfter time.Time) (time.Time, bool) {
+	data, err := os.ReadFile(fcExecStampPath(socketPath))
+	if err != nil {
+		return time.Time{}, false
+	}
+	ns, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	ts := time.Unix(0, ns)
+	if ts.Before(notBefore) || ts.After(notAfter) {
+		return time.Time{}, false
+	}
+	return ts, true
 }
 
 // startFirecrackerViaSystemd writes the start script and launches Firecracker
@@ -4159,14 +4191,20 @@ func (m *Manager) startFirecrackerViaSystemd(ctx context.Context, vmID, socketPa
 	}
 	tSocketReady := time.Now()
 
-	m.log.Info().
+	ev := m.log.Info().
 		Str("vm_id", vmID).
 		Int64("prestart_ms", tStartUnit.Sub(tPrestart).Milliseconds()).
 		Int64("linger_check_ms", lingerCheckMs).
 		Bool("linger_skipped", freshUnit).
 		Int64("start_unit_ms", tStartUnitDone.Sub(tStartUnit).Milliseconds()).
-		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds()).
-		Msg("fc startup phases")
+		Int64("wait_socket_ms", tSocketReady.Sub(tStartUnitDone).Milliseconds())
+	// On the unit path chain_ms also contains PID 1's dispatch of the unit;
+	// fc_socket_ms is Firecracker init plus our detection latency.
+	if ts, ok := readFCExecStamp(socketPath, tStartUnitDone, tSocketReady); ok {
+		ev = ev.Int64("chain_ms", ts.Sub(tStartUnitDone).Milliseconds()).
+			Int64("fc_socket_ms", tSocketReady.Sub(ts).Milliseconds())
+	}
+	ev.Msg("fc startup phases")
 
 	// Read the PID asynchronously so the create path isn't slowed down
 	// by the ~15ms dbus roundtrip. The PID is populated in the instance


### PR DESCRIPTION
Adds chain_ms / fc_socket_ms to the fc startup phases log via a pre-exec timestamp stamped by the launch script, so wait_socket variance can be attributed without guessing.