### PR TITLE
controlplane: bound db pool lifecycle and cap background pool sizes

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -148,7 +148,10 @@ func run() error {
 	poolCfg.MaxConnLifetimeJitter = 5 * time.Minute
 	poolCfg.MaxConnIdleTime = 5 * time.Minute
 	poolCfg.HealthCheckPeriod = 30 * time.Second
-	poolCfg.MinIdleConns = 2
+	// Clamped to the cap: a DB_MAX_CONNS below 2 is a valid override, and
+	// pgxpool rejects (rather than clamps) a minimum above the maximum,
+	// which would fail startup instead of running with a smaller pool.
+	poolCfg.MinIdleConns = min(2, poolCfg.MaxConns)
 	poolCfg.ConnConfig.ConnectTimeout = 5 * time.Second
 	dbPool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -137,6 +137,19 @@ func run() error {
 			poolCfg.MaxConns = int32(n)
 		}
 	}
+	// Lifetime + jitter bound how long any one connection can persist and
+	// stagger recycling so a pool's worth of connections never expires (and
+	// redials) in the same instant. ConnectTimeout bounds the dial itself, so
+	// re-establishment after churn fails fast instead of stacking behind a
+	// slow pooler. All of these act on idle or released connections only: a
+	// connection a caller holds and never releases is out of the pool's
+	// reach, which is what the saturation log below exists to surface.
+	poolCfg.MaxConnLifetime = 30 * time.Minute
+	poolCfg.MaxConnLifetimeJitter = 5 * time.Minute
+	poolCfg.MaxConnIdleTime = 5 * time.Minute
+	poolCfg.HealthCheckPeriod = 30 * time.Second
+	poolCfg.MinIdleConns = 2
+	poolCfg.ConnConfig.ConnectTimeout = 5 * time.Second
 	dbPool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return fmt.Errorf("connect to database: %w", err)
@@ -146,6 +159,10 @@ func run() error {
 		return fmt.Errorf("ping database: %w", err)
 	}
 	log.Info().Msg("connected to database")
+	// Deliberately outside the OTel gate: sustained pool saturation must
+	// surface through plain logs even in cells where metrics export is
+	// disabled or the pipeline is down.
+	telemetry.StartDBPoolSaturationLog(ctx, dbPool, log.Logger, 15*time.Second)
 	if cfg.OTelMetricsEnabled {
 		telemetry.StartDBPoolSampler(ctx, dbPool, recorder, cfg.OTelExportInterval)
 		telemetry.StartHostCapacitySampler(ctx, dbPool, recorder, cfg.OTelExportInterval)

--- a/cmd/secretsproxy/main.go
+++ b/cmd/secretsproxy/main.go
@@ -468,6 +468,10 @@ func buildAuditSink(ctx context.Context, cfg *config) (secretsproxy.AuditSink, f
 	// construction), so a small cap is enough. A ceiling, not a floor: an
 	// explicitly lower pool_max_conns in the URL stays in effect.
 	poolCfg.MaxConns = min(poolCfg.MaxConns, 8)
+	// URL-configured minima above the cap would make the config
+	// invalid and fail startup; lower them with it.
+	poolCfg.MinConns = min(poolCfg.MinConns, poolCfg.MaxConns)
+	poolCfg.MinIdleConns = min(poolCfg.MinIdleConns, poolCfg.MaxConns)
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect to audit DB: %w", err)

--- a/cmd/secretsproxy/main.go
+++ b/cmd/secretsproxy/main.go
@@ -465,8 +465,9 @@ func buildAuditSink(ctx context.Context, cfg *config) (secretsproxy.AuditSink, f
 	// The pgxpool default is max(4, NumCPU), which scales with host cores and
 	// silently consumes the cell pooler's client-connection budget on large
 	// hosts. This pool only serves batched audit flushes (low concurrency by
-	// construction), so a small fixed cap is enough.
-	poolCfg.MaxConns = 8
+	// construction), so a small cap is enough. A ceiling, not a floor: an
+	// explicitly lower pool_max_conns in the URL stays in effect.
+	poolCfg.MaxConns = min(poolCfg.MaxConns, 8)
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect to audit DB: %w", err)

--- a/cmd/secretsproxy/main.go
+++ b/cmd/secretsproxy/main.go
@@ -458,7 +458,16 @@ func buildAuditSink(ctx context.Context, cfg *config) (secretsproxy.AuditSink, f
 		}
 		return nil, nil, fmt.Errorf("DATABASE_URL is required; set SECRETSPROXY_AUDIT_DISABLED=true to run without audit")
 	}
-	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse audit DB URL: %w", err)
+	}
+	// The pgxpool default is max(4, NumCPU), which scales with host cores and
+	// silently consumes the cell pooler's client-connection budget on large
+	// hosts. This pool only serves batched audit flushes (low concurrency by
+	// construction), so a small fixed cap is enough.
+	poolCfg.MaxConns = 8
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("connect to audit DB: %w", err)
 	}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1163,8 +1163,9 @@ func main() {
 		// and silently consumes the cell pooler's client-connection budget on
 		// large hosts. This pool serves serial reconciler passes and the
 		// batched flow sink (low concurrency by construction), so a small
-		// fixed cap is enough.
-		dbCfg.MaxConns = 8
+		// cap is enough. A ceiling, not a floor: an explicitly lower
+		// pool_max_conns in the URL stays in effect.
+		dbCfg.MaxConns = min(dbCfg.MaxConns, 8)
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1166,6 +1166,10 @@ func main() {
 		// cap is enough. A ceiling, not a floor: an explicitly lower
 		// pool_max_conns in the URL stays in effect.
 		dbCfg.MaxConns = min(dbCfg.MaxConns, 8)
+		// URL-configured minima above the cap would make the config
+		// invalid and fail startup; lower them with it.
+		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
+		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1155,7 +1155,17 @@ func main() {
 	// BoltDB ↔ systemd comparison only.
 	var reconcilerDB *dbq.Queries
 	if cfg.DatabaseURL != "" {
-		dbPool, dbErr := pgxpool.New(ctx, cfg.DatabaseURL)
+		dbCfg, dbErr := pgxpool.ParseConfig(cfg.DatabaseURL)
+		if dbErr != nil {
+			log.Fatal().Err(dbErr).Msg("failed to parse database URL for reconciler")
+		}
+		// The pgxpool default is max(4, NumCPU), which scales with host cores
+		// and silently consumes the cell pooler's client-connection budget on
+		// large hosts. This pool serves serial reconciler passes and the
+		// batched flow sink (low concurrency by construction), so a small
+		// fixed cap is enough.
+		dbCfg.MaxConns = 8
+		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")
 		}

--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -163,9 +163,16 @@ module "api" {
 
   cpu_limit    = "2"
   memory_limit = "1Gi"
-  # max_instances * DB_MAX_CONNS must stay under the pooler's client-connection
-  # limit; raising either means re-checking that product. Declared rather than
-  # left to drift: the module's ignore_changes is ineffective for the v2 resource.
+  # Pooler client budget is 1,000 (XL tier), and the binding case is a
+  # deploy under full load: max_instances applies per revision and Cloud Run
+  # can overlap the old and new revisions completely, so the ceiling is
+  # 60 instances x DB_MAX_CONNS. At 15 that is 900, plus explicitly capped
+  # host services (vmd 8, secretsproxy 8) and ops clients ~= 940 worst case.
+  # Any higher per-instance cap breaks that overlap math; burst headroom
+  # comes from fast queries and pool lifecycle bounds, not a larger cap.
+  # MaxConns is a cap, not a floor: idle instances hold ~MinIdleConns each,
+  # so realized usage sits far below the ceiling. Declared rather than left to drift: the
+  # module's ignore_changes is ineffective for the v2 resource.
   min_instances     = 10
   max_instances     = 30
   startup_cpu_boost = true

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -219,6 +219,12 @@ module "api" {
     OTEL_EXPORT_INTERVAL        = "15s"
     OTEL_METRICS_ENABLED        = "true"
     OTEL_SERVICE_NAME           = "sandbox-controlplane"
+
+    # The serving host's identity for VMD-call metric labels, following
+    # active_sandbox_host like the address above. Without it the wrapper
+    # falls back to labeling every series "default", which host-grouped
+    # dashboards cannot attribute and a standby promotion would not update.
+    DEFAULT_HOST_ID = local.metrics_host_id
   }
 
   secrets = {

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -120,6 +120,17 @@ module "network" {
       }]
       description = "Allow API-to-VMD gRPC traffic"
     }
+    allow_otel_ingress = {
+      name          = "superserve-usw2-allow-cr-to-host-otel"
+      direction     = "INGRESS"
+      source_ranges = [var.connector_subnet_cidr]
+      target_tags   = ["vmd-usw2"]
+      allow = [{
+        protocol = "tcp"
+        ports    = ["4317", "4318"]
+      }]
+      description = "Allow Cloud Run connector traffic to host-local OTLP endpoints."
+    }
   }
 
   labels = local.common_labels
@@ -170,8 +181,15 @@ module "api" {
 
   cpu_limit    = "2"
   memory_limit = "1Gi"
-  # max_instances * DB_MAX_CONNS must stay under this cell's pooler
-  # client-connection limit; raising either means re-checking that product.
+  # Pooler client budget is 1,000 (XL tier), and the binding case is a
+  # deploy under full load: max_instances applies per revision and Cloud Run
+  # can overlap the old and new revisions completely, so the ceiling is
+  # 60 instances x DB_MAX_CONNS. At 15 that is 900, plus explicitly capped
+  # host services (vmd 8, secretsproxy 8) and ops clients ~= 940 worst case.
+  # Any higher per-instance cap breaks that overlap math; burst headroom
+  # comes from fast queries and pool lifecycle bounds, not a larger cap.
+  # MaxConns is a cap, not a floor: idle instances hold ~MinIdleConns each,
+  # so realized usage sits far below the ceiling.
   min_instances     = 10
   max_instances     = 30
   startup_cpu_boost = true
@@ -187,6 +205,20 @@ module "api" {
     DB_MAX_CONNS           = "15"
     VMD_GRPC_ADDRESS       = format("%s:50051", local.active_vmd_ip)
     KMS_KEY_RESOURCE       = "projects/rayai-prod/locations/us-central1/keyRings/superserve/cryptoKeys/credentials-kek"
+
+    # Control-plane OTLP metrics export, matching us-east4. The host-local
+    # superserve-otel-collector receives OTLP on :4318 and forwards to Google
+    # Managed Prometheus; the usw2 firewall admits the Cloud Run sender range
+    # to the host on 4317/4318 (allow_otel_ingress). The endpoint follows
+    # active_vmd_ip, but the collector is installed by the deploy workflow
+    # (which targets the active host's labels): a standby promotion must
+    # re-run the otel deploy or metrics export silently drops until it does.
+    # Export failure is non-fatal to the control plane.
+    OTEL_ENVIRONMENT            = local.environment
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://${local.active_vmd_ip}:4318"
+    OTEL_EXPORT_INTERVAL        = "15s"
+    OTEL_METRICS_ENABLED        = "true"
+    OTEL_SERVICE_NAME           = "sandbox-controlplane"
   }
 
   secrets = {

--- a/internal/telemetry/dbpool.go
+++ b/internal/telemetry/dbpool.go
@@ -83,8 +83,10 @@ const saturationStreakThreshold = 4
 // ambiguity with memory: zero-idle samples hold the episode open (and count
 // toward the threshold), cancellation evidence at ANY point in the episode
 // arms it, and it fires only when armed. Legit full utilization never arms;
-// a real wedge always does, because every caller here carries a deadline and
-// its cancellation is evidence. Fires once per episode; a sample with idle
+// a wedge touched by request traffic always does, because request-path
+// callers carry deadlines whose cancellations are the evidence (see
+// StartDBPoolSaturationLog for the accepted boundaries beyond that).
+// Fires once per episode; a sample with idle
 // connections ends the episode and re-arms. Pure state machine so the
 // decision is testable without a live pool.
 type saturationDetector struct {
@@ -123,9 +125,13 @@ func (d *saturationDetector) observe(zeroIdle, waited bool) bool {
 // EmptyAcquireCount also counts routine connection construction during
 // scale-up and would page on a cold burst doing legitimate work. Two
 // boundaries are accepted and deliberate: a caller with no deadline blocked
-// forever produces no cancel (every caller here carries one), and a fully
-// unreachable database fails dials with errors counted by neither counter,
-// but that mode is already loud in per-request error logs. One residual
+// forever produces no cancel on its own — request-path callers all carry
+// deadlines and share the pool, so any wedge with request traffic in the
+// episode still arms this, but background workers acquiring under the
+// process root context (the billing services) could starve silently in a
+// window with no request traffic at all. And a fully unreachable database
+// fails dials with errors counted by neither counter, but that mode is
+// already loud in per-request error logs. One residual
 // ambiguity is also accepted: pgxpool counts an Acquire under an
 // already-dead context as canceled without proving it waited, and Stat()
 // exposes no blocked-waiter gauge to do better — a full minute of zero idle

--- a/internal/telemetry/dbpool.go
+++ b/internal/telemetry/dbpool.go
@@ -125,9 +125,13 @@ func (d *saturationDetector) observe(zeroIdle, waited bool) bool {
 // boundaries are accepted and deliberate: a caller with no deadline blocked
 // forever produces no cancel (every caller here carries one), and a fully
 // unreachable database fails dials with errors counted by neither counter,
-// but that mode is already loud in per-request error logs. This log exists
-// for the quiet wedge: requests queuing then timing out while the database
-// looks healthy. Unlike StartDBPoolSampler it is not gated on metrics
+// but that mode is already loud in per-request error logs. One residual
+// ambiguity is also accepted: pgxpool counts an Acquire under an
+// already-dead context as canceled without proving it waited, and Stat()
+// exposes no blocked-waiter gauge to do better — a full minute of zero idle
+// plus a canceled acquire is judged worth an error either way. This log
+// exists for the quiet wedge: requests queuing then timing out while the
+// database looks healthy. Unlike StartDBPoolSampler it is not gated on metrics
 // export.
 func StartDBPoolSaturationLog(ctx context.Context, pool *pgxpool.Pool, log zerolog.Logger, interval time.Duration) {
 	if pool == nil {

--- a/internal/telemetry/dbpool.go
+++ b/internal/telemetry/dbpool.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
 )
 
 // StartDBPoolSampler periodically records pgxpool stats until ctx is canceled.
@@ -60,6 +61,115 @@ func StartDBPoolSampler(ctx context.Context, pool *pgxpool.Pool, recorder Record
 				return
 			case <-ticker.C:
 				sample()
+			}
+		}
+	}()
+}
+
+// saturationStreakThreshold is how many consecutive zero-idle samples must
+// accumulate before an evidenced episode is logged. One or two are normal
+// under burst; a sustained streak means the pool cannot serve demand,
+// whether because every connection is held (possibly by a caller that never
+// releases, which lifecycle settings cannot recover) or because replacement
+// connections are failing to establish and the pool is running below its
+// cap.
+const saturationStreakThreshold = 4
+
+// saturationDetector decides when a saturation episode is worth logging.
+// Pool statistics cannot prove a blocked acquirer from utilization alone: a
+// pool with zero idle connections may be serving legitimate long-running
+// work with nobody queued, while a genuinely blocked acquirer advances no
+// counter until it completes or cancels. The detector resolves that
+// ambiguity with memory: zero-idle samples hold the episode open (and count
+// toward the threshold), cancellation evidence at ANY point in the episode
+// arms it, and it fires only when armed. Legit full utilization never arms;
+// a real wedge always does, because every caller here carries a deadline and
+// its cancellation is evidence. Fires once per episode; a sample with idle
+// connections ends the episode and re-arms. Pure state machine so the
+// decision is testable without a live pool.
+type saturationDetector struct {
+	streak   int
+	evidence bool
+	fired    bool
+}
+
+// observe records one sample: zeroIdle is whether the pool had no idle
+// connections at the sample instant; waited is whether any acquirer waited
+// or canceled since the previous sample. Reports whether to log now.
+func (d *saturationDetector) observe(zeroIdle, waited bool) bool {
+	if !zeroIdle {
+		d.streak = 0
+		d.evidence = false
+		d.fired = false
+		return false
+	}
+	d.streak++
+	if waited {
+		d.evidence = true
+	}
+	if d.streak >= saturationStreakThreshold && d.evidence && !d.fired {
+		d.fired = true
+		return true
+	}
+	return false
+}
+
+// StartDBPoolSaturationLog watches pool health until ctx is canceled and logs
+// at error level when the pool has had zero idle connections for
+// saturationStreakThreshold consecutive samples with a canceled acquire
+// somewhere in the episode (see saturationDetector for why both are
+// required). Cancellation is deliberately the only evidence: a caller
+// abandoning its wait at zero idle is unambiguous distress, where
+// EmptyAcquireCount also counts routine connection construction during
+// scale-up and would page on a cold burst doing legitimate work. Two
+// boundaries are accepted and deliberate: a caller with no deadline blocked
+// forever produces no cancel (every caller here carries one), and a fully
+// unreachable database fails dials with errors counted by neither counter,
+// but that mode is already loud in per-request error logs. This log exists
+// for the quiet wedge: requests queuing then timing out while the database
+// looks healthy. Unlike StartDBPoolSampler it is not gated on metrics
+// export.
+func StartDBPoolSaturationLog(ctx context.Context, pool *pgxpool.Pool, log zerolog.Logger, interval time.Duration) {
+	if pool == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+
+	go func() {
+		var det saturationDetector
+		// Seed so waits accumulated before this watcher started (startup
+		// churn) do not count toward the first sample's deltas.
+		seed := pool.Stat()
+		prevEmptyAcquire := seed.EmptyAcquireCount()
+		prevCanceledAcquire := seed.CanceledAcquireCount()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				stat := pool.Stat()
+				emptyAcquire := stat.EmptyAcquireCount()
+				canceledAcquire := stat.CanceledAcquireCount()
+				emptyDelta := emptyAcquire - prevEmptyAcquire
+				canceledDelta := canceledAcquire - prevCanceledAcquire
+				prevEmptyAcquire = emptyAcquire
+				prevCanceledAcquire = canceledAcquire
+				if det.observe(stat.IdleConns() == 0, canceledDelta > 0) {
+					log.Error().
+						Int64("empty_acquire_delta", emptyDelta).
+						Int64("canceled_acquire_delta", canceledDelta).
+						Int32("acquired_conns", stat.AcquiredConns()).
+						Int32("idle_conns", stat.IdleConns()).
+						Int32("total_conns", stat.TotalConns()).
+						Int32("max_conns", stat.MaxConns()).
+						Dur("sample_interval", interval).
+						Int("consecutive_samples", saturationStreakThreshold).
+						Msg("db pool acquire waits sustained; pool exhausted or connections failing to establish")
+				}
 			}
 		}
 	}()

--- a/internal/telemetry/dbpool_test.go
+++ b/internal/telemetry/dbpool_test.go
@@ -1,0 +1,73 @@
+package telemetry
+
+import "testing"
+
+func TestSaturationDetector(t *testing.T) {
+	type sample struct {
+		zeroIdle bool
+		waited   bool
+	}
+	// shorthand: h = zero-idle hold sample without wait evidence,
+	// w = zero-idle sample with wait/cancel evidence, i = idle present.
+	h := sample{zeroIdle: true}
+	w := sample{zeroIdle: true, waited: true}
+	i := sample{}
+
+	tests := []struct {
+		name    string
+		samples []sample
+		want    []bool
+	}{
+		{
+			name:    "fires on the threshold sample when every sample carries evidence",
+			samples: []sample{w, w, w, w},
+			want:    []bool{false, false, false, true},
+		},
+		{
+			name:    "quiet zero-idle samples hold the streak; one evidence sample arms it",
+			samples: []sample{h, h, h, w},
+			want:    []bool{false, false, false, true},
+		},
+		{
+			name:    "evidence early in the episode still counts at threshold",
+			samples: []sample{w, h, h, h},
+			want:    []bool{false, false, false, true},
+		},
+		{
+			name:    "full utilization without any wait evidence never fires",
+			samples: []sample{h, h, h, h, h, h},
+			want:    []bool{false, false, false, false, false, false},
+		},
+		{
+			name:    "does not refire while the episode continues",
+			samples: []sample{w, w, w, w, w, w},
+			want:    []bool{false, false, false, true, false, false},
+		},
+		{
+			name:    "idle sample resets streak and evidence",
+			samples: []sample{w, w, i, w, w, w, w},
+			want:    []bool{false, false, false, false, false, false, true},
+		},
+		{
+			name:    "re-arms after the episode ends and fires on the next one",
+			samples: []sample{w, w, w, w, i, w, w, w, w},
+			want:    []bool{false, false, false, true, false, false, false, false, true},
+		},
+		{
+			name:    "wait evidence with idle connections present does not build a streak",
+			samples: []sample{i, i, i, i},
+			want:    []bool{false, false, false, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var det saturationDetector
+			for n, smp := range tt.samples {
+				if got := det.observe(smp.zeroIdle, smp.waited); got != tt.want[n] {
+					t.Errorf("sample %d (zeroIdle=%v waited=%v): observe() = %v, want %v", n, smp.zeroIdle, smp.waited, got, tt.want[n])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a traffic spike hit the west API, its database connection pools jammed and stayed jammed for over half an hour after the spike ended — and nobody could see it, because the west service exported no pool health data at all. This bounds every pool so bad connections get recycled instead of lingering, turns on the missing telemetry, and adds a plain-log alarm that names a wedged pool within a minute instead of after 40 minutes of cross-referencing dashboards.

- Control-plane pool: explicit lifecycle bounds (30m lifetime + 5m jitter, 5m idle, 30s health checks, 2 warm conns, 5s dial timeout). These act on idle/released connections; a held connection is out of the pool's reach, which is what the saturation log exists to surface.
- New sustained-saturation error log (not gated on metrics export): fires after 4 consecutive zero-idle samples with a canceled acquire in the episode. Cancellation is deliberately the only evidence — callers abandoning waits is unambiguous distress, where empty-acquire counts also cover routine scale-up construction and would page on cold bursts. Accepted boundaries are documented in-line (no-deadline callers don't exist here; a fully unreachable DB is already loud in per-request error logs).
- vmd and secretsproxy pools get explicit MaxConns=8: the pgxpool default is max(4, NumCPU), i.e. 192 each on the 192-core metal host, silently consuming the cell pooler's client budget.
- DB_MAX_CONNS stays 15 — deliberately. Raising it (25, then 20) was evaluated and rejected: max_instances applies per revision and a deploy under full load can overlap old+new revisions completely, so the binding ceiling is 60 x DB_MAX_CONNS against the XL pooler's 1,000 clients. 15 -> 900 + capped host services ~= 940 worst case; any raise breaks deploys-under-load. The terraform guardrail comment now carries this overlap math. Burst headroom comes from fast queries and the lifecycle bounds, not a larger cap.
- West gets the OTel metrics env + firewall rule that east already had — the west service was exporting no db_pool_* metrics, which is why the pool's state during the incident is unknowable. Noted in-line: a standby promotion must re-run the otel deploy or export silently drops (non-fatal).

Testing: unit tests for the saturation detector state machine (8 cases incl. hold/arm/re-arm semantics); gofmt/vet; GOOS=linux build of all packages; internal/telemetry, internal/api, internal/db tests; terraform fmt. cpu_idle and Cloud Run concurrency deliberately untouched.