### PR TITLE
vmd: persist dirty-tracking-armed state so a restart doesn't force a full pause

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -450,6 +450,7 @@ func main() {
 	resumeUffdEnabled := envOrDefault("VMD_RESUME_UFFD", "false") == "true"
 	verifySnapshotEnabled := envOrDefault("VMD_VERIFY_SNAPSHOT_ENABLED", "false") == "true"
 	incrementalSnapshotEnabled := envOrDefault("VMD_INCREMENTAL_SNAPSHOT", "false") == "true"
+	persistDirtyTrackingEnabled := envOrDefault("VMD_PERSIST_DIRTY_TRACKING", "false") == "true"
 	handlerDeathAbortEnabled := envOrDefault("VMD_HANDLER_DEATH_ABORT", "false") == "true"
 	// Tri-state: "auto" (default) lets vmd enforce only after its convergence
 	// sweep proves every layered overlay has a presence side-car; "always"
@@ -599,6 +600,7 @@ func main() {
 		ResumeUffdEnabled:                   resumeUffdEnabled,
 		VerifySnapshotEnabled:               verifySnapshotEnabled,
 		IncrementalSnapshotEnabled:          incrementalSnapshotEnabled,
+		PersistDirtyTrackingEnabled:         persistDirtyTrackingEnabled,
 		HandlerDeathAbortEnabled:            handlerDeathAbortEnabled,
 		RequirePresenceSidecar:              requirePresenceSidecar,
 		PausedNetworkReclaimEnabled:         pausedNetworkReclaimEnabled,

--- a/internal/vm/cgroup_linux_test.go
+++ b/internal/vm/cgroup_linux_test.go
@@ -290,7 +290,7 @@ func TestUnknownSupervisionFailsClosed(t *testing.T) {
 // after which every unit oracle reads it as dead.
 func TestSupervisionRoundTrip(t *testing.T) {
 	inst := &VMInstance{ID: "vm-1", Supervision: SupervisionCgroup}
-	rec := toRecord(inst)
+	rec := toRecord(inst, false)
 	if rec.Supervision != SupervisionCgroup {
 		t.Fatal("toRecord dropped Supervision")
 	}
@@ -308,7 +308,7 @@ func TestSupervisionRoundTrip(t *testing.T) {
 	if cgroupSupervised(legacy.Supervision) || legacy.Supervision != SupervisionUnit {
 		t.Fatal("legacy record must be unit-supervised")
 	}
-	out, err := json.Marshal(toRecord(&VMInstance{ID: "u", Supervision: SupervisionUnit}))
+	out, err := json.Marshal(toRecord(&VMInstance{ID: "u", Supervision: SupervisionUnit}, false))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -4031,7 +4031,7 @@ func (m *Manager) UpdateSandboxPreviewPolicy(vmID, previewAccess string, preview
 	// record before advancing memory so a failed write leaves the old revision
 	// retryable instead of acknowledging a policy that a restart would lose.
 	if m.state != nil && !isBuildVM(inst.ID) {
-		record := toRecordLocked(inst)
+		record := toRecordLocked(inst, m.cfg.PersistDirtyTrackingEnabled)
 		record.PreviewAccess = previewAccess
 		record.PreviewPorts = previewPortsToRecord(nextPorts)
 		record.PreviewPortAccess = previewPortAccessToRecord(nextPorts)
@@ -4455,7 +4455,7 @@ func (m *Manager) releasePausedNetworkSlot(rec VMRecord, shrink bool) (bool, err
 			return false, nil
 		}
 		inst.mu.Unlock()
-		cleared := toRecord(inst)
+		cleared := toRecord(inst, m.cfg.PersistDirtyTrackingEnabled)
 		cleared.Namespace = ""
 		cleared.IP = ""
 		cleared.TAPDevice = ""
@@ -4518,7 +4518,7 @@ func (m *Manager) persistState(inst *VMInstance) bool {
 	if isBuildVM(inst.ID) {
 		return true
 	}
-	if err := m.state.Put(toRecord(inst)); err != nil {
+	if err := m.state.Put(toRecord(inst, m.cfg.PersistDirtyTrackingEnabled)); err != nil {
 		m.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to persist VM state to BoltDB")
 		return false
 	}
@@ -4534,7 +4534,7 @@ func (m *Manager) persistStateIfPresent(inst *VMInstance) (wrote bool, err error
 	if m.state == nil || isBuildVM(inst.ID) {
 		return true, nil
 	}
-	wrote, err = m.state.PutIfPresent(toRecord(inst))
+	wrote, err = m.state.PutIfPresent(toRecord(inst, m.cfg.PersistDirtyTrackingEnabled))
 	if err != nil {
 		m.log.Error().Err(err).Str("vm_id", inst.ID).Msg("failed to persist VM state to BoltDB")
 		return false, err

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2136,18 +2136,21 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 
 // CreateVMSnapshot captures a point-in-time snapshot of a running VM.
 func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
-	// Serialize with pause/resume/reattach on this VM (see lockVMOp). This
-	// ad-hoc Full snapshot resets Firecracker's dirty bitmap, so it must not
-	// interleave with a concurrent lifecycle write that could durably re-arm
-	// dirty tracking between the write-ahead disarm and the bitmap reset — which
-	// would leave a stale armed=true for a reattach to trust against a reset
-	// bitmap. Taken before getInstance so a racing lazy-reattach is serialized
-	// too. The RPC is the sole caller and holds no lock, so this cannot deadlock.
-	unlockOp, err := m.lockVMOp(ctx, vmID)
-	if err != nil {
-		return "", "", err
+	// Only when dirty-tracking persistence is on: serialize with pause/resume/
+	// reattach (see lockVMOp) so the write-ahead disarm below cannot race a
+	// concurrent write that durably re-arms between the clear and the bitmap
+	// reset — which would leave a stale armed=true for a reattach to trust. With
+	// the feature off there is no disarm, so no lock is taken and this path's
+	// behavior is unchanged. Taken before getInstance so a racing lazy-reattach
+	// is serialized too; the RPC is the sole caller and holds no lock, so this
+	// cannot deadlock.
+	if m.cfg.PersistDirtyTrackingEnabled {
+		unlockOp, err := m.lockVMOp(ctx, vmID)
+		if err != nil {
+			return "", "", err
+		}
+		defer unlockOp()
 	}
-	defer unlockOp()
 
 	inst, err := m.getInstance(vmID)
 	if err != nil {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1266,6 +1266,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	}
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
+	tPauseStart := time.Now()
 
 	// Retried pause (response lost mid-RPC): re-snapshotting a stopped VM
 	// dials a dead socket and ends with the record deleted. Return the
@@ -1364,6 +1365,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			return "", "", nil, fmt.Errorf("write-ahead disarm before pause snapshot for vm %s: %w", vmID, err)
 		}
 	}
+	// snapshotType classifies which memory image this pause wrote, for the phase
+	// log below: "full" writes the whole guest RAM (seconds), "layered"/"diff"
+	// write only dirtied pages (fast). It defaults to "full" so the two Full
+	// branches need no assignment.
+	snapshotType := "full"
+	tSnapStart := time.Now()
 	switch {
 	case layered:
 		memPath = overlayPath
@@ -1394,6 +1401,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			}
 		}
 		if usable {
+			snapshotType = "layered"
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating layered diff snapshot")
 			saveStart := time.Now()
 			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
@@ -1424,6 +1432,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		// mem.snap when tracking was armed this run and mem.snap is the resume base —
 		// dirtied offsets are resident/never re-faulted, disjoint from clean reads.
 		if shouldWriteDiff(m.cfg.IncrementalSnapshotEnabled, dirtyTracked, memPath, instMemFile, fileExists(memPath)) {
+			snapshotType = "diff"
 			log.Info().Str("snapshot_path", snapshotPath).Msg("pausing VM — creating diff snapshot")
 			if err := CreateDiffSnapshot(socketPath, snapshotPath, memPath); err != nil {
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("create diff snapshot: %w", err))
@@ -1435,6 +1444,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			}
 		}
 	}
+
+	tSnapDone := time.Now()
 
 	// Stop the Firecracker process — snapshot is already on disk. A stop
 	// that fails must NOT fail the pause: the artifacts are valid and the
@@ -1468,6 +1479,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		}
 	}
 	stopCancel()
+	tStopDone := time.Now()
 
 	inst.mu.Lock()
 	inst.Status = StatusPaused
@@ -1529,7 +1541,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 		go m.rehashPendingBackup(ctx, pb, log)
 	}
 
-	log.Info().Msg("VM paused")
+	log.Info().
+		Str("snapshot_type", snapshotType).
+		Int64("snapshot_ms", tSnapDone.Sub(tSnapStart).Milliseconds()).
+		Int64("stop_ms", tStopDone.Sub(tSnapDone).Milliseconds()).
+		Int64("pause_ms", time.Since(tPauseStart).Milliseconds()).
+		Msg("VM paused")
 	return snapshotPath, memPath, manifest, nil
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1368,9 +1368,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 			return "", "", nil, fmt.Errorf("write-ahead disarm before pause snapshot for vm %s: %w", vmID, err)
 		}
 	}
-	// snapshotType classifies which memory image this pause wrote, for the phase
-	// log below: "full" writes the whole guest RAM (seconds), "layered"/"diff"
-	// write only dirtied pages (fast). It defaults to "full" so the two Full
+	// snapshotType for the phase log below; defaults to "full" so the two Full
 	// branches need no assignment.
 	snapshotType := "full"
 	tSnapStart := time.Now()
@@ -1575,13 +1573,11 @@ func shouldRearmDirtyTracking(enabled bool, rec VMRecord) bool {
 }
 
 // writeAheadDisarm clears the in-memory dirty-tracking flag and durably clears
-// the persisted armed bit BEFORE returning, so a snapshot that is about to
-// reset Firecracker's dirty bitmap cannot leave a stale armed=true for a later
-// reattach to trust. Callers that hold no vm-op lock are safe: the field-level
-// clear never clobbers a concurrent lifecycle op, and disarming is monotonically
-// safe (worst case a spurious Full snapshot, never a diff against a stale
-// bitmap). Returns an error only if the durable clear fails, so the caller can
-// refuse the snapshot rather than proceed on an un-disarmed record.
+// the persisted armed bit before returning, so a snapshot about to reset
+// Firecracker's dirty bitmap cannot leave a stale armed=true for a later
+// reattach to trust. Returns an error only if the durable clear fails, so the
+// caller can refuse the snapshot rather than proceed un-disarmed. Callers hold
+// the vm-op lock across this and the snapshot.
 func (m *Manager) writeAheadDisarm(inst *VMInstance) error {
 	inst.mu.Lock()
 	inst.DirtyTracked = false

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -302,6 +302,17 @@ type ManagerConfig struct {
 	// ResumeUffdEnabled. Default false.
 	IncrementalSnapshotEnabled bool
 
+	// PersistDirtyTrackingEnabled persists the dirty-tracking-armed state and
+	// re-arms it when a running VM is reattached after a vmd restart, so the
+	// restart no longer forces that VM's next pause to a Full snapshot. Default
+	// false: enabling it re-arms a diff against Firecracker's existing dirty
+	// bitmap after a reattach, which is only correct if that bitmap survives a
+	// vmd restart on the deployed Firecracker fork — an invariant that must be
+	// verified before turning this on, since re-arming against a reset bitmap
+	// would corrupt the diff. Requires IncrementalSnapshotEnabled to have any
+	// effect.
+	PersistDirtyTrackingEnabled bool
+
 	// HandlerDeathAbortEnabled tells the in-process UFFD handler to abort Firecracker
 	// on an unexpected handler death (instead of letting the guest freeze on its next
 	// page fault). The dead VM then surfaces via the unit-inactive → reconciler path
@@ -1342,6 +1353,17 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	// of the file it overwrites (for layered, only the session delta — the template
 	// base is untouched; for in-place, the VM's own mem.snap). Crash-atomicity of the
 	// diff is the durability-boundary work, intentionally out of scope here.
+	//
+	// The Diff-vs-Full decision above already read dirtyTracked into locals, so
+	// disarm the durable armed bit now — before any snapshot resets the bitmap.
+	// A crash between here and the paused record must not leave armed=true, or a
+	// reattach would re-arm a diff against a bitmap this snapshot reset. Refuse
+	// the pause if the durable clear fails rather than take that risk.
+	if m.cfg.PersistDirtyTrackingEnabled {
+		if err := m.writeAheadDisarm(inst); err != nil {
+			return "", "", nil, fmt.Errorf("write-ahead disarm before pause snapshot for vm %s: %w", vmID, err)
+		}
+	}
 	switch {
 	case layered:
 		memPath = overlayPath
@@ -1519,6 +1541,35 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 // not a template/layered base — the in-place diff merges into that resume file.
 func shouldWriteDiff(incremental, dirtyTracked bool, memPath, resumeMemPath string, memFileExists bool) bool {
 	return incremental && dirtyTracked && memPath == resumeMemPath && memFileExists
+}
+
+// shouldRearmDirtyTracking reports whether a reattached record's persisted
+// dirty-tracking-armed state is safe to restore into the live instance. Only a
+// confirmed-Running record qualifies (a paused VM re-arms through its next
+// resume; a reattach re-arms an already-live Firecracker), and only when the
+// feature is enabled. The write-ahead disarm guarantees the persisted bit is
+// false throughout the window where a snapshot has reset the bitmap but the
+// record still reads Running, so a true here means the live bitmap is intact.
+func shouldRearmDirtyTracking(enabled bool, rec VMRecord) bool {
+	return enabled && rec.Status == StatusRunning && rec.DirtyTrackingArmed
+}
+
+// writeAheadDisarm clears the in-memory dirty-tracking flag and durably clears
+// the persisted armed bit BEFORE returning, so a snapshot that is about to
+// reset Firecracker's dirty bitmap cannot leave a stale armed=true for a later
+// reattach to trust. Callers that hold no vm-op lock are safe: the field-level
+// clear never clobbers a concurrent lifecycle op, and disarming is monotonically
+// safe (worst case a spurious Full snapshot, never a diff against a stale
+// bitmap). Returns an error only if the durable clear fails, so the caller can
+// refuse the snapshot rather than proceed on an un-disarmed record.
+func (m *Manager) writeAheadDisarm(inst *VMInstance) error {
+	inst.mu.Lock()
+	inst.DirtyTracked = false
+	inst.mu.Unlock()
+	if m.state == nil {
+		return nil
+	}
+	return m.state.ClearDirtyTrackingArmed(inst.ID)
 }
 
 // layeredBaseSidecarPath is where the layered base (template) path is recorded
@@ -2084,20 +2135,27 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	snapshotPath = filepath.Join(snapshotDir, "vmstate.snap")
 	memPath = filepath.Join(snapshotDir, "mem.snap")
 
+	// This Full snapshot resets Firecracker's dirty bitmap, so the diff baseline
+	// relative to the resume base is gone; the next pause must go Full. When
+	// persistence is enabled, disarm DURABLY and ahead of the snapshot: this path
+	// holds no vm-op lock, so a field-level clear (never a whole-record write) is
+	// used to avoid clobbering a concurrent lifecycle op, and doing it before the
+	// bitmap reset closes the crash window a reattach could otherwise re-arm into.
+	if m.cfg.PersistDirtyTrackingEnabled {
+		if err := m.writeAheadDisarm(inst); err != nil {
+			return "", "", fmt.Errorf("write-ahead disarm before ad-hoc snapshot for vm %s: %w", vmID, err)
+		}
+	}
+
 	if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 		return "", "", fmt.Errorf("create snapshot: %w", err)
 	}
 
-	// This Full snapshot reset Firecracker's dirty bitmap, so the diff baseline
-	// relative to the resume base is gone. Clear the flag now — before the unpause,
-	// which can fail and return early — so a later pause can't take the Diff path
-	// against the stale baseline and miss pages dirtied between resume and this
-	// ad-hoc snapshot. Forces the next pause back to Full.
-	//
-	// Not persisted, deliberately: DirtyTracked is not in VMRecord, so a write
-	// here would duplicate the durable record while clobbering fields a
-	// concurrent lifecycle op just changed — this path holds no vm-op lock.
-	// Persisting from here needs that lock; see TestToRecordIgnoresDirtyTracked.
+	// Clear the in-memory flag before the unpause (which can fail and return
+	// early) so a later pause can't take the Diff path against the reset bitmap
+	// and miss pages dirtied between resume and this ad-hoc snapshot. When
+	// persistence is enabled the durable clear above already covers the reattach
+	// case; this keeps the in-memory field consistent on the flag-off path too.
 	inst.mu.Lock()
 	inst.DirtyTracked = false
 	inst.mu.Unlock()
@@ -3322,6 +3380,19 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	}
 
 	inst := toInstance(rec)
+
+	// Re-arm dirty tracking for a confirmed-Running reattach: the Firecracker
+	// process survived the vmd restart and kept tracking, so the persisted armed
+	// bit is safe to restore — without this, DirtyTracked defaults false and the
+	// VM's next pause writes a Full snapshot. toInstance leaves it false by
+	// design; this is the one path that reconnects to a live FC without going
+	// through an arming restore. Gated on the feature flag (pending the
+	// bitmap-survives-restart verification) and guarded so it never re-arms a
+	// paused/parked record or the crash-during-snapshot window (write-ahead
+	// disarm keeps the bit false there).
+	if shouldRearmDirtyTracking(m.cfg.PersistDirtyTrackingEnabled, rec) {
+		inst.DirtyTracked = true
+	}
 
 	// Bail early if another caller (a request, or the background pass) already
 	// published this VM.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1252,6 +1252,10 @@ func (m *Manager) DestroyVM(ctx context.Context, vmID string, force bool) (err e
 // durable artifacts (disk state + vmstate); see collectPauseManifest for
 // what is included and why memory files are not.
 func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, manifest []ManifestEntry, err error) {
+	// Before lockVMOp so pause_ms includes lock-queueing/contention, not just the
+	// work after the lock is held.
+	tPauseStart := time.Now()
+
 	// Serialize same-vmID lifecycle ops (see lockVMOp): a duplicate pause
 	// waits, then hits the already-paused guard.
 	unlockOp, err := m.lockVMOp(ctx, vmID)
@@ -1266,7 +1270,6 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir string) (snapsh
 	}
 
 	log := m.log.With().Str("vm_id", vmID).Logger()
-	tPauseStart := time.Now()
 
 	// Retried pause (response lost mid-RPC): re-snapshotting a stopped VM
 	// dials a dead socket and ends with the record deleted. Return the
@@ -2137,6 +2140,19 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 
 // CreateVMSnapshot captures a point-in-time snapshot of a running VM.
 func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
+	// Serialize with pause/resume/reattach on this VM (see lockVMOp). This
+	// ad-hoc Full snapshot resets Firecracker's dirty bitmap, so it must not
+	// interleave with a concurrent lifecycle write that could durably re-arm
+	// dirty tracking between the write-ahead disarm and the bitmap reset — which
+	// would leave a stale armed=true for a reattach to trust against a reset
+	// bitmap. Taken before getInstance so a racing lazy-reattach is serialized
+	// too. The RPC is the sole caller and holds no lock, so this cannot deadlock.
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return "", "", err
+	}
+	defer unlockOp()
+
 	inst, err := m.getInstance(vmID)
 	if err != nil {
 		return "", "", err
@@ -2154,10 +2170,10 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 
 	// This Full snapshot resets Firecracker's dirty bitmap, so the diff baseline
 	// relative to the resume base is gone; the next pause must go Full. When
-	// persistence is enabled, disarm DURABLY and ahead of the snapshot: this path
-	// holds no vm-op lock, so a field-level clear (never a whole-record write) is
-	// used to avoid clobbering a concurrent lifecycle op, and doing it before the
-	// bitmap reset closes the crash window a reattach could otherwise re-arm into.
+	// persistence is enabled, disarm DURABLY and ahead of the snapshot — under
+	// the vm-op lock above, so no concurrent write re-arms between the clear and
+	// the reset. The field-level clear (never a whole-record write) is still
+	// used so it touches only the armed bit and preserves any newer fields.
 	if m.cfg.PersistDirtyTrackingEnabled {
 		if err := m.writeAheadDisarm(inst); err != nil {
 			return "", "", fmt.Errorf("write-ahead disarm before ad-hoc snapshot for vm %s: %w", vmID, err)

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -1858,14 +1858,14 @@ func TestRetriedLaunchTargetFlagsUnverifiedRecord(t *testing.T) {
 		t.Fatal("a verified Running record must be adoptable without verification")
 	}
 
-	out, err := json.Marshal(toRecord(existing))
+	out, err := json.Marshal(toRecord(existing, false))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(string(out), "unverified") {
 		t.Fatalf("verified records must omit the unverified key, got %s", out)
 	}
-	unv := toRecord(&VMInstance{ID: "u", Status: StatusRunning, Unverified: true})
+	unv := toRecord(&VMInstance{ID: "u", Status: StatusRunning, Unverified: true}, false)
 	round, err := json.Marshal(unv)
 	if err != nil {
 		t.Fatal(err)
@@ -2077,7 +2077,7 @@ func TestResumeVM_UnverifiedTarget_VerifiedAndAdopted(t *testing.T) {
 		SnapshotPath: "/snapshots/vm-1/vmstate.snap",
 		MemFilePath:  "/snapshots/vm-1/mem.snap",
 	}
-	if err := store.Put(toRecord(existing)); err != nil {
+	if err := store.Put(toRecord(existing, false)); err != nil {
 		t.Fatal(err)
 	}
 	mgr := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}}
@@ -2402,7 +2402,7 @@ func TestResumeVM_CorpseVerdict_ClearsRunningBeforeRelaunch(t *testing.T) {
 		ID: "vm-1", Status: StatusRunning, Unverified: true, IP: "192.0.2.5",
 		SnapshotPath: "/nonexistent/vmstate.snap", MemFilePath: "/nonexistent/mem.snap",
 	}
-	if err := store.Put(toRecord(existing)); err != nil {
+	if err := store.Put(toRecord(existing, false)); err != nil {
 		t.Fatal(err)
 	}
 	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}}
@@ -2439,14 +2439,19 @@ func TestResumeVM_CorpseVerdict_ClearsRunningBeforeRelaunch(t *testing.T) {
 // Firecracker whose dirty bitmap survived the restart.
 func TestToRecordPersistsDirtyTrackingArmed(t *testing.T) {
 	armed := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: true}
-	if rec := toRecord(armed); !rec.DirtyTrackingArmed {
-		t.Fatal("toRecord must persist DirtyTracked as DirtyTrackingArmed")
+	if rec := toRecord(armed, true); !rec.DirtyTrackingArmed {
+		t.Fatal("toRecord must persist DirtyTracked as DirtyTrackingArmed when the feature is enabled")
+	}
+	// Gated off: the armed bit must NOT be persisted, so no stale true can be
+	// trusted the moment the flag is later enabled.
+	if rec := toRecord(armed, false); rec.DirtyTrackingArmed {
+		t.Fatal("toRecord must not persist the armed bit when the feature is off")
 	}
 	unarmed := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: false}
-	if rec := toRecord(unarmed); rec.DirtyTrackingArmed {
+	if rec := toRecord(unarmed, true); rec.DirtyTrackingArmed {
 		t.Fatal("toRecord must not report armed for an un-armed instance")
 	}
-	if inst := toInstance(toRecord(armed)); inst.DirtyTracked {
+	if inst := toInstance(toRecord(armed, true)); inst.DirtyTracked {
 		t.Fatal("toInstance must leave DirtyTracked false; re-arming belongs to reattachRecord")
 	}
 }
@@ -2514,7 +2519,7 @@ func TestResumeVM_CorpseVerdictUnrecordable_RefusesRelaunch(t *testing.T) {
 		ID: "vm-1", Status: StatusRunning, Unverified: true, IP: "192.0.2.5",
 		SnapshotPath: "/nonexistent/vmstate.snap", MemFilePath: "/nonexistent/mem.snap",
 	}
-	if err := store.Put(toRecord(existing)); err != nil {
+	if err := store.Put(toRecord(existing, false)); err != nil {
 		t.Fatal(err)
 	}
 	store.Close() // every later write fails — the store is broken
@@ -3018,7 +3023,7 @@ func TestReleaseFailedRestore_ParksExplicitDurableMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 	inst := &VMInstance{ID: "vm-1", Status: StatusError, Supervision: SupervisionCgroup}
-	if err := store.Put(toRecord(inst)); err != nil {
+	if err := store.Put(toRecord(inst, false)); err != nil {
 		t.Fatal(err)
 	}
 	m := &Manager{log: zerolog.Nop(), state: store, netMgr: &network.Manager{},

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2475,10 +2475,11 @@ func TestShouldRearmDirtyTracking(t *testing.T) {
 	}
 }
 
-// The ad-hoc snapshot path holds no vm-op lock, so it must not do a whole-record
-// write (persistState) that could clobber a concurrent lifecycle op. A
-// field-level ClearDirtyTrackingArmed is the permitted exception: it touches
-// only the armed bit and disarming is monotonically safe.
+// The ad-hoc snapshot path disarms dirty tracking with a field-level
+// ClearDirtyTrackingArmed, not a whole-record persistState: a targeted clear
+// touches only the armed bit and preserves any newer fields a rollback binary
+// wouldn't know about. (The vm-op lock it now holds serializes it with other
+// lifecycle writers; the field-level clear is still preferred for minimality.)
 func TestCreateVMSnapshotDoesNotPersist(t *testing.T) {
 	src, err := os.ReadFile("manager.go")
 	if err != nil {
@@ -2493,8 +2494,14 @@ func TestCreateVMSnapshotDoesNotPersist(t *testing.T) {
 	if end < 0 {
 		t.Fatal("could not bound CreateVMSnapshot")
 	}
-	if body := fn[start : start+end]; strings.Contains(body, "persistState(") {
-		t.Fatal("CreateVMSnapshot must not persist: it holds no vm-op lock, so a full-record write can clobber a concurrent lifecycle op")
+	body := fn[start : start+end]
+	if strings.Contains(body, "persistState(") {
+		t.Fatal("CreateVMSnapshot must not whole-record persist: use the field-level ClearDirtyTrackingArmed clear")
+	}
+	// It must serialize with pause/resume so its disarm+snapshot cannot race a
+	// concurrent write that re-arms dirty tracking against the reset bitmap.
+	if !strings.Contains(body, "lockVMOp(") {
+		t.Fatal("CreateVMSnapshot must hold the vm-op lock across disarm + snapshot")
 	}
 }
 

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2434,25 +2433,47 @@ func TestResumeVM_CorpseVerdict_ClearsRunningBeforeRelaunch(t *testing.T) {
 // be a pure clobber, able to resurrect a concurrent lifecycle op's fields (the
 // crash-window marker most damagingly). If DirtyTracked ever becomes durable,
 // this fails: that path then needs the lock before it may persist.
-func TestToRecordIgnoresDirtyTracked(t *testing.T) {
-	base := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: false}
-	dirty := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: true}
-
-	a, err := json.Marshal(toRecord(base))
-	if err != nil {
-		t.Fatal(err)
+// toRecord persists the dirty-tracking-armed state so a reattach can re-arm it,
+// but toInstance must NOT restore it: re-arming is a reattach-only decision
+// (shouldRearmDirtyTracking), gated on the feature flag and a confirmed-Running
+// Firecracker whose dirty bitmap survived the restart.
+func TestToRecordPersistsDirtyTrackingArmed(t *testing.T) {
+	armed := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: true}
+	if rec := toRecord(armed); !rec.DirtyTrackingArmed {
+		t.Fatal("toRecord must persist DirtyTracked as DirtyTrackingArmed")
 	}
-	b, err := json.Marshal(toRecord(dirty))
-	if err != nil {
-		t.Fatal(err)
+	unarmed := &VMInstance{ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5", DirtyTracked: false}
+	if rec := toRecord(unarmed); rec.DirtyTrackingArmed {
+		t.Fatal("toRecord must not report armed for an un-armed instance")
 	}
-	if !bytes.Equal(a, b) {
-		t.Fatalf("DirtyTracked is now persisted — CreateVMSnapshot must take the vm-op lock before persisting:\n %s\n %s", a, b)
+	if inst := toInstance(toRecord(armed)); inst.DirtyTracked {
+		t.Fatal("toInstance must leave DirtyTracked false; re-arming belongs to reattachRecord")
 	}
 }
 
-// The ad-hoc snapshot path must not write the record at all: it holds no
-// vm-op lock, so any write races whatever lifecycle op is in flight.
+func TestShouldRearmDirtyTracking(t *testing.T) {
+	runningArmed := VMRecord{Status: StatusRunning, DirtyTrackingArmed: true}
+	if !shouldRearmDirtyTracking(true, runningArmed) {
+		t.Fatal("enabled + running + armed must re-arm")
+	}
+	if shouldRearmDirtyTracking(false, runningArmed) {
+		t.Fatal("disabled must never re-arm (flag gate protects the unverified bitmap-survival invariant)")
+	}
+	if shouldRearmDirtyTracking(true, VMRecord{Status: StatusRunning}) {
+		t.Fatal("un-armed record must not re-arm")
+	}
+	if shouldRearmDirtyTracking(true, VMRecord{Status: StatusPaused, DirtyTrackingArmed: true}) {
+		t.Fatal("paused record must not re-arm — it re-arms through its next resume")
+	}
+	if shouldRearmDirtyTracking(true, VMRecord{Status: StatusError, DirtyTrackingArmed: true}) {
+		t.Fatal("error/parked record must not re-arm")
+	}
+}
+
+// The ad-hoc snapshot path holds no vm-op lock, so it must not do a whole-record
+// write (persistState) that could clobber a concurrent lifecycle op. A
+// field-level ClearDirtyTrackingArmed is the permitted exception: it touches
+// only the armed bit and disarming is monotonically safe.
 func TestCreateVMSnapshotDoesNotPersist(t *testing.T) {
 	src, err := os.ReadFile("manager.go")
 	if err != nil {

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -297,7 +297,13 @@ func (s *StateStore) Path() string { return s.db.Path() }
 
 // OpenStateStore opens (or creates) the BoltDB file at path.
 func OpenStateStore(path string) (*StateStore, error) {
-	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second})
+	// NoFreelistSync stops bbolt writing+fsyncing the freelist on every commit,
+	// whose cost otherwise grows with the DB's free-page count (churn) and adds
+	// up on write paths like pause. The freelist is rebuilt from the page tree
+	// on the next open — startup already scans every record below — so this is a
+	// pure write-side win with no data-safety cost (data pages and meta are
+	// still synced).
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second, NoFreelistSync: true})
 	if err != nil {
 		return nil, fmt.Errorf("open state store %s: %w", path, err)
 	}
@@ -445,8 +451,12 @@ func (s *StateStore) PutIfPresent(rec VMRecord) (bool, error) {
 // monotonically safe (worst case a spurious full snapshot next pause, never a
 // diff against a stale bitmap). No-op if the record is absent or already
 // disarmed.
+//
+// Uses Update, not Batch: this is on the synchronous pre-snapshot path, where
+// Batch's coalescing delay would add latency; the read-and-conditional-write
+// stays in one transaction so there is no read-then-write race.
 func (s *StateStore) ClearDirtyTrackingArmed(vmID string) error {
-	return s.db.Batch(func(tx *bolt.Tx) error {
+	return s.db.Update(func(tx *bolt.Tx) error {
 		records := tx.Bucket(bucketName)
 		key := []byte(vmID)
 		data := records.Get(key)

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -178,11 +178,19 @@ type VMRecord struct {
 	// restart: non-empty means MemFilePath is an overlay to be served over this
 	// base. Without it, resume would load the overlay standalone and read the
 	// base's pages as zero holes.
-	BaseMemPath string            `json:"base_mem_path,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	VCPU        uint32            `json:"vcpu"`
-	MemoryMiB   uint32            `json:"memory_mib"`
+	BaseMemPath string `json:"base_mem_path,omitempty"`
+	// DirtyTrackingArmed records whether this VM's current Firecracker run was
+	// launched with dirty-page tracking on. Persisted so a reattach after a vmd
+	// restart can re-arm the in-memory flag (which otherwise defaults false and
+	// forces the next pause of a running VM to a full snapshot). Written false
+	// AHEAD of any snapshot that resets the bitmap (see write-ahead disarm), so
+	// a crash mid-snapshot never leaves a stale true for a reattach to trust
+	// against a reset bitmap. Old records decode to false (safe).
+	DirtyTrackingArmed bool              `json:"dirty_tracking_armed,omitempty"`
+	CreatedAt          time.Time         `json:"created_at"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+	VCPU               uint32            `json:"vcpu"`
+	MemoryMiB          uint32            `json:"memory_mib"`
 	// Persisted so overlay-mode sandboxes can be resumed correctly after a
 	// vmd restart (the start script needs basePath to wire up the
 	// dual-symlink mount namespace). DeltaDir is intentionally NOT
@@ -429,6 +437,38 @@ func (s *StateStore) PutIfPresent(rec VMRecord) (bool, error) {
 	return wrote, err
 }
 
+// ClearDirtyTrackingArmed durably clears the dirty-tracking-armed bit on a
+// record, touching no other field. Snapshot paths that reset Firecracker's
+// dirty bitmap use this to disarm ahead of the reset while holding no vm-op
+// lock: a whole-record write from such a path could roll back a concurrent
+// lifecycle op's changes, whereas a field-level clear cannot — and disarming is
+// monotonically safe (worst case a spurious full snapshot next pause, never a
+// diff against a stale bitmap). No-op if the record is absent or already
+// disarmed.
+func (s *StateStore) ClearDirtyTrackingArmed(vmID string) error {
+	return s.db.Batch(func(tx *bolt.Tx) error {
+		records := tx.Bucket(bucketName)
+		key := []byte(vmID)
+		data := records.Get(key)
+		if data == nil {
+			return nil
+		}
+		var rec VMRecord
+		if err := json.Unmarshal(data, &rec); err != nil {
+			return err
+		}
+		if !rec.DirtyTrackingArmed {
+			return nil
+		}
+		rec.DirtyTrackingArmed = false
+		out, err := json.Marshal(rec)
+		if err != nil {
+			return err
+		}
+		return records.Put(key, out)
+	})
+}
+
 // putRecord writes both representations atomically and reports whether the
 // primary lifecycle record was written. A sidecar without a primary record is
 // an orphan left by an old-binary delete and must never influence a new VM.
@@ -637,6 +677,7 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		SnapshotPath:               inst.SnapshotPath,
 		MemFilePath:                inst.MemFilePath,
 		BaseMemPath:                inst.BaseMemPath,
+		DirtyTrackingArmed:         inst.DirtyTracked,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -438,17 +438,11 @@ func (s *StateStore) PutIfPresent(rec VMRecord) (bool, error) {
 }
 
 // ClearDirtyTrackingArmed durably clears the dirty-tracking-armed bit on a
-// record, touching no other field. Snapshot paths that reset Firecracker's
-// dirty bitmap use this to disarm ahead of the reset while holding no vm-op
-// lock: a whole-record write from such a path could roll back a concurrent
-// lifecycle op's changes, whereas a field-level clear cannot — and disarming is
-// monotonically safe (worst case a spurious full snapshot next pause, never a
-// diff against a stale bitmap). No-op if the record is absent or already
-// disarmed.
-//
-// Uses Update, not Batch: this is on the synchronous pre-snapshot path, where
-// Batch's coalescing delay would add latency; the read-and-conditional-write
-// stays in one transaction so there is no read-then-write race.
+// record, touching no other field, so a snapshot path can disarm ahead of a
+// bitmap-resetting snapshot. Field-level rather than a whole-record write so it
+// preserves any newer fields a rollback binary wouldn't know about. No-op if the
+// record is absent or already disarmed. Uses Update, not Batch, to avoid the
+// coalescing delay on this synchronous pre-snapshot path.
 func (s *StateStore) ClearDirtyTrackingArmed(vmID string) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		records := tx.Bucket(bucketName)

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -297,13 +297,7 @@ func (s *StateStore) Path() string { return s.db.Path() }
 
 // OpenStateStore opens (or creates) the BoltDB file at path.
 func OpenStateStore(path string) (*StateStore, error) {
-	// NoFreelistSync stops bbolt writing+fsyncing the freelist on every commit,
-	// whose cost otherwise grows with the DB's free-page count (churn) and adds
-	// up on write paths like pause. The freelist is rebuilt from the page tree
-	// on the next open — startup already scans every record below — so this is a
-	// pure write-side win with no data-safety cost (data pages and meta are
-	// still synced).
-	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second, NoFreelistSync: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("open state store %s: %w", path, err)
 	}
@@ -463,15 +457,20 @@ func (s *StateStore) ClearDirtyTrackingArmed(vmID string) error {
 		if data == nil {
 			return nil
 		}
-		var rec VMRecord
-		if err := json.Unmarshal(data, &rec); err != nil {
+		// Edit the raw JSON object rather than round-tripping through VMRecord:
+		// a newer VMD (rollback / mixed-version deploy) may have added fields
+		// this binary's struct drops, and this clear must touch only the armed
+		// bit. The field is omitempty, so deleting the key is equivalent to
+		// false and preserves every other key untouched.
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(data, &obj); err != nil {
 			return err
 		}
-		if !rec.DirtyTrackingArmed {
+		if v, ok := obj["dirty_tracking_armed"]; !ok || string(v) != "true" {
 			return nil
 		}
-		rec.DirtyTrackingArmed = false
-		out, err := json.Marshal(rec)
+		delete(obj, "dirty_tracking_armed")
+		out, err := json.Marshal(obj)
 		if err != nil {
 			return err
 		}
@@ -659,15 +658,15 @@ func (s *StateStore) IDs() (map[string]struct{}, error) {
 }
 
 // toRecord converts a VMInstance to a persistable VMRecord.
-func toRecord(inst *VMInstance) VMRecord {
+func toRecord(inst *VMInstance, persistDirtyArmed bool) VMRecord {
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()
-	return toRecordLocked(inst)
+	return toRecordLocked(inst, persistDirtyArmed)
 }
 
 // toRecordLocked snapshots an instance while its caller holds inst.mu. It is
 // used when a state write must be serialized with the in-memory mutation.
-func toRecordLocked(inst *VMInstance) VMRecord {
+func toRecordLocked(inst *VMInstance, persistDirtyArmed bool) VMRecord {
 	return VMRecord{
 		ID:                         inst.ID,
 		PID:                        inst.PID,
@@ -687,7 +686,13 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		SnapshotPath:               inst.SnapshotPath,
 		MemFilePath:                inst.MemFilePath,
 		BaseMemPath:                inst.BaseMemPath,
-		DirtyTrackingArmed:         inst.DirtyTracked,
+		// Only persisted when the feature is on: otherwise a stale armed=true
+		// could survive a bitmap-resetting snapshot (its write-ahead disarm is
+		// gated off too) and be trusted the moment the flag is later enabled.
+		// Gating the write here means no armed bit can exist while off, so
+		// enabling is always safe — a VM whose bit was never persisted simply
+		// takes one full pause after enable, then heals.
+		DirtyTrackingArmed: inst.DirtyTracked && persistDirtyArmed,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,

--- a/internal/vm/state_test.go
+++ b/internal/vm/state_test.go
@@ -137,6 +137,47 @@ func TestStateStorePausedAtRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStateStoreClearDirtyTrackingArmed(t *testing.T) {
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	// A record persisted armed, plus other fields that the field-level clear
+	// must leave untouched.
+	if err := store.Put(VMRecord{
+		ID:                 "vm-armed",
+		Status:             StatusRunning,
+		MemFilePath:        "/snap/mem.snap",
+		DirtyTrackingArmed: true,
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if err := store.ClearDirtyTrackingArmed("vm-armed"); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	got, err := store.Get("vm-armed")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.DirtyTrackingArmed {
+		t.Fatal("armed bit must be cleared")
+	}
+	if got.MemFilePath != "/snap/mem.snap" || got.Status != StatusRunning {
+		t.Fatalf("clear must not touch other fields: %+v", got)
+	}
+
+	// Absent record and already-disarmed record are both no-op successes.
+	if err := store.ClearDirtyTrackingArmed("vm-absent"); err != nil {
+		t.Fatalf("clear absent must be a no-op: %v", err)
+	}
+	if err := store.ClearDirtyTrackingArmed("vm-armed"); err != nil {
+		t.Fatalf("clear already-disarmed must be a no-op: %v", err)
+	}
+}
+
 func TestStateStorePrimaryRecordUsesRestrictiveRollbackFallback(t *testing.T) {
 	s, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
 	if err != nil {

--- a/internal/vm/state_test.go
+++ b/internal/vm/state_test.go
@@ -25,7 +25,7 @@ func TestPreviewPolicyRecordRoundTrip(t *testing.T) {
 		PreviewPolicyRevision: 7,
 	}
 
-	rec := toRecord(inst)
+	rec := toRecord(inst, false)
 	if rec.PreviewAccess != preview.AccessPrivate || rec.PreviewPolicyRevision != 7 {
 		t.Fatalf("record policy = (%q, %d), want restrictive fallback (%q, 7)", rec.PreviewAccess, rec.PreviewPolicyRevision, preview.AccessPrivate)
 	}
@@ -78,7 +78,7 @@ func TestPausedAtRoundTrip(t *testing.T) {
 		PausedAt: pausedAt,
 	}
 
-	rec := toRecord(inst)
+	rec := toRecord(inst, false)
 	if !rec.PausedAt.Equal(pausedAt) {
 		t.Fatalf("record paused_at = %v, want %v", rec.PausedAt, pausedAt)
 	}


### PR DESCRIPTION
A vmd restart reattaches to live Firecracker processes but loses the in-memory `DirtyTracked` flag, so each running VM's next pause writes a full memory snapshot instead of a fast diff (a slow-pause burst after every deploy, self-healing on the next resume). This persists the armed bit and re-arms it on reattach — **gated behind `VMD_PERSIST_DIRTY_TRACKING` (default off)** until we verify Firecracker's dirty bitmap survives a restart, since re-arming against a reset bitmap would corrupt the diff.

Correctness details:
- **Persist is gated on the flag** (`toRecord(inst, persistDirtyArmed)`) — so with the feature off, no `armed` bit is ever written, no stale bit can exist, and enabling is always safe (a VM whose bit was never persisted just takes one full pause, then heals).
- **Write-ahead disarm**: durably clear the armed bit before any bitmap-resetting snapshot, refuse the snapshot if the clear fails. `PauseVM` and `CreateVMSnapshot` both hold the vm-op lock across disarm+snapshot, so no concurrent lifecycle write can re-arm in the gap (`CreateVMSnapshot` is now serialized for exactly this reason).
- **Field-level clear** edits the raw JSON (`dirty_tracking_armed` key only), preserving any newer fields under rollback/mixed-version; uses `Update` (no batch-coalescing delay).
- Re-arm only for a confirmed-Running reattach.

Also adds `snapshot_type` (layered/diff/full) + `snapshot_ms`/`stop_ms`/`pause_ms` to the pause log (not gated) so full-vs-diff pauses are visible; `pause_ms` starts before the vm-op lock so it includes queueing.

Cost: with the flag off there is no added lifecycle write. With it on, the disarm is one extra bbolt commit on the pause path (the pause already does one for its final persist) — small relative to the snapshot the pause writes, and it exists to avoid the multi-second full pause. Not micro-benchmarked; the intent is qualitative (one small commit), and the new `pause_ms`/`snapshot_ms` fields make the real cost measurable once enabled.

Before enabling: verify bitmap-survival end to end (dirty known pages before and after a restart, restore base+diff, validate both sets).