### PR TITLE
docs: allow a Fixes link to the resolving tracker item in PR bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Fixes: <!-- Linear issue or Sentry alert URL, if any. Delete this line if none. -->
+
+## Summary
+<!-- What changed and why, in plain language. See AGENTS.md: no ticket IDs
+     or internal URLs anywhere below this line, no customer names. -->
+
+## Technical decisions / tradeoffs
+<!-- Alternatives considered and why they were rejected, if any. -->
+
+## Testing
+<!-- How this was verified: tests run, manual checks, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
-Fixes: <!-- Linear issue or Sentry alert URL, if any. Delete this line if none. -->
+<!-- Fixes/Implements/Relates to: <Linear issue or Sentry alert URL>
+     Pick the verb that matches: Fixes for a bug fix or resolved Sentry
+     alert, Implements for a Linear issue/spec being built out, Relates to
+     for work that's part of a larger tracked effort. Delete this line if
+     there's no tracker item. -->
 
 ## Summary
 <!-- What changed and why, in plain language. See AGENTS.md: no ticket IDs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,14 +17,17 @@ PR titles, PR descriptions, review comments — is public.
   number.
 - **No internal URLs** (dashboards, trackers, internal docs) in committed
   files.
-- **PR bodies may link the tracker item they resolve.** A single line at the
-  top of a PR description — `Fixes: <Linear issue URL>` or
-  `Fixes: <Sentry issue URL>` — is fine even though the destination is
-  internal-only; outside readers just see a dead link, same as any other
-  private reference. This does not relax anything above: PR titles, code,
-  comments, commits, and fixtures still describe the change in plain words
-  with no ticket IDs or internal URLs, and the PR body must still explain
-  the change in prose, not rely on the link alone.
+- **PR bodies may link the tracker item they relate to.** A single line at
+  the top of a PR description, verb matched to what the PR actually does:
+  `Fixes: <URL>` for a bug fix or a Sentry alert this resolves,
+  `Implements: <URL>` for a Linear issue or spec this builds out,
+  `Relates to: <URL>` for a PR that's part of a larger tracked effort
+  without fully resolving it. The destination being internal-only is fine;
+  outside readers just see a dead link, same as any other private
+  reference. This does not relax anything above: PR titles, code, comments,
+  commits, and fixtures still describe the change in plain words with no
+  ticket IDs or internal URLs, and the PR body must still explain the
+  change in prose, not rely on the link alone.
 
 Cross-referencing public artifacts is fine: other PRs and issues in this
 repository, upstream project issues, and public documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,20 @@ PR titles, PR descriptions, review comments — is public.
   text. Use neutral placeholders (`pilot-team`, `example-team`) in tests and
   plain descriptions ("a customer with a large fleet") in prose.
 - **No internal ticket references.** Do not cite issue-tracker IDs
-  (`SS-123`-style) anywhere in the repo or in PR titles/descriptions. They
+  (`SS-123`-style) in code, comments, test fixtures, or commit messages. They
   are dead links to outside readers and leak internal planning. Describe the
   purpose in words instead: "part of the multi-region rollout", not a ticket
   number.
 - **No internal URLs** (dashboards, trackers, internal docs) in committed
-  files or PR text.
+  files.
+- **PR bodies may link the tracker item they resolve.** A single line at the
+  top of a PR description — `Fixes: <Linear issue URL>` or
+  `Fixes: <Sentry issue URL>` — is fine even though the destination is
+  internal-only; outside readers just see a dead link, same as any other
+  private reference. This does not relax anything above: PR titles, code,
+  comments, commits, and fixtures still describe the change in plain words
+  with no ticket IDs or internal URLs, and the PR body must still explain
+  the change in prose, not rely on the link alone.
 
 Cross-referencing public artifacts is fine: other PRs and issues in this
 repository, upstream project issues, and public documentation.


### PR DESCRIPTION
## Summary
- AGENTS.md previously banned internal ticket references and URLs everywhere, including PR text. That meant a PR couldn't say which Linear issue or Sentry alert it resolves, even for the team merging it.
- Carve out a narrow exception: a PR body may open with `Fixes: <Linear issue URL>` or `Fixes: <Sentry issue URL>`. Everything else is unchanged — code, comments, commits, and fixtures still describe changes in plain words with no ticket IDs or internal URLs, and a PR body must still explain the change in prose rather than relying on the link alone.
- Add `.github/PULL_REQUEST_TEMPLATE.md` with the placeholder so it's the default rather than something to remember each time.

## Testing
- Docs-only change; local `codex exec review --base main` clean.