### PR TITLE
vmd: widen the veth range so slots are not capped at 32k

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -71,9 +71,12 @@ type VMNetInfo struct {
 // ---------------------------------------------------------------------------
 
 // MaxSlots is the maximum number of concurrent VMs. Limited by the IP scheme:
-// hostIP uses 10.11.0.0/16 (one IP per VM), veth pairs use 10.12.0.0/16 (two IPs per VM).
-// This supports up to ~32K concurrent VMs per node — hardware (RAM/CPU) is the real limit.
-const MaxSlots = 32000
+// hostIP uses 10.11.0.0/16 (one IP per VM), veth pairs use 10.12.0.0/15 (two
+// IPs per VM), so both sides top out at 65,536 and this sits just under it.
+// Every sandbox holds a slot for its whole life, paused included, so this is a
+// ceiling on sandboxes per host, not on running VMs — hardware and kernel
+// scale (namespace and mount table growth) bite well before the arithmetic.
+const MaxSlots = 65000
 
 // ErrNoSlots is returned when no network slots are available.
 var ErrNoSlots = fmt.Errorf("no available network slots (max %d concurrent VMs)", MaxSlots)
@@ -270,7 +273,7 @@ func (m *Manager) SetProxyPorts(http, tls, other uint16) {
 //
 // Network topology:
 //
-//	Host:      veth-<idx> (10.12.x.y/31)  ←→  eth0 (10.12.x.y/31) :Namespace
+//	Host:      veth-<idx> (10.12+.x.y/31)  ←→  eth0 (10.12+.x.y/31) :Namespace
 //	Host:      route hostIP/32 via vpeerIP
 //	Namespace: tap0 (169.254.0.22/30)  ←→  VM eth0 (169.254.0.21)
 //	Namespace: nftables SNAT 169.254.0.21 → hostIP (outbound)
@@ -278,8 +281,8 @@ func (m *Manager) SetProxyPorts(http, tls, other uint16) {
 //
 // IP addressing uses /16 subnets to support thousands of concurrent VMs:
 //   - hostIP:  10.11.<idx/256>.<idx%256>  (one per VM)
-//   - vpeerIP: 10.12.<(idx*2)/256>.<(idx*2)%256>  (namespace side of veth)
-//   - vethIP:  10.12.<(idx*2+1)/256>.<(idx*2+1)%256>  (host side of veth)
+//   - vpeerIP: offset idx*2 into 10.12.0.0/15    (namespace side of veth)
+//   - vethIP:  offset idx*2+1 into 10.12.0.0/15  (host side of veth)
 //
 // The host reaches the VM at hostIP:<port>. NAT inside the namespace
 // translates to 169.254.0.21:<port>. No guest IP reconfig needed.
@@ -333,9 +336,18 @@ func hostIPForSlot(idx int) string {
 // the kernel objects carry all the state, nothing needs to be persisted.
 func nsNameForSlot(idx int) string   { return fmt.Sprintf("ns-%d", idx) }
 func vethNameForSlot(idx int) string { return fmt.Sprintf("veth-%d", idx) }
-func vpeerIPForSlot(idx int) string  { return fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256) }
-func vethIPForSlot(idx int) string   { return fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256) }
-func macForSlot(idx int) string      { return fmt.Sprintf("AA:FC:00:%02X:%02X:%02X", 0, idx/256, idx%256) }
+func vpeerIPForSlot(idx int) string  { return vethPairIP(idx * 2) }
+func vethIPForSlot(idx int) string   { return vethPairIP(idx*2 + 1) }
+
+// vethPairIP addresses one end of a slot's veth /31 by its flat offset into
+// 10.12.0.0/15. Slots below 32,768 keep the exact addresses the old /16 scheme
+// gave them, so widening the range leaves every existing namespace untouched.
+// Offsets are even/odd pairs and the /15 boundary is even, so a pair can never
+// straddle it.
+func vethPairIP(offset int) string {
+	return fmt.Sprintf("10.%d.%d.%d", 12+offset/65536, (offset%65536)/256, offset%256)
+}
+func macForSlot(idx int) string { return fmt.Sprintf("AA:FC:00:%02X:%02X:%02X", 0, idx/256, idx%256) }
 
 // setupSlot runs the expensive network setup (namespace, veth, TAP,
 // nftables, routing) for a single slot index. Used by both SetupVM
@@ -579,7 +591,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 			Msg("cleanup: killed lingering processes before namespace teardown")
 	}
 
-	vpeerIP := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
+	vpeerIP := vpeerIPForSlot(idx)
 	hostCIDR := fmt.Sprintf("%s/32", info.HostIP)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -3,6 +3,8 @@ package network
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -639,5 +641,89 @@ func TestReclaimUnusedSlots_FailedScanDoesNotArmCooldown(t *testing.T) {
 	netnsDir = dir // condition clears
 	if n := m.reclaimUnusedSlotsLocked(); n != 4 {
 		t.Fatalf("reclaimed = %d after recovery, want 4 — a failed scan armed the cooldown", n)
+	}
+}
+
+// TestSlotAddressing_LowRangeUnchanged pins backward compatibility: widening the
+// veth range must not move a single existing slot's addresses, or every live and
+// paused VM on a host would need its network rebuilt to match.
+func TestSlotAddressing_LowRangeUnchanged(t *testing.T) {
+	// The scheme before widening: 10.12.0.0/16, two addresses per slot.
+	oldVpeer := func(idx int) string { return fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256) }
+	oldVeth := func(idx int) string { return fmt.Sprintf("10.12.%d.%d", (idx*2+1)/256, (idx*2+1)%256) }
+	for idx := 0; idx < 32768; idx++ {
+		if got, want := vpeerIPForSlot(idx), oldVpeer(idx); got != want {
+			t.Fatalf("vpeerIPForSlot(%d) = %s, want %s (existing slot moved)", idx, got, want)
+		}
+		if got, want := vethIPForSlot(idx), oldVeth(idx); got != want {
+			t.Fatalf("vethIPForSlot(%d) = %s, want %s (existing slot moved)", idx, got, want)
+		}
+	}
+}
+
+// TestSlotAddressing_CrossesIntoSecondHalf pins the widened half and the /31
+// pairing that makes each veth link valid.
+func TestSlotAddressing_CrossesIntoSecondHalf(t *testing.T) {
+	cases := []struct {
+		idx         int
+		vpeer, veth string
+	}{
+		{32767, "10.12.255.254", "10.12.255.255"}, // last slot of the old range
+		{32768, "10.13.0.0", "10.13.0.1"},         // first slot of the new half
+		{MaxSlots - 1, "10.13.251.206", "10.13.251.207"},
+	}
+	for _, tc := range cases {
+		if got := vpeerIPForSlot(tc.idx); got != tc.vpeer {
+			t.Errorf("vpeerIPForSlot(%d) = %s, want %s", tc.idx, got, tc.vpeer)
+		}
+		if got := vethIPForSlot(tc.idx); got != tc.veth {
+			t.Errorf("vethIPForSlot(%d) = %s, want %s", tc.idx, got, tc.veth)
+		}
+	}
+}
+
+// TestSlotAddressing_WithinDeclaredRanges pins the arithmetic against the ranges
+// the scheme claims: host IPs inside vmIPRange (the firewall matches on it) and
+// veth pairs inside 10.12.0.0/15, at both ends of the slot space.
+func TestSlotAddressing_WithinDeclaredRanges(t *testing.T) {
+	_, hostNet, err := net.ParseCIDR(vmIPRange)
+	if err != nil {
+		t.Fatalf("parse vmIPRange: %v", err)
+	}
+	_, vethNet, err := net.ParseCIDR("10.12.0.0/15")
+	if err != nil {
+		t.Fatalf("parse veth range: %v", err)
+	}
+	for _, idx := range []int{0, 1, 32767, 32768, MaxSlots - 1} {
+		if ip := net.ParseIP(hostIPForSlot(idx)); ip == nil || !hostNet.Contains(ip) {
+			t.Errorf("hostIPForSlot(%d) = %s, outside %s", idx, hostIPForSlot(idx), vmIPRange)
+		}
+		for _, ipStr := range []string{vpeerIPForSlot(idx), vethIPForSlot(idx)} {
+			if ip := net.ParseIP(ipStr); ip == nil || !vethNet.Contains(ip) {
+				t.Errorf("slot %d address %s outside 10.12.0.0/15", idx, ipStr)
+			}
+		}
+		// The pair must sit in one /31: same address but for the low bit.
+		vpeer, veth := net.ParseIP(vpeerIPForSlot(idx)).To4(), net.ParseIP(vethIPForSlot(idx)).To4()
+		if vpeer[3]&0xfe != veth[3]&0xfe || vpeer[0] != veth[0] || vpeer[1] != veth[1] || vpeer[2] != veth[2] {
+			t.Errorf("slot %d pair %s/%s does not share a /31", idx, vpeer, veth)
+		}
+	}
+}
+
+// TestCleanupUsesSharedVpeerDerivation pins the route-deletion path to the same
+// derivation the build used. It carried its own hardcoded copy of the formula,
+// which silently deletes the wrong route for any slot in the widened half —
+// leaving a stale host route behind on every teardown up there.
+func TestCleanupUsesSharedVpeerDerivation(t *testing.T) {
+	for _, idx := range []int{5, 32768, MaxSlots - 1} {
+		legacy := fmt.Sprintf("10.12.%d.%d", (idx*2)/256, (idx*2)%256)
+		got := vpeerIPForSlot(idx)
+		if idx < 32768 && got != legacy {
+			t.Fatalf("slot %d: shared derivation %s diverges from the old scheme %s", idx, got, legacy)
+		}
+		if idx >= 32768 && got == legacy {
+			t.Fatalf("slot %d: derivation still produces the wrapped legacy address %s", idx, legacy)
+		}
 	}
 }


### PR DESCRIPTION
A host stops creating sandboxes once it has handed out 32,000 slot indexes, and every sandbox holds its index for its whole life — paused included — so a busy cell reaches that ceiling as a matter of course rather than as an anomaly.

The cap comes from addressing, not from hardware: host IPs take one address each out of a /16 and support 65,536 slots, but veth pairs take two each out of a /16 and run out at 32,768. Widening the veth range to a /15 lifts both sides to the same 65,536.

- Address each veth end by its flat offset into the wider range. Offsets below 65,536 land on exactly the addresses the old scheme produced, so no existing namespace moves and no running or paused VM needs rebuilding. Pairs stay /31-aligned across the boundary.
- Raise the slot ceiling to 65,000, under the 65,536 both ranges now allow.
- Route teardown carried its own hardcoded copy of the veth derivation, which wraps to a wrong address in the widened half and would leave a stale host route behind on every teardown up there; it now shares the one derivation.

Tests pin that all 32,768 existing slots keep their addresses, that the crossover and the top of the range land where they should, that host IPs stay inside the range the firewall matches on, and that each pair shares a /31.

Checked before choosing the range: nothing in either repo, no subnet in either GCP project, and no address or route on either production host uses it.