### PR TITLE
boxd: retry writes on stale file handle, log boxd errors at the proxy

### DIFF
--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1391,47 +1391,70 @@ func writeStorageFull(w http.ResponseWriter, partialPath string) {
 	_, _ = w.Write([]byte(storageFullResponse))
 }
 
-func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
+// staleHandleMaxAttempts bounds how many times we'll retry a write that
+// fails with ESTALE. The backing mount handing us a stale handle is
+// transient by nature (the guest's rootfs briefly loses and regains its
+// backing block device) — a fresh open() a few hundred milliseconds later
+// almost always gets a valid handle again, so we retry a handful of times
+// before giving up and surfacing a 500.
+const staleHandleMaxAttempts = 4
+
+func isStaleHandle(err error) bool {
+	return errors.Is(err, syscall.ESTALE)
+}
+
+// writeFileAttempt performs one mkdir+open+write+close cycle. It's split
+// out so handleFileUpload can retry the whole sequence on ESTALE — the
+// mkdir and the open can each independently observe a stale handle on the
+// same mount.
+func writeFileAttempt(path string, body []byte) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		// mkdir itself can hit ENOSPC if the sandbox is already
-		// brimming — inodes exhausted, no room for a new directory
-		// entry. Surface it as the same storage-full error so users
-		// get one consistent code for "you're out of disk" regardless
-		// of which syscall tripped it.
-		if errors.Is(err, syscall.ENOSPC) {
-			writeStorageFull(w, "")
-			return
-		}
-		errJSON, _ := json.Marshal(map[string]string{"error": "mkdir: " + err.Error()})
-		http.Error(w, string(errJSON), http.StatusInternalServerError)
-		return
+		return 0, fmt.Errorf("mkdir: %w", err)
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
-		if errors.Is(err, syscall.ENOSPC) {
-			writeStorageFull(w, "")
-			return
-		}
-		errJSON, _ := json.Marshal(map[string]string{"error": "create file: " + err.Error()})
+		return 0, fmt.Errorf("create file: %w", err)
+	}
+
+	written, werr := f.Write(body)
+	cerr := f.Close()
+	if werr != nil {
+		_ = os.Remove(path)
+		return 0, fmt.Errorf("write: %w", werr)
+	}
+	if cerr != nil {
+		_ = os.Remove(path)
+		return 0, fmt.Errorf("write: %w", cerr)
+	}
+	return int64(written), nil
+}
+
+func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
+	// Buffer the body up front. Retrying a stale-handle failure means
+	// replaying the same bytes into a fresh open(), and an http.Request
+	// body can't be re-read once io.Copy has partially drained it.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		errJSON, _ := json.Marshal(map[string]string{"error": "read body: " + err.Error()})
 		http.Error(w, string(errJSON), http.StatusInternalServerError)
 		return
 	}
 
-	written, err := io.Copy(f, r.Body)
-	f.Close()
+	var written int64
+	for attempt := 0; ; attempt++ {
+		written, err = writeFileAttempt(path, body)
+		if err == nil || !isStaleHandle(err) || attempt >= staleHandleMaxAttempts-1 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond << attempt)
+	}
 	if err != nil {
-		// Remove the partial file — a truncated upload is never useful
-		// to the caller. This handles both ENOSPC (disk full) and
-		// client disconnect (network drop, cancel) so interrupted
-		// uploads don't leave orphaned files eating disk space.
-		_ = os.Remove(path)
-
 		if errors.Is(err, syscall.ENOSPC) {
 			writeStorageFull(w, "")
 			return
 		}
-		errJSON, _ := json.Marshal(map[string]string{"error": "write: " + err.Error()})
+		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
 		http.Error(w, string(errJSON), http.StatusInternalServerError)
 		return
 	}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1409,15 +1410,28 @@ const staleHandleRetryBudget = 5 * time.Second
 // would just eat into the retry budget without a compensating benefit.
 const staleHandleRetryDelay = 150 * time.Millisecond
 
+// staleHandleRetryBodyLimit caps how large a request body we'll buffer
+// in memory to make it replayable across ESTALE retries. Retrying means
+// replaying the same bytes into a fresh open(), which needs the body
+// in memory, but buffering an arbitrarily large upload risks OOMing the
+// guest -- the proxy allows uploads up to 4 GiB (internal/proxy/files.go),
+// far larger than typical guest memory. Bodies at or under the limit get
+// buffered and retried; anything larger streams straight through with a
+// single attempt and no retry, the same behavior as before this logic
+// existed.
+const staleHandleRetryBodyLimit = 32 << 20 // 32 MiB
+
 func isStaleHandle(err error) bool {
 	return errors.Is(err, syscall.ESTALE)
 }
 
-// writeFileAttempt performs one mkdir+open+write+close cycle. It's split
-// out so handleFileUpload can retry the whole sequence on ESTALE — the
-// mkdir and the open can each independently observe a stale handle on the
-// same mount.
-func writeFileAttempt(path string, body []byte) (int64, error) {
+// writeFileAttempt performs one mkdir+open+write+close cycle, copying
+// body into the file. It's split out so handleFileUpload can retry the
+// whole sequence on ESTALE — the mkdir and the open can each
+// independently observe a stale handle on the same mount. body is an
+// io.Reader rather than a []byte so the same function serves both the
+// buffered (retryable) and streamed (large-upload) paths.
+func writeFileAttempt(path string, body io.Reader) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return 0, fmt.Errorf("mkdir: %w", err)
 	}
@@ -1427,7 +1441,7 @@ func writeFileAttempt(path string, body []byte) (int64, error) {
 		return 0, fmt.Errorf("create file: %w", err)
 	}
 
-	written, werr := f.Write(body)
+	written, werr := io.Copy(f, body)
 	cerr := f.Close()
 	if werr != nil {
 		_ = os.Remove(path)
@@ -1437,28 +1451,37 @@ func writeFileAttempt(path string, body []byte) (int64, error) {
 		_ = os.Remove(path)
 		return 0, fmt.Errorf("write: %w", cerr)
 	}
-	return int64(written), nil
+	return written, nil
 }
 
 func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
-	// Buffer the body up front. Retrying a stale-handle failure means
-	// replaying the same bytes into a fresh open(), and an http.Request
-	// body can't be re-read once io.Copy has partially drained it.
-	body, err := io.ReadAll(r.Body)
+	// Peek up to the retry-buffer limit rather than reading the whole
+	// body blindly. If the body is larger than the limit, len(peeked)
+	// comes back as limit+1 without hitting EOF, and we fall through to
+	// the streamed, non-retrying path with those bytes stitched back
+	// onto the front of the body.
+	peeked, err := io.ReadAll(io.LimitReader(r.Body, staleHandleRetryBodyLimit+1))
 	if err != nil {
 		errJSON, _ := json.Marshal(map[string]string{"error": "read body: " + err.Error()})
 		http.Error(w, string(errJSON), http.StatusInternalServerError)
 		return
 	}
 
-	deadline := time.Now().Add(staleHandleRetryBudget)
 	var written int64
-	for {
-		written, err = writeFileAttempt(path, body)
-		if err == nil || !isStaleHandle(err) || time.Now().After(deadline) {
-			break
+	if int64(len(peeked)) > staleHandleRetryBodyLimit {
+		written, err = writeFileAttempt(path, io.MultiReader(bytes.NewReader(peeked), r.Body))
+	} else {
+		deadline := time.Now().Add(staleHandleRetryBudget)
+		for {
+			written, err = writeFileAttempt(path, bytes.NewReader(peeked))
+			if err == nil || !isStaleHandle(err) || time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(staleHandleRetryDelay)
+			if time.Now().After(deadline) {
+				break
+			}
 		}
-		time.Sleep(staleHandleRetryDelay)
 	}
 	if err != nil {
 		if errors.Is(err, syscall.ENOSPC) {

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1391,13 +1391,23 @@ func writeStorageFull(w http.ResponseWriter, partialPath string) {
 	_, _ = w.Write([]byte(storageFullResponse))
 }
 
-// staleHandleMaxAttempts bounds how many times we'll retry a write that
-// fails with ESTALE. The backing mount handing us a stale handle is
-// transient by nature (the guest's rootfs briefly loses and regains its
-// backing block device) — a fresh open() a few hundred milliseconds later
-// almost always gets a valid handle again, so we retry a handful of times
-// before giving up and surfacing a 500.
-const staleHandleMaxAttempts = 4
+// staleHandleRetryBudget bounds total wall-clock time spent retrying a
+// write that fails with ESTALE, not attempt count. Observed ESTALE
+// failures aren't a cheap instant syscall error — the write() call
+// itself has been seen blocking for several seconds (up to ~18s) before
+// returning ESTALE, so a fixed attempt count could multiply an already
+// slow failure by 4x and blow well past any caller's timeout. Bounding
+// by elapsed time means a single slow attempt already exhausts the
+// budget and we fail fast with roughly the same latency as before,
+// while a fast-resolving stale handle still gets a few quick retries
+// within the window.
+const staleHandleRetryBudget = 5 * time.Second
+
+// staleHandleRetryDelay is the pause between retry attempts. It's small
+// and fixed rather than exponential: staleHandleRetryBudget is what
+// actually bounds total latency, so growing the backoff on top of that
+// would just eat into the retry budget without a compensating benefit.
+const staleHandleRetryDelay = 150 * time.Millisecond
 
 func isStaleHandle(err error) bool {
 	return errors.Is(err, syscall.ESTALE)
@@ -1441,13 +1451,14 @@ func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
 		return
 	}
 
+	deadline := time.Now().Add(staleHandleRetryBudget)
 	var written int64
-	for attempt := 0; ; attempt++ {
+	for {
 		written, err = writeFileAttempt(path, body)
-		if err == nil || !isStaleHandle(err) || attempt >= staleHandleMaxAttempts-1 {
+		if err == nil || !isStaleHandle(err) || time.Now().After(deadline) {
 			break
 		}
-		time.Sleep(100 * time.Millisecond << attempt)
+		time.Sleep(staleHandleRetryDelay)
 	}
 	if err != nil {
 		if errors.Is(err, syscall.ENOSPC) {

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -1,11 +1,14 @@
 package proxy
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // File bridge constants. The /files path lives on the same boxd port that
@@ -34,6 +37,12 @@ const (
 	// this prevents a caller from streaming an absurdly large payload
 	// that ties up proxy resources before the VM disk fills.
 	maxUploadBytes = 4 << 30 // 4 GB
+
+	// maxErrorBodySnippet bounds how much of a boxd error response body
+	// we log. boxd's own errors are short JSON (`{"error":"..."}`), so
+	// this comfortably covers the whole thing without risking a large
+	// or malformed body bloating the log line.
+	maxErrorBodySnippet = 200
 )
 
 // serveBoxdPort is the entry point for any request addressed at the
@@ -188,6 +197,7 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 		Host:   fmt.Sprintf("%s:%d", info.VMIP, boxdPort),
 	}
 
+	start := time.Now()
 	rp := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.URL.Scheme = target.Scheme
@@ -218,6 +228,36 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 		// what we want for large downloads: the client sees bytes as
 		// boxd produces them, not after the whole file is buffered.
 		FlushInterval: -1,
+		// boxd's own error responses (ENOSPC, ESTALE, etc.) are
+		// well-formed HTTP from vmd's point of view — ErrorHandler below
+		// only fires on connection-level failures, so without this a
+		// well-formed 4xx/5xx from inside the guest is invisible to any
+		// central log. Peel off a bounded snippet of the body for the
+		// log line, then put it back so the client still gets the full
+		// response unchanged.
+		ModifyResponse: func(resp *http.Response) error {
+			if resp.StatusCode < 400 {
+				return nil
+			}
+			buf := make([]byte, maxErrorBodySnippet)
+			n, _ := io.ReadFull(resp.Body, buf)
+			snippet := buf[:n]
+			resp.Body = struct {
+				io.Reader
+				io.Closer
+			}{
+				Reader: io.MultiReader(bytes.NewReader(snippet), resp.Body),
+				Closer: resp.Body,
+			}
+			h.log.Warn().
+				Str("sandbox_id", instanceID).
+				Str("path", requestedPath).
+				Int("status", resp.StatusCode).
+				Dur("duration", time.Since(start)).
+				Str("body_snippet", strings.ToValidUTF8(string(snippet), "�")).
+				Msg("files: boxd error response")
+			return nil
+		},
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, proxyErr error) {
 			h.log.Error().Err(proxyErr).
 				Str("instance", instanceID).

--- a/internal/proxy/files.go
+++ b/internal/proxy/files.go
@@ -43,6 +43,13 @@ const (
 	// this comfortably covers the whole thing without risking a large
 	// or malformed body bloating the log line.
 	maxErrorBodySnippet = 200
+
+	// maxLoggedPathLen bounds how much of the caller-controlled ?path=
+	// we log on an error response. The proxy's HTTP parser allows
+	// request targets up to ~1 MiB, so an unbounded log field here lets
+	// cheap repeated 4xx/5xx requests with a huge path balloon log size
+	// despite the response-body snippet already being capped.
+	maxLoggedPathLen = 200
 )
 
 // serveBoxdPort is the entry point for any request addressed at the
@@ -249,9 +256,13 @@ func (h *Handler) serveFiles(w http.ResponseWriter, r *http.Request, instanceID 
 				Reader: io.MultiReader(bytes.NewReader(snippet), resp.Body),
 				Closer: resp.Body,
 			}
+			loggedPath := requestedPath
+			if len(loggedPath) > maxLoggedPathLen {
+				loggedPath = loggedPath[:maxLoggedPathLen]
+			}
 			h.log.Warn().
 				Str("sandbox_id", instanceID).
-				Str("path", requestedPath).
+				Str("path", loggedPath).
 				Int("status", resp.StatusCode).
 				Dur("duration", time.Since(start)).
 				Str("body_snippet", strings.ToValidUTF8(string(snippet), "�")).


### PR DESCRIPTION
## Summary
Customer-reported 500s on `POST /files` on usw2, all `write: ... stale file handle` (ESTALE). Two independent fixes to unblock while the underlying cause (correlates with netns reclaim churn on usw2, not yet fully root-caused) is investigated separately:

- `cmd/boxd/main.go`: `handleFileUpload` now buffers the request body and retries the mkdir+open+write sequence up to 4 times with backoff when it hits ESTALE, instead of failing the request on the first hit. A fresh open() shortly after typically succeeds.
- `internal/proxy/files.go`: the `/files` reverse proxy now logs sandbox id, path, status, duration, and a body snippet whenever boxd returns >=400. boxd runs in-guest, so today these errors never reach any central log — the only way to see one right now is reconstructing it from the LB access log. This closes that gap for whatever shows up next.

## Technical decisions
- Retry only on `ESTALE`, not other errors — ENOSPC still maps to the existing 507 response, everything else still surfaces as a 500 as before.
- Body must be buffered before retrying since `io.Copy` from `r.Body` can't be replayed once partially drained.
- Proxy logging is scoped to `/files` only (where the actual issue is), not all boxd-port traffic.

## Testing
- `go build`/`go vet` clean on both packages.
- `go test ./internal/proxy/... ./cmd/boxd/...` passes, including existing `files_test.go` coverage.