### PR TITLE
api: carry preview access in the sandbox list query instead of a team-wide fetch

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -119,28 +119,38 @@ WHERE base_path IS NOT NULL AND destroyed_at IS NULL;
 -- name/status sorts stay on the flexible query below. Filters and pagination
 -- are identical to the flexible query, including the NULL @row_limit "return
 -- everything" contract.
+--
+-- All three carry the effective preview access, so the list decorates its page
+-- from one round trip. The join is 1:1 on sandbox_preview_policy's primary key,
+-- so it cannot multiply rows and leaves the LIMIT pushdown intact.
 
 -- name: ListSandboxesByTeamCreatedDesc :many
-SELECT * FROM sandbox
-WHERE team_id = @team_id
-  AND destroyed_at IS NULL
-  AND metadata @> @metadata
-  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+SELECT sqlc.embed(s),
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = @team_id
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR s.status::text = sqlc.narg('status')::text)
   AND (sqlc.narg('name_search')::text IS NULL
-       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
-ORDER BY created_at DESC
+       OR s.name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+ORDER BY s.created_at DESC
 LIMIT sqlc.narg('row_limit')::bigint
 OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
 
 -- name: ListSandboxesByTeamCreatedAsc :many
-SELECT * FROM sandbox
-WHERE team_id = @team_id
-  AND destroyed_at IS NULL
-  AND metadata @> @metadata
-  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+SELECT sqlc.embed(s),
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = @team_id
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR s.status::text = sqlc.narg('status')::text)
   AND (sqlc.narg('name_search')::text IS NULL
-       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
-ORDER BY created_at ASC
+       OR s.name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+ORDER BY s.created_at ASC
 LIMIT sqlc.narg('row_limit')::bigint
 OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
 
@@ -158,20 +168,23 @@ OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
 -- no-op), with created_at DESC as the stable tiebreaker and default. A NULL
 -- @row_limit returns all rows, preserving the pre-pagination "return
 -- everything" default so unpaginated SDK/MCP callers are unaffected.
-SELECT * FROM sandbox
-WHERE team_id = @team_id
-  AND destroyed_at IS NULL
-  AND metadata @> @metadata
-  AND (sqlc.narg('status')::text IS NULL OR status::text = sqlc.narg('status')::text)
+SELECT sqlc.embed(s),
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = @team_id
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> @metadata
+  AND (sqlc.narg('status')::text IS NULL OR s.status::text = sqlc.narg('status')::text)
   AND (sqlc.narg('name_search')::text IS NULL
-       OR name ILIKE '%' || sqlc.narg('name_search')::text || '%')
+       OR s.name ILIKE '%' || sqlc.narg('name_search')::text || '%')
 ORDER BY
-  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'asc'  THEN name END ASC,
-  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'desc' THEN name END DESC,
-  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'asc'  THEN status::text END ASC,
-  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'desc' THEN status::text END DESC,
-  CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN created_at END ASC,
-  created_at DESC
+  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'asc'  THEN s.name END ASC,
+  CASE WHEN @sort_by::text = 'name'   AND @sort_dir::text = 'desc' THEN s.name END DESC,
+  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'asc'  THEN s.status::text END ASC,
+  CASE WHEN @sort_by::text = 'status' AND @sort_dir::text = 'desc' THEN s.status::text END DESC,
+  CASE WHEN @sort_by::text = 'created_at' AND @sort_dir::text = 'asc' THEN s.created_at END ASC,
+  s.created_at DESC
 LIMIT sqlc.narg('row_limit')::bigint
 OFFSET COALESCE(sqlc.narg('row_offset')::bigint, 0);
 
@@ -634,15 +647,6 @@ SELECT sqlc.embed(s),
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
 WHERE s.id = $1 AND s.team_id = $2 AND s.destroyed_at IS NULL;
-
--- name: ListSandboxPreviewPoliciesByTeam :many
-SELECT
-  s.id AS sandbox_id,
-  COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
-  COALESCE(p.revision, 0)::bigint AS revision
-FROM sandbox s
-LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
-WHERE s.team_id = $1 AND s.destroyed_at IS NULL;
 
 -- name: LockSandboxForPreviewMutation :one
 -- The sandbox row exists for both legacy (no policy row) and strict sandboxes,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1746,29 +1746,45 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 	// queries the planner can serve from idx_sandbox_team_created_active
 	// instead of sorting the whole filtered set. The rare console-only
 	// name/status sorts stay on the flexible CASE-based query.
-	var sandboxes []db.Sandbox
-	if pg.SortBy == "created_at" {
-		if pg.SortDir == "asc" {
-			sandboxes, err = h.DB.ListSandboxesByTeamCreatedAsc(ctx, db.ListSandboxesByTeamCreatedAscParams{
-				TeamID:     teamID,
-				Metadata:   metadataJSON,
-				Status:     statusFilter,
-				NameSearch: nameSearch,
-				RowOffset:  pg.Offset,
-				RowLimit:   pg.Limit,
-			})
-		} else {
-			sandboxes, err = h.DB.ListSandboxesByTeamCreatedDesc(ctx, db.ListSandboxesByTeamCreatedDescParams{
-				TeamID:     teamID,
-				Metadata:   metadataJSON,
-				Status:     statusFilter,
-				NameSearch: nameSearch,
-				RowOffset:  pg.Offset,
-				RowLimit:   pg.Limit,
-			})
+	// The three variants differ only in ORDER BY, but sqlc names a row type per
+	// query; normalize so the response build below stays one pass.
+	type listRow struct {
+		sandbox       db.Sandbox
+		previewAccess string
+	}
+	var sandboxes []listRow
+	switch {
+	case pg.SortBy == "created_at" && pg.SortDir == "asc":
+		var rows []db.ListSandboxesByTeamCreatedAscRow
+		rows, err = h.DB.ListSandboxesByTeamCreatedAsc(ctx, db.ListSandboxesByTeamCreatedAscParams{
+			TeamID:     teamID,
+			Metadata:   metadataJSON,
+			Status:     statusFilter,
+			NameSearch: nameSearch,
+			RowOffset:  pg.Offset,
+			RowLimit:   pg.Limit,
+		})
+		sandboxes = make([]listRow, len(rows))
+		for i, r := range rows {
+			sandboxes[i] = listRow{sandbox: r.Sandbox, previewAccess: r.PreviewAccess}
 		}
-	} else {
-		sandboxes, err = h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
+	case pg.SortBy == "created_at":
+		var rows []db.ListSandboxesByTeamCreatedDescRow
+		rows, err = h.DB.ListSandboxesByTeamCreatedDesc(ctx, db.ListSandboxesByTeamCreatedDescParams{
+			TeamID:     teamID,
+			Metadata:   metadataJSON,
+			Status:     statusFilter,
+			NameSearch: nameSearch,
+			RowOffset:  pg.Offset,
+			RowLimit:   pg.Limit,
+		})
+		sandboxes = make([]listRow, len(rows))
+		for i, r := range rows {
+			sandboxes[i] = listRow{sandbox: r.Sandbox, previewAccess: r.PreviewAccess}
+		}
+	default:
+		var rows []db.ListSandboxesByTeamPagedRow
+		rows, err = h.DB.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
 			TeamID:     teamID,
 			Metadata:   metadataJSON,
 			Status:     statusFilter,
@@ -1778,6 +1794,10 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 			RowOffset:  pg.Offset,
 			RowLimit:   pg.Limit,
 		})
+		sandboxes = make([]listRow, len(rows))
+		for i, r := range rows {
+			sandboxes[i] = listRow{sandbox: r.Sandbox, previewAccess: r.PreviewAccess}
+		}
 	}
 	if err != nil {
 		log.Error().Err(err).Msg("DB list sandboxes by team failed")
@@ -1799,23 +1819,11 @@ func (h *Handlers) ListSandboxes(c *gin.Context) {
 		return
 	}
 	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
-	policies, err := h.DB.ListSandboxPreviewPoliciesByTeam(ctx, teamID)
-	if err != nil {
-		log.Error().Err(err).Msg("DB ListSandboxPreviewPoliciesByTeam failed")
-		respondError(c, ErrInternal)
-		return
-	}
-	previewAccessBySandbox := make(map[uuid.UUID]string, len(policies))
-	for _, policy := range policies {
-		previewAccessBySandbox[policy.SandboxID] = policy.Access
-	}
 
 	out := make([]sandboxResponse, len(sandboxes))
 	for i, s := range sandboxes {
-		out[i] = h.sandboxToResponse(s)
-		if access, ok := previewAccessBySandbox[s.ID]; ok {
-			out[i].PreviewAccess = access
-		}
+		out[i] = h.sandboxToResponse(s.sandbox)
+		out[i].PreviewAccess = s.previewAccess
 	}
 	c.JSON(http.StatusOK, out)
 }

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1791,42 +1791,6 @@ func (q *Queries) ListRecentlyDestroyedSandboxIDsByHost(ctx context.Context, arg
 	return items, nil
 }
 
-const listSandboxPreviewPoliciesByTeam = `-- name: ListSandboxPreviewPoliciesByTeam :many
-SELECT
-  s.id AS sandbox_id,
-  COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
-  COALESCE(p.revision, 0)::bigint AS revision
-FROM sandbox s
-LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
-WHERE s.team_id = $1 AND s.destroyed_at IS NULL
-`
-
-type ListSandboxPreviewPoliciesByTeamRow struct {
-	SandboxID uuid.UUID `json:"sandbox_id"`
-	Access    string    `json:"access"`
-	Revision  int64     `json:"revision"`
-}
-
-func (q *Queries) ListSandboxPreviewPoliciesByTeam(ctx context.Context, teamID uuid.UUID) ([]ListSandboxPreviewPoliciesByTeamRow, error) {
-	rows, err := q.db.Query(ctx, listSandboxPreviewPoliciesByTeam, teamID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListSandboxPreviewPoliciesByTeamRow{}
-	for rows.Next() {
-		var i ListSandboxPreviewPoliciesByTeamRow
-		if err := rows.Scan(&i.SandboxID, &i.Access, &i.Revision); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listSandboxesByHost = `-- name: ListSandboxesByHost :many
 SELECT s.id, s.status, s.snapshot_id
 FROM sandbox s
@@ -1866,14 +1830,17 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 }
 
 const listSandboxesByTeamCreatedAsc = `-- name: ListSandboxesByTeamCreatedAsc :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
-WHERE team_id = $1
-  AND destroyed_at IS NULL
-  AND metadata @> $2
-  AND ($3::text IS NULL OR status::text = $3::text)
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at,
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = $1
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> $2
+  AND ($3::text IS NULL OR s.status::text = $3::text)
   AND ($4::text IS NULL
-       OR name ILIKE '%' || $4::text || '%')
-ORDER BY created_at ASC
+       OR s.name ILIKE '%' || $4::text || '%')
+ORDER BY s.created_at ASC
 LIMIT $6::bigint
 OFFSET COALESCE($5::bigint, 0)
 `
@@ -1887,7 +1854,12 @@ type ListSandboxesByTeamCreatedAscParams struct {
 	RowLimit   *int64    `json:"row_limit"`
 }
 
-func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSandboxesByTeamCreatedAscParams) ([]Sandbox, error) {
+type ListSandboxesByTeamCreatedAscRow struct {
+	Sandbox       Sandbox `json:"sandbox"`
+	PreviewAccess string  `json:"preview_access"`
+}
+
+func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSandboxesByTeamCreatedAscParams) ([]ListSandboxesByTeamCreatedAscRow, error) {
 	rows, err := q.db.Query(ctx, listSandboxesByTeamCreatedAsc,
 		arg.TeamID,
 		arg.Metadata,
@@ -1900,35 +1872,36 @@ func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSan
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Sandbox{}
+	items := []ListSandboxesByTeamCreatedAscRow{}
 	for rows.Next() {
-		var i Sandbox
+		var i ListSandboxesByTeamCreatedAscRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Status,
-			&i.VcpuCount,
-			&i.MemoryMib,
-			&i.HostID,
-			&i.IpAddress,
-			&i.Pid,
-			&i.SnapshotID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DestroyedAt,
-			&i.NetworkConfig,
-			&i.TimeoutSeconds,
-			&i.Metadata,
-			&i.TemplateID,
-			&i.SnapshotPath,
-			&i.MemPath,
-			&i.BasePath,
-			&i.DeltaPath,
-			&i.DiskMib,
-			&i.AutoDeleteSeconds,
-			&i.AutoDeleteAt,
-			&i.FailedAt,
+			&i.Sandbox.ID,
+			&i.Sandbox.TeamID,
+			&i.Sandbox.Name,
+			&i.Sandbox.Status,
+			&i.Sandbox.VcpuCount,
+			&i.Sandbox.MemoryMib,
+			&i.Sandbox.HostID,
+			&i.Sandbox.IpAddress,
+			&i.Sandbox.Pid,
+			&i.Sandbox.SnapshotID,
+			&i.Sandbox.CreatedAt,
+			&i.Sandbox.UpdatedAt,
+			&i.Sandbox.DestroyedAt,
+			&i.Sandbox.NetworkConfig,
+			&i.Sandbox.TimeoutSeconds,
+			&i.Sandbox.Metadata,
+			&i.Sandbox.TemplateID,
+			&i.Sandbox.SnapshotPath,
+			&i.Sandbox.MemPath,
+			&i.Sandbox.BasePath,
+			&i.Sandbox.DeltaPath,
+			&i.Sandbox.DiskMib,
+			&i.Sandbox.AutoDeleteSeconds,
+			&i.Sandbox.AutoDeleteAt,
+			&i.Sandbox.FailedAt,
+			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
 		}
@@ -1942,14 +1915,17 @@ func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSan
 
 const listSandboxesByTeamCreatedDesc = `-- name: ListSandboxesByTeamCreatedDesc :many
 
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
-WHERE team_id = $1
-  AND destroyed_at IS NULL
-  AND metadata @> $2
-  AND ($3::text IS NULL OR status::text = $3::text)
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at,
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = $1
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> $2
+  AND ($3::text IS NULL OR s.status::text = $3::text)
   AND ($4::text IS NULL
-       OR name ILIKE '%' || $4::text || '%')
-ORDER BY created_at DESC
+       OR s.name ILIKE '%' || $4::text || '%')
+ORDER BY s.created_at DESC
 LIMIT $6::bigint
 OFFSET COALESCE($5::bigint, 0)
 `
@@ -1963,6 +1939,11 @@ type ListSandboxesByTeamCreatedDescParams struct {
 	RowLimit   *int64    `json:"row_limit"`
 }
 
+type ListSandboxesByTeamCreatedDescRow struct {
+	Sandbox       Sandbox `json:"sandbox"`
+	PreviewAccess string  `json:"preview_access"`
+}
+
 // Static created_at variants of ListSandboxesByTeamPaged. The plain ORDER BY
 // lets the planner walk idx_sandbox_team_created_active (forward for DESC,
 // backward for ASC) and stop at LIMIT, where the guarded-CASE ORDER BY in
@@ -1972,7 +1953,11 @@ type ListSandboxesByTeamCreatedDescParams struct {
 // name/status sorts stay on the flexible query below. Filters and pagination
 // are identical to the flexible query, including the NULL @row_limit "return
 // everything" contract.
-func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSandboxesByTeamCreatedDescParams) ([]Sandbox, error) {
+//
+// All three carry the effective preview access, so the list decorates its page
+// from one round trip. The join is 1:1 on sandbox_preview_policy's primary key,
+// so it cannot multiply rows and leaves the LIMIT pushdown intact.
+func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSandboxesByTeamCreatedDescParams) ([]ListSandboxesByTeamCreatedDescRow, error) {
 	rows, err := q.db.Query(ctx, listSandboxesByTeamCreatedDesc,
 		arg.TeamID,
 		arg.Metadata,
@@ -1985,35 +1970,36 @@ func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSa
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Sandbox{}
+	items := []ListSandboxesByTeamCreatedDescRow{}
 	for rows.Next() {
-		var i Sandbox
+		var i ListSandboxesByTeamCreatedDescRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Status,
-			&i.VcpuCount,
-			&i.MemoryMib,
-			&i.HostID,
-			&i.IpAddress,
-			&i.Pid,
-			&i.SnapshotID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DestroyedAt,
-			&i.NetworkConfig,
-			&i.TimeoutSeconds,
-			&i.Metadata,
-			&i.TemplateID,
-			&i.SnapshotPath,
-			&i.MemPath,
-			&i.BasePath,
-			&i.DeltaPath,
-			&i.DiskMib,
-			&i.AutoDeleteSeconds,
-			&i.AutoDeleteAt,
-			&i.FailedAt,
+			&i.Sandbox.ID,
+			&i.Sandbox.TeamID,
+			&i.Sandbox.Name,
+			&i.Sandbox.Status,
+			&i.Sandbox.VcpuCount,
+			&i.Sandbox.MemoryMib,
+			&i.Sandbox.HostID,
+			&i.Sandbox.IpAddress,
+			&i.Sandbox.Pid,
+			&i.Sandbox.SnapshotID,
+			&i.Sandbox.CreatedAt,
+			&i.Sandbox.UpdatedAt,
+			&i.Sandbox.DestroyedAt,
+			&i.Sandbox.NetworkConfig,
+			&i.Sandbox.TimeoutSeconds,
+			&i.Sandbox.Metadata,
+			&i.Sandbox.TemplateID,
+			&i.Sandbox.SnapshotPath,
+			&i.Sandbox.MemPath,
+			&i.Sandbox.BasePath,
+			&i.Sandbox.DeltaPath,
+			&i.Sandbox.DiskMib,
+			&i.Sandbox.AutoDeleteSeconds,
+			&i.Sandbox.AutoDeleteAt,
+			&i.Sandbox.FailedAt,
+			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
 		}
@@ -2026,20 +2012,23 @@ func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSa
 }
 
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at FROM sandbox
-WHERE team_id = $1
-  AND destroyed_at IS NULL
-  AND metadata @> $2
-  AND ($3::text IS NULL OR status::text = $3::text)
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at,
+  COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
+FROM sandbox s
+LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
+WHERE s.team_id = $1
+  AND s.destroyed_at IS NULL
+  AND s.metadata @> $2
+  AND ($3::text IS NULL OR s.status::text = $3::text)
   AND ($4::text IS NULL
-       OR name ILIKE '%' || $4::text || '%')
+       OR s.name ILIKE '%' || $4::text || '%')
 ORDER BY
-  CASE WHEN $5::text = 'name'   AND $6::text = 'asc'  THEN name END ASC,
-  CASE WHEN $5::text = 'name'   AND $6::text = 'desc' THEN name END DESC,
-  CASE WHEN $5::text = 'status' AND $6::text = 'asc'  THEN status::text END ASC,
-  CASE WHEN $5::text = 'status' AND $6::text = 'desc' THEN status::text END DESC,
-  CASE WHEN $5::text = 'created_at' AND $6::text = 'asc' THEN created_at END ASC,
-  created_at DESC
+  CASE WHEN $5::text = 'name'   AND $6::text = 'asc'  THEN s.name END ASC,
+  CASE WHEN $5::text = 'name'   AND $6::text = 'desc' THEN s.name END DESC,
+  CASE WHEN $5::text = 'status' AND $6::text = 'asc'  THEN s.status::text END ASC,
+  CASE WHEN $5::text = 'status' AND $6::text = 'desc' THEN s.status::text END DESC,
+  CASE WHEN $5::text = 'created_at' AND $6::text = 'asc' THEN s.created_at END ASC,
+  s.created_at DESC
 LIMIT $8::bigint
 OFFSET COALESCE($7::bigint, 0)
 `
@@ -2055,6 +2044,11 @@ type ListSandboxesByTeamPagedParams struct {
 	RowLimit   *int64    `json:"row_limit"`
 }
 
+type ListSandboxesByTeamPagedRow struct {
+	Sandbox       Sandbox `json:"sandbox"`
+	PreviewAccess string  `json:"preview_access"`
+}
+
 // Paginated, sortable, filterable team sandbox list backing the console. Only
 // serves the non-default sorts (name/status); the default created_at sort is
 // handled by the static ListSandboxesByTeamCreated{Desc,Asc} queries above,
@@ -2068,7 +2062,7 @@ type ListSandboxesByTeamPagedParams struct {
 // no-op), with created_at DESC as the stable tiebreaker and default. A NULL
 // @row_limit returns all rows, preserving the pre-pagination "return
 // everything" default so unpaginated SDK/MCP callers are unaffected.
-func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxesByTeamPagedParams) ([]Sandbox, error) {
+func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxesByTeamPagedParams) ([]ListSandboxesByTeamPagedRow, error) {
 	rows, err := q.db.Query(ctx, listSandboxesByTeamPaged,
 		arg.TeamID,
 		arg.Metadata,
@@ -2083,35 +2077,36 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Sandbox{}
+	items := []ListSandboxesByTeamPagedRow{}
 	for rows.Next() {
-		var i Sandbox
+		var i ListSandboxesByTeamPagedRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.TeamID,
-			&i.Name,
-			&i.Status,
-			&i.VcpuCount,
-			&i.MemoryMib,
-			&i.HostID,
-			&i.IpAddress,
-			&i.Pid,
-			&i.SnapshotID,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.DestroyedAt,
-			&i.NetworkConfig,
-			&i.TimeoutSeconds,
-			&i.Metadata,
-			&i.TemplateID,
-			&i.SnapshotPath,
-			&i.MemPath,
-			&i.BasePath,
-			&i.DeltaPath,
-			&i.DiskMib,
-			&i.AutoDeleteSeconds,
-			&i.AutoDeleteAt,
-			&i.FailedAt,
+			&i.Sandbox.ID,
+			&i.Sandbox.TeamID,
+			&i.Sandbox.Name,
+			&i.Sandbox.Status,
+			&i.Sandbox.VcpuCount,
+			&i.Sandbox.MemoryMib,
+			&i.Sandbox.HostID,
+			&i.Sandbox.IpAddress,
+			&i.Sandbox.Pid,
+			&i.Sandbox.SnapshotID,
+			&i.Sandbox.CreatedAt,
+			&i.Sandbox.UpdatedAt,
+			&i.Sandbox.DestroyedAt,
+			&i.Sandbox.NetworkConfig,
+			&i.Sandbox.TimeoutSeconds,
+			&i.Sandbox.Metadata,
+			&i.Sandbox.TemplateID,
+			&i.Sandbox.SnapshotPath,
+			&i.Sandbox.MemPath,
+			&i.Sandbox.BasePath,
+			&i.Sandbox.DeltaPath,
+			&i.Sandbox.DiskMib,
+			&i.Sandbox.AutoDeleteSeconds,
+			&i.Sandbox.AutoDeleteAt,
+			&i.Sandbox.FailedAt,
+			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/integration/sandbox_list_preview_test.go
+++ b/internal/integration/sandbox_list_preview_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// A sandbox with no policy row must report the legacy default, one with a
+// policy its own value. Handler unit tests mock the DB, so only a real query
+// catches a join that drops rows or resolves the wrong column.
+func TestIntegration_ListSandboxesCarriesPreviewAccess(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+
+	legacyID := insertSandboxAt(t, teamID, "legacy-"+uuid.New().String()[:8], "active", time.Now().Add(-time.Minute))
+	strictID := insertSandboxAt(t, teamID, "strict-"+uuid.New().String()[:8], "active", time.Now())
+
+	if _, err := testPool.Exec(ctx,
+		`INSERT INTO sandbox_preview_policy (sandbox_id, access, default_access, revision)
+		 VALUES ($1, 'public', 'public', 1)`, strictID); err != nil {
+		t.Fatalf("insert preview policy: %v", err)
+	}
+
+	assertAccess := func(t *testing.T, name string, got map[uuid.UUID]string) {
+		t.Helper()
+		if len(got) != 2 {
+			t.Fatalf("%s: returned %d sandboxes, want 2", name, len(got))
+		}
+		if got[legacyID] != "legacy_public" {
+			t.Errorf("%s: no-policy sandbox access = %q, want legacy_public", name, got[legacyID])
+		}
+		if got[strictID] != "public" {
+			t.Errorf("%s: policy-bearing sandbox access = %q, want public", name, got[strictID])
+		}
+	}
+
+	descRows, err := testQueries.ListSandboxesByTeamCreatedDesc(ctx, db.ListSandboxesByTeamCreatedDescParams{
+		TeamID:   teamID,
+		Metadata: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("ListSandboxesByTeamCreatedDesc: %v", err)
+	}
+	desc := make(map[uuid.UUID]string, len(descRows))
+	for _, r := range descRows {
+		desc[r.Sandbox.ID] = r.PreviewAccess
+	}
+	assertAccess(t, "created_desc", desc)
+	// Newest first: the ordering must survive the join.
+	if descRows[0].Sandbox.ID != strictID {
+		t.Errorf("created_desc: first row = %s, want the newest sandbox %s", descRows[0].Sandbox.ID, strictID)
+	}
+
+	pagedRows, err := testQueries.ListSandboxesByTeamPaged(ctx, db.ListSandboxesByTeamPagedParams{
+		TeamID:   teamID,
+		Metadata: []byte(`{}`),
+		SortBy:   "name",
+		SortDir:  "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListSandboxesByTeamPaged: %v", err)
+	}
+	paged := make(map[uuid.UUID]string, len(pagedRows))
+	for _, r := range pagedRows {
+		paged[r.Sandbox.ID] = r.PreviewAccess
+	}
+	assertAccess(t, "paged", paged)
+}


### PR DESCRIPTION
Listing sandboxes fetched preview policies for the team's entire sandbox set and then used that map to decorate a single page, so the cost scaled with the tenant rather than the page — and it did so even for callers that paginate correctly. On the largest teams that is six figures of rows read per request.

The three list queries now carry the effective preview access through a LEFT JOIN, matching the shape GetSandboxWithPreviewPolicy already uses for single reads, and the team-wide query is removed. The join is 1:1 on the policy table's primary key, so it cannot multiply rows and the LIMIT still pushes down: EXPLAIN on the largest team shows a nested loop doing one primary-key lookup per returned row, reading 20 rows rather than the full set.

No response-shape or behavior change. Reading one snapshot also removes a small race where a sandbox destroyed between the two queries fell back to the default access. Integration test covers both the no-policy default and an explicit policy across the static and flexible query paths.