### PR TITLE
backup: scope the backlog-age alert to the pause tier

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -819,9 +819,15 @@ func main() {
 				} else {
 					log.Warn().Err(err).Msg("backup metrics: journal pending read failed, dropping gauge from sample")
 				}
-				if oldest, ok, err := backupJournal.OldestEnqueuedAt(); err == nil {
-					if ok {
-						s.OldestPendingAge = time.Since(oldest)
+				if oldest, err := backupJournal.OldestEnqueuedAtByPriority(); err == nil {
+					if t, ok := oldest[backup.PriorityPause]; ok {
+						s.OldestPauseAge = time.Since(t)
+					}
+					if t, ok := oldest[backup.PriorityCheckpoint]; ok {
+						s.OldestCheckpointAge = time.Since(t)
+					}
+					if t, ok := oldest[backup.PriorityBestEffort]; ok {
+						s.OldestBestEffortAge = time.Since(t)
 					}
 					s.OldestPendingAgeOK = true
 				} else {

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -35,7 +35,12 @@ locals {
       # minute even on a busy cell. A 30 minute
       # old queue head means the drain loop is stalled or falling behind,
       # and every queued pause is unmet durability (RPO) exposure.
-      query         = "max(backup_oldest_pending_age_seconds{${local.backup_host_matcher}}) > ${var.backup_alerts.oldest_pending_age_seconds}"
+      # Scoped to the pause tier: pause generations should ship in
+      # seconds, while checkpoint and best-effort backlogs (the backfill
+      # sweep in particular) are deliberately patient, drain only in
+      # idle pipe time, and would otherwise hold this alert firing for
+      # the whole enablement window.
+      query         = "max(backup_oldest_pending_age_seconds{priority=\"pause\", ${local.backup_host_matcher}}) > ${var.backup_alerts.oldest_pending_age_seconds}"
       duration      = "900s"
       documentation = <<-EOT
         The oldest queued backup generation on ${var.backup_alerts.host_id} has been waiting more than ${var.backup_alerts.oldest_pending_age_seconds}s. Queued pauses are not yet durable in the bucket, so this is direct restore-point exposure.

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -641,27 +641,28 @@ func mergeRow(existing []byte, task *Task) {
 	}
 }
 
-// OldestEnqueuedAt returns the earliest EnqueuedAt among queued tasks,
-// ok=false when the queue holds none. Enqueue time rather than readiness
-// deliberately: a task deferred by retry backoff is still backlog, and
-// the age gauge this feeds is about how stale the oldest owed upload is.
-func (j *Journal) OldestEnqueuedAt() (time.Time, bool, error) {
-	var oldest time.Time
-	found := false
+// OldestEnqueuedAtByPriority returns the earliest EnqueuedAt among
+// queued tasks per priority tier. Age is measured from enqueue, not
+// readiness: a nacked task in backoff is still unmet backlog. Per-tier
+// resolution exists because the tiers have opposite service
+// expectations: a pause generation should ship in seconds, while a
+// best-effort backfill backlog is deliberately patient and must not
+// trip the pause tier's freshness alerting.
+func (j *Journal) OldestEnqueuedAtByPriority() (map[Priority]time.Time, error) {
+	oldest := map[Priority]time.Time{}
 	err := j.db.View(func(tx *bolt.Tx) error {
 		return tx.Bucket(journalBucket).ForEach(func(_, v []byte) error {
 			var t Task
-			if err := json.Unmarshal(v, &t); err != nil {
-				return nil // corrupt entries are dropped by Next, not counted
+			if json.Unmarshal(v, &t) != nil {
+				return nil
 			}
-			if !found || t.EnqueuedAt.Before(oldest) {
-				oldest = t.EnqueuedAt
-				found = true
+			if cur, ok := oldest[t.Priority]; !ok || t.EnqueuedAt.Before(cur) {
+				oldest[t.Priority] = t.EnqueuedAt
 			}
 			return nil
 		})
 	})
-	return oldest, found, err
+	return oldest, err
 }
 
 // OutboxDepth reports how many completed tasks still owe their

--- a/internal/backup/journal_test.go
+++ b/internal/backup/journal_test.go
@@ -235,38 +235,47 @@ func TestJournalEnqueueRequiresExactlyOneOwner(t *testing.T) {
 	}
 }
 
-func TestJournalOldestEnqueuedAt(t *testing.T) {
+func TestJournalOldestEnqueuedAtByPriority(t *testing.T) {
 	j, _ := testJournal(t)
 
-	if _, ok, err := j.OldestEnqueuedAt(); err != nil || ok {
-		t.Fatalf("empty queue: ok=%v err=%v, want no oldest", ok, err)
+	if oldest, err := j.OldestEnqueuedAtByPriority(); err != nil || len(oldest) != 0 {
+		t.Fatalf("empty queue: %v err=%v, want no entries", oldest, err)
 	}
 
 	base := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
-	newer := Task{SandboxID: "sb-new", Generation: "gen-1", Priority: PriorityPause, EnqueuedAt: base.Add(time.Hour)}
-	older := Task{SandboxID: "sb-old", Generation: "gen-2", Priority: PriorityBestEffort, EnqueuedAt: base}
-	for _, task := range []Task{newer, older} {
+	pauseNew := Task{SandboxID: "sb-new", Generation: "gen-1", Priority: PriorityPause, EnqueuedAt: base.Add(time.Hour)}
+	pauseOld := Task{SandboxID: "sb-old", Generation: "gen-2", Priority: PriorityPause, EnqueuedAt: base.Add(30 * time.Minute)}
+	backfill := Task{SandboxID: "sb-bf", Generation: "gen-3", Priority: PriorityBestEffort, EnqueuedAt: base}
+	for _, task := range []Task{pauseNew, pauseOld, backfill} {
 		if err := j.Enqueue(task); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	oldest, ok, err := j.OldestEnqueuedAt()
-	if err != nil || !ok {
-		t.Fatalf("oldest: ok=%v err=%v", ok, err)
+	oldest, err := j.OldestEnqueuedAtByPriority()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !oldest.Equal(base) {
-		t.Fatalf("oldest = %s, want %s (priority must not mask an older low-priority task)", oldest, base)
+	// Tiers resolve independently: the hours-old best-effort backfill
+	// backlog must not surface as the pause tier's age.
+	if !oldest[PriorityPause].Equal(base.Add(30 * time.Minute)) {
+		t.Fatalf("pause oldest = %s, want the older pause", oldest[PriorityPause])
+	}
+	if !oldest[PriorityBestEffort].Equal(base) {
+		t.Fatalf("best-effort oldest = %s, want the backfill task", oldest[PriorityBestEffort])
+	}
+	if _, ok := oldest[PriorityCheckpoint]; ok {
+		t.Fatal("empty checkpoint tier reported an age")
 	}
 
 	// A Nack defers readiness but the task is still backlog: age keeps
 	// counting from the original enqueue.
-	if err := j.Nack(older, base.Add(2*time.Hour)); err != nil {
+	if err := j.Nack(backfill, base.Add(2*time.Hour)); err != nil {
 		t.Fatal(err)
 	}
-	oldest, ok, err = j.OldestEnqueuedAt()
-	if err != nil || !ok || !oldest.Equal(base) {
-		t.Fatalf("post-nack oldest = %s ok=%v err=%v, want %s", oldest, ok, err, base)
+	oldest, err = j.OldestEnqueuedAtByPriority()
+	if err != nil || !oldest[PriorityBestEffort].Equal(base) {
+		t.Fatalf("post-nack best-effort oldest = %s err=%v, want %s", oldest[PriorityBestEffort], err, base)
 	}
 }
 

--- a/internal/telemetry/backup.go
+++ b/internal/telemetry/backup.go
@@ -48,10 +48,13 @@ type BackupSample struct {
 	PendingPause, PendingCheckpoint, PendingBestEffort int
 	PendingOK                                          bool
 
-	// OldestPendingAge is the age of the oldest queued task's enqueue
-	// time; zero when the queue is empty.
-	OldestPendingAge   time.Duration
-	OldestPendingAgeOK bool
+	// Oldest*Age is the age of each tier's oldest queued task by enqueue
+	// time; zero when that tier is empty. Per tier because the tiers
+	// have opposite service expectations: pause freshness is the alerted
+	// signal, while a best-effort backfill backlog is deliberately
+	// patient.
+	OldestPauseAge, OldestCheckpointAge, OldestBestEffortAge time.Duration
+	OldestPendingAgeOK                                       bool
 
 	PendingMarkers   int
 	PendingMarkersOK bool
@@ -260,11 +263,21 @@ func (r *BackupRecorder) RecordSample(ctx context.Context, s BackupSample) {
 			metric.WithAttributes(r.attrs(attribute.String("priority", BackupPriorityBestEffort))...))
 	}
 	if s.OldestPendingAgeOK {
-		age := s.OldestPendingAge.Seconds()
-		if age < 0 { // clock skew must not report a negative backlog
-			age = 0
+		for _, tier := range []struct {
+			age      time.Duration
+			priority string
+		}{
+			{s.OldestPauseAge, BackupPriorityPause},
+			{s.OldestCheckpointAge, BackupPriorityCheckpoint},
+			{s.OldestBestEffortAge, BackupPriorityBestEffort},
+		} {
+			age := tier.age.Seconds()
+			if age < 0 { // clock skew must not report a negative backlog
+				age = 0
+			}
+			r.oldestPendingAge.Record(ctx, age,
+				metric.WithAttributes(r.attrs(attribute.String("priority", tier.priority))...))
 		}
-		r.oldestPendingAge.Record(ctx, age, opt)
 	}
 	if s.PendingMarkersOK {
 		r.pendingMarkers.Record(ctx, int64(s.PendingMarkers), opt)

--- a/internal/telemetry/backup_test.go
+++ b/internal/telemetry/backup_test.go
@@ -137,17 +137,18 @@ func TestBackupRecorderRecordsSampleGauges(t *testing.T) {
 	r, reader := testBackupRecorder(t)
 
 	r.RecordSample(ctx, BackupSample{
-		Enabled:            false,
-		PendingPause:       3,
-		PendingCheckpoint:  2,
-		PendingBestEffort:  1,
-		PendingOK:          true,
-		OldestPendingAge:   90 * time.Second,
-		OldestPendingAgeOK: true,
-		PendingMarkers:     4,
-		PendingMarkersOK:   true,
-		OutboxPending:      5,
-		OutboxPendingOK:    true,
+		Enabled:             false,
+		PendingPause:        3,
+		PendingCheckpoint:   2,
+		PendingBestEffort:   1,
+		PendingOK:           true,
+		OldestPauseAge:      90 * time.Second,
+		OldestBestEffortAge: 4 * time.Hour,
+		OldestPendingAgeOK:  true,
+		PendingMarkers:      4,
+		PendingMarkersOK:    true,
+		OutboxPending:       5,
+		OutboxPendingOK:     true,
 	})
 
 	metrics := collectMetrics(t, reader)
@@ -178,8 +179,24 @@ func TestBackupRecorderRecordsSampleGauges(t *testing.T) {
 	}
 
 	age := metrics["backup_oldest_pending_age_seconds"].Data.(metricdata.Gauge[float64])
-	if len(age.DataPoints) != 1 || age.DataPoints[0].Value != 90 {
-		t.Fatalf("backup_oldest_pending_age_seconds = %#v, want one point of 90", age.DataPoints)
+	ageByPriority := map[string]float64{}
+	for _, dp := range age.DataPoints {
+		for _, kv := range dp.Attributes.ToSlice() {
+			if string(kv.Key) == "priority" {
+				ageByPriority[kv.Value.AsString()] = dp.Value
+			}
+		}
+	}
+	wantAge := map[string]float64{
+		BackupPriorityPause:      90,
+		BackupPriorityCheckpoint: 0,
+		BackupPriorityBestEffort: 4 * 3600,
+	}
+	for priority, wantValue := range wantAge {
+		if ageByPriority[priority] != wantValue {
+			t.Fatalf("backup_oldest_pending_age_seconds[%s] = %v, want %v (all: %v)",
+				priority, ageByPriority[priority], wantValue, ageByPriority)
+		}
 	}
 
 	markers := metrics["backup_pending_markers"].Data.(metricdata.Gauge[int64])
@@ -199,12 +216,14 @@ func TestBackupRecorderClampsNegativeAge(t *testing.T) {
 	ctx := context.Background()
 	r, reader := testBackupRecorder(t)
 
-	r.RecordSample(ctx, BackupSample{Enabled: true, OldestPendingAge: -time.Minute, OldestPendingAgeOK: true})
+	r.RecordSample(ctx, BackupSample{Enabled: true, OldestPauseAge: -time.Minute, OldestPendingAgeOK: true})
 
 	metrics := collectMetrics(t, reader)
 	age := metrics["backup_oldest_pending_age_seconds"].Data.(metricdata.Gauge[float64])
-	if len(age.DataPoints) != 1 || age.DataPoints[0].Value != 0 {
-		t.Fatalf("backup_oldest_pending_age_seconds = %#v, want one point of 0", age.DataPoints)
+	for _, dp := range age.DataPoints {
+		if dp.Value != 0 {
+			t.Fatalf("backup_oldest_pending_age_seconds = %#v, want every tier clamped to 0", age.DataPoints)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Prepares backfill enablement: the backfill sweep deliberately leaves a slow-draining best-effort backlog, and the priority-blind oldest-pending age gauge would hold the backlog-age alert firing for the whole enablement window. The age gauge now reports per priority tier and the alert reads only the pause tier.

## Technical decisions
- Same priority label shape the depth gauge already uses, so dashboards treat both uniformly; empty tiers report zero age.
- Age still measures from enqueue, not readiness: a nacked task in backoff is unmet backlog.
- Checkpoint and best-effort ages remain exported for dashboards; only alerting narrows to the pause tier, whose seconds-level freshness is the actual RPO signal.

## Testing
Journal test pins per-tier resolution (an hours-old best-effort task does not surface as the pause tier's age) and nack semantics; telemetry test pins the labeled points and negative-age clamping. Both suites green under race in the linux container.