### PR TITLE
grafana: add sandbox reporting views for live-count and failure panels

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -150,8 +150,13 @@ WHERE team_id = @team_id
        OR name ILIKE '%' || sqlc.narg('name_search')::text || '%');
 
 -- name: UpdateSandboxStatus :exec
+-- Generic status setter (reverts to 'active', boot-failure to 'failed',
+-- etc.). failed_at is guarded so any caller landing on 'failed' — present
+-- or future — gets a durable failure timestamp without having to know
+-- about it, same set-once semantics as MarkSandboxFailed.
 UPDATE sandbox
-SET status = $2, updated_at = now()
+SET status = $2, updated_at = now(),
+    failed_at = CASE WHEN $2 = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 
 -- name: UpdateSandboxHost :exec

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -300,7 +300,8 @@ WITH failed AS (
   -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
   -- and a stale one would resurface (or instantly fire) if the sandbox is
   -- ever returned to 'paused' by a recovery path.
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
+      failed_at = COALESCE(failed_at, now())
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
     AND sandbox.status = sqlc.arg(observed_status)
   RETURNING id
@@ -327,7 +328,8 @@ SELECT count(*) FROM failed;
 -- bundling of the active-interval close.
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
+      failed_at = COALESCE(failed_at, now())
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -90,7 +90,7 @@ WITH tpl AS (
   SELECT ins.id, (@secret_ids::uuid[])[i], (@env_keys::text[])[i], (@proxy_tokens::text[])[i]
   FROM ins, generate_subscripts(@secret_ids::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id;
 

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -150,13 +150,8 @@ WHERE team_id = @team_id
        OR name ILIKE '%' || sqlc.narg('name_search')::text || '%');
 
 -- name: UpdateSandboxStatus :exec
--- Generic status setter (reverts to 'active', boot-failure to 'failed',
--- etc.). failed_at is guarded so any caller landing on 'failed' — present
--- or future — gets a durable failure timestamp without having to know
--- about it, same set-once semantics as MarkSandboxFailed.
 UPDATE sandbox
-SET status = $2, updated_at = now(),
-    failed_at = CASE WHEN $2::sandbox_status = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
+SET status = $2, updated_at = now()
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 
 -- name: UpdateSandboxHost :exec
@@ -305,8 +300,7 @@ WITH failed AS (
   -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
   -- and a stale one would resurface (or instantly fire) if the sandbox is
   -- ever returned to 'paused' by a recovery path.
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
-      failed_at = COALESCE(failed_at, now())
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
     AND sandbox.status = sqlc.arg(observed_status)
   RETURNING id
@@ -333,8 +327,7 @@ SELECT count(*) FROM failed;
 -- bundling of the active-interval close.
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
-      failed_at = COALESCE(failed_at, now())
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -156,7 +156,7 @@ WHERE team_id = @team_id
 -- about it, same set-once semantics as MarkSandboxFailed.
 UPDATE sandbox
 SET status = $2, updated_at = now(),
-    failed_at = CASE WHEN $2 = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
+    failed_at = CASE WHEN $2::sandbox_status = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL;
 
 -- name: UpdateSandboxHost :exec

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -250,9 +250,10 @@ func sandboxRow(s db.Sandbox) *mockRow {
 		*dest[21].(*int32) = s.DiskMib
 		*dest[22].(**int32) = s.AutoDeleteSeconds
 		*dest[23].(*pgtype.Timestamptz) = s.AutoDeleteAt
-		if len(dest) == 25 {
+		*dest[24].(*pgtype.Timestamptz) = s.FailedAt
+		if len(dest) == 26 {
 			// GetSandboxWithPreviewPolicy: trailing COALESCE'd effective access.
-			*dest[24].(*string) = "legacy_public"
+			*dest[25].(*string) = "legacy_public"
 		}
 		return nil
 	}}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -174,9 +174,19 @@ type AnalyticsActiveSandboxCount struct {
 	ActiveSandboxes int64 `json:"active_sandboxes"`
 }
 
+type AnalyticsDailySandboxFailure struct {
+	Day      pgtype.Date `json:"day"`
+	Failures int64       `json:"failures"`
+}
+
 type AnalyticsDailySandboxStart struct {
 	Day    pgtype.Date `json:"day"`
 	Starts int64       `json:"starts"`
+}
+
+type AnalyticsSandboxActiveInterval struct {
+	StartedAt time.Time          `json:"started_at"`
+	EndedAt   pgtype.Timestamptz `json:"ended_at"`
 }
 
 type AnalyticsTeamHourlySpend struct {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -487,6 +487,7 @@ type Sandbox struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 type SandboxActiveInterval struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -2228,7 +2228,8 @@ func (q *Queries) UpdateSandboxPreviewAccess(ctx context.Context, arg UpdateSand
 
 const updateSandboxStatus = `-- name: UpdateSandboxStatus :exec
 UPDATE sandbox
-SET status = $2, updated_at = now()
+SET status = $2, updated_at = now(),
+    failed_at = CASE WHEN $2 = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL
 `
 
@@ -2238,6 +2239,10 @@ type UpdateSandboxStatusParams struct {
 	TeamID uuid.UUID     `json:"team_id"`
 }
 
+// Generic status setter (reverts to 'active', boot-failure to 'failed',
+// etc.). failed_at is guarded so any caller landing on 'failed' — present
+// or future — gets a durable failure timestamp without having to know
+// about it, same set-once semantics as MarkSandboxFailed.
 func (q *Queries) UpdateSandboxStatus(ctx context.Context, arg UpdateSandboxStatusParams) error {
 	_, err := q.db.Exec(ctx, updateSandboxStatus, arg.ID, arg.Status, arg.TeamID)
 	return err

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -783,7 +783,7 @@ WITH tpl AS (
   SELECT ins.id, ($21::uuid[])[i], ($22::text[])[i], ($23::text[])[i]
   FROM ins, generate_subscripts($21::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
@@ -839,6 +839,7 @@ type CreateSandboxFromTemplateWithSecretsRow struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 // CreateSandboxFromTemplate plus secret bindings in one statement (see
@@ -897,6 +898,7 @@ func (q *Queries) CreateSandboxFromTemplateWithSecrets(ctx context.Context, arg 
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1898,8 +1898,7 @@ WITH failed AS (
   -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
   -- and a stale one would resurface (or instantly fire) if the sandbox is
   -- ever returned to 'paused' by a recovery path.
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
-      failed_at = COALESCE(failed_at, now())
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
     AND sandbox.status = $2
   RETURNING id
@@ -1953,8 +1952,7 @@ func (q *Queries) MarkSandboxFailed(ctx context.Context, arg MarkSandboxFailedPa
 const markSandboxFailedInTeam = `-- name: MarkSandboxFailedInTeam :exec
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
-      failed_at = COALESCE(failed_at, now())
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),
@@ -2228,8 +2226,7 @@ func (q *Queries) UpdateSandboxPreviewAccess(ctx context.Context, arg UpdateSand
 
 const updateSandboxStatus = `-- name: UpdateSandboxStatus :exec
 UPDATE sandbox
-SET status = $2, updated_at = now(),
-    failed_at = CASE WHEN $2::sandbox_status = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
+SET status = $2, updated_at = now()
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL
 `
 
@@ -2239,10 +2236,6 @@ type UpdateSandboxStatusParams struct {
 	TeamID uuid.UUID     `json:"team_id"`
 }
 
-// Generic status setter (reverts to 'active', boot-failure to 'failed',
-// etc.). failed_at is guarded so any caller landing on 'failed' — present
-// or future — gets a durable failure timestamp without having to know
-// about it, same set-once semantics as MarkSandboxFailed.
 func (q *Queries) UpdateSandboxStatus(ctx context.Context, arg UpdateSandboxStatusParams) error {
 	_, err := q.db.Exec(ctx, updateSandboxStatus, arg.ID, arg.Status, arg.TeamID)
 	return err

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -110,7 +110,7 @@ WITH paused AS (
     AND sandbox.team_id = $2
     AND sandbox.destroyed_at IS NULL
     AND sandbox.status = 'active'
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 ),
 closed_interval AS (
   UPDATE sandbox_active_interval
@@ -126,7 +126,7 @@ closed_billing_compute AS (
     AND ended_at IS NULL
   RETURNING sandbox_id
 )
-SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at
+SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at, p.failed_at
 FROM paused p
 LEFT JOIN closed_interval ci ON ci.sandbox_id = p.id
 `
@@ -161,6 +161,7 @@ type BeginPauseRow struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 // Atomic ownership + state check + transition to 'pausing' AND close of any
@@ -201,6 +202,7 @@ func (q *Queries) BeginPause(ctx context.Context, arg BeginPauseParams) (BeginPa
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -209,7 +211,7 @@ const beginResume = `-- name: BeginResume :one
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 `
 
 type BeginResumeParams struct {
@@ -249,6 +251,7 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -506,13 +509,13 @@ const createSandbox = `-- name: CreateSandbox :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -563,6 +566,7 @@ type CreateSandboxRow struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 // ID is supplied by the caller (generated in Go via uuid.New()) rather
@@ -623,6 +627,7 @@ func (q *Queries) CreateSandbox(ctx context.Context, arg CreateSandboxParams) (C
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -637,13 +642,13 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
   SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib, $20 FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $21::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -696,6 +701,7 @@ type CreateSandboxFromTemplateRow struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 // CreateSandbox variant that holds FOR KEY SHARE on the template row
@@ -752,6 +758,7 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -766,7 +773,7 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds)
   SELECT $4, $2, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, tpl_id, $15, $16, $17, $18, disk_mib, $19 FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $20::text, 0 FROM ins
@@ -898,7 +905,7 @@ const createSandboxWithSecrets = `-- name: CreateSandboxWithSecrets :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
@@ -908,7 +915,7 @@ WITH ins AS (
   SELECT ins.id, ($20::uuid[])[i], ($21::text[])[i], ($22::text[])[i]
   FROM ins, generate_subscripts($20::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -962,6 +969,7 @@ type CreateSandboxWithSecretsRow struct {
 	DiskMib           int32              `json:"disk_mib"`
 	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
 	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 }
 
 // CreateSandbox plus its strict preview policy and secret bindings in ONE
@@ -1020,6 +1028,7 @@ func (q *Queries) CreateSandboxWithSecrets(ctx context.Context, arg CreateSandbo
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -1370,7 +1379,7 @@ func (q *Queries) GetPublishedPreviewPort(ctx context.Context, arg GetPublishedP
 }
 
 const getSandbox = `-- name: GetSandbox :one
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
 `
 
@@ -1407,6 +1416,7 @@ func (q *Queries) GetSandbox(ctx context.Context, arg GetSandboxParams) (Sandbox
 		&i.DiskMib,
 		&i.AutoDeleteSeconds,
 		&i.AutoDeleteAt,
+		&i.FailedAt,
 	)
 	return i, err
 }
@@ -1497,7 +1507,7 @@ func (q *Queries) GetSandboxStatusForPreviewMutation(ctx context.Context, arg Ge
 }
 
 const getSandboxWithPreviewPolicy = `-- name: GetSandboxWithPreviewPolicy :one
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at,
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at,
   COALESCE(p.default_access, p.access, 'legacy_public')::text AS access
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
@@ -1544,6 +1554,7 @@ func (q *Queries) GetSandboxWithPreviewPolicy(ctx context.Context, arg GetSandbo
 		&i.Sandbox.DiskMib,
 		&i.Sandbox.AutoDeleteSeconds,
 		&i.Sandbox.AutoDeleteAt,
+		&i.Sandbox.FailedAt,
 		&i.Access,
 	)
 	return i, err
@@ -1704,7 +1715,7 @@ func (q *Queries) ListSandboxPreviewPoliciesByTeam(ctx context.Context, teamID u
 }
 
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, snap.path AS snapshot_path
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, snap.path AS snapshot_path
 FROM sandbox s
 LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL
@@ -1751,6 +1762,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 			&i.Sandbox.DiskMib,
 			&i.Sandbox.AutoDeleteSeconds,
 			&i.Sandbox.AutoDeleteAt,
+			&i.Sandbox.FailedAt,
 			&i.SnapshotPath,
 		); err != nil {
 			return nil, err
@@ -1764,7 +1776,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 }
 
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
 WHERE team_id = $1
   AND destroyed_at IS NULL
   AND metadata @> $2
@@ -1846,6 +1858,7 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 			&i.DiskMib,
 			&i.AutoDeleteSeconds,
 			&i.AutoDeleteAt,
+			&i.FailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1883,7 +1896,8 @@ WITH failed AS (
   -- auto_delete_at is cleared: the deadline is only meaningful in 'paused',
   -- and a stale one would resurface (or instantly fire) if the sandbox is
   -- ever returned to 'paused' by a recovery path.
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
+      failed_at = COALESCE(failed_at, now())
   WHERE sandbox.id = $1 AND sandbox.destroyed_at IS NULL
     AND sandbox.status = $2
   RETURNING id
@@ -1937,7 +1951,8 @@ func (q *Queries) MarkSandboxFailed(ctx context.Context, arg MarkSandboxFailedPa
 const markSandboxFailedInTeam = `-- name: MarkSandboxFailedInTeam :exec
 WITH failed AS (
   UPDATE sandbox
-  SET status = 'failed', auto_delete_at = NULL, updated_at = now()
+  SET status = 'failed', auto_delete_at = NULL, updated_at = now(),
+      failed_at = COALESCE(failed_at, now())
   WHERE sandbox.id = $1 AND sandbox.team_id = $2 AND sandbox.destroyed_at IS NULL
   RETURNING id
 ),

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -2229,7 +2229,7 @@ func (q *Queries) UpdateSandboxPreviewAccess(ctx context.Context, arg UpdateSand
 const updateSandboxStatus = `-- name: UpdateSandboxStatus :exec
 UPDATE sandbox
 SET status = $2, updated_at = now(),
-    failed_at = CASE WHEN $2 = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
+    failed_at = CASE WHEN $2::sandbox_status = 'failed' THEN COALESCE(failed_at, now()) ELSE failed_at END
 WHERE id = $1 AND team_id = $3 AND destroyed_at IS NULL
 `
 

--- a/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
+++ b/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
@@ -5,6 +5,14 @@
 -- PRIVILEGES in 20260730000002), so panels querying public tables directly
 -- fail with "permission denied".
 
+-- Durable failure timestamp: set once, when a sandbox is actually marked
+-- failed (see MarkSandboxFailed / MarkSandboxFailedInTeam below), and never
+-- overwritten afterward — including by DestroySandbox, which only touches
+-- status/destroyed_at/updated_at on cleanup. Nullable and never backfilled:
+-- sandboxes that failed before this column existed simply have no
+-- failed_at, which is correct since their real failure time isn't known.
+ALTER TABLE sandbox ADD COLUMN IF NOT EXISTS failed_at timestamptz;
+
 -- Minimal projection of sandbox_active_interval (just the two columns the
 -- panel needs) so the live-count panel can reconstruct concurrency at any
 -- point in time via generate_series bucketing, without exposing team_id/
@@ -13,18 +21,17 @@ CREATE OR REPLACE VIEW analytics.sandbox_active_interval AS
 SELECT started_at, ended_at
 FROM sandbox_active_interval;
 
--- Count of sandboxes that ended up in status='failed', bucketed by day.
---
--- Caveat: there is no dedicated "failed_at" timestamp in the schema.
--- activity never logs failures for sandbox start/resume (only
--- status='success' rows exist there), and reconciler_log.mark_failed only
--- covers the fraction of failures caught by drift detection. updated_at is
--- the best available signal, but it isn't purely a failure timestamp: a
--- historical backfill swept ~1.7k stale rows on 2026-07-15, which shows up
--- as an artificial spike on that date rather than real failures.
+-- sandbox.status alone can't drive a failures-over-time trend: DestroySandbox
+-- rewrites 'failed' to 'deleted' on cleanup (and bumps updated_at), so a
+-- day's count would silently shrink as failed sandboxes get reaped later.
+-- failed_at is set once, at the moment a sandbox is actually marked failed
+-- (see MarkSandboxFailed / MarkSandboxFailedInTeam), and is never touched by
+-- the delete path, so it stays a durable per-sandbox failure event even
+-- after the row moves on to 'deleted'. Rows failed before this column
+-- existed have failed_at NULL and are excluded rather than misdated.
 CREATE OR REPLACE VIEW analytics.daily_sandbox_failures AS
-SELECT date_trunc('day', updated_at)::date AS day,
+SELECT date_trunc('day', failed_at)::date AS day,
        count(*) AS failures
 FROM sandbox
-WHERE status = 'failed'
+WHERE failed_at IS NOT NULL
 GROUP BY 1;

--- a/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
+++ b/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
@@ -5,14 +5,40 @@
 -- PRIVILEGES in 20260730000002), so panels querying public tables directly
 -- fail with "permission denied".
 
--- Durable failure timestamp: set once, by every write path that can land a
--- sandbox on 'failed' (MarkSandboxFailed, MarkSandboxFailedInTeam, and the
--- generic UpdateSandboxStatus used by e.g. the post-boot failure path), and
--- never overwritten afterward — including by DestroySandbox, which only
--- touches status/destroyed_at/updated_at on cleanup. Nullable and never
--- backfilled: sandboxes that failed before this column existed simply have
--- no failed_at, which is correct since their real failure time isn't known.
+-- Durable failure timestamp. Nullable and never backfilled: sandboxes that
+-- failed before this column existed simply have no failed_at, which is
+-- correct since their real failure time isn't known.
 ALTER TABLE sandbox ADD COLUMN IF NOT EXISTS failed_at timestamptz;
+
+-- Set at the DB layer rather than in each Go call site: a migration-first
+-- deploy leaves the old API revision serving (with the old binary that has
+-- never heard of failed_at) for the whole window between this migration
+-- landing and the new image rolling out, so any app-level "set failed_at
+-- when writing 'failed'" convention would silently lose every failure that
+-- lands during that window, permanently — nothing revisits the row later
+-- to backfill it. A trigger applies the moment this migration runs,
+-- independent of which binary revision is writing, and also covers any
+-- future write path that forgets the convention. Never overwrites an
+-- existing failed_at (a later UPDATE that leaves status='failed' unchanged,
+-- e.g. a metadata patch, must not move the timestamp), and DestroySandbox
+-- doesn't touch failed_at at all, so it survives the row moving on to
+-- 'deleted'.
+CREATE OR REPLACE FUNCTION sandbox_failed_at_on_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.status = 'failed' AND NEW.failed_at IS NULL THEN
+        NEW.failed_at := now();
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_sandbox_failed_at_on_transition
+    BEFORE INSERT OR UPDATE OF status ON sandbox
+    FOR EACH ROW
+    EXECUTE FUNCTION sandbox_failed_at_on_transition();
 
 -- Minimal projection of sandbox_active_interval (just the two columns the
 -- panel needs) so the live-count panel can reconstruct concurrency at any
@@ -25,11 +51,10 @@ FROM sandbox_active_interval;
 -- sandbox.status alone can't drive a failures-over-time trend: DestroySandbox
 -- rewrites 'failed' to 'deleted' on cleanup (and bumps updated_at), so a
 -- day's count would silently shrink as failed sandboxes get reaped later.
--- failed_at is set once, at the moment a sandbox is actually marked failed
--- by any of the write paths that can do so, and is never touched by the
--- delete path, so it stays a durable per-sandbox failure event even
--- after the row moves on to 'deleted'. Rows failed before this column
--- existed have failed_at NULL and are excluded rather than misdated.
+-- failed_at (set by the trigger above) is a durable per-sandbox failure
+-- event that survives the row moving on to 'deleted'. Rows failed before
+-- this column existed have failed_at NULL and are excluded rather than
+-- misdated.
 CREATE OR REPLACE VIEW analytics.daily_sandbox_failures AS
 SELECT date_trunc('day', failed_at)::date AS day,
        count(*) AS failures

--- a/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
+++ b/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
@@ -1,0 +1,30 @@
+-- Reporting views backing two new Grafana panels: live concurrent sandbox
+-- count by region (5m rollup) and failed sandboxes by region over time.
+-- Same reason as 20260731000001_grafana_overview_views.sql: grafana_readonly
+-- only has grants on the analytics schema (via the blanket ALTER DEFAULT
+-- PRIVILEGES in 20260730000002), so panels querying public tables directly
+-- fail with "permission denied".
+
+-- Minimal projection of sandbox_active_interval (just the two columns the
+-- panel needs) so the live-count panel can reconstruct concurrency at any
+-- point in time via generate_series bucketing, without exposing team_id/
+-- actor_id through the read-only Grafana connection.
+CREATE OR REPLACE VIEW analytics.sandbox_active_interval AS
+SELECT started_at, ended_at
+FROM sandbox_active_interval;
+
+-- Count of sandboxes that ended up in status='failed', bucketed by day.
+--
+-- Caveat: there is no dedicated "failed_at" timestamp in the schema.
+-- activity never logs failures for sandbox start/resume (only
+-- status='success' rows exist there), and reconciler_log.mark_failed only
+-- covers the fraction of failures caught by drift detection. updated_at is
+-- the best available signal, but it isn't purely a failure timestamp: a
+-- historical backfill swept ~1.7k stale rows on 2026-07-15, which shows up
+-- as an artificial spike on that date rather than real failures.
+CREATE OR REPLACE VIEW analytics.daily_sandbox_failures AS
+SELECT date_trunc('day', updated_at)::date AS day,
+       count(*) AS failures
+FROM sandbox
+WHERE status = 'failed'
+GROUP BY 1;

--- a/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
+++ b/supabase/migrations/20260812000001_grafana_live_and_failure_views.sql
@@ -5,12 +5,13 @@
 -- PRIVILEGES in 20260730000002), so panels querying public tables directly
 -- fail with "permission denied".
 
--- Durable failure timestamp: set once, when a sandbox is actually marked
--- failed (see MarkSandboxFailed / MarkSandboxFailedInTeam below), and never
--- overwritten afterward — including by DestroySandbox, which only touches
--- status/destroyed_at/updated_at on cleanup. Nullable and never backfilled:
--- sandboxes that failed before this column existed simply have no
--- failed_at, which is correct since their real failure time isn't known.
+-- Durable failure timestamp: set once, by every write path that can land a
+-- sandbox on 'failed' (MarkSandboxFailed, MarkSandboxFailedInTeam, and the
+-- generic UpdateSandboxStatus used by e.g. the post-boot failure path), and
+-- never overwritten afterward — including by DestroySandbox, which only
+-- touches status/destroyed_at/updated_at on cleanup. Nullable and never
+-- backfilled: sandboxes that failed before this column existed simply have
+-- no failed_at, which is correct since their real failure time isn't known.
 ALTER TABLE sandbox ADD COLUMN IF NOT EXISTS failed_at timestamptz;
 
 -- Minimal projection of sandbox_active_interval (just the two columns the
@@ -25,8 +26,8 @@ FROM sandbox_active_interval;
 -- rewrites 'failed' to 'deleted' on cleanup (and bumps updated_at), so a
 -- day's count would silently shrink as failed sandboxes get reaped later.
 -- failed_at is set once, at the moment a sandbox is actually marked failed
--- (see MarkSandboxFailed / MarkSandboxFailedInTeam), and is never touched by
--- the delete path, so it stays a durable per-sandbox failure event even
+-- by any of the write paths that can do so, and is never touched by the
+-- delete path, so it stays a durable per-sandbox failure event even
 -- after the row moves on to 'deleted'. Rows failed before this column
 -- existed have failed_at NULL and are excluded rather than misdated.
 CREATE OR REPLACE VIEW analytics.daily_sandbox_failures AS


### PR DESCRIPTION
## Summary
- Adds `analytics.sandbox_active_interval` and `analytics.daily_sandbox_failures` views, backing two new panels on the product-metrics Grafana dashboard: live concurrent sandbox count by region (5m rollup) and failed sandboxes by region over time.
- No new grants needed — both land in the `analytics` schema, which `grafana_readonly` already has blanket `SELECT` on via the default-privileges grant from the role migration.

## Technical decisions/tradeoffs
- `sandbox_active_interval`'s view exposes only `started_at`/`ended_at` (not `team_id`/`actor_id`), matching least-privilege intent of the read-only Grafana role.
- `daily_sandbox_failures` buckets on `sandbox.updated_at`, the only available signal — there's no dedicated `failed_at` column, and neither `activity` (never logs failures for start/resume) nor `reconciler_log.mark_failed` (covers a small fraction of failures) are complete. Documented in the migration comment; a historical backfill on 2026-07-15 will show as an artificial one-day spike.

## Testing
- Validated both underlying queries directly against `superserve-us-east` and `superserve-us-west` via read-only SQL before writing the migration.
- Dashboard panels are already wired to these view names; they'll go from "relation does not exist" to live data once this merges and CI pushes the migration to staging then both prod cells.