### PR TITLE
api: seed new sandbox rows with their requested shape

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1906,6 +1906,15 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	sandboxID := uuid.New()
 
 	insertCtx := context.WithoutCancel(c.Request.Context())
+
+	// The shape shown while the sandbox is 'starting' — and kept if the create
+	// fails before activation. ActivateSandbox overwrites it with the actuals
+	// vmd reports once the VM is up.
+	insertVcpu, insertMemMiB := int32(defaultVcpu), int32(defaultMemoryMi)
+	if templateID.Valid && templateVcpu > 0 && templateMemMiB > 0 {
+		insertVcpu, insertMemMiB = int32(templateVcpu), int32(templateMemMiB)
+	}
+
 	type insertResult struct {
 		sandbox db.Sandbox
 		err     error
@@ -1925,8 +1934,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				TeamID:            teamID,
 				Name:              req.Name,
 				Status:            db.SandboxStatusStarting,
-				VcpuCount:         1, // placeholders; real values land via ActivateSandbox
-				MemoryMib:         1,
+				VcpuCount:         insertVcpu,
+				MemoryMib:         insertMemMiB,
 				HostID:            hostID,
 				TimeoutSeconds:    req.TimeoutSeconds,
 				AutoDeleteSeconds: req.AutoDeleteSeconds,
@@ -1947,8 +1956,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			TeamID:            teamID,
 			Name:              req.Name,
 			Status:            db.SandboxStatusStarting,
-			VcpuCount:         1,
-			MemoryMib:         1,
+			VcpuCount:         insertVcpu,
+			MemoryMib:         insertMemMiB,
 			HostID:            hostID,
 			TimeoutSeconds:    req.TimeoutSeconds,
 			AutoDeleteSeconds: req.AutoDeleteSeconds,
@@ -1987,8 +1996,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				ID:                sandboxID,
 				Name:              req.Name,
 				Status:            db.SandboxStatusStarting,
-				VcpuCount:         1, // placeholders; real values land via ActivateSandbox
-				MemoryMib:         1,
+				VcpuCount:         insertVcpu,
+				MemoryMib:         insertMemMiB,
 				HostID:            hostID,
 				TimeoutSeconds:    req.TimeoutSeconds,
 				AutoDeleteSeconds: req.AutoDeleteSeconds,
@@ -2009,8 +2018,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			TeamID:            teamID,
 			Name:              req.Name,
 			Status:            db.SandboxStatusStarting,
-			VcpuCount:         1,
-			MemoryMib:         1,
+			VcpuCount:         insertVcpu,
+			MemoryMib:         insertMemMiB,
 			HostID:            hostID,
 			TimeoutSeconds:    req.TimeoutSeconds,
 			AutoDeleteSeconds: req.AutoDeleteSeconds,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3133,3 +3133,59 @@ func TestPauseWithRetry_NotFoundIsTerminal(t *testing.T) {
 		t.Fatalf("NotFound must not be retried, got %d calls", calls)
 	}
 }
+
+// TestCreateSandbox_InsertCarriesTemplateShape pins the row's initial shape: a
+// 'starting' (or failed-before-activation) sandbox must show the template's
+// vcpu/memory, not 1 vCPU / 1 MiB placeholders.
+func TestCreateSandbox_InsertCarriesTemplateShape(t *testing.T) {
+	teamID := uuid.New()
+	sandboxID := uuid.New()
+
+	tpl := defaultReadyTemplate()
+	tpl.Vcpu = 4
+	tpl.MemoryMib = 8192
+
+	var sawVcpu, sawMem bool
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+			if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+				return previewCapableHostRow()
+			}
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				for _, a := range args {
+					if v, ok := a.(int32); ok {
+						if v == 4 {
+							sawVcpu = true
+						}
+						if v == 8192 {
+							sawMem = true
+						}
+					}
+				}
+				return sandboxRow(db.Sandbox{
+					ID: sandboxID, TeamID: teamID, Name: "shaped",
+					Status: db.SandboxStatusStarting, VcpuCount: 4, MemoryMib: 8192,
+					CreatedAt: time.Now(),
+				})
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(tpl)
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock), Scheduler: &stubScheduler{hostID: "public-host"}}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"shaped"}`))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	if !sawVcpu || !sawMem {
+		t.Errorf("INSERT args missing template shape (vcpu4 seen=%v, mem8192 seen=%v) — placeholders written instead", sawVcpu, sawMem)
+	}
+}


### PR DESCRIPTION
A sandbox row is inserted with 1 vCPU / 1 MiB placeholders while the create is in flight, so anything reading the sandbox in 'starting' shows a bogus shape — and a create that fails before activation keeps those values forever. The real shape is already known at insert time (the template's vcpu/memory, or the default), so seed the row with it; ActivateSandbox still overwrites with the actuals vmd reports once the VM is up.