### PR TITLE
api: pace the reaper maintenance sweeps on their own ticker

### DIFF
--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -14,10 +14,17 @@ import (
 	"github.com/superserve-ai/sandbox/internal/telemetry"
 )
 
+const defaultSweepInterval = 10 * time.Minute
+
 // ReaperConfig controls the timeout reaper loop.
 type ReaperConfig struct {
 	// Interval is how often the reaper polls for expired sandboxes.
 	Interval time.Duration
+	// SweepInterval paces the DB-only maintenance sweeps. They back up cleanup
+	// the request path already does, and each scans accumulated history to
+	// usually find nothing — on every instance, since the loop runs on all of
+	// them. 0 → 10m.
+	SweepInterval time.Duration
 	// BatchSize bounds the number of sandboxes paused per cycle so a
 	// sudden wave of expirations cannot tie up the control plane.
 	BatchSize int32
@@ -28,9 +35,10 @@ type ReaperConfig struct {
 // DefaultReaperConfig returns sensible defaults for the timeout reaper.
 func DefaultReaperConfig() ReaperConfig {
 	return ReaperConfig{
-		Interval:    30 * time.Second,
-		BatchSize:   50,
-		Parallelism: 10,
+		Interval:      30 * time.Second,
+		SweepInterval: defaultSweepInterval,
+		BatchSize:     50,
+		Parallelism:   10,
 	}
 }
 
@@ -62,29 +70,41 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 	if int32(parallelism) > cfg.BatchSize {
 		parallelism = int(cfg.BatchSize)
 	}
+	sweepInterval := cfg.SweepInterval
+	if sweepInterval <= 0 {
+		sweepInterval = defaultSweepInterval
+	}
 
 	log.Info().
 		Dur("interval", cfg.Interval).
+		Dur("sweep_interval", sweepInterval).
 		Int32("batch_size", cfg.BatchSize).
 		Int("parallelism", parallelism).
 		Msg("timeout reaper started")
 
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
+	sweepTicker := time.NewTicker(sweepInterval)
+	defer sweepTicker.Stop()
 
+	// Caller-set deadlines: these keep the poll interval.
 	runTick := func() {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
+		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism) })
+	}
+
+	// On their own ticker, so a slow host during auto-delete's batch teardown
+	// cannot delay them and their scan cost is not tied to the poll rate.
+	runSweeps := func() {
 		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
 		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
 		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx) })
-		// Auto-delete runs after the DB-only sweeps (interval/revocation/
-		// snapshot) so a slow host during its batch teardown can't delay them.
-		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism) })
 	}
 
 	// Run once immediately so a control plane restart does not delay
 	// cleanup by up to `interval` seconds.
 	runTick()
+	runSweeps()
 
 	for {
 		select {
@@ -93,6 +113,8 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 			return
 		case <-ticker.C:
 			runTick()
+		case <-sweepTicker.C:
+			runSweeps()
 		}
 	}
 }

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -20,10 +20,9 @@ const defaultSweepInterval = 10 * time.Minute
 type ReaperConfig struct {
 	// Interval is how often the reaper polls for expired sandboxes.
 	Interval time.Duration
-	// SweepInterval paces the DB-only maintenance sweeps. They back up cleanup
-	// the request path already does, and each scans accumulated history to
-	// usually find nothing — on every instance, since the loop runs on all of
-	// them. 0 → 10m.
+	// SweepInterval paces the DB-only maintenance sweeps (see sweepLoop),
+	// whose scans cost the same whether or not there is anything to find —
+	// on every instance, since the loop runs on all of them. 0 → 10m.
 	SweepInterval time.Duration
 	// BatchSize bounds the number of sandboxes paused per cycle so a
 	// sudden wave of expirations cannot tie up the control plane.
@@ -82,29 +81,24 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 		Int("parallelism", parallelism).
 		Msg("timeout reaper started")
 
+	// Own goroutine, not another case in the select below: the poll's pauses
+	// and auto-delete teardowns block for host round trips, and sharing this
+	// goroutine would let a slow batch hold off the sweeps — the reason they
+	// ran last in the single-ticker loop this replaced. Concurrency here is
+	// not new: every control-plane instance already runs both loops.
+	go h.sweepLoop(ctx, sweepInterval)
+
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
-	sweepTicker := time.NewTicker(sweepInterval)
-	defer sweepTicker.Stop()
 
-	// Caller-set deadlines: these keep the poll interval.
 	runTick := func() {
 		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
 		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism) })
 	}
 
-	// On their own ticker, so a slow host during auto-delete's batch teardown
-	// cannot delay them and their scan cost is not tied to the poll rate.
-	runSweeps := func() {
-		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
-		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
-		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx) })
-	}
-
 	// Run once immediately so a control plane restart does not delay
 	// cleanup by up to `interval` seconds.
 	runTick()
-	runSweeps()
 
 	for {
 		select {
@@ -113,7 +107,32 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 			return
 		case <-ticker.C:
 			runTick()
-		case <-sweepTicker.C:
+		}
+	}
+}
+
+// sweepLoop runs the DB-only maintenance sweeps: backstops for cleanup the
+// request path already performs, each scanning accumulated history to usually
+// find nothing.
+func (h *Handlers) sweepLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	runSweeps := func() {
+		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
+		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
+		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx) })
+	}
+
+	// Immediately, so a restart after a crash cleans up without waiting a
+	// full interval.
+	runSweeps()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
 			runSweeps()
 		}
 	}

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -369,6 +369,40 @@ func TestReaper_LoopRunsImmediately(t *testing.T) {
 	t.Fatal("reaper did not run immediately on startup")
 }
 
+// An unset SweepInterval must fall back to the default — a zero value reaching
+// time.NewTicker panics — and the sweeps must still run at startup so a restart
+// after a crash cleans up without waiting a full sweep period.
+func TestReaper_SweepsRunOnStartupWithUnsetSweepInterval(t *testing.T) {
+	var snapshotSweeps int32
+
+	h := newReaperHandlers(
+		&reaperMockDBTX{
+			execFn: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+				if strings.Contains(sql, "DELETE FROM snapshot s") {
+					atomic.AddInt32(&snapshotSweeps, 1)
+				}
+				return pgconn.NewCommandTag("DELETE 0"), nil
+			},
+		},
+		&stubVMD{},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Long poll interval so nothing here depends on a ticker firing.
+	h.StartTimeoutReaper(ctx, ReaperConfig{Interval: 24 * time.Hour, BatchSize: 10})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&snapshotSweeps) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("snapshot sweep did not run on startup")
+}
+
 // rollbackPausedVM must persist the resumed host/IP before it flips the row
 // back to active, otherwise the DB can keep advertising a recycled slot.
 func TestRollbackPausedVM_PersistsReplacementHostAndIP(t *testing.T) {


### PR DESCRIPTION
The reaper's DB-only sweeps are backstops for cleanup the request path already does, but they ran on every 30-second poll on every instance, each scanning accumulated history to almost always find nothing.

They now run on a separate 10-minute ticker, still once at startup so a restart after a crash cleans up promptly; expiry and auto-delete keep the poll interval.