### PR TITLE
vm: spare cgroup pool for burst launches

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -279,6 +279,20 @@ func runDrainCheck() int {
 	return 3
 }
 
+// spareCgroupTargetFromEnv resolves the spare cgroup pool size:
+// VMD_CGROUP_SPARE_POOL=true enables it at VMD_CGROUP_SPARE_TARGET
+// (default 256); anything else disables (0).
+func spareCgroupTargetFromEnv() int {
+	if envOrDefault("VMD_CGROUP_SPARE_POOL", "false") != "true" {
+		return 0
+	}
+	n, err := strconv.Atoi(envOrDefault("VMD_CGROUP_SPARE_TARGET", "256"))
+	if err != nil || n < 0 {
+		return 256
+	}
+	return n
+}
+
 func main() {
 	// Maintenance subcommands run before any daemon setup and exit. They must
 	// not open the state store in write mode or start services.
@@ -458,6 +472,7 @@ func main() {
 		LaunchViaLauncherNS:        launchViaLauncherNS,
 		LauncherNSPath:             os.Getenv("VMD_LAUNCHER_NS_PATH"),
 		DirectSpawn:                envOrDefault("VMD_DIRECT_SPAWN", "false") == "true",
+		SpareCgroupTarget:          spareCgroupTargetFromEnv(),
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")
@@ -521,6 +536,14 @@ func main() {
 		log.Error().Err(err).Msg("direct spawn not armed — launches use the unit path")
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
+	}
+	// The spare cgroup pool exists only on an armed host; on any other
+	// outcome, reap spares a previously-armed life may have left so the
+	// scope holds nothing but VMs and the keeper.
+	if mgr.DirectSpawnArmed() {
+		mgr.StartSpareCgroupPool(ctx)
+	} else {
+		mgr.ReapStrayLeftoverSpares(ctx)
 	}
 
 	// ---- Backup uploader ----

--- a/deploy/vmd-rollback-guard
+++ b/deploy/vmd-rollback-guard
@@ -38,7 +38,9 @@ if ! VMS_CG=$(systemctl show -p ControlGroup --value superserve-vms.service 2>/d
     exit 1
 fi
 if [ -n "$VMS_CG" ] && [ -d "/sys/fs/cgroup${VMS_CG}" ]; then
-    if ! children=$(find "/sys/fs/cgroup${VMS_CG}" -mindepth 1 -maxdepth 1 -type d ! -name keeper 2>/dev/null); then
+    # keeper and spare-* are vmd's own machinery (the scope keeper's leaf and
+    # the pre-created cgroup pool) — never evidence of a live VM.
+    if ! children=$(find "/sys/fs/cgroup${VMS_CG}" -mindepth 1 -maxdepth 1 -type d ! -name keeper ! -name "spare-*" 2>/dev/null); then
         echo "vmd-rollback-guard: cannot read the delegated VM scope; refusing to start a vmd without cgroup supervision" >&2
         exit 1
     fi

--- a/internal/vm/cgroup_linux.go
+++ b/internal/vm/cgroup_linux.go
@@ -40,7 +40,19 @@ const (
 	// root so controllers can be enabled there (cgroup v2 no-internal-process
 	// rule). Reserved — never a vmID.
 	keeperSubdir = "keeper"
+	// spareCgroupPrefix names pre-created, empty per-VM cgroups awaiting a
+	// launch (see spareCgroupPool). Reserved — never a vmID, and every scan
+	// that interprets a child dir as a VM must skip it (isReservedCgroupName).
+	spareCgroupPrefix = "spare-"
 )
+
+// isReservedCgroupName reports whether a child of the delegated scope is
+// vmd's own machinery rather than a VM: the keeper leaf or a spare from the
+// pre-created cgroup pool. The ONE predicate every scan uses, so a new
+// reserved name can never be half-recognized.
+func isReservedCgroupName(name string) bool {
+	return name == keeperSubdir || strings.HasPrefix(name, spareCgroupPrefix)
+}
 
 // cgroupTree holds the resolved paths of the delegated VM subtree — the
 // superserve-vms.service ControlGroup and its keeper leaf.
@@ -360,7 +372,7 @@ func delegatedTreeHasVMs(ctx context.Context) (bool, error) {
 		return false, err // scope exists but unreadable — caller fails closed
 	}
 	for _, e := range entries {
-		if e.IsDir() && e.Name() != keeperSubdir {
+		if e.IsDir() && !isReservedCgroupName(e.Name()) {
 			return true, nil
 		}
 	}
@@ -557,7 +569,7 @@ func (t *cgroupTree) firstPID(vmID string) int {
 // vms/ subtree onto vmd's own group, and a kill there would take the daemon
 // down with the VM. Defense-in-depth behind the launch-entry check.
 func (t *cgroupTree) safeVMCgroupDir(vmID string) (string, error) {
-	if !isLeafName(vmID) || vmID == keeperSubdir {
+	if !isLeafName(vmID) || isReservedCgroupName(vmID) {
 		return "", fmt.Errorf("invalid vm_id %q for cgroup path", vmID)
 	}
 	return t.vmCgroupDir(vmID), nil
@@ -732,7 +744,7 @@ func (t *cgroupTree) scanVMCgroups() ([]string, error) {
 	}
 	ids := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if e.IsDir() && e.Name() != keeperSubdir {
+		if e.IsDir() && !isReservedCgroupName(e.Name()) {
 			ids = append(ids, e.Name())
 		}
 	}
@@ -798,7 +810,7 @@ func CheckDrained(ctx context.Context, statePath string) (DrainReport, error) {
 		return r, fmt.Errorf("scan scope %s: %w", r.ScopePath, err)
 	}
 	for _, e := range entries {
-		if !e.IsDir() || e.Name() == keeperSubdir {
+		if !e.IsDir() || isReservedCgroupName(e.Name()) {
 			continue
 		}
 		r.PerVMDirs++

--- a/internal/vm/cgroup_spares_linux.go
+++ b/internal/vm/cgroup_spares_linux.go
@@ -1,0 +1,263 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
+)
+
+// Spare cgroup pool. Creating a memory cgroup allocates per-CPU and per-NUMA-
+// node bookkeeping under globally-serialized kernel locks, so concurrent
+// launches queue on it — the wider the burst and the bigger the host, the
+// longer the line. The pool pays that cost in the background: it keeps a
+// reserve of pre-created, empty "spare-<n>" groups in the delegated scope,
+// and a launch claims one with a same-parent rename (cheap, no allocation)
+// instead of a mkdir.
+//
+// The pool is strictly an optimization: every claim failure — empty pool,
+// lost rename race, unwritable attribute — falls back to the inline
+// createVMCgroup path, so correctness never depends on it. Spares are
+// reserved names (isReservedCgroupName): no scan counts them as VMs, the
+// drain report ignores them, and disarming reaps them.
+type spareCgroupPool struct {
+	tree   *cgroupTree
+	log    zerolog.Logger
+	target int
+	free   chan string   // names of ready spares
+	kick   chan struct{} // claims nudge the refiller; buffered 1
+	ctr    atomic.Uint64 // next spare index; monotonic within a life
+}
+
+func newSpareCgroupPool(tree *cgroupTree, target int, log zerolog.Logger) *spareCgroupPool {
+	return &spareCgroupPool{
+		tree:   tree,
+		log:    log,
+		target: target,
+		free:   make(chan string, target),
+		kick:   make(chan struct{}, 1),
+	}
+}
+
+// adoptExisting re-inventories spares left by a previous vmd life (the dirs
+// persist across restarts). Parsable names up to the pool target are reused;
+// excess (a lowered target) and unparsable ones are removed — an empty rmdir
+// is free, and a spare must never outlive the pool's ability to account for
+// it. Returns the number adopted.
+func (p *spareCgroupPool) adoptExisting() int {
+	entries, err := os.ReadDir(p.tree.vms)
+	if err != nil {
+		p.log.Warn().Err(err).Msg("spare cgroup pool: scope scan failed; starting empty")
+		return 0
+	}
+	adopted := 0
+	var maxIdx uint64
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() || !strings.HasPrefix(name, spareCgroupPrefix) {
+			continue
+		}
+		idx, perr := strconv.ParseUint(strings.TrimPrefix(name, spareCgroupPrefix), 10, 64)
+		ok := perr == nil
+		if ok && idx > maxIdx {
+			maxIdx = idx
+		}
+		if ok {
+			select {
+			case p.free <- name:
+				adopted++
+				continue
+			default: // pool full — excess spare
+			}
+		}
+		_ = os.Remove(filepath.Join(p.tree.vms, name))
+	}
+	p.ctr.Store(maxIdx + 1)
+	return adopted
+}
+
+// run refills the pool to target and then tops it up on every claim kick (or
+// a slow tick, catching kicks lost to the buffer). Serial on purpose: one
+// creation at a time is what keeps the refill from competing with live
+// launches for the same kernel locks; creation is slow enough that the loop
+// needs no pacing of its own.
+func (p *spareCgroupPool) run(ctx context.Context) {
+	tick := time.NewTicker(time.Minute)
+	defer tick.Stop()
+	for {
+		for len(p.free) < p.target {
+			if ctx.Err() != nil {
+				return
+			}
+			name, err := p.createSpare()
+			if err != nil {
+				p.log.Warn().Err(err).Msg("spare cgroup pool: create failed; retrying after backoff")
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Second):
+				}
+				continue
+			}
+			select {
+			case p.free <- name:
+			default:
+				// Target shrank underneath us (never at runtime today, but
+				// cheap to tolerate): the spare is excess.
+				_ = os.Remove(filepath.Join(p.tree.vms, name))
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.kick:
+		case <-tick.C:
+		}
+	}
+}
+
+// createSpare makes one spare group, paying the expensive kernel-side
+// creation here so a claim doesn't. The oom.group write is best-effort at
+// creation — claim re-writes it anyway (see claim).
+func (p *spareCgroupPool) createSpare() (string, error) {
+	name := spareCgroupPrefix + strconv.FormatUint(p.ctr.Add(1)-1, 10)
+	dir := filepath.Join(p.tree.vms, name)
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir spare cgroup: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "memory.oom.group"), []byte("1"), 0o644); err != nil {
+		_ = os.Remove(dir)
+		return "", fmt.Errorf("set oom.group on spare: %w", err)
+	}
+	return name, nil
+}
+
+// claim hands the caller a pre-created group renamed to vmID, or (nil, false)
+// when the pool can't — the caller then creates inline. The oom.group write
+// is repeated after the rename: it is idempotent, costs one attribute write,
+// and makes a half-initialized spare (crash mid-create in a prior life)
+// impossible to hand out rather than something to validate.
+func (p *spareCgroupPool) claim(vmID string) (*os.File, bool) {
+	dst, derr := p.tree.safeVMCgroupDir(vmID)
+	if derr != nil {
+		return nil, false
+	}
+	for {
+		var name string
+		select {
+		case name = <-p.free:
+		default:
+			p.log.Info().Str("vm_id", vmID).Msg("spare cgroup pool empty — creating inline")
+			return nil, false
+		}
+		p.kickRefill()
+		if err := os.Rename(filepath.Join(p.tree.vms, name), dst); err != nil {
+			// Return the spare only if it still exists under its own name
+			// (target collision — this vmID already has a dir, which the
+			// inline fallback tolerates). A vanished spare (reaped underneath
+			// us) must be dropped, or its dead name would poison a pool slot
+			// forever: every future claim would pop it, fail, and re-queue it.
+			if _, serr := os.Stat(filepath.Join(p.tree.vms, name)); serr == nil {
+				select {
+				case p.free <- name:
+				default:
+					_ = os.Remove(filepath.Join(p.tree.vms, name))
+				}
+			}
+			return nil, false
+		}
+		if err := os.WriteFile(filepath.Join(dst, "memory.oom.group"), []byte("1"), 0o644); err != nil {
+			// The claimed group is broken; give it back to the kernel and
+			// fall back rather than launch without whole-VM OOM semantics.
+			_ = os.Remove(dst)
+			return nil, false
+		}
+		f, err := os.Open(dst)
+		if err != nil {
+			_ = os.Remove(dst)
+			return nil, false
+		}
+		return f, true
+	}
+}
+
+func (p *spareCgroupPool) kickRefill() {
+	select {
+	case p.kick <- struct{}{}:
+	default:
+	}
+}
+
+// reapSpareCgroups removes every spare under the scope root — used when the
+// pool is disabled or the host is disarming, so a drained tree holds nothing
+// but VMs and the keeper. Spares are empty by construction, so rmdir either
+// succeeds or the dir is not ours to touch (and the error is only logged).
+func reapSpareCgroups(scopeRoot string, log zerolog.Logger) {
+	entries, err := os.ReadDir(scopeRoot)
+	if err != nil {
+		return
+	}
+	reaped := 0
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), spareCgroupPrefix) {
+			if rerr := os.Remove(filepath.Join(scopeRoot, e.Name())); rerr == nil {
+				reaped++
+			} else {
+				log.Warn().Err(rerr).Str("name", e.Name()).Msg("spare cgroup reap failed")
+			}
+		}
+	}
+	if reaped > 0 {
+		log.Info().Int("reaped", reaped).Msg("reaped spare cgroups")
+	}
+}
+
+// DirectSpawnArmed reports whether new launches take the cgroup path.
+func (m *Manager) DirectSpawnArmed() bool { return m.directSpawnArmed.Load() }
+
+// StartSpareCgroupPool builds and starts the pool once direct spawn is armed.
+// No-op unless armed with a positive target — the pool must never exist on a
+// host whose launches wouldn't consume it.
+func (m *Manager) StartSpareCgroupPool(ctx context.Context) {
+	if m.cgroups == nil || !m.directSpawnArmed.Load() || m.cfg.SpareCgroupTarget <= 0 {
+		return
+	}
+	p := newSpareCgroupPool(m.cgroups, m.cfg.SpareCgroupTarget, m.log)
+	adopted := p.adoptExisting()
+	m.spares = p
+	go func() {
+		defer sentrylog.Recover("spare-cgroup-pool")
+		p.run(ctx)
+	}()
+	m.log.Info().Int("target", p.target).Int("adopted", adopted).
+		Msg("spare cgroup pool started (filling in background)")
+}
+
+// claimSpareCgroup is the launch-path entry: a pooled claim when available,
+// (nil, false) otherwise — the caller creates inline.
+func (m *Manager) claimSpareCgroup(vmID string) (*os.File, bool) {
+	if m.spares == nil {
+		return nil, false
+	}
+	return m.spares.claim(vmID)
+}
+
+// ReapStrayLeftoverSpares removes spares a previously-armed life left behind
+// on a host that is now disarmed (the pool never starts, so nothing else
+// would). Resolves the scope read-only via systemd; absent scope means
+// nothing to reap.
+func (m *Manager) ReapStrayLeftoverSpares(ctx context.Context) {
+	rel, err := unitControlGroup(ctx, vmsUnitName)
+	if err != nil || rel == "" {
+		return
+	}
+	reapSpareCgroups(filepath.Join(cgroupMount, rel), m.log)
+}

--- a/internal/vm/cgroup_spares_linux_test.go
+++ b/internal/vm/cgroup_spares_linux_test.go
@@ -1,0 +1,216 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestIsReservedCgroupName(t *testing.T) {
+	for name, reserved := range map[string]bool{
+		"keeper":    true,
+		"spare-0":   true,
+		"spare-131": true,
+		"spare-":    true, // malformed but still ours — never a vmID
+		"keeper2":   false,
+		"a1b2c3d4-0000-0000-0000-000000000000": false,
+	} {
+		if got := isReservedCgroupName(name); got != reserved {
+			t.Errorf("isReservedCgroupName(%q) = %v, want %v", name, got, reserved)
+		}
+	}
+}
+
+func TestScanVMCgroupsSkipsReserved(t *testing.T) {
+	dir := t.TempDir()
+	tree := &cgroupTree{vms: dir}
+	for _, d := range []string{"keeper", "spare-1", "spare-9", "vm-uuid-1"} {
+		if err := os.Mkdir(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ids, err := tree.scanVMCgroups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "vm-uuid-1" {
+		t.Fatalf("scan = %v, want only the VM dir", ids)
+	}
+}
+
+// newTestSparePool builds a pool over a plain tempdir — mkdir/rename/rmdir
+// semantics there match kernfs for everything the pool does, and the
+// oom.group attribute becomes a regular file.
+func newTestSparePool(t *testing.T, target int) *spareCgroupPool {
+	t.Helper()
+	return newSpareCgroupPool(&cgroupTree{vms: t.TempDir()}, target, zerolog.Nop())
+}
+
+func TestSpareCgroupPoolClaim(t *testing.T) {
+	p := newTestSparePool(t, 2)
+	for i := 0; i < 2; i++ {
+		name, err := p.createSpare()
+		if err != nil {
+			t.Fatal(err)
+		}
+		p.free <- name
+	}
+
+	f, ok := p.claim("11111111-1111-1111-1111-111111111111")
+	if !ok || f == nil {
+		t.Fatal("claim from a filled pool must succeed")
+	}
+	f.Close()
+	vmDir := filepath.Join(p.tree.vms, "11111111-1111-1111-1111-111111111111")
+	if _, err := os.Stat(vmDir); err != nil {
+		t.Fatalf("claimed dir missing: %v", err)
+	}
+	if b, err := os.ReadFile(filepath.Join(vmDir, "memory.oom.group")); err != nil || string(b) != "1" {
+		t.Fatalf("oom.group = %q, %v; want \"1\"", b, err)
+	}
+	if _, err := os.Stat(filepath.Join(p.tree.vms, "spare-0")); !os.IsNotExist(err) {
+		t.Fatal("claimed spare must be gone from its old name")
+	}
+
+	if _, ok := p.claim("22222222-2222-2222-2222-222222222222"); !ok {
+		t.Fatal("second claim must succeed")
+	}
+	if _, ok := p.claim("33333333-3333-3333-3333-333333333333"); ok {
+		t.Fatal("claim from an empty pool must report false (inline fallback)")
+	}
+	// A reserved or invalid vmID must never claim.
+	if _, ok := p.claim("spare-7"); ok {
+		t.Fatal("reserved name must not claim a cgroup")
+	}
+}
+
+func TestSpareCgroupPoolClaimDropsVanishedSpare(t *testing.T) {
+	p := newTestSparePool(t, 2)
+	p.free <- "spare-404" // in the pool, but no dir behind it
+
+	if _, ok := p.claim("11111111-1111-1111-1111-111111111111"); ok {
+		t.Fatal("claim of a vanished spare must fall back")
+	}
+	// The dead name must NOT return to the pool — a second claim would
+	// otherwise pop it again forever.
+	select {
+	case name := <-p.free:
+		t.Fatalf("dead spare %q re-queued", name)
+	default:
+	}
+}
+
+func TestSpareCgroupPoolClaimTargetCollisionKeepsSpare(t *testing.T) {
+	p := newTestSparePool(t, 2)
+	name, err := p.createSpare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.free <- name
+	// The vmID already has a NON-EMPTY dir (rename onto it fails): the launch
+	// preamble handles that case inline, and the intact spare must survive
+	// for the next claim.
+	vmID := "11111111-1111-1111-1111-111111111111"
+	if err := os.MkdirAll(filepath.Join(p.tree.vms, vmID, "occupied"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := p.claim(vmID); ok {
+		t.Fatal("claim onto an existing occupied dir must fall back")
+	}
+	select {
+	case back := <-p.free:
+		if back != name {
+			t.Fatalf("pool returned %q, want the intact spare %q", back, name)
+		}
+	default:
+		t.Fatal("intact spare must be returned to the pool")
+	}
+}
+
+func TestSpareCgroupPoolAdoptExisting(t *testing.T) {
+	p := newTestSparePool(t, 2)
+	for _, d := range []string{"spare-3", "spare-7", "spare-bogus", "keeper"} {
+		if err := os.Mkdir(filepath.Join(p.tree.vms, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if adopted := p.adoptExisting(); adopted != 2 {
+		t.Fatalf("adopted = %d, want 2", adopted)
+	}
+	if _, err := os.Stat(filepath.Join(p.tree.vms, "spare-bogus")); !os.IsNotExist(err) {
+		t.Fatal("unparsable spare must be removed")
+	}
+	if _, err := os.Stat(filepath.Join(p.tree.vms, "keeper")); err != nil {
+		t.Fatal("keeper must never be touched")
+	}
+	// The counter resumes past the highest adopted index so a new spare
+	// can't collide with an adopted one.
+	name, err := p.createSpare()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "spare-8" {
+		t.Fatalf("next spare = %q, want spare-8", name)
+	}
+}
+
+func TestSpareCgroupPoolAdoptReapsExcess(t *testing.T) {
+	p := newTestSparePool(t, 1)
+	for _, d := range []string{"spare-1", "spare-2"} {
+		if err := os.Mkdir(filepath.Join(p.tree.vms, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if adopted := p.adoptExisting(); adopted != 1 {
+		t.Fatalf("adopted = %d, want 1 (target)", adopted)
+	}
+	left := 0
+	entries, _ := os.ReadDir(p.tree.vms)
+	for _, e := range entries {
+		left++
+		_ = e
+	}
+	if left != 1 {
+		t.Fatalf("dirs left = %d, want 1 (excess spare reaped)", left)
+	}
+}
+
+func TestReapSpareCgroups(t *testing.T) {
+	dir := t.TempDir()
+	for _, d := range []string{"spare-1", "spare-2", "keeper", "vm-uuid-1"} {
+		if err := os.Mkdir(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reapSpareCgroups(dir, zerolog.Nop())
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if len(names) != 2 {
+		t.Fatalf("left %v, want only keeper and the VM dir", names)
+	}
+}
+
+// The host-resident guard must never read a spare as live-VM evidence — a
+// disarmed host with leftover spares would otherwise be unable to roll back.
+func TestRollbackGuardIgnoresSpares(t *testing.T) {
+	w := newGuardWorld(t)
+	w.systemctl(0, "/scope")
+	w.mkdir("cgfs/scope/keeper")
+	w.mkdir("cgfs/scope/spare-12")
+	if rc := w.run(oldBinary); rc != 0 {
+		t.Fatalf("rc=%d, want allow — spares are not VM evidence", rc)
+	}
+	// And a real VM dir alongside them still blocks.
+	w.mkdir("cgfs/scope/vm-1")
+	if rc := w.run(oldBinary); rc == 0 {
+		t.Fatal("a live VM cgroup must still block")
+	}
+}

--- a/internal/vm/directspawn_dispatch_linux.go
+++ b/internal/vm/directspawn_dispatch_linux.go
@@ -229,10 +229,18 @@ func (m *Manager) startFirecrackerDirect(ctx context.Context, vmID, socketPath, 
 		return 0, fmt.Errorf("write start script: %w", err)
 	}
 
-	cgDir, err := m.cgroups.createVMCgroup(vmID)
-	if err != nil {
-		return 0, err
+	// Claim a pre-created group when the pool has one (a cheap same-parent
+	// rename); otherwise pay the kernel's creation cost inline as before.
+	tCgroup := time.Now()
+	cgDir, spareUsed := m.claimSpareCgroup(vmID)
+	if cgDir == nil {
+		var cerr error
+		cgDir, cerr = m.cgroups.createVMCgroup(vmID)
+		if cerr != nil {
+			return 0, cerr
+		}
 	}
+	cgroupMs := time.Since(tCgroup).Milliseconds()
 	// spawnDirect takes ownership of cgDir and closes it; until the hand-off
 	// this path still owns it, so close it on the openVMConsole error return.
 	console, err := openVMConsole(m.cfg.RunDir, vmID)
@@ -290,6 +298,8 @@ func (m *Manager) startFirecrackerDirect(ctx context.Context, vmID, socketPath, 
 	m.log.Info().
 		Str("vm_id", vmID).
 		Int64("prestart_ms", tStart.Sub(tPrestart).Milliseconds()).
+		Int64("cgroup_ms", cgroupMs).
+		Bool("spare_cgroup", spareUsed).
 		Int64("spawn_ms", tSpawnDone.Sub(tStart).Milliseconds()).
 		Int64("wait_socket_ms", tSocketReady.Sub(tSpawnDone).Milliseconds()).
 		Bool("direct", true).

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -261,6 +261,12 @@ type ManagerConfig struct {
 	// without the preconditions degrades to the unit path with a loud
 	// error, never to a fleet that dies on the next vmd deploy.
 	DirectSpawn bool
+
+	// SpareCgroupTarget sizes the pre-created cgroup pool (see
+	// spareCgroupPool); 0 disables it. Only meaningful when DirectSpawn is
+	// armed — creating a memory cgroup is kernel-serialized and priced by
+	// host size, so wide create bursts otherwise queue on it.
+	SpareCgroupTarget int
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +342,10 @@ type Manager struct {
 	// slot and veth. In-memory only: a restart rebuilds reservations from
 	// scratch and the startup sweep reclaims unprotected namespaces.
 	survivorNS sync.Map
+	// spares is the pre-created cgroup pool; nil unless armed with a
+	// positive SpareCgroupTarget. Launches claim from it best-effort and
+	// fall back to inline creation — never a correctness dependency.
+	spares *spareCgroupPool
 	// orphanScanDone gates the fresh-unit linger skip: it is set only after
 	// startup reattach successfully listed active units and registered the
 	// BoltDB-missing ones as unconfirmed stops. Until then (or forever, if


### PR DESCRIPTION
Creating a memory cgroup allocates per-CPU and per-NUMA-node bookkeeping under globally serialized kernel locks, so concurrent direct-spawn launches queue on it — the wider the burst and the bigger the host, the longer the line. This adds an optional pool of pre-created spare cgroups: the expensive creation happens in a background refiller, and a launch claims a spare with a cheap same-parent rename instead of a mkdir.

- Off by default; enabled with `VMD_CGROUP_SPARE_POOL=true` (size via `VMD_CGROUP_SPARE_TARGET`, default 256), and only active while direct spawn is armed.
- Strictly an optimization: any claim failure (empty pool, rename race, unwritable attribute) falls back to the existing inline creation path, so correctness never depends on the pool.
- `spare-*` joins `keeper` as a reserved name via one shared predicate: scans, the drain report, and the host rollback guard never read a spare as a VM; disarmed hosts reap leftover spares at startup.
- Spares survive vmd restarts and are re-adopted; excess and unparsable ones are removed.
- The launch phase log gains `cgroup_ms` + `spare_cgroup` so the claim-vs-create split is measurable per launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)