### PR TITLE
infra: absorb usw2 pause-backup batches without paging the backlog alert

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -346,18 +346,26 @@ jobs:
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills.
           BACKUP_JOURNAL_PATH: /mnt/localssd/backup.db
-          # Two drain workers to clear the cell's pause-backup backlog:
+          # Drain workers to clear the cell's pause-backup backlog:
           # arrivals outpace the single-worker default here. Workers
           # share one bandwidth cap (task throughput rises, egress does
           # not), and the incremental host cost is one extra hash/read
           # stream on a 192-core metal host with a 12-drive array.
-          # Sized from measured rates with the sandboxes.slice weighting
-          # live: arrivals peak ~1.2k generations/h while each worker
-          # drains ~215/h, so 2 treads water at peak and 6 clears the
-          # backlog (~1.3k/h) with margin. Aggregate egress stays under
-          # the shared bandwidth cap (~22 Mbit/s observed at 2 workers,
-          # cap 100). Rollback is lowering the number.
-          BACKUP_UPLOAD_CONCURRENCY: "6"
+          # Arrivals are not steady: a share of this cell's traffic pauses
+          # in scheduled batches rather than continuously, so a batch can
+          # arrive faster than it drains even when the hourly average is
+          # comfortable. At 6 workers a batch took long enough to drain
+          # that the next one landed before the backlog cleared, so the
+          # backlog-age alert paged on every batch (confirmed against
+          # backup_journal_pending{priority="pause"} and the control
+          # plane's pause-endpoint request log). 12 workers roughly halves
+          # the drain time, leaving real idle time between batches;
+          # re-check against the same series if batch sizes grow.
+          # Aggregate egress stays under the shared bandwidth cap (~22
+          # Mbit/s observed at 2 workers, cap 100) since throughput here
+          # is bounded by per-task overhead, not bandwidth. Rollback is
+          # lowering the number.
+          BACKUP_UPLOAD_CONCURRENCY: "12"
           # Enables vmd's backup metrics exporter (host-local collector);
           # the cell's backup alert policies, including backup-disabled,
           # cannot fire without these series.

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -361,11 +361,20 @@ module "observability" {
   # metric label (HOST_ID on the host matches the instance name). Follows
   # active_sandbox_host so a standby promotion keeps the filter on whichever
   # host is actually emitting.
-  # Thresholds are the module defaults; the rationale for each sits on
-  # the module's variables.
+  # Thresholds are the module defaults except oldest_pending_age_duration;
+  # the rationale for each default sits on the module's variables.
   backup_alerts = {
     host_id        = local.metrics_host_id
     display_prefix = "Backup / ${local.active_host_name}"
+    # A share of this cell's traffic pauses in scheduled batches rather
+    # than steadily, confirmed via backup_journal_pending{priority="pause"}
+    # and the control plane's pause-endpoint request log. The module
+    # default's 15-minute window was shorter than a single batch's drain
+    # time, so it paged on every batch. 20 minutes plus the
+    # BACKUP_UPLOAD_CONCURRENCY bump in deploy-vmd.yml should clear a
+    # batch before this sustains, while still catching a drain that's
+    # actually stalled.
+    oldest_pending_age_duration = "1200s"
   }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount

--- a/infra/modules/observability/backup-alerts.tf
+++ b/infra/modules/observability/backup-alerts.tf
@@ -55,7 +55,7 @@ locals {
       comparison    = "COMPARISON_GT"
       threshold     = var.backup_alerts.oldest_pending_age_seconds
       aligner       = "ALIGN_MAX"
-      duration      = "900s"
+      duration      = var.backup_alerts.oldest_pending_age_duration
       documentation = <<-EOT
         The oldest queued backup generation on ${var.backup_alerts.host_id} has been waiting more than ${var.backup_alerts.oldest_pending_age_seconds}s. Queued pauses are not yet durable in the bucket, so this is direct restore-point exposure.
 

--- a/infra/modules/observability/variables.tf
+++ b/infra/modules/observability/variables.tf
@@ -115,6 +115,13 @@ variable "backup_alerts" {
     # normally well under a minute even on a busy cell, and a 30 minute
     # old head means the drain is stalled or the backlog is growing.
     oldest_pending_age_seconds = optional(number, 1800)
+    # Sustained window for the backlog-age condition. 15 minutes is enough
+    # margin for a cell whose pause arrivals are roughly steady; a cell
+    # whose traffic arrives in scheduled batches (a scheduler firing many
+    # sandboxes' work at once) can legitimately push the queue past the
+    # threshold for longer while it drains a single batch, so that cell's
+    # override should exceed the batch's expected drain time.
+    oldest_pending_age_duration = optional(string, "900s")
     # p99 of the synchronous pause-RPC backup hook. The hook is bounded
     # by design to a marker write, an O(dirtied-bytes) staging copy, and
     # a tens-of-KB vmstate hash: tens to low hundreds of ms. A


### PR DESCRIPTION
## Summary
- usw2 gets a share of its pause traffic in scheduled batches rather than steadily. Each batch outpaced the 6-worker uploader's drain rate for long enough that the next batch landed before the backlog cleared, so the `backup_oldest_pending_age_seconds` backlog alert paged on every batch even though the drain itself was healthy.
- Doubles `BACKUP_UPLOAD_CONCURRENCY` on usw2 (6 → 12) to clear a batch faster.
- Makes the backlog-age alert's sustained window (previously hardcoded at 900s) a configurable `oldest_pending_age_duration` field on the `backup_alerts` module variable, defaulting to 900s for other cells and set to 1200s for usw2 to tolerate one batch's drain time.

## Technical decisions/tradeoffs
- Confirmed the batch pattern directly against `backup_journal_pending{priority="pause"}` and the control plane's pause-endpoint request log rather than assuming from the alert history alone.
- Chose to raise concurrency rather than only loosening the alert window, since per-task overhead (not the shared bandwidth cap) bounds this uploader's throughput — more workers is the intended lever (see `internal/backup/uploader.go`'s doc comment).
- Kept the duration change scoped to usw2 via the module variable instead of changing the module default, since other cells' arrivals are steady.

## Testing
- `terraform fmt` / `terraform validate` clean on `infra/modules/observability`.
- `codex exec review --base main` clean (one round of findings addressed: generalized batch-arrival descriptions that were specific enough to identify a business relationship).