### PR TITLE
vmd: fix pinned-slot reclaim hang; gate VMD deploys on CI

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -51,8 +51,48 @@ on:
       - '.github/workflows/scripts/deploy-vmd.py'
 
 jobs:
+  # Failing CI must not reach production control-plane hosts. CI is a
+  # separate workflow, so `needs:` can't reach it directly — poll the
+  # same-SHA run instead, same pattern as Deploy API's wait-for-migrations.
+  wait-for-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for same-SHA CI to succeed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "Manual dispatch — operator owns this decision; skipping gate."
+            exit 0
+          fi
+
+          # CI runs on every push to main (no path filter), so a run for this
+          # SHA always exists — poll until it's visible and completed. ~20 min
+          # budget (60 × 20s), then fail closed: a deploy built from code that
+          # hasn't passed CI is worse than a late deploy.
+          for i in $(seq 1 60); do
+            run=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&event=push" \
+              --jq '.workflow_runs[0] | if . == null then "absent absent" else "\(.status) \(.conclusion // "pending")" end')
+            status=${run% *}; conclusion=${run#* }
+            echo "attempt $i: status=$status conclusion=$conclusion"
+            if [ "$status" = "completed" ]; then
+              if [ "$conclusion" = "success" ]; then
+                echo "CI succeeded; proceeding."
+                exit 0
+              fi
+              echo "CI concluded '$conclusion' — refusing to deploy unvalidated code."
+              exit 1
+            fi
+            sleep 20
+          done
+          echo "Timed out waiting for CI; refusing to deploy."
+          exit 1
+
   deploy-staging:
     runs-on: ubuntu-latest
+    needs: [wait-for-ci]
     environment: staging
     permissions:
       contents: read

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -961,6 +961,16 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				ceiling = m.maxSlot // WithExactSlot: allow only the pinned index
 			}
 			if m.nextSlot > ceiling {
+				if m.slotPinned {
+					// A reclaim scan only ever refills freeSlots, which a
+					// pinned claim never draws from (see the comment above)
+					// — so it cannot turn this failure into a success.
+					// Skip straight to failing instead of looping forever:
+					// freeSlots staying populated (nothing here ever drains
+					// it) would otherwise keep re-passing the check below.
+					m.mu.Unlock()
+					return 0, ErrNoSlots
+				}
 				// Out of fresh range, which is not the same as out of slots:
 				// indexes are discarded (never returned) whenever a namespace
 				// outlives them, so the gaps below are the only inventory left.
@@ -981,7 +991,10 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				// loses it, in which case this call's own n is 0 even though
 				// the winner just refilled freeSlots. Trusting n here would
 				// fail this claim with ErrNoSlots despite slots being
-				// available right now.
+				// available right now. (Safe from the same loop risk as the
+				// pinned branch above: freeSlots is drained by the pop at
+				// the top of this loop on every non-pinned iteration, so
+				// this always terminates.)
 				if len(m.freeSlots) > 0 {
 					continue
 				}

--- a/internal/network/manager_test.go
+++ b/internal/network/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -312,6 +313,8 @@ func TestClaimSlotIndex_ConcurrentCeilingLoserStillGetsReclaimedSlot(t *testing.
 	m := newTestManager()
 	m.nextSlot = MaxSlots + 1 // fresh range spent; every index below is reclaimable
 
+	const waitBound = 10 * time.Second
+
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
@@ -331,18 +334,31 @@ func TestClaimSlotIndex_ConcurrentCeilingLoserStillGetsReclaimedSlot(t *testing.
 		errCh <- err
 	}()
 
-	<-entered // A is parked mid-scan, holding no lock
+	// A is parked mid-scan, holding no lock. Bounded so an unexpected path
+	// that never reaches the barrier fails fast instead of hanging the suite.
+	select {
+	case <-entered:
+	case <-time.After(waitBound):
+		close(release) // free A's goroutine (a no-op if it's not there) before failing
+		t.Fatal("timed out waiting for A to reach the scan barrier — claimSlotIndex took a path that never scans")
+	}
 
 	// B runs a full claim — including its own reclaim, which is free to merge
 	// since A hasn't reached the merge step yet — while A is still parked.
 	if _, err := m.claimSlotIndex("vm-b"); err != nil {
+		close(release)
 		t.Fatalf("claimSlotIndex (B) = %v, want a reclaimed index", err)
 	}
 
 	close(release) // let A proceed: its merge loses the cooldown race to B's
 
-	if err := <-errCh; err != nil {
-		t.Fatalf("claimSlotIndex (A) = %v, want a reclaimed index — A's own scan lost the cooldown race, but B had already refilled freeSlots", err)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("claimSlotIndex (A) = %v, want a reclaimed index — A's own scan lost the cooldown race, but B had already refilled freeSlots", err)
+		}
+	case <-time.After(waitBound):
+		t.Fatal("timed out waiting for claimSlotIndex (A) to return after release")
 	}
 }
 


### PR DESCRIPTION
## Summary
Two follow-ups after #353 merged:

1. **Fixes a hang #353 introduced.** #353 changed the ceiling-branch retry in `claimSlotIndex` to recheck `freeSlots` after a reclaim scan instead of trusting the scan's own return value — correct for the general pool (a claim that finds `freeSlots` non-empty always pops one, draining it each iteration). But a `WithExactSlot` (pinned) claim never draws from `freeSlots` at all, so a reclaim triggered by its own ceiling failure fills `freeSlots` with entries nothing will ever consume, and the retry check kept finding it non-empty forever. `TestClaimSlotIndex_ExactSlotDoesNotAdvance` hung the whole `internal/network` package when run as part of the full suite — this is what was stuck in both the PR's CI and the post-merge run on main. A `-run`-scoped run of just the new test never reproduced it, which is how it slipped through. Fix: reclaim can never help a pinned claim (it only ever refills `freeSlots`), so skip straight to `ErrNoSlots` for the pinned case instead of scanning.
2. **Gates VMD deploys on CI.** `Deploy VMD` triggers independently off `push: branches: [main]` with no dependency on `CI` at all — a red or hung unit-tests run doesn't block staging/production rollout. Adds a `wait-for-ci` job that polls the same-SHA `CI` run, same pattern as Deploy API's `wait-for-migrations` (`needs:` can't reach a job in a different workflow). Manual `workflow_dispatch` skips the gate — operator owns that call.

## Technical decisions
- Also hardened the new concurrency regression test from #353 with explicit `select`/timeout bounds on its channel waits, so a real hang fails fast with a clear message instead of taking down CI if this class of bug recurs.
- `wait-for-ci` fails closed (deploy refused) on CI failure or a ~20 min timeout waiting for the run to appear/complete — mirrors `wait-for-migrations`'s budget and reasoning exactly.

## Testing
- `go build`/`go vet` clean (`internal/network`).
- Full `internal/network` suite green under `go test -v -short -race ./...` in a Linux container — including `TestClaimSlotIndex_ExactSlotDoesNotAdvance`, which previously hung indefinitely and now completes instantly.