### PR TITLE
infra: bound control-plane scaling to the connection pooler in both prod cells

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -151,11 +151,11 @@ module "api" {
 
   cpu_limit    = "2"
   memory_limit = "1Gi"
-  # 6 matches the live service (raised from 2 during burst tuning). scaling is
-  # in the module's ignore_changes, but that path is ineffective for the v2
-  # resource, so declaring the live value keeps the plan a no-op.
-  min_instances     = 6
-  max_instances     = 100
+  # max_instances * DB_MAX_CONNS must stay under the pooler's client-connection
+  # limit; raising either means re-checking that product. Declared rather than
+  # left to drift: the module's ignore_changes is ineffective for the v2 resource.
+  min_instances     = 10
+  max_instances     = 30
   startup_cpu_boost = true
   cpu_idle          = true
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -132,10 +132,12 @@ module "api" {
   service_account_email = data.google_service_account.api_runner.email
   image                 = "us-central1-docker.pkg.dev/${local.project_id}/superserve/controlplane:replace-me"
 
-  cpu_limit         = "2"
-  memory_limit      = "1Gi"
-  min_instances     = 2
-  max_instances     = 100
+  cpu_limit    = "2"
+  memory_limit = "1Gi"
+  # max_instances * DB_MAX_CONNS must stay under this cell's pooler
+  # client-connection limit; raising either means re-checking that product.
+  min_instances     = 10
+  max_instances     = 30
   startup_cpu_boost = true
   cpu_idle          = true
 
@@ -146,7 +148,7 @@ module "api" {
     SUPABASE_URL           = var.supabase_url
     SECRETS_SIGNING_KEY_ID = "v1"
     ALLOW_EPHEMERAL_SEED   = "0"
-    DB_MAX_CONNS           = "12"
+    DB_MAX_CONNS           = "15"
     VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
   }


### PR DESCRIPTION
Each control-plane instance opens its own client connections, so max_instances * DB_MAX_CONNS is the fleet's demand on the connection pooler. At max 100 that product exceeded the pooler's client limit in both cells — a latent overcommit that only stayed harmless because the services never scaled that far.

Both cells now run min 10 / max 30 with 15 connections per instance, which keeps the product comfortably under the limit while leaving roughly double the headroom over the highest instance count either cell has been observed at. West's per-instance limit also moves 12 to 15 to match east.