### PR TITLE
feat(boxd): support POSIX file mode on file upload

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1913,6 +1913,16 @@ paths:
       description: Creates parent directories as needed and overwrites any existing file.
       security:
         - accessToken: []
+      parameters:
+        - name: mode
+          in: query
+          required: false
+          description: >
+            Optional POSIX file permission mode in octal (e.g. `0755` for executable, `0644` for regular file).
+            Defaults to `0644`.
+          schema:
+            type: string
+            example: "0755"
       requestBody:
         required: true
         content:
@@ -3687,9 +3697,13 @@ components:
           type: integer
           format: int64
           description: Number of bytes written.
+        mode:
+          type: string
+          description: POSIX file mode string in octal representation (e.g. `0644`, `0755`).
       example:
         path: /home/user/out.txt
         size: 1024
+        mode: "0644"
 
     CreateSecretRequest:
       type: object

--- a/cmd/boxd/files_test.go
+++ b/cmd/boxd/files_test.go
@@ -755,3 +755,131 @@ func TestServeDirAsZip_AbortsOnCanceledContext(t *testing.T) {
 		t.Fatalf("zip walk wrote %d entries after the context was canceled; want 0 (aborted)", len(zr.File))
 	}
 }
+
+func TestFileUpload_DefaultMode(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "script.sh")
+	req := httptest.NewRequest(http.MethodPost, "/files?path="+url.QueryEscape(p), strings.NewReader("#!/bin/sh\necho hi\n"))
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["path"] != p {
+		t.Errorf("path = %v, want %q", resp["path"], p)
+	}
+	if resp["mode"] != "0644" {
+		t.Errorf("mode = %v, want 0644", resp["mode"])
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat uploaded file: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("file permissions = %04o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestFileUpload_CustomMode_Executable(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "run.sh")
+	req := httptest.NewRequest(http.MethodPost, "/files?path="+url.QueryEscape(p)+"&mode=0755", strings.NewReader("#!/bin/sh\necho executable\n"))
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["mode"] != "0755" {
+		t.Errorf("mode = %v, want 0755", resp["mode"])
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat uploaded file: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("file permissions = %04o, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestFileUpload_CustomMode_Prefixes(t *testing.T) {
+	cases := []struct {
+		modeQuery string
+		wantPerm  os.FileMode
+		wantMode  string
+	}{
+		{"700", 0o700, "0700"},
+		{"0600", 0o600, "0600"},
+		{"0o750", 0o750, "0750"},
+	}
+	for _, tc := range cases {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "test.bin")
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/files?path=%s&mode=%s", url.QueryEscape(p), tc.modeQuery), strings.NewReader("data"))
+		w := httptest.NewRecorder()
+		handleFiles(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("mode=%q: status = %d, want 200; body: %s", tc.modeQuery, w.Code, w.Body.String())
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if resp["mode"] != tc.wantMode {
+			t.Errorf("mode query %q: response mode = %v, want %q", tc.modeQuery, resp["mode"], tc.wantMode)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if info.Mode().Perm() != tc.wantPerm {
+			t.Errorf("mode query %q: perm = %04o, want %04o", tc.modeQuery, info.Mode().Perm(), tc.wantPerm)
+		}
+	}
+}
+
+func TestFileUpload_InvalidMode_Rejected(t *testing.T) {
+	invalidModes := []string{"invalid", "888", "01777", "999", "-1", "07777"}
+	dir := t.TempDir()
+	for _, m := range invalidModes {
+		p := filepath.Join(dir, "test.txt")
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/files?path=%s&mode=%s", url.QueryEscape(p), m), strings.NewReader("data"))
+		w := httptest.NewRecorder()
+		handleFiles(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("mode=%q: status = %d, want 400; body: %s", m, w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "mode") {
+			t.Errorf("mode=%q: body %q should mention mode", m, w.Body.String())
+		}
+	}
+}
+
+func TestFileUpload_OverwritesExistingFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "perm_change.sh")
+	if err := os.WriteFile(p, []byte("echo 1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/files?path="+url.QueryEscape(p)+"&mode=0755", strings.NewReader("echo 2"))
+	w := httptest.NewRecorder()
+	handleFiles(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("overwritten file perm = %04o, want 0755", info.Mode().Perm())
+	}
+}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1457,20 +1457,42 @@ func isStaleHandle(err error) bool {
 	return errors.Is(err, syscall.ESTALE)
 }
 
+// parseFileMode parses an optional octal mode string (e.g. "0755", "755", "0o755").
+// If raw is empty, it returns 0o644 (default regular file permissions).
+func parseFileMode(raw string) (fs.FileMode, error) {
+	if raw == "" {
+		return 0o644, nil
+	}
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(raw, "0o"), "0O")
+	val, err := strconv.ParseUint(cleaned, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid mode %q: must be an octal permission (e.g. 0755 or 0644)", raw)
+	}
+	if val > 0o777 {
+		return 0, fmt.Errorf("invalid mode %q: permission bits out of range (0000-0777)", raw)
+	}
+	return fs.FileMode(val), nil
+}
+
 // writeFileAttempt performs one mkdir+open+write+close cycle, copying
 // body into the file. It's split out so handleFileUpload can retry the
 // whole sequence on ESTALE — the mkdir and the open can each
 // independently observe a stale handle on the same mount. body is an
 // io.Reader rather than a []byte so the same function serves both the
 // buffered (retryable) and streamed (large-upload) paths.
-func writeFileAttempt(path string, body io.Reader) (int64, error) {
+func writeFileAttempt(path string, body io.Reader, mode fs.FileMode) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return 0, fmt.Errorf("mkdir: %w", err)
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return 0, fmt.Errorf("create file: %w", err)
+	}
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return 0, fmt.Errorf("chmod file: %w", err)
 	}
 
 	written, werr := io.Copy(f, body)
@@ -1487,6 +1509,11 @@ func writeFileAttempt(path string, body io.Reader) (int64, error) {
 }
 
 func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
+	mode, err := parseFileMode(r.URL.Query().Get("mode"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	// Peek up to the retry-buffer limit rather than reading the whole
 	// body blindly. If the body is larger than the limit, len(peeked)
 	// comes back as limit+1 without hitting EOF, and we fall through to
@@ -1505,12 +1532,12 @@ func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
 		// Too large to buffer at all, or the aggregate budget is
 		// currently claimed by other concurrent uploads -- stream
 		// through once with no retry rather than risk an OOM.
-		written, err = writeFileAttempt(path, io.MultiReader(bytes.NewReader(peeked), r.Body))
+		written, err = writeFileAttempt(path, io.MultiReader(bytes.NewReader(peeked), r.Body), mode)
 	} else {
 		defer releaseRetryBudget(peekedLen)
 		deadline := time.Now().Add(staleHandleRetryBudget)
 		for {
-			written, err = writeFileAttempt(path, bytes.NewReader(peeked))
+			written, err = writeFileAttempt(path, bytes.NewReader(peeked), mode)
 			if err == nil || !isStaleHandle(err) || time.Now().After(deadline) {
 				break
 			}
@@ -1531,5 +1558,9 @@ func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{"path": path, "size": written})
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"path": path,
+		"size": written,
+		"mode": fmt.Sprintf("%04o", mode),
+	})
 }


### PR DESCRIPTION
## Summary

When uploading files into a sandbox via `POST /files`, `boxd` previously created all files with hardcoded `0644` permissions. Setting executable bits or restricted file modes required an additional exec round-trip (e.g. `chmod +x`).

This change adds support for an optional `mode` query parameter on `POST /files` (e.g. `POST /files?path=/home/user/script.sh&mode=0755`):
- Parses octal mode strings (supporting formats like `0755`, `755`, `0o755`), defaulting to `0644`.
- Validates permissions within standard POSIX ranges (`0000`–`0777`) and returns `400 Bad Request` on malformed inputs before disk operations.
- Atomically applies permissions to the open descriptor (`f.Chmod`), defeating process umask and updating permissions when overwriting existing files.
- Returns formatted octal mode string in the JSON response (`"mode": "0755"`).
- Updates OpenAPI documentation and response schemas in `api/openapi.yaml`.

## Testing

- Added comprehensive unit tests in `cmd/boxd/files_test.go`:
  - Default `0644` mode validation
  - Custom executable `0755` mode
  - Octal prefix formats (`700`, `0600`, `0o750`)
  - Early rejection of invalid / out-of-bounds mode strings
  - Overwrite permission updates
- Verified OpenAPI route sync tests (`go test ./internal/api -run TestOpenAPISpecMatchesRoutes`)
- Verified full short test suite (`make test-short`)