### PR TITLE
deploy: enable the backup backfill sweep on the usw cell

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -335,6 +335,13 @@ jobs:
           # Enables the pause-backup uploader for the cell (validated on
           # staging first; the bucket is create-only for hosts).
           BACKUP_BUCKET: superserve-artifact-backup-usw2
+          # Sweeps paused sandboxes that predate the uploader into the
+          # backup bucket; without it they have no copy off the host's
+          # local SSD. Backfill work rides the best-effort tier, so live
+          # pause uploads keep queue priority and egress stays under the
+          # shared bandwidth cap. Removing this line disables the sweep
+          # on the next deploy.
+          BACKUP_BACKFILL: "1"
           # Keeps the backup journal off the root disk — it's written
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills.


### PR DESCRIPTION
## Summary
Stage three of the gated backfill rollout (staging, then use4, now usw). Most of the usw cell's paused fleet predates the pause-backup uploader and has no copy off the host's local SSD until the sweep runs; this makes that data durable. Part of the sandbox recovery/durability effort.

## Technical decisions
- Same one-line enablement as the staging and use4 stages; deploy-vmd.py reconciles the flag reversibly (removing the line disables the sweep on the next deploy).
- Backfill work rides the best-effort queue tier, so live pause uploads keep priority, and all workers share the existing bandwidth cap, so egress does not rise.
- The backlog-age alert is scoped to the pause tier, so the one-time backfill queue will not hold it firing during convergence.

## Testing
- YAML parse check on the workflow.
- No binary or terraform changes; rollout is the standard staging -> use4 -> usw deploy order gated on CI.