### PR TITLE
vmd: make the reconciler's per-host sandbox scan index-only

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -260,12 +260,21 @@ SELECT id FROM destroyed;
 SELECT EXISTS(SELECT 1 FROM sandbox WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL);
 
 -- name: ListSandboxesByHost :many
--- Used by the VMD reconciler. snapshot_path is joined so the paused-sandbox
--- drift check can stat the file without a per-row snapshot lookup.
-SELECT sqlc.embed(s), snap.path AS snapshot_path
+-- Used by the VMD reconciler's per-host drift pass. Returns only the fields
+-- the drift checks read (status + snapshot linkage) so the scan stays
+-- index-only via idx_sandbox_host_reconcile even on hosts with very large
+-- live-sandbox counts. Snapshot paths are fetched separately, in one batch,
+-- for just the paused candidates that need them (see GetSnapshotPathsByIDs) —
+-- avoiding a LEFT JOIN across the entire host inventory every pass.
+SELECT s.id, s.status, s.snapshot_id
 FROM sandbox s
-LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL;
+
+-- name: GetSnapshotPathsByIDs :many
+-- Batched snapshot-path lookup for the reconciler's paused-snapshot drift
+-- check. Replaces the old per-inventory join with a PK lookup over just the
+-- snapshot IDs of paused sandboxes.
+SELECT id, path FROM snapshot WHERE id = ANY(@ids::uuid[]);
 
 -- name: ListRecentlyDestroyedSandboxIDsByHost :many
 -- Used by the VMD disk reconciler so a sandbox destroyed within the grace

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1562,6 +1562,38 @@ func (q *Queries) GetSandboxWithPreviewPolicy(ctx context.Context, arg GetSandbo
 	return i, err
 }
 
+const getSnapshotPathsByIDs = `-- name: GetSnapshotPathsByIDs :many
+SELECT id, path FROM snapshot WHERE id = ANY($1::uuid[])
+`
+
+type GetSnapshotPathsByIDsRow struct {
+	ID   uuid.UUID `json:"id"`
+	Path string    `json:"path"`
+}
+
+// Batched snapshot-path lookup for the reconciler's paused-snapshot drift
+// check. Replaces the old per-inventory join with a PK lookup over just the
+// snapshot IDs of paused sandboxes.
+func (q *Queries) GetSnapshotPathsByIDs(ctx context.Context, ids []uuid.UUID) ([]GetSnapshotPathsByIDsRow, error) {
+	rows, err := q.db.Query(ctx, getSnapshotPathsByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetSnapshotPathsByIDsRow{}
+	for rows.Next() {
+		var i GetSnapshotPathsByIDsRow
+		if err := rows.Scan(&i.ID, &i.Path); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const hasLegacySnapshotUnique = `-- name: HasLegacySnapshotUnique :one
 SELECT (to_regclass('public.snapshot_sandbox_unique') IS NOT NULL)::bool AS legacy
 `
@@ -1717,19 +1749,23 @@ func (q *Queries) ListSandboxPreviewPoliciesByTeam(ctx context.Context, teamID u
 }
 
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, snap.path AS snapshot_path
+SELECT s.id, s.status, s.snapshot_id
 FROM sandbox s
-LEFT JOIN snapshot snap ON snap.id = s.snapshot_id
 WHERE s.host_id = $1 AND s.destroyed_at IS NULL
 `
 
 type ListSandboxesByHostRow struct {
-	Sandbox      Sandbox `json:"sandbox"`
-	SnapshotPath *string `json:"snapshot_path"`
+	ID         uuid.UUID     `json:"id"`
+	Status     SandboxStatus `json:"status"`
+	SnapshotID pgtype.UUID   `json:"snapshot_id"`
 }
 
-// Used by the VMD reconciler. snapshot_path is joined so the paused-sandbox
-// drift check can stat the file without a per-row snapshot lookup.
+// Used by the VMD reconciler's per-host drift pass. Returns only the fields
+// the drift checks read (status + snapshot linkage) so the scan stays
+// index-only via idx_sandbox_host_reconcile even on hosts with very large
+// live-sandbox counts. Snapshot paths are fetched separately, in one batch,
+// for just the paused candidates that need them (see GetSnapshotPathsByIDs) —
+// avoiding a LEFT JOIN across the entire host inventory every pass.
 func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]ListSandboxesByHostRow, error) {
 	rows, err := q.db.Query(ctx, listSandboxesByHost, hostID)
 	if err != nil {
@@ -1739,34 +1775,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 	items := []ListSandboxesByHostRow{}
 	for rows.Next() {
 		var i ListSandboxesByHostRow
-		if err := rows.Scan(
-			&i.Sandbox.ID,
-			&i.Sandbox.TeamID,
-			&i.Sandbox.Name,
-			&i.Sandbox.Status,
-			&i.Sandbox.VcpuCount,
-			&i.Sandbox.MemoryMib,
-			&i.Sandbox.HostID,
-			&i.Sandbox.IpAddress,
-			&i.Sandbox.Pid,
-			&i.Sandbox.SnapshotID,
-			&i.Sandbox.CreatedAt,
-			&i.Sandbox.UpdatedAt,
-			&i.Sandbox.DestroyedAt,
-			&i.Sandbox.NetworkConfig,
-			&i.Sandbox.TimeoutSeconds,
-			&i.Sandbox.Metadata,
-			&i.Sandbox.TemplateID,
-			&i.Sandbox.SnapshotPath,
-			&i.Sandbox.MemPath,
-			&i.Sandbox.BasePath,
-			&i.Sandbox.DeltaPath,
-			&i.Sandbox.DiskMib,
-			&i.Sandbox.AutoDeleteSeconds,
-			&i.Sandbox.AutoDeleteAt,
-			&i.Sandbox.FailedAt,
-			&i.SnapshotPath,
-		); err != nil {
+		if err := rows.Scan(&i.ID, &i.Status, &i.SnapshotID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1919,11 +1919,17 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 // is provably gone. Extracted for the same reason as reapDeadActiveVMs — the
 // lock-window race (a new pause writing the artifact while this rule waits on
 // the lifecycle lock) is only testable with the pass data injectable.
+// snapshotPathBatchSize bounds the per-call size of the paused-snapshot PK
+// lookup. A busy host can hold tens of thousands of paused sandboxes, so the
+// lookup is issued in several modest ANY() queries instead of one oversized
+// uuid[] parameter and one very large result set.
+const snapshotPathBatchSize = 10000
+
 // resolvePausedSnapshotPaths batch-fetches on-disk snapshot paths for the
-// paused sandboxes on this host in a single PK lookup, replacing the per-
+// paused sandboxes on this host in chunked PK lookups, replacing the per-
 // inventory LEFT JOIN that ListSandboxesByHost used to carry. Returns nil when
-// the DB is unset, there are no paused candidates, or the lookup fails — Drift
-// 4 then safely no-ops for this pass.
+// the DB is unset, there are no paused candidates, or any chunk lookup fails —
+// Drift 4 then safely no-ops for this pass rather than acting on a partial map.
 func (r *Reconciler) resolvePausedSnapshotPaths(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow) map[uuid.UUID]string {
 	if r.cfg.DB == nil {
 		return nil
@@ -1937,18 +1943,22 @@ func (r *Reconciler) resolvePausedSnapshotPaths(ctx context.Context, log zerolog
 	if len(snapIDs) == 0 {
 		return nil
 	}
-	// ponytail: single ANY() over the paused set; chunk snapIDs if a host ever
-	// holds so many paused sandboxes that the param gets unwieldy.
-	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	rows, err := r.cfg.DB.GetSnapshotPathsByIDs(qctx, snapIDs)
-	cancel()
-	if err != nil {
-		log.Error().Err(err).Msg("resolvePausedSnapshotPaths: batch snapshot-path lookup failed")
-		return nil
-	}
-	pathByID := make(map[uuid.UUID]string, len(rows))
-	for _, row := range rows {
-		pathByID[row.ID] = row.Path
+	pathByID := make(map[uuid.UUID]string, len(snapIDs))
+	for start := 0; start < len(snapIDs); start += snapshotPathBatchSize {
+		end := start + snapshotPathBatchSize
+		if end > len(snapIDs) {
+			end = len(snapIDs)
+		}
+		qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		rows, err := r.cfg.DB.GetSnapshotPathsByIDs(qctx, snapIDs[start:end])
+		cancel()
+		if err != nil {
+			log.Error().Err(err).Msg("resolvePausedSnapshotPaths: batch snapshot-path lookup failed")
+			return nil
+		}
+		for _, row := range rows {
+			pathByID[row.ID] = row.Path
+		}
 	}
 	return pathByID
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -295,7 +295,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		} else {
 			dbSandboxes = make(map[string]db.ListSandboxesByHostRow, len(rows))
 			for _, row := range rows {
-				dbSandboxes[row.Sandbox.ID.String()] = row
+				dbSandboxes[row.ID.String()] = row
 			}
 		}
 	}
@@ -593,8 +593,8 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				return
 			}
 			sb, known := dbSandboxes[id]
-			deleted := known && sb.Sandbox.Status == db.SandboxStatusDeleted
-			failed := known && sb.Sandbox.Status == db.SandboxStatusFailed
+			deleted := known && sb.Status == db.SandboxStatusDeleted
+			failed := known && sb.Status == db.SandboxStatusFailed
 			if known && !deleted && !failed {
 				continue
 			}
@@ -713,7 +713,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		// way, and the flip frees no resource (same reasoning as the wedge
 		// branch below).
 		if dbSandboxes != nil {
-			if sb, known := dbSandboxes[id]; known && sb.Sandbox.Status == db.SandboxStatusActive {
+			if sb, known := dbSandboxes[id]; known && sb.Status == db.SandboxStatusActive {
 				r.markFailedInDB(ctx, id, db.SandboxStatusActive)
 			}
 		}
@@ -777,7 +777,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 			// resource, so the terminal gate doesn't apply. Fires once per
 			// wedge: the next pass's snapshot reads 'failed'.
 			if dbSandboxes != nil {
-				if sb, known := dbSandboxes[id]; known && sb.Sandbox.Status == db.SandboxStatusActive && r.consumeAutoFailBudget(id) {
+				if sb, known := dbSandboxes[id]; known && sb.Status == db.SandboxStatusActive && r.consumeAutoFailBudget(id) {
 					if r.markFailedInDB(ctx, id, db.SandboxStatusActive) {
 						r.writeAudit(ctx, id, "mark_failed", "wedged error VM: row flipped while awaiting terminal unit", "boltdb_error_unit_wedged")
 					}
@@ -795,7 +795,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 		// Drift 1 skips Error records, so the row flip lands here (still
 		// compare-and-set: a relaunch may own the row by now).
 		if dbSandboxes != nil {
-			if sb, known := dbSandboxes[id]; known && sb.Sandbox.Status == db.SandboxStatusActive {
+			if sb, known := dbSandboxes[id]; known && sb.Status == db.SandboxStatusActive {
 				r.markFailedInDB(ctx, id, db.SandboxStatusActive)
 			}
 		}
@@ -823,7 +823,7 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 				return
 			}
 			sb, known := dbSandboxes[id]
-			if !known || sb.Sandbox.Status != db.SandboxStatusPaused {
+			if !known || sb.Status != db.SandboxStatusPaused {
 				r.clearDrift("pausedunit:" + id)
 				continue
 			}
@@ -881,7 +881,9 @@ func (r *Reconciler) runOnce(ctx context.Context) {
 	}
 
 	// Drift 4: DB says paused, snapshot file missing on disk → mark failed.
-	r.failMissingSnapshots(ctx, log, dbSandboxes, now)
+	// Snapshot paths for the paused candidates are resolved in one batched
+	// lookup rather than joined across the whole inventory in the list query.
+	r.failMissingSnapshots(ctx, log, dbSandboxes, r.resolvePausedSnapshotPaths(ctx, log, dbSandboxes), now)
 
 	// Drift 5: BoltDB record exists but DB has no corresponding sandbox
 	// row (either never written or soft-deleted). Clean up the BoltDB
@@ -986,7 +988,7 @@ func (r *Reconciler) detectDiskOrphans(ctx context.Context, snapshotTime time.Ti
 	// Protected live sandboxes — used by the collapse guard and the audit log.
 	var keptActive, keptPaused int
 	for _, row := range dbSandboxes {
-		switch row.Sandbox.Status {
+		switch row.Status {
 		case db.SandboxStatusActive:
 			keptActive++
 		case db.SandboxStatusPaused:
@@ -1586,7 +1588,7 @@ func (r *Reconciler) failEmptyShells(ctx context.Context, log zerolog.Logger, db
 		// probes yield errors (non-evidence) and re-examine next pass.
 		var candidates []string
 		for id, sb := range dbSandboxes {
-			if sb.Sandbox.Status != db.SandboxStatusActive || !active[id] {
+			if sb.Status != db.SandboxStatusActive || !active[id] {
 				r.clearDrift("fcempty:" + id)
 				continue
 			}
@@ -1711,7 +1713,7 @@ func (r *Reconciler) reapUnverifiedOrphans(ctx context.Context, log zerolog.Logg
 				return
 			}
 			sb, known := dbSandboxes[id]
-			if !known || sb.Sandbox.Status != db.SandboxStatusPaused || !r.mgr.instanceUnverifiedRunning(id) {
+			if !known || sb.Status != db.SandboxStatusPaused || !r.mgr.instanceUnverifiedRunning(id) {
 				r.clearDrift("unverifiedorphan:" + id)
 				continue
 			}
@@ -1854,7 +1856,7 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 		if ctx.Err() != nil {
 			return
 		}
-		if sb.Sandbox.Status != db.SandboxStatusActive {
+		if sb.Status != db.SandboxStatusActive {
 			continue
 		}
 		if active[id] {
@@ -1917,21 +1919,54 @@ func (r *Reconciler) reapDeadActiveVMs(ctx context.Context, log zerolog.Logger, 
 // is provably gone. Extracted for the same reason as reapDeadActiveVMs — the
 // lock-window race (a new pause writing the artifact while this rule waits on
 // the lifecycle lock) is only testable with the pass data injectable.
-func (r *Reconciler) failMissingSnapshots(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, now time.Time) {
+// resolvePausedSnapshotPaths batch-fetches on-disk snapshot paths for the
+// paused sandboxes on this host in a single PK lookup, replacing the per-
+// inventory LEFT JOIN that ListSandboxesByHost used to carry. Returns nil when
+// the DB is unset, there are no paused candidates, or the lookup fails — Drift
+// 4 then safely no-ops for this pass.
+func (r *Reconciler) resolvePausedSnapshotPaths(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow) map[uuid.UUID]string {
+	if r.cfg.DB == nil {
+		return nil
+	}
+	snapIDs := make([]uuid.UUID, 0)
+	for _, sb := range dbSandboxes {
+		if sb.Status == db.SandboxStatusPaused && sb.SnapshotID.Valid {
+			snapIDs = append(snapIDs, uuid.UUID(sb.SnapshotID.Bytes))
+		}
+	}
+	if len(snapIDs) == 0 {
+		return nil
+	}
+	// ponytail: single ANY() over the paused set; chunk snapIDs if a host ever
+	// holds so many paused sandboxes that the param gets unwieldy.
+	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	rows, err := r.cfg.DB.GetSnapshotPathsByIDs(qctx, snapIDs)
+	cancel()
+	if err != nil {
+		log.Error().Err(err).Msg("resolvePausedSnapshotPaths: batch snapshot-path lookup failed")
+		return nil
+	}
+	pathByID := make(map[uuid.UUID]string, len(rows))
+	for _, row := range rows {
+		pathByID[row.ID] = row.Path
+	}
+	return pathByID
+}
+
+func (r *Reconciler) failMissingSnapshots(ctx context.Context, log zerolog.Logger, dbSandboxes map[string]db.ListSandboxesByHostRow, pathByID map[uuid.UUID]string, now time.Time) {
 	for id, sb := range dbSandboxes {
 		if ctx.Err() != nil {
 			return
 		}
-		if sb.Sandbox.Status != db.SandboxStatusPaused || !sb.Sandbox.SnapshotID.Valid {
+		if sb.Status != db.SandboxStatusPaused || !sb.SnapshotID.Valid {
 			continue
 		}
-		// snapshot_path is joined in by ListSandboxesByHost, so this
-		// is a cheap struct field read instead of a per-row DB call.
-		// Skip when the snapshot row has been deleted (rare race).
-		if sb.SnapshotPath == nil || *sb.SnapshotPath == "" {
+		// Path from resolvePausedSnapshotPaths' batched lookup. Empty means the
+		// snapshot row was deleted (rare race) or has no path — skip.
+		snapPath := pathByID[uuid.UUID(sb.SnapshotID.Bytes)]
+		if snapPath == "" {
 			continue
 		}
-		snapPath := *sb.SnapshotPath
 		if _, statErr := os.Stat(snapPath); statErr == nil {
 			r.clearDrift("paused:" + id)
 			continue

--- a/internal/vm/reconciler_test.go
+++ b/internal/vm/reconciler_test.go
@@ -117,7 +117,7 @@ func TestDirSize(t *testing.T) {
 // reclaim only UUIDs present in no source at all.
 func TestDiskKeepSet(t *testing.T) {
 	row := func(s db.SandboxStatus) db.ListSandboxesByHostRow {
-		return db.ListSandboxesByHostRow{Sandbox: db.Sandbox{Status: s}}
+		return db.ListSandboxesByHostRow{Status: s}
 	}
 	const (
 		recentID = "44444444-4444-4444-4444-444444444444" // recently destroyed → kept
@@ -278,7 +278,7 @@ func TestReclaimDiskOrphans_SkipsLiveSandbox(t *testing.T) {
 		onDisk[id] = sandboxDirInfo{paths: []string{p}}
 	}
 	dbSandboxes := map[string]db.ListSandboxesByHostRow{
-		uuidA: {Sandbox: db.Sandbox{Status: db.SandboxStatusPaused}}, // live → must not move
+		uuidA: {Status: db.SandboxStatusPaused}, // live → must not move
 	}
 
 	r := &Reconciler{
@@ -662,7 +662,7 @@ func TestReapDeadActiveVMs_StaleRunningRecordDoesNotVetoReap(t *testing.T) {
 	rows := func(id string) map[string]db.ListSandboxesByHostRow {
 		sbID := uuid.MustParse(id)
 		return map[string]db.ListSandboxesByHostRow{
-			id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+			id: {ID: sbID, Status: db.SandboxStatusActive},
 		}
 	}
 	noError := func(string) bool { return false }
@@ -718,7 +718,7 @@ func TestReapDeadActiveVMs_ExpiredContextStopsBeforeAnyWork(t *testing.T) {
 		if err := store.Put(VMRecord{ID: id, Status: StatusRunning}); err != nil {
 			t.Fatal(err)
 		}
-		rows[id] = db.ListSandboxesByHostRow{Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}}
+		rows[id] = db.ListSandboxesByHostRow{ID: sbID, Status: db.SandboxStatusActive}
 	}
 
 	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{}}
@@ -774,14 +774,18 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 		}
 		return r, id, flips
 	}
-	rows := func(id, snapPath string) map[string]db.ListSandboxesByHostRow {
+	// input builds a paused row plus the batched snapshot-path map that
+	// resolvePausedSnapshotPaths would supply in production (path is a
+	// missing file, so Drift 4 evaluates the miss).
+	input := func(t *testing.T, id string) (map[string]db.ListSandboxesByHostRow, map[uuid.UUID]string) {
+		t.Helper()
 		sbID := uuid.MustParse(id)
+		snapPath := filepath.Join(t.TempDir(), "gone.snap")
 		return map[string]db.ListSandboxesByHostRow{
-			id: {
-				Sandbox:      db.Sandbox{ID: sbID, Status: db.SandboxStatusPaused, SnapshotID: pgtype.UUID{Bytes: sbID, Valid: true}},
-				SnapshotPath: &snapPath,
-			},
-		}
+				id: {ID: sbID, Status: db.SandboxStatusPaused, SnapshotID: pgtype.UUID{Bytes: sbID, Valid: true}},
+			}, map[uuid.UUID]string{
+				sbID: snapPath,
+			}
 	}
 	stubStat := func(t *testing.T, present, missing bool) {
 		t.Helper()
@@ -793,7 +797,8 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 	t.Run("new generation written while waiting on the lock heals", func(t *testing.T) {
 		r, id, flips := newFixture(t)
 		stubStat(t, true, false) // the pause completed: artifact present at re-stat
-		r.failMissingSnapshots(context.Background(), zerolog.Nop(), rows(id, filepath.Join(t.TempDir(), "gone.snap")), time.Now())
+		dbRows, paths := input(t, id)
+		r.failMissingSnapshots(context.Background(), zerolog.Nop(), dbRows, paths, time.Now())
 		if len(*flips) != 0 {
 			t.Fatalf("a fresh pause generation must not be failed, got %v", *flips)
 		}
@@ -808,7 +813,8 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 	t.Run("inconclusive stat defers and keeps the marker", func(t *testing.T) {
 		r, id, flips := newFixture(t)
 		stubStat(t, false, false)
-		r.failMissingSnapshots(context.Background(), zerolog.Nop(), rows(id, filepath.Join(t.TempDir(), "gone.snap")), time.Now())
+		dbRows, paths := input(t, id)
+		r.failMissingSnapshots(context.Background(), zerolog.Nop(), dbRows, paths, time.Now())
 		if len(*flips) != 0 {
 			t.Fatalf("an inconclusive read must never fail a sandbox, got %v", *flips)
 		}
@@ -823,7 +829,8 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 	t.Run("proven absence flips the row", func(t *testing.T) {
 		r, id, flips := newFixture(t)
 		stubStat(t, false, true)
-		r.failMissingSnapshots(context.Background(), zerolog.Nop(), rows(id, filepath.Join(t.TempDir(), "gone.snap")), time.Now())
+		dbRows, paths := input(t, id)
+		r.failMissingSnapshots(context.Background(), zerolog.Nop(), dbRows, paths, time.Now())
 		if len(*flips) != 1 {
 			t.Fatalf("proven absence must flip exactly once, got %v", *flips)
 		}
@@ -834,7 +841,8 @@ func TestFailMissingSnapshots_LockWindow(t *testing.T) {
 		stubStat(t, false, true)
 		r.mgr.vmOpCh(id) <- struct{}{} // a pause/resume holds the lock
 		defer func() { <-r.mgr.vmOpCh(id) }()
-		r.failMissingSnapshots(context.Background(), zerolog.Nop(), rows(id, filepath.Join(t.TempDir(), "gone.snap")), time.Now())
+		dbRows, paths := input(t, id)
+		r.failMissingSnapshots(context.Background(), zerolog.Nop(), dbRows, paths, time.Now())
 		if len(*flips) != 0 {
 			t.Fatalf("a locked VM must defer, got %v", *flips)
 		}
@@ -964,7 +972,7 @@ func TestReapUnverifiedOrphans_CgroupOrphan_ModeAwareStopAndProof(t *testing.T) 
 
 	sbID := uuid.MustParse(id)
 	rows := map[string]db.ListSandboxesByHostRow{
-		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusPaused}},
+		id: {ID: sbID, Status: db.SandboxStatusPaused},
 	}
 	active := map[string]bool{id: true}
 	sup := map[string]Supervision{id: SupervisionCgroup}
@@ -1032,7 +1040,7 @@ func TestFailEmptyShells_CgroupShell_ModeAwareStopAndProof(t *testing.T) {
 
 	sbID := uuid.MustParse(id)
 	rows := map[string]db.ListSandboxesByHostRow{
-		id: {Sandbox: db.Sandbox{ID: sbID, Status: db.SandboxStatusActive}},
+		id: {ID: sbID, Status: db.SandboxStatusActive},
 	}
 	active := map[string]bool{id: true}
 	sup := map[string]Supervision{id: SupervisionCgroup}

--- a/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
+++ b/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
@@ -4,6 +4,12 @@
 -- join — so the pass stays cheap even on hosts with very large live-sandbox
 -- counts (where the previous full-row + LEFT JOIN scan dominated DB load).
 --
+-- On a high-churn sandbox table the scan is not literally zero-heap: an
+-- index-only scan still visits the heap for pages the visibility map does not
+-- yet mark all-visible, i.e. recently modified rows, until autovacuum catches
+-- up. It remains a large win — the steady-state bulk of rows is all-visible and
+-- served from the index alone — just not a guarantee of no heap access.
+--
 -- On a populated database this index must be pre-built CONCURRENTLY, by hand:
 -- the migration runner wraps every file in a transaction, where CONCURRENTLY
 -- cannot run, and a plain build blocks all sandbox writes for the duration of

--- a/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
+++ b/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
@@ -1,8 +1,50 @@
 -- The VMD reconciler lists every non-destroyed sandbox on its host every 30s
--- to detect drift, but only reads id/status/snapshot_id per row. This covering
+-- to detect drift, but reads only id/status/snapshot_id per row. This covering
 -- partial index lets that scan run index-only — no heap fetch, no snapshot
 -- join — so the pass stays cheap even on hosts with very large live-sandbox
 -- counts (where the previous full-row + LEFT JOIN scan dominated DB load).
+--
+-- On a populated database this index must be pre-built CONCURRENTLY, by hand:
+-- the migration runner wraps every file in a transaction, where CONCURRENTLY
+-- cannot run, and a plain build blocks all sandbox writes for the duration of
+-- the table scan. Run before merging:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_host_reconcile
+--     ON sandbox(host_id) INCLUDE (id, status, snapshot_id)
+--     WHERE destroyed_at IS NULL;
+--
+--   -- A failed concurrent build leaves an INVALID index that IF NOT EXISTS
+--   -- would silently keep. Verify, and on false DROP INDEX + retry:
+--   SELECT indisvalid FROM pg_index
+--   WHERE indexrelid = 'idx_sandbox_host_reconcile'::regclass;
+--
+-- Pre-built, the statement below is a no-op that records the schema; on a
+-- fresh or small database it builds instantly. The timeouts make a skipped
+-- pre-build fail the push loudly with a bounded stall instead of blocking
+-- sandbox writes for an unbounded build.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10s';
+
+-- IF NOT EXISTS matches by name only: an interrupted concurrent pre-build
+-- leaves an INVALID index that would be silently kept, recording this
+-- migration as applied while the reconciler scan still hits the heap. Fail the
+-- push instead; the fix is DROP INDEX + re-run the pre-build above.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_index
+    WHERE indexrelid = to_regclass('public.idx_sandbox_host_reconcile')
+      AND NOT indisvalid
+  ) THEN
+    RAISE EXCEPTION 'idx_sandbox_host_reconcile exists but is INVALID (interrupted concurrent build); DROP INDEX idx_sandbox_host_reconcile, re-run the concurrent pre-build, then retry this push';
+  END IF;
+END $$;
+
 CREATE INDEX IF NOT EXISTS idx_sandbox_host_reconcile
-ON sandbox (host_id) INCLUDE (id, status, snapshot_id)
-WHERE destroyed_at IS NULL;
+  ON sandbox(host_id) INCLUDE (id, status, snapshot_id)
+  WHERE destroyed_at IS NULL;
+
+COMMIT;

--- a/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
+++ b/supabase/migrations/20260816000001_sandbox_host_reconcile_covering_index.sql
@@ -1,0 +1,8 @@
+-- The VMD reconciler lists every non-destroyed sandbox on its host every 30s
+-- to detect drift, but only reads id/status/snapshot_id per row. This covering
+-- partial index lets that scan run index-only — no heap fetch, no snapshot
+-- join — so the pass stays cheap even on hosts with very large live-sandbox
+-- counts (where the previous full-row + LEFT JOIN scan dominated DB load).
+CREATE INDEX IF NOT EXISTS idx_sandbox_host_reconcile
+ON sandbox (host_id) INCLUDE (id, status, snapshot_id)
+WHERE destroyed_at IS NULL;


### PR DESCRIPTION
The reconciler lists every non-destroyed sandbox on its host every 30s to detect drift. That query (`ListSandboxesByHost`) returned full sandbox rows plus a `LEFT JOIN snapshot`, which becomes expensive on hosts with large live-sandbox counts and drives sustained background DB load regardless of traffic.

This slims the hot path:

- The list query now selects only `id`, `status`, `snapshot_id` — the only fields the drift checks read — with no join. A new covering partial index (`host_id` INCLUDE `(id, status, snapshot_id)` WHERE `destroyed_at IS NULL`) lets the scan run **index-only**: no heap fetch, no join.
- Snapshot paths are needed only by the paused-snapshot drift check, so they're fetched in **one batched PK lookup** over just the paused candidates (`GetSnapshotPathsByIDs`) instead of joined across the whole inventory every pass.

Reconciler behavior is unchanged — it still builds the complete host inventory and detects orphans / dead VMs / missing snapshots identically; only the query shape and where snapshot paths come from changed. Can't just `LIMIT` the list (the drift pass needs the full set), so the win is making the full scan cheap rather than truncating it.

Tests updated (`failMissingSnapshots` now takes the resolved path map); `internal/vm` + `internal/db` pass.