### PR TITLE
observability: use threshold conditions for launch-path alerts

### DIFF
--- a/infra/modules/observability/launch-path-alerts.tf
+++ b/infra/modules/observability/launch-path-alerts.tf
@@ -10,13 +10,14 @@
 # watch the same bounded host_id label as the backup metrics.
 
 locals {
-  # Queries below use fully-qualified typed metric names
-  # (prometheus.googleapis.com/<name>/gauge) rather than bare PromQL names:
-  # Managed Prometheus resolves a bare name ending in _total as a counter —
-  # which does not exist for our gauge — and rejects policies referencing
-  # metrics that have not emitted yet (vmd_launcher_ready ships in the same
-  # change as its policy). The typed form resolves both and is stable.
-  launch_path_host_matcher = var.launch_path_alerts == null ? "" : "host_id=\"${var.launch_path_alerts.host_id}\""
+  # These policies use classic threshold conditions with an explicit
+  # metric.type, NOT PromQL: the managed-Prometheus policy validator rejects
+  # a bare gauge name ending in _total (it resolves it as a counter) AND any
+  # reference to a metric that has not emitted yet — vmd_launcher_ready ships
+  # in the same change as its policy, so PromQL validation can never pass on
+  # first apply. Threshold conditions skip that validation entirely and are
+  # already the pattern the module's CPU policies use.
+  launch_path_filter_suffix = var.launch_path_alerts == null ? "" : " AND metric.labels.host_id = \"${var.launch_path_alerts.host_id}\""
 
   launch_path_alert_conditions = var.launch_path_alerts == null ? {} : {
     launcher_not_ready = {
@@ -27,7 +28,10 @@ locals {
       # here is long enough to let a retry succeed and short enough that a
       # host stuck on the legacy path is caught well before it becomes a
       # multi-hour latency incident.
-      query         = "min({__name__=\"prometheus.googleapis.com/vmd_launcher_ready/gauge\", ${local.launch_path_host_matcher}}) < 1"
+      metric_type   = "prometheus.googleapis.com/vmd_launcher_ready/gauge"
+      comparison    = "COMPARISON_LT"
+      threshold     = 1
+      aligner       = "ALIGN_MIN"
       duration      = var.launch_path_alerts.launcher_not_ready_duration
       documentation = <<-EOT
         Firecracker launches on ${var.launch_path_alerts.host_id} are running on the legacy path (vmd_launcher_ready=0), so every VM start walks the host's full mount table instead of the pruned launcher namespace. Expect VM start latency in the hundreds of milliseconds to seconds, growing with the host's mount table, while creates still succeed and nothing errors.
@@ -44,7 +48,10 @@ locals {
       # (deploy duration), ssh session setup, and the launcher pin build — so
       # sustained growth degrades deploys and host access before it degrades
       # anything customers see.
-      query         = "max({__name__=\"prometheus.googleapis.com/vmd_network_netns_total/gauge\", ${local.launch_path_host_matcher}}) > ${var.launch_path_alerts.netns_total_threshold}"
+      metric_type   = "prometheus.googleapis.com/vmd_network_netns_total/gauge"
+      comparison    = "COMPARISON_GT"
+      threshold     = var.launch_path_alerts.netns_total_threshold
+      aligner       = "ALIGN_MAX"
       duration      = var.launch_path_alerts.netns_total_duration
       documentation = <<-EOT
         ${var.launch_path_alerts.host_id} is carrying more than ${var.launch_path_alerts.netns_total_threshold} live network namespaces. Each contributes roughly two host mount-table entries, and that table is walked on every process start, every systemctl daemon-reload, and every ssh login — so deploys slow down, the host gets harder to reach, and the launcher pin build (which protects VM start latency) becomes more likely to fail.
@@ -61,7 +68,10 @@ locals {
       # covers thousands of namespaces in that time, and every mount-table
       # operation gets more expensive the whole way. Reaching this level at
       # all means the controller is not merely lagging but losing.
-      query         = "max({__name__=\"prometheus.googleapis.com/vmd_network_netns_total/gauge\", ${local.launch_path_host_matcher}}) > ${var.launch_path_alerts.netns_critical_threshold}"
+      metric_type   = "prometheus.googleapis.com/vmd_network_netns_total/gauge"
+      comparison    = "COMPARISON_GT"
+      threshold     = var.launch_path_alerts.netns_critical_threshold
+      aligner       = "ALIGN_MAX"
       duration      = var.launch_path_alerts.netns_critical_duration
       documentation = <<-EOT
         ${var.launch_path_alerts.host_id} has passed ${var.launch_path_alerts.netns_critical_threshold} live network namespaces. Unlike the sustained-growth policy, this fires quickly: at this level the reclaim controller has engaged and is losing to inflow, and the count typically keeps climbing rather than levelling off. Deploys, ssh logins, and the launcher pin build all degrade as the mount table grows, and a vmd restart in this state is likely to fail its pin build and leave every VM start on the slow path.
@@ -84,10 +94,18 @@ resource "google_monitoring_alert_policy" "launch_path" {
   conditions {
     display_name = each.value.display_name
 
-    condition_prometheus_query_language {
-      query               = each.value.query
-      duration            = each.value.duration
-      evaluation_interval = "30s"
+    condition_threshold {
+      filter          = "metric.type = \"${each.value.metric_type}\" AND resource.type = \"prometheus_target\"${local.launch_path_filter_suffix}"
+      comparison      = each.value.comparison
+      threshold_value = each.value.threshold
+      duration        = each.value.duration
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = each.value.aligner
+      }
+      trigger {
+        count = 1
+      }
     }
   }
 


### PR DESCRIPTION
Second fix for the launch-path policy applies: the managed-Prometheus policy validator rejects the bare gauge name (a `_total` suffix resolves as a nonexistent counter), rejects the fully-qualified typed form, and refuses metrics that have not emitted yet — `vmd_launcher_ready` ships in the same change as its policy, so PromQL validation can never pass on first apply.

Classic `condition_threshold` with an explicit `metric.type` skips PromQL validation entirely, creates fine before first emission, and matches the module's existing CPU policies. Same thresholds, durations, and per-host scoping.