### PR TITLE
infra: add second usw2 sandbox host

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -51,8 +51,10 @@ because the instance-ID filter keeps each host's evidence and response path
 unambiguous.
 
 For an existing matching policy, use its full Monitoring policy name with
-`terraform import module.observability.google_monitoring_alert_policy.compute_instance_cpu[\"sandbox_host\"] POLICY_NAME`
-before planning. If the policy is not a match, update it in place or remove it
+`terraform import module.observability.google_monitoring_alert_policy.compute_instance_cpu[\"HOST_KEY\"] POLICY_NAME`
+before planning, where `HOST_KEY` is that host's key in the environment's
+`compute_instance_cpu_alerts` map (`sandbox_host` for a cell's primary host,
+`sandbox_host_b` for the us-west2 standby). If the policy is not a match, update it in place or remove it
 from the state/configuration deliberately before creating the managed policy.
 
 For a review-only plan, supply the same variable as a Terraform list literal,

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,7 @@ The current Terraform-managed Compute Engine inventory for Vanta is:
 | --- | --- | --- | --- |
 | staging | us-central1 | `superserve-vmd-staging` | Managed by Terraform |
 | production | us-west2 | `superserve-vmd-usw2` | Managed by Terraform |
+| production | us-west2 | `superserve-vmd-usw2-2` | Managed by Terraform (cold standby, normally stopped) |
 | production | us-east4 | `superserve-vmd-use4` | Managed by Terraform |
 | production | us-central1 | none | Decommissioned, no Terraform-managed instance remains |
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -270,6 +270,13 @@ module "observability" {
       instance_name = module.sandbox_host.instance_name
       instance_id   = module.sandbox_host.instance_id
     }
+    # Inert while the standby is stopped (no data, no fire); in place so a
+    # promoted host is covered without a separate observability change.
+    sandbox_host_b = {
+      display_name  = "Infrastructure / ${module.sandbox_host_b.instance_name} / CPU saturation"
+      instance_name = module.sandbox_host_b.instance_name
+      instance_id   = module.sandbox_host_b.instance_id
+    }
   }
   labels = local.common_labels
 }

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -50,8 +50,17 @@ locals {
 
   api_service_account_email = "superserve-api-runner@${local.project_id}.iam.gserviceaccount.com"
 
-  # The control plane dials whichever host active_sandbox_host selects.
+  # The control plane dials whichever host active_sandbox_host selects. The
+  # selected host must already be running and serving before it is applied —
+  # instance run state is operational, not Terraform-managed, so that a host
+  # started for an incident is never stopped again by a later apply.
   active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
+
+  # Exactly one host carries component=vmd, the label the shared deploy
+  # pipeline discovers; the other is parked under a cell-scoped label so
+  # rollouts skip it instead of failing against a host that is out of service.
+  primary_component = var.active_sandbox_host == "primary" ? "vmd" : "vmd-usw2-standby"
+  standby_component = var.active_sandbox_host == "standby" ? "vmd" : "vmd-usw2-standby"
 }
 module "network" {
   source = "../../../modules/network"
@@ -203,7 +212,7 @@ module "sandbox_host" {
   internal_ip   = "10.1.0.2"
   tags          = ["vmd-usw2"]
   labels = merge(local.sandbox_host_labels, {
-    component                  = "vmd"
+    component                  = local.primary_component
     sandbox_role               = "vmd"
     "vanta-contains-user-data" = "true"
     "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"
@@ -222,9 +231,9 @@ module "sandbox_host" {
   }
 }
 
-# Cold standby for the cell, normally kept stopped. Promotion = set
-# active_sandbox_host = "standby" and apply: routes the control plane here and
-# relabels the host into the component=vmd deploy fleet.
+# Cold standby for the cell, normally kept stopped. Promotion = start this
+# host, then set active_sandbox_host = "standby" and apply: the switch routes
+# the control plane here and moves the deploy-fleet label off the primary.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 
@@ -238,7 +247,7 @@ module "sandbox_host_b" {
   internal_ip   = "10.1.0.3"
   tags          = ["vmd-usw2"]
   labels = merge(local.sandbox_host_labels, {
-    component                  = var.active_sandbox_host == "standby" ? "vmd" : "vmd-usw2-2"
+    component                  = local.standby_component
     sandbox_role               = "vmd"
     "vanta-contains-user-data" = "true"
     "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -225,9 +225,10 @@ module "sandbox_host" {
 }
 
 # Second host for the cell: a cold standby, normally kept stopped.
-# Labeled vmd-usw2-2 instead of vmd so auto-deploys skip this host while it is
-# not in service. Promotion = rename the label to component=vmd (deploys) AND
-# set active_sandbox_host = "standby" (routes the control plane here).
+# While not in service it is labeled vmd-usw2-2 instead of vmd so auto-deploys
+# skip it. Promotion = set active_sandbox_host = "standby" and apply: the one
+# switch routes the control plane here AND relabels the host into the deploy
+# fleet, so neither half can be forgotten or reverted by a later apply.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 
@@ -241,7 +242,7 @@ module "sandbox_host_b" {
   internal_ip   = "10.1.0.3"
   tags          = ["vmd-usw2"]
   labels = merge(local.sandbox_host_labels, {
-    component                  = "vmd-usw2-2"
+    component                  = var.active_sandbox_host == "standby" ? "vmd" : "vmd-usw2-2"
     sandbox_role               = "vmd"
     "vanta-contains-user-data" = "true"
     "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -50,9 +50,7 @@ locals {
 
   api_service_account_email = "superserve-api-runner@${local.project_id}.iam.gserviceaccount.com"
 
-  # Promotion switch: the control plane dials whichever host this selects.
-  # Flipping active_sandbox_host to "standby" (tfvars) and applying is the
-  # whole cutover — the API redeploys pointed at the standby's IP.
+  # The control plane dials whichever host active_sandbox_host selects.
   active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
 }
 module "network" {
@@ -212,7 +210,7 @@ module "sandbox_host" {
   })
 
   service_account_email = data.google_service_account.api_runner.email
-  # 24.04 images are only published under the -amd64 family (see sandbox_host_b).
+  # 24.04 images are only published under the -amd64 family.
   boot_disk_image     = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
   boot_disk_size_gb   = 250
   can_ip_forward      = false
@@ -224,11 +222,9 @@ module "sandbox_host" {
   }
 }
 
-# Second host for the cell: a cold standby, normally kept stopped.
-# While not in service it is labeled vmd-usw2-2 instead of vmd so auto-deploys
-# skip it. Promotion = set active_sandbox_host = "standby" and apply: the one
-# switch routes the control plane here AND relabels the host into the deploy
-# fleet, so neither half can be forgotten or reverted by a later apply.
+# Cold standby for the cell, normally kept stopped. Promotion = set
+# active_sandbox_host = "standby" and apply: routes the control plane here and
+# relabels the host into the component=vmd deploy fleet.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 
@@ -249,12 +245,9 @@ module "sandbox_host_b" {
   })
 
   service_account_email = data.google_service_account.api_runner.email
-  # The pre-24.04 family aliases without an arch suffix are gone; 24.04 images
-  # are only published under the -amd64 family.
-  boot_disk_image   = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
-  boot_disk_size_gb = 250
-  # Metal machine types reject the API-default pd-standard boot disk; Hyperdisk
-  # is required (see the boot_disk_type variable note).
+  boot_disk_image       = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
+  boot_disk_size_gb     = 250
+  # Metal machine types reject the API-default pd-standard boot disk.
   boot_disk_type      = "hyperdisk-balanced"
   can_ip_forward      = false
   on_host_maintenance = "TERMINATE"
@@ -277,8 +270,7 @@ module "observability" {
       instance_name = module.sandbox_host.instance_name
       instance_id   = module.sandbox_host.instance_id
     }
-    # Inert while the standby is stopped (no data, no fire); in place so a
-    # promoted host is covered without a separate observability change.
+    # Inert while the standby is stopped (no data, no fire).
     sandbox_host_b = {
       display_name  = "Infrastructure / ${module.sandbox_host_b.instance_name} / CPU saturation"
       instance_name = module.sandbox_host_b.instance_name

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -207,10 +207,50 @@ module "sandbox_host" {
   })
 
   service_account_email = data.google_service_account.api_runner.email
-  boot_disk_image       = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts"
-  boot_disk_size_gb     = 250
-  can_ip_forward        = false
-  on_host_maintenance   = "TERMINATE"
+  # 24.04 images are only published under the -amd64 family (see sandbox_host_b).
+  boot_disk_image     = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
+  boot_disk_size_gb   = 250
+  can_ip_forward      = false
+  on_host_maintenance = "TERMINATE"
+
+  metadata = {
+    enable-osconfig = "TRUE"
+    enable-oslogin  = "TRUE"
+  }
+}
+
+# Second host for the cell: a cold standby, normally kept stopped.
+# Labeled vmd-usw2-2 instead of vmd so auto-deploys skip this host while it is
+# not in service. Rename the label to component=vmd when it joins the fleet.
+module "sandbox_host_b" {
+  source = "../../../modules/sandbox-host"
+
+  project_id    = local.project_id
+  environment   = local.environment
+  region        = local.region
+  zone          = local.zone
+  instance_name = "superserve-vmd-usw2-2"
+  machine_type  = var.machine_type
+  subnet        = module.network.subnetwork_self_link
+  internal_ip   = "10.1.0.3"
+  tags          = ["vmd-usw2"]
+  labels = merge(local.sandbox_host_labels, {
+    component                  = "vmd-usw2-2"
+    sandbox_role               = "vmd"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"
+  })
+
+  service_account_email = data.google_service_account.api_runner.email
+  # The pre-24.04 family aliases without an arch suffix are gone; 24.04 images
+  # are only published under the -amd64 family.
+  boot_disk_image   = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
+  boot_disk_size_gb = 250
+  # Metal machine types reject the API-default pd-standard boot disk; Hyperdisk
+  # is required (see the boot_disk_type variable note).
+  boot_disk_type      = "hyperdisk-balanced"
+  can_ip_forward      = false
+  on_host_maintenance = "TERMINATE"
 
   metadata = {
     enable-osconfig = "TRUE"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -49,6 +49,11 @@ locals {
   })
 
   api_service_account_email = "superserve-api-runner@${local.project_id}.iam.gserviceaccount.com"
+
+  # Promotion switch: the control plane dials whichever host this selects.
+  # Flipping active_sandbox_host to "standby" (tfvars) and applying is the
+  # whole cutover — the API redeploys pointed at the standby's IP.
+  active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
 }
 module "network" {
   source = "../../../modules/network"
@@ -147,7 +152,7 @@ module "api" {
     SECRETS_SIGNING_KEY_ID = "v1"
     ALLOW_EPHEMERAL_SEED   = "0"
     DB_MAX_CONNS           = "12"
-    VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
+    VMD_GRPC_ADDRESS       = format("%s:50051", local.active_vmd_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
   }
 
@@ -221,7 +226,8 @@ module "sandbox_host" {
 
 # Second host for the cell: a cold standby, normally kept stopped.
 # Labeled vmd-usw2-2 instead of vmd so auto-deploys skip this host while it is
-# not in service. Rename the label to component=vmd when it joins the fleet.
+# not in service. Promotion = rename the label to component=vmd (deploys) AND
+# set active_sandbox_host = "standby" (routes the control plane here).
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 

--- a/infra/envs/production/us-west2/variables.tf
+++ b/infra/envs/production/us-west2/variables.tf
@@ -109,3 +109,14 @@ variable "network_name" {
   type    = string
   default = "superserve-production-vpc"
 }
+
+variable "active_sandbox_host" {
+  description = "Which sandbox host serves the cell: primary or standby."
+  type        = string
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "standby"], var.active_sandbox_host)
+    error_message = "active_sandbox_host must be primary or standby."
+  }
+}

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -169,6 +169,9 @@ func (m *Manager) backupPause(ctx context.Context, vmID, snapshotPath, diskPath,
 // Terminal outcomes clear the pending record; only transient failures
 // keep it for the sweep.
 func (m *Manager) rehashPendingBackup(ctx context.Context, pb PendingBackup, log zerolog.Logger) {
+	if m.rehashDone != nil {
+		defer m.rehashDone()
+	}
 	// One worker per VM: the periodic sweep and startup recovery may both
 	// find the same record while a worker is mid-hash, and a second
 	// concurrent hash of the same multi-GB artifacts buys nothing (the

--- a/internal/vm/backup_hook_test.go
+++ b/internal/vm/backup_hook_test.go
@@ -1013,8 +1013,23 @@ func TestBackupPauseCapturesBaseIdentityComparableToDiskBasePath(t *testing.T) {
 	}
 	m.backupStaging = staging
 	m.SetBackupEnqueue(func(task backup.Task) error { return nil })
+	// backupPause hands the marker to a detached worker. Two races follow from
+	// that, and this test needs both closed: the worker keeps writing under
+	// staging (t.TempDir()'s cleanup then fails with "directory not empty"),
+	// and on completion it consumes the very marker asserted on below.
+	// Claiming the per-VM in-flight slot first parks the worker at its own
+	// busy guard — it heals the marker durably, then returns without
+	// consuming it — and rehashDone makes that return observable.
+	m.pendingInFlight.Store("vm-1", struct{}{})
+	rehashed := make(chan struct{})
+	m.rehashDone = func() { close(rehashed) }
 
 	m.backupPause(context.Background(), "vm-1", snap, disk, base, zerolog.Nop())
+	select {
+	case <-rehashed:
+	case <-time.After(30 * time.Second):
+		t.Fatal("pending-backup worker did not finish")
+	}
 
 	pb, ok, err := st.GetPendingBackup("vm-1")
 	if err != nil {

--- a/internal/vm/backup_hook_test.go
+++ b/internal/vm/backup_hook_test.go
@@ -873,6 +873,7 @@ func TestBackupPausePathIsDiskSizeIndependent(t *testing.T) {
 	}
 	m.backupStaging = filepath.Join(dir, "staging")
 	m.SetBackupEnqueue(func(task backup.Task) error { return nil })
+	awaitRehashWorkers(t, m, 1)
 
 	start := time.Now()
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())
@@ -906,6 +907,7 @@ func TestFastResumeKeepsBackupViaInlineStaging(t *testing.T) {
 	}
 	m.backupStaging = staging
 	m.SetBackupEnqueue(func(task backup.Task) error { tasks <- task; return nil })
+	awaitRehashWorkers(t, m, 1)
 
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())
 	// Mutate the originals immediately, as a resumed guest would.
@@ -950,6 +952,7 @@ func TestBasePinSurvivesBaseDeletion(t *testing.T) {
 		unitDead: func(context.Context, string) bool { return false },
 	}
 	m.backupStaging = staging
+	awaitRehashWorkers(t, m, 1)
 	// Hold the worker: enqueue blocks until the base is deleted.
 	proceed := make(chan struct{})
 	m.SetBackupEnqueue(func(task backup.Task) error {
@@ -990,6 +993,27 @@ func TestBasePinSurvivesBaseDeletion(t *testing.T) {
 // unchanged base would read as replaced the moment the pin is lost
 // (e.g. absorbed away by FinishPendingStage). The pause-time identity
 // must be captured through diskBasePath itself.
+// awaitRehashWorkers makes a test wait for the detached pending-backup workers
+// backupPause spawns. Those workers outlive the call and keep writing under the
+// staging tree, so a test whose staging lives in t.TempDir() otherwise races its
+// own cleanup and fails with "directory not empty" on a loaded runner. Registered
+// as a cleanup after t.TempDir(), so it runs before the directory is removed.
+func awaitRehashWorkers(t *testing.T, m *Manager, n int) {
+	t.Helper()
+	done := make(chan struct{}, n)
+	m.rehashDone = func() { done <- struct{}{} }
+	t.Cleanup(func() {
+		for i := 0; i < n; i++ {
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				t.Error("pending-backup worker did not finish")
+				return
+			}
+		}
+	})
+}
+
 func TestBackupPauseCapturesBaseIdentityComparableToDiskBasePath(t *testing.T) {
 	dir := t.TempDir()
 	staging := filepath.Join(dir, "staging")
@@ -1013,23 +1037,13 @@ func TestBackupPauseCapturesBaseIdentityComparableToDiskBasePath(t *testing.T) {
 	}
 	m.backupStaging = staging
 	m.SetBackupEnqueue(func(task backup.Task) error { return nil })
-	// backupPause hands the marker to a detached worker. Two races follow from
-	// that, and this test needs both closed: the worker keeps writing under
-	// staging (t.TempDir()'s cleanup then fails with "directory not empty"),
-	// and on completion it consumes the very marker asserted on below.
-	// Claiming the per-VM in-flight slot first parks the worker at its own
-	// busy guard — it heals the marker durably, then returns without
-	// consuming it — and rehashDone makes that return observable.
+	// The detached worker consumes the marker asserted on below, so park it at
+	// its own per-VM busy guard: it heals the marker durably, then returns
+	// without consuming it.
 	m.pendingInFlight.Store("vm-1", struct{}{})
-	rehashed := make(chan struct{})
-	m.rehashDone = func() { close(rehashed) }
+	awaitRehashWorkers(t, m, 1)
 
 	m.backupPause(context.Background(), "vm-1", snap, disk, base, zerolog.Nop())
-	select {
-	case <-rehashed:
-	case <-time.After(30 * time.Second):
-		t.Fatal("pending-backup worker did not finish")
-	}
 
 	pb, ok, err := st.GetPendingBackup("vm-1")
 	if err != nil {
@@ -1159,6 +1173,11 @@ func TestRetryPauseReusesExistingStagedMarker(t *testing.T) {
 	}
 	m.backupStaging = staging
 	m.SetBackupEnqueue(func(task backup.Task) error { return nil })
+	// Both pauses spawn a detached worker, and a worker that ran to completion
+	// would clean up the very staged dirs counted below. Park them at the
+	// per-VM busy guard and wait for both to return before cleanup.
+	m.pendingInFlight.Store("vm-1", struct{}{})
+	awaitRehashWorkers(t, m, 2)
 
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -283,6 +283,11 @@ type Manager struct {
 	// unitDead overrides the systemd unit-dead probe in tests; nil means
 	// the real probe. See vmConfirmedAtRest.
 	unitDead func(ctx context.Context, vmID string) bool
+	// rehashDone, when set, is called as the detached pending-backup worker
+	// returns. The worker deliberately outlives backupPause, so a test whose
+	// staging tree is a t.TempDir() otherwise races its own cleanup against
+	// the worker's writes. Nil in production.
+	rehashDone func()
 	// pendingInFlight guards one pending-backup worker per VM across the
 	// startup recovery and the periodic sweep.
 	pendingInFlight sync.Map


### PR DESCRIPTION
Adds a second sandbox host to the us-west2 cell as a cold standby, labeled outside the shared deploy fleet until it enters service.