### PR TITLE
backup: carry exact object paths through verified-generation reports

### DIFF
--- a/db/queries/backups.sql
+++ b/db/queries/backups.sql
@@ -9,18 +9,51 @@
 -- it exceeds now()) yields to ANY smaller incoming one, sane or merely
 -- less skewed, so repair is monotone even when the correction lands
 -- while some skew remains; redelivery of either report matches neither
--- arm and stays a no-op.
+-- arm and stays a no-op. The third arm lets a report carrying object
+-- paths enrich a row that lacks them regardless of freshness: a
+-- rollout-window fallback can land a pathless copy of the same
+-- verification first (same pinned instant, so the freshness arms never
+-- fire for the redelivery), and the paths are what a lifecycle GC
+-- reasons from. Enrichment leaves completed_at where it stands (the
+-- CASE below): an older rich redelivery must not regress freshness.
 INSERT INTO backup_generation (sandbox_id, generation, bucket, completed_at, files)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (sandbox_id, bucket, generation) WHERE sandbox_id IS NOT NULL
-DO UPDATE SET completed_at = excluded.completed_at, reported_at = now(),
-  -- A coverage-only report (empty files: the outbox seed reconstructs
-  -- no manifest) must never erase a recorded manifest; richer reports
-  -- refresh it.
-  files = CASE WHEN jsonb_array_length(excluded.files) = 0
-               THEN backup_generation.files ELSE excluded.files END
+DO UPDATE SET
+  -- reported_at is the receive-instant freshness cap for skew-bounded
+  -- reads, so it moves only when a freshness arm fires: an
+  -- enrichment-only update re-describes the same verification and must
+  -- not advance when the control plane first learned of it.
+  reported_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+         OR (backup_generation.completed_at > now()
+             AND excluded.completed_at < backup_generation.completed_at)
+      THEN now()
+    ELSE backup_generation.reported_at END,
+  completed_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+      THEN excluded.completed_at
+    WHEN backup_generation.completed_at > now()
+         AND excluded.completed_at < backup_generation.completed_at
+      THEN excluded.completed_at
+    ELSE backup_generation.completed_at END,
+  -- files, in order: a coverage-only report (empty files: the outbox
+  -- seed reconstructs no manifest) must never erase a recorded
+  -- manifest; a manifest that carries object paths is frozen (the
+  -- bucket manifest it mirrors is immutable, redeliveries carry the
+  -- identical set, and nothing conforming can legitimately rename a
+  -- generation's objects, so first-writer-wins is what keeps the paths
+  -- deletion-trustworthy for GC); anything richer refreshes.
+  files = CASE
+    WHEN jsonb_array_length(excluded.files) = 0
+      THEN backup_generation.files
+    WHEN jsonb_path_exists(backup_generation.files, '$[*].object')
+      THEN backup_generation.files
+    ELSE excluded.files END
 WHERE excluded.completed_at > backup_generation.completed_at
-   OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at);
+   OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at)
+   OR (jsonb_path_exists(excluded.files, '$[*].object')
+       AND NOT jsonb_path_exists(backup_generation.files, '$[*].object'));
 
 -- name: RecordTemplateBackupGeneration :execrows
 -- Template variant of RecordSandboxBackupGeneration; the two exist
@@ -28,14 +61,30 @@ WHERE excluded.completed_at > backup_generation.completed_at
 INSERT INTO backup_generation (template_id, build_id, generation, bucket, completed_at, files)
 VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (template_id, build_id, bucket, generation) WHERE template_id IS NOT NULL
-DO UPDATE SET completed_at = excluded.completed_at, reported_at = now(),
-  -- A coverage-only report (empty files: the outbox seed reconstructs
-  -- no manifest) must never erase a recorded manifest; richer reports
-  -- refresh it.
-  files = CASE WHEN jsonb_array_length(excluded.files) = 0
-               THEN backup_generation.files ELSE excluded.files END
+DO UPDATE SET
+  reported_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+         OR (backup_generation.completed_at > now()
+             AND excluded.completed_at < backup_generation.completed_at)
+      THEN now()
+    ELSE backup_generation.reported_at END,
+  completed_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+      THEN excluded.completed_at
+    WHEN backup_generation.completed_at > now()
+         AND excluded.completed_at < backup_generation.completed_at
+      THEN excluded.completed_at
+    ELSE backup_generation.completed_at END,
+  files = CASE
+    WHEN jsonb_array_length(excluded.files) = 0
+      THEN backup_generation.files
+    WHEN jsonb_path_exists(backup_generation.files, '$[*].object')
+      THEN backup_generation.files
+    ELSE excluded.files END
 WHERE excluded.completed_at > backup_generation.completed_at
-   OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at);
+   OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at)
+   OR (jsonb_path_exists(excluded.files, '$[*].object')
+       AND NOT jsonb_path_exists(backup_generation.files, '$[*].object'));
 
 -- name: LatestSandboxBackup :one
 -- Freshness bounds future timestamps at read instead of rewriting them

--- a/internal/api/backups.go
+++ b/internal/api/backups.go
@@ -3,8 +3,10 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +16,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog/log"
 
+	"github.com/superserve-ai/sandbox/internal/backup"
 	"github.com/superserve-ai/sandbox/internal/db"
 )
 
@@ -32,6 +35,14 @@ const maxBackupReportFiles = 512
 
 var sha256Hex = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
+// fingerprintHex bounds a reported packing fingerprint to the hex the
+// uploader emits. Charset over exact length on purpose: today's
+// fingerprints are 12 hex chars, but pinning the width here would make
+// any future widening a silent coverage-dropping incompatibility, while
+// the charset is what keeps arbitrary bytes out of a field that will
+// become deletion authority.
+var fingerprintHex = regexp.MustCompile(`^[0-9a-f]{1,64}$`)
+
 // backupFileReport is one artifact in a verified generation, as recorded
 // in the generation's bucket manifest. Host paths deliberately do not
 // appear: they name staging locations that stop existing after the
@@ -44,6 +55,14 @@ type backupFileReport struct {
 	// Shared marks an artifact stored bucket-wide under bases/ rather
 	// than inside the generation prefix.
 	Shared bool `json:"shared,omitempty"`
+	// Object is the exact bucket object path the host wrote for this
+	// entry (the packing-fingerprint-suffixed name under the generation
+	// prefix, or the full bases/ path for shared entries). Persisted
+	// verbatim into the files jsonb so lifecycle GC can name a
+	// generation's objects from the DB without listing the bucket.
+	// Optional: reports from hosts predating the field omit it, and
+	// those generations' bucket manifests remain their path authority.
+	Object string `json:"object,omitempty"`
 }
 
 // backupReport is a host's notice that one generation is fully uploaded
@@ -58,6 +77,39 @@ type backupReport struct {
 	Bucket      string             `json:"bucket"`
 	CompletedAt time.Time          `json:"completed_at"`
 	Files       []backupFileReport `json:"files"`
+}
+
+// validateReportedObject pins an optional per-file object path to the
+// layout the uploader can actually write: shared entries under their
+// content-addressed bases/ name, everything else under the report
+// owner's generation prefix bound to the entry's own file name, with a
+// non-empty single-segment packing-fingerprint suffix either way. The
+// expected prefix comes from the same layout helpers the uploader
+// names objects with, so this check cannot drift from the write side.
+// It matters because these paths are meant to become deletion authority
+// for a lifecycle GC: a buggy host must not be able to park another
+// owner's object (or a generation's manifest) in this ledger entry.
+func validateReportedObject(req backupReport, f backupFileReport) error {
+	var prefix string
+	if f.Shared {
+		prefix = backup.SharedBaseObject(f.SHA256, "")
+	} else {
+		var err error
+		if req.SandboxID != "" {
+			prefix, err = backup.SandboxObject(req.SandboxID, req.Generation, f.Name)
+		} else {
+			prefix, err = backup.TemplateObject(req.TemplateID, req.BuildID, req.Generation, f.Name)
+		}
+		if err != nil {
+			return fmt.Errorf("object for %q: %w", f.Name, err)
+		}
+		prefix += ".p"
+	}
+	fp, ok := strings.CutPrefix(f.Object, prefix)
+	if !ok || !fingerprintHex.MatchString(fp) {
+		return fmt.Errorf("object for %q must name this entry under its own prefix with a hex packing fingerprint", f.Name)
+	}
+	return nil
 }
 
 // ReportHostBackup handles POST /internal/hosts/:host_id/backups.
@@ -97,6 +149,7 @@ func (h *Handlers) ReportHostBackup(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", "files must carry the generation manifest", http.StatusBadRequest)
 		return
 	}
+	withObjects := 0
 	for _, f := range req.Files {
 		if f.Name == "" || f.SizeBytes < 0 || !sha256Hex.MatchString(f.SHA256) {
 			respondErrorMsg(c, "bad_request", "each file needs a name, size, and sha256", http.StatusBadRequest)
@@ -106,6 +159,22 @@ func (h *Handlers) ReportHostBackup(c *gin.Context) {
 			respondErrorMsg(c, "bad_request", "base_sha256 must be sha256 hex when present", http.StatusBadRequest)
 			return
 		}
+		if f.Object != "" {
+			if err := validateReportedObject(req, f); err != nil {
+				respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
+				return
+			}
+			withObjects++
+		}
+	}
+	// Paths land all-or-none: a conforming host finalizes a report with
+	// every path or (a deduped manifest, a legacy entry) none, and the
+	// upsert's demotion guard treats ANY path as a path-bearing manifest,
+	// so accepting a mixed set would let it replace a complete ledger
+	// entry with a partial one.
+	if withObjects != 0 && withObjects != len(req.Files) {
+		respondErrorMsg(c, "bad_request", "object paths must cover every file or none", http.StatusBadRequest)
+		return
 	}
 	if (req.SandboxID == "") == (req.TemplateID == "") {
 		respondErrorMsg(c, "bad_request", "exactly one of sandbox_id or template_id is required", http.StatusBadRequest)

--- a/internal/api/backups_test.go
+++ b/internal/api/backups_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+func setupBackupReportRouter(h *Handlers) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/internal/hosts/:host_id/backups", h.ReportHostBackup)
+	return r
+}
+
+// backupReportMock records the files jsonb handed to the template
+// generation insert; the template path exercises the shared files
+// marshalling without the sandbox path's lock and size-sync choreography.
+func backupReportMock(t *testing.T, gotFiles *[]byte) *mockDBTX {
+	t.Helper()
+	return &mockDBTX{
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if !strings.Contains(sql, "-- name: RecordTemplateBackupGeneration :execrows") {
+				return pgconn.CommandTag{}, fmt.Errorf("unexpected Exec: %s", sql)
+			}
+			*gotFiles = args[5].([]byte)
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+	}
+}
+
+func postBackupReport(t *testing.T, h *Handlers, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/internal/hosts/host-a/backups", strings.NewReader(body))
+	setupBackupReportRouter(h).ServeHTTP(w, req)
+	return w
+}
+
+// A report carrying per-file object paths persists them verbatim into
+// the files jsonb, shared bases under their full bases/ path: the ledger
+// must let a future GC name a generation's objects without listing the
+// bucket.
+func TestReportHostBackupPersistsObjectPaths(t *testing.T) {
+	var gotFiles []byte
+	h := &Handlers{DB: db.New(backupReportMock(t, &gotFiles))}
+	const tid = "5df6a509-4c9e-4f6a-9f27-1af1a29b1111"
+	gen := strings.Repeat("ab", 32)
+	sha := strings.Repeat("cd", 32)
+	rootObj := "templates/" + tid + "/build-1/" + gen + "/rootfs.ext4.pabc123def456"
+	baseObj := "bases/" + sha + ".p1234abcd5678"
+	body := fmt.Sprintf(`{"template_id":%q,"build_id":"build-1",`+
+		`"generation":%q,"bucket":"cell-bucket","completed_at":"2026-08-01T00:00:00Z","files":[`+
+		`{"name":"rootfs.ext4","size_bytes":4,"sha256":%q,"object":%q},`+
+		`{"name":"base-%s.ext4","size_bytes":8,"sha256":%q,"shared":true,"object":%q}]}`,
+		tid, gen, sha, rootObj, sha, sha, baseObj)
+
+	w := postBackupReport(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var files []backupFileReport
+	if err := json.Unmarshal(gotFiles, &files); err != nil {
+		t.Fatalf("files jsonb: %v", err)
+	}
+	if len(files) != 2 || files[0].Object != rootObj ||
+		files[1].Object != baseObj || !files[1].Shared {
+		t.Fatalf("persisted files = %+v, want the reported object paths", files)
+	}
+}
+
+// Object paths are optional but never free-form: an entry claiming a
+// path outside its own layout (another owner's prefix, a foreign shared
+// object, a traversal segment) is rejected before anything persists,
+// since these paths are meant to become deletion authority for GC.
+func TestReportHostBackupRejectsForeignObjectPaths(t *testing.T) {
+	const tid = "5df6a509-4c9e-4f6a-9f27-1af1a29b1111"
+	gen := strings.Repeat("ab", 32)
+	sha := strings.Repeat("cd", 32)
+	for name, object := range map[string]string{
+		"foreign generation":  "templates/" + tid + "/build-1/" + strings.Repeat("ee", 32) + "/rootfs.ext4.pabc123",
+		"manifest object":     "templates/" + tid + "/build-1/" + gen + "/manifest.json",
+		"missing fingerprint": "templates/" + tid + "/build-1/" + gen + "/rootfs.ext4",
+		"non-hex fingerprint": "templates/" + tid + "/build-1/" + gen + "/rootfs.ext4.pZZ12",
+		"trailing segment":    "templates/" + tid + "/build-1/" + gen + "/rootfs.ext4.pabc123/x",
+	} {
+		var gotFiles []byte
+		h := &Handlers{DB: db.New(backupReportMock(t, &gotFiles))}
+		body := fmt.Sprintf(`{"template_id":%q,"build_id":"build-1",`+
+			`"generation":%q,"bucket":"cell-bucket","completed_at":"2026-08-01T00:00:00Z","files":[`+
+			`{"name":"rootfs.ext4","size_bytes":4,"sha256":%q,"object":%q}]}`, tid, gen, sha, object)
+		if w := postBackupReport(t, h, body); w.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want 400; body: %s", name, w.Code, w.Body.String())
+		}
+		if gotFiles != nil {
+			t.Fatalf("%s: rejected report still persisted files %s", name, gotFiles)
+		}
+	}
+
+	// A shared entry must sit under its own content address.
+	var gotFiles []byte
+	h := &Handlers{DB: db.New(backupReportMock(t, &gotFiles))}
+	body := fmt.Sprintf(`{"template_id":%q,"build_id":"build-1",`+
+		`"generation":%q,"bucket":"cell-bucket","completed_at":"2026-08-01T00:00:00Z","files":[`+
+		`{"name":"base-%s.ext4","size_bytes":8,"sha256":%q,"shared":true,"object":"bases/%s.pabc123"}]}`,
+		tid, gen, sha, sha, strings.Repeat("ee", 32))
+	if w := postBackupReport(t, h, body); w.Code != http.StatusBadRequest {
+		t.Fatalf("foreign shared object: status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+
+	// A mixed set (paths on some entries only) is rejected: paths land
+	// all-or-none, so a partial manifest can never rank as path-bearing
+	// and demote a complete ledger entry.
+	body = fmt.Sprintf(`{"template_id":%q,"build_id":"build-1",`+
+		`"generation":%q,"bucket":"cell-bucket","completed_at":"2026-08-01T00:00:00Z","files":[`+
+		`{"name":"rootfs.ext4","size_bytes":4,"sha256":%q,"object":"templates/%s/build-1/%s/rootfs.ext4.pabc123"},`+
+		`{"name":"vmstate.snap","size_bytes":2,"sha256":%q}]}`, tid, gen, sha, tid, gen, sha)
+	if w := postBackupReport(t, h, body); w.Code != http.StatusBadRequest {
+		t.Fatalf("mixed object coverage: status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// Reports from hosts predating the object field are accepted and stored
+// exactly as before: no object key appears in the persisted jsonb.
+func TestReportHostBackupAcceptsReportsWithoutObjectPaths(t *testing.T) {
+	var gotFiles []byte
+	h := &Handlers{DB: db.New(backupReportMock(t, &gotFiles))}
+	gen := strings.Repeat("ab", 32)
+	sha := strings.Repeat("cd", 32)
+	body := fmt.Sprintf(`{"template_id":"5df6a509-4c9e-4f6a-9f27-1af1a29b1111","build_id":"build-1",`+
+		`"generation":%q,"bucket":"cell-bucket","completed_at":"2026-08-01T00:00:00Z","files":[`+
+		`{"name":"rootfs.ext4","size_bytes":4,"sha256":%q}]}`, gen, sha)
+
+	w := postBackupReport(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var files []backupFileReport
+	if err := json.Unmarshal(gotFiles, &files); err != nil {
+		t.Fatalf("files jsonb: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "rootfs.ext4" {
+		t.Fatalf("persisted files = %+v", files)
+	}
+	if strings.Contains(string(gotFiles), `"object"`) {
+		t.Fatalf("files jsonb = %s, want no object key for a pre-field report", gotFiles)
+	}
+}

--- a/internal/backup/journal.go
+++ b/internal/backup/journal.go
@@ -55,6 +55,14 @@ type TaskFile struct {
 	// so each base version uploads exactly once fleet-wide and every
 	// generation's manifest points at the same immutable object.
 	Shared bool `json:"shared,omitempty"`
+	// Object is the exact bucket object path the upload wrote for this
+	// entry (packing fingerprint included, and the full bases/ path for
+	// shared entries). Captured from the store write itself when the
+	// finalized manifest is banked on the outbox copy, so coverage
+	// reports can name objects without re-deriving them. Empty on queue
+	// rows and on outbox entries written before the field existed;
+	// consumers must treat it as optional.
+	Object string `json:"object,omitempty"`
 }
 
 // Task is one generation awaiting upload. Tasks are idempotent: the
@@ -112,6 +120,17 @@ type Task struct {
 	// and content hash, not chronology), so stamping delivery time would
 	// let an older generation delivered later rank as the newest backup.
 	VerifiedAt time.Time `json:"verified_at,omitempty"`
+}
+
+// filesCarryObjects reports whether any entry records its exact bucket
+// object path.
+func filesCarryObjects(files []TaskFile) bool {
+	for _, f := range files {
+		if f.Object != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // HasVerified reports whether this task already verified object.
@@ -795,6 +814,20 @@ func (j *Journal) Ack(task Task, completedScope string, notify bool) (bool, erro
 			nt := task
 			nt.VerifiedBucket = completedScope
 			nt.VerifiedAt = now.UTC()
+			// An undelivered entry that carries object paths must not be
+			// demoted by a pathless re-completion (an unchanged re-pause
+			// whose manifest create deduped reports no paths, since the
+			// published manifest is the path authority): mirror the seed's
+			// refresh-in-place and keep the richer manifest under the new
+			// instant, matching the control plane's own no-demotion rule.
+			if existing := tx.Bucket(outboxBucket).Get(completionKey(completedScope, task)); existing != nil {
+				var cur Task
+				if json.Unmarshal(existing, &cur) == nil &&
+					filesCarryObjects(cur.Files) && !filesCarryObjects(nt.Files) {
+					nt.Files = cur.Files
+					nt.FilesFinal = cur.FilesFinal
+				}
+			}
 			val, err := json.Marshal(nt)
 			if err != nil {
 				return err

--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -506,7 +506,11 @@ func SharedBaseName(sha string) string {
 // task.Files alone omits. Shared sizes come from the staged or original
 // source when it still exists and are zero otherwise: delivery can
 // outlive ack-time staging cleanup, and the base object's authoritative
-// size lives in the bucket manifest either way.
+// size lives in the bucket manifest either way. Entries carry no object
+// paths: only the finalized manifest knows the packing fingerprints the
+// upload actually wrote, and re-deriving them from local files that may
+// have been relaid (or removed) since could name objects that were never
+// written. The bucket manifest remains those generations' path authority.
 func (t *Task) ReportedFiles() []TaskFile {
 	out := append([]TaskFile(nil), t.Files...)
 	seen := map[string]bool{}
@@ -543,8 +547,12 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 		VMDVersion: u.VMDVersion,
 	}
 	uploadedBases := map[string]bool{}
+	// objectPaths mirrors gen.Files entry for entry with the exact bucket
+	// object each upload wrote (the value handed to the store), so the
+	// finalized report below names objects without re-deriving them.
+	var objectPaths []string
 	for _, file := range task.Files {
-		mf, n, err := u.uploadFile(ctx, task, file)
+		mf, obj, n, err := u.uploadFile(ctx, task, file)
 		streamed += n
 		if err != nil {
 			if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
@@ -559,6 +567,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			return false, nil, streamed, err
 		}
 		gen.Files = append(gen.Files, mf)
+		objectPaths = append(objectPaths, obj)
 		// An overlay's holes are backed by its base image, and the bucket
 		// is the only copy that survives host loss: a generation whose
 		// manifest names a base that exists nowhere durable is not
@@ -577,7 +586,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 				}
 				return false, nil, streamed, err
 			}
-			bmf, n, err := u.uploadFile(ctx, task, bf)
+			bmf, bobj, n, err := u.uploadFile(ctx, task, bf)
 			streamed += n
 			if err != nil {
 				if os.IsNotExist(err) || errors.Is(err, errSourceChanged) || errors.Is(err, ErrTruncatedSource) {
@@ -589,6 +598,7 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 			}
 			uploadedBases[file.BaseSHA256] = true
 			gen.Files = append(gen.Files, bmf)
+			objectPaths = append(objectPaths, bobj)
 		}
 	}
 	manifestObject, err := task.objectName(ManifestObject)
@@ -609,13 +619,30 @@ func (u *Uploader) uploadTask(ctx context.Context, task *Task) (completed bool, 
 	// The finalized reportable set, captured while every size and digest
 	// is authoritative: reconstructing it at delivery time would stat
 	// staged copies that ack-time cleanup may have already removed,
-	// recording zero-size entries in coverage.
+	// recording zero-size entries in coverage. Each entry carries the
+	// exact object path its upload wrote, which is what lets a DB-driven
+	// GC name a generation's objects without listing the bucket.
+	//
+	// ONLY when this attempt published the manifest: a deduped manifest
+	// means an earlier attempt already finalized this generation, and
+	// that manifest is the restore authority for which fingerprinted
+	// objects belong to it. This attempt's paths can disagree (a retry
+	// over physically relaid files packs fresh fingerprints), and hosts
+	// cannot read the manifest back to check, so recording them could
+	// hand GC names the published manifest never blessed. Report no
+	// paths instead; the bucket manifest stays the path authority,
+	// exactly as for pre-upgrade generations.
 	finalized = make([]TaskFile, 0, len(gen.Files))
-	for _, mf := range gen.Files {
+	for i, mf := range gen.Files {
+		object := ""
+		if created {
+			object = objectPaths[i]
+		}
 		finalized = append(finalized, TaskFile{
 			Name: mf.Name, SHA256: mf.SHA256, Size: mf.Size,
 			BasePath: mf.BasePath, BaseSHA256: mf.BaseSHA256,
 			Shared: strings.HasPrefix(mf.Object, "bases/"),
+			Object: object,
 		})
 	}
 	return true, finalized, streamed, nil
@@ -728,21 +755,24 @@ func (u *Uploader) verifiedHere(task *Task, object string) (bool, error) {
 	return u.Journal.WasVerified(u.verificationKey(object), u.clock())
 }
 
-// uploadFile ships one artifact object. shipped counts bytes written
-// into a newly created object (zero on dedupes, skips, and failures that
-// abort the create), so byte accounting reflects storage actually done.
-func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_ ManifestFile, shipped int64, _ error) {
+// uploadFile ships one artifact object. objectPath is the exact bucket
+// object the artifact lives under (the same value handed to the store),
+// returned so completion bookkeeping records the path actually written
+// rather than re-deriving it. shipped counts bytes written into a newly
+// created object (zero on dedupes, skips, and failures that abort the
+// create), so byte accounting reflects storage actually done.
+func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_ ManifestFile, objectPath string, shipped int64, _ error) {
 	if file.Name == ManifestObject {
-		return ManifestFile{}, 0, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
+		return ManifestFile{}, "", 0, fmt.Errorf("artifact name %q collides with the manifest object", file.Name)
 	}
 	f, err := os.Open(file.Path)
 	if err != nil {
-		return ManifestFile{}, 0, err
+		return ManifestFile{}, "", 0, err
 	}
 	defer f.Close()
 	extents, apparent, err := Extents(f)
 	if err != nil {
-		return ManifestFile{}, 0, fmt.Errorf("extents %s: %w", file.Path, err)
+		return ManifestFile{}, "", 0, fmt.Errorf("extents %s: %w", file.Path, err)
 	}
 	// The object name embeds the packing fingerprint: a retry over a
 	// physically relaid file (same apparent content, different extents)
@@ -760,7 +790,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 		objectName = file.Name + ".p" + PackFingerprint(extents, apparent)
 		object, err = task.objectName(objectName)
 		if err != nil {
-			return ManifestFile{}, 0, err
+			return ManifestFile{}, "", 0, err
 		}
 	}
 	if file.Shared {
@@ -800,7 +830,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 				Size:       apparent,
 				PackedSize: PackedSize(extents),
 				Extents:    extents,
-			}, 0, nil
+			}, object, 0, nil
 		}
 	}
 	// Verify the source still matches the digest recorded at pause time
@@ -809,12 +839,12 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 	// above, so an already-verified base is never re-read at all.
 	sum, err := hashApparent(ctx, f, extents, apparent)
 	if err != nil {
-		return ManifestFile{}, 0, fmt.Errorf("verify %s: %w", file.Path, err)
+		return ManifestFile{}, "", 0, fmt.Errorf("verify %s: %w", file.Path, err)
 	}
 	if sum != file.SHA256 {
 		task.logOwner(u.lossEvent(task).Str("path", file.Path).Str("want", file.SHA256).Str("got", sum)).
 			Msg("backup source changed since pause; abandoning generation")
-		return ManifestFile{}, 0, errSourceChanged
+		return ManifestFile{}, "", 0, errSourceChanged
 	}
 	// The stream hasher digests the apparent content of what is ACTUALLY
 	// shipped (packed bytes as streamed, zeros for the holes), closing the
@@ -827,7 +857,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 	reader := &limitedReader{r: hasher, limiter: u.Limiter, ctx: ctx}
 	created, err := u.Store.Create(ctx, object, reader)
 	if err != nil {
-		return ManifestFile{}, 0, storeError{err}
+		return ManifestFile{}, "", 0, storeError{err}
 	}
 	if created {
 		// The store finalized a new object from this stream; these bytes
@@ -843,7 +873,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 			task.logOwner(u.lossEvent(task).Str("path", file.Path).Str("want", file.SHA256).Str("got", sum)).
 				Bool("fully_streamed", complete).
 				Msg("backup source changed during upload; abandoning generation")
-			return ManifestFile{}, shipped, errSourceChanged
+			return ManifestFile{}, "", shipped, errSourceChanged
 		}
 		// Persist that these exact object bytes were verified BEFORE any
 		// further progress, both in the task (survives nacks) and in the
@@ -872,7 +902,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 			time.Sleep(delay)
 		}
 		if recErr != nil {
-			return ManifestFile{}, shipped, fmt.Errorf("record verification of %s: %w", object, recErr)
+			return ManifestFile{}, "", shipped, fmt.Errorf("record verification of %s: %w", object, recErr)
 		}
 		task.VerifiedObjects = verified
 	} else if file.Shared {
@@ -896,11 +926,11 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), u.verificationKey(object))
 		}
 		if err := u.Journal.RecordVerification(next, u.verificationKey(object), u.clock()); err != nil {
-			return ManifestFile{}, 0, fmt.Errorf("record shared dedupe of %s: %w", object, err)
+			return ManifestFile{}, "", 0, fmt.Errorf("record shared dedupe of %s: %w", object, err)
 		}
 		task.VerifiedObjects = next.VerifiedObjects
 	} else if ok, err := u.verifiedHere(task, object); err != nil {
-		return ManifestFile{}, 0, err
+		return ManifestFile{}, "", 0, err
 	} else if !ok {
 		// The object already existed (dedupe). Stream consumption proves
 		// nothing here: small objects buffer fully before the
@@ -913,7 +943,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 		// identity cannot read them back).
 		task.logOwner(u.Log.Warn().Str("object", object)).
 			Msg("deduped object has no verification history; abandoning generation")
-		return ManifestFile{}, 0, errSourceChanged
+		return ManifestFile{}, "", 0, errSourceChanged
 	}
 	return ManifestFile{
 		Name:       file.Name,
@@ -924,7 +954,7 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 		Size:       apparent,
 		PackedSize: PackedSize(extents),
 		Extents:    extents,
-	}, shipped, nil
+	}, object, shipped, nil
 }
 
 // HashFileApparent digests a file's full apparent content the sparse

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -144,8 +144,60 @@ func TestUploaderShipsGenerationAndAcks(t *testing.T) {
 	if len(verified) != 1 || verified[0].Generation != "gen-abc" {
 		t.Fatalf("verified hook = %+v", verified)
 	}
+	// The outboxed completion carries the finalized manifest whose object
+	// paths are exactly the store keys the upload wrote, fingerprints
+	// included: this is what lets a DB-driven GC name objects without
+	// listing the bucket.
+	if !verified[0].FilesFinal || len(verified[0].Files) != 2 {
+		t.Fatalf("finalized outbox files = %+v", verified[0].Files)
+	}
+	if got := verified[0].Files[0].Object; got != overlayObj {
+		t.Fatalf("recorded overlay object = %q, want %q", got, overlayObj)
+	}
+	if got := verified[0].Files[1].Object; got != vmstateObj {
+		t.Fatalf("recorded vmstate object = %q, want %q", got, vmstateObj)
+	}
+	for _, f := range verified[0].Files {
+		if _, ok := store.objects[f.Object]; !ok {
+			t.Fatalf("recorded object %q was never written to the store", f.Object)
+		}
+	}
 	if counts, _ := j.Pending(); counts[PriorityPause] != 0 {
 		t.Fatalf("task not acked: %v", counts)
+	}
+}
+
+// A completion whose manifest create deduped reports its coverage
+// WITHOUT object paths: an earlier attempt's manifest is the published
+// restore authority and may name different packing fingerprints (a
+// retry over relaid files), so the DB must never claim paths that
+// manifest never blessed. The rest of the manifest facts still travel.
+func TestDedupedManifestReportsNoObjectPaths(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	var verified []Task
+	u := &Uploader{Journal: j, Store: store, OnVerified: func(task Task) error { verified = append(verified, task); return nil }}
+
+	task := writeTask(t, t.TempDir())
+	// An earlier attempt already published this generation's manifest.
+	store.objects["sandboxes/sb-1/gen-abc/manifest.json"] = []byte(`{"generation":"gen-abc"}`)
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	worked, err := u.drainOne(context.Background(), task.EnqueuedAt.Add(time.Minute))
+	if err != nil || !worked {
+		t.Fatalf("drain: worked=%v err=%v", worked, err)
+	}
+	if len(verified) != 1 || !verified[0].FilesFinal || len(verified[0].Files) != 2 {
+		t.Fatalf("verified = %+v, want one finalized completion", verified)
+	}
+	for _, f := range verified[0].Files {
+		if f.Object != "" {
+			t.Fatalf("deduped-manifest completion claims object %q; the published manifest is the authority", f.Object)
+		}
+		if f.SHA256 == "" || f.Size == 0 {
+			t.Fatalf("finalized entry lost manifest facts: %+v", f)
+		}
 	}
 }
 
@@ -797,6 +849,111 @@ func TestAbandonedAckLeavesNoNotification(t *testing.T) {
 	}
 }
 
+// Outbox entries are durable BoltDB records, so the object-path field is
+// additive: a new entry round-trips its recorded paths, and an entry a
+// pre-upgrade binary wrote (no object field anywhere) still decodes and
+// delivers with the field empty.
+func TestOutboxRoundTripsObjectPathsAndDecodesLegacyEntries(t *testing.T) {
+	j, _ := testJournal(t)
+	task := Task{SandboxID: "sb-new", Generation: "gen-new", EnqueuedAt: time.Unix(1, 0),
+		Files: []TaskFile{{Name: "rootfs.ext4", Path: "/staging/rootfs.ext4", SHA256: "aa", Size: 4}}}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	// Mirror drainOne's completion ack: the outbox copy carries the
+	// finalized manifest with the exact object paths the upload wrote.
+	ackTask := task
+	ackTask.Files = []TaskFile{{Name: "rootfs.ext4", SHA256: "aa", Size: 4,
+		Object: "sandboxes/sb-new/gen-new/rootfs.ext4.pdeadbeef"}}
+	ackTask.FilesFinal = true
+	if _, err := j.Ack(ackTask, "bucket-a", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// A pre-upgrade outbox entry, byte-for-byte as an older binary
+	// serialized it.
+	legacyTask := Task{SandboxID: "sb-old", Generation: "gen-old", VerifiedBucket: "bucket-a"}
+	legacy := []byte(`{"sandbox_id":"sb-old","generation":"gen-old",` +
+		`"files":[{"name":"rootfs.ext4","path":"/staging/old.ext4","sha256":"bb","size":9}],` +
+		`"files_final":true,"verified_bucket":"bucket-a","verified_at":"2026-08-01T00:00:00Z"}`)
+	if err := j.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(outboxBucket).Put(completionKey("bucket-a", legacyTask), legacy)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := j.PendingNotifications(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("outbox = %+v, want both entries", pending)
+	}
+	byOwner := map[string]Task{}
+	for _, p := range pending {
+		byOwner[p.SandboxID] = p
+	}
+	fresh := byOwner["sb-new"]
+	if !fresh.FilesFinal || len(fresh.Files) != 1 ||
+		fresh.Files[0].Object != "sandboxes/sb-new/gen-new/rootfs.ext4.pdeadbeef" {
+		t.Fatalf("upgraded entry = %+v, want the recorded object path back", fresh.Files)
+	}
+	old := byOwner["sb-old"]
+	if len(old.Files) != 1 || old.Files[0].SHA256 != "bb" || old.Files[0].Object != "" {
+		t.Fatalf("legacy entry = %+v, want intact files with no object path", old.Files)
+	}
+	if old.VerifiedBucket != "bucket-a" || old.VerifiedAt.IsZero() {
+		t.Fatalf("legacy entry lost pinned fields: %+v", old)
+	}
+}
+
+// An unchanged re-pause whose manifest create deduped acks a PATHLESS
+// completion for a generation whose path-bearing signal may still sit
+// undelivered in the outbox (the control plane was unreachable). The
+// re-ack must refresh the instant without demoting the richer manifest,
+// mirroring the control plane's own no-demotion rule.
+func TestReAckDoesNotDemotePathBearingOutboxEntry(t *testing.T) {
+	j, _ := testJournal(t)
+	task := Task{SandboxID: "sb", Generation: "gen", EnqueuedAt: time.Unix(1, 0),
+		Files: []TaskFile{{Name: "rootfs.ext4", Path: "/staging/r", SHA256: "aa", Size: 4}}}
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	rich := task
+	rich.Files = []TaskFile{{Name: "rootfs.ext4", SHA256: "aa", Size: 4,
+		Object: "sandboxes/sb/gen/rootfs.ext4.pabc123"}}
+	rich.FilesFinal = true
+	if _, err := j.Ack(rich, "bucket-a", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// The re-pause re-enqueues the same generation; its manifest create
+	// dedupes, so this completion carries no paths.
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	pathless := task
+	pathless.Files = []TaskFile{{Name: "rootfs.ext4", SHA256: "aa", Size: 4}}
+	pathless.FilesFinal = true
+	if _, err := j.Ack(pathless, "bucket-a", true); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := j.PendingNotifications(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("outbox = %+v, want the merged entry", pending)
+	}
+	if got := pending[0].Files[0].Object; got != "sandboxes/sb/gen/rootfs.ext4.pabc123" {
+		t.Fatalf("re-ack demoted the outboxed manifest: %+v", pending[0].Files)
+	}
+	if !pending[0].FilesFinal || pending[0].VerifiedAt.IsZero() {
+		t.Fatalf("merged entry lost finalization or its instant: %+v", pending[0])
+	}
+}
+
 // A verification write that never reached disk must not ride into the
 // Nack inside the task's VerifiedObjects: the retry would then trust a
 // dedupe against durable history that does not exist.
@@ -829,7 +986,7 @@ func TestFailedVerificationWriteNotCarriedIntoTask(t *testing.T) {
 	db.Close()
 
 	u := &Uploader{Journal: j, Store: newMemStore()}
-	_, _, err = u.uploadFile(context.Background(), &task, task.Files[0])
+	_, _, _, err = u.uploadFile(context.Background(), &task, task.Files[0])
 	if err == nil {
 		t.Fatal("uploadFile succeeded despite a failed verification write")
 	}
@@ -1154,6 +1311,33 @@ func TestOverlayGenerationUploadsSharedBase(t *testing.T) {
 	}
 	if !foundBase {
 		t.Fatalf("manifest lacks the shared base entry: %+v", gen.Files)
+	}
+	// Both outboxed completions record exact object paths, the shared
+	// base under its full bucket-wide bases/ path: including sb-y's,
+	// whose base upload was skipped via the verification history rather
+	// than streamed.
+	pending, err := j.PendingNotifications(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("outbox = %+v, want both completions", pending)
+	}
+	for _, task := range pending {
+		if !task.FilesFinal || len(task.Files) != 2 {
+			t.Fatalf("finalized files for %s = %+v", task.SandboxID, task.Files)
+		}
+		for _, f := range task.Files {
+			if _, ok := store.objects[f.Object]; !ok {
+				t.Fatalf("recorded object %q was never written to the store", f.Object)
+			}
+			if f.Shared != strings.HasPrefix(f.Object, "bases/"+baseSHA+".p") {
+				t.Fatalf("shared flag and object path disagree: %+v", f)
+			}
+			if !f.Shared && !strings.HasPrefix(f.Object, "sandboxes/"+task.SandboxID+"/"+task.Generation+"/") {
+				t.Fatalf("overlay object %q outside its generation prefix", f.Object)
+			}
+		}
 	}
 }
 

--- a/internal/db/backups.sql.go
+++ b/internal/db/backups.sql.go
@@ -125,14 +125,41 @@ const recordSandboxBackupGeneration = `-- name: RecordSandboxBackupGeneration :e
 INSERT INTO backup_generation (sandbox_id, generation, bucket, completed_at, files)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (sandbox_id, bucket, generation) WHERE sandbox_id IS NOT NULL
-DO UPDATE SET completed_at = excluded.completed_at, reported_at = now(),
-  -- A coverage-only report (empty files: the outbox seed reconstructs
-  -- no manifest) must never erase a recorded manifest; richer reports
-  -- refresh it.
-  files = CASE WHEN jsonb_array_length(excluded.files) = 0
-               THEN backup_generation.files ELSE excluded.files END
+DO UPDATE SET
+  -- reported_at is the receive-instant freshness cap for skew-bounded
+  -- reads, so it moves only when a freshness arm fires: an
+  -- enrichment-only update re-describes the same verification and must
+  -- not advance when the control plane first learned of it.
+  reported_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+         OR (backup_generation.completed_at > now()
+             AND excluded.completed_at < backup_generation.completed_at)
+      THEN now()
+    ELSE backup_generation.reported_at END,
+  completed_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+      THEN excluded.completed_at
+    WHEN backup_generation.completed_at > now()
+         AND excluded.completed_at < backup_generation.completed_at
+      THEN excluded.completed_at
+    ELSE backup_generation.completed_at END,
+  -- files, in order: a coverage-only report (empty files: the outbox
+  -- seed reconstructs no manifest) must never erase a recorded
+  -- manifest; a manifest that carries object paths is frozen (the
+  -- bucket manifest it mirrors is immutable, redeliveries carry the
+  -- identical set, and nothing conforming can legitimately rename a
+  -- generation's objects, so first-writer-wins is what keeps the paths
+  -- deletion-trustworthy for GC); anything richer refreshes.
+  files = CASE
+    WHEN jsonb_array_length(excluded.files) = 0
+      THEN backup_generation.files
+    WHEN jsonb_path_exists(backup_generation.files, '$[*].object')
+      THEN backup_generation.files
+    ELSE excluded.files END
 WHERE excluded.completed_at > backup_generation.completed_at
    OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at)
+   OR (jsonb_path_exists(excluded.files, '$[*].object')
+       AND NOT jsonb_path_exists(backup_generation.files, '$[*].object'))
 `
 
 type RecordSandboxBackupGenerationParams struct {
@@ -153,7 +180,13 @@ type RecordSandboxBackupGenerationParams struct {
 // it exceeds now()) yields to ANY smaller incoming one, sane or merely
 // less skewed, so repair is monotone even when the correction lands
 // while some skew remains; redelivery of either report matches neither
-// arm and stays a no-op.
+// arm and stays a no-op. The third arm lets a report carrying object
+// paths enrich a row that lacks them regardless of freshness: a
+// rollout-window fallback can land a pathless copy of the same
+// verification first (same pinned instant, so the freshness arms never
+// fire for the redelivery), and the paths are what a lifecycle GC
+// reasons from. Enrichment leaves completed_at where it stands (the
+// CASE below): an older rich redelivery must not regress freshness.
 func (q *Queries) RecordSandboxBackupGeneration(ctx context.Context, arg RecordSandboxBackupGenerationParams) (int64, error) {
 	result, err := q.db.Exec(ctx, recordSandboxBackupGeneration,
 		arg.SandboxID,
@@ -172,14 +205,30 @@ const recordTemplateBackupGeneration = `-- name: RecordTemplateBackupGeneration 
 INSERT INTO backup_generation (template_id, build_id, generation, bucket, completed_at, files)
 VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (template_id, build_id, bucket, generation) WHERE template_id IS NOT NULL
-DO UPDATE SET completed_at = excluded.completed_at, reported_at = now(),
-  -- A coverage-only report (empty files: the outbox seed reconstructs
-  -- no manifest) must never erase a recorded manifest; richer reports
-  -- refresh it.
-  files = CASE WHEN jsonb_array_length(excluded.files) = 0
-               THEN backup_generation.files ELSE excluded.files END
+DO UPDATE SET
+  reported_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+         OR (backup_generation.completed_at > now()
+             AND excluded.completed_at < backup_generation.completed_at)
+      THEN now()
+    ELSE backup_generation.reported_at END,
+  completed_at = CASE
+    WHEN excluded.completed_at > backup_generation.completed_at
+      THEN excluded.completed_at
+    WHEN backup_generation.completed_at > now()
+         AND excluded.completed_at < backup_generation.completed_at
+      THEN excluded.completed_at
+    ELSE backup_generation.completed_at END,
+  files = CASE
+    WHEN jsonb_array_length(excluded.files) = 0
+      THEN backup_generation.files
+    WHEN jsonb_path_exists(backup_generation.files, '$[*].object')
+      THEN backup_generation.files
+    ELSE excluded.files END
 WHERE excluded.completed_at > backup_generation.completed_at
    OR (backup_generation.completed_at > now() AND excluded.completed_at < backup_generation.completed_at)
+   OR (jsonb_path_exists(excluded.files, '$[*].object')
+       AND NOT jsonb_path_exists(backup_generation.files, '$[*].object'))
 `
 
 type RecordTemplateBackupGenerationParams struct {

--- a/internal/integration/backup_report_test.go
+++ b/internal/integration/backup_report_test.go
@@ -286,3 +286,114 @@ func TestIntegration_BackupReport_CoverageOnlyPreservesManifest(t *testing.T) {
 		t.Fatalf("completed_at = %s, want the newer instant kept", completedAt)
 	}
 }
+
+// The files jsonb follows a strict enrichment order, because the paths
+// are what a lifecycle GC reasons from: a pathless report (an older
+// host re-verifying the same content-addressed generation) refreshes
+// freshness without demoting recorded paths; a path-bearing report
+// enriches a pathless row even at an identical pinned instant (a
+// rollout-window fallback can land the pathless copy first) without
+// regressing freshness; and once paths are recorded they are frozen,
+// since the immutable bucket manifest they mirror can never change.
+func TestIntegration_BackupReport_ObjectPathEnrichmentOrder(t *testing.T) {
+	ctx := context.Background()
+	_, apiKey := seedTeamAndKey(t)
+	t.Setenv("INTERNAL_API_TOKEN", "itok-paths")
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"path-guard"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	diskObj := "sandboxes/" + sid + "/" + genKey + "/rootfs.ext4.pabc123"
+	send := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/internal/hosts/host-1/backups", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer itok-paths")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("report: %d %s", w.Code, w.Body.String())
+		}
+	}
+	readFiles := func() string {
+		t.Helper()
+		var files string
+		if err := testPool.QueryRow(ctx,
+			`SELECT files::text FROM backup_generation WHERE sandbox_id = $1`, sid).Scan(&files); err != nil {
+			t.Fatal(err)
+		}
+		return files
+	}
+
+	send(`{"sandbox_id":"` + sid + `","generation":"` + genKey + `",` +
+		`"bucket":"cell-bucket","completed_at":"2026-08-11T10:00:00Z","files":[` +
+		`{"name":"rootfs.ext4","size_bytes":4096,"sha256":"` + diskSHA + `","object":"` + diskObj + `"}]}`)
+	if files := readFiles(); !strings.Contains(files, "rootfs.ext4.pabc123") {
+		t.Fatalf("path-bearing report not recorded: files = %s", files)
+	}
+
+	// The pathless redelivery: same generation, newer instant, no paths.
+	send(`{"sandbox_id":"` + sid + `","generation":"` + genKey + `",` +
+		`"bucket":"cell-bucket","completed_at":"2026-08-11T11:00:00Z","files":[` +
+		`{"name":"rootfs.ext4","size_bytes":4096,"sha256":"` + diskSHA + `"}]}`)
+	if files := readFiles(); !strings.Contains(files, "rootfs.ext4.pabc123") {
+		t.Fatalf("pathless redelivery erased the object paths: files = %s", files)
+	}
+
+	// Recorded paths are frozen: a newer report claiming different
+	// (structurally valid) fingerprints refreshes freshness only, since
+	// nothing conforming can rename an immutable generation's objects.
+	send(`{"sandbox_id":"` + sid + `","generation":"` + genKey + `",` +
+		`"bucket":"cell-bucket","completed_at":"2026-08-11T12:00:00Z","files":[` +
+		`{"name":"rootfs.ext4","size_bytes":4096,"sha256":"` + diskSHA + `","object":"` + diskObj + `2"}]}`)
+	files := readFiles()
+	if strings.Contains(files, "rootfs.ext4.pabc1232") || !strings.Contains(files, "rootfs.ext4.pabc123") {
+		t.Fatalf("recorded paths were not frozen: files = %s", files)
+	}
+	var completedAt string
+	if err := testPool.QueryRow(ctx,
+		`SELECT completed_at::text FROM backup_generation WHERE sandbox_id = $1`, sid).Scan(&completedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(completedAt, "12:00:00") {
+		t.Fatalf("completed_at = %s, want freshness refreshed past the frozen files", completedAt)
+	}
+
+	// Enrichment at an identical pinned instant: the rollout-window
+	// fallback landed a pathless copy of this verification first, and
+	// the rich redelivery carries the same completed_at. The paths must
+	// land without moving completed_at.
+	gen2 := strings.Repeat("f0", 32)
+	disk2 := "sandboxes/" + sid + "/" + gen2 + "/rootfs.ext4.pdef456"
+	send(`{"sandbox_id":"` + sid + `","generation":"` + gen2 + `",` +
+		`"bucket":"cell-bucket","completed_at":"2026-08-11T10:30:00Z","files":[` +
+		`{"name":"rootfs.ext4","size_bytes":4096,"sha256":"` + diskSHA + `"}]}`)
+	// Pin reported_at so the enrichment below provably leaves the
+	// freshness cap where the first receipt set it.
+	if _, err := testPool.Exec(ctx,
+		`UPDATE backup_generation SET reported_at = '2026-08-11T09:00:00Z' WHERE sandbox_id = $1 AND generation = $2`,
+		sid, gen2); err != nil {
+		t.Fatal(err)
+	}
+	send(`{"sandbox_id":"` + sid + `","generation":"` + gen2 + `",` +
+		`"bucket":"cell-bucket","completed_at":"2026-08-11T10:30:00Z","files":[` +
+		`{"name":"rootfs.ext4","size_bytes":4096,"sha256":"` + diskSHA + `","object":"` + disk2 + `"}]}`)
+	var reportedAt string
+	if err := testPool.QueryRow(ctx,
+		`SELECT files::text, completed_at::text, reported_at::text FROM backup_generation WHERE sandbox_id = $1 AND generation = $2`,
+		sid, gen2).Scan(&files, &completedAt, &reportedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(files, "rootfs.ext4.pdef456") {
+		t.Fatalf("equal-instant rich redelivery did not enrich: files = %s", files)
+	}
+	if !strings.Contains(completedAt, "10:30:00") {
+		t.Fatalf("completed_at = %s, want the pinned instant untouched by enrichment", completedAt)
+	}
+	if !strings.Contains(reportedAt, "09:00:00") {
+		t.Fatalf("reported_at = %s, want the freshness cap untouched by enrichment", reportedAt)
+	}
+}

--- a/internal/vm/backup_report.go
+++ b/internal/vm/backup_report.go
@@ -38,13 +38,18 @@ type BackupReporter struct {
 
 // backupReportFile mirrors the control plane's manifest entry shape.
 // Host paths deliberately do not travel: they name staging locations
-// that stop existing once the upload acks.
+// that stop existing once the upload acks. Object is the exact bucket
+// object path the upload wrote (fingerprint-suffixed, full bases/ path
+// for shared entries), empty on entries outboxed before the field
+// existed; the control plane stores it so a future GC can name a
+// generation's objects without listing the bucket.
 type backupReportFile struct {
 	Name       string `json:"name"`
 	SizeBytes  int64  `json:"size_bytes"`
 	SHA256     string `json:"sha256"`
 	BaseSHA256 string `json:"base_sha256,omitempty"`
 	Shared     bool   `json:"shared,omitempty"`
+	Object     string `json:"object,omitempty"`
 }
 
 type backupReportBody struct {
@@ -99,18 +104,115 @@ func (r *BackupReporter) Deliver(task backup.Task) error {
 			SHA256:     f.SHA256,
 			BaseSHA256: f.BaseSHA256,
 			Shared:     f.Shared,
+			Object:     f.Object,
 		})
 	}
+	status, statusLine, msg, err := r.post(body)
+	if err != nil {
+		return err
+	}
+	// Any 2xx clears the outbox entry, including accepted-but-orphaned
+	// reports: only the control plane knows whether an owner row exists,
+	// and redelivering an unacceptable report forever helps nobody.
+	if status >= 200 && status < 300 {
+		return nil
+	}
+	// A control plane from before the object field binds report bodies
+	// strictly and 400s the unknown field, which the permanent-rejection
+	// drop below would turn into a lost coverage row on every report this
+	// host sends during the rollout (or rollback) window. Degrade once to
+	// the pre-field payload: the report then lands exactly as an old
+	// vmd's would, and the acceptance clears the outbox entry, so those
+	// generations keep their coverage but stay pathless in the ledger
+	// permanently (their bucket manifests remain the path authority,
+	// like every pre-upgrade generation's; the control plane's
+	// enrichment arm upgrades the row if a rich report is ever
+	// redelivered). Deliberately NOT retained for a rich redelivery:
+	// holding the entry would re-deliver it every flush against the old
+	// control plane and head-of-line block every signal behind it.
+	// Gated on the binder's own unknown-field message so a rejection a
+	// NEW control plane issues (a path failing validation) is never
+	// stripped past the check it failed.
+	if permanentReject(status) && isUnknownObjectField(msg) && stripObjectPaths(&body) {
+		r.Log.Warn().Str("generation", task.Generation).
+			Str("status", statusLine).Str("response", string(msg)).
+			Msg("backup report rejected; retrying without object paths for an older control plane")
+		status, statusLine, msg, err = r.post(body)
+		if err != nil {
+			return err
+		}
+		if status >= 200 && status < 300 {
+			return nil
+		}
+	}
+	// A permanent rejection can never succeed on retry, and the flush
+	// stops at the first failure, so returning an error here would wedge
+	// every later report on this host behind one poisoned entry forever.
+	// Drop it loudly instead: the generation stays durable in the bucket,
+	// only its coverage row is lost.
+	if permanentReject(status) {
+		r.Log.Error().Str("generation", task.Generation).
+			Str("sandbox_id", task.SandboxID).Str("template_id", task.TemplateID).
+			Str("status", statusLine).Str("response", string(msg)).
+			Msg("backup report permanently rejected; dropping its coverage row")
+		return nil
+	}
+	return fmt.Errorf("backup report rejected: %s: %s", statusLine, msg)
+}
+
+// permanentReject reports whether a status can never succeed on
+// redelivery. Auth and pressure statuses stay retryable, since a rotated
+// token or a throttled control plane would otherwise silently drain the
+// whole outbox; 404 means the control plane has not deployed the route
+// yet (vmd can roll out first), so the report becomes deliverable when
+// the rollout completes and must survive in the outbox.
+func permanentReject(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusRequestTimeout, http.StatusTooManyRequests,
+		http.StatusNotFound:
+		return false
+	}
+	return status >= 400 && status < 500
+}
+
+// isUnknownObjectField matches a pre-field control plane's strict-binder
+// rejection, which names the field it refused (encoding/json's
+// DisallowUnknownFields error, quoted or JSON-escaped in the response
+// body). Anything else is a genuine rejection of the report's content
+// and must not be retried stripped.
+func isUnknownObjectField(msg []byte) bool {
+	return bytes.Contains(msg, []byte(`unknown field "object"`)) ||
+		bytes.Contains(msg, []byte(`unknown field \"object\"`))
+}
+
+// stripObjectPaths clears every per-file object path in place, reporting
+// whether any were present.
+func stripObjectPaths(body *backupReportBody) bool {
+	stripped := false
+	for i := range body.Files {
+		if body.Files[i].Object != "" {
+			body.Files[i].Object = ""
+			stripped = true
+		}
+	}
+	return stripped
+}
+
+// post performs one delivery attempt, returning the response status and
+// up to 512 bytes of a non-2xx body. err is transport-level only; HTTP
+// rejections are the caller's to classify.
+func (r *BackupReporter) post(body backupReportBody) (status int, statusLine string, msg []byte, err error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
-		return fmt.Errorf("marshal backup report: %w", err)
+		return 0, "", nil, fmt.Errorf("marshal backup report: %w", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	url := fmt.Sprintf("%s/internal/hosts/%s/backups", r.ControlPlaneURL, r.HostID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("build backup report request: %w", err)
+		return 0, "", nil, fmt.Errorf("build backup report request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+r.Token)
@@ -120,38 +222,12 @@ func (r *BackupReporter) Deliver(task backup.Task) error {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("deliver backup report: %w", err)
+		return 0, "", nil, fmt.Errorf("deliver backup report: %w", err)
 	}
 	defer resp.Body.Close()
-	// Any 2xx clears the outbox entry, including accepted-but-orphaned
-	// reports: only the control plane knows whether an owner row exists,
-	// and redelivering an unacceptable report forever helps nobody.
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return nil
+		return resp.StatusCode, resp.Status, nil, nil
 	}
-	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	// A permanent rejection can never succeed on retry, and the flush
-	// stops at the first failure, so returning an error here would wedge
-	// every later report on this host behind one poisoned entry forever.
-	// Drop it loudly instead: the generation stays durable in the bucket,
-	// only its coverage row is lost. Auth and pressure statuses stay
-	// retryable, since a rotated token or a throttled control plane would
-	// otherwise silently drain the whole outbox.
-	switch resp.StatusCode {
-	case http.StatusUnauthorized, http.StatusForbidden,
-		http.StatusRequestTimeout, http.StatusTooManyRequests,
-		// 404 means the control plane has not deployed the route yet
-		// (vmd can roll out first); the report becomes deliverable when
-		// the rollout completes, so it must survive in the outbox.
-		http.StatusNotFound:
-	default:
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-			r.Log.Error().Str("generation", task.Generation).
-				Str("sandbox_id", task.SandboxID).Str("template_id", task.TemplateID).
-				Str("status", resp.Status).Str("response", string(msg)).
-				Msg("backup report permanently rejected; dropping its coverage row")
-			return nil
-		}
-	}
-	return fmt.Errorf("backup report rejected: %s: %s", resp.Status, string(msg))
+	msg, _ = io.ReadAll(io.LimitReader(resp.Body, 512))
+	return resp.StatusCode, resp.Status, msg, nil
 }

--- a/internal/vm/backup_report_test.go
+++ b/internal/vm/backup_report_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,5 +130,106 @@ func TestBackupReporterDropsPermanentRejections(t *testing.T) {
 	status = http.StatusUnauthorized
 	if err := r.Deliver(task); err == nil {
 		t.Fatal("Deliver on 401 = nil, want error so a rotated token retries")
+	}
+}
+
+// A finalized manifest's exact object paths travel on the wire, shared
+// bases under their full bases/ path; entries without recorded paths
+// serialize no object key at all, so an old vmd's payload shape is
+// unchanged.
+func TestBackupReporterCarriesObjectPaths(t *testing.T) {
+	var raw []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	r := &BackupReporter{ControlPlaneURL: srv.URL, HostID: "h", Token: "t", Bucket: "b", Log: zerolog.Nop()}
+
+	task := backup.Task{SandboxID: "sb", Generation: "g", FilesFinal: true,
+		Files: []backup.TaskFile{
+			{Name: "rootfs.ext4", SHA256: "aa", Size: 4, Object: "sandboxes/sb/g/rootfs.ext4.pabc123"},
+			{Name: "base-bb.ext4", SHA256: "bb", Size: 8, Shared: true, Object: "bases/bb.pdef456"},
+		}}
+	if err := r.Deliver(task); err != nil {
+		t.Fatal(err)
+	}
+	var gotBody backupReportBody
+	if err := json.Unmarshal(raw, &gotBody); err != nil {
+		t.Fatal(err)
+	}
+	if len(gotBody.Files) != 2 ||
+		gotBody.Files[0].Object != "sandboxes/sb/g/rootfs.ext4.pabc123" ||
+		gotBody.Files[1].Object != "bases/bb.pdef456" {
+		t.Fatalf("files = %+v, want the recorded object paths", gotBody.Files)
+	}
+
+	legacy := backup.Task{SandboxID: "sb", Generation: "g", FilesFinal: true,
+		Files: []backup.TaskFile{{Name: "rootfs.ext4", SHA256: "aa", Size: 4}}}
+	if err := r.Deliver(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"object"`) {
+		t.Fatalf("legacy payload = %s, want no object key on the wire", raw)
+	}
+}
+
+// An old control plane binds report bodies strictly and 400s the object
+// field as unknown; the reporter degrades once to the pre-field payload
+// instead of dropping the coverage row, and still drops when even that
+// is rejected. Only the binder's own unknown-field message triggers the
+// degraded retry: any other 400 (a new control plane rejecting a
+// malformed path) drops on the first attempt, never stripped past the
+// validation it failed.
+func TestBackupReporterStripsObjectPathsForOldControlPlane(t *testing.T) {
+	acceptStripped := true
+	// The strict binder's message as respondErrorMsg actually ships it:
+	// JSON-escaped inside the error envelope.
+	reject := `{"error":{"code":"bad_request","message":"Invalid request body: json: unknown field \"object\""}}`
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		if strings.Contains(string(body), `"object"`) || !acceptStripped {
+			http.Error(w, reject, http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	r := &BackupReporter{ControlPlaneURL: srv.URL, HostID: "h", Token: "t", Bucket: "b", Log: zerolog.Nop()}
+	task := backup.Task{SandboxID: "sb", Generation: "g", FilesFinal: true,
+		Files: []backup.TaskFile{{Name: "rootfs.ext4", SHA256: "aa", Size: 4,
+			Object: "sandboxes/sb/g/rootfs.ext4.pabc123"}}}
+
+	if err := r.Deliver(task); err != nil {
+		t.Fatalf("Deliver = %v, want nil after the stripped retry lands", err)
+	}
+	if len(bodies) != 2 || !strings.Contains(bodies[0], `"object"`) || strings.Contains(bodies[1], `"object"`) {
+		t.Fatalf("bodies = %q, want one attempt with objects then one without", bodies)
+	}
+
+	// A rejection that persists without the field is genuinely permanent:
+	// exactly one stripped retry, then the drop that keeps the outbox
+	// moving.
+	bodies = nil
+	acceptStripped = false
+	if err := r.Deliver(task); err != nil {
+		t.Fatalf("Deliver = %v, want nil so the poisoned entry clears", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("attempts = %d, want exactly one stripped retry", len(bodies))
+	}
+
+	// A 400 without the unknown-field marker is a content rejection from
+	// a control plane that understands the field: no stripped retry.
+	bodies = nil
+	reject = `{"error":{"code":"bad_request","message":"object for \"rootfs.ext4\" must name this entry under its own prefix"}}`
+	acceptStripped = true
+	if err := r.Deliver(task); err != nil {
+		t.Fatalf("Deliver = %v, want nil so the poisoned entry clears", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("attempts = %d, want a single non-stripped attempt", len(bodies))
 	}
 }


### PR DESCRIPTION
## Summary

Verified-generation reports recorded only names, sizes, and digests, so the backup_generation.files ledger could not name a generation's bucket objects (object names embed the extent-packing fingerprint, known only at upload time). This PR captures each upload's exact object path from the store write itself and carries it through the BoltDB outbox, the report wire format, and into the files jsonb, making the ledger sufficient for a future DB-driven lifecycle GC to name objects without listing the bucket. Part of the sandbox recovery and durability effort; no deletion or read path is implemented here.

## Technical decisions

- Single naming source: the recorded path is the literal value handed to the blob store's create call, returned from the same function that writes the object, so it cannot drift from the write side. Control-plane validation rebuilds the expected prefix from the same layout helpers the uploader uses.
- Durable/wire compatibility, all additive with omitempty:
  - BoltDB outbox: pre-upgrade entries decode and deliver unchanged (tested against a byte-for-byte legacy entry).
  - Old vmd + new control plane: pathless reports are accepted and stored exactly as before.
  - New vmd + old control plane: the control plane binds report JSON strictly, so the unknown field is rejected; the reporter detects that specific rejection and retries once with the paths stripped, landing the report exactly as an old vmd would instead of dropping the coverage row. Generations reported through that window keep coverage but stay pathless (their bucket manifests remain the path authority); an upsert enrichment arm upgrades a pathless row if a rich report is redelivered, without moving completed_at or the reported_at freshness cap.
- Ledger integrity for future GC: paths are validated against the owner's layout (fingerprint suffix must be hex; charset pinned, not length, so a future fingerprint widening is not a silent incompatibility), accepted all-or-none per report, and frozen once recorded, since the bucket manifest they mirror is immutable. A completion whose manifest create deduped reports no paths (the earlier attempt's published manifest is the authority), and a pathless re-ack never demotes an undelivered path-bearing outbox entry.

## Testing

- Unit: recorded paths exactly match the store keys written (both the streamed and history-skip shared-base paths); outbox round-trip with and without paths including a pre-upgrade entry; deduped-manifest completions report pathless; pathless re-ack keeps the richer outbox entry; reporter carries paths on the wire, omits the key for legacy entries, strip-retries only on the unknown-field rejection; handler accepts/persists reports with and without paths and rejects foreign, unfingerprinted, or mixed paths.
- Integration: enrichment ordering over backup_generation (pathless never demotes, equal-instant rich redelivery enriches without touching completed_at/reported_at, recorded paths frozen).
- go build ./..., go vet, and the backup/vm/api unit suites plus the backup-report integration suite run on linux.
