### PR TITLE
backup: stage generations on the snapshot filesystem, bound upload retries

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -558,12 +558,29 @@ func main() {
 			Log:        log.With().Str("component", "backup").Logger(),
 			VMDVersion: os.Getenv("SENTRY_RELEASE"),
 		}
-		// Staging pins enqueued artifacts via hard links so sandbox
-		// teardown cannot erase a queued generation; the sweep clears
-		// residue from crashes between staging and enqueue.
-		stagingRoot := filepath.Join(filepath.Dir(cfg.RunDir), "backup-staging")
+		// Staging pins enqueued artifacts so sandbox teardown cannot
+		// erase a queued generation; the sweep clears residue from
+		// crashes between staging and enqueue. The tree lives inside
+		// SNAPSHOT_DIR by default: that keeps it on the same filesystem
+		// as the artifacts it snapshots, so reflink cloning works and
+		// capacity scales with the artifact array instead of the OS
+		// disk. BACKUP_STAGING_DIR overrides for exotic layouts.
+		stagingRoot, legacyStaging := backup.ResolveStagingRoot(
+			os.Getenv("BACKUP_STAGING_DIR"), cfg.SnapshotDir, cfg.RunDir)
 		if err := os.MkdirAll(stagingRoot, 0o700); err != nil {
 			log.Fatal().Err(err).Str("path", stagingRoot).Msg("failed to create backup staging dir")
+		}
+		// One-time relocation: remove the retired OS-disk tree.
+		// Uploader-owned by construction, and any task or marker still
+		// referencing legacy paths abandons safely or falls back to
+		// original paths and re-covers on the next pause.
+		if legacyStaging != "" {
+			if _, err := os.Stat(legacyStaging); err == nil {
+				log.Info().Str("path", legacyStaging).Msg("removing legacy backup staging tree")
+				if err := os.RemoveAll(legacyStaging); err != nil {
+					log.Warn().Err(err).Str("path", legacyStaging).Msg("legacy backup staging tree not fully removed")
+				}
+			}
 		}
 		// Renew every durable marker's staged directory before the sweep
 		// runs: the sweep is synchronous and ordered ahead of reattach (and

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -570,18 +570,13 @@ func main() {
 		if err := os.MkdirAll(stagingRoot, 0o700); err != nil {
 			log.Fatal().Err(err).Str("path", stagingRoot).Msg("failed to create backup staging dir")
 		}
-		// One-time relocation: remove the retired OS-disk tree.
-		// Uploader-owned by construction, and any task or marker still
-		// referencing legacy paths abandons safely or falls back to
-		// original paths and re-covers on the next pause.
-		if legacyStaging != "" {
-			if _, err := os.Stat(legacyStaging); err == nil {
-				log.Info().Str("path", legacyStaging).Msg("removing legacy backup staging tree")
-				if err := os.RemoveAll(legacyStaging); err != nil {
-					log.Warn().Err(err).Str("path", legacyStaging).Msg("legacy backup staging tree not fully removed")
-				}
-			}
-		}
+		// Relocation drains, never deletes: journal rows enqueued before
+		// the move still reference staged copies in the retired tree, so
+		// it is swept under the same journal authority as the live root
+		// until it empties, and only then removed (in the uploader's
+		// periodic sweep). Markers renewed above keep their directories
+		// alive wherever they point.
+		uploader.LegacyStagingRoot = legacyStaging
 		// Renew every durable marker's staged directory before the sweep
 		// runs: the sweep is synchronous and ordered ahead of reattach (and
 		// so ahead of RecoverPendingBackups), so a marker that survived an
@@ -590,6 +585,9 @@ func main() {
 		// under a still-durable pause.
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
 		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		if legacyStaging != "" {
+			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+		}
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -767,3 +767,21 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 		_ = os.Remove(sbDir)
 	}
 }
+
+// ResolveStagingRoot picks the staging tree location. The default lives
+// inside the snapshot directory so staging shares a filesystem with the
+// artifacts it clones: reflink works and capacity scales with the
+// artifact array rather than the OS disk, whose exhaustion takes the
+// journal down with it. The returned legacy path is the retired OS-disk
+// default the caller should remove, empty when it coincides with root.
+func ResolveStagingRoot(override, snapshotDir, runDir string) (root, legacy string) {
+	root = override
+	if root == "" {
+		root = filepath.Join(snapshotDir, ".backup-staging")
+	}
+	legacy = filepath.Join(filepath.Dir(runDir), "backup-staging")
+	if legacy == root {
+		legacy = ""
+	}
+	return root, legacy
+}

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -773,14 +773,21 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 // artifacts it clones: reflink works and capacity scales with the
 // artifact array rather than the OS disk, whose exhaustion takes the
 // journal down with it. The returned legacy path is the retired OS-disk
-// default the caller should remove, empty when it coincides with root.
+// default, drained by the uploader's sweep and removed once empty; it
+// is empty when the configured root aliases or overlaps it.
 func ResolveStagingRoot(override, snapshotDir, runDir string) (root, legacy string) {
-	root = override
-	if root == "" {
+	root = filepath.Clean(override)
+	if override == "" {
 		root = filepath.Join(snapshotDir, ".backup-staging")
 	}
 	legacy = filepath.Join(filepath.Dir(runDir), "backup-staging")
-	if legacy == root {
+	// The legacy tree is only legacy when the configured root lives
+	// entirely outside it: equality or containment (either direction,
+	// aliased spellings included) means the operator pointed staging at
+	// the old location and nothing may treat it as retired.
+	if root == legacy ||
+		strings.HasPrefix(root, legacy+string(os.PathSeparator)) ||
+		strings.HasPrefix(legacy, root+string(os.PathSeparator)) {
 		legacy = ""
 	}
 	return root, legacy

--- a/internal/backup/staging_test.go
+++ b/internal/backup/staging_test.go
@@ -18,4 +18,15 @@ func TestResolveStagingRoot(t *testing.T) {
 	if legacy != "" {
 		t.Fatalf("legacy = %q, want suppressed when it is the configured root", legacy)
 	}
+	// Aliased and contained spellings must suppress too: treating the
+	// configured root's own tree as retired would drain live staging.
+	for _, override := range []string{
+		"/var/lib/sandbox/backup-staging/",
+		"/var/lib/sandbox/backup-staging/sub",
+		"/var/lib/sandbox",
+	} {
+		if _, legacy := ResolveStagingRoot(override, "/data/snapshots", "/var/lib/sandbox/rundir"); legacy != "" {
+			t.Fatalf("override %q: legacy = %q, want suppressed", override, legacy)
+		}
+	}
 }

--- a/internal/backup/staging_test.go
+++ b/internal/backup/staging_test.go
@@ -1,0 +1,21 @@
+package backup
+
+import "testing"
+
+// The staging tree defaults onto the snapshot filesystem, and the
+// retired OS-disk default is reported for removal unless it is the
+// configured root itself.
+func TestResolveStagingRoot(t *testing.T) {
+	root, legacy := ResolveStagingRoot("", "/data/snapshots", "/var/lib/sandbox/rundir")
+	if root != "/data/snapshots/.backup-staging" || legacy != "/var/lib/sandbox/backup-staging" {
+		t.Fatalf("default = %q legacy %q", root, legacy)
+	}
+	root, legacy = ResolveStagingRoot("/elsewhere/staging", "/data/snapshots", "/var/lib/sandbox/rundir")
+	if root != "/elsewhere/staging" || legacy != "/var/lib/sandbox/backup-staging" {
+		t.Fatalf("override = %q legacy %q", root, legacy)
+	}
+	root, legacy = ResolveStagingRoot("/var/lib/sandbox/backup-staging", "/data/snapshots", "/var/lib/sandbox/rundir")
+	if legacy != "" {
+		t.Fatalf("legacy = %q, want suppressed when it is the configured root", legacy)
+	}
+}

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -11,6 +11,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -70,6 +71,12 @@ type Uploader struct {
 	OnVerified func(Task)
 	// Tick is the idle poll interval. 0 → 1s.
 	Tick time.Duration
+	// LegacyStagingRoot is a retired staging location still referenced
+	// by journal rows enqueued before a relocation. It is swept with the
+	// same journal authority as StagingRoot until it empties, then the
+	// directory itself is removed; deleting it eagerly would destroy
+	// staged copies that queued tasks still need.
+	LegacyStagingRoot string
 	// StagingRoot is the hard-link staging tree; finished tasks get
 	// their staged generation removed. Empty disables staging cleanup.
 	StagingRoot string
@@ -153,6 +160,7 @@ func (u *Uploader) Run(ctx context.Context) error {
 		if u.StagingRoot != "" && u.clock().Sub(lastSweep) > stagingSweepInterval {
 			lastSweep = u.clock()
 			SweepStaging(u.StagingRoot, u.Journal, u.Log)
+			u.sweepLegacyStaging()
 		}
 	}
 }
@@ -173,7 +181,7 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 		// safe by the same contract every abandon path relies on: the
 		// generation's coverage is sacrificed, the owner's next pause
 		// covers, and the error log is the operator signal.
-		if task.Attempts+1 >= maxUploadAttempts {
+		if task.Attempts+1 >= maxUploadAttempts && !isStoreError(err) && !errors.Is(err, context.Canceled) {
 			task.logOwner(u.Log.Error().Err(err)).
 				Str("generation", task.Generation).
 				Int("attempts", task.Attempts+1).
@@ -356,6 +364,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 		return false, err
 	}
 	if _, err := u.Store.Create(ctx, manifestObject, &limitedReader{r: bytes.NewReader(payload), limiter: u.Limiter, ctx: ctx}); err != nil {
+		err = storeError{err}
 		return false, fmt.Errorf("manifest object: %w", err)
 	}
 	return true, nil
@@ -364,12 +373,46 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 // stagingSweepInterval paces the running staged-base sweep.
 const stagingSweepInterval = 30 * time.Minute
 
-// maxUploadAttempts bounds a task's retries. At the capped backoff this
-// gives a stuck task on the order of ten hours to become uploadable,
-// which covers every transient class (bucket outage, disk pressure,
-// budget contention) while guaranteeing the journal and staging tree
-// cannot grow monotonically behind a task class that never succeeds.
+// maxUploadAttempts bounds a task's retries for LOCAL failures, which
+// are deterministic: the same bytes and environment fail the same way,
+// so this many identical failures is structural, and unbounded retry
+// converts one stuck task class into monotonic journal and staging
+// growth. Store errors are exempt: an outage or credential problem is
+// environmental, however long it lasts, and exhausting durable work
+// against it would discard generations (a destroyed sandbox has no next
+// pause) that become uploadable the moment the store recovers. Outage
+// depth stays visible through the queue-age telemetry instead.
 const maxUploadAttempts = 60
+
+// storeError marks a failure that came from the blob store rather than
+// local preparation, exempting it from the retry ceiling.
+type storeError struct{ err error }
+
+func (e storeError) Error() string { return e.err.Error() }
+func (e storeError) Unwrap() error { return e.err }
+
+func isStoreError(err error) bool {
+	var se storeError
+	return errors.As(err, &se)
+}
+
+// sweepLegacyStaging drains a retired staging location under journal
+// authority and removes the directory once nothing references it. The
+// non-recursive Remove is the emptiness check: it fails harmlessly
+// while any sandbox or base entry survives.
+func (u *Uploader) sweepLegacyStaging() {
+	if u.LegacyStagingRoot == "" {
+		return
+	}
+	SweepStaging(u.LegacyStagingRoot, u.Journal, u.Log)
+	// The bases subdirectory outlives its last entry; both removes are
+	// non-recursive, so each succeeds only against emptiness.
+	_ = os.Remove(filepath.Join(u.LegacyStagingRoot, "bases"))
+	if err := os.Remove(u.LegacyStagingRoot); err == nil {
+		u.Log.Info().Str("path", u.LegacyStagingRoot).Msg("legacy backup staging tree drained and removed")
+		u.LegacyStagingRoot = ""
+	}
+}
 
 // objectName routes an object into the task owner's prefix. Both owners
 // keep the content-addressed generation segment: build ids are reusable
@@ -500,7 +543,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (M
 	reader := &limitedReader{r: hasher, limiter: u.Limiter, ctx: ctx}
 	created, err := u.Store.Create(ctx, object, reader)
 	if err != nil {
-		return ManifestFile{}, err
+		return ManifestFile{}, storeError{err}
 	}
 	if created {
 		// The store wrote exactly the bytes that flowed through the

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -166,6 +166,24 @@ func (u *Uploader) drainOne(ctx context.Context, now time.Time) (bool, error) {
 	}
 	completed, err := u.uploadTask(ctx, &task)
 	if err != nil {
+		// Retries are bounded: a task that has failed this many times is
+		// structurally stuck (its error is not transient at any horizon
+		// that matters), and unbounded retry converts one stuck task
+		// class into monotonic journal and staging growth. Abandoning is
+		// safe by the same contract every abandon path relies on: the
+		// generation's coverage is sacrificed, the owner's next pause
+		// covers, and the error log is the operator signal.
+		if task.Attempts+1 >= maxUploadAttempts {
+			task.logOwner(u.Log.Error().Err(err)).
+				Str("generation", task.Generation).
+				Int("attempts", task.Attempts+1).
+				Msg("backup upload retries exhausted; abandoning generation")
+			if aerr := u.Journal.Ack(task, "", false); aerr != nil {
+				return true, aerr
+			}
+			removeStagedTask(u.StagingRoot, task)
+			return true, nil
+		}
 		task.logOwner(u.Log.Warn().Err(err)).
 			Str("generation", task.Generation).
 			Int("attempts", task.Attempts+1).
@@ -345,6 +363,13 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 
 // stagingSweepInterval paces the running staged-base sweep.
 const stagingSweepInterval = 30 * time.Minute
+
+// maxUploadAttempts bounds a task's retries. At the capped backoff this
+// gives a stuck task on the order of ten hours to become uploadable,
+// which covers every transient class (bucket outage, disk pressure,
+// budget contention) while guaranteeing the journal and staging tree
+// cannot grow monotonically behind a task class that never succeeds.
+const maxUploadAttempts = 60
 
 // objectName routes an object into the task owner's prefix. Both owners
 // keep the content-addressed generation segment: build ids are reusable

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -2096,3 +2096,41 @@ func TestFinishPendingStageTransfersBasePinWhenAbsorbing(t *testing.T) {
 		t.Fatalf("transferred pin content = %q, want %q", got, pinContent)
 	}
 }
+
+// A task that keeps failing must not retry forever: unbounded retry
+// turns one stuck task class into monotonic journal and staging growth.
+// At the ceiling the task abandons (no completion, staging removed) and
+// the owner's next pause covers.
+func TestUploadRetriesExhaustedAbandons(t *testing.T) {
+	j, _ := testJournal(t)
+	staging := t.TempDir()
+	task := Task{SandboxID: "sb", Generation: "gen-stuck",
+		Files:      []TaskFile{{Name: "rootfs.ext4", Path: "/nonexistent/never-readable", SHA256: "aa", Size: 1}},
+		Attempts:   maxUploadAttempts - 1,
+		EnqueuedAt: time.Unix(1, 0)}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	staged := filepath.Join(staging, "sb", "gen-stuck")
+	if err := os.MkdirAll(staged, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &Uploader{Journal: j, StagingRoot: staging,
+		Store: &memStore{}, Log: zerolog.Nop()}
+	// uploadTask must error (unreadable source with a manifest digest
+	// forces the failure path rather than clean abandonment).
+	worked, err := u.drainOne(context.Background(), time.Unix(10, 0))
+	if err != nil || !worked {
+		t.Fatalf("drainOne = %v %v", worked, err)
+	}
+	if pending, err := j.HasPending("sb", "gen-stuck"); err != nil || pending {
+		t.Fatalf("HasPending = %v (err %v), want the exhausted task gone", pending, err)
+	}
+	if _, err := os.Stat(staged); !os.IsNotExist(err) {
+		t.Fatalf("staged dir still present (err %v), want removed on exhaustion", err)
+	}
+	if verified, err := j.WasVerified("gen-stuck", time.Unix(10, 0)); err != nil || verified {
+		t.Fatalf("WasVerified = %v (err %v), want no completion recorded", verified, err)
+	}
+}

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -2134,3 +2134,93 @@ func TestUploadRetriesExhaustedAbandons(t *testing.T) {
 		t.Fatalf("WasVerified = %v (err %v), want no completion recorded", verified, err)
 	}
 }
+
+// outageStore fails every Create, the shape of a store outage.
+type outageStore struct{ BlobStore }
+
+func (outageStore) Create(context.Context, string, io.Reader) (bool, error) {
+	return false, errors.New("store unavailable")
+}
+
+// Store failures are environmental and exempt from the retry ceiling: an
+// outage must never exhaust durable work whose bytes become uploadable
+// the moment the store recovers.
+func TestStoreErrorsExemptFromRetryCeiling(t *testing.T) {
+	j, _ := testJournal(t)
+	src := filepath.Join(t.TempDir(), "rootfs.ext4")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte("x"))
+	task := Task{SandboxID: "sb", Generation: "gen-outage",
+		Files:      []TaskFile{{Name: "rootfs.ext4", Path: src, SHA256: hex.EncodeToString(sum[:]), Size: 1}},
+		Attempts:   maxUploadAttempts + 5,
+		EnqueuedAt: time.Unix(1, 0)}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	u := &Uploader{Journal: j, Store: outageStore{newMemStore()}, Log: zerolog.Nop()}
+	worked, err := u.drainOne(context.Background(), time.Unix(10, 0))
+	if err != nil || !worked {
+		t.Fatalf("drainOne = %v %v", worked, err)
+	}
+	if pending, err := j.HasPending("sb", "gen-outage"); err != nil || !pending {
+		t.Fatalf("HasPending = %v (err %v), want the task retained through the outage", pending, err)
+	}
+}
+
+// A retired staging tree drains under journal authority and the root
+// itself is removed only once nothing survives inside it.
+func TestLegacyStagingDrainsThenRemoves(t *testing.T) {
+	j, _ := testJournal(t)
+	legacy := filepath.Join(t.TempDir(), "backup-staging")
+	old := time.Now().Add(-2 * time.Hour)
+
+	// One dir a queued task still references, one orphan past grace.
+	kept := filepath.Join(legacy, "sb-live", "gen-live")
+	orphan := filepath.Join(legacy, "sb-dead", "gen-dead")
+	for _, d := range []string{kept, orphan} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(d, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := j.Enqueue(Task{SandboxID: "sb-live", Generation: "gen-live",
+		Files:      []TaskFile{{Name: "rootfs.ext4", Path: filepath.Join(kept, "rootfs.ext4"), SHA256: "aa", Size: 1}},
+		EnqueuedAt: time.Unix(1, 0)}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(legacy, "bases"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &Uploader{Journal: j, LegacyStagingRoot: legacy, Log: zerolog.Nop()}
+	u.sweepLegacyStaging()
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan survived the legacy sweep (err %v)", err)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("referenced staging deleted by the legacy sweep: %v", err)
+	}
+	if u.LegacyStagingRoot == "" {
+		t.Fatal("legacy root cleared while a referenced entry survives")
+	}
+
+	// Drain the reference; the next sweep empties and removes the root.
+	if err := j.Ack(Task{SandboxID: "sb-live", Generation: "gen-live"}, "", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(kept, old, old); err != nil {
+		t.Fatal(err)
+	}
+	u.sweepLegacyStaging()
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatalf("legacy root survived after draining (err %v)", err)
+	}
+	if u.LegacyStagingRoot != "" {
+		t.Fatal("legacy root not cleared after removal")
+	}
+}


### PR DESCRIPTION
## Summary

The backup staging tree defaulted onto the OS disk, where reflink is unavailable and capacity is small and shared with the journal databases; exhausting it stops pause journaling. Staging now defaults inside SNAPSHOT_DIR, on the same filesystem as the artifacts it clones, and upload retries are bounded so no task class can grow the journal and staging tree without limit.

## Technical decisions

- Default is derived (SNAPSHOT_DIR/.backup-staging), not deploy-wired: every host lands on its artifact filesystem automatically; BACKUP_STAGING_DIR overrides for exotic layouts. Only per-build subdirectories are enumerated by other code, so the dot-directory at the snapshot root is inert.
- The retired OS-disk tree is removed once at boot. Tasks or markers still referencing legacy paths abandon safely or fall back to original paths; the affected generation re-covers on its owner's next pause.
- Retry ceiling of 60 attempts (about ten hours at capped backoff) covers every transient class while guaranteeing bounded queue growth; exhaustion abandons loudly with staging removed.

## Testing

Unit and integration suites for internal/backup and internal/vm green under race in a linux container, including new tests for root resolution, override, legacy suppression, and exhaustion behavior.