### PR TITLE
fix: harden sandbox create retries

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -520,6 +520,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "503":
+          description: |
+            Temporary create failure. Retry the request after the outage
+            clears.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           $ref: "#/components/responses/InternalError"
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/netip"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -43,6 +45,63 @@ const sandboxQuotaErrCode = "SS001"
 func isSandboxQuotaErr(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == sandboxQuotaErrCode
+}
+
+// isTransientCreateDBErr reports DB errors that are likely to resolve on a
+// retry instead of indicating a permanent create failure. Postgres restart and
+// shutdown states surface as SQLSTATE 57P0x; a context timeout/cancel from the
+// bounded insert context means the DB stayed unavailable past the create budget.
+func isTransientCreateDBErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if pgconn.SafeToRetry(err) {
+		return true
+	}
+	var netErr interface{ Timeout() bool }
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.EOF) {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.Code {
+	case "57P01", "57P02", "57P03":
+		return true
+	default:
+		return false
+	}
+}
+
+func createSandboxTransientFailureReason(dbErr, vmdErr error) string {
+	switch {
+	case isVMDDeadline(vmdErr):
+		return "vmd timed out"
+	case isVMDUnavailable(vmdErr):
+		return fmt.Sprintf("vmd unavailable: %s", vmdErrorMessage(vmdErr))
+	case isTransientCreateDBErr(dbErr):
+		switch {
+		case errors.Is(dbErr, context.DeadlineExceeded):
+			return "database insert timed out"
+		case errors.Is(dbErr, context.Canceled):
+			return "database insert was canceled"
+		default:
+			var pgErr *pgconn.PgError
+			if errors.As(dbErr, &pgErr) {
+				return fmt.Sprintf("database restart: %s", pgErr.Code)
+			}
+			return "database insert is temporarily unavailable"
+		}
+	default:
+		return "sandbox create failed"
+	}
 }
 
 // respondQuotaExceeded best-effort fetches the team's cap for the message;
@@ -205,6 +264,12 @@ func (h *Handlers) vmdForHost(ctx context.Context, hostID string) (VMDClient, er
 
 // vmdTimeout is the default deadline for VMD gRPC calls.
 const vmdTimeout = 30 * time.Second
+
+// createInsertTimeout bounds the detached DB insert during sandbox create so a
+// Postgres restart cannot leave the write pending indefinitely after the boot
+// path has already given up. Kept at the same worst-case window as the
+// transient VMD retry budget.
+const createInsertTimeout = 2 * vmdTimeout
 
 // retryTransientBoot runs one vmd boot call under vmdTimeout and, when the
 // attempt dies on a transient — DeadlineExceeded, or Unavailable that
@@ -785,7 +850,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// VM unreachable — nothing to preserve; mark failed rather than
 			// wedge in 'resuming' (the CTE also closes any open interval).
 			log.Error().Err(perr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: PauseInstance failed, marking sandbox failed")
-			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID, sandbox.HostID)
+			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID, sandbox.HostID, false)
 			return
 		}
 		// Fresh deadline so a slow snapshot above can't starve the DB write.
@@ -1905,7 +1970,11 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// VMD's ~100-200ms create latency, shaving that much off the p50.
 	sandboxID := uuid.New()
 
-	insertCtx := context.WithoutCancel(c.Request.Context())
+	// The detached insert keeps the happy path parallel, but it still needs a
+	// deadline so a DB restart cannot let the write linger long after the boot
+	// path has already failed.
+	insertCtx, insertCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), createInsertTimeout)
+	defer insertCancel()
 
 	// The shape shown while the sandbox is 'starting' — and kept if the create
 	// fails before activation. ActivateSandbox overwrites it with the actuals
@@ -2062,6 +2131,11 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		return ip, vcpu, memMiB, err
 	})
 	tVmdEnd := time.Now()
+	if vmdErr != nil {
+		// A failed boot should stop the detached insert from materializing a row
+		// after the VM path has already given up.
+		insertCancel()
+	}
 
 	// Wait for the parallel INSERT to complete — its result determines
 	// how we handle a VMD failure (mark row failed vs. nothing to mark).
@@ -2075,35 +2149,66 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 
 	// Per-team sandbox count cap; raised by sandbox_quota_on_insert trigger.
 	quotaExceeded := isSandboxQuotaErr(dbErr)
+	transientCreateFailure := isTransientCreateDBErr(dbErr) || isVMDDeadline(vmdErr) || isVMDUnavailable(vmdErr)
+	transientReason := createSandboxTransientFailureReason(dbErr, vmdErr)
+
+	if dbErr != nil || vmdErr != nil {
+		// Any non-empty error can leave a VM behind, so clean it up best-effort
+		// before deciding which failure mode to report.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
+		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
+		cleanupCancel()
+	}
+
+	// If the create failed after the row may have been written, converge the
+	// sandbox to a terminal state asynchronously so the request does not sit on
+	// DB restarts or other transient cleanup work.
+	var failDone <-chan bool
+	if !templateRace && !quotaExceeded && (vmdErr != nil || transientCreateFailure) {
+		failDone = h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, hostID, dbErr != nil)
+	}
 
 	switch {
 	case dbErr != nil && vmdErr != nil:
-		// Both failed — nothing persisted, nothing to clean up.
-		log.Error().Err(dbErr).AnErr("vmd_err", vmdErr).Msg("CreateSandbox: DB and VMD both failed")
+		// Both failed — no durable row to keep, and cleanup above already ran
+		// best-effort in case the VM made it far enough to exist.
+		log.Error().Err(dbErr).AnErr("vmd_err", vmdErr).Str("reason", transientReason).Msg("CreateSandbox: DB and VMD both failed")
 		if templateRace {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
 			return
 		}
 		if quotaExceeded {
 			h.respondQuotaExceeded(c, teamID)
+			return
+		}
+		if isVMDFileMissing(vmdErr) {
+			respondError(c, ErrHostStateMissing)
+			return
+		}
+		if transientCreateFailure {
+			respondErrorMsg(c, "service_unavailable", sandboxCreateTransientResponseMessage, http.StatusServiceUnavailable)
 			return
 		}
 		respondError(c, ErrInternal)
 		return
 	case dbErr != nil:
-		// DB insert failed but VMD succeeded — destroy the orphan VM so
-		// it doesn't linger on the host. Use a detached context so client
-		// disconnect doesn't leak the VM.
-		log.Error().Err(dbErr).Str("sandbox_id", sandboxID.String()).Msg("CreateSandbox: INSERT failed, destroying orphan VM")
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
-		cleanupCancel()
+		// DB insert failed but VMD succeeded or failed independently — the VM
+		// was already cleaned up best-effort above.
+		log.Error().Err(dbErr).Str("sandbox_id", sandboxID.String()).Str("reason", transientReason).Msg("CreateSandbox: INSERT failed")
 		if templateRace {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
 			return
 		}
 		if quotaExceeded {
 			h.respondQuotaExceeded(c, teamID)
+			return
+		}
+		if isVMDFileMissing(vmdErr) {
+			respondError(c, ErrHostStateMissing)
+			return
+		}
+		if transientCreateFailure {
+			respondErrorMsg(c, "service_unavailable", sandboxCreateTransientResponseMessage, http.StatusServiceUnavailable)
 			return
 		}
 		respondError(c, ErrInternal)
@@ -2113,29 +2218,27 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// doesn't leave it stuck in "starting". The request middleware
 		// records the create failure metric from the HTTP status, so avoid
 		// emitting a second request-scoped transition here.
-		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Msg("VMD create/resume failed")
-		// A cancelled attempt can still complete on the host just after the
-		// deadline; best-effort destroy so a booted VM can't idle against a
-		// failed row until the reconciler sweeps it.
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
-		cleanupCancel()
-		failCtx, failCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), asyncTimeout)
-		defer failCancel()
-		if err := h.DB.UpdateSandboxStatus(failCtx, db.UpdateSandboxStatusParams{
-			ID:     sandbox.ID,
-			Status: db.SandboxStatusFailed,
-			TeamID: teamID,
-		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("mark failed after VMD create failure")
-		} // Bindings are written before RestoreSnapshot, so a restore failure
-		// leaves them; clear them or this dead sandbox still shows as bound.
-		_ = h.DB.DeleteSandboxSecrets(failCtx, sandbox.ID)
-		// FailedPrecondition from vmd = snapshot/mem file missing on host.
-		// Surfaces on the from_template restore path; map to 503 so the
-		// user understands this is ops-side, not a bad request.
+		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Str("reason", transientReason).Msg("VMD create/resume failed")
+		if dbErr == nil && transientCreateFailure && failDone != nil {
+			select {
+			case released := <-failDone:
+				if !released {
+					log.Warn().Str("sandbox_id", sandbox.ID.String()).Msg("failed-state reconciliation did not finish before create response")
+					respondError(c, ErrInternal)
+					return
+				}
+			case <-time.After(asyncTimeout):
+				log.Warn().Str("sandbox_id", sandbox.ID.String()).Msg("timed out waiting for failed-state reconciliation after create failure")
+				respondError(c, ErrInternal)
+				return
+			}
+		}
 		if isVMDFileMissing(vmdErr) {
 			respondError(c, ErrHostStateMissing)
+			return
+		}
+		if transientCreateFailure {
+			respondErrorMsg(c, "service_unavailable", sandboxCreateTransientResponseMessage, http.StatusServiceUnavailable)
 			return
 		}
 		respondError(c, ErrInternal)
@@ -2459,7 +2562,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		// already dead, "active" was a lie.
 		if isVMDNotFound(err) {
 			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
-			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, sandbox.HostID)
+			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, sandbox.HostID, false)
 			respondError(c, ErrSandboxGone)
 			return
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2149,6 +2149,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 
 	// Per-team sandbox count cap; raised by sandbox_quota_on_insert trigger.
 	quotaExceeded := isSandboxQuotaErr(dbErr)
+	vmdTransientFailure := isVMDDeadline(vmdErr) || isVMDUnavailable(vmdErr)
 	transientCreateFailure := isTransientCreateDBErr(dbErr) || isVMDDeadline(vmdErr) || isVMDUnavailable(vmdErr)
 	transientReason := createSandboxTransientFailureReason(dbErr, vmdErr)
 
@@ -2156,8 +2157,15 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// Any non-empty error can leave a VM behind, so clean it up best-effort
 		// before deciding which failure mode to report.
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), vmdTimeout)
-		_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
-		cleanupCancel()
+		if vmdErr != nil {
+			go func() {
+				defer cleanupCancel()
+				_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
+			}()
+		} else {
+			_ = vmd.DestroyInstance(cleanupCtx, sandboxID.String(), true)
+			cleanupCancel()
+		}
 	}
 
 	// If the create failed after the row may have been written, converge the
@@ -2183,6 +2191,10 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		}
 		if isVMDFileMissing(vmdErr) {
 			respondError(c, ErrHostStateMissing)
+			return
+		}
+		if vmdErr != nil && !vmdTransientFailure {
+			respondError(c, ErrInternal)
 			return
 		}
 		if transientCreateFailure {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2407,13 +2407,13 @@ func TestCreateSandbox_TransientVMDErrorCancelsPendingInsert(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			teamID := uuid.New()
 			insertCanceled := make(chan struct{})
-			var destroyed bool
+			var destroyed atomic.Bool
 			vmd := &stubVMD{
 				restoreFn: func(context.Context, string, string, string) (string, error) {
 					return "", tt.err
 				},
 				destroyFn: func(context.Context, string, bool) error {
-					destroyed = true
+					destroyed.Store(true)
 					return nil
 				},
 			}
@@ -2450,7 +2450,7 @@ func TestCreateSandbox_TransientVMDErrorCancelsPendingInsert(t *testing.T) {
 			if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
 				t.Fatalf("error code = %q, want service_unavailable", code)
 			}
-			if !destroyed {
+			if !destroyed.Load() {
 				t.Fatal("VM was not torn down after transient VMD failure")
 			}
 			select {
@@ -2516,11 +2516,13 @@ func TestCreateSandbox_PermanentVMDFailureReturnsInternalWithoutWaitingForCleanu
 	insertCanceled := make(chan struct{})
 	destroyStarted := make(chan struct{})
 	destroyRelease := make(chan struct{})
+	var destroyed atomic.Bool
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "", status.Error(codes.InvalidArgument, "bad restore request")
 		},
 		destroyFn: func(context.Context, string, bool) error {
+			destroyed.Store(true)
 			close(destroyStarted)
 			<-destroyRelease
 			return nil
@@ -2581,6 +2583,9 @@ func TestCreateSandbox_PermanentVMDFailureReturnsInternalWithoutWaitingForCleanu
 	default:
 		t.Fatal("detached insert was not canceled after permanent VMD failure")
 	}
+	if !destroyed.Load() {
+		t.Fatal("VM was not torn down after permanent VMD failure")
+	}
 }
 
 func TestCreateSandbox_TransientDBErrorReturnsRetryableFailure(t *testing.T) {
@@ -2591,14 +2596,14 @@ func TestCreateSandbox_TransientDBErrorReturnsRetryableFailure(t *testing.T) {
 	markRelease := make(chan struct{})
 	done := make(chan struct{})
 	sandboxID := uuid.New()
-	var destroyed bool
+	var destroyed atomic.Bool
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
 			<-insertFailed
 			return "10.0.0.9", nil
 		},
 		destroyFn: func(context.Context, string, bool) error {
-			destroyed = true
+			destroyed.Store(true)
 			return nil
 		},
 	}
@@ -2673,7 +2678,7 @@ func TestCreateSandbox_TransientDBErrorReturnsRetryableFailure(t *testing.T) {
 	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
 		t.Fatalf("error code = %q, want service_unavailable", code)
 	}
-	if !destroyed {
+	if !destroyed.Load() {
 		t.Fatal("orphan VM was not destroyed after transient DB failure")
 	}
 }
@@ -2682,7 +2687,7 @@ func TestCreateSandbox_TransientDBErrorSkipsMissingRowReconcile(t *testing.T) {
 	teamID := uuid.New()
 	insertFailed := make(chan struct{})
 	var lookupCalls atomic.Int32
-	var destroyed bool
+	var destroyed atomic.Bool
 	var markCalls atomic.Int32
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
@@ -2690,7 +2695,7 @@ func TestCreateSandbox_TransientDBErrorSkipsMissingRowReconcile(t *testing.T) {
 			return "10.0.0.9", nil
 		},
 		destroyFn: func(context.Context, string, bool) error {
-			destroyed = true
+			destroyed.Store(true)
 			return nil
 		},
 	}
@@ -2731,7 +2736,7 @@ func TestCreateSandbox_TransientDBErrorSkipsMissingRowReconcile(t *testing.T) {
 	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
 		t.Fatalf("error code = %q, want service_unavailable", code)
 	}
-	if !destroyed {
+	if !destroyed.Load() {
 		t.Fatal("orphan VM was not destroyed after transient DB failure")
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -2749,14 +2754,14 @@ func TestCreateSandbox_TransientDBErrorSkipsMissingRowReconcile(t *testing.T) {
 func TestCreateSandbox_VMDTransientFailureRetriesFailedStateWrite(t *testing.T) {
 	teamID := uuid.New()
 	sandboxID := uuid.New()
-	var destroyed bool
+	var destroyed atomic.Bool
 	var markCalls atomic.Int32
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "", status.Error(codes.Unavailable, "connection refused")
 		},
 		destroyFn: func(context.Context, string, bool) error {
-			destroyed = true
+			destroyed.Store(true)
 			return nil
 		},
 	}
@@ -2799,7 +2804,7 @@ func TestCreateSandbox_VMDTransientFailureRetriesFailedStateWrite(t *testing.T) 
 	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
 		t.Fatalf("error code = %q, want service_unavailable", code)
 	}
-	if !destroyed {
+	if !destroyed.Load() {
 		t.Fatal("VM was not torn down after VMD failure")
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -2813,13 +2818,13 @@ func TestCreateSandbox_VMDTransientFailureRetriesFailedStateWrite(t *testing.T) 
 
 func TestCreateSandbox_VMDTransientFailureWithoutReconciliationReturnsInternal(t *testing.T) {
 	teamID := uuid.New()
-	var destroyed bool
+	var destroyed atomic.Bool
 	vmd := &stubVMD{
 		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "", status.Error(codes.Unavailable, "connection refused")
 		},
 		destroyFn: func(context.Context, string, bool) error {
-			destroyed = true
+			destroyed.Store(true)
 			return nil
 		},
 	}
@@ -2859,7 +2864,7 @@ func TestCreateSandbox_VMDTransientFailureWithoutReconciliationReturnsInternal(t
 	if code := errorCode(parseJSON(t, w)); code != "internal_error" {
 		t.Fatalf("error code = %q, want internal_error", code)
 	}
-	if !destroyed {
+	if !destroyed.Load() {
 		t.Fatal("VM was not torn down after VMD failure")
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2450,13 +2450,17 @@ func TestCreateSandbox_TransientVMDErrorCancelsPendingInsert(t *testing.T) {
 			if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
 				t.Fatalf("error code = %q, want service_unavailable", code)
 			}
-			if !destroyed.Load() {
-				t.Fatal("VM was not torn down after transient VMD failure")
-			}
 			select {
 			case <-insertCanceled:
 			default:
 				t.Fatal("detached insert was not canceled after VMD failure")
+			}
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) && !destroyed.Load() {
+				time.Sleep(10 * time.Millisecond)
+			}
+			if !destroyed.Load() {
+				t.Fatal("VM was not torn down after transient VMD failure")
 			}
 		})
 	}
@@ -2582,6 +2586,10 @@ func TestCreateSandbox_PermanentVMDFailureReturnsInternalWithoutWaitingForCleanu
 	case <-insertCanceled:
 	default:
 		t.Fatal("detached insert was not canceled after permanent VMD failure")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !destroyed.Load() {
+		time.Sleep(10 * time.Millisecond)
 	}
 	if !destroyed.Load() {
 		t.Fatal("VM was not torn down after permanent VMD failure")
@@ -2863,6 +2871,10 @@ func TestCreateSandbox_VMDTransientFailureWithoutReconciliationReturnsInternal(t
 	}
 	if code := errorCode(parseJSON(t, w)); code != "internal_error" {
 		t.Fatalf("error code = %q, want internal_error", code)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !destroyed.Load() {
+		time.Sleep(10 * time.Millisecond)
 	}
 	if !destroyed.Load() {
 		t.Fatal("VM was not torn down after VMD failure")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -2390,6 +2391,404 @@ func TestCreateSandbox_QuotaExceeded(t *testing.T) {
 	}
 	if !destroyCalled {
 		t.Error("orphan VM was not destroyed after quota rejection")
+	}
+}
+
+func TestCreateSandbox_TransientVMDErrorCancelsPendingInsert(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "deadline exceeded", err: status.Error(codes.DeadlineExceeded, "context deadline exceeded")},
+		{name: "unavailable", err: status.Error(codes.Unavailable, "connection refused")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			teamID := uuid.New()
+			insertCanceled := make(chan struct{})
+			var destroyed bool
+			vmd := &stubVMD{
+				restoreFn: func(context.Context, string, string, string) (string, error) {
+					return "", tt.err
+				},
+				destroyFn: func(context.Context, string, bool) error {
+					destroyed = true
+					return nil
+				},
+			}
+
+			mock := &mockDBTX{
+				queryRowFn: func(ctx context.Context, sql string, _ ...any) pgx.Row {
+					if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+						return previewCapableHostRow()
+					}
+					if strings.Contains(sql, "-- name: GetSandbox :one") {
+						return errorRow(pgx.ErrNoRows)
+					}
+					if strings.Contains(sql, "INSERT INTO sandbox") {
+						return &mockRow{scanFn: func(dest ...any) error {
+							<-ctx.Done()
+							close(insertCanceled)
+							return ctx.Err()
+						}}
+					}
+					if strings.Contains(sql, "FROM template") {
+						return templateRow(defaultReadyTemplate())
+					}
+					return activityRow()
+				},
+			}
+
+			h := &Handlers{VMD: vmd, DB: db.New(mock)}
+			w := httptest.NewRecorder()
+			setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+			if w.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+			}
+			if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
+				t.Fatalf("error code = %q, want service_unavailable", code)
+			}
+			if !destroyed {
+				t.Fatal("VM was not torn down after transient VMD failure")
+			}
+			select {
+			case <-insertCanceled:
+			default:
+				t.Fatal("detached insert was not canceled after VMD failure")
+			}
+		})
+	}
+}
+
+func TestCreateSandbox_VMDFileMissingReturnsHostStateMissingEvenIfInsertCancels(t *testing.T) {
+	teamID := uuid.New()
+	insertCanceled := make(chan struct{})
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			return "", status.Error(codes.FailedPrecondition, "snapshot missing")
+		},
+		destroyFn: func(context.Context, string, bool) error { return nil },
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(ctx context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+				return previewCapableHostRow()
+			}
+			if strings.Contains(sql, "-- name: GetSandbox :one") {
+				return errorRow(pgx.ErrNoRows)
+			}
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				return &mockRow{scanFn: func(dest ...any) error {
+					<-ctx.Done()
+					close(insertCanceled)
+					return ctx.Err()
+				}}
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "host_state_missing" {
+		t.Fatalf("error code = %q, want host_state_missing", code)
+	}
+	select {
+	case <-insertCanceled:
+	default:
+		t.Fatal("detached insert was not canceled after file-missing VMD failure")
+	}
+}
+
+func TestCreateSandbox_TransientDBErrorReturnsRetryableFailure(t *testing.T) {
+	teamID := uuid.New()
+	insertFailed := make(chan struct{})
+	lookupStarted := make(chan struct{})
+	markStarted := make(chan struct{})
+	markRelease := make(chan struct{})
+	done := make(chan struct{})
+	sandboxID := uuid.New()
+	var destroyed bool
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			<-insertFailed
+			return "10.0.0.9", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed = true
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+				return previewCapableHostRow()
+			}
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				close(insertFailed)
+				return errorRow(&pgconn.PgError{Code: "57P03", Message: "the database system is starting up"})
+			}
+			if strings.Contains(sql, "-- name: GetSandbox :one") {
+				close(lookupStarted)
+				return sandboxRow(db.Sandbox{
+					ID: sandboxID, TeamID: teamID, Name: "sb",
+					Status: db.SandboxStatusStarting, VcpuCount: 1, MemoryMib: 256,
+					CreatedAt: time.Now(),
+				})
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "UPDATE sandbox\n  SET status = 'failed'") || strings.Contains(sql, "UPDATE sandbox\nSET status = 'failed'") {
+				<-lookupStarted
+				close(markStarted)
+				<-markRelease
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	go func() {
+		setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+		close(done)
+	}()
+
+	select {
+	case <-lookupStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("transient insert failure did not verify sandbox existence before marking failed")
+	}
+
+	select {
+	case <-markStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("failed-state write was not scheduled after transient DB failure")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("request waited on the failed-state write instead of returning 503")
+	}
+
+	close(markRelease)
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("request did not finish after releasing the failed-state write")
+	}
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
+		t.Fatalf("error code = %q, want service_unavailable", code)
+	}
+	if !destroyed {
+		t.Fatal("orphan VM was not destroyed after transient DB failure")
+	}
+}
+
+func TestCreateSandbox_TransientDBErrorSkipsMissingRowReconcile(t *testing.T) {
+	teamID := uuid.New()
+	insertFailed := make(chan struct{})
+	var lookupCalls atomic.Int32
+	var destroyed bool
+	var markCalls atomic.Int32
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			<-insertFailed
+			return "10.0.0.9", nil
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed = true
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+				return previewCapableHostRow()
+			}
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				close(insertFailed)
+				return errorRow(&pgconn.PgError{Code: "57P03", Message: "the database system is starting up"})
+			}
+			if strings.Contains(sql, "-- name: GetSandbox :one") {
+				lookupCalls.Add(1)
+				return errorRow(pgx.ErrNoRows)
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "UPDATE sandbox\n  SET status = 'failed'") || strings.Contains(sql, "UPDATE sandbox\nSET status = 'failed'") {
+				markCalls.Add(1)
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
+		t.Fatalf("error code = %q, want service_unavailable", code)
+	}
+	if !destroyed {
+		t.Fatal("orphan VM was not destroyed after transient DB failure")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && lookupCalls.Load() < 2 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := lookupCalls.Load(); got < 2 {
+		t.Fatalf("GetSandbox calls = %d, want repeated absent-row verification", got)
+	}
+	if got := markCalls.Load(); got != 0 {
+		t.Fatalf("failed-state write calls = %d, want no-op when sandbox row is absent", got)
+	}
+}
+
+func TestCreateSandbox_VMDTransientFailureRetriesFailedStateWrite(t *testing.T) {
+	teamID := uuid.New()
+	sandboxID := uuid.New()
+	var destroyed bool
+	var markCalls atomic.Int32
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			return "", status.Error(codes.Unavailable, "connection refused")
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed = true
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+				return previewCapableHostRow()
+			case strings.Contains(sql, "INSERT INTO sandbox"):
+				return sandboxRow(db.Sandbox{
+					ID: sandboxID, TeamID: teamID, Name: "sb",
+					Status: db.SandboxStatusStarting, VcpuCount: 1, MemoryMib: 256,
+					CreatedAt: time.Now(),
+				})
+			case strings.Contains(sql, "FROM template"):
+				return templateRow(defaultReadyTemplate())
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "UPDATE sandbox\n  SET status = 'failed'") || strings.Contains(sql, "UPDATE sandbox\nSET status = 'failed'") {
+				if markCalls.Add(1) == 1 {
+					return pgconn.CommandTag{}, &pgconn.PgError{Code: "57P01", Message: "the database system is shutting down"}
+				}
+				return pgconn.NewCommandTag("UPDATE 1"), nil
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "service_unavailable" {
+		t.Fatalf("error code = %q, want service_unavailable", code)
+	}
+	if !destroyed {
+		t.Fatal("VM was not torn down after VMD failure")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && markCalls.Load() < 2 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := markCalls.Load(); got < 2 {
+		t.Fatalf("failed-state write calls = %d, want retry after transient DB error", got)
+	}
+}
+
+func TestCreateSandbox_VMDTransientFailureWithoutReconciliationReturnsInternal(t *testing.T) {
+	teamID := uuid.New()
+	var destroyed bool
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			return "", status.Error(codes.Unavailable, "connection refused")
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			destroyed = true
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+				return previewCapableHostRow()
+			case strings.Contains(sql, "INSERT INTO sandbox"):
+				return sandboxRow(db.Sandbox{
+					ID: uuid.New(), TeamID: teamID, Name: "sb",
+					Status: db.SandboxStatusStarting, VcpuCount: 1, MemoryMib: 256,
+					CreatedAt: time.Now(),
+				})
+			case strings.Contains(sql, "FROM template"):
+				return templateRow(defaultReadyTemplate())
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "UPDATE sandbox\n  SET status = 'failed'") || strings.Contains(sql, "UPDATE sandbox\nSET status = 'failed'") {
+				return pgconn.CommandTag{}, errors.New("mark failed unavailable")
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "internal_error" {
+		t.Fatalf("error code = %q, want internal_error", code)
+	}
+	if !destroyed {
+		t.Fatal("VM was not torn down after VMD failure")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2511,6 +2511,78 @@ func TestCreateSandbox_VMDFileMissingReturnsHostStateMissingEvenIfInsertCancels(
 	}
 }
 
+func TestCreateSandbox_PermanentVMDFailureReturnsInternalWithoutWaitingForCleanup(t *testing.T) {
+	teamID := uuid.New()
+	insertCanceled := make(chan struct{})
+	destroyStarted := make(chan struct{})
+	destroyRelease := make(chan struct{})
+	vmd := &stubVMD{
+		restoreFn: func(context.Context, string, string, string) (string, error) {
+			return "", status.Error(codes.InvalidArgument, "bad restore request")
+		},
+		destroyFn: func(context.Context, string, bool) error {
+			close(destroyStarted)
+			<-destroyRelease
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(ctx context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+				return previewCapableHostRow()
+			}
+			if strings.Contains(sql, "-- name: GetSandbox :one") {
+				return errorRow(pgx.ErrNoRows)
+			}
+			if strings.Contains(sql, "INSERT INTO sandbox") {
+				return &mockRow{scanFn: func(dest ...any) error {
+					<-ctx.Done()
+					close(insertCanceled)
+					return ctx.Err()
+				}}
+			}
+			if strings.Contains(sql, "FROM template") {
+				return templateRow(defaultReadyTemplate())
+			}
+			return activityRow()
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"sb"}`))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request waited on cleanup after permanent VMD failure")
+	}
+
+	select {
+	case <-destroyStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not start after permanent VMD failure")
+	}
+	close(destroyRelease)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	if code := errorCode(parseJSON(t, w)); code != "internal_error" {
+		t.Fatalf("error code = %q, want internal_error", code)
+	}
+	select {
+	case <-insertCanceled:
+	default:
+		t.Fatal("detached insert was not canceled after permanent VMD failure")
+	}
+}
+
 func TestCreateSandbox_TransientDBErrorReturnsRetryableFailure(t *testing.T) {
 	teamID := uuid.New()
 	insertFailed := make(chan struct{})

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -128,29 +129,140 @@ func vmdErrorMessage(err error) string {
 	return err.Error()
 }
 
+const sandboxCreateTransientResponseMessage = "Sandbox create is temporarily unavailable."
+const sandboxCreateAbsentRowRetryWindow = 500 * time.Millisecond
+
 // markSandboxFailedAsync writes status=failed in a detached goroutine. The
 // underlying MarkSandboxFailedInTeam query is a CTE that also closes any
 // open sandbox_active_interval row atomically, so a crash/timeout between
-// the two writes is unreachable. Detaches cancellation so the state
-// transition survives client disconnect, but keeps the request's trace
-// context so the write appears in the same span.
-func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, teamID uuid.UUID, hostID string) {
+// the two writes is unreachable. When the create path got a transient insert
+// error, the caller asks this helper to first confirm the row exists so a
+// missing insert becomes a no-op instead of noisy retries.
+func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, teamID uuid.UUID, hostID string, verifyRow bool) <-chan bool {
 	asyncCtx := context.WithoutCancel(reqCtx)
+	done := make(chan bool, 1)
+	complete := func(ok bool) {
+		select {
+		case done <- ok:
+		default:
+		}
+	}
 	go func() {
+		defer close(done)
 		defer sentrylog.Recover("mark-failed-async")
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
 		started := time.Now()
-		if err := h.DB.MarkSandboxFailedInTeam(ctx, db.MarkSandboxFailedInTeamParams{
-			ID:     sandboxID,
-			TeamID: teamID,
-		}); err != nil {
-			RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async mark-failed write failed")
-			return
+		if verifyRow {
+			verifyDeadline := time.Now().Add(sandboxCreateAbsentRowRetryWindow)
+			backoff := 100 * time.Millisecond
+			for {
+				exists, err := h.sandboxExists(ctx, sandboxID, teamID)
+				if err == nil && exists {
+					break
+				}
+				if err == nil && !exists {
+					if time.Now().Before(verifyDeadline) && ctx.Err() == nil {
+						timer := time.NewTimer(backoff)
+						select {
+						case <-ctx.Done():
+							timer.Stop()
+							complete(true)
+							return
+						case <-timer.C:
+						}
+						if backoff < 250*time.Millisecond {
+							backoff *= 2
+						}
+						continue
+					}
+					complete(true)
+					return
+				}
+				if !isTransientCreateDBErr(err) || ctx.Err() != nil {
+					log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async verify sandbox before failed-state write failed")
+					RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
+					complete(false)
+					return
+				}
+				log.Warn().
+					Err(err).
+					Str("sandbox_id", sandboxID.String()).
+					Dur("retry_in", backoff).
+					Msg("async verify sandbox before failed-state write hit a transient DB error; retrying")
+				timer := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
+					complete(false)
+					return
+				case <-timer.C:
+				}
+				if backoff < 2*time.Second {
+					backoff *= 2
+				}
+			}
 		}
-		RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
+		backoff := 100 * time.Millisecond
+		for {
+			err := h.DB.MarkSandboxFailedInTeam(ctx, db.MarkSandboxFailedInTeamParams{
+				ID:     sandboxID,
+				TeamID: teamID,
+			})
+			if err == nil {
+				if secErr := h.DB.DeleteSandboxSecrets(ctx, sandboxID); secErr != nil {
+					log.Warn().Err(secErr).Str("sandbox_id", sandboxID.String()).Msg("async clear secret bindings after failed state failed")
+				}
+				RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
+				complete(true)
+				return
+			}
+			if errors.Is(err, pgx.ErrNoRows) {
+				RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
+				complete(true)
+				return
+			}
+			if !isTransientCreateDBErr(err) || ctx.Err() != nil {
+				RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
+				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async mark-failed write failed")
+				complete(false)
+				return
+			}
+			log.Warn().
+				Err(err).
+				Str("sandbox_id", sandboxID.String()).
+				Dur("retry_in", backoff).
+				Msg("async mark-failed write hit a transient DB error; retrying")
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
+				complete(false)
+				return
+			case <-timer.C:
+			}
+			if backoff < 2*time.Second {
+				backoff *= 2
+			}
+		}
 	}()
+	return done
+}
+
+func (h *Handlers) sandboxExists(ctx context.Context, sandboxID, teamID uuid.UUID) (bool, error) {
+	_, err := h.DB.GetSandbox(ctx, db.GetSandboxParams{
+		ID:     sandboxID,
+		TeamID: teamID,
+	})
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
 }
 
 // failSandboxAfterBoot destroys a running VM and marks the sandbox row as failed.

--- a/internal/api/vmd_retry_test.go
+++ b/internal/api/vmd_retry_test.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type retryableCreateErr struct{}
+
+func (retryableCreateErr) Error() string     { return "retryable create error" }
+func (retryableCreateErr) SafeToRetry() bool { return true }
 
 func TestRetryBootOnDeadline(t *testing.T) {
 	grpcDeadline := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
@@ -97,5 +103,17 @@ func TestIsVMDDeadline(t *testing.T) {
 	if isVMDDeadline(nil) || isVMDDeadline(errors.New("boom")) ||
 		isVMDDeadline(status.Error(codes.Unavailable, "x")) || isVMDDeadline(context.Canceled) {
 		t.Error("nil, plain, Unavailable, and Canceled must not classify")
+	}
+}
+
+func TestIsTransientCreateDBErr(t *testing.T) {
+	if !isTransientCreateDBErr(retryableCreateErr{}) {
+		t.Error("SafeToRetry errors should classify as transient create DB failures")
+	}
+	if !isTransientCreateDBErr(&pgconn.PgError{Code: "57P01", Message: "shutdown"}) {
+		t.Error("postgres restart SQLSTATE should classify as transient")
+	}
+	if isTransientCreateDBErr(errors.New("boom")) {
+		t.Error("plain errors must not classify as transient create DB failures")
 	}
 }


### PR DESCRIPTION
## Summary
- bound the detached sandbox insert so a Postgres restart cannot leave it pending indefinitely
- make failed-state reconciliation asynchronous and row-existence-aware for transient create failures
- broaden transient create classification for DB restart and VMD restart shapes
- return 503 for retryable create failures with clearer error messages

## Validation
- `gofmt -w internal/api/handlers.go internal/api/handlers_test.go internal/api/vmd_errors.go internal/api/vmd_retry_test.go`
- `GOCACHE=/private/tmp/codex-gocache go test ./internal/api -run 'Test(IsTransientCreateDBErr|CreateSandbox_(TransientVMDErrorCancelsPendingInsert|TransientDBErrorReturnsRetryableFailure|TransientDBErrorSkipsMissingRowReconcile|VMDTransientFailureRetriesFailedStateWrite|VMDError|QuotaExceeded))$' -count=1`

## Notes
- Insert failures now verify whether the sandbox row exists before attempting failed-state cleanup.
- Missing rows are treated as a no-op instead of noisy retries.