### PR TITLE
Backup pipeline observability: vmd OTLP metrics and alert policies

### DIFF
--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -72,14 +72,27 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       # The use4 cell host is the primary production host (api.superserve.ai).
-      # Skipped until CLOUD_RUN_SERVICE_USE4 is set. (usw remains uncovered here
-      # — pre-existing gap, tracked separately.)
+      # Skipped until CLOUD_RUN_SERVICE_USE4 is set.
       - name: Deploy OTEL Collector to use4 cell VMD instances
         if: vars.CLOUD_RUN_SERVICE_USE4 != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: us-east4
           VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-east4
+          OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
+        run: |
+          python3 .github/workflows/scripts/deploy-otel-collector.py
+
+      # Both production cells need a host-local collector: without one,
+      # vmd's OTLP export lands on a closed localhost port and every
+      # backup alert policy for the cell (including backup-disabled)
+      # watches series that never arrive.
+      - name: Deploy OTEL Collector to usw2 cell VMD instances
+        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: us-west2
+          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-west2
           OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
           python3 .github/workflows/scripts/deploy-otel-collector.py

--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -52,7 +52,11 @@ jobs:
           python3 .github/workflows/scripts/deploy-otel-collector.py
 
   deploy-production:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
+    # Runs on ordinary main pushes like deploy-vmd.yml and terraform-cd:
+    # the collector must roll out on the same automatic path as the vmd
+    # metrics exporter and the alert policies that watch its series, or a
+    # merge leaves alerts staring at ports nothing listens on.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -86,9 +86,10 @@ jobs:
       # Both production cells need a host-local collector: without one,
       # vmd's OTLP export lands on a closed localhost port and every
       # backup alert policy for the cell (including backup-disabled)
-      # watches series that never arrive.
+      # watches series that never arrive. Gated on the usw cell's own
+      # rollout flag, matching deploy-vmd.yml's usw step.
       - name: Deploy OTEL Collector to usw2 cell VMD instances
-        if: vars.CLOUD_RUN_SERVICE_USE4 != ''
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: us-west2

--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -55,8 +55,18 @@ jobs:
     # Runs on ordinary main pushes like deploy-vmd.yml and terraform-cd:
     # the collector must roll out on the same automatic path as the vmd
     # metrics exporter and the alert policies that watch its series, or a
-    # merge leaves alerts staring at ports nothing listens on.
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    # merge leaves alerts staring at ports nothing listens on. A push only
+    # proceeds once deploy-staging (which always runs on push) has
+    # actually succeeded, so a broken collector build or config never
+    # reaches production. deploy-staging is conditional on the dispatch
+    # input and never runs on a production-only workflow_dispatch, so that
+    # path is evaluated on its own, preserving the manual behavior.
+    if: |
+      always() && (
+        (github.event_name == 'push' && needs.deploy-staging.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+      )
+    needs: [deploy-staging]
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -28,6 +28,7 @@ on:
       - 'proto/**'
       - 'internal/vm/**'
       - 'internal/backup/**'
+      - 'internal/telemetry/**'
       - 'internal/network/**'
       - 'internal/builder/**'
       - 'internal/db/**'

--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -100,6 +100,9 @@ jobs:
           # Staging validates the backup uploader first; the production
           # cells get their buckets after the staging soak.
           BACKUP_BUCKET: superserve-artifact-backup-staging-usc1
+          # Enables vmd's backup metrics exporter (host-local collector);
+          # the backup alert policies read these series.
+          OTEL_ENVIRONMENT: staging
         run: |
           python3 .github/workflows/scripts/deploy-vmd.py
 
@@ -157,6 +160,10 @@ jobs:
           SHA: ${{ github.sha }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           BACKUP_BUCKET: superserve-artifact-backup-use4
+          # Enables vmd's backup metrics exporter (host-local collector);
+          # the cell's backup alert policies, including backup-disabled,
+          # cannot fire without these series.
+          OTEL_ENVIRONMENT: production
           # use4 is the "use" cell's Supabase + control plane.
           CONTROL_PLANE_URL: ${{ vars.CONTROL_PLANE_URL_PROD }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
@@ -202,6 +209,10 @@ jobs:
           # Enables the pause-backup uploader for the cell (validated on
           # staging first; the bucket is create-only for hosts).
           BACKUP_BUCKET: superserve-artifact-backup-usw2
+          # Enables vmd's backup metrics exporter (host-local collector);
+          # the cell's backup alert policies, including backup-disabled,
+          # cannot fire without these series.
+          OTEL_ENVIRONMENT: production
         run: |
           # Fail closed: an empty GCP_REGION makes deploy-vmd.py drop the region
           # filter and fan out to every VMD_LABEL match — which would push

--- a/.github/workflows/scripts/deploy-otel-collector.py
+++ b/.github/workflows/scripts/deploy-otel-collector.py
@@ -209,6 +209,7 @@ def main() -> int:
             sudo tee /etc/sandbox/otel/collector.env >/dev/null <<'OTELENV'
             GCP_PROJECT={collector_project}
             GCP_ZONE={zone_name}
+            HOST_ID={name}
             OTELENV
             sudo chmod 0644 /etc/sandbox/otel/collector.env
 

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -20,6 +20,17 @@ Env vars:
                        into vmd.env when set; empty = skip, leaving the
                        host's backup uploader disabled. Staged rollout:
                        staging first, production after the staging soak.
+  OTEL_ENVIRONMENT     optional — enables vmd's OTLP backup-metrics exporter
+                       by upserting OTEL_METRICS_ENABLED=true and this value
+                       as OTEL_ENVIRONMENT into vmd.env. Empty = skip,
+                       leaving the host's existing setting alone. The
+                       endpoint stays vmd's compiled default
+                       (http://localhost:4318, the host-local collector), so
+                       only the enable flag and environment ship. The backup
+                       alert policies key on these series, including the
+                       backup-disabled alert, which cannot fire on absent
+                       data — so metrics must be on wherever those alerts
+                       are instantiated.
   CONTROL_PLANE_URL    optional — control-plane base URL (e.g.
                        https://api.superserve.ai). Upserted into vmd.env when
                        set. vmd reads it via os.Getenv("CONTROL_PLANE_URL").
@@ -117,6 +128,7 @@ def main() -> int:
     sha = os.environ["SHA"][:8]
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
     backup_bucket = os.environ.get("BACKUP_BUCKET", "")
+    otel_environment = os.environ.get("OTEL_ENVIRONMENT", "")
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
     database_url = os.environ.get("DATABASE_URL", "")
@@ -132,6 +144,9 @@ def main() -> int:
     q_sentry_line = shlex.quote(f"SENTRY_DSN={sentry_dsn}")
     q_backup = shlex.quote(backup_bucket)
     q_backup_line = shlex.quote(f"BACKUP_BUCKET={backup_bucket}")
+    q_otel = shlex.quote(otel_environment)
+    q_otel_enabled_line = shlex.quote("OTEL_METRICS_ENABLED=true")
+    q_otel_env_line = shlex.quote(f"OTEL_ENVIRONMENT={otel_environment}")
     q_cpu = shlex.quote(control_plane_url)
     q_cpu_line = shlex.quote(f"CONTROL_PLANE_URL={control_plane_url}")
     q_dns = shlex.quote(dns_redirect_port)
@@ -385,6 +400,18 @@ def main() -> int:
             if [ -n {q_backup} ]; then
                 sudo sed -i '/^BACKUP_BUCKET=/d' /etc/sandbox/vmd.env
                 echo {q_backup_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            fi
+
+            # Upsert the OTLP backup-metrics contract: enable flag plus
+            # environment label. Empty = skip. The exporter endpoint stays
+            # vmd's compiled default (the host-local collector on
+            # localhost:4318). The backup alert policies read these series,
+            # so hosts they watch must have this set.
+            if [ -n {q_otel} ]; then
+                sudo sed -i '/^OTEL_METRICS_ENABLED=/d' /etc/sandbox/vmd.env
+                sudo sed -i '/^OTEL_ENVIRONMENT=/d' /etc/sandbox/vmd.env
+                echo {q_otel_enabled_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+                echo {q_otel_env_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
 
             # Upsert SECRETSPROXY_SOCKET on both env files. The daemon writes

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -204,6 +204,7 @@ def main() -> int:
     def deploy(inst):
         name, zone = inst["name"], inst["zone"]
         tag = f"{name}/{zone}"
+        q_host_id_line = shlex.quote(f"HOST_ID={name}")
 
         # Single SCP — one IAP tunnel for the whole bundle.
         run_or_die(
@@ -413,6 +414,15 @@ def main() -> int:
                 echo {q_otel_enabled_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
                 echo {q_otel_env_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
             fi
+
+            # Upsert HOST_ID with the instance name. vmd falls back to
+            # "default" without it, which breaks reconciler DB scoping,
+            # heartbeat identity, and the host_id metric label the backup
+            # alert policies filter on. The instance name is the host's
+            # identity in the host table and in those filters; on hosts
+            # where it was seeded by hand this rewrites the same value.
+            sudo sed -i '/^HOST_ID=/d' /etc/sandbox/vmd.env
+            echo {q_host_id_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
 
             # Upsert SECRETSPROXY_SOCKET on both env files. The daemon writes
             # its control socket into RuntimeDirectory=/run/secretsproxy under

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -32,6 +32,7 @@ import (
 	dbq "github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vm"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
@@ -523,13 +524,52 @@ func main() {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
 
+	// ---- Backup metrics recorder ----
+	// Optional OTLP recorder for the backup pipeline, exporting to the
+	// host-local collector under the same env contract as the control
+	// plane's recorder but with the vmd service name. Constructed OUTSIDE
+	// the BACKUP_BUCKET gate on purpose: a production host running with
+	// backup silently disabled must still emit backup_enabled=0 rather
+	// than nothing. Nil when metrics are off; every call site is nil-safe.
+	var backupMetrics *telemetry.BackupRecorder
+	if envOrDefault("OTEL_METRICS_ENABLED", "false") == "true" {
+		exportInterval, perr := time.ParseDuration(envOrDefault("OTEL_EXPORT_INTERVAL", "15s"))
+		if perr != nil {
+			log.Warn().Err(perr).Msg("invalid OTEL_EXPORT_INTERVAL; using 15s")
+			exportInterval = 15 * time.Second
+		}
+		rec, err := telemetry.NewBackupRecorder(ctx, telemetry.BackupOTelConfig{
+			OTelConfig: telemetry.OTelConfig{
+				ServiceName:    envOrDefault("OTEL_SERVICE_NAME", "sandbox-vmd"),
+				ServiceVersion: os.Getenv("OTEL_SERVICE_VERSION"),
+				Environment:    envOrDefault("OTEL_ENVIRONMENT", "dev"),
+				Endpoint:       envOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
+				Insecure:       os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "true",
+				ExportInterval: exportInterval,
+			},
+			HostID: cfg.HostID,
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("backup metrics init failed; continuing without metrics")
+		} else {
+			backupMetrics = rec
+			lc.addCloser("backup metrics", func(sctx context.Context) error {
+				return rec.Shutdown(sctx)
+			})
+			log.Info().Msg("backup metrics recorder enabled")
+		}
+	}
+	mgr.SetBackupMetrics(backupMetrics)
+
 	// ---- Backup uploader ----
 	// Ships each pause's durable artifacts (disk overlay + vmstate) to the
 	// cell's backup bucket, content-addressed and create-only. Disabled
 	// unless BACKUP_BUCKET is set; the journal makes uploads crash-safe
 	// across vmd restarts, and the bandwidth cap keeps backups from
 	// competing with guest traffic.
-	if bucket := os.Getenv("BACKUP_BUCKET"); bucket != "" {
+	backupBucket := os.Getenv("BACKUP_BUCKET")
+	var backupJournal *backup.Journal
+	if bucket := backupBucket; bucket != "" {
 		journalPath := envOrDefault("BACKUP_JOURNAL_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "backup.db"))
 		bdb, err := bolt.Open(journalPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
@@ -540,6 +580,7 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to init backup journal")
 		}
+		backupJournal = journal
 		gcsClient, err := storage.NewClient(ctx)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to create GCS client for backup")
@@ -557,6 +598,7 @@ func main() {
 			Limiter:    rate.NewLimiter(bytesPerSec, 32<<20),
 			Log:        log.With().Str("component", "backup").Logger(),
 			VMDVersion: os.Getenv("SENTRY_RELEASE"),
+			Metrics:    backupMetrics,
 		}
 		// Staging pins enqueued artifacts via hard links so sandbox
 		// teardown cannot erase a queued generation; the sweep clears
@@ -604,6 +646,48 @@ func main() {
 			return uploader.Run(upCtx)
 		})
 		log.Info().Str("bucket", bucket).Int("bandwidth_mbps", mbps).Msg("backup uploader enabled")
+	}
+
+	// ---- Backup metrics sampler ----
+	// Periodic gauges every 30s: the enabled flag, journal depth and
+	// backlog age, pending-marker count, and outbox depth. All reads are
+	// read-only BoltDB views off the hot path; any error just skips that
+	// field for the sample and can never affect backup behavior.
+	if backupMetrics != nil {
+		sample := func() {
+			s := telemetry.BackupSample{Enabled: backupBucket != ""}
+			if backupJournal != nil {
+				if pending, err := backupJournal.Pending(); err == nil {
+					s.PendingPause = pending[backup.PriorityPause]
+					s.PendingCheckpoint = pending[backup.PriorityCheckpoint]
+					s.PendingBestEffort = pending[backup.PriorityBestEffort]
+				}
+				if oldest, ok, err := backupJournal.OldestEnqueuedAt(); err == nil && ok {
+					s.OldestPendingAge = time.Since(oldest)
+				}
+				if depth, err := backupJournal.OutboxDepth(); err == nil {
+					s.OutboxPending = depth
+				}
+			}
+			if markers, err := stateStore.ListPendingBackups(); err == nil {
+				s.PendingMarkers = len(markers)
+			}
+			backupMetrics.RecordSample(ctx, s)
+		}
+		go func() {
+			defer sentrylog.Recover("backup metrics sampler")
+			t := time.NewTicker(30 * time.Second)
+			defer t.Stop()
+			sample()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					sample()
+				}
+			}
+		}()
 	}
 
 	// ---- gRPC server ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -651,8 +651,9 @@ func main() {
 	// ---- Backup metrics sampler ----
 	// Periodic gauges every 30s: the enabled flag, journal depth and
 	// backlog age, pending-marker count, and outbox depth. All reads are
-	// read-only BoltDB views off the hot path; any error just skips that
-	// field for the sample and can never affect backup behavior.
+	// read-only BoltDB views off the hot path; a failed read drops that
+	// gauge from the sample instead of publishing a false zero, and can
+	// never affect backup behavior.
 	if backupMetrics != nil {
 		sample := func() {
 			s := telemetry.BackupSample{Enabled: backupBucket != ""}
@@ -661,16 +662,30 @@ func main() {
 					s.PendingPause = pending[backup.PriorityPause]
 					s.PendingCheckpoint = pending[backup.PriorityCheckpoint]
 					s.PendingBestEffort = pending[backup.PriorityBestEffort]
+					s.PendingOK = true
+				} else {
+					log.Warn().Err(err).Msg("backup metrics: journal pending read failed, dropping gauge from sample")
 				}
-				if oldest, ok, err := backupJournal.OldestEnqueuedAt(); err == nil && ok {
-					s.OldestPendingAge = time.Since(oldest)
+				if oldest, ok, err := backupJournal.OldestEnqueuedAt(); err == nil {
+					if ok {
+						s.OldestPendingAge = time.Since(oldest)
+					}
+					s.OldestPendingAgeOK = true
+				} else {
+					log.Warn().Err(err).Msg("backup metrics: oldest-pending read failed, dropping gauge from sample")
 				}
 				if depth, err := backupJournal.OutboxDepth(); err == nil {
 					s.OutboxPending = depth
+					s.OutboxPendingOK = true
+				} else {
+					log.Warn().Err(err).Msg("backup metrics: outbox depth read failed, dropping gauge from sample")
 				}
 			}
 			if markers, err := stateStore.ListPendingBackups(); err == nil {
 				s.PendingMarkers = len(markers)
+				s.PendingMarkersOK = true
+			} else {
+				log.Warn().Err(err).Msg("backup metrics: pending markers read failed, dropping gauge from sample")
 			}
 			backupMetrics.RecordSample(ctx, s)
 		}

--- a/deploy/otel/README.md
+++ b/deploy/otel/README.md
@@ -39,6 +39,18 @@ rate(db_pool_acquire_duration_seconds_total[5m]) / rate(db_pool_acquire_total[5m
 
 Do not add customer, user, sandbox, request, raw URL, or raw error-message labels to Phase 1 metrics. The collector config also defensively drops known high-cardinality internal labels, but application code should avoid emitting them in the first place.
 
+## VMD backup metrics
+
+`vmd` emits its own OTLP metric set for the backup pipeline under service name `sandbox-vmd`, using the same env contract (`OTEL_METRICS_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_ENVIRONMENT`, `OTEL_EXPORT_INTERVAL`) against the host-local collector:
+
+- `backup_enabled` gauge (1/0). Emitted whether or not `BACKUP_BUCKET` is set, so a host with backup silently disabled is visible as `0` rather than as missing data.
+- `backup_journal_pending` gauge labeled `priority` (`pause`, `checkpoint`, `best_effort`), `backup_oldest_pending_age_seconds` gauge.
+- `backup_upload_total` counter labeled `result` (`verified`, `deduped`, `abandoned`, `failed`), `backup_upload_bytes_total` counter.
+- `backup_hash_duration_seconds`, `backup_stage_duration_seconds`, `backup_upload_duration_seconds`, `backup_pause_hook_duration_seconds` histograms. The pause-hook histogram measures the synchronous backup time on the pause RPC path.
+- `backup_pending_markers`, `backup_outbox_pending` gauges, `backup_notify_failures_total` counter.
+
+Labels stay within the bounded vocabulary above plus `priority`; `host_id` comes from `HOST_ID` and identifies the cell. Alert policies over these metrics live in `infra/modules/observability/backup-alerts.tf`.
+
 ## Phase 2 collector
 
 Use [collector-gmp.yaml](/home/lando/superserve-ai/sandbox/deploy/otel/collector-gmp.yaml) for staging and later production rollout. It:

--- a/deploy/otel/README.md
+++ b/deploy/otel/README.md
@@ -58,8 +58,11 @@ Use [collector-gmp.yaml](/home/lando/superserve-ai/sandbox/deploy/otel/collector
 - receives OTLP from the control plane on `4317` and `4318`
 - exports to GMP through `googlemanagedprometheus`
 - scrapes collector self-metrics from `127.0.0.1:8888`
+- scrapes root-filesystem utilization through `hostmetrics`, scoped to the root mountpoint only so the series means the OS disk rather than the sandbox data arrays, and stamps it with `host_id` from `HOST_ID` in `collector.env` (written by the deploy path, matches the instance name)
 - drops banned high-cardinality labels before export
 - keeps exporter queueing and memory limiting visible through self-metrics
+
+Alert policies over the root-filesystem series live next to the backup policies in `infra/modules/observability/backup-alerts.tf`.
 
 ### Bare-metal host deployment
 

--- a/deploy/otel/collector-bootstrap.sh.tftpl
+++ b/deploy/otel/collector-bootstrap.sh.tftpl
@@ -41,6 +41,9 @@ cat <<'EOF' >/etc/sandbox/otel/collector.env
 GCP_PROJECT=${project_id}
 GCP_ZONE=${zone}
 EOF
+# HOST_ID scopes host-level metric series (root-filesystem utilization) to
+# this cell's host; the GCE short hostname matches the instance name.
+echo "HOST_ID=$(hostname -s)" >>/etc/sandbox/otel/collector.env
 
 systemctl daemon-reload
 systemctl enable --now superserve-otel-collector

--- a/deploy/otel/collector-gmp.yaml
+++ b/deploy/otel/collector-gmp.yaml
@@ -17,6 +17,20 @@ receivers:
           scrape_interval: 30s
           static_configs:
             - targets: ["127.0.0.1:8888"]
+  # Root-filesystem telemetry for the OS disk. Scoped to the root
+  # mountpoint only: the sandbox data arrays are separate, far larger
+  # filesystems with their own reclaim logic, and folding them in would
+  # make utilization mean the wrong disk.
+  hostmetrics:
+    collection_interval: 60s
+    scrapers:
+      filesystem:
+        include_mount_points:
+          mount_points: ["/"]
+          match_type: strict
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
 
 processors:
   memory_limiter:
@@ -49,6 +63,15 @@ processors:
         action: delete
       - key: error
         action: delete
+  # Host-level series carry the same bounded host_id label the vmd backup
+  # metrics use, so alert policies scope one cell's host the same way for
+  # both. HOST_ID is written into collector.env by the deploy path and
+  # matches the instance name.
+  attributes/host_id:
+    actions:
+      - key: host_id
+        value: ${env:HOST_ID}
+        action: upsert
   batch:
     send_batch_size: 256
     timeout: 5s
@@ -77,4 +100,10 @@ service:
     metrics:
       receivers: [otlp, prometheus/self]
       processors: [memory_limiter, resourcedetection/gcp, resource/gmp_location, attributes/drop_internal_high_cardinality, batch]
+      exporters: [googlemanagedprometheus]
+    # Separate pipeline so host_id is only stamped onto host-level series;
+    # OTLP senders (control plane, vmd) already set their own host_id.
+    metrics/host:
+      receivers: [hostmetrics]
+      processors: [memory_limiter, resourcedetection/gcp, resource/gmp_location, attributes/host_id, batch]
       exporters: [googlemanagedprometheus]

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -346,6 +346,13 @@ module "observability" {
     host_id        = module.sandbox_host.instance_name
     display_prefix = "Backup / ${module.sandbox_host.instance_name}"
   }
+  # Root-filesystem (OS disk) utilization for the same host, scoped through
+  # the same host_id label the backup metrics use. Module defaults: warn at
+  # 85% sustained 30 minutes, page at 95%.
+  host_disk_alerts = {
+    host_id        = module.sandbox_host.instance_name
+    display_prefix = "Infrastructure / ${module.sandbox_host.instance_name}"
+  }
   host_maintenance_event_alerts = {
     sandbox_host = {
       display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -337,6 +337,15 @@ module "observability" {
       instance_id   = module.sandbox_host.instance_id
     }
   }
+  # Backup pipeline alerts scoped to this cell's host via the host_id
+  # metric label (HOST_ID on the host matches the instance name). Module
+  # defaults hold for this cell's ~10 pauses/day too: the failure-rate
+  # threshold keys on retry pressure (one stuck generation retries ~6
+  # times/hour), not on traffic volume.
+  backup_alerts = {
+    host_id        = module.sandbox_host.instance_name
+    display_prefix = "Backup / ${module.sandbox_host.instance_name}"
+  }
   labels = local.common_labels
 }
 

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -339,9 +339,9 @@ module "observability" {
   }
   # Backup pipeline alerts scoped to this cell's host via the host_id
   # metric label (HOST_ID on the host matches the instance name). Module
-  # defaults hold for this cell's ~10 pauses/day too: the failure-rate
+  # defaults hold regardless of the cell's traffic: the failure-rate
   # threshold keys on retry pressure (one stuck generation retries ~6
-  # times/hour), not on traffic volume.
+  # times/hour under the capped backoff), not on pause volume.
   backup_alerts = {
     host_id        = module.sandbox_host.instance_name
     display_prefix = "Backup / ${module.sandbox_host.instance_name}"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -310,11 +310,12 @@ module "observability" {
     display_prefix = "Backup / ${local.active_host_name}"
   }
   # Root-filesystem (OS disk) utilization for the same host, scoped through
-  # the same host_id label the backup metrics use. Module defaults: warn at
-  # 85% sustained 30 minutes, page at 95%.
+  # the same host_id label the backup metrics use, and following
+  # active_sandbox_host for the same reason. Module defaults: warn at 85%
+  # sustained 30 minutes, page at 95%.
   host_disk_alerts = {
-    host_id        = module.sandbox_host.instance_name
-    display_prefix = "Infrastructure / ${module.sandbox_host.instance_name}"
+    host_id        = local.active_host_name
+    display_prefix = "Infrastructure / ${local.active_host_name}"
   }
   labels = local.common_labels
 }

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -233,8 +233,8 @@ module "observability" {
   }
   # Backup pipeline alerts scoped to this cell's host via the host_id
   # metric label (HOST_ID on the host matches the instance name).
-  # Thresholds are the module defaults, sized in the module against this
-  # cell's ~1000 pauses/day and tens-of-MB packed overlays.
+  # Thresholds are the module defaults; the rationale for each sits on
+  # the module's variables.
   backup_alerts = {
     host_id        = module.sandbox_host.instance_name
     display_prefix = "Backup / ${module.sandbox_host.instance_name}"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -56,6 +56,12 @@ locals {
   # started for an incident is never stopped again by a later apply.
   active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
 
+  # The host currently serving vmd traffic, and so the host whose HOST_ID
+  # tags its metrics. Alert filters must key on this, not on sandbox_host,
+  # or a standby promotion leaves them watching a host_id that stopped
+  # emitting.
+  active_host_name = var.active_sandbox_host == "standby" ? module.sandbox_host_b.instance_name : module.sandbox_host.instance_name
+
   # Exactly one host carries component=vmd, the label the shared deploy
   # pipeline discovers; the other is parked under a cell-scoped label so
   # rollouts skip it instead of failing against a host that is out of service.
@@ -294,12 +300,14 @@ module "observability" {
     }
   }
   # Backup pipeline alerts scoped to this cell's host via the host_id
-  # metric label (HOST_ID on the host matches the instance name).
+  # metric label (HOST_ID on the host matches the instance name). Follows
+  # active_sandbox_host so a standby promotion keeps the filter on whichever
+  # host is actually emitting.
   # Thresholds are the module defaults; the rationale for each sits on
   # the module's variables.
   backup_alerts = {
-    host_id        = module.sandbox_host.instance_name
-    display_prefix = "Backup / ${module.sandbox_host.instance_name}"
+    host_id        = local.active_host_name
+    display_prefix = "Backup / ${local.active_host_name}"
   }
   # Root-filesystem (OS disk) utilization for the same host, scoped through
   # the same host_id label the backup metrics use. Module defaults: warn at

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -301,6 +301,13 @@ module "observability" {
     host_id        = module.sandbox_host.instance_name
     display_prefix = "Backup / ${module.sandbox_host.instance_name}"
   }
+  # Root-filesystem (OS disk) utilization for the same host, scoped through
+  # the same host_id label the backup metrics use. Module defaults: warn at
+  # 85% sustained 30 minutes, page at 95%.
+  host_disk_alerts = {
+    host_id        = module.sandbox_host.instance_name
+    display_prefix = "Infrastructure / ${module.sandbox_host.instance_name}"
+  }
   labels = local.common_labels
 }
 

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -231,6 +231,14 @@ module "observability" {
       instance_id   = module.sandbox_host.instance_id
     }
   }
+  # Backup pipeline alerts scoped to this cell's host via the host_id
+  # metric label (HOST_ID on the host matches the instance name).
+  # Thresholds are the module defaults, sized in the module against this
+  # cell's ~1000 pauses/day and tens-of-MB packed overlays.
+  backup_alerts = {
+    host_id        = module.sandbox_host.instance_name
+    display_prefix = "Backup / ${module.sandbox_host.instance_name}"
+  }
   labels = local.common_labels
 }
 

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -298,6 +298,14 @@ module "observability" {
 
   project_id  = local.project_id
   environment = local.environment
+  # Backup pipeline alerts, same set as the production cells so staging
+  # validates the queries before they matter. The disabled-host alert
+  # stays off here: staging toggles BACKUP_BUCKET deliberately.
+  backup_alerts = {
+    host_id             = module.sandbox_host.instance_name
+    display_prefix      = "Backup / ${module.sandbox_host.instance_name}"
+    alert_disabled_host = false
+  }
   dashboards = {
     sandbox_operations = {
       display_name = "Sandbox Telemetry / Staging Operations"

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -306,6 +306,13 @@ module "observability" {
     display_prefix      = "Backup / ${module.sandbox_host.instance_name}"
     alert_disabled_host = false
   }
+  # Root-filesystem (OS disk) utilization, same policies as the production
+  # cells so staging validates the query shape first. Module defaults:
+  # warn at 85% sustained 30 minutes, page at 95%.
+  host_disk_alerts = {
+    host_id        = module.sandbox_host.instance_name
+    display_prefix = "Infrastructure / ${module.sandbox_host.instance_name}"
+  }
   dashboards = {
     sandbox_operations = {
       display_name = "Sandbox Telemetry / Staging Operations"

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -132,3 +132,83 @@ resource "google_monitoring_alert_policy" "backup" {
     managed_by = "terraform"
   })
 }
+
+# Host root-filesystem alerting. The host-local collector's hostmetrics
+# receiver exports utilization for the root mountpoint only (the sandbox
+# data arrays are separate filesystems with their own reclaim logic), so
+# these policies watch the OS disk that the host's control services live
+# on. Series carry the same bounded host_id label as the backup metrics.
+
+locals {
+  host_disk_matcher = var.host_disk_alerts == null ? "" : "host_id=\"${var.host_disk_alerts.host_id}\""
+
+  host_disk_alert_conditions = var.host_disk_alerts == null ? {} : {
+    root_fs_warning = {
+      display_name = "${var.host_disk_alerts.display_prefix} / root filesystem filling"
+      severity     = "WARNING"
+      # 85% still leaves working headroom for logs, package state, and
+      # deploy artifacts, so cleanup can happen deliberately instead of
+      # under pressure. Sustaining it for 30 minutes filters spikes from
+      # transient files that free themselves.
+      query         = "max(system_filesystem_utilization{mountpoint=\"/\", ${local.host_disk_matcher}}) > ${var.host_disk_alerts.warning_utilization}"
+      duration      = var.host_disk_alerts.warning_duration
+      documentation = <<-EOT
+        Root filesystem utilization on ${var.host_disk_alerts.host_id} has stayed above ${format("%.0f", var.host_disk_alerts.warning_utilization * 100)}% for the alert window. This is the OS disk, not the sandbox data arrays; it holds logs, journals, package state, and deployed binaries, and it has no automatic reclaim.
+
+        Owner: Infrastructure Operations. Response: find the growth with `sudo du -x -d1 /` on the host (journal, /var/log, and /tmp are the usual suspects), clean up or rotate, and confirm utilization drops back below the threshold. If steady-state usage has genuinely grown, resize before it reaches the paging threshold.
+      EOT
+    }
+
+    root_fs_critical = {
+      display_name = "${var.host_disk_alerts.display_prefix} / root filesystem near capacity"
+      severity     = "CRITICAL"
+      # At 95% the OS disk is close to exhaustion: writes for logs,
+      # journals, and system state start failing shortly after, which
+      # takes down the host's control services and blocks deploys. That
+      # is worth a page while there is still room to act; the short
+      # window only debounces single-scrape blips.
+      query         = "max(system_filesystem_utilization{mountpoint=\"/\", ${local.host_disk_matcher}}) > ${var.host_disk_alerts.critical_utilization}"
+      duration      = var.host_disk_alerts.critical_duration
+      documentation = <<-EOT
+        Root filesystem utilization on ${var.host_disk_alerts.host_id} is above ${format("%.0f", var.host_disk_alerts.critical_utilization * 100)}%. The OS disk is close to exhaustion; once writes fail, the host's control services (vmd, the collector, systemd journal) degrade and deploys to the host stop working.
+
+        Owner: Infrastructure Operations. Response: free space immediately (`sudo journalctl --vacuum-size=500M`, clear /tmp and old artifacts under /var), then chase the source of growth. Treat sustained utilization at this level as a capacity problem, not a cleanup problem.
+      EOT
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "host_disk" {
+  for_each = local.host_disk_alert_conditions
+
+  project               = var.project_id
+  display_name          = each.value.display_name
+  combiner              = "OR"
+  enabled               = true
+  severity              = each.value.severity
+  notification_channels = var.notification_channel_ids
+
+  conditions {
+    display_name = each.value.display_name
+
+    condition_prometheus_query_language {
+      query               = each.value.query
+      duration            = each.value.duration
+      evaluation_interval = "30s"
+    }
+  }
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content   = each.value.documentation
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type = "host_disk_${each.key}"
+    managed_by = "terraform"
+  })
+}

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -1,0 +1,131 @@
+# Backup pipeline alerting. The vmd daemon exports backup metrics through
+# the host-local OTel collector into Managed Prometheus; these policies
+# watch one cell's host via the bounded host_id label (never sandbox or
+# customer identifiers). PromQL conditions fire while the query returns a
+# series, so each query folds its threshold into the expression.
+#
+# The set exists for two incident classes: pause-path latency regressions
+# that only a pause-hook duration metric can catch, and a production host
+# running with backup silently disabled (backup_enabled=0).
+
+locals {
+  backup_host_matcher = var.backup_alerts == null ? "" : "host_id=\"${var.backup_alerts.host_id}\""
+
+  backup_alert_conditions = var.backup_alerts == null ? {} : merge({
+    upload_failures = {
+      display_name = "${var.backup_alerts.display_prefix} / upload failures sustained"
+      # Failed attempts per hour over a 30m window. Retry backoff caps at
+      # 10m, so one permanently failing generation alone produces ~6
+      # attempts/hour; the threshold catches a single stuck task on any
+      # cell (west ~1000 pauses/day, east ~10/day) without firing on
+      # transient bucket errors that clear on retry.
+      query         = "sum(rate(backup_upload_total{result=\"failed\", ${local.backup_host_matcher}}[30m])) * 3600 > ${var.backup_alerts.upload_failures_per_hour}"
+      duration      = "1800s"
+      documentation = <<-EOT
+        Backup upload attempts on ${var.backup_alerts.host_id} have been failing at more than ${var.backup_alerts.upload_failures_per_hour}/hour for 30 minutes. The journal retries with capped backoff, so sustained failures mean the bucket, credentials, or network path is broken and the backlog is growing.
+
+        Owner: Infrastructure Operations. Response: check vmd backup logs on the host for the failing generation and error, verify bucket IAM and connectivity, and confirm backup_journal_pending drains after the fix.
+      EOT
+    }
+
+    backlog_age = {
+      display_name = "${var.backup_alerts.display_prefix} / oldest pending generation too old"
+      # Overlays are tens of MB packed and ship in seconds under the
+      # default 100 Mbit/s cap; west's ~1000 pauses/day is one pause per
+      # ~90s, so queue residence is normally under a minute. A 30 minute
+      # old queue head means the drain loop is stalled or falling behind,
+      # and every queued pause is unmet durability (RPO) exposure.
+      query         = "max(backup_oldest_pending_age_seconds{${local.backup_host_matcher}}) > ${var.backup_alerts.oldest_pending_age_seconds}"
+      duration      = "900s"
+      documentation = <<-EOT
+        The oldest queued backup generation on ${var.backup_alerts.host_id} has been waiting more than ${var.backup_alerts.oldest_pending_age_seconds}s. Queued pauses are not yet durable in the bucket, so this is direct restore-point exposure.
+
+        Owner: Infrastructure Operations. Response: check whether the uploader is failing (backup_upload_total{result="failed"}), bandwidth-capped behind a large template upload, or wedged; drain must resume before the local staging tier fills.
+      EOT
+    }
+
+    pause_hook_p99 = {
+      display_name = "${var.backup_alerts.display_prefix} / pause hook p99 regression"
+      # The synchronous hook is bounded by design to a marker write, an
+      # O(dirtied-bytes) staging copy, and a tens-of-KB vmstate hash:
+      # tens to low hundreds of ms. The manifest-hashing regression this
+      # alert exists for added ~5s to every pause with only a log line to
+      # show for it; 2s p99 catches that class while tolerating the
+      # occasional large staged overlay. The 1h rate window keeps the
+      # quantile meaningful on the east cell's ~10 pauses/day.
+      query         = "histogram_quantile(0.99, sum by (le) (rate(backup_pause_hook_duration_seconds_bucket{${local.backup_host_matcher}}[1h]))) > ${var.backup_alerts.pause_hook_p99_seconds}"
+      duration      = "1800s"
+      documentation = <<-EOT
+        The p99 of the synchronous backup hook on the pause RPC path on ${var.backup_alerts.host_id} exceeded ${var.backup_alerts.pause_hook_p99_seconds}s for 30 minutes. This latency is paid by every pause the control plane issues.
+
+        Owner: Infrastructure Operations. Response: compare backup_stage_duration_seconds and backup_pause_hook_duration_seconds to find the regressing stage, and check recent vmd deploys for work added to the pause path; size-dependent hashing belongs on the detached worker, never on the RPC path.
+      EOT
+    }
+
+    outbox_stalled = {
+      display_name = "${var.backup_alerts.display_prefix} / completion write-back stalled"
+      # The notification outbox drains on every ack and on idle ticks
+      # (seconds end to end), so entries standing for an hour mean
+      # completion signals are not reaching downstream bookkeeping and
+      # staging GC is pinned.
+      query         = "min(backup_outbox_pending{${local.backup_host_matcher}}) > 0"
+      duration      = var.backup_alerts.outbox_stalled_duration
+      documentation = <<-EOT
+        Completed backup generations on ${var.backup_alerts.host_id} have had undelivered completion notifications for the whole alert window. Downstream coverage bookkeeping and staging cleanup key on these signals.
+
+        Owner: Infrastructure Operations. Response: check vmd logs for "backup notification" failures (outbox read or clear errors point at the journal DB; callback errors point at the write-back consumer) and confirm backup_outbox_pending returns to zero.
+      EOT
+    }
+    },
+    var.backup_alerts.alert_disabled_host ? {
+      backup_disabled = {
+        display_name = "${var.backup_alerts.display_prefix} / backup disabled on host"
+        # vmd emits backup_enabled from outside the BACKUP_BUCKET gate
+        # precisely so a host with backup misconfigured reports 0 instead
+        # of nothing: a production cell once ran a full day with backup
+        # silently disabled. 30 minutes tolerates deploy churn.
+        query         = "max(backup_enabled{${local.backup_host_matcher}}) < 1"
+        duration      = "1800s"
+        documentation = <<-EOT
+          ${var.backup_alerts.host_id} is running with the backup pipeline disabled (backup_enabled=0, meaning BACKUP_BUCKET is unset). Every pause on this host is currently without a durable copy.
+
+          Owner: Infrastructure Operations. Response: restore BACKUP_BUCKET in the host's vmd environment and restart vmd; the pending-marker sweep re-enqueues pauses that were owed a backup while disabled.
+        EOT
+      }
+    } : {}
+  )
+}
+
+resource "google_monitoring_alert_policy" "backup" {
+  for_each = local.backup_alert_conditions
+
+  project               = var.project_id
+  display_name          = each.value.display_name
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.notification_channel_ids
+
+  conditions {
+    display_name = each.value.display_name
+
+    condition_prometheus_query_language {
+      query               = each.value.query
+      duration            = each.value.duration
+      evaluation_interval = "30s"
+    }
+  }
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content   = each.value.documentation
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type = "backup_${each.key}"
+    managed_by = "terraform"
+  })
+}

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -67,7 +67,10 @@ locals {
       # The notification outbox drains on every ack and on idle ticks
       # (seconds end to end), so entries standing for an hour mean
       # completion signals are not reaching downstream bookkeeping and
-      # staging GC is pinned.
+      # staging GC is pinned. Until a notification consumer is wired
+      # onto the uploader (its own change), the gauge sits at zero and
+      # this policy is armed but structurally quiet; it cannot false
+      # positive, only wake once a consumer exists.
       query         = "min(backup_outbox_pending{${local.backup_host_matcher}}) > 0"
       duration      = var.backup_alerts.outbox_stalled_duration
       documentation = <<-EOT

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -17,7 +17,7 @@ locals {
       # Failed attempts per hour over a 30m window. Retry backoff caps at
       # 10m, so one permanently failing generation alone produces ~6
       # attempts/hour; the threshold catches a single stuck task on any
-      # cell (west ~1000 pauses/day, east ~10/day) without firing on
+      # cell regardless of its pause volume, without firing on
       # transient bucket errors that clear on retry.
       query         = "sum(rate(backup_upload_total{result=\"failed\", ${local.backup_host_matcher}}[30m])) * 3600 > ${var.backup_alerts.upload_failures_per_hour}"
       duration      = "1800s"
@@ -30,9 +30,9 @@ locals {
 
     backlog_age = {
       display_name = "${var.backup_alerts.display_prefix} / oldest pending generation too old"
-      # Overlays are tens of MB packed and ship in seconds under the
-      # default 100 Mbit/s cap; west's ~1000 pauses/day is one pause per
-      # ~90s, so queue residence is normally under a minute. A 30 minute
+      # Sparse-packed overlays ship in seconds under the default
+      # bandwidth cap, so queue residence is normally well under a
+      # minute even on a busy cell. A 30 minute
       # old queue head means the drain loop is stalled or falling behind,
       # and every queued pause is unmet durability (RPO) exposure.
       query         = "max(backup_oldest_pending_age_seconds{${local.backup_host_matcher}}) > ${var.backup_alerts.oldest_pending_age_seconds}"
@@ -48,11 +48,11 @@ locals {
       display_name = "${var.backup_alerts.display_prefix} / pause hook p99 regression"
       # The synchronous hook is bounded by design to a marker write, an
       # O(dirtied-bytes) staging copy, and a tens-of-KB vmstate hash:
-      # tens to low hundreds of ms. The manifest-hashing regression this
-      # alert exists for added ~5s to every pause with only a log line to
-      # show for it; 2s p99 catches that class while tolerating the
-      # occasional large staged overlay. The 1h rate window keeps the
-      # quantile meaningful on the east cell's ~10 pauses/day.
+      # tens to low hundreds of ms. The class this alert exists for is a
+      # synchronous term that scales with disk size instead of dirtied
+      # bytes; 2s p99 catches that while tolerating the occasional large
+      # staged overlay. The 1h rate window keeps the quantile meaningful
+      # on a low-traffic cell.
       query         = "histogram_quantile(0.99, sum by (le) (rate(backup_pause_hook_duration_seconds_bucket{${local.backup_host_matcher}}[1h]))) > ${var.backup_alerts.pause_hook_p99_seconds}"
       duration      = "1800s"
       documentation = <<-EOT
@@ -82,8 +82,8 @@ locals {
         display_name = "${var.backup_alerts.display_prefix} / backup disabled on host"
         # vmd emits backup_enabled from outside the BACKUP_BUCKET gate
         # precisely so a host with backup misconfigured reports 0 instead
-        # of nothing: a production cell once ran a full day with backup
-        # silently disabled. 30 minutes tolerates deploy churn.
+        # of nothing; without it, a misconfigured host is indistinguishable
+        # from one emitting no metrics. 30 minutes tolerates deploy churn.
         query         = "max(backup_enabled{${local.backup_host_matcher}}) < 1"
         duration      = "1800s"
         documentation = <<-EOT

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -4,7 +4,7 @@
 # customer identifiers). PromQL conditions fire while the query returns a
 # series, so each query folds its threshold into the expression.
 #
-# The set exists for two incident classes: pause-path latency regressions
+# The set exists for two failure classes: pause-path latency regressions
 # that only a pause-hook duration metric can catch, and a production host
 # running with backup silently disabled (backup_enabled=0).
 

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -86,6 +86,7 @@ locals {
     notification_email          = var.notification_email
     notification_channel_ids    = var.notification_channel_ids
     compute_instance_cpu_alerts = var.compute_instance_cpu_alerts
+    backup_alerts               = var.backup_alerts
     log_buckets                 = var.log_buckets
     uptime_checks               = var.uptime_checks
     alert_policies              = var.alert_policies

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -154,6 +154,7 @@ locals {
     compute_instance_cpu_alerts   = var.compute_instance_cpu_alerts
     host_maintenance_event_alerts = var.host_maintenance_event_alerts
     backup_alerts                 = var.backup_alerts
+    host_disk_alerts              = var.host_disk_alerts
     log_buckets                   = var.log_buckets
     uptime_checks                 = var.uptime_checks
     alert_policies                = var.alert_policies

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -132,3 +132,33 @@ variable "backup_alerts" {
   })
   default = null
 }
+
+variable "host_disk_alerts" {
+  description = <<-EOT
+    Alert policies over root-filesystem utilization exported by the
+    host-local OTel collector's hostmetrics receiver, scoped to one
+    cell's vmd host via the host_id metric label (stamped from HOST_ID
+    in the collector env, which matches the instance name). The metric
+    covers the root mountpoint only, so utilization means the OS disk
+    rather than the sandbox data arrays. Null disables the set.
+  EOT
+  type = object({
+    host_id        = string
+    display_prefix = string
+    # Warning threshold as a fraction of capacity. 85% still leaves
+    # working headroom for logs, package state, and deploy artifacts,
+    # so cleanup can happen deliberately instead of under pressure.
+    warning_utilization = optional(number, 0.85)
+    # Sustained window for the warning. 30 minutes filters spikes from
+    # transient files that free themselves.
+    warning_duration = optional(string, "1800s")
+    # Paging threshold. At 95% the OS disk is close to exhaustion:
+    # writes for logs, journals, and system state start failing shortly
+    # after, which takes down the host's control services.
+    critical_utilization = optional(number, 0.95)
+    # Short window on the paging path; it only debounces single-scrape
+    # blips.
+    critical_duration = optional(string, "300s")
+  })
+  default = null
+}

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -113,8 +113,9 @@ variable "backup_alerts" {
     # standing entries means completion write-back is stalled.
     outbox_stalled_duration = optional(string, "3600s")
     # Fire when the host reports backup_enabled=0 (BACKUP_BUCKET unset).
-    # On in production, where a silently disabled host once ran for a
-    # day; staging may disable backup deliberately.
+    # On in production, where a host without backup accrues unmet
+    # durability with no other signal; staging may disable backup
+    # deliberately.
     alert_disabled_host = optional(bool, true)
   })
   default = null

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -80,3 +80,43 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "backup_alerts" {
+  description = <<-EOT
+    Alert policies over the vmd backup pipeline's Managed Prometheus
+    metrics (exported by the host-local OTel collector), scoped to one
+    cell's vmd host via the host_id metric label. host_id follows the
+    sandbox host's HOST_ID runtime env, which matches the instance name.
+    Null disables the whole set.
+  EOT
+  type = object({
+    host_id        = string
+    display_prefix = string
+    # Sustained failed upload attempts per hour. The retry backoff caps at
+    # 10 minutes, so a single permanently failing generation produces ~6
+    # attempts/hour; the default catches one stuck task on any cell while
+    # ignoring transient bucket blips that succeed on retry.
+    upload_failures_per_hour = optional(number, 4)
+    # Age of the oldest queued generation. Overlays are tens of MB packed
+    # and upload in seconds under the default 100 Mbit/s cap; even the
+    # west cell's ~1000 pauses/day is one pause per ~90s, so queue
+    # residence is normally under a minute and a 30 minute old head means
+    # the drain is stalled or the backlog is growing.
+    oldest_pending_age_seconds = optional(number, 1800)
+    # p99 of the synchronous pause-RPC backup hook. The hook is bounded
+    # by design to a marker write, an O(dirtied-bytes) staging copy, and
+    # a tens-of-KB vmstate hash: tens to low hundreds of ms. The hashing
+    # regression this alert exists for added ~5s; 2s catches that class
+    # while tolerating occasional large staged overlays.
+    pause_hook_p99_seconds = optional(number, 2)
+    # How long the completion-notification outbox may stay nonzero. The
+    # outbox drains on every ack and idle tick (seconds), so an hour of
+    # standing entries means completion write-back is stalled.
+    outbox_stalled_duration = optional(string, "3600s")
+    # Fire when the host reports backup_enabled=0 (BACKUP_BUCKET unset).
+    # On in production, where a silently disabled host once ran for a
+    # day; staging may disable backup deliberately.
+    alert_disabled_host = optional(bool, true)
+  })
+  default = null
+}

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -104,9 +104,10 @@ variable "backup_alerts" {
     oldest_pending_age_seconds = optional(number, 1800)
     # p99 of the synchronous pause-RPC backup hook. The hook is bounded
     # by design to a marker write, an O(dirtied-bytes) staging copy, and
-    # a tens-of-KB vmstate hash: tens to low hundreds of ms. The hashing
-    # regression this alert exists for added ~5s; 2s catches that class
-    # while tolerating occasional large staged overlays.
+    # a tens-of-KB vmstate hash: tens to low hundreds of ms. A
+    # synchronous term that scales with disk size instead of dirtied
+    # bytes lands far above that; 2s catches the class while tolerating
+    # occasional large staged overlays.
     pause_hook_p99_seconds = optional(number, 2)
     # How long the completion-notification outbox may stay nonzero. The
     # outbox drains on every ack and idle tick (seconds), so an hour of

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -97,11 +97,10 @@ variable "backup_alerts" {
     # attempts/hour; the default catches one stuck task on any cell while
     # ignoring transient bucket blips that succeed on retry.
     upload_failures_per_hour = optional(number, 4)
-    # Age of the oldest queued generation. Overlays are tens of MB packed
-    # and upload in seconds under the default 100 Mbit/s cap; even the
-    # west cell's ~1000 pauses/day is one pause per ~90s, so queue
-    # residence is normally under a minute and a 30 minute old head means
-    # the drain is stalled or the backlog is growing.
+    # Age of the oldest queued generation. Sparse-packed overlays upload
+    # in seconds under the default bandwidth cap, so queue residence is
+    # normally well under a minute even on a busy cell, and a 30 minute
+    # old head means the drain is stalled or the backlog is growing.
     oldest_pending_age_seconds = optional(number, 1800)
     # p99 of the synchronous pause-RPC backup hook. The hook is bounded
     # by design to a marker write, an O(dirtied-bytes) staging copy, and

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -597,6 +597,42 @@ func mergeRow(existing []byte, task *Task) {
 	}
 }
 
+// OldestEnqueuedAt returns the earliest EnqueuedAt among queued tasks,
+// ok=false when the queue holds none. Enqueue time rather than readiness
+// deliberately: a task deferred by retry backoff is still backlog, and
+// the age gauge this feeds is about how stale the oldest owed upload is.
+func (j *Journal) OldestEnqueuedAt() (time.Time, bool, error) {
+	var oldest time.Time
+	found := false
+	err := j.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(journalBucket).ForEach(func(_, v []byte) error {
+			var t Task
+			if err := json.Unmarshal(v, &t); err != nil {
+				return nil // corrupt entries are dropped by Next, not counted
+			}
+			if !found || t.EnqueuedAt.Before(oldest) {
+				oldest = t.EnqueuedAt
+				found = true
+			}
+			return nil
+		})
+	})
+	return oldest, found, err
+}
+
+// OutboxDepth reports how many completed tasks still owe their
+// completion notification.
+func (j *Journal) OutboxDepth() (int, error) {
+	n := 0
+	err := j.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(outboxBucket).ForEach(func(_, _ []byte) error {
+			n++
+			return nil
+		})
+	})
+	return n, err
+}
+
 // Pending reports queue depth per priority, the uploader's lag gauge.
 func (j *Journal) Pending() (map[Priority]int, error) {
 	counts := map[Priority]int{}

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -234,3 +234,63 @@ func TestJournalEnqueueRequiresExactlyOneOwner(t *testing.T) {
 		t.Fatalf("pending after dedupe = %v", counts)
 	}
 }
+
+func TestJournalOldestEnqueuedAt(t *testing.T) {
+	j, _ := testJournal(t)
+
+	if _, ok, err := j.OldestEnqueuedAt(); err != nil || ok {
+		t.Fatalf("empty queue: ok=%v err=%v, want no oldest", ok, err)
+	}
+
+	base := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
+	newer := Task{SandboxID: "sb-new", Generation: "gen-1", Priority: PriorityPause, EnqueuedAt: base.Add(time.Hour)}
+	older := Task{SandboxID: "sb-old", Generation: "gen-2", Priority: PriorityBestEffort, EnqueuedAt: base}
+	for _, task := range []Task{newer, older} {
+		if err := j.Enqueue(task); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldest, ok, err := j.OldestEnqueuedAt()
+	if err != nil || !ok {
+		t.Fatalf("oldest: ok=%v err=%v", ok, err)
+	}
+	if !oldest.Equal(base) {
+		t.Fatalf("oldest = %s, want %s (priority must not mask an older low-priority task)", oldest, base)
+	}
+
+	// A Nack defers readiness but the task is still backlog: age keeps
+	// counting from the original enqueue.
+	if err := j.Nack(older, base.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	oldest, ok, err = j.OldestEnqueuedAt()
+	if err != nil || !ok || !oldest.Equal(base) {
+		t.Fatalf("post-nack oldest = %s ok=%v err=%v, want %s", oldest, ok, err, base)
+	}
+}
+
+func TestJournalOutboxDepth(t *testing.T) {
+	j, _ := testJournal(t)
+
+	if depth, err := j.OutboxDepth(); err != nil || depth != 0 {
+		t.Fatalf("empty outbox depth = %d err=%v, want 0", depth, err)
+	}
+
+	task := Task{SandboxID: "sb-1", Generation: "gen-1", Priority: PriorityPause, EnqueuedAt: time.Now().UTC()}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Ack(task, "bucket", true); err != nil {
+		t.Fatal(err)
+	}
+	if depth, err := j.OutboxDepth(); err != nil || depth != 1 {
+		t.Fatalf("outbox depth after notify ack = %d err=%v, want 1", depth, err)
+	}
+	if err := j.ClearNotification(task); err != nil {
+		t.Fatal(err)
+	}
+	if depth, err := j.OutboxDepth(); err != nil || depth != 0 {
+		t.Fatalf("outbox depth after clear = %d err=%v, want 0", depth, err)
+	}
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -140,7 +140,7 @@ func uploadFixture(t *testing.T, store *memBlobs, task Task) {
 	t.Helper()
 	j, _ := testJournal(t)
 	u := &Uploader{Journal: j, Store: store}
-	completed, err := u.uploadTask(context.Background(), &task)
+	completed, _, err := u.uploadTask(context.Background(), &task)
 	if err != nil || !completed {
 		t.Fatalf("upload fixture: completed=%v err=%v", completed, err)
 	}
@@ -1106,7 +1106,7 @@ func TestRestoreValidatesStagedCopyFallbackGeneration(t *testing.T) {
 	j, _ := testJournal(t)
 	store := newMemStore()
 	u := &Uploader{Journal: j, Store: store}
-	if completed, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
+	if completed, _, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
 		t.Fatalf("upload: completed=%v err=%v", completed, err)
 	}
 

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/rs/zerolog"
 	"golang.org/x/time/rate"
+
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
 // GenerationManifest is the completion marker object, written after every
@@ -77,6 +79,11 @@ type Uploader struct {
 	// for failure-time backoff, where the drain-start time would let a
 	// late failure retry immediately.
 	Now func() time.Time
+	// Metrics optionally records upload outcomes and notify failures.
+	// Nil disables recording (every recorder method is nil-safe), and a
+	// metrics error can never affect backup behavior: the recorder only
+	// observes, it is never consulted.
+	Metrics *telemetry.BackupRecorder
 }
 
 func (u *Uploader) clock() time.Time {
@@ -164,8 +171,17 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 	if err != nil || !ok {
 		return false, err
 	}
-	completed, err := u.uploadTask(ctx, &task)
+	start := u.clock()
+	completed, streamed, err := u.uploadTask(ctx, &task)
+	// Bytes count what actually reached new bucket objects, failures
+	// included: partial progress is real upload traffic.
+	u.Metrics.AddUploadBytes(ctx, streamed)
 	if err != nil {
+		// A shutdown-canceled attempt is not a failure signal; the task
+		// retries on the next boot.
+		if ctx.Err() == nil {
+			u.Metrics.RecordUpload(ctx, telemetry.BackupUploadFailed, u.clock().Sub(start))
+		}
 		task.logOwner(u.Log.Warn().Err(err)).
 			Str("generation", task.Generation).
 			Int("attempts", task.Attempts+1).
@@ -175,6 +191,14 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 		// NotBefore and retry immediately.
 		return true, u.Journal.Nack(task, u.clock())
 	}
+	result := telemetry.BackupUploadAbandoned
+	if completed {
+		result = telemetry.BackupUploadDeduped
+		if streamed > 0 {
+			result = telemetry.BackupUploadVerified
+		}
+	}
+	u.Metrics.RecordUpload(ctx, result, u.clock().Sub(start))
 	if !completed && !task.Staged {
 		// Abandonment of a mutable-path task: a concurrent dedupe may
 		// have upgraded the row to staged snapshots that would survive
@@ -216,12 +240,14 @@ func (u *Uploader) flushNotifications() {
 	}
 	pending, err := u.Journal.PendingNotifications()
 	if err != nil {
+		u.Metrics.AddNotifyFailure(context.Background())
 		u.Log.Warn().Err(err).Msg("backup notification outbox read failed")
 		return
 	}
 	for _, t := range pending {
 		u.OnVerified(t)
 		if err := u.Journal.ClearNotification(t); err != nil {
+			u.Metrics.AddNotifyFailure(context.Background())
 			t.logOwner(u.Log.Warn().Err(err)).
 				Str("generation", t.Generation).
 				Msg("backup notification clear failed; will redeliver")
@@ -273,8 +299,10 @@ func SharedBaseName(sha string) string {
 // task is done, but nothing was made durable, so verification hooks must
 // not fire.
 // task is a pointer so verification progress recorded during the attempt
-// survives into the Nack that re-persists the task on failure.
-func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, _ error) {
+// survives into the Nack that re-persists the task on failure. streamed
+// counts bytes written into newly created objects across the attempt,
+// error paths included (dedupes and skips add nothing).
+func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, streamed int64, _ error) {
 	gen := GenerationManifest{
 		SandboxID:  task.SandboxID,
 		TemplateID: task.TemplateID,
@@ -284,7 +312,8 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 	}
 	uploadedBases := map[string]bool{}
 	for _, file := range task.Files {
-		mf, err := u.uploadFile(ctx, task, file)
+		mf, n, err := u.uploadFile(ctx, task, file)
+		streamed += n
 		if err != nil {
 			if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
 				// The artifact vanished or mutated between enqueue and
@@ -293,9 +322,9 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 				// address; the generation is abandoned, not retried.
 				task.logOwner(u.Log.Warn().Str("path", file.Path)).
 					Msg("backup source file gone; abandoning generation")
-				return false, nil
+				return false, streamed, nil
 			}
-			return false, err
+			return false, streamed, err
 		}
 		gen.Files = append(gen.Files, mf)
 		// An overlay's holes are backed by its base image, and the bucket
@@ -312,18 +341,19 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 				if os.IsNotExist(err) {
 					task.logOwner(u.Log.Warn().Str("path", file.BasePath)).
 						Msg("backup base image gone; abandoning generation")
-					return false, nil
+					return false, streamed, nil
 				}
-				return false, err
+				return false, streamed, err
 			}
-			bmf, err := u.uploadFile(ctx, task, bf)
+			bmf, n, err := u.uploadFile(ctx, task, bf)
+			streamed += n
 			if err != nil {
 				if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
 					task.logOwner(u.Log.Warn().Str("path", bf.Path)).
 						Msg("backup base image gone or rebuilt; abandoning generation")
-					return false, nil
+					return false, streamed, nil
 				}
-				return false, err
+				return false, streamed, err
 			}
 			uploadedBases[file.BaseSHA256] = true
 			gen.Files = append(gen.Files, bmf)
@@ -331,16 +361,20 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 	}
 	manifestObject, err := task.objectName(ManifestObject)
 	if err != nil {
-		return false, err
+		return false, streamed, err
 	}
 	payload, err := json.Marshal(gen)
 	if err != nil {
-		return false, err
+		return false, streamed, err
 	}
-	if _, err := u.Store.Create(ctx, manifestObject, &limitedReader{r: bytes.NewReader(payload), limiter: u.Limiter, ctx: ctx}); err != nil {
-		return false, fmt.Errorf("manifest object: %w", err)
+	created, err := u.Store.Create(ctx, manifestObject, &limitedReader{r: bytes.NewReader(payload), limiter: u.Limiter, ctx: ctx})
+	if err != nil {
+		return false, streamed, fmt.Errorf("manifest object: %w", err)
 	}
-	return true, nil
+	if created {
+		streamed += int64(len(payload))
+	}
+	return true, streamed, nil
 }
 
 // stagingSweepInterval paces the running staged-base sweep.
@@ -396,30 +430,33 @@ func (u *Uploader) verifiedHere(task *Task, object string) (bool, error) {
 	return u.Journal.WasVerified(u.verificationKey(object), u.clock())
 }
 
-func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (ManifestFile, error) {
+// uploadFile ships one artifact object. shipped counts bytes written
+// into a newly created object (zero on dedupes, skips, and failures that
+// abort the create), so byte accounting reflects storage actually done.
+func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_ ManifestFile, shipped int64, _ error) {
 	if file.Name == ManifestObject {
-		return ManifestFile{}, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
+		return ManifestFile{}, 0, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
 	}
 	f, err := os.Open(file.Path)
 	if err != nil {
-		return ManifestFile{}, err
+		return ManifestFile{}, 0, err
 	}
 	defer f.Close()
 	extents, apparent, err := Extents(f)
 	if err != nil {
-		return ManifestFile{}, fmt.Errorf("extents %s: %w", file.Path, err)
+		return ManifestFile{}, 0, fmt.Errorf("extents %s: %w", file.Path, err)
 	}
 	// Verify the source still matches the digest recorded at pause time
 	// before any bytes ship: a cheap early abort for the common mutation
 	// case (the sandbox resumed before the drain).
 	sum, err := hashApparent(ctx, f, extents, apparent)
 	if err != nil {
-		return ManifestFile{}, fmt.Errorf("verify %s: %w", file.Path, err)
+		return ManifestFile{}, 0, fmt.Errorf("verify %s: %w", file.Path, err)
 	}
 	if sum != file.SHA256 {
 		u.Log.Warn().Str("path", file.Path).Str("want", file.SHA256).Str("got", sum).
 			Msg("backup source changed since pause; abandoning generation")
-		return ManifestFile{}, errSourceChanged
+		return ManifestFile{}, 0, errSourceChanged
 	}
 	// The object name embeds the packing fingerprint: a retry over a
 	// physically relaid file (same apparent content, different extents)
@@ -437,7 +474,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		objectName = file.Name + ".p" + PackFingerprint(extents, apparent)
 		object, err = task.objectName(objectName)
 		if err != nil {
-			return ManifestFile{}, err
+			return ManifestFile{}, 0, err
 		}
 	}
 	if file.Shared {
@@ -461,7 +498,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 				Size:       apparent,
 				PackedSize: PackedSize(extents),
 				Extents:    extents,
-			}, nil
+			}, 0, nil
 		}
 	}
 	// The stream hasher digests the apparent content of what is ACTUALLY
@@ -475,19 +512,23 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 	reader := &limitedReader{r: hasher, limiter: u.Limiter, ctx: ctx}
 	created, err := u.Store.Create(ctx, object, reader)
 	if err != nil {
-		return ManifestFile{}, err
+		return ManifestFile{}, 0, err
 	}
 	if created {
+		// The store finalized a new object from this stream; these bytes
+		// are real upload traffic even when verification below rejects
+		// the generation.
+		shipped = hasher.consumed
 		// The store wrote exactly the bytes that flowed through the
 		// hasher; anything short of full consumption with a matching
 		// digest means the stored object is not what the manifest would
 		// claim.
-		shipped, complete := hasher.finish()
-		if !complete || shipped != file.SHA256 {
-			u.Log.Warn().Str("path", file.Path).Str("want", file.SHA256).Str("got", shipped).
+		sum, complete := hasher.finish()
+		if !complete || sum != file.SHA256 {
+			u.Log.Warn().Str("path", file.Path).Str("want", file.SHA256).Str("got", sum).
 				Bool("fully_streamed", complete).
 				Msg("backup source changed during upload; abandoning generation")
-			return ManifestFile{}, errSourceChanged
+			return ManifestFile{}, shipped, errSourceChanged
 		}
 		// Persist that these exact object bytes were verified BEFORE any
 		// further progress, both in the task (survives nacks) and in the
@@ -516,7 +557,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 			time.Sleep(delay)
 		}
 		if recErr != nil {
-			return ManifestFile{}, fmt.Errorf("record verification of %s: %w", object, recErr)
+			return ManifestFile{}, shipped, fmt.Errorf("record verification of %s: %w", object, recErr)
 		}
 		task.VerifiedObjects = verified
 	} else if file.Shared {
@@ -540,11 +581,11 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), u.verificationKey(object))
 		}
 		if err := u.Journal.RecordVerification(next, u.verificationKey(object), u.clock()); err != nil {
-			return ManifestFile{}, fmt.Errorf("record shared dedupe of %s: %w", object, err)
+			return ManifestFile{}, 0, fmt.Errorf("record shared dedupe of %s: %w", object, err)
 		}
 		task.VerifiedObjects = next.VerifiedObjects
 	} else if ok, err := u.verifiedHere(task, object); err != nil {
-		return ManifestFile{}, err
+		return ManifestFile{}, 0, err
 	} else if !ok {
 		// The object already existed (dedupe). Stream consumption proves
 		// nothing here: small objects buffer fully before the
@@ -557,7 +598,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		// identity cannot read them back).
 		task.logOwner(u.Log.Warn().Str("object", object)).
 			Msg("deduped object has no verification history; abandoning generation")
-		return ManifestFile{}, errSourceChanged
+		return ManifestFile{}, 0, errSourceChanged
 	}
 	return ManifestFile{
 		Name:       file.Name,
@@ -568,7 +609,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 		Size:       apparent,
 		PackedSize: PackedSize(extents),
 		Extents:    extents,
-	}, nil
+	}, shipped, nil
 }
 
 // HashFileApparent digests a file's full apparent content the sparse

--- a/internal/backup/uploader_metrics_test.go
+++ b/internal/backup/uploader_metrics_test.go
@@ -1,0 +1,145 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+func testMetricsRecorder(t *testing.T) (*telemetry.BackupRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown meter provider: %v", err)
+		}
+	})
+	rec, err := telemetry.NewBackupRecorderWithProvider(provider, telemetry.BackupOTelConfig{HostID: "host-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rec, reader
+}
+
+// uploadCounts collects backup_upload_total datapoints keyed by result,
+// plus the total bytes counter.
+func uploadCounts(t *testing.T, reader *sdkmetric.ManualReader) (map[string]int64, int64) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
+	byResult := map[string]int64{}
+	var bytes int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "backup_upload_total":
+				for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+					for _, kv := range dp.Attributes.ToSlice() {
+						if string(kv.Key) == "result" {
+							byResult[kv.Value.AsString()] += dp.Value
+						}
+					}
+				}
+			case "backup_upload_bytes_total":
+				for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+					bytes += dp.Value
+				}
+			}
+		}
+	}
+	return byResult, bytes
+}
+
+func TestUploaderRecordsVerifiedThenDeduped(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	rec, reader := testMetricsRecorder(t)
+	u := &Uploader{Journal: j, Store: store, Metrics: rec}
+
+	task := writeTask(t, t.TempDir())
+	task.Files = task.Files[1:] // vmstate only: no base dependency needed
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	now := task.EnqueuedAt.Add(time.Minute)
+	if worked, err := u.drainOne(context.Background(), now); err != nil || !worked {
+		t.Fatalf("drain: worked=%v err=%v", worked, err)
+	}
+
+	byResult, bytes := uploadCounts(t, reader)
+	if byResult[telemetry.BackupUploadVerified] != 1 {
+		t.Fatalf("verified count = %d, want 1 (all: %v)", byResult[telemetry.BackupUploadVerified], byResult)
+	}
+	if bytes <= 0 {
+		t.Fatalf("upload bytes = %d, want > 0", bytes)
+	}
+
+	// An unchanged re-pause re-enqueues the identical generation: every
+	// object dedupes against verified history and nothing streams.
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if worked, err := u.drainOne(context.Background(), now.Add(time.Minute)); err != nil || !worked {
+		t.Fatalf("re-drain: worked=%v err=%v", worked, err)
+	}
+	byResult, _ = uploadCounts(t, reader)
+	if byResult[telemetry.BackupUploadDeduped] != 1 {
+		t.Fatalf("deduped count = %d, want 1 (all: %v)", byResult[telemetry.BackupUploadDeduped], byResult)
+	}
+}
+
+func TestUploaderRecordsFailedAttempt(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	rec, reader := testMetricsRecorder(t)
+	u := &Uploader{Journal: j, Store: store, Metrics: rec}
+
+	task := writeTask(t, t.TempDir())
+	task.Files = task.Files[1:]
+	store.fail["sandboxes/sb-1/gen-abc/"+packedName(t, task.Files[0].Path, "vmstate.snap")] = errors.New("transient")
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if worked, err := u.drainOne(context.Background(), task.EnqueuedAt.Add(time.Minute)); err != nil || !worked {
+		t.Fatalf("drain: worked=%v err=%v", worked, err)
+	}
+
+	byResult, _ := uploadCounts(t, reader)
+	if byResult[telemetry.BackupUploadFailed] != 1 {
+		t.Fatalf("failed count = %d, want 1 (all: %v)", byResult[telemetry.BackupUploadFailed], byResult)
+	}
+}
+
+func TestUploaderRecordsAbandonedGeneration(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	rec, reader := testMetricsRecorder(t)
+	u := &Uploader{Journal: j, Store: store, Metrics: rec}
+
+	task := writeTask(t, t.TempDir())
+	task.Files = task.Files[1:]
+	if err := os.Remove(task.Files[0].Path); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if worked, err := u.drainOne(context.Background(), task.EnqueuedAt.Add(time.Minute)); err != nil || !worked {
+		t.Fatalf("drain: worked=%v err=%v", worked, err)
+	}
+
+	byResult, _ := uploadCounts(t, reader)
+	if byResult[telemetry.BackupUploadAbandoned] != 1 {
+		t.Fatalf("abandoned count = %d, want 1 (all: %v)", byResult[telemetry.BackupUploadAbandoned], byResult)
+	}
+}

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -823,7 +823,7 @@ func TestFailedVerificationWriteNotCarriedIntoTask(t *testing.T) {
 	db.Close()
 
 	u := &Uploader{Journal: j, Store: newMemStore()}
-	_, err = u.uploadFile(context.Background(), &task, task.Files[0])
+	_, _, err = u.uploadFile(context.Background(), &task, task.Files[0])
 	if err == nil {
 		t.Fatal("uploadFile succeeded despite a failed verification write")
 	}
@@ -1399,7 +1399,7 @@ func TestSharedBaseUploadsOnceThenSkipsTheStream(t *testing.T) {
 	}
 
 	t1 := makeTask("sb-one", "overlay one")
-	if completed, err := u.uploadTask(context.Background(), &t1); err != nil || !completed {
+	if completed, _, err := u.uploadTask(context.Background(), &t1); err != nil || !completed {
 		t.Fatalf("first upload: completed=%v err=%v", completed, err)
 	}
 	var baseObject string
@@ -1416,7 +1416,7 @@ func TestSharedBaseUploadsOnceThenSkipsTheStream(t *testing.T) {
 	}
 
 	t2 := makeTask("sb-two", "overlay two")
-	if completed, err := u.uploadTask(context.Background(), &t2); err != nil || !completed {
+	if completed, _, err := u.uploadTask(context.Background(), &t2); err != nil || !completed {
 		t.Fatalf("second upload: completed=%v err=%v", completed, err)
 	}
 	if store.creates[baseObject] != 1 {
@@ -1489,7 +1489,7 @@ func TestSharedDedupeRecordsHistoryForFutureSkips(t *testing.T) {
 	baseObject := SharedBaseObject(baseSHA, PackFingerprint(extents, apparent))
 	store.objects[baseObject] = []byte("already there")
 
-	if completed, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
+	if completed, _, err := u.uploadTask(context.Background(), &task); err != nil || !completed {
 		t.Fatalf("upload: completed=%v err=%v", completed, err)
 	}
 	if store.creates[baseObject] != 1 {
@@ -1609,7 +1609,7 @@ func TestLegacyUnscopedVerificationRecordsStillTrusted(t *testing.T) {
 	if err := j.MigrateVerificationScope(store.Identity()); err != nil {
 		t.Fatal(err)
 	}
-	completed, err := u.uploadTask(context.Background(), &task)
+	completed, _, err := u.uploadTask(context.Background(), &task)
 	if err != nil || !completed {
 		t.Fatalf("upload with migrated record: completed=%v err=%v (want dedupe trusted)", completed, err)
 	}

--- a/internal/telemetry/backup.go
+++ b/internal/telemetry/backup.go
@@ -38,16 +38,26 @@ type BackupOTelConfig struct {
 // Enabled is emitted even when the pipeline is off: a production host
 // running with backup silently disabled must be visible as
 // backup_enabled=0, not as an absence of data.
+// Each read that backs a gauge below carries its own OK flag: a failed
+// BoltDB/state-store read must drop that gauge from the sample rather than
+// publish a zero, which would read as an empty queue and could reset the
+// backlog-age alert or suppress the stalled-outbox alert.
 type BackupSample struct {
-	Enabled           bool
-	PendingPause      int
-	PendingCheckpoint int
-	PendingBestEffort int
+	Enabled bool
+
+	PendingPause, PendingCheckpoint, PendingBestEffort int
+	PendingOK                                          bool
+
 	// OldestPendingAge is the age of the oldest queued task's enqueue
 	// time; zero when the queue is empty.
-	OldestPendingAge time.Duration
+	OldestPendingAge   time.Duration
+	OldestPendingAgeOK bool
+
 	PendingMarkers   int
-	OutboxPending    int
+	PendingMarkersOK bool
+
+	OutboxPending   int
+	OutboxPendingOK bool
 }
 
 // BackupRecorder emits the backup pipeline's bounded operational metrics
@@ -80,8 +90,8 @@ type BackupRecorder struct {
 // chosen for milliseconds, which would collapse every second-scale
 // observation into one bucket and make the p99 alerts meaningless.
 var (
-	// Hook and staging work is O(dirtied bytes): normally tens of ms,
-	// regressions (the hashing incident) land in whole seconds.
+	// Hook and staging work is O(dirtied bytes): normally tens of ms; a
+	// disk-size-scaled synchronous regression lands in whole seconds.
 	backupFastBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 	// Hashing and uploads scale with artifact size under the bandwidth
 	// cap: seconds for typical overlays, minutes for multi-GB bases.
@@ -241,19 +251,27 @@ func (r *BackupRecorder) RecordSample(ctx context.Context, s BackupSample) {
 		enabled = 1
 	}
 	r.enabled.Record(ctx, enabled, opt)
-	r.journalPending.Record(ctx, int64(s.PendingPause),
-		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityPause))...))
-	r.journalPending.Record(ctx, int64(s.PendingCheckpoint),
-		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityCheckpoint))...))
-	r.journalPending.Record(ctx, int64(s.PendingBestEffort),
-		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityBestEffort))...))
-	age := s.OldestPendingAge.Seconds()
-	if age < 0 { // clock skew must not report a negative backlog
-		age = 0
+	if s.PendingOK {
+		r.journalPending.Record(ctx, int64(s.PendingPause),
+			metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityPause))...))
+		r.journalPending.Record(ctx, int64(s.PendingCheckpoint),
+			metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityCheckpoint))...))
+		r.journalPending.Record(ctx, int64(s.PendingBestEffort),
+			metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityBestEffort))...))
 	}
-	r.oldestPendingAge.Record(ctx, age, opt)
-	r.pendingMarkers.Record(ctx, int64(s.PendingMarkers), opt)
-	r.outboxPending.Record(ctx, int64(s.OutboxPending), opt)
+	if s.OldestPendingAgeOK {
+		age := s.OldestPendingAge.Seconds()
+		if age < 0 { // clock skew must not report a negative backlog
+			age = 0
+		}
+		r.oldestPendingAge.Record(ctx, age, opt)
+	}
+	if s.PendingMarkersOK {
+		r.pendingMarkers.Record(ctx, int64(s.PendingMarkers), opt)
+	}
+	if s.OutboxPendingOK {
+		r.outboxPending.Record(ctx, int64(s.OutboxPending), opt)
+	}
 }
 
 func (r *BackupRecorder) attrs(extra ...attribute.KeyValue) []attribute.KeyValue {

--- a/internal/telemetry/backup.go
+++ b/internal/telemetry/backup.go
@@ -211,9 +211,8 @@ func (r *BackupRecorder) RecordStageDuration(ctx context.Context, d time.Duratio
 }
 
 // RecordPauseHookDuration observes the synchronous time the pause RPC
-// path spends in the backup hook. This is the incident metric: manifest
-// hashing once silently added seconds here with only a log to show for
-// it.
+// path spends in the backup hook. It exists so any synchronous term
+// added to this path alerts instead of surfacing only in logs.
 func (r *BackupRecorder) RecordPauseHookDuration(ctx context.Context, d time.Duration) {
 	if r == nil {
 		return

--- a/internal/telemetry/backup.go
+++ b/internal/telemetry/backup.go
@@ -1,0 +1,276 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// Backup upload results. Bounded by safeUploadResult; anything outside the
+// vocabulary is recorded as failed rather than minting a new label value.
+const (
+	BackupUploadVerified  = "verified"  // generation streamed and digest-verified in the bucket
+	BackupUploadDeduped   = "deduped"   // generation completed without streaming new bytes
+	BackupUploadAbandoned = "abandoned" // sources gone or mutated; nothing made durable
+	BackupUploadFailed    = "failed"    // attempt errored; task nacked for retry
+)
+
+// Journal priorities as metric label values. Bounded by construction: the
+// recorder only ever emits these three.
+const (
+	BackupPriorityPause      = "pause"
+	BackupPriorityCheckpoint = "checkpoint"
+	BackupPriorityBestEffort = "best_effort"
+)
+
+// BackupOTelConfig configures the vmd-side backup recorder. HostID is
+// static per process (one vmd per host), unlike the control plane's
+// per-call host label.
+type BackupOTelConfig struct {
+	OTelConfig
+	HostID string
+}
+
+// BackupSample is one periodic gauge snapshot of the backup pipeline.
+// Enabled is emitted even when the pipeline is off: a production host
+// running with backup silently disabled must be visible as
+// backup_enabled=0, not as an absence of data.
+type BackupSample struct {
+	Enabled           bool
+	PendingPause      int
+	PendingCheckpoint int
+	PendingBestEffort int
+	// OldestPendingAge is the age of the oldest queued task's enqueue
+	// time; zero when the queue is empty.
+	OldestPendingAge time.Duration
+	PendingMarkers   int
+	OutboxPending    int
+}
+
+// BackupRecorder emits the backup pipeline's bounded operational metrics
+// through OTLP. All methods are nil-safe: a nil recorder (metrics
+// disabled) makes every call a no-op, so instrumented code paths never
+// branch on whether metrics are configured, and recording can never
+// affect backup behavior.
+type BackupRecorder struct {
+	provider *sdkmetric.MeterProvider
+
+	serviceName string
+	environment string
+	hostID      string
+
+	enabled           metric.Int64Gauge
+	journalPending    metric.Int64Gauge
+	oldestPendingAge  metric.Float64Gauge
+	pendingMarkers    metric.Int64Gauge
+	outboxPending     metric.Int64Gauge
+	uploads           metric.Int64Counter
+	uploadBytes       metric.Int64Counter
+	notifyFailures    metric.Int64Counter
+	hashDuration      metric.Float64Histogram
+	stageDuration     metric.Float64Histogram
+	uploadDuration    metric.Float64Histogram
+	pauseHookDuration metric.Float64Histogram
+}
+
+// Explicit histogram boundaries: the SDK defaults top out at 10 and were
+// chosen for milliseconds, which would collapse every second-scale
+// observation into one bucket and make the p99 alerts meaningless.
+var (
+	// Hook and staging work is O(dirtied bytes): normally tens of ms,
+	// regressions (the hashing incident) land in whole seconds.
+	backupFastBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+	// Hashing and uploads scale with artifact size under the bandwidth
+	// cap: seconds for typical overlays, minutes for multi-GB bases.
+	backupSlowBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600}
+)
+
+// NewBackupRecorder constructs an OTLP/HTTP backup metrics recorder, the
+// same env-driven construction as NewOTelRecorder but under the vmd
+// service name. Call Shutdown on process exit to flush briefly.
+func NewBackupRecorder(ctx context.Context, cfg BackupOTelConfig) (*BackupRecorder, error) {
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = "sandbox-vmd"
+	}
+	if cfg.Environment == "" {
+		cfg.Environment = "dev"
+	}
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = "http://localhost:4318"
+	}
+	if cfg.ExportInterval <= 0 {
+		cfg.ExportInterval = 15 * time.Second
+	}
+	provider, err := newOTLPMeterProvider(ctx, cfg.OTelConfig)
+	if err != nil {
+		return nil, err
+	}
+	return NewBackupRecorderWithProvider(provider, cfg)
+}
+
+// NewBackupRecorderWithProvider builds the recorder's instruments on an
+// existing meter provider. Tests pass one backed by a manual reader.
+func NewBackupRecorderWithProvider(provider *sdkmetric.MeterProvider, cfg BackupOTelConfig) (*BackupRecorder, error) {
+	meter := provider.Meter(instrumentationName)
+	r := &BackupRecorder{
+		provider:    provider,
+		serviceName: cfg.ServiceName,
+		environment: cfg.Environment,
+		hostID:      safeHostID(cfg.HostID),
+	}
+	var err error
+	if r.enabled, err = meter.Int64Gauge("backup_enabled"); err != nil {
+		return nil, err
+	}
+	if r.journalPending, err = meter.Int64Gauge("backup_journal_pending"); err != nil {
+		return nil, err
+	}
+	if r.oldestPendingAge, err = meter.Float64Gauge("backup_oldest_pending_age_seconds"); err != nil {
+		return nil, err
+	}
+	if r.pendingMarkers, err = meter.Int64Gauge("backup_pending_markers"); err != nil {
+		return nil, err
+	}
+	if r.outboxPending, err = meter.Int64Gauge("backup_outbox_pending"); err != nil {
+		return nil, err
+	}
+	if r.uploads, err = meter.Int64Counter("backup_upload_total"); err != nil {
+		return nil, err
+	}
+	if r.uploadBytes, err = meter.Int64Counter("backup_upload_bytes_total"); err != nil {
+		return nil, err
+	}
+	if r.notifyFailures, err = meter.Int64Counter("backup_notify_failures_total"); err != nil {
+		return nil, err
+	}
+	if r.hashDuration, err = meter.Float64Histogram("backup_hash_duration_seconds",
+		metric.WithExplicitBucketBoundaries(backupSlowBuckets...)); err != nil {
+		return nil, err
+	}
+	if r.stageDuration, err = meter.Float64Histogram("backup_stage_duration_seconds",
+		metric.WithExplicitBucketBoundaries(backupFastBuckets...)); err != nil {
+		return nil, err
+	}
+	if r.uploadDuration, err = meter.Float64Histogram("backup_upload_duration_seconds",
+		metric.WithExplicitBucketBoundaries(backupSlowBuckets...)); err != nil {
+		return nil, err
+	}
+	if r.pauseHookDuration, err = meter.Float64Histogram("backup_pause_hook_duration_seconds",
+		metric.WithExplicitBucketBoundaries(backupFastBuckets...)); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *BackupRecorder) Shutdown(ctx context.Context) error {
+	if r == nil || r.provider == nil {
+		return nil
+	}
+	return r.provider.Shutdown(ctx)
+}
+
+// RecordUpload counts one task attempt's outcome and its wall time.
+func (r *BackupRecorder) RecordUpload(ctx context.Context, result string, d time.Duration) {
+	if r == nil {
+		return
+	}
+	opt := metric.WithAttributes(r.attrs(attribute.String("result", safeUploadResult(result)))...)
+	r.uploads.Add(ctx, 1, opt)
+	if d >= 0 {
+		r.uploadDuration.Record(ctx, d.Seconds(), opt)
+	}
+}
+
+// AddUploadBytes counts bytes streamed into newly created bucket objects
+// (dedupes ship nothing new and count zero).
+func (r *BackupRecorder) AddUploadBytes(ctx context.Context, n int64) {
+	if r == nil || n <= 0 {
+		return
+	}
+	r.uploadBytes.Add(ctx, n, metric.WithAttributes(r.attrs()...))
+}
+
+// RecordHashDuration observes one artifact-manifest hashing pass.
+func (r *BackupRecorder) RecordHashDuration(ctx context.Context, d time.Duration) {
+	if r == nil {
+		return
+	}
+	r.hashDuration.Record(ctx, d.Seconds(), metric.WithAttributes(r.attrs()...))
+}
+
+// RecordStageDuration observes one staging copy (pause artifacts or an
+// enqueue-path snapshot).
+func (r *BackupRecorder) RecordStageDuration(ctx context.Context, d time.Duration) {
+	if r == nil {
+		return
+	}
+	r.stageDuration.Record(ctx, d.Seconds(), metric.WithAttributes(r.attrs()...))
+}
+
+// RecordPauseHookDuration observes the synchronous time the pause RPC
+// path spends in the backup hook. This is the incident metric: manifest
+// hashing once silently added seconds here with only a log to show for
+// it.
+func (r *BackupRecorder) RecordPauseHookDuration(ctx context.Context, d time.Duration) {
+	if r == nil {
+		return
+	}
+	r.pauseHookDuration.Record(ctx, d.Seconds(), metric.WithAttributes(r.attrs()...))
+}
+
+// AddNotifyFailure counts one failed completion-notification delivery
+// step (outbox read or clear); the outbox retries, so a sustained rate
+// means write-back is stalled.
+func (r *BackupRecorder) AddNotifyFailure(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	r.notifyFailures.Add(ctx, 1, metric.WithAttributes(r.attrs()...))
+}
+
+// RecordSample emits the periodic gauge snapshot.
+func (r *BackupRecorder) RecordSample(ctx context.Context, s BackupSample) {
+	if r == nil {
+		return
+	}
+	opt := metric.WithAttributes(r.attrs()...)
+	enabled := int64(0)
+	if s.Enabled {
+		enabled = 1
+	}
+	r.enabled.Record(ctx, enabled, opt)
+	r.journalPending.Record(ctx, int64(s.PendingPause),
+		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityPause))...))
+	r.journalPending.Record(ctx, int64(s.PendingCheckpoint),
+		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityCheckpoint))...))
+	r.journalPending.Record(ctx, int64(s.PendingBestEffort),
+		metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityBestEffort))...))
+	age := s.OldestPendingAge.Seconds()
+	if age < 0 { // clock skew must not report a negative backlog
+		age = 0
+	}
+	r.oldestPendingAge.Record(ctx, age, opt)
+	r.pendingMarkers.Record(ctx, int64(s.PendingMarkers), opt)
+	r.outboxPending.Record(ctx, int64(s.OutboxPending), opt)
+}
+
+func (r *BackupRecorder) attrs(extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.String("service.name", r.serviceName),
+		attribute.String("environment", r.environment),
+		attribute.String("host_id", r.hostID),
+	}
+	return append(attrs, extra...)
+}
+
+func safeUploadResult(v string) string {
+	switch v {
+	case BackupUploadVerified, BackupUploadDeduped, BackupUploadAbandoned, BackupUploadFailed:
+		return v
+	default:
+		return BackupUploadFailed
+	}
+}

--- a/internal/telemetry/backup_test.go
+++ b/internal/telemetry/backup_test.go
@@ -137,13 +137,17 @@ func TestBackupRecorderRecordsSampleGauges(t *testing.T) {
 	r, reader := testBackupRecorder(t)
 
 	r.RecordSample(ctx, BackupSample{
-		Enabled:           false,
-		PendingPause:      3,
-		PendingCheckpoint: 2,
-		PendingBestEffort: 1,
-		OldestPendingAge:  90 * time.Second,
-		PendingMarkers:    4,
-		OutboxPending:     5,
+		Enabled:            false,
+		PendingPause:       3,
+		PendingCheckpoint:  2,
+		PendingBestEffort:  1,
+		PendingOK:          true,
+		OldestPendingAge:   90 * time.Second,
+		OldestPendingAgeOK: true,
+		PendingMarkers:     4,
+		PendingMarkersOK:   true,
+		OutboxPending:      5,
+		OutboxPendingOK:    true,
 	})
 
 	metrics := collectMetrics(t, reader)
@@ -195,11 +199,36 @@ func TestBackupRecorderClampsNegativeAge(t *testing.T) {
 	ctx := context.Background()
 	r, reader := testBackupRecorder(t)
 
-	r.RecordSample(ctx, BackupSample{Enabled: true, OldestPendingAge: -time.Minute})
+	r.RecordSample(ctx, BackupSample{Enabled: true, OldestPendingAge: -time.Minute, OldestPendingAgeOK: true})
 
 	metrics := collectMetrics(t, reader)
 	age := metrics["backup_oldest_pending_age_seconds"].Data.(metricdata.Gauge[float64])
 	if len(age.DataPoints) != 1 || age.DataPoints[0].Value != 0 {
 		t.Fatalf("backup_oldest_pending_age_seconds = %#v, want one point of 0", age.DataPoints)
+	}
+}
+
+// A failed read must drop its gauge from the sample rather than publish a
+// zero: a zero backlog age would reset the sustained-backlog alert, and a
+// zero outbox depth would suppress the stalled-outbox alert.
+func TestBackupRecorderOmitsGaugesOnUnreadFields(t *testing.T) {
+	ctx := context.Background()
+	r, reader := testBackupRecorder(t)
+
+	r.RecordSample(ctx, BackupSample{Enabled: true})
+
+	metrics := collectMetrics(t, reader)
+	for _, name := range []string{
+		"backup_journal_pending",
+		"backup_oldest_pending_age_seconds",
+		"backup_pending_markers",
+		"backup_outbox_pending",
+	} {
+		if _, ok := metrics[name]; ok {
+			t.Fatalf("%s was recorded despite its OK flag being false", name)
+		}
+	}
+	if _, ok := metrics["backup_enabled"]; !ok {
+		t.Fatal("backup_enabled must always be recorded, even when other reads fail")
 	}
 }

--- a/internal/telemetry/backup_test.go
+++ b/internal/telemetry/backup_test.go
@@ -1,0 +1,205 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// A nil recorder is the metrics-disabled configuration; every method must
+// be a safe no-op so instrumented code paths never branch on it.
+func TestBackupRecorderNilSafe(t *testing.T) {
+	ctx := context.Background()
+	var r *BackupRecorder
+	r.RecordUpload(ctx, BackupUploadVerified, time.Second)
+	r.AddUploadBytes(ctx, 1024)
+	r.RecordHashDuration(ctx, time.Second)
+	r.RecordStageDuration(ctx, time.Second)
+	r.RecordPauseHookDuration(ctx, time.Second)
+	r.AddNotifyFailure(ctx)
+	r.RecordSample(ctx, BackupSample{Enabled: true})
+	if err := r.Shutdown(ctx); err != nil {
+		t.Fatalf("nil recorder Shutdown = %v", err)
+	}
+}
+
+func TestSafeUploadResultBoundsValues(t *testing.T) {
+	for _, result := range []string{BackupUploadVerified, BackupUploadDeduped, BackupUploadAbandoned, BackupUploadFailed} {
+		if got := safeUploadResult(result); got != result {
+			t.Fatalf("safeUploadResult(%q) = %q", result, got)
+		}
+	}
+	if got := safeUploadResult("gs://bucket/raw-object-name"); got != BackupUploadFailed {
+		t.Fatalf("unexpected fallback result: %q", got)
+	}
+}
+
+func testBackupRecorder(t *testing.T) (*BackupRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown meter provider: %v", err)
+		}
+	})
+	r, err := NewBackupRecorderWithProvider(provider, BackupOTelConfig{
+		OTelConfig: OTelConfig{ServiceName: "sandbox-vmd", Environment: "staging"},
+		HostID:     "host-1",
+	})
+	if err != nil {
+		t.Fatalf("create backup recorder: %v", err)
+	}
+	return r, reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]metricdata.Metrics{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+func TestBackupRecorderRecordsUploadOutcome(t *testing.T) {
+	ctx := context.Background()
+	r, reader := testBackupRecorder(t)
+
+	r.RecordUpload(ctx, BackupUploadVerified, 2*time.Second)
+	r.AddUploadBytes(ctx, 4096)
+
+	metrics := collectMetrics(t, reader)
+
+	uploads, ok := metrics["backup_upload_total"].Data.(metricdata.Sum[int64])
+	if !ok || len(uploads.DataPoints) != 1 {
+		t.Fatalf("backup_upload_total = %#v, want one int64 sum point", metrics["backup_upload_total"].Data)
+	}
+	dp := uploads.DataPoints[0]
+	if dp.Value != 1 {
+		t.Fatalf("backup_upload_total = %d, want 1", dp.Value)
+	}
+	attrs := map[string]string{}
+	for _, kv := range dp.Attributes.ToSlice() {
+		attrs[string(kv.Key)] = kv.Value.AsString()
+	}
+	for key, want := range map[string]string{
+		"service.name": "sandbox-vmd",
+		"environment":  "staging",
+		"host_id":      "host-1",
+		"result":       BackupUploadVerified,
+	} {
+		if attrs[key] != want {
+			t.Fatalf("attribute %q = %q, want %q; all: %#v", key, attrs[key], want, attrs)
+		}
+	}
+
+	bytesSum, ok := metrics["backup_upload_bytes_total"].Data.(metricdata.Sum[int64])
+	if !ok || len(bytesSum.DataPoints) != 1 || bytesSum.DataPoints[0].Value != 4096 {
+		t.Fatalf("backup_upload_bytes_total = %#v, want one point of 4096", metrics["backup_upload_bytes_total"].Data)
+	}
+
+	hist, ok := metrics["backup_upload_duration_seconds"].Data.(metricdata.Histogram[float64])
+	if !ok || len(hist.DataPoints) != 1 || hist.DataPoints[0].Count != 1 || hist.DataPoints[0].Sum != 2 {
+		t.Fatalf("backup_upload_duration_seconds = %#v, want one 2s observation", metrics["backup_upload_duration_seconds"].Data)
+	}
+}
+
+func TestBackupRecorderBoundsUnknownResult(t *testing.T) {
+	ctx := context.Background()
+	r, reader := testBackupRecorder(t)
+
+	r.RecordUpload(ctx, "raw error: bucket denied for sandbox sb-123", 0)
+
+	metrics := collectMetrics(t, reader)
+	uploads := metrics["backup_upload_total"].Data.(metricdata.Sum[int64])
+	if len(uploads.DataPoints) != 1 {
+		t.Fatalf("datapoints = %d, want 1", len(uploads.DataPoints))
+	}
+	for _, kv := range uploads.DataPoints[0].Attributes.ToSlice() {
+		if string(kv.Key) == "result" && kv.Value.AsString() != BackupUploadFailed {
+			t.Fatalf("result = %q, want %q", kv.Value.AsString(), BackupUploadFailed)
+		}
+	}
+}
+
+func TestBackupRecorderRecordsSampleGauges(t *testing.T) {
+	ctx := context.Background()
+	r, reader := testBackupRecorder(t)
+
+	r.RecordSample(ctx, BackupSample{
+		Enabled:           false,
+		PendingPause:      3,
+		PendingCheckpoint: 2,
+		PendingBestEffort: 1,
+		OldestPendingAge:  90 * time.Second,
+		PendingMarkers:    4,
+		OutboxPending:     5,
+	})
+
+	metrics := collectMetrics(t, reader)
+
+	enabled := metrics["backup_enabled"].Data.(metricdata.Gauge[int64])
+	if len(enabled.DataPoints) != 1 || enabled.DataPoints[0].Value != 0 {
+		t.Fatalf("backup_enabled = %#v, want one point of 0", enabled.DataPoints)
+	}
+
+	pending := metrics["backup_journal_pending"].Data.(metricdata.Gauge[int64])
+	byPriority := map[string]int64{}
+	for _, dp := range pending.DataPoints {
+		for _, kv := range dp.Attributes.ToSlice() {
+			if string(kv.Key) == "priority" {
+				byPriority[kv.Value.AsString()] = dp.Value
+			}
+		}
+	}
+	want := map[string]int64{
+		BackupPriorityPause:      3,
+		BackupPriorityCheckpoint: 2,
+		BackupPriorityBestEffort: 1,
+	}
+	for priority, wantValue := range want {
+		if byPriority[priority] != wantValue {
+			t.Fatalf("backup_journal_pending{priority=%q} = %d, want %d", priority, byPriority[priority], wantValue)
+		}
+	}
+
+	age := metrics["backup_oldest_pending_age_seconds"].Data.(metricdata.Gauge[float64])
+	if len(age.DataPoints) != 1 || age.DataPoints[0].Value != 90 {
+		t.Fatalf("backup_oldest_pending_age_seconds = %#v, want one point of 90", age.DataPoints)
+	}
+
+	markers := metrics["backup_pending_markers"].Data.(metricdata.Gauge[int64])
+	if len(markers.DataPoints) != 1 || markers.DataPoints[0].Value != 4 {
+		t.Fatalf("backup_pending_markers = %#v, want one point of 4", markers.DataPoints)
+	}
+
+	outbox := metrics["backup_outbox_pending"].Data.(metricdata.Gauge[int64])
+	if len(outbox.DataPoints) != 1 || outbox.DataPoints[0].Value != 5 {
+		t.Fatalf("backup_outbox_pending = %#v, want one point of 5", outbox.DataPoints)
+	}
+}
+
+// Clock skew between the sampler and a task's EnqueuedAt must never
+// report a negative backlog age.
+func TestBackupRecorderClampsNegativeAge(t *testing.T) {
+	ctx := context.Background()
+	r, reader := testBackupRecorder(t)
+
+	r.RecordSample(ctx, BackupSample{Enabled: true, OldestPendingAge: -time.Minute})
+
+	metrics := collectMetrics(t, reader)
+	age := metrics["backup_oldest_pending_age_seconds"].Data.(metricdata.Gauge[float64])
+	if len(age.DataPoints) != 1 || age.DataPoints[0].Value != 0 {
+		t.Fatalf("backup_oldest_pending_age_seconds = %#v, want one point of 0", age.DataPoints)
+	}
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -65,31 +65,10 @@ func NewOTelRecorder(ctx context.Context, cfg OTelConfig) (*OTelRecorder, error)
 		cfg.ExportInterval = 15 * time.Second
 	}
 
-	exporterOpts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(cfg.Endpoint)}
-	if cfg.Insecure || strings.HasPrefix(cfg.Endpoint, "http://") {
-		exporterOpts = append(exporterOpts, otlpmetrichttp.WithInsecure())
-	}
-	exporter, err := otlpmetrichttp.New(ctx, exporterOpts...)
+	provider, err := newOTLPMeterProvider(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("create otlp metric exporter: %w", err)
+		return nil, err
 	}
-
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes("",
-			attribute.String("service.name", cfg.ServiceName),
-			attribute.String("service.version", cfg.ServiceVersion),
-			attribute.String("environment", cfg.Environment),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("create otel resource: %w", err)
-	}
-
-	provider := sdkmetric.NewMeterProvider(
-		sdkmetric.WithResource(res),
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(cfg.ExportInterval))),
-	)
 	meter := provider.Meter(instrumentationName)
 
 	r := &OTelRecorder{
@@ -266,4 +245,35 @@ func safeHostID(v string) string {
 		return "unknown"
 	}
 	return v
+}
+
+// newOTLPMeterProvider builds the OTLP/HTTP exporter, resource, and
+// periodic-reader meter provider shared by every recorder in this
+// package. cfg must already have its defaults applied.
+func newOTLPMeterProvider(ctx context.Context, cfg OTelConfig) (*sdkmetric.MeterProvider, error) {
+	exporterOpts := []otlpmetrichttp.Option{otlpmetrichttp.WithEndpointURL(cfg.Endpoint)}
+	if cfg.Insecure || strings.HasPrefix(cfg.Endpoint, "http://") {
+		exporterOpts = append(exporterOpts, otlpmetrichttp.WithInsecure())
+	}
+	exporter, err := otlpmetrichttp.New(ctx, exporterOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("create otlp metric exporter: %w", err)
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes("",
+			attribute.String("service.name", cfg.ServiceName),
+			attribute.String("service.version", cfg.ServiceVersion),
+			attribute.String("environment", cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create otel resource: %w", err)
+	}
+
+	return sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(cfg.ExportInterval))),
+	), nil
 }

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/backup"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
 // SetBackupStaging points the enqueue path at the uploader's hard-link
@@ -29,6 +30,14 @@ func (m *Manager) SetBackupStaging(dir string) {
 // as covered while nothing reached BoltDB.
 func (m *Manager) SetBackupEnqueue(fn func(backup.Task) error) {
 	m.backupEnqueue = fn
+}
+
+// SetBackupMetrics installs the optional backup metrics recorder. Same
+// startup-only pattern as SetBackupEnqueue; a nil recorder (metrics
+// disabled) is safe at every call site, and recording never affects
+// backup behavior.
+func (m *Manager) SetBackupMetrics(rec *telemetry.BackupRecorder) {
+	m.backupMetrics = rec
 }
 
 // SetBackupCovered installs the journal's coverage probe: whether a
@@ -94,6 +103,15 @@ func pauseManifestComplete(manifest []ManifestEntry) bool {
 // and the uploader's pre-verification abandons that generation, which is
 // the same safe outcome as any mutated source.
 func (m *Manager) backupPause(ctx context.Context, vmID, snapshotPath, diskPath, diskBasePath string, log zerolog.Logger) []ManifestEntry {
+	// The pause-hook histogram measures exactly the synchronous time this
+	// hook holds the pause RPC path (detached workers are excluded by
+	// construction: they run past the return). Manifest hashing once
+	// added seconds here with only a log line to show for it; this metric
+	// exists so that class of regression alerts instead of hiding.
+	start := time.Now()
+	defer func() {
+		m.backupMetrics.RecordPauseHookDuration(ctx, time.Since(start))
+	}()
 	// NOTHING here may scale with apparent disk size: pause latency must
 	// track what the guest dirtied, and hashing a sparse overlay's full
 	// apparent content costs seconds regardless of hasher. All
@@ -121,10 +139,13 @@ func (m *Manager) backupPause(ctx context.Context, vmID, snapshotPath, diskPath,
 			go m.rehashPendingBackup(ctx, prev, log)
 			return manifest
 		}
-		if dir, staged, err := backup.StagePending(ctx, m.backupStaging, vmID, pb.Token, diskBasePath, map[string]string{
+		stageStart := time.Now()
+		dir, staged, err := backup.StagePending(ctx, m.backupStaging, vmID, pb.Token, diskBasePath, map[string]string{
 			"vmstate.snap": snapshotPath,
 			"rootfs.ext4":  diskPath,
-		}); err == nil {
+		})
+		m.backupMetrics.RecordStageDuration(ctx, time.Since(stageStart))
+		if err == nil {
 			pb.OrigSnapshotPath = snapshotPath
 			pb.OrigDiskPath = diskPath
 			pb.StagedDir = dir
@@ -252,7 +273,9 @@ func (m *Manager) rehashUnstagedLocked(rctx context.Context, pb PendingBackup, l
 			return
 		}
 	}
+	hashStart := time.Now()
 	retried := collectPauseManifest(rctx, pb.SnapshotPath, pb.DiskPath, pb.DiskBasePath, pb.DiskBasePath, log)
+	m.backupMetrics.RecordHashDuration(rctx, time.Since(hashStart))
 	if pb.DiskBasePath != "" {
 		// Re-check AFTER hashing too: the disk hash can run for minutes,
 		// and a base swapped inside that window would have been stat'ed
@@ -413,7 +436,9 @@ func (m *Manager) enqueueStagedPending(ctx context.Context, pb PendingBackup, lo
 			}
 		}
 	}
+	hashStart := time.Now()
 	entries := collectPauseManifest(ctx, pb.SnapshotPath, pb.DiskPath, baseSrc, pb.DiskBasePath, log)
+	m.backupMetrics.RecordHashDuration(ctx, time.Since(hashStart))
 	if !pauseManifestComplete(entries) {
 		log.Warn().Str("vm_id", pb.VMID).
 			Msg("staged pause backup hash failed transiently; keeping pending record")
@@ -440,7 +465,9 @@ func (m *Manager) enqueueStagedPending(ctx context.Context, pb PendingBackup, lo
 	// above), so the enqueued task is FULLY staged and needs no at-rest
 	// fallback, which could not succeed for a resumed sandbox anyway.
 	if pb.DiskBasePath != "" {
+		baseStageStart := time.Now()
 		stagedBase, err := backup.StageSharedBase(m.backupStaging, baseSrc, baseSHAFromEntries(entries), false)
+		m.backupMetrics.RecordStageDuration(ctx, time.Since(baseStageStart))
 		if err != nil {
 			log.Warn().Err(err).Str("vm_id", pb.VMID).
 				Msg("staged pause backup: base staging failed; keeping pending record")
@@ -941,8 +968,11 @@ func (m *Manager) enqueueBackup(vmID string, manifest []ManifestEntry) (bool, bo
 		}
 		before, statErr := os.Stat(diskPath)
 		if statErr == nil && m.atRest(probeCtx(), vmID, snapPath) {
-			if err := backup.StageTask(m.backupStaging, &task); err != nil {
-				m.log.Warn().Err(err).Str("vm_id", vmID).
+			stageStart := time.Now()
+			stageErr := backup.StageTask(m.backupStaging, &task)
+			m.backupMetrics.RecordStageDuration(context.Background(), time.Since(stageStart))
+			if stageErr != nil {
+				m.log.Warn().Err(stageErr).Str("vm_id", vmID).
 					Msg("backup staging failed; uploading from original paths")
 			} else if after, err := os.Stat(diskPath); err == nil &&
 				os.SameFile(before, after) &&

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -105,9 +105,9 @@ func pauseManifestComplete(manifest []ManifestEntry) bool {
 func (m *Manager) backupPause(ctx context.Context, vmID, snapshotPath, diskPath, diskBasePath string, log zerolog.Logger) []ManifestEntry {
 	// The pause-hook histogram measures exactly the synchronous time this
 	// hook holds the pause RPC path (detached workers are excluded by
-	// construction: they run past the return). Manifest hashing once
-	// added seconds here with only a log line to show for it; this metric
-	// exists so that class of regression alerts instead of hiding.
+	// construction: they run past the return). A size-dependent
+	// synchronous term added here would otherwise surface only in logs;
+	// the metric makes that class of regression alert instead of hide.
 	start := time.Now()
 	defer func() {
 		m.backupMetrics.RecordPauseHookDuration(ctx, time.Since(start))

--- a/internal/vm/backup_hook_test.go
+++ b/internal/vm/backup_hook_test.go
@@ -1144,6 +1144,13 @@ func TestRetryPauseReusesExistingStagedMarker(t *testing.T) {
 	}
 	m.backupStaging = staging
 	m.SetBackupEnqueue(func(task backup.Task) error { return nil })
+	// Pin the per-VM worker slot: staging happens synchronously inside
+	// backupPause, but the detached staged worker needs no at-rest proof
+	// and would rename the pending directory to its generation name,
+	// racing the directory inspection below (the unitDead=false stall
+	// only holds the UNSTAGED flow). With the slot occupied, workers heal
+	// the marker and exit, so the pending directory provably survives.
+	m.pendingInFlight.Store("vm-1", struct{}{})
 
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())
 	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())

--- a/internal/vm/backup_metrics_test.go
+++ b/internal/vm/backup_metrics_test.go
@@ -1,0 +1,79 @@
+package vm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+// The pause hook must observe its synchronous RPC-path time whenever a
+// recorder is installed, including with backup disabled: the histogram
+// exists precisely to catch work silently creeping onto the pause path.
+func TestBackupPauseRecordsHookDuration(t *testing.T) {
+	dir := t.TempDir()
+	snap := filepath.Join(dir, "vmstate.snap")
+	disk := filepath.Join(dir, "rootfs.ext4")
+	for _, path := range []string{snap, disk} {
+		if err := os.WriteFile(path, []byte("bytes"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		if err := provider.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown meter provider: %v", err)
+		}
+	})
+	rec, err := telemetry.NewBackupRecorderWithProvider(provider, telemetry.BackupOTelConfig{HostID: "host-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{}
+	m.SetBackupMetrics(rec)
+	// Backup disabled (no enqueue hook): the hook returns after the
+	// vmstate entry, and the histogram must still see the call.
+	m.backupPause(context.Background(), "vm-1", snap, disk, "", zerolog.Nop())
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
+	var count uint64
+	for _, sm := range rm.ScopeMetrics {
+		for _, metric := range sm.Metrics {
+			if metric.Name != "backup_pause_hook_duration_seconds" {
+				continue
+			}
+			for _, dp := range metric.Data.(metricdata.Histogram[float64]).DataPoints {
+				count += dp.Count
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("backup_pause_hook_duration_seconds count = %d, want 1", count)
+	}
+}
+
+// A Manager without a recorder (metrics disabled) must run the pause
+// hook untouched: the nil recorder is a no-op, never a nil dereference.
+func TestBackupPauseNilRecorderSafe(t *testing.T) {
+	dir := t.TempDir()
+	snap := filepath.Join(dir, "vmstate.snap")
+	if err := os.WriteFile(snap, []byte("bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{}
+	if got := m.backupPause(context.Background(), "vm-1", snap, filepath.Join(dir, "rootfs.ext4"), "", zerolog.Nop()); len(got) != 1 {
+		t.Fatalf("manifest entries = %d, want the vmstate entry", len(got))
+	}
+}

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -251,7 +251,9 @@ func (m *Manager) backupBuildArtifacts(ctx context.Context, templateID, buildVMI
 	if m.backupEnqueue == nil {
 		return
 	}
+	hashStart := time.Now()
 	entries, complete := collectBuildManifest(ctx, snapshotDir, []string{basePath}, log)
+	m.backupMetrics.RecordHashDuration(ctx, time.Since(hashStart))
 	if len(entries) == 0 {
 		log.Warn().Str("dir", snapshotDir).
 			Msg("build manifest hashed no artifacts; build not enqueued for backup")

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/preview"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/shellquote"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	pb "github.com/superserve-ai/sandbox/proto/boxdpb"
 )
 
@@ -298,6 +299,9 @@ type Manager struct {
 	// already pending or completed; nil means never covered. See
 	// SetBackupCovered.
 	backupCovered func(backup.Task) (bool, error)
+	// backupMetrics optionally observes backup hook timings; nil (metrics
+	// disabled) is safe at every call site. See SetBackupMetrics.
+	backupMetrics *telemetry.BackupRecorder
 	// adoptedBuildBackups guards backup reconciliation of completed
 	// builds adopted from disk: one IN-FLIGHT reconcile per build id.
 	// Cross-process and cross-attempt dedupe is the journal's job (owner


### PR DESCRIPTION
## Summary

The backup pipeline had no metrics: a manifest-hashing change added ~5s to every pause with only a log line to show for it, and a production host ran a full day with backup silently disabled. This adds a vmd-side OTLP metric set for the backup subsystem (exported through the existing host-local collector into Managed Prometheus) plus Terraform alert policies over it for both production cells and staging.

## Metrics

- `backup_enabled` gauge, emitted whether or not `BACKUP_BUCKET` is set, so a disabled host reports 0 instead of nothing
- `backup_journal_pending` (by priority), `backup_oldest_pending_age_seconds`, `backup_pending_markers`, `backup_outbox_pending` gauges sampled every 30s from read-only BoltDB views
- `backup_upload_total` (result: verified/deduped/abandoned/failed), `backup_upload_bytes_total`, `backup_notify_failures_total` counters
- `backup_hash_duration_seconds`, `backup_stage_duration_seconds`, `backup_upload_duration_seconds`, `backup_pause_hook_duration_seconds` histograms with second-scale buckets; the pause-hook histogram measures the synchronous backup time on the pause RPC path

## Technical decisions

- New `BackupRecorder` in internal/telemetry follows the control plane recorder's construction and env contract, service name `sandbox-vmd`; the OTLP provider setup is factored into a shared helper.
- The recorder is optional and nil-safe everywhere: metrics disabled means a nil recorder and zero behavior change, and a metrics failure can never affect backup behavior.
- Labels stay within the bounded vocabulary (service.name, environment, host_id, result, priority); nothing per sandbox or per customer.
- Alerts use PromQL conditions scoped per cell by `host_id`, instantiated in both production roots and staging: sustained upload failures, backlog age, pause-hook p99, stalled completion write-back, and (production only) backup disabled on a host. Thresholds are documented in the module against fleet numbers.

## Testing

- `go test -short -race ./internal/...` under linux (docker): counters/gauges/histograms verified through a manual reader for the uploader outcomes (verified/deduped/failed/abandoned), pause-hook timing, journal depth/age probes, and nil-recorder safety.
- `terraform fmt -check -recursive infra/` and `terraform init -backend=false && terraform validate` on all four roots; the plan diff is adds-only (new alert policies, no changes to existing resources).