### PR TITLE
fix(boxd): allow root directory in safePath for directory listing and stat

### DIFF
--- a/cmd/boxd/files_test.go
+++ b/cmd/boxd/files_test.go
@@ -755,3 +755,76 @@ func TestServeDirAsZip_AbortsOnCanceledContext(t *testing.T) {
 		t.Fatalf("zip walk wrote %d entries after the context was canceled; want 0 (aborted)", len(zr.File))
 	}
 }
+
+func TestFilesystemService_ListDir_Root(t *testing.T) {
+	svc := &filesystemService{}
+	resp, err := svc.ListDir(context.Background(), connect.NewRequest(&pb.ListDirRequest{Path: "/"}))
+	if err != nil {
+		t.Fatalf("ListDir(/): %v", err)
+	}
+	if len(resp.Msg.GetEntries()) == 0 {
+		t.Errorf("got 0 entries for /, expected directory entries")
+	}
+}
+
+func TestFilesystemService_Stat_Root(t *testing.T) {
+	svc := &filesystemService{}
+	resp, err := svc.Stat(context.Background(), connect.NewRequest(&pb.StatRequest{Path: "/"}))
+	if err != nil {
+		t.Fatalf("Stat(/): %v", err)
+	}
+	if !resp.Msg.GetIsDir() {
+		t.Errorf("Stat(/) IsDir = false, want true")
+	}
+}
+
+func TestFileDownload_JSON_RootDir(t *testing.T) {
+	w := zipFilesGet(t, "/", "json")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", w.Code, w.Body.String())
+	}
+	listing := parseListing(t, w.Body.Bytes())
+	if len(listing.Entries) == 0 {
+		t.Errorf("got 0 entries for /, expected directory entries")
+	}
+}
+
+func TestFileDownload_Zip_RootDir_Rejected(t *testing.T) {
+	w := zipFilesGet(t, "/", "zip")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "refusing to archive root directory") {
+		t.Errorf("got body %q, want 'refusing to archive root directory'", w.Body.String())
+	}
+}
+
+func TestFileUpload_RootDir_Rejected(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/files?path=/", strings.NewReader("data"))
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cannot upload to root directory") {
+		t.Errorf("got body %q, want 'cannot upload to root directory'", w.Body.String())
+	}
+}
+
+func TestFilesystemService_Mutations_RootRejected(t *testing.T) {
+	svc := &filesystemService{}
+	ctx := context.Background()
+
+	if _, err := svc.MakeDir(ctx, connect.NewRequest(&pb.MakeDirRequest{Path: "/"})); err == nil {
+		t.Error("MakeDir(/) succeeded, want error")
+	}
+	if _, err := svc.Remove(ctx, connect.NewRequest(&pb.RemoveRequest{Path: "/"})); err == nil {
+		t.Error("Remove(/) succeeded, want error")
+	}
+	if _, err := svc.Move(ctx, connect.NewRequest(&pb.MoveRequest{Source: "/", Destination: "/tmp/dst"})); err == nil {
+		t.Error("Move(src=/) succeeded, want error")
+	}
+	if _, err := svc.Move(ctx, connect.NewRequest(&pb.MoveRequest{Source: "/tmp/src", Destination: "/"})); err == nil {
+		t.Error("Move(dst=/) succeeded, want error")
+	}
+}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -53,7 +53,7 @@ func blockedPath(p string) error {
 
 // safePath validates and cleans a filesystem path. It rejects paths that could
 // damage the VM's ability to function (init, boxd, /proc, /sys, /dev) and
-// prevents path traversal to root.
+// requires paths to be absolute.
 //
 // NOTE: this is purely lexical — it does NOT resolve symlinks, so a path whose
 // components symlink into a blocklisted location still passes here. Directory
@@ -61,8 +61,8 @@ func blockedPath(p string) error {
 // (resolveWithinBlocklist) before reading it.
 func safePath(raw string) (string, error) {
 	p := filepath.Clean(raw)
-	if p == "/" || p == "." {
-		return "", fmt.Errorf("cannot operate on root directory")
+	if p == "." || !strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path must be absolute")
 	}
 	if err := blockedPath(p); err != nil {
 		return "", err
@@ -833,6 +833,9 @@ func (s *filesystemService) MakeDir(ctx context.Context, req *connect.Request[pb
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	if path == "/" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot create root directory"))
+	}
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
@@ -843,6 +846,9 @@ func (s *filesystemService) Remove(ctx context.Context, req *connect.Request[pb.
 	path, err := safePath(req.Msg.GetPath())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if path == "/" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot remove root directory"))
 	}
 	if err := os.RemoveAll(path); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -858,6 +864,9 @@ func (s *filesystemService) Move(ctx context.Context, req *connect.Request[pb.Mo
 	dst, err := safePath(req.Msg.GetDestination())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if src == "/" || dst == "/" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("cannot move root directory"))
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -1186,6 +1195,10 @@ func (c *cappedWriter) seal() { c.sealed = true }
 // whole download. Entries are written as the walk proceeds — constant memory,
 // no temp file.
 func serveDirAsZip(ctx context.Context, w http.ResponseWriter, dirPath string) {
+	if dirPath == "/" {
+		writeJSONError(w, http.StatusBadRequest, "refusing to archive root directory")
+		return
+	}
 	// Resolve the parent's real path first so a symlinked component — a leaf, or
 	// an INTERMEDIATE one (a -> /, then a/proc) — can't anchor the archive root
 	// outside the requested tree: os.OpenRoot follows symlinks while opening its
@@ -1487,6 +1500,12 @@ func writeFileAttempt(path string, body io.Reader) (int64, error) {
 }
 
 func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
+	if path == "/" {
+		errJSON, _ := json.Marshal(map[string]string{"error": "cannot upload to root directory"})
+		http.Error(w, string(errJSON), http.StatusBadRequest)
+		return
+	}
+
 	// Peek up to the retry-buffer limit rather than reading the whole
 	// body blindly. If the body is larger than the limit, len(peeked)
 	// comes back as limit+1 without hitting EOF, and we fall through to

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3774,6 +3774,45 @@ func TestListSandboxFiles_Success(t *testing.T) {
 	}
 }
 
+func TestListSandboxFiles_DefaultPath(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "test-sb", Status: db.SandboxStatusActive}
+
+	var gotPath string
+	vmd := &stubVMD{
+		listDirFn: func(_ context.Context, id, path string) ([]vmdclient.DirEntry, error) {
+			gotPath = path
+			return []vmdclient.DirEntry{
+				{Name: "home", IsDir: true, Size: 4096, ModifiedUnix: 1700000000},
+			}, nil
+		},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "FROM sandbox") {
+				return sandboxRow(sb)
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sandboxes/"+sandboxID.String()+"/files", nil)
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if gotPath != "/" {
+		t.Errorf("ListDir path = %q, want %q", gotPath, "/")
+	}
+}
+
 // A missing directory must surface as 404, never 410 Gone: listing must not
 // mistake a boxd "not found" for a dead VM and mark the sandbox failed.
 func TestListSandboxFiles_NotFoundIsNotFatal(t *testing.T) {


### PR DESCRIPTION
## Summary

- Allow the root directory `"/"` in `boxd`'s `safePath` validator so read-only filesystem queries (`FilesystemService.ListDir`, `FilesystemService.Stat`, and `GET /files?path=/&format=json`) can inspect the sandbox root.
- Add explicit guards to mutating operations (`MakeDir`, `Remove`, `Move`, and `handleFileUpload`) to reject `"/"` so root cannot be created, deleted, renamed, or overwritten.
- Add a guard in `serveDirAsZip` to cleanly reject archiving the entire microVM root directory (`"refusing to archive root directory"`).
- Add unit tests in `cmd/boxd` covering root directory `ListDir`, `Stat`, JSON directory listing, zip download rejection, upload rejection, and mutating operation rejection.
- Add a unit test in `internal/api` verifying `GET /sandboxes/:id/files` with omitted `path` parameter defaults to `"/"` and completes successfully.

## Why

Per the OpenAPI contract, `GET /sandboxes/{sandbox_id}/files` defaults the `path` query parameter to `"/"` when omitted. However, `safePath` in `boxd` previously contained an unconditional check `if p == "/" || p == "."` that returned `"cannot operate on root directory"`.

Consequently:
1. Every control plane directory listing using the default path (or `?path=/`) failed with `400 Bad Request: {"error":{"code":"bad_request","message":"Path is not a listable directory."}}`.
2. Direct REST queries to `GET /files?path=/&format=json` failed with `400 Bad Request`.
3. Connect-RPC calls to `FilesystemService.ListDir(Path: "/")` and `FilesystemService.Stat(Path: "/")` failed with `InvalidArgument`.

This change allows non-destructive inspection of the root directory while preserving strict mutation protection on root.

## Test Plan

- [x] Unit tests pass: `go test -v ./cmd/boxd` passed
- [x] API handler tests pass: `go test -v ./internal/api -run TestListSandboxFiles` passed
- [x] Full test suite: `go test ./...` passed
- [x] Integration test suite: `DATABASE_URL="postgres://postgres:postgres@localhost:5433/sandbox_test?sslmode=disable" go test -tags integration ./internal/integration/ ./cmd/migrate-team/` passed
- [x] Full build verification: `make clean && make build` passed
- [x] CLI commands build: `go build ./cmd/...` passed
- [x] Commits signed off with DCO (`git commit -s`)

/cc @meAmitPatil @mohamedsobhi777 @msmhmorsi @pavitrabhalla @awille-ai