### PR TITLE
feat(telemetry): attribute sandbox operations to hosts

### DIFF
--- a/cmd/boxd/exec_http.go
+++ b/cmd/boxd/exec_http.go
@@ -245,12 +245,17 @@ func (s *processService) handleExecStream(w http.ResponseWriter, r *http.Request
 	var writeMu sync.Mutex
 
 	keepaliveCtx, stopKeepalive := context.WithCancel(r.Context())
-	defer stopKeepalive()
+	keepaliveDone := make(chan struct{})
+	defer func() {
+		stopKeepalive()
+		<-keepaliveDone
+	}()
 	// Read the interval before spawning: the goroutine can outlive this
 	// handler's return by a scheduling beat, and tests that override the
 	// package var between cases must never race that late read.
 	keepaliveInterval := sseKeepaliveInterval
 	go func() {
+		defer close(keepaliveDone)
 		ticker := time.NewTicker(keepaliveInterval)
 		defer ticker.Stop()
 		for {

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -367,8 +367,10 @@ func fsyncBuildArtifacts(snapDir string, paths ...string) error {
 
 func setupNetwork(ctx context.Context, hostIface string, slotIndex int, vmID string) (*network.Manager, *network.VMNetInfo, func(), error) {
 	log := newLogger("network")
+	// template-builder inherits HOST_ID from the VMD process that launches it.
 	mgr, err := network.NewManager(ctx, hostIface, log,
 		network.WithExactSlot(slotIndex),
+		network.WithHostID(os.Getenv("HOST_ID")),
 		network.WithHTTPProxyPort(0), // no egress proxy for builds
 	)
 	if err != nil {

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -435,6 +435,7 @@ func main() {
 
 	// ---- Network manager + host firewall ----
 	netMgrOpts = append(netMgrOpts,
+		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
@@ -632,6 +633,7 @@ func main() {
 		maxConnsPerSandbox,
 		log,
 	)
+	egressProxy.SetHostID(cfg.HostID)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
 	if blockList != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -289,7 +289,7 @@ const createInsertTimeout = 2 * vmdTimeout
 // (pauseWithRetry deliberately differs on both points — any-error retry,
 // detached context — because a late pause reconciles state instead of
 // surprising the caller.)
-func retryTransientBoot(parent context.Context, sandboxID string, boot func(context.Context) (string, uint32, uint32, error)) (ip string, vcpu, memMiB uint32, retried bool, err error) {
+func retryTransientBoot(parent context.Context, sandboxID, hostID string, boot func(context.Context) (string, uint32, uint32, error)) (ip string, vcpu, memMiB uint32, retried bool, err error) {
 	attempt := func() (string, uint32, uint32, error) {
 		ctx, cancel := context.WithTimeout(parent, vmdTimeout)
 		defer cancel()
@@ -299,7 +299,8 @@ func retryTransientBoot(parent context.Context, sandboxID string, boot func(cont
 	if err == nil || !(isVMDDeadline(err) || isVMDUnavailable(err)) || parent.Err() != nil {
 		return ip, vcpu, memMiB, false, err
 	}
-	log.Warn().Str("sandbox_id", sandboxID).Msg("vmd boot hit a transient — retrying once")
+	l := sandboxLogger(sandboxID, hostID)
+	l.Warn().Msg("vmd boot hit a transient — retrying once")
 	ip, vcpu, memMiB, err = attempt()
 	return ip, vcpu, memMiB, true, err
 }
@@ -669,9 +670,10 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 // after VMD resume succeeds, destroys the VM + reverts to paused.
 func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, teamID uuid.UUID) (string, bool) {
 	sandboxID := sandbox.ID
+	l := sandboxLogger(sandboxID.String(), sandbox.HostID)
 
 	if !sandbox.SnapshotID.Valid {
-		log.Error().Str("sandbox_id", sandboxID.String()).Msg("paused sandbox has no snapshot_id")
+		l.Error().Msg("paused sandbox has no snapshot_id")
 		respondError(c, ErrInternal)
 		return "", false
 	}
@@ -682,7 +684,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// The snapshot is also the fallback payload if VMD lost its in-memory VM.
 	resumePolicy, err := h.loadPreviewPolicySnapshot(c.Request.Context(), sandboxID, teamID)
 	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("load preview policy for resume failed")
+		l.Error().Err(err).Msg("load preview policy for resume failed")
 		respondError(c, ErrInternal)
 		return "", false
 	}
@@ -748,7 +750,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			h.respondQuotaExceeded(c, teamID)
 			return "", false
 		}
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB BeginResume failed")
+		l.Error().Err(err).Msg("DB BeginResume failed")
 		respondError(c, ErrInternal)
 		return "", false
 	}
@@ -762,7 +764,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			ID:     sandboxID,
 			TeamID: teamID,
 		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")
+			l.Error().Err(err).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")
 		}
 	}
 
@@ -771,7 +773,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		TeamID: teamID,
 	})
 	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB GetSnapshot failed")
+		l.Error().Err(err).Msg("DB GetSnapshot failed")
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return "", false
@@ -798,7 +800,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 	if vmdLookupErr != nil {
-		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for resume failed")
+		l.Error().Err(vmdLookupErr).Msg("resolve VMD for resume failed")
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return "", false
@@ -814,12 +816,12 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// no matter which path it walks.
 	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdTimeout)
 	defer bootCancel()
-	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), sandbox.HostID, func(ctx context.Context) (string, uint32, uint32, error) {
 		return vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath, sandbox.NetworkConfig)
 	})
 	if err != nil {
 		if isVMDNotFound(err) {
-			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).
+			l.Warn().Err(err).
 				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
 			// because resume is supposed to preserve whatever envs the sandbox
@@ -832,7 +834,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			ipAddress, actualVcpu, actualMemMiB, _, err = vmd.RestoreSnapshot(fctx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), resumeVMDAccess, resumePolicy.vmdPorts(), resumePolicy.Revision, nil)
 			fcancel()
 			if err != nil {
-				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD RestoreSnapshot fallback failed")
+				l.Error().Err(err).Msg("VMD RestoreSnapshot fallback failed")
 				// Deliberately no destroy for a boot that may land late: the
 				// row reverts to paused, so a follow-up resume on this ID
 				// adopts the live VM (instant resume), and the reconciler
@@ -842,7 +844,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 				return "", false
 			}
 		} else {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD ResumeInstance failed")
+			l.Error().Err(err).Msg("VMD ResumeInstance failed")
 			// Same deliberate no-destroy as the fallback branch above.
 			revertToPaused()
 			respondError(c, ErrInternal)
@@ -888,7 +890,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		if perr != nil {
 			// VM unreachable — nothing to preserve; mark failed rather than
 			// wedge in 'resuming' (the CTE also closes any open interval).
-			log.Error().Err(perr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: PauseInstance failed, marking sandbox failed")
+			l.Error().Err(perr).Msg("resume revert: PauseInstance failed, marking sandbox failed")
 			h.markSandboxFailedAsync(revertCtx, sandboxID, teamID, sandbox.HostID, false)
 			return
 		}
@@ -907,7 +909,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		if _, ferr := h.finalizePause(fctx, params); ferr != nil {
 			// VM is safely paused; only bookkeeping failed. Best-effort status
 			// flip — the reconciler is the backstop.
-			log.Error().Err(ferr).Str("sandbox_id", sandboxID.String()).Msg("resume revert: FinalizePause failed, best-effort revert to paused")
+			l.Error().Err(ferr).Msg("resume revert: FinalizePause failed, best-effort revert to paused")
 			revertToPaused()
 		}
 	}
@@ -918,7 +920,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// VMD's monotonic revision check rejects this older snapshot.
 	currentPolicy, policyErr := h.loadPreviewPolicySnapshot(postCtx, sandboxID, teamID)
 	if policyErr != nil {
-		log.Error().Err(policyErr).Str("sandbox_id", sandboxID.String()).Msg("reload preview policy after resume failed")
+		l.Error().Err(policyErr).Msg("reload preview policy after resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
 		return "", false
@@ -939,9 +941,9 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// Legacy sandboxes remain compatible with a VMD from before policy
 			// updates existed. Strict resumes were capability-gated above and may
 			// never take this fallback.
-			log.Warn().Str("sandbox_id", sandboxID.String()).Msg("vmd lacks preview policy update for legacy resume")
+			l.Warn().Msg("vmd lacks preview policy update for legacy resume")
 		} else {
-			log.Error().Err(policyErr).Str("sandbox_id", sandboxID.String()).Msg("reapply preview policy after resume failed")
+			l.Error().Err(policyErr).Msg("reapply preview policy after resume failed")
 			pauseAndRevert()
 			respondError(c, ErrInternal)
 			return "", false
@@ -951,7 +953,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// Apply egress rules before committing to 'active' so "active ⇒ rules
 	// applied" holds by construction.
 	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("reapply network config on resume failed")
+		l.Error().Err(err).Msg("reapply network config on resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
 		return "", false
@@ -963,13 +965,13 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// single round trip. The fresh IP binds the re-minted JWT.
 	sandbox.IpAddress = ipAddr
 	if meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID); merr != nil {
-		log.Error().Err(merr).Str("sandbox_id", sandboxID.String()).Msg("load secret bindings on resume failed")
+		l.Error().Err(merr).Msg("load secret bindings on resume failed")
 		pauseAndRevert()
 		respondError(c, ErrInternal)
 		return "", false
 	} else if len(meta) > 0 {
 		if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
-			log.Error().Err(aerr).Str("sandbox_id", sandboxID.String()).Msg("reapply secret bindings on resume failed")
+			l.Error().Err(aerr).Msg("reapply secret bindings on resume failed")
 			pauseAndRevert()
 			respondError(c, ErrInternal)
 			return "", false
@@ -995,7 +997,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			TeamID:    teamID,
 			ActorID:   actorID,
 		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async DB ActivateSandbox failed — re-pausing")
+			l.Error().Err(err).Msg("async DB ActivateSandbox failed — re-pausing")
 			pauseAndRevert()
 		}
 	})
@@ -1247,8 +1249,8 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		default:
 			result = telemetry.SettleResultDiverged
 		}
-		log.Warn().
-			Str("sandbox_id", sandboxID.String()).
+		l := sandboxLogger(sandboxID.String(), sandbox.HostID)
+		l.Warn().
 			Dur("waited", waited).
 			Int("reads", reads).
 			Str("result", result).
@@ -1314,6 +1316,7 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 	}
 
 	SetTelemetryHostID(c, sandbox.HostID)
+	l := sandboxLogger(sandboxID.String(), sandbox.HostID)
 	// Claim the sandbox for deletion atomically. The guarded soft-delete fires
 	// from a quiescent state (active/paused/failed) or a transitional state whose
 	// worker is provably gone (stale), so it serializes against a live resume/pause
@@ -1335,15 +1338,15 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 			case gerr == pgx.ErrNoRows:
 				c.Status(http.StatusNoContent)
 			case gerr != nil:
-				log.Error().Err(gerr).Str("sandbox_id", sandboxID.String()).Msg("DB GetSandbox re-read failed")
+				l.Error().Err(gerr).Msg("DB GetSandbox re-read failed")
 				respondError(c, ErrInternal)
 			default:
-				log.Warn().Str("sandbox_id", sandboxID.String()).Str("status", string(cur.Status)).Msg("delete deferred: sandbox is mid-transition")
+				l.Warn().Str("status", string(cur.Status)).Msg("delete deferred: sandbox is mid-transition")
 				respondError(c, ErrInvalidState)
 			}
 			return
 		}
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB DestroySandbox failed")
+		l.Error().Err(err).Msg("DB DestroySandbox failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -1364,6 +1367,7 @@ func (h *Handlers) DeleteSandbox(c *gin.Context) {
 // user-initiated deletes and the auto-delete reaper so the two paths cannot
 // diverge.
 func (h *Handlers) teardownDestroyedSandbox(ctx context.Context, sandboxID uuid.UUID, hostID string, basePath *string, templateID pgtype.UUID) {
+	l := sandboxLogger(sandboxID.String(), hostID)
 	// The revocation row is committed with the delete claim; fan it out to the
 	// host so the daemon refuses the JWT now. Best-effort — bootstrap re-fans
 	// from the persisted row on restart.
@@ -1375,11 +1379,11 @@ func (h *Handlers) teardownDestroyedSandbox(ctx context.Context, sandboxID uuid.
 	// failure here is reconciled by the vm reconciler, so a vmd hiccup must not fail
 	// an already-committed delete.
 	if vmd, lookupErr := h.vmdForHost(ctx, hostID); lookupErr != nil {
-		log.Warn().Err(lookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for delete teardown; reconciler will reclaim")
+		l.Warn().Err(lookupErr).Msg("resolve VMD for delete teardown; reconciler will reclaim")
 	} else {
 		vmdCtx, vmdCancel := context.WithTimeout(ctx, vmdTimeout)
 		if derr := vmd.DestroyInstance(vmdCtx, sandboxID.String(), true); derr != nil && !isVMDNotFound(derr) {
-			log.Warn().Err(derr).Str("sandbox_id", sandboxID.String()).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
+			l.Warn().Err(derr).Msg("VMD DestroyInstance for delete teardown; reconciler will reclaim")
 		}
 		vmdCancel()
 	}
@@ -1442,11 +1446,12 @@ func (h *Handlers) gcOldBuildArtifacts(reqCtx context.Context, hostID string, sa
 // cleanupSandboxSnapshots deletes the on-disk snapshot files via vmd and
 // the snapshot DB rows for a destroyed sandbox. Best-effort.
 func (h *Handlers) cleanupSandboxSnapshots(reqCtx context.Context, sandboxID uuid.UUID, hostID string) {
+	l := sandboxLogger(sandboxID.String(), hostID)
 	// List snapshot rows first: they feed the per-file fallback below and are
 	// cleared at the end.
 	snaps, err := h.DB.ListSnapshotsBySandbox(reqCtx, sandboxID)
 	if err != nil {
-		log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("list snapshots for cleanup")
+		l.Warn().Err(err).Msg("list snapshots for cleanup")
 	}
 
 	// Remove the whole <SnapshotDir>/<id>/ tree path-based, independent of
@@ -1455,7 +1460,7 @@ func (h *Handlers) cleanupSandboxSnapshots(reqCtx context.Context, sandboxID uui
 	// fall back to the per-file delete so cleanup still runs. Best-effort;
 	// anything missed is left for out-of-band GC.
 	if vmd, verr := h.vmdForHost(reqCtx, hostID); verr != nil {
-		log.Warn().Err(verr).Str("sandbox_id", sandboxID.String()).Msg("resolve vmd for snapshot cleanup; files may need GC")
+		l.Warn().Err(verr).Msg("resolve vmd for snapshot cleanup; files may need GC")
 	} else {
 		ctx, cancel := context.WithTimeout(reqCtx, vmdTimeout)
 		switch delErr := vmd.DeleteSandboxSnapshots(ctx, sandboxID.String()); {
@@ -1467,11 +1472,11 @@ func (h *Handlers) cleanupSandboxSnapshots(reqCtx context.Context, sandboxID uui
 					memPath = *s.MemPath
 				}
 				if e := vmd.DeleteSnapshot(ctx, sandboxID.String(), s.Path, memPath); e != nil && !isVMDNotFound(e) {
-					log.Warn().Err(e).Str("sandbox_id", sandboxID.String()).Str("snapshot_id", s.ID.String()).Msg("vmd DeleteSnapshot (fallback) failed")
+					l.Warn().Err(e).Str("snapshot_id", s.ID.String()).Msg("vmd DeleteSnapshot (fallback) failed")
 				}
 			}
 		default:
-			log.Warn().Err(delErr).Str("sandbox_id", sandboxID.String()).Msg("vmd DeleteSandboxSnapshots failed; files may need GC")
+			l.Warn().Err(delErr).Msg("vmd DeleteSandboxSnapshots failed; files may need GC")
 		}
 		cancel()
 	}
@@ -2091,7 +2096,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// a host we can't reach.
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), hostID)
 	if vmdLookupErr != nil {
-		log.Error().Err(vmdLookupErr).Msg("resolve VMD for create failed")
+		hostLog := log.With().Str("host_id", hostID).Logger()
+		hostLog.Error().Err(vmdLookupErr).Msg("resolve VMD for create failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -2101,6 +2107,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// wait on the other. This hides the ~10-20ms INSERT roundtrip behind
 	// VMD's ~100-200ms create latency, shaving that much off the p50.
 	sandboxID := uuid.New()
+	l := sandboxLogger(sandboxID.String(), hostID)
 
 	// The detached insert keeps the happy path parallel, but it still needs a
 	// deadline so a DB restart cannot let the write linger long after the boot
@@ -2257,7 +2264,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// The closure runs synchronously inside retryTransientBoot; a retry
 	// overwrites the capture with the attempt that produced the returned VM.
 	var previewProtocol string
-	ipAddress, actualVcpu, actualMemMiB, vmdRetried, vmdErr := retryTransientBoot(c.Request.Context(), sandboxID.String(), func(ctx context.Context) (string, uint32, uint32, error) {
+	ipAddress, actualVcpu, actualMemMiB, vmdRetried, vmdErr := retryTransientBoot(c.Request.Context(), sandboxID.String(), hostID, func(ctx context.Context) (string, uint32, uint32, error) {
 		ip, vcpu, memMiB, protocol, err := vmd.RestoreSnapshot(ctx, sandboxID.String(), snapshotPath, snapshotMemPath, basePath, deltaDir, teamID.String(), ownerIDFromContext(c), previewAccess, nil, 0, req.EnvVars)
 		previewProtocol = protocol
 		return ip, vcpu, memMiB, err
@@ -2338,7 +2345,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	case dbErr != nil:
 		// DB insert failed but VMD succeeded or failed independently — the VM
 		// was already cleaned up best-effort above.
-		log.Error().Err(dbErr).Str("sandbox_id", sandboxID.String()).Str("reason", transientReason).Msg("CreateSandbox: INSERT failed")
+		l.Error().Err(dbErr).Str("reason", transientReason).Msg("CreateSandbox: INSERT failed")
 		if templateRace {
 			respondErrorMsg(c, "not_found", "Template not found", http.StatusNotFound)
 			return
@@ -2362,17 +2369,17 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// doesn't leave it stuck in "starting". The request middleware
 		// records the create failure metric from the HTTP status, so avoid
 		// emitting a second request-scoped transition here.
-		log.Error().Err(vmdErr).Str("sandbox_id", sandbox.ID.String()).Str("reason", transientReason).Msg("VMD create/resume failed")
+		l.Error().Err(vmdErr).Str("reason", transientReason).Msg("VMD create/resume failed")
 		if dbErr == nil && transientCreateFailure && failDone != nil {
 			select {
 			case released := <-failDone:
 				if !released {
-					log.Warn().Str("sandbox_id", sandbox.ID.String()).Msg("failed-state reconciliation did not finish before create response")
+					l.Warn().Msg("failed-state reconciliation did not finish before create response")
 					respondError(c, ErrInternal)
 					return
 				}
 			case <-time.After(asyncTimeout):
-				log.Warn().Str("sandbox_id", sandbox.ID.String()).Msg("timed out waiting for failed-state reconciliation after create failure")
+				l.Warn().Msg("timed out waiting for failed-state reconciliation after create failure")
 				respondError(c, ErrInternal)
 				return
 			}
@@ -2409,9 +2416,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// policy (the echo is newer than enforcement), so attest the way its
 		// generation supports: the policy RPC, which fails Unimplemented on a
 		// truly pre-policy VMD. Remove once the fleet echoes.
-		log.Warn().Str("sandbox_id", sandboxID.String()).Msg("vmd boot response carries no preview attestation; attesting via the policy RPC (version skew)")
+		l.Warn().Msg("vmd boot response carries no preview attestation; attesting via the policy RPC (version skew)")
 		if err := vmd.UpdateSandboxPreviewPolicy(postCtx, sandboxID.String(), previewAccess, nil, 0); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD preview policy attestation failed after restore")
+			l.Error().Err(err).Msg("VMD preview policy attestation failed after restore")
 			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID)
 			respondError(c, ErrInternal)
 			return
@@ -2419,7 +2426,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	default:
 		// An unrecognized echo — fail closed rather than guess what it
 		// enforces.
-		log.Error().Str("sandbox_id", sandboxID.String()).Str("preview_protocol", previewProtocol).Msg("VMD attested an unknown preview protocol at restore")
+		l.Error().Str("preview_protocol", previewProtocol).Msg("VMD attested an unknown preview protocol at restore")
 		h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID)
 		respondError(c, ErrInternal)
 		return
@@ -2435,7 +2442,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			NetworkConfig: networkConfig,
 			TeamID:        teamID,
 		}); err != nil {
-			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("persist network_config before env inject failed")
+			l.Warn().Err(err).Msg("persist network_config before env inject failed")
 		}
 	}
 
@@ -2443,7 +2450,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	if len(secretMeta) > 0 {
 		jwt, jerr := h.mintSecretsJWT(sandboxID.String(), teamID.String(), ipAddress, secretMeta)
 		if jerr != nil {
-			log.Error().Err(jerr).Str("sandbox_id", sandboxID.String()).Msg("mint secrets JWT")
+			l.Error().Err(jerr).Msg("mint secrets JWT")
 			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID)
 			respondError(c, ErrInternal)
 			return
@@ -2463,9 +2470,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			// A vmd without this RPC already applied these env vars during
 			// RestoreSnapshot; tolerate its absence only when no JWT needs this path.
 			if secretsJWT == "" && isVMDUnimplemented(injErr) {
-				log.Warn().Str("sandbox_id", sandboxID.String()).Msg("vmd lacks InjectSandboxEnv; env applied during restore")
+				l.Warn().Msg("vmd lacks InjectSandboxEnv; env applied during restore")
 			} else {
-				log.Error().Err(injErr).Str("sandbox_id", sandboxID.String()).Msg("VMD InjectSandboxEnv failed")
+				l.Error().Err(injErr).Msg("VMD InjectSandboxEnv failed")
 				h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID)
 				respondError(c, ErrInternal)
 				return
@@ -2481,7 +2488,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			pctx, pcancel := context.WithTimeout(context.Background(), vmdTimeout)
 			defer pcancel()
 			if err := vmd.InvalidateSandboxRules(pctx, sandboxID.String()); err != nil {
-				log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("prime egress rules cache failed (fetch fallback)")
+				l.Warn().Err(err).Msg("prime egress rules cache failed (fetch fallback)")
 			}
 		}()
 	}
@@ -2545,7 +2552,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				// pre-activation the VM can only be gone abnormally — and
 				// ActivateSandbox has no status guard, so proceeding could
 				// resurrect a row another path just marked failed.
-				log.Error().Err(stampErr).Str("sandbox_id", sandboxID.String()).
+				l.Error().Err(stampErr).
 					Int64("stamp_ms", time.Since(tStamp).Milliseconds()).
 					Msg("post-boot guest init failed; failing sandbox instead of activating")
 				fctx, fcancel := context.WithTimeout(activateCtx, vmdTimeout)
@@ -2564,7 +2571,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			TeamID:    teamID,
 			ActorID:   actorUUID(actorID),
 		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("async DB ActivateSandbox failed")
+			l.Error().Err(err).Msg("async DB ActivateSandbox failed")
 		}
 	})
 
@@ -2575,7 +2582,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		// only pushes the nftables rules, which need the booted VM.
 		allowedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
 		if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, req.Network.DenyOut, allowedDomains); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("failed to apply network rules at creation")
+			l.Error().Err(err).Msg("failed to apply network rules at creation")
 		}
 	}
 	tPostDone := time.Now()
@@ -2600,8 +2607,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
 		resp.Network = req.Network
 	}
-	log.Info().
-		Str("sandbox_id", sandbox.ID.String()).
+	l.Info().
 		Int64("auth_ms", c.GetInt64("auth_ms")).
 		Int64("lookup_ms", tLookupDone.Sub(tStart).Milliseconds()).
 		Int64("sched_ms", tVmdStart.Sub(tLookupDone).Milliseconds()).
@@ -2685,6 +2691,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		return
 	}
 	SetTelemetryHostID(c, sandbox.HostID)
+	l := sandboxLogger(sandboxID.String(), sandbox.HostID)
 
 	// BeginPause's CTE atomically closed the open active interval together
 	// with the status transition; nothing to do here. If the pause
@@ -2693,7 +2700,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 	// Resolve the VMD client for this sandbox's host.
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 	if vmdLookupErr != nil {
-		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for pause failed")
+		l.Error().Err(vmdLookupErr).Msg("resolve VMD for pause failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -2705,13 +2712,13 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		// Mark the sandbox failed and return 410 Gone. No revert — the VM is
 		// already dead, "active" was a lie.
 		if isVMDNotFound(err) {
-			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
+			l.Warn().Err(err).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
 			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, sandbox.HostID, false)
 			respondError(c, ErrSandboxGone)
 			return
 		}
 
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD PauseInstance failed")
+		l.Error().Err(err).Msg("VMD PauseInstance failed")
 		// Revert status to active asynchronously. Detach cancellation so
 		// the revert survives client disconnect, but keep trace context
 		// so the revert is linked to the original pause request.
@@ -2725,7 +2732,7 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 				Status: db.SandboxStatusActive,
 				TeamID: teamID,
 			}); revertErr != nil {
-				log.Error().Err(revertErr).Str("sandbox_id", sandboxID.String()).Msg("async revert to active failed")
+				l.Error().Err(revertErr).Msg("async revert to active failed")
 				return
 			}
 			// Reopen the interval we closed at BeginPause — sandbox is
@@ -2735,15 +2742,14 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 				TeamID:    teamID,
 				ActorID:   actorUUID(actorID),
 			}); openErr != nil {
-				log.Error().Err(openErr).Str("sandbox_id", sandboxID.String()).Msg("async reopen interval after revert failed")
+				l.Error().Err(openErr).Msg("async reopen interval after revert failed")
 			}
 		}()
 		respondError(c, ErrInternal)
 		return
 	}
 
-	log.Debug().
-		Str("sandbox_id", sandboxID.String()).
+	l.Debug().
 		Str("snapshot_path", snapshotPath).
 		Str("mem_path", memPath).
 		Msg("VMD pause complete")
@@ -2775,10 +2781,10 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 			// already stopped and its snapshot files are on disk — nothing to
 			// finalize for a sandbox that no longer exists.
 			if err == pgx.ErrNoRows {
-				log.Warn().Str("sandbox_id", sandboxID.String()).Msg("FinalizePause: sandbox deleted mid-pause")
+				l.Warn().Msg("FinalizePause: sandbox deleted mid-pause")
 				return
 			}
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async DB FinalizePause failed — sandbox may be stuck in 'pausing'")
+			l.Error().Err(err).Msg("async DB FinalizePause failed — sandbox may be stuck in 'pausing'")
 			return
 		}
 	})
@@ -2828,6 +2834,7 @@ func (h *Handlers) ListSandboxFiles(c *gin.Context) {
 	if sandbox == nil {
 		return
 	}
+	l := sandboxLogger(sandbox.ID.String(), sandbox.HostID)
 
 	path := c.Query("path")
 	if path == "" {
@@ -2840,7 +2847,7 @@ func (h *Handlers) ListSandboxFiles(c *gin.Context) {
 
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 	if vmdLookupErr != nil {
-		log.Error().Err(vmdLookupErr).Str("sandbox_id", sandbox.ID.String()).Msg("resolve VMD for list-dir failed")
+		l.Error().Err(vmdLookupErr).Msg("resolve VMD for list-dir failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -2857,7 +2864,7 @@ func (h *Handlers) ListSandboxFiles(c *gin.Context) {
 			respondErrorMsg(c, "bad_request", "Path is not a listable directory.", http.StatusBadRequest)
 			return
 		}
-		log.Error().Err(err).Str("sandbox_id", sandbox.ID.String()).Msg("VMD ListDir failed")
+		l.Error().Err(err).Msg("VMD ListDir failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -2997,6 +3004,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	l := sandboxLogger(sandbox.ID.String(), sandbox.HostID)
 
 	// Network updates require an active sandbox (rules are applied live to the VM).
 	if body.Network != nil && sandbox.Status != db.SandboxStatusActive {
@@ -3018,7 +3026,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		// Resolve the VMD client for this sandbox's host.
 		vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 		if vmdLookupErr != nil {
-			log.Error().Err(vmdLookupErr).Str("sandbox_id", sandboxID.String()).Msg("resolve VMD for patch failed")
+			l.Error().Err(vmdLookupErr).Msg("resolve VMD for patch failed")
 			respondError(c, ErrInternal)
 			return
 		}
@@ -3027,7 +3035,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 		defer vmdCancel()
 		if err := vmd.UpdateSandboxNetwork(vmdCtx, sandboxID.String(), allowedCIDRs, body.Network.DenyOut, allowedDomains); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("VMD UpdateSandboxNetwork failed")
+			l.Error().Err(err).Msg("VMD UpdateSandboxNetwork failed")
 			respondError(c, ErrInternal)
 			return
 		}
@@ -3045,7 +3053,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 			NetworkConfig: networkConfig,
 			TeamID:        teamID,
 		}); err != nil {
-			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB UpdateSandboxNetworkConfig failed (rules applied, persistence failed)")
+			l.Warn().Err(err).Msg("DB UpdateSandboxNetworkConfig failed (rules applied, persistence failed)")
 		}
 
 		h.logSandboxActivity(c.Request.Context(), sandbox.ID, teamID, actorIDFromContext(c), "network", "updated", "success", &sandbox.Name, nil, networkConfig)
@@ -3059,7 +3067,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 			ictx, icancel := context.WithTimeout(context.Background(), vmdTimeout)
 			defer icancel()
 			if err := vmd.InvalidateSandboxRules(ictx, sandboxID.String()); err != nil {
-				log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("PATCH: invalidate sandbox rules failed (TTL fallback)")
+				l.Warn().Err(err).Msg("PATCH: invalidate sandbox rules failed (TTL fallback)")
 			}
 		}()
 	}
@@ -3076,7 +3084,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 			Metadata: metadataJSON,
 			TeamID:   teamID,
 		}); err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB UpdateSandboxMetadata failed")
+			l.Error().Err(err).Msg("DB UpdateSandboxMetadata failed")
 			respondError(c, ErrInternal)
 			return
 		}

--- a/internal/api/handlers_network.go
+++ b/internal/api/handlers_network.go
@@ -73,9 +73,10 @@ func (h *Handlers) GetSandboxNetwork(c *gin.Context) {
 		return
 	}
 
-	if _, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
+	sandbox, err := h.DB.GetSandbox(c.Request.Context(), db.GetSandboxParams{
 		ID: sandboxID, TeamID: teamID,
-	}); err != nil {
+	})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			respondError(c, ErrSandboxNotFound)
 			return
@@ -84,6 +85,7 @@ func (h *Handlers) GetSandboxNetwork(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	l := sandboxLogger(sandbox.ID.String(), sandbox.HostID)
 
 	limit, err := parseAuditLimit(c.Query("limit"))
 	if err != nil {
@@ -114,7 +116,7 @@ func (h *Handlers) GetSandboxNetwork(c *gin.Context) {
 		CursorTs: cursor.ts, CursorKind: cursor.kind, CursorID: cursor.id,
 	})
 	if err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ListNetFlowEvents failed")
+		l.Error().Err(err).Msg("DB ListNetFlowEvents failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -127,7 +129,7 @@ func (h *Handlers) GetSandboxNetwork(c *gin.Context) {
 			CursorTs: cursor.ts, CursorKind: cursor.kind, CursorID: cursor.id,
 		})
 		if err != nil {
-			log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("DB ListProxyAuditEvents failed")
+			l.Error().Err(err).Msg("DB ListProxyAuditEvents failed")
 			respondError(c, ErrInternal)
 			return
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -21,6 +22,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -749,6 +752,81 @@ func TestDeleteSandbox_TeardownError_StillCommits(t *testing.T) {
 
 	if w.Code != http.StatusNoContent {
 		t.Errorf("status = %d, want %d (teardown is best-effort after the claim); body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+}
+
+func TestDeleteSandbox_TeardownError_RecordsTelemetryAndHostAwareLog(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	hostID := "host-1"
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, HostID: hostID, Name: "sb", Status: db.SandboxStatusActive}
+
+	rec := &captureTelemetryRecorder{}
+	SetTelemetryRecorder(rec)
+	t.Cleanup(func() {
+		SetTelemetryRecorder(nil)
+	})
+
+	var buf bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+	})
+
+	vmd := &stubVMD{destroyFn: func(context.Context, string, bool) error {
+		return fmt.Errorf("vmd unreachable")
+	}}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "FROM destroyed"):
+				return idRow(sandboxID)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag(""), nil
+		},
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(SandboxLifecycleTelemetry())
+	r.Use(func(c *gin.Context) {
+		c.Set("team_id", teamID.String())
+		c.Next()
+	})
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	r.DELETE("/sandboxes/:sandbox_id", h.DeleteSandbox)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, deleteRequest(sandboxID.String()))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if len(rec.transitions) != 1 {
+		t.Fatalf("recorded %d lifecycle transitions, want 1", len(rec.transitions))
+	}
+	got := rec.transitions[0]
+	if got.Operation != "delete" {
+		t.Fatalf("operation = %q, want delete", got.Operation)
+	}
+	if got.Result != telemetry.ResultSuccess {
+		t.Fatalf("result = %q, want %q", got.Result, telemetry.ResultSuccess)
+	}
+	if got.HostID != hostID {
+		t.Fatalf("host_id = %q, want %q", got.HostID, hostID)
+	}
+	out := buf.String()
+	for _, want := range []string{`"sandbox_id":"` + sandboxID.String() + `"`, `"host_id":"` + hostID + `"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("log output %q missing %q", out, want)
+		}
 	}
 }
 

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -242,6 +242,7 @@ const autoDeleteTeardownTimeout = 2 * time.Minute
 func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDeleteSandboxesRow) {
 	l := log.With().
 		Str("sandbox_id", sbx.ID.String()).
+		Str("host_id", sbx.HostID).
 		Str("team_id", sbx.TeamID.String()).
 		Str("name", sbx.Name).
 		Logger()
@@ -275,6 +276,7 @@ func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDele
 func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxesRow) {
 	l := log.With().
 		Str("sandbox_id", sbx.ID.String()).
+		Str("host_id", sbx.HostID).
 		Str("team_id", sbx.TeamID.String()).
 		Str("name", sbx.Name).
 		Logger()
@@ -354,7 +356,7 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	// retry as the user-facing boots — the background ctx never reads dead,
 	// which is right: a rollback landing late still beats marking the
 	// sandbox failed.
-	ipAddr, _, _, _, err := retryTransientBoot(ctx, sbx.ID.String(), func(rctx context.Context) (string, uint32, uint32, error) {
+	ipAddr, _, _, _, err := retryTransientBoot(ctx, sbx.ID.String(), sbx.HostID, func(rctx context.Context) (string, uint32, uint32, error) {
 		return vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath, sbx.NetworkConfig)
 	})
 	if err != nil {

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
@@ -64,6 +66,17 @@ func telemetryHostID(c *gin.Context) string {
 	}
 	hostID, _ := v.(string)
 	return hostID
+}
+
+func sandboxLogger(sandboxID, hostID string) zerolog.Logger {
+	return sandboxLoggerFrom(log.Logger, sandboxID, hostID)
+}
+
+func sandboxLoggerFrom(base zerolog.Logger, sandboxID, hostID string) zerolog.Logger {
+	return base.With().
+		Str("sandbox_id", sandboxID).
+		Str("host_id", hostID).
+		Logger()
 }
 
 func RecordSandboxTransition(ctx context.Context, operation, result, hostID string, duration time.Duration) {

--- a/internal/api/telemetry_test.go
+++ b/internal/api/telemetry_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/telemetry"
+)
+
+type captureTelemetryRecorder struct {
+	transitions []telemetry.SandboxTransition
+}
+
+func (r *captureTelemetryRecorder) RecordSandboxTransition(_ context.Context, t telemetry.SandboxTransition) {
+	r.transitions = append(r.transitions, t)
+}
+
+func (r *captureTelemetryRecorder) RecordSandboxResumeSettleWait(context.Context, telemetry.SandboxResumeSettleWait) {
+}
+func (r *captureTelemetryRecorder) RecordVMDCall(context.Context, telemetry.VMDCall) {}
+func (r *captureTelemetryRecorder) RecordHostCapacity(context.Context, telemetry.HostCapacity) {
+}
+func (r *captureTelemetryRecorder) RecordDBPoolStats(context.Context, telemetry.DBPoolStats) {}
+func (r *captureTelemetryRecorder) RecordPausedNetworkPressure(context.Context, telemetry.PausedNetworkPressure) {
+}
+func (r *captureTelemetryRecorder) RecordLauncherState(context.Context, telemetry.LauncherState) {}
+
+func TestSandboxLifecycleTelemetryUsesHostID(t *testing.T) {
+	rec := &captureTelemetryRecorder{}
+	SetTelemetryRecorder(rec)
+	t.Cleanup(func() {
+		SetTelemetryRecorder(nil)
+	})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(SandboxLifecycleTelemetry())
+	r.POST("/sandboxes", func(c *gin.Context) {
+		SetTelemetryHostID(c, "host-123")
+		c.Status(http.StatusCreated)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+	if len(rec.transitions) != 1 {
+		t.Fatalf("recorded %d lifecycle transitions, want 1", len(rec.transitions))
+	}
+	got := rec.transitions[0]
+	if got.Operation != "create" {
+		t.Fatalf("operation = %q, want create", got.Operation)
+	}
+	if got.Result != telemetry.ResultSuccess {
+		t.Fatalf("result = %q, want %q", got.Result, telemetry.ResultSuccess)
+	}
+	if got.HostID != "host-123" {
+		t.Fatalf("host_id = %q, want host-123", got.HostID)
+	}
+	if got.Region != SandboxIDRegion() {
+		t.Fatalf("region = %q, want %q", got.Region, SandboxIDRegion())
+	}
+	if got.Duration <= 0 {
+		t.Fatalf("duration = %s, want positive", got.Duration)
+	}
+}
+
+func TestSandboxLifecycleTelemetryUsesHostIDForPauseResumeDelete(t *testing.T) {
+	cases := []struct {
+		name      string
+		method    string
+		route     string
+		path      string
+		hostID    string
+		status    int
+		operation string
+	}{
+		{
+			name:      "pause",
+			method:    http.MethodPost,
+			route:     "/sandboxes/:sandbox_id/pause",
+			path:      "/sandboxes/sb-123/pause",
+			hostID:    "host-pause",
+			status:    http.StatusNoContent,
+			operation: "pause",
+		},
+		{
+			name:      "resume",
+			method:    http.MethodPost,
+			route:     "/sandboxes/:sandbox_id/resume",
+			path:      "/sandboxes/sb-123/resume",
+			hostID:    "host-resume",
+			status:    http.StatusOK,
+			operation: "resume",
+		},
+		{
+			name:      "delete",
+			method:    http.MethodDelete,
+			route:     "/sandboxes/:sandbox_id",
+			path:      "/sandboxes/sb-123",
+			hostID:    "host-delete",
+			status:    http.StatusNoContent,
+			operation: "delete",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &captureTelemetryRecorder{}
+			SetTelemetryRecorder(rec)
+			t.Cleanup(func() {
+				SetTelemetryRecorder(nil)
+			})
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.Use(SandboxLifecycleTelemetry())
+			r.POST("/sandboxes/:sandbox_id/pause", func(c *gin.Context) {
+				SetTelemetryHostID(c, "host-pause")
+				c.Status(http.StatusNoContent)
+			})
+			r.POST("/sandboxes/:sandbox_id/resume", func(c *gin.Context) {
+				SetTelemetryHostID(c, "host-resume")
+				c.Status(http.StatusOK)
+			})
+			r.DELETE("/sandboxes/:sandbox_id", func(c *gin.Context) {
+				SetTelemetryHostID(c, "host-delete")
+				c.Status(http.StatusNoContent)
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tc.status {
+				t.Fatalf("status = %d, want %d", w.Code, tc.status)
+			}
+			if len(rec.transitions) != 1 {
+				t.Fatalf("recorded %d lifecycle transitions, want 1", len(rec.transitions))
+			}
+			got := rec.transitions[0]
+			if got.Operation != tc.operation {
+				t.Fatalf("operation = %q, want %q", got.Operation, tc.operation)
+			}
+			if got.Result != telemetry.ResultSuccess {
+				t.Fatalf("result = %q, want %q", got.Result, telemetry.ResultSuccess)
+			}
+			if got.HostID != tc.hostID {
+				t.Fatalf("host_id = %q, want %q", got.HostID, tc.hostID)
+			}
+			if got.Region != SandboxIDRegion() {
+				t.Fatalf("region = %q, want %q", got.Region, SandboxIDRegion())
+			}
+			if got.Duration <= 0 {
+				t.Fatalf("duration = %s, want positive", got.Duration)
+			}
+		})
+	}
+}
+
+func TestLifecycleResultBucketsTimeoutsAndConflicts(t *testing.T) {
+	cases := map[int]string{
+		http.StatusOK:                  telemetry.ResultSuccess,
+		http.StatusCreated:             telemetry.ResultSuccess,
+		http.StatusConflict:            telemetry.ResultConflict,
+		http.StatusRequestTimeout:      telemetry.ResultTimeout,
+		http.StatusGatewayTimeout:      telemetry.ResultTimeout,
+		http.StatusInternalServerError: telemetry.ResultError,
+	}
+	for status, want := range cases {
+		if got := lifecycleResult(status); got != want {
+			t.Fatalf("lifecycleResult(%d) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestSandboxLifecycleOperationMatchesContractRoutes(t *testing.T) {
+	cases := []struct {
+		method string
+		route  string
+		want   string
+	}{
+		{http.MethodPost, "/sandboxes", "create"},
+		{http.MethodPost, "/sandboxes/:sandbox_id/pause", "pause"},
+		{http.MethodPost, "/sandboxes/:sandbox_id/resume", "resume"},
+		{http.MethodDelete, "/sandboxes/:sandbox_id", "delete"},
+	}
+	for _, tc := range cases {
+		got, ok := sandboxLifecycleOperation(tc.method, tc.route)
+		if !ok {
+			t.Fatalf("%s %s did not match a lifecycle route", tc.method, tc.route)
+		}
+		if got != tc.want {
+			t.Fatalf("%s %s = %q, want %q", tc.method, tc.route, got, tc.want)
+		}
+	}
+}
+
+func TestSandboxLoggerIncludesSandboxAndHostID(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := sandboxLoggerFrom(zerolog.New(&buf), "sandbox-123", "host-123")
+	l.Error().Msg("boom")
+
+	out := buf.String()
+	for _, want := range []string{`"sandbox_id":"sandbox-123"`, `"host_id":"host-123"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("log output %q missing %q", out, want)
+		}
+	}
+}
+
+var _ telemetry.Recorder = (*captureTelemetryRecorder)(nil)

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -153,6 +152,7 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 		ctx, cancel := context.WithTimeout(asyncCtx, asyncTimeout)
 		defer cancel()
 		started := time.Now()
+		l := sandboxLogger(sandboxID.String(), hostID)
 		if verifyRow {
 			verifyDeadline := time.Now().Add(sandboxCreateAbsentRowRetryWindow)
 			backoff := 100 * time.Millisecond
@@ -180,14 +180,13 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 					return
 				}
 				if !isTransientCreateDBErr(err) || ctx.Err() != nil {
-					log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async verify sandbox before failed-state write failed")
+					l.Error().Err(err).Msg("async verify sandbox before failed-state write failed")
 					RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
 					complete(false)
 					return
 				}
-				log.Warn().
+				l.Warn().
 					Err(err).
-					Str("sandbox_id", sandboxID.String()).
 					Dur("retry_in", backoff).
 					Msg("async verify sandbox before failed-state write hit a transient DB error; retrying")
 				timer := time.NewTimer(backoff)
@@ -212,7 +211,7 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 			})
 			if err == nil {
 				if secErr := h.DB.DeleteSandboxSecrets(ctx, sandboxID); secErr != nil {
-					log.Warn().Err(secErr).Str("sandbox_id", sandboxID.String()).Msg("async clear secret bindings after failed state failed")
+					l.Warn().Err(secErr).Msg("async clear secret bindings after failed state failed")
 				}
 				RecordSandboxTransition(ctx, "fail", telemetry.ResultSuccess, hostID, time.Since(started))
 				complete(true)
@@ -225,13 +224,12 @@ func (h *Handlers) markSandboxFailedAsync(reqCtx context.Context, sandboxID, tea
 			}
 			if !isTransientCreateDBErr(err) || ctx.Err() != nil {
 				RecordSandboxTransition(ctx, "fail", telemetry.ResultError, hostID, time.Since(started))
-				log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("async mark-failed write failed")
+				l.Error().Err(err).Msg("async mark-failed write failed")
 				complete(false)
 				return
 			}
-			log.Warn().
+			l.Warn().
 				Err(err).
-				Str("sandbox_id", sandboxID.String()).
 				Dur("retry_in", backoff).
 				Msg("async mark-failed write hit a transient DB error; retrying")
 			timer := time.NewTimer(backoff)
@@ -272,13 +270,14 @@ func (h *Handlers) sandboxExists(ctx context.Context, sandboxID, teamID uuid.UUI
 // on a non-default host. Request middleware records the create failure metric
 // from the HTTP response, so this helper only updates state and logs.
 func (h *Handlers) failSandboxAfterBoot(ctx context.Context, vmd VMDClient, sandboxID, teamID uuid.UUID, instanceID, hostID string) {
+	l := sandboxLogger(sandboxID.String(), hostID)
 	// The post-restore operation that brought us here may have exhausted or
 	// cancelled its context. Cleanup owns fresh detached deadlines so a timed-out
 	// policy/env RPC cannot strand a running VM or prevent the failed-row write.
 	cleanupBase := context.WithoutCancel(ctx)
 	destroyCtx, destroyCancel := context.WithTimeout(cleanupBase, vmdTimeout)
 	if err := vmd.DestroyInstance(destroyCtx, instanceID, true); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("destroy after failed boot")
+		l.Error().Err(err).Msg("destroy after failed boot")
 	}
 	destroyCancel()
 
@@ -289,12 +288,12 @@ func (h *Handlers) failSandboxAfterBoot(ctx context.Context, vmd VMDClient, sand
 		Status: db.SandboxStatusFailed,
 		TeamID: teamID,
 	}); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("mark-failed after destroy")
+		l.Error().Err(err).Msg("mark-failed after destroy")
 	}
 	// A failed sandbox keeps status=failed with destroyed_at NULL, and the
 	// secret-binding queries filter only on destroyed_at, so clear the bindings
 	// here or a never-usable sandbox would still report as bound to its secrets.
 	if err := h.DB.DeleteSandboxSecrets(dbCtx, sandboxID); err != nil {
-		log.Error().Err(err).Str("sandbox_id", sandboxID.String()).Msg("clear secret bindings after failed boot")
+		l.Error().Err(err).Msg("clear secret bindings after failed boot")
 	}
 }

--- a/internal/api/vmd_retry_test.go
+++ b/internal/api/vmd_retry_test.go
@@ -36,7 +36,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("success first try", func(t *testing.T) {
 		calls := 0
-		ip, vcpu, mem, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{nil}, &calls))
+		ip, vcpu, mem, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{nil}, &calls))
 		if err != nil || retried || calls != 1 || ip != "10.0.0.9" || vcpu != 2 || mem != 512 {
 			t.Fatalf("got ip=%q vcpu=%d mem=%d retried=%v err=%v calls=%d", ip, vcpu, mem, retried, err, calls)
 		}
@@ -44,7 +44,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("non-deadline error is not retried", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{other}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{other}, &calls))
 		if !errors.Is(err, other) || retried || calls != 1 {
 			t.Fatalf("err=%v retried=%v calls=%d, want boom/false/1", err, retried, calls)
 		}
@@ -52,7 +52,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("grpc deadline retried once then succeeds with attempt-2 outputs", func(t *testing.T) {
 		calls := 0
-		ip, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{grpcDeadline, nil}, &calls))
+		ip, _, _, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{grpcDeadline, nil}, &calls))
 		if err != nil || !retried || calls != 2 || ip != "10.0.0.9" {
 			t.Fatalf("got ip=%q retried=%v err=%v calls=%d", ip, retried, err, calls)
 		}
@@ -60,7 +60,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("wrapped context deadline from the interceptor is retried", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{wrappedCtxDeadline, nil}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{wrappedCtxDeadline, nil}, &calls))
 		if err != nil || !retried || calls != 2 {
 			t.Fatalf("err=%v retried=%v calls=%d, want nil/true/2", err, retried, calls)
 		}
@@ -68,7 +68,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("unavailable that outlived the interceptor window is retried", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{status.Error(codes.Unavailable, "connection refused"), nil}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{status.Error(codes.Unavailable, "connection refused"), nil}, &calls))
 		if err != nil || !retried || calls != 2 {
 			t.Fatalf("err=%v retried=%v calls=%d, want nil/true/2", err, retried, calls)
 		}
@@ -76,7 +76,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 
 	t.Run("deadline twice returns the second error", func(t *testing.T) {
 		calls := 0
-		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", boot([]error{grpcDeadline, grpcDeadline}, &calls))
+		_, _, _, retried, err := retryTransientBoot(context.Background(), "sb", "host-1", boot([]error{grpcDeadline, grpcDeadline}, &calls))
 		if !isVMDDeadline(err) || !retried || calls != 2 {
 			t.Fatalf("err=%v retried=%v calls=%d, want deadline/true/2", err, retried, calls)
 		}
@@ -86,7 +86,7 @@ func TestRetryBootOnDeadline(t *testing.T) {
 		parent, cancel := context.WithCancel(context.Background())
 		cancel()
 		calls := 0
-		_, _, _, retried, err := retryTransientBoot(parent, "sb", boot([]error{grpcDeadline, nil}, &calls))
+		_, _, _, retried, err := retryTransientBoot(parent, "sb", "host-1", boot([]error{grpcDeadline, nil}, &calls))
 		if !isVMDDeadline(err) || retried || calls != 1 {
 			t.Fatalf("err=%v retried=%v calls=%d, want deadline/false/1", err, retried, calls)
 		}

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -122,6 +122,7 @@ const poolWaitLogThreshold = 250 * time.Millisecond
 
 type Manager struct {
 	hostInterface string
+	hostID        string
 	log           zerolog.Logger
 
 	// setupSem bounds concurrent setupSlot builds (see setupSlotConcurrency).
@@ -205,6 +206,11 @@ func (m *Manager) SetEgressProxy(p *EgressProxy) {
 
 // ManagerOption configures optional Manager behavior.
 type ManagerOption func(*Manager)
+
+// WithHostID supplies the persisted VMD host identity for network-operation logs.
+func WithHostID(hostID string) ManagerOption {
+	return func(m *Manager) { m.hostID = hostID }
+}
 
 // WithExactSlot pins the Manager to exactly slot idx: it claims that one index
 // or fails with ErrNoSlots, never advancing to idx+1. A template-builder
@@ -329,7 +335,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		if info := m.pool.ClaimWait(ctx, vmID); info != nil {
 			m.registerEgress(vmID, info)
 			if waited := time.Since(tWait); waited >= poolWaitLogThreshold {
-				m.log.Info().Str("vm_id", vmID).
+				m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).
 					Int64("pool_wait_ms", waited.Milliseconds()).
 					Msg("pool: claim satisfied after waiting on refill")
 			}
@@ -341,7 +347,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		m.log.Info().Str("vm_id", vmID).
+		m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).
 			Int64("pool_wait_ms", time.Since(tWait).Milliseconds()).
 			Msg("network pool empty, falling back to on-demand setup")
 	}
@@ -366,7 +372,7 @@ func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNet
 	m.registerEgress(vmID, info)
 
 	m.log.Info().
-		Str("vm_id", vmID).
+		Str("vm_id", vmID).Str("host_id", m.hostID).
 		Str("namespace", info.Namespace).
 		Str("host_ip", info.HostIP).
 		Int64("on_demand_setup_ms", time.Since(tBuild).Milliseconds()).
@@ -581,7 +587,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 
 	idx, parsed := slotFromNamespace(info.Namespace)
 	if !parsed {
-		m.log.Warn().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("cleanup: unparseable namespace — skipping slot reclaim")
+		m.log.Warn().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", info.Namespace).Msg("cleanup: unparseable namespace — skipping slot reclaim")
 		return
 	}
 	vethName := fmt.Sprintf("veth-%d", idx)
@@ -600,7 +606,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 		owned := m.slotOwner[idx] == vmID
 		m.mu.Unlock()
 		if !owned {
-			m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+			m.log.Warn().Str("vm_id", vmID).Str("host_id", m.hostID).Int("slot", idx).
 				Msg("cleanup skipped — slot no longer owned by this VM")
 			return
 		}
@@ -617,7 +623,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	// concurrent claim pop the idx, see the netns still present, and discard it
 	// for good.
 	if !m.claimTeardown(idx, vmID) {
-		m.log.Warn().Str("vm_id", vmID).Int("slot", idx).
+		m.log.Warn().Str("vm_id", vmID).Str("host_id", m.hostID).Int("slot", idx).
 			Msg("teardown skipped — slot no longer owned by this VM")
 		return
 	}
@@ -628,7 +634,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	}
 	if info.Firewall != nil {
 		if err := info.Firewall.Close(); err != nil {
-			m.log.Warn().Err(err).Str("vm_id", vmID).Msg("error closing namespace firewall")
+			m.log.Warn().Err(err).Str("vm_id", vmID).Str("host_id", m.hostID).Msg("error closing namespace firewall")
 		}
 	}
 
@@ -637,7 +643,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	// owner on the teardown-not-recycle path) would keep the namespace and its
 	// tap alive but anonymous: unfindable by pidsInNs, the sweep, or the gauge.
 	if killed := killProcessesInNs(info.Namespace); killed > 0 {
-		m.log.Info().Str("namespace", info.Namespace).Int("killed", killed).
+		m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", info.Namespace).Int("killed", killed).
 			Msg("cleanup: killed lingering processes before namespace teardown")
 	}
 
@@ -651,7 +657,7 @@ func (m *Manager) cleanupVM(vmID string, recycle bool) {
 	_ = run(ctx, "ip", "link", "del", vethName)
 	_ = run(ctx, "ip", "netns", "del", info.Namespace)
 
-	m.log.Info().Str("vm_id", vmID).Str("namespace", info.Namespace).Msg("network namespace cleaned up")
+	m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", info.Namespace).Msg("network namespace cleaned up")
 }
 
 // CleanupVMOrNamespace tears down a VM's network slot. When the VM is tracked
@@ -686,13 +692,13 @@ func (m *Manager) CleanupVMOrNamespace(vmID, fallbackNamespace string) {
 	// only unlinks the name, so a namespace with a live holder lingers (keeping
 	// its tap0) until that process exits. Mirrors SweepOrphanNamespaces.
 	if killed := killProcessesInNs(fallbackNamespace); killed > 0 {
-		m.log.Info().Str("namespace", fallbackNamespace).Int("killed", killed).
+		m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", fallbackNamespace).Int("killed", killed).
 			Msg("cleanup: killed lingering processes before namespace teardown")
 	}
 	// Tear down both sides even if the netns is already gone: `ip netns del`
 	// only removes the in-namespace side, so the host-side veth-N can outlive it.
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
-	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
+	m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("reclaimed network slot for untracked VM")
 }
 
@@ -717,11 +723,11 @@ func (m *Manager) TeardownVMOrNamespace(vmID, fallbackNamespace string) {
 	defer m.releaseIfOwned(idx, teardownOwner)
 
 	if killed := killProcessesInNs(fallbackNamespace); killed > 0 {
-		m.log.Info().Str("namespace", fallbackNamespace).Int("killed", killed).
+		m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", fallbackNamespace).Int("killed", killed).
 			Msg("cleanup: killed lingering processes before namespace teardown")
 	}
 	m.cleanupFull(fallbackNamespace, fmt.Sprintf("veth-%d", idx))
-	m.log.Info().Str("vm_id", vmID).Str("namespace", fallbackNamespace).Int("slot", idx).
+	m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", fallbackNamespace).Int("slot", idx).
 		Msg("forcefully tore down network slot for untracked VM")
 }
 
@@ -774,7 +780,7 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 		fw = f
 		return nil
 	}); err != nil {
-		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
+		m.log.Warn().Err(err).Str("vm_id", vmID).Str("host_id", m.hostID).Msg("reattach: in-namespace firewall handle not restored (existing rules still enforce traffic)")
 	}
 
 	m.mu.Lock()
@@ -804,7 +810,7 @@ func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
 	}
 	m.registerEgress(vmID, info)
 
-	m.log.Info().Str("vm_id", vmID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
+	m.log.Info().Str("vm_id", vmID).Str("host_id", m.hostID).Int("slot", idx).Str("host_ip", hostIP).Bool("fw_attached", fw != nil).Msg("reattached VM network state")
 	return nil
 }
 
@@ -863,7 +869,7 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 		// Preserve Firewall handle for future UpdateFirewallRules.
 		info = existing
 	case !nsExists(namespace):
-		m.log.Warn().Str("vm_id", vmID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
+		m.log.Warn().Str("vm_id", vmID).Str("host_id", m.hostID).Str("namespace", namespace).Int("slot", idx).Msg("netns missing — rebuilding slot at original index")
 		// ip netns delete only tears down the inside-ns side; the host-side
 		// veth-N can survive and collide with setupSlot's fresh veth creation.
 		m.cleanupFull(namespace, fmt.Sprintf("veth-%d", idx))
@@ -872,7 +878,7 @@ func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, mac
 			return nil, fmt.Errorf("ensure %s: rebuild slot %d: %w", vmID, idx, err)
 		}
 		if macAddress != "" && built.MACAddress != macAddress {
-			m.log.Warn().Str("vm_id", vmID).Str("expected", macAddress).Str("got", built.MACAddress).Msg("rebuilt MAC differs from stored — deterministic mapping may have drifted")
+			m.log.Warn().Str("vm_id", vmID).Str("host_id", m.hostID).Str("expected", macAddress).Str("got", built.MACAddress).Msg("rebuilt MAC differs from stored — deterministic mapping may have drifted")
 		}
 		info = built
 	default:

--- a/internal/network/proxy.go
+++ b/internal/network/proxy.go
@@ -38,6 +38,7 @@ type EgressProxy struct {
 	otherPort uint16
 
 	log     zerolog.Logger
+	hostID  string
 	limiter *ConnectionLimiter
 
 	// maxConnsPerSandbox is the per-sandbox connection limit. -1 = unlimited.
@@ -79,6 +80,14 @@ func NewEgressProxy(httpPort, tlsPort, otherPort uint16, maxConns int, log zerol
 		flowSink:           NewNopFlowSink(),
 		rules:              make(map[string]*EgressRules),
 	}
+}
+
+// SetHostID records the VMD host identity for sandbox-scoped proxy logs.
+// Call before Start; the value is immutable while connections are served.
+func (p *EgressProxy) SetHostID(hostID string) { p.hostID = hostID }
+
+func (p *EgressProxy) sandboxLogger(sandboxID string) zerolog.Logger {
+	return p.log.With().Str("sandbox_id", sandboxID).Str("host_id", p.hostID).Logger()
 }
 
 // SetFlowSink installs the connection-flow logging sink. Safe to call after Start.
@@ -228,11 +237,17 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol st
 	// Identify sandbox by source IP.
 	srcAddr := conn.RemoteAddr().String()
 	srcHost, _, _ := net.SplitHostPort(srcAddr)
+	rules := p.getRules(srcHost)
+	var sandboxID string
+	if rules != nil {
+		sandboxID = rules.SandboxID
+	}
+	sandboxLog := p.sandboxLogger(sandboxID)
 
 	// Connection limit check.
 	_, acquired := p.limiter.TryAcquire(srcHost, p.maxConnsPerSandbox)
 	if !acquired {
-		p.log.Warn().Str("src", srcHost).Msg("connection limit exceeded")
+		sandboxLog.Warn().Str("src", srcHost).Msg("connection limit exceeded")
 		return
 	}
 	defer p.limiter.Release(srcHost)
@@ -274,11 +289,6 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol st
 
 	// Identify the sandbox up front so every block path (global blocklist,
 	// per-sandbox rule, dial-time) can attribute a flow-log row.
-	rules := p.getRules(srcHost)
-	var sandboxID string
-	if rules != nil {
-		sandboxID = rules.SandboxID
-	}
 	flow := FlowEvent{
 		SandboxID: sandboxID,
 		Protocol:  protocol,
@@ -291,7 +301,7 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol st
 	// sandbox's own allow rules.
 	if p.blocklist != nil {
 		if blocked, dim := p.blocklist.Blocked(hostname, dstIP); blocked {
-			p.log.Warn().
+			sandboxLog.Warn().
 				Str("src", srcHost).
 				Str("dst", dstIP.String()).
 				Str("hostname", hostname).
@@ -311,7 +321,7 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol st
 	flow.MatchRule = matchType
 
 	if !allowed {
-		p.log.Info().
+		sandboxLog.Info().
 			Str("src", srcHost).
 			Str("dst", dstIP.String()).
 			Str("hostname", hostname).
@@ -362,7 +372,7 @@ func (p *EgressProxy) handleConn(ctx context.Context, conn net.Conn, protocol st
 
 	upstream, err := dialer.DialContext(ctx, "tcp", upstreamAddr)
 	if err != nil {
-		p.log.Debug().Err(err).Str("upstream", upstreamAddr).Msg("dial failed")
+		sandboxLog.Debug().Err(err).Str("upstream", upstreamAddr).Msg("dial failed")
 		if sandboxID != "" {
 			// A resolved-IP rejection is a policy block; anything else failed
 			// to connect.

--- a/internal/network/proxy_test.go
+++ b/internal/network/proxy_test.go
@@ -1,7 +1,9 @@
 package network
 
 import (
+	"bytes"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -252,6 +254,19 @@ func TestIsAllowed(t *testing.T) {
 					tc.hostname, tc.dstIP, gotAllowed, gotMatch, tc.wantAllowed, tc.wantMatch)
 			}
 		})
+	}
+}
+
+func TestEgressProxySandboxLoggerIncludesHostID(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewEgressProxy(0, 0, 0, 1, zerolog.New(&buf))
+	p.SetHostID("host-123")
+	l := p.sandboxLogger("sandbox-123")
+	l.Warn().Msg("blocked")
+	for _, want := range []string{`"sandbox_id":"sandbox-123"`, `"host_id":"host-123"`} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("log output %q missing %q", buf.String(), want)
+		}
 	}
 }
 

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -196,6 +196,96 @@ func TestRecordVMDCallEmitsHostIDAndMethodAttributes(t *testing.T) {
 			)
 		}
 	}
+	if _, ok := attributes["sandbox_id"]; ok {
+		t.Fatalf("vmd_call_duration_seconds unexpectedly included sandbox_id: %#v", attributes)
+	}
+}
+
+func TestRecordSandboxTransitionEmitsHostIDAndNoSandboxID(t *testing.T) {
+	ctx := context.Background()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+	)
+	t.Cleanup(func() {
+		if err := provider.Shutdown(ctx); err != nil {
+			t.Errorf("shutdown meter provider: %v", err)
+		}
+	})
+
+	meter := provider.Meter(instrumentationName)
+
+	transitionTotal, err := meter.Int64Counter("sandbox_transition_total")
+	if err != nil {
+		t.Fatalf("create sandbox transition counter: %v", err)
+	}
+	transitionDuration, err := meter.Float64Histogram("sandbox_transition_duration_seconds")
+	if err != nil {
+		t.Fatalf("create sandbox transition duration histogram: %v", err)
+	}
+
+	recorder := &OTelRecorder{
+		provider:           provider,
+		serviceName:        "sandbox-controlplane",
+		environment:        "staging",
+		sandboxTransitions: transitionTotal,
+		sandboxDuration:    transitionDuration,
+	}
+
+	recorder.RecordSandboxTransition(ctx, SandboxTransition{
+		Operation: "create",
+		Result:    ResultSuccess,
+		Region:    "us-central1",
+		HostID:    "host-123",
+		Duration:  125 * time.Millisecond,
+	})
+
+	var resourceMetrics metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &resourceMetrics); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+
+	var datapoint *metricdata.HistogramDataPoint[float64]
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name != "sandbox_transition_duration_seconds" {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric data type = %T, want metricdata.Histogram[float64]", metric.Data)
+			}
+			if len(histogram.DataPoints) != 1 {
+				t.Fatalf("histogram datapoints = %d, want 1", len(histogram.DataPoints))
+			}
+			datapoint = &histogram.DataPoints[0]
+		}
+	}
+	if datapoint == nil {
+		t.Fatal("sandbox_transition_duration_seconds metric not found")
+	}
+
+	attributes := make(map[string]string)
+	for _, attr := range datapoint.Attributes.ToSlice() {
+		attributes[string(attr.Key)] = attr.Value.AsString()
+	}
+
+	for key, wantValue := range map[string]string{
+		"service.name": "sandbox-controlplane",
+		"environment":  "staging",
+		"operation":    "create",
+		"result":       ResultSuccess,
+		"region":       "us-central1",
+		"host_id":      "host-123",
+	} {
+		if got := attributes[key]; got != wantValue {
+			t.Fatalf("attribute %q = %q, want %q; all attributes: %#v", key, got, wantValue, attributes)
+		}
+	}
+	if _, ok := attributes["sandbox_id"]; ok {
+		t.Fatalf("sandbox_transition_duration_seconds unexpectedly included sandbox_id: %#v", attributes)
+	}
 }
 
 func TestRecordPausedNetworkPressureEmitsControllerMetrics(t *testing.T) {


### PR DESCRIPTION
## Summary

- Attribute sandbox lifecycle and VMD telemetry to the owning host without adding sandbox IDs to metric labels.
- Include sandbox and host identifiers in sandbox-scoped lifecycle, proxy, network-slot, and failure logs where both are known.
- Preserve the existing host identity across pause and resume paths.
- Add focused regression coverage for telemetry attributes, structured attribution, and proxy logging.

## Validation

- Focused API, network, telemetry, and VMD Go tests pass.
- The repository validation suite passes in the Linux Docker environment.
