### PR TITLE
fix: Bill storage from referenced rootfs/template artifacts and sandbox overlays

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -25,6 +25,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/superserve-ai/sandbox/internal/analytics"
 	"github.com/superserve-ai/sandbox/internal/api"
@@ -452,11 +453,12 @@ func (c *grpcVMDClient) PauseInstance(ctx context.Context, vmID, snapshotDir, pa
 	manifest := make([]vmdclient.ManifestEntry, 0, len(resp.GetManifest()))
 	for _, e := range resp.GetManifest() {
 		manifest = append(manifest, vmdclient.ManifestEntry{
-			FileName:  e.GetFileName(),
-			Path:      e.GetPath(),
-			SizeBytes: e.GetSizeBytes(),
-			SHA256:    e.GetSha256(),
-			BasePath:  e.GetBasePath(),
+			FileName:       e.GetFileName(),
+			Path:           e.GetPath(),
+			SizeBytes:      e.GetSizeBytes(),
+			SHA256:         e.GetSha256(),
+			BasePath:       e.GetBasePath(),
+			AllocatedBytes: artifactManifestAllocatedBytes(e),
 		})
 	}
 	acked := ""
@@ -730,19 +732,46 @@ func (c *grpcVMDClient) GetBuildStatus(ctx context.Context, buildVMID string) (v
 		return vmdclient.BuildStatusResult{}, fmt.Errorf("gRPC GetBuildStatus: %w", err)
 	}
 	return vmdclient.BuildStatusResult{
-		NotFound:       resp.GetNotFound(),
-		Status:         resp.GetStatus(),
-		SnapshotPath:   resp.GetSnapshotPath(),
-		MemFilePath:    resp.GetMemFilePath(),
-		RootfsPath:     resp.GetRootfsPath(),
-		BasePath:       resp.GetBasePath(),
-		DeltaPath:      resp.GetDeltaPath(),
-		ResolvedDigest: resp.GetResolvedDigest(),
-		SizeBytes:      resp.GetSizeBytes(),
-		ErrorMessage:   resp.GetErrorMessage(),
-		StartedAtUnix:  resp.GetStartedAtUnix(),
-		EndedAtUnix:    resp.GetEndedAtUnix(),
+		NotFound:                resp.GetNotFound(),
+		Status:                  resp.GetStatus(),
+		SnapshotPath:            resp.GetSnapshotPath(),
+		MemFilePath:             resp.GetMemFilePath(),
+		RootfsPath:              resp.GetRootfsPath(),
+		BasePath:                resp.GetBasePath(),
+		DeltaPath:               resp.GetDeltaPath(),
+		ResolvedDigest:          resp.GetResolvedDigest(),
+		SizeBytes:               resp.GetSizeBytes(),
+		RootfsAllocatedBytes:    resp.GetRootfsAllocatedBytes(),
+		BaseAllocatedBytes:      resp.GetBaseAllocatedBytes(),
+		DeltaAllocatedBytes:     resp.GetDeltaAllocatedBytes(),
+		AllocatedBytesSupported: resp.GetAllocatedBytesSupported(),
+		ErrorMessage:            resp.GetErrorMessage(),
+		StartedAtUnix:           resp.GetStartedAtUnix(),
+		EndedAtUnix:             resp.GetEndedAtUnix(),
 	}, nil
+}
+
+func artifactManifestAllocatedBytes(entry *vmdpb.ArtifactManifestEntry) int64 {
+	if entry == nil {
+		return -1
+	}
+	unknown := entry.ProtoReflect().GetUnknown()
+	for len(unknown) > 0 {
+		num, typ, n := protowire.ConsumeTag(unknown)
+		if n < 0 {
+			break
+		}
+		unknown = unknown[n:]
+		value, n := protowire.ConsumeVarint(unknown)
+		if n < 0 {
+			break
+		}
+		unknown = unknown[n:]
+		if num == 6 && typ == protowire.VarintType {
+			return int64(value)
+		}
+	}
+	return -1
 }
 
 func (c *grpcVMDClient) CancelBuild(ctx context.Context, buildVMID string) error {

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -8,6 +8,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/time/rate"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -69,6 +70,12 @@ type Config struct {
 	// heartbeat is disabled.
 	ControlPlaneURL string
 
+	// Heartbeat self-description overrides. When unset, the daemon infers
+	// addresses and region from the local interface and deployment defaults.
+	VMDAdvertiseAddr   string
+	ProxyAdvertiseAddr string
+	HostRegion         string
+
 	// SecretsProxySocket is the local secretsproxy daemon's control-RPC unix-socket path.
 	// When empty, broker registration is skipped.
 	SecretsProxySocket string
@@ -102,6 +109,9 @@ func loadConfig() (Config, error) {
 		HostID:                  requireEnv("HOST_ID"),
 		DatabaseURL:             os.Getenv("DATABASE_URL"),
 		ControlPlaneURL:         os.Getenv("CONTROL_PLANE_URL"),
+		VMDAdvertiseAddr:        os.Getenv("VMD_ADVERTISE_ADDR"),
+		ProxyAdvertiseAddr:      os.Getenv("PROXY_ADVERTISE_ADDR"),
+		HostRegion:              envOrDefault("HOST_REGION", os.Getenv("SANDBOX_ID_REGION")),
 		SecretsProxySocket:      os.Getenv("SECRETSPROXY_SOCKET"),
 		SecretsProxySandboxAddr: os.Getenv("SECRETSPROXY_SANDBOX_ADDR"),
 	}
@@ -159,6 +169,75 @@ func envOrDefault(key, fallback string) string {
 
 func requireEnv(key string) string {
 	return os.Getenv(key)
+}
+
+func hostInterfaceAddress(interfaceName string) (string, error) {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return "", err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil {
+			continue
+		}
+		if ipv4 := ip.To4(); ipv4 != nil {
+			return ipv4.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no IPv4 address found on interface %q", interfaceName)
+}
+
+func advertisedVMDAddr(interfaceName string, grpcPort int, explicit string) (string, error) {
+	if explicit != "" {
+		if _, _, err := net.SplitHostPort(explicit); err != nil {
+			return "", err
+		}
+		return explicit, nil
+	}
+	ip, err := hostInterfaceAddress(interfaceName)
+	if err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(ip, strconv.Itoa(grpcPort)), nil
+}
+
+func advertisedProxyAddr(interfaceName, proxyHealthURL, explicit string) (string, error) {
+	if explicit != "" {
+		if _, _, err := net.SplitHostPort(explicit); err != nil {
+			return "", err
+		}
+		return explicit, nil
+	}
+	u, err := url.Parse(proxyHealthURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("proxy health URL %q has no host", proxyHealthURL)
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return "", err
+	}
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		ip, err := hostInterfaceAddress(interfaceName)
+		if err != nil {
+			return "", err
+		}
+		return net.JoinHostPort(ip, port), nil
+	}
+	return u.Host, nil
 }
 
 // envInt32Fatal parses an optional non-negative int32 env var. Unset or
@@ -1450,17 +1529,33 @@ func main() {
 				Int32("configured_vcpus", vcpus).Int32("physical_vcpus", physCPU).
 				Msg("configured schedulable capacity exceeds physical capacity — check for a units mistake")
 		}
+		proxyHealthURL := os.Getenv("PROXY_HEALTH_URL")
+		if proxyHealthURL == "" {
+			proxyHealthURL = "http://127.0.0.1:5007/health"
+		}
+		vmdAddr, err := advertisedVMDAddr(cfg.HostInterface, cfg.GRPCPort, cfg.VMDAdvertiseAddr)
+		if err != nil {
+			log.Warn().Err(err).Str("host_interface", cfg.HostInterface).
+				Int("grpc_port", cfg.GRPCPort).
+				Msg("unable to resolve advertised VMD address; heartbeat will omit host self-description")
+		}
+		proxyAddr, err := advertisedProxyAddr(cfg.HostInterface, proxyHealthURL, cfg.ProxyAdvertiseAddr)
+		if err != nil {
+			log.Warn().Err(err).Str("proxy_health_url", proxyHealthURL).
+				Msg("unable to derive advertised proxy address; heartbeat will omit host self-description")
+		}
 		lc.start("heartbeat", func() error {
 			vm.StartHeartbeat(ctx, vm.HeartbeatConfig{
-				ControlPlaneURL:    cfg.ControlPlaneURL,
-				HostID:             cfg.HostID,
-				Token:              os.Getenv("INTERNAL_API_TOKEN"),
-				ProxyHealthURL:     os.Getenv("PROXY_HEALTH_URL"),
-				AdvertiseVMDAddr:   os.Getenv("VMD_ADVERTISE_ADDR"),
-				AdvertiseProxyAddr: os.Getenv("PROXY_ADVERTISE_ADDR"),
-				Region:             os.Getenv("HOST_REGION"),
-				CapacityMemoryMib:  memoryMib,
-				CapacityVcpus:      vcpus,
+				ControlPlaneURL:   cfg.ControlPlaneURL,
+				HostID:            cfg.HostID,
+				Token:             os.Getenv("INTERNAL_API_TOKEN"),
+				ProxyHealthURL:    proxyHealthURL,
+				RunDir:            cfg.RunDir,
+				VMDAddr:           vmdAddr,
+				ProxyAddr:         proxyAddr,
+				Region:            cfg.HostRegion,
+				CapacityMemoryMib: memoryMib,
+				CapacityVcpus:     vcpus,
 			}, log)
 			return nil
 		})

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -44,6 +44,48 @@ func TestLoadConfigRequiresExplicitHostID(t *testing.T) {
 	}
 }
 
+func TestLoadConfigUsesHeartbeatOverrides(t *testing.T) {
+	t.Setenv("KERNEL_PATH", "/tmp/kernel")
+	t.Setenv("BASE_ROOTFS_PATH", "/tmp/rootfs")
+	t.Setenv("HOST_ID", "host-a")
+	t.Setenv("VMD_ADVERTISE_ADDR", "10.0.0.2:50051")
+	t.Setenv("PROXY_ADVERTISE_ADDR", "10.0.0.2:5007")
+	t.Setenv("HOST_REGION", "region-explicit")
+	t.Setenv("SANDBOX_ID_REGION", "region-fallback")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig() error: %v", err)
+	}
+	if cfg.VMDAdvertiseAddr != "10.0.0.2:50051" {
+		t.Fatalf("cfg.VMDAdvertiseAddr = %q, want explicit override", cfg.VMDAdvertiseAddr)
+	}
+	if cfg.ProxyAdvertiseAddr != "10.0.0.2:5007" {
+		t.Fatalf("cfg.ProxyAdvertiseAddr = %q, want explicit override", cfg.ProxyAdvertiseAddr)
+	}
+	if cfg.HostRegion != "region-explicit" {
+		t.Fatalf("cfg.HostRegion = %q, want explicit override", cfg.HostRegion)
+	}
+}
+
+func TestAdvertisedAddrsPreferExplicitOverrides(t *testing.T) {
+	vmdAddr, err := advertisedVMDAddr("does-not-matter", 50051, "10.0.0.2:50051")
+	if err != nil {
+		t.Fatalf("advertisedVMDAddr: %v", err)
+	}
+	if vmdAddr != "10.0.0.2:50051" {
+		t.Fatalf("advertisedVMDAddr = %q, want explicit override", vmdAddr)
+	}
+
+	proxyAddr, err := advertisedProxyAddr("does-not-matter", "http://127.0.0.1:5007/health", "10.0.0.2:5007")
+	if err != nil {
+		t.Fatalf("advertisedProxyAddr: %v", err)
+	}
+	if proxyAddr != "10.0.0.2:5007" {
+		t.Fatalf("advertisedProxyAddr = %q, want explicit override", proxyAddr)
+	}
+}
+
 func TestParseSecretsProxyAddr(t *testing.T) {
 	t.Parallel()
 

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -1,3 +1,33 @@
+-- name: UpdateHostSandboxStorageMeasurements :execrows
+-- Apply trusted host-side overlay allocations without rewriting history.
+-- statement_timestamp() is stable for the whole statement, so closing and
+-- opening an interval use the exact same measurement boundary.
+WITH measurements AS MATERIALIZED (
+    SELECT unnest(sqlc.arg(sandbox_ids)::uuid[]) AS sandbox_id,
+           unnest(sqlc.arg(disk_mib)::int[]) AS disk_mib
+), eligible AS MATERIALIZED (
+    SELECT s.id, s.team_id, m.disk_mib
+    FROM measurements m
+    JOIN sandbox s ON s.id = m.sandbox_id
+    WHERE s.host_id = sqlc.arg(host_id)
+      AND s.destroyed_at IS NULL
+      AND feature_enabled('billing_metrics_write', s.team_id)
+), closed AS (
+    UPDATE sandbox_storage_interval i
+    SET ended_at = statement_timestamp(), end_reason = 'measurement'
+    FROM eligible e
+    WHERE i.sandbox_id = e.id
+      AND i.team_id = e.team_id
+      AND i.ended_at IS NULL
+      AND i.disk_mib IS DISTINCT FROM e.disk_mib
+    RETURNING i.sandbox_id, i.team_id
+)
+INSERT INTO sandbox_storage_interval (sandbox_id, team_id, disk_mib, started_at)
+SELECT e.id, e.team_id, e.disk_mib, statement_timestamp()
+FROM eligible e
+LEFT JOIN closed c ON c.sandbox_id = e.id AND c.team_id = e.team_id
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING;
+
 -- name: GetTeamBillingUsage :one
 -- Allocated usage for one team clipped to [period_start, period_end).
 WITH compute AS (
@@ -20,15 +50,66 @@ WITH compute AS (
       AND i.started_at < LEAST(now(), sqlc.arg(period_end))
       AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = sqlc.arg(team_id)
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(now(), sqlc.arg(period_end))
+      AND s.created_at < LEAST(now(), sqlc.arg(period_end))
+      AND COALESCE(s.destroyed_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
+),
+artifact_ranges AS (
+    SELECT p.path,
+           MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+           range_agg(tstzrange(
+               GREATEST(s.billing_started_at, sqlc.arg(period_start)),
+               LEAST(COALESCE(s.destroyed_at, now()), sqlc.arg(period_end)), '[)'
+           )) AS retained_ranges
+    FROM artifact_bounds s
+    LEFT JOIN template t ON t.id = s.template_id
+    CROSS JOIN LATERAL unnest(ARRAY[
+        s.base_path,
+        s.delta_path,
+        CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END
+    ]) AS p(path)
+    LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+      AND am.path = p.path
+    WHERE p.path IS NOT NULL
+    GROUP BY p.path
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM artifact_ranges ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
+    -- Overlay intervals are per sandbox; template artifacts are a separate
+    -- distinct-path set so shared bases and deltas are never multiplied by
+    -- the number of sandboxes that pin them.
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, now()), sqlc.arg(period_end))
             - GREATEST(i.started_at, sqlc.arg(period_start))
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = sqlc.arg(team_id)
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = sqlc.arg(team_id)
       AND sqlc.arg(period_start) < LEAST(now(), sqlc.arg(period_end))
       AND i.started_at < LEAST(now(), sqlc.arg(period_end))
       AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
@@ -73,15 +154,55 @@ WITH compute AS (
       AND i.started_at < LEAST(now(), sqlc.arg(period_end))
       AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = sqlc.arg(team_id)
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(now(), sqlc.arg(period_end))
+      AND s.created_at < LEAST(now(), sqlc.arg(period_end))
+      AND COALESCE(s.destroyed_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM (
+        SELECT p.path,
+               MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+               range_agg(tstzrange(GREATEST(s.billing_started_at, sqlc.arg(period_start)), LEAST(COALESCE(s.destroyed_at, now()), sqlc.arg(period_end)), '[)')) AS retained_ranges
+        FROM artifact_bounds s
+        LEFT JOIN template t ON t.id = s.template_id
+        CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+        LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+          AND am.path = p.path
+        WHERE p.path IS NOT NULL
+        GROUP BY p.path
+    ) ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, now()), sqlc.arg(period_end))
             - GREATEST(i.started_at, sqlc.arg(period_start))
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = sqlc.arg(team_id)
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = sqlc.arg(team_id)
       AND sqlc.arg(period_start) < LEAST(now(), sqlc.arg(period_end))
       AND i.started_at < LEAST(now(), sqlc.arg(period_end))
       AND COALESCE(i.ended_at, LEAST(now(), sqlc.arg(period_end))) > sqlc.arg(period_start)
@@ -181,15 +302,55 @@ WITH compute AS (
       AND sqlc.arg(hour_start) < LEAST(billing_request_now(), sqlc.arg(hour_end))
       AND COALESCE(i.ended_at, LEAST(billing_request_now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = sqlc.arg(team_id)
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(billing_request_now(), sqlc.arg(hour_end))
+      AND s.created_at < LEAST(billing_request_now(), sqlc.arg(hour_end))
+      AND COALESCE(s.destroyed_at, LEAST(billing_request_now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM (
+        SELECT p.path,
+               MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+               range_agg(tstzrange(GREATEST(s.billing_started_at, sqlc.arg(hour_start)), LEAST(COALESCE(s.destroyed_at, billing_request_now()), sqlc.arg(hour_end)), '[)')) AS retained_ranges
+        FROM artifact_bounds s
+        LEFT JOIN template t ON t.id = s.template_id
+        CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+        LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+          AND am.path = p.path
+        WHERE p.path IS NOT NULL
+        GROUP BY p.path
+    ) ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, billing_request_now()), sqlc.arg(hour_end))
             - GREATEST(i.started_at, sqlc.arg(hour_start))
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = sqlc.arg(team_id)
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = sqlc.arg(team_id)
       AND i.started_at < sqlc.arg(hour_end)
       AND sqlc.arg(hour_start) < LEAST(billing_request_now(), sqlc.arg(hour_end))
       AND COALESCE(i.ended_at, LEAST(billing_request_now(), sqlc.arg(hour_end))) > sqlc.arg(hour_start)

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -561,17 +561,26 @@ fresh AS (
   SELECT unnest(@manifest_file_names::text[]) AS file_name,
          unnest(@manifest_paths::text[])      AS path,
          unnest(@manifest_sizes::bigint[])    AS size_bytes,
+         unnest(@manifest_allocated_bytes::bigint[]) AS allocated_bytes,
          unnest(@manifest_digests::text[])    AS sha256,
          unnest(@manifest_base_paths::text[]) AS base_path
 ),
 kept AS (
-  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256, base_path)
-  SELECT u.snap_id, f.file_name, f.path, f.size_bytes, f.sha256, NULLIF(f.base_path, '')
+  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256, base_path)
+  SELECT u.snap_id, f.file_name, f.path, f.size_bytes,
+         CASE WHEN f.allocated_bytes IS NULL OR f.allocated_bytes < 0 THEN
+                COALESCE((SELECT am.allocated_bytes
+                          FROM artifact_manifest am
+                          WHERE am.snapshot_id = u.snap_id
+                            AND am.file_name = f.file_name), 0)
+              ELSE COALESCE(f.allocated_bytes, 0) END,
+         f.sha256, NULLIF(f.base_path, '')
   FROM upserted u CROSS JOIN fresh f
   ON CONFLICT (snapshot_id, file_name) WHERE snapshot_id IS NOT NULL
   DO UPDATE SET
       path = EXCLUDED.path,
       size_bytes = EXCLUDED.size_bytes,
+      allocated_bytes = EXCLUDED.allocated_bytes,
       sha256 = EXCLUDED.sha256,
       base_path = EXCLUDED.base_path,
       created_at = now()
@@ -644,12 +653,21 @@ fresh AS (
   SELECT unnest(@manifest_file_names::text[]) AS file_name,
          unnest(@manifest_paths::text[])      AS path,
          unnest(@manifest_sizes::bigint[])    AS size_bytes,
+         unnest(@manifest_allocated_bytes::bigint[]) AS allocated_bytes,
          unnest(@manifest_digests::text[])    AS sha256,
          unnest(@manifest_base_paths::text[]) AS base_path
 ),
 manifested AS (
-  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256, base_path)
-  SELECT i.snap_id, f.file_name, f.path, f.size_bytes, f.sha256, NULLIF(f.base_path, '')
+  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256, base_path)
+  SELECT i.snap_id, f.file_name, f.path, f.size_bytes,
+         CASE WHEN f.allocated_bytes IS NULL OR f.allocated_bytes < 0 THEN
+                COALESCE((SELECT am.allocated_bytes
+                          FROM artifact_manifest am
+                          JOIN sandbox sb ON sb.snapshot_id = am.snapshot_id
+                          WHERE sb.id = @id
+                            AND am.file_name = f.file_name), 0)
+              ELSE COALESCE(f.allocated_bytes, 0) END,
+         f.sha256, NULLIF(f.base_path, '')
   FROM inserted i CROSS JOIN fresh f
   RETURNING id
 )

--- a/db/queries/templates.sql
+++ b/db/queries/templates.sql
@@ -282,7 +282,7 @@ WITH build_done AS (
       updated_at = now()
   WHERE template_build.id = $1 AND status IN ('building', 'snapshotting')
   RETURNING template_id
-)
+), updated AS (
 UPDATE template
 SET status = 'ready',
     rootfs_path = $2,
@@ -296,7 +296,29 @@ SET status = 'ready',
     error_message = NULL
 FROM build_done
 WHERE template.id = build_done.template_id
-RETURNING template.*;
+RETURNING template.*
+), artifacts AS (
+INSERT INTO artifact_manifest (
+    template_id, file_name, path, size_bytes, allocated_bytes, sha256
+)
+SELECT DISTINCT ON (a.path) updated.id, a.file_name, a.path, a.size_bytes, a.allocated_bytes,
+       repeat('0', 64)
+FROM updated
+CROSS JOIN LATERAL (
+    VALUES
+        ('rootfs.ext4', updated.rootfs_path, COALESCE(updated.size_bytes, 0), sqlc.arg('rootfs_allocated_bytes')::bigint),
+        ('base.ext4', updated.base_path, 0::bigint, sqlc.arg('base_allocated_bytes')::bigint),
+        ('delta.ext4', updated.delta_path, 0::bigint, sqlc.arg('delta_allocated_bytes')::bigint)
+) AS a(file_name, path, size_bytes, allocated_bytes)
+WHERE a.path IS NOT NULL
+ORDER BY a.path, (a.file_name = 'rootfs.ext4') DESC
+ON CONFLICT (template_id, path) WHERE template_id IS NOT NULL DO UPDATE
+SET path = EXCLUDED.path,
+    size_bytes = EXCLUDED.size_bytes,
+    allocated_bytes = EXCLUDED.allocated_bytes
+RETURNING 1
+)
+SELECT * FROM updated;
 
 -- name: FailBuild :one
 -- Build row flips to failed if not already terminal; template flips only if

--- a/internal/api/finalize.go
+++ b/internal/api/finalize.go
@@ -47,17 +47,18 @@ func (h *Handlers) finalizePause(ctx context.Context, params db.FinalizePausePar
 		// The index dropped between the probe and the statement.
 	}
 	return h.DB.FinalizePauseGeneration(ctx, db.FinalizePauseGenerationParams{
-		ID:                params.ID,
-		TeamID:            params.TeamID,
-		Path:              params.Path,
-		MemPath:           params.MemPath,
-		SizeBytes:         params.SizeBytes,
-		Trigger:           params.Trigger,
-		ManifestFileNames: params.ManifestFileNames,
-		ManifestPaths:     params.ManifestPaths,
-		ManifestSizes:     params.ManifestSizes,
-		ManifestDigests:   params.ManifestDigests,
-		ManifestBasePaths: params.ManifestBasePaths,
-		PauseToken:        params.PauseToken,
+		ID:                     params.ID,
+		TeamID:                 params.TeamID,
+		Path:                   params.Path,
+		MemPath:                params.MemPath,
+		SizeBytes:              params.SizeBytes,
+		Trigger:                params.Trigger,
+		PauseToken:             params.PauseToken,
+		ManifestFileNames:      params.ManifestFileNames,
+		ManifestPaths:          params.ManifestPaths,
+		ManifestSizes:          params.ManifestSizes,
+		ManifestAllocatedBytes: params.ManifestAllocatedBytes,
+		ManifestDigests:        params.ManifestDigests,
+		ManifestBasePaths:      params.ManifestBasePaths,
 	})
 }

--- a/internal/api/handlers_platform_billing.go
+++ b/internal/api/handlers_platform_billing.go
@@ -283,6 +283,29 @@ compute_usage AS (
 	 AND COALESCE(i.ended_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
 	GROUP BY sp.team_id
 ),
+artifact_bounds AS (
+	SELECT
+		s.id,
+		s.team_id,
+		s.snapshot_id,
+		s.template_id,
+		s.base_path,
+		s.delta_path,
+		s.destroyed_at,
+		first_interval.started_at AS billing_started_at
+	FROM selected_plans sp
+	JOIN sandbox s ON s.team_id = sp.team_id
+	LEFT JOIN LATERAL (
+		SELECT MIN(i.started_at) AS started_at
+		FROM sandbox_storage_interval i
+		WHERE i.sandbox_id = s.id
+		  AND i.team_id = s.team_id
+	) first_interval ON true
+	WHERE first_interval.started_at IS NOT NULL
+	  AND first_interval.started_at < LEAST(sp.calculated_at, sp.period_end)
+	  AND s.created_at < LEAST(sp.calculated_at, sp.period_end)
+	  AND COALESCE(s.destroyed_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
+),
 storage_usage AS (
 	SELECT
 		sp.team_id,
@@ -291,14 +314,26 @@ storage_usage AS (
 				LEAST(COALESCE(i.ended_at, sp.calculated_at), sp.period_end)
 				- GREATEST(i.started_at, sp.period_start)
 			)) * i.disk_mib
-		), 0)::numeric AS storage_mib_seconds
+		), 0)::numeric + COALESCE((SELECT FLOOR(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r))))) FROM (
+			SELECT p.path,
+				MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+				range_agg(tstzrange(GREATEST(s.billing_started_at, sp.period_start), LEAST(COALESCE(s.destroyed_at, sp.calculated_at), sp.period_end), '[)')) AS retained_ranges
+			FROM artifact_bounds s
+			LEFT JOIN template t ON t.id = s.template_id
+			CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+			LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+				AND am.path = p.path
+			WHERE s.team_id = sp.team_id
+  				AND p.path IS NOT NULL
+			GROUP BY p.path
+		) ar CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)), 0) AS storage_mib_seconds
 	FROM selected_plans sp
 	LEFT JOIN sandbox_storage_interval i
 	  ON i.team_id = sp.team_id
 	 AND sp.period_start < LEAST(sp.calculated_at, sp.period_end)
 	 AND i.started_at < LEAST(sp.calculated_at, sp.period_end)
 	 AND COALESCE(i.ended_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
-	GROUP BY sp.team_id
+	GROUP BY sp.team_id, sp.calculated_at, sp.period_start, sp.period_end
 ),
 credits AS (
 	SELECT
@@ -335,6 +370,7 @@ costed AS (
 		sp.*,
 		r.plan_name,
 		r.currency,
+		su.storage_mib_seconds,
 		ac.available_usd,
 		(cu.vcpu_seconds * r.vcpu_rate) AS compute_usd,
 		((cu.memory_mib_seconds / 1024.0) * r.memory_rate) AS memory_usd,
@@ -403,6 +439,7 @@ response_rows AS (
 				'credits_applied_usd', credits_applied_usd,
 				'credits_remaining_usd', credits_remaining_usd,
 				'expected_invoice_amount_usd', expected_invoice_amount_usd,
+				'storage_mib_seconds', storage_mib_seconds,
 				'cost_breakdown_usd', jsonb_build_object(
 					'compute', compute_usd,
 					'memory', memory_usd,
@@ -553,6 +590,29 @@ compute_usage AS (
 	 AND COALESCE(i.ended_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
 	GROUP BY sp.team_id
 ),
+artifact_bounds AS (
+	SELECT
+		s.id,
+		s.team_id,
+		s.snapshot_id,
+		s.template_id,
+		s.base_path,
+		s.delta_path,
+		s.destroyed_at,
+		first_interval.started_at AS billing_started_at
+	FROM selected_plans sp
+	JOIN sandbox s ON s.team_id = sp.team_id
+	LEFT JOIN LATERAL (
+		SELECT MIN(i.started_at) AS started_at
+		FROM sandbox_storage_interval i
+		WHERE i.sandbox_id = s.id
+		  AND i.team_id = s.team_id
+	) first_interval ON true
+	WHERE first_interval.started_at IS NOT NULL
+	  AND first_interval.started_at < LEAST(sp.calculated_at, sp.period_end)
+	  AND s.created_at < LEAST(sp.calculated_at, sp.period_end)
+	  AND COALESCE(s.destroyed_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
+),
 storage_usage AS (
 	SELECT
 		sp.team_id,
@@ -561,14 +621,26 @@ storage_usage AS (
 				LEAST(COALESCE(i.ended_at, sp.calculated_at), sp.period_end)
 				- GREATEST(i.started_at, sp.period_start)
 			)) * i.disk_mib
-		), 0)::numeric AS storage_mib_seconds
+		), 0)::numeric + COALESCE((SELECT FLOOR(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r))))) FROM (
+			SELECT p.path,
+				MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+				range_agg(tstzrange(GREATEST(s.billing_started_at, sp.period_start), LEAST(COALESCE(s.destroyed_at, sp.calculated_at), sp.period_end), '[)')) AS retained_ranges
+			FROM artifact_bounds s
+			LEFT JOIN template t ON t.id = s.template_id
+			CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+			LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+				AND am.path = p.path
+			WHERE s.team_id = sp.team_id
+  				AND p.path IS NOT NULL
+			GROUP BY p.path
+		) ar CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)), 0) AS storage_mib_seconds
 	FROM selected_plans sp
 	LEFT JOIN sandbox_storage_interval i
 	  ON i.team_id = sp.team_id
 	 AND sp.period_start < LEAST(sp.calculated_at, sp.period_end)
 	 AND i.started_at < LEAST(sp.calculated_at, sp.period_end)
 	 AND COALESCE(i.ended_at, LEAST(sp.calculated_at, sp.period_end)) > sp.period_start
-	GROUP BY sp.team_id
+	GROUP BY sp.team_id, sp.calculated_at, sp.period_start, sp.period_end
 ),
 credits AS (
 	SELECT
@@ -605,6 +677,7 @@ costed AS (
 		sp.*,
 		r.plan_name,
 		r.currency,
+		su.storage_mib_seconds,
 		ac.available_usd,
 		(cu.vcpu_seconds * r.vcpu_rate) AS compute_usd,
 		((cu.memory_mib_seconds / 1024.0) * r.memory_rate) AS memory_usd,
@@ -666,6 +739,7 @@ response_rows AS (
 				'credits_applied_usd', credits_applied_usd,
 				'credits_remaining_usd', credits_remaining_usd,
 				'expected_invoice_amount_usd', expected_invoice_amount_usd,
+				'storage_mib_seconds', storage_mib_seconds,
 				'cost_breakdown_usd', jsonb_build_object(
 					'compute', compute_usd,
 					'memory', memory_usd,

--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog/log"
@@ -17,10 +18,17 @@ const (
 	maxHostCapabilities     = 32
 	maxHostCapabilityLength = 64
 	maxHostFieldLength      = 256
+	maxHostStorageSamples   = 200000
 )
 
+type hostStorageMeasurement struct {
+	SandboxID      string `json:"sandbox_id"`
+	AllocatedBytes int64  `json:"allocated_bytes"`
+}
+
 type hostHeartbeatRequest struct {
-	Capabilities []string `json:"capabilities"`
+	Capabilities []string                 `json:"capabilities"`
+	Storage      []hostStorageMeasurement `json:"storage,omitempty"`
 
 	// Self-description, sent by vmds that support self-registration. When a
 	// heartbeat arrives for an unknown host id with a complete description,
@@ -49,14 +57,6 @@ var (
 // last_heartbeat_at; a background detector marks hosts unhealthy after
 // 2 minutes of silence. If the host was previously marked unhealthy, the
 // heartbeat automatically re-activates it (recovery from transient outage).
-//
-// A heartbeat for an unknown host id that carries a complete self-description
-// registers the host in 'provisioning' — never serving — until an operator
-// activates it. A heartbeat claiming an existing id from a different vmd_addr
-// is rejected while the row's holder is still heartbeating: two live daemons
-// must never share an identity (each would reconcile the other's sandboxes).
-// If the holder has gone silent past the unhealthy threshold, the identity is
-// released to the new address (re-provisioned host, new internal IP).
 func (h *Handlers) HostHeartbeat(c *gin.Context) {
 	hostID := c.Param("host_id")
 	if hostID == "" {
@@ -75,6 +75,10 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		respondErrorMsg(c, "bad_request", "too many capabilities", http.StatusBadRequest)
 		return
 	}
+	if len(req.Storage) > maxHostStorageSamples {
+		respondErrorMsg(c, "bad_request", "too many storage measurements", http.StatusBadRequest)
+		return
+	}
 	for _, f := range []string{req.VMDAddr, req.ProxyAddr, req.Region} {
 		if len(f) > maxHostFieldLength {
 			respondErrorMsg(c, "bad_request", "host description fields must be short", http.StatusBadRequest)
@@ -89,15 +93,31 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		}
 		capabilities = append(capabilities, capability)
 	}
+	storageIDs := make([]uuid.UUID, 0, len(req.Storage))
+	storageMiB := make([]int32, 0, len(req.Storage))
+	for _, measurement := range req.Storage {
+		sandboxID, err := uuid.Parse(measurement.SandboxID)
+		if err != nil || measurement.AllocatedBytes < 0 {
+			respondErrorMsg(c, "bad_request", "invalid storage measurement", http.StatusBadRequest)
+			return
+		}
+		mib := (measurement.AllocatedBytes + (1 << 20) - 1) >> 20
+		if mib > int64(^uint32(0)>>1) {
+			respondErrorMsg(c, "bad_request", "storage measurement is too large", http.StatusBadRequest)
+			return
+		}
+		storageIDs = append(storageIDs, sandboxID)
+		storageMiB = append(storageMiB, int32(mib))
+	}
 
 	ctx := c.Request.Context()
 	registered := false
 	reclaimed := false
-	beat := func(q *db.Queries) (status, prevStatus string, lastHeartbeatAt pgtype.Timestamptz, _ error) {
+	beat := func(q *db.Queries) (status, prevStatus string, _ error) {
 		host, err := q.GetHostForUpdate(ctx, hostID)
 		if err == pgx.ErrNoRows {
 			if !req.describesHost() {
-				return "", "", pgtype.Timestamptz{}, errHostNotRegistered
+				return "", "", errHostNotRegistered
 			}
 			created, err := q.RegisterHost(ctx, db.RegisterHostParams{
 				ID:                hostID,
@@ -108,43 +128,41 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 				CapacityVcpus:     req.CapacityVcpus,
 			})
 			if err != nil {
-				return "", "", pgtype.Timestamptz{}, err
+				return "", "", err
 			}
 			registered = true
 			if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
 				HostID: hostID, Capabilities: capabilities,
 			}); err != nil {
-				return "", "", pgtype.Timestamptz{}, err
+				return "", "", err
 			}
-			return created.Status, created.Status, created.LastHeartbeatAt, nil
+			if len(storageIDs) > 0 {
+				if _, err := q.UpdateHostSandboxStorageMeasurements(ctx, db.UpdateHostSandboxStorageMeasurementsParams{
+					SandboxIds: storageIDs,
+					DiskMib:    storageMiB,
+					HostID:     hostID,
+				}); err != nil {
+					return "", "", err
+				}
+			}
+			return created.Status, created.Status, nil
 		}
 		if err != nil {
-			return "", "", pgtype.Timestamptz{}, err
+			return "", "", err
 		}
 
-		// Once a row is identity-bound, description-less heartbeats are
-		// rejected outright. The shared internal token cannot distinguish
-		// daemons, so after a reclaim the previous holder's legacy
-		// heartbeats would otherwise keep refreshing liveness and
-		// capabilities on a row that now belongs to another machine —
-		// and its reconciler would keep operating under an id it lost.
 		if host.IdentityBound && !req.describesHost() {
-			return "", "", pgtype.Timestamptz{}, errHostIdentityRequired
+			return "", "", errHostIdentityRequired
 		}
 
 		if req.VMDAddr != "" && req.VMDAddr != host.VmdAddr {
 			holderAlive := host.LastHeartbeatAt.Valid &&
 				time.Since(host.LastHeartbeatAt.Time) < heartbeatTimeout
 			if holderAlive {
-				return "", "", pgtype.Timestamptz{}, errHostIdentityConflict
+				return "", "", errHostIdentityConflict
 			}
-			// Claiming an existing identity from a new address is a
-			// re-registration: it rewrites the whole row, so it needs the
-			// whole description. A partial one would blank proxy_addr or
-			// region, and heartbeating without reclaiming would mark a row
-			// live while its address points at the silent old machine.
 			if !req.describesHost() {
-				return "", "", pgtype.Timestamptz{}, errHostPartialDescription
+				return "", "", errHostPartialDescription
 			}
 			if err := q.UpdateHostAddresses(ctx, db.UpdateHostAddressesParams{
 				ID:                hostID,
@@ -154,7 +172,7 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 				CapacityMemoryMib: req.CapacityMemoryMib,
 				CapacityVcpus:     req.CapacityVcpus,
 			}); err != nil {
-				return "", "", pgtype.Timestamptz{}, err
+				return "", "", err
 			}
 			reclaimed = true
 			log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
@@ -163,63 +181,75 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 
 		row, err := q.UpdateHostHeartbeat(ctx, hostID)
 		if err != nil {
-			return "", "", pgtype.Timestamptz{}, err
+			return "", "", err
 		}
-		// Missing capabilities is an explicit empty replacement. This clears a
-		// stale attestation immediately when VMD can no longer verify its proxy.
 		if err := q.SyncHostCapabilities(ctx, db.SyncHostCapabilitiesParams{
 			HostID: hostID, Capabilities: capabilities,
 		}); err != nil {
-			return "", "", pgtype.Timestamptz{}, err
+			return "", "", err
 		}
-		// Opt-in: a complete description at the row's current address binds
-		// the identity, so later description-less heartbeats for this id
-		// are rejected. (Registration and reclaim bind in their own writes.)
-		if !host.IdentityBound && req.describesHost() && req.VMDAddr == host.VmdAddr {
-			if err := q.BindHostIdentity(ctx, hostID); err != nil {
-				return "", "", pgtype.Timestamptz{}, err
+		if len(storageIDs) > 0 {
+			if _, err := q.UpdateHostSandboxStorageMeasurements(ctx, db.UpdateHostSandboxStorageMeasurementsParams{
+				SandboxIds: storageIDs,
+				DiskMib:    storageMiB,
+				HostID:     hostID,
+			}); err != nil {
+				return "", "", err
 			}
 		}
-		return row.Status, row.PrevStatus, row.LastHeartbeatAt, nil
+		if !host.IdentityBound && req.describesHost() && req.VMDAddr == host.VmdAddr {
+			if err := q.BindHostIdentity(ctx, hostID); err != nil {
+				return "", "", err
+			}
+		}
+		return row.Status, row.PrevStatus, nil
 	}
 
-	var status, prevStatus string
-	var lastHeartbeatAt pgtype.Timestamptz
+	var host db.UpdateHostHeartbeatRow
 	var err error
 	if h.Pool == nil {
-		status, prevStatus, lastHeartbeatAt, err = beat(h.DB)
+		var status, prevStatus string
+		status, prevStatus, err = beat(h.DB)
+		host.Status = status
+		host.PrevStatus = prevStatus
 	} else {
 		var tx pgx.Tx
 		if tx, err = h.Pool.Begin(ctx); err == nil {
 			defer tx.Rollback(ctx)
-			if status, prevStatus, lastHeartbeatAt, err = beat(h.DB.WithTx(tx)); err == nil {
+			var status, prevStatus string
+			if status, prevStatus, err = beat(h.DB.WithTx(tx)); err == nil {
+				host.Status = status
+				host.PrevStatus = prevStatus
 				err = tx.Commit(ctx)
 			}
 		}
 	}
-	switch {
-	case err == errHostNotRegistered:
-		respondErrorMsg(c, "not_found", "host not found", http.StatusNotFound)
-		return
-	case err == errHostIdentityConflict:
-		log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
-			Msg("heartbeat rejected: identity in use by a live host at another address")
-		respondErrorMsg(c, "conflict", "host identity in use by a live host", http.StatusConflict)
-		return
-	case err == errHostIdentityRequired:
-		log.Warn().Str("host_id", hostID).
-			Msg("heartbeat rejected: identity-bound host sent a description-less heartbeat")
-		respondErrorMsg(c, "conflict",
-			"host identity is bound; heartbeats must carry the complete self-description",
-			http.StatusConflict)
-		return
-	case err == errHostPartialDescription:
-		log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
-			Msg("heartbeat rejected: address claim without a complete host description")
-		respondErrorMsg(c, "bad_request", "claiming a host address requires a complete host description", http.StatusBadRequest)
-		return
-	case err != nil:
-		log.Error().Err(err).Str("host_id", hostID).Msg("host heartbeat failed")
+	if err != nil {
+		if err == errHostNotRegistered {
+			respondErrorMsg(c, "not_found", "host not found", http.StatusNotFound)
+			return
+		}
+		if err == errHostIdentityConflict {
+			log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
+				Msg("heartbeat rejected: identity in use by a live host at another address")
+			respondErrorMsg(c, "conflict", "host identity in use by a live host", http.StatusConflict)
+			return
+		}
+		if err == errHostIdentityRequired {
+			log.Warn().Str("host_id", hostID).
+				Msg("heartbeat rejected: identity-bound host sent a description-less heartbeat")
+			respondErrorMsg(c, "conflict",
+				"host identity is bound; heartbeats must carry the complete self-description",
+				http.StatusConflict)
+			return
+		}
+		if err == errHostPartialDescription {
+			log.Warn().Str("host_id", hostID).Str("vmd_addr", req.VMDAddr).
+				Msg("heartbeat rejected: address claim without a complete host description")
+			respondErrorMsg(c, "bad_request", "claiming a host address requires a complete host description", http.StatusBadRequest)
+			return
+		}
+		log.Error().Err(err).Str("host_id", hostID).Msg("UpdateHostHeartbeat failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -230,22 +260,16 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 	}
 	if reclaimed {
 		if h.Hosts != nil {
-			// The row's vmd_addr changed; a cached client still dials the old
-			// machine (the registry only self-evicts on dead transports, and a
-			// live old daemon would silently take the wrong host's RPCs).
 			h.Hosts.Invalidate(hostID)
 		}
 		if h.Scheduler != nil {
-			// The reclaim demoted the row to provisioning; a previously
-			// active host must leave the candidate set now, not at TTL.
 			h.Scheduler.Invalidate()
 		}
 	}
 	log.Debug().Str("host_id", hostID).Strs("capabilities", capabilities).
-		Interface("last_heartbeat_at", timestamptzString(lastHeartbeatAt)).
-		Str("status", status).Str("prev_status", prevStatus).
+		Str("status", host.Status).Str("prev_status", host.PrevStatus).
 		Msg("host heartbeat persisted")
-	if prevStatus == "unhealthy" && status == "active" {
+	if host.PrevStatus == "unhealthy" && host.Status == "active" {
 		// The heartbeat just recovered this host; drop the scheduler's cached
 		// list so its capacity is usable now, not after the cache TTL.
 		log.Info().Str("host_id", hostID).Msg("host recovered via heartbeat")
@@ -254,7 +278,7 @@ func (h *Handlers) HostHeartbeat(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": status})
+	c.JSON(http.StatusOK, gin.H{"status": host.Status})
 }
 
 type hostStatusRequest struct {
@@ -344,8 +368,11 @@ func (h *Handlers) HostList(c *gin.Context) {
 	hosts := make([]hostView, 0, len(rows))
 	for _, r := range rows {
 		v := hostView{
-			ID: r.ID, Status: r.Status, Region: r.Region,
-			VMDAddr: r.VmdAddr, ProxyAddr: r.ProxyAddr,
+			ID:                r.ID,
+			Status:            r.Status,
+			Region:            r.Region,
+			VMDAddr:           r.VmdAddr,
+			ProxyAddr:         r.ProxyAddr,
 			CapacityMemoryMib: r.CapacityMemoryMib,
 			CapacityVcpus:     r.CapacityVcpus,
 			RunningCount:      r.RunningCount,

--- a/internal/api/manifest.go
+++ b/internal/api/manifest.go
@@ -22,6 +22,7 @@ func applyManifest(p *db.FinalizePauseParams, manifest []vmdclient.ManifestEntry
 		p.ManifestFileNames = append(p.ManifestFileNames, e.FileName)
 		p.ManifestPaths = append(p.ManifestPaths, e.Path)
 		p.ManifestSizes = append(p.ManifestSizes, e.SizeBytes)
+		p.ManifestAllocatedBytes = append(p.ManifestAllocatedBytes, e.AllocatedBytes)
 		p.ManifestDigests = append(p.ManifestDigests, e.SHA256)
 		p.ManifestBasePaths = append(p.ManifestBasePaths, e.BasePath)
 	}

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -720,15 +720,66 @@ WITH compute AS (
       AND i.started_at < LEAST(now(), $3)
       AND COALESCE(i.ended_at, LEAST(now(), $3)) > $2
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = $1
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(now(), $3)
+      AND s.created_at < LEAST(now(), $3)
+      AND COALESCE(s.destroyed_at, LEAST(now(), $3)) > $2
+),
+artifact_ranges AS (
+    SELECT p.path,
+           MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+           range_agg(tstzrange(
+               GREATEST(s.billing_started_at, $2),
+               LEAST(COALESCE(s.destroyed_at, now()), $3), '[)'
+           )) AS retained_ranges
+    FROM artifact_bounds s
+    LEFT JOIN template t ON t.id = s.template_id
+    CROSS JOIN LATERAL unnest(ARRAY[
+        s.base_path,
+        s.delta_path,
+        CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END
+    ]) AS p(path)
+    LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+      AND am.path = p.path
+    WHERE p.path IS NOT NULL
+    GROUP BY p.path
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM artifact_ranges ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
+    -- Overlay intervals are per sandbox; template artifacts are a separate
+    -- distinct-path set so shared bases and deltas are never multiplied by
+    -- the number of sandboxes that pin them.
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, now()), $3)
             - GREATEST(i.started_at, $2)
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = $1
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = $1
       AND $2 < LEAST(now(), $3)
       AND i.started_at < LEAST(now(), $3)
       AND COALESCE(i.ended_at, LEAST(now(), $3)) > $2
@@ -2019,6 +2070,51 @@ func (q *Queries) UpdateBillingUsageExportStatus(ctx context.Context, arg Update
 	return i, err
 }
 
+const updateHostSandboxStorageMeasurements = `-- name: UpdateHostSandboxStorageMeasurements :execrows
+WITH measurements AS MATERIALIZED (
+    SELECT unnest($1::uuid[]) AS sandbox_id,
+           unnest($2::int[]) AS disk_mib
+), eligible AS MATERIALIZED (
+    SELECT s.id, s.team_id, m.disk_mib
+    FROM measurements m
+    JOIN sandbox s ON s.id = m.sandbox_id
+    WHERE s.host_id = $3
+      AND s.destroyed_at IS NULL
+      AND feature_enabled('billing_metrics_write', s.team_id)
+), closed AS (
+    UPDATE sandbox_storage_interval i
+    SET ended_at = statement_timestamp(), end_reason = 'measurement'
+    FROM eligible e
+    WHERE i.sandbox_id = e.id
+      AND i.team_id = e.team_id
+      AND i.ended_at IS NULL
+      AND i.disk_mib IS DISTINCT FROM e.disk_mib
+    RETURNING i.sandbox_id, i.team_id
+)
+INSERT INTO sandbox_storage_interval (sandbox_id, team_id, disk_mib, started_at)
+SELECT e.id, e.team_id, e.disk_mib, statement_timestamp()
+FROM eligible e
+LEFT JOIN closed c ON c.sandbox_id = e.id AND c.team_id = e.team_id
+ON CONFLICT (sandbox_id) WHERE ended_at IS NULL DO NOTHING
+`
+
+type UpdateHostSandboxStorageMeasurementsParams struct {
+	SandboxIds []uuid.UUID `json:"sandbox_ids"`
+	DiskMib    []int32     `json:"disk_mib"`
+	HostID     string      `json:"host_id"`
+}
+
+// Apply trusted host-side overlay allocations without rewriting history.
+// statement_timestamp() is stable for the whole statement, so closing and
+// opening an interval use the exact same measurement boundary.
+func (q *Queries) UpdateHostSandboxStorageMeasurements(ctx context.Context, arg UpdateHostSandboxStorageMeasurementsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateHostSandboxStorageMeasurements, arg.SandboxIds, arg.DiskMib, arg.HostID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const upsertTeamBillingAccountCustomer = `-- name: UpsertTeamBillingAccountCustomer :one
 INSERT INTO team_billing_account (team_id, stripe_customer_id)
 VALUES ($1, $2)
@@ -2210,15 +2306,55 @@ WITH compute AS (
       AND i.started_at < LEAST(now(), $1)
       AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = $3
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(now(), $1)
+      AND s.created_at < LEAST(now(), $1)
+      AND COALESCE(s.destroyed_at, LEAST(now(), $1)) > $2
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM (
+        SELECT p.path,
+               MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+               range_agg(tstzrange(GREATEST(s.billing_started_at, $2), LEAST(COALESCE(s.destroyed_at, now()), $1), '[)')) AS retained_ranges
+        FROM artifact_bounds s
+        LEFT JOIN template t ON t.id = s.template_id
+        CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+        LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+          AND am.path = p.path
+        WHERE p.path IS NOT NULL
+        GROUP BY p.path
+    ) ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, now()), $1)
             - GREATEST(i.started_at, $2)
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = $3
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = $3
       AND $2 < LEAST(now(), $1)
       AND i.started_at < LEAST(now(), $1)
       AND COALESCE(i.ended_at, LEAST(now(), $1)) > $2
@@ -2356,15 +2492,55 @@ WITH compute AS (
       AND $2 < LEAST(billing_request_now(), $1)
       AND COALESCE(i.ended_at, LEAST(billing_request_now(), $1)) > $2
 ),
+artifact_bounds AS (
+    SELECT
+        s.id,
+        s.team_id,
+        s.snapshot_id,
+        s.template_id,
+        s.base_path,
+        s.delta_path,
+        s.destroyed_at,
+        first_interval.started_at AS billing_started_at
+    FROM sandbox s
+    LEFT JOIN LATERAL (
+        SELECT MIN(i.started_at) AS started_at
+        FROM sandbox_storage_interval i
+        WHERE i.sandbox_id = s.id
+          AND i.team_id = s.team_id
+    ) first_interval ON true
+    WHERE s.team_id = $3
+      AND first_interval.started_at IS NOT NULL
+      AND first_interval.started_at < LEAST(billing_request_now(), $1)
+      AND s.created_at < LEAST(billing_request_now(), $1)
+      AND COALESCE(s.destroyed_at, LEAST(billing_request_now(), $1)) > $2
+),
+artifact_storage AS (
+    SELECT FLOOR(COALESCE(SUM(ar.artifact_mib * EXTRACT(EPOCH FROM (upper(r) - lower(r)))), 0))::numeric AS mib_seconds
+    FROM (
+        SELECT p.path,
+               MAX(COALESCE(NULLIF(am.allocated_bytes, 0), 0))::numeric / 1048576.0 AS artifact_mib,
+               range_agg(tstzrange(GREATEST(s.billing_started_at, $2), LEAST(COALESCE(s.destroyed_at, billing_request_now()), $1), '[)')) AS retained_ranges
+        FROM artifact_bounds s
+        LEFT JOIN template t ON t.id = s.template_id
+        CROSS JOIN LATERAL unnest(ARRAY[s.base_path, s.delta_path, CASE WHEN s.base_path IS NULL AND s.delta_path IS NULL THEN t.rootfs_path END]) AS p(path)
+        LEFT JOIN artifact_manifest am ON (am.snapshot_id = s.snapshot_id OR am.template_id = t.id)
+          AND am.path = p.path
+        WHERE p.path IS NOT NULL
+        GROUP BY p.path
+    ) ar
+    CROSS JOIN LATERAL unnest(ar.retained_ranges) AS ranges(r)
+),
 storage AS (
     SELECT COALESCE(SUM(
         EXTRACT(EPOCH FROM (
             LEAST(COALESCE(i.ended_at, billing_request_now()), $1)
             - GREATEST(i.started_at, $2)
         )) * i.disk_mib
-    ), 0)::numeric AS storage_mib_seconds
-    FROM sandbox_storage_interval i
-    WHERE i.team_id = $3
+    ), 0)::numeric + COALESCE(MAX(artifact_storage.mib_seconds), 0) AS storage_mib_seconds
+    FROM artifact_storage
+    LEFT JOIN sandbox_storage_interval i ON
+      i.team_id = $3
       AND i.started_at < $1
       AND $2 < LEAST(billing_request_now(), $1)
       AND COALESCE(i.ended_at, LEAST(billing_request_now(), $1)) > $2

--- a/internal/db/manifests.sql.go
+++ b/internal/db/manifests.sql.go
@@ -21,7 +21,7 @@ func (q *Queries) DeleteSnapshotManifest(ctx context.Context, snapshotID pgtype.
 }
 
 const listSnapshotManifest = `-- name: ListSnapshotManifest :many
-SELECT id, snapshot_id, template_id, file_name, path, size_bytes, sha256, base_path, guest_kernel, vmd_version, created_at FROM artifact_manifest
+SELECT id, snapshot_id, template_id, file_name, path, size_bytes, sha256, base_path, guest_kernel, vmd_version, created_at, allocated_bytes FROM artifact_manifest
 WHERE snapshot_id = $1
 ORDER BY file_name
 `
@@ -47,6 +47,7 @@ func (q *Queries) ListSnapshotManifest(ctx context.Context, snapshotID pgtype.UU
 			&i.GuestKernel,
 			&i.VmdVersion,
 			&i.CreatedAt,
+			&i.AllocatedBytes,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -227,17 +227,18 @@ type ApiKey struct {
 }
 
 type ArtifactManifest struct {
-	ID          uuid.UUID   `json:"id"`
-	SnapshotID  pgtype.UUID `json:"snapshot_id"`
-	TemplateID  pgtype.UUID `json:"template_id"`
-	FileName    string      `json:"file_name"`
-	Path        string      `json:"path"`
-	SizeBytes   int64       `json:"size_bytes"`
-	Sha256      string      `json:"sha256"`
-	BasePath    *string     `json:"base_path"`
-	GuestKernel *string     `json:"guest_kernel"`
-	VmdVersion  *string     `json:"vmd_version"`
-	CreatedAt   time.Time   `json:"created_at"`
+	ID             uuid.UUID   `json:"id"`
+	SnapshotID     pgtype.UUID `json:"snapshot_id"`
+	TemplateID     pgtype.UUID `json:"template_id"`
+	FileName       string      `json:"file_name"`
+	Path           string      `json:"path"`
+	SizeBytes      int64       `json:"size_bytes"`
+	Sha256         string      `json:"sha256"`
+	BasePath       *string     `json:"base_path"`
+	GuestKernel    *string     `json:"guest_kernel"`
+	VmdVersion     *string     `json:"vmd_version"`
+	CreatedAt      time.Time   `json:"created_at"`
+	AllocatedBytes int64       `json:"allocated_bytes"`
 }
 
 type AuditLog struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -1267,17 +1267,26 @@ fresh AS (
   SELECT unnest($8::text[]) AS file_name,
          unnest($9::text[])      AS path,
          unnest($10::bigint[])    AS size_bytes,
-         unnest($11::text[])    AS sha256,
-         unnest($12::text[]) AS base_path
+         unnest($11::bigint[]) AS allocated_bytes,
+         unnest($12::text[])    AS sha256,
+         unnest($13::text[]) AS base_path
 ),
 kept AS (
-  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256, base_path)
-  SELECT u.snap_id, f.file_name, f.path, f.size_bytes, f.sha256, NULLIF(f.base_path, '')
+  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256, base_path)
+  SELECT u.snap_id, f.file_name, f.path, f.size_bytes,
+         CASE WHEN f.allocated_bytes IS NULL OR f.allocated_bytes < 0 THEN
+                COALESCE((SELECT am.allocated_bytes
+                          FROM artifact_manifest am
+                          WHERE am.snapshot_id = u.snap_id
+                            AND am.file_name = f.file_name), 0)
+              ELSE COALESCE(f.allocated_bytes, 0) END,
+         f.sha256, NULLIF(f.base_path, '')
   FROM upserted u CROSS JOIN fresh f
   ON CONFLICT (snapshot_id, file_name) WHERE snapshot_id IS NOT NULL
   DO UPDATE SET
       path = EXCLUDED.path,
       size_bytes = EXCLUDED.size_bytes,
+      allocated_bytes = EXCLUDED.allocated_bytes,
       sha256 = EXCLUDED.sha256,
       base_path = EXCLUDED.base_path,
       created_at = now()
@@ -1303,18 +1312,19 @@ RETURNING upserted.snap_id::uuid AS snapshot_id
 `
 
 type FinalizePauseParams struct {
-	ID                uuid.UUID `json:"id"`
-	TeamID            uuid.UUID `json:"team_id"`
-	Path              string    `json:"path"`
-	MemPath           *string   `json:"mem_path"`
-	SizeBytes         int64     `json:"size_bytes"`
-	Trigger           string    `json:"trigger"`
-	PauseToken        string    `json:"pause_token"`
-	ManifestFileNames []string  `json:"manifest_file_names"`
-	ManifestPaths     []string  `json:"manifest_paths"`
-	ManifestSizes     []int64   `json:"manifest_sizes"`
-	ManifestDigests   []string  `json:"manifest_digests"`
-	ManifestBasePaths []string  `json:"manifest_base_paths"`
+	ID                     uuid.UUID `json:"id"`
+	TeamID                 uuid.UUID `json:"team_id"`
+	Path                   string    `json:"path"`
+	MemPath                *string   `json:"mem_path"`
+	SizeBytes              int64     `json:"size_bytes"`
+	Trigger                string    `json:"trigger"`
+	PauseToken             string    `json:"pause_token"`
+	ManifestFileNames      []string  `json:"manifest_file_names"`
+	ManifestPaths          []string  `json:"manifest_paths"`
+	ManifestSizes          []int64   `json:"manifest_sizes"`
+	ManifestAllocatedBytes []int64   `json:"manifest_allocated_bytes"`
+	ManifestDigests        []string  `json:"manifest_digests"`
+	ManifestBasePaths      []string  `json:"manifest_base_paths"`
 }
 
 // Upsert the sandbox's live snapshot row and flip status to 'paused'.
@@ -1344,6 +1354,7 @@ func (q *Queries) FinalizePause(ctx context.Context, arg FinalizePauseParams) (u
 		arg.ManifestFileNames,
 		arg.ManifestPaths,
 		arg.ManifestSizes,
+		arg.ManifestAllocatedBytes,
 		arg.ManifestDigests,
 		arg.ManifestBasePaths,
 	)
@@ -1387,12 +1398,21 @@ fresh AS (
   SELECT unnest($8::text[]) AS file_name,
          unnest($9::text[])      AS path,
          unnest($10::bigint[])    AS size_bytes,
-         unnest($11::text[])    AS sha256,
-         unnest($12::text[]) AS base_path
+         unnest($11::bigint[]) AS allocated_bytes,
+         unnest($12::text[])    AS sha256,
+         unnest($13::text[]) AS base_path
 ),
 manifested AS (
-  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256, base_path)
-  SELECT i.snap_id, f.file_name, f.path, f.size_bytes, f.sha256, NULLIF(f.base_path, '')
+  INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256, base_path)
+  SELECT i.snap_id, f.file_name, f.path, f.size_bytes,
+         CASE WHEN f.allocated_bytes IS NULL OR f.allocated_bytes < 0 THEN
+                COALESCE((SELECT am.allocated_bytes
+                          FROM artifact_manifest am
+                          JOIN sandbox sb ON sb.snapshot_id = am.snapshot_id
+                          WHERE sb.id = $1
+                            AND am.file_name = f.file_name), 0)
+              ELSE COALESCE(f.allocated_bytes, 0) END,
+         f.sha256, NULLIF(f.base_path, '')
   FROM inserted i CROSS JOIN fresh f
   RETURNING id
 )
@@ -1408,18 +1428,19 @@ RETURNING inserted.snap_id::uuid AS snapshot_id
 `
 
 type FinalizePauseGenerationParams struct {
-	ID                uuid.UUID   `json:"id"`
-	TeamID            uuid.UUID   `json:"team_id"`
-	Path              string      `json:"path"`
-	MemPath           *string     `json:"mem_path"`
-	SizeBytes         interface{} `json:"size_bytes"`
-	Trigger           string      `json:"trigger"`
-	PauseToken        string      `json:"pause_token"`
-	ManifestFileNames []string    `json:"manifest_file_names"`
-	ManifestPaths     []string    `json:"manifest_paths"`
-	ManifestSizes     []int64     `json:"manifest_sizes"`
-	ManifestDigests   []string    `json:"manifest_digests"`
-	ManifestBasePaths []string    `json:"manifest_base_paths"`
+	ID                     uuid.UUID   `json:"id"`
+	TeamID                 uuid.UUID   `json:"team_id"`
+	Path                   string      `json:"path"`
+	MemPath                *string     `json:"mem_path"`
+	SizeBytes              interface{} `json:"size_bytes"`
+	Trigger                string      `json:"trigger"`
+	PauseToken             string      `json:"pause_token"`
+	ManifestFileNames      []string    `json:"manifest_file_names"`
+	ManifestPaths          []string    `json:"manifest_paths"`
+	ManifestSizes          []int64     `json:"manifest_sizes"`
+	ManifestAllocatedBytes []int64     `json:"manifest_allocated_bytes"`
+	ManifestDigests        []string    `json:"manifest_digests"`
+	ManifestBasePaths      []string    `json:"manifest_base_paths"`
 }
 
 // Generations-mode finalize: INSERT a new snapshot row per pause instead of
@@ -1441,6 +1462,7 @@ func (q *Queries) FinalizePauseGeneration(ctx context.Context, arg FinalizePause
 		arg.ManifestFileNames,
 		arg.ManifestPaths,
 		arg.ManifestSizes,
+		arg.ManifestAllocatedBytes,
 		arg.ManifestDigests,
 		arg.ManifestBasePaths,
 	)

--- a/internal/db/templates.sql.go
+++ b/internal/db/templates.sql.go
@@ -390,7 +390,7 @@ WITH build_done AS (
       updated_at = now()
   WHERE template_build.id = $1 AND status IN ('building', 'snapshotting')
   RETURNING template_id
-)
+), updated AS (
 UPDATE template
 SET status = 'ready',
     rootfs_path = $2,
@@ -405,16 +405,63 @@ SET status = 'ready',
 FROM build_done
 WHERE template.id = build_done.template_id
 RETURNING template.id, template.team_id, template.name, template.status, template.build_spec, template.vcpu, template.memory_mib, template.disk_mib, template.rootfs_path, template.snapshot_path, template.mem_path, template.size_bytes, template.error_message, template.created_at, template.updated_at, template.built_at, template.deleted_at, template.base_path, template.delta_path
+), artifacts AS (
+INSERT INTO artifact_manifest (
+    template_id, file_name, path, size_bytes, allocated_bytes, sha256
+)
+SELECT DISTINCT ON (a.path) updated.id, a.file_name, a.path, a.size_bytes, a.allocated_bytes,
+       repeat('0', 64)
+FROM updated
+CROSS JOIN LATERAL (
+    VALUES
+        ('rootfs.ext4', updated.rootfs_path, COALESCE(updated.size_bytes, 0), $8::bigint),
+        ('base.ext4', updated.base_path, 0::bigint, $9::bigint),
+        ('delta.ext4', updated.delta_path, 0::bigint, $10::bigint)
+) AS a(file_name, path, size_bytes, allocated_bytes)
+WHERE a.path IS NOT NULL
+ORDER BY a.path, (a.file_name = 'rootfs.ext4') DESC
+ON CONFLICT (template_id, path) WHERE template_id IS NOT NULL DO UPDATE
+SET path = EXCLUDED.path,
+    size_bytes = EXCLUDED.size_bytes,
+    allocated_bytes = EXCLUDED.allocated_bytes
+RETURNING 1
+)
+SELECT id, team_id, name, status, build_spec, vcpu, memory_mib, disk_mib, rootfs_path, snapshot_path, mem_path, size_bytes, error_message, created_at, updated_at, built_at, deleted_at, base_path, delta_path FROM updated
 `
 
 type FinalizeBuildParams struct {
-	ID           uuid.UUID `json:"id"`
-	RootfsPath   *string   `json:"rootfs_path"`
-	SnapshotPath *string   `json:"snapshot_path"`
-	MemPath      *string   `json:"mem_path"`
-	SizeBytes    *int64    `json:"size_bytes"`
-	BasePath     *string   `json:"base_path"`
-	DeltaPath    *string   `json:"delta_path"`
+	ID                   uuid.UUID `json:"id"`
+	RootfsPath           *string   `json:"rootfs_path"`
+	SnapshotPath         *string   `json:"snapshot_path"`
+	MemPath              *string   `json:"mem_path"`
+	SizeBytes            *int64    `json:"size_bytes"`
+	BasePath             *string   `json:"base_path"`
+	DeltaPath            *string   `json:"delta_path"`
+	RootfsAllocatedBytes int64     `json:"rootfs_allocated_bytes"`
+	BaseAllocatedBytes   int64     `json:"base_allocated_bytes"`
+	DeltaAllocatedBytes  int64     `json:"delta_allocated_bytes"`
+}
+
+type FinalizeBuildRow struct {
+	ID           uuid.UUID          `json:"id"`
+	TeamID       uuid.UUID          `json:"team_id"`
+	Name         string             `json:"name"`
+	Status       TemplateStatus     `json:"status"`
+	BuildSpec    []byte             `json:"build_spec"`
+	Vcpu         int32              `json:"vcpu"`
+	MemoryMib    int32              `json:"memory_mib"`
+	DiskMib      int32              `json:"disk_mib"`
+	RootfsPath   *string            `json:"rootfs_path"`
+	SnapshotPath *string            `json:"snapshot_path"`
+	MemPath      *string            `json:"mem_path"`
+	SizeBytes    *int64             `json:"size_bytes"`
+	ErrorMessage *string            `json:"error_message"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
+	BuiltAt      pgtype.Timestamptz `json:"built_at"`
+	DeletedAt    pgtype.Timestamptz `json:"deleted_at"`
+	BasePath     *string            `json:"base_path"`
+	DeltaPath    *string            `json:"delta_path"`
 }
 
 // Atomically transition template_build → ready and template → ready with
@@ -424,7 +471,7 @@ type FinalizeBuildParams struct {
 //
 // INVARIANT: status='ready' and template.base_path must become visible
 // together — the reconciler GCs build dirs not referenced by base_path.
-func (q *Queries) FinalizeBuild(ctx context.Context, arg FinalizeBuildParams) (Template, error) {
+func (q *Queries) FinalizeBuild(ctx context.Context, arg FinalizeBuildParams) (FinalizeBuildRow, error) {
 	row := q.db.QueryRow(ctx, finalizeBuild,
 		arg.ID,
 		arg.RootfsPath,
@@ -433,8 +480,11 @@ func (q *Queries) FinalizeBuild(ctx context.Context, arg FinalizeBuildParams) (T
 		arg.SizeBytes,
 		arg.BasePath,
 		arg.DeltaPath,
+		arg.RootfsAllocatedBytes,
+		arg.BaseAllocatedBytes,
+		arg.DeltaAllocatedBytes,
 	)
-	var i Template
+	var i FinalizeBuildRow
 	err := row.Scan(
 		&i.ID,
 		&i.TeamID,

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -3207,6 +3207,201 @@ func TestIntegration_GetTeamBillingUsage(t *testing.T) {
 	}
 }
 
+func TestIntegration_GetTeamBillingUsageDeduplicatesSharedArtifact(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	var sandboxIDs []uuid.UUID
+	for _, name := range []string{"shared-artifact-a", "shared-artifact-b"} {
+		cw := do(r, "POST", "/sandboxes", apiKey, fmt.Sprintf(`{"name":%q}`, name))
+		if cw.Code != http.StatusCreated {
+			t.Fatalf("create %s: %d %s", name, cw.Code, cw.Body.String())
+		}
+		sandboxIDs = append(sandboxIDs, uuid.MustParse(mustJSON(t, cw)["id"].(string)))
+	}
+
+	periodStart := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	periodEnd := periodStart.Add(time.Minute)
+	const artifactPath = "/tmp/test/shared-rootfs.ext4"
+	const artifactBytes = int64(8 * 1024 * 1024)
+	for i, sandboxID := range sandboxIDs {
+		if _, err := testPool.Exec(ctx, `
+			UPDATE sandbox
+			SET created_at = $2, base_path = NULL, delta_path = NULL
+			WHERE id = $1 AND team_id = $3
+		`, sandboxID, periodStart, teamID); err != nil {
+			t.Fatalf("prepare sandbox %d: %v", i, err)
+		}
+		var snapshotID uuid.UUID
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO snapshot (sandbox_id, team_id, path, trigger)
+			VALUES ($1, $2, $3, 'pause')
+			RETURNING id
+		`, sandboxID, teamID, fmt.Sprintf("/tmp/test/snapshot-%d", i)).Scan(&snapshotID); err != nil {
+			t.Fatalf("seed snapshot %d: %v", i, err)
+		}
+		if _, err := testPool.Exec(ctx, `UPDATE sandbox SET snapshot_id = $2 WHERE id = $1`, sandboxID, snapshotID); err != nil {
+			t.Fatalf("link snapshot %d: %v", i, err)
+		}
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, snapshotID, fmt.Sprintf("rootfs-%d.ext4", i), artifactPath, artifactBytes, artifactBytes, strings.Repeat("0", 64)); err != nil {
+			t.Fatalf("seed artifact manifest %d: %v", i, err)
+		}
+		if _, err := testPool.Exec(ctx, `
+			UPDATE sandbox_storage_interval
+			SET started_at = $2, ended_at = $3, end_reason = 'deleted', disk_mib = 1
+			WHERE sandbox_id = $1 AND ended_at IS NULL
+		`, sandboxID, periodStart.Add(10*time.Second), periodStart.Add(20*time.Second)); err != nil {
+			t.Fatalf("set overlay interval %d: %v", i, err)
+		}
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE template SET rootfs_path = $1, size_bytes = $2 WHERE name = 'superserve/base'`, artifactPath, artifactBytes); err != nil {
+		t.Fatalf("set shared template artifact: %v", err)
+	}
+
+	usage, err := testQueries.GetTeamBillingUsage(ctx, db.GetTeamBillingUsageParams{
+		TeamID: teamID, PeriodStart: periodStart, PeriodEnd: periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("get team billing usage: %v", err)
+	}
+	if got, want := numericFloat64(t, usage.StorageGibSeconds), float64(artifactBytes/1024/1024*50+20)/1024; got != want {
+		t.Fatalf("storage GiB seconds = %v, want %v", got, want)
+	}
+}
+
+func TestIntegration_GetTeamBillingUsageStartsArtifactRetentionAtStorageBoundary(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"billing-artifact-boundary"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+
+	periodStart := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	periodEnd := periodStart.Add(time.Minute)
+	const artifactPath = "/tmp/test/boundary-rootfs.ext4"
+	const artifactBytes = int64(8 * 1024 * 1024)
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET created_at = $2, base_path = NULL, delta_path = NULL
+		WHERE id = $1 AND team_id = $3
+	`, sandboxID, periodStart, teamID); err != nil {
+		t.Fatalf("prepare sandbox: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_storage_interval
+		SET started_at = $2
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, periodStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("set storage boundary: %v", err)
+	}
+	var snapshotID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO snapshot (sandbox_id, team_id, path, trigger)
+		VALUES ($1, $2, $3, 'pause')
+		RETURNING id
+	`, sandboxID, teamID, "/tmp/test/boundary-snapshot").Scan(&snapshotID); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET snapshot_id = $2 WHERE id = $1`, sandboxID, snapshotID); err != nil {
+		t.Fatalf("link snapshot: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256)
+		VALUES ($1, 'boundary-rootfs.ext4', $2, $3, $4, $5)
+	`, snapshotID, artifactPath, artifactBytes, artifactBytes, strings.Repeat("0", 64)); err != nil {
+		t.Fatalf("seed artifact manifest: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE template SET rootfs_path = $1, size_bytes = $2 WHERE name = 'superserve/base'`, artifactPath, artifactBytes); err != nil {
+		t.Fatalf("set template artifact: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_storage_interval
+		SET started_at = $2, ended_at = $2, end_reason = 'deleted', disk_mib = 1
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, periodStart.Add(30*time.Second)); err != nil {
+		t.Fatalf("close overlay interval at boundary: %v", err)
+	}
+
+	usage, err := testQueries.GetTeamBillingUsage(ctx, db.GetTeamBillingUsageParams{
+		TeamID: teamID, PeriodStart: periodStart, PeriodEnd: periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("get team billing usage: %v", err)
+	}
+	if got, want := numericFloat64(t, usage.StorageGibSeconds), float64(artifactBytes/1024/1024*30)/1024; got != want {
+		t.Fatalf("storage GiB seconds = %v, want %v", got, want)
+	}
+}
+
+func TestIntegration_GetTeamBillingUsageExcludesUnmeasuredArtifact(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"billing-unmeasured-artifact"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sandboxID := uuid.MustParse(mustJSON(t, cw)["id"].(string))
+
+	periodStart := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Minute)
+	periodEnd := periodStart.Add(time.Minute)
+	const artifactPath = "/tmp/test/unmeasured-rootfs.ext4"
+	const logicalArtifactBytes = int64(64 * 1024 * 1024)
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox
+		SET created_at = $2, base_path = NULL, delta_path = NULL
+		WHERE id = $1 AND team_id = $3
+	`, sandboxID, periodStart, teamID); err != nil {
+		t.Fatalf("prepare sandbox: %v", err)
+	}
+	var snapshotID uuid.UUID
+	if err := testPool.QueryRow(ctx, `
+		INSERT INTO snapshot (sandbox_id, team_id, path, trigger)
+		VALUES ($1, $2, $3, 'pause')
+		RETURNING id
+	`, sandboxID, teamID, "/tmp/test/unmeasured-snapshot").Scan(&snapshotID); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET snapshot_id = $2 WHERE id = $1`, sandboxID, snapshotID); err != nil {
+		t.Fatalf("link snapshot: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256)
+		VALUES ($1, 'unmeasured-rootfs.ext4', $2, $3, $4)
+	`, snapshotID, artifactPath, logicalArtifactBytes, strings.Repeat("0", 64)); err != nil {
+		t.Fatalf("seed unmeasured artifact: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE template SET rootfs_path = $1, size_bytes = $2 WHERE name = 'superserve/base'`, artifactPath, logicalArtifactBytes); err != nil {
+		t.Fatalf("set template artifact: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE sandbox_storage_interval
+		SET started_at = $2, ended_at = $3, end_reason = 'deleted', disk_mib = 2
+		WHERE sandbox_id = $1 AND ended_at IS NULL
+	`, sandboxID, periodStart.Add(10*time.Second), periodStart.Add(20*time.Second)); err != nil {
+		t.Fatalf("set overlay interval: %v", err)
+	}
+
+	usage, err := testQueries.GetTeamBillingUsage(ctx, db.GetTeamBillingUsageParams{
+		TeamID: teamID, PeriodStart: periodStart, PeriodEnd: periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("get team billing usage: %v", err)
+	}
+	if got, want := numericFloat64(t, usage.StorageGibSeconds), float64(2*10)/1024; got != want {
+		t.Fatalf("storage GiB seconds = %v, want %v; logical artifact size must not be used", got, want)
+	}
+}
+
 func TestIntegration_BillingRollupWorkersProcessDistinctJobs(t *testing.T) {
 	ctx := context.Background()
 	teamA, _ := seedTeamAndKey(t)
@@ -5719,6 +5914,50 @@ func TestIntegration_FinalizePause_StaleFinalizeCannotOverwriteManifest(t *testi
 	}
 }
 
+func TestIntegration_FinalizePause_UnavailableAllocationKeepsPriorMeasurement(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"manifest-allocation-retention"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	sandboxID, _ := uuid.Parse(sid)
+	mem := "/snapshots/" + sid + "/mem.snap"
+	finalize := func(allocatedBytes int64) uuid.UUID {
+		t.Helper()
+		if _, err := testPool.Exec(ctx, `UPDATE sandbox SET status = 'pausing' WHERE id = $1`, sandboxID); err != nil {
+			t.Fatalf("force pausing: %v", err)
+		}
+		snapID, err := testQueries.FinalizePause(ctx, db.FinalizePauseParams{
+			ID: sandboxID, TeamID: teamID, Path: "/snapshots/" + sid + "/vmstate.snap",
+			MemPath: &mem, Trigger: "pause", ManifestFileNames: []string{"rootfs.ext4"},
+			ManifestPaths: []string{"/snapshots/" + sid + "/rootfs.ext4"}, ManifestSizes: []int64{4096},
+			ManifestAllocatedBytes: []int64{allocatedBytes}, ManifestDigests: []string{strings.Repeat("a", 64)},
+			ManifestBasePaths: []string{""},
+		})
+		if err != nil {
+			t.Fatalf("finalize: %v", err)
+		}
+		return snapID
+	}
+
+	snapID := finalize(8192)
+	updatedSnapID := finalize(-1)
+	if updatedSnapID != snapID {
+		t.Fatalf("finalize allocated a new snapshot %s; want conflict update of %s", updatedSnapID, snapID)
+	}
+	manifest, err := testQueries.ListSnapshotManifest(ctx, pgtype.UUID{Bytes: snapID, Valid: true})
+	if err != nil {
+		t.Fatalf("list manifest: %v", err)
+	}
+	if len(manifest) != 1 || manifest[0].AllocatedBytes != 8192 {
+		t.Fatalf("allocated_bytes = %+v, want retained 8192", manifest)
+	}
+}
+
 // The generations expand ships with the legacy unique index retained:
 // finalizes upsert in place (generation advancing) until the contract phase
 // drops the index, at which point the same binary starts inserting real
@@ -5833,6 +6072,83 @@ func TestIntegration_FinalizePause_GenerationModes(t *testing.T) {
 	}
 	if lastSize != 4096 {
 		t.Fatalf("partial-manifest generation size = %d, want prior size 4096 carried forward", lastSize)
+	}
+	// A failed host allocation sample on a new generation carries the prior
+	// head's allocation forward.
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET status = 'pausing' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatal(err)
+	}
+	allocationPath := "/snapshots/" + sid + "/overlay.ext4"
+	if _, err := testQueries.FinalizePauseGeneration(ctx, db.FinalizePauseGenerationParams{
+		ID: sandboxID, TeamID: teamID, Path: "p7", MemPath: &memPath, SizeBytes: 4096, Trigger: "pause",
+		ManifestFileNames: []string{"overlay.ext4"}, ManifestPaths: []string{allocationPath},
+		ManifestSizes: []int64{4096}, ManifestAllocatedBytes: []int64{8192},
+		ManifestDigests: []string{strings.Repeat("c", 64)}, ManifestBasePaths: []string{""},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET status = 'pausing' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatal(err)
+	}
+	failedAllocationHead, err := testQueries.FinalizePauseGeneration(ctx, db.FinalizePauseGenerationParams{
+		ID: sandboxID, TeamID: teamID, Path: "p8", MemPath: &memPath, SizeBytes: 4096, Trigger: "pause",
+		ManifestFileNames: []string{"overlay.ext4"}, ManifestPaths: []string{allocationPath},
+		ManifestSizes: []int64{4096}, ManifestAllocatedBytes: []int64{-1},
+		ManifestDigests: []string{strings.Repeat("d", 64)}, ManifestBasePaths: []string{""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var retainedAllocation int64
+	if err := testPool.QueryRow(ctx,
+		`SELECT allocated_bytes FROM artifact_manifest WHERE snapshot_id = $1 AND file_name = 'overlay.ext4'`, failedAllocationHead).
+		Scan(&retainedAllocation); err != nil {
+		t.Fatal(err)
+	}
+	if retainedAllocation != 8192 {
+		t.Fatalf("failed allocation = %d, want prior 8192", retainedAllocation)
+	}
+	// An omitted allocation sample is also unavailable and must retain the
+	// prior generation's physical allocation rather than becoming zero.
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET status = 'pausing' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatal(err)
+	}
+	nilAllocationHead, err := testQueries.FinalizePauseGeneration(ctx, db.FinalizePauseGenerationParams{
+		ID: sandboxID, TeamID: teamID, Path: "p8b", MemPath: &memPath, SizeBytes: 4096, Trigger: "pause",
+		ManifestFileNames: []string{"overlay.ext4"}, ManifestPaths: []string{allocationPath},
+		ManifestSizes:   []int64{4096},
+		ManifestDigests: []string{strings.Repeat("d", 64)}, ManifestBasePaths: []string{""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`SELECT allocated_bytes FROM artifact_manifest WHERE snapshot_id = $1 AND file_name = 'overlay.ext4'`, nilAllocationHead).
+		Scan(&retainedAllocation); err != nil {
+		t.Fatal(err)
+	}
+	if retainedAllocation != 8192 {
+		t.Fatalf("omitted allocation = %d, want prior 8192", retainedAllocation)
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE sandbox SET status = 'pausing' WHERE id = $1`, sandboxID); err != nil {
+		t.Fatal(err)
+	}
+	zeroAllocationHead, err := testQueries.FinalizePauseGeneration(ctx, db.FinalizePauseGenerationParams{
+		ID: sandboxID, TeamID: teamID, Path: "p9", MemPath: &memPath, SizeBytes: 4096, Trigger: "pause",
+		ManifestFileNames: []string{"overlay.ext4"}, ManifestPaths: []string{allocationPath},
+		ManifestSizes: []int64{4096}, ManifestAllocatedBytes: []int64{0},
+		ManifestDigests: []string{strings.Repeat("e", 64)}, ManifestBasePaths: []string{""},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := testPool.QueryRow(ctx,
+		`SELECT allocated_bytes FROM artifact_manifest WHERE snapshot_id = $1 AND file_name = 'overlay.ext4'`, zeroAllocationHead).
+		Scan(&retainedAllocation); err != nil {
+		t.Fatal(err)
+	}
+	if retainedAllocation != 0 {
+		t.Fatalf("successful zero allocation = %d, want 0", retainedAllocation)
 	}
 	// A stale finalize is still rejected whole in generations mode.
 	mem := "/snapshots/" + sid + "/mem.snap"

--- a/internal/integration/platform_billing_test.go
+++ b/internal/integration/platform_billing_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -242,6 +244,131 @@ func TestPlatformBillingUsesCurrentPeriodLedgerToReconstructOpeningBalance(t *te
 	}
 	if got := row.Summary["credits_remaining_usd"].(float64); got < -0.000001 || got > 0.000001 {
 		t.Fatalf("credits_remaining_usd = %v, want 0", got)
+	}
+}
+
+func TestPlatformBillingDeduplicatesSharedArtifactStorage(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	fixedNow := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	r := newInternalRouterWithNow(t, func() time.Time { return fixedNow })
+	periodStart, _ := billing.CurrentBillingPeriod(fixedNow)
+	seedPlatformBillingRatesForTest(t, ctx, teamID, "platform-billing-shared-artifact-"+uuid.NewString(), periodStart.Add(-time.Hour))
+
+	const sharedPath = "/tmp/test/platform-shared-rootfs.ext4"
+	const sharedBytes = int64(8 * 1024 * 1024)
+	const sharedAllocatedBytes = int64(4096) // sparse artifact: logical length is intentionally much larger
+	const deltaPath = "/tmp/test/platform-derived-delta.ext4"
+	const deltaBytes = int64(2 * 1024 * 1024)
+	const deltaAllocatedBytes = int64(4096)
+	const zeroReferencePath = "/tmp/test/platform-zero-reference.ext4"
+	var sandboxIDs []uuid.UUID
+	var zeroReferenceSnapshotID uuid.UUID
+	for _, name := range []string{"platform-shared-a", "platform-shared-b", "platform-derived"} {
+		cw := do(r, http.MethodPost, "/sandboxes", ownerKey, fmt.Sprintf(`{"name":%q}`, name))
+		if cw.Code != http.StatusCreated {
+			t.Fatalf("create %s: %d %s", name, cw.Code, cw.Body.String())
+		}
+		sandboxIDs = append(sandboxIDs, uuid.MustParse(mustJSON(t, cw)["id"].(string)))
+	}
+
+	for i, sandboxID := range sandboxIDs {
+		basePath, deltaPathForSandbox := sharedPath, ""
+		if i == 2 {
+			deltaPathForSandbox = deltaPath
+		}
+		if _, err := testPool.Exec(ctx, `
+			UPDATE sandbox
+			SET created_at = $2, base_path = $4, delta_path = $5
+			WHERE id = $1 AND team_id = $3
+		`, sandboxID, periodStart, teamID, basePath, deltaPathForSandbox); err != nil {
+			t.Fatalf("prepare sandbox %d: %v", i, err)
+		}
+		var snapshotID uuid.UUID
+		if err := testPool.QueryRow(ctx, `
+			INSERT INTO snapshot (sandbox_id, team_id, path, trigger)
+			VALUES ($1, $2, $3, 'pause')
+			RETURNING id
+		`, sandboxID, teamID, fmt.Sprintf("/tmp/test/platform-snapshot-%d", i)).Scan(&snapshotID); err != nil {
+			t.Fatalf("seed snapshot %d: %v", i, err)
+		}
+		if i == 0 {
+			zeroReferenceSnapshotID = snapshotID
+		}
+		if _, err := testPool.Exec(ctx, `UPDATE sandbox SET snapshot_id = $2 WHERE id = $1`, sandboxID, snapshotID); err != nil {
+			t.Fatalf("link snapshot %d: %v", i, err)
+		}
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, snapshotID, fmt.Sprintf("platform-rootfs-%d.ext4", i), basePath, sharedBytes, sharedAllocatedBytes, strings.Repeat("0", 64)); err != nil {
+			t.Fatalf("seed artifact manifest %d: %v", i, err)
+		}
+		if i == 2 {
+			if _, err := testPool.Exec(ctx, `
+				INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, allocated_bytes, sha256)
+				VALUES ($1, 'platform-derived-delta.ext4', $2, $3, $4, $5)
+			`, snapshotID, deltaPath, deltaBytes, deltaAllocatedBytes, strings.Repeat("1", 64)); err != nil {
+				t.Fatalf("seed derived delta: %v", err)
+			}
+		}
+		if _, err := testPool.Exec(ctx, `DELETE FROM sandbox_storage_interval WHERE sandbox_id = $1`, sandboxID); err != nil {
+			t.Fatalf("clear seeded storage interval %d: %v", i, err)
+		}
+		if _, err := testPool.Exec(ctx, `
+			INSERT INTO sandbox_storage_interval (sandbox_id, team_id, disk_mib, started_at, ended_at, end_reason)
+			VALUES ($1, $2, 1, $3, $4, 'deleted')
+		`, sandboxID, teamID, fixedNow.Add(-time.Minute), fixedNow); err != nil {
+			t.Fatalf("seed overlay interval %d: %v", i, err)
+		}
+	}
+	if _, err := testPool.Exec(ctx, `UPDATE template SET rootfs_path = $1, size_bytes = $2 WHERE name = 'superserve/base'`, sharedPath, sharedBytes); err != nil {
+		t.Fatalf("set shared template artifact: %v", err)
+	}
+	// This retained manifest has no sandbox path reference and must not affect usage.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO artifact_manifest (snapshot_id, file_name, path, size_bytes, sha256)
+		VALUES ($1, 'platform-zero-reference.ext4', $2, 64 * 1024 * 1024, $3)
+	`, zeroReferenceSnapshotID, zeroReferencePath, strings.Repeat("2", 64)); err != nil {
+		t.Fatalf("seed zero-reference artifact: %v", err)
+	}
+
+	actorID := seedPlatformAdminProfile(t)
+	storageUSD := func(sort string) float64 {
+		resp := doInternal(r, http.MethodGet, fmt.Sprintf("/internal/billing?search=%s&sort=%s&order=asc", teamID, sort), actorID.String(), "")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("platform billing (%s): %d %s", sort, resp.Code, resp.Body.String())
+		}
+		body := decodePlatformBilling(t, resp.Body.Bytes())
+		if len(body.Rows) != 1 || body.Rows[0].Summary == nil {
+			t.Fatalf("platform billing (%s) rows = %+v", sort, body.Rows)
+		}
+		return body.Rows[0].Summary["cost_breakdown_usd"].(map[string]any)["storage"].(float64)
+	}
+
+	metadataStorage := storageUSD("team_name")
+	chargesStorage := storageUSD("current_charges_usd")
+	if metadataStorage <= 0 || chargesStorage <= 0 {
+		t.Fatalf("storage charge = metadata:%v charges:%v, want positive", metadataStorage, chargesStorage)
+	}
+	if metadataStorage != chargesStorage {
+		t.Fatalf("storage charge differs by query path: metadata:%v charges:%v", metadataStorage, chargesStorage)
+	}
+	// The sparse shared and derived artifacts are retained through the billing
+	// request and must be charged once by allocated bytes, in addition to overlays.
+	artifactSeconds := (sharedAllocatedBytes + deltaAllocatedBytes) * int64(time.Minute.Seconds()) / (1024 * 1024)
+	wantStorage := (float64(artifactSeconds+3*60) / 1024) * 0.00000003
+	if diff := math.Abs(metadataStorage - wantStorage); diff > 1e-12 {
+		t.Fatalf("storage charge = %v, want %v (diff %v)", metadataStorage, wantStorage, diff)
+	}
+	resp := doInternal(r, http.MethodGet, fmt.Sprintf("/internal/billing?search=%s&sort=team_name&order=asc", teamID), actorID.String(), "")
+	body := decodePlatformBilling(t, resp.Body.Bytes())
+	gotStorageSeconds, ok := body.Rows[0].Summary["storage_mib_seconds"].(float64)
+	if !ok {
+		t.Fatalf("storage_mib_seconds = %v, want numeric", body.Rows[0].Summary["storage_mib_seconds"])
+	}
+	if diff := math.Abs(gotStorageSeconds - float64(artifactSeconds+3*60)); diff > 1e-6 {
+		t.Fatalf("storage_mib_seconds = %v, want %v (diff %v)", gotStorageSeconds, artifactSeconds+3*60, diff)
 	}
 }
 

--- a/internal/supervisor/build_supervisor.go
+++ b/internal/supervisor/build_supervisor.go
@@ -493,11 +493,18 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 			rowLog.Info().Msg("build entered snapshotting phase")
 		}
 	case "ready":
+		if !res.AllocatedBytesSupported {
+			rowLog.Info().Msg("vmd build status lacks allocation-field support; waiting for upgraded host before finalizing")
+			return
+		}
 		finCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		rootfs := res.RootfsPath
 		snapPath := res.SnapshotPath
 		memPath := res.MemFilePath
 		size := res.SizeBytes
+		rootfsAllocated := res.RootfsAllocatedBytes
+		baseAllocated := res.BaseAllocatedBytes
+		deltaAllocated := res.DeltaAllocatedBytes
 		var basePathArg, deltaPathArg *string
 		if res.BasePath != "" {
 			basePathArg = &res.BasePath
@@ -506,13 +513,16 @@ func (s *BuildSupervisor) pollOne(ctx context.Context, row db.TemplateBuild) {
 			deltaPathArg = &res.DeltaPath
 		}
 		tpl, err := s.q.FinalizeBuild(finCtx, db.FinalizeBuildParams{
-			ID:           row.ID,
-			RootfsPath:   &rootfs,
-			SnapshotPath: &snapPath,
-			MemPath:      &memPath,
-			SizeBytes:    &size,
-			BasePath:     basePathArg,
-			DeltaPath:    deltaPathArg,
+			ID:                   row.ID,
+			RootfsPath:           &rootfs,
+			SnapshotPath:         &snapPath,
+			MemPath:              &memPath,
+			SizeBytes:            &size,
+			BasePath:             basePathArg,
+			DeltaPath:            deltaPathArg,
+			RootfsAllocatedBytes: rootfsAllocated,
+			BaseAllocatedBytes:   baseAllocated,
+			DeltaAllocatedBytes:  deltaAllocated,
 		})
 		cancel()
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -39,13 +39,16 @@ type BuildTemplateRequest struct {
 
 // BuildTemplateResult is returned on success.
 type BuildTemplateResult struct {
-	SnapshotPath   string
-	MemFilePath    string
-	RootfsPath     string
-	BasePath       string // overlay-mode templates only
-	DeltaPath      string // overlay-mode templates only
-	ResolvedDigest string // sha256:... of the resolved base image
-	SizeBytes      int64  // on-disk rootfs size
+	SnapshotPath         string
+	MemFilePath          string
+	RootfsPath           string
+	BasePath             string // overlay-mode templates only
+	DeltaPath            string // overlay-mode templates only
+	ResolvedDigest       string // sha256:... of the resolved base image
+	SizeBytes            int64  // on-disk rootfs size
+	RootfsAllocatedBytes int64
+	BaseAllocatedBytes   int64
+	DeltaAllocatedBytes  int64
 }
 
 // BuildTemplate starts a template build asynchronously and returns the
@@ -183,6 +186,7 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	if err != nil {
 		return nil, fmt.Errorf("read build meta: %w", err)
 	}
+	populateBuildAllocations(result)
 
 	// Best-effort: a missing access.log just means sandboxes fall back
 	// to sequential prefetch. The "build-" prefix must remain so isBuildVM
@@ -222,6 +226,21 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 
 	log.Info().Dur("total", time.Since(buildStart)).Msg("template build complete")
 	return result, nil
+}
+
+func physicalAllocatedBytes(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return stat.Blocks * 512
 }
 
 // backupBuildArtifacts makes a finished build's artifact set durable: hash

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -242,6 +242,7 @@ func loadDurableBuild(snapshotRoot, buildVMID string) (BuildStatusSnapshot, bool
 	if err != nil || !buildArtifactsPresent(res) {
 		return BuildStatusSnapshot{}, false
 	}
+	populateBuildAllocations(res)
 	return BuildStatusSnapshot{
 		BuildVMID:  buildVMID,
 		TemplateID: filepath.Base(filepath.Dir(dir)),
@@ -266,6 +267,15 @@ func buildArtifactsPresent(r *BuildTemplateResult) bool {
 		}
 	}
 	return true
+}
+
+func populateBuildAllocations(result *BuildTemplateResult) {
+	if result == nil {
+		return
+	}
+	result.RootfsAllocatedBytes = physicalAllocatedBytes(result.RootfsPath)
+	result.BaseAllocatedBytes = physicalAllocatedBytes(result.BasePath)
+	result.DeltaAllocatedBytes = physicalAllocatedBytes(result.DeltaPath)
 }
 
 // CancelBuild marks a build cancelled and signals its template-builder

--- a/internal/vm/durable_build_test.go
+++ b/internal/vm/durable_build_test.go
@@ -59,6 +59,9 @@ func TestLoadDurableBuild(t *testing.T) {
 		if got.Result == nil || got.Result.ResolvedDigest != "sha256:abc" {
 			t.Error("result must be populated from build.meta.json")
 		}
+		if got.Result.RootfsAllocatedBytes == 0 || got.Result.BaseAllocatedBytes == 0 || got.Result.DeltaAllocatedBytes == 0 {
+			t.Fatalf("allocated bytes must be recomputed for adopted builds: %+v", got.Result)
+		}
 	})
 
 	t.Run("missing referenced artifact is not adopted", func(t *testing.T) {

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/superserve-ai/sandbox/internal/builder"
 	"github.com/superserve-ai/sandbox/internal/network"
@@ -52,13 +53,18 @@ func (a *GRPCAdapter) PauseVM(ctx context.Context, req *vmdpb.PauseVMRequest) (*
 	}
 	entries := make([]*vmdpb.ArtifactManifestEntry, 0, len(manifest))
 	for _, e := range manifest {
-		entries = append(entries, &vmdpb.ArtifactManifestEntry{
+		entry := &vmdpb.ArtifactManifestEntry{
 			FileName:  e.FileName,
 			Path:      e.Path,
 			SizeBytes: e.SizeBytes,
 			Sha256:    e.SHA256,
 			BasePath:  e.BasePath,
-		})
+		}
+		unknown := entry.ProtoReflect().GetUnknown()
+		unknown = protowire.AppendTag(unknown, 6, protowire.VarintType)
+		unknown = protowire.AppendVarint(unknown, uint64(e.AllocatedBytes))
+		entry.ProtoReflect().SetUnknown(unknown)
+		entries = append(entries, entry)
 	}
 	return &vmdpb.PauseVMResponse{
 		VmId:         req.GetVmId(),
@@ -575,6 +581,10 @@ func (a *GRPCAdapter) GetBuildStatus(ctx context.Context, req *vmdpb.GetBuildSta
 		resp.DeltaPath = snap.Result.DeltaPath
 		resp.ResolvedDigest = snap.Result.ResolvedDigest
 		resp.SizeBytes = snap.Result.SizeBytes
+		resp.SetAllocatedBytesSupported(true)
+		resp.SetRootfsAllocatedBytes(snap.Result.RootfsAllocatedBytes)
+		resp.SetBaseAllocatedBytes(snap.Result.BaseAllocatedBytes)
+		resp.SetDeltaAllocatedBytes(snap.Result.DeltaAllocatedBytes)
 	}
 	return resp, nil
 }

--- a/internal/vm/heartbeat.go
+++ b/internal/vm/heartbeat.go
@@ -8,115 +8,225 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/preview"
 )
 
-// HeartbeatConfig controls the VMD → control plane heartbeat loop.
+// Keep the stale logical-size billing window short for overlays activated
+// after startup while retaining a bounded, periodic fleet scan.
+const overlayStorageSampleInterval = 5 * time.Minute
+
 type HeartbeatConfig struct {
-	// ControlPlaneURL is the base URL of the control plane API (e.g.
-	// "http://localhost:8080"). The heartbeat POSTs to
-	// {ControlPlaneURL}/internal/hosts/{HostID}/heartbeat.
-	ControlPlaneURL string
-
-	// HostID is this host's identifier in the host table.
-	HostID string
-
-	// Token is the shared secret for authenticating internal API calls.
-	// Sent as `Authorization: Bearer <token>`.
-	Token string
-
-	// ProxyHealthURL is the host-local edge proxy health endpoint. The default
-	// is http://127.0.0.1:5007/health. VMD advertises preview-port enforcement
-	// only when this endpoint confirms the matching proxy protocol.
-	ProxyHealthURL string
-
-	// Interval is how often the heartbeat fires. Default: 30s.
-	Interval time.Duration
-
-	// Self-description for control-plane self-registration. Sent only when
-	// AdvertiseVMDAddr, AdvertiseProxyAddr, and Region are all set: older
-	// control planes bind heartbeat bodies strictly and reject unknown
-	// fields, so advertising is opt-in per host (deploy sets the env only
-	// once the control plane understands it). With none set, the payload is
-	// byte-identical to what pre-registration vmds send.
-	AdvertiseVMDAddr   string
-	AdvertiseProxyAddr string
-	Region             string
-	// Capacity fields are the host's SCHEDULABLE capacity — explicitly
-	// configured limits that placement may admit against — never detected
-	// physical totals.
+	ControlPlaneURL   string
+	HostID            string
+	Token             string
+	ProxyHealthURL    string
+	RunDir            string
+	Interval          time.Duration
+	VMDAddr           string
+	ProxyAddr         string
+	Region            string
 	CapacityMemoryMib int32
 	CapacityVcpus     int32
 }
 
-// StartHeartbeat launches a background goroutine that periodically POSTs
-// to the control plane's heartbeat endpoint. Blocks until ctx is cancelled.
 func StartHeartbeat(ctx context.Context, cfg HeartbeatConfig, log zerolog.Logger) {
 	log = log.With().Str("component", "heartbeat").Logger()
-
 	interval := cfg.Interval
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
-
+	runDir := cfg.RunDir
+	if runDir == "" {
+		runDir = "/var/lib/sandbox/rundir"
+	}
 	url := fmt.Sprintf("%s/internal/hosts/%s/heartbeat", cfg.ControlPlaneURL, cfg.HostID)
-	token := cfg.Token
 	proxyHealthURL := cfg.ProxyHealthURL
 	if proxyHealthURL == "" {
 		proxyHealthURL = "http://127.0.0.1:5007/health"
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{Timeout: 30 * time.Second}
+	log.Info().Str("url", url).Str("proxy_health_url", proxyHealthURL).Dur("interval", interval).Msg("heartbeat started")
 
-	log.Info().
-		Str("host_id", cfg.HostID).
-		Str("url", url).
-		Str("proxy_health_url", proxyHealthURL).
-		Dur("interval", interval).
-		Msg("heartbeat started")
+	cache := &heartbeatStorageCache{}
 
+	// Keep the first liveness POST independent of the fleet-sized filesystem
+	// scan. Storage sampling runs in a separate goroutine so heartbeat posts
+	// can continue even if a host has a large number of sandboxes.
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-
-	// Fire once immediately so the host is marked alive on startup.
-	sendHeartbeat(ctx, client, cfg, url, token, proxyHealthURL, log)
-
+	_, _ = sendHeartbeat(ctx, client, cfg, url, cfg.Token, proxyHealthURL, nil, log)
+	go runOverlayStorageSampler(ctx, runDir, overlayStorageSampleInterval, cache, log)
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info().Msg("heartbeat exiting")
 			return
 		case <-ticker.C:
-			sendHeartbeat(ctx, client, cfg, url, token, proxyHealthURL, log)
+			now := time.Now()
+			version, storage := cache.snapshot()
+			publishStorage := cache.shouldSend(version, now)
+			if !publishStorage {
+				storage = nil
+			}
+			if ok, accepted := sendHeartbeat(ctx, client, cfg, url, cfg.Token, proxyHealthURL, storage, log); ok && publishStorage && accepted {
+				cache.markSent(version, now)
+			}
 		}
 	}
 }
 
-type heartbeatRequest struct {
-	Capabilities []string `json:"capabilities"`
-
-	VMDAddr           string `json:"vmd_addr,omitempty"`
-	ProxyAddr         string `json:"proxy_addr,omitempty"`
-	Region            string `json:"region,omitempty"`
-	CapacityMemoryMib int32  `json:"capacity_memory_mib,omitempty"`
-	CapacityVcpus     int32  `json:"capacity_vcpus,omitempty"`
+type heartbeatStorageMeasurement struct {
+	SandboxID      string `json:"sandbox_id"`
+	AllocatedBytes int64  `json:"allocated_bytes"`
 }
 
-// buildHeartbeatRequest attaches the self-description only when it is
-// complete; a partial description would register a broken host row, and any
-// description at all breaks against control planes that predate it.
-func buildHeartbeatRequest(cfg HeartbeatConfig, capabilities []string) heartbeatRequest {
-	req := heartbeatRequest{Capabilities: capabilities}
-	if cfg.AdvertiseVMDAddr != "" && cfg.AdvertiseProxyAddr != "" && cfg.Region != "" &&
+type heartbeatRequest struct {
+	Capabilities      []string                      `json:"capabilities"`
+	Storage           []heartbeatStorageMeasurement `json:"storage,omitempty"`
+	VMDAddr           string                        `json:"vmd_addr,omitempty"`
+	ProxyAddr         string                        `json:"proxy_addr,omitempty"`
+	Region            string                        `json:"region,omitempty"`
+	CapacityMemoryMib int32                         `json:"capacity_memory_mib,omitempty"`
+	CapacityVcpus     int32                         `json:"capacity_vcpus,omitempty"`
+}
+
+type proxyHealthResponse struct {
+	Capabilities []string `json:"capabilities"`
+}
+
+type heartbeatStorageCache struct {
+	mu           sync.RWMutex
+	measurements []heartbeatStorageMeasurement
+	version      uint64
+	sentVersion  uint64
+	sentAt       time.Time
+}
+
+func (c *heartbeatStorageCache) snapshot() (uint64, []heartbeatStorageMeasurement) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.measurements) == 0 {
+		return c.version, nil
+	}
+	out := make([]heartbeatStorageMeasurement, len(c.measurements))
+	copy(out, c.measurements)
+	return c.version, out
+}
+
+func (c *heartbeatStorageCache) shouldSend(version uint64, now time.Time) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.measurements) == 0 {
+		return false
+	}
+	if version > c.sentVersion {
+		return true
+	}
+	return !c.sentAt.IsZero() && now.Sub(c.sentAt) >= overlayStorageSampleInterval
+}
+
+func (c *heartbeatStorageCache) markSent(version uint64, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if version < c.sentVersion {
+		return
+	}
+	c.sentVersion = version
+	c.sentAt = now
+}
+
+func (c *heartbeatStorageCache) store(measurements []heartbeatStorageMeasurement) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if reflect.DeepEqual(c.measurements, measurements) {
+		return
+	}
+	if len(measurements) == 0 {
+		c.measurements = nil
+		c.version++
+		return
+	}
+	c.measurements = make([]heartbeatStorageMeasurement, len(measurements))
+	copy(c.measurements, measurements)
+	c.version++
+}
+
+func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig, url, token, proxyHealthURL string, storage []heartbeatStorageMeasurement, log zerolog.Logger) (bool, bool) {
+	started := time.Now()
+	capabilities, err := proxyPreviewCapabilities(ctx, client, proxyHealthURL)
+	if err != nil {
+		log.Warn().Err(err).
+			Dur("duration", time.Since(started)).
+			Msg("proxy capability probe failed; advertising no preview capabilities")
+		capabilities = nil
+	}
+	return postHeartbeat(ctx, client, cfg, url, token, capabilities, storage, log, started)
+}
+
+func postHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig, url, token string, capabilities []string, storage []heartbeatStorageMeasurement, log zerolog.Logger, started time.Time) (bool, bool) {
+	body, err := json.Marshal(buildHeartbeatRequest(cfg, capabilities, storage))
+	if err != nil {
+		log.Error().Err(err).Msg("failed to encode heartbeat body")
+		return false, false
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create heartbeat request")
+		return false, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Warn().Err(err).Str("host_id", cfg.HostID).
+			Strs("capabilities", capabilities).Dur("duration", time.Since(started)).
+			Msg("heartbeat failed")
+		return false, false
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if len(storage) > 0 && resp.StatusCode == http.StatusBadRequest && isStorageFieldUnsupported(respBody) {
+			log.Warn().
+				Int("status", resp.StatusCode).
+				Msg("heartbeat storage field rejected by an older control plane; retrying without storage")
+			return postHeartbeat(ctx, client, cfg, url, token, capabilities, nil, log, started)
+		}
+		log.Warn().Int("status", resp.StatusCode).Msg("heartbeat got non-200 response")
+		return false, false
+	}
+	return true, storage != nil
+}
+
+func isStorageFieldUnsupported(body []byte) bool {
+	return bytes.Contains(body, []byte(`unknown field "storage"`)) ||
+		bytes.Contains(body, []byte(`unknown field \"storage\"`))
+}
+
+func buildHeartbeatRequest(cfg HeartbeatConfig, capabilities []string, storage []heartbeatStorageMeasurement) heartbeatRequest {
+	req := heartbeatRequest{
+		Capabilities: capabilities,
+		Storage:      storage,
+	}
+	if cfg.VMDAddr != "" && cfg.ProxyAddr != "" && cfg.Region != "" &&
 		cfg.CapacityMemoryMib > 0 && cfg.CapacityVcpus > 0 {
-		req.VMDAddr = cfg.AdvertiseVMDAddr
-		req.ProxyAddr = cfg.AdvertiseProxyAddr
+		req.VMDAddr = cfg.VMDAddr
+		req.ProxyAddr = cfg.ProxyAddr
 		req.Region = cfg.Region
 		req.CapacityMemoryMib = cfg.CapacityMemoryMib
 		req.CapacityVcpus = cfg.CapacityVcpus
@@ -124,75 +234,37 @@ func buildHeartbeatRequest(cfg HeartbeatConfig, capabilities []string) heartbeat
 	return req
 }
 
-type proxyHealthResponse struct {
-	Capabilities []string `json:"capabilities"`
+func sampleOverlayStorage(runDir string, cache *heartbeatStorageCache, log zerolog.Logger) {
+	measurements, err := measureOverlayStorage(runDir)
+	if err != nil {
+		log.Warn().Err(err).Msg("overlay storage measurement failed; keeping previous cached sample")
+		return
+	}
+	cache.store(measurements)
 }
 
-func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig, url, token, proxyHealthURL string, log zerolog.Logger) {
-	started := time.Now()
-	capabilities, err := proxyPreviewCapabilities(ctx, client, proxyHealthURL)
-	if err != nil {
-		log.Warn().Err(err).Str("host_id", cfg.HostID).
-			Dur("duration", time.Since(started)).
-			Msg("proxy capability probe failed; advertising no preview capabilities")
-		capabilities = nil
+func runOverlayStorageSampler(ctx context.Context, runDir string, interval time.Duration, cache *heartbeatStorageCache, log zerolog.Logger) {
+	if interval <= 0 {
+		interval = overlayStorageSampleInterval
 	}
-	log.Debug().Str("host_id", cfg.HostID).
-		Str("proxy_health_url", proxyHealthURL).Strs("capabilities", capabilities).
-		Msg("sending heartbeat")
-
-	body, err := json.Marshal(buildHeartbeatRequest(cfg, capabilities))
-	if err != nil {
-		log.Error().Err(err).Msg("failed to encode heartbeat body")
-		return
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		log.Error().Err(err).Msg("failed to create heartbeat request")
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Warn().Err(err).Str("host_id", cfg.HostID).
-			Strs("capabilities", capabilities).Dur("duration", time.Since(started)).
-			Msg("heartbeat failed")
-		return
-	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
-
-	switch {
-	case resp.StatusCode == http.StatusConflict:
-		// Another live daemon holds this host identity. Keep heartbeating —
-		// the control plane refuses updates either way — but say why loudly:
-		// this is a provisioning error an operator must resolve.
-		log.Error().Int("status", resp.StatusCode).
-			Str("host_id", cfg.HostID).Strs("capabilities", capabilities).
-			Dur("duration", time.Since(started)).
-			Msg("heartbeat rejected: host identity in use by a live host at another address")
-	case resp.StatusCode != http.StatusOK:
-		log.Warn().Int("status", resp.StatusCode).Str("host_id", cfg.HostID).
-			Strs("capabilities", capabilities).Dur("duration", time.Since(started)).
-			Msg("heartbeat got non-200 response")
-	default:
-		log.Debug().Str("host_id", cfg.HostID).Strs("capabilities", capabilities).
-			Int("status", resp.StatusCode).Dur("duration", time.Since(started)).
-			Msg("heartbeat completed")
+	sampleOverlayStorage(runDir, cache, log)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sampleOverlayStorage(runDir, cache, log)
+		}
 	}
 }
 
 // DetectHostCapacity reports the machine's PHYSICAL memory (MiB) and
-// logical CPU count. Never advertised as capacity — the schedulable
-// capacity a host registers is explicitly configured, because physical
-// totals include everything the OS, the daemons, and the cgroup headroom
-// already spend, and publishing them as admission limits would over-admit.
-// Used only to sanity-check the configured values. Memory comes from
-// /proc/meminfo; on any read or parse failure it returns 0.
+// logical CPU count. Never advertised as capacity: the schedulable
+// capacity a host registers is explicitly configured because physical
+// totals include everything the OS, the daemons, and the deliberate cgroup
+// headroom already spend.
 func DetectHostCapacity() (memoryMib, vcpus int32) {
 	vcpus = int32(runtime.NumCPU())
 	data, err := os.ReadFile("/proc/meminfo")
@@ -216,6 +288,44 @@ func DetectHostCapacity() (memoryMib, vcpus int32) {
 	return 0, vcpus
 }
 
+// measureOverlayStorage reads allocation metadata only; it never walks ext4
+// contents. st_blocks is the same physical allocation quantity used by du.
+func measureOverlayStorage(runDir string) ([]heartbeatStorageMeasurement, error) {
+	entries, err := os.ReadDir(runDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]heartbeatStorageMeasurement, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := uuid.Parse(entry.Name()); err != nil {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(runDir, entry.Name(), "overlay.ext4"))
+		if os.IsNotExist(err) {
+			// Legacy sandboxes keep their per-sandbox disk as rootfs.ext4.
+			info, err = os.Stat(filepath.Join(runDir, entry.Name(), "rootfs.ext4"))
+		}
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			continue
+		}
+		out = append(out, heartbeatStorageMeasurement{
+			SandboxID:      entry.Name(),
+			AllocatedBytes: stat.Blocks * 512,
+		})
+	}
+	return out, nil
+}
+
 func proxyPreviewCapabilities(ctx context.Context, client *http.Client, healthURL string) ([]string, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
@@ -235,7 +345,6 @@ func proxyPreviewCapabilities(ctx context.Context, client *http.Client, healthUR
 	var health proxyHealthResponse
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<10)).Decode(&health); err != nil {
 		if err == io.EOF {
-			// Pre-capability proxies returned an empty 200 health response.
 			return nil, nil
 		}
 		return nil, fmt.Errorf("decode proxy health: %w", err)

--- a/internal/vm/heartbeat_test.go
+++ b/internal/vm/heartbeat_test.go
@@ -5,9 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/preview"
@@ -37,7 +41,14 @@ func TestSendHeartbeatAdvertisesVerifiedPreviewCapabilities(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{}, server.URL+"/internal/hosts/host-a/heartbeat", "shared", server.URL+"/health", zerolog.Nop())
+	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{
+		HostID:            "host-a",
+		VMDAddr:           "10.0.0.2:50051",
+		ProxyAddr:         "10.0.0.2:5007",
+		Region:            "region-a",
+		CapacityMemoryMib: 1024,
+		CapacityVcpus:     8,
+	}, server.URL+"/internal/hosts/host-a/heartbeat", "shared", server.URL+"/health", nil, zerolog.Nop())
 
 	if gotPath != "/internal/hosts/host-a/heartbeat" {
 		t.Fatalf("path = %q", gotPath)
@@ -51,6 +62,12 @@ func TestSendHeartbeatAdvertisesVerifiedPreviewCapabilities(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.Capabilities, want) {
 		t.Fatalf("capabilities = %#v, want %#v", got.Capabilities, want)
+	}
+	if got.VMDAddr != "10.0.0.2:50051" || got.ProxyAddr != "10.0.0.2:5007" || got.Region != "region-a" {
+		t.Fatalf("heartbeat description = %#v", got)
+	}
+	if got.CapacityMemoryMib != 1024 || got.CapacityVcpus != 8 {
+		t.Fatalf("capacity = %#v", got)
 	}
 }
 
@@ -188,7 +205,7 @@ func TestSendHeartbeatOmitsCapabilityForOldOrUnavailableProxy(t *testing.T) {
 			}))
 			defer server.Close()
 
-			sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{}, server.URL+"/internal/hosts/host-a/heartbeat", "", server.URL+"/health", zerolog.Nop())
+			sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a"}, server.URL+"/internal/hosts/host-a/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
 			if len(got.Capabilities) != 0 {
 				t.Fatalf("capabilities = %#v, want empty", got.Capabilities)
 			}
@@ -196,41 +213,162 @@ func TestSendHeartbeatOmitsCapabilityForOldOrUnavailableProxy(t *testing.T) {
 	}
 }
 
-// The heartbeat payload must stay byte-identical to the pre-registration
-// format unless a complete self-description is configured: control planes
-// that predate self-registration bind the body strictly and reject unknown
-// fields, so a partial or accidental description would kill every heartbeat.
-func TestBuildHeartbeatRequestOmitsIncompleteDescription(t *testing.T) {
-	full := HeartbeatConfig{
-		AdvertiseVMDAddr:   "10.0.0.5:50051",
-		AdvertiseProxyAddr: "10.0.0.5:5007",
-		Region:             "region-a",
-		CapacityMemoryMib:  1024,
-		CapacityVcpus:      8,
+func TestMeasureOverlayStorageUsesAllocatedBlocks(t *testing.T) {
+	runDir := t.TempDir()
+	sandboxID := uuid.NewString()
+	if err := os.Mkdir(filepath.Join(runDir, sandboxID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(runDir, sandboxID, "overlay.ext4")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(64 << 20); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt([]byte{1}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
 
-	partials := map[string]HeartbeatConfig{
-		"nothing set":    {},
-		"missing vmd":    {AdvertiseProxyAddr: full.AdvertiseProxyAddr, Region: full.Region, CapacityMemoryMib: 1024, CapacityVcpus: 8},
-		"missing proxy":  {AdvertiseVMDAddr: full.AdvertiseVMDAddr, Region: full.Region, CapacityMemoryMib: 1024, CapacityVcpus: 8},
-		"missing region": {AdvertiseVMDAddr: full.AdvertiseVMDAddr, AdvertiseProxyAddr: full.AdvertiseProxyAddr, CapacityMemoryMib: 1024, CapacityVcpus: 8},
-		"zero memory":    {AdvertiseVMDAddr: full.AdvertiseVMDAddr, AdvertiseProxyAddr: full.AdvertiseProxyAddr, Region: full.Region, CapacityVcpus: 8},
+	got, err := measureOverlayStorage(runDir)
+	if err != nil {
+		t.Fatal(err)
 	}
-	legacy, _ := json.Marshal(heartbeatRequest{Capabilities: []string{"preview_ports_v1"}})
-	for name, cfg := range partials {
-		got, err := json.Marshal(buildHeartbeatRequest(cfg, []string{"preview_ports_v1"}))
-		if err != nil {
-			t.Fatalf("%s: marshal: %v", name, err)
-		}
-		if string(got) != string(legacy) {
-			t.Fatalf("%s: payload = %s, want legacy %s", name, got, legacy)
-		}
+	if len(got) != 1 || got[0].SandboxID != sandboxID {
+		t.Fatalf("measurements = %#v", got)
+	}
+	if got[0].AllocatedBytes >= 64<<20 || got[0].AllocatedBytes == 0 {
+		t.Fatalf("allocated bytes = %d, want nonzero and less than logical length", got[0].AllocatedBytes)
+	}
+}
+
+func TestMeasureOverlayStorageSkipsMissingOverlay(t *testing.T) {
+	runDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(runDir, uuid.NewString()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := measureOverlayStorage(runDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("measurements = %#v, want empty", got)
+	}
+}
+
+func TestMeasureOverlayStorageUsesLegacyRootfs(t *testing.T) {
+	runDir := t.TempDir()
+	sandboxID := uuid.NewString()
+	if err := os.Mkdir(filepath.Join(runDir, sandboxID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(runDir, sandboxID, "rootfs.ext4")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(64 << 20); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteAt([]byte{1}, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
 
-	got, _ := json.Marshal(buildHeartbeatRequest(full, nil))
-	want := `{"capabilities":null,"vmd_addr":"10.0.0.5:50051","proxy_addr":"10.0.0.5:5007",` +
-		`"region":"region-a","capacity_memory_mib":1024,"capacity_vcpus":8}`
-	if string(got) != want {
-		t.Fatalf("full description = %s, want %s", got, want)
+	got, err := measureOverlayStorage(runDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SandboxID != sandboxID {
+		t.Fatalf("measurements = %#v", got)
+	}
+	if got[0].AllocatedBytes >= 64<<20 || got[0].AllocatedBytes == 0 {
+		t.Fatalf("allocated bytes = %d, want nonzero and less than logical length", got[0].AllocatedBytes)
+	}
+}
+
+func TestSendHeartbeatOmitsStorageWhenNil(t *testing.T) {
+	var got heartbeatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_ = json.NewEncoder(w).Encode(proxyHealthResponse{})
+		case "/heartbeat":
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode heartbeat: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a"}, server.URL+"/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
+	if got.Storage != nil {
+		t.Fatalf("storage = %#v, want omitted", got.Storage)
+	}
+}
+
+func TestSendHeartbeatRetriesWithoutStorageOnCompatibilityError(t *testing.T) {
+	var got []heartbeatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_ = json.NewEncoder(w).Encode(proxyHealthResponse{})
+		case "/heartbeat":
+			var req heartbeatRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode heartbeat: %v", err)
+			}
+			got = append(got, req)
+			if len(got) == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"json: unknown field \"storage\""}}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ok, accepted := sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a"}, server.URL+"/heartbeat", "", server.URL+"/health", []heartbeatStorageMeasurement{{SandboxID: "sandbox-a", AllocatedBytes: 1}}, zerolog.Nop())
+	if !ok {
+		t.Fatal("heartbeat should succeed after retrying without storage")
+	}
+	if accepted {
+		t.Fatal("storage should not be marked accepted when the control plane rejected it")
+	}
+	if len(got) != 2 {
+		t.Fatalf("requests = %d, want 2", len(got))
+	}
+	if len(got[0].Storage) == 0 {
+		t.Fatal("first request should carry storage")
+	}
+	if got[1].Storage != nil {
+		t.Fatalf("second request storage = %#v, want omitted", got[1].Storage)
+	}
+}
+
+func TestHeartbeatStorageCacheRetriesUnchangedSamplesAfterInterval(t *testing.T) {
+	cache := &heartbeatStorageCache{}
+	cache.store([]heartbeatStorageMeasurement{{SandboxID: "host-a", AllocatedBytes: 1}})
+	version, _ := cache.snapshot()
+	now := time.Now()
+
+	if !cache.shouldSend(version, now) {
+		t.Fatal("fresh measurements must be sent")
+	}
+	cache.markSent(version, now)
+
+	if cache.shouldSend(version, now.Add(overlayStorageSampleInterval-time.Second)) {
+		t.Fatal("unchanged measurements should stay suppressed until the retry interval")
+	}
+	if !cache.shouldSend(version, now.Add(overlayStorageSampleInterval)) {
+		t.Fatal("unchanged measurements must be retried after the retry interval")
 	}
 }

--- a/internal/vm/manifest.go
+++ b/internal/vm/manifest.go
@@ -26,8 +26,10 @@ type ManifestEntry struct {
 	FileName  string
 	Path      string
 	SizeBytes int64
-	SHA256    string
-	BasePath  string
+	// -1 means allocation metadata was unavailable; zero is a valid measurement.
+	AllocatedBytes int64
+	SHA256         string
+	BasePath       string
 	// BaseStagedPath is the staged snapshot to READ the base from when
 	// staging captured one; BasePath remains the recorded identity.
 	BaseStagedPath string
@@ -36,6 +38,18 @@ type ManifestEntry struct {
 	// same path changes the effective filesystem under an unchanged
 	// overlay, and only the content digest makes that a new generation.
 	BaseSHA256 string
+}
+
+func allocatedBytes(path string) (int64, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return st.Blocks * 512, true
 }
 
 const (
@@ -146,6 +160,10 @@ func collectPauseManifest(ctx context.Context, snapshotPath, diskPath, diskBaseP
 			log.Warn().Err(err).Str("path", path).Msg("pause manifest: hash failed, entry skipped")
 			return
 		}
+		allocated := int64(-1)
+		if value, ok := allocatedBytes(path); ok {
+			allocated = value
+		}
 		var baseSum string
 		if basePath != "" {
 			baseSum, err = baseDigest(hctx, basePath, baseKeyPath)
@@ -156,12 +174,13 @@ func collectPauseManifest(ctx context.Context, snapshotPath, diskPath, diskBaseP
 			}
 		}
 		entries = append(entries, ManifestEntry{
-			FileName:   name,
-			Path:       path,
-			SizeBytes:  size,
-			SHA256:     sum,
-			BasePath:   basePath,
-			BaseSHA256: baseSum,
+			FileName:       name,
+			Path:           path,
+			SizeBytes:      size,
+			AllocatedBytes: allocated,
+			SHA256:         sum,
+			BasePath:       basePath,
+			BaseSHA256:     baseSum,
 		})
 	}
 	// vmstate first: tiny and guaranteed inside any budget, so even a
@@ -384,11 +403,16 @@ func collectBuildManifest(ctx context.Context, snapshotDir string, extraPaths []
 			complete = false
 			return
 		}
+		allocated := int64(-1)
+		if value, ok := allocatedBytes(path); ok {
+			allocated = value
+		}
 		entries = append(entries, ManifestEntry{
-			FileName:  name,
-			Path:      path,
-			SizeBytes: size,
-			SHA256:    sum,
+			FileName:       name,
+			Path:           path,
+			SizeBytes:      size,
+			AllocatedBytes: allocated,
+			SHA256:         sum,
 		})
 	}
 	for _, de := range dirEntries {

--- a/internal/vm/manifest_test.go
+++ b/internal/vm/manifest_test.go
@@ -37,6 +37,24 @@ func TestHashFile(t *testing.T) {
 	}
 }
 
+func TestAllocatedBytesUnavailableIsDistinctFromZero(t *testing.T) {
+	if value, ok := allocatedBytes(filepath.Join(t.TempDir(), "missing")); ok || value != 0 {
+		t.Fatalf("missing allocation = (%d, %v), want unavailable", value, ok)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	value, ok := allocatedBytes(path)
+	if !ok {
+		t.Fatal("empty file allocation measurement unavailable")
+	}
+	if value < 0 {
+		t.Fatalf("empty file allocation = %d, want non-negative", value)
+	}
+}
+
 func TestCollectPauseManifest(t *testing.T) {
 	dir := t.TempDir()
 	vmstate := filepath.Join(dir, "vmstate.snap")

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -22,8 +22,10 @@ type ManifestEntry struct {
 	FileName  string
 	Path      string
 	SizeBytes int64
-	SHA256    string
-	BasePath  string
+	// -1 means the host could not read allocation metadata; zero is valid.
+	AllocatedBytes int64
+	SHA256         string
+	BasePath       string
 }
 
 // Client defines the subset of the VM daemon gRPC interface used by the
@@ -183,16 +185,20 @@ type BuildLogEvent struct {
 // BuildStatusResult is the decoded form of vmdpb.GetBuildStatusResponse.
 // Status values: "running", "snapshotting", "ready", "failed", "cancelled".
 type BuildStatusResult struct {
-	NotFound       bool
-	Status         string
-	SnapshotPath   string // populated on ready
-	MemFilePath    string // populated on ready
-	RootfsPath     string // populated on ready
-	BasePath       string // populated on ready, overlay-mode templates only
-	DeltaPath      string // populated on ready, overlay-mode templates only
-	ResolvedDigest string // populated on ready
-	SizeBytes      int64  // populated on ready
-	ErrorMessage   string // populated on failed/cancelled
-	StartedAtUnix  int64
-	EndedAtUnix    int64
+	NotFound                bool
+	Status                  string
+	SnapshotPath            string // populated on ready
+	MemFilePath             string // populated on ready
+	RootfsPath              string // populated on ready
+	BasePath                string // populated on ready, overlay-mode templates only
+	DeltaPath               string // populated on ready, overlay-mode templates only
+	ResolvedDigest          string // populated on ready
+	SizeBytes               int64  // populated on ready
+	RootfsAllocatedBytes    int64  // populated on ready
+	BaseAllocatedBytes      int64  // populated on ready
+	DeltaAllocatedBytes     int64  // populated on ready
+	AllocatedBytesSupported bool   // true when the daemon populated allocation fields
+	ErrorMessage            string // populated on failed/cancelled
+	StartedAtUnix           int64
+	EndedAtUnix             int64
 }

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -193,6 +193,11 @@ message GetBuildStatusResponse {
   // Supervisors treat "unknown on this host" as a hard failure since vmd
   // doesn't survive across restarts for in-memory registry.
   bool not_found = 10;
+
+  // Host-side physical allocation for the reported template artifacts.
+  int64 rootfs_allocated_bytes = 13;
+  int64 base_allocated_bytes = 14;
+  int64 delta_allocated_bytes = 15;
 }
 
 message CancelBuildRequest {
@@ -360,7 +365,9 @@ message ArtifactManifestEntry {
   string path = 2;        // absolute path on the host
   int64 size_bytes = 3;
   string sha256 = 4;      // lowercase hex
-  string base_path = 5;   // overlay dependency ("" when self-contained)
+	string base_path = 5;   // overlay dependency ("" when self-contained)
+	// -1 means allocation metadata was unavailable; zero is a valid measurement.
+	int64 allocated_bytes = 6; // host physical allocation (st_blocks * 512)
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/vmdpb/build_status_compat.go
+++ b/proto/vmdpb/build_status_compat.go
@@ -1,0 +1,79 @@
+package vmdpb
+
+import "google.golang.org/protobuf/encoding/protowire"
+
+const (
+	getBuildStatusRootfsAllocatedField  protowire.Number = 13
+	getBuildStatusBaseAllocatedField    protowire.Number = 14
+	getBuildStatusDeltaAllocatedField   protowire.Number = 15
+	getBuildStatusAllocatedSupportField protowire.Number = 16
+)
+
+func (x *GetBuildStatusResponse) GetRootfsAllocatedBytes() int64 {
+	return getBuildStatusResponseVarint(x, getBuildStatusRootfsAllocatedField)
+}
+
+func (x *GetBuildStatusResponse) GetBaseAllocatedBytes() int64 {
+	return getBuildStatusResponseVarint(x, getBuildStatusBaseAllocatedField)
+}
+
+func (x *GetBuildStatusResponse) GetDeltaAllocatedBytes() int64 {
+	return getBuildStatusResponseVarint(x, getBuildStatusDeltaAllocatedField)
+}
+
+func (x *GetBuildStatusResponse) GetAllocatedBytesSupported() bool {
+	return getBuildStatusResponseVarint(x, getBuildStatusAllocatedSupportField) != 0
+}
+
+func (x *GetBuildStatusResponse) SetRootfsAllocatedBytes(value int64) {
+	setBuildStatusResponseVarint(x, getBuildStatusRootfsAllocatedField, uint64(value))
+}
+
+func (x *GetBuildStatusResponse) SetBaseAllocatedBytes(value int64) {
+	setBuildStatusResponseVarint(x, getBuildStatusBaseAllocatedField, uint64(value))
+}
+
+func (x *GetBuildStatusResponse) SetDeltaAllocatedBytes(value int64) {
+	setBuildStatusResponseVarint(x, getBuildStatusDeltaAllocatedField, uint64(value))
+}
+
+func (x *GetBuildStatusResponse) SetAllocatedBytesSupported(value bool) {
+	var encoded uint64
+	if value {
+		encoded = 1
+	}
+	setBuildStatusResponseVarint(x, getBuildStatusAllocatedSupportField, encoded)
+}
+
+func getBuildStatusResponseVarint(x *GetBuildStatusResponse, field protowire.Number) int64 {
+	if x == nil {
+		return 0
+	}
+	unknown := x.ProtoReflect().GetUnknown()
+	for len(unknown) > 0 {
+		num, typ, n := protowire.ConsumeTag(unknown)
+		if n < 0 {
+			break
+		}
+		unknown = unknown[n:]
+		value, n := protowire.ConsumeVarint(unknown)
+		if n < 0 {
+			break
+		}
+		unknown = unknown[n:]
+		if num == field && typ == protowire.VarintType {
+			return int64(value)
+		}
+	}
+	return 0
+}
+
+func setBuildStatusResponseVarint(x *GetBuildStatusResponse, field protowire.Number, value uint64) {
+	if x == nil {
+		return
+	}
+	unknown := x.ProtoReflect().GetUnknown()
+	unknown = protowire.AppendTag(unknown, field, protowire.VarintType)
+	unknown = protowire.AppendVarint(unknown, value)
+	x.ProtoReflect().SetUnknown(unknown)
+}

--- a/supabase/migrations/20260825000001_artifact_allocated_bytes.sql
+++ b/supabase/migrations/20260825000001_artifact_allocated_bytes.sql
@@ -1,0 +1,4 @@
+-- Preserve apparent size for integrity while recording host allocation for billing.
+ALTER TABLE artifact_manifest
+    ADD COLUMN allocated_bytes bigint NOT NULL DEFAULT 0
+    CHECK (allocated_bytes >= 0);

--- a/supabase/migrations/20260825000002_storage_measurement_constraints.sql
+++ b/supabase/migrations/20260825000002_storage_measurement_constraints.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sandbox_storage_interval
+    DROP CONSTRAINT sandbox_storage_interval_disk_positive,
+    DROP CONSTRAINT sandbox_storage_interval_reason_valid,
+    ADD CONSTRAINT sandbox_storage_interval_disk_nonnegative
+        CHECK (disk_mib >= 0),
+    ADD CONSTRAINT sandbox_storage_interval_reason_valid
+        CHECK (end_reason IS NULL OR end_reason IN ('deleted', 'measurement'));

--- a/supabase/migrations/20260825000003_artifact_manifest_template_path.sql
+++ b/supabase/migrations/20260825000003_artifact_manifest_template_path.sql
@@ -1,0 +1,8 @@
+-- Preserve allocation manifests for older build paths while a template is
+-- still pinned by retained sandboxes. A template may therefore have one row
+-- per physical path and file name is only descriptive.
+DROP INDEX IF EXISTS artifact_manifest_template_file;
+
+CREATE UNIQUE INDEX artifact_manifest_template_path
+    ON artifact_manifest (template_id, path)
+    WHERE template_id IS NOT NULL;

--- a/supabase/migrations/20260825000004_backfill_template_artifact_manifests.sql
+++ b/supabase/migrations/20260825000004_backfill_template_artifact_manifests.sql
@@ -1,0 +1,41 @@
+-- Seed manifests for templates that were already ready before template
+-- manifests were written during FinalizeBuild. The database cannot stat paths
+-- on a VMD host, so leave the historical allocation at zero until the artifact
+-- is rebuilt and measured by the host.
+INSERT INTO artifact_manifest (
+    template_id, file_name, path, size_bytes, allocated_bytes, sha256
+)
+SELECT t.id,
+       'rootfs.ext4',
+       t.rootfs_path,
+       COALESCE(t.size_bytes, 0),
+       0,
+       repeat('0', 64)
+FROM template AS t
+WHERE t.status = 'ready'
+  AND t.deleted_at IS NULL
+  AND t.base_path IS NULL
+  AND t.delta_path IS NULL
+  AND t.rootfs_path IS NOT NULL
+ON CONFLICT (template_id, path) WHERE template_id IS NOT NULL DO NOTHING;
+
+-- Overlay-mode paths are independently retained artifacts. Their historical
+-- allocation is unavailable to the control-plane database and is therefore
+-- left at zero until a host-side build measurement records it.
+INSERT INTO artifact_manifest (
+    template_id, file_name, path, size_bytes, allocated_bytes, sha256
+)
+SELECT t.id,
+       CASE WHEN p.path = t.base_path THEN 'base.ext4' ELSE 'delta.ext4' END,
+       p.path,
+       0,
+       0,
+       repeat('0', 64)
+FROM template AS t
+CROSS JOIN LATERAL (
+    VALUES (t.base_path), (t.delta_path)
+) AS p(path)
+WHERE t.status = 'ready'
+  AND t.deleted_at IS NULL
+  AND p.path IS NOT NULL
+ON CONFLICT (template_id, path) WHERE template_id IS NOT NULL DO NOTHING;

--- a/supabase/migrations/20260825000005_sandbox_storage_interval_lookup_index.sql
+++ b/supabase/migrations/20260825000005_sandbox_storage_interval_lookup_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS sandbox_storage_interval_sandbox_team_started_at_idx
+    ON sandbox_storage_interval (sandbox_id, team_id, started_at);


### PR DESCRIPTION
## Summary

- meter each referenced rootfs/template artifact once instead of multiplying shared storage per sandbox
- meter each sandbox overlay from trusted host-side physical allocation
- preserve time-weighted overlay history and existing CPU/memory billing

## Testing

- focused overlay sampler and interval tests
- shared template reference/deduplication tests
- relevant Go suites and repository validation

## Testing

- `codex-workflow validate`

Fixes SS-423
