### PR TITLE
api: let resume settle through a racing pause finalize instead of 409ing it

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -139,7 +139,7 @@ type Handlers struct {
 	Encryptor secrets.Encryptor // KMS envelope used by /secrets endpoints; nil disables them
 	Signer    *SecretsSigner    // signs sandbox JWTs and serves the JWKS; nil disables both
 	Stripe    StripeBillingClient
-	Now       func() time.Time  // when set, returns the current UTC time for testable handlers
+	Now       func() time.Time // when set, returns the current UTC time for testable handlers
 
 	// asyncMu/asyncCond/asyncCount track fire-and-forget bookkeeping goroutines
 	// (ActivateSandbox, FinalizePause) so tests can wait for quiescence;
@@ -306,15 +306,13 @@ func retryTransientBoot(parent context.Context, sandboxID string, boot func(cont
 // asyncTimeout is the deadline for fire-and-forget DB writes.
 const asyncTimeout = 5 * time.Second
 
-// activateSettleWindow bounds how long status-gated read paths wait for a
-// fire-and-forget write to land. Two distinct writes use it: create/resume's
-// starting/resuming→active flip (read by loadActiveOrResumeSandbox) and
-// pause's pausing→paused flip (read by ResumeSandbox) — in both cases the
-// owner's own immediate follow-up (create then exec; pause then resume — the
-// canonical SDK flows) may read the pre-flip status, so waiting briefly
-// preserves read-your-writes instead of 409ing an operation the client was
-// just told succeeded. The write lands in single-digit ms in the common
-// case, which this covers.
+// activateSettleWindow bounds how long loadActiveOrResumeSandbox waits for
+// create/resume's fire-and-forget starting/resuming→active flip to land. The
+// owner's own immediate follow-up (create then exec — the canonical SDK
+// flow) may read the pre-flip status, so waiting briefly preserves
+// read-your-writes instead of 409ing an operation the client was just told
+// succeeded. The write lands in single-digit ms in the common case, which
+// this covers.
 //
 // It deliberately does NOT try to outlast a hostname-only create's pre-flip
 // stamp: that guest round trip can take tens of seconds on a cold-fault stall
@@ -328,6 +326,41 @@ var activateSettleWindow = 6 * time.Second
 
 // activateSettlePoll is the re-read interval within activateSettleWindow.
 const activateSettlePoll = 50 * time.Millisecond
+
+// pausingSettleWindow bounds how long ResumeSandbox waits for a racing
+// finalize-pause write (pausing→paused, read by ResumeSandbox) to land
+// before treating the sandbox as genuinely stuck and returning 409. It is
+// separate from activateSettleWindow on purpose: unlike create/resume's
+// hostname stamp, finalize-pause has no guest round trip — it is a local DB
+// write that either lands in single-digit ms (the common case) or is stuck
+// for a reason more waiting won't fix (DB contention, a crashed worker), so
+// riding out the full 6s activate window buys nothing here and just holds
+// the resume request open. Var, not const, so tests can shrink it.
+var pausingSettleWindow = 2 * time.Second
+
+// pausingSettlePollStart is the first re-read interval in ResumeSandbox's
+// pausing-settle loop, matching activateSettlePoll so the common case
+// settles just as fast as a fixed-interval poll would. pausingSettlePollMax
+// caps how far nextSettlePollInterval backs off.
+//
+// A fixed 50ms poll over the full settle window costs up to ~120
+// synchronous reads when a sandbox is genuinely stuck in 'pausing' — a burst
+// of pause/resume calls hitting that case amplifies DB load exactly when
+// finalize-pause is already struggling to land. Backing off (see
+// nextSettlePollInterval) bounds that worst case to roughly a dozen reads.
+const (
+	pausingSettlePollStart = 50 * time.Millisecond
+	pausingSettlePollMax   = 500 * time.Millisecond
+)
+
+// nextSettlePollInterval doubles cur, capped at pausingSettlePollMax.
+func nextSettlePollInterval(cur time.Duration) time.Duration {
+	next := cur * 2
+	if next <= 0 || next > pausingSettlePollMax {
+		return pausingSettlePollMax
+	}
+	return next
+}
 
 // staleTransitionGrace is how long a sandbox must sit in a transitional state
 // (starting/resuming/pausing) before DELETE may claim it: past this, its worker
@@ -1149,10 +1182,14 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	// flips pausing -> paused via fire-and-forget bookkeeping (deliberately
 	// off the pause hot path — see finalize-pause in PauseSandbox). The
 	// owner's own immediate follow-up resume can therefore read the row
-	// before that write lands; poll through 'pausing' for the settle window
-	// rather than 409 an operation the client was just told succeeded. Any
-	// other non-paused status is a real conflict and fails immediately.
-	deadline := time.Now().Add(activateSettleWindow)
+	// before that write lands; poll through 'pausing' with a backed-off
+	// interval (nextSettlePollInterval) over pausingSettleWindow rather than
+	// 409 an operation the client was just told succeeded. Any other
+	// non-paused status is a real conflict and fails immediately.
+	deadline := time.Now().Add(pausingSettleWindow)
+	waitStart := time.Now()
+	poll := pausingSettlePollStart
+	reads := 0
 	var sandbox db.Sandbox
 	for {
 		var err error
@@ -1160,6 +1197,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 			ID:     sandboxID,
 			TeamID: teamID,
 		})
+		reads++
 		if err != nil {
 			if err == pgx.ErrNoRows {
 				respondError(c, ErrSandboxNotFound)
@@ -1170,10 +1208,25 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 			return
 		}
 		if sandbox.Status == db.SandboxStatusPausing && time.Now().Before(deadline) {
-			time.Sleep(activateSettlePoll)
+			time.Sleep(poll)
+			poll = nextSettlePollInterval(poll)
 			continue
 		}
 		break
+	}
+	// The common case resolves on the first read, so this only fires for the
+	// racing/stuck case — once per affected resume, not once per poll — and
+	// stays off the hot path.
+	if reads > 1 {
+		waited := time.Since(waitStart)
+		settled := sandbox.Status != db.SandboxStatusPausing
+		log.Warn().
+			Str("sandbox_id", sandboxID.String()).
+			Dur("waited", waited).
+			Int("reads", reads).
+			Bool("settled", settled).
+			Msg("resume waited for racing pause finalize to settle")
+		RecordResumeSettleWait(c.Request.Context(), settled, sandbox.HostID, waited, reads)
 	}
 	SetTelemetryHostID(c, sandbox.HostID)
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -306,12 +306,15 @@ func retryTransientBoot(parent context.Context, sandboxID string, boot func(cont
 // asyncTimeout is the deadline for fire-and-forget DB writes.
 const asyncTimeout = 5 * time.Second
 
-// activateSettleWindow bounds how long status-gated read paths wait for the
-// fire-and-forget activate write to land. Create/resume respond before the
-// starting/resuming→active flip commits, so the owner's immediate follow-up
-// (create then exec — the canonical SDK flow) may read the pre-flip status;
-// waiting briefly preserves read-your-writes instead of 409ing it. The write
-// lands in single-digit ms in the common case, which this covers.
+// activateSettleWindow bounds how long status-gated read paths wait for a
+// fire-and-forget write to land. Two distinct writes use it: create/resume's
+// starting/resuming→active flip (read by loadActiveOrResumeSandbox) and
+// pause's pausing→paused flip (read by ResumeSandbox) — in both cases the
+// owner's own immediate follow-up (create then exec; pause then resume — the
+// canonical SDK flows) may read the pre-flip status, so waiting briefly
+// preserves read-your-writes instead of 409ing an operation the client was
+// just told succeeded. The write lands in single-digit ms in the common
+// case, which this covers.
 //
 // It deliberately does NOT try to outlast a hostname-only create's pre-flip
 // stamp: that guest round trip can take tens of seconds on a cold-fault stall
@@ -1142,18 +1145,35 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 
-	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
-		ID:     sandboxID,
-		TeamID: teamID,
-	})
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			respondError(c, ErrSandboxNotFound)
+	// PauseSandbox responds as soon as vmd's PauseVM RPC completes, then
+	// flips pausing -> paused via fire-and-forget bookkeeping (deliberately
+	// off the pause hot path — see finalize-pause in PauseSandbox). The
+	// owner's own immediate follow-up resume can therefore read the row
+	// before that write lands; poll through 'pausing' for the settle window
+	// rather than 409 an operation the client was just told succeeded. Any
+	// other non-paused status is a real conflict and fails immediately.
+	deadline := time.Now().Add(activateSettleWindow)
+	var sandbox db.Sandbox
+	for {
+		var err error
+		sandbox, err = h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+			ID:     sandboxID,
+			TeamID: teamID,
+		})
+		if err != nil {
+			if err == pgx.ErrNoRows {
+				respondError(c, ErrSandboxNotFound)
+				return
+			}
+			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
+			respondError(c, ErrInternal)
 			return
 		}
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox failed")
-		respondError(c, ErrInternal)
-		return
+		if sandbox.Status == db.SandboxStatusPausing && time.Now().Before(deadline) {
+			time.Sleep(activateSettlePoll)
+			continue
+		}
+		break
 	}
 	SetTelemetryHostID(c, sandbox.HostID)
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/preview"
 	"github.com/superserve-ai/sandbox/internal/secrets"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -1190,6 +1191,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	waitStart := time.Now()
 	poll := pausingSettlePollStart
 	reads := 0
+	canceled := false
 	var sandbox db.Sandbox
 	for {
 		var err error
@@ -1208,9 +1210,20 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 			return
 		}
 		if sandbox.Status == db.SandboxStatusPausing && time.Now().Before(deadline) {
-			time.Sleep(poll)
-			poll = nextSettlePollInterval(poll)
-			continue
+			// Context-aware wait: a client that disconnects or hits its
+			// deadline mid-backoff releases this goroutine at cancellation
+			// instead of holding it for the rest of the interval — and skips
+			// the re-read, which on a canceled context could only fail and be
+			// misreported as an internal DB error.
+			timer := time.NewTimer(poll)
+			select {
+			case <-timer.C:
+				poll = nextSettlePollInterval(poll)
+				continue
+			case <-c.Request.Context().Done():
+				timer.Stop()
+				canceled = true
+			}
 		}
 		break
 	}
@@ -1219,14 +1232,28 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	// stays off the hot path.
 	if reads > 1 {
 		waited := time.Since(waitStart)
-		settled := sandbox.Status != db.SandboxStatusPausing
+		// Only pausing→paused counts as settled: a row that left 'pausing'
+		// for any other state (a failed pause reverting to active, a delete
+		// claiming the row) still 409s below, and folding it into "settled"
+		// would contaminate the metric with pause failures.
+		var result string
+		switch {
+		case canceled:
+			result = telemetry.SettleResultCanceled
+		case sandbox.Status == db.SandboxStatusPaused:
+			result = telemetry.SettleResultSettled
+		case sandbox.Status == db.SandboxStatusPausing:
+			result = telemetry.SettleResultTimeout
+		default:
+			result = telemetry.SettleResultDiverged
+		}
 		log.Warn().
 			Str("sandbox_id", sandboxID.String()).
 			Dur("waited", waited).
 			Int("reads", reads).
-			Bool("settled", settled).
+			Str("result", result).
 			Msg("resume waited for racing pause finalize to settle")
-		RecordResumeSettleWait(c.Request.Context(), settled, sandbox.HostID, waited, reads)
+		RecordResumeSettleWait(c.Request.Context(), result, sandbox.HostID, waited, reads)
 	}
 	SetTelemetryHostID(c, sandbox.HostID)
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1377,19 +1377,30 @@ func TestResumeSandbox_SettlesPausingToPaused(t *testing.T) {
 }
 
 // A sandbox stuck in 'pausing' past the settle window (finalize-pause lost
-// or genuinely stalled, not just racing) still 409s. Shrink the window so
-// this persistent case stays fast.
+// or genuinely stalled, not just racing) still 409s. This is also the
+// regression test for the settle poll's backoff: the pre-backoff code
+// re-read on a fixed 50ms interval, which over the (longer) 6s activate
+// window it used to share cost up to ~120 synchronous GetSandbox calls per
+// stuck resume — a burst of pause/resume calls against the same stuck
+// sandbox would amplify DB load exactly when finalize-pause is already
+// struggling. Shrink pausingSettleWindow so the persistent case stays fast
+// while still exercising several backoff steps, and assert the read count
+// stays in the single digits instead of growing with the window.
 func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
-	prev := activateSettleWindow
-	activateSettleWindow = 100 * time.Millisecond
-	defer func() { activateSettleWindow = prev }()
+	prev := pausingSettleWindow
+	pausingSettleWindow = time.Second
+	defer func() { pausingSettleWindow = prev }()
 
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusPausing}
 
+	var reads int32
 	mock := &mockDBTX{
-		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			atomic.AddInt32(&reads, 1)
+			return sandboxRow(sb)
+		},
 	}
 	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
 	w := httptest.NewRecorder()
@@ -1397,6 +1408,12 @@ func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+	// A fixed 50ms poll over this 1s window would read ~20 times; the
+	// backed-off poll (50ms doubling up to 500ms) should land around 6 and
+	// stay nowhere near the old ~120-read worst case.
+	if got := atomic.LoadInt32(&reads); got < 2 || got > 15 {
+		t.Errorf("GetSandbox reads = %d, want in [2, 15] (bounded, backed-off poll)", got)
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1317,6 +1317,89 @@ func TestResumeSandbox_NotPaused(t *testing.T) {
 	}
 }
 
+// PauseSandbox responds once vmd's PauseVM RPC completes, then flips
+// pausing -> paused via fire-and-forget bookkeeping. The owner's own
+// immediate follow-up resume may read the row before that write lands; the
+// settle window must absorb it: a 'pausing' row that flips to 'paused'
+// mid-poll returns 200, not 409.
+func TestResumeSandbox_SettlesPausingToPaused(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", SizeBytes: 1024, Trigger: "pause",
+	}
+
+	var reads int32
+	vmd := &stubVMD{
+		resumeFn: func(_ context.Context, id, _, _ string, _ []byte) (string, error) {
+			return "10.0.0.5", nil
+		},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			case strings.Contains(sql, "FROM sandbox"):
+				row := sb
+				if atomic.AddInt32(&reads, 1) == 1 {
+					row.Status = db.SandboxStatusPausing // finalize-pause still in flight
+				}
+				return sandboxRow(row)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{
+		VMD:    vmd,
+		DB:     db.New(mock),
+		Config: &config.Config{SandboxAccessTokenSeed: []byte("test-seed-for-hmac-32-bytes-min!!")},
+	}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (settle window must absorb the async finalize-pause); body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := atomic.LoadInt32(&reads); got < 2 {
+		t.Errorf("GetSandbox reads = %d, want >= 2 (must have polled)", got)
+	}
+}
+
+// A sandbox stuck in 'pausing' past the settle window (finalize-pause lost
+// or genuinely stalled, not just racing) still 409s. Shrink the window so
+// this persistent case stays fast.
+func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
+	prev := activateSettleWindow
+	activateSettleWindow = 100 * time.Millisecond
+	defer func() { activateSettleWindow = prev }()
+
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusPausing}
+
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return sandboxRow(sb) },
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
 func TestResumeSandbox_NoSnapshotID(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -1414,6 +1415,86 @@ func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
 	// stay nowhere near the old ~120-read worst case.
 	if got := atomic.LoadInt32(&reads); got < 2 || got > 15 {
 		t.Errorf("GetSandbox reads = %d, want in [2, 15] (bounded, backed-off poll)", got)
+	}
+}
+
+// settleWaitCapture records the last resume-settle-wait metric emission,
+// delegating everything else to the noop recorder.
+type settleWaitCapture struct {
+	telemetry.Recorder
+	last *telemetry.SandboxResumeSettleWait
+}
+
+func (s *settleWaitCapture) RecordSandboxResumeSettleWait(_ context.Context, w telemetry.SandboxResumeSettleWait) {
+	s.last = &w
+}
+
+// A row that leaves 'pausing' for a non-paused state mid-poll (a failed
+// pause reverting to active) is not a settle: the resume still 409s and the
+// metric must say "diverged", not "settled".
+func TestResumeSandbox_PausingDivergesToActive_409(t *testing.T) {
+	capture := &settleWaitCapture{Recorder: telemetry.NewNoopRecorder()}
+	SetTelemetryRecorder(capture)
+	defer SetTelemetryRecorder(nil)
+
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+
+	var reads int32
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			status := db.SandboxStatusPausing
+			if atomic.AddInt32(&reads, 1) > 1 {
+				status = db.SandboxStatusActive // pause failed; async revert landed
+			}
+			return sandboxRow(db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: status})
+		},
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+	if capture.last == nil {
+		t.Fatal("settle-wait metric not emitted despite a waited resume")
+	}
+	if capture.last.Result != telemetry.SettleResultDiverged {
+		t.Errorf("settle result = %q, want %q (reverted pause must not count as settled)", capture.last.Result, telemetry.SettleResultDiverged)
+	}
+}
+
+// A client that cancels mid-backoff must release the handler at cancellation:
+// no riding out the rest of the poll interval, and no follow-up GetSandbox on
+// the already-canceled context.
+func TestResumeSandbox_CanceledDuringSettle_StopsPolling(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var reads int32
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row {
+			atomic.AddInt32(&reads, 1)
+			cancel() // client goes away right after the first read
+			return sandboxRow(db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusPausing})
+		},
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	start := time.Now()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()).WithContext(ctx))
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+	if got := atomic.LoadInt32(&reads); got != 1 {
+		t.Errorf("GetSandbox reads = %d, want 1 (no re-read on a canceled context)", got)
+	}
+	if elapsed >= pausingSettleWindow {
+		t.Errorf("handler held for %v, want prompt return on cancellation (window %v)", elapsed, pausingSettleWindow)
 	}
 }
 

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -76,6 +76,24 @@ func RecordSandboxTransition(ctx context.Context, operation, result, hostID stri
 	})
 }
 
+// RecordResumeSettleWait records ResumeSandbox waiting through a racing
+// finalize-pause write. Callers should only invoke this when the loop
+// actually waited (more than one read) — it is meant to run once per
+// affected resume, not once per poll iteration.
+func RecordResumeSettleWait(ctx context.Context, settled bool, hostID string, waited time.Duration, reads int) {
+	result := telemetry.SettleResultTimeout
+	if settled {
+		result = telemetry.SettleResultSettled
+	}
+	currentTelemetryRecorder().RecordSandboxResumeSettleWait(ctx, telemetry.SandboxResumeSettleWait{
+		Result:   result,
+		Region:   SandboxIDRegion(),
+		HostID:   hostID,
+		Duration: waited,
+		Reads:    int64(reads),
+	})
+}
+
 // SandboxLifecycleTelemetry records coarse user-visible sandbox lifecycle
 // transitions from the routed API surface. It intentionally emits only bounded
 // labels; sandbox IDs, team IDs, user IDs, request IDs, URLs, and raw errors are

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -77,14 +77,11 @@ func RecordSandboxTransition(ctx context.Context, operation, result, hostID stri
 }
 
 // RecordResumeSettleWait records ResumeSandbox waiting through a racing
-// finalize-pause write. Callers should only invoke this when the loop
-// actually waited (more than one read) — it is meant to run once per
-// affected resume, not once per poll iteration.
-func RecordResumeSettleWait(ctx context.Context, settled bool, hostID string, waited time.Duration, reads int) {
-	result := telemetry.SettleResultTimeout
-	if settled {
-		result = telemetry.SettleResultSettled
-	}
+// finalize-pause write; result is one of the telemetry.SettleResult*
+// constants. Callers should only invoke this when the loop actually waited
+// (more than one read) — it is meant to run once per affected resume, not
+// once per poll iteration.
+func RecordResumeSettleWait(ctx context.Context, result, hostID string, waited time.Duration, reads int) {
 	currentTelemetryRecorder().RecordSandboxResumeSettleWait(ctx, telemetry.SandboxResumeSettleWait{
 		Result:   result,
 		Region:   SandboxIDRegion(),

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -43,6 +43,9 @@ type OTelRecorder struct {
 
 	sandboxTransitions       metric.Int64Counter
 	sandboxDuration          metric.Float64Histogram
+	resumeSettleWaits        metric.Int64Counter
+	resumeSettleWaitDuration metric.Float64Histogram
+	resumeSettleWaitReads    metric.Int64Histogram
 	vmdCalls                 metric.Int64Counter
 	vmdDuration              metric.Float64Histogram
 	hostVCPU                 metric.Int64Gauge
@@ -99,6 +102,15 @@ func NewOTelRecorder(ctx context.Context, cfg OTelConfig) (*OTelRecorder, error)
 		return nil, err
 	}
 	if r.sandboxDuration, err = meter.Float64Histogram("sandbox_transition_duration_seconds"); err != nil {
+		return nil, err
+	}
+	if r.resumeSettleWaits, err = meter.Int64Counter("sandbox_resume_settle_wait_total"); err != nil {
+		return nil, err
+	}
+	if r.resumeSettleWaitDuration, err = meter.Float64Histogram("sandbox_resume_settle_wait_duration_seconds"); err != nil {
+		return nil, err
+	}
+	if r.resumeSettleWaitReads, err = meter.Int64Histogram("sandbox_resume_settle_wait_reads"); err != nil {
 		return nil, err
 	}
 	if r.vmdCalls, err = meter.Int64Counter("vmd_call_total"); err != nil {
@@ -191,6 +203,28 @@ func (r *OTelRecorder) RecordSandboxTransition(ctx context.Context, t SandboxTra
 	r.sandboxTransitions.Add(ctx, 1, opt)
 	if t.Duration > 0 {
 		r.sandboxDuration.Record(ctx, t.Duration.Seconds(), opt)
+	}
+}
+
+// RecordSandboxResumeSettleWait is called at most once per resume request —
+// only when ResumeSandbox actually had to wait out a racing finalize-pause —
+// so its cost does not scale with poll count.
+func (r *OTelRecorder) RecordSandboxResumeSettleWait(ctx context.Context, w SandboxResumeSettleWait) {
+	if r == nil {
+		return
+	}
+	attrs := r.attrs(
+		attribute.String("result", safeSettleResult(w.Result)),
+		attribute.String("region", safeRegion(w.Region)),
+		attribute.String("host_id", safeHostID(w.HostID)),
+	)
+	opt := metric.WithAttributes(attrs...)
+	r.resumeSettleWaits.Add(ctx, 1, opt)
+	if w.Duration > 0 {
+		r.resumeSettleWaitDuration.Record(ctx, w.Duration.Seconds(), opt)
+	}
+	if w.Reads > 0 {
+		r.resumeSettleWaitReads.Record(ctx, w.Reads, opt)
 	}
 }
 
@@ -320,6 +354,15 @@ func safeResult(v string) string {
 		return v
 	default:
 		return ResultError
+	}
+}
+
+func safeSettleResult(v string) string {
+	switch v {
+	case SettleResultSettled, SettleResultTimeout:
+		return v
+	default:
+		return SettleResultTimeout
 	}
 }
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -13,11 +13,17 @@ const (
 )
 
 // Result values for SandboxResumeSettleWait. Distinct from the ResultX enum
-// above: a settle wait always resolves as either "the racing write landed"
-// or "we gave up waiting for it" — neither maps onto success/error/conflict.
+// above: none of these outcomes map onto success/error/conflict.
+// "Settled" means specifically pausing→paused — the outcome the wait exists
+// for. A row that left 'pausing' for any other state (a failed pause
+// reverting to active, a delete claiming the row) diverged: the resume still
+// 409s, and counting it as settled would contaminate the settle metric with
+// pause failures.
 const (
-	SettleResultSettled = "settled"
-	SettleResultTimeout = "timeout"
+	SettleResultSettled  = "settled"  // pausing → paused; the resume proceeds
+	SettleResultDiverged = "diverged" // pausing → any non-paused state; the resume 409s
+	SettleResultTimeout  = "timeout"  // still 'pausing' when the window expired
+	SettleResultCanceled = "canceled" // caller disconnected or timed out mid-wait
 )
 
 // SandboxTransition records low-cardinality operational lifecycle metrics.
@@ -39,7 +45,7 @@ type SandboxTransition struct {
 // was just slow" in dashboards, since both would otherwise fold into the
 // same overall resume duration histogram.
 type SandboxResumeSettleWait struct {
-	Result   string // "settled" or "timeout"
+	Result   string // one of the SettleResult* constants
 	Region   string
 	HostID   string
 	Duration time.Duration

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -12,6 +12,14 @@ const (
 	ResultTimeout  = "timeout"
 )
 
+// Result values for SandboxResumeSettleWait. Distinct from the ResultX enum
+// above: a settle wait always resolves as either "the racing write landed"
+// or "we gave up waiting for it" — neither maps onto success/error/conflict.
+const (
+	SettleResultSettled = "settled"
+	SettleResultTimeout = "timeout"
+)
+
 // SandboxTransition records low-cardinality operational lifecycle metrics.
 // Keep tenant, user, API key, and sandbox identifiers out of metric labels;
 // use logs or traces for per-sandbox investigation.
@@ -21,6 +29,21 @@ type SandboxTransition struct {
 	Region    string
 	HostID    string
 	Duration  time.Duration
+}
+
+// SandboxResumeSettleWait records ResumeSandbox waiting through a racing
+// finalize-pause write (pausing -> paused) before it could proceed or gave
+// up. Emitted once per resume that had to wait past the first read — never
+// per poll — so its volume tracks resume request rate, not poll count. This
+// is what lets "resume settled through a race" be told apart from "resume
+// was just slow" in dashboards, since both would otherwise fold into the
+// same overall resume duration histogram.
+type SandboxResumeSettleWait struct {
+	Result   string // "settled" or "timeout"
+	Region   string
+	HostID   string
+	Duration time.Duration
+	Reads    int64
 }
 
 // VMDCall records operational health for calls to VM daemons. Method and
@@ -89,6 +112,7 @@ type LauncherState struct {
 // operational metrics into Postgres.
 type Recorder interface {
 	RecordSandboxTransition(context.Context, SandboxTransition)
+	RecordSandboxResumeSettleWait(context.Context, SandboxResumeSettleWait)
 	RecordVMDCall(context.Context, VMDCall)
 	RecordHostCapacity(context.Context, HostCapacity)
 	RecordDBPoolStats(context.Context, DBPoolStats)
@@ -98,10 +122,11 @@ type Recorder interface {
 
 type noopRecorder struct{}
 
-func NewNoopRecorder() Recorder                                                         { return noopRecorder{} }
-func (noopRecorder) RecordSandboxTransition(context.Context, SandboxTransition)         {}
-func (noopRecorder) RecordVMDCall(context.Context, VMDCall)                             {}
-func (noopRecorder) RecordHostCapacity(context.Context, HostCapacity)                   {}
-func (noopRecorder) RecordDBPoolStats(context.Context, DBPoolStats)                     {}
-func (noopRecorder) RecordPausedNetworkPressure(context.Context, PausedNetworkPressure) {}
-func (noopRecorder) RecordLauncherState(context.Context, LauncherState)                 {}
+func NewNoopRecorder() Recorder                                                             { return noopRecorder{} }
+func (noopRecorder) RecordSandboxTransition(context.Context, SandboxTransition)             {}
+func (noopRecorder) RecordSandboxResumeSettleWait(context.Context, SandboxResumeSettleWait) {}
+func (noopRecorder) RecordVMDCall(context.Context, VMDCall)                                 {}
+func (noopRecorder) RecordHostCapacity(context.Context, HostCapacity)                       {}
+func (noopRecorder) RecordDBPoolStats(context.Context, DBPoolStats)                         {}
+func (noopRecorder) RecordPausedNetworkPressure(context.Context, PausedNetworkPressure)     {}
+func (noopRecorder) RecordLauncherState(context.Context, LauncherState)                     {}

--- a/internal/telemetry/vmd_client_test.go
+++ b/internal/telemetry/vmd_client_test.go
@@ -12,6 +12,8 @@ type captureRecorder struct {
 
 func (r *captureRecorder) RecordSandboxTransition(context.Context, SandboxTransition) {}
 
+func (r *captureRecorder) RecordSandboxResumeSettleWait(context.Context, SandboxResumeSettleWait) {}
+
 func (r *captureRecorder) RecordVMDCall(_ context.Context, call VMDCall) {
 	r.vmdCalls = append(r.vmdCalls, call)
 }


### PR DESCRIPTION
## Summary

`PauseSandbox` responds success as soon as vmd's `PauseVM` RPC completes; the DB status flip (`pausing` -> `paused`) happens afterward as fire-and-forget bookkeeping, deliberately, so pause stays fast even on an idle host that could otherwise wait on the write. The tradeoff: an immediate follow-up resume can read the sandbox row before that write lands, see it still `pausing`, and 409 against an operation the client was just told succeeded. Reproduced consistently (~5% of resumes) under concurrent burst pause/resume against staging.

This closes the race without touching pause's latency at all: `ResumeSandbox` now polls briefly through a `pausing` row instead of failing on the first read, giving the racing bookkeeping write a chance to land.

## Technical decisions

- Reused the settle-window mechanism that already exists for the equivalent create/resume race (`activateSettleWindow`/`activateSettlePoll`, used by `loadActiveOrResumeSandbox` to poll through a `starting`/`resuming` row) instead of inventing a second one.
- The fix lives entirely on the resume side. Pause's response time is unchanged — resume already does a real VMD round trip, so absorbing a short bounded poll for the rare race is cheap relative to its existing latency.
- Any other non-`paused` status (`active`, `failed`, etc.) still 409s on the first read, same as before. A sandbox genuinely stuck in `pausing` past the settle window (finalize lost or truly stalled, not just racing) still 409s once the window expires.

## Testing

- `go test ./internal/api/...` — full package passes.
- Added `TestResumeSandbox_SettlesPausingToPaused` (row flips from `pausing` to `paused` mid-poll, resume succeeds) and `TestResumeSandbox_PersistentPausing_409` (row stays `pausing` past a shrunk window, resume still 409s).
- Reproduced the race pre-fix with a burst script against staging (20 concurrent sandboxes: create, pause all, resume all) — consistent 1/20 resume failures across two runs. Plan to re-run the same script post-deploy to confirm 0 failures.