### PR TITLE
us-east4: point the cell at the standby sandbox host

### DIFF
--- a/infra/envs/production/us-east4/terraform.tfvars
+++ b/infra/envs/production/us-east4/terraform.tfvars
@@ -21,6 +21,11 @@ boot_disk_type        = "hyperdisk-balanced"
 # default affinity, which auto-consumes that matching reservation in the zone.
 reservation_name = null
 
+# Which host serves the cell. "standby" points the control-plane dial
+# (VMD_GRPC_ADDRESS + DEFAULT_HOST_ID), the deploy-fleet component label, and
+# the alert identity at the standby host module.
+active_sandbox_host = "standby"
+
 # A5 control plane — same "use" cell as us-central1. Point every runtime secret
 # at the shared, suffix-less use-cell secrets (not per-region "-use4" names) so
 # this service reads the same DB, seeds, and signing keys as us-central1 during


### PR DESCRIPTION
Sets `active_sandbox_host = "standby"` for the us-east4 cell. This moves the control-plane dial (`VMD_GRPC_ADDRESS`, `DEFAULT_HOST_ID`, OTLP endpoint), the deploy-fleet `component=vmd` label, and the alert identity onto the standby host module.

Plan: 0 to add, 14 to change, 0 to destroy — all in-place (CP service revision, two instance label flips, alert-policy identities).