### PR TITLE
backup: escalate staged-task loss to the error channel

### DIFF
--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -291,7 +291,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 				// upload (sandbox deleted or resumed, local GC won the
 				// race). Nothing valid to back up under this content
 				// address; the generation is abandoned, not retried.
-				task.logOwner(u.Log.Warn().Str("path", file.Path)).
+				task.logOwner(u.lossEvent(task).Str("path", file.Path)).
 					Msg("backup source file gone; abandoning generation")
 				return false, nil
 			}
@@ -310,7 +310,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			bf, err := baseTaskFile(file)
 			if err != nil {
 				if os.IsNotExist(err) {
-					task.logOwner(u.Log.Warn().Str("path", file.BasePath)).
+					task.logOwner(u.lossEvent(task).Str("path", file.BasePath)).
 						Msg("backup base image gone; abandoning generation")
 					return false, nil
 				}
@@ -319,7 +319,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			bmf, err := u.uploadFile(ctx, task, bf)
 			if err != nil {
 				if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
-					task.logOwner(u.Log.Warn().Str("path", bf.Path)).
+					task.logOwner(u.lossEvent(task).Str("path", bf.Path)).
 						Msg("backup base image gone or rebuilt; abandoning generation")
 					return false, nil
 				}
@@ -363,6 +363,19 @@ func (t *Task) logOwner(e *zerolog.Event) *zerolog.Event {
 		return e.Str("template_id", t.TemplateID).Str("build_id", t.BuildID)
 	}
 	return e.Str("sandbox_id", t.SandboxID)
+}
+
+// lossEvent picks the log level for an abandoned generation: staged
+// tasks upload from immutable snapshots, so a vanished or mutated
+// source there means corruption or an invariant break and must reach
+// the error channel (Sentry forwards errors only); unstaged tasks
+// upload from mutable paths where abandonment is the designed outcome
+// of a resume or teardown winning the race, and stays a warning.
+func (u *Uploader) lossEvent(task *Task) *zerolog.Event {
+	if task.Staged {
+		return u.Log.Error()
+	}
+	return u.Log.Warn()
 }
 
 // errSourceChanged marks a source file whose current content no longer
@@ -417,7 +430,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		return ManifestFile{}, fmt.Errorf("verify %s: %w", file.Path, err)
 	}
 	if sum != file.SHA256 {
-		u.Log.Warn().Str("path", file.Path).Str("want", file.SHA256).Str("got", sum).
+		task.logOwner(u.lossEvent(task).Str("path", file.Path).Str("want", file.SHA256).Str("got", sum)).
 			Msg("backup source changed since pause; abandoning generation")
 		return ManifestFile{}, errSourceChanged
 	}
@@ -484,7 +497,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// claim.
 		shipped, complete := hasher.finish()
 		if !complete || shipped != file.SHA256 {
-			u.Log.Warn().Str("path", file.Path).Str("want", file.SHA256).Str("got", shipped).
+			task.logOwner(u.lossEvent(task).Str("path", file.Path).Str("want", file.SHA256).Str("got", shipped)).
 				Bool("fully_streamed", complete).
 				Msg("backup source changed during upload; abandoning generation")
 			return ManifestFile{}, errSourceChanged


### PR DESCRIPTION
## Summary

First slice of backup observability: durability-loss events for staged tasks now reach the error channel, which the Sentry writer forwards. A staged task uploads from immutable snapshots, so a vanished or digest-divergent source there is corruption or an invariant break, not the designed fast-resume abandonment that unstaged tasks legitimately hit; today both log a warning visible only in one host's journald.

## Technical decisions

Level is chosen per task: error when staged, warn when unstaged, so the expected mutable-path abandonment pattern cannot flood Sentry while the never-expected staged losses page. Owner fields ride on every loss line.

## Testing

Both packages green on linux. Behavior change is log level only.