### PR TITLE
vmd: log startup phase durations and inventory counts

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1176,9 +1176,13 @@ func main() {
 		// adopt-in-cutover would cost.
 		reattachStart := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
-		log.Info().Str("startup_phase", "reattach_background").
+		// Concurrent with the sequential startup partition (runs in this
+		// goroutine), so its phase_ms must NOT be summed with the partition
+		// marks. Flagged concurrent=true and given a distinct message so a
+		// grep for "startup phase timing" excludes it from the partition sum.
+		log.Info().Str("startup_phase", "reattach_background").Bool("concurrent", true).
 			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
-			Msg("startup phase timing")
+			Msg("startup background phase timing")
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,6 +317,34 @@ func runDrainCheck() int {
 	return 3
 }
 
+// startupTimer emits one structured log line per startup phase — the phase's
+// own wall-clock duration, the cumulative time since the daemon began starting,
+// and, where cheap to compute, the aggregate count the phase processed.
+// Observability only: it changes no control flow and runs only on the startup
+// path, so a prod-sized restart reveals which phase dominates and what scales
+// with fleet size.
+type startupTimer struct {
+	log   zerolog.Logger
+	start time.Time
+}
+
+func newStartupTimer(log zerolog.Logger) *startupTimer {
+	return &startupTimer{log: log, start: time.Now()}
+}
+
+// done records a phase that began at t0. Pass count >= 0 to log an aggregate
+// size (VM records, staged entries); pass -1 to omit it.
+func (s *startupTimer) done(phase string, t0 time.Time, count int) {
+	e := s.log.Info().
+		Str("startup_phase", phase).
+		Dur("phase_ms", time.Since(t0)).
+		Dur("since_start_ms", time.Since(s.start))
+	if count >= 0 {
+		e = e.Int("count", count)
+	}
+	e.Msg("startup phase timing")
+}
+
 func main() {
 	// Maintenance subcommands run before any daemon setup and exit. They must
 	// not open the state store in write mode or start services.
@@ -391,6 +419,11 @@ func main() {
 
 	lc := newLifecycle(log)
 
+	// Startup phase timing — observability only (see startupTimer). Started as
+	// early as the daemon path allows so since_start_ms approximates the full
+	// time to readiness.
+	st := newStartupTimer(log)
+
 	// ---- Egress blocklist (optional) ----
 	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
@@ -437,10 +470,12 @@ func main() {
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
+	netFirewallT0 := time.Now()
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
+	st.done("network_firewall", netFirewallT0, -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -657,12 +692,32 @@ func main() {
 
 	// ---- BoltDB state store ----
 	statePath := envOrDefault("VMD_STATE_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "vmd.db"))
+	stateStoreT0 := time.Now()
 	stateStore, err := vm.OpenStateStore(statePath)
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
+	st.done("state_store_open", stateStoreT0, -1)
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
+
+	// Startup inventory — observability only. One cheap read of the record set
+	// gives the master N and its network/cgroup breakdown, to correlate with
+	// the phase durations. Host-total netns/mounts are emitted separately by
+	// the reconciler's periodic gauge shortly after startup.
+	if recs, aerr := stateStore.All(); aerr == nil {
+		var withNS, cgroup int
+		for _, r := range recs {
+			if r.Namespace != "" {
+				withNS++
+			}
+			if r.Supervision == vm.SupervisionCgroup {
+				cgroup++
+			}
+		}
+		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
+			Int("cgroup_records", cgroup).Msg("startup inventory")
+	}
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -671,6 +726,7 @@ func main() {
 	// unit's config proves the survival property (Delegate + KillMode=
 	// process); a refusal degrades new launches to the unit path but still
 	// initializes the subtree for managing any existing cgroup VMs.
+	cgroupArmT0 := time.Now()
 	if arms, err := mgr.ArmDirectSpawn(ctx); err != nil {
 		if errors.Is(err, vm.ErrCgroupVMsUnmanageable) {
 			// Existing cgroup VMs can't be adopted — refuse to come up "ready"
@@ -682,6 +738,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
+	st.done("cgroup_arm", cgroupArmT0, -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -793,11 +850,17 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
+		stagingT0 := time.Now()
+		stagedEntries := 0
+		if entries, rerr := os.ReadDir(stagingRoot); rerr == nil {
+			stagedEntries = len(entries)
+		}
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
 		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
 			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
+		st.done("backup_staging_scan", stagingT0, stagedEntries)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -1020,7 +1083,9 @@ func main() {
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
+	slotReserveT0 := time.Now()
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
+	st.done("slot_reserve", slotReserveT0, -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1040,7 +1105,9 @@ func main() {
 		// Skip the sweep when the reap couldn't guarantee a live survivor's
 		// ns is spared (see ReapRecordlessCgroupVMs).
 		if sweepSafe {
+			nsSweepT0 := time.Now()
 			mgr.SweepStartupOrphanNamespaces(protectedNs...)
+			st.done("namespace_sweep", nsSweepT0, -1)
 			// The reservation-time reclaim ran before this sweep and counted
 			// these namespaces as occupied. Nothing revisits them below the
 			// ceiling — claims just take fresh indexes — so rescan now or the
@@ -1109,7 +1176,12 @@ func main() {
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
+		reattachT0 := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
+		// Off the critical path (backgrounded), but it is the O(N) reattach
+		// work — timed with its record count to size what a synchronous
+		// adopt-in-cutover would cost.
+		st.done("reattach_background", reattachT0, reattached+stale)
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}
@@ -1172,6 +1244,7 @@ func main() {
 		// invalid and fail startup; lower them with it.
 		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
 		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
+		dbConnectT0 := time.Now()
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")
@@ -1179,6 +1252,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
+		st.done("db_connect", dbConnectT0, -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1280,6 +1354,7 @@ func main() {
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
 	startupReady.Store(true)
+	st.done("ready", st.start, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -675,6 +675,7 @@ func main() {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
 		// are enforced on every port, not just the proxied web ports.
+		hostEgressT0 := time.Now()
 		hostBlock, err := network.NewHostEgressBlock(log)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to install host egress block table")
@@ -684,7 +685,9 @@ func main() {
 		// the first feed fetch (which may block up to feedFetchTimeout per
 		// feed). Otherwise seeded CIDRs go unenforced on non-proxied ports
 		// during the startup window.
-		hostBlock.UpdateCIDRs(blockList.CIDRs())
+		seedCIDRs := blockList.CIDRs()
+		hostBlock.UpdateCIDRs(seedCIDRs)
+		st.done("host_egress_block", hostEgressT0, len(seedCIDRs))
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
@@ -787,10 +790,12 @@ func main() {
 	var backupJournal *backup.Journal
 	if bucket := backupBucket; bucket != "" {
 		journalPath := envOrDefault("BACKUP_JOURNAL_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "backup.db"))
+		journalOpenT0 := time.Now()
 		bdb, err := bolt.Open(journalPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
 			log.Fatal().Err(err).Str("path", journalPath).Msg("failed to open backup journal")
 		}
+		st.done("backup_journal_open", journalOpenT0, -1)
 		lc.addCloser("backup journal", func(_ context.Context) error { return bdb.Close() })
 		journal, err := backup.NewJournal(bdb)
 		if err != nil {
@@ -1097,7 +1102,9 @@ func main() {
 	// namespaces so the non-adoption sweep keeps them too. sweepSafe=false
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
+	cgroupReapT0 := time.Now()
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
+	st.done("cgroup_reap", cgroupReapT0, len(protectedNs))
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
@@ -1353,6 +1360,14 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
+	// Startup host inventory — observability only. The host-scale netns count
+	// is the O(N) driver for the network setup, namespace sweep, and reattach
+	// phases; logged here so it sits in the same startup burst as their
+	// durations. Host mount counts arrive shortly after from the mount sampler.
+	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
+		Int("netns_orphaned", netnsOrphaned).Msg("startup host inventory")
+
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -788,9 +788,9 @@ func main() {
 	oss := stateStore.OpenStats()
 	st.emit(func() {
 		log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
-			Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
-			Int("policies", oss.Policies).Int("orphans_deleted", oss.OrphansDeleted).
-			Msg("state store open breakdown")
+			Dur("record_scan_ms", oss.RecordScan).Dur("tx_residual_ms", oss.TxResidual).
+			Int("records", oss.Records).Int("policies", oss.Policies).
+			Int("orphans_deleted", oss.OrphansDeleted).Msg("state store open breakdown")
 	})
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
@@ -1256,10 +1256,6 @@ func main() {
 			Msg("skipping network pool adoption: live namespaces not provably protected")
 	}
 
-	// Leak gauge for network namespaces — independent of the launcher path, and
-	// started after StartPool so its first read observes an initialized pool.
-	mgr.StartNetnsLeakSampler(ctx, time.Minute)
-
 	// pool_start: StartPool (async fill), adoption wiring, launcher-ns setup.
 	st.mark("pool_start", true, -1)
 
@@ -1461,6 +1457,12 @@ func main() {
 	startupReady.Store(true)
 	st.mark("ready", true, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
+
+	// Leak gauge for network namespaces — independent of the launcher path.
+	// Started AFTER readiness (and so after StartPool): its immediate first
+	// sample walks the fleet under the allocator lock, which must not contend
+	// with pool fill, reattach, or a first slot-allocating request pre-ready.
+	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
 	// ---- Wait for signal or service failure ----
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -332,12 +332,16 @@ func newStartupTimer(log zerolog.Logger) *startupTimer {
 }
 
 // mark logs the segment ending here (duration since the previous mark, plus
-// cumulative since start). Main-goroutine only — it mutates last; background
-// work logs its own duration. count >= 0 attaches an aggregate, -1 omits it.
-func (s *startupTimer) mark(phase string, count int) {
+// cumulative since start). Every phase boundary is emitted even when its
+// optional work is skipped (enabled=false, ~0 duration) so phase labels stay
+// comparable across host configs and the partition stays attributable. Main-
+// goroutine only — it mutates last; background work logs its own duration.
+// count >= 0 attaches an aggregate, -1 omits it.
+func (s *startupTimer) mark(phase string, enabled bool, count int) {
 	now := time.Now()
 	e := s.log.Info().
 		Str("startup_phase", phase).
+		Bool("enabled", enabled).
 		Dur("phase_ms", now.Sub(s.last)).
 		Dur("since_start_ms", now.Sub(s.start))
 	if count >= 0 {
@@ -374,6 +378,10 @@ func main() {
 		Timestamp().
 		Str("service", "vmd").
 		Logger()
+
+	// Startup phase timing (observability only) — created at the earliest point
+	// the logger is up, so since_start_ms covers all daemon-start work.
+	st := newStartupTimer(log)
 
 	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
 		if err := sentry.Init(sentry.ClientOptions{Dsn: dsn, EnableLogs: true}); err != nil {
@@ -421,9 +429,6 @@ func main() {
 
 	lc := newLifecycle(log)
 
-	// Startup phase timing (observability only) — see startupTimer.
-	st := newStartupTimer(log)
-
 	// ---- Egress blocklist (optional) ----
 	// VMD_EGRESS_BLOCKLIST_CONFIG points at the operator-supplied config
 	// (feeds, pinned domains/CIDRs, blocked ports). Unset = no global
@@ -467,6 +472,9 @@ func main() {
 	}
 
 	// ---- Network manager + host firewall ----
+	// preliminary: sentry init, config parse, tool lookups, dir creation, and
+	// egress/DNS option wiring — everything before the network manager builds.
+	st.mark("preliminary", true, -1)
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
@@ -474,7 +482,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
-	st.mark("network_firewall", -1)
+	st.mark("network_firewall", true, -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -670,7 +678,8 @@ func main() {
 	egressProxy.SetHostID(cfg.HostID)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
-	st.mark("vm_manager_init", -1)
+	st.mark("vm_manager_init", true, -1)
+	hostEgressCIDRs := 0
 	if blockList != nil {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
@@ -686,10 +695,11 @@ func main() {
 		// during the startup window.
 		seedCIDRs := blockList.CIDRs()
 		hostBlock.UpdateCIDRs(seedCIDRs)
-		st.mark("host_egress_block", len(seedCIDRs))
+		hostEgressCIDRs = len(seedCIDRs)
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
+	st.mark("host_egress_block", blockList != nil, hostEgressCIDRs)
 	lc.start("egress proxy", func() error { return egressProxy.Start(ctx) })
 
 	// ---- BoltDB state store ----
@@ -698,7 +708,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
-	st.mark("state_store_open", -1)
+	st.mark("state_store_open", true, -1)
 	oss := stateStore.OpenStats()
 	log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
 		Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
@@ -725,7 +735,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
-	st.mark("cgroup_arm", -1)
+	st.mark("cgroup_arm", true, -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -813,7 +823,7 @@ func main() {
 			Metrics:     backupMetrics,
 		}
 		// backup_setup: metrics recorder, journal open, GCS storage.NewClient, uploader.
-		st.mark("backup_setup", -1)
+		st.mark("backup_setup", true, -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
 		// crashes between staging and enqueue. The tree lives inside
@@ -851,7 +861,7 @@ func main() {
 		log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
 			Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
 			Msg("backup staging scan breakdown")
-		st.mark("backup_staging_scan", -1)
+		st.mark("backup_staging_scan", true, -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -901,6 +911,11 @@ func main() {
 			return uploader.Run(upCtx)
 		})
 		log.Info().Str("bucket", bucket).Int("bandwidth_mbps", mbps).Int("workers", workers).Msg("backup uploader enabled")
+	} else {
+		// Backups disabled: emit the phase boundaries anyway so the partition
+		// stays comparable across hosts (skipped => ~0 duration).
+		st.mark("backup_setup", false, -1)
+		st.mark("backup_staging_scan", false, -1)
 	}
 
 	// ---- Backup metrics sampler ----
@@ -1071,14 +1086,14 @@ func main() {
 	// first on shutdown — stop accepting before those are torn down.
 
 	// grpc_setup: server construction, listener bind, adapter registration.
-	st.mark("grpc_setup", -1)
+	st.mark("grpc_setup", true, -1)
 
 	// ---- Startup network prep (fast; must precede StartPool) ----
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
-	st.mark("slot_reserve", -1)
+	st.mark("slot_reserve", true, -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1091,8 +1106,9 @@ func main() {
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
-	st.mark("cgroup_reap", -1)
+	st.mark("cgroup_reap", true, -1)
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
+	sweepRan := false
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
 		// of garbage; the adoption pass below validates or sweeps each one.
@@ -1107,11 +1123,12 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
-			st.mark("namespace_sweep", -1) // sweep + the slot reclaim it feeds
+			sweepRan = true // sweep + the slot reclaim it feeds
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
 	}
+	st.mark("namespace_sweep", sweepRan, -1)
 
 	// Launcher launch path, enabled per host via VMD_LAUNCH_VIA_LAUNCHER_NS.
 	if launchViaLauncherNS {
@@ -1164,7 +1181,7 @@ func main() {
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
 	// pool_start: StartPool (async fill), adoption wiring, launcher-ns setup.
-	st.mark("pool_start", -1)
+	st.mark("pool_start", true, -1)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively
@@ -1250,7 +1267,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
-		st.mark("db_connect", -1)
+		st.mark("db_connect", true, -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1268,6 +1285,7 @@ func main() {
 		log.Info().Msg("egress flow logging enabled")
 	} else {
 		log.Warn().Msg("DATABASE_URL unset — reconciler will run in BoltDB↔systemd-only mode")
+		st.mark("db_connect", false, -1)
 	}
 
 	// ---- Continuous reconciler ----
@@ -1352,9 +1370,9 @@ func main() {
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
 	// pre_ready: reconciler, heartbeat, local HTTP — the tail before serving.
-	st.mark("pre_ready", -1)
+	st.mark("pre_ready", true, -1)
 	startupReady.Store(true)
-	st.mark("ready", -1)
+	st.mark("ready", true, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1365,8 +1365,10 @@ func main() {
 	// phases; logged here so it sits in the same startup burst as their
 	// durations. Host mount counts arrive shortly after from the mount sampler.
 	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+	mountTotal, nsfsTotal := vm.HostMountCounts()
 	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-		Int("netns_orphaned", netnsOrphaned).Msg("startup host inventory")
+		Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
+		Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
 
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -839,7 +839,7 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
-		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
+		renewedMarkers := mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
 		ss := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
 			ls := backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
@@ -848,8 +848,9 @@ func main() {
 			ss.Bases += ls.Bases
 			ss.Pending += ls.Pending
 		}
-		log.Info().Int("sandboxes", ss.Sandboxes).Int("generations", ss.Generations).
-			Int("bases", ss.Bases).Int("pending", ss.Pending).Msg("backup staging scan breakdown")
+		log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
+			Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
+			Msg("backup staging scan breakdown")
 		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -324,30 +324,54 @@ type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
 	last  time.Time
+	// Marks are timestamped on the startup goroutine but WRITTEN from a
+	// dedicated goroutine: a backpressured stdout/collector must never let the
+	// instrumentation delay the readiness it is measuring. Buffered well above
+	// the phase count, so sends never block; an overflow drops the record
+	// (telemetry) rather than stalling startup.
+	ch chan startupPhaseRecord
+}
+
+type startupPhaseRecord struct {
+	phase      string
+	enabled    bool
+	phaseDur   time.Duration
+	sinceStart time.Duration
+	count      int
 }
 
 func newStartupTimer(log zerolog.Logger) *startupTimer {
 	now := time.Now()
-	return &startupTimer{log: log, start: now, last: now}
+	s := &startupTimer{log: log, start: now, last: now, ch: make(chan startupPhaseRecord, 64)}
+	go func() {
+		for r := range s.ch {
+			e := s.log.Info().
+				Str("startup_phase", r.phase).
+				Bool("enabled", r.enabled).
+				Dur("phase_ms", r.phaseDur).
+				Dur("since_start_ms", r.sinceStart)
+			if r.count >= 0 {
+				e = e.Int("count", r.count)
+			}
+			e.Msg("startup phase timing")
+		}
+	}()
+	return s
 }
 
-// mark logs the segment ending here (duration since the previous mark, plus
-// cumulative since start). Every phase boundary is emitted even when its
-// optional work is skipped (enabled=false, ~0 duration) so phase labels stay
-// comparable across host configs and the partition stays attributable. Main-
-// goroutine only — it mutates last; background work logs its own duration.
+// mark records the segment ending here (duration since the previous mark, plus
+// cumulative since start); the log write happens off this goroutine. Every
+// phase boundary is emitted even when its optional work is skipped
+// (enabled=false, ~0 duration) so phase labels stay comparable across host
+// configs and the partition stays attributable. Main-goroutine only — it
+// mutates last; background work logs its own duration.
 // count >= 0 attaches an aggregate, -1 omits it.
 func (s *startupTimer) mark(phase string, enabled bool, count int) {
 	now := time.Now()
-	e := s.log.Info().
-		Str("startup_phase", phase).
-		Bool("enabled", enabled).
-		Dur("phase_ms", now.Sub(s.last)).
-		Dur("since_start_ms", now.Sub(s.start))
-	if count >= 0 {
-		e = e.Int("count", count)
+	select {
+	case s.ch <- startupPhaseRecord{phase: phase, enabled: enabled, phaseDur: now.Sub(s.last), sinceStart: now.Sub(s.start), count: count}:
+	default:
 	}
-	e.Msg("startup phase timing")
 	s.last = now
 }
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -376,11 +376,10 @@ type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
 	last  time.Time
-	// Marks are timestamped on the startup goroutine but WRITTEN from a
-	// dedicated goroutine: a backpressured stdout/collector must never let the
-	// instrumentation delay the readiness it is measuring. Buffered well above
-	// the phase count, so sends never block; an overflow drops the record
-	// (telemetry) rather than stalling startup.
+	// Marks are timestamped on the startup goroutine but written from a
+	// dedicated one, so a backpressured stdout can't delay the readiness being
+	// measured. Buffered above the phase count: sends never block, overflow
+	// drops the record rather than stalling startup.
 	ch chan startupPhaseRecord
 }
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -704,11 +704,17 @@ func main() {
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
-	// Startup inventory — observability only. One cheap read of the record set
-	// gives the master N and its network/cgroup breakdown, to correlate with
-	// the phase durations. Host-total netns/mounts are emitted separately by
-	// the reconciler's periodic gauge shortly after startup.
-	if recs, aerr := stateStore.All(); aerr == nil {
+	// Startup inventory — observability only, emitted asynchronously so its
+	// full-record scan never sits on the readiness path (BoltDB allows
+	// concurrent readers). Gives the master N and its network/cgroup breakdown
+	// to correlate with the phase durations; the same records are scanned by
+	// ArmDirectSpawn/ReserveStartupSlots on the critical path, so this adds no
+	// synchronous work.
+	go func() {
+		recs, aerr := stateStore.All()
+		if aerr != nil {
+			return
+		}
 		var withNS, cgroup int
 		for _, r := range recs {
 			if r.Namespace != "" {
@@ -720,7 +726,7 @@ func main() {
 		}
 		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
 			Int("cgroup_records", cgroup).Msg("startup inventory")
-	}
+	}()
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -856,14 +862,10 @@ func main() {
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
 		stagingT0 := time.Now()
-		stagedEntries := 0
-		if entries, rerr := os.ReadDir(stagingRoot); rerr == nil {
-			stagedEntries = len(entries)
-		}
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		stagedEntries := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			stagedEntries += backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
 		st.done("backup_staging_scan", stagingT0, stagedEntries)
 		uploader.StagingRoot = stagingRoot
@@ -1360,15 +1362,17 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// Startup host inventory — observability only. The host-scale netns count
-	// is the O(N) driver for the network setup, namespace sweep, and reattach
-	// phases; logged here so it sits in the same startup burst as their
-	// durations. Host mount counts arrive shortly after from the mount sampler.
-	netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
-	mountTotal, nsfsTotal := vm.HostMountCounts()
-	log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-		Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
-		Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
+	// Startup host inventory — observability only, emitted asynchronously so
+	// its /run/netns and /proc/mounts scans never sit on the readiness path.
+	// These host-scale counts drive O(N) for the network setup, namespace
+	// sweep, and reattach phases.
+	go func() {
+		netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
+		mountTotal, nsfsTotal := vm.HostMountCounts()
+		log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
+			Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
+			Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
+	}()
 
 	startupReady.Store(true)
 	st.done("ready", st.start, -1)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -376,38 +376,31 @@ type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
 	last  time.Time
-	// Marks are timestamped on the startup goroutine but written from a
-	// dedicated one, so a backpressured stdout can't delay the readiness being
-	// measured. Buffered above the phase count: sends never block, overflow
-	// drops the record rather than stalling startup.
-	ch chan startupPhaseRecord
-}
-
-type startupPhaseRecord struct {
-	phase      string
-	enabled    bool
-	phaseDur   time.Duration
-	sinceStart time.Duration
-	count      int
+	// Marks and breakdown records are timestamped on the startup goroutine but
+	// written from a dedicated one, so a backpressured stdout can't delay the
+	// readiness being measured. Buffered above the record count: sends never
+	// block, overflow drops the record rather than stalling startup.
+	ch chan func()
 }
 
 func newStartupTimer(log zerolog.Logger) *startupTimer {
 	now := time.Now()
-	s := &startupTimer{log: log, start: now, last: now, ch: make(chan startupPhaseRecord, 64)}
+	s := &startupTimer{log: log, start: now, last: now, ch: make(chan func(), 64)}
 	go func() {
-		for r := range s.ch {
-			e := s.log.Info().
-				Str("startup_phase", r.phase).
-				Bool("enabled", r.enabled).
-				Dur("phase_ms", r.phaseDur).
-				Dur("since_start_ms", r.sinceStart)
-			if r.count >= 0 {
-				e = e.Int("count", r.count)
-			}
-			e.Msg("startup phase timing")
+		for fn := range s.ch {
+			fn()
 		}
 	}()
 	return s
+}
+
+// emit queues a log write on the timer's writer goroutine — for startup
+// breakdown records whose values are already computed; never blocks.
+func (s *startupTimer) emit(fn func()) {
+	select {
+	case s.ch <- fn:
+	default:
+	}
 }
 
 // mark records the segment ending here (duration since the previous mark, plus
@@ -419,10 +412,18 @@ func newStartupTimer(log zerolog.Logger) *startupTimer {
 // count >= 0 attaches an aggregate, -1 omits it.
 func (s *startupTimer) mark(phase string, enabled bool, count int) {
 	now := time.Now()
-	select {
-	case s.ch <- startupPhaseRecord{phase: phase, enabled: enabled, phaseDur: now.Sub(s.last), sinceStart: now.Sub(s.start), count: count}:
-	default:
-	}
+	phaseDur, sinceStart := now.Sub(s.last), now.Sub(s.start)
+	s.emit(func() {
+		e := s.log.Info().
+			Str("startup_phase", phase).
+			Bool("enabled", enabled).
+			Dur("phase_ms", phaseDur).
+			Dur("since_start_ms", sinceStart)
+		if count >= 0 {
+			e = e.Int("count", count)
+		}
+		e.Msg("startup phase timing")
+	})
 	s.last = now
 }
 
@@ -785,10 +786,12 @@ func main() {
 	}
 	st.mark("state_store_open", true, -1)
 	oss := stateStore.OpenStats()
-	log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
-		Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
-		Int("policies", oss.Policies).Int("orphans_deleted", oss.OrphansDeleted).
-		Msg("state store open breakdown")
+	st.emit(func() {
+		log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
+			Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
+			Int("policies", oss.Policies).Int("orphans_deleted", oss.OrphansDeleted).
+			Msg("state store open breakdown")
+	})
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
@@ -933,9 +936,11 @@ func main() {
 			ss.Bases += ls.Bases
 			ss.Pending += ls.Pending
 		}
-		log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
-			Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
-			Msg("backup staging scan breakdown")
+		st.emit(func() {
+			log.Info().Int("renewed_markers", renewedMarkers).Int("sandboxes", ss.Sandboxes).
+				Int("generations", ss.Generations).Int("bases", ss.Bases).Int("pending", ss.Pending).
+				Msg("backup staging scan breakdown")
+		})
 		st.mark("backup_staging_scan", true, -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,32 +317,38 @@ func runDrainCheck() int {
 	return 3
 }
 
-// startupTimer emits one structured log line per startup phase — the phase's
-// own wall-clock duration, the cumulative time since the daemon began starting,
-// and, where cheap to compute, the aggregate count the phase processed.
+// startupTimer emits one structured log line per startup phase. Each mark
+// records the interval since the previous mark, so consecutive marks partition
+// the whole startup with no gap — no phase's cost can hide between timers.
 // Observability only: it changes no control flow and runs only on the startup
-// path, so a prod-sized restart reveals which phase dominates and what scales
-// with fleet size.
+// path, so a prod-sized restart reveals which phase dominates.
 type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
+	last  time.Time
 }
 
 func newStartupTimer(log zerolog.Logger) *startupTimer {
-	return &startupTimer{log: log, start: time.Now()}
+	now := time.Now()
+	return &startupTimer{log: log, start: now, last: now}
 }
 
-// done records a phase that began at t0. Pass count >= 0 to log an aggregate
-// size (VM records, staged entries); pass -1 to omit it.
-func (s *startupTimer) done(phase string, t0 time.Time, count int) {
+// mark logs the segment that ended here: its duration since the previous mark
+// and the cumulative time since startup began. Call only from the main startup
+// goroutine — it mutates last; background work logs its own duration directly.
+// count >= 0 attaches an aggregate that accurately represents this phase's
+// work; -1 omits it.
+func (s *startupTimer) mark(phase string, count int) {
+	now := time.Now()
 	e := s.log.Info().
 		Str("startup_phase", phase).
-		Dur("phase_ms", time.Since(t0)).
-		Dur("since_start_ms", time.Since(s.start))
+		Dur("phase_ms", now.Sub(s.last)).
+		Dur("since_start_ms", now.Sub(s.start))
 	if count >= 0 {
 		e = e.Int("count", count)
 	}
 	e.Msg("startup phase timing")
+	s.last = now
 }
 
 func main() {
@@ -470,12 +476,11 @@ func main() {
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
-	netFirewallT0 := time.Now()
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
 	}
-	st.done("network_firewall", netFirewallT0, -1)
+	st.mark("network_firewall", -1)
 	lc.addCloser("network manager", func(_ context.Context) error { return netMgr.Close() })
 
 	// ---- VM manager ----
@@ -671,11 +676,11 @@ func main() {
 	egressProxy.SetHostID(cfg.HostID)
 	mgr.SetEgressProxy(egressProxy)
 	netMgr.SetEgressProxy(egressProxy)
+	st.mark("vm_manager_init", -1)
 	if blockList != nil {
 		egressProxy.SetBlocklist(blockList)
 		// Mirror IP/CIDR entries into a host-level nftables drop set so they
 		// are enforced on every port, not just the proxied web ports.
-		hostEgressT0 := time.Now()
 		hostBlock, err := network.NewHostEgressBlock(log)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to install host egress block table")
@@ -687,7 +692,7 @@ func main() {
 		// during the startup window.
 		seedCIDRs := blockList.CIDRs()
 		hostBlock.UpdateCIDRs(seedCIDRs)
-		st.done("host_egress_block", hostEgressT0, len(seedCIDRs))
+		st.mark("host_egress_block", len(seedCIDRs))
 		lc.addCloser("host egress block", func(_ context.Context) error { return hostBlock.Close() })
 		lc.start("egress blocklist", func() error { return blockList.Start(ctx) })
 	}
@@ -695,38 +700,13 @@ func main() {
 
 	// ---- BoltDB state store ----
 	statePath := envOrDefault("VMD_STATE_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "vmd.db"))
-	stateStoreT0 := time.Now()
 	stateStore, err := vm.OpenStateStore(statePath)
 	if err != nil {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
-	st.done("state_store_open", stateStoreT0, -1)
+	st.mark("state_store_open", -1)
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
-
-	// Startup inventory — observability only, emitted asynchronously so its
-	// full-record scan never sits on the readiness path (BoltDB allows
-	// concurrent readers). Gives the master N and its network/cgroup breakdown
-	// to correlate with the phase durations; the same records are scanned by
-	// ArmDirectSpawn/ReserveStartupSlots on the critical path, so this adds no
-	// synchronous work.
-	go func() {
-		recs, aerr := stateStore.All()
-		if aerr != nil {
-			return
-		}
-		var withNS, cgroup int
-		for _, r := range recs {
-			if r.Namespace != "" {
-				withNS++
-			}
-			if r.Supervision == vm.SupervisionCgroup {
-				cgroup++
-			}
-		}
-		log.Info().Int("vm_records", len(recs)).Int("records_with_namespace", withNS).
-			Int("cgroup_records", cgroup).Msg("startup inventory")
-	}()
 
 	// Arm direct spawn AFTER the state store is attached (hasCgroupRecords
 	// reads it to decide rollback-management; the rollback-guard breadcrumb
@@ -735,7 +715,6 @@ func main() {
 	// unit's config proves the survival property (Delegate + KillMode=
 	// process); a refusal degrades new launches to the unit path but still
 	// initializes the subtree for managing any existing cgroup VMs.
-	cgroupArmT0 := time.Now()
 	if arms, err := mgr.ArmDirectSpawn(ctx); err != nil {
 		if errors.Is(err, vm.ErrCgroupVMsUnmanageable) {
 			// Existing cgroup VMs can't be adopted — refuse to come up "ready"
@@ -747,7 +726,7 @@ func main() {
 	} else if arms {
 		log.Info().Msg("direct spawn armed: new VMs launch into the delegated cgroup subtree")
 	}
-	st.done("cgroup_arm", cgroupArmT0, -1)
+	st.mark("cgroup_arm", -1)
 
 	// ---- Backup metrics recorder ----
 	// Optional OTLP recorder for the backup pipeline, exporting to the
@@ -796,12 +775,10 @@ func main() {
 	var backupJournal *backup.Journal
 	if bucket := backupBucket; bucket != "" {
 		journalPath := envOrDefault("BACKUP_JOURNAL_PATH", filepath.Join(filepath.Dir(cfg.RunDir), "backup.db"))
-		journalOpenT0 := time.Now()
 		bdb, err := bolt.Open(journalPath, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 		if err != nil {
 			log.Fatal().Err(err).Str("path", journalPath).Msg("failed to open backup journal")
 		}
-		st.done("backup_journal_open", journalOpenT0, -1)
 		lc.addCloser("backup journal", func(_ context.Context) error { return bdb.Close() })
 		journal, err := backup.NewJournal(bdb)
 		if err != nil {
@@ -836,6 +813,9 @@ func main() {
 			VMDVersion:  os.Getenv("SENTRY_RELEASE"),
 			Metrics:     backupMetrics,
 		}
+		// backup_setup covers the whole backup-subsystem init: metrics
+		// recorder, journal open, GCS storage.NewClient, and uploader.
+		st.mark("backup_setup", -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
 		// crashes between staging and enqueue. The tree lives inside
@@ -861,13 +841,12 @@ func main() {
 		// outage longer than the sweep's orphan horizon needs this renewal
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
-		stagingT0 := time.Now()
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		stagedEntries := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			stagedEntries += backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
 		}
-		st.done("backup_staging_scan", stagingT0, stagedEntries)
+		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)
 		mgr.SetBackupEnqueue(journal.Enqueue)
@@ -1086,13 +1065,16 @@ func main() {
 	// Closer is registered later (after the manager/pool closers) so it runs
 	// first on shutdown — stop accepting before those are torn down.
 
+	// grpc_setup covers gRPC server construction, listener inherit/bind, and
+	// adapter registration since the previous mark.
+	st.mark("grpc_setup", -1)
+
 	// ---- Startup network prep (fast; must precede StartPool) ----
 	// Reserve slots held by existing VMs (so the pool can't hand out a colliding
 	// one) and sweep leaked namespaces. The per-VM reattach runs in the background
 	// below; VMs it hasn't reached are loaded on-demand on first request.
-	slotReserveT0 := time.Now()
 	slotsReserved := mgr.ReserveStartupSlots(ctx)
-	st.done("slot_reserve", slotReserveT0, -1)
+	st.mark("slot_reserve", -1)
 	// Reap direct-spawn VMs whose record never persisted (crash between spawn
 	// and first write). They have no record to reserve their slot, so the
 	// sweep/adoption below would tear their netns down under a live FC or
@@ -1104,9 +1086,8 @@ func main() {
 	// namespaces so the non-adoption sweep keeps them too. sweepSafe=false
 	// means a survivor could NOT be protected — every reclaim path below
 	// (sweep AND adoption) must stand down for this boot.
-	cgroupReapT0 := time.Now()
 	protectedNs, sweepSafe := mgr.ReapRecordlessCgroupVMs(ctx)
-	st.done("cgroup_reap", cgroupReapT0, len(protectedNs))
+	st.mark("cgroup_reap", -1)
 	adoptNetPool := envOrDefault("VMD_NET_POOL_ADOPT", "false") == "true"
 	if !adoptNetPool {
 		// Under adoption, orphan namespaces are warm-pool candidates instead
@@ -1114,9 +1095,7 @@ func main() {
 		// Skip the sweep when the reap couldn't guarantee a live survivor's
 		// ns is spared (see ReapRecordlessCgroupVMs).
 		if sweepSafe {
-			nsSweepT0 := time.Now()
 			mgr.SweepStartupOrphanNamespaces(protectedNs...)
-			st.done("namespace_sweep", nsSweepT0, -1)
 			// The reservation-time reclaim ran before this sweep and counted
 			// these namespaces as occupied. Nothing revisits them below the
 			// ceiling — claims just take fresh indexes — so rescan now or the
@@ -1124,6 +1103,8 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
+			// Covers the orphan sweep AND the slot reclaim it feeds.
+			st.mark("namespace_sweep", -1)
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
@@ -1179,18 +1160,25 @@ func main() {
 	// started after StartPool so its first read observes an initialized pool.
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
+	// pool_start covers StartPool (returns immediately; fills in the
+	// background), pool adoption wiring, and the launcher-namespace setup.
+	st.mark("pool_start", -1)
+
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively
 	// populates the map and GCs stale records. Plain goroutine, not an lc
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
-		reattachT0 := time.Now()
-		reattached, stale := mgr.ReattachAll(ctx)
-		// Off the critical path (backgrounded), but it is the O(N) reattach
-		// work — timed with its record count to size what a synchronous
+		// Off the critical path, but it is the O(N) reattach work. Timed
+		// independently of the startup marks (which are single-goroutine) and
+		// logged with its record count to size what a synchronous
 		// adopt-in-cutover would cost.
-		st.done("reattach_background", reattachT0, reattached+stale)
+		reattachStart := time.Now()
+		reattached, stale := mgr.ReattachAll(ctx)
+		log.Info().Str("startup_phase", "reattach_background").
+			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
+			Msg("startup phase timing")
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}
@@ -1253,7 +1241,6 @@ func main() {
 		// invalid and fail startup; lower them with it.
 		dbCfg.MinConns = min(dbCfg.MinConns, dbCfg.MaxConns)
 		dbCfg.MinIdleConns = min(dbCfg.MinIdleConns, dbCfg.MaxConns)
-		dbConnectT0 := time.Now()
 		dbPool, dbErr := pgxpool.NewWithConfig(ctx, dbCfg)
 		if dbErr != nil {
 			log.Fatal().Err(dbErr).Msg("failed to connect to database for reconciler")
@@ -1261,7 +1248,7 @@ func main() {
 		if err := dbPool.Ping(ctx); err != nil {
 			log.Fatal().Err(err).Msg("failed to ping database for reconciler")
 		}
-		st.done("db_connect", dbConnectT0, -1)
+		st.mark("db_connect", -1)
 		reconcilerDB = dbq.New(dbPool)
 		lc.addCloser("reconciler db pool", func(_ context.Context) error {
 			dbPool.Close()
@@ -1362,20 +1349,11 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// Startup host inventory — observability only, emitted asynchronously so
-	// its /run/netns and /proc/mounts scans never sit on the readiness path.
-	// These host-scale counts drive O(N) for the network setup, namespace
-	// sweep, and reattach phases.
-	go func() {
-		netnsTotal, netnsOwned, netnsOrphaned := netMgr.NetnsStats()
-		mountTotal, nsfsTotal := vm.HostMountCounts()
-		log.Info().Int("netns_total", netnsTotal).Int("netns_owned", netnsOwned).
-			Int("netns_orphaned", netnsOrphaned).Int("host_mount_count", mountTotal).
-			Int("host_nsfs_count", nsfsTotal).Msg("startup host inventory")
-	}()
-
+	// pre_ready covers the reconciler, heartbeat, and local HTTP setup since
+	// db_connect — the tail of the critical path before requests are served.
+	st.mark("pre_ready", -1)
 	startupReady.Store(true)
-	st.done("ready", st.start, -1)
+	st.mark("ready", -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
 
 	// ---- Wait for signal or service failure ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -699,6 +699,11 @@ func main() {
 		log.Fatal().Err(err).Str("path", statePath).Msg("failed to open state store")
 	}
 	st.mark("state_store_open", -1)
+	oss := stateStore.OpenStats()
+	log.Info().Dur("bolt_open_ms", oss.BoltOpen).Dur("policy_scan_ms", oss.PolicyScan).
+		Dur("record_scan_ms", oss.RecordScan).Int("records", oss.Records).
+		Int("policies", oss.Policies).Int("orphans_deleted", oss.OrphansDeleted).
+		Msg("state store open breakdown")
 	mgr.SetStateStore(stateStore)
 	lc.addCloser("state store", func(_ context.Context) error { return stateStore.Close() })
 
@@ -835,10 +840,16 @@ func main() {
 		// or it reads as an abandoned directory and gets deleted out from
 		// under a still-durable pause.
 		mgr.RenewPendingStaging(log.With().Str("component", "backup").Logger())
-		backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
+		ss := backup.SweepStaging(stagingRoot, journal, log.With().Str("component", "backup").Logger())
 		if legacyStaging != "" {
-			backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			ls := backup.SweepStaging(legacyStaging, journal, log.With().Str("component", "backup").Logger())
+			ss.Sandboxes += ls.Sandboxes
+			ss.Generations += ls.Generations
+			ss.Bases += ls.Bases
+			ss.Pending += ls.Pending
 		}
+		log.Info().Int("sandboxes", ss.Sandboxes).Int("generations", ss.Generations).
+			Int("bases", ss.Bases).Int("pending", ss.Pending).Msg("backup staging scan breakdown")
 		st.mark("backup_staging_scan", -1)
 		uploader.StagingRoot = stagingRoot
 		mgr.SetBackupStaging(stagingRoot)

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -317,11 +317,9 @@ func runDrainCheck() int {
 	return 3
 }
 
-// startupTimer emits one structured log line per startup phase. Each mark
-// records the interval since the previous mark, so consecutive marks partition
-// the whole startup with no gap — no phase's cost can hide between timers.
-// Observability only: it changes no control flow and runs only on the startup
-// path, so a prod-sized restart reveals which phase dominates.
+// startupTimer partitions startup into contiguous phases: each mark logs the
+// interval since the previous mark, so the segments tile the whole start→ready
+// timeline with no gap. Observability only — no control flow, startup path only.
 type startupTimer struct {
 	log   zerolog.Logger
 	start time.Time
@@ -333,11 +331,9 @@ func newStartupTimer(log zerolog.Logger) *startupTimer {
 	return &startupTimer{log: log, start: now, last: now}
 }
 
-// mark logs the segment that ended here: its duration since the previous mark
-// and the cumulative time since startup began. Call only from the main startup
-// goroutine — it mutates last; background work logs its own duration directly.
-// count >= 0 attaches an aggregate that accurately represents this phase's
-// work; -1 omits it.
+// mark logs the segment ending here (duration since the previous mark, plus
+// cumulative since start). Main-goroutine only — it mutates last; background
+// work logs its own duration. count >= 0 attaches an aggregate, -1 omits it.
 func (s *startupTimer) mark(phase string, count int) {
 	now := time.Now()
 	e := s.log.Info().
@@ -425,9 +421,7 @@ func main() {
 
 	lc := newLifecycle(log)
 
-	// Startup phase timing — observability only (see startupTimer). Started as
-	// early as the daemon path allows so since_start_ms approximates the full
-	// time to readiness.
+	// Startup phase timing (observability only) — see startupTimer.
 	st := newStartupTimer(log)
 
 	// ---- Egress blocklist (optional) ----
@@ -813,8 +807,7 @@ func main() {
 			VMDVersion:  os.Getenv("SENTRY_RELEASE"),
 			Metrics:     backupMetrics,
 		}
-		// backup_setup covers the whole backup-subsystem init: metrics
-		// recorder, journal open, GCS storage.NewClient, and uploader.
+		// backup_setup: metrics recorder, journal open, GCS storage.NewClient, uploader.
 		st.mark("backup_setup", -1)
 		// Staging pins enqueued artifacts so sandbox teardown cannot
 		// erase a queued generation; the sweep clears residue from
@@ -1065,8 +1058,7 @@ func main() {
 	// Closer is registered later (after the manager/pool closers) so it runs
 	// first on shutdown — stop accepting before those are torn down.
 
-	// grpc_setup covers gRPC server construction, listener inherit/bind, and
-	// adapter registration since the previous mark.
+	// grpc_setup: server construction, listener bind, adapter registration.
 	st.mark("grpc_setup", -1)
 
 	// ---- Startup network prep (fast; must precede StartPool) ----
@@ -1103,8 +1095,7 @@ func main() {
 			if n := netMgr.ReclaimUnusedSlots(); n > 0 {
 				log.Info().Int("slots", n).Msg("reclaimed slot indexes freed by the startup orphan sweep")
 			}
-			// Covers the orphan sweep AND the slot reclaim it feeds.
-			st.mark("namespace_sweep", -1)
+			st.mark("namespace_sweep", -1) // sweep + the slot reclaim it feeds
 		} else {
 			log.Warn().Msg("skipping startup orphan namespace sweep: an unresolved live cgroup survivor could be reclaimed")
 		}
@@ -1160,8 +1151,7 @@ func main() {
 	// started after StartPool so its first read observes an initialized pool.
 	mgr.StartNetnsLeakSampler(ctx, time.Minute)
 
-	// pool_start covers StartPool (returns immediately; fills in the
-	// background), pool adoption wiring, and the launcher-namespace setup.
+	// pool_start: StartPool (async fill), adoption wiring, launcher-ns setup.
 	st.mark("pool_start", -1)
 
 	// ---- Background full reattach ----
@@ -1170,16 +1160,12 @@ func main() {
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
-		// Off the critical path, but it is the O(N) reattach work. Timed
-		// independently of the startup marks (which are single-goroutine) and
-		// logged with its record count to size what a synchronous
-		// adopt-in-cutover would cost.
+		// O(N) reattach, off the critical path — timed here (not via the
+		// single-goroutine marks) and flagged concurrent, distinct message, so
+		// its phase_ms is never summed into the partition. count sizes a
+		// synchronous adopt-in-cutover.
 		reattachStart := time.Now()
 		reattached, stale := mgr.ReattachAll(ctx)
-		// Concurrent with the sequential startup partition (runs in this
-		// goroutine), so its phase_ms must NOT be summed with the partition
-		// marks. Flagged concurrent=true and given a distinct message so a
-		// grep for "startup phase timing" excludes it from the partition sum.
 		log.Info().Str("startup_phase", "reattach_background").Bool("concurrent", true).
 			Dur("phase_ms", time.Since(reattachStart)).Int("count", reattached+stale).
 			Msg("startup background phase timing")
@@ -1353,8 +1339,7 @@ func main() {
 	// restore) allocates like a create and shares its bounded wait. A gate
 	// at this level would hold even the non-allocating paths behind
 	// inventory they never use.
-	// pre_ready covers the reconciler, heartbeat, and local HTTP setup since
-	// db_connect — the tail of the critical path before requests are served.
+	// pre_ready: reconciler, heartbeat, local HTTP — the tail before serving.
 	st.mark("pre_ready", -1)
 	startupReady.Store(true)
 	st.mark("ready", -1)

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,16 +679,19 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) {
+// SweepStaging reaps orphaned staged artifacts under root. It returns the
+// number of top-level staged entries it enumerated — a telemetry signal for
+// startup timing that callers may ignore.
+func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
 	if root == "" {
-		return
+		return 0
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return
+		return 0
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -766,6 +769,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 		}
 		_ = os.Remove(sbDir)
 	}
+	return len(sandboxes)
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,16 +679,23 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) {
+// SweepStats reports what a SweepStaging pass visited — a telemetry signal for
+// startup timing that callers may ignore.
+type SweepStats struct {
+	Sandboxes, Generations, Bases, Pending int
+}
+
+func SweepStaging(root string, j *Journal, log zerolog.Logger) SweepStats {
+	var stats SweepStats
 	if root == "" {
-		return
+		return stats
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return
+		return stats
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -710,6 +717,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 				continue
 			}
 			for _, b := range bases {
+				stats.Bases++
 				staged := filepath.Join(root, "bases", b.Name())
 				if !referenced[b.Name()] {
 					// Serialize with renewStaged and re-check freshness
@@ -726,6 +734,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			}
 			continue
 		}
+		stats.Sandboxes++
 		sbDir := filepath.Join(root, sb.Name())
 		gens, err := os.ReadDir(sbDir)
 		if err != nil {
@@ -735,6 +744,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			if !g.IsDir() {
 				continue
 			}
+			stats.Generations++
 			pending, err := j.HasPending(sb.Name(), g.Name())
 			if err != nil {
 				log.Warn().Err(err).Msg("backup staging sweep: journal lookup failed")
@@ -742,6 +752,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 			}
 			staged := filepath.Join(sbDir, g.Name())
 			if strings.HasPrefix(g.Name(), "pending-") {
+				stats.Pending++
 				// Marker-owned: the journal has no row for a pause that
 				// has not enqueued yet. Live markers renew the dir; only
 				// long-dead orphans are reaped.
@@ -766,6 +777,7 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 		}
 		_ = os.Remove(sbDir)
 	}
+	return stats
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/backup/staging.go
+++ b/internal/backup/staging.go
@@ -679,19 +679,16 @@ func fresherThan(path string, grace time.Duration) bool {
 // residue of a crash between staging and enqueue, or of an ack whose
 // cleanup was interrupted. Runs at startup before the uploader drains
 // and periodically from the drain loop thereafter.
-// SweepStaging reaps orphaned staged artifacts under root. It returns the
-// number of top-level staged entries it enumerated — a telemetry signal for
-// startup timing that callers may ignore.
-func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
+func SweepStaging(root string, j *Journal, log zerolog.Logger) {
 	if root == "" {
-		return 0
+		return
 	}
 	sandboxes, err := os.ReadDir(root)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Warn().Err(err).Msg("backup staging sweep: read root failed")
 		}
-		return 0
+		return
 	}
 	referenced, err := j.PendingBaseSHAs()
 	if err != nil {
@@ -769,7 +766,6 @@ func SweepStaging(root string, j *Journal, log zerolog.Logger) int {
 		}
 		_ = os.Remove(sbDir)
 	}
-	return len(sandboxes)
 }
 
 // ResolveStagingRoot picks the staging tree location. The default lives

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -263,6 +263,9 @@ func WithEgressPortChainOwner() ManagerOption {
 }
 
 func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, opts ...ManagerOption) (*Manager, error) {
+	// Split pre-network config (ip_forward + option wiring) from the actual
+	// firewall install so a slow startup network_firewall phase is unambiguous.
+	tPreNet := time.Now()
 	if err := enableIPForward(ctx); err != nil {
 		return nil, err
 	}
@@ -281,10 +284,14 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 	for _, opt := range opts {
 		opt(mgr)
 	}
+	preNet := time.Since(tPreNet)
 
+	tFW := time.Now()
 	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.secretsProxyDst, mgr.secretsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
+	mgr.log.Info().Dur("pre_network_ms", preNet).Dur("firewall_install_ms", time.Since(tFW)).
+		Msg("network manager init breakdown")
 
 	return mgr, nil
 }

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -290,8 +290,13 @@ func NewManager(ctx context.Context, hostInterface string, log zerolog.Logger, o
 	if err := installHostFirewall(hostInterface, mgr.httpProxyPort, mgr.tlsProxyPort, mgr.dnsRedirectPort, mgr.secretsProxyDst, mgr.secretsProxyPort, mgr.blockedEgressPorts, mgr.ownsEgressPortChain, log.With().Str("component", "host_fw").Logger()); err != nil {
 		return nil, fmt.Errorf("install host firewall: %w", err)
 	}
-	mgr.log.Info().Dur("pre_network_ms", preNet).Dur("firewall_install_ms", time.Since(tFW)).
-		Msg("network manager init breakdown")
+	// Async: a backpressured log writer must not extend startup — the values
+	// are already computed.
+	fwInstall := time.Since(tFW)
+	go func() {
+		mgr.log.Info().Dur("pre_network_ms", preNet).Dur("firewall_install_ms", fwInstall).
+			Msg("network manager init breakdown")
+	}()
 
 	return mgr, nil
 }

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -858,6 +858,7 @@ func (p *Pool) placeVouched(slot *preallocSlot, preferRecycled bool) bool {
 // scanning phase before its goroutine is spawned, so no request can observe
 // the gap between launch and the pass actually starting.
 func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped int64) {
+	tStart := time.Now()
 	// Direct callers (tests, legacy paths) enter the phase here; via
 	// StartAdoption it is already scanning and the CAS no-ops. The deferred
 	// reset is the panic backstop AND clears the trust state for the next
@@ -941,7 +942,8 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				Msg("pool: adoption aborted — validation timing out systemically; remaining slots left for a later boot")
 		}
 		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
-			Int64("skipped", nSkipped.Load()).Msg("pool: adoption pass complete")
+			Int64("skipped", nSkipped.Load()).Int("candidates", len(indexes)).
+			Dur("duration_ms", time.Since(tStart)).Msg("pool: adoption pass complete")
 		// Accumulate — adopted already carries the receipt fast path's count.
 		adopted += nAdopted.Load()
 		invalid, skipped = nInvalid.Load(), nSkipped.Load()

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -941,9 +941,6 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 			p.log.Error().Int64("timeouts", nTimeouts.Load()).
 				Msg("pool: adoption aborted — validation timing out systemically; remaining slots left for a later boot")
 		}
-		p.log.Info().Int64("adopted", nAdopted.Load()).Int64("torn_down", nInvalid.Load()).
-			Int64("skipped", nSkipped.Load()).Int("candidates", len(indexes)).
-			Dur("duration_ms", time.Since(tStart)).Msg("pool: adoption pass complete")
 		// Accumulate — adopted already carries the receipt fast path's count.
 		adopted += nAdopted.Load()
 		invalid, skipped = nInvalid.Load(), nSkipped.Load()
@@ -952,6 +949,12 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 	p.adoptPhase.Store(adoptPhaseIdle)
 	p.signalProgress()
 	p.mgr.SweepStrayHostVeths()
+	// Emitted on every completion path — including the receipt fast path
+	// adopting all slots, or no orphans at all — so startup timing always has
+	// an adoption duration, not only when the worker pass ran.
+	p.log.Info().Int64("adopted", adopted).Int64("torn_down", invalid).
+		Int64("skipped", skipped).Dur("duration_ms", time.Since(tStart)).
+		Msg("pool: adoption pass complete")
 	return adopted, invalid, skipped
 }
 

--- a/internal/vm/backup_hook.go
+++ b/internal/vm/backup_hook.go
@@ -639,15 +639,16 @@ func (m *Manager) dropStagedPending(pb PendingBackup, log zerolog.Logger) {
 // from an abandoned directory, and the sweep deletes it — discarding the
 // only durable copy of an otherwise-recoverable pause. Needs only the
 // BoltDB state (no instance map), so it's safe to call this early.
-func (m *Manager) RenewPendingStaging(log zerolog.Logger) {
+func (m *Manager) RenewPendingStaging(log zerolog.Logger) int {
 	if m.state == nil {
-		return
+		return 0
 	}
 	pending, err := m.state.ListPendingBackups()
 	if err != nil {
 		log.Warn().Err(err).Msg("renew pending staging: list failed")
-		return
+		return 0
 	}
+	renewed := 0
 	for _, pb := range pending {
 		if pb.StagedDir == "" {
 			continue
@@ -660,7 +661,9 @@ func (m *Manager) RenewPendingStaging(log zerolog.Logger) {
 		// unrenewed and indistinguishable from an orphan to the sweep.
 		resolved := m.resolveStagedLocation(pb)
 		backup.RenewStaged(resolved.StagedDir)
+		renewed++
 	}
+	return renewed
 }
 
 // RecoverPendingBackups re-runs every pause that still owed its backup

--- a/internal/vm/cgroup_linux.go
+++ b/internal/vm/cgroup_linux.go
@@ -101,9 +101,14 @@ func (m *Manager) ArmDirectSpawn(ctx context.Context) (bool, error) {
 		}
 	}
 	// Detection (record + delegated-tree scan) split from the systemd/cgroup
-	// validation below, for startup timing.
-	m.log.Info().Dur("cgroup_detect_ms", time.Since(tScan)).Bool("has_cgroup_vms", haveCgroupVMs).
-		Msg("cgroup arm: detection scan")
+	// validation below, for startup timing. Async: the write must not sit on
+	// the startup path.
+	detectDur := time.Since(tScan)
+	haveVMs := haveCgroupVMs
+	go func() {
+		m.log.Info().Dur("cgroup_detect_ms", detectDur).Bool("has_cgroup_vms", haveVMs).
+			Msg("cgroup arm: detection scan")
+	}()
 	if !wantArm && !haveCgroupVMs {
 		return false, nil // nothing to arm, nothing to manage
 	}

--- a/internal/vm/cgroup_linux.go
+++ b/internal/vm/cgroup_linux.go
@@ -82,6 +82,7 @@ func (m *Manager) ArmDirectSpawn(ctx context.Context) (bool, error) {
 	// A state-store read failure is FATAL: a corrupt/unreadable BoltDB means the
 	// daemon can't load any VM record (reattach and the reconciler both fail),
 	// so coming up "ready" would hide it and leave every cgroup VM unmanaged.
+	tScan := time.Now()
 	hasRecords, rerr := m.hasCgroupRecords()
 	if rerr != nil {
 		return false, fmt.Errorf("%w: cannot read state store: %v", ErrCgroupVMsUnmanageable, rerr)
@@ -99,6 +100,10 @@ func (m *Manager) ArmDirectSpawn(ctx context.Context) (bool, error) {
 			haveCgroupVMs = treeHas
 		}
 	}
+	// Detection (record + delegated-tree scan) split from the systemd/cgroup
+	// validation below, for startup timing.
+	m.log.Info().Dur("cgroup_detect_ms", time.Since(tScan)).Bool("has_cgroup_vms", haveCgroupVMs).
+		Msg("cgroup arm: detection scan")
 	if !wantArm && !haveCgroupVMs {
 		return false, nil // nothing to arm, nothing to manage
 	}

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -375,6 +375,11 @@ func (m *Manager) retryLauncherBuild(ctx context.Context) {
 
 // hostMountCounts returns the total mount count and the nsfs subset (the
 // per-netns bind mounts) from /proc/mounts.
+// HostMountCounts returns the host's total mount count and its nsfs subset,
+// read from /proc/mounts. Exported for the one-shot startup host inventory;
+// StartMountCountSampler emits the same counts periodically. Observability only.
+func HostMountCounts() (total, nsfs int) { return hostMountCounts() }
+
 func hostMountCounts() (total, nsfs int) {
 	data, err := os.ReadFile("/proc/mounts")
 	if err != nil {

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -375,11 +375,6 @@ func (m *Manager) retryLauncherBuild(ctx context.Context) {
 
 // hostMountCounts returns the total mount count and the nsfs subset (the
 // per-netns bind mounts) from /proc/mounts.
-// HostMountCounts returns the host's total mount count and its nsfs subset,
-// read from /proc/mounts. Exported for the one-shot startup host inventory;
-// StartMountCountSampler emits the same counts periodically. Observability only.
-func HostMountCounts() (total, nsfs int) { return hostMountCounts() }
-
 func hostMountCounts() (total, nsfs int) {
 	data, err := os.ReadFile("/proc/mounts")
 	if err != nil {

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -282,12 +282,11 @@ func (m *Manager) startSampler(ctx context.Context, name string, every time.Dura
 // the per-launch warns carry the vm_id detail but make a poor time series.
 // One /proc/mounts read per tick.
 func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duration) {
-	// One immediate gauge-only sample so the startup window has a mount count
-	// (the fleet-size correlate for the startup phase timings) without waiting
-	// out the first interval. Async: the caller is the startup goroutine and
-	// this scan must not sit on the readiness path. Deliberately NOT the full
-	// tick body: revalidation during the in-flight boot-time launcher build
-	// would burn the rebuild cooldown on a single-flight no-op.
+	// One immediate sample so the startup window has a mount count (a
+	// fleet-size correlate for the startup phase timings); async so the scan
+	// stays off the readiness path. Gauge-only, NOT the full tick body:
+	// revalidation during the in-flight boot-time launcher build would burn
+	// the rebuild cooldown on a single-flight no-op.
 	go func() {
 		defer sentrylog.Recover("mount-count first sample")
 		total, nsfs := hostMountCounts()
@@ -320,10 +319,8 @@ func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration
 			Int("netns_orphaned", orphaned).
 			Msg("netns leak gauge")
 	}
-	// One immediate sample so the startup window has a netns count — the
-	// fleet-size correlate for the startup phase timings. Async: the caller is
-	// the startup goroutine and NetnsStats readdirs /run/netns under the
-	// allocator lock, which must not sit on the readiness path.
+	// Immediate first sample (same rationale as StartMountCountSampler); async
+	// because NetnsStats readdirs /run/netns under the allocator lock.
 	go func() {
 		defer sentrylog.Recover("netns-leak first sample")
 		sample()

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -262,10 +262,6 @@ func unescapeMountinfo(s string) string {
 func (m *Manager) startSampler(ctx context.Context, name string, every time.Duration, fn func()) {
 	go func() {
 		defer sentrylog.Recover(name)
-		// One immediate sample so the startup window has a value, not only after
-		// the first interval — the netns/mount counts are the fleet-size
-		// correlates for the startup phase timings.
-		fn()
 		t := time.NewTicker(every)
 		defer t.Stop()
 		for {
@@ -286,6 +282,19 @@ func (m *Manager) startSampler(ctx context.Context, name string, every time.Dura
 // the per-launch warns carry the vm_id detail but make a poor time series.
 // One /proc/mounts read per tick.
 func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duration) {
+	// One immediate gauge-only sample so the startup window has a mount count
+	// (the fleet-size correlate for the startup phase timings) without waiting
+	// out the first interval. Async: the caller is the startup goroutine and
+	// this scan must not sit on the readiness path. Deliberately NOT the full
+	// tick body: revalidation during the in-flight boot-time launcher build
+	// would burn the rebuild cooldown on a single-flight no-op.
+	go func() {
+		defer sentrylog.Recover("mount-count first sample")
+		total, nsfs := hostMountCounts()
+		m.log.Info().Int("host_mount_count", total).Int("host_nsfs_count", nsfs).
+			Bool("launcher_ready", m.launcherReady.Load()).
+			Msg("host mount table")
+	}()
 	m.startSampler(ctx, "mount-count sampler", every, func() {
 		total, nsfs := hostMountCounts()
 		m.log.Info().Int("host_mount_count", total).Int("host_nsfs_count", nsfs).
@@ -305,12 +314,21 @@ func (m *Manager) StartMountCountSampler(ctx context.Context, every time.Duratio
 // netns_orphaned (namespaces with no owning slot) is the leak signal: sustained
 // growth means teardown is leaking. One /run/netns readdir per tick.
 func (m *Manager) StartNetnsLeakSampler(ctx context.Context, every time.Duration) {
-	m.startSampler(ctx, "netns-leak sampler", every, func() {
+	sample := func() {
 		netnsTotal, ownedSlots, orphaned := m.netMgr.NetnsStats()
 		m.log.Info().Int("netns_total", netnsTotal).Int("owned_slots", ownedSlots).
 			Int("netns_orphaned", orphaned).
 			Msg("netns leak gauge")
-	})
+	}
+	// One immediate sample so the startup window has a netns count — the
+	// fleet-size correlate for the startup phase timings. Async: the caller is
+	// the startup goroutine and NetnsStats readdirs /run/netns under the
+	// allocator lock, which must not sit on the readiness path.
+	go func() {
+		defer sentrylog.Recover("netns-leak first sample")
+		sample()
+	}()
+	m.startSampler(ctx, "netns-leak sampler", every, sample)
 }
 
 // revalidateLauncher re-syncs launcherReady with the live pin each tick: drop to

--- a/internal/vm/launcher.go
+++ b/internal/vm/launcher.go
@@ -262,6 +262,10 @@ func unescapeMountinfo(s string) string {
 func (m *Manager) startSampler(ctx context.Context, name string, every time.Duration, fn func()) {
 	go func() {
 		defer sentrylog.Recover(name)
+		// One immediate sample so the startup window has a value, not only after
+		// the first interval — the netns/mount counts are the fleet-size
+		// correlates for the startup phase timings.
+		fn()
 		t := time.NewTicker(every)
 		defer t.Stop()
 		for {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3509,9 +3509,13 @@ func (m *Manager) ReserveStartupSlots(context.Context) bool {
 	// every unused index below it. Hand those back now, while records are the
 	// only owners and "unowned with no namespace" provably means free.
 	reclaimed := m.netMgr.ReclaimUnusedSlots()
-	m.log.Info().Dur("record_load_ms", loadMS).Dur("reserve_reclaim_ms", time.Since(tReserve)).
-		Int("records", len(recs)).Int("reservations", len(slots)).Int("reclaimed", reclaimed).
-		Msg("startup slot reservation breakdown")
+	// Async: the write must not sit on the startup path.
+	reserveDur := time.Since(tReserve)
+	go func() {
+		m.log.Info().Dur("record_load_ms", loadMS).Dur("reserve_reclaim_ms", reserveDur).
+			Int("records", len(recs)).Int("reservations", len(slots)).Int("reclaimed", reclaimed).
+			Msg("startup slot reservation breakdown")
+	}()
 	if reclaimed > 0 {
 		m.log.Info().Int("slots", reclaimed).Msg("reclaimed unused network slot indexes")
 	}
@@ -3600,8 +3604,12 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 			}
 		}
 	}
-	m.log.Info().Int("scanned", scanned).Int("recorded", recorded).Int("recordless", recordless).
-		Int("reaped", reaped).Int("protected", len(protected)).Msg("cgroup reap breakdown")
+	// Async: the write must not sit on the startup path.
+	nProtected := len(protected)
+	go func() {
+		m.log.Info().Int("scanned", scanned).Int("recorded", recorded).Int("recordless", recordless).
+			Int("reaped", reaped).Int("protected", nProtected).Msg("cgroup reap breakdown")
+	}()
 	return protected, sweepSafe
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3495,17 +3495,25 @@ func (m *Manager) ReserveStartupSlots(context.Context) bool {
 	if m.state == nil {
 		return false
 	}
+	tLoad := time.Now()
 	recs, err := m.state.All()
 	if err != nil {
 		m.log.Error().Err(err).Msg("failed to read state for startup slot reservation")
 		return false
 	}
-	m.netMgr.ReserveSlotsAbove(collectStartupSlots(recs))
+	loadMS := time.Since(tLoad)
+	tReserve := time.Now()
+	slots := collectStartupSlots(recs)
+	m.netMgr.ReserveSlotsAbove(slots)
 	// Reservations pin the allocator above the highest record index, stranding
 	// every unused index below it. Hand those back now, while records are the
 	// only owners and "unowned with no namespace" provably means free.
-	if n := m.netMgr.ReclaimUnusedSlots(); n > 0 {
-		m.log.Info().Int("slots", n).Msg("reclaimed unused network slot indexes")
+	reclaimed := m.netMgr.ReclaimUnusedSlots()
+	m.log.Info().Dur("record_load_ms", loadMS).Dur("reserve_reclaim_ms", time.Since(tReserve)).
+		Int("records", len(recs)).Int("reservations", len(slots)).Int("reclaimed", reclaimed).
+		Msg("startup slot reservation breakdown")
+	if reclaimed > 0 {
+		m.log.Info().Int("slots", reclaimed).Msg("reclaimed unused network slot indexes")
 	}
 	return true
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3549,6 +3549,8 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 		return nil, false
 	}
 	sweepSafe = true
+	scanned := len(cgIDs)
+	var recorded, recordless, reaped int
 	for _, id := range cgIDs {
 		// Build VMs ARE reaped here: pre-gate every cgroup is a previous-life
 		// survivor, and a build's cgroup is recordless (persistState omits build
@@ -3562,14 +3564,21 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 				// protected set — the sweep must not run on this startup.
 				sweepSafe = false
 				m.log.Warn().Err(herr).Str("vm_id", id).Msg("record lookup failed for cgroup survivor — skipping startup orphan sweep")
+			} else {
+				recorded++
 			}
 			continue // recorded (reattach owns it) or unreadable
 		}
+		recordless++
 		m.log.Warn().Str("vm_id", id).Msg("recordless cgroup survivor at startup — reaping")
 		// Capture the netns before the kill: an FC that survives it is still in
 		// the group, but a clean kill removes it and firstPID would read empty.
 		ns := m.netMgr.NamespaceForPID(m.cgroups.firstPID(id))
-		if serr := m.stopVM(ctx, id, SupervisionCgroup); serr != nil {
+		serr := m.stopVM(ctx, id, SupervisionCgroup)
+		if serr == nil {
+			reaped++
+		}
+		if serr != nil {
 			m.log.Error().Err(serr).Str("vm_id", id).Msg("failed to reap recordless cgroup")
 			// Liveness decides first — populated or unreadable == maybe-alive.
 			// A confirmed-empty group whose rmdir merely failed is dead, its
@@ -3591,6 +3600,8 @@ func (m *Manager) ReapRecordlessCgroupVMs(ctx context.Context) (protected []stri
 			}
 		}
 	}
+	m.log.Info().Int("scanned", scanned).Int("recorded", recorded).Int("recordless", recordless).
+		Int("reaped", reaped).Int("protected", len(protected)).Msg("cgroup reap breakdown")
 	return protected, sweepSafe
 }
 

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -291,6 +291,7 @@ type StateStoreOpenStats struct {
 	BoltOpen       time.Duration // bolt.Open: mmap + freelist load
 	PolicyScan     time.Duration // sidecar orphan scan + deletes
 	RecordScan     time.Duration // primary record scan + policy migration
+	TxResidual     time.Duration // db.Update outside the scans: bucket creates + commit/fsync
 	Records        int
 	Policies       int
 	OrphansDeleted int
@@ -311,6 +312,7 @@ func OpenStateStore(path string) (*StateStore, error) {
 		return nil, fmt.Errorf("open state store %s: %w", path, err)
 	}
 	stats.BoltOpen = time.Since(tOpen)
+	tTx := time.Now()
 	if err := db.Update(func(tx *bolt.Tx) error {
 		records, err := tx.CreateBucketIfNotExists(bucketName)
 		if err != nil {
@@ -374,6 +376,9 @@ func OpenStateStore(path string) (*StateStore, error) {
 		db.Close()
 		return nil, fmt.Errorf("initialize state store: %w", err)
 	}
+	// db.Update time outside the two scans: bucket creation plus the Bolt
+	// commit/fsync, which only happens after the callback returns.
+	stats.TxResidual = time.Since(tTx) - stats.PolicyScan - stats.RecordScan
 	return &StateStore{db: db, openStats: stats}, nil
 }
 

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -281,18 +281,36 @@ func writeStateBreadcrumbTo(at, statePath string) error {
 
 // StateStore wraps a BoltDB database for VM state persistence.
 type StateStore struct {
-	db *bolt.DB
+	db        *bolt.DB
+	openStats StateStoreOpenStats
 }
+
+// StateStoreOpenStats breaks OpenStateStore's cost into its sub-steps for
+// startup timing. Observability only.
+type StateStoreOpenStats struct {
+	BoltOpen       time.Duration // bolt.Open: mmap + freelist load
+	PolicyScan     time.Duration // sidecar orphan scan + deletes
+	RecordScan     time.Duration // primary record scan + policy migration
+	Records        int
+	Policies       int
+	OrphansDeleted int
+}
+
+// OpenStats returns the timing/count breakdown captured while the store opened.
+func (s *StateStore) OpenStats() StateStoreOpenStats { return s.openStats }
 
 // Path returns the resolved filesystem path of the open store.
 func (s *StateStore) Path() string { return s.db.Path() }
 
 // OpenStateStore opens (or creates) the BoltDB file at path.
 func OpenStateStore(path string) (*StateStore, error) {
+	var stats StateStoreOpenStats
+	tOpen := time.Now()
 	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("open state store %s: %w", path, err)
 	}
+	stats.BoltOpen = time.Since(tOpen)
 	if err := db.Update(func(tx *bolt.Tx) error {
 		records, err := tx.CreateBucketIfNotExists(bucketName)
 		if err != nil {
@@ -312,8 +330,10 @@ func OpenStateStore(path string) (*StateStore, error) {
 		// An old VMD can delete the primary record without knowing about the
 		// sidecar bucket. Remove those orphans before migrating so a later VM
 		// reusing the same key cannot inherit deleted policy state.
+		tPolicy := time.Now()
 		var orphanKeys [][]byte
 		if err := policies.ForEach(func(k, _ []byte) error {
+			stats.Policies++
 			if records.Get(k) == nil {
 				orphanKeys = append(orphanKeys, append([]byte(nil), k...))
 			}
@@ -326,11 +346,15 @@ func OpenStateStore(path string) (*StateStore, error) {
 				return err
 			}
 		}
+		stats.OrphansDeleted = len(orphanKeys)
+		stats.PolicyScan = time.Since(tPolicy)
 
 		// Seed the sidecar for records written by the immediately preceding
 		// schema. Once present, the sidecar is authoritative and is never
 		// replaced from the primary JSON during startup.
-		return records.ForEach(func(k, v []byte) error {
+		tRecord := time.Now()
+		err = records.ForEach(func(k, v []byte) error {
+			stats.Records++
 			if policies.Get(k) != nil {
 				return nil
 			}
@@ -344,11 +368,13 @@ func OpenStateStore(path string) (*StateStore, error) {
 			}
 			return putPreviewPolicy(policies, k, policy)
 		})
+		stats.RecordScan = time.Since(tRecord)
+		return err
 	}); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("initialize state store: %w", err)
 	}
-	return &StateStore{db: db}, nil
+	return &StateStore{db: db, openStats: stats}, nil
 }
 
 // OpenStateStoreReadOnly opens the BoltDB file for reading only. Unlike


### PR DESCRIPTION
Observability-only instrumentation so a single prod-sized vmd restart answers both "which phase owns the ~12s" and "why," without a second restart. No behavior change, no new scans, no readiness- or hot-path work — every timer/counter piggybacks on work already happening.

## Top-level partition
A running-mark model logs each startup phase as the interval since the previous mark, so the segments tile the whole start→ready timeline with no gap (sum of phase_ms == since_start_ms at ready — nothing can hide between timers):

network_firewall, vm_manager_init, host_egress_block, state_store_open, cgroup_arm, backup_setup, backup_staging_scan, grpc_setup, slot_reserve, cgroup_reap, namespace_sweep, pool_start, db_connect, pre_ready, ready.

reattach_background (the O(N) reattach) runs concurrently in its own goroutine — flagged concurrent=true with a distinct message so it is NOT summed into the partition.

## Per-phase breakdowns (why a phase is slow)
- state_store_open: bolt_open_ms / policy_scan_ms / record_scan_ms + records, policies, orphans_deleted.
- network_firewall: pre_network_ms vs firewall_install_ms.
- cgroup_arm: cgroup_detect_ms (record + tree scan) split from systemd/cgroup validation.
- slot_reserve: record_load_ms vs reserve_reclaim_ms + records, reservations, reclaimed.
- cgroup_reap: scanned, recorded, recordless, reaped, protected.
- backup_staging_scan: renewed_markers (durable pending markers) + sandboxes, generations, bases, pending.
- pool adoption (AdoptOrphanSlots): duration_ms + candidates alongside its existing adopted/torn_down/skipped.

## Scale (the N to correlate against)
vm_records from reattach_background; host netns_total / host_mount_count from the existing periodic samplers. No dedicated inventory scans on the startup path.

Touches cmd/vmd/main.go plus internal {vm,backup,network}; StateStore/SweepStaging/RenewPendingStaging gained return values used only for telemetry (existing callers ignore them). gofmt clean, Linux build + affected vm/backup/network tests green.