### PR TITLE
billing: make the rollup interval-overlap scan sargable

### DIFF
--- a/internal/billing/rollup.go
+++ b/internal/billing/rollup.go
@@ -237,12 +237,20 @@ RETURNING true`
 	return claimed, err
 }
 
-func enqueueHour(ctx context.Context, pool *pgxpool.Pool, hourStart, hourEnd time.Time, refreshCompleted bool) (int64, error) {
-	// interval_team_set is MATERIALIZED so the flag check runs against the
-	// deduplicated team set (~tens of rows). Without the fence the planner
-	// pushes feature_enabled() into the interval scans and evaluates it once
-	// per interval row — tens of thousands of flag lookups per call.
-	const query = `
+// intervalTeamSetCTE selects the teams holding a compute or storage billing
+// interval overlapping the window [$1, $2). Both schedulers below bind $1/$2 to
+// their window bounds and append their own trailing CTEs.
+//
+// MATERIALIZED so the flag check runs against the deduplicated team set (~tens
+// of rows). Without the fence the planner pushes feature_enabled() into the
+// interval scans and evaluates it once per interval row.
+//
+// The open-interval arm has to stay sargable: wrapping ended_at in COALESCE
+// hides it from the planner and costs a full scan of both tables. This spelling
+// is equivalent — `$1 < LEAST(now(), $2)` is a row-independent guard in the
+// same conjunction, so wherever a row can match at all the COALESCE fallback
+// already exceeds $1 — and it reaches the partial index on each arm.
+const intervalTeamSetCTE = `
 WITH interval_team_set AS MATERIALIZED (
     SELECT DISTINCT team_id
     FROM (
@@ -250,7 +258,7 @@ WITH interval_team_set AS MATERIALIZED (
         FROM sandbox_compute_billing_interval i
         WHERE i.started_at < $2
           AND $1 < LEAST(now(), $2)
-          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+          AND (i.ended_at IS NULL OR i.ended_at > $1)
 
         UNION
 
@@ -258,9 +266,12 @@ WITH interval_team_set AS MATERIALIZED (
         FROM sandbox_storage_interval i
         WHERE i.started_at < $2
           AND $1 < LEAST(now(), $2)
-          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
+          AND (i.ended_at IS NULL OR i.ended_at > $1)
     ) billing_teams
-),
+)`
+
+func enqueueHour(ctx context.Context, pool *pgxpool.Pool, hourStart, hourEnd time.Time, refreshCompleted bool) (int64, error) {
+	const query = intervalTeamSetCTE + `,
 candidate_teams AS (
     SELECT team_id FROM interval_team_set
     WHERE feature_enabled('billing_hourly_rollups', team_id)
@@ -427,27 +438,7 @@ func nextTeamBackfillBatches(ctx context.Context, pool *pgxpool.Pool, startHour,
 		teamLimit = defaultHourlyRollupBatchSize
 	}
 
-	// Same MATERIALIZED fence as enqueueHour: dedup the interval scan first,
-	// flag-check the resulting team set — not every interval row.
-	const query = `
-WITH interval_team_set AS MATERIALIZED (
-    SELECT DISTINCT team_id
-    FROM (
-        SELECT i.team_id
-        FROM sandbox_compute_billing_interval i
-        WHERE i.started_at < $2
-          AND $1 < LEAST(now(), $2)
-          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
-
-        UNION
-
-        SELECT i.team_id
-        FROM sandbox_storage_interval i
-        WHERE i.started_at < $2
-          AND $1 < LEAST(now(), $2)
-          AND COALESCE(i.ended_at, LEAST(now(), $2)) > $1
-    ) billing_teams
-),
+	const query = intervalTeamSetCTE + `,
 interval_teams AS (
     SELECT team_id FROM interval_team_set
     WHERE feature_enabled('billing_hourly_rollups', team_id)

--- a/internal/integration/billing_interval_overlap_test.go
+++ b/internal/integration/billing_interval_overlap_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The rollup scheduler's overlap predicate is spelled for sargability (see
+// intervalTeamSetCTE), which is only safe if it selects exactly what the
+// COALESCE form did. On a billing path that equivalence is proved against
+// Postgres rather than argued: both spellings run over the same rows across
+// windows hitting every boundary, and must select identically.
+
+const (
+	oldOverlapPredicate = `COALESCE(i.ended_at, LEAST(now(), $2)) > $1`
+	newOverlapPredicate = `(i.ended_at IS NULL OR i.ended_at > $1)`
+)
+
+// selectOverlapping runs one spelling of the overlap predicate against one
+// interval table, scoped to a team so concurrent fixtures cannot bleed in.
+func selectOverlapping(t *testing.T, table, predicate string, teamID uuid.UUID, from, to time.Time) []uuid.UUID {
+	t.Helper()
+	q := `SELECT i.id FROM ` + table + ` i
+	      WHERE i.started_at < $2
+	        AND $1 < LEAST(now(), $2)
+	        AND ` + predicate + `
+	        AND i.team_id = $3
+	      ORDER BY i.id`
+	rows, err := testPool.Query(context.Background(), q, from, to, teamID)
+	if err != nil {
+		t.Fatalf("%s [%s]: %v", table, predicate, err)
+	}
+	defer rows.Close()
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate: %v", err)
+	}
+	return ids
+}
+
+// interval describes one fixture row relative to the primary window [W0, W1).
+type interval struct {
+	label string
+	start time.Duration // offset from W0
+	end   *time.Duration
+	// inWindow is membership in the primary window, asserted explicitly so the
+	// test cannot pass by both spellings being equally wrong.
+	inWindow bool
+}
+
+func dur(d time.Duration) *time.Duration { return &d }
+
+func TestIntegration_BillingIntervalOverlapPredicateEquivalence(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+
+	// Anchor a day back so the fixture windows are unaffected by the wall clock
+	// crossing an hour boundary mid-test.
+	w0 := time.Now().UTC().Truncate(time.Hour).Add(-24 * time.Hour)
+	w1 := w0.Add(time.Hour)
+
+	hour := time.Hour
+	cases := []interval{
+		{"closed-entirely-before", -3 * hour, dur(-2 * hour), false},
+		// Boundary: ended_at == W0. `> $1` is strict, so it does not overlap.
+		{"closed-ends-at-window-start", -2 * hour, dur(0), false},
+		{"closed-overlaps-start", -30 * time.Minute, dur(30 * time.Minute), true},
+		{"closed-entirely-inside", 10 * time.Minute, dur(20 * time.Minute), true},
+		{"closed-overlaps-end", 30 * time.Minute, dur(90 * time.Minute), true},
+		// Boundary: started_at == W1. `< $2` is strict, so it does not overlap.
+		{"closed-starts-at-window-end", hour, dur(2 * hour), false},
+		{"closed-spans-window", -hour, dur(2 * hour), true},
+		{"closed-entirely-after", 2 * hour, dur(3 * hour), false},
+		// Zero-length interval exactly at W0: starts before W1 but ends at W0.
+		{"closed-zero-length-at-start", 0, dur(0), false},
+		{"open-started-before", -5 * hour, nil, true},
+		{"open-started-inside", 30 * time.Minute, nil, true},
+		{"open-started-at-window-end", hour, nil, false},
+		{"open-started-after", 2 * hour, nil, false},
+	}
+
+	// Both tables carry the same predicate, and both FK to (sandbox_id, team_id).
+	// storage's end_reason CHECK admits only 'deleted', which compute accepts
+	// too, so one reason serves both inserts.
+	idsByLabel := map[string]map[string]uuid.UUID{
+		"sandbox_compute_billing_interval": {},
+		"sandbox_storage_interval":         {},
+	}
+	for _, c := range cases {
+		sandboxID := insertSandboxAt(t, teamID, "ivl-"+uuid.New().String()[:8], "active", w0)
+		start := w0.Add(c.start)
+		var end *time.Time
+		var reason *string
+		if c.end != nil {
+			e := w0.Add(*c.end)
+			r := "deleted"
+			end, reason = &e, &r
+		}
+
+		var computeID, storageID uuid.UUID
+		if err := testPool.QueryRow(ctx,
+			`INSERT INTO sandbox_compute_billing_interval
+			   (sandbox_id, team_id, vcpu_count, memory_mib, started_at, ended_at, end_reason)
+			 VALUES ($1, $2, 1, 512, $3, $4, $5) RETURNING id`,
+			sandboxID, teamID, start, end, reason,
+		).Scan(&computeID); err != nil {
+			t.Fatalf("insert compute interval %s: %v", c.label, err)
+		}
+		if err := testPool.QueryRow(ctx,
+			`INSERT INTO sandbox_storage_interval
+			   (sandbox_id, team_id, disk_mib, started_at, ended_at, end_reason)
+			 VALUES ($1, $2, 1024, $3, $4, $5) RETURNING id`,
+			sandboxID, teamID, start, end, reason,
+		).Scan(&storageID); err != nil {
+			t.Fatalf("insert storage interval %s: %v", c.label, err)
+		}
+		idsByLabel["sandbox_compute_billing_interval"][c.label] = computeID
+		idsByLabel["sandbox_storage_interval"][c.label] = storageID
+	}
+
+	now := time.Now().UTC()
+	windows := []struct {
+		name     string
+		from, to time.Time
+	}{
+		{"primary-hour", w0, w1},
+		{"wide", w0.Add(-3 * hour), w0.Add(3 * hour)},
+		{"empty-region", w0.Add(-10 * hour), w0.Add(-9 * hour)},
+		// Straddles now(), so LEAST(now(), $2) resolves to now() rather than $2 —
+		// the case where the two spellings could diverge if the guard were dropped.
+		{"straddles-now", now.Add(-hour), now.Add(hour)},
+		// Entirely in the future: the guard is false, so both must select nothing.
+		{"future", now.Add(2 * hour), now.Add(3 * hour)},
+	}
+
+	for table := range idsByLabel {
+		for _, w := range windows {
+			oldIDs := selectOverlapping(t, table, oldOverlapPredicate, teamID, w.from, w.to)
+			newIDs := selectOverlapping(t, table, newOverlapPredicate, teamID, w.from, w.to)
+
+			if len(oldIDs) != len(newIDs) {
+				t.Fatalf("%s/%s: predicates disagree on count: old=%d new=%d",
+					table, w.name, len(oldIDs), len(newIDs))
+			}
+			for i := range oldIDs {
+				if oldIDs[i] != newIDs[i] {
+					t.Fatalf("%s/%s: predicates disagree at %d: old=%s new=%s",
+						table, w.name, i, oldIDs[i], newIDs[i])
+				}
+			}
+		}
+
+		// Equivalence alone would hold if both spellings were wrong in the same
+		// way, so pin the primary window's membership to the intended semantics.
+		got := map[uuid.UUID]bool{}
+		for _, id := range selectOverlapping(t, table, newOverlapPredicate, teamID, w0, w1) {
+			got[id] = true
+		}
+		for _, c := range cases {
+			id := idsByLabel[table][c.label]
+			if got[id] != c.inWindow {
+				t.Errorf("%s: %s in primary window = %v, want %v",
+					table, c.label, got[id], c.inWindow)
+			}
+		}
+		if len(got) == 0 {
+			t.Fatalf("%s: primary window selected nothing — fixture is not exercising the predicate", table)
+		}
+	}
+}


### PR DESCRIPTION
The hourly rollup and backfill schedulers find the teams active in a window with `COALESCE(ended_at, LEAST(now(), $2)) > $1`. Wrapping the column hides it from the planner, so both interval scans fall back to a full table read whose cost grows with total billing history rather than with the window.

Given the `$1 < LEAST(now(), $2)` guard already in the same conjunction, that is exactly equivalent to `ended_at IS NULL OR ended_at > $1` — which the partial indexes already on these tables can serve, turning the sequential scan into a bitmap OR across them. No schema change; the two schedulers' duplicated CTE is also collapsed into one shared constant.

Since this is a billing path the equivalence is proved against Postgres rather than argued: an integration test runs both spellings over the same rows across windows hitting every boundary (open intervals, zero-length, exact start/end, straddling now, future) and requires identical row sets.