### PR TITLE
vmd: close two revival races found after #387 merged

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3086,15 +3086,20 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		// first step) and already owns this record's fate; stopping its
 		// newly launched replacement or overwriting its state out from
 		// under it would be exactly the corruption this cleanup exists
-		// to prevent for a CRASHED attempt. Skip when the lock is held
-		// (non-blocking: this pass must not stall on a live revival) and
-		// let that attempt's own commit or rollback resolve the record.
-		if unlockTry, ok := m.tryLockVMOp(rec.ID); ok {
-			unlockTry()
-		} else {
+		// to prevent for a CRASHED attempt. The lock is held through the
+		// WHOLE cleanup below (stop and park), not just checked and
+		// released, or a fresh revive could start the instant it
+		// released and race the rest of this block exactly as if the
+		// check had never happened. Non-blocking: this pass must not
+		// stall on a live revival, so a held lock skips cleanup entirely
+		// and leaves that attempt's own commit or rollback to resolve
+		// the record.
+		unlockTry, ok := m.tryLockVMOp(rec.ID)
+		if !ok {
 			log.Info().Msg("revival in flight (op lock held) — leaving pending record for that attempt to resolve")
 			return nil, false
 		}
+		defer unlockTry()
 		log.Warn().Msg("revival interrupted by restart — stopping residue and parking record for retry")
 		// The interrupted attempt may have left a live replacement, and
 		// the retry's at-rest probe would refuse while it runs; without a

--- a/internal/vm/revive.go
+++ b/internal/vm/revive.go
@@ -102,6 +102,21 @@ func (m *Manager) ReviveVM(ctx context.Context, vmID, diskPath, basePath string,
 							return nil, status.Errorf(codes.Internal, "reapply network rules on idempotent revive: %v", perr)
 						}
 					}
+					// A concurrent DestroyVM can complete between the
+					// liveness check above and here, recycling the
+					// network info the reapply just used and removing the
+					// instance; report the destroy instead of a stale
+					// success. lockVMOp is held for the whole RPC but
+					// DestroyVM deliberately bypasses it, so this is the
+					// same destroy-wins recheck the fresh-boot commit path
+					// uses, applied to the idempotent shortcut.
+					m.mu.RLock()
+					_, stillTracked := m.vms[vmID]
+					m.mu.RUnlock()
+					_, beingDestroyed := m.destroying.Load(vmID)
+					if !stillTracked || beingDestroyed {
+						return nil, status.Errorf(codes.Aborted, "vm %s was destroyed while revival's idempotent retry was completing", vmID)
+					}
 					return inst, nil
 				}
 			}

--- a/internal/vm/revive.go
+++ b/internal/vm/revive.go
@@ -109,12 +109,23 @@ func (m *Manager) ReviveVM(ctx context.Context, vmID, diskPath, basePath string,
 					// success. lockVMOp is held for the whole RPC but
 					// DestroyVM deliberately bypasses it, so this is the
 					// same destroy-wins recheck the fresh-boot commit path
-					// uses, applied to the idempotent shortcut.
+					// uses, applied to the idempotent shortcut. The two
+					// observations must be atomic with DestroyVM's own
+					// run, not just with each other: DestroyVM holds the
+					// record-owner mutex for its whole run (tombstone
+					// through epoch bump and tombstone clear), so taking
+					// it here means either DestroyVM hasn't started (we
+					// see live), is mid-flight (we block until it
+					// finishes, then see gone), or has fully finished (we
+					// already see gone, since removeVM runs before the
+					// mutex releases) — never the torn read a separate
+					// tracked-then-destroying check could observe.
+					unlockOwner := m.lockRecordOwner(vmID)
 					m.mu.RLock()
 					_, stillTracked := m.vms[vmID]
 					m.mu.RUnlock()
-					_, beingDestroyed := m.destroying.Load(vmID)
-					if !stillTracked || beingDestroyed {
+					unlockOwner()
+					if !stillTracked {
 						return nil, status.Errorf(codes.Aborted, "vm %s was destroyed while revival's idempotent retry was completing", vmID)
 					}
 					return inst, nil


### PR DESCRIPTION
## Summary
- Two P1 races in the ReviveVM path, found by a local Codex review round after #387 merged.
- Startup reattach's interrupted-revival cleanup checked the VM op lock and released it immediately, so a fresh revive could start the instant the check passed and race the rest of the cleanup (stopping the newly launched replacement, overwriting its record). The lock now holds through the whole cleanup via `defer`.
- The idempotent shortcut (a retry matching a live, verified replacement's salvage path) lacked a destroy-wins recheck, and my first attempt at one had a torn-read window of its own (two separate reads, a destroy could complete between them). Fixed by taking the record-owner mutex `DestroyVM` holds for its entire run, making the tracked-ness check atomic with the whole destroy lifecycle.

## Technical decisions
- Both fixes reuse existing synchronization primitives from #387 (`tryLockVMOp`, `lockRecordOwner`) rather than introducing new ones.
- The destroy-wins recheck trades a small serialization window (blocking on the record-owner mutex if a destroy is mid-flight) for correctness; DestroyVM already does this for the same tradeoff.

## Testing
- `go vet` clean, full `internal/vm` suite green under `-race` in the Linux container.
- Local Codex holistic review pass (`codex exec review --base main`) came back clean: "No actionable correctness issues were found in the diff."