### PR TITLE
fix(billing): enforce trial eligibility and Stripe credit transition

### DIFF
--- a/cmd/migrate-team/main_test.go
+++ b/cmd/migrate-team/main_test.go
@@ -214,6 +214,10 @@ func seedFixture(t *testing.T) *fixture {
 
 	// Source cell: the team under migration.
 	mustExec(t, srcPool, `INSERT INTO team (id, name) VALUES ($1, 'migration-drill')`, f.team)
+	// This fixture supplies its own credit ledger below; do not include the
+	// signup grant that current team creation provisions automatically.
+	mustExec(t, srcPool, `DELETE FROM team_credit_grant WHERE team_id = $1 AND reason = 'signup trial credit'`, f.team)
+	mustExec(t, srcPool, `DELETE FROM team_trial_eligibility_cache WHERE team_id = $1`, f.team)
 	mustExec(t, srcPool, `INSERT INTO profile (id, email, provider, provider_id) VALUES ($1, 'owner@example.com', 'google', 'google-owner')`, f.owner)
 	mustExec(t, srcPool, `INSERT INTO profile (id, email, provider, provider_id) VALUES ($1, 'member@example.com', 'google', 'google-member')`, f.member)
 	mustExec(t, srcPool, `INSERT INTO team_member (team_id, profile_id, role) VALUES ($1, $2, 'owner'), ($1, $3, 'member')`, f.team, f.owner, f.member)
@@ -446,6 +450,8 @@ func seedFixture(t *testing.T) *fixture {
 		"billing_rollup_job":                 1,
 		"billing_rollup_team_backfill_state": 1,
 		"team_feature_flag":                  2,
+		"team_billing_account":               0,
+		"team_trial_eligibility_cache":       0,
 		"team_pricing_plan":                  1,
 		"team_credit_grant":                  1,
 		"team_credit_ledger":                 1,

--- a/cmd/migrate-team/migrate.go
+++ b/cmd/migrate-team/migrate.go
@@ -421,6 +421,19 @@ func runCopy(ctx context.Context, src, dst *pgxpool.Pool, cfg config) error {
 	for _, t := range migratedTables {
 		copied, skipped, err := copyTable(ctx, src, dst, t, cfg.teamID, transforms[t.name])
 		if err == nil && t.name == "team" {
+			// Team creation in a current cell provisions the signup grant. A
+			// migration must preserve the source ledger exactly, so remove the
+			// destination-side default before team_credit_grant is copied.
+			if _, herr := dst.Exec(ctx, `
+				DELETE FROM team_credit_grant
+				WHERE team_id = $1 AND reason = 'signup trial credit'`, cfg.teamID); herr != nil {
+				return fmt.Errorf("clear destination signup credit: %w", herr)
+			}
+			if _, herr := dst.Exec(ctx, `
+				DELETE FROM team_trial_eligibility_cache
+				WHERE team_id = $1`, cfg.teamID); herr != nil {
+				return fmt.Errorf("clear destination trial eligibility cache: %w", herr)
+			}
 			// The moment intervals land, the dest scheduler could discover
 			// this team under the default-TRUE rollup flag and mint jobs,
 			// cursors, and hourly rows that never existed in source —

--- a/cmd/migrate-team/tables.go
+++ b/cmd/migrate-team/tables.go
@@ -74,6 +74,8 @@ var migratedTables = []tableSpec{
 	{"profile", profileScope},
 	{"team", "id = $1"},
 	{"team_feature_flag", "team_id = $1"},
+	{"team_billing_account", "team_id = $1"},
+	{"team_trial_eligibility_cache", "team_id = $1"},
 	{"team_member", "team_id = $1"},
 	// team_memberships before user_role_assignments: a dest-side trigger
 	// requires an active membership before accepting an active team-scoped

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -421,12 +421,12 @@ WHERE billing_period_anomaly.id = sqlc.arg(id)
 RETURNING *;
 
 -- name: GetTeamBillingAccount :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 FROM team_billing_account
 WHERE team_id = sqlc.arg(team_id);
 
 -- name: GetTeamBillingAccountByStripeCustomerID :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 FROM team_billing_account
 WHERE stripe_customer_id = sqlc.arg(stripe_customer_id);
 
@@ -777,6 +777,43 @@ FROM team_credit_grant
 WHERE team_id = sqlc.arg(team_id)
   AND remaining_usd > 0
   AND (expires_at IS NULL OR expires_at > now());
+
+-- name: IsTeamSandboxBillingEligible :one
+SELECT team_sandbox_billing_eligible(sqlc.arg(team_id)) AS eligible;
+
+-- name: RefreshTeamTrialEligibility :exec
+INSERT INTO team_trial_eligibility_cache (team_id, eligible, updated_at)
+SELECT sqlc.arg(team_id), refresh_team_trial_eligibility(sqlc.arg(team_id)), now()
+ON CONFLICT (team_id) DO UPDATE
+SET eligible = EXCLUDED.eligible,
+    updated_at = EXCLUDED.updated_at;
+
+-- name: ListTeamsWithActiveTrialSandboxes :many
+SELECT DISTINCT s.team_id
+FROM sandbox s
+JOIN team_credit_grant g
+  ON g.team_id = s.team_id
+  AND g.reason = 'signup trial credit'
+LEFT JOIN team_billing_account a ON a.team_id = s.team_id
+WHERE s.destroyed_at IS NULL
+  AND s.status = 'active'
+  AND a.trial_ended_at IS NULL
+  AND s.team_id > COALESCE(sqlc.narg(after_team_id)::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+ORDER BY s.team_id
+LIMIT sqlc.arg(batch_limit);
+
+-- name: ListTeamsWithActiveIneligibleSandboxes :many
+SELECT DISTINCT s.team_id
+FROM sandbox s
+WHERE s.destroyed_at IS NULL
+  AND s.status = 'active'
+  AND NOT team_sandbox_billing_eligible(s.team_id)
+  AND s.team_id > COALESCE(sqlc.narg(after_team_id)::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+ORDER BY s.team_id
+LIMIT sqlc.arg(batch_limit);
+
+-- name: ActivateTeamBilling :exec
+SELECT activate_team_billing(sqlc.arg(team_id), sqlc.arg(stripe_grant_id));
 
 -- name: ListTeamCreditGrants :many
 SELECT *

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -822,6 +822,43 @@ SELECT p.id, p.team_id, p.name, p.snapshot_id, p.host_id, p.network_config
 FROM paused p
 LEFT JOIN closed_intervals ci ON ci.sandbox_id = p.id;
 
+-- name: ClaimBillingIneligibleSandboxes :many
+-- Atomically claims active sandboxes for a team whose billing eligibility was
+-- lost. The bounded batch and SKIP LOCKED make this safe to retry and keep
+-- webhook reconciliation off the request's critical path.
+WITH candidates AS (
+  SELECT s.id, s.team_id, s.name, s.snapshot_id, s.host_id
+  FROM sandbox s
+  WHERE s.team_id = $1
+    AND s.destroyed_at IS NULL
+    AND s.status = 'active'
+    AND NOT team_sandbox_billing_eligible(s.team_id)
+  ORDER BY s.created_at ASC
+  LIMIT $2
+  FOR UPDATE OF s SKIP LOCKED
+), paused AS (
+  UPDATE sandbox
+  SET status = 'pausing', updated_at = now()
+  FROM candidates
+  WHERE sandbox.id = candidates.id
+  RETURNING candidates.id, candidates.team_id, candidates.name, candidates.snapshot_id, candidates.host_id, sandbox.network_config
+), closed_intervals AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'paused'
+  WHERE sandbox_id IN (SELECT id FROM paused)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+), closed_billing_compute AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'paused'
+  WHERE sandbox_id IN (SELECT id FROM paused)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT p.id, p.team_id, p.name, p.snapshot_id, p.host_id, p.network_config
+FROM paused p
+LEFT JOIN closed_intervals ci ON ci.sandbox_id = p.id;
+
 -- name: UpdateSandboxAutoDelete :execrows
 -- Set or clear (NULL) the auto-delete window. The deadline counts continuous
 -- paused time since the setting was applied: on an already-paused sandbox it

--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+const billingEligibilityPauseBatchSize int32 = 50
+
+func (h *Handlers) refreshActiveTrialEligibility(ctx context.Context) {
+	var after *uuid.UUID
+	for {
+		var afterID pgtype.UUID
+		if after != nil {
+			afterID = pgtype.UUID{Bytes: *after, Valid: true}
+		}
+		teams, err := h.DB.ListTeamsWithActiveTrialSandboxes(ctx, db.ListTeamsWithActiveTrialSandboxesParams{AfterTeamID: afterID, BatchLimit: 1000})
+		if err != nil {
+			log.Error().Err(err).Msg("billing: list active trial teams failed")
+			return
+		}
+		if len(teams) == 0 {
+			break
+		}
+		dispatchBounded(ctx, teams, 10, func(teamID uuid.UUID) {
+			if err := h.DB.RefreshTeamTrialEligibility(ctx, teamID); err != nil {
+				log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: refresh trial eligibility failed")
+				return
+			}
+			h.pauseBillingIneligibleTeam(ctx, teamID)
+		})
+		last := teams[len(teams)-1]
+		after = &last
+		if len(teams) < 1000 {
+			break
+		}
+	}
+	h.reconcileActiveIneligibleTeams(ctx)
+}
+
+// reconcileActiveIneligibleTeams is the durable safety net for terminal
+// subscription transitions. It scans all active teams, not just trials, so a
+// restart or a failed webhook goroutine cannot leave paid sandboxes running.
+func (h *Handlers) reconcileActiveIneligibleTeams(ctx context.Context) {
+	var after *uuid.UUID
+	for {
+		var afterID pgtype.UUID
+		if after != nil {
+			afterID = pgtype.UUID{Bytes: *after, Valid: true}
+		}
+		teams, err := h.DB.ListTeamsWithActiveIneligibleSandboxes(ctx, db.ListTeamsWithActiveIneligibleSandboxesParams{AfterTeamID: afterID, BatchLimit: 1000})
+		if err != nil {
+			log.Error().Err(err).Msg("billing: list active ineligible teams failed")
+			return
+		}
+		if len(teams) == 0 {
+			return
+		}
+		dispatchBounded(ctx, teams, 10, func(teamID uuid.UUID) {
+			h.pauseBillingIneligibleTeam(ctx, teamID)
+		})
+		last := teams[len(teams)-1]
+		after = &last
+		if len(teams) < 1000 {
+			return
+		}
+	}
+}
+
+func (h *Handlers) reconcileActivatedSandbox(ctx context.Context, teamID uuid.UUID) {
+	eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed")
+		return
+	}
+	if !eligible {
+		h.pauseBillingIneligibleTeam(ctx, teamID)
+	}
+}
+
+// pauseBillingIneligibleTeam claims and pauses active sandboxes after Stripe
+// reports a terminal subscription state. Claiming is DB-atomic and the VMD
+// saga runs in the background so webhook acknowledgement is not held on host
+// work. A later reconciliation can safely pick up any rows beyond the batch.
+func (h *Handlers) pauseBillingIneligibleTeam(ctx context.Context, teamID uuid.UUID) {
+	for batch := 0; ; batch++ {
+		rows, err := h.DB.ClaimBillingIneligibleSandboxes(ctx, db.ClaimBillingIneligibleSandboxesParams{
+			TeamID: teamID,
+			Limit:  billingEligibilityPauseBatchSize,
+		})
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: claim ineligible sandboxes failed")
+			h.retryBillingEligibilityReconciliation(teamID)
+			return
+		}
+		if len(rows) == 0 {
+			return
+		}
+		cleanupCtx := context.WithoutCancel(ctx)
+		dispatchBounded(cleanupCtx, rows, 10, func(sbx db.ClaimBillingIneligibleSandboxesRow) {
+			itemCtx, itemCancel := context.WithTimeout(cleanupCtx, 2*time.Minute)
+			defer itemCancel()
+			h.pauseBillingIneligible(itemCtx, sbx)
+		})
+		if len(rows) < int(billingEligibilityPauseBatchSize) || batch >= 99 {
+			if len(rows) > 0 {
+				h.retryBillingEligibilityReconciliation(teamID)
+			}
+			if batch >= 99 && len(rows) == int(billingEligibilityPauseBatchSize) {
+				log.Warn().Str("team_id", teamID.String()).Msg("billing: reconciliation batch limit reached")
+			}
+			return
+		}
+	}
+}
+
+func (h *Handlers) retryBillingEligibilityReconciliation(teamID uuid.UUID) {
+	go func() {
+		timer := time.NewTimer(30 * time.Second)
+		defer timer.Stop()
+		<-timer.C
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		h.pauseBillingIneligibleTeam(ctx, teamID)
+	}()
+}
+
+func (h *Handlers) scheduleBillingEligibilityReconciliation(ctx context.Context, event stripeEventEnvelope) {
+	if h.DB == nil {
+		return
+	}
+	var obj stripeSubscriptionObject
+	if event.Type == "customer.subscription.deleted" {
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return
+		}
+		obj.Status = "canceled"
+	} else if event.Type == "customer.subscription.updated" || event.Type == "customer.subscription.created" || event.Type == "customer.subscription.paused" || event.Type == "customer.subscription.resumed" {
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return
+		}
+		if !strings.EqualFold(obj.Status, "unpaid") && !strings.EqualFold(obj.Status, "canceled") && !strings.EqualFold(obj.Status, "paused") {
+			return
+		}
+	} else {
+		return
+	}
+	if obj.Customer == "" {
+		return
+	}
+
+	baseCtx := context.WithoutCancel(ctx)
+	h.asyncBookkeeping("billing-ineligible-reconcile", func() {
+		qctx, cancel := context.WithTimeout(baseCtx, 2*time.Minute)
+		defer cancel()
+		account, err := h.DB.GetTeamBillingAccountByStripeCustomerID(qctx, &obj.Customer)
+		if err != nil {
+			if err != pgx.ErrNoRows {
+				log.Error().Err(err).Str("customer_id", obj.Customer).Msg("billing: lookup ineligible team failed")
+			}
+			return
+		}
+		h.pauseBillingIneligibleTeam(qctx, account.TeamID)
+	})
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -639,6 +639,9 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 		case db.SandboxStatusActive:
 			return &sandbox, row.Access
 		case db.SandboxStatusPaused:
+			if !h.requireBillingEligible(c, teamID) {
+				return nil, ""
+			}
 			// The resume returns the post-restore access it pushed to VMD, so
 			// the response reports exactly what the VM enforces.
 			resumedAccess, ok := h.resumePausedSandbox(c, &sandbox, teamID)
@@ -999,7 +1002,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}); err != nil {
 			l.Error().Err(err).Msg("async DB ActivateSandbox failed — re-pausing")
 			pauseAndRevert()
+			return
 		}
+		billingCtx, billingCancel := context.WithTimeout(context.WithoutCancel(revertCtx), 2*time.Minute)
+		h.reconcileActivatedSandbox(billingCtx, teamID)
+		billingCancel()
 	})
 
 	sandbox.VcpuCount = int32(actualVcpu)
@@ -1178,6 +1185,9 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 	if !h.requireTeamSandboxWrite(c, teamID) {
+		return
+	}
+	if !h.requireBillingEligible(c, teamID) {
 		return
 	}
 
@@ -1998,6 +2008,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	if !h.requireTeamSandboxWrite(c, teamID) {
 		return
 	}
+	if !h.requireBillingEligible(c, teamID) {
+		return
+	}
 
 	// Resolve secret references before spinning up the VM so a typo 400s cleanly.
 	secretBindings, secretMeta, appErr := h.resolveSecretBindingsForCreate(c.Request.Context(), teamID, req.Secrets)
@@ -2572,7 +2585,11 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			ActorID:   actorUUID(actorID),
 		}); err != nil {
 			l.Error().Err(err).Msg("async DB ActivateSandbox failed")
+			return
 		}
+		billingCtx, billingCancel := context.WithTimeout(context.WithoutCancel(activateCtx), 2*time.Minute)
+		h.reconcileActivatedSandbox(billingCtx, teamID)
+		billingCancel()
 	})
 
 	// Network rules stay blocking: a 201 must imply "egress rules applied",

--- a/internal/api/handlers_billing.go
+++ b/internal/api/handlers_billing.go
@@ -299,7 +299,6 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 			checkoutAvailable = true
 		}
 	}
-	paymentSetupRequired := mode == billingModeLive && !hasEstablishedSubscription
 	charges := billing.CalculateSummaryCharges(
 		vcpuSeconds,
 		memoryGibSeconds,
@@ -310,6 +309,9 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		creditsAvailable,
 		storageBillingEnabled,
 	)
+	paymentSetupRequired := mode == billingModeLive &&
+		!hasEstablishedSubscription &&
+		charges.CreditsRemainingUSD <= 0
 	summaryResources := billingSummaryResourcesFromState(resourceStates, vcpuSeconds, memoryGibSeconds, storageGibSeconds, charges)
 
 	setPrivateBillingCacheHeaders(c)
@@ -540,6 +542,27 @@ func billingAccountHasEstablishedSubscription(account db.GetTeamBillingAccountRo
 	default:
 		return false
 	}
+}
+
+func (h *Handlers) requireBillingEligible(c *gin.Context, teamID uuid.UUID) bool {
+	// Lightweight handler tests use a query mock without the billing schema;
+	// production handlers always have a pool-backed database.
+	if h.Pool == nil {
+		return true
+	}
+	started := time.Now()
+	eligible, err := h.DB.IsTeamSandboxBillingEligible(c.Request.Context(), teamID)
+	log.Debug().Str("team_id", teamID.String()).Int64("billing_eligibility_ms", time.Since(started).Milliseconds()).Msg("billing eligibility check")
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("read sandbox billing eligibility failed")
+		respondError(c, ErrInternal)
+		return false
+	}
+	if !eligible {
+		respondErrorMsg(c, "billing_ineligible", "Sandbox usage is unavailable until billing is active", http.StatusPaymentRequired)
+		return false
+	}
+	return true
 }
 
 func currentBillingPeriod(now time.Time) (time.Time, time.Time) {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -41,6 +41,7 @@ var errBillingRedirectOriginsNotConfigured = errors.New("billing redirect origin
 
 type StripeBillingClient interface {
 	CreateCustomer(ctx context.Context, params StripeCreateCustomerParams) (StripeCustomer, error)
+	CreateBillingCreditGrant(ctx context.Context, params StripeCreateBillingCreditGrantParams) (StripeBillingCreditGrant, error)
 	CreateCheckoutSession(ctx context.Context, params StripeCreateCheckoutSessionParams) (StripeCheckoutSession, error)
 	CreateCustomerPortalSession(ctx context.Context, params StripeCreateCustomerPortalSessionParams) (StripePortalSession, error)
 	ReportMeterEvent(ctx context.Context, params StripeReportMeterEventParams) error
@@ -57,6 +58,16 @@ type StripeCreateCustomerParams struct {
 }
 
 type StripeCustomer struct {
+	ID string
+}
+
+type StripeCreateBillingCreditGrantParams struct {
+	CustomerID     string
+	AmountCents    int64
+	IdempotencyKey string
+}
+
+type StripeBillingCreditGrant struct {
 	ID string
 }
 
@@ -275,6 +286,23 @@ func (c *stripeHTTPClient) CreateCustomer(ctx context.Context, params StripeCrea
 		return StripeCustomer{}, err
 	}
 	return StripeCustomer{ID: resp.ID}, nil
+}
+
+func (c *stripeHTTPClient) CreateBillingCreditGrant(ctx context.Context, params StripeCreateBillingCreditGrantParams) (StripeBillingCreditGrant, error) {
+	form := url.Values{}
+	form.Set("customer", params.CustomerID)
+	form.Set("category", "promotional")
+	form.Set("amount[type]", "monetary")
+	form.Set("amount[monetary][currency]", "usd")
+	form.Set("amount[monetary][value]", strconv.FormatInt(params.AmountCents, 10))
+	form.Set("applicability_config[scope][price_type]", "metered")
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.doForm(ctx, http.MethodPost, "/v1/billing/credit_grants", form, &resp, params.IdempotencyKey); err != nil {
+		return StripeBillingCreditGrant{}, err
+	}
+	return StripeBillingCreditGrant{ID: resp.ID}, nil
 }
 
 func (c *stripeHTTPClient) CreateCheckoutSession(ctx context.Context, params StripeCreateCheckoutSessionParams) (StripeCheckoutSession, error) {
@@ -1401,6 +1429,7 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 					respondError(c, ErrInternal)
 					return
 				}
+				h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
 				c.JSON(http.StatusOK, gin.H{"status": "duplicate"})
 				return
 			}
@@ -1438,6 +1467,7 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 				respondError(c, ErrInternal)
 				return
 			}
+			h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
 			c.JSON(http.StatusOK, gin.H{"status": "ok"})
 			return
 		}
@@ -1481,6 +1511,7 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
@@ -1531,7 +1562,7 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			StripeSubscriptionID: stringPtr(obj.Subscription),
 		})
 		return err
-	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted":
+	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted", "customer.subscription.paused", "customer.subscription.resumed":
 		var obj stripeSubscriptionObject
 		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
 			return err
@@ -1558,20 +1589,50 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 			}
 		}
 		start, end, ok := stripeSubscriptionPeriodBounds(obj)
-		if !ok {
+		terminalStatus := strings.EqualFold(obj.Status, "unpaid") || strings.EqualFold(obj.Status, "canceled") || strings.EqualFold(obj.Status, "paused") || event.Type == "customer.subscription.deleted"
+		if !ok && !terminalStatus {
 			return nil
+		}
+		var periodStart, periodEnd pgtype.Timestamptz
+		if ok {
+			periodStart = timestamptzFromUnix(start)
+			periodEnd = timestamptzFromUnix(end)
 		}
 		_, err = q.UpsertTeamBillingAccountSubscription(ctx, db.UpsertTeamBillingAccountSubscriptionParams{
 			TeamID:                    account.TeamID,
 			StripeCustomerID:          stringPtr(obj.Customer),
 			StripeSubscriptionID:      stringPtr(obj.ID),
 			StripeSubscriptionStatus:  stringPtr(obj.Status),
-			CurrentPeriodStart:        timestamptzFromUnix(start),
-			CurrentPeriodEnd:          timestamptzFromUnix(end),
+			CurrentPeriodStart:        periodStart,
+			CurrentPeriodEnd:          periodEnd,
 			CancelAtPeriodEnd:         boolPtr(obj.CancelAtPeriodEnd),
 			StripeSubscriptionEventAt: timestamptzFromUnix(int64(event.Created)),
 		})
-		return err
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(obj.Status, "active") || strings.EqualFold(obj.Status, "trialing") {
+			grantID := derefString(account.StripeActivationCreditGrantID)
+			if grantID == "" {
+				if h.Stripe == nil {
+					return fmt.Errorf("Stripe billing client is not configured")
+				}
+				grant, gerr := h.Stripe.CreateBillingCreditGrant(ctx, StripeCreateBillingCreditGrantParams{
+					CustomerID:     obj.Customer,
+					AmountCents:    9500,
+					IdempotencyKey: "stripe-activation-credit-" + account.TeamID.String(),
+				})
+				if gerr != nil {
+					return gerr
+				}
+				if strings.TrimSpace(grant.ID) == "" {
+					return fmt.Errorf("Stripe credit grant response did not include an ID")
+				}
+				grantID = grant.ID
+			}
+			return q.ActivateTeamBilling(ctx, db.ActivateTeamBillingParams{TeamID: account.TeamID, StripeGrantID: grantID})
+		}
+		return nil
 	case "invoice.payment_failed", "invoice.payment_succeeded", "invoice.finalized":
 		var obj stripeInvoiceObject
 		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -59,6 +59,30 @@ func DefaultReaperConfig() ReaperConfig {
 //     cannot starve the control plane for extended periods.
 func (h *Handlers) StartTimeoutReaper(ctx context.Context, cfg ReaperConfig) {
 	go h.reaperLoop(ctx, cfg)
+	go h.trialEligibilityLoop(ctx, cfg.Interval)
+}
+
+func (h *Handlers) trialEligibilityLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	run := func() {
+		deadline := 2 * time.Minute
+		if interval > 0 && interval < deadline {
+			deadline = interval
+		}
+		qctx, cancel := context.WithTimeout(ctx, deadline)
+		defer cancel()
+		sentrylog.RunSafe("billing-trial-eligibility", func() { h.refreshActiveTrialEligibility(qctx) })
+	}
+	run()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			run()
+		}
+	}
 }
 
 func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
@@ -315,6 +339,21 @@ func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDele
 //   - Step 1 fails → VM is still running → revert DB to 'active'.
 //   - Step 2 fails → VM is stopped → call rollbackPausedVM (resume + revert).
 func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxesRow) {
+	h.pauseClaimed(ctx, sbx, "timeout", "timeout_pause", "timeout_paused", "reaper: sandbox paused due to timeout")
+}
+
+func (h *Handlers) pauseBillingIneligible(ctx context.Context, sbx db.ClaimBillingIneligibleSandboxesRow) {
+	h.pauseClaimed(ctx, db.ClaimExpiredSandboxesRow{
+		ID:            sbx.ID,
+		TeamID:        sbx.TeamID,
+		Name:          sbx.Name,
+		SnapshotID:    sbx.SnapshotID,
+		HostID:        sbx.HostID,
+		NetworkConfig: sbx.NetworkConfig,
+	}, "billing_ineligible", "billing_ineligible_pause", "billing_ineligible_paused", "billing: sandbox paused after eligibility loss")
+}
+
+func (h *Handlers) pauseClaimed(ctx context.Context, sbx db.ClaimExpiredSandboxesRow, trigger, transition, activity, successMessage string) {
 	l := log.With().
 		Str("sandbox_id", sbx.ID.String()).
 		Str("host_id", sbx.HostID).
@@ -330,7 +369,7 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 	vmd, vmdLookupErr := h.vmdForHost(ctx, sbx.HostID)
 	if vmdLookupErr != nil {
 		l.Error().Err(vmdLookupErr).Msg("reaper: resolve VMD failed — reverting to active")
-		RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultError, sbx.HostID, time.Since(started))
+		RecordSandboxTransition(ctx, transition, telemetry.ResultError, sbx.HostID, time.Since(started))
 		h.revertToActiveOrFail(ctx, sbx, vmdLookupErr, l)
 		return
 	}
@@ -340,7 +379,7 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 		// Retry (see pauseWithRetry) didn't converge — the VM genuinely
 		// didn't pause, so revert to active and let the next tick retry.
 		l.Error().Err(err).Msg("reaper: VMD PauseInstance failed — reverting to active")
-		RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultError, sbx.HostID, time.Since(started))
+		RecordSandboxTransition(ctx, transition, telemetry.ResultError, sbx.HostID, time.Since(started))
 		h.revertToActiveOrFail(ctx, sbx, err, l)
 		return
 	}
@@ -353,21 +392,21 @@ func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxe
 		TeamID:  sbx.TeamID,
 		Path:    snapshotPath,
 		MemPath: &memPath,
-		Trigger: "timeout",
+		Trigger: trigger,
 	}
 	applyManifest(&params, manifest)
 	if _, err := h.finalizePause(postCtx, params); err != nil {
 		l.Error().Err(err).Msg("reaper: FinalizePause failed — rolling back VMD pause")
-		RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultError, sbx.HostID, time.Since(started))
+		RecordSandboxTransition(ctx, transition, telemetry.ResultError, sbx.HostID, time.Since(started))
 		h.rollbackPausedVM(ctx, sbx, snapshotPath, memPath, err, l)
 		return
 	}
 
-	l.Info().Msg("reaper: sandbox paused due to timeout")
-	RecordSandboxTransition(ctx, "timeout_pause", telemetry.ResultSuccess, sbx.HostID, time.Since(started))
+	l.Info().Msg(successMessage)
+	RecordSandboxTransition(ctx, transition, telemetry.ResultSuccess, sbx.HostID, time.Since(started))
 	// Interval was already closed at the top of pauseExpired; FinalizePause
 	// is the end of the VMD pause work, not the leave-active moment.
-	h.logSandboxActivity(ctx, sbx.ID, sbx.TeamID, nil, "sandbox", "timeout_paused", "success", &sbx.Name, nil, nil)
+	h.logSandboxActivity(ctx, sbx.ID, sbx.TeamID, nil, "sandbox", activity, "success", &sbx.Name, nil, nil)
 }
 
 // rollbackPausedVM is the saga compensation for a failed pause. The VM is

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -13,6 +13,20 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const activateTeamBilling = `-- name: ActivateTeamBilling :exec
+SELECT activate_team_billing($1, $2)
+`
+
+type ActivateTeamBillingParams struct {
+	TeamID        uuid.UUID `json:"team_id"`
+	StripeGrantID string    `json:"stripe_grant_id"`
+}
+
+func (q *Queries) ActivateTeamBilling(ctx context.Context, arg ActivateTeamBillingParams) error {
+	_, err := q.db.Exec(ctx, activateTeamBilling, arg.TeamID, arg.StripeGrantID)
+	return err
+}
+
 const applyTeamCreditGrant = `-- name: ApplyTeamCreditGrant :one
 UPDATE team_credit_grant
 SET remaining_usd = remaining_usd - $1,
@@ -521,23 +535,26 @@ func (q *Queries) GetTeamActivePricingPlan(ctx context.Context, teamID uuid.UUID
 }
 
 const getTeamBillingAccount = `-- name: GetTeamBillingAccount :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 FROM team_billing_account
 WHERE team_id = $1
 `
 
 type GetTeamBillingAccountRow struct {
-	TeamID                    uuid.UUID          `json:"team_id"`
-	StripeCustomerID          *string            `json:"stripe_customer_id"`
-	StripeSubscriptionID      *string            `json:"stripe_subscription_id"`
-	StripeSubscriptionStatus  *string            `json:"stripe_subscription_status"`
-	StripeInvoiceStatus       *string            `json:"stripe_invoice_status"`
-	StripeSubscriptionEventAt pgtype.Timestamptz `json:"stripe_subscription_event_at"`
-	CurrentPeriodStart        pgtype.Timestamptz `json:"current_period_start"`
-	CurrentPeriodEnd          pgtype.Timestamptz `json:"current_period_end"`
-	CancelAtPeriodEnd         bool               `json:"cancel_at_period_end"`
-	CreatedAt                 time.Time          `json:"created_at"`
-	UpdatedAt                 time.Time          `json:"updated_at"`
+	TeamID                          uuid.UUID          `json:"team_id"`
+	StripeCustomerID                *string            `json:"stripe_customer_id"`
+	StripeSubscriptionID            *string            `json:"stripe_subscription_id"`
+	StripeSubscriptionStatus        *string            `json:"stripe_subscription_status"`
+	StripeInvoiceStatus             *string            `json:"stripe_invoice_status"`
+	StripeSubscriptionEventAt       pgtype.Timestamptz `json:"stripe_subscription_event_at"`
+	CurrentPeriodStart              pgtype.Timestamptz `json:"current_period_start"`
+	CurrentPeriodEnd                pgtype.Timestamptz `json:"current_period_end"`
+	CancelAtPeriodEnd               bool               `json:"cancel_at_period_end"`
+	CreatedAt                       time.Time          `json:"created_at"`
+	UpdatedAt                       time.Time          `json:"updated_at"`
+	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
+	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
+	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
 }
 
 func (q *Queries) GetTeamBillingAccount(ctx context.Context, teamID uuid.UUID) (GetTeamBillingAccountRow, error) {
@@ -555,28 +572,34 @@ func (q *Queries) GetTeamBillingAccount(ctx context.Context, teamID uuid.UUID) (
 		&i.CancelAtPeriodEnd,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TrialEndedAt,
+		&i.StripeActivationCreditGrantedAt,
+		&i.StripeActivationCreditGrantID,
 	)
 	return i, err
 }
 
 const getTeamBillingAccountByStripeCustomerID = `-- name: GetTeamBillingAccountByStripeCustomerID :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 FROM team_billing_account
 WHERE stripe_customer_id = $1
 `
 
 type GetTeamBillingAccountByStripeCustomerIDRow struct {
-	TeamID                    uuid.UUID          `json:"team_id"`
-	StripeCustomerID          *string            `json:"stripe_customer_id"`
-	StripeSubscriptionID      *string            `json:"stripe_subscription_id"`
-	StripeSubscriptionStatus  *string            `json:"stripe_subscription_status"`
-	StripeInvoiceStatus       *string            `json:"stripe_invoice_status"`
-	StripeSubscriptionEventAt pgtype.Timestamptz `json:"stripe_subscription_event_at"`
-	CurrentPeriodStart        pgtype.Timestamptz `json:"current_period_start"`
-	CurrentPeriodEnd          pgtype.Timestamptz `json:"current_period_end"`
-	CancelAtPeriodEnd         bool               `json:"cancel_at_period_end"`
-	CreatedAt                 time.Time          `json:"created_at"`
-	UpdatedAt                 time.Time          `json:"updated_at"`
+	TeamID                          uuid.UUID          `json:"team_id"`
+	StripeCustomerID                *string            `json:"stripe_customer_id"`
+	StripeSubscriptionID            *string            `json:"stripe_subscription_id"`
+	StripeSubscriptionStatus        *string            `json:"stripe_subscription_status"`
+	StripeInvoiceStatus             *string            `json:"stripe_invoice_status"`
+	StripeSubscriptionEventAt       pgtype.Timestamptz `json:"stripe_subscription_event_at"`
+	CurrentPeriodStart              pgtype.Timestamptz `json:"current_period_start"`
+	CurrentPeriodEnd                pgtype.Timestamptz `json:"current_period_end"`
+	CancelAtPeriodEnd               bool               `json:"cancel_at_period_end"`
+	CreatedAt                       time.Time          `json:"created_at"`
+	UpdatedAt                       time.Time          `json:"updated_at"`
+	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
+	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
+	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
 }
 
 func (q *Queries) GetTeamBillingAccountByStripeCustomerID(ctx context.Context, stripeCustomerID *string) (GetTeamBillingAccountByStripeCustomerIDRow, error) {
@@ -594,6 +617,9 @@ func (q *Queries) GetTeamBillingAccountByStripeCustomerID(ctx context.Context, s
 		&i.CancelAtPeriodEnd,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TrialEndedAt,
+		&i.StripeActivationCreditGrantedAt,
+		&i.StripeActivationCreditGrantID,
 	)
 	return i, err
 }
@@ -854,6 +880,17 @@ func (q *Queries) IsFeatureEnabledForTeam(ctx context.Context, arg IsFeatureEnab
 	var enabled bool
 	err := row.Scan(&enabled)
 	return enabled, err
+}
+
+const isTeamSandboxBillingEligible = `-- name: IsTeamSandboxBillingEligible :one
+SELECT team_sandbox_billing_eligible($1) AS eligible
+`
+
+func (q *Queries) IsTeamSandboxBillingEligible(ctx context.Context, teamID uuid.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, isTeamSandboxBillingEligible, teamID)
+	var eligible bool
+	err := row.Scan(&eligible)
+	return eligible, err
 }
 
 const listActivePricingRates = `-- name: ListActivePricingRates :many
@@ -1351,6 +1388,82 @@ func (q *Queries) ListTeamCreditGrants(ctx context.Context, teamID uuid.UUID) ([
 	return items, nil
 }
 
+const listTeamsWithActiveIneligibleSandboxes = `-- name: ListTeamsWithActiveIneligibleSandboxes :many
+SELECT DISTINCT s.team_id
+FROM sandbox s
+WHERE s.destroyed_at IS NULL
+  AND s.status = 'active'
+  AND NOT team_sandbox_billing_eligible(s.team_id)
+  AND s.team_id > COALESCE($1::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+ORDER BY s.team_id
+LIMIT $2
+`
+
+type ListTeamsWithActiveIneligibleSandboxesParams struct {
+	AfterTeamID pgtype.UUID `json:"after_team_id"`
+	BatchLimit  int32       `json:"batch_limit"`
+}
+
+func (q *Queries) ListTeamsWithActiveIneligibleSandboxes(ctx context.Context, arg ListTeamsWithActiveIneligibleSandboxesParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listTeamsWithActiveIneligibleSandboxes, arg.AfterTeamID, arg.BatchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []uuid.UUID{}
+	for rows.Next() {
+		var team_id uuid.UUID
+		if err := rows.Scan(&team_id); err != nil {
+			return nil, err
+		}
+		items = append(items, team_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTeamsWithActiveTrialSandboxes = `-- name: ListTeamsWithActiveTrialSandboxes :many
+SELECT DISTINCT s.team_id
+FROM sandbox s
+JOIN team_credit_grant g
+  ON g.team_id = s.team_id
+  AND g.reason = 'signup trial credit'
+LEFT JOIN team_billing_account a ON a.team_id = s.team_id
+WHERE s.destroyed_at IS NULL
+  AND s.status = 'active'
+  AND a.trial_ended_at IS NULL
+  AND s.team_id > COALESCE($1::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+ORDER BY s.team_id
+LIMIT $2
+`
+
+type ListTeamsWithActiveTrialSandboxesParams struct {
+	AfterTeamID pgtype.UUID `json:"after_team_id"`
+	BatchLimit  int32       `json:"batch_limit"`
+}
+
+func (q *Queries) ListTeamsWithActiveTrialSandboxes(ctx context.Context, arg ListTeamsWithActiveTrialSandboxesParams) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listTeamsWithActiveTrialSandboxes, arg.AfterTeamID, arg.BatchLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []uuid.UUID{}
+	for rows.Next() {
+		var team_id uuid.UUID
+		if err := rows.Scan(&team_id); err != nil {
+			return nil, err
+		}
+		items = append(items, team_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUnresolvedBillingPeriodAnomalies = `-- name: ListUnresolvedBillingPeriodAnomalies :many
 SELECT id, team_id, period_start, period_end, severity, kind, sandbox_id, details, detected_at, resolved_at, resolved_by
 FROM billing_period_anomaly
@@ -1712,6 +1825,19 @@ func (q *Queries) RecordTeamCreditLedgerEntry(ctx context.Context, arg RecordTea
 	return i, err
 }
 
+const refreshTeamTrialEligibility = `-- name: RefreshTeamTrialEligibility :exec
+INSERT INTO team_trial_eligibility_cache (team_id, eligible, updated_at)
+SELECT $1, refresh_team_trial_eligibility($1), now()
+ON CONFLICT (team_id) DO UPDATE
+SET eligible = EXCLUDED.eligible,
+    updated_at = EXCLUDED.updated_at
+`
+
+func (q *Queries) RefreshTeamTrialEligibility(ctx context.Context, teamID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, refreshTeamTrialEligibility, teamID)
+	return err
+}
+
 const resolveBillingPeriodAnomaly = `-- name: ResolveBillingPeriodAnomaly :one
 UPDATE billing_period_anomaly
 SET resolved_at = now(),
@@ -1890,7 +2016,7 @@ VALUES ($1, $2)
 ON CONFLICT (team_id) DO UPDATE
 SET stripe_customer_id = EXCLUDED.stripe_customer_id,
     updated_at = now()
-RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at
+RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 `
 
 type UpsertTeamBillingAccountCustomerParams struct {
@@ -1913,6 +2039,9 @@ func (q *Queries) UpsertTeamBillingAccountCustomer(ctx context.Context, arg Upse
 		&i.UpdatedAt,
 		&i.StripeInvoiceStatus,
 		&i.StripeSubscriptionEventAt,
+		&i.TrialEndedAt,
+		&i.StripeActivationCreditGrantedAt,
+		&i.StripeActivationCreditGrantID,
 	)
 	return i, err
 }
@@ -1950,7 +2079,7 @@ SET stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, team_billing_acco
     current_period_end = COALESCE(EXCLUDED.current_period_end, team_billing_account.current_period_end),
     cancel_at_period_end = COALESCE($9, team_billing_account.cancel_at_period_end),
     updated_at = now()
-RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at
+RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
 `
 
 type UpsertTeamBillingAccountSubscriptionParams struct {
@@ -1990,6 +2119,9 @@ func (q *Queries) UpsertTeamBillingAccountSubscription(ctx context.Context, arg 
 		&i.UpdatedAt,
 		&i.StripeInvoiceStatus,
 		&i.StripeSubscriptionEventAt,
+		&i.TrialEndedAt,
+		&i.StripeActivationCreditGrantedAt,
+		&i.StripeActivationCreditGrantID,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -664,17 +664,20 @@ type TeamActiveSandboxCount struct {
 }
 
 type TeamBillingAccount struct {
-	TeamID                    uuid.UUID          `json:"team_id"`
-	StripeCustomerID          *string            `json:"stripe_customer_id"`
-	StripeSubscriptionID      *string            `json:"stripe_subscription_id"`
-	StripeSubscriptionStatus  *string            `json:"stripe_subscription_status"`
-	CurrentPeriodStart        pgtype.Timestamptz `json:"current_period_start"`
-	CurrentPeriodEnd          pgtype.Timestamptz `json:"current_period_end"`
-	CancelAtPeriodEnd         bool               `json:"cancel_at_period_end"`
-	CreatedAt                 time.Time          `json:"created_at"`
-	UpdatedAt                 time.Time          `json:"updated_at"`
-	StripeInvoiceStatus       *string            `json:"stripe_invoice_status"`
-	StripeSubscriptionEventAt pgtype.Timestamptz `json:"stripe_subscription_event_at"`
+	TeamID                          uuid.UUID          `json:"team_id"`
+	StripeCustomerID                *string            `json:"stripe_customer_id"`
+	StripeSubscriptionID            *string            `json:"stripe_subscription_id"`
+	StripeSubscriptionStatus        *string            `json:"stripe_subscription_status"`
+	CurrentPeriodStart              pgtype.Timestamptz `json:"current_period_start"`
+	CurrentPeriodEnd                pgtype.Timestamptz `json:"current_period_end"`
+	CancelAtPeriodEnd               bool               `json:"cancel_at_period_end"`
+	CreatedAt                       time.Time          `json:"created_at"`
+	UpdatedAt                       time.Time          `json:"updated_at"`
+	StripeInvoiceStatus             *string            `json:"stripe_invoice_status"`
+	StripeSubscriptionEventAt       pgtype.Timestamptz `json:"stripe_subscription_event_at"`
+	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
+	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
+	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
 }
 
 type TeamBillingPeriod struct {
@@ -779,6 +782,12 @@ type TeamSandboxCounter struct {
 	TeamID uuid.UUID `json:"team_id"`
 	Shard  int16     `json:"shard"`
 	Cnt    int32     `json:"cnt"`
+}
+
+type TeamTrialEligibilityCache struct {
+	TeamID    uuid.UUID `json:"team_id"`
+	Eligible  bool      `json:"eligible"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type Template struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -358,6 +358,85 @@ func (q *Queries) ClaimAutoDeleteSandboxes(ctx context.Context, arg ClaimAutoDel
 	return items, nil
 }
 
+const claimBillingIneligibleSandboxes = `-- name: ClaimBillingIneligibleSandboxes :many
+WITH candidates AS (
+  SELECT s.id, s.team_id, s.name, s.snapshot_id, s.host_id
+  FROM sandbox s
+  WHERE s.team_id = $1
+    AND s.destroyed_at IS NULL
+    AND s.status = 'active'
+    AND NOT team_sandbox_billing_eligible(s.team_id)
+  ORDER BY s.created_at ASC
+  LIMIT $2
+  FOR UPDATE OF s SKIP LOCKED
+), paused AS (
+  UPDATE sandbox
+  SET status = 'pausing', updated_at = now()
+  FROM candidates
+  WHERE sandbox.id = candidates.id
+  RETURNING candidates.id, candidates.team_id, candidates.name, candidates.snapshot_id, candidates.host_id, sandbox.network_config
+), closed_intervals AS (
+  UPDATE sandbox_active_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'paused'
+  WHERE sandbox_id IN (SELECT id FROM paused)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+), closed_billing_compute AS (
+  UPDATE sandbox_compute_billing_interval
+  SET ended_at = GREATEST(now(), started_at), end_reason = 'paused'
+  WHERE sandbox_id IN (SELECT id FROM paused)
+    AND ended_at IS NULL
+  RETURNING sandbox_id
+)
+SELECT p.id, p.team_id, p.name, p.snapshot_id, p.host_id, p.network_config
+FROM paused p
+LEFT JOIN closed_intervals ci ON ci.sandbox_id = p.id
+`
+
+type ClaimBillingIneligibleSandboxesParams struct {
+	TeamID uuid.UUID `json:"team_id"`
+	Limit  int32     `json:"limit"`
+}
+
+type ClaimBillingIneligibleSandboxesRow struct {
+	ID            uuid.UUID   `json:"id"`
+	TeamID        uuid.UUID   `json:"team_id"`
+	Name          string      `json:"name"`
+	SnapshotID    pgtype.UUID `json:"snapshot_id"`
+	HostID        string      `json:"host_id"`
+	NetworkConfig []byte      `json:"network_config"`
+}
+
+// Atomically claims active sandboxes for a team whose billing eligibility was
+// lost. The bounded batch and SKIP LOCKED make this safe to retry and keep
+// webhook reconciliation off the request's critical path.
+func (q *Queries) ClaimBillingIneligibleSandboxes(ctx context.Context, arg ClaimBillingIneligibleSandboxesParams) ([]ClaimBillingIneligibleSandboxesRow, error) {
+	rows, err := q.db.Query(ctx, claimBillingIneligibleSandboxes, arg.TeamID, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ClaimBillingIneligibleSandboxesRow{}
+	for rows.Next() {
+		var i ClaimBillingIneligibleSandboxesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.Name,
+			&i.SnapshotID,
+			&i.HostID,
+			&i.NetworkConfig,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const claimExpiredSandboxes = `-- name: ClaimExpiredSandboxes :many
 WITH open_sessions AS (
   -- Current session start per sandbox: the open interval, computed once.

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -32,16 +32,17 @@ import (
 const testStripeWebhookSecret = "whsec_test_secret"
 
 type fakeStripeClient struct {
-	mu              sync.Mutex
-	reportCalls     []api.StripeReportMeterEventParams
-	checkoutCalls   []api.StripeCreateCheckoutSessionParams
-	portalCalls     []api.StripeCreateCustomerPortalSessionParams
-	customerCalls   []api.StripeCreateCustomerParams
-	reportErr       error
-	reportErrAt     int
-	nextCustomerID  string
-	nextCheckoutURL string
-	nextPortalURL   string
+	mu               sync.Mutex
+	reportCalls      []api.StripeReportMeterEventParams
+	checkoutCalls    []api.StripeCreateCheckoutSessionParams
+	portalCalls      []api.StripeCreateCustomerPortalSessionParams
+	customerCalls    []api.StripeCreateCustomerParams
+	creditGrantCalls []api.StripeCreateBillingCreditGrantParams
+	reportErr        error
+	reportErrAt      int
+	nextCustomerID   string
+	nextCheckoutURL  string
+	nextPortalURL    string
 }
 
 type thinEventStripeClient struct {
@@ -62,6 +63,13 @@ func (f *fakeStripeClient) CreateCustomer(_ context.Context, params api.StripeCr
 		id = "cus_test_default"
 	}
 	return api.StripeCustomer{ID: id}, nil
+}
+
+func (f *fakeStripeClient) CreateBillingCreditGrant(_ context.Context, params api.StripeCreateBillingCreditGrantParams) (api.StripeBillingCreditGrant, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.creditGrantCalls = append(f.creditGrantCalls, params)
+	return api.StripeBillingCreditGrant{ID: "credgrant_test_123"}, nil
 }
 
 func (f *fakeStripeClient) CreateCheckoutSession(_ context.Context, params api.StripeCreateCheckoutSessionParams) (api.StripeCheckoutSession, error) {
@@ -458,6 +466,82 @@ func TestIntegration_CreateStripeCheckoutSessionUsesConfiguredPrice(t *testing.T
 	}
 	if got := stripe.checkoutCalls[0].IdempotencyKey; got == "" {
 		t.Fatal("checkout idempotency key was not set")
+	}
+}
+
+func TestIntegration_StripeActivationEndsTrialAndGrantsPromoCreditOnce(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _ := seedTeamAndKeyWithRole(t, "team_owner")
+	customerID := "cus_" + teamID.String()
+	subscriptionID := "sub_" + teamID.String()
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_billing_account (team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status)
+		VALUES ($1, $2, $3, 'incomplete')
+	`, teamID, customerID, subscriptionID); err != nil {
+		t.Fatalf("seed incomplete billing account: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
+		VALUES ($1, 5.000000, 5.000000, 'signup trial credit')
+	`, teamID); err != nil {
+		t.Fatalf("seed signup trial credit: %v", err)
+	}
+
+	created := time.Now().UTC().Truncate(time.Second)
+	periodStart := created
+	periodEnd := created.AddDate(0, 1, 0)
+	stripe := &fakeStripeClient{}
+	r := newBillingRouter(t, stripe)
+	for i, eventID := range []string{"evt_trial_activation", "evt_trial_activation_replay"} {
+		eventCreated := created.Add(time.Duration(i) * time.Second)
+		payload := stripeSubscriptionWebhookPayload(t, eventID, "customer.subscription.updated", subscriptionID, customerID, "active", eventCreated, periodStart, periodEnd)
+		req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Stripe-Signature", stripeSignature(t, payload, eventCreated))
+		w := doRequest(r, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("activation webhook %s: expected 200, got %d: %s", eventID, w.Code, w.Body.String())
+		}
+	}
+
+	var trialRemaining float64
+	if err := testPool.QueryRow(ctx, `
+		SELECT remaining_usd
+		FROM team_credit_grant
+		WHERE team_id = $1 AND reason = 'signup trial credit'
+	`, teamID).Scan(&trialRemaining); err != nil {
+		t.Fatalf("load trial credit after activation: %v", err)
+	}
+	if trialRemaining != 0 {
+		t.Fatalf("trial credit remaining = %v, want 0", trialRemaining)
+	}
+	var promoCount int
+	if err := testPool.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM team_credit_grant
+		WHERE team_id = $1 AND reason = 'stripe promotional credit' AND amount_usd = 95
+	`, teamID).Scan(&promoCount); err != nil {
+		t.Fatalf("count promotional grants: %v", err)
+	}
+	if promoCount != 0 {
+		t.Fatalf("local promotional grant count = %d, want 0", promoCount)
+	}
+	var trialEndedAt, promoGrantedAt *time.Time
+	var stripeGrantID *string
+	if err := testPool.QueryRow(ctx, `
+		SELECT trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+		FROM team_billing_account WHERE team_id = $1
+	`, teamID).Scan(&trialEndedAt, &promoGrantedAt, &stripeGrantID); err != nil {
+		t.Fatalf("load billing transition state: %v", err)
+	}
+	if trialEndedAt == nil || promoGrantedAt == nil || stripeGrantID == nil || *stripeGrantID != "credgrant_test_123" {
+		t.Fatal("billing activation state was not persisted")
+	}
+	if got := len(stripe.creditGrantCalls); got != 1 {
+		t.Fatalf("Stripe credit grant calls = %d, want 1", got)
+	}
+	if got := stripe.creditGrantCalls[0].AmountCents; got != 9500 {
+		t.Fatalf("Stripe credit grant amount = %d, want 9500 cents", got)
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -983,6 +983,12 @@ func seedTeamAndKeyWithRole(t *testing.T, roleName string) (uuid.UUID, string, u
 	if err != nil {
 		t.Fatalf("seedTeamAndKeyWithRole: create team: %v", err)
 	}
+	if _, err := testPool.Exec(ctx, `
+		DELETE FROM team_credit_grant
+		WHERE team_id = $1 AND reason = 'signup trial credit'
+	`, team.ID); err != nil {
+		t.Fatalf("seedTeamAndKeyWithRole: clear default trial grant: %v", err)
+	}
 
 	profileID := uuid.New()
 	if _, err := testPool.Exec(ctx,
@@ -1550,6 +1556,110 @@ func TestIntegration_GetBillingSummary(t *testing.T) {
 	}
 	if _, ok := body["calculated_at"].(string); !ok {
 		t.Fatalf("calculated_at missing or not a string: %v", body["calculated_at"])
+	}
+}
+
+func TestIntegration_NewTeamReceivesSignupTrialCredit(t *testing.T) {
+	ctx := context.Background()
+	team, err := testQueries.CreateTeam(ctx, "trial-credit-"+uuid.NewString()[:8])
+	if err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+	teamID := team.ID
+
+	var amount, remaining float64
+	if err := testPool.QueryRow(ctx, `
+		SELECT amount_usd, remaining_usd
+		FROM team_credit_grant
+		WHERE team_id = $1 AND reason = 'signup trial credit'
+	`, teamID).Scan(&amount, &remaining); err != nil {
+		t.Fatalf("load signup trial credit: %v", err)
+	}
+	if amount != 5 || remaining != 5 {
+		t.Fatalf("signup trial credit = (%v, %v), want (5, 5)", amount, remaining)
+	}
+}
+
+func TestIntegration_CreateSandboxBlockedWhenTrialCreditIsExhausted(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
+		VALUES ($1, 5.000000, 0, 'signup trial credit')
+	`, teamID); err != nil {
+		t.Fatalf("exhaust signup trial credit: %v", err)
+	}
+
+	w := do(newRouter(t), "POST", "/sandboxes", ownerKey, `{"name":"trial-exhausted"}`)
+	if w.Code != http.StatusPaymentRequired {
+		t.Fatalf("create with exhausted trial: expected 402, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegration_GetBillingSummaryDefersPaymentSetupWhileCreditsRemain(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", ownerKey, `{"name":"billing-credit-trial"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create sandbox: expected 201, got %d: %s", cw.Code, cw.Body.String())
+	}
+	sandboxID, err := uuid.Parse(mustJSON(t, cw)["id"].(string))
+	if err != nil {
+		t.Fatalf("parse sandbox id: %v", err)
+	}
+
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_compute_billing_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded compute billing interval: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_storage_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+		t.Fatalf("clear seeded storage billing interval: %v", err)
+	}
+
+	periodStart, periodEnd := billing.CurrentBillingPeriod(time.Now().UTC())
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'billing_export_enabled', true)
+		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
+	`, teamID); err != nil {
+		t.Fatalf("enable live billing mode: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_billing_account (team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status)
+		VALUES ($1, $2, $3, 'incomplete')
+		ON CONFLICT (team_id) DO UPDATE
+		SET stripe_customer_id = EXCLUDED.stripe_customer_id,
+		    stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+		    stripe_subscription_status = EXCLUDED.stripe_subscription_status
+	`, teamID, "cus_"+teamID.String(), "sub_"+teamID.String()); err != nil {
+		t.Fatalf("seed incomplete billing account: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
+		VALUES ($1, 10.000000, 10.000000, 'integration test trial credit')
+	`, teamID); err != nil {
+		t.Fatalf("seed billing trial credit: %v", err)
+	}
+
+	liveRouter := newBillingRouter(t, &fakeStripeClient{})
+	live := do(liveRouter, "GET", "/billing/summary", ownerKey, "")
+	if live.Code != http.StatusOK {
+		t.Fatalf("live billing summary with trial credit: expected 200, got %d: %s", live.Code, live.Body.String())
+	}
+	liveBody := mustJSON(t, live)
+	if got := liveBody["payment_setup_required"].(bool); got {
+		t.Fatal("payment_setup_required should be false while trial credit remains")
+	}
+	period, ok := liveBody["billing_period"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("billing_period not an object: %v", liveBody["billing_period"])
+	}
+	if got := period["start"].(string); got != periodStart.Format(time.RFC3339) {
+		t.Fatalf("period start = %q, want %q", got, periodStart.Format(time.RFC3339))
+	}
+	if got := period["end"].(string); got != periodEnd.Format(time.RFC3339) {
+		t.Fatalf("period end = %q, want %q", got, periodEnd.Format(time.RFC3339))
 	}
 }
 

--- a/supabase/migrations/20260818000001_billing_trial_eligibility.sql
+++ b/supabase/migrations/20260818000001_billing_trial_eligibility.sql
@@ -1,0 +1,189 @@
+-- Persist the transition away from the Superserve trial. Billing eligibility
+-- is intentionally derived from normalized subscription state after this
+-- transition; the trial balance must never make a former Stripe customer
+-- eligible again.
+ALTER TABLE team_billing_account
+    ADD COLUMN trial_ended_at timestamptz,
+    ADD COLUMN stripe_activation_credit_granted_at timestamptz,
+    ADD COLUMN stripe_activation_credit_grant_id text;
+
+CREATE TABLE team_trial_eligibility_cache (
+    team_id uuid PRIMARY KEY REFERENCES team(id) ON DELETE CASCADE,
+    eligible boolean NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_credit_grant_team_reason_expiry
+    ON team_credit_grant (team_id, reason, expires_at);
+
+ALTER TABLE team_trial_eligibility_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION refresh_team_trial_eligibility(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    WITH account AS (
+        SELECT trial_ended_at, stripe_subscription_status
+        FROM team_billing_account
+        WHERE team_id = p_team_id
+    ), grant_balance AS (
+        SELECT COALESCE(SUM(remaining_usd), 0)::numeric AS remaining_usd,
+               COUNT(*)::int AS grant_count
+        FROM team_credit_grant
+        WHERE team_id = p_team_id
+          AND reason = 'signup trial credit'
+          AND (expires_at IS NULL OR expires_at > now())
+    ), period AS (
+        SELECT date_trunc('month', now()) AS period_start,
+               date_trunc('month', now()) + interval '1 month' AS period_end
+    ), compute AS (
+        SELECT
+            COALESCE(SUM(EXTRACT(EPOCH FROM (
+                LEAST(COALESCE(i.ended_at, now()), period.period_end)
+                - GREATEST(i.started_at, period.period_start)
+            )) * i.vcpu_count), 0)::numeric AS vcpu_seconds,
+            COALESCE(SUM(EXTRACT(EPOCH FROM (
+                LEAST(COALESCE(i.ended_at, now()), period.period_end)
+                - GREATEST(i.started_at, period.period_start)
+            )) * i.memory_mib / 1024.0), 0)::numeric AS memory_gib_seconds
+        FROM sandbox_compute_billing_interval i
+        CROSS JOIN period
+        WHERE i.team_id = p_team_id
+          AND i.started_at < period.period_end
+          AND COALESCE(i.ended_at, period.period_end) > period.period_start
+    ), storage AS (
+        SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (
+            LEAST(COALESCE(i.ended_at, now()), period.period_end)
+            - GREATEST(i.started_at, period.period_start)
+        )) * i.disk_mib / 1024.0), 0)::numeric AS storage_gib_seconds
+        FROM sandbox_storage_interval i
+        CROSS JOIN period
+        WHERE i.team_id = p_team_id
+          AND i.started_at < period.period_end
+          AND COALESCE(i.ended_at, period.period_end) > period.period_start
+    ), usage AS (
+        SELECT compute.vcpu_seconds, compute.memory_gib_seconds, storage.storage_gib_seconds
+        FROM compute, storage
+    ), plan AS (
+        SELECT COALESCE((
+            SELECT tpp.plan_key
+            FROM team_pricing_plan tpp
+            JOIN pricing_plan pp ON pp.key = tpp.plan_key AND pp.active
+            WHERE tpp.team_id = p_team_id
+              AND tpp.effective_from <= now()
+              AND (tpp.effective_to IS NULL OR tpp.effective_to > now())
+            ORDER BY tpp.effective_from DESC
+            LIMIT 1
+        ), 'payg') AS plan_key
+    ), ranked_rates AS (
+        SELECT
+            r.resource,
+            r.unit,
+            r.price_usd,
+            row_number() OVER (
+                PARTITION BY r.resource, r.unit
+                ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC
+            ) AS rate_rank
+        FROM plan
+        JOIN pricing_rate r ON r.plan_key = plan.plan_key
+        WHERE r.unit = 'second'
+          AND r.effective_from <= now()
+          AND (r.effective_to IS NULL OR r.effective_to > now())
+    ), rates AS (
+        SELECT
+            COALESCE(MAX(price_usd) FILTER (WHERE resource = 'vcpu'), 0)::numeric AS vcpu_rate,
+            COALESCE(MAX(price_usd) FILTER (WHERE resource = 'memory_gib'), 0)::numeric AS memory_rate,
+            COALESCE(MAX(price_usd) FILTER (WHERE resource = 'storage_gib'), 0)::numeric AS storage_rate
+        FROM ranked_rates
+        WHERE rate_rank = 1
+    ), charges AS (
+        SELECT usage.vcpu_seconds * rates.vcpu_rate
+             + usage.memory_gib_seconds * rates.memory_rate
+             + CASE WHEN feature_enabled('billing_storage_billing_enabled', p_team_id)
+                    THEN usage.storage_gib_seconds * rates.storage_rate
+                    ELSE 0
+               END AS amount_usd
+        FROM usage, rates
+    )
+    SELECT CASE
+        WHEN COALESCE(account.trial_ended_at, NULL) IS NULL THEN
+            grant_balance.grant_count = 0
+            OR grant_balance.remaining_usd - charges.amount_usd > 0
+        ELSE lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
+    END
+    FROM (SELECT 1) one
+    LEFT JOIN account ON true
+    CROSS JOIN grant_balance
+    CROSS JOIN charges;
+$$;
+
+CREATE OR REPLACE FUNCTION team_sandbox_billing_eligible(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT CASE
+        WHEN account.trial_ended_at IS NULL THEN
+            (grant_balance.grant_count = 0 AND account.stripe_subscription_id IS NULL)
+            OR (account.stripe_subscription_id IS NOT NULL
+                AND lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due'))
+            OR (grant_balance.remaining_usd > 0 AND COALESCE(cache.eligible, true))
+        ELSE lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
+    END
+    FROM (SELECT trial_ended_at, stripe_subscription_id, stripe_subscription_status
+          FROM team_billing_account WHERE team_id = p_team_id) account
+    FULL JOIN (SELECT COALESCE(SUM(remaining_usd), 0)::numeric AS remaining_usd,
+                      COUNT(*)::int AS grant_count
+               FROM team_credit_grant
+               WHERE team_id = p_team_id
+                 AND reason = 'signup trial credit'
+                 AND (expires_at IS NULL OR expires_at > now())) grant_balance ON true
+    LEFT JOIN team_trial_eligibility_cache cache ON cache.team_id = p_team_id;
+$$;
+
+CREATE OR REPLACE FUNCTION grant_signup_trial_credit()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
+    VALUES (NEW.id, 5.000000, 5.000000, 'signup trial credit');
+    INSERT INTO team_trial_eligibility_cache (team_id, eligible)
+    VALUES (NEW.id, true)
+    ON CONFLICT (team_id) DO UPDATE SET eligible = true, updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS team_signup_trial_credit ON team;
+CREATE TRIGGER team_signup_trial_credit
+AFTER INSERT ON team
+FOR EACH ROW
+EXECUTE FUNCTION grant_signup_trial_credit();
+
+CREATE OR REPLACE FUNCTION activate_team_billing(p_team_id uuid, p_stripe_grant_id text)
+RETURNS void
+LANGUAGE sql
+AS $$
+    WITH marked AS (
+        UPDATE team_billing_account
+        SET trial_ended_at = COALESCE(trial_ended_at, now()),
+            stripe_activation_credit_granted_at = COALESCE(stripe_activation_credit_granted_at, now()),
+            stripe_activation_credit_grant_id = COALESCE(stripe_activation_credit_grant_id, p_stripe_grant_id),
+            updated_at = now()
+        WHERE team_id = p_team_id
+          AND lower(coalesce(stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
+          AND stripe_activation_credit_granted_at IS NULL
+        RETURNING team_id
+    ), zeroed AS (
+        UPDATE team_credit_grant g
+        SET remaining_usd = 0,
+            updated_at = now()
+        FROM marked
+        WHERE g.team_id = marked.team_id
+          AND g.reason = 'signup trial credit'
+        RETURNING g.team_id
+    )
+    SELECT 1 FROM marked;
+$$;

--- a/supabase/migrations/20260818000002_stripe_activation_credit.sql
+++ b/supabase/migrations/20260818000002_stripe_activation_credit.sql
@@ -1,0 +1,40 @@
+-- Stripe owns post-activation monetary credits. Keep only the auditable grant
+-- reference in Superserve; never create a local spendable promotional balance.
+ALTER TABLE team_billing_account
+    ADD COLUMN IF NOT EXISTS stripe_activation_credit_grant_id text;
+
+-- Remove balances created by the earlier local-only implementation. Stripe is
+-- authoritative for the promotional credit after this migration.
+UPDATE team_credit_grant
+SET remaining_usd = 0,
+    updated_at = now()
+WHERE reason = 'stripe promotional credit'
+  AND remaining_usd > 0;
+
+DROP FUNCTION IF EXISTS activate_team_billing(uuid);
+
+CREATE OR REPLACE FUNCTION activate_team_billing(p_team_id uuid, p_stripe_grant_id text)
+RETURNS void
+LANGUAGE sql
+AS $$
+    WITH marked AS (
+        UPDATE team_billing_account
+        SET trial_ended_at = COALESCE(trial_ended_at, now()),
+            stripe_activation_credit_granted_at = COALESCE(stripe_activation_credit_granted_at, now()),
+            stripe_activation_credit_grant_id = COALESCE(stripe_activation_credit_grant_id, p_stripe_grant_id),
+            updated_at = now()
+        WHERE team_id = p_team_id
+          AND lower(coalesce(stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
+          AND stripe_activation_credit_grant_id IS NULL
+        RETURNING team_id
+    ), zeroed AS (
+        UPDATE team_credit_grant g
+        SET remaining_usd = 0,
+            updated_at = now()
+        FROM marked
+        WHERE g.team_id = marked.team_id
+          AND g.reason = 'signup trial credit'
+        RETURNING g.team_id
+    )
+    SELECT 1 FROM marked;
+$$;


### PR DESCRIPTION
## Summary

- Enforce sandbox billing eligibility for create and resume operations.
- Pause active sandboxes asynchronously when Stripe reports an unpaid or canceled subscription.
- Create the activation promotion as a Stripe Billing Credit Grant and persist only its audit reference locally.
- Stop treating the first invoice payment failure as a suspension trigger.
- Provision signup trial credit for new teams without backfilling every existing team.

## Verification

- Unit and integration tests
- Migration and sqlc validation
- Terraform checks
- Docker-based full package compile