### PR TITLE
backup: try reflink staging before applying the inline copy guards

### DIFF
--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -96,24 +96,34 @@ func stageTask(root string, task *Task, cloneOnly bool) (bool, error) {
 	return all, nil
 }
 
-// inlineStageLimit bounds the packed bytes a pause may copy on the RPC
+// inlineStageLimit bounds the packed bytes a pause may COPY on the RPC
 // path. Sparse copies scale with REAL bytes, so a typical overlay (tens
 // of MB dirtied) stages in tens of milliseconds; a pathologically dense
 // overlay must not drag the pause RPC back into seconds, and falls back
-// to the marker-only worker path.
+// to the marker-only worker path. Reflink clones are exempt: a clone is
+// O(metadata) regardless of packed size, so on a reflink-capable
+// filesystem no pause is ever too large to stage inline.
 const inlineStageLimit = 256 << 20
 
 // ErrStageTooLarge reports a pause whose packed disk exceeds the inline
 // staging budget.
 var ErrStageTooLarge = errors.New("packed size exceeds the inline staging budget")
 
-// StagePending sparse-copies a pause's mutable artifacts into a
+// cloneFn is the reflink implementation, swappable by tests: whether
+// FICLONE works depends on the filesystem the test tree happens to live
+// on, and both the clone-first and copy-fallback paths need to be
+// exercisable deterministically.
+var cloneFn = cloneFile
+
+// StagePending snapshots a pause's mutable artifacts into a
 // pending-token directory under the staging root, called on the pause
 // RPC path WHILE the VM operation lock is held: nothing can resume yet,
 // so the copies are pause-time bytes by construction, and the detached
 // worker can hash them at leisure with no at-rest race. Returns the
-// staged directory and the staged path per file name. The copy is
-// O(real bytes), the same scaling as the pause itself.
+// staged directory and the staged path per file name. Each file is
+// reflink-cloned when the filesystem supports it — O(metadata), no size
+// cap — and sparse-copied otherwise, O(real bytes) under the inline
+// budget, the same scaling as the pause itself.
 // BasePinName is the hard link StagePending creates to the overlay's
 // base image inside the pending directory. A link is O(1) on the RPC
 // path and keeps the base's inode alive past template GC, so a pause
@@ -125,26 +135,6 @@ const BasePinName = "base.pin"
 func StagePending(ctx context.Context, root, vmID, token, basePath string, files map[string]string) (string, map[string]string, error) {
 	if root == "" {
 		return "", nil, errors.New("staging disabled")
-	}
-	// The copy is O(real bytes) but a contended disk makes even that
-	// slow; respect the RPC deadline the way hashing always did, and
-	// fall back to the marker-only path rather than pinning the caller.
-	if dl, ok := ctx.Deadline(); ok && time.Until(dl) < 3*time.Second {
-		return "", nil, ErrStageTooLarge
-	}
-	if disk, ok := files["rootfs.ext4"]; ok {
-		f, err := os.Open(disk)
-		if err != nil {
-			return "", nil, err
-		}
-		extents, _, err := Extents(f)
-		f.Close()
-		if err != nil {
-			return "", nil, err
-		}
-		if PackedSize(extents) > inlineStageLimit {
-			return "", nil, ErrStageTooLarge
-		}
 	}
 	dir := filepath.Join(root, vmID, "pending-"+token)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -160,12 +150,30 @@ func StagePending(ctx context.Context, root, vmID, token, basePath string, files
 		return "", nil, err
 	}
 	staged := make(map[string]string, len(files))
+	// The deadline and packed-size guards protect the RPC path from the
+	// byte COPY only, so they run lazily on the first file a reflink
+	// clone cannot cover — never before a clone attempt. Guarding up
+	// front would demote every large pause to the marker-only path (and
+	// concede its fast-resume window) on exactly the filesystems where
+	// staging it is free.
+	copyGuarded := false
 	for name, src := range files {
 		if err := ctx.Err(); err != nil {
 			_ = os.RemoveAll(dir)
 			return "", nil, err
 		}
 		dst := filepath.Join(dir, name)
+		if err := snapshotFileMode(ctx, dst, src, true); err == nil {
+			staged[name] = dst
+			continue
+		}
+		if !copyGuarded {
+			copyGuarded = true
+			if err := inlineCopyBudget(ctx, files); err != nil {
+				_ = os.RemoveAll(dir)
+				return "", nil, err
+			}
+		}
 		if err := snapshotFileMode(ctx, dst, src, false); err != nil {
 			_ = os.RemoveAll(dir)
 			return "", nil, err
@@ -190,6 +198,33 @@ func StagePending(ctx context.Context, root, vmID, token, basePath string, files
 		return "", nil, err
 	}
 	return dir, staged, nil
+}
+
+// inlineCopyBudget decides whether the byte-copy fallback may run on the
+// RPC path at all: a contended disk makes even an O(real bytes) copy
+// slow, so an almost-spent deadline falls back to the marker-only path
+// rather than pinning the caller, and a pathologically dense overlay
+// (packed bytes over the inline limit) does the same rather than drag
+// the pause RPC back into seconds.
+func inlineCopyBudget(ctx context.Context, files map[string]string) error {
+	if dl, ok := ctx.Deadline(); ok && time.Until(dl) < 3*time.Second {
+		return ErrStageTooLarge
+	}
+	if disk, ok := files["rootfs.ext4"]; ok {
+		f, err := os.Open(disk)
+		if err != nil {
+			return err
+		}
+		extents, _, err := Extents(f)
+		f.Close()
+		if err != nil {
+			return err
+		}
+		if PackedSize(extents) > inlineStageLimit {
+			return ErrStageTooLarge
+		}
+	}
+	return nil
 }
 
 // FinishPendingStage renames a hashed pending directory to its
@@ -445,7 +480,7 @@ func snapshotClone(dst, src string) error {
 		return err
 	}
 	tmp := out.Name()
-	if err := cloneFile(out, in); err != nil {
+	if err := cloneFn(out, in); err != nil {
 		out.Close()
 		os.Remove(tmp)
 		return err
@@ -484,7 +519,7 @@ func snapshotFile(ctx context.Context, dst, src string) error {
 		return err
 	}
 	tmp := out.Name()
-	if err := cloneFile(out, in); err != nil {
+	if err := cloneFn(out, in); err != nil {
 		extents, _, xerr := Extents(in)
 		if xerr != nil {
 			out.Close()

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -1742,9 +1742,21 @@ func TestSweepStagingProtectsLivePendingDirs(t *testing.T) {
 	}
 }
 
-// The RPC-path staging respects the caller's deadline: an exhausted
-// deadline falls back rather than copying.
+// overrideClone pins the reflink implementation for one test: whether
+// FICLONE works depends on the filesystem the test tree lives on, and
+// both the clone-first and copy-fallback behaviors must be testable
+// anywhere.
+func overrideClone(t *testing.T, fn func(dst, src *os.File) error) {
+	t.Helper()
+	prev := cloneFn
+	cloneFn = fn
+	t.Cleanup(func() { cloneFn = prev })
+}
+
+// The RPC-path staging respects the caller's deadline when it has to
+// COPY: an exhausted deadline falls back rather than copying.
 func TestStagePendingRespectsDeadline(t *testing.T) {
+	overrideClone(t, func(dst, src *os.File) error { return errors.ErrUnsupported })
 	root := t.TempDir()
 	src := filepath.Join(root, "rootfs.ext4")
 	if err := os.WriteFile(src, []byte("bytes"), 0o600); err != nil {
@@ -1754,6 +1766,33 @@ func TestStagePendingRespectsDeadline(t *testing.T) {
 	defer cancel()
 	if _, _, err := StagePending(ctx, root, "sb", "tok", "", map[string]string{"rootfs.ext4": src}); !errors.Is(err, ErrStageTooLarge) {
 		t.Fatalf("err = %v, want deadline fallback", err)
+	}
+}
+
+// A reflink clone is O(metadata) regardless of packed size, so neither
+// the exhausted-deadline guard nor the packed-size cap may demote a
+// clonable pause to the marker-only path — that would concede the
+// fast-resume window on exactly the filesystems where staging is free.
+func TestStagePendingCloneBypassesCopyGuards(t *testing.T) {
+	overrideClone(t, func(dst, src *os.File) error {
+		_, err := io.Copy(dst, src)
+		return err
+	})
+	root := t.TempDir()
+	src := filepath.Join(root, "rootfs.ext4")
+	if err := os.WriteFile(src, []byte("pause-time bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The same nearly-spent deadline that forces the copy path to give up.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
+	defer cancel()
+	_, staged, err := StagePending(ctx, root, "sb", "tok", "", map[string]string{"rootfs.ext4": src})
+	if err != nil {
+		t.Fatalf("clonable staging failed under a short deadline: %v", err)
+	}
+	got, err := os.ReadFile(staged["rootfs.ext4"])
+	if err != nil || string(got) != "pause-time bytes" {
+		t.Fatalf("staged clone content = %q, err = %v", got, err)
 	}
 }
 

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -116,20 +116,22 @@ func (m *Manager) backupPause(ctx context.Context, vmID, snapshotPath, diskPath,
 	// track what the guest dirtied, and hashing a sparse overlay's full
 	// apparent content costs seconds regardless of hasher. All
 	// size-dependent hashing runs in the detached worker; the RPC path
-	// pays a marker write, an O(real bytes) staging copy, and the
-	// tens-of-KB vmstate hash for the control plane's manifest rows.
+	// pays a marker write, a staging step (reflink clone where the
+	// filesystem supports it, O(real bytes) capped copy otherwise), and
+	// the tens-of-KB vmstate hash for the control plane's manifest rows.
 	manifest := collectVMStateEntry(ctx, snapshotPath, log)
 	if m.backupEnqueue == nil {
 		return manifest
 	}
 	pb := newPendingBackup(vmID, snapshotPath, diskPath, diskBasePath)
-	// Inline sparse staging under the still-held VM operation lock:
-	// copying scales with REAL bytes (the same O(dirtied) scaling as the
-	// pause itself, tens of ms for typical overlays), and the immutable
-	// copies close the fast-resume window entirely: a resume racing the
-	// worker cannot mutate a snapshot, so even an instantly-resumed
-	// pause keeps its backup. Oversized or failed staging falls back to
-	// the marker-only path, whose worker requires the at-rest proof and
+	// Inline staging under the still-held VM operation lock: a reflink
+	// clone is O(metadata) at any size, and the copy fallback scales
+	// with REAL bytes (the same O(dirtied) scaling as the pause itself,
+	// tens of ms for typical overlays). The immutable snapshots close
+	// the fast-resume window entirely: a resume racing the worker
+	// cannot mutate them, so even an instantly-resumed pause keeps its
+	// backup. Oversized-copy or failed staging falls back to the
+	// marker-only path, whose worker requires the at-rest proof and
 	// concedes fast-resume pauses to supersession.
 	if m.backupStaging != "" {
 		// A control-plane retry of the same pause must not pay a second


### PR DESCRIPTION
StagePending now attempts a FICLONE clone per file before the deadline and packed-size guards, so on reflink-capable filesystems staging is O(metadata) at any size and no pause is demoted to the marker-only path. The guards now apply only to the byte-copy fallback, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)