### PR TITLE
fix(vmd): jitter the reconciler DB pool's connection lifetime

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1172,6 +1172,19 @@ func main() {
 		// invalid and fail startup; lower them with it.
 		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
 		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
+		// Without an explicit lifetime, pgxpool defaults to an unjittered
+		// 1-hour MaxConnLifetime. Every host in a fleet booted around the
+		// same time then expires its reconciler connections in lockstep,
+		// which the pooler sees as a synchronized mass-reconnect storm.
+		// Same tuning as the controlplane pool (cmd/controlplane/main.go),
+		// which sets these unconditionally rather than trying to detect a
+		// DATABASE_URL override — pgxpool.ParseConfig can't tell "operator
+		// set this to the default value" apart from "left it unset," and
+		// nothing in this repo's deployments configures these via DSN.
+		dbCfg.MaxConnLifetime = 30 * time.Minute
+		dbCfg.MaxConnLifetimeJitter = 5 * time.Minute
+		dbCfg.MaxConnIdleTime = 5 * time.Minute
+		dbCfg.HealthCheckPeriod = 30 * time.Second
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")


### PR DESCRIPTION
## Summary
- The VMD reconciler's Postgres pool (`cmd/vmd/main.go`) never set `MaxConnLifetime`/`MaxConnLifetimeJitter`/`MaxConnIdleTime`/`HealthCheckPeriod`, so it silently inherited pgx's unjittered 1-hour default lifetime.
- Every host in a fleet that boots around the same time expires its reconciler connections in lockstep on that shared clock, which the transaction pooler sees as a synchronized mass-reconnect storm (`Terminate received from client` / `ECLIENTSOCKETCLOSED ... idle` bursts of 100-230+ events within the same second) rather than steady churn — surfacing app-side as `connection reset by peer` / `context deadline exceeded` across every reconciler code path (reaper jobs, host detector, build listing).
- This mirrors an already-shipped fix: `cmd/controlplane/main.go` sets the same four fields with a comment explaining exactly this failure mode ("stagger recycling so a pool's worth of connections never expires (and redials) in the same instant"). This PR applies the identical tuning to the sibling reconciler pool.

## Technical decisions/tradeoffs
- Values (30m lifetime, 5m jitter, 5m idle, 30s health check) match the controlplane pool exactly rather than introducing a second tuning profile.
- No DATABASE_URL-override detection: mirrors the controlplane pool's own precedent of setting these fields unconditionally. Nothing in this repo's deployments configures `pool_max_conn_lifetime` et al. via DSN, and pgxpool's `ParseConfig` output can't reliably distinguish "operator explicitly set the default value" from "left it unset" without re-parsing (and re-doing pgpass/service-file I/O) on the VMD boot path — not worth it for a config surface nobody uses.

## Testing
- `go build ./...` and `go test ./cmd/vmd/...` pass (run under `GOOS=linux`/Linux container — `cmd/vmd` links `nftables`, which doesn't build on macOS).
- Local Codex review (`codex exec review --base main`) iterated to a clean pass with no findings.