### PR TITLE
Alert on failed sandbox transitions in us-west2

### DIFF
--- a/infra/dashboards/cloud-monitoring/sandbox-telemetry-fleet.json.tftpl
+++ b/infra/dashboards/cloud-monitoring/sandbox-telemetry-fleet.json.tftpl
@@ -84,12 +84,12 @@
         "width": 6,
         "height": 4,
         "widget": {
-          "title": "Lifecycle Error Rate",
+          "title": "Lifecycle Errors and Failed-State Transitions",
           "xyChart": {
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (operation, result) (rate(sandbox_transition_total{environment=\"${environment}\",result=~\"error|timeout|conflict\"}[30m]))"
+                  "prometheusQuery": "sum by (operation, result) (rate(sandbox_transition_total{environment=\"${environment}\",result=~\"error|timeout|conflict\"}[30m])) or sum by (operation, result) (rate(sandbox_transition_total{environment=\"${environment}\",operation=\"fail\",result=\"success\"}[30m]))"
                 },
                 "plotType": "LINE",
                 "targetAxis": "Y1"

--- a/infra/dashboards/cloud-monitoring/sandbox-telemetry-operations.json.tftpl
+++ b/infra/dashboards/cloud-monitoring/sandbox-telemetry-operations.json.tftpl
@@ -262,12 +262,12 @@
         "width": 6,
         "height": 4,
         "widget": {
-          "title": "Sandbox Error Rate",
+          "title": "Sandbox Errors and Failed-State Transitions",
           "xyChart": {
             "dataSets": [
               {
                 "timeSeriesQuery": {
-                  "prometheusQuery": "sum by (result) (rate(sandbox_transition_total{environment=\"${environment}\",result=~\"conflict|error|timeout\"}[5m]))"
+                  "prometheusQuery": "sum by (operation, result) (rate(sandbox_transition_total{environment=\"${environment}\",result=~\"conflict|error|timeout\"}[5m])) or sum by (operation, result) (rate(sandbox_transition_total{environment=\"${environment}\",operation=\"fail\",result=\"success\"}[5m]))"
                 },
                 "plotType": "LINE",
                 "targetAxis": "Y1"

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -231,6 +231,13 @@ module "observability" {
       instance_id   = module.sandbox_host.instance_id
     }
   }
+  sandbox_failure_alerts = {
+    fleet = {
+      display_name = "Sandbox / us-west2 / High failed sandbox count"
+      threshold    = 5
+      lookback     = "10m"
+    }
+  }
   labels = local.common_labels
 }
 

--- a/infra/modules/observability/main.tf
+++ b/infra/modules/observability/main.tf
@@ -93,3 +93,56 @@ locals {
     labels                      = var.labels
   }
 }
+
+resource "google_monitoring_alert_policy" "sandbox_failures" {
+  for_each = var.sandbox_failure_alerts
+
+  project               = var.project_id
+  display_name          = each.value.display_name
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.notification_channel_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(var.notification_channel_ids) > 0
+      error_message = "notification_channel_ids must contain an existing monitored channel when sandbox failure alerts are configured"
+    }
+    precondition {
+      condition     = each.value.threshold > 0
+      error_message = "Sandbox failure alert thresholds must be greater than 0"
+    }
+  }
+
+  conditions {
+    display_name = "Failed sandbox transitions"
+
+    condition_prometheus_query_language {
+      query = <<-EOT
+        sum(increase(sandbox_transition_total{environment="${var.environment}",operation="fail",result="success"}[${each.value.lookback}])) > ${each.value.threshold}
+      EOT
+
+      duration            = each.value.evaluation_duration
+      evaluation_interval = "60s"
+    }
+  }
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content = coalesce(each.value.documentation, <<-EOT
+      More than ${each.value.threshold} sandboxes were successfully transitioned into the terminal failed state during the preceding ${each.value.lookback} in ${var.environment}.
+
+      This is distinct from lifecycle API errors: the failure transition itself is recorded with operation="fail", result="success". Inspect the Sandbox Telemetry Operations dashboard, then correlate the affected host and VMD logs.
+    EOT
+    )
+    mime_type = "text/markdown"
+  }
+
+  user_labels = merge(var.labels, {
+    alert_type = "sandbox_failed_transitions"
+    managed_by = "terraform"
+  })
+}

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -80,3 +80,15 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "sandbox_failure_alerts" {
+  description = "Alerts on successful transitions of sandbox rows into the terminal failed state."
+  type = map(object({
+    display_name        = string
+    threshold           = optional(number, 5)
+    lookback            = optional(string, "10m")
+    evaluation_duration = optional(string, "0s")
+    documentation       = optional(string, null)
+  }))
+  default = {}
+}


### PR DESCRIPTION
## Summary

- alert when more than 5 sandboxes transition into the terminal `failed` state within 10 minutes in us-west2
- reuse the environment's existing Cloud Monitoring notification channels
- show successful `operation="fail"` transitions alongside lifecycle errors in the fleet and operations dashboards

## Why the current dashboard is empty

The existing error panels filter `result=~"error|timeout|conflict"`. A sandbox that is successfully marked failed emits:

```promql
sandbox_transition_total{operation="fail",result="success"}
```

So the state transition we need operationally is excluded by the current error-panel selector.

## Alert query

```promql
sum(increase(sandbox_transition_total{environment="us-west2",operation="fail",result="success"}[10m])) > 5
```

## Important semantic note

This detects new transitions into `failed`; it does not measure the number of database rows currently in `status='failed'`. The latter would require a periodically observed state gauge or a database-derived metric.

## Verification

- reviewed the branch diff against `main`
- confirmed the Google provider supports `condition_prometheus_query_language`
- Terraform plan/apply remains required in the production deployment workflow to validate the configured notification channel IDs and install the policy
