### PR TITLE
telemetry: give every OTLP recorder a stable per-process instance id

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -536,6 +536,12 @@ func main() {
 				Msg("paused network reclaim is enabled but no pressure trigger is configured; reclamation will remain inert until at least one threshold is raised")
 		}
 	}
+	// One instance ID for the whole process: vmd builds both an
+	// OTelRecorder (below) and a BackupRecorder (further down) under the
+	// same service.name, and each defaults its own random ID independently
+	// if not told otherwise — which would misrepresent this single vmd
+	// process as two separate GMP targets.
+	otelInstanceID := telemetry.NewInstanceID()
 	recorder := telemetry.NewNoopRecorder()
 	if envOrDefault("OTEL_METRICS_ENABLED", "false") == "true" {
 		otelExportInterval, err := time.ParseDuration(envOrDefault("OTEL_EXPORT_INTERVAL", "15s"))
@@ -544,6 +550,7 @@ func main() {
 		}
 		otelRecorder, err := telemetry.NewOTelRecorder(ctx, telemetry.OTelConfig{
 			HostID:         cfg.HostID,
+			InstanceID:     otelInstanceID,
 			ServiceName:    envOrDefault("OTEL_SERVICE_NAME", "sandbox-vmd"),
 			ServiceVersion: os.Getenv("OTEL_SERVICE_VERSION"),
 			Environment:    envOrDefault("OTEL_ENVIRONMENT", "dev"),
@@ -703,6 +710,7 @@ func main() {
 				Endpoint:       envOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
 				Insecure:       os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "true",
 				ExportInterval: exportInterval,
+				InstanceID:     otelInstanceID,
 			},
 			HostID: cfg.HostID,
 		})

--- a/internal/telemetry/backup.go
+++ b/internal/telemetry/backup.go
@@ -74,6 +74,7 @@ type BackupRecorder struct {
 	serviceName string
 	environment string
 	hostID      string
+	instanceID  string
 
 	enabled           metric.Int64Gauge
 	journalPending    metric.Int64Gauge
@@ -117,6 +118,10 @@ func NewBackupRecorder(ctx context.Context, cfg BackupOTelConfig) (*BackupRecord
 	if cfg.ExportInterval <= 0 {
 		cfg.ExportInterval = 15 * time.Second
 	}
+	// Every meter-provider constructor in this package must resolve its own
+	// InstanceID — see resolveInstanceID for why this can't live in a
+	// shared helper further down the call chain.
+	cfg.InstanceID = resolveInstanceID(cfg.InstanceID)
 	provider, err := newOTLPMeterProvider(ctx, cfg.OTelConfig)
 	if err != nil {
 		return nil, err
@@ -133,6 +138,7 @@ func NewBackupRecorderWithProvider(provider *sdkmetric.MeterProvider, cfg Backup
 		serviceName: cfg.ServiceName,
 		environment: cfg.Environment,
 		hostID:      safeHostID(cfg.HostID),
+		instanceID:  cfg.InstanceID,
 	}
 	var err error
 	if r.enabled, err = meter.Int64Gauge("backup_enabled"); err != nil {

--- a/internal/telemetry/backup_test.go
+++ b/internal/telemetry/backup_test.go
@@ -26,6 +26,43 @@ func TestBackupRecorderNilSafe(t *testing.T) {
 	}
 }
 
+// NewBackupRecorder calls newOTLPMeterProvider directly rather than going
+// through NewOTelRecorder, so it must resolve InstanceID itself — this
+// guards against that defaulting silently drifting out of sync between the
+// two constructors again (see resolveInstanceID).
+func TestNewBackupRecorderDefaultsInstanceID(t *testing.T) {
+	ctx := context.Background()
+
+	makeRecorder := func() *BackupRecorder {
+		t.Helper()
+		r, err := NewBackupRecorder(ctx, BackupOTelConfig{
+			HostID: "usw2",
+		})
+		if err != nil {
+			t.Fatalf("NewBackupRecorder: %v", err)
+		}
+		t.Cleanup(func() {
+			shutdownCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			// Best-effort: nothing is listening on the default OTLP
+			// endpoint in this test, so the force-flush inside Shutdown is
+			// expected to fail; that's orthogonal to what's under test.
+			_ = r.Shutdown(shutdownCtx)
+		})
+		return r
+	}
+
+	first := makeRecorder()
+	second := makeRecorder()
+
+	if first.instanceID == "" {
+		t.Fatal("NewBackupRecorder left InstanceID empty; every replica would export identical series")
+	}
+	if first.instanceID == second.instanceID {
+		t.Fatalf("two NewBackupRecorder calls produced the same instanceID %q", first.instanceID)
+	}
+}
+
 func TestSafeUploadResultBoundsValues(t *testing.T) {
 	for _, result := range []string{BackupUploadVerified, BackupUploadDeduped, BackupUploadAbandoned, BackupUploadFailed} {
 		if got := safeUploadResult(result); got != result {

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
@@ -30,6 +31,23 @@ type OTelConfig struct {
 	// alerted on per host. Empty (the control plane, which is not per-host)
 	// records as "unknown".
 	HostID string
+	// InstanceID identifies this specific process for the resource-level
+	// service.instance.id attribute. Every db_pool_*/vmd_call_*/etc. series
+	// this recorder emits shares the same metric name, service.name, and
+	// (for host-scoped calls) host_id — nothing distinguishes one process
+	// from another. That's invisible with exactly one process per service,
+	// but the control plane runs as multiple concurrent Cloud Run
+	// instances, so every replica exports identical series in the same
+	// window. The collector's resourcedetection/gcp processor only fills in
+	// a resource attribute when the sender didn't already set it (its
+	// override:false), and it has nothing GCP-native to detect for a
+	// Cloud Run OTLP client — so without InstanceID every replica's data
+	// collapses onto the collector's own host identity once it lands in
+	// Google Managed Prometheus, and GMP's one-point-per-series-per-request
+	// rule drops every write past the first. Left empty, NewOTelRecorder
+	// generates a random one so uniqueness never depends on the caller
+	// remembering to plumb one through.
+	InstanceID string
 }
 
 // OTelRecorder emits the sandbox control plane's bounded operational metrics
@@ -40,6 +58,7 @@ type OTelRecorder struct {
 	serviceName string
 	environment string
 	hostID      string
+	instanceID  string
 
 	sandboxTransitions       metric.Int64Counter
 	sandboxDuration          metric.Float64Histogram
@@ -85,6 +104,7 @@ func NewOTelRecorder(ctx context.Context, cfg OTelConfig) (*OTelRecorder, error)
 	if cfg.ExportInterval <= 0 {
 		cfg.ExportInterval = 15 * time.Second
 	}
+	cfg.InstanceID = resolveInstanceID(cfg.InstanceID)
 
 	provider, err := newOTLPMeterProvider(ctx, cfg)
 	if err != nil {
@@ -97,6 +117,7 @@ func NewOTelRecorder(ctx context.Context, cfg OTelConfig) (*OTelRecorder, error)
 		serviceName: cfg.ServiceName,
 		environment: cfg.Environment,
 		hostID:      safeHostID(cfg.HostID),
+		instanceID:  cfg.InstanceID,
 	}
 	if r.sandboxTransitions, err = meter.Int64Counter("sandbox_transition_total"); err != nil {
 		return nil, err
@@ -422,14 +443,7 @@ func newOTLPMeterProvider(ctx context.Context, cfg OTelConfig) (*sdkmetric.Meter
 		return nil, fmt.Errorf("create otlp metric exporter: %w", err)
 	}
 
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes("",
-			attribute.String("service.name", cfg.ServiceName),
-			attribute.String("service.version", cfg.ServiceVersion),
-			attribute.String("environment", cfg.Environment),
-		),
-	)
+	res, err := buildOTelResource(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create otel resource: %w", err)
 	}
@@ -438,4 +452,50 @@ func newOTLPMeterProvider(ctx context.Context, cfg OTelConfig) (*sdkmetric.Meter
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(cfg.ExportInterval))),
 	), nil
+}
+
+// NewInstanceID generates a random per-process identity for
+// OTelConfig.InstanceID / BackupOTelConfig.InstanceID. A process that
+// constructs more than one recorder — vmd builds both an OTelRecorder and
+// a BackupRecorder — must call this once and pass the same value to every
+// recorder it builds. Left to each constructor's own default, every
+// recorder in the process mints its own random ID, and GMP ends up
+// representing one process as several different service.instance.id
+// targets instead of one.
+func NewInstanceID() string {
+	return resolveInstanceID("")
+}
+
+// resolveInstanceID returns id unchanged if the caller supplied one, or a
+// freshly generated one otherwise. Every constructor that builds a meter
+// provider (NewOTelRecorder, NewBackupRecorder) must call this itself
+// before using cfg.InstanceID: OTelConfig is passed by value throughout
+// this package, so a default applied only inside a shared helper like
+// newOTLPMeterProvider or buildOTelResource never propagates back to the
+// caller's copy, silently leaving that caller's resource attribute empty.
+func resolveInstanceID(id string) string {
+	if id != "" {
+		return id
+	}
+	return uuid.New().String()
+}
+
+// buildOTelResource is the process-level identity attached once per
+// MeterProvider (as opposed to attrs()/selfAttrs(), which are stamped on
+// every individual data point). cfg must already have InstanceID resolved
+// via resolveInstanceID — see NewOTelRecorder and NewBackupRecorder.
+func buildOTelResource(cfg OTelConfig) (*resource.Resource, error) {
+	return resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes("",
+			attribute.String("service.name", cfg.ServiceName),
+			attribute.String("service.version", cfg.ServiceVersion),
+			attribute.String("environment", cfg.Environment),
+			// Gives GMP's prometheus_target resource mapping a real
+			// per-process instance identity to key on instead of falling
+			// back to whatever the collector's own resourcedetection fills
+			// in — see OTelConfig.InstanceID.
+			attribute.String("service.instance.id", cfg.InstanceID),
+		),
+	)
 }

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -92,6 +94,119 @@ func TestHostCapacityQueryTimeoutIndependentOfInterval(t *testing.T) {
 		}
 	}
 }
+
+// resourceAttr looks up a single resource-level attribute by key, the
+// counterpart to the point-level attribute maps the other tests build from
+// datapoint.Attributes.
+func resourceAttr(t *testing.T, kvs []attribute.KeyValue, key string) (string, bool) {
+	t.Helper()
+	for _, kv := range kvs {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewInstanceIDIsUniqueAndNonEmpty(t *testing.T) {
+	a := NewInstanceID()
+	b := NewInstanceID()
+	if a == "" || b == "" {
+		t.Fatalf("NewInstanceID returned empty value: a=%q b=%q", a, b)
+	}
+	if a == b {
+		t.Fatalf("two NewInstanceID calls returned the same value %q", a)
+	}
+}
+
+func TestBuildOTelResourceGeneratesUniqueInstanceIDsPerReplica(t *testing.T) {
+	// Simulates two concurrent Cloud Run replicas of the same service, each
+	// constructing its own recorder from the same base config. Without a
+	// per-process instance.id, both would export identical
+	// service.name+environment series and collide as duplicate time series
+	// once they land in Google Managed Prometheus (the bug this fix closes).
+	cfg := OTelConfig{
+		ServiceName: "sandbox-controlplane",
+		Environment: "production",
+	}
+	cfg.InstanceID = uuid.New().String()
+	resA, err := buildOTelResource(cfg)
+	if err != nil {
+		t.Fatalf("buildOTelResource (replica A): %v", err)
+	}
+
+	cfg.InstanceID = uuid.New().String()
+	resB, err := buildOTelResource(cfg)
+	if err != nil {
+		t.Fatalf("buildOTelResource (replica B): %v", err)
+	}
+
+	idA, ok := resourceAttr(t, resA.Attributes(), "service.instance.id")
+	if !ok || idA == "" {
+		t.Fatalf("replica A resource missing non-empty service.instance.id: %#v", resA.Attributes())
+	}
+	idB, ok := resourceAttr(t, resB.Attributes(), "service.instance.id")
+	if !ok || idB == "" {
+		t.Fatalf("replica B resource missing non-empty service.instance.id: %#v", resB.Attributes())
+	}
+	if idA == idB {
+		t.Fatalf("replica A and B share service.instance.id %q; each replica must be independently identifiable", idA)
+	}
+}
+
+func TestBuildOTelResourceHonorsExplicitInstanceID(t *testing.T) {
+	cfg := OTelConfig{
+		ServiceName: "sandbox-vmd",
+		Environment: "production",
+		InstanceID:  "usw2-fixed-id",
+	}
+	res, err := buildOTelResource(cfg)
+	if err != nil {
+		t.Fatalf("buildOTelResource: %v", err)
+	}
+	if got, ok := resourceAttr(t, res.Attributes(), "service.instance.id"); !ok || got != "usw2-fixed-id" {
+		t.Fatalf("service.instance.id = %q, ok=%v, want %q", got, ok, "usw2-fixed-id")
+	}
+}
+
+func TestNewOTelRecorderDefaultsInstanceIDWhenUnset(t *testing.T) {
+	ctx := context.Background()
+
+	makeRecorder := func() *OTelRecorder {
+		t.Helper()
+		r, err := NewOTelRecorder(ctx, OTelConfig{
+			ServiceName: "sandbox-controlplane",
+			Environment: "production",
+			// Endpoint left at its default; NewOTelRecorder only
+			// constructs the OTLP client here, it does not dial out.
+		})
+		if err != nil {
+			t.Fatalf("NewOTelRecorder: %v", err)
+		}
+		t.Cleanup(func() {
+			shutdownCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			// Best-effort: Shutdown force-flushes to the configured OTLP
+			// endpoint, which nothing is listening on in this test. That
+			// flush failure is expected here and orthogonal to what this
+			// test checks (instance ID uniqueness), so it's swallowed
+			// rather than failing the test.
+			_ = r.Shutdown(shutdownCtx)
+		})
+		return r
+	}
+
+	first := makeRecorder()
+	second := makeRecorder()
+
+	if first.instanceID == "" {
+		t.Fatal("NewOTelRecorder left InstanceID empty; every replica would export identical series")
+	}
+	if first.instanceID == second.instanceID {
+		t.Fatalf("two NewOTelRecorder calls produced the same instanceID %q", first.instanceID)
+	}
+}
+
 func TestRecordVMDCallEmitsHostIDAndMethodAttributes(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

West's controlplane replicas started reaching the shared regional OTel collector once #403 wired up the OTLP ingress path, and every `db_pool_*`/`vmd_call_*`/`host_capacity_*` series immediately started colliding: none of these instruments carry anything that distinguishes one process from another, so concurrent Cloud Run replicas (and, within vmd, its two separate recorders) all export identical series. Google Managed Prometheus allows one point per time series per request and drops the rest, so ~99% of every export batch was silently discarded since the west OTLP path went live, confirmed directly from the collector's own `otelcol_exporter_send_failed_metric_points` counter on `superserve-vmd-usw2`.

This closes the resulting blind spot: right now there's no dashboard visibility into west's DB pool health, which matters given the DB-timeout incident earlier this cycle only ever surfaced through Sentry error cascades, never a metric.

## Technical decisions

- Stamp `service.instance.id` on the OTel resource so GMP's `prometheus_target` mapping has something real to key each process on, instead of falling back to whatever the collector's own `resourcedetection/gcp` fills in.
- Every constructor that builds a meter provider (`NewOTelRecorder`, `NewBackupRecorder`) resolves its own instance id via a shared `resolveInstanceID` helper, rather than defaulting it once in the shared provider/resource path. `OTelConfig` is passed by value throughout this package, so a default applied only inside `newOTLPMeterProvider`/`buildOTelResource` never propagates back to the caller's copy.
- vmd builds two recorders in one process (`NewOTelRecorder` for db-pool/host metrics, `NewBackupRecorder` for backup metrics). Left to each constructor's own default, that's two random ids for one physical process, misrepresenting it as two GMP targets. `telemetry.NewInstanceID()` is generated once in `cmd/vmd/main.go` and shared across both.
- controlplane and secretsproxy only construct one recorder each, so the auto-generated default is correct there as-is.

## Testing

- `go test ./internal/telemetry/...` (including `-race`): new coverage for uniqueness-when-unset, honoring an explicit id, and both `NewOTelRecorder`/`NewBackupRecorder` defaulting correctly.
- `gofmt` / `go vet` clean.
- Cross-compiled `cmd/controlplane`, `cmd/vmd`, `cmd/secretsproxy` for `linux/amd64` (native build fails on macOS for an unrelated pre-existing reason: `internal/network`'s nftables dependency is Linux-only, reproduced on unmodified `main` too).
- Two rounds of local Codex review (`codex exec review --base main`), both findings fixed; final round came back clean.