### PR TITLE
vmd: keep the socket up on steady-state deploys and bound daemon shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Run unit tests
         run: go test -v -short -count=1 -race ./...
 
+      - name: Run deploy-script tests
+        run: python3 -m unittest discover -s .github/workflows/scripts -p 'test_*.py'
+
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1053,14 +1053,16 @@ def main() -> int:
             READY=0
             for i in $(seq 1 90); do
                 INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)
-                if [ -n "$INVOCATION" ]; then
-                    MATCH=$(sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" -g 'gRPC serving requests' --no-pager 2>/dev/null || true)
-                    if [ -n "$MATCH" ] \
-                       && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
-                       && sudo systemctl is-active --quiet {service}; then
-                        READY=1
-                        break
-                    fi
+                # journalctl -g exits nonzero on no match (and prints
+                # "-- No entries --" to stdout), so drive the check off its exit
+                # status — capturing stdout would read that marker as a false
+                # positive. No `|| true`: that would swallow the no-match status.
+                if [ -n "$INVOCATION" ] \
+                   && sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" --quiet -g 'gRPC serving requests' --no-pager >/dev/null 2>&1 \
+                   && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
+                   && sudo systemctl is-active --quiet {service}; then
+                    READY=1
+                    break
                 fi
                 sleep 1
             done

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,26 +1040,35 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
-            # Timestamp before the restart so the readiness scan sees only the
-            # new process's log line.
-            READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
             # Wait for APPLICATION readiness, not is-active: the unit is
-            # Type=simple, so "active" only means the process forked, while vmd
+            # Type=simple, so "active" only proves the process forked, while vmd
             # answers Unavailable until it logs startup-complete (its real gate,
-            # ~12s in prod). Fail with the recovery trap still armed on timeout.
+            # ~12s in prod). Scope the scan to the unit's CURRENT systemd
+            # invocation so neither a prior boot's nor a crashed-and-replaced
+            # process's ready line counts, then re-confirm that invocation is
+            # still current+active when the line is seen. Read journalctl into a
+            # var (no pipe) so a match can't SIGPIPE it under pipefail — same
+            # reason as the find -print -quit above. Fail with the recovery trap
+            # still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
-                if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then
-                    READY=1
-                    break
+                INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)
+                if [ -n "$INVOCATION" ]; then
+                    MATCH=$(sudo journalctl "_SYSTEMD_INVOCATION_ID=$INVOCATION" -g 'gRPC serving requests' --no-pager 2>/dev/null || true)
+                    if [ -n "$MATCH" ] \
+                       && [ "$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)" = "$INVOCATION" ] \
+                       && sudo systemctl is-active --quiet {service}; then
+                        READY=1
+                        break
+                    fi
                 fi
                 sleep 1
             done
             if [ "$READY" != 1 ]; then
                 echo "ERROR: {service} did not reach application readiness (startupReady) within 90s after restart" >&2
                 sudo systemctl status --no-pager {service} >&2 || true
-                sudo journalctl -u {service} --since "$READY_SINCE" --no-pager -n 80 >&2 || true
+                sudo journalctl -u {service} --no-pager -n 80 >&2 || true
                 exit 1
             fi
             # {service} is confirmed serving requests on the final config: disarm

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,16 +1040,14 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
-            # Capture the moment just before restart so the readiness scan sees
-            # only the NEW process's log line, never a prior boot's.
+            # Timestamp before the restart so the readiness scan sees only the
+            # new process's log line.
             READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
-            # Wait for APPLICATION readiness, not just is-active. The unit is
-            # Type=simple, so "active" means only that the process forked, while
-            # vmd answers Unavailable until it logs startup-complete — its real
-            # request gate, which measured prod startup reaches in ~12s. Poll for
-            # that line, bounded well above it, and fail (leaving the recovery
-            # trap armed) if the process never gets there or dies trying.
+            # Wait for APPLICATION readiness, not is-active: the unit is
+            # Type=simple, so "active" only means the process forked, while vmd
+            # answers Unavailable until it logs startup-complete (its real gate,
+            # ~12s in prod). Fail with the recovery trap still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
                 if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1040,18 +1040,34 @@ def main() -> int:
             # `restart` guarantees the process running once this script
             # exits is always the one reading the final, fully-migrated
             # config, whether or not a reactivation race occurred.
+            # Capture the moment just before restart so the readiness scan sees
+            # only the NEW process's log line, never a prior boot's.
+            READY_SINCE="$(date '+%Y-%m-%d %H:%M:%S')"
             sudo systemctl restart {service}
-            sleep 3
-            sudo systemctl is-active --quiet {service} || (
-                echo "ERROR: {service} failed to become active after restart" >&2
+            # Wait for APPLICATION readiness, not just is-active. The unit is
+            # Type=simple, so "active" means only that the process forked, while
+            # vmd answers Unavailable until it logs startup-complete — its real
+            # request gate, which measured prod startup reaches in ~12s. Poll for
+            # that line, bounded well above it, and fail (leaving the recovery
+            # trap armed) if the process never gets there or dies trying.
+            READY=0
+            for i in $(seq 1 90); do
+                if sudo journalctl -u {service} --since "$READY_SINCE" --no-pager 2>/dev/null | grep -qF "gRPC serving requests"; then
+                    READY=1
+                    break
+                fi
+                sleep 1
+            done
+            if [ "$READY" != 1 ]; then
+                echo "ERROR: {service} did not reach application readiness (startupReady) within 90s after restart" >&2
                 sudo systemctl status --no-pager {service} >&2 || true
-                sudo journalctl -u {service} --no-pager -n 40 >&2 || true
+                sudo journalctl -u {service} --since "$READY_SINCE" --no-pager -n 80 >&2 || true
                 exit 1
-            )
-            # {service} is confirmed active on the final config: disarm the
-            # journal-migration recovery trap (a no-op if it was never
-            # armed this run). Anything past this point is unrelated to the
-            # backup journal and shouldn't restart vmd on failure.
+            fi
+            # {service} is confirmed serving requests on the final config: disarm
+            # the journal-migration recovery trap (a no-op if it was never armed
+            # this run). Anything past this point is unrelated to the backup
+            # journal and shouldn't restart vmd on failure.
             trap - EXIT
 
             # Restart secretsproxy; tolerate missing env file on hosts not

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -1043,14 +1043,13 @@ def main() -> int:
             sudo systemctl restart {service}
             # Wait for APPLICATION readiness, not is-active: the unit is
             # Type=simple, so "active" only proves the process forked, while vmd
-            # answers Unavailable until it logs startup-complete (its real gate,
-            # ~12s in prod). Scope the scan to the unit's CURRENT systemd
-            # invocation so neither a prior boot's nor a crashed-and-replaced
-            # process's ready line counts, then re-confirm that invocation is
-            # still current+active when the line is seen. Read journalctl into a
-            # var (no pipe) so a match can't SIGPIPE it under pipefail — same
-            # reason as the find -print -quit above. Fail with the recovery trap
-            # still armed on timeout.
+            # answers Unavailable until it logs startup-complete — its real gate,
+            # which can lag the fork. Scope the scan to the unit's CURRENT
+            # systemd invocation so no prior-boot or crashed-and-replaced ready
+            # line counts, and re-confirm that invocation is still current+active
+            # when the line is seen. Read journalctl into a var (no pipe) so a
+            # match can't SIGPIPE it under pipefail (as with the find -print
+            # -quit above). Fail with the recovery trap still armed on timeout.
             READY=0
             for i in $(seq 1 90); do
                 INVOCATION=$(systemctl show -p InvocationID --value {service} 2>/dev/null || true)

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -790,11 +790,20 @@ def main() -> int:
                 fi
             fi
 
-            # Stop before starting the socket unit: on the first deploy of
-            # socket activation the old direct-bound vmd still holds the
-            # ports, and a plain restart can bind the socket unit before the
-            # old process has released them. Idempotent in steady state.
-            sudo systemctl stop {service}
+            # Stop vmd here ONLY in the exceptional cases that need the ports
+            # released before the socket unit (re)binds: the one-time migration
+            # from a direct-bound vmd to socket activation (the socket unit is
+            # not yet the active listener, so the old process still owns the
+            # ports), or a socket-definition change that forces a rebind. In
+            # steady state the socket unit already owns the ports and stays up
+            # across the swap — stopping vmd here instead would leave it down
+            # for the whole config window with the socket still listening, so a
+            # connection arriving in that gap socket-activates a throwaway vmd
+            # that the restart below then kills. The single restart further
+            # down does the cutover with connections backlogging on the socket.
+            if ! systemctl is-active --quiet superserve-vmd.socket || [ "$SOCKET_CHANGED" = 1 ]; then
+                sudo systemctl stop {service}
+            fi
 
             # Migrate the backup journal to its new path now that vmd is
             # stopped (the file is closed, safe to move), then upsert
@@ -809,17 +818,16 @@ def main() -> int:
             # migrated by an earlier deploy) so this is a no-op in steady
             # state.
             if [ -n {q_backup_journal} ]; then
-                # {service} was already stopped above (unconditionally, for
-                # every deploy) before this block is even reached, so any
-                # failure exit between here and the restart/health-check
-                # block further down would otherwise leave it down with
-                # nothing to bring it back — including from the mount
-                # recheck just below, and from the fallible env write later
-                # in this block. Arm recovery up front, for the whole
-                # section, rather than only around the parts that also stop
-                # the socket. A no-op start on units that were never
-                # stopped. Disarmed only once {service} is confirmed active
-                # again, near the end of this script.
+                # This block stops superserve-vmd.socket and {service} itself
+                # when the journal path changes (below), and the gated stop
+                # above may already have stopped {service} on a socket
+                # migration. Either way, arm recovery up front for the whole
+                # section so any failure exit between here and the
+                # restart/health-check block — the mount recheck just below, or
+                # the fallible env write later — cannot leave a unit down with
+                # nothing to bring it back. A start on units that were never
+                # stopped is a harmless no-op. Disarmed only once {service} is
+                # confirmed active again, near the end of this script.
                 #
                 # Re-verifies the mount at fire time rather than blindly
                 # restarting: $BJ_ANCESTOR is set below and stays valid for
@@ -903,24 +911,21 @@ def main() -> int:
                 fi
 
                 if [ "$OLD_BACKUP_JOURNAL_PATH" != "$NEW_BACKUP_JOURNAL_PATH" ]; then
-                    # {service} was stopped above, but superserve-vmd.socket
-                    # stays active the rest of this script by design
-                    # (zero-downtime deploys), so a connection landing in the
-                    # gap between that stop and here can already have
-                    # socket-activated vmd against the still-current old
-                    # path — even when $OLD_BACKUP_JOURNAL_PATH has no file
-                    # yet (a host's first deploy of this setting): vmd would
-                    # then create one there on activation, and it becomes an
-                    # orphan the moment vmd.env is rewritten below to name
-                    # the new path, with nothing left to migrate it. Stop the
-                    # socket too, whenever the path is changing at all, not
-                    # just when there's a file to migrate. Re-enabled by the
-                    # socket restart/start block and the {service} restart
-                    # later in this script, once vmd.env names the new path.
-                    # The recovery trap armed at the top of this block
-                    # already covers a failure here too — it stops the
-                    # socket now as well, not just {service}, but the trap's
-                    # start of both units on any exit applies regardless.
+                    # The socket unit stays up across a normal deploy by design
+                    # (connections backlog instead of refusing), so a
+                    # connection landing here could socket-activate vmd against
+                    # the still-current old path — even when
+                    # $OLD_BACKUP_JOURNAL_PATH has no file yet (a host's first
+                    # deploy of this setting): vmd would then create one there
+                    # on activation, and it becomes an orphan the moment
+                    # vmd.env is rewritten below to name the new path, with
+                    # nothing left to migrate it. Stop BOTH units here,
+                    # whenever the path is changing at all, not just when
+                    # there's a file to migrate. Re-enabled by the socket
+                    # restart/start block and the {service} restart later in
+                    # this script, once vmd.env names the new path. The
+                    # recovery trap armed at the top of this block covers a
+                    # failure here too.
                     sudo systemctl stop superserve-vmd.socket {service}
                     if [ -f "$OLD_BACKUP_JOURNAL_PATH" ]; then
                         # $OLD_BACKUP_JOURNAL_PATH still present under its

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -790,7 +790,7 @@ def main() -> int:
                 fi
             fi
 
-            # Stop vmd here ONLY in the exceptional cases that need the ports
+            # Stop here ONLY in the exceptional cases that need the ports
             # released before the socket unit (re)binds: the one-time migration
             # from a direct-bound vmd to socket activation (the socket unit is
             # not yet the active listener, so the old process still owns the
@@ -799,10 +799,19 @@ def main() -> int:
             # across the swap — stopping vmd here instead would leave it down
             # for the whole config window with the socket still listening, so a
             # connection arriving in that gap socket-activates a throwaway vmd
-            # that the restart below then kills. The single restart further
-            # down does the cutover with connections backlogging on the socket.
+            # that the restart below then kills. A normal binary deploy never
+            # reaches this stop; the single restart further down does its
+            # cutover with connections backlogging on the socket.
+            #
+            # Stop BOTH units, not just vmd: on a socket-definition change the
+            # old socket is still active, so leaving it listening would let a
+            # connection socket-activate an interim vmd during the rebind
+            # window — the very race this gating exists to remove. Stopping an
+            # inactive socket (the migration case) is a harmless no-op. The
+            # socket comes back with its new definition at the rebind block
+            # below; that rare deploy accepts a brief refused window.
             if ! systemctl is-active --quiet superserve-vmd.socket || [ "$SOCKET_CHANGED" = 1 ]; then
-                sudo systemctl stop {service}
+                sudo systemctl stop superserve-vmd.socket {service}
             fi
 
             # Migrate the backup journal to its new path now that vmd is

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -1,0 +1,57 @@
+"""Regression guards for the vmd deploy-ordering that caused the
+socket-activation double-restart incident.
+
+The ordering is a shell sequence built into a heredoc by deploy-vmd.py, so it is
+not a pure function; these assert on the rendered template text. Each test pins
+one property whose violation reintroduces the incident.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).with_name("deploy-vmd.py").read_text()
+
+
+class DeployVmdOrderingTests(unittest.TestCase):
+    def test_no_bare_service_stop(self):
+        # The early service stop that opened the socket-activation window must
+        # never be unconditional/bare: every stop of the vmd service also stops
+        # superserve-vmd.socket (both-units form) so no connection can
+        # socket-activate an interim vmd during the window.
+        self.assertNotRegex(
+            SOURCE,
+            r"systemctl stop \{service\}",
+            "found a bare `systemctl stop {service}`; every service stop must "
+            "also stop superserve-vmd.socket",
+        )
+
+    def test_steady_state_stop_is_guarded_and_stops_both(self):
+        # The steady-state early stop runs ONLY on a fresh socket migration
+        # (socket inactive) or a socket-definition change, and stops BOTH units.
+        self.assertRegex(
+            SOURCE,
+            r'if ! systemctl is-active --quiet superserve-vmd\.socket'
+            r' \|\| \[ "\$SOCKET_CHANGED" = 1 \]; then\s*\n'
+            r'\s*sudo systemctl stop superserve-vmd\.socket \{service\}',
+        )
+
+    def test_exactly_one_cutover_restart(self):
+        # Steady state does exactly one service restart (the cutover). A second
+        # is the double-restart this fix removed.
+        self.assertEqual(len(re.findall(r"systemctl restart \{service\}", SOURCE)), 1)
+
+    def test_waits_for_application_readiness_not_just_is_active(self):
+        # The post-restart gate waits for vmd's real request gate (startupReady,
+        # logged as "gRPC serving requests"): the unit is Type=simple, so
+        # is-active alone means only that the process forked.
+        self.assertIn('grep -qF "gRPC serving requests"', SOURCE)
+        # ...and must not gate readiness on a bare sleep + is-active.
+        self.assertNotRegex(
+            SOURCE,
+            r"sleep 3\s*\n\s*sudo systemctl is-active --quiet \{service\}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -42,15 +42,23 @@ class DeployVmdOrderingTests(unittest.TestCase):
         self.assertEqual(len(re.findall(r"systemctl restart \{service\}", SOURCE)), 1)
 
     def test_waits_for_application_readiness_not_just_is_active(self):
-        # The post-restart gate waits for vmd's real request gate (startupReady,
-        # logged as "gRPC serving requests"): the unit is Type=simple, so
-        # is-active alone means only that the process forked.
-        self.assertIn('grep -qF "gRPC serving requests"', SOURCE)
+        # Readiness gates on vmd's real request gate (startupReady, logged as
+        # "gRPC serving requests"), scoped to the unit's CURRENT systemd
+        # invocation — not a bare is-active (Type=simple only proves the process
+        # forked) and not a prior/crashed invocation's line.
+        self.assertRegex(SOURCE, r"-g 'gRPC serving requests'")
+        self.assertIn("_SYSTEMD_INVOCATION_ID", SOURCE)
         # ...and must not gate readiness on a bare sleep + is-active.
         self.assertNotRegex(
             SOURCE,
             r"sleep 3\s*\n\s*sudo systemctl is-active --quiet \{service\}",
         )
+
+    def test_readiness_scan_does_not_pipe_journalctl_to_grep(self):
+        # Under `set -o pipefail`, grep closing the pipe on a match SIGPIPEs
+        # journalctl and the pipeline reads non-zero even on success — a false
+        # timeout. The readiness scan must capture output, not pipe to grep -q.
+        self.assertNotRegex(SOURCE, r"journalctl[^\n]*\|\s*grep -q")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -6,7 +6,10 @@ not a pure function; these assert on the rendered template text. Each test pins
 one property whose violation reintroduces the incident.
 """
 
+import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -59,6 +62,39 @@ class DeployVmdOrderingTests(unittest.TestCase):
         # journalctl and the pipeline reads non-zero even on success — a false
         # timeout. The readiness scan must capture output, not pipe to grep -q.
         self.assertNotRegex(SOURCE, r"journalctl[^\n]*\|\s*grep -q")
+
+    def test_readiness_query_drives_off_exit_status_not_captured_output(self):
+        # journalctl -g prints "-- No entries --" to stdout and exits nonzero on
+        # no match; capturing that stdout (esp. with `|| true`) reads the marker
+        # as a false-ready. The query must drive off exit status: --quiet, output
+        # to /dev/null, and never `|| true` on the readiness journalctl.
+        self.assertRegex(
+            SOURCE,
+            r"journalctl[^\n]*--quiet[^\n]*-g 'gRPC serving requests'[^\n]*>/dev/null",
+        )
+        self.assertNotRegex(SOURCE, r"journalctl[^\n]*gRPC serving requests[^\n]*\|\| true")
+
+    def test_no_match_journalctl_is_not_ready(self):
+        # Behavioral: a journalctl that prints the empty-result marker and exits
+        # nonzero (the real no-match behavior) must make the exit-status query
+        # read as not-ready; a matching one (exit 0) as ready.
+        query = (
+            "if journalctl --quiet -g 'gRPC serving requests' --no-pager "
+            ">/dev/null 2>&1; then echo READY; else echo NOTREADY; fi"
+        )
+        for exit_code, stdout, expect in (
+            (1, "-- No entries --", "NOTREADY"),
+            (0, "match", "READY"),
+        ):
+            with tempfile.TemporaryDirectory() as d:
+                fake = Path(d) / "journalctl"
+                fake.write_text("#!/bin/sh\necho '%s'\nexit %d\n" % (stdout, exit_code))
+                fake.chmod(0o755)
+                env = dict(os.environ, PATH="%s:%s" % (d, os.environ["PATH"]))
+                out = subprocess.run(
+                    ["sh", "-c", query], env=env, capture_output=True, text=True
+                ).stdout
+                self.assertIn(expect, out, "exit=%d" % exit_code)
 
 
 if __name__ == "__main__":

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -193,6 +193,11 @@ type lifecycle struct {
 	// receipt: only a deliberate, fully clean shutdown may vouch.
 	signalInitiated bool
 	closerErr       error
+	// forcedRPCStop is set when the gRPC drain hit its budget and active RPCs
+	// were force-cancelled. A cancelled create/pause/resume may have left state
+	// the next boot must reconcile, so this bars the pool receipt — the drain
+	// budget is a circuit breaker, never a proven-safe cancellation bound.
+	forcedRPCStop bool
 
 	done   chan struct{}
 	doneCh sync.Once
@@ -249,13 +254,21 @@ func (lc *lifecycle) noteSignalInitiated() {
 	lc.mu.Unlock()
 }
 
+// noteForcedRPCStop marks that the gRPC drain overran its budget and active
+// RPCs were force-cancelled, so this shutdown can never be treated as clean.
+func (lc *lifecycle) noteForcedRPCStop() {
+	lc.mu.Lock()
+	lc.forcedRPCStop = true
+	lc.mu.Unlock()
+}
+
 // cleanIntentionalShutdown reports whether this was a signal-initiated
 // shutdown in which no service errored and every closer succeeded — the
 // only condition under which state may be vouched for.
 func (lc *lifecycle) cleanIntentionalShutdown() bool {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
-	return lc.signalInitiated && lc.firstErr == nil && lc.closerErr == nil
+	return lc.signalInitiated && lc.firstErr == nil && lc.closerErr == nil && !lc.forcedRPCStop
 }
 
 // wait blocks until shutdown is signaled (by a service exit, context
@@ -271,9 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
-// so total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
-// if the process itself wedges past this.
-// ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
+// so total shutdown stays bounded. When it bounds the gRPC drain, a hit budget
+// force-cancels active RPCs AND marks the shutdown unclean (see the gRPC
+// closer), so overrunning it costs a next-boot reconcile — never a silent clean
+// handoff. It is a circuit breaker, not a proven-safe cancellation bound.
+// systemd TimeoutStopSec is the final backstop if the process wedges past this.
 var perCloserShutdownTimeout = 12 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1299,7 +1314,13 @@ func main() {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
 		case <-shutdownCtx.Done():
-			log.Warn().Msg("graceful shutdown timed out, forcing stop")
+			// Force-cancel active RPCs to stay bounded, but mark the shutdown
+			// unclean: a cancelled create/pause/resume may have left state the
+			// next boot must reconcile, so this can never be a clean handoff
+			// that vouches the pool receipt. Return nil (not an error) so the
+			// remaining closers still flush their state gracefully.
+			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
+			lc.noteForcedRPCStop()
 			grpcServer.Stop()
 		}
 		return nil

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -270,18 +270,21 @@ func (lc *lifecycle) wait(ctx context.Context) {
 
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
-// hang the process — the loop abandons one that overruns and moves on, so
-// total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
-// if the process itself wedges past the sum of these.
+// hang the process — the loop aborts the graceful sequence if one overruns,
+// so total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
+// if the process itself wedges past this.
 // ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
 var perCloserShutdownTimeout = 12 * time.Second
 
-// shutdown runs every registered closer in reverse order, collecting errors
-// but never stopping on the first failure — every resource gets a chance to
-// clean up. Each closer runs under its own deadline and off the main
-// goroutine, so one that wedges is abandoned rather than hanging the daemon;
-// an abandoned or failed closer records closerErr, which bars this shutdown
-// from vouching for inventory it may have left inconsistent.
+// shutdown runs every registered closer in reverse (dependency) order. A
+// closer that RETURNS an error is logged and the loop continues — it is done
+// touching its resources, so its dependencies are safe to close. A closer that
+// OVERRUNS its deadline is still running, so the loop must NOT keep closing the
+// dependencies it may still be using (use-after-close): it records the failure
+// and aborts the sequence, leaving the rest to process exit (and systemd
+// TimeoutStopSec). Each closer runs under its own deadline and off the main
+// goroutine. Any failed or timed-out closer records closerErr, which bars this
+// shutdown from vouching for inventory it may have left inconsistent.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -291,23 +294,25 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 	for _, c := range closers {
 		lc.log.Info().Str("service", c.name).Msg("closing")
 		closerCtx, cancel := context.WithTimeout(ctx, perCloserShutdownTimeout)
-		// Buffered so an abandoned closer's goroutine can still send and exit
-		// (or leak harmlessly — the process is on its way down) rather than
-		// block forever on a receiver that has already moved on.
+		// Buffered so a closer that overruns can still send and exit (or leak
+		// harmlessly — the process is on its way down) rather than block
+		// forever on a receiver that has moved on.
 		done := make(chan error, 1)
 		go func() { done <- c.close(closerCtx) }()
 		select {
 		case err := <-done:
+			cancel()
 			if err != nil {
 				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
 				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			}
 		case <-closerCtx.Done():
+			cancel()
 			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
-				Msg("closer exceeded its shutdown deadline; abandoning")
+				Msg("closer exceeded its shutdown deadline; aborting graceful shutdown")
 			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
+			return
 		}
-		cancel()
 	}
 }
 

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -268,9 +268,20 @@ func (lc *lifecycle) wait(ctx context.Context) {
 	}
 }
 
-// shutdown runs every registered closer in reverse order, collecting
-// errors but never stopping on the first failure — we want every
-// resource to get a chance to clean up.
+// perCloserShutdownTimeout bounds each closer independently during shutdown.
+// A closer that ignores cancellation must not stall the closers after it or
+// hang the process — the loop abandons one that overruns and moves on, so
+// total shutdown stays bounded. systemd TimeoutStopSec is the final backstop
+// if the process itself wedges past the sum of these.
+// ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
+var perCloserShutdownTimeout = 12 * time.Second
+
+// shutdown runs every registered closer in reverse order, collecting errors
+// but never stopping on the first failure — every resource gets a chance to
+// clean up. Each closer runs under its own deadline and off the main
+// goroutine, so one that wedges is abandoned rather than hanging the daemon;
+// an abandoned or failed closer records closerErr, which bars this shutdown
+// from vouching for inventory it may have left inconsistent.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -279,15 +290,33 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 
 	for _, c := range closers {
 		lc.log.Info().Str("service", c.name).Msg("closing")
-		if err := c.close(ctx); err != nil {
-			lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
-			lc.mu.Lock()
-			if lc.closerErr == nil {
-				lc.closerErr = fmt.Errorf("%s: %w", c.name, err)
+		closerCtx, cancel := context.WithTimeout(ctx, perCloserShutdownTimeout)
+		// Buffered so an abandoned closer's goroutine can still send and exit
+		// (or leak harmlessly — the process is on its way down) rather than
+		// block forever on a receiver that has already moved on.
+		done := make(chan error, 1)
+		go func() { done <- c.close(closerCtx) }()
+		select {
+		case err := <-done:
+			if err != nil {
+				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
+				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			}
-			lc.mu.Unlock()
+		case <-closerCtx.Done():
+			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
+				Msg("closer exceeded its shutdown deadline; abandoning")
+			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
 		}
+		cancel()
 	}
+}
+
+func (lc *lifecycle) recordCloserErr(err error) {
+	lc.mu.Lock()
+	if lc.closerErr == nil {
+		lc.closerErr = err
+	}
+	lc.mu.Unlock()
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -193,10 +193,9 @@ type lifecycle struct {
 	// receipt: only a deliberate, fully clean shutdown may vouch.
 	signalInitiated bool
 	closerErr       error
-	// forcedRPCStop is set when the gRPC drain hit its budget and active RPCs
-	// were force-cancelled. A cancelled create/pause/resume may have left state
-	// the next boot must reconcile, so this bars the pool receipt — the drain
-	// budget is a circuit breaker, never a proven-safe cancellation bound.
+	// forcedRPCStop is set when the gRPC drain overran its budget and active
+	// RPCs were force-cancelled — a possibly-inconsistent state the next boot
+	// must reconcile, so it bars the pool receipt.
 	forcedRPCStop bool
 
 	done   chan struct{}
@@ -284,11 +283,10 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // perCloserShutdownTimeout bounds each closer independently during shutdown.
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
-// so total shutdown stays bounded. When it bounds the gRPC drain, a hit budget
-// force-cancels active RPCs AND marks the shutdown unclean (see the gRPC
-// closer), so overrunning it costs a next-boot reconcile — never a silent clean
-// handoff. It is a circuit breaker, not a proven-safe cancellation bound.
-// systemd TimeoutStopSec is the final backstop if the process wedges past this.
+// so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
+// force-cancels active RPCs and marks the shutdown unclean (see the gRPC
+// closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
+// cancellation bound. systemd TimeoutStopSec is the final backstop.
 var perCloserShutdownTimeout = 12 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1314,11 +1312,9 @@ func main() {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
 		case <-shutdownCtx.Done():
-			// Force-cancel active RPCs to stay bounded, but mark the shutdown
-			// unclean: a cancelled create/pause/resume may have left state the
-			// next boot must reconcile, so this can never be a clean handoff
-			// that vouches the pool receipt. Return nil (not an error) so the
-			// remaining closers still flush their state gracefully.
+			// Force-cancel to stay bounded, but mark the shutdown unclean so it
+			// can't vouch the pool receipt. Return nil (below) so the remaining
+			// closers still flush state.
 			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -284,10 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
-// force-cancels active RPCs and marks the shutdown unclean (see the gRPC
-// closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
-// cancellation bound. Chosen to sit under the 30s overall shutdown budget and
-// the unit's TimeoutStopSec backstop, leaving room for the closers after it.
+// force-cancels active RPCs, aborts the remaining closers (a forced stop leaves
+// handlers running — see the gRPC closer), and marks the shutdown unclean — a
+// circuit breaker (overrun costs a reconcile), not a proven-safe cancellation
+// bound. Chosen to sit under the 30s overall shutdown budget and the unit's
+// TimeoutStopSec backstop, leaving room for the closers after it.
 var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1312,15 +1313,21 @@ func main() {
 		select {
 		case <-done:
 			log.Info().Msg("gRPC server stopped gracefully")
+			return nil
 		case <-shutdownCtx.Done():
-			// Force-cancel to stay bounded, but mark the shutdown unclean so it
-			// can't vouch the pool receipt. Return nil (below) so the remaining
-			// closers still flush state.
-			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; marking shutdown unclean")
+			// Stop() closes transports but does NOT wait for handler goroutines
+			// (no WaitForHandlers — deliberately, so a handler that detached its
+			// context via WithoutCancel can't defeat the shutdown bound). Those
+			// handlers may still be using the store/pool/DB, so return an error:
+			// the shutdown loop then ABORTS the remaining dependency closers
+			// instead of closing resources out from under a live handler, and
+			// process exit reclaims everything together. Marked unclean so the
+			// next boot reconciles.
+			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; aborting remaining cleanup")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()
+			return fmt.Errorf("forced gRPC stop; handlers may still be running")
 		}
-		return nil
 	})
 
 	// Fast pre-serve init is done (slots reserved, namespaces swept, pool fill

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -284,11 +284,11 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // A closer that ignores cancellation must not stall the closers after it or
 // hang the process — the loop aborts the graceful sequence if one overruns,
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
-// force-cancels active RPCs, aborts the remaining closers (a forced stop leaves
-// handlers running — see the gRPC closer), and marks the shutdown unclean — a
-// circuit breaker (overrun costs a reconcile), not a proven-safe cancellation
-// bound. Chosen to sit under the 30s overall shutdown budget and the unit's
-// TimeoutStopSec backstop, leaving room for the closers after it.
+// force-cancels active RPCs, aborts the remaining closers, and marks the
+// shutdown unclean — a circuit breaker (overrun costs a reconcile), not a
+// proven-safe cancellation bound. Chosen to sit under the 30s overall shutdown
+// budget and the unit's TimeoutStopSec backstop, leaving room for the closers
+// after it.
 var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
@@ -1315,14 +1315,11 @@ func main() {
 			log.Info().Msg("gRPC server stopped gracefully")
 			return nil
 		case <-shutdownCtx.Done():
-			// Stop() closes transports but does NOT wait for handler goroutines
-			// (no WaitForHandlers — deliberately, so a handler that detached its
-			// context via WithoutCancel can't defeat the shutdown bound). Those
-			// handlers may still be using the store/pool/DB, so return an error:
-			// the shutdown loop then ABORTS the remaining dependency closers
-			// instead of closing resources out from under a live handler, and
-			// process exit reclaims everything together. Marked unclean so the
-			// next boot reconciles.
+			// Stop() force-cancels transports but does not wait for handlers (no
+			// WaitForHandlers — that would let a WithoutCancel handler defeat the
+			// bound), so they may still be using the store/pool/DB. Return an
+			// error to abort the remaining closers rather than close those under
+			// a live handler; process exit reclaims the rest.
 			log.Warn().Msg("graceful shutdown timed out — forcing gRPC stop; aborting remaining cleanup")
 			lc.noteForcedRPCStop()
 			grpcServer.Stop()

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -276,15 +276,19 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // ponytail: a circuit-breaker budget, not a correctness assumption — tune freely.
 var perCloserShutdownTimeout = 12 * time.Second
 
-// shutdown runs every registered closer in reverse (dependency) order. A
-// closer that RETURNS an error is logged and the loop continues — it is done
-// touching its resources, so its dependencies are safe to close. A closer that
-// OVERRUNS its deadline is still running, so the loop must NOT keep closing the
-// dependencies it may still be using (use-after-close): it records the failure
-// and aborts the sequence, leaving the rest to process exit (and systemd
-// TimeoutStopSec). Each closer runs under its own deadline and off the main
-// goroutine. Any failed or timed-out closer records closerErr, which bars this
-// shutdown from vouching for inventory it may have left inconsistent.
+// shutdown runs registered closers in reverse (dependency) order, each under
+// its own deadline and off the main goroutine. Any non-nil outcome — a returned
+// error OR an overrun deadline — aborts the sequence rather than continuing.
+// The two are indistinguishable and both unsafe to continue past: a closer that
+// returns ctx.Err() at its deadline (the uploader and flow sink do) may still
+// have a worker touching the resources its dependencies own, and at the
+// deadline the select can receive that error from done instead of selecting
+// closerCtx.Done(). Because closers run in dependency order, continuing would
+// close BoltDB/GCS/DB out from under a live worker — a use-after-close. On
+// abort the remaining descriptors are reclaimed by process exit (systemd
+// TimeoutStopSec is the final backstop), and the recorded closerErr bars this
+// shutdown from vouching for inventory it may have left inconsistent. A clean
+// shutdown returns nil from every closer and closes the whole chain.
 func (lc *lifecycle) shutdown(ctx context.Context) {
 	lc.mu.Lock()
 	closers := slices.Clone(lc.closers)
@@ -299,18 +303,17 @@ func (lc *lifecycle) shutdown(ctx context.Context) {
 		// forever on a receiver that has moved on.
 		done := make(chan error, 1)
 		go func() { done <- c.close(closerCtx) }()
+		var err error
 		select {
-		case err := <-done:
-			cancel()
-			if err != nil {
-				lc.log.Error().Err(err).Str("service", c.name).Msg("close returned error")
-				lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
-			}
+		case err = <-done:
 		case <-closerCtx.Done():
-			cancel()
-			lc.log.Error().Str("service", c.name).Dur("deadline", perCloserShutdownTimeout).
-				Msg("closer exceeded its shutdown deadline; aborting graceful shutdown")
-			lc.recordCloserErr(fmt.Errorf("%s: shutdown deadline exceeded", c.name))
+			err = fmt.Errorf("shutdown deadline exceeded")
+		}
+		cancel()
+		if err != nil {
+			lc.log.Error().Err(err).Str("service", c.name).
+				Msg("closer failed or overran; aborting graceful shutdown")
+			lc.recordCloserErr(fmt.Errorf("%s: %w", c.name, err))
 			return
 		}
 	}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -286,8 +286,9 @@ func (lc *lifecycle) wait(ctx context.Context) {
 // so total shutdown stays bounded. Bounding the gRPC drain, a hit budget
 // force-cancels active RPCs and marks the shutdown unclean (see the gRPC
 // closer) — a circuit breaker (overrun costs a reconcile), not a proven-safe
-// cancellation bound. systemd TimeoutStopSec is the final backstop.
-var perCloserShutdownTimeout = 12 * time.Second
+// cancellation bound. Chosen to sit under the 30s overall shutdown budget and
+// the unit's TimeoutStopSec backstop, leaving room for the closers after it.
+var perCloserShutdownTimeout = 15 * time.Second
 
 // shutdown runs registered closers in reverse (dependency) order, each under
 // its own deadline and off the main goroutine. Any non-nil outcome — a returned

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -157,6 +157,18 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 			t.Fatal("a failing closer must disqualify")
 		}
 	})
+
+	t.Run("forced gRPC stop", func(t *testing.T) {
+		// A drain that overran its budget and force-cancelled active RPCs may
+		// have left state the next boot must reconcile — never a clean handoff.
+		lc := newLifecycle(log)
+		lc.noteSignalInitiated()
+		lc.noteForcedRPCStop()
+		lc.shutdown(context.Background())
+		if lc.cleanIntentionalShutdown() {
+			t.Fatal("a forced gRPC stop must disqualify")
+		}
+	})
 }
 
 // A closer that fails or overruns may still have a worker touching its

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -155,4 +157,32 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 			t.Fatal("a failing closer must disqualify")
 		}
 	})
+}
+
+// A closer that ignores cancellation must be abandoned rather than hang the
+// daemon: shutdown stays bounded and the closers after it still run.
+func TestShutdownAbandonsWedgedCloser(t *testing.T) {
+	prev := perCloserShutdownTimeout
+	perCloserShutdownTimeout = 50 * time.Millisecond
+	defer func() { perCloserShutdownTimeout = prev }()
+
+	lc := newLifecycle(zerolog.Nop())
+	var earliestRan atomic.Bool
+	// LIFO shutdown: registered A, B, C runs as C, B, A. B wedges in the
+	// middle; A (registered first, run last) proves the loop moved past it.
+	lc.addCloser("A-earliest", func(context.Context) error { earliestRan.Store(true); return nil })
+	lc.addCloser("B-wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
+	lc.addCloser("C-latest", func(context.Context) error { return nil })
+
+	start := time.Now()
+	lc.shutdown(context.Background())
+	if d := time.Since(start); d > 2*time.Second {
+		t.Fatalf("shutdown not bounded: took %v", d)
+	}
+	if !earliestRan.Load() {
+		t.Fatal("closer after the wedged one never ran — abandonment failed")
+	}
+	if lc.closerErr == nil {
+		t.Fatal("wedged closer must record closerErr (bars vouching)")
+	}
 }

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -159,32 +159,50 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 	})
 }
 
-// A closer that overruns its deadline is still running, so shutdown must abort
-// rather than close the dependency it may still be using out from under it. The
-// sequence stays bounded and records the failure.
-func TestShutdownAbortsOnWedgedCloser(t *testing.T) {
+// A closer that fails or overruns may still have a worker touching its
+// dependencies' resources, so shutdown must abort rather than close those
+// dependencies out from under it. Covers all three failure shapes; each must
+// leave the dependency unclosed, stay bounded, and record the error.
+func TestShutdownAbortsOnCloserFailure(t *testing.T) {
 	prev := perCloserShutdownTimeout
 	perCloserShutdownTimeout = 50 * time.Millisecond
 	defer func() { perCloserShutdownTimeout = prev }()
 
-	lc := newLifecycle(zerolog.Nop())
-	var depClosed atomic.Bool
-	// LIFO shutdown: registered dep, wedged, latest runs as latest, wedged,
-	// dep. dep (registered first, run last) is the wedged closer's dependency;
-	// it must NOT be closed while the wedged closer is still running.
-	lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
-	lc.addCloser("wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
-	lc.addCloser("latest", func(context.Context) error { return nil })
+	run := func(t *testing.T, failing func(context.Context) error) {
+		lc := newLifecycle(zerolog.Nop())
+		var depClosed atomic.Bool
+		// LIFO shutdown: registered dep, failing, latest runs as latest,
+		// failing, dep. dep (registered first, run last) is the failing
+		// closer's dependency and must NOT be closed after the abort.
+		lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
+		lc.addCloser("failing", failing)
+		lc.addCloser("latest", func(context.Context) error { return nil })
 
-	start := time.Now()
-	lc.shutdown(context.Background())
-	if d := time.Since(start); d > 2*time.Second {
-		t.Fatalf("shutdown not bounded: took %v", d)
+		start := time.Now()
+		lc.shutdown(context.Background())
+		if d := time.Since(start); d > 2*time.Second {
+			t.Fatalf("shutdown not bounded: took %v", d)
+		}
+		if depClosed.Load() {
+			t.Fatal("dependency closed after a failed/overrun closer — must abort instead")
+		}
+		if lc.closerErr == nil {
+			t.Fatal("failed closer must record closerErr (bars vouching)")
+		}
 	}
-	if depClosed.Load() {
-		t.Fatal("dependency closed under a still-running closer — must abort instead")
-	}
-	if lc.closerErr == nil {
-		t.Fatal("wedged closer must record closerErr (bars vouching)")
-	}
+
+	// Respects ctx and returns ctx.Err() at its deadline — its worker may still
+	// be live, and the outer select can receive this from done instead of
+	// selecting closerCtx.Done(). Must still abort.
+	t.Run("returns ctx.Err at deadline", func(t *testing.T) {
+		run(t, func(ctx context.Context) error { <-ctx.Done(); return ctx.Err() })
+	})
+	// Returns a plain error promptly — the done branch must also abort.
+	t.Run("returns error", func(t *testing.T) {
+		run(t, func(context.Context) error { return fmt.Errorf("boom") })
+	})
+	// Ignores ctx entirely and never returns — the deadline branch aborts.
+	t.Run("wedged, ignores ctx", func(t *testing.T) {
+		run(t, func(context.Context) error { select {} }) // ponytail: never returns
+	})
 }

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -159,28 +159,30 @@ func TestLifecycle_CleanIntentionalShutdownGate(t *testing.T) {
 	})
 }
 
-// A closer that ignores cancellation must be abandoned rather than hang the
-// daemon: shutdown stays bounded and the closers after it still run.
-func TestShutdownAbandonsWedgedCloser(t *testing.T) {
+// A closer that overruns its deadline is still running, so shutdown must abort
+// rather than close the dependency it may still be using out from under it. The
+// sequence stays bounded and records the failure.
+func TestShutdownAbortsOnWedgedCloser(t *testing.T) {
 	prev := perCloserShutdownTimeout
 	perCloserShutdownTimeout = 50 * time.Millisecond
 	defer func() { perCloserShutdownTimeout = prev }()
 
 	lc := newLifecycle(zerolog.Nop())
-	var earliestRan atomic.Bool
-	// LIFO shutdown: registered A, B, C runs as C, B, A. B wedges in the
-	// middle; A (registered first, run last) proves the loop moved past it.
-	lc.addCloser("A-earliest", func(context.Context) error { earliestRan.Store(true); return nil })
-	lc.addCloser("B-wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
-	lc.addCloser("C-latest", func(context.Context) error { return nil })
+	var depClosed atomic.Bool
+	// LIFO shutdown: registered dep, wedged, latest runs as latest, wedged,
+	// dep. dep (registered first, run last) is the wedged closer's dependency;
+	// it must NOT be closed while the wedged closer is still running.
+	lc.addCloser("dep", func(context.Context) error { depClosed.Store(true); return nil })
+	lc.addCloser("wedged", func(context.Context) error { select {} }) // ponytail: never returns, ignores ctx
+	lc.addCloser("latest", func(context.Context) error { return nil })
 
 	start := time.Now()
 	lc.shutdown(context.Background())
 	if d := time.Since(start); d > 2*time.Second {
 		t.Fatalf("shutdown not bounded: took %v", d)
 	}
-	if !earliestRan.Load() {
-		t.Fatal("closer after the wedged one never ran — abandonment failed")
+	if depClosed.Load() {
+		t.Fatal("dependency closed under a still-running closer — must abort instead")
 	}
 	if lc.closerErr == nil {
 		t.Fatal("wedged closer must record closerErr (bars vouching)")

--- a/deploy/superserve-vmd.service
+++ b/deploy/superserve-vmd.service
@@ -38,6 +38,12 @@ Delegate=yes
 Restart=always
 RestartSec=2
 
+# Bounded stop: vmd runs its own per-closer-deadline shutdown and exits well
+# within this window. If the process itself wedges, systemd force-kills here
+# rather than letting a stop drag on (the default is 90s). Set above vmd's
+# internal shutdown budget so a healthy stop always completes on its own first.
+TimeoutStopSec=45s
+
 # Environment
 EnvironmentFile=/etc/sandbox/vmd.env
 


### PR DESCRIPTION
Deploy-safety fixes for the vmd CD path. Fresh PR — supersedes the previous one, whose head got stuck after a branch rewind; identical content at `edcb151a`. The startup-observability work lives in its own PR and is intentionally NOT here, so this can deploy once on its own.

**Deploy ordering.** The early service stop is gated to the exceptional cases only (first socket migration / socket-definition change), and stops both the socket and the service so no interim vmd can socket-activate during the window. Steady-state deploys keep the socket up and do a single restart with connections backlogging — no throwaway-vmd double-restart.

**Bounded, abort-safe shutdown.** Each closer runs under its own deadline off the main goroutine; any error or overrun aborts the remaining dependency closers (no use-after-close) and leaves reclamation to process exit. A forced gRPC stop (drain budget exceeded) marks the shutdown unclean so it can't vouch the pool receipt, and returns an error so it aborts too — `grpc.Server.Stop()` doesn't wait for handlers, and detached (`WithoutCancel`) handlers like ResumeVM can still be using the store/pool/DB. `TimeoutStopSec` is the systemd backstop.

**Application-aware deploy readiness.** After the restart the script waits for vmd's real request gate (the `startupReady` log line) rather than `is-active` (which, for a `Type=simple` unit, only proves the process forked). The wait is scoped to the current systemd invocation (so a crashed-and-replaced process can't false-pass) and drives off `journalctl` exit status, not captured stdout (which would read `-- No entries --` as a false ready).

Tests: lifecycle/shutdown unit tests (incl. forced-stop, abort-on-error) and Python deploy-ordering tests (guarded stop, single restart, exit-status readiness with a no-match case) — now run in CI.
