### PR TITLE
east: add a z3 cold-standby host on the west HA pattern

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -13,6 +13,7 @@ The current Terraform-managed Compute Engine inventory for Vanta is:
 | production | us-west2 | `superserve-vmd-usw2` | Managed by Terraform |
 | production | us-west2 | `superserve-vmd-usw2-2` | Managed by Terraform (cold standby, normally stopped) |
 | production | us-east4 | `superserve-vmd-use4` | Managed by Terraform |
+| production | us-east4 | `superserve-vmd-use4-2` | Managed by Terraform (cold standby, normally stopped) |
 | production | us-central1 | none | Decommissioned, no Terraform-managed instance remains |
 
 Each live instance is managed through the shared `sandbox-host` module and

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -416,7 +416,9 @@ module "sandbox_host_b" {
   can_ip_forward      = false
   on_host_maintenance = "TERMINATE"
 
-  reservation_name = var.reservation_name
+  # Distinct from the primary's reservation_name: that names a c4-metal
+  # reservation a z3 cannot consume (see standby_reservation_name).
+  reservation_name = var.standby_reservation_name
 
   metadata = {
     enable-osconfig = "TRUE"

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -358,13 +358,33 @@ module "sandbox_host" {
   }
 }
 
-# Cold standby for the cell, normally kept stopped. Promotion = start this
-# host, then set active_sandbox_host = "standby" and apply: the switch routes
-# the control plane here and moves the deploy-fleet label off the primary.
-# A DISTINCT identity (use4-2) from the primary's HOST_ID=default: while the
-# c4 primary still serves, two hosts under one identity would reconcile each
-# other's sandboxes. Paused-sandbox continuity at cutover is an operational
-# step (restore from GCS backup), not a Terraform concern.
+# Cold standby for the cell, normally kept stopped, on a DISTINCT identity
+# (use4-2) from the primary's HOST_ID=default — while the c4 primary still
+# serves, two hosts under one identity would reconcile each other's sandboxes.
+#
+# active_sandbox_host controls only what Terraform owns: which host the
+# control plane DIALS (VMD_GRPC_ADDRESS), the deploy-fleet label, and the
+# alert/metrics identity. It does NOT move sandbox PLACEMENT: the scheduler
+# selects any host row with status='active' (ListActiveHostsByLoad), which is
+# DB state, not Terraform. So the flag alone is not a safe promotion — with
+# both rows active, new creates would land on both hosts, including the
+# standby before its restore/cutover work is done.
+#
+# Promotion procedure, in this order:
+#   1. The standby's host row starts and STAYS status='draining' through
+#      provisioning and validation — the scheduler never places on a draining
+#      host, and a heartbeat does not un-drain it (UpdateHostHeartbeat only
+#      reactivates 'unhealthy'). So the standby can run and heartbeat safely
+#      while parked.
+#   2. When ready: drain the PRIMARY (status='draining' + pause its active
+#      sandboxes via the host-drain path) so it stops taking new creates.
+#   3. Promote the standby: its row 'draining' -> 'active', then set
+#      active_sandbox_host = "standby" and apply so the control plane dials it
+#      and the deploy fleet follows.
+#   4. Retire the primary once drained and its paused sandboxes are restored
+#      onto the standby from GCS backup (local-SSD snapshots do not migrate).
+# Steps 1-2 and 4 are operational (DB/status + backup restore), not Terraform;
+# only step 3's apply is captured here.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -62,7 +62,11 @@ locals {
   # series like filesystem utilization carry the instance name while vmd's own
   # OTLP series carry this. One machine, two host_id values, depending on which
   # process emitted the metric.
-  metrics_host_id = var.active_sandbox_host == "standby" ? "use4-2" : "default"
+  # Standby value is the instance name, NOT a short "use4-2": deploy-vmd.py
+  # initializes a new host's HOST_ID from its instance name, so the alert
+  # filter must match that exact identity or it selects a series vmd never
+  # emits. The primary keeps the legacy "default" (predates the convention).
+  metrics_host_id = var.active_sandbox_host == "standby" ? module.sandbox_host_b.instance_name : "default"
 
   # The control plane dials whichever host active_sandbox_host selects. The
   # selected host must already be running and serving before it is applied —
@@ -359,8 +363,11 @@ module "sandbox_host" {
 }
 
 # Cold standby for the cell, normally kept stopped, on a DISTINCT identity
-# (use4-2) from the primary's HOST_ID=default — while the c4 primary still
-# serves, two hosts under one identity would reconcile each other's sandboxes.
+# from the primary's HOST_ID=default — while the c4 primary still serves, two
+# hosts under one identity would reconcile each other's sandboxes. The
+# standby's HOST_ID is its instance name (superserve-vmd-use4-2), set by
+# deploy-vmd.py's new-host default; do not hand-provision a different value,
+# or the alert filters (metrics_host_id) will watch a series vmd never emits.
 #
 # active_sandbox_host controls only what Terraform owns: which host the
 # control plane DIALS (VMD_GRPC_ADDRESS), the deploy-fleet label, and the

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -62,7 +62,23 @@ locals {
   # series like filesystem utilization carry the instance name while vmd's own
   # OTLP series carry this. One machine, two host_id values, depending on which
   # process emitted the metric.
-  metrics_host_id = "default"
+  metrics_host_id = var.active_sandbox_host == "standby" ? "use4-2" : "default"
+
+  # The control plane dials whichever host active_sandbox_host selects. The
+  # selected host must already be running and serving before it is applied —
+  # instance run state is operational, not Terraform-managed.
+  active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
+
+  # The host currently serving vmd traffic, and so the host whose instance name
+  # tags its host-level (collector) metrics. Alert filters key on this so a
+  # standby promotion keeps them watching whichever host is actually emitting.
+  active_host_name = var.active_sandbox_host == "standby" ? module.sandbox_host_b.instance_name : module.sandbox_host.instance_name
+
+  # Exactly one host carries component=vmd, the label the shared deploy
+  # pipeline discovers; the other is parked under a cell-scoped label so
+  # rollouts skip it instead of failing against a host that is out of service.
+  primary_component = var.active_sandbox_host == "primary" ? "vmd" : "vmd-use4-standby"
+  standby_component = var.active_sandbox_host == "standby" ? "vmd" : "vmd-use4-standby"
 }
 
 module "network" {
@@ -184,7 +200,7 @@ module "api" {
     SECRETS_SIGNING_KEY_ID = "v1"
     ALLOW_EPHEMERAL_SEED   = "0"
     DB_MAX_CONNS           = "15"
-    VMD_GRPC_ADDRESS       = format("%s:50051", module.sandbox_host.internal_ip)
+    VMD_GRPC_ADDRESS       = format("%s:50051", local.active_vmd_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
 
     # Control-plane OTLP metrics export, mirroring the retired us-central1
@@ -192,7 +208,7 @@ module "api" {
     # and forwards to Google Managed Prometheus; the use4 network already admits
     # the Cloud Run sender range to the host on 4317/4318 (allow_otel_ingress).
     OTEL_ENVIRONMENT            = local.environment
-    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${module.sandbox_host.internal_ip}:4318"
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${local.active_vmd_ip}:4318"
     OTEL_EXPORT_INTERVAL        = "15s"
     OTEL_METRICS_ENABLED        = "true"
     OTEL_SERVICE_NAME           = "sandbox-controlplane"
@@ -296,7 +312,7 @@ module "sandbox_host" {
   # flipping it to "ready" (to match the deployment-registry selector) is a
   # separate, intentional change, not part of this import PR.
   labels = merge(local.sandbox_host_labels, {
-    component                  = "vmd"
+    component                  = local.primary_component
     sandbox_role               = "vmd"
     sandbox_status             = "provisioning"
     "goog-ops-agent-policy"    = "v2-template-1-7-0"
@@ -342,6 +358,64 @@ module "sandbox_host" {
   }
 }
 
+# Cold standby for the cell, normally kept stopped. Promotion = start this
+# host, then set active_sandbox_host = "standby" and apply: the switch routes
+# the control plane here and moves the deploy-fleet label off the primary.
+# A DISTINCT identity (use4-2) from the primary's HOST_ID=default: while the
+# c4 primary still serves, two hosts under one identity would reconcile each
+# other's sandboxes. Paused-sandbox continuity at cutover is an operational
+# step (restore from GCS backup), not a Terraform concern.
+module "sandbox_host_b" {
+  source = "../../../modules/sandbox-host"
+
+  project_id    = local.project_id
+  environment   = local.environment
+  region        = local.region
+  zone          = local.zone
+  instance_name = "superserve-vmd-${local.resource_suffix}-2"
+  # Explicit, NOT var.machine_type (c4): this standby is the z3 replacement
+  # for the maintenance-prone c4 primary.
+  machine_type = "z3-highmem-192-highlssd-metal"
+  subnet       = module.network.subnetwork_self_link
+  internal_ip  = "10.2.0.3"
+  tags         = ["vmd-use4"]
+
+  labels = merge(local.sandbox_host_labels, {
+    component                  = local.standby_component
+    sandbox_role               = "vmd"
+    sandbox_status             = "provisioning"
+    "goog-ops-agent-policy"    = "v2-template-1-7-0"
+    "vanta-contains-user-data" = "true"
+    "vanta-user-data-stored"   = "customer_sandbox_files_and_runtime_data"
+  })
+
+  service_account_email = data.google_service_account.api_runner.email
+
+  # 22.04 to match the primary and this cell's snapshot lineage (existing
+  # paused sandboxes and us-central1-seeded snapshots are 22.04-taken); a
+  # host-OS mismatch has been observed to break snapshot restore.
+  boot_disk_image = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
+
+  # Metal machine types reject the API-default pd-standard boot disk.
+  boot_disk_type = var.boot_disk_type
+
+  can_ip_forward      = false
+  on_host_maintenance = "TERMINATE"
+
+  reservation_name = var.reservation_name
+
+  metadata = {
+    enable-osconfig = "TRUE"
+    enable-oslogin  = "TRUE"
+    startup-script = templatefile("${path.module}/../../../../deploy/unbound/unbound-bootstrap.sh.tftpl", {
+      guest_cidr         = "10.11.0.0/16"
+      local_dns_port     = "19053"
+      dot_hostname       = "j0mqwd9sm7.cloudflare-gateway.com"
+      dot_upstream_addrs = ["162.159.36.5", "162.159.46.5"]
+    })
+  }
+}
+
 module "observability" {
   source = "../../../modules/observability"
 
@@ -354,6 +428,12 @@ module "observability" {
       instance_name = module.sandbox_host.instance_name
       instance_id   = module.sandbox_host.instance_id
     }
+    # Inert while the standby is stopped (no data, no fire).
+    sandbox_host_b = {
+      display_name  = "Infrastructure / ${module.sandbox_host_b.instance_name} / CPU saturation"
+      instance_name = module.sandbox_host_b.instance_name
+      instance_id   = module.sandbox_host_b.instance_id
+    }
   }
   # Backup pipeline alerts scoped to this cell's host via the host_id
   # metric label (vmd's HOST_ID — see metrics_host_id, which is not the
@@ -363,7 +443,7 @@ module "observability" {
   # times/hour under the capped backoff), not on pause volume.
   backup_alerts = {
     host_id        = local.metrics_host_id
-    display_prefix = "Backup / ${module.sandbox_host.instance_name}"
+    display_prefix = "Backup / ${local.active_host_name}"
   }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount
@@ -379,20 +459,27 @@ module "observability" {
   # doing its job" — move them together with the ceiling or not at all.
   launch_path_alerts = {
     host_id        = local.metrics_host_id
-    display_prefix = "Launch path / ${module.sandbox_host.instance_name}"
+    display_prefix = "Launch path / ${local.active_host_name}"
   }
   # Root-filesystem (OS disk) utilization for the same host, scoped through
   # the same host_id label the backup metrics use. Module defaults: warn at
   # 85% sustained 30 minutes, page at 95%.
   host_disk_alerts = {
-    host_id        = module.sandbox_host.instance_name
-    display_prefix = "Infrastructure / ${module.sandbox_host.instance_name}"
+    host_id        = local.active_host_name
+    display_prefix = "Infrastructure / ${local.active_host_name}"
   }
   host_maintenance_event_alerts = {
     sandbox_host = {
       display_name  = "Infrastructure / ${module.sandbox_host.instance_name} / host maintenance event"
       instance_name = module.sandbox_host.instance_name
       instance_id   = module.sandbox_host.instance_id
+    }
+    # Inert while stopped; fires once the standby is running and a window is
+    # scheduled on it — the exact signal that motivated this replacement.
+    sandbox_host_b = {
+      display_name  = "Infrastructure / ${module.sandbox_host_b.instance_name} / host maintenance event"
+      instance_name = module.sandbox_host_b.instance_name
+      instance_id   = module.sandbox_host_b.instance_id
     }
   }
   labels = local.common_labels

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -62,25 +62,16 @@ locals {
   # series like filesystem utilization carry the instance name while vmd's own
   # OTLP series carry this. One machine, two host_id values, depending on which
   # process emitted the metric.
-  # Standby value is the instance name, NOT a short "use4-2": deploy-vmd.py
-  # initializes a new host's HOST_ID from its instance name, so the alert
-  # filter must match that exact identity or it selects a series vmd never
-  # emits. The primary keeps the legacy "default" (predates the convention).
+  # Standby value derives from the instance name so it always matches the
+  # host's deployed HOST_ID; the primary keeps its existing "default".
   metrics_host_id = var.active_sandbox_host == "standby" ? module.sandbox_host_b.instance_name : "default"
 
-  # The control plane dials whichever host active_sandbox_host selects. The
-  # selected host must already be running and serving before it is applied —
-  # instance run state is operational, not Terraform-managed.
-  active_vmd_ip = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
-
-  # The host currently serving vmd traffic, and so the host whose instance name
-  # tags its host-level (collector) metrics. Alert filters key on this so a
-  # standby promotion keeps them watching whichever host is actually emitting.
+  # The host selected by active_sandbox_host, used for the control-plane
+  # address and the alert identity.
+  active_vmd_ip    = var.active_sandbox_host == "standby" ? module.sandbox_host_b.internal_ip : module.sandbox_host.internal_ip
   active_host_name = var.active_sandbox_host == "standby" ? module.sandbox_host_b.instance_name : module.sandbox_host.instance_name
 
-  # Exactly one host carries component=vmd, the label the shared deploy
-  # pipeline discovers; the other is parked under a cell-scoped label so
-  # rollouts skip it instead of failing against a host that is out of service.
+  # The active host is labelled for the deploy pipeline; the other is parked.
   primary_component = var.active_sandbox_host == "primary" ? "vmd" : "vmd-use4-standby"
   standby_component = var.active_sandbox_host == "standby" ? "vmd" : "vmd-use4-standby"
 }
@@ -205,11 +196,8 @@ module "api" {
     ALLOW_EPHEMERAL_SEED   = "0"
     DB_MAX_CONNS           = "15"
     VMD_GRPC_ADDRESS       = format("%s:50051", local.active_vmd_ip)
-    # The active host's row identity, following active_sandbox_host in lock
-    # step with VMD_GRPC_ADDRESS. The build supervisor and the scheduler
-    # fallback resolve a host row through this; leaving it at the implicit
-    # "default" would, after promotion, dispatch template builds to the
-    # retired primary. Same value as metrics_host_id (the host's HOST_ID).
+    # Active host's identity, following active_sandbox_host alongside the
+    # address above. Same value as metrics_host_id.
     DEFAULT_HOST_ID  = local.metrics_host_id
     KMS_KEY_RESOURCE = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
 
@@ -368,17 +356,9 @@ module "sandbox_host" {
   }
 }
 
-# Cold standby for the cell, normally kept stopped, on a DISTINCT identity
-# from the primary's HOST_ID=default — two hosts under one identity would
-# reconcile each other's sandboxes. Its HOST_ID is its instance name (the
-# deploy script's new-host default); do not hand-provision a different value,
-# or the alert filters (metrics_host_id) watch a series vmd never emits.
-#
-# active_sandbox_host flips only what Terraform owns: the control-plane dial,
-# DEFAULT_HOST_ID, the deploy-fleet label, and the alert identity. It does NOT
-# move sandbox placement (the scheduler keys on host.status) or the data-plane
-# proxy backend, so promotion is a multi-step operational cutover, not a lone
-# flag flip — follow the internal host-migration runbook.
+# Cold standby for the cell, normally kept stopped. Distinct identity from
+# the primary (its HOST_ID is its instance name) so the two never share one.
+# Promotion is an operational procedure, not just flipping active_sandbox_host.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -205,7 +205,13 @@ module "api" {
     ALLOW_EPHEMERAL_SEED   = "0"
     DB_MAX_CONNS           = "15"
     VMD_GRPC_ADDRESS       = format("%s:50051", local.active_vmd_ip)
-    KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
+    # The active host's row identity, following active_sandbox_host in lock
+    # step with VMD_GRPC_ADDRESS. The build supervisor and the scheduler
+    # fallback resolve a host row through this; leaving it at the implicit
+    # "default" would, after promotion, dispatch template builds to the
+    # retired primary. Same value as metrics_host_id (the host's HOST_ID).
+    DEFAULT_HOST_ID  = local.metrics_host_id
+    KMS_KEY_RESOURCE = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
 
     # Control-plane OTLP metrics export, mirroring the retired us-central1
     # primary. The host-local superserve-otel-collector receives OTLP on :4318

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -369,35 +369,16 @@ module "sandbox_host" {
 }
 
 # Cold standby for the cell, normally kept stopped, on a DISTINCT identity
-# from the primary's HOST_ID=default — while the c4 primary still serves, two
-# hosts under one identity would reconcile each other's sandboxes. The
-# standby's HOST_ID is its instance name (superserve-vmd-use4-2), set by
-# deploy-vmd.py's new-host default; do not hand-provision a different value,
-# or the alert filters (metrics_host_id) will watch a series vmd never emits.
+# from the primary's HOST_ID=default — two hosts under one identity would
+# reconcile each other's sandboxes. Its HOST_ID is its instance name (the
+# deploy script's new-host default); do not hand-provision a different value,
+# or the alert filters (metrics_host_id) watch a series vmd never emits.
 #
-# active_sandbox_host controls only what Terraform owns: which host the
-# control plane DIALS (VMD_GRPC_ADDRESS), the deploy-fleet label, and the
-# alert/metrics identity. It does NOT move sandbox PLACEMENT: the scheduler
-# selects any host row with status='active' (ListActiveHostsByLoad), which is
-# DB state, not Terraform. So the flag alone is not a safe promotion — with
-# both rows active, new creates would land on both hosts, including the
-# standby before its restore/cutover work is done.
-#
-# Promotion procedure, in this order:
-#   1. The standby's host row starts and STAYS status='draining' through
-#      provisioning and validation — the scheduler never places on a draining
-#      host, and a heartbeat does not un-drain it (UpdateHostHeartbeat only
-#      reactivates 'unhealthy'). So the standby can run and heartbeat safely
-#      while parked.
-#   2. When ready: drain the PRIMARY (status='draining' + pause its active
-#      sandboxes via the host-drain path) so it stops taking new creates.
-#   3. Promote the standby: its row 'draining' -> 'active', then set
-#      active_sandbox_host = "standby" and apply so the control plane dials it
-#      and the deploy fleet follows.
-#   4. Retire the primary once drained and its paused sandboxes are restored
-#      onto the standby from GCS backup (local-SSD snapshots do not migrate).
-# Steps 1-2 and 4 are operational (DB/status + backup restore), not Terraform;
-# only step 3's apply is captured here.
+# active_sandbox_host flips only what Terraform owns: the control-plane dial,
+# DEFAULT_HOST_ID, the deploy-fleet label, and the alert identity. It does NOT
+# move sandbox placement (the scheduler keys on host.status) or the data-plane
+# proxy backend, so promotion is a multi-step operational cutover, not a lone
+# flag flip — follow the internal host-migration runbook.
 module "sandbox_host_b" {
   source = "../../../modules/sandbox-host"
 

--- a/infra/envs/production/us-east4/variables.tf
+++ b/infra/envs/production/us-east4/variables.tf
@@ -70,6 +70,12 @@ variable "reservation_name" {
   default     = null
 }
 
+variable "standby_reservation_name" {
+  description = "Reservation to target for the z3 standby, kept SEPARATE from reservation_name: the latter names a c4-metal reservation that a z3 instance cannot consume, so sharing the variable would break the standby the moment the primary's reservation is set. Null uses default affinity (a matching z3 reservation, if any)."
+  type        = string
+  default     = null
+}
+
 variable "create_network" {
   type    = bool
   default = false

--- a/infra/envs/production/us-east4/variables.tf
+++ b/infra/envs/production/us-east4/variables.tf
@@ -130,3 +130,14 @@ variable "notification_channel_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "active_sandbox_host" {
+  description = "Which sandbox host serves the cell: primary or standby."
+  type        = string
+  default     = "primary"
+
+  validation {
+    condition     = contains(["primary", "standby"], var.active_sandbox_host)
+    error_message = "active_sandbox_host must be primary or standby."
+  }
+}


### PR DESCRIPTION
Adds a z3 cold-standby to the east cell using west's primary/standby pattern (Ubuntu 22.04 to match the cell's snapshot lineage); defaults to primary, so nothing changes until it is provisioned and promoted.