### PR TITLE
vmd: recover the slot range instead of failing at the ceiling

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -735,6 +735,13 @@ func main() {
 		// ns is spared (see ReapRecordlessCgroupVMs).
 		if sweepSafe {
 			mgr.SweepStartupOrphanNamespaces(protectedNs...)
+			// The reservation-time reclaim ran before this sweep and counted
+			// these namespaces as occupied. Nothing revisits them below the
+			// ceiling — claims just take fresh indexes — so rescan now or the
+			// indexes the sweep freed stay stranded until the next restart.
+			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
+				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
+			}
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1004,7 +1004,6 @@ func (m *Manager) reclaimUnusedSlotsLocked() int {
 	if time.Since(m.lastReclaim) < reclaimCooldown {
 		return 0
 	}
-	m.lastReclaim = time.Now()
 
 	entries, err := os.ReadDir(netnsDir)
 	if err != nil && !os.IsNotExist(err) {
@@ -1046,6 +1045,10 @@ func (m *Manager) reclaimUnusedSlotsLocked() int {
 	for _, idx := range m.freeSlots {
 		occupied[idx] = true
 	}
+	// Armed only now that both reads succeeded: a scan that bailed on a
+	// transient read has learned nothing, and must not silence the next one
+	// for the cooldown while the host may have capacity to hand out.
+	m.lastReclaim = time.Now()
 
 	limit := m.nextSlot - 1
 	if limit > MaxSlots {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1007,6 +1007,30 @@ func (m *Manager) reclaimUnusedSlotsLocked() int {
 			occupied[idx] = true
 		}
 	}
+	// A host-side veth can outlive its namespace, and building over one fails
+	// at the move-to-host step. A failed build releases the index onto the top
+	// of the LIFO free list, so handing out such an index doesn't just waste a
+	// build — the next claim pops the same index and retries it forever,
+	// starving every other reclaimed slot. SweepStrayHostVeths is what clears
+	// them; until it does, they are not free.
+	// A host-side veth can outlive its namespace, and building over one fails
+	// at the move-to-host step. A failed build releases the index onto the top
+	// of the LIFO free list, so handing out such an index doesn't just waste a
+	// build — the next claim pops the same index and retries it forever,
+	// starving every other reclaimed slot. SweepStrayHostVeths is what clears
+	// them; until it does, they are not free.
+	veths, err := listHostVeths()
+	if err != nil {
+		m.log.Warn().Err(err).Msg("allocator: cannot list host veths — skipping slot reclaim")
+		return 0
+	}
+	for _, veth := range veths {
+		if idxStr, ok := strings.CutPrefix(veth, "veth-"); ok {
+			if idx, convErr := strconv.Atoi(idxStr); convErr == nil {
+				occupied[idx] = true
+			}
+		}
+	}
 	for _, idx := range m.freeSlots {
 		occupied[idx] = true
 	}
@@ -1400,7 +1424,7 @@ func pidsInNs(name string) (pids []int, ok bool) {
 
 // listHostVeths returns all veth-N interfaces visible in the host namespace.
 func listHostVeths() ([]string, error) {
-	entries, err := os.ReadDir("/sys/class/net")
+	entries, err := os.ReadDir(hostNetDir)
 	if err != nil {
 		return nil, err
 	}
@@ -1433,6 +1457,9 @@ func (m *Manager) UpdateFirewallRules(vmID string, allowedCIDRs, deniedCIDRs []s
 
 // netnsDir is overridden by tests.
 var netnsDir = "/run/netns"
+
+// hostNetDir is where host-side interfaces appear; overridden by tests.
+var hostNetDir = "/sys/class/net"
 
 // NamespaceForPID returns the ns-N name of the network namespace that pid is
 // in, by matching /proc/<pid>/ns/net's inode against the named namespaces in

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -78,6 +78,11 @@ const MaxSlots = 32000
 // ErrNoSlots is returned when no network slots are available.
 var ErrNoSlots = fmt.Errorf("no available network slots (max %d concurrent VMs)", MaxSlots)
 
+// reclaimCooldown bounds how often a claim at the ceiling rescans for unused
+// indexes. The scan is cheap but pointless to repeat while nothing has been
+// released, and a host at the ceiling is exactly when claims arrive fastest.
+const reclaimCooldown = 30 * time.Second
+
 // setupSlotConcurrency caps concurrent slot builds across every caller
 // (on-demand fallback and pool refill). Each build forks a dozen ip/nsenter
 // commands that serialize on the kernel's netlink lock, so unbounded
@@ -119,6 +124,9 @@ type Manager struct {
 	// every slot path must route through them so ownership can never be dropped
 	// (leak) or duplicated (double hand-out).
 	slotOwner map[int]string
+
+	// lastReclaim is when the ceiling path last rescanned for unused indexes.
+	lastReclaim time.Time
 
 	// TCP egress proxy — receives per-sandbox rule updates and cleanup.
 	egressProxy *EgressProxy
@@ -929,6 +937,12 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				ceiling = m.maxSlot // WithExactSlot: allow only the pinned index
 			}
 			if m.nextSlot > ceiling {
+				// Out of fresh range, which is not the same as out of slots:
+				// indexes are discarded (never returned) whenever a namespace
+				// outlives them, so the gaps below are the only inventory left.
+				if n := m.reclaimUnusedSlotsLocked(); n > 0 {
+					continue
+				}
 				return 0, ErrNoSlots
 			}
 			idx = m.nextSlot
@@ -945,6 +959,65 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 		m.assignSlotLocked(idx, owner)
 		return idx, nil
 	}
+}
+
+// reclaimUnusedSlotsLocked refills freeSlots from the range below nextSlot:
+// every index that no owner holds and no kernel namespace occupies. Returns
+// how many it recovered.
+//
+// The allocator only ever advances nextSlot, and discards any index whose
+// namespace outlived it (returning it to freeSlots would loop). On a
+// long-lived host those discards accumulate until the fresh range is spent
+// while most of the space below it is idle — and a restart does not clear it,
+// because boot re-reserves each record's index and resumes above the highest.
+// So the ceiling has to be recoverable in place.
+//
+// One directory read rather than a stat per index: at the ceiling there are
+// tens of thousands of indexes to test, and namespace presence is the only
+// thing that makes one unusable. Caller must hold m.mu.
+func (m *Manager) reclaimUnusedSlotsLocked() int {
+	if time.Since(m.lastReclaim) < reclaimCooldown {
+		return 0
+	}
+	m.lastReclaim = time.Now()
+
+	entries, err := os.ReadDir(netnsDir)
+	if err != nil && !os.IsNotExist(err) {
+		// Fail closed: an unreadable namespace directory means every index
+		// might still be occupied, and handing one out would collide.
+		m.log.Warn().Err(err).Msg("allocator: cannot list namespaces — skipping slot reclaim")
+		return 0
+	}
+	occupied := make(map[int]bool, len(entries))
+	for _, entry := range entries {
+		if idx, ok := slotFromNamespace(entry.Name()); ok {
+			occupied[idx] = true
+		}
+	}
+	for _, idx := range m.freeSlots {
+		occupied[idx] = true
+	}
+
+	limit := m.nextSlot - 1
+	if limit > MaxSlots {
+		limit = MaxSlots
+	}
+	reclaimed := 0
+	for idx := 1; idx <= limit; idx++ {
+		if occupied[idx] {
+			continue
+		}
+		if _, owned := m.slotOwner[idx]; owned {
+			continue
+		}
+		m.freeSlots = append(m.freeSlots, idx)
+		reclaimed++
+	}
+	if reclaimed > 0 {
+		m.log.Warn().Int("reclaimed", reclaimed).Int("namespaces", len(entries)).
+			Msg("allocator: slot range spent — reclaimed unused indexes")
+	}
+	return reclaimed
 }
 
 // SweepOrphanNamespaces removes host namespaces and veth interfaces

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -970,8 +970,14 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 func (m *Manager) ReclaimUnusedSlots() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.lastReclaim = time.Time{} // startup always scans; the cooldown paces the ceiling path
-	return m.reclaimUnusedSlotsLocked()
+	m.lastReclaim = time.Time{} // startup always scans
+	n := m.reclaimUnusedSlotsLocked()
+	// The startup orphan sweep runs after this and deletes namespaces, so
+	// indexes this pass counted as occupied can be free moments later. Leave
+	// the cooldown unarmed so the first claim at the ceiling rescans rather
+	// than failing for the cooldown's duration over stale evidence.
+	m.lastReclaim = time.Time{}
+	return n
 }
 
 // reclaimUnusedSlotsLocked refills freeSlots from the range below nextSlot:

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -396,15 +396,21 @@ func (m *Manager) setupSlot(ctx context.Context, idx int) (*VMNetInfo, string, e
 	}
 
 	if err := run(ctx, "ip", "link", "set", vethName, "up"); err != nil {
-		m.removeNS(nsName)
+		// The veth now lives on the host, so it outlives the namespace:
+		// tear both down or the next build at this index collides with it.
+		m.cleanupFull(nsName, vethName)
 		return nil, "", fmt.Errorf("bring up veth: %w", err)
 	}
 	if err := run(ctx, "ip", "link", "set", vethName, "mtu", ifaceMTU); err != nil {
-		m.removeNS(nsName)
+		// The veth now lives on the host, so it outlives the namespace:
+		// tear both down or the next build at this index collides with it.
+		m.cleanupFull(nsName, vethName)
 		return nil, "", fmt.Errorf("set veth MTU: %w", err)
 	}
 	if err := run(ctx, "ip", "addr", "add", vethIP+"/31", "dev", vethName); err != nil {
-		m.removeNS(nsName)
+		// The veth now lives on the host, so it outlives the namespace:
+		// tear both down or the next build at this index collides with it.
+		m.cleanupFull(nsName, vethName)
 		return nil, "", fmt.Errorf("assign veth IP: %w", err)
 	}
 

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -961,6 +961,19 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 	}
 }
 
+// ReclaimUnusedSlots seeds the free list with every index below the
+// allocator's high-water mark that no owner holds and no namespace occupies.
+// Startup pins the mark above the highest record index, so on a host whose
+// records reach into the upper range, everything below it is unreachable for
+// the whole process lifetime unless it is reclaimed deliberately. Call it once
+// startup reservations are in place, when the only owners are records.
+func (m *Manager) ReclaimUnusedSlots() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastReclaim = time.Time{} // startup always scans; the cooldown paces the ceiling path
+	return m.reclaimUnusedSlotsLocked()
+}
+
 // reclaimUnusedSlotsLocked refills freeSlots from the range below nextSlot:
 // every index that no owner holds and no kernel namespace occupies. Returns
 // how many it recovered.

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -615,3 +615,29 @@ func TestReclaimUnusedSlots_LeavesCooldownUnarmed(t *testing.T) {
 		t.Fatalf("rescan = %d, want 3 — the cooldown blocked recovery of a just-swept index", n)
 	}
 }
+
+// TestReclaimUnusedSlots_FailedScanDoesNotArmCooldown pins the pacing to real
+// evidence: a scan that could not read the host's state has learned nothing,
+// so it must not suppress the next attempt — at the ceiling that would mean
+// refusing claims for the cooldown while capacity was actually available.
+func TestReclaimUnusedSlots_FailedScanDoesNotArmCooldown(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	notADir := filepath.Join(dir, "wedged")
+	if err := os.WriteFile(notADir, nil, 0o644); err != nil {
+		t.Fatalf("seed unreadable path: %v", err)
+	}
+	netnsDir = notADir // read fails with something other than "not exist"
+
+	m := newTestManager()
+	m.nextSlot = 5
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if n := m.reclaimUnusedSlotsLocked(); n != 0 {
+		t.Fatalf("reclaimed = %d on an unreadable host, want 0", n)
+	}
+	netnsDir = dir // condition clears
+	if n := m.reclaimUnusedSlotsLocked(); n != 4 {
+		t.Fatalf("reclaimed = %d after recovery, want 4 — a failed scan armed the cooldown", n)
+	}
+}

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -17,7 +17,15 @@ func withTestNetnsDir(t *testing.T) string {
 	dir := t.TempDir()
 	old := netnsDir
 	netnsDir = dir
-	t.Cleanup(func() { netnsDir = old })
+	// Host interfaces are consulted alongside namespaces when deciding whether
+	// a slot index is free, so isolate them too — otherwise a runner carrying
+	// its own veth-N silently changes what these tests observe.
+	oldHostNet := hostNetDir
+	hostNetDir = t.TempDir()
+	t.Cleanup(func() {
+		netnsDir = old
+		hostNetDir = oldHostNet
+	})
 	return dir
 }
 
@@ -564,11 +572,7 @@ func TestReclaimUnusedSlots_RecoversRangeStrandedByReservations(t *testing.T) {
 // endless retry of the same index.
 func TestReclaimUnusedSlots_SkipsStrayHostVeths(t *testing.T) {
 	withTestNetnsDir(t)
-	netDir := t.TempDir()
-	oldNet := hostNetDir
-	hostNetDir = netDir
-	t.Cleanup(func() { hostNetDir = oldNet })
-	if err := os.Mkdir(filepath.Join(netDir, "veth-4"), 0o755); err != nil {
+	if err := os.Mkdir(filepath.Join(hostNetDir, "veth-4"), 0o755); err != nil {
 		t.Fatalf("create stray veth: %v", err)
 	}
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -527,3 +527,32 @@ func TestSetupSlotQueueFailsFastOnExpiredContext(t *testing.T) {
 		t.Fatalf("setupSlot = %v, want the build-queue refusal (no kernel work attempted)", err)
 	}
 }
+
+// TestReclaimUnusedSlots_RecoversRangeStrandedByReservations pins the startup
+// recovery: reservations pin the allocator above the highest record index, and
+// every unused index below it must come back as claimable inventory rather than
+// staying unreachable for the process lifetime.
+func TestReclaimUnusedSlots_RecoversRangeStrandedByReservations(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-3")
+	m := newTestManager()
+
+	// A record high in the range pins nextSlot above everything below it.
+	m.ReserveSlotsAbove(map[string]string{"vm-hi": "ns-500", "vm-3": "ns-3"})
+	if m.nextSlot != 501 {
+		t.Fatalf("nextSlot = %d, want 501 (past the highest reserved index)", m.nextSlot)
+	}
+
+	reclaimed := m.ReclaimUnusedSlots()
+	// Everything below the mark except the two reserved indexes.
+	if want := 498; reclaimed != want {
+		t.Fatalf("reclaimed = %d, want %d", reclaimed, want)
+	}
+	idx, err := m.claimSlotIndex("vm-new")
+	if err != nil {
+		t.Fatalf("claimSlotIndex after reclaim: %v", err)
+	}
+	if idx == 3 || idx == 500 {
+		t.Errorf("idx = %d, want an index that no record reserved", idx)
+	}
+}

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -556,3 +556,32 @@ func TestReclaimUnusedSlots_RecoversRangeStrandedByReservations(t *testing.T) {
 		t.Errorf("idx = %d, want an index that no record reserved", idx)
 	}
 }
+
+// TestReclaimUnusedSlots_SkipsStrayHostVeths pins the exclusion: an index whose
+// host veth outlived its namespace cannot be built on (the move-to-host step
+// collides), and a failed build returns the index to the top of the LIFO free
+// list — so handing one out starves every other reclaimed slot behind an
+// endless retry of the same index.
+func TestReclaimUnusedSlots_SkipsStrayHostVeths(t *testing.T) {
+	withTestNetnsDir(t)
+	netDir := t.TempDir()
+	oldNet := hostNetDir
+	hostNetDir = netDir
+	t.Cleanup(func() { hostNetDir = oldNet })
+	if err := os.Mkdir(filepath.Join(netDir, "veth-4"), 0o755); err != nil {
+		t.Fatalf("create stray veth: %v", err)
+	}
+
+	m := newTestManager()
+	m.nextSlot = 6 // indexes 1..5 are below the high-water mark
+
+	reclaimed := m.ReclaimUnusedSlots()
+	if reclaimed != 4 {
+		t.Fatalf("reclaimed = %d, want 4 (1,2,3,5 — never the stray veth's index)", reclaimed)
+	}
+	for _, idx := range m.freeSlots {
+		if idx == 4 {
+			t.Fatal("index 4 reclaimed despite a stray host veth — builds there fail and relock the free list")
+		}
+	}
+}

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -257,10 +257,55 @@ func TestClaimSlotIndex_ErrNoSlotsWhenExhausted(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
 	m.nextSlot = MaxSlots + 1
+	// Genuinely exhausted: spending the fresh range is not enough, since the
+	// ceiling path reclaims unused indexes below it — every index must be held.
+	for idx := 1; idx <= MaxSlots; idx++ {
+		m.slotOwner[idx] = "vm"
+	}
 
 	_, err := m.claimSlotIndex(poolOwner)
 	if !errors.Is(err, ErrNoSlots) {
 		t.Errorf("err = %v, want ErrNoSlots", err)
+	}
+}
+
+// TestClaimSlotIndex_ReclaimsUnusedIndexesAtCeiling pins the recovery path: a
+// spent fresh range must not fail while indexes below it hold neither an owner
+// nor a namespace — those discards are the only inventory a long-lived host
+// has left, and a restart cannot recover them.
+func TestClaimSlotIndex_ReclaimsUnusedIndexesAtCeiling(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	touchNS(t, dir, "ns-7")       // namespace outlived its index
+	m.assignSlotLocked(9, "vm-9") // still owned by a record
+	m.nextSlot = MaxSlots + 1     // fresh range spent
+
+	idx, err := m.claimSlotIndex("vm-new")
+	if err != nil {
+		t.Fatalf("claimSlotIndex = %v, want a reclaimed index", err)
+	}
+	if idx == 7 || idx == 9 {
+		t.Fatalf("idx = %d, want neither the namespace-backed (7) nor the owned (9) index", idx)
+	}
+	if owner := m.slotOwner[idx]; owner != "vm-new" {
+		t.Errorf("slotOwner[%d] = %q, want vm-new", idx, owner)
+	}
+}
+
+// TestReclaimUnusedSlots_CooldownSkipsRescan pins the pacing: a host that is
+// truly out of slots must not rescan on every claim.
+func TestReclaimUnusedSlots_CooldownSkipsRescan(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	m.nextSlot = MaxSlots + 1
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n := m.reclaimUnusedSlotsLocked(); n == 0 {
+		t.Fatal("first reclaim recovered nothing, want the empty range back")
+	}
+	m.freeSlots = nil
+	if n := m.reclaimUnusedSlotsLocked(); n != 0 {
+		t.Errorf("second reclaim recovered %d within the cooldown, want 0", n)
 	}
 }
 

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -585,3 +585,29 @@ func TestReclaimUnusedSlots_SkipsStrayHostVeths(t *testing.T) {
 		}
 	}
 }
+
+// TestReclaimUnusedSlots_LeavesCooldownUnarmed pins the startup ordering: the
+// orphan sweep deletes namespaces after the startup reclaim runs, so a claim
+// that hits the ceiling moments later must rescan on the fresher evidence
+// instead of failing for the cooldown's duration.
+func TestReclaimUnusedSlots_LeavesCooldownUnarmed(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	touchNS(t, dir, "ns-2")
+	m := newTestManager()
+	m.nextSlot = 4
+
+	if n := m.ReclaimUnusedSlots(); n != 2 {
+		t.Fatalf("startup reclaim = %d, want 2 (ns-2 still occupied)", n)
+	}
+	// The sweep frees it, as it does on the non-adoption startup path.
+	m.freeSlots = nil
+	if err := os.Remove(filepath.Join(dir, "ns-2")); err != nil {
+		t.Fatalf("remove ns: %v", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n := m.reclaimUnusedSlotsLocked(); n != 3 {
+		t.Fatalf("rescan = %d, want 3 — the cooldown blocked recovery of a just-swept index", n)
+	}
+}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -102,6 +102,11 @@ const (
 	// rebuilds are short once uncontended, so a small window drains a backlog
 	// quickly.
 	resetTapConcurrency = 8
+	// refillFailureBackoff paces retries after a failed slot build. Failures
+	// are host-wide conditions (an exhausted slot range, a sick netlink), not
+	// per-attempt luck, so retrying immediately burns a core and floods the
+	// log with thousands of identical lines a second without fixing anything.
+	refillFailureBackoff = 2 * time.Second
 	// refillConcurrency is the number of refill workers rebuilding the fresh
 	// pool. A single worker refills at one slot per build-time, which cannot
 	// catch a drained pool back up while claims keep arriving; builds stay
@@ -606,6 +611,9 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		slot, err := p.allocate(ctx)
 		if err != nil {
 			p.log.Error().Err(err).Msg("pool refill failed")
+			if !p.pauseAfterFailure(ctx) {
+				return
+			}
 			continue
 		}
 		select {
@@ -627,13 +635,22 @@ func (p *Pool) mustAllocate(ctx context.Context) *preallocSlot {
 			return slot
 		}
 		p.log.Error().Err(err).Msg("pool allocate retry")
-		select {
-		case <-p.stopCh:
+		if !p.pauseAfterFailure(ctx) {
 			return nil
-		case <-ctx.Done():
-			return nil
-		default:
 		}
+	}
+}
+
+// pauseAfterFailure waits out the retry backoff, reporting false when the pool
+// is shutting down and the caller should give up instead of retrying.
+func (p *Pool) pauseAfterFailure(ctx context.Context) bool {
+	select {
+	case <-time.After(refillFailureBackoff):
+		return true
+	case <-p.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3064,6 +3064,12 @@ func (m *Manager) ReserveStartupSlots(context.Context) bool {
 		return false
 	}
 	m.netMgr.ReserveSlotsAbove(collectStartupSlots(recs))
+	// Reservations pin the allocator above the highest record index, stranding
+	// every unused index below it. Hand those back now, while records are the
+	// only owners and "unowned with no namespace" provably means free.
+	if n := m.netMgr.ReclaimUnusedSlots(); n > 0 {
+		m.log.Info().Int("slots", n).Msg("reclaimed unused network slot indexes")
+	}
 	return true
 }
 


### PR DESCRIPTION
A host that has been up long enough stops being able to create sandboxes: every create fails with `no available network slots`, and a restart does not clear it.

The allocator only ever advances `nextSlot`, and any index whose kernel namespace outlived it is discarded rather than returned (returning it would loop). Those discards accumulate, so the fresh range is eventually spent while most of the space below it holds neither an owner nor a namespace. Restarting does not help: boot re-reserves each record's index and resumes above the highest one, landing straight back at the ceiling.

- Reclaim the unused indexes when the fresh range is spent, from a single namespace-directory read, paced by a cooldown so a genuinely full host does not rescan on every claim. Exhaustion now means every index is held, which is what the error claims.
- Back off after a failed slot build in both retry loops. They retried immediately, so an exhausted host span every refill worker at full tilt and logged the same error hundreds of times a second.

The exhaustion test asserted its premise with a spent range alone, which is no longer exhaustion; it now holds every index.