### PR TITLE
fix: Stop destructive host capability replacement on VMD heartbeat

### DIFF
--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -40,16 +40,27 @@ FROM prev
 WHERE host.id = prev.id
 RETURNING host.*, prev.status AS prev_status;
 
--- name: DeleteHostCapabilities :exec
-DELETE FROM host_capability WHERE host_id = $1;
-
--- name: InsertHostCapability :exec
-INSERT INTO host_capability (host_id, capability, heartbeat_at)
-SELECT id, sqlc.arg(capability), last_heartbeat_at
-FROM host
-WHERE id = sqlc.arg(host_id) AND last_heartbeat_at IS NOT NULL
-ON CONFLICT (host_id, capability)
-DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at;
+-- name: SyncHostCapabilities :exec
+-- Refresh the advertised set in place and prune only capabilities omitted by
+-- this heartbeat. Empty capabilities intentionally remove the entire set.
+WITH current_host AS (
+    SELECT id, last_heartbeat_at
+    FROM host
+    WHERE id = sqlc.arg(host_id) AND last_heartbeat_at IS NOT NULL
+), advertised AS (
+    SELECT DISTINCT unnest(COALESCE(sqlc.arg(capabilities)::text[], ARRAY[]::text[])) AS capability
+), upserted AS (
+    INSERT INTO host_capability (host_id, capability, heartbeat_at)
+    SELECT h.id, a.capability, h.last_heartbeat_at
+    FROM current_host h
+    CROSS JOIN advertised a
+    ON CONFLICT (host_id, capability)
+    DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at
+    RETURNING capability
+)
+DELETE FROM host_capability hc
+WHERE hc.host_id = sqlc.arg(host_id)
+  AND NOT (hc.capability = ANY(COALESCE(sqlc.arg(capabilities)::text[], ARRAY[]::text[])));
 
 -- name: HostHasCapabilities :one
 -- Lock the one active host row whose heartbeat anchors this capability set.

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -59,15 +59,10 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		}
 		// Missing capabilities is an explicit empty replacement. This clears a
 		// stale attestation immediately when VMD can no longer verify its proxy.
-		if err := q.DeleteHostCapabilities(ctx, hostID); err != nil {
+		if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+			HostID: hostID, Capabilities: capabilities,
+		}); err != nil {
 			return db.UpdateHostHeartbeatRow{}, err
-		}
-		for _, capability := range capabilities {
-			if err := q.InsertHostCapability(ctx, db.InsertHostCapabilityParams{
-				HostID: hostID, Capability: capability,
-			}); err != nil {
-				return db.UpdateHostHeartbeatRow{}, err
-			}
 		}
 		return host, nil
 	}

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -23,7 +23,7 @@ func setupHostHeartbeatRouter(h *Handlers) *gin.Engine {
 	return r
 }
 
-func TestHostHeartbeatReplacesAdvertisedCapabilities(t *testing.T) {
+func TestHostHeartbeatSyncsAdvertisedCapabilities(t *testing.T) {
 	var gotHostID string
 	var gotCapabilities []string
 	mock := &mockDBTX{
@@ -35,20 +35,13 @@ func TestHostHeartbeatReplacesAdvertisedCapabilities(t *testing.T) {
 			return hostRow(db.Host{ID: gotHostID, Status: "active"})
 		},
 		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
-			switch {
-			case strings.Contains(sql, "-- name: DeleteHostCapabilities :exec"):
-				if args[0] != "host-a" {
-					t.Errorf("delete host id = %v, want host-a", args[0])
-				}
-				gotCapabilities = nil
-			case strings.Contains(sql, "-- name: InsertHostCapability :exec"):
-				if args[1] != "host-a" {
-					t.Errorf("insert host id = %v, want host-a", args[1])
-				}
-				gotCapabilities = append(gotCapabilities, args[0].(string))
-			default:
+			if !strings.Contains(sql, "-- name: SyncHostCapabilities :exec") {
 				return pgconn.CommandTag{}, fmt.Errorf("unexpected Exec: %s", sql)
 			}
+			if args[0] != "host-a" {
+				t.Errorf("sync host id = %v, want host-a", args[0])
+			}
+			gotCapabilities = append(gotCapabilities, args[1].([]string)...)
 			return pgconn.NewCommandTag("INSERT 0 1"), nil
 		},
 	}
@@ -70,7 +63,7 @@ func TestHostHeartbeatReplacesAdvertisedCapabilities(t *testing.T) {
 
 func TestHostHeartbeatWithoutBodyClearsCapabilities(t *testing.T) {
 	called := false
-	cleared := false
+	var gotCapabilities []string
 	mock := &mockDBTX{
 		queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 			if !strings.Contains(sql, "-- name: UpdateHostHeartbeat :one") {
@@ -80,13 +73,13 @@ func TestHostHeartbeatWithoutBodyClearsCapabilities(t *testing.T) {
 			return hostRow(db.Host{ID: args[0].(string), Status: "active"})
 		},
 		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
-			if !strings.Contains(sql, "-- name: DeleteHostCapabilities :exec") {
+			if !strings.Contains(sql, "-- name: SyncHostCapabilities :exec") {
 				return pgconn.CommandTag{}, fmt.Errorf("unexpected Exec: %s", sql)
 			}
 			if args[0] != "host-old" {
-				t.Errorf("delete host id = %v, want host-old", args[0])
+				t.Errorf("sync host id = %v, want host-old", args[0])
 			}
-			cleared = true
+			gotCapabilities = args[1].([]string)
 			return pgconn.NewCommandTag("DELETE 1"), nil
 		},
 	}
@@ -95,8 +88,8 @@ func TestHostHeartbeatWithoutBodyClearsCapabilities(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/internal/hosts/host-old/heartbeat", nil)
 	setupHostHeartbeatRouter(h).ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK || !called || !cleared {
-		t.Fatalf("status = %d called = %v cleared = %v, want 200/true/true; body: %s", w.Code, called, cleared, w.Body.String())
+	if w.Code != http.StatusOK || !called || gotCapabilities == nil || len(gotCapabilities) != 0 {
+		t.Fatalf("status = %d called = %v capabilities = %#v, want 200/true/empty; body: %s", w.Code, called, gotCapabilities, w.Body.String())
 	}
 }
 

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -52,15 +52,6 @@ func (q *Queries) CreateHost(ctx context.Context, arg CreateHostParams) (Host, e
 	return i, err
 }
 
-const deleteHostCapabilities = `-- name: DeleteHostCapabilities :exec
-DELETE FROM host_capability WHERE host_id = $1
-`
-
-func (q *Queries) DeleteHostCapabilities(ctx context.Context, hostID string) error {
-	_, err := q.db.Exec(ctx, deleteHostCapabilities, hostID)
-	return err
-}
-
 const getHost = `-- name: GetHost :one
 SELECT id, vmd_addr, proxy_addr, region, status, capacity_memory_mib, capacity_vcpus, last_heartbeat_at, created_at, updated_at FROM host WHERE id = $1
 `
@@ -164,25 +155,6 @@ func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCa
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
-}
-
-const insertHostCapability = `-- name: InsertHostCapability :exec
-INSERT INTO host_capability (host_id, capability, heartbeat_at)
-SELECT id, $1, last_heartbeat_at
-FROM host
-WHERE id = $2 AND last_heartbeat_at IS NOT NULL
-ON CONFLICT (host_id, capability)
-DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at
-`
-
-type InsertHostCapabilityParams struct {
-	Capability string `json:"capability"`
-	HostID     string `json:"host_id"`
-}
-
-func (q *Queries) InsertHostCapability(ctx context.Context, arg InsertHostCapabilityParams) error {
-	_, err := q.db.Exec(ctx, insertHostCapability, arg.Capability, arg.HostID)
-	return err
 }
 
 const listActiveHosts = `-- name: ListActiveHosts :many
@@ -380,6 +352,39 @@ WHERE id = $1 AND status = 'active'
 
 func (q *Queries) MarkHostUnhealthy(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, markHostUnhealthy, id)
+	return err
+}
+
+const syncHostCapabilities = `-- name: SyncHostCapabilities :exec
+WITH current_host AS (
+    SELECT id, last_heartbeat_at
+    FROM host
+    WHERE id = $1 AND last_heartbeat_at IS NOT NULL
+), advertised AS (
+    SELECT DISTINCT unnest(COALESCE($2::text[], ARRAY[]::text[])) AS capability
+), upserted AS (
+    INSERT INTO host_capability (host_id, capability, heartbeat_at)
+    SELECT h.id, a.capability, h.last_heartbeat_at
+    FROM current_host h
+    CROSS JOIN advertised a
+    ON CONFLICT (host_id, capability)
+    DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at
+    RETURNING capability
+)
+DELETE FROM host_capability hc
+WHERE hc.host_id = $1
+  AND NOT (hc.capability = ANY(COALESCE($2::text[], ARRAY[]::text[])))
+`
+
+type SyncHostCapabilitiesParams struct {
+	HostID       string   `json:"host_id"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// Refresh the advertised set in place and prune only capabilities omitted by
+// this heartbeat. Empty capabilities intentionally remove the entire set.
+func (q *Queries) SyncHostCapabilities(ctx context.Context, arg SyncHostCapabilitiesParams) error {
+	_, err := q.db.Exec(ctx, syncHostCapabilities, arg.HostID, arg.Capabilities)
 	return err
 }
 

--- a/internal/db/preview_schema_compat_test.go
+++ b/internal/db/preview_schema_compat_test.go
@@ -141,7 +141,8 @@ func TestHostCapabilityAttestationIsBoundToCurrentHeartbeat(t *testing.T) {
 		t.Fatalf("read host queries: %v", err)
 	}
 	queries := string(raw)
-	if !strings.Contains(queries, "SELECT id, sqlc.arg(capability), last_heartbeat_at") {
+	if !strings.Contains(queries, "INSERT INTO host_capability (host_id, capability, heartbeat_at)") ||
+		!strings.Contains(queries, "SELECT h.id, a.capability, h.last_heartbeat_at") {
 		t.Fatal("capability insert is not stamped with the heartbeat it attests")
 	}
 	if got := strings.Count(queries, "hc.heartbeat_at = h.last_heartbeat_at"); got < 2 {
@@ -149,6 +150,35 @@ func TestHostCapabilityAttestationIsBoundToCurrentHeartbeat(t *testing.T) {
 	}
 	if !strings.Contains(queries, "h.status = 'active'") {
 		t.Fatal("host capability gate accepts capabilities from an unhealthy host")
+	}
+}
+
+func TestSyncHostCapabilitiesUsesCompleteSetSemantics(t *testing.T) {
+	path := filepath.Join("..", "..", "db", "queries", "hosts.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read host queries: %v", err)
+	}
+	queries := string(raw)
+	start := strings.Index(queries, "-- name: SyncHostCapabilities :exec")
+	if start < 0 {
+		t.Fatal("capability synchronization query is missing")
+	}
+	end := strings.Index(queries[start:], "-- name:")
+	if end > 0 {
+		queries = queries[start : start+end]
+	} else {
+		queries = queries[start:]
+	}
+	for _, required := range []string{
+		"unnest(COALESCE(sqlc.arg(capabilities)::text[], ARRAY[]::text[]))",
+		"ON CONFLICT (host_id, capability)",
+		"DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at",
+		"NOT (hc.capability = ANY(COALESCE(sqlc.arg(capabilities)::text[], ARRAY[]::text[])))",
+	} {
+		if !strings.Contains(queries, required) {
+			t.Errorf("sync query is missing %q", required)
+		}
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -156,17 +156,16 @@ func seedPreviewCapableHost(ctx context.Context, q *db.Queries) error {
 	if _, err := q.UpdateHostHeartbeat(ctx, testDefaultHostID); err != nil {
 		return fmt.Errorf("heartbeat default host: %w", err)
 	}
-	for _, capability := range []string{
+	capabilities := []string{
 		preview.HostCapabilityPorts,
 		preview.HostCapabilityPortAccess,
 		preview.HostCapabilityPortTokens,
 		preview.HostCapabilityPortBrowserAuth,
-	} {
-		if err := q.InsertHostCapability(ctx, db.InsertHostCapabilityParams{
-			HostID: testDefaultHostID, Capability: capability,
-		}); err != nil {
-			return fmt.Errorf("advertise %s: %w", capability, err)
-		}
+	}
+	if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+		HostID: testDefaultHostID, Capabilities: capabilities,
+	}); err != nil {
+		return fmt.Errorf("advertise capabilities: %w", err)
 	}
 
 	capable, err := q.HostHasCapabilities(ctx, db.HostHasCapabilitiesParams{
@@ -209,8 +208,9 @@ func TestIntegration_HostCapabilityRequiresActiveCurrentHeartbeat(t *testing.T) 
 	if _, err := testQueries.UpdateHostHeartbeat(ctx, hostID); err != nil {
 		t.Fatalf("heartbeat host: %v", err)
 	}
-	params := db.InsertHostCapabilityParams{HostID: hostID, Capability: preview.HostCapabilityPorts}
-	if err := testQueries.InsertHostCapability(ctx, params); err != nil {
+	if err := testQueries.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+		HostID: hostID, Capabilities: []string{preview.HostCapabilityPorts},
+	}); err != nil {
 		t.Fatalf("advertise capability: %v", err)
 	}
 	hasCapability := func() bool {
@@ -669,12 +669,10 @@ func seedActivePreviewHost(t *testing.T, capabilities ...string) string {
 	if _, err := testQueries.UpdateHostHeartbeat(ctx, hostID); err != nil {
 		t.Fatalf("heartbeat preview host: %v", err)
 	}
-	for _, capability := range capabilities {
-		if err := testQueries.InsertHostCapability(ctx, db.InsertHostCapabilityParams{
-			HostID: hostID, Capability: capability,
-		}); err != nil {
-			t.Fatalf("advertise preview host %s: %v", capability, err)
-		}
+	if err := testQueries.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+		HostID: hostID, Capabilities: capabilities,
+	}); err != nil {
+		t.Fatalf("advertise preview host capabilities: %v", err)
 	}
 	return hostID
 }
@@ -702,6 +700,97 @@ func readPreviewCredentialState(t *testing.T, sandboxID uuid.UUID) (version, rev
 		t.Fatalf("read preview credential state: %v", err)
 	}
 	return version, revision
+}
+
+func TestIntegration_SyncHostCapabilitiesRefreshesCompleteSet(t *testing.T) {
+	ctx := context.Background()
+	hostID := "sync-capability-host-" + uuid.New().String()[:8]
+	if _, err := testQueries.CreateHost(ctx, db.CreateHostParams{
+		ID: hostID, VmdAddr: "localhost:0", ProxyAddr: "localhost:0", Region: "test",
+		CapacityMemoryMib: 1024, CapacityVcpus: 1,
+	}); err != nil {
+		t.Fatalf("create host: %v", err)
+	}
+	if _, err := testQueries.UpdateHostHeartbeat(ctx, hostID); err != nil {
+		t.Fatalf("initial heartbeat: %v", err)
+	}
+	if err := testQueries.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+		HostID: hostID, Capabilities: []string{"cap-a", "cap-b"},
+	}); err != nil {
+		t.Fatalf("initial capability sync: %v", err)
+	}
+	var initialHeartbeat, initialCapabilityCreatedAt time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT h.last_heartbeat_at, hc.created_at
+		FROM host h
+		JOIN host_capability hc ON hc.host_id = h.id AND hc.capability = 'cap-a'
+		WHERE h.id = $1`, hostID).Scan(&initialHeartbeat, &initialCapabilityCreatedAt); err != nil {
+		t.Fatalf("read initial heartbeat: %v", err)
+	}
+
+	if _, err := testQueries.UpdateHostHeartbeat(ctx, hostID); err != nil {
+		t.Fatalf("refresh heartbeat: %v", err)
+	}
+	if err := testQueries.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
+		HostID: hostID, Capabilities: []string{"cap-a", "cap-c"},
+	}); err != nil {
+		t.Fatalf("refresh capability sync: %v", err)
+	}
+
+	rows, err := testPool.Query(ctx, `
+		SELECT hc.capability, hc.heartbeat_at, hc.created_at, h.last_heartbeat_at
+		FROM host_capability hc
+		JOIN host h ON h.id = hc.host_id
+		WHERE hc.host_id = $1
+		ORDER BY hc.capability`, hostID)
+	if err != nil {
+		t.Fatalf("read synchronized capabilities: %v", err)
+	}
+	defer rows.Close()
+	got := make(map[string]time.Time)
+	for rows.Next() {
+		var capability string
+		var capabilityHeartbeat, capabilityCreatedAt, hostHeartbeat time.Time
+		if err := rows.Scan(&capability, &capabilityHeartbeat, &capabilityCreatedAt, &hostHeartbeat); err != nil {
+			t.Fatalf("scan synchronized capability: %v", err)
+		}
+		if !capabilityHeartbeat.Equal(hostHeartbeat) {
+			t.Fatalf("capability %q heartbeat = %v, host heartbeat = %v", capability, capabilityHeartbeat, hostHeartbeat)
+		}
+		got[capability] = capabilityHeartbeat
+		if capability == "cap-a" && !capabilityCreatedAt.Equal(initialCapabilityCreatedAt) {
+			t.Fatalf("unchanged capability created_at = %v, initial = %v; want row identity preserved", capabilityCreatedAt, initialCapabilityCreatedAt)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate synchronized capabilities: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("synchronized capabilities = %#v, want cap-a and cap-c", got)
+	}
+	if _, ok := got["cap-a"]; !ok {
+		t.Fatal("unchanged capability cap-a was not refreshed")
+	}
+	if !got["cap-a"].After(initialHeartbeat) {
+		t.Fatalf("unchanged capability heartbeat = %v, initial heartbeat = %v; want refresh", got["cap-a"], initialHeartbeat)
+	}
+	if _, ok := got["cap-c"]; !ok {
+		t.Fatal("new capability cap-c was not inserted")
+	}
+	if _, ok := got["cap-b"]; ok {
+		t.Fatal("omitted capability cap-b was not pruned")
+	}
+
+	if err := testQueries.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{HostID: hostID}); err != nil {
+		t.Fatalf("empty capability sync: %v", err)
+	}
+	var remaining int
+	if err := testPool.QueryRow(ctx, `SELECT count(*) FROM host_capability WHERE host_id = $1`, hostID).Scan(&remaining); err != nil {
+		t.Fatalf("count cleared capabilities: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("capabilities after empty sync = %d, want 0", remaining)
+	}
 }
 
 func TestIntegration_MintDeliveryFailureRollsBackRevisionAndReturnsNoCredential(t *testing.T) {


### PR DESCRIPTION
## Summary

- synchronize advertised host capabilities in place on each heartbeat
- prune only capabilities omitted from the current heartbeat
- preserve heartbeat timestamp anchoring and explicit empty-set removal

## Testing

- regenerate sqlc output
- run focused host heartbeat tests
- run relevant Go test suite

## Testing

- `codex-workflow validate`
