### PR TITLE
api: finalize pause synchronously before responding

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2619,39 +2619,46 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		Msg("VMD pause complete")
 
 	// Past this point the snapshot already exists on disk — the pause has
-	// physically happened, so the bookkeeping (snapshot row upsert + status
-	// flip pausing → paused in a single CTE) is fire-and-forget. BeginPause's
-	// gate write owns the row and every other transition is status-gated, so
-	// a racing resume sees 'pausing' and 409s until this lands. Detached from
-	// cancellation so a client disconnect cannot orphan the bookkeeping;
-	// trace/span context preserved. The upsert replaces the old "insert a new
-	// row + delete the previous" flow, so there's no explicit prev-snapshot
-	// cleanup to schedule here.
-	finalizeCtx := context.WithoutCancel(c.Request.Context())
-	h.asyncBookkeeping("finalize-pause", func() {
-		fctx, fcancel := context.WithTimeout(finalizeCtx, asyncTimeout)
-		defer fcancel()
-		params := db.FinalizePauseParams{
-			ID:      sandboxID,
-			TeamID:  teamID,
-			Path:    snapshotPath,
-			MemPath: &memPath,
-			Trigger: "pause",
-		}
-		applyManifest(&params, manifest)
-		if _, err := h.finalizePause(fctx, params); err != nil {
-			// ErrNoRows means the sandbox was soft-deleted between BeginPause
-			// and FinalizePause (a rare race with DeleteSandbox). The VM is
-			// already stopped and its snapshot files are on disk — nothing to
-			// finalize for a sandbox that no longer exists.
-			if err == pgx.ErrNoRows {
-				log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
-				return
-			}
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async DB FinalizePause failed — sandbox may be stuck in 'pausing'")
+	// physically happened, so all that's left is bookkeeping (snapshot row
+	// upsert + status flip pausing → paused in a single CTE). This now runs
+	// synchronously and gates the response: BeginPause's gate write owns the
+	// row and every other transition is status-gated, so responding success
+	// before this lands would tell the client "paused" while a racing resume
+	// still sees 'pausing' and 409s against an operation it was just told
+	// succeeded. Detached from cancellation so a client disconnect cannot
+	// orphan the write mid-flight and strand the sandbox in 'pausing' with
+	// nothing left to retry it; trace/span context preserved. The upsert
+	// replaces the old "insert a new row + delete the previous" flow, so
+	// there's no explicit prev-snapshot cleanup to schedule here.
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), asyncTimeout)
+	defer finalizeCancel()
+	params := db.FinalizePauseParams{
+		ID:      sandboxID,
+		TeamID:  teamID,
+		Path:    snapshotPath,
+		MemPath: &memPath,
+		Trigger: "pause",
+	}
+	applyManifest(&params, manifest)
+	if _, err := h.finalizePause(finalizeCtx, params); err != nil {
+		// ErrNoRows means the sandbox was soft-deleted between BeginPause
+		// and FinalizePause (a rare race with DeleteSandbox). The VM is
+		// already stopped and its snapshot files are on disk — nothing to
+		// finalize for a sandbox that no longer exists, so this still
+		// reports success; the delete already owns the outcome.
+		if err == pgx.ErrNoRows {
+			log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
+			c.Status(http.StatusNoContent)
 			return
 		}
-	})
+		// Unlike the old fire-and-forget path, this must not report success:
+		// the sandbox is stuck in 'pausing' (VM already paused, row not
+		// flipped), and telling the client otherwise would just relocate the
+		// race instead of closing it.
+		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB FinalizePause failed — sandbox stuck in 'pausing', VM already paused")
+		respondError(c, ErrInternal)
+		return
+	}
 
 	// Interval was already closed at BeginPause; FinalizePause is the
 	// end of the VMD pause work, not the moment the sandbox left active.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2949,17 +2949,20 @@ func TestPauseSandbox_Success(t *testing.T) {
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
-			case strings.Contains(sql, "'pausing'"):
-				// BeginPause: atomic transition active → pausing, returns *
-				return sandboxRow(sb)
 			case strings.Contains(sql, "upserted AS"):
-				// FinalizePause: CTE upsert + update, returns snapshot_id
+				// FinalizePause: CTE upsert + update, returns snapshot_id.
+				// Checked before the "'pausing'" case below: FinalizePause's
+				// own WHERE clause also matches status IN ('pausing', ...),
+				// so the more specific CTE marker must win first.
 				return finalizePauseRow(snapshotID)
 			case strings.Contains(sql, "INSERT INTO snapshot"):
 				// Belt-and-braces: FinalizePause contains an INSERT inside
 				// the upserted CTE; match that too in case the SQL text
 				// routing misses the CTE alias.
 				return finalizePauseRow(snapshotID)
+			case strings.Contains(sql, "'pausing'"):
+				// BeginPause: atomic transition active → pausing, returns *
+				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM sandbox"):
 				// Generic GetSandbox (fallback from BeginPause)
 				return sandboxRow(sb)


### PR DESCRIPTION
## Summary

`PauseSandbox` returned success once vmd's `PauseVM` RPC completed, leaving the DB status flip (`pausing` -> `paused`) as fire-and-forget bookkeeping in a background goroutine. A resume issued right after a successful pause could race that goroutine, see the sandbox still in `pausing`, and 409 against an operation the client was just told succeeded. Reproduced consistently (~5% of resumes) under concurrent burst pause/resume against staging.

## Technical decisions

- Await `finalizePause` before responding instead of backgrounding it. Closes the race, at the cost of adding the DB write's latency to every pause call, not just the ones that would have raced.
- A hard finalize failure now returns 500 instead of a false-positive 204 — the sandbox is genuinely stuck in `pausing` with the VM already paused underneath it, and reporting success would just relocate the race instead of closing it.
- The soft-delete-mid-pause edge case (`pgx.ErrNoRows`, a rare race with `DeleteSandbox`) still reports success, matching prior behavior: the VM is already stopped and there's nothing to reconcile for a sandbox that no longer exists.
- Also fixes a latent test-mock bug this change exposed: the mock's SQL router checked for `'pausing'` before `upserted AS`, so `FinalizePause`'s own WHERE clause (which matches `status IN ('pausing', 'resuming')`) was misrouted to the `BeginPause` mock row. It never surfaced before because the panic happened inside the async goroutine, silently swallowed by its `recover()`.

## Testing

- `go test ./internal/api/...` — full package passes, including the previously-masked mock bug now fixed.
- Reproduced the race pre-fix with a burst script against staging (20 concurrent sandboxes: create, pause all, resume all) — consistent 1/20 resume failures across two runs. Plan to re-run the same script post-deploy to confirm 0 failures, and compare `sandbox_transition_duration_seconds{operation="pause"}` before/after to quantify the added latency.