### PR TITLE
deploy: raise usw2 pause-backup drain to six workers

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -331,9 +331,13 @@ jobs:
           # share one bandwidth cap (task throughput rises, egress does
           # not), and the incremental host cost is one extra hash/read
           # stream on a 192-core metal host with a 12-drive array.
-          # Held at 2 until the sandboxes.slice weighting lands; raise
-          # further only after it. Rollback is removing this line.
-          BACKUP_UPLOAD_CONCURRENCY: "2"
+          # Sized from measured rates with the sandboxes.slice weighting
+          # live: arrivals peak ~1.2k generations/h while each worker
+          # drains ~215/h, so 2 treads water at peak and 6 clears the
+          # backlog (~1.3k/h) with margin. Aggregate egress stays under
+          # the shared bandwidth cap (~22 Mbit/s observed at 2 workers,
+          # cap 100). Rollback is lowering the number.
+          BACKUP_UPLOAD_CONCURRENCY: "6"
           # Enables vmd's backup metrics exporter (host-local collector);
           # the cell's backup alert policies, including backup-disabled,
           # cannot fire without these series.


### PR DESCRIPTION
## Summary
usw2's pause-backup backlog kept growing after the two-worker deploy: arrivals peak ~1.2k generations/h while each worker drains ~215/h, so 2 workers tread water at peak. 6 workers (~1.3k/h) clear the ~39k backlog in roughly 1.5-2 days. Follows the parallel-drain rollout; the sandboxes.slice weighting is deployed, so backup work yields to VMs under contention.

## Technical decisions
- 6 rather than 4: 4 (~860/h) is below peak arrivals, so it only stabilizes; 6 clears with margin. Egress stays under the shared 100 Mbit limiter (~22 Mbit observed at 2 workers).
- Staging stays at 2; it has no backlog and no traffic to justify more.
- Rollback is lowering the env value and redeploying.

## Testing
Rates measured from production metrics over today's activity peak (backup_journal_pending slope, backup_upload_total increase). The claims/worker code itself has soaked in production since last night (concurrency 1 fleet-wide, then 2 on usw2 since 16:11 UTC) with zero abandonments outside deploy restarts.