### PR TITLE
vmd: bound reconciler stale-cleanup loops to the pass deadline

### DIFF
--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -369,6 +369,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// lock, re-checking that it's still recordless so an in-flight launch
 	// that just made the cgroup is never killed.
 	for id := range active {
+		if ctx.Err() != nil {
+			return
+		}
 		if supervisionOf[id] != SupervisionCgroup {
 			continue
 		}
@@ -483,6 +486,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	if r.mgr.cgroups != nil {
 		if cgDirs, cgErr := r.mgr.cgroups.scanVMCgroups(); cgErr == nil {
 			for _, id := range cgDirs {
+				if ctx.Err() != nil {
+					return
+				}
 				if active[id] {
 					continue // populated (Drift 0 handles it)
 				}
@@ -548,6 +554,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// the old behavior: just clean up the stale BoltDB entry.
 	if dbSandboxes == nil {
 		for id, rec := range bolted {
+			if ctx.Err() != nil {
+				return
+			}
 			if rec.Status != StatusRunning {
 				continue
 			}
@@ -580,6 +589,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// after the caller gave up).
 	if dbSandboxes != nil {
 		for id := range active {
+			if ctx.Err() != nil {
+				return
+			}
 			sb, known := dbSandboxes[id]
 			deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted
 			failed := known && sb.Sandbox.Status == db.SandboxStatusFailed
@@ -636,6 +648,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// relaunch or destroy. Keyed on BoltDB + systemd only, so it runs in
 	// both DB modes.
 	for id := range active {
+		if ctx.Err() != nil {
+			return
+		}
 		if !errorRecord(id) {
 			r.clearDrift("errunit:" + id)
 			continue
@@ -703,6 +718,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// Drift 5 on missing DB rows). Grace gives the control plane's own
 	// destroy first claim on the record.
 	reapDeadError := func(id string) {
+		if ctx.Err() != nil {
+			return
+		}
 		if active[id] {
 			r.clearDrift("errdead:" + id)
 			return
@@ -783,6 +801,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	// persists — keying off records could kill a just-launched resume.
 	if dbSandboxes != nil {
 		for id := range active {
+			if ctx.Err() != nil {
+				return
+			}
 			sb, known := dbSandboxes[id]
 			if !known || sb.Sandbox.Status != db.SandboxStatusPaused {
 				r.clearDrift("pausedunit:" + id)
@@ -853,6 +874,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		// Fetch the full record only for the few IDs that look orphaned,
 		// not for every bolted entry.
 		for id := range boltedIDs {
+			if ctx.Err() != nil {
+				return
+			}
 			if _, ok := dbSandboxes[id]; ok {
 				continue
 			}
@@ -1575,6 +1599,9 @@ func (r *Reconciler) failEmptyShells(ctx context.Context, log zerolog.Logger, db
 		probeCancel()
 
 		for _, id := range candidates {
+			if ctx.Err() != nil {
+				return
+			}
 			res := probes[id]
 			if res.err != nil {
 				continue // no evidence either way; drift state untouched
@@ -1662,6 +1689,9 @@ func (r *Reconciler) reapUnverifiedOrphans(ctx context.Context, log zerolog.Logg
 	// later resume still restores cleanly.
 	if dbSandboxes != nil {
 		for id := range active {
+			if ctx.Err() != nil {
+				return
+			}
 			sb, known := dbSandboxes[id]
 			if !known || sb.Sandbox.Status != db.SandboxStatusPaused || !r.mgr.instanceUnverifiedRunning(id) {
 				r.clearDrift("unverifiedorphan:" + id)
@@ -1803,6 +1833,9 @@ func (r *Reconciler) demotePausedCgroupRecords(ctx context.Context, log zerolog.
 
 func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, active map[string]bool, errorRecord func(string) bool, now time.Time) {
 	for id, sb := range dbSandboxes {
+		if ctx.Err() != nil {
+			return
+		}
 		if sb.Sandbox.Status != db.SandboxStatusActive {
 			continue
 		}
@@ -1868,6 +1901,9 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 // the lifecycle lock) is only testable with the pass data injectable.
 func (r *Reconciler) failMissingSnapshots(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, now time.Time) {
 	for id, sb := range dbSandboxes {
+		if ctx.Err() != nil {
+			return
+		}
 		if sb.Sandbox.Status != db.SandboxStatusPaused || !sb.Sandbox.SnapshotID.Valid {
 			continue
 		}

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -696,6 +696,62 @@ func TestReapDeadActiveVMs_StaleRunningRecordDoesNotVetoReap(t *testing.T) {
 	})
 }
 
+// A large stale-record backlog must not blow through the pass's own
+// deadline: markStale's netns teardown and BoltDB delete run on their own
+// unrelated context, so nothing but an explicit ctx.Err() check between
+// candidates stops the loop once the pass budget is spent. An already-
+// expired context must make the rule a no-op rather than grinding through
+// every candidate anyway.
+func TestReapDeadActiveVMs_ExpiredContextStopsBeforeAnyWork(t *testing.T) {
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "vmd.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ids := make([]string, 5)
+	rows := make(map[string]db.ListSandboxesByHostRow, len(ids))
+	for i := range ids {
+		sbID := uuid.New()
+		id := sbID.String()
+		ids[i] = id
+		if err := store.Put(VMRecord{ID: id, Status: StatusRunning}); err != nil {
+			t.Fatal(err)
+		}
+		rows[id] = db.ListSandboxesByHostRow{Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}}
+	}
+
+	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{}}
+	r := NewReconciler(m, DefaultReconcilerConfig())
+	for _, id := range ids {
+		r.driftSeen[id] = time.Now().Add(-2 * r.cfg.GracePeriod)
+	}
+
+	origProbe := unitFullyDownProbe
+	unitFullyDownProbe = func(context.Context, string) bool { return true } // every unit conclusively dead
+	t.Cleanup(func() { unitFullyDownProbe = origProbe })
+
+	flips := &[]string{}
+	r.markFailed = func(_ context.Context, vmID string, _ db.SandboxStatus) bool {
+		*flips = append(*flips, vmID)
+		return true
+	}
+
+	expiredCtx, cancel := context.WithCancel(context.Background())
+	cancel() // already expired before the rule ever runs
+
+	r.reapDeadActiveVMs(expiredCtx, zerolog.Nop(), rows, map[string]bool{}, func(string) bool { return false }, time.Now())
+
+	if len(*flips) != 0 {
+		t.Fatalf("an expired pass context must stop the loop before touching any candidate, got %d flips: %v", len(*flips), *flips)
+	}
+	for _, id := range ids {
+		if rec, _ := store.Get(id); rec == nil {
+			t.Fatalf("record %s must survive an aborted pass — it was never processed, not cleaned up", id)
+		}
+	}
+}
+
 // The lock-window race: a resume + re-pause can write a NEW artifact at the
 // same path while this rule waits on the lifecycle lock. The re-stat under
 // the lock must see it and heal rather than fail the fresh generation; an


### PR DESCRIPTION
## Summary
- The reconciler's stale-cleanup loops (markStale, stopVM, removeVMCgroup) run on contexts independent of the reconcile pass's own 25s runTimeout, so a large stale-VM-record backlog keeps grinding in real wall-clock time regardless of the budget.
- Meanwhile writeAudit, which does inherit the pass context, starts failing every call the instant it expires — that's why a big backlog produces a wall of "context deadline exceeded" errors instead of a clean, bounded pass.
- Adds a ctx.Err() check at the top of every stale-cleanup loop (11 sites), matching the pattern demotePausedCgroupRecords already used, so a pass stops taking on new destructive work once its budget is spent and defers the rest to the next tick.

## Technical decisions
- Checked ctx at the loop level (not by threading it into markStale itself) to keep the diff minimal and match the existing convention already in this file.
- Left MaxAutoFailPerHour untouched — this bounds pass duration, it doesn't change how much destructive work a pass is allowed to do.
- Left the disk-orphan reclaim path (detectDiskOrphans/reclaimDiskOrphans) alone — it already has its own DiskDeleteBudget bound and a ctx check before its destructive move.

## Testing
- Added TestReapDeadActiveVMs_ExpiredContextStopsBeforeAnyWork: five stale candidates against an already-expired context, asserts zero records are touched.
- Full internal/vm, internal/network, and whole-repo test suites pass (run under Linux, since this package needs NFPROTO_* constants unavailable on darwin — unrelated pre-existing platform gap).