### PR TITLE
vmd: bound concurrent network slot builds and parallelize pool refill

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -78,9 +78,19 @@ const MaxSlots = 32000
 // ErrNoSlots is returned when no network slots are available.
 var ErrNoSlots = fmt.Errorf("no available network slots (max %d concurrent VMs)", MaxSlots)
 
+// setupSlotConcurrency caps concurrent slot builds across every caller
+// (on-demand fallback and pool refill). Each build forks a dozen ip/nsenter
+// commands that serialize on the kernel's netlink lock, so unbounded
+// concurrent builds convoy each other into multi-second latencies; a small
+// window keeps every build near its uncontended cost.
+const setupSlotConcurrency = 8
+
 type Manager struct {
 	hostInterface string
 	log           zerolog.Logger
+
+	// setupSem bounds concurrent setupSlot builds (see setupSlotConcurrency).
+	setupSem chan struct{}
 
 	mu         sync.Mutex
 	devices    map[string]*VMNetInfo
@@ -216,6 +226,7 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 	mgr := &Manager{
 		hostInterface:  hostInterface,
 		log:            log.With().Str("component", "network").Logger(),
+		setupSem:       make(chan struct{}, setupSlotConcurrency),
 		devices:        make(map[string]*VMNetInfo),
 		slotOwner:      make(map[int]string),
 		nextSlot:       1,
@@ -279,6 +290,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		return nil, err
 	}
 
+	tBuild := time.Now()
 	info, _, err := m.setupSlot(ctx, idx)
 	if err != nil {
 		// Build failed — release the index (we are its sole owner) so it isn't
@@ -296,6 +308,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		Str("vm_id", vmID).
 		Str("namespace", info.Namespace).
 		Str("host_ip", info.HostIP).
+		Int64("on_demand_setup_ms", time.Since(tBuild).Milliseconds()).
 		Msg("network namespace created")
 
 	return info, nil
@@ -320,6 +333,15 @@ func macForSlot(idx int) string      { return fmt.Sprintf("AA:FC:00:%02X:%02X:%0
 // nftables, routing) for a single slot index. Used by both SetupVM
 // (on-demand) and Pool (pre-allocation).
 func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, error) {
+	// Bounded build window: a caller whose deadline expires while queued fails
+	// fast instead of building a slot its request can no longer use.
+	select {
+	case m.setupSem <- struct{}{}:
+		defer func() { <-m.setupSem }()
+	case <-ctx.Done():
+		return nil, "", fmt.Errorf("slot build queue: %w", ctx.Err())
+	}
+
 	// Ownership of idx is NOT touched here: claimSlotIndex owns it before this
 	// runs (pool/on-demand), and record paths reserve it. On success the slot is
 	// live and stays owned; on failure the caller releases idx (freeSlot).

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -32,6 +33,7 @@ func touchNS(t *testing.T, dir, name string) {
 func newTestManager() *Manager {
 	return &Manager{
 		log:       zerolog.Nop(),
+		setupSem:  make(chan struct{}, setupSlotConcurrency),
 		devices:   make(map[string]*VMNetInfo),
 		slotOwner: make(map[int]string),
 		nextSlot:  1,
@@ -464,5 +466,19 @@ func TestCleanupVMOrNamespace_ReleasesOwnership(t *testing.T) {
 	}
 	if len(m.freeSlots) != 1 || m.freeSlots[0] != 5 {
 		t.Errorf("freeSlots = %v, want [5] (slot reclaimed)", m.freeSlots)
+	}
+}
+
+func TestSetupSlotQueueFailsFastOnExpiredContext(t *testing.T) {
+	m := newTestManager()
+	// Occupy every build permit so the new caller must queue.
+	for i := 0; i < setupSlotConcurrency; i++ {
+		m.setupSem <- struct{}{}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := m.setupSlot(ctx, 1)
+	if err == nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "slot build queue") {
+		t.Fatalf("setupSlot = %v, want the build-queue refusal (no kernel work attempted)", err)
 	}
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -102,6 +102,11 @@ const (
 	// rebuilds are short once uncontended, so a small window drains a backlog
 	// quickly.
 	resetTapConcurrency = 8
+	// refillConcurrency is the number of refill workers rebuilding the fresh
+	// pool. A single worker refills at one slot per build-time, which cannot
+	// catch a drained pool back up while claims keep arriving; builds stay
+	// individually cheap because Manager.setupSem bounds them globally.
+	refillConcurrency = 4
 	// resetTapTimeout bounds one batched rebuild — a healthy one takes well
 	// under a second, and a tight bound keeps a stalled backlog (and Stop)
 	// from dragging.
@@ -158,8 +163,10 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 
 	p.log.Info().Int("target", newSize).Int("recycle_cap", recycleSize).
 		Bool("reset_tap_on_recycle", p.resetTapOnRecycle).Msg("network pool starting (filling in background)")
-	p.wg.Add(1)
-	go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
+	for i := 0; i < refillConcurrency; i++ {
+		p.wg.Add(1)
+		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
+	}
 
 	return p
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -163,7 +163,15 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 
 	p.log.Info().Int("target", newSize).Int("recycle_cap", recycleSize).
 		Bool("reset_tap_on_recycle", p.resetTapOnRecycle).Msg("network pool starting (filling in background)")
-	for i := 0; i < refillConcurrency; i++ {
+	// Each worker can park one pre-built slot in a blocked send when the pool
+	// is full, so inventory can exceed the target by up to the worker count.
+	// Clamping workers to the target keeps that overshoot proportionate for
+	// pools smaller than the default worker count.
+	workers := refillConcurrency
+	if newSize < workers {
+		workers = newSize
+	}
+	for i := 0; i < workers; i++ {
 		p.wg.Add(1)
 		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 	}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -575,13 +575,22 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		}
 
 		if len(p.fresh) >= p.newSize {
-			// Pool full — block until a slot is consumed or shutdown.
+			// Pool full — pre-build one slot and block until it is consumed or
+			// shutdown. Built outside the select so a shutdown while blocked
+			// can dispose of the slot instead of dropping it.
+			slot := p.mustAllocate(ctx)
+			if slot == nil {
+				// mustAllocate only returns nil at shutdown.
+				return
+			}
 			select {
 			case <-p.stopCh:
+				p.stopSlot(slot)
 				return
 			case <-ctx.Done():
+				p.stopSlot(slot)
 				return
-			case p.fresh <- p.mustAllocate(ctx):
+			case p.fresh <- slot:
 			}
 			continue
 		}


### PR DESCRIPTION
Under a burst of creates/resumes that outruns the warm network pool, every request falls back to on-demand slot setup at once. Each build forks a dozen ip/nsenter commands that serialize on the kernel's netlink lock, so the unbounded fallback convoys them into multi-second builds — and the pool's single serial refill worker sits in the same convoy, so a drained pool cannot recover while claims keep arriving.

- Bound all slot builds (fallback, refill, and the pinned-index rebuild path) with a shared semaphore so each build stays near its uncontended cost; a caller whose deadline expires while queued fails fast instead of building a slot it can no longer use.
- Refill the fresh pool with a small worker set instead of one serial loop.
- Log on-demand setup duration so the real per-build cost is visible in production.