### PR TITLE
deploy: fix staging backup journal path (unblocks CD)

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -171,8 +171,10 @@ jobs:
           BACKUP_BUCKET: superserve-artifact-backup-staging-usc1
           # Keeps the backup journal off the root disk — it's written
           # continuously while backups drain and can stall the uploader
-          # if the (small) root disk fills.
-          BACKUP_JOURNAL_PATH: /mnt/localssd/backup.db
+          # if the (small) root disk fills. Staging is a smaller instance
+          # with no NVMe-backed local SSD (unlike use4/usw2), so this
+          # points at its attached persistent disk instead of /mnt/localssd.
+          BACKUP_JOURNAL_PATH: /mnt/sandbox-data/backup.db
           # Enables vmd's backup metrics exporter (host-local collector);
           # the backup alert policies read these series.
           OTEL_ENVIRONMENT: staging


### PR DESCRIPTION
## Summary

#359 hardcoded `BACKUP_JOURNAL_PATH=/mnt/localssd/backup.db` for all three deploy targets (staging, use4, usw2), based on manually verifying `/mnt/localssd` exists on use4 and usw2. Staging was never checked and doesn't have it — it's a smaller instance with no NVMe-backed local SSD. Its equivalent separate volume is mounted at `/mnt/sandbox-data`.

The mount-validation guard added in #359 correctly caught this and refused to deploy rather than silently falling back to the root disk — but that means every staging deploy has failed since #359 merged. `vmd` itself was untouched throughout (the guard runs before any host mutation), so this was a blocked deploy, not an outage.

## Fix

Point staging's `BACKUP_JOURNAL_PATH` at `/mnt/sandbox-data/backup.db` instead. Confirmed via SSH that `/mnt/sandbox-data` is a genuinely separate device from `/` on `superserve-vmd-staging` (device ids 2064 vs 2049), so the mount check will pass, and that a legacy journal exists at the RUN_DIR-derived default path for the migration logic to pick up.

## Testing

- YAML parse check
- Manually verified via SSH that `/mnt/sandbox-data` is mounted separately from root on `superserve-vmd-staging`, and that the pre-existing journal is at the expected legacy path for migration