### PR TITLE
deploy: enable the backup backfill sweep on staging

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -169,6 +169,11 @@ jobs:
           # Staging validates the backup uploader first; the production
           # cells get their buckets after the staging soak.
           BACKUP_BUCKET: superserve-artifact-backup-staging-usc1
+          # Stage one of the backfill rollout: staging first, then use4,
+          # then usw2, each gated on coverage convergence verified via
+          # the backup_generation table. Removing this line disables the
+          # sweep on the next deploy.
+          BACKUP_BACKFILL: "1"
           # Keeps the backup journal off the root disk — it's written
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills. Staging is a smaller instance

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -20,6 +20,11 @@ Env vars:
                        into vmd.env when set; empty = skip, leaving the
                        host's backup uploader disabled. Staged rollout:
                        staging first, production after the staging soak.
+  BACKUP_BACKFILL      optional — "1" enables the paused-sandbox backup
+                       backfill sweep (startup + six-hourly re-sweeps).
+                       Reconciled, not merely upserted: unset in the
+                       workflow removes the line on the next deploy, which
+                       is the rollout's documented off switch.
   BACKUP_JOURNAL_PATH  optional — path for the backup uploader's BoltDB
                        journal. Upserted into vmd.env when set; empty = skip,
                        leaving vmd's default (next to RUN_DIR, i.e. on the
@@ -162,6 +167,7 @@ def main() -> int:
     sentry_dsn = os.environ.get("SENTRY_DSN", "")
     backup_bucket = os.environ.get("BACKUP_BUCKET", "")
     backup_journal_path = os.environ.get("BACKUP_JOURNAL_PATH", "")
+    backup_backfill = os.environ.get("BACKUP_BACKFILL", "")
     otel_environment = os.environ.get("OTEL_ENVIRONMENT", "")
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     internal_api_token = os.environ.get("INTERNAL_API_TOKEN", "")
@@ -178,6 +184,8 @@ def main() -> int:
     q_sentry_line = shlex.quote(f"SENTRY_DSN={sentry_dsn}")
     q_backup = shlex.quote(backup_bucket)
     q_backup_line = shlex.quote(f"BACKUP_BUCKET={backup_bucket}")
+    q_backup_backfill = shlex.quote(backup_backfill)
+    q_backup_backfill_line = shlex.quote(f"BACKUP_BACKFILL={backup_backfill}")
     q_backup_journal = shlex.quote(backup_journal_path)
     q_backup_journal_line = shlex.quote(f"BACKUP_JOURNAL_PATH={backup_journal_path}")
     q_otel = shlex.quote(otel_environment)
@@ -592,6 +600,18 @@ def main() -> int:
                     echo 'SECRETSPROXY_SOCKET=/run/secretsproxy/control.sock' | sudo tee -a "$env_file" > /dev/null
                 fi
             done
+
+            # Reconcile the backfill flag: unlike the skip-when-empty vars,
+            # the stale line is ALWAYS removed and re-added only when the
+            # workflow sets it. This is a rollout flag with an explicit off
+            # step (coverage verified, flag removed), and unsetting it in the
+            # workflow must actually disable the sweep on the next deploy
+            # rather than requiring a manual host edit.
+            sudo touch /etc/sandbox/vmd.env
+            sudo sed -i '/^BACKUP_BACKFILL=/d' /etc/sandbox/vmd.env
+            if [ -n {q_backup_backfill} ]; then
+                echo {q_backup_backfill_line} | sudo tee -a /etc/sandbox/vmd.env > /dev/null
+            fi
 
             # Upsert the control-plane URL. Empty = skip. vmd.env is safe to
             # create; secretsproxy.env is only UPSERTED when it ALREADY exists —


### PR DESCRIPTION
## Summary
Stage one of the backfill rollout: enables the paused-sandbox backup backfill sweep on the staging host. Production cells follow as one-line changes, each gated on the previous stage's coverage convergence.

## Technical decisions
- The deploy script reconciles the flag instead of skip-when-empty upserting: unsetting it in the workflow removes the line on the next deploy, making the documented off switch (coverage verified, flag removed) real rather than a manual host edit.
- Rollout order: staging, then the east cell (about 200 uncovered sandboxes at ~10 pauses/day), then the west cell (about 1,200). Convergence at each stage verified by joining paused sandboxes against the backup_generation coverage table.
- Hold until the pause-tier alert scoping (#377) merges, or the backlog-age alert fires on the deliberately patient best-effort backlog during the window.

## Testing
Script parses; workflow YAML validates. The sweep itself ships dark in the current release and is exercised by its own merged test suite; this change only turns the flag on for staging.