### PR TITLE
vmd: scan slot reclaim without holding the allocator lock

### DIFF
--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -939,7 +939,6 @@ func (m *Manager) claimTeardown(idx int, owner string) bool {
 // or the vmID for an on-demand SetupVM.
 func (m *Manager) claimSlotIndex(owner string) (int, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	for {
 		var idx int
@@ -958,9 +957,21 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				// Out of fresh range, which is not the same as out of slots:
 				// indexes are discarded (never returned) whenever a namespace
 				// outlives them, so the gaps below are the only inventory left.
-				if n := m.reclaimUnusedSlotsLocked(); n > 0 {
+				//
+				// reclaimUnusedSlots manages its own locking and must be
+				// called without m.mu held: it reads the whole netns and
+				// host-veth directories, which at the ceiling means tens of
+				// thousands of entries. Holding the single allocator lock
+				// across that scan would stall every other claim on the
+				// host — including an on-demand RestoreSnapshot setup
+				// racing its gRPC deadline — for the scan's full duration.
+				m.mu.Unlock()
+				n := m.reclaimUnusedSlots()
+				m.mu.Lock()
+				if n > 0 {
 					continue
 				}
+				m.mu.Unlock()
 				return 0, ErrNoSlots
 			}
 			idx = m.nextSlot
@@ -975,6 +986,7 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 		}
 
 		m.assignSlotLocked(idx, owner)
+		m.mu.Unlock()
 		return idx, nil
 	}
 }
@@ -987,18 +999,20 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 // startup reservations are in place, when the only owners are records.
 func (m *Manager) ReclaimUnusedSlots() int {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.lastReclaim = time.Time{} // startup always scans
-	n := m.reclaimUnusedSlotsLocked()
+	m.mu.Unlock()
+	n := m.reclaimUnusedSlots()
 	// The startup orphan sweep runs after this and deletes namespaces, so
 	// indexes this pass counted as occupied can be free moments later. Leave
 	// the cooldown unarmed so the first claim at the ceiling rescans rather
 	// than failing for the cooldown's duration over stale evidence.
+	m.mu.Lock()
 	m.lastReclaim = time.Time{}
+	m.mu.Unlock()
 	return n
 }
 
-// reclaimUnusedSlotsLocked refills freeSlots from the range below nextSlot:
+// reclaimUnusedSlots refills freeSlots from the range below nextSlot:
 // every index that no owner holds and no kernel namespace occupies. Returns
 // how many it recovered.
 //
@@ -1011,9 +1025,16 @@ func (m *Manager) ReclaimUnusedSlots() int {
 //
 // One directory read rather than a stat per index: at the ceiling there are
 // tens of thousands of indexes to test, and namespace presence is the only
-// thing that makes one unusable. Caller must hold m.mu.
-func (m *Manager) reclaimUnusedSlotsLocked() int {
-	if time.Since(m.lastReclaim) < reclaimCooldown {
+// thing that makes one unusable. Caller must NOT hold m.mu: the directory
+// reads below are the expensive part of this call (tens of thousands of
+// entries at the ceiling), and every other slot claim on the host blocks on
+// m.mu for as long as it's held — this method takes the lock itself, only
+// for the cheap cooldown check and the final merge into freeSlots.
+func (m *Manager) reclaimUnusedSlots() int {
+	m.mu.Lock()
+	onCooldown := time.Since(m.lastReclaim) < reclaimCooldown
+	m.mu.Unlock()
+	if onCooldown {
 		return 0
 	}
 
@@ -1054,6 +1075,21 @@ func (m *Manager) reclaimUnusedSlotsLocked() int {
 			}
 		}
 	}
+
+	// Everything from here on is cheap in-memory bookkeeping against mutable
+	// allocator state, so it takes the lock — unlike the directory reads
+	// above, which ran unlocked.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Re-check: another goroutine may have scanned and armed the cooldown
+	// while this one was reading the filesystem unlocked. Its scan is at
+	// least as fresh as this one's, so defer to it rather than redoing the
+	// merge with a stale occupied set.
+	if time.Since(m.lastReclaim) < reclaimCooldown {
+		return 0
+	}
+
 	for _, idx := range m.freeSlots {
 		occupied[idx] = true
 	}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -86,6 +86,13 @@ var ErrNoSlots = fmt.Errorf("no available network slots (max %d concurrent VMs)"
 // released, and a host at the ceiling is exactly when claims arrive fastest.
 const reclaimCooldown = 30 * time.Second
 
+// reclaimScanBarrier runs inside reclaimUnusedSlots after the unlocked
+// directory reads finish and before it re-locks to merge. No-op in
+// production; tests override it to pause one scan there so a second,
+// concurrent scan can complete its own merge first — deterministically
+// reproducing the "this call's own reclaim lost the cooldown race" path.
+var reclaimScanBarrier = func() {}
+
 // setupSlotConcurrency caps concurrent slot builds across every caller
 // (on-demand fallback and pool refill). Each build forks a dozen ip/nsenter
 // commands that serialize on the kernel's netlink lock, so unbounded
@@ -966,9 +973,16 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				// host — including an on-demand RestoreSnapshot setup
 				// racing its gRPC deadline — for the scan's full duration.
 				m.mu.Unlock()
-				n := m.reclaimUnusedSlots()
+				m.reclaimUnusedSlots()
 				m.mu.Lock()
-				if n > 0 {
+				// Check current state, not this call's own return value: a
+				// concurrent caller's scan can win the merge (see the
+				// cooldown re-check in reclaimUnusedSlots) while this one
+				// loses it, in which case this call's own n is 0 even though
+				// the winner just refilled freeSlots. Trusting n here would
+				// fail this claim with ErrNoSlots despite slots being
+				// available right now.
+				if len(m.freeSlots) > 0 {
 					continue
 				}
 				m.mu.Unlock()
@@ -1075,6 +1089,11 @@ func (m *Manager) reclaimUnusedSlots() int {
 			}
 		}
 	}
+
+	// Test seam: no-op in production. Tests override this to pause a scan
+	// here, after the unlocked directory reads and before the merge lock, to
+	// deterministically interleave a concurrent scan that merges first.
+	reclaimScanBarrier()
 
 	// Everything from here on is cheap in-memory bookkeeping against mutable
 	// allocator state, so it takes the lock — unlike the directory reads

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -308,13 +308,11 @@ func TestReclaimUnusedSlots_CooldownSkipsRescan(t *testing.T) {
 	withTestNetnsDir(t)
 	m := newTestManager()
 	m.nextSlot = MaxSlots + 1
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if n := m.reclaimUnusedSlotsLocked(); n == 0 {
+	if n := m.reclaimUnusedSlots(); n == 0 {
 		t.Fatal("first reclaim recovered nothing, want the empty range back")
 	}
 	m.freeSlots = nil
-	if n := m.reclaimUnusedSlotsLocked(); n != 0 {
+	if n := m.reclaimUnusedSlots(); n != 0 {
 		t.Errorf("second reclaim recovered %d within the cooldown, want 0", n)
 	}
 }
@@ -611,9 +609,7 @@ func TestReclaimUnusedSlots_LeavesCooldownUnarmed(t *testing.T) {
 		t.Fatalf("remove ns: %v", err)
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if n := m.reclaimUnusedSlotsLocked(); n != 3 {
+	if n := m.reclaimUnusedSlots(); n != 3 {
 		t.Fatalf("rescan = %d, want 3 — the cooldown blocked recovery of a just-swept index", n)
 	}
 }
@@ -632,14 +628,12 @@ func TestReclaimUnusedSlots_FailedScanDoesNotArmCooldown(t *testing.T) {
 
 	m := newTestManager()
 	m.nextSlot = 5
-	m.mu.Lock()
-	defer m.mu.Unlock()
 
-	if n := m.reclaimUnusedSlotsLocked(); n != 0 {
+	if n := m.reclaimUnusedSlots(); n != 0 {
 		t.Fatalf("reclaimed = %d on an unreadable host, want 0", n)
 	}
 	netnsDir = dir // condition clears
-	if n := m.reclaimUnusedSlotsLocked(); n != 4 {
+	if n := m.reclaimUnusedSlots(); n != 4 {
 		t.Fatalf("reclaimed = %d after recovery, want 4 — a failed scan armed the cooldown", n)
 	}
 }

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -302,6 +302,50 @@ func TestClaimSlotIndex_ReclaimsUnusedIndexesAtCeiling(t *testing.T) {
 	}
 }
 
+// TestClaimSlotIndex_ConcurrentCeilingLoserStillGetsReclaimedSlot pins the
+// concurrent path: two callers hitting the ceiling at once both scan, but
+// only one merges (the other loses the cooldown race in reclaimUnusedSlots
+// and gets n=0 back). The loser must still succeed off the freeSlots the
+// winner just populated, not fail with ErrNoSlots.
+func TestClaimSlotIndex_ConcurrentCeilingLoserStillGetsReclaimedSlot(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	m.nextSlot = MaxSlots + 1 // fresh range spent; every index below is reclaimable
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	orig := reclaimScanBarrier
+	reclaimScanBarrier = func() {
+		first := false
+		once.Do(func() { first = true; close(entered) })
+		if first {
+			<-release
+		}
+	}
+	defer func() { reclaimScanBarrier = orig }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := m.claimSlotIndex("vm-a")
+		errCh <- err
+	}()
+
+	<-entered // A is parked mid-scan, holding no lock
+
+	// B runs a full claim — including its own reclaim, which is free to merge
+	// since A hasn't reached the merge step yet — while A is still parked.
+	if _, err := m.claimSlotIndex("vm-b"); err != nil {
+		t.Fatalf("claimSlotIndex (B) = %v, want a reclaimed index", err)
+	}
+
+	close(release) // let A proceed: its merge loses the cooldown race to B's
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("claimSlotIndex (A) = %v, want a reclaimed index — A's own scan lost the cooldown race, but B had already refilled freeSlots", err)
+	}
+}
+
 // TestReclaimUnusedSlots_CooldownSkipsRescan pins the pacing: a host that is
 // truly out of slots must not rescan on every claim.
 func TestReclaimUnusedSlots_CooldownSkipsRescan(t *testing.T) {


### PR DESCRIPTION
## Summary
Intermittent sandbox-creation failures on us-west (usw2) persisted after #348/#350 landed. Root cause: `claimSlotIndex` held the single global `Manager.mu` across the reclaim scan added in #348 — two full directory reads (`/run/netns`, `/sys/class/net`, tens of thousands of entries at the ceiling) plus a loop over up to `MaxSlots` (65,000 as of #350) indexes. Every other slot claim on the host, including an on-demand `RestoreSnapshot` build racing the API's gRPC deadline, blocked on that lock for the scan's full duration — exactly when the host is under the most pressure (fresh index range spent).

## Technical decisions
- `reclaimUnusedSlots` (renamed from `reclaimUnusedSlotsLocked`) now manages its own locking: the directory reads run unlocked; only the cooldown check and the final in-memory merge into `freeSlots` take the lock, with a re-check of the cooldown after reacquiring it in case a concurrent caller scanned first.
- `claimSlotIndex` unlocks before calling the reclaim, relocks after, and re-reads state from the top of its loop — standard recheck-after-reacquire, no new invariants.
- Scoped to this lock-contention fix only. Two other threads from the investigation (tap-reset-on-recycle churn forcing full rebuilds, and the reconciler's chronic auto-fail budget exhaustion on usw2) are separate and need more evidence before touching — not addressed here.

## Testing
- `GOOS=linux go build ./... ` and `go vet` clean.
- Full `internal/network` suite green, including `-race -count=3` (Docker `golang:1.25`, since nftables deps are Linux-only).
- Updated the 4 test call sites that previously held `m.mu` themselves before calling the (now self-locking) reclaim function.