### PR TITLE
backup: refresh dedupe verification history on every valid hit

### DIFF
--- a/internal/backup/uploader.go
+++ b/internal/backup/uploader.go
@@ -914,6 +914,25 @@ func (u *Uploader) uploadFile(ctx context.Context, task *Task, file TaskFile) (_
 		task.logOwner(u.Log.Warn().Str("object", object)).
 			Msg("deduped object has no verification history; abandoning generation")
 		return ManifestFile{}, 0, errSourceChanged
+	} else {
+		// Verified within retention, but the record's clock has run since
+		// the object's ORIGINAL write and is never touched again on a
+		// plain read. Without a refresh, an object that dedupes
+		// successfully on every single re-pause still runs out the
+		// original write's window and abandons once verifiedRetention
+		// passes, forever after (a content-addressed object that already
+		// exists can never be freshly re-uploaded to reset the clock).
+		// Resetting it here only ever extends trust that is CURRENTLY
+		// valid; an expired record is never resurrected, that stays the
+		// abandon path above.
+		next := *task
+		if !next.HasVerified(u.verificationKey(object)) {
+			next.VerifiedObjects = append(append([]string(nil), task.VerifiedObjects...), u.verificationKey(object))
+		}
+		if err := u.Journal.RecordVerification(next, u.verificationKey(object), u.clock()); err != nil {
+			return ManifestFile{}, 0, fmt.Errorf("refresh verification of %s: %w", object, err)
+		}
+		task.VerifiedObjects = next.VerifiedObjects
 	}
 	return ManifestFile{
 		Name:       file.Name,

--- a/internal/backup/uploader_test.go
+++ b/internal/backup/uploader_test.go
@@ -686,6 +686,99 @@ func TestUploaderTrustsHistoryForUnchangedRepause(t *testing.T) {
 	}
 }
 
+// TestUploaderRefreshesVerificationOnRepeatedDedupe covers a real
+// production regression: a verification record's clock used to be set
+// once, at the object's original upload, and never touched again on a
+// later dedupe. An object whose content stays unchanged for longer than
+// verifiedRetention would then abandon forever, even though every
+// intervening re-pause had successfully deduped and proven the bytes were
+// still good. This proves the clock now resets on every valid dedupe, so
+// continued legitimate reference never runs out the window.
+func TestUploaderRefreshesVerificationOnRepeatedDedupe(t *testing.T) {
+	j, _ := testJournal(t)
+	store := newMemStore()
+	var verified []Task
+	// Anchored to the real clock, not writeTask's fixed EnqueuedAt: Ack's
+	// incremental prune sweep (journal.go) stamps and compares against
+	// real time.Now() regardless of Uploader.Now, so a fake clock started
+	// far from the present would look already-expired the instant it is
+	// written, independent of anything this test is trying to exercise.
+	start := time.Now()
+	fake := start
+	u := &Uploader{
+		Journal:    j,
+		Store:      store,
+		OnVerified: func(task Task) error { verified = append(verified, task); return nil },
+		Now:        func() time.Time { return fake },
+	}
+
+	// First pause: full upload, verified, acked.
+	task := writeTask(t, t.TempDir())
+	task.EnqueuedAt = fake
+	if err := j.Enqueue(task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := u.drainOne(context.Background(), fake); err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 1 {
+		t.Fatalf("first pause not verified: %+v", verified)
+	}
+	overlayObj := "sandboxes/sb-1/gen-abc/" + packedName(t, task.Files[0].Path, "overlay.ext4")
+	key := store.Identity() + "\x00" + overlayObj
+	if ok, err := j.WasVerified(key, fake); err != nil || !ok {
+		t.Fatalf("WasVerified immediately after first upload = %v (err %v), want valid", ok, err)
+	}
+
+	// Repause just before the ORIGINAL write's retention window closes.
+	// Every object dedupes; per the fix this must refresh the durable
+	// record instead of merely reading it.
+	step := verifiedRetention - time.Hour
+	fake = fake.Add(step)
+	repause2 := task
+	repause2.EnqueuedAt = fake
+	repause2.VerifiedObjects = nil
+	if err := j.Enqueue(repause2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := u.drainOne(context.Background(), fake); err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 2 {
+		t.Fatalf("repause within the original window abandoned instead of completing: %+v", verified)
+	}
+
+	// Advance by the same distance again: elapsed time since the
+	// ORIGINAL write now exceeds verifiedRetention, so without the
+	// refresh above this repause would abandon. Elapsed time since the
+	// REFRESH is still within the window, so it must complete.
+	fake = fake.Add(step)
+	if elapsed := fake.Sub(start); elapsed <= verifiedRetention {
+		t.Fatalf("test setup: elapsed %v does not exceed original retention %v", elapsed, verifiedRetention)
+	}
+	repause3 := task
+	repause3.EnqueuedAt = fake
+	repause3.VerifiedObjects = nil
+	if err := j.Enqueue(repause3); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := u.drainOne(context.Background(), fake); err != nil {
+		t.Fatal(err)
+	}
+	if len(verified) != 3 {
+		t.Fatalf("repause past the original write's retention window abandoned; verification was not refreshed: %+v", verified)
+	}
+	if counts, _ := j.Pending(); counts[PriorityPause] != 0 {
+		t.Fatalf("final repause task still pending: %v", counts)
+	}
+
+	// Direct check: the record reads valid at a time that is only within
+	// retention when measured from the refresh, not the original write.
+	if ok, err := j.WasVerified(key, fake); err != nil || !ok {
+		t.Fatalf("WasVerified after refresh = %v (err %v), want valid", ok, err)
+	}
+}
+
 func TestJournalSameContentSandboxesDoNotCollide(t *testing.T) {
 	j, _ := testJournal(t)
 	base := time.Date(2026, 7, 31, 0, 0, 0, 0, time.UTC)
@@ -1624,6 +1717,9 @@ func TestLegacyUnscopedVerificationRecordsStillTrusted(t *testing.T) {
 	// The startup migration (as Run performs) claims the legacy record
 	// for the current bucket.
 	if err := j.MigrateVerificationScope(store.Identity()); err != nil {
+		t.Fatal(err)
+	}
+	if err := j.Enqueue(task); err != nil {
 		t.Fatal(err)
 	}
 	completed, _, _, err := u.uploadTask(context.Background(), &task)


### PR DESCRIPTION
Resolves the recurring backup-abandon alert fired for long-idle sandboxes whose backup content hasn't changed in over two weeks.

## Summary
- A backup generation's local verification record was written once, at the object's original upload, and never refreshed on later successful dedupes. Content that stays unchanged for longer than `verifiedRetention` (14 days) crosses that original window and abandons the generation permanently, even though every intervening re-pause had already re-proven the bytes were good, because the object already exists under its content-addressed name and can never be freshly re-uploaded to reset the clock.
- Fix: reset the record on every dedupe that's still within the retention window, mirroring the pattern already used for shared base images. An expired record is never resurrected; the existing abandon path for missing/expired history is unchanged.

## Technical decisions / tradeoffs
- Considered extending shared-base "structural trust" (content-address alone) to non-shared per-generation objects — rejected: shared bases have many independent uploaders continually re-attesting the same name and a documented operator remediation path; a single sandbox's own object has neither, and there's no restore fallback to an older generation if a wrongly-trusted object turns out torn.
- Considered treating an *expired* record as proof-of-history and completing the generation — rejected after review: `Ack`'s incremental prune sweep deletes expired records, so "expired" isn't a stable, distinguishable state from "never verified" (crash residue) once pruned. Resurrecting trust in an already-expired record also has no bound on how long ago the object was last actually checked.
- Landed on refreshing only currently-valid records (sliding TTL). This introduces no new trust decision — it only closes the gap where continued legitimate reference was never being recorded — and reuses the existing `RecordVerification` call already proven in the shared-base branch, including its claim-fencing behavior.
- Already-expired/stuck cases are explicitly out of scope for this PR; unsticking them needs an out-of-band operator re-verification path, tracked separately.

## Testing
- `go test ./internal/backup/...` (full package, run inside a Linux container since this repo isn't macOS-buildable locally)
- `go build ./...` / `go vet ./...`
- New test proves the actual regression: an object dedupes successfully twice in a row, spaced such that the second repause's elapsed time from the *original* write exceeds retention, but elapsed time from the *refresh* does not — and the generation completes rather than abandoning.
- One existing test (`TestLegacyUnscopedVerificationRecordsStillTrusted`) needed a missing `Enqueue` call added: it previously called `uploadTask` on a never-enqueued task, which happened to work only because the old code was a no-op on the valid-dedupe path.
- Local `codex exec review --base main` clean.
