### PR TITLE
api: serve the default sandbox list sort from an index

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -110,8 +110,45 @@ WHERE base_path = $1 AND destroyed_at IS NULL;
 SELECT DISTINCT base_path FROM sandbox
 WHERE base_path IS NOT NULL AND destroyed_at IS NULL;
 
+-- Static created_at variants of ListSandboxesByTeamPaged. The plain ORDER BY
+-- lets the planner walk idx_sandbox_team_created_active (forward for DESC,
+-- backward for ASC) and stop at LIMIT, where the guarded-CASE ORDER BY in
+-- ListSandboxesByTeamPaged is opaque to it and forces a sort of the entire
+-- filtered set on every call. created_at is the default sort and the only one
+-- unpaginated SDK/MCP callers ever use, so these two cover the hot path;
+-- name/status sorts stay on the flexible query below. Filters and pagination
+-- are identical to the flexible query, including the NULL @row_limit "return
+-- everything" contract.
+
+-- name: ListSandboxesByTeamCreatedDesc :many
+SELECT * FROM sandbox
+WHERE team_id = @team_id
+  AND destroyed_at IS NULL
+  AND metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+ORDER BY created_at DESC
+LIMIT sqlc.narg('row_limit')::bigint
+OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
+
+-- name: ListSandboxesByTeamCreatedAsc :many
+SELECT * FROM sandbox
+WHERE team_id = @team_id
+  AND destroyed_at IS NULL
+  AND metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+  AND (sqlc.narg('name_search')::text IS NULL
+       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+ORDER BY created_at ASC
+LIMIT sqlc.narg('row_limit')::bigint
+OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
+
 -- name: ListSandboxesByTeamPaged :many
--- Paginated, sortable, filterable team sandbox list backing the console.
+-- Paginated, sortable, filterable team sandbox list backing the console. Only
+-- serves the non-default sorts (name/status); the default created_at sort is
+-- handled by the static ListSandboxesByTeamCreated{Desc,Asc} queries above,
+-- which the planner can satisfy from an index.
 --
 -- Filters (all optional, AND'd): metadata containment (@> — pass '{}'::jsonb
 -- to match everything), status equality, and a case-insensitive name

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1655,8 +1655,10 @@ func decodeMetadata(raw []byte) map[string]string {
 // Sandbox List + Get
 // ---------------------------------------------------------------------------
 
-// sandboxSortColumns are the columns ListSandboxes accepts for `?sort=`. Each
-// maps to a guarded ORDER BY term in ListSandboxesByTeamPaged.
+// sandboxSortColumns are the columns ListSandboxes accepts for `?sort=`.
+// created_at routes to the static ListSandboxesByTeamCreated{Desc,Asc}
+// queries; name and status map to guarded ORDER BY terms in
+// ListSandboxesByTeamPaged.
 var sandboxSortColumns = []string{"created_at", "name", "status"}
 
 // sandboxStatusFilterValues are the values ListSandboxes accepts for
@@ -1724,18 +1726,46 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 	nameSearch := searchTerm(c.Query("q"))
 
 	ctx := c.Request.Context()
-	sandboxes, err := h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
-		TeamID:     teamID,
-		Metadata:   metadataJSON,
-		Status:     statusFilter,
-		NameSearch: nameSearch,
-		SortBy:     pg.SortBy,
-		SortDir:    pg.SortDir,
-		RowOffset:  pg.Offset,
-		RowLimit:   pg.Limit,
-	})
+	// The default created_at sort is the hot path (and the only sort
+	// unpaginated SDK callers use), so it goes through the static-ORDER BY
+	// queries the planner can serve from idx_sandbox_team_created_active
+	// instead of sorting the whole filtered set. The rare console-only
+	// name/status sorts stay on the flexible CASE-based query.
+	var sandboxes []db.Sandbox
+	if pg.SortBy == "created_at" {
+		if pg.SortDir == "asc" {
+			sandboxes, err = h.DB.ListSandboxesByTeamCreatedAsc(ctx, db.ListSandboxesByTeamCreatedAscParams{
+				TeamID:     teamID,
+				Metadata:   metadataJSON,
+				Status:     statusFilter,
+				NameSearch: nameSearch,
+				RowOffset:  pg.Offset,
+				RowLimit:   pg.Limit,
+			})
+		} else {
+			sandboxes, err = h.DB.ListSandboxesByTeamCreatedDesc(ctx, db.ListSandboxesByTeamCreatedDescParams{
+				TeamID:     teamID,
+				Metadata:   metadataJSON,
+				Status:     statusFilter,
+				NameSearch: nameSearch,
+				RowOffset:  pg.Offset,
+				RowLimit:   pg.Limit,
+			})
+		}
+	} else {
+		sandboxes, err = h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
+			TeamID:     teamID,
+			Metadata:   metadataJSON,
+			Status:     statusFilter,
+			NameSearch: nameSearch,
+			SortBy:     pg.SortBy,
+			SortDir:    pg.SortDir,
+			RowOffset:  pg.Offset,
+			RowLimit:   pg.Limit,
+		})
+	}
 	if err != nil {
-		log.Error().Err(err).Msg("DB ListSandboxesByTeamPaged failed")
+		log.Error().Err(err).Msg("DB list sandboxes by team failed")
 		respondError(c, ErrInternal)
 		return
 	}

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1777,6 +1777,166 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 	return items, nil
 }
 
+const listSandboxesByTeamCreatedAsc = `-- name: ListSandboxesByTeamCreatedAsc :many
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
+WHERE team_id = $1
+  AND destroyed_at IS NULL
+  AND metadata @> $2
+  AND ($3::text IS NULL OR status::text = $3::text)
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+ORDER BY created_at ASC
+LIMIT $6::bigint
+OFFSET COALESCE($5::bigint, 0)
+`
+
+type ListSandboxesByTeamCreatedAscParams struct {
+	TeamID     uuid.UUID `json:"team_id"`
+	Metadata   []byte    `json:"metadata"`
+	Status     *string   `json:"status"`
+	NameSearch *string   `json:"name_search"`
+	RowOffset  *int64    `json:"row_offset"`
+	RowLimit   *int64    `json:"row_limit"`
+}
+
+func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSandboxesByTeamCreatedAscParams) ([]Sandbox, error) {
+	rows, err := q.db.Query(ctx, listSandboxesByTeamCreatedAsc,
+		arg.TeamID,
+		arg.Metadata,
+		arg.Status,
+		arg.NameSearch,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Sandbox{}
+	for rows.Next() {
+		var i Sandbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.Name,
+			&i.Status,
+			&i.VcpuCount,
+			&i.MemoryMib,
+			&i.HostID,
+			&i.IpAddress,
+			&i.Pid,
+			&i.SnapshotID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DestroyedAt,
+			&i.NetworkConfig,
+			&i.TimeoutSeconds,
+			&i.Metadata,
+			&i.TemplateID,
+			&i.SnapshotPath,
+			&i.MemPath,
+			&i.BasePath,
+			&i.DeltaPath,
+			&i.DiskMib,
+			&i.AutoDeleteSeconds,
+			&i.AutoDeleteAt,
+			&i.FailedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSandboxesByTeamCreatedDesc = `-- name: ListSandboxesByTeamCreatedDesc :many
+
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
+WHERE team_id = $1
+  AND destroyed_at IS NULL
+  AND metadata @> $2
+  AND ($3::text IS NULL OR status::text = $3::text)
+  AND ($4::text IS NULL
+       OR name ILIKE '%' || $4::text || '%')
+ORDER BY created_at DESC
+LIMIT $6::bigint
+OFFSET COALESCE($5::bigint, 0)
+`
+
+type ListSandboxesByTeamCreatedDescParams struct {
+	TeamID     uuid.UUID `json:"team_id"`
+	Metadata   []byte    `json:"metadata"`
+	Status     *string   `json:"status"`
+	NameSearch *string   `json:"name_search"`
+	RowOffset  *int64    `json:"row_offset"`
+	RowLimit   *int64    `json:"row_limit"`
+}
+
+// Static created_at variants of ListSandboxesByTeamPaged. The plain ORDER BY
+// lets the planner walk idx_sandbox_team_created_active (forward for DESC,
+// backward for ASC) and stop at LIMIT, where the guarded-CASE ORDER BY in
+// ListSandboxesByTeamPaged is opaque to it and forces a sort of the entire
+// filtered set on every call. created_at is the default sort and the only one
+// unpaginated SDK/MCP callers ever use, so these two cover the hot path;
+// name/status sorts stay on the flexible query below. Filters and pagination
+// are identical to the flexible query, including the NULL @row_limit "return
+// everything" contract.
+func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSandboxesByTeamCreatedDescParams) ([]Sandbox, error) {
+	rows, err := q.db.Query(ctx, listSandboxesByTeamCreatedDesc,
+		arg.TeamID,
+		arg.Metadata,
+		arg.Status,
+		arg.NameSearch,
+		arg.RowOffset,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Sandbox{}
+	for rows.Next() {
+		var i Sandbox
+		if err := rows.Scan(
+			&i.ID,
+			&i.TeamID,
+			&i.Name,
+			&i.Status,
+			&i.VcpuCount,
+			&i.MemoryMib,
+			&i.HostID,
+			&i.IpAddress,
+			&i.Pid,
+			&i.SnapshotID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DestroyedAt,
+			&i.NetworkConfig,
+			&i.TimeoutSeconds,
+			&i.Metadata,
+			&i.TemplateID,
+			&i.SnapshotPath,
+			&i.MemPath,
+			&i.BasePath,
+			&i.DeltaPath,
+			&i.DiskMib,
+			&i.AutoDeleteSeconds,
+			&i.AutoDeleteAt,
+			&i.FailedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
 SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
 WHERE team_id = $1
@@ -1807,7 +1967,10 @@ type ListSandboxesByTeamPagedParams struct {
 	RowLimit   *int64    `json:"row_limit"`
 }
 
-// Paginated, sortable, filterable team sandbox list backing the console.
+// Paginated, sortable, filterable team sandbox list backing the console. Only
+// serves the non-default sorts (name/status); the default created_at sort is
+// handled by the static ListSandboxesByTeamCreated{Desc,Asc} queries above,
+// which the planner can satisfy from an index.
 //
 // Filters (all optional, AND'd): metadata containment (@> — pass '{}'::jsonb
 // to match everything), status equality, and a case-insensitive name

--- a/supabase/migrations/20260817000001_sandbox_team_created_at_index.sql
+++ b/supabase/migrations/20260817000001_sandbox_team_created_at_index.sql
@@ -1,0 +1,67 @@
+-- The team sandbox list defaults to created_at ordering, and its static
+-- ORDER BY queries (ListSandboxesByTeamCreated{Desc,Asc}) can only skip the
+-- sort if the planner has a matching index to walk. Without one, every list
+-- call sorts the entire live set for the team — for large teams that spills
+-- past work_mem to disk on the hot path. Partial index: only live rows
+-- (destroyed_at IS NULL) are ever listed. DESC on created_at matches the
+-- default sort direction; the planner walks it backward for ASC.
+--
+-- On a populated database this index must be pre-built CONCURRENTLY, by hand:
+-- the migration runner wraps every file in a transaction, where CONCURRENTLY
+-- cannot run, and a plain build blocks all sandbox writes for the duration of
+-- the table scan. Run before merging:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sandbox_team_created_active
+--     ON sandbox(team_id, created_at DESC)
+--     WHERE destroyed_at IS NULL;
+--
+--   -- A failed concurrent build leaves an INVALID index that IF NOT EXISTS
+--   -- would silently keep. Verify, and on false DROP INDEX + retry:
+--   SELECT indisvalid FROM pg_index
+--   WHERE indexrelid = 'idx_sandbox_team_created_active'::regclass;
+--
+-- Pre-built, the statement below is a no-op that records the schema; on a
+-- fresh or small database it builds instantly. The timeouts make a skipped
+-- pre-build fail the push loudly with a bounded stall instead of blocking
+-- sandbox writes for an unbounded build.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10s';
+
+-- IF NOT EXISTS matches by name only: an interrupted concurrent pre-build
+-- leaves an INVALID index that would be silently kept, recording this
+-- migration as applied while the list queries still sort the whole set. Fail
+-- the push instead; the fix is DROP INDEX + re-run the concurrent pre-build
+-- above. A valid index whose definition differs from the expected one (a
+-- same-named index built by hand with the wrong columns or predicate) is
+-- warned about rather than failed, so it is loud in the push log without
+-- bricking the deploy.
+DO $$
+DECLARE
+  actual_def text;
+  expected_def text := 'CREATE INDEX idx_sandbox_team_created_active ON public.sandbox USING btree (team_id, created_at DESC) WHERE (destroyed_at IS NULL)';
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_index
+    WHERE indexrelid = to_regclass('public.idx_sandbox_team_created_active')
+      AND NOT indisvalid
+  ) THEN
+    RAISE EXCEPTION 'idx_sandbox_team_created_active exists but is INVALID (interrupted concurrent build); DROP INDEX idx_sandbox_team_created_active, re-run the concurrent pre-build, then retry this push';
+  END IF;
+
+  SELECT pg_get_indexdef(oid) INTO actual_def
+  FROM pg_class
+  WHERE oid = to_regclass('public.idx_sandbox_team_created_active');
+
+  IF actual_def IS NOT NULL AND actual_def <> expected_def THEN
+    RAISE WARNING 'idx_sandbox_team_created_active exists with an unexpected definition; got %, expected %', actual_def, expected_def;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_sandbox_team_created_active
+  ON sandbox(team_id, created_at DESC)
+  WHERE destroyed_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Every time anyone lists their sandboxes, the database re-sorts the entire list from scratch — for the biggest team that means grinding through ~80K rows and writing ~68MB of scratch files to disk on every single call, thousands of times a day. This adds a pre-sorted index so the database just reads the list in order: same results, ~200x faster on the paged path, zero disk churn.

GET /sandboxes sorts via a stack of guarded CASE ORDER BY terms, which the planner can never satisfy from an index — every call sorts the entire filtered set. For a team with ~80K live sandboxes that spills ~68MB to temp disk per call (external merge sort, measured on prod) and is the query behind the bulk of the database's cumulative temp-file volume.

- Adds static ORDER BY created_at DESC/ASC variants of the paged list query (identical filters and pagination, including the NULL-limit "return everything" compat contract) and routes the default sort to them; rare console-only name/status sorts keep the flexible CASE query.
- Adds partial index (team_id, created_at DESC) WHERE destroyed_at IS NULL, in the house guarded-migration pattern (manual CONCURRENTLY pre-build on populated DBs, INVALID-index check, lock/statement timeouts), plus a definition check that warns if a same-named index exists with the wrong shape.

Measured on prod (read-only), against the live 81K-row team:
- today's default path: external merge sort, 27MB+20MB+20MB temp disk across 3 workers, 198ms warm (p50 under load was ~1.4s, max 6.3s)
- same table with an exactly-matching partial composite index (demonstrated via the existing (team_id, status) index): LIMIT 100 → 1.15ms, no Sort node; full unpaginated list → 89ms, zero temp I/O — the planner picks the ordered index scan even for the no-LIMIT path.

Not addressed here (deliberate): the unpaginated path still returns every live row (compat contract), and a selective metadata filter may still choose the GIN index + sort. Acceptance criterion is eliminating the observed default-path spill.

Testing: sqlc regenerate idempotent; GOOS=linux build; internal/api + internal/db tests pass. Index pre-build must run on staging + both prod cells before merge (runbook in the migration header).