### PR TITLE
deploy: enable the backup backfill sweep on use4

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -260,6 +260,13 @@ jobs:
           VMD_PAUSED_NETWORK_RECLAIM_COOLDOWN: "30s"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           BACKUP_BUCKET: superserve-artifact-backup-use4
+          # Stage two of the backfill rollout, expedited: 585 of the
+          # cell's 678 paused sandboxes predate the uploader and have no
+          # copy off the host's SSD, which has now failed twice in one
+          # day. The sweep makes them durable within hours of the host
+          # returning. Removing this line disables the sweep on the next
+          # deploy.
+          BACKUP_BACKFILL: "1"
           # Keeps the backup journal off the root disk — it's written
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills.


### PR DESCRIPTION
## Summary
Expedited stage two of the backfill rollout. The use4 host has had two hardware failures today, and 585 of the cell's 678 paused sandboxes have no copy anywhere but its local SSD (they last paused before the uploader existed). Enabling the sweep makes them durable within hours of the host returning; every future repair then risks nothing.

## Technical decisions
One env line: the sweep machinery is deployed fleet-wide and has been soaking on staging. Best-effort priority means live pause backups always win; the pause-tier alert scoping already landed so the deliberately slow backfill backlog cannot trip freshness alerting.

## Testing
Coverage convergence verified via backup_generation after the sweep runs: the acceptance query is paused sandboxes without coverage rows reaching zero.