### PR TITLE
network: adopt the previous process's pool inventory from a shutdown receipt

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -38,6 +38,7 @@ on:
       - 'deploy/superserve-vms.service'
       - 'deploy/vmd-rollback-guard'
       - 'deploy/superserve-vmd-rollback-guard.conf'
+      - 'deploy/superserve-vmd-start-generation.conf'
       - 'deploy/superserve-secretsproxy.service'
       - 'deploy/firecracker@.service'
       - 'deploy/firecracker-netns@.service'

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -139,6 +139,7 @@ BUNDLE_FILES = [
     "deploy/superserve-vms.service",
     "deploy/vmd-rollback-guard",
     "deploy/superserve-vmd-rollback-guard.conf",
+    "deploy/superserve-vmd-start-generation.conf",
     "deploy/superserve-secretsproxy.service",
     "deploy/firecracker@.service",
     "deploy/firecracker-netns@.service",
@@ -435,6 +436,10 @@ def main() -> int:
             sudo install -m 0755 {extract_dir}/deploy/vmd-rollback-guard {install_dir}/vmd-rollback-guard
             sudo install -d -m 0755 /etc/systemd/system/superserve-vmd.service.d
             sudo install -m 0644 {extract_dir}/deploy/superserve-vmd-rollback-guard.conf /etc/systemd/system/superserve-vmd.service.d/10-rollback-guard.conf
+            # Start-generation stamp: proves receipt succession (see the
+            # drop-in's header). A drop-in for the same reason as the guard
+            # above — it must survive deploys of revisions that predate it.
+            sudo install -m 0644 {extract_dir}/deploy/superserve-vmd-start-generation.conf /etc/systemd/system/superserve-vmd.service.d/20-start-generation.conf
             sudo systemctl daemon-reload
             sudo systemctl enable --quiet superserve-vmd.socket
             sudo systemctl enable --now --quiet superserve-maintenance-watch.timer

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1262,6 +1262,12 @@ func main() {
 		log.Error().Err(lc.firstErr).Str("service", lc.errName).Msg("VM daemon shutdown after service error")
 		os.Exit(1)
 	}
+	// The final act of a fully successful, signal-initiated shutdown: vouch
+	// for the pool inventory the stopped-and-quiesced pool snapshotted, so
+	// the next boot can adopt it without the paranoid per-slot rebuild. A
+	// failure-triggered shutdown exits above and vouches for nothing, and
+	// CommitReceipt itself refuses unless the pool fully quiesced.
+	netPool.CommitReceipt()
 	log.Info().Msg("VM daemon shutdown complete")
 }
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -178,6 +178,13 @@ type lifecycle struct {
 	closers  []serviceCloser
 	firstErr error
 	errName  string
+	// signalInitiated records that shutdown was requested by an operator
+	// signal (deploy, systemctl stop) rather than a service exiting on its
+	// own — even a nil-error service return is NOT an intentional shutdown.
+	// closerErr records the first closer failure. Both gate the pool
+	// receipt: only a deliberate, fully clean shutdown may vouch.
+	signalInitiated bool
+	closerErr       error
 
 	done   chan struct{}
 	doneCh sync.Once
@@ -226,6 +233,23 @@ func (lc *lifecycle) signalShutdown() {
 	lc.doneCh.Do(func() { close(lc.done) })
 }
 
+// noteSignalInitiated marks this shutdown as operator-requested. Call before
+// signalShutdown from the signal handler only.
+func (lc *lifecycle) noteSignalInitiated() {
+	lc.mu.Lock()
+	lc.signalInitiated = true
+	lc.mu.Unlock()
+}
+
+// cleanIntentionalShutdown reports whether this was a signal-initiated
+// shutdown in which no service errored and every closer succeeded — the
+// only condition under which state may be vouched for.
+func (lc *lifecycle) cleanIntentionalShutdown() bool {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	return lc.signalInitiated && lc.firstErr == nil && lc.closerErr == nil
+}
+
 // wait blocks until shutdown is signaled (by a service exit, context
 // cancellation, or an external caller).
 func (lc *lifecycle) wait(ctx context.Context) {
@@ -249,6 +273,11 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 		lc.log.Info().Str("service", c.name).Msg("closing")
 		if err := c.close(ctx); err != nil {
 			lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
+			lc.mu.Lock()
+			if lc.closerErr == nil {
+				lc.closerErr = fmt.Errorf("%s: %w", c.name, err)
+			}
+			lc.mu.Unlock()
 		}
 	}
 }
@@ -1227,6 +1256,7 @@ func main() {
 		select {
 		case sig := <-sigCh:
 			log.Info().Str("signal", sig.String()).Msg("received shutdown signal")
+			lc.noteSignalInitiated()
 			lc.signalShutdown()
 		case <-ctx.Done():
 		}
@@ -1262,12 +1292,18 @@ func main() {
 		log.Error().Err(lc.firstErr).Str("service", lc.errName).Msg("VM daemon shutdown after service error")
 		os.Exit(1)
 	}
-	// The final act of a fully successful, signal-initiated shutdown: vouch
-	// for the pool inventory the stopped-and-quiesced pool snapshotted, so
-	// the next boot can adopt it without the paranoid per-slot rebuild. A
-	// failure-triggered shutdown exits above and vouches for nothing, and
-	// CommitReceipt itself refuses unless the pool fully quiesced.
-	netPool.CommitReceipt()
+	// The final act of a fully clean, operator-initiated shutdown: vouch for
+	// the pool inventory the stopped-and-quiesced pool snapshotted, so the
+	// next boot can adopt it without the paranoid per-slot rebuild. Every
+	// other ending vouches for nothing: a service error exits above, an
+	// unexpected service return (even error-free) is not intentional, a
+	// failed closer means teardown is suspect, and CommitReceipt itself
+	// refuses unless the pool fully quiesced.
+	if lc.cleanIntentionalShutdown() {
+		netPool.CommitReceipt()
+	} else {
+		log.Info().Msg("shutdown not clean-and-intentional — no pool receipt written")
+	}
 	log.Info().Msg("VM daemon shutdown complete")
 }
 

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
 
 func TestParseSecretsProxyAddr(t *testing.T) {
 	t.Parallel()
@@ -67,4 +73,52 @@ func TestPausedNetworkReclaimTriggersConfigured(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLifecycle_CleanIntentionalShutdownGate pins the receipt-minting
+// invariant: only a signal-initiated shutdown with no service error and no
+// closer failure qualifies. An unexpected service return — even error-free —
+// and a failing closer must both disqualify.
+func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
+	log := zerolog.Nop()
+
+	t.Run("signal initiated and clean", func(t *testing.T) {
+		lc := newLifecycle(log)
+		lc.noteSignalInitiated()
+		lc.shutdown(context.Background())
+		if !lc.cleanIntentionalShutdown() {
+			t.Fatal("clean signal-initiated shutdown must qualify")
+		}
+	})
+
+	t.Run("unexpected error-free service return", func(t *testing.T) {
+		lc := newLifecycle(log)
+		lc.start("svc", func() error { return nil })
+		lc.wait(context.Background())
+		lc.shutdown(context.Background())
+		if lc.cleanIntentionalShutdown() {
+			t.Fatal("a service returning on its own is not intentional, even without error")
+		}
+	})
+
+	t.Run("service error", func(t *testing.T) {
+		lc := newLifecycle(log)
+		lc.noteSignalInitiated()
+		lc.start("svc", func() error { return fmt.Errorf("boom") })
+		lc.wait(context.Background())
+		lc.shutdown(context.Background())
+		if lc.cleanIntentionalShutdown() {
+			t.Fatal("a service error must disqualify")
+		}
+	})
+
+	t.Run("closer failure", func(t *testing.T) {
+		lc := newLifecycle(log)
+		lc.noteSignalInitiated()
+		lc.addCloser("bad", func(context.Context) error { return fmt.Errorf("close failed") })
+		lc.shutdown(context.Background())
+		if lc.cleanIntentionalShutdown() {
+			t.Fatal("a failing closer must disqualify")
+		}
+	})
 }

--- a/deploy/superserve-vmd-start-generation.conf
+++ b/deploy/superserve-vmd-start-generation.conf
@@ -1,0 +1,19 @@
+# Drop-in for superserve-vmd.service: stamp a per-boot start generation
+# before every vmd start.
+#
+# The network pool's shutdown receipt is honored only when written by the
+# IMMEDIATELY preceding vmd process (generation N accepted by generation
+# N+1). This counter is what proves succession: it lives in the unit, not
+# the binary, so ANY start bumps it — including a rolled-back older binary
+# that knows nothing about receipts. An intermediate process therefore
+# breaks the generation chain and the receipt is rejected, instead of a
+# newer process trusting slot state the intermediate one may have changed.
+#
+# Installed as a drop-in (like 10-rollback-guard.conf) because a deploy of
+# an older revision overwrites the unit file but never touches drop-in
+# directories — the mechanism survives the exact rollback it guards.
+#
+# /run is tmpfs: the counter resets on host reboot, which is correct — the
+# receipt is also boot-id-scoped and a reboot invalidates it regardless.
+[Service]
+ExecStartPre=/bin/sh -c 'mkdir -p /run/vmd && echo $(( $(cat /run/vmd/generation 2>/dev/null || echo 0) + 1 )) > /run/vmd/generation'

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -41,22 +41,22 @@ type Firewall struct {
 	userDenySet        *nftables.Set
 	userAllowSet       *nftables.Set
 
-	tapIface   string
-	vethPeer   string // namespace-side veth (e.g. "eth0")
-	vmIP       string // VM internal IP (169.254.0.21)
-	hostIP     string // host-side IP for this sandbox
-	gatewayIP  string // orchestrator IP allowed through firewall
+	tapIface  string
+	vethPeer  string // namespace-side veth (e.g. "eth0")
+	vmIP      string // VM internal IP (169.254.0.21)
+	hostIP    string // host-side IP for this sandbox
+	gatewayIP string // orchestrator IP allowed through firewall
 
 	// TCP proxy ports for domain-based filtering.
 }
 
 // FirewallConfig holds the parameters needed to create a Firewall.
 type FirewallConfig struct {
-	TAPInterface   string
-	VethPeer       string // namespace-side veth name
-	VMIP           string
-	HostIP         string
-	GatewayIP      string // IP always allowed (orchestrator/gateway)
+	TAPInterface string
+	VethPeer     string // namespace-side veth name
+	VMIP         string
+	HostIP       string
+	GatewayIP    string // IP always allowed (orchestrator/gateway)
 }
 
 // NewFirewall creates nftables rules inside the current network namespace.
@@ -246,43 +246,6 @@ func ReinstallFirewall(cfg FirewallConfig) (*Firewall, error) {
 	return NewFirewall(cfg)
 }
 
-// VerifyAttached confirms the kernel actually holds the objects this handle
-// merely names: the table with all four chains, the four IP sets, and a
-// non-empty filter chain. AttachFirewall alone proves nothing — it binds
-// names without querying — so an attach to a flushed or corrupted namespace
-// would otherwise succeed and publish a slot with no enforcement. Must run
-// inside the slot's namespace, like the attach itself.
-func (fw *Firewall) VerifyAttached() error {
-	chains, err := fw.conn.ListChainsOfTableFamily(nftables.TableFamilyINet)
-	if err != nil {
-		return fmt.Errorf("list chains: %w", err)
-	}
-	found := map[string]bool{}
-	for _, c := range chains {
-		if c.Table != nil && c.Table.Name == fw.table.Name {
-			found[c.Name] = true
-		}
-	}
-	for _, want := range []string{fw.filterChain.Name, fw.natChain.Name, fw.postChain.Name, fw.fwdChain.Name} {
-		if !found[want] {
-			return fmt.Errorf("chain %q missing from kernel", want)
-		}
-	}
-	for _, set := range []*nftables.Set{fw.predefinedDenySet, fw.predefinedAllowSet, fw.userDenySet, fw.userAllowSet} {
-		if _, err := fw.conn.GetSetByName(fw.table, set.Name); err != nil {
-			return fmt.Errorf("set %q missing from kernel: %w", set.Name, err)
-		}
-	}
-	rules, err := fw.conn.GetRules(fw.table, fw.filterChain)
-	if err != nil {
-		return fmt.Errorf("get filter rules: %w", err)
-	}
-	if len(rules) == 0 {
-		return fmt.Errorf("filter chain present but empty")
-	}
-	return nil
-}
-
 // Close tears down the nftables connection. Kernel-level table and
 // rules persist across the close — they're owned by the kernel, not
 // by this netlink handle. AttachFirewall can re-bind to them later.
@@ -463,7 +426,6 @@ func (fw *Firewall) installMSSClamping() {
 		),
 	})
 }
-
 
 // ---------------------------------------------------------------------------
 // ReplaceUserRules — atomic set replacement

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -246,6 +246,43 @@ func ReinstallFirewall(cfg FirewallConfig) (*Firewall, error) {
 	return NewFirewall(cfg)
 }
 
+// VerifyAttached confirms the kernel actually holds the objects this handle
+// merely names: the table with all four chains, the four IP sets, and a
+// non-empty filter chain. AttachFirewall alone proves nothing — it binds
+// names without querying — so an attach to a flushed or corrupted namespace
+// would otherwise succeed and publish a slot with no enforcement. Must run
+// inside the slot's namespace, like the attach itself.
+func (fw *Firewall) VerifyAttached() error {
+	chains, err := fw.conn.ListChainsOfTableFamily(nftables.TableFamilyINet)
+	if err != nil {
+		return fmt.Errorf("list chains: %w", err)
+	}
+	found := map[string]bool{}
+	for _, c := range chains {
+		if c.Table != nil && c.Table.Name == fw.table.Name {
+			found[c.Name] = true
+		}
+	}
+	for _, want := range []string{fw.filterChain.Name, fw.natChain.Name, fw.postChain.Name, fw.fwdChain.Name} {
+		if !found[want] {
+			return fmt.Errorf("chain %q missing from kernel", want)
+		}
+	}
+	for _, set := range []*nftables.Set{fw.predefinedDenySet, fw.predefinedAllowSet, fw.userDenySet, fw.userAllowSet} {
+		if _, err := fw.conn.GetSetByName(fw.table, set.Name); err != nil {
+			return fmt.Errorf("set %q missing from kernel: %w", set.Name, err)
+		}
+	}
+	rules, err := fw.conn.GetRules(fw.table, fw.filterChain)
+	if err != nil {
+		return fmt.Errorf("get filter rules: %w", err)
+	}
+	if len(rules) == 0 {
+		return fmt.Errorf("filter chain present but empty")
+	}
+	return nil
+}
+
 // Close tears down the nftables connection. Kernel-level table and
 // rules persist across the close — they're owned by the kernel, not
 // by this netlink handle. AttachFirewall can re-bind to them later.

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1606,18 +1606,21 @@ func pidsInNs(name string) (pids []int, ok bool) {
 	return pids, true
 }
 
-// occupiedNamespaces reports which named network namespaces have at least
-// one live process, from a SINGLE /proc pass — the per-slot pidsInNs scan
-// costs a full /proc readdir each, which is exactly the multiplier the
-// receipt fast path exists to remove. ok=false means /proc itself was
-// unreadable: "don't know", never "all clear".
-func occupiedNamespaces() (occupied map[string]bool, ok bool) {
+// occupiedNamespaces reports every named network namespace (names) and which
+// of them have at least one live process (occupied), from ONE netns readdir
+// and ONE /proc pass — the per-slot pidsInNs scan costs a full /proc readdir
+// each, which is exactly the multiplier the receipt fast path exists to
+// remove. ok=false means a directory was unreadable: "don't know", never
+// "all clear".
+func occupiedNamespaces() (names, occupied map[string]bool, ok bool) {
 	entries, err := os.ReadDir(netnsDir)
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
+	names = make(map[string]bool, len(entries))
 	inoToName := make(map[uint64]string, len(entries))
 	for _, e := range entries {
+		names[e.Name()] = true
 		st, err := os.Stat(netnsDir + "/" + e.Name())
 		if err != nil {
 			continue
@@ -1626,7 +1629,7 @@ func occupiedNamespaces() (occupied map[string]bool, ok bool) {
 	}
 	procs, err := os.ReadDir("/proc")
 	if err != nil {
-		return nil, false
+		return nil, nil, false
 	}
 	occupied = make(map[string]bool)
 	for _, e := range procs {
@@ -1644,7 +1647,7 @@ func occupiedNamespaces() (occupied map[string]bool, ok bool) {
 			occupied[name] = true
 		}
 	}
-	return occupied, true
+	return names, occupied, true
 }
 
 // listHostVeths returns all veth-N interfaces visible in the host namespace.

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -1606,6 +1606,47 @@ func pidsInNs(name string) (pids []int, ok bool) {
 	return pids, true
 }
 
+// occupiedNamespaces reports which named network namespaces have at least
+// one live process, from a SINGLE /proc pass — the per-slot pidsInNs scan
+// costs a full /proc readdir each, which is exactly the multiplier the
+// receipt fast path exists to remove. ok=false means /proc itself was
+// unreadable: "don't know", never "all clear".
+func occupiedNamespaces() (occupied map[string]bool, ok bool) {
+	entries, err := os.ReadDir(netnsDir)
+	if err != nil {
+		return nil, false
+	}
+	inoToName := make(map[uint64]string, len(entries))
+	for _, e := range entries {
+		st, err := os.Stat(netnsDir + "/" + e.Name())
+		if err != nil {
+			continue
+		}
+		inoToName[st.Sys().(*syscall.Stat_t).Ino] = e.Name()
+	}
+	procs, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, false
+	}
+	occupied = make(map[string]bool)
+	for _, e := range procs {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(e.Name()); err != nil {
+			continue
+		}
+		st, err := os.Stat("/proc/" + e.Name() + "/ns/net")
+		if err != nil {
+			continue
+		}
+		if name, hit := inoToName[st.Sys().(*syscall.Stat_t).Ino]; hit {
+			occupied[name] = true
+		}
+	}
+	return occupied, true
+}
+
 // listHostVeths returns all veth-N interfaces visible in the host namespace.
 func listHostVeths() ([]string, error) {
 	entries, err := os.ReadDir(hostNetDir)

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -739,7 +739,7 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 		}
 	}
 
-	var demoted int64
+	var demoted, quarantined int64
 	var timeouts atomic.Int64
 	var mu sync.Mutex
 	work := make(chan int)
@@ -752,7 +752,17 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 			for idx := range work {
 				slot, timedOut := p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
 				if timedOut {
+					// The abandoned validator may still be mutating this
+					// namespace; the index must not re-enter ANY path this
+					// boot. Release it — the nsExists guard keeps the index
+					// from being rebuilt while the namespace lives, the leak
+					// gauge surfaces it, and the next boot re-adopts it.
 					timeouts.Add(1)
+					p.mgr.releaseIfOwned(idx, poolOwner)
+					mu.Lock()
+					quarantined++
+					mu.Unlock()
+					continue
 				}
 				if slot == nil {
 					mu.Lock()
@@ -815,7 +825,8 @@ feed:
 	workers.Wait()
 
 	p.log.Info().Int("vouched", len(toValidate)).Int64("placed", placed).
-		Int64("demoted", demoted).Int("unvouched", len(candidates)-len(toValidate)).
+		Int64("demoted", demoted).Int64("quarantined", quarantined).
+		Int("unvouched", len(candidates)-len(toValidate)).
 		Int64("fast_path_ms", time.Since(tStart).Milliseconds()).
 		Msg("pool: receipt fast adoption complete")
 	return remaining, placed

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"errors"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,6 +86,15 @@ type Pool struct {
 	// valid is unknowable without receipt/version evidence.
 	adoptStreak       atomic.Int64
 	adoptEscapeStreak int64
+
+	// quiesced is set by Stop (abandon mode) only when every pool worker
+	// joined within the bound; receiptFresh/receiptRecycled are the settled
+	// channel membership drained at that moment. CommitReceipt refuses to
+	// write unless quiesced — a receipt may vouch only for slots no worker
+	// could still have been touching.
+	quiesced        bool
+	receiptFresh    []int
+	receiptRecycled []int
 
 	// notifyCh broadcasts producer progress (a delivery or a state change) to
 	// ClaimWait waiters by close-and-replace, so a burst of claimants wakes on
@@ -664,6 +674,144 @@ func (p *Pool) stopSlot(slot *preallocSlot) {
 	p.cleanup(slot)
 }
 
+// adoptFromReceipt consumes the previous process's receipt and, for every
+// candidate it vouches for, runs cheap batched validation and places the
+// slot straight into inventory — no kill/poll, no firewall reinstall, no
+// route rewrite, no tap rebuild: those exist to re-derive or repair state
+// the receipt proves is already settled and current. Returns the remaining
+// candidates (unvouched plus demoted) for the full path, and the count
+// placed. All scans are batched: one netns readdir, one host-interface
+// readdir, one /proc pass — the per-slot multiplier is the cost being
+// removed.
+func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remaining []int, placed int64) {
+	r, reason := consumePoolReceipt()
+	if r == nil {
+		if reason != "absent" {
+			p.log.Warn().Str("reason", reason).Msg("pool: receipt rejected — full adoption for all candidates")
+		}
+		return candidates, 0
+	}
+
+	tStart := time.Now()
+	vouched := make(map[int]bool, len(r.Fresh)+len(r.Recycled))
+	preferRecycled := make(map[int]bool, len(r.Recycled))
+	for _, idx := range r.Fresh {
+		vouched[idx] = true
+	}
+	for _, idx := range r.Recycled {
+		vouched[idx] = true
+		preferRecycled[idx] = true
+	}
+
+	occupied, ok := occupiedNamespaces()
+	if !ok {
+		p.log.Warn().Msg("pool: /proc scan failed — receipt discarded, full adoption for all candidates")
+		return candidates, 0
+	}
+	nsSet := make(map[string]bool)
+	if entries, err := os.ReadDir(netnsDir); err == nil {
+		for _, e := range entries {
+			nsSet[e.Name()] = true
+		}
+	}
+	vethSet := make(map[string]bool)
+	if veths, err := listHostVeths(); err == nil {
+		for _, v := range veths {
+			vethSet[v] = true
+		}
+	}
+
+	var toValidate []int
+	for _, idx := range candidates {
+		if vouched[idx] {
+			toValidate = append(toValidate, idx)
+		} else {
+			remaining = append(remaining, idx)
+		}
+	}
+
+	var demoted int64
+	var mu sync.Mutex
+	work := make(chan int)
+	var workers sync.WaitGroup
+	for i := 0; i < adoptConcurrency; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			defer sentrylog.Recover("netpool-receipt-adopt")
+			for idx := range work {
+				slot := p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
+				if slot == nil {
+					mu.Lock()
+					remaining = append(remaining, idx)
+					demoted++
+					mu.Unlock()
+					continue
+				}
+				if !p.placeVouched(slot, preferRecycled[idx]) {
+					// No channel space: not a defect, just surplus. Route
+					// through the full path, which owns overflow teardown.
+					mu.Lock()
+					remaining = append(remaining, idx)
+					demoted++
+					mu.Unlock()
+					continue
+				}
+				p.adoptDelivered()
+				p.signalProgress()
+				mu.Lock()
+				placed++
+				mu.Unlock()
+			}
+		}()
+	}
+feed:
+	for i, idx := range toValidate {
+		select {
+		case work <- idx:
+		case <-p.stopCh:
+			mu.Lock()
+			remaining = append(remaining, toValidate[i:]...)
+			mu.Unlock()
+			break feed
+		case <-ctx.Done():
+			mu.Lock()
+			remaining = append(remaining, toValidate[i:]...)
+			mu.Unlock()
+			break feed
+		}
+	}
+	close(work)
+	workers.Wait()
+
+	p.log.Info().Int("vouched", len(toValidate)).Int64("placed", placed).
+		Int64("demoted", demoted).Int("unvouched", len(candidates)-len(toValidate)).
+		Int64("fast_path_ms", time.Since(tStart).Milliseconds()).
+		Msg("pool: receipt fast adoption complete")
+	return remaining, placed
+}
+
+// placeVouched returns a vouched slot to inventory, preferring the channel
+// it occupied in its previous life; a full preferred channel falls over to
+// the other (both directions are safe — the slot is fully built).
+func (p *Pool) placeVouched(slot *preallocSlot, preferRecycled bool) bool {
+	first, second := p.fresh, p.recycled
+	if preferRecycled {
+		first, second = p.recycled, p.fresh
+	}
+	select {
+	case first <- slot:
+		return true
+	default:
+	}
+	select {
+	case second <- slot:
+		return true
+	default:
+	}
+	return false
+}
+
 // AdoptOrphanSlots claims every namespace a previous vmd lifetime left behind
 // and feeds the valid ones through the recycle verification path, so a restart
 // starts with a warm pool instead of rebuilding it from scratch. Slots that
@@ -690,6 +838,16 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 	indexes := p.mgr.claimOrphanSlots()
 	p.adoptPhase.Store(adoptPhaseVerifying)
 	p.signalProgress()
+
+	// Receipt fast path. Consumed (one-shot) and validated BEFORE the worker
+	// pass; whatever it vouches for — intersected with the candidates the
+	// scan actually claimed, so ownership decided above always outranks the
+	// receipt — skips the paranoid rebuild and rejoins inventory after cheap
+	// batched validation. Everything else, including vouched slots that fail
+	// a check, takes the full path below unchanged.
+	indexes, fastAdopted := p.adoptFromReceipt(ctx, indexes)
+	adopted += fastAdopted
+
 	if len(indexes) > 0 {
 		p.log.Info().Int("candidates", len(indexes)).Msg("pool: adopting slots left by previous run")
 
@@ -750,7 +908,9 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 		}
 		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
 			Int64("skipped", nSkipped.Load()).Msg("pool: adoption pass complete")
-		adopted, invalid, skipped = nAdopted.Load(), nInvalid.Load(), nSkipped.Load()
+		// Accumulate — adopted already carries the receipt fast path's count.
+		adopted += nAdopted.Load()
+		invalid, skipped = nInvalid.Load(), nSkipped.Load()
 	}
 
 	p.adoptPhase.Store(adoptPhaseIdle)
@@ -881,18 +1041,44 @@ func (p *Pool) Stop() {
 	close(p.stopCh)
 
 	if p.abandonOnStop {
-		// Bounded wait purely to let in-flight goroutines observe stopCh and
-		// quiesce; slots stay in the kernel either way, so an expired wait
-		// abandons nothing that boot-time adoption doesn't already cover.
+		// Bounded wait for every mutation source (refill, verify, adoption)
+		// to observe stopCh and join. Slots stay in the kernel either way —
+		// an expired wait abandons nothing that boot-time adoption doesn't
+		// already cover — but only a COMPLETE join permits the receipt
+		// snapshot below: a worker still running could deliver or tear down
+		// a slot after we recorded it, and a receipt must vouch only for
+		// settled state.
 		done := make(chan struct{})
 		go func() { p.wg.Wait(); close(done) }()
 		select {
 		case <-done:
+			// Fully quiesced: nothing else touches the channels, so their
+			// membership is a fact, not a race. Drain them into the snapshot
+			// (the structs are abandoned regardless; only indexes matter).
+			for {
+				select {
+				case slot := <-p.fresh:
+					p.receiptFresh = append(p.receiptFresh, slot.idx)
+					continue
+				default:
+				}
+				break
+			}
+			for {
+				select {
+				case slot := <-p.recycled:
+					p.receiptRecycled = append(p.receiptRecycled, slot.idx)
+					continue
+				default:
+				}
+				break
+			}
+			p.quiesced = true
 		case <-time.After(abandonStopWait):
-			p.log.Warn().Msg("pool: in-flight workers still settling at exit — slots remain adoptable")
+			p.log.Warn().Msg("pool: in-flight workers still settling at exit — slots remain adoptable, no receipt will be written")
 		}
-		p.log.Info().Int("fresh", len(p.fresh)).Int("recycled", len(p.recycled)).
-			Msg("network pool stopped (slots abandoned for adoption)")
+		p.log.Info().Int("fresh", len(p.receiptFresh)).Int("recycled", len(p.receiptRecycled)).
+			Bool("quiesced", p.quiesced).Msg("network pool stopped (slots abandoned for adoption)")
 		return
 	}
 
@@ -907,6 +1093,40 @@ func (p *Pool) Stop() {
 		p.cleanup(slot)
 	}
 	p.log.Info().Msg("network pool stopped")
+}
+
+// CommitReceipt writes the pool receipt as the caller's final shutdown act.
+// It refuses — silently falling back to full adoption on next boot — unless
+// this was an abandon-mode stop that fully quiesced, and the start-generation
+// mechanism is installed. Call only after every other shutdown step has
+// completed successfully; an aborted or failing shutdown must not vouch.
+func (p *Pool) CommitReceipt() {
+	if !p.abandonOnStop || !p.quiesced {
+		return
+	}
+	gen, ok := readGeneration()
+	if !ok {
+		p.log.Info().Msg("pool: start-generation mechanism not installed — no receipt written")
+		return
+	}
+	bootID, err := readBootID()
+	if err != nil {
+		p.log.Warn().Err(err).Msg("pool: boot id unreadable — no receipt written")
+		return
+	}
+	r := &poolReceipt{
+		BootID:      bootID,
+		Generation:  gen,
+		Fingerprint: slotPolicyFingerprint(),
+		Fresh:       p.receiptFresh,
+		Recycled:    p.receiptRecycled,
+	}
+	if err := writePoolReceipt(r); err != nil {
+		p.log.Warn().Err(err).Msg("pool: receipt write failed — next boot takes the full adoption path")
+		return
+	}
+	p.log.Info().Int("fresh", len(r.Fresh)).Int("recycled", len(r.Recycled)).
+		Uint64("generation", gen).Msg("pool: receipt committed for next boot")
 }
 
 // refillStep outcomes: the worker delivered/discarded a slot and should loop,

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"errors"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -712,16 +711,10 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 		preferRecycled[idx] = true
 	}
 
-	occupied, ok := occupiedNamespaces()
+	nsSet, occupied, ok := occupiedNamespaces()
 	if !ok {
-		p.log.Warn().Msg("pool: /proc scan failed — receipt discarded, full adoption for all candidates")
+		p.log.Warn().Msg("pool: namespace/proc scan failed — receipt discarded, full adoption for all candidates")
 		return candidates, 0
-	}
-	nsSet := make(map[string]bool)
-	if entries, err := os.ReadDir(netnsDir); err == nil {
-		for _, e := range entries {
-			nsSet[e.Name()] = true
-		}
 	}
 	vethSet := make(map[string]bool)
 	if veths, err := listHostVeths(); err == nil {

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -166,7 +166,6 @@ const (
 	// under a second, and a tight bound keeps a stalled backlog (and Stop)
 	// from dragging.
 	resetTapTimeout = 3 * time.Second
-	PLACEHOLDER_REMOVED
 	// adoptConcurrency bounds parallel orphan adoptions: each runs /proc
 	// scans and possibly a tap rebuild, and boot is exactly when the host is
 	// also reattaching VMs — keep the sweep gentle.
@@ -684,10 +683,11 @@ func (p *Pool) stopSlot(slot *preallocSlot) {
 }
 
 // adoptFromReceipt consumes the previous process's receipt and, for every
-// candidate it vouches for, runs cheap batched validation and places the
-// slot straight into inventory — no kill/poll, no firewall reinstall, no
-// route rewrite, no tap rebuild: those exist to re-derive or repair state
-// the receipt proves is already settled and current. Returns the remaining
+// candidate it vouches for, runs cheap batched validation — plus an
+// in-process firewall rebuild from current policy — and places the slot
+// straight into inventory. What it skips is the expensive re-derivation:
+// no kill/poll, no route-rewrite subprocesses, no tap rebuild; the receipt
+// proves that state is already settled and current. Returns the remaining
 // candidates (unvouched plus demoted) for the full path, and the count
 // placed. All scans are batched: one netns readdir, one host-interface
 // readdir, one /proc pass — the per-slot multiplier is the cost being

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -166,10 +166,7 @@ const (
 	// under a second, and a tight bound keeps a stalled backlog (and Stop)
 	// from dragging.
 	resetTapTimeout = 3 * time.Second
-	// abandonStopWait bounds Stop's wait for in-flight pool goroutines under
-	// abandon-on-stop. Only quiesces logging — abandoned slots are recovered
-	// by boot-time adoption regardless.
-	abandonStopWait = 2 * time.Second
+	PLACEHOLDER_REMOVED
 	// adoptConcurrency bounds parallel orphan adoptions: each runs /proc
 	// scans and possibly a tap rebuild, and boot is exactly when the host is
 	// also reattaching VMs — keep the sweep gentle.
@@ -190,6 +187,18 @@ const (
 	// forgets. The escape is bounded by the claim budget regardless.
 	defaultAdoptEscapeStreak = 32
 )
+
+// abandonStopWait bounds Stop's wait for in-flight pool goroutines under
+// abandon-on-stop. It must exceed the longest operation a worker can
+// legally be inside — a queued tap rebuild (resetTapTimeout) plus
+// scheduling margin — because a completed join is what licenses the
+// shutdown receipt: a bound shorter than legal work would silently forfeit
+// the receipt on every deploy that lands during churn, exactly when it
+// matters. Verify-polls waiting out a slow guest (up to verifyMaxWait) can
+// still exceed this; those shutdowns forfeit the receipt deliberately
+// rather than holding the restart hostage. A var so tests can bound their
+// own runtime.
+var abandonStopWait = 10 * time.Second
 
 // Adoption pass phases (Pool.adoptPhase).
 const (
@@ -731,6 +740,7 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 	}
 
 	var demoted int64
+	var timeouts atomic.Int64
 	var mu sync.Mutex
 	work := make(chan int)
 	var workers sync.WaitGroup
@@ -740,7 +750,10 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 			defer workers.Done()
 			defer sentrylog.Recover("netpool-receipt-adopt")
 			for idx := range work {
-				slot := p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
+				slot, timedOut := p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
+				if timedOut {
+					timeouts.Add(1)
+				}
 				if slot == nil {
 					mu.Lock()
 					remaining = append(remaining, idx)
@@ -749,8 +762,13 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 					continue
 				}
 				if !p.placeVouched(slot, preferRecycled[idx]) {
-					// No channel space: not a defect, just surplus. Route
-					// through the full path, which owns overflow teardown.
+					// No channel space: not a defect, just surplus. Close the
+					// attached handle — the full path opens its own — and
+					// route the index through it, which owns overflow
+					// teardown.
+					if slot.info.Firewall != nil {
+						_ = slot.info.Firewall.Close()
+					}
 					mu.Lock()
 					remaining = append(remaining, idx)
 					demoted++
@@ -767,6 +785,18 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 	}
 feed:
 	for i, idx := range toValidate {
+		if timeouts.Load() >= adoptTimeoutAbort {
+			// Wedges are systemic (a stuck netlink wedges every candidate)
+			// and each strands a pinned thread — same reasoning as the full
+			// pass's abort. The remainder goes to the full path, which has
+			// its own bound and abort.
+			p.log.Error().Int64("timeouts", timeouts.Load()).
+				Msg("pool: receipt fast path aborting — validation timing out systemically")
+			mu.Lock()
+			remaining = append(remaining, toValidate[i:]...)
+			mu.Unlock()
+			break feed
+		}
 		select {
 		case work <- idx:
 		case <-p.stopCh:

--- a/internal/network/receipt.go
+++ b/internal/network/receipt.go
@@ -199,7 +199,13 @@ var fastAdoptSlotTimeout = 3 * time.Second
 
 // fastAdoptVouched runs the cheap validation a vouched slot must still pass
 // before rejoining inventory: namespace present, host veth present, zero
-// occupants (from the caller's single batched /proc scan), and — inside the
+// occupants (from the caller's single batched /proc scan — advisory triage,
+// not the safety boundary: every candidate is pool-OWNED from the moment
+// claimOrphanSlots claimed it, launches only ever enter namespaces via a
+// claimed pool slot or a freshly claimed free index, and running VMs' slots
+// are record-owned and never candidates, so nothing can enter a candidate's
+// namespace between this scan and the rebuild; the full path's kill/poll
+// relies on the same ownership exclusion across its own gap), and — inside the
 // namespace — the tap device present and the firewall ruleset rebuilt from
 // current policy (in-process netlink; requires the zero-occupant guarantee,
 // as the rebuild briefly drops enforcement). No kill/poll, no route

--- a/internal/network/receipt.go
+++ b/internal/network/receipt.go
@@ -179,20 +179,16 @@ func consumePoolReceipt() (*poolReceipt, string) {
 // validation without real kernel namespaces.
 var nsExecGoFunc = nsExecGo
 
-// attachAndVerifyFirewall binds a handle to the namespace's existing ruleset
-// and confirms the kernel actually holds it. A seam so tests can exercise
-// the demotion paths without kernel nftables.
-var attachAndVerifyFirewall = func(cfg FirewallConfig) (*Firewall, error) {
-	fw, err := AttachFirewall(cfg)
-	if err != nil {
-		return nil, err
-	}
-	if err := fw.VerifyAttached(); err != nil {
-		_ = fw.Close()
-		return nil, fmt.Errorf("attached but unverified: %w", err)
-	}
-	return fw, nil
-}
+// reinstallFirewallFunc is a seam over ReinstallFirewall so tests can
+// exercise the demotion paths without kernel nftables. The fast path
+// REBUILDS the ruleset rather than attaching to the previous process's:
+// rebuilding is a single in-process netlink batch (milliseconds — the
+// receipt's savings are the kill/poll, the route subprocesses, and the tap
+// rebuild, not this), and it makes the rules correct by construction
+// against current policy. Attach-and-verify was the alternative, and any
+// verification deep enough to actually prove enforcement converges on
+// reinstallation anyway.
+var reinstallFirewallFunc = ReinstallFirewall
 
 // fastAdoptSlotTimeout bounds one vouched slot's in-namespace validation.
 // The checks are milliseconds when healthy; the bound exists because netlink
@@ -204,11 +200,12 @@ var fastAdoptSlotTimeout = 3 * time.Second
 // fastAdoptVouched runs the cheap validation a vouched slot must still pass
 // before rejoining inventory: namespace present, host veth present, zero
 // occupants (from the caller's single batched /proc scan), and — inside the
-// namespace — the tap device present and the previous process's ruleset
-// verified present in the kernel and attached. No teardown, no reinstall,
-// no routes: the kernel objects were settled inventory of the immediately
-// preceding process and the fingerprint proves the policy that built them
-// is current. Failure demotes to the full path (slot=nil); timedOut also
+// namespace — the tap device present and the firewall ruleset rebuilt from
+// current policy (in-process netlink; requires the zero-occupant guarantee,
+// as the rebuild briefly drops enforcement). No kill/poll, no route
+// rewrites, no tap rebuild: the kernel objects were settled inventory of
+// the immediately preceding process and the fingerprint proves the policy
+// that shaped them is current. Failure demotes to the full path (slot=nil); timedOut also
 // reports the in-namespace worker wedging so the caller can abort the fast
 // pass systemically. A panic in the validation demotes rather than killing
 // the worker — a pool-owned index must always land in one path or the other.
@@ -249,7 +246,7 @@ func (p *Pool) fastAdoptVouched(idx int, nsSet, vethSet map[string]bool, occupie
 					return fmt.Errorf("tap missing: %w", err)
 				}
 				var aerr error
-				fw, aerr = attachAndVerifyFirewall(FirewallConfig{
+				fw, aerr = reinstallFirewallFunc(FirewallConfig{
 					TAPInterface: TAPName,
 					VethPeer:     "eth0",
 					VMIP:         VMInternalIP,

--- a/internal/network/receipt.go
+++ b/internal/network/receipt.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // The pool receipt is not cached state — it is a short-lived capability
@@ -178,51 +179,122 @@ func consumePoolReceipt() (*poolReceipt, string) {
 // validation without real kernel namespaces.
 var nsExecGoFunc = nsExecGo
 
+// attachAndVerifyFirewall binds a handle to the namespace's existing ruleset
+// and confirms the kernel actually holds it. A seam so tests can exercise
+// the demotion paths without kernel nftables.
+var attachAndVerifyFirewall = func(cfg FirewallConfig) (*Firewall, error) {
+	fw, err := AttachFirewall(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := fw.VerifyAttached(); err != nil {
+		_ = fw.Close()
+		return nil, fmt.Errorf("attached but unverified: %w", err)
+	}
+	return fw, nil
+}
+
+// fastAdoptSlotTimeout bounds one vouched slot's in-namespace validation.
+// The checks are milliseconds when healthy; the bound exists because netlink
+// can wedge with a pinned thread (the same failure the full path bounds at
+// its larger budget), and a wedged fast path must degrade to the full path,
+// never hang the adoption pass.
+var fastAdoptSlotTimeout = 3 * time.Second
+
 // fastAdoptVouched runs the cheap validation a vouched slot must still pass
 // before rejoining inventory: namespace present, host veth present, zero
 // occupants (from the caller's single batched /proc scan), and — inside the
-// namespace — the tap device present and a firewall handle attachable to
-// the previous process's ruleset. No teardown, no reinstall, no routes: the
-// kernel objects were settled inventory of the immediately preceding
-// process and the fingerprint proves the policy that built them is current.
-// Any failure returns nil and the slot is demoted to the full path.
-func (p *Pool) fastAdoptVouched(idx int, nsSet, vethSet map[string]bool, occupied map[string]bool) *preallocSlot {
+// namespace — the tap device present and the previous process's ruleset
+// verified present in the kernel and attached. No teardown, no reinstall,
+// no routes: the kernel objects were settled inventory of the immediately
+// preceding process and the fingerprint proves the policy that built them
+// is current. Failure demotes to the full path (slot=nil); timedOut also
+// reports the in-namespace worker wedging so the caller can abort the fast
+// pass systemically. A panic in the validation demotes rather than killing
+// the worker — a pool-owned index must always land in one path or the other.
+func (p *Pool) fastAdoptVouched(idx int, nsSet, vethSet map[string]bool, occupied map[string]bool) (slot *preallocSlot, timedOut bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.log.Error().Interface("panic", r).Int("slot", idx).
+				Msg("pool: vouched slot validation panicked — demoting to full adoption")
+			slot = nil
+		}
+	}()
 	nsName := nsNameForSlot(idx)
 	vethName := vethNameForSlot(idx)
 	if !nsSet[nsName] || !vethSet[vethName] || occupied[nsName] {
-		return nil
+		return nil, false
 	}
-	var fw *Firewall
-	err := nsExecGoFunc(nsName, func() error {
-		if _, err := net.InterfaceByName(TAPName); err != nil {
-			return fmt.Errorf("tap missing: %w", err)
+
+	type result struct {
+		fw  *Firewall
+		err error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		// The result send must happen on EVERY exit — a panic that killed
+		// this goroutine silently would leave the select below waiting out
+		// the timeout and misclassify the failure as a wedge, feeding the
+		// systemic abort counter.
+		var fw *Firewall
+		var err error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("validation panicked: %v", r)
+				}
+			}()
+			err = nsExecGoFunc(nsName, func() error {
+				if _, err := net.InterfaceByName(TAPName); err != nil {
+					return fmt.Errorf("tap missing: %w", err)
+				}
+				var aerr error
+				fw, aerr = attachAndVerifyFirewall(FirewallConfig{
+					TAPInterface: TAPName,
+					VethPeer:     "eth0",
+					VMIP:         VMInternalIP,
+					HostIP:       hostIPForSlot(idx),
+					GatewayIP:    VMGatewayIP,
+				})
+				return aerr
+			})
+		}()
+		if err != nil && fw != nil {
+			_ = fw.Close()
+			fw = nil
 		}
-		var aerr error
-		fw, aerr = AttachFirewall(FirewallConfig{
-			TAPInterface: TAPName,
-			VethPeer:     "eth0",
-			VMIP:         VMInternalIP,
-			HostIP:       hostIPForSlot(idx),
-			GatewayIP:    VMGatewayIP,
-		})
-		return aerr
-	})
-	if err != nil {
-		p.log.Debug().Err(err).Int("slot", idx).Msg("pool: vouched slot failed fast validation — demoting to full adoption")
-		return nil
-	}
-	return &preallocSlot{
-		idx: idx,
-		info: &VMNetInfo{
-			Namespace:  nsName,
-			TAPDevice:  TAPName,
-			VMIP:       VMInternalIP,
-			GatewayIP:  VMGatewayIP,
-			HostIP:     hostIPForSlot(idx),
-			MACAddress: macForSlot(idx),
-			Firewall:   fw,
-		},
-		vethName: vethName,
-		adopted:  true,
+		resCh <- result{fw, err}
+	}()
+
+	select {
+	case r := <-resCh:
+		if r.err != nil {
+			p.log.Debug().Err(r.err).Int("slot", idx).Msg("pool: vouched slot failed fast validation — demoting to full adoption")
+			return nil, false
+		}
+		return &preallocSlot{
+			idx: idx,
+			info: &VMNetInfo{
+				Namespace:  nsName,
+				TAPDevice:  TAPName,
+				VMIP:       VMInternalIP,
+				GatewayIP:  VMGatewayIP,
+				HostIP:     hostIPForSlot(idx),
+				MACAddress: macForSlot(idx),
+				Firewall:   r.fw,
+			},
+			vethName: vethName,
+			adopted:  true,
+		}, false
+	case <-time.After(fastAdoptSlotTimeout):
+		// Abandon the pinned worker; when it eventually finishes, its handle
+		// must not leak.
+		go func() {
+			if r := <-resCh; r.fw != nil {
+				_ = r.fw.Close()
+			}
+		}()
+		p.log.Warn().Int("slot", idx).Msg("pool: vouched slot validation timed out — demoting to full adoption")
+		return nil, true
 	}
 }

--- a/internal/network/receipt.go
+++ b/internal/network/receipt.go
@@ -285,13 +285,19 @@ func (p *Pool) fastAdoptVouched(idx int, nsSet, vethSet map[string]bool, occupie
 		}, false
 	case <-time.After(fastAdoptSlotTimeout):
 		// Abandon the pinned worker; when it eventually finishes, its handle
-		// must not leak.
+		// must not leak. CRITICALLY, the caller must NOT route this index
+		// anywhere this boot: the abandoned worker may still be mid-rebuild
+		// inside the namespace, and republishing the slot would let it wipe
+		// a claimed sandbox's rules when it wakes. Timed-out slots are
+		// released and left for the next boot, mirroring the full path's
+		// timeout semantics — only failures whose validator provably
+		// finished (an error or panic result) may demote to the full path.
 		go func() {
 			if r := <-resCh; r.fw != nil {
 				_ = r.fw.Close()
 			}
 		}()
-		p.log.Warn().Int("slot", idx).Msg("pool: vouched slot validation timed out — demoting to full adoption")
+		p.log.Warn().Int("slot", idx).Msg("pool: vouched slot validation timed out — releasing for a later boot")
 		return nil, true
 	}
 }

--- a/internal/network/receipt.go
+++ b/internal/network/receipt.go
@@ -1,0 +1,228 @@
+package network
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// The pool receipt is not cached state — it is a short-lived capability
+// issued by the immediately preceding, fully quiesced vmd process. A clean
+// shutdown snapshots the slots the pool knows are good (settled members of
+// the fresh and recycled channels) and vouches for them; the next boot may
+// then skip the paranoid per-slot rebuild for vouched slots and run cheap
+// validation instead. Every gate fails closed: no receipt, a malformed
+// receipt, a crash (which never writes one), a host reboot, an intervening
+// process, or a slot-policy change all land on the existing full adoption
+// path.
+//
+// Succession is proven, not assumed: a start generation is bumped by a
+// systemd drop-in before every vmd start — including starts of older
+// binaries that know nothing of receipts, since drop-ins survive rollback
+// deploys — and a receipt written by generation N is honored only by
+// generation N+1. Same-boot-ID plus consecutive-generation together mean
+// "no other process touched these slots since the writer quiesced".
+
+// slotPolicyVersion names the per-namespace slot contract: the nftables
+// table/chain/set layout, tap addressing and MTU, the index-derived IP and
+// MAC formulas. Bump it whenever any of those change so receipts written
+// under the old contract are rejected and adoption rebuilds every slot —
+// the rebuild is also the mechanism that installs new policy onto old
+// slots. Deploys that do not touch the slot contract keep the fast path.
+const slotPolicyVersion = 1
+
+var (
+	receiptPath    = "/run/vmd/netpool-receipt.json"
+	generationPath = "/run/vmd/generation"
+	bootIDPath     = "/proc/sys/kernel/random/boot_id"
+)
+
+type poolReceipt struct {
+	BootID      string `json:"boot_id"`
+	Generation  uint64 `json:"generation"`
+	Fingerprint string `json:"fingerprint"`
+	Fresh       []int  `json:"fresh"`
+	Recycled    []int  `json:"recycled"`
+}
+
+// slotPolicyFingerprint digests every input that determines what a correct
+// slot looks like from inside its namespace. Deliberately NOT the binary
+// version — that would invalidate the receipt on every deploy, and deploys
+// are the case the receipt exists for. Runtime-reloadable policy (user rule
+// sets, blocklist CIDR reloads) is excluded: pool slots carry no user rules,
+// and per-VM sets are replaced at claim time regardless.
+func slotPolicyFingerprint() string {
+	h := sha256.New()
+	fmt.Fprintf(h, "v%d|%s|%s|%s|%s|%s|%s|%d|%s|", slotPolicyVersion,
+		VMInternalIP, VMGatewayIP, TAPName, tapCIDR, tapMAC, ifaceMTU,
+		MaxSlots, tableName)
+	for _, c := range DeniedCIDRs {
+		io.WriteString(h, c)
+		io.WriteString(h, ",")
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func readBootID() (string, error) {
+	b, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// readGeneration reports the start generation the systemd drop-in stamped
+// for this process, or ok=false when the mechanism isn't installed — in
+// which case receipts are neither written nor honored.
+func readGeneration() (uint64, bool) {
+	b, err := os.ReadFile(generationPath)
+	if err != nil {
+		return 0, false
+	}
+	gen, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return gen, true
+}
+
+// writePoolReceipt commits the receipt durably: temp + fsync + rename +
+// directory fsync, so a crash mid-write leaves either no receipt or a
+// complete one — never a torn file (a torn file would be rejected as
+// malformed anyway; this keeps the failure mode boring).
+func writePoolReceipt(r *poolReceipt) error {
+	data, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal receipt: %w", err)
+	}
+	dir := filepath.Dir(receiptPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("receipt dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".netpool-receipt-*")
+	if err != nil {
+		return fmt.Errorf("receipt temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("receipt write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("receipt sync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("receipt close: %w", err)
+	}
+	if err := os.Rename(tmpName, receiptPath); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("receipt rename: %w", err)
+	}
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}
+
+// consumePoolReceipt reads and validates the receipt, DELETING IT BEFORE
+// acting on its contents — the one-shot invariant: a receipt on disk means
+// nobody has acted on it, so a crash mid-adoption can only destroy trust,
+// never mint it. Returns the receipt or nil plus a reason for the log line.
+func consumePoolReceipt() (*poolReceipt, string) {
+	data, err := os.ReadFile(receiptPath)
+	if os.IsNotExist(err) {
+		return nil, "absent"
+	}
+	if err != nil {
+		return nil, "unreadable: " + err.Error()
+	}
+	// One-shot: remove before parsing or validating. If the remove fails the
+	// invariant can't be guaranteed, so the receipt must not be trusted.
+	if err := os.Remove(receiptPath); err != nil {
+		return nil, "irrevocable: " + err.Error()
+	}
+	var r poolReceipt
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, "malformed: " + err.Error()
+	}
+	bootID, err := readBootID()
+	if err != nil || bootID != r.BootID {
+		return nil, "boot id mismatch"
+	}
+	gen, ok := readGeneration()
+	if !ok {
+		return nil, "generation unavailable"
+	}
+	if r.Generation+1 != gen {
+		return nil, fmt.Sprintf("not the immediate successor (receipt gen %d, ours %d)", r.Generation, gen)
+	}
+	if r.Fingerprint != slotPolicyFingerprint() {
+		return nil, "slot policy changed"
+	}
+	return &r, "accepted"
+}
+
+// nsExecGoFunc is a seam over nsExecGo so tests can drive the vouched-slot
+// validation without real kernel namespaces.
+var nsExecGoFunc = nsExecGo
+
+// fastAdoptVouched runs the cheap validation a vouched slot must still pass
+// before rejoining inventory: namespace present, host veth present, zero
+// occupants (from the caller's single batched /proc scan), and — inside the
+// namespace — the tap device present and a firewall handle attachable to
+// the previous process's ruleset. No teardown, no reinstall, no routes: the
+// kernel objects were settled inventory of the immediately preceding
+// process and the fingerprint proves the policy that built them is current.
+// Any failure returns nil and the slot is demoted to the full path.
+func (p *Pool) fastAdoptVouched(idx int, nsSet, vethSet map[string]bool, occupied map[string]bool) *preallocSlot {
+	nsName := nsNameForSlot(idx)
+	vethName := vethNameForSlot(idx)
+	if !nsSet[nsName] || !vethSet[vethName] || occupied[nsName] {
+		return nil
+	}
+	var fw *Firewall
+	err := nsExecGoFunc(nsName, func() error {
+		if _, err := net.InterfaceByName(TAPName); err != nil {
+			return fmt.Errorf("tap missing: %w", err)
+		}
+		var aerr error
+		fw, aerr = AttachFirewall(FirewallConfig{
+			TAPInterface: TAPName,
+			VethPeer:     "eth0",
+			VMIP:         VMInternalIP,
+			HostIP:       hostIPForSlot(idx),
+			GatewayIP:    VMGatewayIP,
+		})
+		return aerr
+	})
+	if err != nil {
+		p.log.Debug().Err(err).Int("slot", idx).Msg("pool: vouched slot failed fast validation — demoting to full adoption")
+		return nil
+	}
+	return &preallocSlot{
+		idx: idx,
+		info: &VMNetInfo{
+			Namespace:  nsName,
+			TAPDevice:  TAPName,
+			VMIP:       VMInternalIP,
+			GatewayIP:  VMGatewayIP,
+			HostIP:     hostIPForSlot(idx),
+			MACAddress: macForSlot(idx),
+			Firewall:   fw,
+		},
+		vethName: vethName,
+		adopted:  true,
+	}
+}

--- a/internal/network/receipt_test.go
+++ b/internal/network/receipt_test.go
@@ -1,0 +1,389 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// withReceiptSeams points the receipt machinery's paths at a temp dir and
+// writes the given boot-id and reader generation; empty generation means
+// the mechanism is not installed.
+func withReceiptSeams(t *testing.T, bootID, generation string) {
+	t.Helper()
+	dir := t.TempDir()
+	oldReceipt, oldGen, oldBoot := receiptPath, generationPath, bootIDPath
+	receiptPath = filepath.Join(dir, "netpool-receipt.json")
+	generationPath = filepath.Join(dir, "generation")
+	bootIDPath = filepath.Join(dir, "boot_id")
+	t.Cleanup(func() { receiptPath, generationPath, bootIDPath = oldReceipt, oldGen, oldBoot })
+	if err := os.WriteFile(bootIDPath, []byte(bootID+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if generation != "" {
+		if err := os.WriteFile(generationPath, []byte(generation+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// stubNsExecGo replaces the namespace-entry seam so vouched-slot validation
+// runs without kernel namespaces. The default stub succeeds without calling
+// fn (no tap/firewall to inspect); pass a custom fn to fail selectively.
+func stubNsExecGo(t *testing.T, fn func(ns string, inner func() error) error) {
+	t.Helper()
+	old := nsExecGoFunc
+	nsExecGoFunc = fn
+	t.Cleanup(func() { nsExecGoFunc = old })
+}
+
+func writeTestReceipt(t *testing.T, r *poolReceipt) {
+	t.Helper()
+	if err := writePoolReceipt(r); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReceipt_RoundtripAndOneShot(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "8")
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 7, Fingerprint: slotPolicyFingerprint(),
+		Fresh: []int{1, 2}, Recycled: []int{3},
+	})
+
+	r, reason := consumePoolReceipt()
+	if r == nil {
+		t.Fatalf("valid receipt rejected: %s", reason)
+	}
+	if len(r.Fresh) != 2 || len(r.Recycled) != 1 {
+		t.Fatalf("receipt contents lost: %+v", r)
+	}
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatal("receipt file must be deleted on consumption")
+	}
+	if r2, reason2 := consumePoolReceipt(); r2 != nil || reason2 != "absent" {
+		t.Fatalf("second consume must find nothing, got %v / %s", r2, reason2)
+	}
+}
+
+func TestReceipt_RejectionGates(t *testing.T) {
+	cases := []struct {
+		name       string
+		bootID     string
+		writerGen  uint64
+		readerGen  string
+		fp         string
+		wantReason string
+	}{
+		{"boot id mismatch", "boot-other", 7, "8", slotPolicyFingerprint(), "boot id mismatch"},
+		{"generation gap", "boot-a", 6, "8", slotPolicyFingerprint(), "not the immediate successor"},
+		{"same generation", "boot-a", 8, "8", slotPolicyFingerprint(), "not the immediate successor"},
+		{"mechanism missing", "boot-a", 7, "", slotPolicyFingerprint(), "generation unavailable"},
+		{"policy changed", "boot-a", 7, "8", "stale-fingerprint", "slot policy changed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withReceiptSeams(t, "boot-a", tc.readerGen)
+			writeTestReceipt(t, &poolReceipt{
+				BootID: tc.bootID, Generation: tc.writerGen, Fingerprint: tc.fp, Fresh: []int{1},
+			})
+			r, reason := consumePoolReceipt()
+			if r != nil {
+				t.Fatalf("receipt must be rejected, got %+v", r)
+			}
+			if len(reason) < len(tc.wantReason) || reason[:len(tc.wantReason)] != tc.wantReason {
+				t.Fatalf("reason = %q, want prefix %q", reason, tc.wantReason)
+			}
+			// Rejection must still consume: trust is destroyed, not retried.
+			if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+				t.Fatal("rejected receipt must still be deleted")
+			}
+		})
+	}
+}
+
+func TestReceipt_MalformedRejected(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "8")
+	if err := os.WriteFile(receiptPath, []byte("{torn"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if r, reason := consumePoolReceipt(); r != nil || reason[:9] != "malformed" {
+		t.Fatalf("torn receipt must be rejected as malformed, got %v / %s", r, reason)
+	}
+}
+
+func TestPoolStop_QuiesceSnapshotsInventory(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	touchNS(t, dir, "ns-1")
+	touchNS(t, dir, "ns-2")
+	m.assignSlotLocked(1, poolOwner)
+	m.assignSlotLocked(2, poolOwner)
+	p.fresh <- &preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}}
+	p.recycled <- &preallocSlot{idx: 2, info: &VMNetInfo{Namespace: "ns-2"}}
+
+	p.Stop()
+
+	if !p.quiesced {
+		t.Fatal("an idle pool must quiesce within the bound")
+	}
+	if len(p.receiptFresh) != 1 || p.receiptFresh[0] != 1 {
+		t.Fatalf("fresh snapshot = %v, want [1]", p.receiptFresh)
+	}
+	if len(p.receiptRecycled) != 1 || p.receiptRecycled[0] != 2 {
+		t.Fatalf("recycled snapshot = %v, want [2]", p.receiptRecycled)
+	}
+}
+
+func TestCommitReceipt_WritesOnlyWhenQuiesced(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "8")
+	withTestNetnsDir(t)
+	m := newTestManager()
+
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+	p.quiesced = false
+	p.CommitReceipt()
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatal("unquiesced pool must not write a receipt")
+	}
+
+	p.quiesced = true
+	p.receiptFresh = []int{4}
+	p.receiptRecycled = []int{5}
+	p.CommitReceipt()
+	r, reason := consumePoolReceipt()
+	if r != nil {
+		t.Fatalf("commit stamped writer generation; same-process consume must reject, got %+v", r)
+	}
+	if reason[:25] != "not the immediate success" {
+		t.Fatalf("unexpected reason %q", reason)
+	}
+}
+
+func TestCommitReceipt_AcceptedBySuccessor(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "8")
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+	p.quiesced = true
+	p.receiptFresh = []int{4}
+	p.receiptRecycled = []int{5}
+	p.CommitReceipt()
+
+	// Simulate the successor: the drop-in bumps the generation.
+	if err := os.WriteFile(generationPath, []byte("9\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, reason := consumePoolReceipt()
+	if r == nil {
+		t.Fatalf("successor must accept, got %s", reason)
+	}
+	if len(r.Fresh) != 1 || r.Fresh[0] != 4 || len(r.Recycled) != 1 || r.Recycled[0] != 5 {
+		t.Fatalf("snapshot mangled: %+v", r)
+	}
+}
+
+func TestCommitReceipt_NoGenerationMechanismNoReceipt(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "")
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+	p.quiesced = true
+	p.receiptFresh = []int{4}
+	p.CommitReceipt()
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatal("no generation mechanism → no receipt")
+	}
+}
+
+// TestAdoptFromReceipt_FastPathSkipsFullAdoption pins the payoff: vouched,
+// validating slots rejoin inventory without the full per-slot rebuild, and
+// everything else still takes the full path.
+func TestAdoptFromReceipt_FastPathSkipsFullAdoption(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "9")
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	// Three orphans: 1 and 2 vouched, 3 not. Slot 2's host veth is missing,
+	// so its voucher must not save it — demoted to the full path.
+	for _, idx := range []int{1, 2, 3} {
+		touchNS(t, dir, fmt.Sprintf("ns-%d", idx))
+	}
+	for _, idx := range []int{1, 3} {
+		if err := os.WriteFile(filepath.Join(hostNetDir, fmt.Sprintf("veth-%d", idx)), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(),
+		Fresh: []int{1}, Recycled: []int{2},
+	})
+
+	stubNsExecGo(t, func(ns string, inner func() error) error { return nil })
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	var fullPathMu sync.Mutex
+	var fullPath []int
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		fullPathMu.Lock()
+		fullPath = append(fullPath, idx)
+		fullPathMu.Unlock()
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	adopted, invalid, _ := p.AdoptOrphanSlots(context.Background())
+
+	if adopted != 3 || invalid != 0 {
+		t.Fatalf("adopted=%d invalid=%d, want 3/0", adopted, invalid)
+	}
+	// Slot 1 must have been placed by the fast path — never seen by adoptSlot.
+	for _, idx := range fullPath {
+		if idx == 1 {
+			t.Fatal("vouched slot 1 went through full adoption")
+		}
+	}
+	// Slots 2 (demoted) and 3 (unvouched) must have taken the full path.
+	seen := map[int]bool{}
+	for _, idx := range fullPath {
+		seen[idx] = true
+	}
+	if !seen[2] || !seen[3] {
+		t.Fatalf("full path handled %v, want it to include 2 and 3", fullPath)
+	}
+	// Fast-placed slot 1 must be claimable with its identity intact.
+	var got *VMNetInfo
+	for i := 0; i < 3; i++ {
+		if info := p.Claim(fmt.Sprintf("vm-%d", i)); info != nil && info.Namespace == "ns-1" {
+			got = info
+		}
+	}
+	if got == nil {
+		t.Fatal("fast-adopted slot never became claimable")
+	}
+	if got.HostIP != hostIPForSlot(1) || got.MACAddress != macForSlot(1) {
+		t.Fatalf("fast-adopted identity wrong: %+v", got)
+	}
+}
+
+// TestAdoptFromReceipt_CrashNeverMintsTrust pins the one-shot invariant end
+// to end: a pass that consumed the receipt and then died (simulated by a
+// second AdoptOrphanSlots run) must find nothing to trust.
+func TestAdoptFromReceipt_CrashNeverMintsTrust(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "9")
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	touchNS(t, dir, "ns-1")
+	if err := os.WriteFile(filepath.Join(hostNetDir, "veth-1"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(), Fresh: []int{1},
+	})
+	stubNsExecGo(t, func(ns string, inner func() error) error { return nil })
+
+	p.AdoptOrphanSlots(context.Background())
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatal("receipt must be consumed by the pass")
+	}
+
+	// "Crash and retry": a fresh pool adopting the same host state again.
+	p2 := newTestPool(t, m)
+	p2.abandonOnStop = true
+	var fullPath atomic.Int64
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		fullPath.Add(1)
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	// Slot 1 is still owned by pool from the first pass, so re-adoption sees
+	// no candidates — the point is only that no receipt survives to consult.
+	p2.AdoptOrphanSlots(context.Background())
+	if n := fullPath.Load(); n != 0 {
+		t.Fatalf("no candidates expected on re-adoption, full path ran %d times", n)
+	}
+}
+
+func TestPlaceVouched_PrefersPriorChannel(t *testing.T) {
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+
+	if !p.placeVouched(&preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}}, true) {
+		t.Fatal("place failed with empty channels")
+	}
+	select {
+	case s := <-p.recycled:
+		if s.idx != 1 {
+			t.Fatalf("wrong slot in recycled: %d", s.idx)
+		}
+	default:
+		t.Fatal("recycled-vouched slot must land in recycled")
+	}
+
+	for i := 0; i < cap(p.recycled); i++ {
+		p.recycled <- &preallocSlot{idx: 100 + i}
+	}
+	if !p.placeVouched(&preallocSlot{idx: 2, info: &VMNetInfo{Namespace: "ns-2"}}, true) {
+		t.Fatal("overflow must fall to the other channel")
+	}
+	select {
+	case s := <-p.fresh:
+		if s.idx != 2 {
+			t.Fatalf("wrong slot in fresh: %d", s.idx)
+		}
+	default:
+		t.Fatal("overflow slot must land in fresh")
+	}
+}
+
+func TestFingerprint_StableWithinProcess(t *testing.T) {
+	a, b := slotPolicyFingerprint(), slotPolicyFingerprint()
+	if a == "" || a != b {
+		t.Fatalf("fingerprint must be non-empty and stable, got %q / %q", a, b)
+	}
+}
+
+func TestReceipt_QuiesceTimeoutWritesNothing(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "8")
+	withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	// A worker that never observes stopCh in time: hold the wait group past
+	// the quiesce bound so Stop must give up.
+	p.wg.Add(1)
+	release := make(chan struct{})
+	go func() { defer p.wg.Done(); <-release }()
+
+	tStart := time.Now()
+	p.Stop()
+	close(release)
+	if time.Since(tStart) > 10*time.Second {
+		t.Fatal("Stop must stay bounded")
+	}
+	if p.quiesced {
+		t.Fatal("an un-joined pool must not report quiesced")
+	}
+	p.CommitReceipt()
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatal("timeout quiesce must write no receipt")
+	}
+}

--- a/internal/network/receipt_test.go
+++ b/internal/network/receipt_test.go
@@ -392,18 +392,18 @@ func TestReceipt_QuiesceTimeoutWritesNothing(t *testing.T) {
 	}
 }
 
-// stubAttachVerify overrides the attach+verify seam.
-func stubAttachVerify(t *testing.T, fn func(FirewallConfig) (*Firewall, error)) {
+// stubReinstallFirewall overrides the in-namespace firewall rebuild seam.
+func stubReinstallFirewall(t *testing.T, fn func(FirewallConfig) (*Firewall, error)) {
 	t.Helper()
-	old := attachAndVerifyFirewall
-	attachAndVerifyFirewall = fn
-	t.Cleanup(func() { attachAndVerifyFirewall = old })
+	old := reinstallFirewallFunc
+	reinstallFirewallFunc = fn
+	t.Cleanup(func() { reinstallFirewallFunc = old })
 }
 
-// TestFastAdopt_UnverifiedFirewallDemotes pins the security gate: an attach
-// that cannot verify the kernel objects must demote, never publish a slot
-// whose namespace may hold no enforcement.
-func TestFastAdopt_UnverifiedFirewallDemotes(t *testing.T) {
+// TestFastAdopt_FirewallRebuildFailureDemotes pins the security gate: a
+// slot whose ruleset cannot be rebuilt must demote, never publish with
+// unknown enforcement.
+func TestFastAdopt_FirewallRebuildFailureDemotes(t *testing.T) {
 	withReceiptSeams(t, "boot-a", "9")
 	dir := withTestNetnsDir(t)
 	m := newTestManager()
@@ -418,8 +418,8 @@ func TestFastAdopt_UnverifiedFirewallDemotes(t *testing.T) {
 		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(), Fresh: []int{1},
 	})
 	stubNsExecGo(t, func(ns string, inner func() error) error { return inner() })
-	stubAttachVerify(t, func(FirewallConfig) (*Firewall, error) {
-		return nil, fmt.Errorf("attached but unverified: chain missing")
+	stubReinstallFirewall(t, func(FirewallConfig) (*Firewall, error) {
+		return nil, fmt.Errorf("delete stale table: netlink refused")
 	})
 	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
 	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
@@ -431,7 +431,7 @@ func TestFastAdopt_UnverifiedFirewallDemotes(t *testing.T) {
 
 	adopted, _, _ := p.AdoptOrphanSlots(context.Background())
 	if adopted != 1 || fullPath.Load() != 1 {
-		t.Fatalf("unverified slot must demote to full path: adopted=%d fullPath=%d", adopted, fullPath.Load())
+		t.Fatalf("unrebuildable slot must demote to full path: adopted=%d fullPath=%d", adopted, fullPath.Load())
 	}
 }
 

--- a/internal/network/receipt_test.go
+++ b/internal/network/receipt_test.go
@@ -535,7 +535,27 @@ func TestFastAdopt_TimeoutDemotesAndAborts(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("adoption hung on wedged fast-path validation")
 	}
-	if adopted != slots || fullPath.Load() != slots {
-		t.Fatalf("every wedged slot must reach the full path: adopted=%d fullPath=%d", adopted, fullPath.Load())
+	// Timed-out slots must be RELEASED for a later boot — their abandoned
+	// validators may still be mutating the namespace, so republishing them
+	// this boot (fast or full path) would risk a claimed sandbox's rules.
+	// Only the never-dispatched remainder (after the systemic abort) may
+	// take the full path. Every index must land in exactly one bucket.
+	if adopted != fullPath.Load() {
+		t.Fatalf("full path adopted %d but pass counted %d", fullPath.Load(), adopted)
+	}
+	m.mu.Lock()
+	var released int64
+	for i := 1; i <= slots; i++ {
+		if _, owned := m.slotOwner[i]; !owned {
+			released++
+		}
+	}
+	m.mu.Unlock()
+	if released == 0 {
+		t.Fatal("wedged validation must release at least the timed-out slots")
+	}
+	if released+adopted != slots {
+		t.Fatalf("slots must split between released and adopted: released=%d adopted=%d of %d",
+			released, adopted, slots)
 	}
 }

--- a/internal/network/receipt_test.go
+++ b/internal/network/receipt_test.go
@@ -367,6 +367,10 @@ func TestReceipt_QuiesceTimeoutWritesNothing(t *testing.T) {
 	p := newTestPool(t, m)
 	p.abandonOnStop = true
 
+	oldWait := abandonStopWait
+	abandonStopWait = 50 * time.Millisecond
+	t.Cleanup(func() { abandonStopWait = oldWait })
+
 	// A worker that never observes stopCh in time: hold the wait group past
 	// the quiesce bound so Stop must give up.
 	p.wg.Add(1)
@@ -376,7 +380,7 @@ func TestReceipt_QuiesceTimeoutWritesNothing(t *testing.T) {
 	tStart := time.Now()
 	p.Stop()
 	close(release)
-	if time.Since(tStart) > 10*time.Second {
+	if time.Since(tStart) > 5*time.Second {
 		t.Fatal("Stop must stay bounded")
 	}
 	if p.quiesced {
@@ -385,5 +389,153 @@ func TestReceipt_QuiesceTimeoutWritesNothing(t *testing.T) {
 	p.CommitReceipt()
 	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
 		t.Fatal("timeout quiesce must write no receipt")
+	}
+}
+
+// stubAttachVerify overrides the attach+verify seam.
+func stubAttachVerify(t *testing.T, fn func(FirewallConfig) (*Firewall, error)) {
+	t.Helper()
+	old := attachAndVerifyFirewall
+	attachAndVerifyFirewall = fn
+	t.Cleanup(func() { attachAndVerifyFirewall = old })
+}
+
+// TestFastAdopt_UnverifiedFirewallDemotes pins the security gate: an attach
+// that cannot verify the kernel objects must demote, never publish a slot
+// whose namespace may hold no enforcement.
+func TestFastAdopt_UnverifiedFirewallDemotes(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "9")
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	touchNS(t, dir, "ns-1")
+	if err := os.WriteFile(filepath.Join(hostNetDir, "veth-1"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(), Fresh: []int{1},
+	})
+	stubNsExecGo(t, func(ns string, inner func() error) error { return inner() })
+	stubAttachVerify(t, func(FirewallConfig) (*Firewall, error) {
+		return nil, fmt.Errorf("attached but unverified: chain missing")
+	})
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	var fullPath atomic.Int64
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		fullPath.Add(1)
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	adopted, _, _ := p.AdoptOrphanSlots(context.Background())
+	if adopted != 1 || fullPath.Load() != 1 {
+		t.Fatalf("unverified slot must demote to full path: adopted=%d fullPath=%d", adopted, fullPath.Load())
+	}
+}
+
+// TestFastAdopt_PanicDemotes pins index accounting: a panic inside vouched
+// validation must land the index in the full path, never strand it.
+func TestFastAdopt_PanicDemotes(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "9")
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	touchNS(t, dir, "ns-1")
+	if err := os.WriteFile(filepath.Join(hostNetDir, "veth-1"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(), Fresh: []int{1},
+	})
+	stubNsExecGo(t, func(ns string, inner func() error) error { panic("validation blew up") })
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	var fullPath atomic.Int64
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		fullPath.Add(1)
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	adopted, _, _ := p.AdoptOrphanSlots(context.Background())
+	if adopted != 1 || fullPath.Load() != 1 {
+		t.Fatalf("panicking validation must demote: adopted=%d fullPath=%d", adopted, fullPath.Load())
+	}
+}
+
+// TestFastAdopt_TimeoutDemotesAndAborts pins the wedge protection: a hung
+// in-namespace validation demotes its slot after the bound, and systemic
+// timeouts abort the whole fast pass instead of hanging adoption.
+func TestFastAdopt_TimeoutDemotesAndAborts(t *testing.T) {
+	withReceiptSeams(t, "boot-a", "9")
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	p := newTestPool(t, m)
+	p.abandonOnStop = true
+
+	oldTimeout := fastAdoptSlotTimeout
+	fastAdoptSlotTimeout = 30 * time.Millisecond
+	t.Cleanup(func() { fastAdoptSlotTimeout = oldTimeout })
+
+	const slots = 6
+	var vouched []int
+	for i := 1; i <= slots; i++ {
+		touchNS(t, dir, fmt.Sprintf("ns-%d", i))
+		if err := os.WriteFile(filepath.Join(hostNetDir, fmt.Sprintf("veth-%d", i)), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		vouched = append(vouched, i)
+	}
+	writeTestReceipt(t, &poolReceipt{
+		BootID: "boot-a", Generation: 8, Fingerprint: slotPolicyFingerprint(), Fresh: vouched,
+	})
+	// The abandoned validation goroutines outlive the adoption pass by
+	// design; the test must unblock AND drain them before the stub seam is
+	// restored, or their late reads race the cleanup write. t.Cleanup runs
+	// LIFO: restore is registered first (runs last), drain second (runs
+	// first).
+	block := make(chan struct{})
+	var entered, exited atomic.Int64
+	oldExec := nsExecGoFunc
+	t.Cleanup(func() { nsExecGoFunc = oldExec })
+	nsExecGoFunc = func(ns string, inner func() error) error {
+		entered.Add(1)
+		<-block
+		exited.Add(1)
+		return nil
+	}
+	t.Cleanup(func() {
+		close(block)
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			e := entered.Load()
+			time.Sleep(50 * time.Millisecond)
+			if entered.Load() == e && exited.Load() == e {
+				return
+			}
+		}
+		t.Log("warning: abandoned validators did not drain")
+	})
+	stubPidsInNs(t, func(string) ([]int, bool) { return nil, true })
+	stubResetTap(t, func(*Manager, context.Context, string) error { return nil })
+	var fullPath atomic.Int64
+	stubAdoptSlot(t, func(_ *Manager, _ context.Context, idx int) (*VMNetInfo, string, error) {
+		fullPath.Add(1)
+		return &VMNetInfo{Namespace: nsNameForSlot(idx), HostIP: hostIPForSlot(idx)}, vethNameForSlot(idx), nil
+	})
+
+	done := make(chan struct{})
+	var adopted int64
+	go func() { adopted, _, _ = p.AdoptOrphanSlots(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("adoption hung on wedged fast-path validation")
+	}
+	if adopted != slots || fullPath.Load() != slots {
+		t.Fatalf("every wedged slot must reach the full path: adopted=%d fullPath=%d", adopted, fullPath.Load())
 	}
 }


### PR DESCRIPTION
Boot-time adoption currently forces every slot the previous run left behind through the full paranoid rebuild — kill/poll, firewall reinstall, route rewrites, tap reset — re-deriving state the previous process already knew was good. The pass scales with warm-pool depth and dominates the restart window, degrading launch latency while it churns.

A clean shutdown now writes a receipt: a short-lived capability vouching for the settled channel inventory of a fully quiesced pool, honored only by the immediate successor (start generation bumped by a systemd drop-in on every start — surviving rollbacks — plus boot-id and a slot-policy fingerprint, deliberately not the binary version). The receipt is consumed one-shot (deleted before it is acted on). Vouched slots rejoin inventory after cheap batched validation — one netns readdir, one interface readdir, one /proc pass, then a tap-presence check and an in-process firewall rebuild from current policy per slot, making the rules correct by construction. What the fast path skips is the expensive re-derivation: the kill/poll, the route-rewrite subprocesses, and the tap rebuild. Any gate failing, any slot failing a check, a crash, a reboot, an intervening process, or a policy change falls back to the full path unchanged; a slot whose validator times out is released for the next boot rather than republished.