### PR TITLE
backup: read-only discrepancy report over the uncovered paused fleet

### DIFF
--- a/cmd/backup-restore/discrepancy.go
+++ b/cmd/backup-restore/discrepancy.go
@@ -1,0 +1,259 @@
+package main
+
+// The discrepancy subcommand classifies every paused, non-destroyed
+// sandbox lacking a verified backup generation in the audited bucket
+// into exactly one class (no_snapshot_row, stale_zero_byte,
+// sweep_missed) and emits a JSON ledger plus a human summary. Read-only
+// by construction: it runs SELECTs against the control-plane DB,
+// optionally lists the backup bucket, and writes nothing but the local
+// report file.
+//
+// Like the rest of this tool it talks raw SQL over pgx rather than the
+// control plane's query layer: DR tooling must keep working when the
+// control plane is down, so its only inputs are a DB URL and the name
+// of the bucket being audited. The default run needs no GCS
+// credentials; -probe-bucket adds an optional bucket confirmation pass
+// over the classified rows.
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/superserve-ai/sandbox/internal/backup"
+)
+
+// discrepancyQuery enumerates the uncovered paused fleet. Two shapes
+// carry its semantics:
+//
+//   - The join target is the HEAD snapshot row, the one
+//     sandbox.snapshot_id points at (pause finalize maintains it). Not a
+//     lateral newest-by-created_at over snapshot history: a sandbox whose
+//     head pointer is NULL must classify as no_snapshot_row even when
+//     historical rows exist, because the head is what restore would
+//     consume. The FK is ON DELETE SET NULL and the reaper deletes
+//     snapshot rows of destroyed sandboxes, so NULL heads are real.
+//   - Coverage is plain existence of a backup_generation row for the
+//     sandbox in the audited bucket. Per-bucket because that is how the
+//     uploader and sweep track coverage (vmd's Covered callback scopes
+//     journal.Covered to its bucket, and backup_generation stores the
+//     bucket for exactly this reason): after a bucket rotation, rows
+//     pointing at the old bucket are not coverage in the new one, and
+//     an unqualified EXISTS would undercount the gap. Existence, with no
+//     latest-generation join or recency ranking, because the report
+//     enumerates the never-covered backlog the backfill sweep owes:
+//     sandboxes with no verified generation in the bucket at all. A
+//     sandbox whose newest pause lost its upload while an older
+//     generation exists is a coverage-recency question for per-pause
+//     monitoring, and answering it takes per-generation manifest
+//     correlation that is outside this ledger's scope.
+const discrepancyQuery = `
+SELECT sb.id::text,
+       COALESCE(sb.host_id, ''),
+       s.id IS NOT NULL AS has_snapshot,
+       COALESCE(s.size_bytes, 0),
+       s.created_at
+FROM sandbox sb
+LEFT JOIN snapshot s ON s.id = sb.snapshot_id
+WHERE sb.status = 'paused'
+  AND sb.destroyed_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM backup_generation bg WHERE bg.sandbox_id = sb.id AND bg.bucket = $2)
+  AND ($1 = '' OR sb.host_id = $1)
+ORDER BY sb.id`
+
+func runDiscrepancy(args []string) int {
+	fs := flag.NewFlagSet("discrepancy", flag.ExitOnError)
+	dbURL := fs.String("db-url", os.Getenv("DATABASE_URL"), "control-plane DB URL (default $DATABASE_URL)")
+	bucket := fs.String("bucket", "", "backup bucket whose coverage is audited (required: coverage is recorded per bucket)")
+	host := fs.String("host", "", "restrict the report to one host id")
+	staleDays := fs.Int("stale-days", 30, "zero-byte snapshot records older than this classify as stale_zero_byte")
+	out := fs.String("out", "", "report path (default ./discrepancy-report-<timestamp>.json)")
+	probeBucket := fs.Bool("probe-bucket", false, "confirm classified rows against the bucket over GCS (requires credentials; default is DB-only)")
+	_ = fs.Parse(args)
+	if *dbURL == "" {
+		fmt.Fprintln(os.Stderr, "discrepancy: -db-url (or DATABASE_URL) is required")
+		return 2
+	}
+	if *bucket == "" {
+		fmt.Fprintln(os.Stderr, "discrepancy: -bucket is required; coverage is recorded per bucket, so the report must name which cell's backup bucket it audits")
+		return 2
+	}
+	// The upper bound keeps the horizon inside representable time (and
+	// any real fleet's age); an operator typo like a pasted timestamp
+	// should fail loudly, not classify everything as stale.
+	if *staleDays < 0 || *staleDays > 36500 {
+		fmt.Fprintln(os.Stderr, "discrepancy: -stale-days must be between 0 and 36500")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	conn, err := pgx.Connect(ctx, *dbURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discrepancy: connect: %v\n", err)
+		return 1
+	}
+	defer conn.Close(ctx)
+
+	// A mistyped or foreign-cell host id must not read as a clean zero:
+	// verify the host row exists so "unknown host" and "no uncovered
+	// rows" stay distinguishable. Unlike host restore this is a report,
+	// not an inventory a recovery depends on, so an active host gets the
+	// churn warning rather than a refusal.
+	if *host != "" {
+		var hostStatus string
+		err := conn.QueryRow(ctx, `SELECT status FROM host WHERE id = $1`, *host).Scan(&hostStatus)
+		if err == pgx.ErrNoRows {
+			fmt.Fprintf(os.Stderr, "discrepancy: host %q is not in this cell's host table; check the id and the cell\n", *host)
+			return 1
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "discrepancy: verify host: %v\n", err)
+			return 1
+		}
+		if hostStatus == "active" {
+			fmt.Fprintf(os.Stderr, "warning: host %q is active and taking placements; %s\n", *host, backup.DiscrepancyLiveWarning)
+		}
+	}
+
+	dbRows, err := conn.Query(ctx, discrepancyQuery, *host, *bucket)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discrepancy: query: %v\n", err)
+		return 1
+	}
+	defer dbRows.Close()
+	var rows []backup.DiscrepancyRow
+	for dbRows.Next() {
+		var row backup.DiscrepancyRow
+		var created *time.Time
+		if err := dbRows.Scan(&row.SandboxID, &row.HostID, &row.HasSnapshot, &row.SnapshotSize, &created); err != nil {
+			fmt.Fprintf(os.Stderr, "discrepancy: scan: %v\n", err)
+			return 1
+		}
+		if created != nil {
+			row.SnapshotCreated = *created
+		}
+		rows = append(rows, row)
+	}
+	if err := dbRows.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "discrepancy: query: %v\n", err)
+		return 1
+	}
+	// The DB work ends with enumeration; release the control-plane
+	// connection now rather than holding it across the optional GCS
+	// probe, which walks the fleet serially and can run long. The
+	// deferred Close stays as the safety net on early returns above
+	// (Close on a closed pgx conn is a no-op).
+	conn.Close(ctx)
+
+	report := backup.BuildDiscrepancyReport(rows, time.Now().UTC(), *staleDays, *bucket, *host)
+
+	exit := 0
+	if *probeBucket {
+		report.Probed = true
+		if err := probeDiscrepancyBucket(ctx, *bucket, report); err != nil {
+			// The DB-only classification is complete and worth keeping,
+			// so fall through to the ledger write; but a requested probe
+			// that did not finish must not read as a confirmed run, so
+			// the failure lands in the ledger and the exit code.
+			report.ProbeError = err.Error()
+			fmt.Fprintf(os.Stderr, "warning: bucket probe incomplete: %v\n", err)
+			exit = 1
+		}
+	}
+
+	fmt.Printf("discrepancy report: %d paused sandboxes lack a verified backup generation in %s\n", report.Total, *bucket)
+	fmt.Printf("  %-16s %d\n", backup.DiscrepancyStaleZeroByte, report.StaleZeroByte)
+	fmt.Printf("  %-16s %d\n", backup.DiscrepancyNoSnapshotRow, report.NoSnapshotRow)
+	fmt.Printf("  %-16s %d\n", backup.DiscrepancySweepMissed, report.SweepMissed)
+	fmt.Fprintf(os.Stderr, "warning: %s\n", report.Warning)
+
+	ledger, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discrepancy: marshal report: %v\n", err)
+		return 1
+	}
+	path := *out
+	if path == "" {
+		path = fmt.Sprintf("discrepancy-report-%s.json", report.GeneratedAt.Format("20060102T150405Z"))
+	}
+	// O_EXCL: a ledger must never silently truncate an existing report
+	// (two runs sharing a second-resolution default name, or an -out
+	// pointing at a prior ledger), and overwriting in place would keep
+	// the old file's permissions instead of 0600.
+	f, werr := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if werr == nil {
+		_, werr = f.Write(ledger)
+		if cerr := f.Close(); werr == nil {
+			werr = cerr
+		}
+		if werr != nil {
+			// A truncated ledger must not survive (it would parse as a
+			// smaller fleet), and leaving it would also block an O_EXCL
+			// retry at the same path.
+			os.Remove(path)
+		}
+	}
+	if werr != nil {
+		// The classification still reaches the operator via stderr, but
+		// the run failed its contract: automation pointing -out at a
+		// collection path must not read a missing artifact as success.
+		fmt.Fprintf(os.Stderr, "ledger write failed (%v); printing instead:\n%s\n", werr, ledger)
+		return 1
+	}
+	fmt.Printf("ledger: %s\n", path)
+	return exit
+}
+
+// probeDiscrepancyBucket lists each classified sandbox's prefix in the
+// backup bucket and records how many completed generations exist there.
+// A nonzero count on an uncovered row means durable bytes exist that
+// the DB does not record, which points the investigation at report
+// ingestion rather than the upload path; whether those generations
+// capture the current pause is a manifest question the restore tooling
+// answers, not this report.
+func probeDiscrepancyBucket(ctx context.Context, bucket string, report *backup.DiscrepancyReport) error {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storage client: %w", err)
+	}
+	defer client.Close()
+	reader := backup.NewGCSReader(client, bucket)
+	covered, failed := 0, 0
+	for i := range report.Records {
+		if ctx.Err() != nil {
+			// Unprobed rows keep a nil bucket_generations, which the
+			// ledger distinguishes from a probed zero.
+			return fmt.Errorf("canceled after %d of %d rows", i, len(report.Records))
+		}
+		gens, err := backup.ListGenerations(ctx, reader, report.Records[i].SandboxID)
+		if err != nil {
+			// A per-row listing failure must not zero the row (nil means
+			// "not probed", never "absent"); record it and keep going so
+			// the pass stays a full ledger.
+			report.Records[i].ProbeError = err.Error()
+			failed++
+			continue
+		}
+		n := len(gens)
+		report.Records[i].BucketGenerations = &n
+		if n > 0 {
+			covered++
+		}
+	}
+	fmt.Printf("bucket probe: %d of %d classified rows have completed generations in %s (durable bytes exist that the DB does not record; whether they capture the current pause needs the manifest)\n",
+		covered, len(report.Records), bucket)
+	if failed > 0 {
+		return fmt.Errorf("%d of %d listings failed; their rows carry probe_error in the ledger", failed, len(report.Records))
+	}
+	return nil
+}

--- a/cmd/backup-restore/discrepancy_test.go
+++ b/cmd/backup-restore/discrepancy_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A textual pin on the query's semantics-bearing clauses (head-pointer
+// join, bucket-scoped existence coverage, selection predicates). No SQL
+// parser is in the module, so this test does not execute the query.
+func TestDiscrepancyQueryInvariants(t *testing.T) {
+	mustContain := []string{
+		// The join target is the head pointer, never snapshot history.
+		"LEFT JOIN snapshot s ON s.id = sb.snapshot_id",
+		// Coverage is existence of a backup_generation row scoped to the
+		// audited bucket, matching how the uploader and sweep track
+		// coverage: a sandbox whose only rows point at a different
+		// (rotated-out) bucket must enumerate as uncovered.
+		"NOT EXISTS (SELECT 1 FROM backup_generation bg WHERE bg.sandbox_id = sb.id AND bg.bucket = $2)",
+		// Selection: paused, live, with the optional host filter.
+		"sb.status = 'paused'",
+		"sb.destroyed_at IS NULL",
+		"($1 = '' OR sb.host_id = $1)",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(discrepancyQuery, s) {
+			t.Errorf("query lost required clause %q", s)
+		}
+	}
+	mustNotContain := []string{
+		// A lateral newest-by-created_at join would misclassify NULL
+		// heads with historical rows; recency over backup_generation is
+		// irrelevant to existence-based coverage.
+		"LATERAL",
+		"created_at DESC",
+		"completed_at",
+	}
+	for _, s := range mustNotContain {
+		if strings.Contains(discrepancyQuery, s) {
+			t.Errorf("query must not contain %q", s)
+		}
+	}
+}

--- a/cmd/backup-restore/main.go
+++ b/cmd/backup-restore/main.go
@@ -29,10 +29,15 @@ import (
 )
 
 func main() {
-	// Subcommand dispatch ahead of flag parsing: `revive` drives vmd
-	// directly and has its own flag set.
-	if len(os.Args) > 1 && os.Args[1] == "revive" {
-		os.Exit(runRevive(os.Args[2:]))
+	// Subcommand dispatch ahead of flag parsing: `revive` and
+	// `discrepancy` own their flag sets.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "revive":
+			os.Exit(runRevive(os.Args[2:]))
+		case "discrepancy":
+			os.Exit(runDiscrepancy(os.Args[2:]))
+		}
 	}
 	bucket := flag.String("bucket", "", "backup bucket name")
 	sandbox := flag.String("sandbox", "", "sandbox id")
@@ -48,6 +53,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "usage: backup-restore -bucket <bucket> -sandbox <id> -generation <gen> -dest <dir>")
 		fmt.Fprintln(os.Stderr, "       backup-restore -bucket <bucket> -sandbox <id>   (list restorable generations, newest first)")
 		fmt.Fprintln(os.Stderr, "       backup-restore revive -manifest <file>          (cold-boot dead sandboxes from salvaged disks, on-host)")
+		fmt.Fprintln(os.Stderr, "       backup-restore discrepancy -bucket <bucket>     (classify paused sandboxes lacking a verified backup; read-only)")
 		flag.PrintDefaults()
 	}
 	flag.Parse()

--- a/internal/backup/discrepancy.go
+++ b/internal/backup/discrepancy.go
@@ -1,0 +1,166 @@
+package backup
+
+import (
+	"fmt"
+	"time"
+)
+
+// Discrepancy classification: every paused, non-destroyed sandbox lacking
+// a verified backup generation in the audited bucket falls into exactly
+// one class, so a backup coverage gap reads as a small set of named
+// causes instead of one opaque count. Coverage is per bucket, mirroring
+// how the uploader and sweep track it (Journal.Covered takes the bucket
+// as its scope): after a bucket rotation, rows pointing at the old
+// bucket are not coverage in the new one. The policy lives here with
+// no DB dependency; cmd/backup-restore/discrepancy.go owns the
+// enumeration query and feeds rows in.
+//
+// The classes come from how a pause can end up uncovered:
+//
+//   - no_snapshot_row: the sandbox's head snapshot pointer
+//     (sandbox.snapshot_id) is NULL, so the control plane records no
+//     current pause artifact at all. The pointer is maintained by pause
+//     finalize and is ON DELETE SET NULL, so a NULL head on a paused
+//     sandbox is drift, not a transient.
+//   - stale_zero_byte: the head snapshot row exists but records zero
+//     bytes and predates the staleness horizon. size_bytes starts at
+//     zero and gains a value from a pause-time manifest total or a
+//     verified backup report, so an old row still at zero means neither
+//     ever arrived for that pause.
+//   - sweep_missed: everything else — a recent or sized head snapshot
+//     with no verified generation. The backfill sweep has not converged
+//     on it yet, or is not running on its host; the per-row host id is
+//     what tells those two apart.
+type DiscrepancyClass string
+
+const (
+	DiscrepancyNoSnapshotRow DiscrepancyClass = "no_snapshot_row"
+	DiscrepancyStaleZeroByte DiscrepancyClass = "stale_zero_byte"
+	DiscrepancySweepMissed   DiscrepancyClass = "sweep_missed"
+)
+
+// DiscrepancyLiveWarning travels in every report: enumeration is one
+// point-in-time query, so while placement and the sweep are live, rows
+// pause, resume, and gain coverage between runs and counts churn. For a
+// fleet-wide report that churn is noise to be aware of, not a reason to
+// refuse to run; only a frozen host yields stable numbers.
+const DiscrepancyLiveWarning = "counts are a point-in-time snapshot; while placement and the backfill sweep are live they will churn between runs, and per-host zeros are provisional unless the host is frozen"
+
+// DiscrepancyRow is one uncovered paused sandbox as enumerated from the
+// control plane: the sandbox joined to its HEAD snapshot row (the one
+// sandbox.snapshot_id points at), never a newest-by-created_at guess over
+// snapshot history. A sandbox whose head is NULL classifies as
+// no_snapshot_row even if historical snapshot rows exist, because the
+// head is what pause finalize maintains and what restore would consume.
+type DiscrepancyRow struct {
+	SandboxID string
+	HostID    string
+	// HasSnapshot reports whether the head pointer resolved to a snapshot
+	// row. False means sandbox.snapshot_id is NULL (the FK is ON DELETE
+	// SET NULL, so a deleted row nulls the pointer rather than dangling).
+	HasSnapshot     bool
+	SnapshotSize    int64
+	SnapshotCreated time.Time // zero when HasSnapshot is false
+}
+
+// DiscrepancyRecord is one classified row of the report ledger.
+type DiscrepancyRecord struct {
+	SandboxID string           `json:"sandbox_id"`
+	HostID    string           `json:"host_id"`
+	Class     DiscrepancyClass `json:"class"`
+	Reason    string           `json:"reason"`
+	// Head snapshot facts, present only when a head row exists.
+	SnapshotCreated   *time.Time `json:"snapshot_created,omitempty"`
+	SnapshotAgeDays   *int64     `json:"snapshot_age_days,omitempty"`
+	SnapshotSizeBytes *int64     `json:"snapshot_size_bytes,omitempty"`
+	// Optional GCS confirmation pass (-probe-bucket): how many completed
+	// generations the bucket actually holds for this sandbox. Nonzero
+	// means durable bytes exist that the DB does not record; whether
+	// they capture the current pause takes a manifest comparison, which
+	// is restore tooling's job, not this report's. Nil when the probe
+	// did not run or failed for this row.
+	BucketGenerations *int   `json:"bucket_generations,omitempty"`
+	ProbeError        string `json:"probe_error,omitempty"`
+}
+
+// DiscrepancyReport aggregates a run: per-class counts first so the
+// verdict reads before the detail, then every classified row.
+type DiscrepancyReport struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	// Bucket is the backup bucket whose coverage this report audits;
+	// the enumeration's coverage predicate is scoped to it, so rows
+	// pointing at a rotated-out bucket never count as coverage.
+	Bucket        string `json:"bucket"`
+	HostFilter    string `json:"host_filter,omitempty"`
+	StaleDays     int    `json:"stale_days"`
+	Warning       string `json:"warning"`
+	Total         int    `json:"total"`
+	NoSnapshotRow int    `json:"no_snapshot_row"`
+	StaleZeroByte int    `json:"stale_zero_byte"`
+	SweepMissed   int    `json:"sweep_missed"`
+	// Probed reports whether the optional GCS confirmation pass ran;
+	// ProbeError records why it did not complete, so a ledger with an
+	// unconfirmed probe never reads as a confirmed one.
+	Probed     bool                `json:"probed,omitempty"`
+	ProbeError string              `json:"probe_error,omitempty"`
+	Records    []DiscrepancyRecord `json:"records"`
+}
+
+// ClassifyDiscrepancy assigns exactly one class to an uncovered row. The
+// staleness boundary is strict: a zero-byte snapshot created exactly
+// staleDays ago is not yet stale and classifies as sweep_missed.
+func ClassifyDiscrepancy(row DiscrepancyRow, now time.Time, staleDays int) DiscrepancyRecord {
+	rec := DiscrepancyRecord{SandboxID: row.SandboxID, HostID: row.HostID}
+	if !row.HasSnapshot {
+		rec.Class = DiscrepancyNoSnapshotRow
+		rec.Reason = "paused with a NULL head snapshot pointer: the control plane records no current pause artifact"
+		return rec
+	}
+	created := row.SnapshotCreated
+	size := row.SnapshotSize
+	ageDays := int64(now.Sub(created).Hours() / 24)
+	rec.SnapshotCreated = &created
+	rec.SnapshotAgeDays = &ageDays
+	rec.SnapshotSizeBytes = &size
+	// AddDate rather than a Duration multiply: day counts near
+	// time.Duration's ~106751-day ceiling would overflow the multiply
+	// and invert the cutoff into the future. In UTC a calendar day is
+	// exactly 24h, so the horizon is staleDays whole days.
+	cutoff := now.AddDate(0, 0, -staleDays)
+	if size == 0 && created.Before(cutoff) {
+		rec.Class = DiscrepancyStaleZeroByte
+		rec.Reason = fmt.Sprintf("zero-byte head snapshot older than %d days: no pause manifest total or backup report ever recorded a size", staleDays)
+	} else {
+		rec.Class = DiscrepancySweepMissed
+		rec.Reason = "head snapshot recorded but no verified generation: sweep not yet converged, or not running on this host"
+	}
+	return rec
+}
+
+// BuildDiscrepancyReport classifies every row and aggregates counts.
+// Rows arrive pre-filtered (paused, not destroyed, no backup_generation
+// row for the audited bucket); this function only classifies and counts.
+func BuildDiscrepancyReport(rows []DiscrepancyRow, now time.Time, staleDays int, bucket, hostFilter string) *DiscrepancyReport {
+	report := &DiscrepancyReport{
+		GeneratedAt: now,
+		Bucket:      bucket,
+		HostFilter:  hostFilter,
+		StaleDays:   staleDays,
+		Warning:     DiscrepancyLiveWarning,
+		Total:       len(rows),
+		Records:     make([]DiscrepancyRecord, 0, len(rows)),
+	}
+	for _, row := range rows {
+		rec := ClassifyDiscrepancy(row, now, staleDays)
+		switch rec.Class {
+		case DiscrepancyNoSnapshotRow:
+			report.NoSnapshotRow++
+		case DiscrepancyStaleZeroByte:
+			report.StaleZeroByte++
+		case DiscrepancySweepMissed:
+			report.SweepMissed++
+		}
+		report.Records = append(report.Records, rec)
+	}
+	return report
+}

--- a/internal/backup/discrepancy_test.go
+++ b/internal/backup/discrepancy_test.go
@@ -1,0 +1,190 @@
+package backup
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Fixed clock: classification depends only on now-relative ages, so the
+// tests pin now and derive creation times from it.
+var discNow = time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+
+func discRow(hasSnapshot bool, size int64, age time.Duration) DiscrepancyRow {
+	row := DiscrepancyRow{SandboxID: "sb-1", HostID: "usw2", HasSnapshot: hasSnapshot}
+	if hasSnapshot {
+		row.SnapshotSize = size
+		row.SnapshotCreated = discNow.Add(-age)
+	}
+	return row
+}
+
+func TestClassifyDiscrepancy(t *testing.T) {
+	const day = 24 * time.Hour
+	cases := []struct {
+		name string
+		row  DiscrepancyRow
+		want DiscrepancyClass
+	}{
+		// A NULL head classifies as no_snapshot_row regardless of any
+		// historical snapshot rows: the enumeration query joins ONLY the
+		// head pointer (sandbox.snapshot_id), so history never reaches
+		// classification. Both realities present as HasSnapshot=false.
+		{"null head, no history", discRow(false, 0, 0), DiscrepancyNoSnapshotRow},
+		{"null head, history exists but is not the head", discRow(false, 0, 0), DiscrepancyNoSnapshotRow},
+		{"zero-byte old", discRow(true, 0, 31*day), DiscrepancyStaleZeroByte},
+		{"zero-byte recent", discRow(true, 0, 5*day), DiscrepancySweepMissed},
+		{"nonzero old", discRow(true, 4096, 45*day), DiscrepancySweepMissed},
+		{"nonzero recent", discRow(true, 4096, time.Hour), DiscrepancySweepMissed},
+		// Strict boundary: created exactly staleDays ago is not yet
+		// stale.
+		{"zero-byte exactly at stale-days", discRow(true, 0, 30*day), DiscrepancySweepMissed},
+		{"zero-byte one second past stale-days", discRow(true, 0, 30*day+time.Second), DiscrepancyStaleZeroByte},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := ClassifyDiscrepancy(tc.row, discNow, 30)
+			if rec.Class != tc.want {
+				t.Fatalf("class = %q, want %q", rec.Class, tc.want)
+			}
+			if rec.Reason == "" {
+				t.Fatal("reason must never be empty")
+			}
+			if rec.SandboxID != tc.row.SandboxID || rec.HostID != tc.row.HostID {
+				t.Fatalf("identity not carried: %+v", rec)
+			}
+			if tc.row.HasSnapshot {
+				if rec.SnapshotCreated == nil || rec.SnapshotSizeBytes == nil || rec.SnapshotAgeDays == nil {
+					t.Fatalf("snapshot facts missing on a row with a head: %+v", rec)
+				}
+				if *rec.SnapshotSizeBytes != tc.row.SnapshotSize {
+					t.Fatalf("size = %d, want %d", *rec.SnapshotSizeBytes, tc.row.SnapshotSize)
+				}
+			} else if rec.SnapshotCreated != nil || rec.SnapshotSizeBytes != nil || rec.SnapshotAgeDays != nil {
+				t.Fatalf("snapshot facts must be absent without a head: %+v", rec)
+			}
+		})
+	}
+}
+
+// A horizon at the flag's upper bound must stay a past cutoff: a naive
+// duration multiply overflows near 106751 days and flips the cutoff
+// into the future, classifying everything as stale.
+func TestClassifyDiscrepancyLargeStaleDays(t *testing.T) {
+	rec := ClassifyDiscrepancy(discRow(true, 0, 40*24*time.Hour), discNow, 36500)
+	if rec.Class != DiscrepancySweepMissed {
+		t.Fatalf("class = %q, want %q", rec.Class, DiscrepancySweepMissed)
+	}
+}
+
+func TestClassifyDiscrepancyAgeDays(t *testing.T) {
+	rec := ClassifyDiscrepancy(discRow(true, 0, 31*24*time.Hour+time.Hour), discNow, 30)
+	if *rec.SnapshotAgeDays != 31 {
+		t.Fatalf("age days = %d, want 31", *rec.SnapshotAgeDays)
+	}
+}
+
+func TestBuildDiscrepancyReportCounts(t *testing.T) {
+	const day = 24 * time.Hour
+	rows := []DiscrepancyRow{
+		discRow(false, 0, 0),
+		discRow(true, 0, 40*day),
+		discRow(true, 0, 50*day),
+		discRow(true, 0, day),
+		discRow(true, 1<<20, 90*day),
+	}
+	report := BuildDiscrepancyReport(rows, discNow, 30, "cell-backups", "usw2")
+	if report.Total != 5 || len(report.Records) != 5 {
+		t.Fatalf("total = %d, records = %d, want 5", report.Total, len(report.Records))
+	}
+	if report.NoSnapshotRow != 1 || report.StaleZeroByte != 2 || report.SweepMissed != 2 {
+		t.Fatalf("counts = %d/%d/%d, want 1/2/2", report.NoSnapshotRow, report.StaleZeroByte, report.SweepMissed)
+	}
+	if report.NoSnapshotRow+report.StaleZeroByte+report.SweepMissed != report.Total {
+		t.Fatal("every row must land in exactly one class")
+	}
+	if report.Bucket != "cell-backups" || report.HostFilter != "usw2" || report.StaleDays != 30 {
+		t.Fatalf("parameters not recorded: %+v", report)
+	}
+	if report.Warning != DiscrepancyLiveWarning {
+		t.Fatal("the live-churn warning must travel in the ledger")
+	}
+	// Covered, destroyed, and non-paused sandboxes never reach this
+	// function: the enumeration query excludes them (status='paused',
+	// destroyed_at IS NULL, NOT EXISTS over backup_generation scoped to
+	// the audited bucket, so a row for a different bucket does NOT count
+	// as coverage), which the cmd-level SQL invariant test pins.
+}
+
+func TestBuildDiscrepancyReportEmpty(t *testing.T) {
+	report := BuildDiscrepancyReport(nil, discNow, 30, "cell-backups", "")
+	if report.Total != 0 || len(report.Records) != 0 {
+		t.Fatalf("empty input must yield an empty report: %+v", report)
+	}
+	// Records must marshal as [] rather than null so ledger consumers
+	// can iterate without a nil check.
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"records":null`) {
+		t.Fatalf("records must marshal as an empty array: %s", data)
+	}
+}
+
+// TestDiscrepancyReportJSONShape pins the ledger's wire shape: field
+// names and per-class keys are parsed by operators and downstream
+// tooling, so renaming any of them is a breaking change.
+func TestDiscrepancyReportJSONShape(t *testing.T) {
+	const day = 24 * time.Hour
+	rows := []DiscrepancyRow{
+		discRow(false, 0, 0),
+		discRow(true, 0, 40*day),
+	}
+	report := BuildDiscrepancyReport(rows, discNow, 30, "cell-backups", "usw2")
+	got, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{
+  "generated_at": "2026-08-16T12:00:00Z",
+  "bucket": "cell-backups",
+  "host_filter": "usw2",
+  "stale_days": 30,
+  "warning": ` + string(mustJSON(t, DiscrepancyLiveWarning)) + `,
+  "total": 2,
+  "no_snapshot_row": 1,
+  "stale_zero_byte": 1,
+  "sweep_missed": 0,
+  "records": [
+    {
+      "sandbox_id": "sb-1",
+      "host_id": "usw2",
+      "class": "no_snapshot_row",
+      "reason": "paused with a NULL head snapshot pointer: the control plane records no current pause artifact"
+    },
+    {
+      "sandbox_id": "sb-1",
+      "host_id": "usw2",
+      "class": "stale_zero_byte",
+      "reason": "zero-byte head snapshot older than 30 days: no pause manifest total or backup report ever recorded a size",
+      "snapshot_created": "2026-07-07T12:00:00Z",
+      "snapshot_age_days": 40,
+      "snapshot_size_bytes": 0
+    }
+  ]
+}`
+	if string(got) != want {
+		t.Fatalf("ledger shape drifted:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}


### PR DESCRIPTION
## Summary

Adds a `discrepancy` subcommand to `cmd/backup-restore` that classifies every paused, non-destroyed sandbox lacking a verified backup generation in the audited bucket into exactly one class (`no_snapshot_row`, `stale_zero_byte`, `sweep_missed`) and emits a JSON ledger plus a per-class summary. This is the discrepancy-report deliverable of the sandbox recovery and durability effort: it turns an opaque uncovered count into named causes with per-row host attribution, so hosts whose paused fleet predates the uploader are distinguishable from sweep gaps.

## Technical decisions

- The snapshot join targets the head pointer only (`sandbox.snapshot_id`, maintained by pause finalize), never a newest-by-created_at lateral over snapshot history: a NULL head must classify as `no_snapshot_row` even when historical rows exist, since the FK is ON DELETE SET NULL and the reaper deletes snapshot rows.
- Coverage is `NOT EXISTS` over `backup_generation` scoped to the audited bucket (`-bucket` is required and recorded in the ledger): the uploader and sweep track coverage per bucket, so rows pointing at a rotated-out bucket never mask a gap. No recency ranking beyond that: the report enumerates the never-covered backlog, deliberately.
- Raw pgx with inline SQL, matching the rest of the tool: DR tooling must run when the control plane is down. DB-only is the default; `-probe-bucket` adds an optional GCS confirmation pass.
- Read-only by construction; the ledger warns that counts churn while placement is live rather than refusing to run.

## Testing

- `go test ./internal/backup/... ./cmd/backup-restore/...` and `go vet` pass (linux, Go 1.25): exhaustive classification table tests (NULL head, zero-byte old/recent, sized old, exact stale-days boundary, large stale-days horizon), aggregate counting, and a golden test pinning the ledger JSON shape.
- No SQL parser is in the module, so the query text is pinned by an invariant test (head-pointer join, bucket-scoped `NOT EXISTS`, selection predicates, no LATERAL/recency clauses). Execution verified against Postgres 16 with a fixture covering all classes plus the exclusions, including a sandbox whose only `backup_generation` rows name a different bucket, which enumerates as uncovered as required.