### PR TITLE
deploy: drain usw2 pause backups with two workers

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -326,6 +326,14 @@ jobs:
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills.
           BACKUP_JOURNAL_PATH: /mnt/localssd/backup.db
+          # Two drain workers to clear the cell's pause-backup backlog:
+          # arrivals outpace the single-worker default here. Workers
+          # share one bandwidth cap (task throughput rises, egress does
+          # not), and the incremental host cost is one extra hash/read
+          # stream on a 192-core metal host with a 12-drive array.
+          # Held at 2 until the sandboxes.slice weighting lands; raise
+          # further only after it. Rollback is removing this line.
+          BACKUP_UPLOAD_CONCURRENCY: "2"
           # Enables vmd's backup metrics exporter (host-local collector);
           # the cell's backup alert policies, including backup-disabled,
           # cannot fire without these series.


### PR DESCRIPTION
## Summary
Flips usw2's backup uploader from the single-worker default to 2 drain workers, to clear the pause-backup backlog behind the open backlog-age alert (oldest pending pause is past 45 hours; arrivals outpace serial drain).

## Technical notes
- Workers share the existing bandwidth limiter: task throughput rises, total egress stays at the tuned cap.
- Incremental host cost is one extra hash/read stream on a 192-core metal host with a 12-drive NVMe array.
- Held at 2 (not higher) until the sandboxes.slice weighting deploys; raising further is gated on it.
- Rollback is removing the line and redeploying.

## Testing
- Staging has been running the same concurrency since the parallel-drain change deployed there.
- Merge gate: a clean staging soak (journal depth draining, no abandonment spike, pause-hook latency flat).
- Post-deploy canary on usw2: pause/resume latency and success rate, host CPU, and journal pending slope going negative; the backlog-age alert clearing is the exit signal.