### PR TITLE
chore: Instrument west heartbeat capability race and dual-proxy hypothesis

### DIFF
--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -227,3 +227,37 @@ FROM host h
 LEFT JOIN sandbox s ON s.host_id = h.id
 GROUP BY h.id
 ORDER BY h.created_at ASC;
+
+-- name: GetHostCapabilityDiagnostics :many
+-- Snapshot the host heartbeat generation and every capability attestation for
+-- best-effort diagnostics when capability enforcement rejects a request.
+WITH host_snapshot AS (
+  SELECT h.id,
+         h.status,
+         h.last_heartbeat_at,
+         (
+           h.status = 'active'
+           AND h.last_heartbeat_at IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM unnest(sqlc.arg('required_capabilities')::text[]) AS required(capability)
+             WHERE NOT EXISTS (
+               SELECT 1
+               FROM host_capability required_hc
+               WHERE required_hc.host_id = h.id
+                 AND required_hc.capability = required.capability
+                 AND required_hc.heartbeat_at = h.last_heartbeat_at
+             )
+           )
+         ) AS capabilities_match
+  FROM host h
+  WHERE h.id = sqlc.arg('host_id')
+)
+SELECT hs.last_heartbeat_at,
+       hs.status,
+       hs.capabilities_match,
+       hc.capability,
+       hc.heartbeat_at
+FROM host_snapshot hs
+LEFT JOIN host_capability hc ON hc.host_id = hs.id
+ORDER BY hc.capability ASC;

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/auth"
@@ -170,6 +171,10 @@ type Handlers struct {
 	// the standalone pre-flight checks (see hostcap_cache.go). Zero value is
 	// ready to use.
 	hostCaps hostCapCache
+
+	// diagnosticGroup coalesces concurrent capability rejection snapshots for
+	// the same host and required capability set.
+	diagnosticGroup singleflight.Group
 }
 
 // asyncBookkeeping runs fire-and-forget post-VMD work in a background

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -26,6 +26,11 @@ import (
 
 const maxPreviewTokenExpirySeconds = 7 * 24 * 60 * 60
 
+// Capability rejection diagnostics are best-effort and must not inherit the
+// request's potentially long server timeout while waiting for a DB connection
+// or a stalled query.
+const previewCapabilityDiagnosticTimeout = 250 * time.Millisecond
+
 var (
 	errPreviewPortNotPublished = errors.New("preview port is not published")
 	errPreviewPortIsPublic     = errors.New("preview port is public")
@@ -344,6 +349,59 @@ func (h *Handlers) requireHostPreviewCapabilities(c *gin.Context, hostID string,
 		return false
 	}
 	if !hasCapabilities {
+		sandboxID := c.Param("sandbox_id")
+		requiredCapabilities := append([]string(nil), capabilities...)
+		h.asyncBookkeeping("preview-capability-diagnostics", func() {
+			diagnosticCtx, cancel := context.WithTimeout(context.WithoutCancel(context.Background()), previewCapabilityDiagnosticTimeout)
+			defer cancel()
+			flightKey := hostID + ":" + strings.Join(requiredCapabilities, ",")
+			result, diagnosticErr, _ := h.diagnosticGroup.Do(flightKey, func() (any, error) {
+				return h.DB.GetHostCapabilityDiagnostics(diagnosticCtx, db.GetHostCapabilityDiagnosticsParams{
+					HostID:               hostID,
+					RequiredCapabilities: requiredCapabilities,
+				})
+			})
+			if diagnosticErr != nil {
+				log.Warn().Err(diagnosticErr).
+					Str("host_id", hostID).
+					Strs("required_capabilities", requiredCapabilities).
+					Str("sandbox_id", sandboxID).
+					Msg("preview capability rejection diagnostics failed")
+				return
+			}
+			snapshot, ok := result.([]db.GetHostCapabilityDiagnosticsRow)
+			if !ok {
+				log.Warn().Str("host_id", hostID).Msg("preview capability rejection diagnostics returned an unexpected result")
+				return
+			}
+			rows := make([]map[string]any, 0, len(snapshot))
+			for _, row := range snapshot {
+				if row.Capability == nil {
+					continue
+				}
+				rows = append(rows, map[string]any{
+					"capability":   *row.Capability,
+					"heartbeat_at": timestamptzString(row.HeartbeatAt),
+				})
+			}
+			var generation any
+			var hostStatus any
+			var capabilitiesMatch any
+			if len(snapshot) > 0 {
+				generation = timestamptzString(snapshot[0].LastHeartbeatAt)
+				hostStatus = snapshot[0].Status
+				capabilitiesMatch = snapshot[0].CapabilitiesMatch
+			}
+			log.Warn().
+				Str("host_id", hostID).
+				Strs("required_capabilities", requiredCapabilities).
+				Str("sandbox_id", sandboxID).
+				Interface("last_heartbeat_at", generation).
+				Interface("host_status", hostStatus).
+				Interface("capabilities_match", capabilitiesMatch).
+				Interface("host_capabilities", rows).
+				Msg("preview capability enforcement rejected request")
+		})
 		respondErrorMsg(c, "conflict",
 			fmt.Sprintf("The sandbox's host does not enforce all required capabilities (%s); retry after the fleet is upgraded", strings.Join(capabilities, ", ")),
 			http.StatusConflict)

--- a/internal/api/handlers_preview_test.go
+++ b/internal/api/handlers_preview_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -17,6 +18,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -354,12 +358,130 @@ func TestPublishPreviewPortRejectsHostWithoutCapabilityBeforeMutation(t *testing
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/sandboxes/"+sandboxID.String()+"/preview-ports", strings.NewReader(`{"port":3000}`))
 	setupPreviewRouter(h, teamID.String()).ServeHTTP(w, req)
+	h.WaitAsyncBookkeeping()
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
 	}
 	if mutated || vmdCalled {
 		t.Fatalf("incapable host reached mutation=%v vmd=%v", mutated, vmdCalled)
+	}
+}
+
+func TestRequireHostPreviewCapabilitiesDiagnosticFailurePreservesConflict(t *testing.T) {
+	var diagnosticCalls int
+	var logOutput bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&logOutput).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = oldLogger }()
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "HostHasCapabilitiesUnlocked") {
+				return scalarBoolRow(false)
+			}
+			return errorRow(fmt.Errorf("unexpected QueryRow: %s", sql))
+		},
+		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+			if strings.Contains(sql, "GetHostCapabilityDiagnostics") {
+				diagnosticCalls++
+				return nil, fmt.Errorf("diagnostic read unavailable")
+			}
+			return nil, fmt.Errorf("unexpected Query: %s", sql)
+		},
+	}
+	h := &Handlers{DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/sandboxes/example/preview-ports", nil)
+
+	if h.requireHostPreviewCapabilities(c, "example-host", preview.HostCapabilityPorts) {
+		t.Fatal("capability rejection unexpectedly succeeded")
+	}
+	h.WaitAsyncBookkeeping()
+	assertPreviewCapabilityConflictResponse(t, w)
+	if diagnosticCalls != 1 {
+		t.Fatalf("diagnostic query calls=%d, want 1", diagnosticCalls)
+	}
+	if !strings.Contains(logOutput.String(), `"host_id":"example-host"`) ||
+		!strings.Contains(logOutput.String(), `"required_capabilities":["preview_ports_v1"]`) {
+		t.Fatalf("diagnostic failure log=%s, want host and required capabilities", logOutput.String())
+	}
+}
+
+func TestRequireHostPreviewCapabilitiesLogsDiagnosticSnapshot(t *testing.T) {
+	var diagnosticCalls int
+	var logOutput bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&logOutput).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = oldLogger }()
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			if strings.Contains(sql, "HostHasCapabilitiesUnlocked") {
+				return scalarBoolRow(false)
+			}
+			return errorRow(fmt.Errorf("unexpected QueryRow: %s", sql))
+		},
+		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+			if strings.Contains(sql, "GetHostCapabilityDiagnostics") {
+				diagnosticCalls++
+				capability := "preview_ports_v1"
+				matched := true
+				heartbeatAt := pgtype.Timestamptz{Time: time.Date(2026, 8, 19, 12, 34, 56, 0, time.UTC), Valid: true}
+				return &scanRows{rows: []func(dest ...any) error{func(dest ...any) error {
+					*dest[0].(*pgtype.Timestamptz) = heartbeatAt
+					*dest[1].(*string) = "active"
+					*dest[2].(**bool) = &matched
+					*dest[3].(**string) = &capability
+					*dest[4].(*pgtype.Timestamptz) = heartbeatAt
+					return nil
+				}}}, nil
+			}
+			return nil, fmt.Errorf("unexpected Query: %s", sql)
+		},
+	}
+	h := &Handlers{DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "sandbox_id", Value: "example-sandbox"}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/sandboxes/example-sandbox/preview-ports", nil)
+
+	if h.requireHostPreviewCapabilities(c, "example-host", preview.HostCapabilityPorts) {
+		t.Fatal("capability rejection unexpectedly succeeded")
+	}
+	h.WaitAsyncBookkeeping()
+	assertPreviewCapabilityConflictResponse(t, w)
+	if diagnosticCalls != 1 {
+		t.Fatalf("diagnostic query calls=%d, want 1", diagnosticCalls)
+	}
+	if !strings.Contains(logOutput.String(), `"message":"preview capability enforcement rejected request"`) ||
+		!strings.Contains(logOutput.String(), `"host_capabilities":[{"capability":"preview_ports_v1"`) ||
+		!strings.Contains(logOutput.String(), `"heartbeat_at":"2026-08-19T12:34:56Z"`) ||
+		!strings.Contains(logOutput.String(), `"last_heartbeat_at":"2026-08-19T12:34:56Z"`) ||
+		!strings.Contains(logOutput.String(), `"sandbox_id":"example-sandbox"`) {
+		t.Fatalf("diagnostic snapshot log=%s, want rejection fields", logOutput.String())
+	}
+}
+
+func assertPreviewCapabilityConflictResponse(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var response struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
+	}
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409; body=%s", w.Code, w.Body.String())
+	}
+	if response.Error.Code != "conflict" {
+		t.Fatalf("error.code=%q, want %q; body=%s", response.Error.Code, "conflict", w.Body.String())
+	}
+	wantMessage := "The sandbox's host does not enforce all required capabilities (preview_ports_v1); retry after the fleet is upgraded"
+	if response.Error.Message != wantMessage {
+		t.Fatalf("error.message=%q, want %q", response.Error.Message, wantMessage)
 	}
 }
 
@@ -398,6 +520,9 @@ func TestPublishPrivatePreviewPathsRequireBrowserCapabilityBeforeMutation(t *tes
 				queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
 					if strings.Contains(sql, "-- name: ListPublishedPorts :many") {
 						return previewPortPolicyRows(tt.existingRows...), nil
+					}
+					if strings.Contains(sql, "-- name: GetHostCapabilityDiagnostics :many") {
+						return emptyRows{}, nil
 					}
 					mutated = true
 					return nil, fmt.Errorf("unexpected mutation Query: %s", sql)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3931,6 +3931,7 @@ func TestCreateSandbox_InsertCarriesTemplateShape(t *testing.T) {
 	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock), Scheduler: &stubScheduler{hostID: "public-host"}}
 	w := httptest.NewRecorder()
 	setupTestRouter(h, teamID.String()).ServeHTTP(w, createSandboxReq(`{"name":"shaped"}`))
+	h.WaitAsyncBookkeeping()
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -93,11 +93,11 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 	ctx := c.Request.Context()
 	registered := false
 	reclaimed := false
-	beat := func(q *db.Queries) (status, prevStatus string, _ error) {
+	beat := func(q *db.Queries) (status, prevStatus string, lastHeartbeatAt pgtype.Timestamptz, _ error) {
 		host, err := q.GetHostForUpdate(ctx, hostID)
 		if err == pgx.ErrNoRows {
 			if !req.describesHost() {
-				return "", "", errHostNotRegistered
+				return "", "", pgtype.Timestamptz{}, errHostNotRegistered
 			}
 			created, err := q.RegisterHost(ctx, db.RegisterHostParams{
 				ID:                hostID,
@@ -108,18 +108,18 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 				CapacityVcpus:     req.CapacityVcpus,
 			})
 			if err != nil {
-				return "", "", err
+				return "", "", pgtype.Timestamptz{}, err
 			}
 			registered = true
 			if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
 				HostID: hostID, Capabilities: capabilities,
 			}); err != nil {
-				return "", "", err
+				return "", "", pgtype.Timestamptz{}, err
 			}
-			return created.Status, created.Status, nil
+			return created.Status, created.Status, created.LastHeartbeatAt, nil
 		}
 		if err != nil {
-			return "", "", err
+			return "", "", pgtype.Timestamptz{}, err
 		}
 
 		// Once a row is identity-bound, description-less heartbeats are
@@ -129,14 +129,14 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		// capabilities on a row that now belongs to another machine —
 		// and its reconciler would keep operating under an id it lost.
 		if host.IdentityBound && !req.describesHost() {
-			return "", "", errHostIdentityRequired
+			return "", "", pgtype.Timestamptz{}, errHostIdentityRequired
 		}
 
 		if req.VMDAddr != "" && req.VMDAddr != host.VmdAddr {
 			holderAlive := host.LastHeartbeatAt.Valid &&
 				time.Since(host.LastHeartbeatAt.Time) < heartbeatTimeout
 			if holderAlive {
-				return "", "", errHostIdentityConflict
+				return "", "", pgtype.Timestamptz{}, errHostIdentityConflict
 			}
 			// Claiming an existing identity from a new address is a
 			// re-registration: it rewrites the whole row, so it needs the
@@ -144,7 +144,7 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 			// region, and heartbeating without reclaiming would mark a row
 			// live while its address points at the silent old machine.
 			if !req.describesHost() {
-				return "", "", errHostPartialDescription
+				return "", "", pgtype.Timestamptz{}, errHostPartialDescription
 			}
 			if err := q.UpdateHostAddresses(ctx, db.UpdateHostAddressesParams{
 				ID:                hostID,
@@ -154,7 +154,7 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 				CapacityMemoryMib: req.CapacityMemoryMib,
 				CapacityVcpus:     req.CapacityVcpus,
 			}); err != nil {
-				return "", "", err
+				return "", "", pgtype.Timestamptz{}, err
 			}
 			reclaimed = true
 			log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
@@ -163,35 +163,36 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 
 		row, err := q.UpdateHostHeartbeat(ctx, hostID)
 		if err != nil {
-			return "", "", err
+			return "", "", pgtype.Timestamptz{}, err
 		}
 		// Missing capabilities is an explicit empty replacement. This clears a
 		// stale attestation immediately when VMD can no longer verify its proxy.
 		if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
 			HostID: hostID, Capabilities: capabilities,
 		}); err != nil {
-			return "", "", err
+			return "", "", pgtype.Timestamptz{}, err
 		}
 		// Opt-in: a complete description at the row's current address binds
 		// the identity, so later description-less heartbeats for this id
 		// are rejected. (Registration and reclaim bind in their own writes.)
 		if !host.IdentityBound && req.describesHost() && req.VMDAddr == host.VmdAddr {
 			if err := q.BindHostIdentity(ctx, hostID); err != nil {
-				return "", "", err
+				return "", "", pgtype.Timestamptz{}, err
 			}
 		}
-		return row.Status, row.PrevStatus, nil
+		return row.Status, row.PrevStatus, row.LastHeartbeatAt, nil
 	}
 
 	var status, prevStatus string
+	var lastHeartbeatAt pgtype.Timestamptz
 	var err error
 	if h.Pool == nil {
-		status, prevStatus, err = beat(h.DB)
+		status, prevStatus, lastHeartbeatAt, err = beat(h.DB)
 	} else {
 		var tx pgx.Tx
 		if tx, err = h.Pool.Begin(ctx); err == nil {
 			defer tx.Rollback(ctx)
-			if status, prevStatus, err = beat(h.DB.WithTx(tx)); err == nil {
+			if status, prevStatus, lastHeartbeatAt, err = beat(h.DB.WithTx(tx)); err == nil {
 				err = tx.Commit(ctx)
 			}
 		}
@@ -240,6 +241,10 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 			h.Scheduler.Invalidate()
 		}
 	}
+	log.Debug().Str("host_id", hostID).Strs("capabilities", capabilities).
+		Interface("last_heartbeat_at", timestamptzString(lastHeartbeatAt)).
+		Str("status", status).Str("prev_status", prevStatus).
+		Msg("host heartbeat persisted")
 	if prevStatus == "unhealthy" && status == "active" {
 		// The heartbeat just recovered this host; drop the scheduler's cached
 		// list so its capacity is usable now, not after the cache TTL.
@@ -349,4 +354,11 @@ func (h *Handlers) HostList(c *gin.Context) {
 		hosts = append(hosts, v)
 	}
 	c.JSON(http.StatusOK, gin.H{"hosts": hosts})
+}
+
+func timestamptzString(ts pgtype.Timestamptz) any {
+	if !ts.Valid {
+		return nil
+	}
+	return ts.Time.Format(time.RFC3339Nano)
 }

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -89,6 +89,80 @@ func (q *Queries) GetHost(ctx context.Context, id string) (Host, error) {
 	return i, err
 }
 
+const getHostCapabilityDiagnostics = `-- name: GetHostCapabilityDiagnostics :many
+WITH host_snapshot AS (
+  SELECT h.id,
+         h.status,
+         h.last_heartbeat_at,
+         (
+           h.status = 'active'
+           AND h.last_heartbeat_at IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM unnest($1::text[]) AS required(capability)
+             WHERE NOT EXISTS (
+               SELECT 1
+               FROM host_capability required_hc
+               WHERE required_hc.host_id = h.id
+                 AND required_hc.capability = required.capability
+                 AND required_hc.heartbeat_at = h.last_heartbeat_at
+             )
+           )
+         ) AS capabilities_match
+  FROM host h
+  WHERE h.id = $2
+)
+SELECT hs.last_heartbeat_at,
+       hs.status,
+       hs.capabilities_match,
+       hc.capability,
+       hc.heartbeat_at
+FROM host_snapshot hs
+LEFT JOIN host_capability hc ON hc.host_id = hs.id
+ORDER BY hc.capability ASC
+`
+
+type GetHostCapabilityDiagnosticsParams struct {
+	RequiredCapabilities []string `json:"required_capabilities"`
+	HostID               string   `json:"host_id"`
+}
+
+type GetHostCapabilityDiagnosticsRow struct {
+	LastHeartbeatAt   pgtype.Timestamptz `json:"last_heartbeat_at"`
+	Status            string             `json:"status"`
+	CapabilitiesMatch *bool              `json:"capabilities_match"`
+	Capability        *string            `json:"capability"`
+	HeartbeatAt       pgtype.Timestamptz `json:"heartbeat_at"`
+}
+
+// Snapshot the host heartbeat generation and every capability attestation for
+// best-effort diagnostics when capability enforcement rejects a request.
+func (q *Queries) GetHostCapabilityDiagnostics(ctx context.Context, arg GetHostCapabilityDiagnosticsParams) ([]GetHostCapabilityDiagnosticsRow, error) {
+	rows, err := q.db.Query(ctx, getHostCapabilityDiagnostics, arg.RequiredCapabilities, arg.HostID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetHostCapabilityDiagnosticsRow{}
+	for rows.Next() {
+		var i GetHostCapabilityDiagnosticsRow
+		if err := rows.Scan(
+			&i.LastHeartbeatAt,
+			&i.Status,
+			&i.CapabilitiesMatch,
+			&i.Capability,
+			&i.HeartbeatAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getHostForUpdate = `-- name: GetHostForUpdate :one
 SELECT id, vmd_addr, proxy_addr, region, status, capacity_memory_mib, capacity_vcpus, last_heartbeat_at, created_at, updated_at, identity_bound FROM host WHERE id = $1 FOR UPDATE
 `

--- a/internal/vm/heartbeat.go
+++ b/internal/vm/heartbeat.go
@@ -75,6 +75,7 @@ func StartHeartbeat(ctx context.Context, cfg HeartbeatConfig, log zerolog.Logger
 	client := &http.Client{Timeout: 10 * time.Second}
 
 	log.Info().
+		Str("host_id", cfg.HostID).
 		Str("url", url).
 		Str("proxy_health_url", proxyHealthURL).
 		Dur("interval", interval).
@@ -128,11 +129,17 @@ type proxyHealthResponse struct {
 }
 
 func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig, url, token, proxyHealthURL string, log zerolog.Logger) {
+	started := time.Now()
 	capabilities, err := proxyPreviewCapabilities(ctx, client, proxyHealthURL)
 	if err != nil {
-		log.Warn().Err(err).Msg("proxy capability probe failed; advertising no preview capabilities")
+		log.Warn().Err(err).Str("host_id", cfg.HostID).
+			Dur("duration", time.Since(started)).
+			Msg("proxy capability probe failed; advertising no preview capabilities")
 		capabilities = nil
 	}
+	log.Debug().Str("host_id", cfg.HostID).
+		Str("proxy_health_url", proxyHealthURL).Strs("capabilities", capabilities).
+		Msg("sending heartbeat")
 
 	body, err := json.Marshal(buildHeartbeatRequest(cfg, capabilities))
 	if err != nil {
@@ -151,7 +158,9 @@ func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Warn().Err(err).Msg("heartbeat failed")
+		log.Warn().Err(err).Str("host_id", cfg.HostID).
+			Strs("capabilities", capabilities).Dur("duration", time.Since(started)).
+			Msg("heartbeat failed")
 		return
 	}
 	io.Copy(io.Discard, resp.Body)
@@ -163,9 +172,17 @@ func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig
 		// the control plane refuses updates either way — but say why loudly:
 		// this is a provisioning error an operator must resolve.
 		log.Error().Int("status", resp.StatusCode).
+			Str("host_id", cfg.HostID).Strs("capabilities", capabilities).
+			Dur("duration", time.Since(started)).
 			Msg("heartbeat rejected: host identity in use by a live host at another address")
 	case resp.StatusCode != http.StatusOK:
-		log.Warn().Int("status", resp.StatusCode).Msg("heartbeat got non-200 response")
+		log.Warn().Int("status", resp.StatusCode).Str("host_id", cfg.HostID).
+			Strs("capabilities", capabilities).Dur("duration", time.Since(started)).
+			Msg("heartbeat got non-200 response")
+	default:
+		log.Debug().Str("host_id", cfg.HostID).Strs("capabilities", capabilities).
+			Int("status", resp.StatusCode).Dur("duration", time.Since(started)).
+			Msg("heartbeat completed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- log the capability set VMD is about to advertise, with host identity, status, and duration
- log the capability set and heartbeat generation persisted by the control plane
- add a DB-backed snapshot log on the preview capability 409 path so the next recurrence identifies whether rows are absent or generation-mismatched

## Testing

- `go test ./internal/vm/...`
- `go test ./internal/api/...`
- `go test ./...`

## Testing

- `codex-workflow validate`
