### PR TITLE
vmd: keep the socket up on steady-state deploys and bound daemon shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Run unit tests
         run: go test -v -short -count=1 -race ./...
 
+      - name: Run deploy-script tests
+        run: python3 -m unittest discover -s .github/workflows/scripts -p 'test_*.py'
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1053,14 +1053,16 @@ def main() -> int:
             READY=0
             for i in $(seq 1 90); do
                 INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)
-                if [ -n "$INVOCATION" ]; then
-                    MATCH=$(sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" -g 'gRPC serving requests' --no-pager 2>/dev/null || true)
-                    if [ -n "$MATCH" ] \
-                       && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
-                       && sudo systemctl is-active --quiet {service}; then
-                        READY=1
-                        break
-                    fi
+                # journalctl -g exits nonzero on no match (and prints
+                # "-- No entries --" to stdout), so drive the check off its exit
+                # status — capturing stdout would read that marker as a false
+                # positive. No `|| true`: that would swallow the no-match status.
+                if [ -n "$INVOCATION" ] \
+                   && sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" --quiet -g 'gRPC serving requests' --no-pager >/dev/null 2>&1 \
+                   && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
+                   && sudo systemctl is-active --quiet {service}; then
+                    READY=1
+                    break
                 fi
                 sleep 1
             done

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,26 +1040,35 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
-            # Timestamp before the restart so the readiness scan sees only the
-            # new process's log line.
-            READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
             # Wait for APPLICATION readiness, not is-active: the unit is
-            # Type=simple, so "active" only means the process forked, while vmd
+            # Type=simple, so "active" only proves the process forked, while vmd
             # answers Unavailable until it logs startup-complete (its real gate,
-            # ~12s in prod). Fail with the recovery trap still armed on timeout.
+            # ~12s in prod). Scope the scan to the unit's CURRENT systemd
+            # invocation so neither a prior boot's nor a crashed-and-replaced
+            # process's ready line counts, then re-confirm that invocation is
+            # still current+active when the line is seen. Read journalctl into a
+            # var (no pipe) so a match can't SIGPIPE it under pipefail — same
+            # reason as the find -print -quit above. Fail with the recovery trap
+            # still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
-                if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then
-                    READY=1
-                    break
+                INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)
+                if [ -n "$INVOCATION" ]; then
+                    MATCH=$(sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" -g 'gRPC serving requests' --no-pager 2>/dev/null || true)
+                    if [ -n "$MATCH" ] \
+                       && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
+                       && sudo systemctl is-active --quiet {service}; then
+                        READY=1
+                        break
+                    fi
                 fi
                 sleep 1
             done
             if [ "$READY" != 1 ]; then
                 echo "ERROR: {service} did not reach application readiness (startupReady) within 90s after restart" >&2
                 sudo systemctl status --no-pager {service} >&2 || true
-                sudo journalctl -u {service} --since "$READY_SINCE" --no-pager -n 80 >&2 || true
+                sudo journalctl -u {service} --no-pager -n 80 >&2 || true
                 exit 1
             fi
             # {service} is confirmed serving requests on the final config: disarm

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,16 +1040,14 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
-            # Capture the moment just before restart so the readiness scan sees
-            # only the NEW process's log line, never a prior boot's.
+            # Timestamp before the restart so the readiness scan sees only the
+            # new process's log line.
             READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
-            # Wait for APPLICATION readiness, not just is-active. The unit is
-            # Type=simple, so "active" means only that the process forked, while
-            # vmd answers Unavailable until it logs startup-complete — its real
-            # request gate, which measured prod startup reaches in ~12s. Poll for
-            # that line, bounded well above it, and fail (leaving the recovery
-            # trap armed) if the process never gets there or dies trying.
+            # Wait for APPLICATION readiness, not is-active: the unit is
+            # Type=simple, so "active" only means the process forked, while vmd
+            # answers Unavailable until it logs startup-complete (its real gate,
+            # ~12s in prod). Fail with the recovery trap still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
                 if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,18 +1040,34 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
+            # Capture the moment just before restart so the readiness scan sees
+            # only the NEW process's log line, never a prior boot's.
+            READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
-            sleep 3
-            sudo systemctl is-active --quiet {service} || (
-                echo "ERROR: {service} failed to become active after restart" >&2
+            # Wait for APPLICATION readiness, not just is-active. The unit is
+            # Type=simple, so "active" means only that the process forked, while
+            # vmd answers Unavailable until it logs startup-complete — its real
+            # request gate, which measured prod startup reaches in ~12s. Poll for
+            # that line, bounded well above it, and fail (leaving the recovery
+            # trap armed) if the process never gets there or dies trying.
+            READY=0
+            for i in $(seq 1 90); do
+                if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then
+                    READY=1
+                    break
+                fi
+                sleep 1
+            done
+            if [ "$READY" != 1 ]; then
+                echo "ERROR: {service} did not reach application readiness (startupReady) within 90s after restart" >&2
                 sudo systemctl status --no-pager {service} >&2 || true
-                sudo journalctl -u {service} --no-pager -n 40 >&2 || true
+                sudo journalctl -u {service} --since "$READY_SINCE" --no-pager -n 80 >&2 || true
                 exit 1
-            )
-            # {service} is confirmed active on the final config: disarm the
-            # journal-migration recovery trap (a no-op if it was never
-            # armed this run). Anything past this point is unrelated to the
-            # backup journal and shouldn't restart vmd on failure.
+            fi
+            # {service} is confirmed serving requests on the final config: disarm
+            # the journal-migration recovery trap (a no-op if it was never armed
+            # this run). Anything past this point is unrelated to the backup
+            # journal and shouldn't restart vmd on failure.
             trap - EXIT
 
             # Restart secretsproxy; tolerate missing env file on hosts not

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1043,14 +1043,13 @@ def main() -> int:
             sudo systemctl restart {service}
             # Wait for APPLICATION readiness, not is-active: the unit is
             # Type=simple, so "active" only proves the process forked, while vmd
-            # answers Unavailable until it logs startup-complete (its real gate,
-            # ~12s in prod). Scope the scan to the unit's CURRENT systemd
-            # invocation so neither a prior boot's nor a crashed-and-replaced
-            # process's ready line counts, then re-confirm that invocation is
-            # still current+active when the line is seen. Read journalctl into a
-            # var (no pipe) so a match can't SIGPIPE it under pipefail — same
-            # reason as the find -print -quit above. Fail with the recovery trap
-            # still armed on timeout.
+            # answers Unavailable until it logs startup-complete — its real gate,
+            # which can lag the fork. Scope the scan to the unit's CURRENT
+            # systemd invocation so no prior-boot or crashed-and-replaced ready
+            # line counts, and re-confirm that invocation is still current+active
+            # when the line is seen. Read journalctl into a var (no pipe) so a
+            # match can't SIGPIPE it under pipefail (as with the find -print
+            # -quit above). Fail with the recovery trap still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
                 INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -790,11 +790,20 @@ def main() -> int:
                 fi
             fi
 
-            # Stop before starting the socket unit: on the first deploy of
-            # socket activation the old direct-bound vmd still holds the
-            # ports, and a plain restart can bind the socket unit before the
-            # old process has released them. Idempotent in steady state.
-            sudo systemctl stop {service}
+            # Stop vmd here ONLY in the exceptional cases that need the ports
+            # released before the socket unit (re)binds: the one-time migration
+            # from a direct-bound vmd to socket activation (the socket unit is
+            # not yet the active listener, so the old process still owns the
+            # ports), or a socket-definition change that forces a rebind. In
+            # steady state the socket unit already owns the ports and stays up
+            # across the swap — stopping vmd here instead would leave it down
+            # for the whole config window with the socket still listening, so a
+            # connection arriving in that gap socket-activates a throwaway vmd
+            # that the restart below then kills. The single restart further
+            # down does the cutover with connections backlogging on the socket.
+            if ! systemctl is-active --quiet superserve-vmd.socket || [ "$SOCKET_CHANGED" = 1 ]; then
+                sudo systemctl stop {service}
+            fi
 
             # Migrate the backup journal to its new path now that vmd is
             # stopped (the file is closed, safe to move), then upsert
@@ -809,17 +818,16 @@ def main() -> int:
             # migrated by an earlier deploy) so this is a no-op in steady
             # state.
             if [ -n {q_backup_journal} ]; then
-                # {service} was already stopped above (unconditionally, for
-                # every deploy) before this block is even reached, so any
-                # failure exit between here and the restart/health-check
-                # block further down would otherwise leave it down with
-                # nothing to bring it back — including from the mount
-                # recheck just below, and from the fallible env write later
-                # in this block. Arm recovery up front, for the whole
-                # section, rather than only around the parts that also stop
-                # the socket. A no-op start on units that were never
-                # stopped. Disarmed only once {service} is confirmed active
-                # again, near the end of this script.
+                # This block stops superserve-vmd.socket and {service} itself
+                # when the journal path changes (below), and the gated stop
+                # above may already have stopped {service} on a socket
+                # migration. Either way, arm recovery up front for the whole
+                # section so any failure exit between here and the
+                # restart/health-check block — the mount recheck just below, or
+                # the fallible env write later — cannot leave a unit down with
+                # nothing to bring it back. A start on units that were never
+                # stopped is a harmless no-op. Disarmed only once {service} is
+                # confirmed active again, near the end of this script.
                 #
                 # Re-verifies the mount at fire time rather than blindly
                 # restarting: $BJ_ANCESTOR is set below and stays valid for
@@ -903,24 +911,21 @@ def main() -> int:
                 fi
 
                 if [ "$OLD_BACKUP_JOURNAL_PATH" != "$NEW_BACKUP_JOURNAL_PATH" ]; then
-                    # {service} was stopped above, but superserve-vmd.socket
-                    # stays active the rest of this script by design
-                    # (zero-downtime deploys), so a connection landing in the
-                    # gap between that stop and here can already have
-                    # socket-activated vmd against the still-current old
-                    # path — even when $OLD_BACKUP_JOURNAL_PATH has no file
-                    # yet (a host's first deploy of this setting): vmd would
-                    # then create one there on activation, and it becomes an
-                    # orphan the moment vmd.env is rewritten below to name
-                    # the new path, with nothing left to migrate it. Stop the
-                    # socket too, whenever the path is changing at all, not
-                    # just when there's a file to migrate. Re-enabled by the
-                    # socket restart/start block and the {service} restart
-                    # later in this script, once vmd.env names the new path.
-                    # The recovery trap armed at the top of this block
-                    # already covers a failure here too — it stops the
-                    # socket now as well, not just {service}, but the trap's
-                    # start of both units on any exit applies regardless.
+                    # The socket unit stays up across a normal deploy by design
+                    # (connections backlog instead of refusing), so a
+                    # connection landing here could socket-activate vmd against
+                    # the still-current old path — even when
+                    # $OLD_BACKUP_JOURNAL_PATH has no file yet (a host's first
+                    # deploy of this setting): vmd would then create one there
+                    # on activation, and it becomes an orphan the moment
+                    # vmd.env is rewritten below to name the new path, with
+                    # nothing left to migrate it. Stop BOTH units here,
+                    # whenever the path is changing at all, not just when
+                    # there's a file to migrate. Re-enabled by the socket
+                    # restart/start block and the {service} restart later in
+                    # this script, once vmd.env names the new path. The
+                    # recovery trap armed at the top of this block covers a
+                    # failure here too.
                     sudo systemctl stop superserve-vmd.socket {service}
                     if [ -f "$OLD_BACKUP_JOURNAL_PATH" ]; then
                         # $OLD_BACKUP_JOURNAL_PATH still present under its

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -790,7 +790,7 @@ def main() -> int:
                 fi
             fi
 
-            # Stop vmd here ONLY in the exceptional cases that need the ports
+            # Stop here ONLY in the exceptional cases that need the ports
             # released before the socket unit (re)binds: the one-time migration
             # from a direct-bound vmd to socket activation (the socket unit is
             # not yet the active listener, so the old process still owns the
@@ -799,10 +799,19 @@ def main() -> int:
             # across the swap — stopping vmd here instead would leave it down
             # for the whole config window with the socket still listening, so a
             # connection arriving in that gap socket-activates a throwaway vmd
-            # that the restart below then kills. The single restart further
-            # down does the cutover with connections backlogging on the socket.
+            # that the restart below then kills. A normal binary deploy never
+            # reaches this stop; the single restart further down does its
+            # cutover with connections backlogging on the socket.
+            #
+            # Stop BOTH units, not just vmd: on a socket-definition change the
+            # old socket is still active, so leaving it listening would let a
+            # connection socket-activate an interim vmd during the rebind
+            # window — the very race this gating exists to remove. Stopping an
+            # inactive socket (the migration case) is a harmless no-op. The
+            # socket comes back with its new definition at the rebind block
+            # below; that rare deploy accepts a brief refused window.
             if ! systemctl is-active --quiet superserve-vmd.socket || [ "$SOCKET_CHANGED" = 1 ]; then
-                sudo systemctl stop {service}
+                sudo systemctl stop superserve-vmd.socket {service}
             fi
 
             # Migrate the backup journal to its new path now that vmd is

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -1,0 +1,57 @@
+"""Regression guards for the vmd deploy-ordering that caused the
+socket-activation double-restart incident.
+
+The ordering is a shell sequence built into a heredoc by deploy-vmd.py, so it is
+not a pure function; these assert on the rendered template text. Each test pins
+one property whose violation reintroduces the incident.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).with_name("deploy-vmd.py").read_text()
+
+
+class DeployVmdOrderingTests(unittest.TestCase):
+    def test_no_bare_service_stop(self):
+        # The early service stop that opened the socket-activation window must
+        # never be unconditional/bare: every stop of the vmd service also stops
+        # superserve-vmd.socket (both-units form) so no connection can
+        # socket-activate an interim vmd during the window.
+        self.assertNotRegex(
+            SOURCE,
+            r"systemctl stop \{service\}",
+            "found a bare `systemctl stop {service}`; every service stop must "
+            "also stop superserve-vmd.socket",
+        )
+
+    def test_steady_state_stop_is_guarded_and_stops_both(self):
+        # The steady-state early stop runs ONLY on a fresh socket migration
+        # (socket inactive) or a socket-definition change, and stops BOTH units.
+        self.assertRegex(
+            SOURCE,
+            r'if ! systemctl is-active --quiet superserve-vmd\.socket'
+            r' \|\| \[ "\$SOCKET_CHANGED" = 1 \]; then\s*\n'
+            r'\s*sudo systemctl stop superserve-vmd\.socket \{service\}',
+        )
+
+    def test_exactly_one_cutover_restart(self):
+        # Steady state does exactly one service restart (the cutover). A second
+        # is the double-restart this fix removed.
+        self.assertEqual(len(re.findall(r"systemctl restart \{service\}", SOURCE)), 1)
+
+    def test_waits_for_application_readiness_not_just_is_active(self):
+        # The post-restart gate waits for vmd's real request gate (startupReady,
+        # logged as "gRPC serving requests"): the unit is Type=simple, so
+        # is-active alone means only that the process forked.
+        self.assertIn('grep -qF "gRPC serving requests"', SOURCE)
+        # ...and must not gate readiness on a bare sleep + is-active.
+        self.assertNotRegex(
+            SOURCE,
+            r"sleep 3\s*\n\s*sudo systemctl is-active --quiet \{service\}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -42,15 +42,23 @@ class DeployVmdOrderingTests(unittest.TestCase):
         self.assertEqual(len(re.findall(r"systemctl restart \{service\}", SOURCE)), 1)
 
     def test_waits_for_application_readiness_not_just_is_active(self):
-        # The post-restart gate waits for vmd's real request gate (startupReady,
-        # logged as "gRPC serving requests"): the unit is Type=simple, so
-        # is-active alone means only that the process forked.
-        self.assertIn('grep -qF "gRPC serving requests"', SOURCE)
+        # Readiness gates on vmd's real request gate (startupReady, logged as
+        # "gRPC serving requests"), scoped to the unit's CURRENT systemd
+        # invocation — not a bare is-active (Type=simple only proves the process
+        # forked) and not a prior/crashed invocation's line.
+        self.assertRegex(SOURCE, r"-g 'gRPC serving requests'")
+        self.assertIn("_SYSTEMD_INVOCATION_ID", SOURCE)
         # ...and must not gate readiness on a bare sleep + is-active.
         self.assertNotRegex(
             SOURCE,
             r"sleep 3\s*\n\s*sudo systemctl is-active --quiet \{service\}",
         )
+
+    def test_readiness_scan_does_not_pipe_journalctl_to_grep(self):
+        # Under `set -o pipefail`, grep closing the pipe on a match SIGPIPEs
+        # journalctl and the pipeline reads non-zero even on success — a false
+        # timeout. The readiness scan must capture output, not pipe to grep -q.
+        self.assertNotRegex(SOURCE, r"journalctl[^\n]*\|\s*grep -q")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -6,7 +6,10 @@ not a pure function; these assert on the rendered template text. Each test pins
 one property whose violation reintroduces the incident.
 """
 
+import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -59,6 +62,39 @@ class DeployVmdOrderingTests(unittest.TestCase):
         # journalctl and the pipeline reads non-zero even on success — a false
         # timeout. The readiness scan must capture output, not pipe to grep -q.
         self.assertNotRegex(SOURCE, r"journalctl[^\n]*\|\s*grep -q")
+
+    def test_readiness_query_drives_off_exit_status_not_captured_output(self):
+        # journalctl -g prints "-- No entries --" to stdout and exits nonzero on
+        # no match; capturing that stdout (esp. with `|| true`) reads the marker
+        # as a false-ready. The query must drive off exit status: --quiet, output
+        # to /dev/null, and never `|| true` on the readiness journalctl.
+        self.assertRegex(
+            SOURCE,
+            r"journalctl[^\n]*--quiet[^\n]*-g 'gRPC serving requests'[^\n]*>/dev/null",
+        )
+        self.assertNotRegex(SOURCE, r"journalctl[^\n]*gRPC serving requests[^\n]*\|\| true")
+
+    def test_no_match_journalctl_is_not_ready(self):
+        # Behavioral: a journalctl that prints the empty-result marker and exits
+        # nonzero (the real no-match behavior) must make the exit-status query
+        # read as not-ready; a matching one (exit 0) as ready.
+        query = (
+            "if journalctl --quiet -g 'gRPC serving requests' --no-pager "
+            ">/dev/null 2>&1; then echo READY; else echo NOTREADY; fi"
+        )
+        for exit_code, stdout, expect in (
+            (1, "-- No entries --", "NOTREADY"),
+            (0, "match", "READY"),
+        ):
+            with tempfile.TemporaryDirectory() as d:
+                fake = Path(d) / "journalctl"
+                fake.write_text("#!/bin/sh\necho '%s'\nexit %d\n" % (stdout, exit_code))
+                fake.chmod(0o755)
+                env = dict(os.environ, PATH="%s:%s" % (d, os.environ["PATH"]))
+                out = subprocess.run(
+                    ["sh", "-c", query], env=env, capture_output=True, text=True
+                ).stdout
+                self.assertIn(expect, out, "exit=%d" % exit_code)
 
 
 if __name__ == "__main__":

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1176,9 +1176,13 @@ func main() {
 		// adopt-in-cutover would cost.
 		reattachStart := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
-		log.Info().Str("startup_phase", "reattach_background").
+		// Concurrent with the sequential startup partition (runs in this
+		// goroutine), so its phase_ms must NOT be summed with the partition
+		// marks. Flagged concurrent=true and given a distinct message so a
+		// grep for "startup phase timing" excludes it from the partition sum.
+		log.Info().Str("startup_phase", "reattach_background").Bool("concurrent", true).
 			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
-			Msg("startup phase timing")
+			Msg("startup background phase timing")
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -193,6 +193,11 @@ type lifecycle struct {
 	// receipt: only a deliberate, fully clean shutdown may vouch.
 	signalInitiated bool
 	closerErr       error
+	// forcedRPCStop is set when the gRPC drain hit its budget and active RPCs
+	// were force-cancelled. A cancelled create/pause/resume may have left state
+	// the next boot must reconcile, so this bars the pool receipt — the drain
+	// budget is a circuit breaker, never a proven-safe cancellation bound.
+	forcedRPCStop bool
 
 	done   chan struct{}
 	doneCh sync.Once
@@ -249,13 +254,21 @@ func (lc *lifecycle) noteSignalInitiated() {
 	lc.mu.Unlock()
 }
 
+// noteForcedRPCStop marks that the gRPC drain overran its budget and active
+// RPCs were force-cancelled, so this shutdown can never be treated as clean.
+func (lc *lifecycle) noteForcedRPCStop() {
+	lc.mu.Lock()
+	lc.forcedRPCStop = true
+	lc.mu.Unlock()
+}
+
 // cleanIntentionalShutdown reports whether this was a signal-initiated
 // shutdown in which no service errored and every closer succeeded — the
 // only condition under which state may be vouched for.
 func (lc *lifecycle) cleanIntentionalShutdown() bool {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
-	return lc.signalInitiated && lc.firstErr == nil && lc.closerErr == nil
+	return lc.signalInitiated && lc.firstErr == nil && lc.closerErr == nil && !lc.forcedRPCStop
 }
 
 // wait blocks until shutdown is signaled (by a service exit, context
@@ -271,9 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
-// so total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
-// if the process itself wedges past this.
-// ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
+// so total shutdown stays bounded. When it bounds the gRPC drain, a hit budget
+// force-cancels active RPCs AND marks the shutdown unclean (see the gRPC
+// closer), so overrunning it costs a next-boot reconcile — never a silent clean
+// handoff. It is a circuit breaker, not a proven-safe cancellation bound.
+// systemd TimeoutStopSec is the final backstop if the process wedges past this.
 var perCloserShutdownTimeout = 12 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1299,7 +1314,13 @@ func main() {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
 		case <-shutdownCtx.Done():
-			log.Warn().Msg("graceful shutdown timed out, forcing stop")
+			// Force-cancel active RPCs to stay bounded, but mark the shutdown
+			// unclean: a cancelled create/pause/resume may have left state the
+			// next boot must reconcile, so this can never be a clean handoff
+			// that vouches the pool receipt. Return nil (not an error) so the
+			// remaining closers still flush their state gracefully.
+			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
+			lc.noteForcedRPCStop()
 			grpcServer.Stop()
 		}
 		return nil

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,6 +317,34 @@ func runDrainCheck() int {
 	return 3
 }
 
+// startupTimer emits one structured log line per startup phase — the phase's
+// own wall-clock duration, the cumulative time since the daemon began starting,
+// and, where cheap to compute, the aggregate count the phase processed.
+// Observability only: it changes no control flow and runs only on the startup
+// path, so a prod-sized restart reveals which phase dominates and what scales
+// with fleet size.
+type startupTimer struct {
+	log   zerolog.Logger
+	start time.Time
+}
+
+func newStartupTimer(log zerolog.Logger) *startupTimer {
+	return &startupTimer{log: log, start: time.Now()}
+}
+
+// done records a phase that began at t0. Pass count >= 0 to log an aggregate
+// size (VM records, staged entries); pass -1 to omit it.
+func (s *startupTimer) done(phase string, t0 time.Time, count int) {
+	e := s.log.Info().
+		Str("startup_phase", phase).
+		Dur("phase_ms", time.Since(t0)).
+		Dur("since_start_ms", time.Since(s.start))
+	if count >= 0 {
+		e = e.Int("count", count)
+	}
+	e.Msg("startup phase timing")
+}
+
 func main() {
 	// Maintenance subcommands run before any daemon setup and exit. They must
 	// not open the state store in write mode or start services.
@@ -391,6 +419,11 @@ func main() {
 
 	lc := newLifecycle(log)
 
+	// Startup phase timing — observability only (see startupTimer). Started as
+	// early as the daemon path allows so since_start_ms approximates the full
+	// time to readiness.
+	st := newStartupTimer(log)
+
 	// ---- Egress blocklist (optional) ----
 	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
@@ -437,10 +470,12 @@ func main() {
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
+	netFirewallT0 := time.Now()
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
+	st.done("network_firewall", netFirewallT0, -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -657,12 +692,32 @@ func main() {
 
 	// ---- BoltDB state store ----
 	statePath := envOrDefault("VMD_STATE_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "vmd.db"))
+	stateStoreT0 := time.Now()
 	stateStore, err := vm.OpenStateStore(statePath)
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
+	st.done("state_store_open", stateStoreT0, -1)
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
+
+	// Startup inventory — observability only. One cheap read of the record set
+	// gives the master N and its network/cgroup breakdown, to correlate with
+	// the phase durations. Host-total netns/mounts are emitted separately by
+	// the reconciler's periodic gauge shortly after startup.
+	if recs, aerr := stateStore.All(); aerr == nil {
+		var withNS, cgroup int
+		for _, r := range recs {
+			if r.Namespace != "" {
+				withNS++
+			}
+			if r.Supervision == vm.SupervisionCgroup {
+				cgroup++
+			}
+		}
+		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
+			Int("cgroup_records", cgroup).Msg("startup inventory")
+	}
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -671,6 +726,7 @@ func main() {
 	// unit's config proves the survival property (Delegate + KillMode=
 	// process); a refusal degrades new launches to the unit path but still
 	// initializes the subtree for managing any existing cgroup VMs.
+	cgroupArmT0 := time.Now()
 	if arms, err := mgr.ArmDirectSpawn(ctx); err != nil {
 		if errors.Is(err, vm.ErrCgroupVMsUnmanageable) {
 			// Existing cgroup VMs can't be adopted — refuse to come up "ready"
@@ -682,6 +738,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
+	st.done("cgroup_arm", cgroupArmT0, -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -793,11 +850,17 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
+		stagingT0 := time.Now()
+		stagedEntries := 0
+		if entries, rerr := os.ReadDir(stagingRoot); rerr == nil {
+			stagedEntries = len(entries)
+		}
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
 		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
 			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
+		st.done("backup_staging_scan", stagingT0, stagedEntries)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -1020,7 +1083,9 @@ func main() {
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
+	slotReserveT0 := time.Now()
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
+	st.done("slot_reserve", slotReserveT0, -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1040,7 +1105,9 @@ func main() {
 		// Skip the sweep when the reap couldn't guarantee a live survivor's
 		// ns is spared (see ReapRecordlessCgroupVMs).
 		if sweepSafe {
+			nsSweepT0 := time.Now()
 			mgr.SweepStartupOrphanNamespaces(protectedNs...)
+			st.done("namespace_sweep", nsSweepT0, -1)
 			// The reservation-time reclaim ran before this sweep and counted
 			// these namespaces as occupied. Nothing revisits them below the
 			// ceiling — claims just take fresh indexes — so rescan now or the
@@ -1109,7 +1176,12 @@ func main() {
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
+		reattachT0 := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
+		// Off the critical path (backgrounded), but it is the O(N) reattach
+		// work — timed with its record count to size what a synchronous
+		// adopt-in-cutover would cost.
+		st.done("reattach_background", reattachT0, reattached+stale)
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}
@@ -1172,6 +1244,7 @@ func main() {
 		// invalid and fail startup; lower them with it.
 		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
 		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
+		dbConnectT0 := time.Now()
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")
@@ -1179,6 +1252,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
+		st.done("db_connect", dbConnectT0, -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1280,6 +1354,7 @@ func main() {
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
 	startupReady.Store(true)
+	st.done("ready", st.start, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -675,6 +675,7 @@ func main() {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
 		// are enforced on every port, not just the proxied web ports.
+		hostEgressT0 := time.Now()
 		hostBlock, err := network.NewHostEgressBlock(log)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to install host egress block table")
@@ -684,7 +685,9 @@ func main() {
 		// the first feed fetch (which may block up to feedFetchTimeout per
 		// feed). Otherwise seeded CIDRs go unenforced on non-proxied ports
 		// during the startup window.
-		hostBlock.UpdateCIDRs(blockList.CIDRs())
+		seedCIDRs := blockList.CIDRs()
+		hostBlock.UpdateCIDRs(seedCIDRs)
+		st.done("host_egress_block", hostEgressT0, len(seedCIDRs))
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
@@ -787,10 +790,12 @@ func main() {
 	var backupJournal *backup.Journal
 	if bucket := backupBucket; bucket != "" {
 		journalPath := envOrDefault("BACKUP_JOURNAL_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "backup.db"))
+		journalOpenT0 := time.Now()
 		bdb, err := bolt.Open(journalPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
 			log.Fatal().Err(err).Str("path", journalPath).Msg("failed to open backup journal")
 		}
+		st.done("backup_journal_open", journalOpenT0, -1)
 		lc.addCloser("backup journal", func(_ context.Context) error { return bdb.Close() })
 		journal, err := backup.NewJournal(bdb)
 		if err != nil {
@@ -1097,7 +1102,9 @@ func main() {
 	// namespaces so the non-adoption sweep keeps them too. sweepSafe=false
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
+	cgroupReapT0 := time.Now()
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
+	st.done("cgroup_reap", cgroupReapT0, len(protectedNs))
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
@@ -1353,6 +1360,14 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
+	// Startup host inventory — observability only. The host-scale netns count
+	// is the O(N) driver for the network setup, namespace sweep, and reattach
+	// phases; logged here so it sits in the same startup burst as their
+	// durations. Host mount counts arrive shortly after from the mount sampler.
+	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
+		Int("netns_orphaned", netnsOrphaned).Msg("startup host inventory")
+
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1365,8 +1365,10 @@ func main() {
 	// phases; logged here so it sits in the same startup burst as their
 	// durations. Host mount counts arrive shortly after from the mount sampler.
 	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+	mountTotal, nsfsTotal := vm.HostMountCounts()
 	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-		Int("netns_orphaned", netnsOrphaned).Msg("startup host inventory")
+		Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
+		Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
 
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -270,18 +270,21 @@ func (lc *lifecycle) wait(ctx context.Context) {
 
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
-// hang the process — the loop abandons one that overruns and moves on, so
-// total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
-// if the process itself wedges past the sum of these.
+// hang the process — the loop aborts the graceful sequence if one overruns,
+// so total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
+// if the process itself wedges past this.
 // ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
 var perCloserShutdownTimeout = 12 * time.Second
 
-// shutdown runs every registered closer in reverse order, collecting errors
-// but never stopping on the first failure — every resource gets a chance to
-// clean up. Each closer runs under its own deadline and off the main
-// goroutine, so one that wedges is abandoned rather than hanging the daemon;
-// an abandoned or failed closer records closerErr, which bars this shutdown
-// from vouching for inventory it may have left inconsistent.
+// shutdown runs every registered closer in reverse (dependency) order. A
+// closer that RETURNS an error is logged and the loop continues — it is done
+// touching its resources, so its dependencies are safe to close. A closer that
+// OVERRUNS its deadline is still running, so the loop must NOT keep closing the
+// dependencies it may still be using (use-after-close): it records the failure
+// and aborts the sequence, leaving the rest to process exit (and systemd
+// TimeoutStopSec). Each closer runs under its own deadline and off the main
+// goroutine. Any failed or timed-out closer records closerErr, which bars this
+// shutdown from vouching for inventory it may have left inconsistent.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -291,23 +294,25 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 	for _, c := range closers {
 		lc.log.Info().Str("service", c.name).Msg("closing")
 		closerCtx, cancel := context.WithTimeout(ctx, perCloserShutdownTimeout)
-		// Buffered so an abandoned closer's goroutine can still send and exit
-		// (or leak harmlessly — the process is on its way down) rather than
-		// block forever on a receiver that has already moved on.
+		// Buffered so a closer that overruns can still send and exit (or leak
+		// harmlessly — the process is on its way down) rather than block
+		// forever on a receiver that has moved on.
 		done := make(chan error, 1)
 		go func() { done <- c.close(closerCtx) }()
 		select {
 		case err := <-done:
+			cancel()
 			if err != nil {
 				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
 				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			}
 		case <-closerCtx.Done():
+			cancel()
 			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
-				Msg("closer exceeded its shutdown deadline; abandoning")
+				Msg("closer exceeded its shutdown deadline; aborting graceful shutdown")
 			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
+			return
 		}
-		cancel()
 	}
 }
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -839,7 +839,7 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
-		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
+		renewedMarkers := mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
 		ss := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
 			ls := backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
@@ -848,8 +848,9 @@ func main() {
 			ss.Bases += ls.Bases
 			ss.Pending += ls.Pending
 		}
-		log.Info().Int("sandboxes", ss.Sandboxes).Int("generations", ss.Generations).
-			Int("bases", ss.Bases).Int("pending", ss.Pending).Msg("backup staging scan breakdown")
+		log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
+			Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
+			Msg("backup staging scan breakdown")
 		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -268,9 +268,20 @@ func (lc *lifecycle) wait(ctx context.Context) {
 	}
 }
 
-// shutdown runs every registered closer in reverse order, collecting
-// errors but never stopping on the first failure — we want every
-// resource to get a chance to clean up.
+// perCloserShutdownTimeout bounds each closer independently during shutdown.
+// A closer that ignores cancellation must not stall the closers after it or
+// hang the process — the loop abandons one that overruns and moves on, so
+// total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
+// if the process itself wedges past the sum of these.
+// ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
+var perCloserShutdownTimeout = 12 * time.Second
+
+// shutdown runs every registered closer in reverse order, collecting errors
+// but never stopping on the first failure — every resource gets a chance to
+// clean up. Each closer runs under its own deadline and off the main
+// goroutine, so one that wedges is abandoned rather than hanging the daemon;
+// an abandoned or failed closer records closerErr, which bars this shutdown
+// from vouching for inventory it may have left inconsistent.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -279,15 +290,33 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 
 	for _, c := range closers {
 		lc.log.Info().Str("service", c.name).Msg("closing")
-		if err := c.close(ctx); err != nil {
-			lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
-			lc.mu.Lock()
-			if lc.closerErr == nil {
-				lc.closerErr = fmt.Errorf("%s: %w", c.name, err)
+		closerCtx, cancel := context.WithTimeout(ctx, perCloserShutdownTimeout)
+		// Buffered so an abandoned closer's goroutine can still send and exit
+		// (or leak harmlessly — the process is on its way down) rather than
+		// block forever on a receiver that has already moved on.
+		done := make(chan error, 1)
+		go func() { done <- c.close(closerCtx) }()
+		select {
+		case err := <-done:
+			if err != nil {
+				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
+				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			}
-			lc.mu.Unlock()
+		case <-closerCtx.Done():
+			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
+				Msg("closer exceeded its shutdown deadline; abandoning")
+			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
 		}
+		cancel()
 	}
+}
+
+func (lc *lifecycle) recordCloserErr(err error) {
+	lc.mu.Lock()
+	if lc.closerErr == nil {
+		lc.closerErr = err
+	}
+	lc.mu.Unlock()
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -193,10 +193,9 @@ type lifecycle struct {
 	// receipt: only a deliberate, fully clean shutdown may vouch.
 	signalInitiated bool
 	closerErr       error
-	// forcedRPCStop is set when the gRPC drain hit its budget and active RPCs
-	// were force-cancelled. A cancelled create/pause/resume may have left state
-	// the next boot must reconcile, so this bars the pool receipt — the drain
-	// budget is a circuit breaker, never a proven-safe cancellation bound.
+	// forcedRPCStop is set when the gRPC drain overran its budget and active
+	// RPCs were force-cancelled — a possibly-inconsistent state the next boot
+	// must reconcile, so it bars the pool receipt.
 	forcedRPCStop bool
 
 	done   chan struct{}
@@ -284,11 +283,10 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
-// so total shutdown stays bounded. When it bounds the gRPC drain, a hit budget
-// force-cancels active RPCs AND marks the shutdown unclean (see the gRPC
-// closer), so overrunning it costs a next-boot reconcile — never a silent clean
-// handoff. It is a circuit breaker, not a proven-safe cancellation bound.
-// systemd TimeoutStopSec is the final backstop if the process wedges past this.
+// so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
+// force-cancels active RPCs and marks the shutdown unclean (see the gRPC
+// closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
+// cancellation bound. systemd TimeoutStopSec is the final backstop.
 var perCloserShutdownTimeout = 12 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1314,11 +1312,9 @@ func main() {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
 		case <-shutdownCtx.Done():
-			// Force-cancel active RPCs to stay bounded, but mark the shutdown
-			// unclean: a cancelled create/pause/resume may have left state the
-			// next boot must reconcile, so this can never be a clean handoff
-			// that vouches the pool receipt. Return nil (not an error) so the
-			// remaining closers still flush their state gracefully.
+			// Force-cancel to stay bounded, but mark the shutdown unclean so it
+			// can't vouch the pool receipt. Return nil (below) so the remaining
+			// closers still flush state.
 			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -704,11 +704,17 @@ func main() {
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
-	// Startup inventory — observability only. One cheap read of the record set
-	// gives the master N and its network/cgroup breakdown, to correlate with
-	// the phase durations. Host-total netns/mounts are emitted separately by
-	// the reconciler's periodic gauge shortly after startup.
-	if recs, aerr := stateStore.All(); aerr == nil {
+	// Startup inventory — observability only, emitted asynchronously so its
+	// full-record scan never sits on the readiness path (BoltDB allows
+	// concurrent readers). Gives the master N and its network/cgroup breakdown
+	// to correlate with the phase durations; the same records are scanned by
+	// ArmDirectSpawn/ReserveStartupSlots on the critical path, so this adds no
+	// synchronous work.
+	go func() {
+		recs, aerr := stateStore.All()
+		if aerr != nil {
+			return
+		}
 		var withNS, cgroup int
 		for _, r := range recs {
 			if r.Namespace != "" {
@@ -720,7 +726,7 @@ func main() {
 		}
 		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
 			Int("cgroup_records", cgroup).Msg("startup inventory")
-	}
+	}()
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -856,14 +862,10 @@ func main() {
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
 		stagingT0 := time.Now()
-		stagedEntries := 0
-		if entries, rerr := os.ReadDir(stagingRoot); rerr == nil {
-			stagedEntries = len(entries)
-		}
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		stagedEntries := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			stagedEntries += backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
 		st.done("backup_staging_scan", stagingT0, stagedEntries)
 		uploader.StagingRoot = stagingRoot
@@ -1360,15 +1362,17 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// Startup host inventory — observability only. The host-scale netns count
-	// is the O(N) driver for the network setup, namespace sweep, and reattach
-	// phases; logged here so it sits in the same startup burst as their
-	// durations. Host mount counts arrive shortly after from the mount sampler.
-	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
-	mountTotal, nsfsTotal := vm.HostMountCounts()
-	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-		Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
-		Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
+	// Startup host inventory — observability only, emitted asynchronously so
+	// its /run/netns and /proc/mounts scans never sit on the readiness path.
+	// These host-scale counts drive O(N) for the network setup, namespace
+	// sweep, and reattach phases.
+	go func() {
+		netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+		mountTotal, nsfsTotal := vm.HostMountCounts()
+		log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
+			Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
+			Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
+	}()
 
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -284,10 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
-// force-cancels active RPCs and marks the shutdown unclean (see the gRPC
-// closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
-// cancellation bound. Chosen to sit under the 30s overall shutdown budget and
-// the unit's TimeoutStopSec backstop, leaving room for the closers after it.
+// force-cancels active RPCs, aborts the remaining closers (a forced stop leaves
+// handlers running — see the gRPC closer), and marks the shutdown unclean — a
+// circuit breaker (overrun costs a reconcile), not a proven-safe cancellation
+// bound. Chosen to sit under the 30s overall shutdown budget and the unit's
+// TimeoutStopSec backstop, leaving room for the closers after it.
 var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1312,15 +1313,21 @@ func main() {
 		select {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
+			return nil
 		case <-shutdownCtx.Done():
-			// Force-cancel to stay bounded, but mark the shutdown unclean so it
-			// can't vouch the pool receipt. Return nil (below) so the remaining
-			// closers still flush state.
-			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
+			// Stop() closes transports but does NOT wait for handler goroutines
+			// (no WaitForHandlers — deliberately, so a handler that detached its
+			// context via WithoutCancel can't defeat the shutdown bound). Those
+			// handlers may still be using the store/pool/DB, so return an error:
+			// the shutdown loop then ABORTS the remaining dependency closers
+			// instead of closing resources out from under a live handler, and
+			// process exit reclaims everything together. Marked unclean so the
+			// next boot reconciles.
+			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; aborting remaining cleanup")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()
+			return fmt.Errorf("forced gRPC stop; handlers may still be running")
 		}
-		return nil
 	})
 
 	// Fast pre-serve init is done (slots reserved, namespaces swept, pool fill

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,32 +317,38 @@ func runDrainCheck() int {
 	return 3
 }
 
-// startupTimer emits one structured log line per startup phase — the phase's
-// own wall-clock duration, the cumulative time since the daemon began starting,
-// and, where cheap to compute, the aggregate count the phase processed.
+// startupTimer emits one structured log line per startup phase. Each mark
+// records the interval since the previous mark, so consecutive marks partition
+// the whole startup with no gap — no phase's cost can hide between timers.
 // Observability only: it changes no control flow and runs only on the startup
-// path, so a prod-sized restart reveals which phase dominates and what scales
-// with fleet size.
+// path, so a prod-sized restart reveals which phase dominates.
 type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
+	last  time.Time
 }
 
 func newStartupTimer(log zerolog.Logger) *startupTimer {
-	return &startupTimer{log: log, start: time.Now()}
+	now := time.Now()
+	return &startupTimer{log: log, start: now, last: now}
 }
 
-// done records a phase that began at t0. Pass count >= 0 to log an aggregate
-// size (VM records, staged entries); pass -1 to omit it.
-func (s *startupTimer) done(phase string, t0 time.Time, count int) {
+// mark logs the segment that ended here: its duration since the previous mark
+// and the cumulative time since startup began. Call only from the main startup
+// goroutine — it mutates last; background work logs its own duration directly.
+// count >= 0 attaches an aggregate that accurately represents this phase's
+// work; -1 omits it.
+func (s *startupTimer) mark(phase string, count int) {
+	now := time.Now()
 	e := s.log.Info().
 		Str("startup_phase", phase).
-		Dur("phase_ms", time.Since(t0)).
-		Dur("since_start_ms", time.Since(s.start))
+		Dur("phase_ms", now.Sub(s.last)).
+		Dur("since_start_ms", now.Sub(s.start))
 	if count >= 0 {
 		e = e.Int("count", count)
 	}
 	e.Msg("startup phase timing")
+	s.last = now
 }
 
 func main() {
@@ -470,12 +476,11 @@ func main() {
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
-	netFirewallT0 := time.Now()
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
-	st.done("network_firewall", netFirewallT0, -1)
+	st.mark("network_firewall", -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -671,11 +676,11 @@ func main() {
 	egressProxy.SetHostID(cfg.HostID)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
+	st.mark("vm_manager_init", -1)
 	if blockList != nil {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
 		// are enforced on every port, not just the proxied web ports.
-		hostEgressT0 := time.Now()
 		hostBlock, err := network.NewHostEgressBlock(log)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to install host egress block table")
@@ -687,7 +692,7 @@ func main() {
 		// during the startup window.
 		seedCIDRs := blockList.CIDRs()
 		hostBlock.UpdateCIDRs(seedCIDRs)
-		st.done("host_egress_block", hostEgressT0, len(seedCIDRs))
+		st.mark("host_egress_block", len(seedCIDRs))
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
@@ -695,38 +700,13 @@ func main() {
 
 	// ---- BoltDB state store ----
 	statePath := envOrDefault("VMD_STATE_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "vmd.db"))
-	stateStoreT0 := time.Now()
 	stateStore, err := vm.OpenStateStore(statePath)
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
-	st.done("state_store_open", stateStoreT0, -1)
+	st.mark("state_store_open", -1)
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
-
-	// Startup inventory — observability only, emitted asynchronously so its
-	// full-record scan never sits on the readiness path (BoltDB allows
-	// concurrent readers). Gives the master N and its network/cgroup breakdown
-	// to correlate with the phase durations; the same records are scanned by
-	// ArmDirectSpawn/ReserveStartupSlots on the critical path, so this adds no
-	// synchronous work.
-	go func() {
-		recs, aerr := stateStore.All()
-		if aerr != nil {
-			return
-		}
-		var withNS, cgroup int
-		for _, r := range recs {
-			if r.Namespace != "" {
-				withNS++
-			}
-			if r.Supervision == vm.SupervisionCgroup {
-				cgroup++
-			}
-		}
-		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
-			Int("cgroup_records", cgroup).Msg("startup inventory")
-	}()
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -735,7 +715,6 @@ func main() {
 	// unit's config proves the survival property (Delegate + KillMode=
 	// process); a refusal degrades new launches to the unit path but still
 	// initializes the subtree for managing any existing cgroup VMs.
-	cgroupArmT0 := time.Now()
 	if arms, err := mgr.ArmDirectSpawn(ctx); err != nil {
 		if errors.Is(err, vm.ErrCgroupVMsUnmanageable) {
 			// Existing cgroup VMs can't be adopted — refuse to come up "ready"
@@ -747,7 +726,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
-	st.done("cgroup_arm", cgroupArmT0, -1)
+	st.mark("cgroup_arm", -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -796,12 +775,10 @@ func main() {
 	var backupJournal *backup.Journal
 	if bucket := backupBucket; bucket != "" {
 		journalPath := envOrDefault("BACKUP_JOURNAL_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "backup.db"))
-		journalOpenT0 := time.Now()
 		bdb, err := bolt.Open(journalPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
 			log.Fatal().Err(err).Str("path", journalPath).Msg("failed to open backup journal")
 		}
-		st.done("backup_journal_open", journalOpenT0, -1)
 		lc.addCloser("backup journal", func(_ context.Context) error { return bdb.Close() })
 		journal, err := backup.NewJournal(bdb)
 		if err != nil {
@@ -836,6 +813,9 @@ func main() {
 			VMDVersion:  os.Getenv("SENTRY_RELEASE"),
 			Metrics:     backupMetrics,
 		}
+		// backup_setup covers the whole backup-subsystem init: metrics
+		// recorder, journal open, GCS storage.NewClient, and uploader.
+		st.mark("backup_setup", -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
 		// crashes between staging and enqueue. The tree lives inside
@@ -861,13 +841,12 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
-		stagingT0 := time.Now()
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		stagedEntries := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			stagedEntries += backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
-		st.done("backup_staging_scan", stagingT0, stagedEntries)
+		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -1086,13 +1065,16 @@ func main() {
 	// Closer is registered later (after the manager/pool closers) so it runs
 	// first on shutdown — stop accepting before those are torn down.
 
+	// grpc_setup covers gRPC server construction, listener inherit/bind, and
+	// adapter registration since the previous mark.
+	st.mark("grpc_setup", -1)
+
 	// ---- Startup network prep (fast; must precede StartPool) ----
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
-	slotReserveT0 := time.Now()
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
-	st.done("slot_reserve", slotReserveT0, -1)
+	st.mark("slot_reserve", -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1104,9 +1086,8 @@ func main() {
 	// namespaces so the non-adoption sweep keeps them too. sweepSafe=false
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
-	cgroupReapT0 := time.Now()
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
-	st.done("cgroup_reap", cgroupReapT0, len(protectedNs))
+	st.mark("cgroup_reap", -1)
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
@@ -1114,9 +1095,7 @@ func main() {
 		// Skip the sweep when the reap couldn't guarantee a live survivor's
 		// ns is spared (see ReapRecordlessCgroupVMs).
 		if sweepSafe {
-			nsSweepT0 := time.Now()
 			mgr.SweepStartupOrphanNamespaces(protectedNs...)
-			st.done("namespace_sweep", nsSweepT0, -1)
 			// The reservation-time reclaim ran before this sweep and counted
 			// these namespaces as occupied. Nothing revisits them below the
 			// ceiling — claims just take fresh indexes — so rescan now or the
@@ -1124,6 +1103,8 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
+			// Covers the orphan sweep AND the slot reclaim it feeds.
+			st.mark("namespace_sweep", -1)
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
@@ -1179,18 +1160,25 @@ func main() {
 	// started after StartPool so its first read observes an initialized pool.
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
+	// pool_start covers StartPool (returns immediately; fills in the
+	// background), pool adoption wiring, and the launcher-namespace setup.
+	st.mark("pool_start", -1)
+
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively
 	// populates the map and GCs stale records. Plain goroutine, not an lc
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
-		reattachT0 := time.Now()
-		reattached, stale := mgr.ReattachAll(ctx)
-		// Off the critical path (backgrounded), but it is the O(N) reattach
-		// work — timed with its record count to size what a synchronous
+		// Off the critical path, but it is the O(N) reattach work. Timed
+		// independently of the startup marks (which are single-goroutine) and
+		// logged with its record count to size what a synchronous
 		// adopt-in-cutover would cost.
-		st.done("reattach_background", reattachT0, reattached+stale)
+		reattachStart := time.Now()
+		reattached, stale := mgr.ReattachAll(ctx)
+		log.Info().Str("startup_phase", "reattach_background").
+			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
+			Msg("startup phase timing")
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}
@@ -1253,7 +1241,6 @@ func main() {
 		// invalid and fail startup; lower them with it.
 		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
 		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
-		dbConnectT0 := time.Now()
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")
@@ -1261,7 +1248,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
-		st.done("db_connect", dbConnectT0, -1)
+		st.mark("db_connect", -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1362,20 +1349,11 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// Startup host inventory — observability only, emitted asynchronously so
-	// its /run/netns and /proc/mounts scans never sit on the readiness path.
-	// These host-scale counts drive O(N) for the network setup, namespace
-	// sweep, and reattach phases.
-	go func() {
-		netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
-		mountTotal, nsfsTotal := vm.HostMountCounts()
-		log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-			Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
-			Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
-	}()
-
+	// pre_ready covers the reconciler, heartbeat, and local HTTP setup since
+	// db_connect — the tail of the critical path before requests are served.
+	st.mark("pre_ready", -1)
 	startupReady.Store(true)
-	st.done("ready", st.start, -1)
+	st.mark("ready", -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -284,11 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
-// force-cancels active RPCs, aborts the remaining closers (a forced stop leaves
-// handlers running — see the gRPC closer), and marks the shutdown unclean — a
-// circuit breaker (overrun costs a reconcile), not a proven-safe cancellation
-// bound. Chosen to sit under the 30s overall shutdown budget and the unit's
-// TimeoutStopSec backstop, leaving room for the closers after it.
+// force-cancels active RPCs, aborts the remaining closers, and marks the
+// shutdown unclean — a circuit breaker (overrun costs a reconcile), not a
+// proven-safe cancellation bound. Chosen to sit under the 30s overall shutdown
+// budget and the unit's TimeoutStopSec backstop, leaving room for the closers
+// after it.
 var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1315,14 +1315,11 @@ func main() {
 			log.Info().Msg("gRPC server stopped gracefully")
 			return nil
 		case <-shutdownCtx.Done():
-			// Stop() closes transports but does NOT wait for handler goroutines
-			// (no WaitForHandlers — deliberately, so a handler that detached its
-			// context via WithoutCancel can't defeat the shutdown bound). Those
-			// handlers may still be using the store/pool/DB, so return an error:
-			// the shutdown loop then ABORTS the remaining dependency closers
-			// instead of closing resources out from under a live handler, and
-			// process exit reclaims everything together. Marked unclean so the
-			// next boot reconciles.
+			// Stop() force-cancels transports but does not wait for handlers (no
+			// WaitForHandlers — that would let a WithoutCancel handler defeat the
+			// bound), so they may still be using the store/pool/DB. Return an
+			// error to abort the remaining closers rather than close those under
+			// a live handler; process exit reclaims the rest.
 			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; aborting remaining cleanup")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -276,15 +276,19 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
 var perCloserShutdownTimeout = 12 * time.Second
 
-// shutdown runs every registered closer in reverse (dependency) order. A
-// closer that RETURNS an error is logged and the loop continues — it is done
-// touching its resources, so its dependencies are safe to close. A closer that
-// OVERRUNS its deadline is still running, so the loop must NOT keep closing the
-// dependencies it may still be using (use-after-close): it records the failure
-// and aborts the sequence, leaving the rest to process exit (and systemd
-// TimeoutStopSec). Each closer runs under its own deadline and off the main
-// goroutine. Any failed or timed-out closer records closerErr, which bars this
-// shutdown from vouching for inventory it may have left inconsistent.
+// shutdown runs registered closers in reverse (dependency) order, each under
+// its own deadline and off the main goroutine. Any non-nil outcome — a returned
+// error OR an overrun deadline — aborts the sequence rather than continuing.
+// The two are indistinguishable and both unsafe to continue past: a closer that
+// returns ctx.Err() at its deadline (the uploader and flow sink do) may still
+// have a worker touching the resources its dependencies own, and at the
+// deadline the select can receive that error from done instead of selecting
+// closerCtx.Done(). Because closers run in dependency order, continuing would
+// close BoltDB/GCS/DB out from under a live worker — a use-after-close. On
+// abort the remaining descriptors are reclaimed by process exit (systemd
+// TimeoutStopSec is the final backstop), and the recorded closerErr bars this
+// shutdown from vouching for inventory it may have left inconsistent. A clean
+// shutdown returns nil from every closer and closes the whole chain.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -299,18 +303,17 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 		// forever on a receiver that has moved on.
 		done := make(chan error, 1)
 		go func() { done <- c.close(closerCtx) }()
+		var err error
 		select {
-		case err := <-done:
-			cancel()
-			if err != nil {
-				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
-				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
-			}
+		case err = <-done:
 		case <-closerCtx.Done():
-			cancel()
-			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
-				Msg("closer exceeded its shutdown deadline; aborting graceful shutdown")
-			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
+			err = fmt.Errorf("shutdown deadline exceeded")
+		}
+		cancel()
+		if err != nil {
+			lc.log.Error().Err(err).Str("service", c.name).
+				Msg("closer failed or overran; aborting graceful shutdown")
+			lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			return
 		}
 	}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -699,6 +699,11 @@ func main() {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
 	st.mark("state_store_open", -1)
+	oss := stateStore.OpenStats()
+	log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
+		Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
+		Int("policies", oss.Policies).Int("orphans_deleted", oss.OrphansDeleted).
+		Msg("state store open breakdown")
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
@@ -835,10 +840,16 @@ func main() {
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		ss := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			ls := backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			ss.Sandboxes += ls.Sandboxes
+			ss.Generations += ls.Generations
+			ss.Bases += ls.Bases
+			ss.Pending += ls.Pending
 		}
+		log.Info().Int("sandboxes", ss.Sandboxes).Int("generations", ss.Generations).
+			Int("bases", ss.Bases).Int("pending", ss.Pending).Msg("backup staging scan breakdown")
 		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -384,12 +384,16 @@ func newStartupTimer(log zerolog.Logger) *startupTimer {
 }
 
 // mark logs the segment ending here (duration since the previous mark, plus
-// cumulative since start). Main-goroutine only — it mutates last; background
-// work logs its own duration. count >= 0 attaches an aggregate, -1 omits it.
-func (s *startupTimer) mark(phase string, count int) {
+// cumulative since start). Every phase boundary is emitted even when its
+// optional work is skipped (enabled=false, ~0 duration) so phase labels stay
+// comparable across host configs and the partition stays attributable. Main-
+// goroutine only — it mutates last; background work logs its own duration.
+// count >= 0 attaches an aggregate, -1 omits it.
+func (s *startupTimer) mark(phase string, enabled bool, count int) {
 	now := time.Now()
 	e := s.log.Info().
 		Str("startup_phase", phase).
+		Bool("enabled", enabled).
 		Dur("phase_ms", now.Sub(s.last)).
 		Dur("since_start_ms", now.Sub(s.start))
 	if count >= 0 {
@@ -426,6 +430,10 @@ func main() {
 		Timestamp().
 		Str("service", "vmd").
 		Logger()
+
+	// Startup phase timing (observability only) — created at the earliest point
+	// the logger is up, so since_start_ms covers all daemon-start work.
+	st := newStartupTimer(log)
 
 	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
 		if err := sentry.Init(sentry.ClientOptions{Dsn: dsn, EnableLogs: true}); err != nil {
@@ -473,9 +481,6 @@ func main() {
 
 	lc := newLifecycle(log)
 
-	// Startup phase timing (observability only) — see startupTimer.
-	st := newStartupTimer(log)
-
 	// ---- Egress blocklist (optional) ----
 	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
@@ -519,6 +524,9 @@ func main() {
 	}
 
 	// ---- Network manager + host firewall ----
+	// preliminary: sentry init, config parse, tool lookups, dir creation, and
+	// egress/DNS option wiring — everything before the network manager builds.
+	st.mark("preliminary", true, -1)
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
@@ -526,7 +534,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
-	st.mark("network_firewall", -1)
+	st.mark("network_firewall", true, -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -722,7 +730,8 @@ func main() {
 	egressProxy.SetHostID(cfg.HostID)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
-	st.mark("vm_manager_init", -1)
+	st.mark("vm_manager_init", true, -1)
+	hostEgressCIDRs := 0
 	if blockList != nil {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
@@ -738,10 +747,11 @@ func main() {
 		// during the startup window.
 		seedCIDRs := blockList.CIDRs()
 		hostBlock.UpdateCIDRs(seedCIDRs)
-		st.mark("host_egress_block", len(seedCIDRs))
+		hostEgressCIDRs = len(seedCIDRs)
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
+	st.mark("host_egress_block", blockList != nil, hostEgressCIDRs)
 	lc.start("egress proxy", func() error { return egressProxy.Start(ctx) })
 
 	// ---- BoltDB state store ----
@@ -750,7 +760,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
-	st.mark("state_store_open", -1)
+	st.mark("state_store_open", true, -1)
 	oss := stateStore.OpenStats()
 	log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
 		Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
@@ -777,7 +787,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
-	st.mark("cgroup_arm", -1)
+	st.mark("cgroup_arm", true, -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -865,7 +875,7 @@ func main() {
 			Metrics:     backupMetrics,
 		}
 		// backup_setup: metrics recorder, journal open, GCS storage.NewClient, uploader.
-		st.mark("backup_setup", -1)
+		st.mark("backup_setup", true, -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
 		// crashes between staging and enqueue. The tree lives inside
@@ -903,7 +913,7 @@ func main() {
 		log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
 			Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
 			Msg("backup staging scan breakdown")
-		st.mark("backup_staging_scan", -1)
+		st.mark("backup_staging_scan", true, -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -953,6 +963,11 @@ func main() {
 			return uploader.Run(upCtx)
 		})
 		log.Info().Str("bucket", bucket).Int("bandwidth_mbps", mbps).Int("workers", workers).Msg("backup uploader enabled")
+	} else {
+		// Backups disabled: emit the phase boundaries anyway so the partition
+		// stays comparable across hosts (skipped => ~0 duration).
+		st.mark("backup_setup", false, -1)
+		st.mark("backup_staging_scan", false, -1)
 	}
 
 	// ---- Backup metrics sampler ----
@@ -1123,14 +1138,14 @@ func main() {
 	// first on shutdown — stop accepting before those are torn down.
 
 	// grpc_setup: server construction, listener bind, adapter registration.
-	st.mark("grpc_setup", -1)
+	st.mark("grpc_setup", true, -1)
 
 	// ---- Startup network prep (fast; must precede StartPool) ----
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
-	st.mark("slot_reserve", -1)
+	st.mark("slot_reserve", true, -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1143,8 +1158,9 @@ func main() {
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
-	st.mark("cgroup_reap", -1)
+	st.mark("cgroup_reap", true, -1)
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
+	sweepRan := false
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
 		// of garbage; the adoption pass below validates or sweeps each one.
@@ -1159,11 +1175,12 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
-			st.mark("namespace_sweep", -1) // sweep + the slot reclaim it feeds
+			sweepRan = true // sweep + the slot reclaim it feeds
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
 	}
+	st.mark("namespace_sweep", sweepRan, -1)
 
 	// Launcher launch path, enabled per host via VMD_LAUNCH_VIA_LAUNCHER_NS.
 	if launchViaLauncherNS {
@@ -1216,7 +1233,7 @@ func main() {
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
 	// pool_start: StartPool (async fill), adoption wiring, launcher-ns setup.
-	st.mark("pool_start", -1)
+	st.mark("pool_start", true, -1)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively
@@ -1302,7 +1319,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
-		st.mark("db_connect", -1)
+		st.mark("db_connect", true, -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1320,6 +1337,7 @@ func main() {
 		log.Info().Msg("egress flow logging enabled")
 	} else {
 		log.Warn().Msg("DATABASE_URL unset — reconciler will run in BoltDB↔systemd-only mode")
+		st.mark("db_connect", false, -1)
 	}
 
 	// ---- Continuous reconciler ----
@@ -1411,9 +1429,9 @@ func main() {
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
 	// pre_ready: reconciler, heartbeat, local HTTP — the tail before serving.
-	st.mark("pre_ready", -1)
+	st.mark("pre_ready", true, -1)
 	startupReady.Store(true)
-	st.mark("ready", -1)
+	st.mark("ready", true, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,11 +317,9 @@ func runDrainCheck() int {
 	return 3
 }
 
-// startupTimer emits one structured log line per startup phase. Each mark
-// records the interval since the previous mark, so consecutive marks partition
-// the whole startup with no gap — no phase's cost can hide between timers.
-// Observability only: it changes no control flow and runs only on the startup
-// path, so a prod-sized restart reveals which phase dominates.
+// startupTimer partitions startup into contiguous phases: each mark logs the
+// interval since the previous mark, so the segments tile the whole start→ready
+// timeline with no gap. Observability only — no control flow, startup path only.
 type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
@@ -333,11 +331,9 @@ func newStartupTimer(log zerolog.Logger) *startupTimer {
 	return &startupTimer{log: log, start: now, last: now}
 }
 
-// mark logs the segment that ended here: its duration since the previous mark
-// and the cumulative time since startup began. Call only from the main startup
-// goroutine — it mutates last; background work logs its own duration directly.
-// count >= 0 attaches an aggregate that accurately represents this phase's
-// work; -1 omits it.
+// mark logs the segment ending here (duration since the previous mark, plus
+// cumulative since start). Main-goroutine only — it mutates last; background
+// work logs its own duration. count >= 0 attaches an aggregate, -1 omits it.
 func (s *startupTimer) mark(phase string, count int) {
 	now := time.Now()
 	e := s.log.Info().
@@ -425,9 +421,7 @@ func main() {
 
 	lc := newLifecycle(log)
 
-	// Startup phase timing — observability only (see startupTimer). Started as
-	// early as the daemon path allows so since_start_ms approximates the full
-	// time to readiness.
+	// Startup phase timing (observability only) — see startupTimer.
 	st := newStartupTimer(log)
 
 	// ---- Egress blocklist (optional) ----
@@ -813,8 +807,7 @@ func main() {
 			VMDVersion:  os.Getenv("SENTRY_RELEASE"),
 			Metrics:     backupMetrics,
 		}
-		// backup_setup covers the whole backup-subsystem init: metrics
-		// recorder, journal open, GCS storage.NewClient, and uploader.
+		// backup_setup: metrics recorder, journal open, GCS storage.NewClient, uploader.
 		st.mark("backup_setup", -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
@@ -1065,8 +1058,7 @@ func main() {
 	// Closer is registered later (after the manager/pool closers) so it runs
 	// first on shutdown — stop accepting before those are torn down.
 
-	// grpc_setup covers gRPC server construction, listener inherit/bind, and
-	// adapter registration since the previous mark.
+	// grpc_setup: server construction, listener bind, adapter registration.
 	st.mark("grpc_setup", -1)
 
 	// ---- Startup network prep (fast; must precede StartPool) ----
@@ -1103,8 +1095,7 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
-			// Covers the orphan sweep AND the slot reclaim it feeds.
-			st.mark("namespace_sweep", -1)
+			st.mark("namespace_sweep", -1) // sweep + the slot reclaim it feeds
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
@@ -1160,8 +1151,7 @@ func main() {
 	// started after StartPool so its first read observes an initialized pool.
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
-	// pool_start covers StartPool (returns immediately; fills in the
-	// background), pool adoption wiring, and the launcher-namespace setup.
+	// pool_start: StartPool (async fill), adoption wiring, launcher-ns setup.
 	st.mark("pool_start", -1)
 
 	// ---- Background full reattach ----
@@ -1170,16 +1160,12 @@ func main() {
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
-		// Off the critical path, but it is the O(N) reattach work. Timed
-		// independently of the startup marks (which are single-goroutine) and
-		// logged with its record count to size what a synchronous
-		// adopt-in-cutover would cost.
+		// O(N) reattach, off the critical path — timed here (not via the
+		// single-goroutine marks) and flagged concurrent, distinct message, so
+		// its phase_ms is never summed into the partition. count sizes a
+		// synchronous adopt-in-cutover.
 		reattachStart := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
-		// Concurrent with the sequential startup partition (runs in this
-		// goroutine), so its phase_ms must NOT be summed with the partition
-		// marks. Flagged concurrent=true and given a distinct message so a
-		// grep for "startup phase timing" excludes it from the partition sum.
 		log.Info().Str("startup_phase", "reattach_background").Bool("concurrent", true).
 			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
 			Msg("startup background phase timing")
@@ -1353,8 +1339,7 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// pre_ready covers the reconciler, heartbeat, and local HTTP setup since
-	// db_connect — the tail of the critical path before requests are served.
+	// pre_ready: reconciler, heartbeat, local HTTP — the tail before serving.
 	st.mark("pre_ready", -1)
 	startupReady.Store(true)
 	st.mark("ready", -1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -286,8 +286,9 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
 // force-cancels active RPCs and marks the shutdown unclean (see the gRPC
 // closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
-// cancellation bound. systemd TimeoutStopSec is the final backstop.
-var perCloserShutdownTimeout = 12 * time.Second
+// cancellation bound. Chosen to sit under the 30s overall shutdown budget and
+// the unit's TimeoutStopSec backstop, leaving room for the closers after it.
+var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
 // its own deadline and off the main goroutine. Any non-nil outcome — a returned

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -157,6 +157,18 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 			t.Fatal("a failing closer must disqualify")
 		}
 	})
+
+	t.Run("forced gRPC stop", func(t *testing.T) {
+		// A drain that overran its budget and force-cancelled active RPCs may
+		// have left state the next boot must reconcile — never a clean handoff.
+		lc := newLifecycle(log)
+		lc.noteSignalInitiated()
+		lc.noteForcedRPCStop()
+		lc.shutdown(context.Background())
+		if lc.cleanIntentionalShutdown() {
+			t.Fatal("a forced gRPC stop must disqualify")
+		}
+	})
 }
 
 // A closer that fails or overruns may still have a worker touching its

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -155,4 +157,32 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 			t.Fatal("a failing closer must disqualify")
 		}
 	})
+}
+
+// A closer that ignores cancellation must be abandoned rather than hang the
+// daemon: shutdown stays bounded and the closers after it still run.
+func TestShutdownAbandonsWedgedCloser(t *testing.T) {
+	prev := perCloserShutdownTimeout
+	perCloserShutdownTimeout = 50 * time.Millisecond
+	defer func() { perCloserShutdownTimeout = prev }()
+
+	lc := newLifecycle(zerolog.Nop())
+	var earliestRan atomic.Bool
+	// LIFO shutdown: registered A, B, C runs as C, B, A. B wedges in the
+	// middle; A (registered first, run last) proves the loop moved past it.
+	lc.addCloser("A-earliest", func(context.Context) error { earliestRan.Store(true); return nil })
+	lc.addCloser("B-wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
+	lc.addCloser("C-latest", func(context.Context) error { return nil })
+
+	start := time.Now()
+	lc.shutdown(context.Background())
+	if d := time.Since(start); d > 2*time.Second {
+		t.Fatalf("shutdown not bounded: took %v", d)
+	}
+	if !earliestRan.Load() {
+		t.Fatal("closer after the wedged one never ran — abandonment failed")
+	}
+	if lc.closerErr == nil {
+		t.Fatal("wedged closer must record closerErr (bars vouching)")
+	}
 }

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -159,32 +159,50 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 	})
 }
 
-// A closer that overruns its deadline is still running, so shutdown must abort
-// rather than close the dependency it may still be using out from under it. The
-// sequence stays bounded and records the failure.
-func TestShutdownAbortsOnWedgedCloser(t *testing.T) {
+// A closer that fails or overruns may still have a worker touching its
+// dependencies' resources, so shutdown must abort rather than close those
+// dependencies out from under it. Covers all three failure shapes; each must
+// leave the dependency unclosed, stay bounded, and record the error.
+func TestShutdownAbortsOnCloserFailure(t *testing.T) {
 	prev := perCloserShutdownTimeout
 	perCloserShutdownTimeout = 50 * time.Millisecond
 	defer func() { perCloserShutdownTimeout = prev }()
 
-	lc := newLifecycle(zerolog.Nop())
-	var depClosed atomic.Bool
-	// LIFO shutdown: registered dep, wedged, latest runs as latest, wedged,
-	// dep. dep (registered first, run last) is the wedged closer's dependency;
-	// it must NOT be closed while the wedged closer is still running.
-	lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
-	lc.addCloser("wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
-	lc.addCloser("latest", func(context.Context) error { return nil })
+	run := func(t *testing.T, failing func(context.Context) error) {
+		lc := newLifecycle(zerolog.Nop())
+		var depClosed atomic.Bool
+		// LIFO shutdown: registered dep, failing, latest runs as latest,
+		// failing, dep. dep (registered first, run last) is the failing
+		// closer's dependency and must NOT be closed after the abort.
+		lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
+		lc.addCloser("failing", failing)
+		lc.addCloser("latest", func(context.Context) error { return nil })
 
-	start := time.Now()
-	lc.shutdown(context.Background())
-	if d := time.Since(start); d > 2*time.Second {
-		t.Fatalf("shutdown not bounded: took %v", d)
+		start := time.Now()
+		lc.shutdown(context.Background())
+		if d := time.Since(start); d > 2*time.Second {
+			t.Fatalf("shutdown not bounded: took %v", d)
+		}
+		if depClosed.Load() {
+			t.Fatal("dependency closed after a failed/overrun closer — must abort instead")
+		}
+		if lc.closerErr == nil {
+			t.Fatal("failed closer must record closerErr (bars vouching)")
+		}
 	}
-	if depClosed.Load() {
-		t.Fatal("dependency closed under a still-running closer — must abort instead")
-	}
-	if lc.closerErr == nil {
-		t.Fatal("wedged closer must record closerErr (bars vouching)")
-	}
+
+	// Respects ctx and returns ctx.Err() at its deadline — its worker may still
+	// be live, and the outer select can receive this from done instead of
+	// selecting closerCtx.Done(). Must still abort.
+	t.Run("returns ctx.Err at deadline", func(t *testing.T) {
+		run(t, func(ctx context.Context) error { <-ctx.Done(); return ctx.Err() })
+	})
+	// Returns a plain error promptly — the done branch must also abort.
+	t.Run("returns error", func(t *testing.T) {
+		run(t, func(context.Context) error { return fmt.Errorf("boom") })
+	})
+	// Ignores ctx entirely and never returns — the deadline branch aborts.
+	t.Run("wedged, ignores ctx", func(t *testing.T) {
+		run(t, func(context.Context) error { select {} }) // ponytail: never returns
+	})
 }

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -159,28 +159,30 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 	})
 }
 
-// A closer that ignores cancellation must be abandoned rather than hang the
-// daemon: shutdown stays bounded and the closers after it still run.
-func TestShutdownAbandonsWedgedCloser(t *testing.T) {
+// A closer that overruns its deadline is still running, so shutdown must abort
+// rather than close the dependency it may still be using out from under it. The
+// sequence stays bounded and records the failure.
+func TestShutdownAbortsOnWedgedCloser(t *testing.T) {
 	prev := perCloserShutdownTimeout
 	perCloserShutdownTimeout = 50 * time.Millisecond
 	defer func() { perCloserShutdownTimeout = prev }()
 
 	lc := newLifecycle(zerolog.Nop())
-	var earliestRan atomic.Bool
-	// LIFO shutdown: registered A, B, C runs as C, B, A. B wedges in the
-	// middle; A (registered first, run last) proves the loop moved past it.
-	lc.addCloser("A-earliest", func(context.Context) error { earliestRan.Store(true); return nil })
-	lc.addCloser("B-wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
-	lc.addCloser("C-latest", func(context.Context) error { return nil })
+	var depClosed atomic.Bool
+	// LIFO shutdown: registered dep, wedged, latest runs as latest, wedged,
+	// dep. dep (registered first, run last) is the wedged closer's dependency;
+	// it must NOT be closed while the wedged closer is still running.
+	lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
+	lc.addCloser("wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
+	lc.addCloser("latest", func(context.Context) error { return nil })
 
 	start := time.Now()
 	lc.shutdown(context.Background())
 	if d := time.Since(start); d > 2*time.Second {
 		t.Fatalf("shutdown not bounded: took %v", d)
 	}
-	if !earliestRan.Load() {
-		t.Fatal("closer after the wedged one never ran — abandonment failed")
+	if depClosed.Load() {
+		t.Fatal("dependency closed under a still-running closer — must abort instead")
 	}
 	if lc.closerErr == nil {
 		t.Fatal("wedged closer must record closerErr (bars vouching)")

--- a/deploy/superserve-vmd.service
+++ b/deploy/superserve-vmd.service
@@ -38,6 +38,12 @@ Delegate=yes
 Restart=always
 RestartSec=2
 
+# Bounded stop: vmd runs its own per-closer-deadline shutdown and exits well
+# within this window. If the process itself wedges, systemd force-kills here
+# rather than letting a stop drag on (the default is 90s). Set above vmd's
+# internal shutdown budget so a healthy stop always completes on its own first.
+TimeoutStopSec=45s
+
 # Environment
 EnvironmentFile=/etc/sandbox/vmd.env
 

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,16 +679,19 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) {
+// SweepStaging reaps orphaned staged artifacts under root. It returns the
+// number of top-level staged entries it enumerated — a telemetry signal for
+// startup timing that callers may ignore.
+func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
 	if root == "" {
-		return
+		return 0
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return
+		return 0
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -766,6 +769,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 		}
 		_ = os.Remove(sbDir)
 	}
+	return len(sandboxes)
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,16 +679,23 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) {
+// SweepStats reports what a SweepStaging pass visited — a telemetry signal for
+// startup timing that callers may ignore.
+type SweepStats struct {
+	Sandboxes, Generations, Bases, Pending int
+}
+
+func SweepStaging(root string, j *Journal, log zerolog.Logger) SweepStats {
+	var stats SweepStats
 	if root == "" {
-		return
+		return stats
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return
+		return stats
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -710,6 +717,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 				continue
 			}
 			for _, b := range bases {
+				stats.Bases++
 				staged := filepath.Join(root, "bases", b.Name())
 				if !referenced[b.Name()] {
 					// Serialize with renewStaged and re-check freshness
@@ -726,6 +734,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			}
 			continue
 		}
+		stats.Sandboxes++
 		sbDir := filepath.Join(root, sb.Name())
 		gens, err := os.ReadDir(sbDir)
 		if err != nil {
@@ -735,6 +744,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			if !g.IsDir() {
 				continue
 			}
+			stats.Generations++
 			pending, err := j.HasPending(sb.Name(), g.Name())
 			if err != nil {
 				log.Warn().Err(err).Msg("backup staging sweep: journal lookup failed")
@@ -742,6 +752,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			}
 			staged := filepath.Join(sbDir, g.Name())
 			if strings.HasPrefix(g.Name(), "pending-") {
+				stats.Pending++
 				// Marker-owned: the journal has no row for a pause that
 				// has not enqueued yet. Live markers renew the dir; only
 				// long-dead orphans are reaped.
@@ -766,6 +777,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 		}
 		_ = os.Remove(sbDir)
 	}
+	return stats
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,19 +679,16 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-// SweepStaging reaps orphaned staged artifacts under root. It returns the
-// number of top-level staged entries it enumerated — a telemetry signal for
-// startup timing that callers may ignore.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
+func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 	if root == "" {
-		return 0
+		return
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return 0
+		return
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -769,7 +766,6 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
 		}
 		_ = os.Remove(sbDir)
 	}
-	return len(sandboxes)
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -263,6 +263,9 @@ func WithEgressPortChainOwner() ManagerOption {
 }
 
 func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, opts ...ManagerOption) (*Manager, error) {
+	// Split pre-network config (ip_forward + option wiring) from the actual
+	// firewall install so a slow startup network_firewall phase is unambiguous.
+	tPreNet := time.Now()
 	if err := enableIPForward(ctx); err != nil {
 		return nil, err
 	}
@@ -281,10 +284,14 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 	for _, opt := range opts {
 		opt(mgr)
 	}
+	preNet := time.Since(tPreNet)
 
+	tFW := time.Now()
 	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.secretsProxyDst, mgr.secretsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
+	mgr.log.Info().Dur("pre_network_ms", preNet).Dur("firewall_install_ms", time.Since(tFW)).
+		Msg("network manager init breakdown")
 
 	return mgr, nil
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -858,6 +858,7 @@ func (p *Pool) placeVouched(slot *preallocSlot, preferRecycled bool) bool {
 // scanning phase before its goroutine is spawned, so no request can observe
 // the gap between launch and the pass actually starting.
 func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped int64) {
+	tStart := time.Now()
 	// Direct callers (tests, legacy paths) enter the phase here; via
 	// StartAdoption it is already scanning and the CAS no-ops. The deferred
 	// reset is the panic backstop AND clears the trust state for the next
@@ -941,7 +942,8 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				Msg("pool: adoption aborted — validation timing out systemically; remaining slots left for a later boot")
 		}
 		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
-			Int64("skipped", nSkipped.Load()).Msg("pool: adoption pass complete")
+			Int64("skipped", nSkipped.Load()).Int("candidates", len(indexes)).
+			Dur("duration_ms", time.Since(tStart)).Msg("pool: adoption pass complete")
 		// Accumulate — adopted already carries the receipt fast path's count.
 		adopted += nAdopted.Load()
 		invalid, skipped = nInvalid.Load(), nSkipped.Load()

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -941,9 +941,6 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 			p.log.Error().Int64("timeouts", nTimeouts.Load()).
 				Msg("pool: adoption aborted — validation timing out systemically; remaining slots left for a later boot")
 		}
-		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
-			Int64("skipped", nSkipped.Load()).Int("candidates", len(indexes)).
-			Dur("duration_ms", time.Since(tStart)).Msg("pool: adoption pass complete")
 		// Accumulate — adopted already carries the receipt fast path's count.
 		adopted += nAdopted.Load()
 		invalid, skipped = nInvalid.Load(), nSkipped.Load()
@@ -952,6 +949,12 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 	p.adoptPhase.Store(adoptPhaseIdle)
 	p.signalProgress()
 	p.mgr.SweepStrayHostVeths()
+	// Emitted on every completion path — including the receipt fast path
+	// adopting all slots, or no orphans at all — so startup timing always has
+	// an adoption duration, not only when the worker pass ran.
+	p.log.Info().Int64("adopted", adopted).Int64("torn_down", invalid).
+		Int64("skipped", skipped).Dur("duration_ms", time.Since(tStart)).
+		Msg("pool: adoption pass complete")
 	return adopted, invalid, skipped
 }
 

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -639,15 +639,16 @@ func (m *Manager) dropStagedPending(pb PendingBackup, log zerolog.Logger) {
 // from an abandoned directory, and the sweep deletes it — discarding the
 // only durable copy of an otherwise-recoverable pause. Needs only the
 // BoltDB state (no instance map), so it's safe to call this early.
-func (m *Manager) RenewPendingStaging(log zerolog.Logger) {
+func (m *Manager) RenewPendingStaging(log zerolog.Logger) int {
 	if m.state == nil {
-		return
+		return 0
 	}
 	pending, err := m.state.ListPendingBackups()
 	if err != nil {
 		log.Warn().Err(err).Msg("renew pending staging: list failed")
-		return
+		return 0
 	}
+	renewed := 0
 	for _, pb := range pending {
 		if pb.StagedDir == "" {
 			continue
@@ -660,7 +661,9 @@ func (m *Manager) RenewPendingStaging(log zerolog.Logger) {
 		// unrenewed and indistinguishable from an orphan to the sweep.
 		resolved := m.resolveStagedLocation(pb)
 		backup.RenewStaged(resolved.StagedDir)
+		renewed++
 	}
+	return renewed
 }
 
 // RecoverPendingBackups re-runs every pause that still owed its backup

--- a/internal/vm/cgroup_linux.go
+++ b/internal/vm/cgroup_linux.go
@@ -82,6 +82,7 @@ func (m *Manager) ArmDirectSpawn(ctx context.Context) (bool, error) {
 	// A state-store read failure is FATAL: a corrupt/unreadable BoltDB means the
 	// daemon can't load any VM record (reattach and the reconciler both fail),
 	// so coming up "ready" would hide it and leave every cgroup VM unmanaged.
+	tScan := time.Now()
 	hasRecords, rerr := m.hasCgroupRecords()
 	if rerr != nil {
 		return false, fmt.Errorf("%w: cannot read state store: %v", ErrCgroupVMsUnmanageable, rerr)
@@ -99,6 +100,10 @@ func (m *Manager) ArmDirectSpawn(ctx context.Context) (bool, error) {
 			haveCgroupVMs = treeHas
 		}
 	}
+	// Detection (record + delegated-tree scan) split from the systemd/cgroup
+	// validation below, for startup timing.
+	m.log.Info().Dur("cgroup_detect_ms", time.Since(tScan)).Bool("has_cgroup_vms", haveCgroupVMs).
+		Msg("cgroup arm: detection scan")
 	if !wantArm && !haveCgroupVMs {
 		return false, nil // nothing to arm, nothing to manage
 	}

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -375,6 +375,11 @@ func (m *Manager) retryLauncherBuild(ctx context.Context) {
 
 // hostMountCounts returns the total mount count and the nsfs subset (the
 // per-netns bind mounts) from /proc/mounts.
+// HostMountCounts returns the host's total mount count and its nsfs subset,
+// read from /proc/mounts. Exported for the one-shot startup host inventory;
+// StartMountCountSampler emits the same counts periodically. Observability only.
+func HostMountCounts() (total, nsfs int) { return hostMountCounts() }
+
 func hostMountCounts() (total, nsfs int) {
 	data, err := os.ReadFile("/proc/mounts")
 	if err != nil {

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -375,11 +375,6 @@ func (m *Manager) retryLauncherBuild(ctx context.Context) {
 
 // hostMountCounts returns the total mount count and the nsfs subset (the
 // per-netns bind mounts) from /proc/mounts.
-// HostMountCounts returns the host's total mount count and its nsfs subset,
-// read from /proc/mounts. Exported for the one-shot startup host inventory;
-// StartMountCountSampler emits the same counts periodically. Observability only.
-func HostMountCounts() (total, nsfs int) { return hostMountCounts() }
-
 func hostMountCounts() (total, nsfs int) {
 	data, err := os.ReadFile("/proc/mounts")
 	if err != nil {

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -262,6 +262,10 @@ func unescapeMountinfo(s string) string {
 func (m *Manager) startSampler(ctx context.Context, name string, every time.Duration, fn func()) {
 	go func() {
 		defer sentrylog.Recover(name)
+		// One immediate sample so the startup window has a value, not only after
+		// the first interval — the netns/mount counts are the fleet-size
+		// correlates for the startup phase timings.
+		fn()
 		t := time.NewTicker(every)
 		defer t.Stop()
 		for {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3495,17 +3495,25 @@ func (m *Manager) ReserveStartupSlots(context.Context) bool {
 	if m.state == nil {
 		return false
 	}
+	tLoad := time.Now()
 	recs, err := m.state.All()
 	if err != nil {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return false
 	}
-	m.netMgr.ReserveSlotsAbove(collectStartupSlots(recs))
+	loadMS := time.Since(tLoad)
+	tReserve := time.Now()
+	slots := collectStartupSlots(recs)
+	m.netMgr.ReserveSlotsAbove(slots)
 	// Reservations pin the allocator above the highest record index, stranding
 	// every unused index below it. Hand those back now, while records are the
 	// only owners and "unowned with no namespace" provably means free.
-	if n := m.netMgr.ReclaimUnusedSlots(); n > 0 {
-		m.log.Info().Int("slots", n).Msg("reclaimed unused network slot indexes")
+	reclaimed := m.netMgr.ReclaimUnusedSlots()
+	m.log.Info().Dur("record_load_ms", loadMS).Dur("reserve_reclaim_ms", time.Since(tReserve)).
+		Int("records", len(recs)).Int("reservations", len(slots)).Int("reclaimed", reclaimed).
+		Msg("startup slot reservation breakdown")
+	if reclaimed > 0 {
+		m.log.Info().Int("slots", reclaimed).Msg("reclaimed unused network slot indexes")
 	}
 	return true
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3549,6 +3549,8 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 		return nil, false
 	}
 	sweepSafe = true
+	scanned := len(cgIDs)
+	var recorded, recordless, reaped int
 	for _, id := range cgIDs {
 		// Build VMs ARE reaped here: pre-gate every cgroup is a previous-life
 		// survivor, and a build's cgroup is recordless (persistState omits build
@@ -3562,14 +3564,21 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 				// protected set — the sweep must not run on this startup.
 				sweepSafe = false
 				m.log.Warn().Err(herr).Str("vm_id", id).Msg("record lookup failed for cgroup survivor — skipping startup orphan sweep")
+			} else {
+				recorded++
 			}
 			continue // recorded (reattach owns it) or unreadable
 		}
+		recordless++
 		m.log.Warn().Str("vm_id", id).Msg("recordless cgroup survivor at startup — reaping")
 		// Capture the netns before the kill: an FC that survives it is still in
 		// the group, but a clean kill removes it and firstPID would read empty.
 		ns := m.netMgr.NamespaceForPID(m.cgroups.firstPID(id))
-		if serr := m.stopVM(ctx, id, SupervisionCgroup); serr != nil {
+		serr := m.stopVM(ctx, id, SupervisionCgroup)
+		if serr == nil {
+			reaped++
+		}
+		if serr != nil {
 			m.log.Error().Err(serr).Str("vm_id", id).Msg("failed to reap recordless cgroup")
 			// Liveness decides first — populated or unreadable == maybe-alive.
 			// A confirmed-empty group whose rmdir merely failed is dead, its
@@ -3591,6 +3600,8 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 			}
 		}
 	}
+	m.log.Info().Int("scanned", scanned).Int("recorded", recorded).Int("recordless", recordless).
+		Int("reaped", reaped).Int("protected", len(protected)).Msg("cgroup reap breakdown")
 	return protected, sweepSafe
 }
 

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -281,18 +281,36 @@ func writeStateBreadcrumbTo(at, statePath string) error {
 
 // StateStore wraps a BoltDB database for VM state persistence.
 type StateStore struct {
-	db *bolt.DB
+	db        *bolt.DB
+	openStats StateStoreOpenStats
 }
+
+// StateStoreOpenStats breaks OpenStateStore's cost into its sub-steps for
+// startup timing. Observability only.
+type StateStoreOpenStats struct {
+	BoltOpen       time.Duration // bolt.Open: mmap + freelist load
+	PolicyScan     time.Duration // sidecar orphan scan + deletes
+	RecordScan     time.Duration // primary record scan + policy migration
+	Records        int
+	Policies       int
+	OrphansDeleted int
+}
+
+// OpenStats returns the timing/count breakdown captured while the store opened.
+func (s *StateStore) OpenStats() StateStoreOpenStats { return s.openStats }
 
 // Path returns the resolved filesystem path of the open store.
 func (s *StateStore) Path() string { return s.db.Path() }
 
 // OpenStateStore opens (or creates) the BoltDB file at path.
 func OpenStateStore(path string) (*StateStore, error) {
+	var stats StateStoreOpenStats
+	tOpen := time.Now()
 	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("open state store %s: %w", path, err)
 	}
+	stats.BoltOpen = time.Since(tOpen)
 	if err := db.Update(func(tx *bolt.Tx) error {
 		records, err := tx.CreateBucketIfNotExists(bucketName)
 		if err != nil {
@@ -312,8 +330,10 @@ func OpenStateStore(path string) (*StateStore, error) {
 		// An old VMD can delete the primary record without knowing about the
 		// sidecar bucket. Remove those orphans before migrating so a later VM
 		// reusing the same key cannot inherit deleted policy state.
+		tPolicy := time.Now()
 		var orphanKeys [][]byte
 		if err := policies.ForEach(func(k, _ []byte) error {
+			stats.Policies++
 			if records.Get(k) == nil {
 				orphanKeys = append(orphanKeys, append([]byte(nil), k...))
 			}
@@ -326,11 +346,15 @@ func OpenStateStore(path string) (*StateStore, error) {
 				return err
 			}
 		}
+		stats.OrphansDeleted = len(orphanKeys)
+		stats.PolicyScan = time.Since(tPolicy)
 
 		// Seed the sidecar for records written by the immediately preceding
 		// schema. Once present, the sidecar is authoritative and is never
 		// replaced from the primary JSON during startup.
-		return records.ForEach(func(k, v []byte) error {
+		tRecord := time.Now()
+		err = records.ForEach(func(k, v []byte) error {
+			stats.Records++
 			if policies.Get(k) != nil {
 				return nil
 			}
@@ -344,11 +368,13 @@ func OpenStateStore(path string) (*StateStore, error) {
 			}
 			return putPreviewPolicy(policies, k, policy)
 		})
+		stats.RecordScan = time.Since(tRecord)
+		return err
 	}); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("initialize state store: %w", err)
 	}
-	return &StateStore{db: db}, nil
+	return &StateStore{db: db, openStats: stats}, nil
 }
 
 // OpenStateStoreReadOnly opens the BoltDB file for reading only. Unlike


### PR DESCRIPTION
Gate the early `stop` in the vmd deploy so steady-state deploys keep the systemd socket up (connections backlog across the swap instead of a throwaway vmd being socket-activated and killed). Bound vmd's shutdown with a per-closer deadline plus `TimeoutStopSec` so a stop can never drag on.