### PR TITLE
fix: Enable control-plane OTLP metrics in production us-west2

### DIFF
--- a/.github/workflows/deploy-otel-collector.yml
+++ b/.github/workflows/deploy-otel-collector.yml
@@ -107,7 +107,11 @@ jobs:
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: us-west2
-          VMD_FILTER: labels.component=vmd AND labels.environment=production AND labels.region=us-west2
+          # sandbox_role remains vmd on both the active host and the cold
+          # standby, while component is intentionally moved during promotion.
+          # Provisioning both running hosts keeps the collector ready before
+          # active_sandbox_host routes control-plane OTLP traffic to standby.
+          VMD_FILTER: labels.sandbox_role=vmd AND labels.environment=production AND labels.region=us-west2
           OTEL_COLLECTOR_PROJECT: ${{ vars.GCP_PROJECT }}
         run: |
           python3 .github/workflows/scripts/deploy-otel-collector.py

--- a/.github/workflows/terraform-plans.yml
+++ b/.github/workflows/terraform-plans.yml
@@ -147,6 +147,11 @@ jobs:
           } > "$summary_file"
           exit "$plan_status"
 
+      - name: Verify west promotion and OTLP ingress
+        if: env.HAS_GCP_AUTH == 'true' && matrix.name == 'production-us-west2'
+        shell: bash
+        run: bash "${GITHUB_WORKSPACE}/scripts/terraform-plan-west.sh"
+
       - name: Upload Terraform plan summary
         if: always()
         uses: actions/upload-artifact@v4

--- a/infra/envs/production/us-west2/terraform.tfvars
+++ b/infra/envs/production/us-west2/terraform.tfvars
@@ -15,3 +15,4 @@ internal_api_token_secret_name        = "internal-api-token"
 sandbox_access_token_seed_secret_name = "sandbox-access-token-seed"
 secrets_signing_key_secret_name       = "secretsproxy-signing-key"
 system_team_id_secret_name            = "system-team-id-production"
+notification_channel_ids              = ["projects/rayai-prod/notificationChannels/7690949645937454026"]

--- a/scripts/terraform-plan-west.sh
+++ b/scripts/terraform-plan-west.sh
@@ -16,7 +16,7 @@ verify_plan() {
 
   terraform show -json "${plan_file}" | jq -e --arg host_address "${host_address}" '
   def resources: .. | objects | select(has("address") and has("values"));
-  ([resources | select(.address == "module.api.google_cloud_run_v2_service.this")][0].values.template.containers[0].env
+  ([resources | select(.address == "module.api.google_cloud_run_v2_service.this")][0].values.template[0].containers[0].env
     | map({key: .name, value: .value}) | from_entries) as $env
   | ([resources | select(.address == $host_address)][0].values.network_interface[0].network_ip) as $host_ip
   | ([resources | select(.address == $host_address)][0].values.tags) as $host_tags

--- a/scripts/terraform-plan-west.sh
+++ b/scripts/terraform-plan-west.sh
@@ -10,4 +10,41 @@ terraform validate
 terraform plan -out=tfplan
 terraform show -no-color tfplan > plan.txt
 
+verify_plan() {
+  local plan_file="$1"
+  local host_address="$2"
+
+  terraform show -json "${plan_file}" | jq -e --arg host_address "${host_address}" '
+  def resources: .. | objects | select(has("address") and has("values"));
+  ([resources | select(.address == "module.api.google_cloud_run_v2_service.this")][0].values.template.containers[0].env
+    | map({key: .name, value: .value}) | from_entries) as $env
+  | ([resources | select(.address == $host_address)][0].values.network_interface[0].network_ip) as $host_ip
+  | ([resources | select(.address == $host_address)][0].values.tags) as $host_tags
+  | ([resources | select(.address == "module.network.google_compute_subnetwork.connector[0]")][0].values.ip_cidr_range) as $connector_cidr
+  | ([resources | select(.address == "module.network.google_compute_firewall.rules[\"allow_vmd_grpc\"]")][0].values) as $grpc_firewall
+  | ([resources | select(.address == "module.network.google_compute_firewall.rules[\"allow_otel_ingress\"]")][0].values) as $otel_firewall
+  | select($host_tags == ["vmd-usw2"])
+  | select($env.VMD_GRPC_ADDRESS == ($host_ip + ":50051"))
+  | select($env.DB_MAX_CONNS == "15")
+  | select($env.OTEL_ENVIRONMENT == "production")
+  | select($env.OTEL_EXPORTER_OTLP_ENDPOINT == ("http://" + $host_ip + ":4318"))
+  | select($env.OTEL_EXPORT_INTERVAL == "15s")
+  | select($env.OTEL_METRICS_ENABLED == "true")
+  | select($env.OTEL_SERVICE_NAME == "sandbox-controlplane")
+  | select($grpc_firewall.allow == [{"protocol": "tcp", "ports": ["50051"]}])
+  | select($otel_firewall.direction == "INGRESS")
+  | select($otel_firewall.source_ranges == [$connector_cidr])
+  | select($otel_firewall.target_tags == ["vmd-usw2"])
+  | select($otel_firewall.allow == [{"protocol": "tcp", "ports": ["4317", "4318"]}])
+  | true
+' >/dev/null
+}
+
+# Check both active-host selections so exporter and gRPC routing cannot regress
+# for either the default primary or promoted standby path.
+verify_plan tfplan 'module.sandbox_host.google_compute_instance.this'
+terraform plan -var='active_sandbox_host=standby' -out=tfplan-standby
+verify_plan tfplan-standby 'module.sandbox_host_b.google_compute_instance.this'
+
 echo "Wrote ${ENV_DIR}/plan.txt"
+echo "Verified primary and standby VMD and OTLP endpoints in ${ENV_DIR}"


### PR DESCRIPTION
## Summary

- enable control-plane OTLP export for production us-west2
- allow the Cloud Run egress range to reach the active VMD host collector on 4317/4318
- preserve active-host failover behavior by using `local.active_vmd_ip`

## Testing

- `terraform fmt -check infra/envs/production/us-west2`
- `terraform -chdir=infra/envs/production/us-west2 validate`
- review the production us-west2 Terraform plan for only the intended Cloud Run env and firewall changes
- after rollout, verify west `sandbox-controlplane` DB-pool series appear in GMP

## Testing

- `codex-workflow validate`
