### PR TITLE
fix(billing): correct Stripe meter conversion and retries

### DIFF
--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -511,13 +511,22 @@ SET status = sqlc.arg(status),
 WHERE id = sqlc.arg(id)
 RETURNING *;
 
+-- name: MarkBillingUsageExportSent :one
+UPDATE billing_usage_export
+SET status = 'sent',
+    sent_at = sqlc.arg(sent_at),
+    updated_at = now()
+WHERE id = sqlc.arg(id)
+  AND status = 'pending'
+RETURNING *;
+
 -- name: ListBillingUsageExportsForPeriod :many
 SELECT *
 FROM billing_usage_export
 WHERE team_id = sqlc.arg(team_id)
   AND period_start = sqlc.arg(period_start)
   AND period_end = sqlc.arg(period_end)
-ORDER BY created_at ASC;
+ORDER BY created_at ASC, id ASC;
 
 -- name: CreateStripeWebhookEvent :one
 INSERT INTO stripe_webhook_event (event_id, event_type, payload)

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -522,6 +522,14 @@ WHERE id = sqlc.arg(id)
   AND status = 'pending'
 RETURNING *;
 
+-- name: SetBillingUsageExportIdempotencyKey :one
+UPDATE billing_usage_export
+SET stripe_idempotency_key = sqlc.arg(stripe_idempotency_key),
+    updated_at = now()
+WHERE id = sqlc.arg(id)
+  AND stripe_idempotency_key IS NULL
+RETURNING *;
+
 -- name: ListBillingUsageExportsForPeriod :many
 SELECT *
 FROM billing_usage_export

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -527,7 +527,7 @@ UPDATE billing_usage_export
 SET stripe_idempotency_key = sqlc.arg(stripe_idempotency_key),
     updated_at = now()
 WHERE id = sqlc.arg(id)
-  AND stripe_idempotency_key IS NULL
+  AND (stripe_idempotency_key IS NULL OR stripe_idempotency_key = stripe_meter_event_identifier)
 RETURNING *;
 
 -- name: ListBillingUsageExportsForPeriod :many
@@ -542,6 +542,13 @@ ORDER BY created_at ASC, id ASC;
 SELECT *
 FROM billing_usage_export
 WHERE stripe_idempotency_key = sqlc.arg(stripe_idempotency_key)
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
+
+-- name: GetBillingUsageExportByIdentifier :one
+SELECT *
+FROM billing_usage_export
+WHERE stripe_meter_event_identifier = sqlc.arg(stripe_meter_event_identifier)
 ORDER BY created_at DESC, id DESC
 LIMIT 1;
 

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -481,6 +481,7 @@ INSERT INTO billing_usage_export (
     resource_type,
     stripe_customer_id,
     stripe_meter_event_identifier,
+    stripe_idempotency_key,
     stripe_event_name,
     value,
     status,
@@ -494,6 +495,7 @@ VALUES (
     sqlc.arg(resource_type),
     sqlc.narg(stripe_customer_id),
     sqlc.arg(stripe_meter_event_identifier),
+    sqlc.narg(stripe_idempotency_key),
     sqlc.arg(stripe_event_name),
     sqlc.arg(value),
     sqlc.arg(status),
@@ -527,6 +529,13 @@ WHERE team_id = sqlc.arg(team_id)
   AND period_start = sqlc.arg(period_start)
   AND period_end = sqlc.arg(period_end)
 ORDER BY created_at ASC, id ASC;
+
+-- name: GetBillingUsageExportByIdempotencyKey :one
+SELECT *
+FROM billing_usage_export
+WHERE stripe_idempotency_key = sqlc.arg(stripe_idempotency_key)
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
 
 -- name: CreateStripeWebhookEvent :one
 INSERT INTO stripe_webhook_event (event_id, event_type, payload)

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1072,10 +1072,24 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 			}
 			continue
 		}
+		idempotencyKey := derefString(row.StripeIdempotencyKey)
+		if idempotencyKey == "" {
+			idempotencyKey = stripeMeterEventIdempotencyKey(row.StripeMeterEventIdentifier, row.StripeEventName, derefString(row.StripeCustomerID), meterValue, periodEnd.UTC().Add(-time.Second).Unix())
+			_, setErr := h.DB.SetBillingUsageExportIdempotencyKey(ctx, db.SetBillingUsageExportIdempotencyKeyParams{
+				ID:                   row.ID,
+				StripeIdempotencyKey: stringPtr(idempotencyKey),
+			})
+			if setErr != nil {
+				if !errors.Is(setErr, pgx.ErrNoRows) {
+					respondError(c, ErrInternal)
+					return
+				}
+			}
+		}
 
 		err = h.Stripe.ReportMeterEvent(ctx, StripeReportMeterEventParams{
 			Identifier:     row.StripeMeterEventIdentifier,
-			IdempotencyKey: stripeMeterEventIdempotencyKey(row.StripeMeterEventIdentifier, row.StripeEventName, derefString(row.StripeCustomerID), meterValue, periodEnd.UTC().Add(-time.Second).Unix()),
+			IdempotencyKey: idempotencyKey,
 			EventName:      row.StripeEventName,
 			CustomerID:     derefString(row.StripeCustomerID),
 			Value:          meterValue,
@@ -1573,6 +1587,17 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		})
 		return err
 	case "billing.meter.error_report_triggered", "v1.billing.meter.error_report_triggered":
+		if samples := stripeMeterErrorSamplePayloads(event.Data.Object); len(samples) > 1 {
+			for _, sample := range samples[1:] {
+				if err := h.processStripeWebhookEvent(ctx, q, stripeEventEnvelope{
+					ID:   event.ID,
+					Type: event.Type,
+					Data: stripeEventEnvelopeData{Object: sample},
+				}); err != nil {
+					return err
+				}
+			}
+		}
 		identifier, eventName, customerID, requestKey, errMsg, err := stripeMeterErrorDetails(event.Data.Object)
 		if err != nil {
 			return err
@@ -1692,11 +1717,55 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 	}
 }
 
+func stripeMeterErrorSamplePayloads(payload []byte) [][]byte {
+	var value any
+	if json.Unmarshal(payload, &value) != nil {
+		return nil
+	}
+	var samples []map[string]any
+	var walk func(any)
+	walk = func(current any) {
+		switch item := current.(type) {
+		case map[string]any:
+			if request, ok := item["request"].(map[string]any); ok {
+				sample := map[string]any{}
+				for key, value := range request {
+					sample[key] = value
+				}
+				if message, ok := item["error_message"].(string); ok {
+					sample["reason"] = message
+				}
+				samples = append(samples, sample)
+			}
+			for _, nested := range item {
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range item {
+				walk(nested)
+			}
+		}
+	}
+	walk(value)
+	if len(samples) == 0 {
+		return [][]byte{payload}
+	}
+	encoded := make([][]byte, 0, len(samples))
+	for _, sample := range samples {
+		data, err := json.Marshal(sample)
+		if err == nil {
+			encoded = append(encoded, data)
+		}
+	}
+	return encoded
+}
+
 func stripeMeterErrorDetails(payload []byte) (identifier, eventName, customerID, requestKey, message string, err error) {
 	var value any
 	if err = json.Unmarshal(payload, &value); err != nil {
 		return "", "", "", "", "", err
 	}
+	var summary string
 	var walk func(any)
 	walk = func(current any) {
 		switch item := current.(type) {
@@ -1722,6 +1791,9 @@ func stripeMeterErrorDetails(payload []byte) (identifier, eventName, customerID,
 							requestKey = text
 						}
 					case "reason", "error_message", "developer_message_summary":
+						if key == "developer_message_summary" {
+							summary = text
+						}
 						if message == "" {
 							message = text
 						}
@@ -1736,6 +1808,9 @@ func stripeMeterErrorDetails(payload []byte) (identifier, eventName, customerID,
 		}
 	}
 	walk(value)
+	if summary != "" {
+		message = summary
+	}
 	return
 }
 

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1627,7 +1627,7 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 				if err != nil {
 					return err
 				}
-				return fmt.Errorf("stripe meter error arrived after billing period finalization")
+				return nil
 			}
 			return fmt.Errorf("stripe meter error has no matching finalized export")
 		}

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -43,6 +44,10 @@ type StripeBillingClient interface {
 	CreateCheckoutSession(ctx context.Context, params StripeCreateCheckoutSessionParams) (StripeCheckoutSession, error)
 	CreateCustomerPortalSession(ctx context.Context, params StripeCreateCustomerPortalSessionParams) (StripePortalSession, error)
 	ReportMeterEvent(ctx context.Context, params StripeReportMeterEventParams) error
+}
+
+type stripeEventRetriever interface {
+	RetrieveEvent(ctx context.Context, eventID string) (json.RawMessage, error)
 }
 
 type StripeCreateCustomerParams struct {
@@ -181,8 +186,31 @@ type billingSessionResponse struct {
 type stripeEventEnvelope struct {
 	ID      string                  `json:"id"`
 	Type    string                  `json:"type"`
-	Created int64                   `json:"created"`
+	Created stripeEventTimestamp    `json:"created"`
 	Data    stripeEventEnvelopeData `json:"data"`
+}
+
+type stripeEventTimestamp int64
+
+func (t *stripeEventTimestamp) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var value string
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			return err
+		}
+		*t = stripeEventTimestamp(parsed.Unix())
+		return nil
+	}
+	var value int64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*t = stripeEventTimestamp(value)
+	return nil
 }
 
 type stripeEventEnvelopeData struct {
@@ -292,6 +320,14 @@ func (c *stripeHTTPClient) ReportMeterEvent(ctx context.Context, params StripeRe
 	form.Set("payload[stripe_customer_id]", params.CustomerID)
 	form.Set("payload[value]", params.Value)
 	return c.doForm(ctx, http.MethodPost, "/v1/billing/meter_events", form, nil, params.IdempotencyKey)
+}
+
+func (c *stripeHTTPClient) RetrieveEvent(ctx context.Context, eventID string) (json.RawMessage, error) {
+	var raw json.RawMessage
+	if err := c.doForm(ctx, http.MethodGet, "/v2/core/events/"+url.PathEscape(eventID), nil, &raw, ""); err != nil {
+		return nil, err
+	}
+	return raw, nil
 }
 
 func (c *stripeHTTPClient) doForm(ctx context.Context, method, path string, form url.Values, out any, idempotencyKey string) error {
@@ -764,7 +800,7 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 		activeResources[item.ResourceType] = struct{}{}
 	}
 	for i, row := range existing {
-		if (row.Status != "pending" && row.Status != "failed") || hasResource(activeResources, row.ResourceType) {
+		if (row.Status != "pending" && row.Status != "failed") || (exportEnabled && hasResource(activeResources, row.ResourceType)) {
 			continue
 		}
 		updatedRow, updateErr := q.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
@@ -956,6 +992,7 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 				ResourceType:               resourceType,
 				StripeCustomerID:           account.StripeCustomerID,
 				StripeMeterEventIdentifier: item.Identifier,
+				StripeIdempotencyKey:       stringPtr(stripeMeterEventIdempotencyKey(item.Identifier, item.EventName, derefString(account.StripeCustomerID), stripeMeterQuantityString(item.Value), periodEnd.UTC().Add(-time.Second).Unix())),
 				StripeEventName:            item.EventName,
 				Value:                      numericFromFloat(item.Value),
 				Status:                     status,
@@ -1315,6 +1352,31 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", "Stripe webhook payload is missing id or type", http.StatusBadRequest)
 		return
 	}
+	if isStripeMeterErrorEvent(event.Type) && len(bytes.TrimSpace(event.Data.Object)) == 0 {
+		retriever, ok := h.Stripe.(stripeEventRetriever)
+		if !ok {
+			respondErrorMsg(c, "service_unavailable", "Stripe event retrieval is not configured", http.StatusServiceUnavailable)
+			return
+		}
+		fullEvent, err := retriever.RetrieveEvent(c.Request.Context(), event.ID)
+		if err != nil {
+			log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		var retrieved struct {
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(fullEvent, &retrieved); err != nil || len(bytes.TrimSpace(retrieved.Data)) == 0 {
+			if err == nil {
+				err = errors.New("Stripe thin event response has no data")
+			}
+			log.Error().Err(err).Str("event_id", event.ID).Msg("decode Stripe thin event failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		event.Data.Object = retrieved.Data
+	}
 
 	if h.Pool == nil {
 		respondErrorMsg(c, "service_unavailable", "billing transactions are not configured", http.StatusServiceUnavailable)
@@ -1424,8 +1486,12 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
+func isStripeMeterErrorEvent(eventType string) bool {
+	return eventType == "billing.meter.error_report_triggered" || eventType == "v1.billing.meter.error_report_triggered"
+}
+
 func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries, event stripeEventEnvelope) error {
-	eventAt := stripeEventTime(event.Created)
+	eventAt := stripeEventTime(int64(event.Created))
 	switch event.Type {
 	case "checkout.session.completed":
 		var obj stripeCheckoutCompletedObject
@@ -1480,7 +1546,7 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			CurrentPeriodStart:        timestamptzFromUnix(start),
 			CurrentPeriodEnd:          timestamptzFromUnix(end),
 			CancelAtPeriodEnd:         boolPtr(obj.CancelAtPeriodEnd),
-			StripeSubscriptionEventAt: timestamptzFromUnix(event.Created),
+			StripeSubscriptionEventAt: timestamptzFromUnix(int64(event.Created)),
 		})
 		return err
 	case "invoice.payment_failed", "invoice.payment_succeeded", "invoice.finalized":
@@ -1507,14 +1573,19 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		})
 		return err
 	case "billing.meter.error_report_triggered", "v1.billing.meter.error_report_triggered":
-		var raw map[string]any
-		if err := json.Unmarshal(event.Data.Object, &raw); err != nil {
+		identifier, eventName, customerID, requestKey, errMsg, err := stripeMeterErrorDetails(event.Data.Object)
+		if err != nil {
 			return err
 		}
-		identifier, _ := raw["identifier"].(string)
-		eventName, _ := raw["event_name"].(string)
-		customerID, _ := raw["stripe_customer_id"].(string)
-		errMsg, _ := raw["reason"].(string)
+		if identifier == "" && requestKey != "" {
+			row, lookupErr := q.GetBillingUsageExportByIdempotencyKey(ctx, stringPtr(requestKey))
+			if lookupErr == nil {
+				identifier = row.StripeMeterEventIdentifier
+			}
+		}
+		if identifier == "" {
+			return fmt.Errorf("stripe meter error event has no export identifier")
+		}
 		teamID, start, end, resourceType, err := parseMeterIdentifier(identifier)
 		if err != nil {
 			return nil
@@ -1535,9 +1606,6 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			}
 			return perr
 		}
-		if period.FinalizedAt.Valid {
-			return nil
-		}
 		existing, lerr := q.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
 			TeamID:      teamID,
 			PeriodStart: start,
@@ -1545,6 +1613,20 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		})
 		if lerr != nil {
 			return lerr
+		}
+		if period.FinalizedAt.Valid {
+			for i := len(existing) - 1; i >= 0; i-- {
+				if existing[i].StripeMeterEventIdentifier != identifier {
+					continue
+				}
+				_, err = q.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+					ID:     existing[i].ID,
+					Status: "failed",
+					Error:  stringPtr(errMsg),
+				})
+				return err
+			}
+			return fmt.Errorf("stripe meter error has no matching finalized export")
 		}
 		latest := latestLiveExportByResource(existing)[billingExportResourceType(resourceType)]
 		if latest.ID != uuid.Nil && latest.StripeMeterEventIdentifier != identifier {
@@ -1595,6 +1677,7 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			ResourceType:               billingExportResourceType(resourceType),
 			StripeCustomerID:           stringPtr(customerID),
 			StripeMeterEventIdentifier: identifier,
+			StripeIdempotencyKey:       stringPtr(requestKey),
 			StripeEventName:            eventName,
 			Value:                      numericFromFloat(0),
 			Status:                     "failed",
@@ -1604,6 +1687,53 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 	default:
 		return nil
 	}
+}
+
+func stripeMeterErrorDetails(payload []byte) (identifier, eventName, customerID, requestKey, message string, err error) {
+	var value any
+	if err = json.Unmarshal(payload, &value); err != nil {
+		return "", "", "", "", "", err
+	}
+	var walk func(any)
+	walk = func(current any) {
+		switch item := current.(type) {
+		case map[string]any:
+			for key, nested := range item {
+				text, ok := nested.(string)
+				if ok {
+					switch key {
+					case "identifier":
+						if identifier == "" {
+							identifier = text
+						}
+					case "event_name":
+						if eventName == "" {
+							eventName = text
+						}
+					case "stripe_customer_id":
+						if customerID == "" {
+							customerID = text
+						}
+					case "idempotency_key":
+						if requestKey == "" {
+							requestKey = text
+						}
+					case "reason", "error_message", "developer_message_summary":
+						if message == "" {
+							message = text
+						}
+					}
+				}
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range item {
+				walk(nested)
+			}
+		}
+	}
+	walk(value)
+	return
 }
 
 func (h *Handlers) authorizeTeamBillingRead(c *gin.Context, platform bool) (uuid.UUID, bool) {
@@ -2206,6 +2336,11 @@ func stripeMeterQuantity(value float64) (string, bool) {
 		return "", false
 	}
 	return formatted, true
+}
+
+func stripeMeterQuantityString(value float64) string {
+	formatted, _ := stripeMeterQuantity(value)
+	return formatted
 }
 
 func stripeMeterRoundedValue(value float64) float64 {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1366,32 +1366,6 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", "Stripe webhook payload is missing id or type", http.StatusBadRequest)
 		return
 	}
-	if isStripeMeterErrorEvent(event.Type) && len(bytes.TrimSpace(event.Data.Object)) == 0 {
-		retriever, ok := h.Stripe.(stripeEventRetriever)
-		if !ok {
-			respondErrorMsg(c, "service_unavailable", "Stripe event retrieval is not configured", http.StatusServiceUnavailable)
-			return
-		}
-		fullEvent, err := retriever.RetrieveEvent(c.Request.Context(), event.ID)
-		if err != nil {
-			log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		var retrieved struct {
-			Data json.RawMessage `json:"data"`
-		}
-		if err := json.Unmarshal(fullEvent, &retrieved); err != nil || len(bytes.TrimSpace(retrieved.Data)) == 0 {
-			if err == nil {
-				err = errors.New("Stripe thin event response has no data")
-			}
-			log.Error().Err(err).Str("event_id", event.ID).Msg("decode Stripe thin event failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		event.Data.Object = retrieved.Data
-	}
-
 	if h.Pool == nil {
 		respondErrorMsg(c, "service_unavailable", "billing transactions are not configured", http.StatusServiceUnavailable)
 		return
@@ -1428,6 +1402,11 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 					return
 				}
 				c.JSON(http.StatusOK, gin.H{"status": "duplicate"})
+				return
+			}
+			if err := h.expandStripeThinMeterEvent(c.Request.Context(), &event); err != nil {
+				log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
+				respondError(c, ErrInternal)
 				return
 			}
 			if err := h.processStripeWebhookEvent(c.Request.Context(), q, event); err != nil {
@@ -1467,6 +1446,11 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		return
 	}
 	_ = row
+	if err := h.expandStripeThinMeterEvent(c.Request.Context(), &event); err != nil {
+		log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
+		respondError(c, ErrInternal)
+		return
+	}
 
 	if err := h.processStripeWebhookEvent(c.Request.Context(), q, event); err != nil {
 		msg := err.Error()
@@ -1498,6 +1482,31 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (h *Handlers) expandStripeThinMeterEvent(ctx context.Context, event *stripeEventEnvelope) error {
+	if !isStripeMeterErrorEvent(event.Type) || len(bytes.TrimSpace(event.Data.Object)) != 0 {
+		return nil
+	}
+	retriever, ok := h.Stripe.(stripeEventRetriever)
+	if !ok {
+		return errors.New("Stripe event retrieval is not configured")
+	}
+	fullEvent, err := retriever.RetrieveEvent(ctx, event.ID)
+	if err != nil {
+		return err
+	}
+	var retrieved struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(fullEvent, &retrieved); err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(retrieved.Data)) == 0 {
+		return errors.New("Stripe thin event response has no data")
+	}
+	event.Data.Object = retrieved.Data
+	return nil
 }
 
 func isStripeMeterErrorEvent(eventType string) bool {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1624,7 +1624,10 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 					Status: "failed",
 					Error:  stringPtr(errMsg),
 				})
-				return err
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("stripe meter error arrived after billing period finalization")
 			}
 			return fmt.Errorf("stripe meter error has no matching finalized export")
 		}

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -79,11 +79,12 @@ type StripePortalSession struct {
 }
 
 type StripeReportMeterEventParams struct {
-	Identifier string
-	EventName  string
-	CustomerID string
-	Value      string
-	Timestamp  int64
+	Identifier     string
+	IdempotencyKey string
+	EventName      string
+	CustomerID     string
+	Value          string
+	Timestamp      int64
 }
 
 type stripeHTTPClient struct {
@@ -290,7 +291,7 @@ func (c *stripeHTTPClient) ReportMeterEvent(ctx context.Context, params StripeRe
 	}
 	form.Set("payload[stripe_customer_id]", params.CustomerID)
 	form.Set("payload[value]", params.Value)
-	return c.doForm(ctx, http.MethodPost, "/v1/billing/meter_events", form, nil, params.Identifier)
+	return c.doForm(ctx, http.MethodPost, "/v1/billing/meter_events", form, nil, params.IdempotencyKey)
 }
 
 func (c *stripeHTTPClient) doForm(ctx context.Context, method, path string, form url.Values, out any, idempotencyKey string) error {
@@ -553,7 +554,7 @@ func (h *Handlers) getTeamBillingExportPreview(c *gin.Context, platform bool) {
 	}
 	resourceStates := h.billingResourceStates(storageBillingEnabled)
 
-	items, err := billingPreviewItems(teamID, periodStart, periodEnd, usage, resourceStates)
+	items, err := billingPreviewItems(teamID, periodStart, periodEnd, usage, resourceStates, derefString(account.StripeCustomerID))
 	if err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("build billing preview failed")
 		respondError(c, ErrInternal)
@@ -748,15 +749,38 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 		usage = billingTeamUsageFromUpsertRow(usageRow)
 	}
 
-	items, err := billingPreviewItems(teamID, periodStart, periodEnd, usage, resourceStates)
+	items, err := billingPreviewItems(teamID, periodStart, periodEnd, usage, resourceStates, derefString(account.StripeCustomerID))
 	if err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("build billing export items failed")
 		respondError(c, ErrInternal)
 		return
 	}
-
+	if err := validateBillingExportItems(items); err != nil {
+		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+		return
+	}
+	activeResources := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		activeResources[item.ResourceType] = struct{}{}
+	}
+	for i, row := range existing {
+		if (row.Status != "pending" && row.Status != "failed") || hasResource(activeResources, row.ResourceType) {
+			continue
+		}
+		updatedRow, updateErr := q.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+			ID:     row.ID,
+			Status: "skipped_disabled",
+		})
+		if updateErr != nil {
+			log.Error().Err(updateErr).Str("team_id", teamID.String()).Msg("mark disabled billing export attempt skipped failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		existing[i] = updatedRow
+	}
+	liveExisting = latestLiveExportByResource(existing)
 	if period.Status == "exported" && len(liveExisting) > 0 {
-		if !billingExportAllFinalized(items, liveExisting) {
+		if !billingExportRowsFinalized(existing) {
 			respondErrorMsg(c, "conflict", "billing export is still in progress", http.StatusConflict)
 			return
 		}
@@ -778,6 +802,23 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 	}
 
 	if !exportEnabled {
+		if period.Status == "exported" {
+			if err := tx.Commit(ctx); err != nil {
+				log.Error().Err(err).Str("team_id", teamID.String()).Msg("commit already-exported shadow billing period failed")
+				respondError(c, ErrInternal)
+				return
+			}
+			c.JSON(http.StatusOK, billingExportPreviewResponse{
+				Mode:             mode,
+				PeriodID:         billingPeriodID(periodStart, periodEnd),
+				TeamID:           teamID.String(),
+				Status:           period.Status,
+				StripeCustomerID: account.StripeCustomerID,
+				Items:            items,
+				Attempts:         billingExportAttemptsFromRows(existing),
+			})
+			return
+		}
 		for _, item := range items {
 			resourceType := billingExportResourceType(item.ResourceType)
 			if _, err := q.CreateBillingUsageExport(ctx, db.CreateBillingUsageExportParams{
@@ -852,56 +893,56 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 	}
 
 	if period.Status == "exporting" && !billingExportHasFailedRow(existing) {
-		if !billingExportAllFinalized(items, liveExisting) {
-			respondErrorMsg(c, "conflict", "billing export is still in progress", http.StatusConflict)
-			return
-		}
-		if err := tx.Commit(ctx); err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("commit already-finalized billing export failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		exported, err := h.DB.MarkTeamBillingPeriodExported(ctx, db.MarkTeamBillingPeriodExportedParams{
-			TeamID:      teamID,
-			PeriodStart: periodStart,
-			PeriodEnd:   periodEnd,
-		})
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				respondErrorMsg(c, "conflict", "billing period could not be marked exported", http.StatusConflict)
+		if billingExportAllFinalized(items, liveExisting) {
+			if err := tx.Commit(ctx); err != nil {
+				log.Error().Err(err).Str("team_id", teamID.String()).Msg("commit already-finalized billing export failed")
+				respondError(c, ErrInternal)
 				return
 			}
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("mark team billing period exported failed")
-			respondError(c, ErrInternal)
+			exported, err := h.DB.MarkTeamBillingPeriodExported(ctx, db.MarkTeamBillingPeriodExportedParams{
+				TeamID:      teamID,
+				PeriodStart: periodStart,
+				PeriodEnd:   periodEnd,
+			})
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					respondErrorMsg(c, "conflict", "billing period could not be marked exported", http.StatusConflict)
+					return
+				}
+				log.Error().Err(err).Str("team_id", teamID.String()).Msg("mark team billing period exported failed")
+				respondError(c, ErrInternal)
+				return
+			}
+			updated, err := h.DB.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+				TeamID:      teamID,
+				PeriodStart: periodStart,
+				PeriodEnd:   periodEnd,
+			})
+			if err != nil {
+				log.Error().Err(err).Str("team_id", teamID.String()).Msg("refresh exported billing attempts failed")
+				respondError(c, ErrInternal)
+				return
+			}
+			c.JSON(http.StatusOK, billingExportPreviewResponse{
+				Mode:             mode,
+				PeriodID:         billingPeriodID(periodStart, periodEnd),
+				TeamID:           teamID.String(),
+				Status:           exported.Status,
+				StripeCustomerID: account.StripeCustomerID,
+				Items:            items,
+				Attempts:         billingExportAttemptsFromRows(updated),
+			})
 			return
 		}
-		updated, err := h.DB.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
-			TeamID:      teamID,
-			PeriodStart: periodStart,
-			PeriodEnd:   periodEnd,
-		})
-		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("refresh exported billing attempts failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		c.JSON(http.StatusOK, billingExportPreviewResponse{
-			Mode:             mode,
-			PeriodID:         billingPeriodID(periodStart, periodEnd),
-			TeamID:           teamID.String(),
-			Status:           exported.Status,
-			StripeCustomerID: account.StripeCustomerID,
-			Items:            items,
-			Attempts:         billingExportAttemptsFromRows(updated),
-		})
-		return
 	}
 
 	if period.Status == "approved" || period.Status == "exporting" || period.Status == "exported" || len(liveExisting) > 0 {
 		for _, item := range items {
 			resourceType := billingExportResourceType(item.ResourceType)
-			if _, ok := liveExisting[resourceType]; ok {
-				continue
+			if existing, ok := liveExisting[resourceType]; ok {
+				if (existing.Status != "failed" && existing.Status != "skipped_disabled") || existing.StripeMeterEventIdentifier == item.Identifier {
+					continue
+				}
 			}
 			_, meterOK := stripeMeterQuantity(item.Value)
 			status := "pending"
@@ -967,7 +1008,22 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 		if row.Status == "sent" || row.Status == "accepted" || row.Status == "skipped_zero" {
 			continue
 		}
-		meterValue, ok := stripeMeterQuantity(item.Value)
+		if row.Status == "failed" || row.Status == "skipped_disabled" {
+			row, err = h.DB.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+				ID:     row.ID,
+				Status: "pending",
+			})
+			if err != nil {
+				respondError(c, ErrInternal)
+				return
+			}
+		}
+		rowValue, err := numericFloat64(row.Value)
+		if err != nil {
+			respondError(c, ErrInternal)
+			return
+		}
+		meterValue, ok := stripeMeterQuantity(rowValue)
 		if !ok {
 			if _, err := h.DB.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
 				ID:     row.ID,
@@ -980,12 +1036,13 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 			continue
 		}
 
-		err := h.Stripe.ReportMeterEvent(ctx, StripeReportMeterEventParams{
-			Identifier: item.Identifier,
-			EventName:  item.EventName,
-			CustomerID: *account.StripeCustomerID,
-			Value:      meterValue,
-			Timestamp:  periodEnd.UTC().Add(-time.Second).Unix(),
+		err = h.Stripe.ReportMeterEvent(ctx, StripeReportMeterEventParams{
+			Identifier:     row.StripeMeterEventIdentifier,
+			IdempotencyKey: stripeMeterEventIdempotencyKey(row.StripeMeterEventIdentifier, row.StripeEventName, derefString(row.StripeCustomerID), meterValue, periodEnd.UTC().Add(-time.Second).Unix()),
+			EventName:      row.StripeEventName,
+			CustomerID:     derefString(row.StripeCustomerID),
+			Value:          meterValue,
+			Timestamp:      periodEnd.UTC().Add(-time.Second).Unix(),
 		})
 		if err != nil {
 			msg := err.Error()
@@ -1003,11 +1060,14 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 		}
 
 		sentAt := h.nowUTC()
-		if _, err := h.DB.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+		if _, err := h.DB.MarkBillingUsageExportSent(ctx, db.MarkBillingUsageExportSentParams{
 			ID:     row.ID,
-			Status: "sent",
 			SentAt: pgtype.Timestamptz{Time: sentAt, Valid: true},
 		}); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				respondErrorMsg(c, "conflict", "billing export attempt was superseded", http.StatusConflict)
+				return
+			}
 			log.Error().Err(err).Str("team_id", teamID.String()).Msg("mark billing export sent failed")
 			respondError(c, ErrInternal)
 			return
@@ -1025,7 +1085,7 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 		return
 	}
 	updatedLive = latestLiveExportByResource(updated)
-	if !billingExportAllFinalized(items, updatedLive) {
+	if !billingExportRowsFinalized(updated) {
 		respondErrorMsg(c, "conflict", "billing export is still in progress", http.StatusConflict)
 		return
 	}
@@ -1464,6 +1524,70 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 				customerID = derefString(account.StripeCustomerID)
 			}
 		}
+		period, perr := q.GetTeamBillingPeriodForUpdate(ctx, db.GetTeamBillingPeriodForUpdateParams{
+			TeamID:      teamID,
+			PeriodStart: start,
+			PeriodEnd:   end,
+		})
+		if perr != nil {
+			if errors.Is(perr, pgx.ErrNoRows) {
+				return nil
+			}
+			return perr
+		}
+		if period.FinalizedAt.Valid {
+			return nil
+		}
+		existing, lerr := q.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+			TeamID:      teamID,
+			PeriodStart: start,
+			PeriodEnd:   end,
+		})
+		if lerr != nil {
+			return lerr
+		}
+		latest := latestLiveExportByResource(existing)[billingExportResourceType(resourceType)]
+		if latest.ID != uuid.Nil && latest.StripeMeterEventIdentifier != identifier {
+			return nil
+		}
+		for i := len(existing) - 1; i >= 0; i-- {
+			row := existing[i]
+			if row.StripeMeterEventIdentifier != identifier {
+				continue
+			}
+			_, err = q.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+				ID:     row.ID,
+				Status: "failed",
+				Error:  stringPtr(errMsg),
+			})
+			if err != nil {
+				return err
+			}
+			_, err = q.MarkTeamBillingPeriodExporting(ctx, db.MarkTeamBillingPeriodExportingParams{
+				TeamID:      teamID,
+				PeriodStart: start,
+				PeriodEnd:   end,
+			})
+			if errors.Is(err, pgx.ErrNoRows) {
+				enabled, featureErr := q.IsFeatureEnabledForTeam(ctx, db.IsFeatureEnabledForTeamParams{
+					Key:    "billing_export_enabled",
+					TeamID: pgtype.UUID{Bytes: teamID, Valid: true},
+				})
+				if featureErr != nil {
+					return featureErr
+				}
+				if enabled {
+					return err
+				}
+				_, err = q.UpdateBillingUsageExportStatus(ctx, db.UpdateBillingUsageExportStatusParams{
+					ID:     row.ID,
+					Status: "skipped_disabled",
+					Error:  stringPtr(errMsg),
+				})
+				return err
+			}
+			return err
+		}
 		_, err = q.CreateBillingUsageExport(ctx, db.CreateBillingUsageExportParams{
 			TeamID:                     teamID,
 			PeriodStart:                start,
@@ -1788,7 +1912,7 @@ func billingPeriodResponseFromDB(period db.TeamBillingPeriod, account db.GetTeam
 	return resp
 }
 
-func billingPreviewItems(teamID uuid.UUID, periodStart, periodEnd time.Time, usage db.TeamBillingUsage, resources []billingResourceState) ([]billingExportPreviewItem, error) {
+func billingPreviewItems(teamID uuid.UUID, periodStart, periodEnd time.Time, usage db.TeamBillingUsage, resources []billingResourceState, customerID string) ([]billingExportPreviewItem, error) {
 	vcpuSeconds, err := numericFloat64(usage.VcpuSeconds)
 	if err != nil {
 		return nil, err
@@ -1817,6 +1941,10 @@ func billingPreviewItems(teamID uuid.UUID, periodStart, periodEnd time.Time, usa
 		default:
 			continue
 		}
+		if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+			return nil, fmt.Errorf("billing export quantity must be finite and non-negative")
+		}
+		value = stripeMeterRoundedValue(value)
 		items = append(items, billingExportPreviewItem{
 			ResourceType: billingExportResourceType(resource.ResourceKey),
 			ResourceKey:  resource.ResourceKey,
@@ -1824,11 +1952,25 @@ func billingPreviewItems(teamID uuid.UUID, periodStart, periodEnd time.Time, usa
 			SortOrder:    resource.SortOrder,
 			DisplayUnit:  resource.DisplayUnit,
 			EventName:    resource.StripeEventName,
-			Identifier:   meterIdentifier(teamID, periodStart, periodEnd, billingExportResourceType(resource.ResourceKey)),
+			Identifier:   meterIdentifierForPayload(teamID, periodStart, periodEnd, billingExportResourceType(resource.ResourceKey), resource.StripeEventName, customerID, value),
 			Value:        value,
 		})
 	}
 	return items, nil
+}
+
+func validateBillingExportItems(items []billingExportPreviewItem) error {
+	for _, item := range items {
+		if item.Value < 0 || math.IsNaN(item.Value) || math.IsInf(item.Value, 0) {
+			return fmt.Errorf("billing export quantity must be finite and non-negative")
+		}
+	}
+	return nil
+}
+
+func hasResource(resources map[string]struct{}, resource string) bool {
+	_, ok := resources[resource]
+	return ok
 }
 
 func billingExportResourceType(resourceKey string) string {
@@ -1854,6 +1996,31 @@ func meterIdentifier(teamID uuid.UUID, periodStart, periodEnd time.Time, resourc
 	)
 }
 
+func meterIdentifierForPayload(teamID uuid.UUID, periodStart, periodEnd time.Time, resourceType, eventName, customerID string, value float64) string {
+	quantity := strconv.FormatFloat(stripeMeterRoundedValue(value), 'f', 12, 64)
+	digest := sha256.Sum256([]byte(strings.Join([]string{
+		eventName,
+		customerID,
+		strconv.FormatInt(periodEnd.UTC().Add(-time.Second).Unix(), 10),
+		quantity,
+	}, "\x00")))
+	return meterIdentifier(teamID, periodStart, periodEnd, resourceType) + ":" + hex.EncodeToString(digest[:])[:12]
+}
+
+func stripeMeterEventIdempotencyKey(identifier, eventName, customerID, value string, timestamp int64) string {
+	parts := []string{
+		identifier,
+		eventName,
+		customerID,
+		value,
+	}
+	if timestamp > 0 {
+		parts = append(parts, strconv.FormatInt(timestamp, 10))
+	}
+	digest := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return "meter-event:" + hex.EncodeToString(digest[:])
+}
+
 func parseMeterIdentifier(raw string) (uuid.UUID, time.Time, time.Time, string, error) {
 	const periodMarker = ":period:"
 	const meterMarker = ":meter:"
@@ -1872,6 +2039,19 @@ func parseMeterIdentifier(raw string) (uuid.UUID, time.Time, time.Time, string, 
 	periodRaw, resourceType, ok := strings.Cut(remainder, meterMarker)
 	if !ok {
 		return uuid.Nil, time.Time{}, time.Time{}, "", fmt.Errorf("invalid meter identifier")
+	}
+	parts := strings.SplitN(resourceType, ":", 2)
+	resourceType = parts[0]
+	if resourceType != "cpu" && resourceType != "memory" && resourceType != "storage" {
+		return uuid.Nil, time.Time{}, time.Time{}, "", fmt.Errorf("invalid meter resource type")
+	}
+	if len(parts) == 2 {
+		if len(parts[1]) != 12 {
+			return uuid.Nil, time.Time{}, time.Time{}, "", fmt.Errorf("invalid meter identifier fingerprint")
+		}
+		if _, err := hex.DecodeString(parts[1]); err != nil {
+			return uuid.Nil, time.Time{}, time.Time{}, "", fmt.Errorf("invalid meter identifier fingerprint: %w", err)
+		}
 	}
 	bounds := strings.SplitN(periodRaw, ",", 2)
 	if len(bounds) != 2 {
@@ -1918,6 +2098,18 @@ func billingExportHasFailedRow(rows []db.BillingUsageExport) bool {
 		}
 	}
 	return false
+}
+
+func billingExportRowsFinalized(rows []db.BillingUsageExport) bool {
+	for _, row := range latestLiveExportByResource(rows) {
+		switch row.Status {
+		case "sent", "accepted", "skipped_zero", "skipped_shadow", "skipped_disabled":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func billingExportAllFinalized(items []billingExportPreviewItem, rows map[string]db.BillingUsageExport) bool {
@@ -1999,15 +2191,29 @@ func numericFromFloat(v float64) pgtype.Numeric {
 }
 
 func formatDecimal(v float64) string {
-	return strconv.FormatFloat(v, 'f', 6, 64)
+	return strconv.FormatFloat(v, 'f', -1, 64)
 }
 
-func stripeMeterQuantity(hours float64) (string, bool) {
-	seconds := math.Round(hours * 3600.0)
-	if seconds <= 0 {
+// Stripe meter events should carry the same normalized billing quantity that
+// appears in the export preview, not the raw interval seconds.
+func stripeMeterQuantity(value float64) (string, bool) {
+	if value <= 0 || math.IsNaN(value) || math.IsInf(value, 0) {
 		return "", false
 	}
-	return strconv.FormatInt(int64(seconds), 10), true
+	formatted := strconv.FormatFloat(value, 'f', 12, 64)
+	rounded, err := strconv.ParseFloat(formatted, 64)
+	if err != nil || rounded <= 0 {
+		return "", false
+	}
+	return formatted, true
+}
+
+func stripeMeterRoundedValue(value float64) float64 {
+	rounded, err := strconv.ParseFloat(strconv.FormatFloat(value, 'f', 12, 64), 64)
+	if err != nil {
+		return value
+	}
+	return rounded
 }
 
 func stripeSubscriptionPeriodBounds(obj stripeSubscriptionObject) (int64, int64, bool) {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -1073,7 +1073,7 @@ func (h *Handlers) ExportTeamBillingPeriod(c *gin.Context) {
 			continue
 		}
 		idempotencyKey := derefString(row.StripeIdempotencyKey)
-		if idempotencyKey == "" {
+		if idempotencyKey == "" || idempotencyKey == row.StripeMeterEventIdentifier {
 			idempotencyKey = stripeMeterEventIdempotencyKey(row.StripeMeterEventIdentifier, row.StripeEventName, derefString(row.StripeCustomerID), meterValue, periodEnd.UTC().Add(-time.Second).Unix())
 			_, setErr := h.DB.SetBillingUsageExportIdempotencyKey(ctx, db.SetBillingUsageExportIdempotencyKeyParams{
 				ID:                   row.ID,
@@ -1606,6 +1606,11 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			row, lookupErr := q.GetBillingUsageExportByIdempotencyKey(ctx, stringPtr(requestKey))
 			if lookupErr == nil {
 				identifier = row.StripeMeterEventIdentifier
+			} else if errors.Is(lookupErr, pgx.ErrNoRows) {
+				row, lookupErr = q.GetBillingUsageExportByIdentifier(ctx, requestKey)
+				if lookupErr == nil {
+					identifier = row.StripeMeterEventIdentifier
+				}
 			}
 		}
 		if identifier == "" {

--- a/internal/api/handlers_billing_stripe_test.go
+++ b/internal/api/handlers_billing_stripe_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type stripeMeterEventRoundTripper struct {
+	identifier     string
+	idempotencyKey string
+}
+
+func (r *stripeMeterEventRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+	r.identifier = form.Get("identifier")
+	r.idempotencyKey = req.Header.Get("Idempotency-Key")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestValidateBillingExportItemsRejectsNegativeValue(t *testing.T) {
+	err := validateBillingExportItems([]billingExportPreviewItem{
+		{ResourceType: "cpu", Value: 1},
+		{ResourceType: "memory", Value: -0.25},
+	})
+	if err == nil {
+		t.Fatal("expected negative billing export quantity to be rejected")
+	}
+}
+
+func TestStripeMeterEventIdempotencyKeySeparatesPayloadFromIdentifier(t *testing.T) {
+	identifier := "team:example:period:1,2:meter:memory"
+	first := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours", "cus_example", "1.000000000000", 2)
+	if got := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours", "cus_example", "1.000000000000", 2); got != first {
+		t.Fatalf("same payload idempotency key = %q, want %q", got, first)
+	}
+	if got := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours", "cus_example", "2.000000000000", 2); got == first {
+		t.Fatal("changed payload reused the same idempotency key")
+	}
+	if got := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours_v2", "cus_example", "1.000000000000", 2); got == first {
+		t.Fatal("changed event name reused the same idempotency key")
+	}
+	if got := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours", "cus_other", "1.000000000000", 2); got == first {
+		t.Fatal("changed customer reused the same idempotency key")
+	}
+	if got := stripeMeterEventIdempotencyKey(identifier, "memory_gib_hours", "cus_example", "1.000000000000", 3); got == first {
+		t.Fatal("changed timestamp reused the same idempotency key")
+	}
+}
+
+func TestMeterIdentifierForPayloadKeepsLogicalPrefixAndSeparatesPayloads(t *testing.T) {
+	teamID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	start := time.Unix(100, 0).UTC()
+	end := time.Unix(200, 0).UTC()
+	cpu := meterIdentifierForPayload(teamID, start, end, "cpu", "cpu_hours", "cus_example", 1)
+	same := meterIdentifierForPayload(teamID, start, end, "cpu", "cpu_hours", "cus_example", 1)
+	changed := meterIdentifierForPayload(teamID, start, end, "cpu", "cpu_hours", "cus_example", 2)
+	memory := meterIdentifierForPayload(teamID, start, end, "memory", "memory_gib_hours", "cus_example", 1)
+	prefix := meterIdentifier(teamID, start, end, "cpu") + ":"
+
+	if cpu != same {
+		t.Fatalf("same payload identifiers differ: %q != %q", cpu, same)
+	}
+	if cpu == changed {
+		t.Fatalf("changed payload reused identifier %q", cpu)
+	}
+	if !strings.HasPrefix(cpu, prefix) {
+		t.Fatalf("identifier %q does not preserve logical meter prefix", cpu)
+	}
+	if cpu == memory {
+		t.Fatalf("different resource types reused identifier %q", cpu)
+	}
+	if _, _, _, _, err := parseMeterIdentifier(cpu); err != nil {
+		t.Fatalf("parse payload identifier %q: %v", cpu, err)
+	}
+}
+
+func TestStripeReportMeterEventUsesSeparateIdentifierAndIdempotencyKey(t *testing.T) {
+	transport := &stripeMeterEventRoundTripper{}
+
+	client := &stripeHTTPClient{
+		baseURL:    "https://stripe.example.test",
+		secretKey:  "sk_test_example",
+		apiVersion: "2025-06-30",
+		httpClient: &http.Client{Transport: transport},
+	}
+	params := StripeReportMeterEventParams{
+		Identifier:     "team:example:period:1,2:meter:memory",
+		IdempotencyKey: "meter-event:payload-hash",
+		EventName:      "memory_gib_hours",
+		CustomerID:     "cus_example",
+		Value:          "1.000000000000",
+		Timestamp:      2,
+	}
+	if err := client.ReportMeterEvent(t.Context(), params); err != nil {
+		t.Fatalf("report meter event: %v", err)
+	}
+	if transport.identifier != params.Identifier {
+		t.Fatalf("request identifier = %q, want %q", transport.identifier, params.Identifier)
+	}
+	if transport.idempotencyKey != params.IdempotencyKey {
+		t.Fatalf("request idempotency key = %q, want %q", transport.idempotencyKey, params.IdempotencyKey)
+	}
+	if transport.identifier == transport.idempotencyKey {
+		t.Fatal("logical identifier and HTTP idempotency key must be distinct")
+	}
+}
+
+func TestStripeMeterQuantityPreservesNormalizedUnits(t *testing.T) {
+	tests := []struct {
+		name  string
+		value float64
+		want  string
+		ok    bool
+	}{
+		{
+			name:  "integer quantity",
+			value: 2,
+			want:  "2.000000000000",
+			ok:    true,
+		},
+		{
+			name:  "rounded decimal quantity",
+			value: 977.2464597941668,
+			want:  "977.246459794167",
+			ok:    true,
+		},
+		{
+			name:  "tiny quantity",
+			value: 123.0 / 3600.0,
+			want:  "0.034166666667",
+			ok:    true,
+		},
+		{
+			name:  "rounds below precision to zero",
+			value: 1e-13,
+			ok:    false,
+		},
+		{
+			name:  "zero quantity",
+			value: 0,
+			ok:    false,
+		},
+		{
+			name:  "negative quantity",
+			value: -1,
+			ok:    false,
+		},
+		{
+			name:  "not a number",
+			value: math.NaN(),
+			ok:    false,
+		},
+		{
+			name:  "positive infinity",
+			value: math.Inf(1),
+			ok:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := stripeMeterQuantity(tc.value)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.want {
+				t.Fatalf("quantity = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers_billing_stripe_test.go
+++ b/internal/api/handlers_billing_stripe_test.go
@@ -42,6 +42,27 @@ func TestStripeEventTimestampAcceptsSnapshotAndThinFormats(t *testing.T) {
 	}
 }
 
+func TestStripeMeterErrorSamplePayloadsIncludesEveryRequest(t *testing.T) {
+	payload := json.RawMessage(`{"reason":{"error_types":[{"sample_errors":[{"error_message":"first","request":{"idempotency_key":"meter-event:first"}},{"error_message":"second","request":{"idempotency_key":"meter-event:second"}}]}]}}`)
+	samples := stripeMeterErrorSamplePayloads(payload)
+	if len(samples) != 2 {
+		t.Fatalf("sample count = %d, want 2", len(samples))
+	}
+	for _, want := range []string{"meter-event:first", "meter-event:second"} {
+		found := false
+		for _, sample := range samples {
+			_, _, _, key, _, err := stripeMeterErrorDetails(sample)
+			if err == nil && key == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing sample %q", want)
+		}
+	}
+}
+
 type stripeMeterEventRoundTripper struct {
 	identifier     string
 	idempotencyKey string

--- a/internal/api/handlers_billing_stripe_test.go
+++ b/internal/api/handlers_billing_stripe_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"math"
 	"net/http"
@@ -11,6 +12,35 @@ import (
 
 	"github.com/google/uuid"
 )
+
+func TestStripeMeterErrorDetailsExtractsThinEventRequest(t *testing.T) {
+	payload := json.RawMessage(`{"developer_message_summary":"There is 1 invalid event","reason":{"error_types":[{"sample_errors":[{"error_message":"invalid customer","request":{"idempotency_key":"meter-event:test"}}]}]}}`)
+	identifier, eventName, customerID, requestKey, message, err := stripeMeterErrorDetails(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identifier != "" || eventName != "" || customerID != "" {
+		t.Fatalf("unexpected direct fields: %q %q %q", identifier, eventName, customerID)
+	}
+	if requestKey != "meter-event:test" {
+		t.Fatalf("request key = %q", requestKey)
+	}
+	if message != "There is 1 invalid event" {
+		t.Fatalf("message = %q", message)
+	}
+}
+
+func TestStripeEventTimestampAcceptsSnapshotAndThinFormats(t *testing.T) {
+	for _, input := range []string{`1724910852`, `"2024-08-28T20:54:12.051Z"`} {
+		var timestamp stripeEventTimestamp
+		if err := json.Unmarshal([]byte(input), &timestamp); err != nil {
+			t.Fatalf("unmarshal %s: %v", input, err)
+		}
+		if timestamp == 0 {
+			t.Fatalf("timestamp %s was zero", input)
+		}
+	}
+}
 
 type stripeMeterEventRoundTripper struct {
 	identifier     string

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -957,7 +957,7 @@ FROM billing_usage_export
 WHERE team_id = $1
   AND period_start = $2
   AND period_end = $3
-ORDER BY created_at ASC
+ORDER BY created_at ASC, id ASC
 `
 
 type ListBillingUsageExportsForPeriodParams struct {
@@ -1335,6 +1335,43 @@ func (q *Queries) ListUnresolvedBillingPeriodAnomalies(ctx context.Context, arg 
 		return nil, err
 	}
 	return items, nil
+}
+
+const markBillingUsageExportSent = `-- name: MarkBillingUsageExportSent :one
+UPDATE billing_usage_export
+SET status = 'sent',
+    sent_at = $1,
+    updated_at = now()
+WHERE id = $2
+  AND status = 'pending'
+RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at
+`
+
+type MarkBillingUsageExportSentParams struct {
+	SentAt pgtype.Timestamptz `json:"sent_at"`
+	ID     uuid.UUID          `json:"id"`
+}
+
+func (q *Queries) MarkBillingUsageExportSent(ctx context.Context, arg MarkBillingUsageExportSentParams) (BillingUsageExport, error) {
+	row := q.db.QueryRow(ctx, markBillingUsageExportSent, arg.SentAt, arg.ID)
+	var i BillingUsageExport
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.ResourceType,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventIdentifier,
+		&i.StripeEventName,
+		&i.Value,
+		&i.Status,
+		&i.Error,
+		&i.CreatedAt,
+		&i.SentAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const markStripeWebhookEventFailed = `-- name: MarkStripeWebhookEventFailed :one

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -1714,6 +1714,43 @@ func (q *Queries) ResolveBillingPeriodAnomaly(ctx context.Context, arg ResolveBi
 	return i, err
 }
 
+const setBillingUsageExportIdempotencyKey = `-- name: SetBillingUsageExportIdempotencyKey :one
+UPDATE billing_usage_export
+SET stripe_idempotency_key = $1,
+    updated_at = now()
+WHERE id = $2
+  AND stripe_idempotency_key IS NULL
+RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
+`
+
+type SetBillingUsageExportIdempotencyKeyParams struct {
+	StripeIdempotencyKey *string   `json:"stripe_idempotency_key"`
+	ID                   uuid.UUID `json:"id"`
+}
+
+func (q *Queries) SetBillingUsageExportIdempotencyKey(ctx context.Context, arg SetBillingUsageExportIdempotencyKeyParams) (BillingUsageExport, error) {
+	row := q.db.QueryRow(ctx, setBillingUsageExportIdempotencyKey, arg.StripeIdempotencyKey, arg.ID)
+	var i BillingUsageExport
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.ResourceType,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventIdentifier,
+		&i.StripeEventName,
+		&i.Value,
+		&i.Status,
+		&i.Error,
+		&i.CreatedAt,
+		&i.SentAt,
+		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
+	)
+	return i, err
+}
+
 const setFeatureFlag = `-- name: SetFeatureFlag :one
 INSERT INTO feature_flag (key, enabled, description)
 VALUES ($1, $2, $3)

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -259,6 +259,7 @@ INSERT INTO billing_usage_export (
     resource_type,
     stripe_customer_id,
     stripe_meter_event_identifier,
+    stripe_idempotency_key,
     stripe_event_name,
     value,
     status,
@@ -276,9 +277,10 @@ VALUES (
     $8,
     $9,
     $10,
-    $11
+    $11,
+    $12
 )
-RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at
+RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
 `
 
 type CreateBillingUsageExportParams struct {
@@ -288,6 +290,7 @@ type CreateBillingUsageExportParams struct {
 	ResourceType               string             `json:"resource_type"`
 	StripeCustomerID           *string            `json:"stripe_customer_id"`
 	StripeMeterEventIdentifier string             `json:"stripe_meter_event_identifier"`
+	StripeIdempotencyKey       *string            `json:"stripe_idempotency_key"`
 	StripeEventName            string             `json:"stripe_event_name"`
 	Value                      pgtype.Numeric     `json:"value"`
 	Status                     string             `json:"status"`
@@ -303,6 +306,7 @@ func (q *Queries) CreateBillingUsageExport(ctx context.Context, arg CreateBillin
 		arg.ResourceType,
 		arg.StripeCustomerID,
 		arg.StripeMeterEventIdentifier,
+		arg.StripeIdempotencyKey,
 		arg.StripeEventName,
 		arg.Value,
 		arg.Status,
@@ -325,6 +329,7 @@ func (q *Queries) CreateBillingUsageExport(ctx context.Context, arg CreateBillin
 		&i.CreatedAt,
 		&i.SentAt,
 		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
 	)
 	return i, err
 }
@@ -385,6 +390,37 @@ func (q *Queries) GetActiveTeamBillingPeriod(ctx context.Context, teamID uuid.UU
 		&i.GrossChargesUsd,
 		&i.CreditsAppliedUsd,
 		&i.NetInvoiceAmountUsd,
+	)
+	return i, err
+}
+
+const getBillingUsageExportByIdempotencyKey = `-- name: GetBillingUsageExportByIdempotencyKey :one
+SELECT id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
+FROM billing_usage_export
+WHERE stripe_idempotency_key = $1
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+func (q *Queries) GetBillingUsageExportByIdempotencyKey(ctx context.Context, stripeIdempotencyKey *string) (BillingUsageExport, error) {
+	row := q.db.QueryRow(ctx, getBillingUsageExportByIdempotencyKey, stripeIdempotencyKey)
+	var i BillingUsageExport
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.ResourceType,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventIdentifier,
+		&i.StripeEventName,
+		&i.Value,
+		&i.Status,
+		&i.Error,
+		&i.CreatedAt,
+		&i.SentAt,
+		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
 	)
 	return i, err
 }
@@ -952,7 +988,7 @@ func (q *Queries) ListActivePricingRatesForTeam(ctx context.Context, arg ListAct
 }
 
 const listBillingUsageExportsForPeriod = `-- name: ListBillingUsageExportsForPeriod :many
-SELECT id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at
+SELECT id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
 FROM billing_usage_export
 WHERE team_id = $1
   AND period_start = $2
@@ -990,6 +1026,7 @@ func (q *Queries) ListBillingUsageExportsForPeriod(ctx context.Context, arg List
 			&i.CreatedAt,
 			&i.SentAt,
 			&i.UpdatedAt,
+			&i.StripeIdempotencyKey,
 		); err != nil {
 			return nil, err
 		}
@@ -1344,7 +1381,7 @@ SET status = 'sent',
     updated_at = now()
 WHERE id = $2
   AND status = 'pending'
-RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at
+RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
 `
 
 type MarkBillingUsageExportSentParams struct {
@@ -1370,6 +1407,7 @@ func (q *Queries) MarkBillingUsageExportSent(ctx context.Context, arg MarkBillin
 		&i.CreatedAt,
 		&i.SentAt,
 		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
 	)
 	return i, err
 }
@@ -1740,7 +1778,7 @@ SET status = $1,
     sent_at = COALESCE($3, billing_usage_export.sent_at),
     updated_at = now()
 WHERE id = $4
-RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at
+RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
 `
 
 type UpdateBillingUsageExportStatusParams struct {
@@ -1773,6 +1811,7 @@ func (q *Queries) UpdateBillingUsageExportStatus(ctx context.Context, arg Update
 		&i.CreatedAt,
 		&i.SentAt,
 		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
 	)
 	return i, err
 }

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -425,6 +425,37 @@ func (q *Queries) GetBillingUsageExportByIdempotencyKey(ctx context.Context, str
 	return i, err
 }
 
+const getBillingUsageExportByIdentifier = `-- name: GetBillingUsageExportByIdentifier :one
+SELECT id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
+FROM billing_usage_export
+WHERE stripe_meter_event_identifier = $1
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+func (q *Queries) GetBillingUsageExportByIdentifier(ctx context.Context, stripeMeterEventIdentifier string) (BillingUsageExport, error) {
+	row := q.db.QueryRow(ctx, getBillingUsageExportByIdentifier, stripeMeterEventIdentifier)
+	var i BillingUsageExport
+	err := row.Scan(
+		&i.ID,
+		&i.TeamID,
+		&i.PeriodStart,
+		&i.PeriodEnd,
+		&i.ResourceType,
+		&i.StripeCustomerID,
+		&i.StripeMeterEventIdentifier,
+		&i.StripeEventName,
+		&i.Value,
+		&i.Status,
+		&i.Error,
+		&i.CreatedAt,
+		&i.SentAt,
+		&i.UpdatedAt,
+		&i.StripeIdempotencyKey,
+	)
+	return i, err
+}
+
 const getStripeWebhookEvent = `-- name: GetStripeWebhookEvent :one
 SELECT event_id, event_type, payload, received_at, processed_at, last_error, updated_at
 FROM stripe_webhook_event
@@ -1719,7 +1750,7 @@ UPDATE billing_usage_export
 SET stripe_idempotency_key = $1,
     updated_at = now()
 WHERE id = $2
-  AND stripe_idempotency_key IS NULL
+  AND (stripe_idempotency_key IS NULL OR stripe_idempotency_key = stripe_meter_event_identifier)
 RETURNING id, team_id, period_start, period_end, resource_type, stripe_customer_id, stripe_meter_event_identifier, stripe_event_name, value, status, error, created_at, sent_at, updated_at, stripe_idempotency_key
 `
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -328,6 +328,7 @@ type BillingUsageExport struct {
 	CreatedAt                  time.Time          `json:"created_at"`
 	SentAt                     pgtype.Timestamptz `json:"sent_at"`
 	UpdatedAt                  time.Time          `json:"updated_at"`
+	StripeIdempotencyKey       *string            `json:"stripe_idempotency_key"`
 }
 
 type DeviceCode struct {

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -10,8 +10,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -288,6 +290,14 @@ func TestIntegration_ShadowBillingSkipsStripeCalls(t *testing.T) {
 	if got := exportAttemptCount(t, teamID, "skipped_shadow"); got != 2 {
 		t.Fatalf("skipped shadow attempts = %d, want 2", got)
 	}
+
+	replay := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
+	if replay.Code != http.StatusOK {
+		t.Fatalf("shadow export replay: expected 200, got %d: %s", replay.Code, replay.Body.String())
+	}
+	if got := exportAttemptCount(t, teamID, "skipped_shadow"); got != 2 {
+		t.Fatalf("shadow replay changed skipped shadow attempts to %d, want still 2", got)
+	}
 }
 
 func TestIntegration_LiveBillingSendsStripeEventsAndIsIdempotent(t *testing.T) {
@@ -295,24 +305,99 @@ func TestIntegration_LiveBillingSendsStripeEventsAndIsIdempotent(t *testing.T) {
 	adminID := seedPlatformAdminProfile(t)
 	stripe := &fakeStripeClient{}
 	r := newBillingRouter(t, stripe)
+	viewerKey := seedKeyForExistingTeamWithRole(t, teamID, "viewer")
+	const (
+		wantCPUHours     = 1.0
+		wantMemoryHours  = 1.0
+		wantStorageHours = 1.0
+	)
+	result, err := testPool.Exec(context.Background(), `
+		UPDATE sandbox_compute_billing_interval
+		SET ended_at = $2
+		WHERE team_id = $1
+	`, teamID, periodStart.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("update compute billing interval: %v", err)
+	}
+	if rows := result.RowsAffected(); rows != 1 {
+		t.Fatalf("updated compute billing intervals = %d, want 1", rows)
+	}
+	if _, err := testPool.Exec(context.Background(), `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'billing_storage_billing_enabled', true)
+		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
+	`, teamID); err != nil {
+		t.Fatalf("enable storage billing: %v", err)
+	}
+
+	previewResp := do(r, "GET", "/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export-preview", viewerKey, "")
+	if previewResp.Code != http.StatusOK {
+		t.Fatalf("export preview: expected 200, got %d: %s", previewResp.Code, previewResp.Body.String())
+	}
+	var preview struct {
+		Items []struct {
+			EventName string  `json:"stripe_event_name"`
+			Value     float64 `json:"value"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(previewResp.Body.Bytes(), &preview); err != nil {
+		t.Fatalf("decode export preview: %v", err)
+	}
+	if got := len(preview.Items); got != 3 {
+		t.Fatalf("preview item count = %d, want 3", got)
+	}
+	wantPreview := map[string]float64{}
+	for _, item := range preview.Items {
+		wantPreview[item.EventName] = item.Value
+	}
+	if got := len(wantPreview); got != 3 {
+		t.Fatalf("preview item count = %d, want 3", got)
+	}
+	for eventName, wantValue := range map[string]float64{
+		"cpu_vcpu_hours":    wantCPUHours,
+		"memory_gib_hours":  wantMemoryHours,
+		"storage_gib_hours": wantStorageHours,
+	} {
+		if got, ok := wantPreview[eventName]; !ok || math.Abs(got-wantValue) > 1e-9 {
+			t.Fatalf("preview %s quantity = %v, want %v", eventName, got, wantValue)
+		}
+	}
 
 	first := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
 	if first.Code != http.StatusOK {
 		t.Fatalf("live export: expected 200, got %d: %s", first.Code, first.Body.String())
 	}
-	if got := len(stripe.reportCalls); got != 2 {
-		t.Fatalf("first export stripe calls = %d, want 2", got)
+	if got := len(stripe.reportCalls); got != 3 {
+		t.Fatalf("first export stripe calls = %d, want 3", got)
 	}
+	stripeEventCounts := map[string]int{}
 	for i, call := range stripe.reportCalls {
+		stripeEventCounts[call.EventName]++
 		if got := len(call.Identifier); got > 100 {
 			t.Fatalf("stripe identifier %d length = %d, want <= 100", i, got)
 		}
-		if got := call.Value; got != "7200" {
-			t.Fatalf("stripe call %d quantity = %q, want 7200 seconds", i, got)
+		wantValue, ok := wantPreview[call.EventName]
+		if !ok {
+			t.Fatalf("unexpected stripe event name %q", call.EventName)
+		}
+		gotValue, err := strconv.ParseFloat(call.Value, 64)
+		if err != nil {
+			t.Fatalf("parse stripe call %d quantity %q: %v", i, call.Value, err)
+		}
+		if call.Value != "1.000000000000" {
+			t.Fatalf("stripe call %d serialized quantity = %q, want 1.000000000000", i, call.Value)
+		}
+		if math.Abs(gotValue-wantValue) > 1e-6 {
+			t.Fatalf("stripe call %d quantity = %v, want %v from preview", i, gotValue, wantValue)
 		}
 		wantTimestamp := periodEnd.UTC().Add(-time.Second).Unix()
 		if call.Timestamp != wantTimestamp {
 			t.Fatalf("stripe call %d timestamp = %d, want %d", i, call.Timestamp, wantTimestamp)
+		}
+	}
+	for eventName := range wantPreview {
+		if got := stripeEventCounts[eventName]; got != 1 {
+			t.Fatalf("stripe %s event count = %d, want 1", eventName, got)
 		}
 	}
 	if got := billingPeriodStatus(t, teamID, periodStart, periodEnd); got != "exported" {
@@ -326,8 +411,8 @@ func TestIntegration_LiveBillingSendsStripeEventsAndIsIdempotent(t *testing.T) {
 	if second.Code != http.StatusOK {
 		t.Fatalf("idempotent export replay: expected 200, got %d: %s", second.Code, second.Body.String())
 	}
-	if got := len(stripe.reportCalls); got != 2 {
-		t.Fatalf("second export changed stripe call count to %d, want still 2", got)
+	if got := len(stripe.reportCalls); got != 3 {
+		t.Fatalf("second export changed stripe call count to %d, want still 3", got)
 	}
 }
 
@@ -893,17 +978,19 @@ func TestIntegration_StripeSubmissionFailureFreezesUsageOnRetry(t *testing.T) {
 		t.Fatalf("partial live export stripe calls = %d, want 2", got)
 	}
 	for i, call := range stripe.reportCalls {
-		if got := call.Value; got != "7200" {
-			t.Fatalf("partial export call %d quantity = %q, want 7200 seconds", i, got)
+		if got := call.Value; got != "2.000000000000" {
+			t.Fatalf("partial export call %d quantity = %q, want 2 normalized hours", i, got)
 		}
 	}
+	failedCall := stripe.reportCalls[1]
 
 	if _, err := testPool.Exec(context.Background(), `
-		UPDATE sandbox_compute_billing_interval
-		SET ended_at = $1
-		WHERE team_id = $2
-	`, periodStart.Add(3*time.Hour), teamID); err != nil {
-		t.Fatalf("mutate compute interval for retry: %v", err)
+		UPDATE team_billing_usage
+		SET vcpu_seconds = 10800,
+		    memory_mib_seconds = 11059200
+		WHERE team_id = $1 AND period_start = $2 AND period_end = $3
+	`, teamID, periodStart, periodEnd); err != nil {
+		t.Fatalf("mutate frozen usage for retry: %v", err)
 	}
 
 	second := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
@@ -913,11 +1000,47 @@ func TestIntegration_StripeSubmissionFailureFreezesUsageOnRetry(t *testing.T) {
 	if got := len(stripe.reportCalls); got != 3 {
 		t.Fatalf("retry stripe calls = %d, want 3", got)
 	}
-	if got := stripe.reportCalls[2].Value; got != "7200" {
-		t.Fatalf("retry stripe quantity = %q, want frozen 7200 seconds", got)
+	if got := stripe.reportCalls[2].Value; got != "3.000000000000" {
+		t.Fatalf("retry stripe quantity = %q, want changed 3 normalized hours", got)
+	}
+	if got := stripe.reportCalls[2].Identifier; got == failedCall.Identifier {
+		t.Fatalf("retry reused Stripe meter identifier %q after payload changed", got)
+	}
+	if !strings.HasPrefix(stripe.reportCalls[2].Identifier, "team:") {
+		t.Fatalf("retry Stripe meter identifier = %q, want logical meter identifier prefix", stripe.reportCalls[2].Identifier)
+	}
+	if got := stripe.reportCalls[2].IdempotencyKey; got == failedCall.IdempotencyKey {
+		t.Fatalf("retry reused idempotency key %q after payload changed", got)
 	}
 	if got := billingPeriodStatus(t, teamID, periodStart, periodEnd); got != "exported" {
 		t.Fatalf("period status after retry = %q, want exported", got)
+	}
+}
+
+func TestIntegration_StripeSubmissionFailureRetryKeepsIdentifierForUnchangedPayload(t *testing.T) {
+	teamID, periodID, _, _ := seedBillingPeriodForStripe(t, true, true)
+	adminID := seedPlatformAdminProfile(t)
+	stripe := &fakeStripeClient{reportErr: fmt.Errorf("meter rejected"), reportErrAt: 2}
+	r := newBillingRouter(t, stripe)
+
+	first := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
+	if first.Code != http.StatusBadGateway {
+		t.Fatalf("failed live export: expected 502, got %d: %s", first.Code, first.Body.String())
+	}
+	failedCall := stripe.reportCalls[1]
+
+	second := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
+	if second.Code != http.StatusOK {
+		t.Fatalf("unchanged payload retry: expected 200, got %d: %s", second.Code, second.Body.String())
+	}
+	if got := stripe.reportCalls[2].Identifier; got != failedCall.Identifier {
+		t.Fatalf("unchanged payload retry identifier = %q, want %q", got, failedCall.Identifier)
+	}
+	if got := stripe.reportCalls[2].IdempotencyKey; got != failedCall.IdempotencyKey {
+		t.Fatalf("unchanged payload retry idempotency key = %q, want %q", got, failedCall.IdempotencyKey)
+	}
+	if got := stripe.reportCalls[2].Value; got != failedCall.Value {
+		t.Fatalf("unchanged payload retry value = %q, want %q", got, failedCall.Value)
 	}
 }
 

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -44,6 +44,15 @@ type fakeStripeClient struct {
 	nextPortalURL   string
 }
 
+type thinEventStripeClient struct {
+	*fakeStripeClient
+	retrieved json.RawMessage
+}
+
+func (f *thinEventStripeClient) RetrieveEvent(context.Context, string) (json.RawMessage, error) {
+	return f.retrieved, nil
+}
+
 func (f *fakeStripeClient) CreateCustomer(_ context.Context, params api.StripeCreateCustomerParams) (api.StripeCustomer, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -831,6 +840,46 @@ func TestIntegration_StripeWebhookDuplicateDeliveryIsSafe(t *testing.T) {
 	}
 	if !account.StripeSubscriptionEventAt.Valid || !account.StripeSubscriptionEventAt.Time.Equal(createdAt) {
 		t.Fatalf("subscription event at = %v, want %v", account.StripeSubscriptionEventAt, createdAt)
+	}
+}
+
+func TestIntegration_StripeThinMeterErrorReconcilesByIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	teamID, periodID, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
+	adminID := seedPlatformAdminProfile(t)
+	baseStripe := &fakeStripeClient{}
+	if w := doInternal(newBillingRouter(t, baseStripe), "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), ""); w.Code != http.StatusOK {
+		t.Fatalf("live export: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	rows, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{TeamID: teamID, PeriodStart: periodStart, PeriodEnd: periodEnd})
+	if err != nil || len(rows) == 0 || rows[0].StripeIdempotencyKey == nil {
+		t.Fatalf("load live export attempts: err=%v rows=%d", err, len(rows))
+	}
+	fullData, err := json.Marshal(map[string]any{
+		"developer_message_summary": "There is 1 invalid event",
+		"reason":                    map[string]any{"error_types": []any{map[string]any{"sample_errors": []any{map[string]any{"request": map[string]any{"idempotency_key": *rows[0].StripeIdempotencyKey}}}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retrieved, err := json.Marshal(map[string]json.RawMessage{"data": fullData})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripe := &thinEventStripeClient{fakeStripeClient: &fakeStripeClient{}, retrieved: retrieved}
+	r := newBillingRouter(t, stripe)
+	payload, err := json.Marshal(map[string]any{"id": "evt_thin_meter_error", "type": "v1.billing.meter.error_report_triggered", "created": "2026-07-02T12:00:00.000Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC()))
+	if w := doRequest(r, req); w.Code != http.StatusOK {
+		t.Fatalf("thin meter webhook: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := exportAttemptCount(t, teamID, "failed"); got == 0 {
+		t.Fatal("thin meter webhook did not mark the matched export failed")
 	}
 }
 

--- a/supabase/migrations/20260817000002_billing_export_skipped_disabled.sql
+++ b/supabase/migrations/20260817000002_billing_export_skipped_disabled.sql
@@ -1,0 +1,6 @@
+ALTER TABLE billing_usage_export
+    DROP CONSTRAINT billing_usage_export_status_valid;
+
+ALTER TABLE billing_usage_export
+    ADD CONSTRAINT billing_usage_export_status_valid
+        CHECK (status IN ('pending', 'sent', 'accepted', 'failed', 'skipped_shadow', 'skipped_zero', 'skipped_disabled'));

--- a/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
+++ b/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
@@ -1,6 +1,24 @@
 ALTER TABLE billing_usage_export
     ADD COLUMN stripe_idempotency_key text;
 
+UPDATE billing_usage_export
+SET stripe_idempotency_key = 'meter-event:' || encode(
+    digest(
+        concat_ws(
+            E'\\x00',
+            stripe_meter_event_identifier,
+            stripe_event_name,
+            COALESCE(stripe_customer_id, ''),
+            to_char(value, 'FM999999999999999990.000000000000'),
+            (extract(epoch FROM period_end AT TIME ZONE 'UTC')::bigint - 1)::text
+        ),
+        'sha256'
+    ),
+    'hex'
+)
+WHERE stripe_idempotency_key IS NULL
+  AND status IN ('pending', 'failed', 'sent', 'accepted');
+
 CREATE INDEX idx_billing_usage_export_idempotency_key
     ON billing_usage_export(stripe_idempotency_key)
     WHERE stripe_idempotency_key IS NOT NULL;

--- a/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
+++ b/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
@@ -1,0 +1,6 @@
+ALTER TABLE billing_usage_export
+    ADD COLUMN stripe_idempotency_key text;
+
+CREATE INDEX idx_billing_usage_export_idempotency_key
+    ON billing_usage_export(stripe_idempotency_key)
+    WHERE stripe_idempotency_key IS NOT NULL;

--- a/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
+++ b/supabase/migrations/20260817000003_billing_export_idempotency_key.sql
@@ -2,20 +2,7 @@ ALTER TABLE billing_usage_export
     ADD COLUMN stripe_idempotency_key text;
 
 UPDATE billing_usage_export
-SET stripe_idempotency_key = 'meter-event:' || encode(
-    digest(
-        concat_ws(
-            E'\\x00',
-            stripe_meter_event_identifier,
-            stripe_event_name,
-            COALESCE(stripe_customer_id, ''),
-            to_char(value, 'FM999999999999999990.000000000000'),
-            (extract(epoch FROM period_end AT TIME ZONE 'UTC')::bigint - 1)::text
-        ),
-        'sha256'
-    ),
-    'hex'
-)
+SET stripe_idempotency_key = stripe_meter_event_identifier
 WHERE stripe_idempotency_key IS NULL
   AND status IN ('pending', 'failed', 'sent', 'accepted');
 


### PR DESCRIPTION
## Summary

- Normalize CPU, memory, and storage usage into Stripe billing units before export.
- Cap serialized Stripe meter values at 12 decimal places.
- Keep HTTP idempotency keys separate from Stripe event identifiers.
- Derive payload-specific Stripe event identifiers from a stable logical meter prefix so corrected retries are not deduplicated as the previous payload.
- Reconcile meter-error webhooks against the newest matching export attempt and make export ordering deterministic.

## Verification

- Focused API tests pass.
- Focused integration tests pass for conversion, retries, idempotency, zero usage, shadow mode, and duplicate webhook delivery.
- No workflow runs were reported for the latest commit yet.