### PR TITLE
fix: Short-circuit cross-cell Stripe webhooks before DB processing

### DIFF
--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -109,7 +109,7 @@ func (h *Handlers) pauseBillingIneligibleTeam(ctx context.Context, teamID uuid.U
 		dispatchBounded(cleanupCtx, rows, 10, func(sbx db.ClaimBillingIneligibleSandboxesRow) {
 			itemCtx, itemCancel := context.WithTimeout(cleanupCtx, 2*time.Minute)
 			defer itemCancel()
-			h.pauseBillingIneligible(itemCtx, sbx)
+			h.pauseBillingIneligible(itemCtx, sbx, log.Logger)
 		})
 		if len(rows) < int(billingEligibilityPauseBatchSize) || batch >= 99 {
 			if len(rows) > 0 {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -261,6 +261,15 @@ type stripeInvoiceObject struct {
 	Status       string `json:"status"`
 }
 
+type stripeWebhookRoutingDecision string
+
+const (
+	stripeWebhookRoutingDecisionInvalid  stripeWebhookRoutingDecision = "invalid"
+	stripeWebhookRoutingDecisionOwned    stripeWebhookRoutingDecision = "owned"
+	stripeWebhookRoutingDecisionNotOwned stripeWebhookRoutingDecision = "not_owned"
+	stripeWebhookRoutingDecisionGlobal   stripeWebhookRoutingDecision = "global"
+)
+
 func NewStripeBillingClient(cfg *config.Config) StripeBillingClient {
 	if cfg == nil || strings.TrimSpace(cfg.StripeSecretKey) == "" || strings.TrimSpace(cfg.StripeAPIVersion) == "" {
 		return nil
@@ -1399,115 +1408,113 @@ func (h *Handlers) HandleStripeWebhook(c *gin.Context) {
 		return
 	}
 
-	tx, err := h.Pool.BeginTx(c.Request.Context(), pgx.TxOptions{})
+	routing, err := h.resolveStripeWebhookRouting(c.Request.Context(), &event)
 	if err != nil {
-		log.Error().Err(err).Str("event_id", event.ID).Msg("begin Stripe webhook transaction failed")
+		log.Error().Err(err).Str("event_id", event.ID).Str("event_type", event.Type).Msg("resolve Stripe webhook routing failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	if routing == stripeWebhookRoutingDecisionNotOwned {
+		log.Info().Str("routing_decision", string(routing)).Str("event_id", event.ID).Str("event_type", event.Type).Msg("Stripe webhook ignored for non-local ownership")
+		c.JSON(http.StatusOK, gin.H{"status": "ignored"})
+		return
+	}
+	if routing == stripeWebhookRoutingDecisionInvalid {
+		respondError(c, ErrInternal)
+		return
+	}
+
+	recordTx, err := h.Pool.BeginTx(c.Request.Context(), pgx.TxOptions{})
+	if err != nil {
+		log.Error().Err(err).Str("event_id", event.ID).Msg("begin Stripe webhook record transaction failed")
 		respondError(c, ErrInternal)
 		return
 	}
 	defer func() {
-		_ = tx.Rollback(c.Request.Context())
+		_ = recordTx.Rollback(c.Request.Context())
 	}()
-	q := h.DB.WithTx(tx)
+	recordQ := h.DB.WithTx(recordTx)
 
-	row, err := q.CreateStripeWebhookEvent(c.Request.Context(), db.CreateStripeWebhookEventParams{
+	if _, err := recordQ.CreateStripeWebhookEvent(c.Request.Context(), db.CreateStripeWebhookEventParams{
 		EventID:   event.ID,
 		EventType: event.Type,
 		Payload:   payload,
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			existing, gerr := q.GetStripeWebhookEventForUpdate(c.Request.Context(), event.ID)
-			if gerr != nil {
-				log.Error().Err(gerr).Str("event_id", event.ID).Msg("load existing Stripe webhook event failed")
-				respondError(c, ErrInternal)
-				return
-			}
-			if existing.ProcessedAt.Valid {
-				if err := tx.Commit(c.Request.Context()); err != nil {
-					log.Error().Err(err).Str("event_id", event.ID).Msg("commit duplicate Stripe webhook failed")
-					respondError(c, ErrInternal)
-					return
-				}
-				h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
-				c.JSON(http.StatusOK, gin.H{"status": "duplicate"})
-				return
-			}
-			if err := h.expandStripeThinMeterEvent(c.Request.Context(), &event); err != nil {
-				log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
-				respondError(c, ErrInternal)
-				return
-			}
-			if err := h.processStripeWebhookEvent(c.Request.Context(), q, event); err != nil {
-				msg := err.Error()
-				if _, uerr := q.MarkStripeWebhookEventFailed(c.Request.Context(), db.MarkStripeWebhookEventFailedParams{
-					EventID:   event.ID,
-					LastError: &msg,
-				}); uerr != nil {
-					log.Error().Err(uerr).Str("event_id", event.ID).Msg("mark Stripe webhook failed state failed")
-					respondError(c, ErrInternal)
-					return
-				}
-				if err := tx.Commit(c.Request.Context()); err != nil {
-					log.Error().Err(err).Str("event_id", event.ID).Msg("commit failed Stripe webhook state failed")
-					respondError(c, ErrInternal)
-					return
-				}
-				log.Error().Err(err).Str("event_id", event.ID).Str("event_type", event.Type).Msg("process Stripe webhook retry failed")
-				respondError(c, ErrInternal)
-				return
-			}
-			if _, err := q.MarkStripeWebhookEventProcessed(c.Request.Context(), event.ID); err != nil {
-				log.Error().Err(err).Str("event_id", event.ID).Msg("mark Stripe webhook processed failed")
-				respondError(c, ErrInternal)
-				return
-			}
-			if err := tx.Commit(c.Request.Context()); err != nil {
-				log.Error().Err(err).Str("event_id", event.ID).Msg("commit retried Stripe webhook failed")
+	}); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Error().Err(err).Str("event_id", event.ID).Msg("record Stripe webhook event failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		existing, gerr := recordQ.GetStripeWebhookEventForUpdate(c.Request.Context(), event.ID)
+		if gerr != nil {
+			log.Error().Err(gerr).Str("event_id", event.ID).Msg("load existing Stripe webhook event failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		if existing.ProcessedAt.Valid {
+			if err := recordTx.Commit(c.Request.Context()); err != nil {
+				log.Error().Err(err).Str("event_id", event.ID).Msg("commit duplicate Stripe webhook failed")
 				respondError(c, ErrInternal)
 				return
 			}
 			h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
-			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+			c.JSON(http.StatusOK, gin.H{"status": "duplicate"})
 			return
 		}
-		log.Error().Err(err).Str("event_id", event.ID).Msg("record Stripe webhook event failed")
-		respondError(c, ErrInternal)
-		return
 	}
-	_ = row
-	if err := h.expandStripeThinMeterEvent(c.Request.Context(), &event); err != nil {
-		log.Error().Err(err).Str("event_id", event.ID).Msg("retrieve Stripe thin event failed")
+	if err := recordTx.Commit(c.Request.Context()); err != nil {
+		log.Error().Err(err).Str("event_id", event.ID).Msg("commit Stripe webhook record failed")
 		respondError(c, ErrInternal)
 		return
 	}
 
+	processTx, err := h.Pool.BeginTx(c.Request.Context(), pgx.TxOptions{})
+	if err != nil {
+		log.Error().Err(err).Str("event_id", event.ID).Msg("begin Stripe webhook processing transaction failed")
+		if ferr := h.persistStripeWebhookFailure(c.Request.Context(), event.ID, err.Error()); ferr != nil {
+			log.Error().Err(ferr).Str("event_id", event.ID).Msg("persist Stripe webhook failed state failed")
+		}
+		respondError(c, ErrInternal)
+		return
+	}
+	defer func() {
+		_ = processTx.Rollback(c.Request.Context())
+	}()
+	q := h.DB.WithTx(processTx)
+
+	existing, err := q.GetStripeWebhookEventForUpdate(c.Request.Context(), event.ID)
+	if err != nil {
+		log.Error().Err(err).Str("event_id", event.ID).Msg("lock Stripe webhook event failed")
+		h.rollbackAndPersistStripeWebhookFailure(c.Request.Context(), processTx, event.ID, err.Error())
+		respondError(c, ErrInternal)
+		return
+	}
+	if existing.ProcessedAt.Valid {
+		if err := processTx.Commit(c.Request.Context()); err != nil {
+			log.Error().Err(err).Str("event_id", event.ID).Msg("commit duplicate Stripe webhook failed")
+			respondError(c, ErrInternal)
+			return
+		}
+		h.scheduleBillingEligibilityReconciliation(c.Request.Context(), event)
+		c.JSON(http.StatusOK, gin.H{"status": "duplicate"})
+		return
+	}
+
 	if err := h.processStripeWebhookEvent(c.Request.Context(), q, event); err != nil {
-		msg := err.Error()
-		if _, uerr := q.MarkStripeWebhookEventFailed(c.Request.Context(), db.MarkStripeWebhookEventFailedParams{
-			EventID:   event.ID,
-			LastError: &msg,
-		}); uerr != nil {
-			log.Error().Err(uerr).Str("event_id", event.ID).Msg("mark Stripe webhook failed state failed")
-			respondError(c, ErrInternal)
-			return
-		}
-		if err := tx.Commit(c.Request.Context()); err != nil {
-			log.Error().Err(err).Str("event_id", event.ID).Msg("commit failed Stripe webhook state failed")
-			respondError(c, ErrInternal)
-			return
-		}
+		h.rollbackAndPersistStripeWebhookFailure(c.Request.Context(), processTx, event.ID, err.Error())
 		log.Error().Err(err).Str("event_id", event.ID).Str("event_type", event.Type).Msg("process Stripe webhook failed")
 		respondError(c, ErrInternal)
 		return
 	}
 	if _, err := q.MarkStripeWebhookEventProcessed(c.Request.Context(), event.ID); err != nil {
 		log.Error().Err(err).Str("event_id", event.ID).Msg("mark Stripe webhook processed failed")
+		h.rollbackAndPersistStripeWebhookFailure(c.Request.Context(), processTx, event.ID, err.Error())
 		respondError(c, ErrInternal)
 		return
 	}
-	if err := tx.Commit(c.Request.Context()); err != nil {
+	if err := processTx.Commit(c.Request.Context()); err != nil {
 		log.Error().Err(err).Str("event_id", event.ID).Msg("commit Stripe webhook failed")
+		h.rollbackAndPersistStripeWebhookFailure(c.Request.Context(), processTx, event.ID, err.Error())
 		respondError(c, ErrInternal)
 		return
 	}
@@ -1540,12 +1547,104 @@ func (h *Handlers) expandStripeThinMeterEvent(ctx context.Context, event *stripe
 	return nil
 }
 
+func (h *Handlers) persistStripeWebhookFailure(ctx context.Context, eventID, lastError string) error {
+	if h.Pool == nil {
+		return errors.New("billing transactions are not configured")
+	}
+	tx, err := h.Pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+	q := h.DB.WithTx(tx)
+	if _, err := q.MarkStripeWebhookEventFailed(ctx, db.MarkStripeWebhookEventFailedParams{
+		EventID:   eventID,
+		LastError: &lastError,
+	}); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (h *Handlers) rollbackAndPersistStripeWebhookFailure(ctx context.Context, tx pgx.Tx, eventID, lastError string) {
+	if rerr := tx.Rollback(ctx); rerr != nil {
+		log.Error().Err(rerr).Str("event_id", eventID).Msg("rollback failed Stripe webhook transaction failed")
+	}
+	if ferr := h.persistStripeWebhookFailure(ctx, eventID, lastError); ferr != nil {
+		log.Error().Err(ferr).Str("event_id", eventID).Msg("persist Stripe webhook failed state failed")
+	}
+}
+
+func (h *Handlers) resolveStripeWebhookRouting(ctx context.Context, event *stripeEventEnvelope) (stripeWebhookRoutingDecision, error) {
+	switch event.Type {
+	case "checkout.session.completed":
+		var obj stripeCheckoutCompletedObject
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		teamID, err := uuid.Parse(strings.TrimSpace(obj.ClientReferenceID))
+		if err != nil {
+			return stripeWebhookRoutingDecisionNotOwned, nil
+		}
+		if _, err := h.DB.GetTeam(ctx, teamID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return stripeWebhookRoutingDecisionNotOwned, nil
+			}
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		return stripeWebhookRoutingDecisionOwned, nil
+	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted", "customer.subscription.paused", "customer.subscription.resumed":
+		var obj stripeSubscriptionObject
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		customerID := strings.TrimSpace(obj.Customer)
+		if customerID == "" {
+			return stripeWebhookRoutingDecisionInvalid, fmt.Errorf("stripe subscription event has no customer")
+		}
+		if _, err := h.DB.GetTeamBillingAccountByStripeCustomerID(ctx, stringPtr(customerID)); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return stripeWebhookRoutingDecisionNotOwned, nil
+			}
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		return stripeWebhookRoutingDecisionOwned, nil
+	case "invoice.payment_failed", "invoice.payment_succeeded", "invoice.finalized":
+		var obj stripeInvoiceObject
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		customerID := strings.TrimSpace(obj.Customer)
+		if customerID == "" {
+			return stripeWebhookRoutingDecisionInvalid, fmt.Errorf("stripe invoice event has no customer")
+		}
+		if _, err := h.DB.GetTeamBillingAccountByStripeCustomerID(ctx, stringPtr(customerID)); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return stripeWebhookRoutingDecisionNotOwned, nil
+			}
+			return stripeWebhookRoutingDecisionInvalid, err
+		}
+		return stripeWebhookRoutingDecisionOwned, nil
+	case "billing.meter.error_report_triggered", "v1.billing.meter.error_report_triggered":
+		return stripeWebhookRoutingDecisionGlobal, nil
+	default:
+		return stripeWebhookRoutingDecisionGlobal, nil
+	}
+}
+
 func isStripeMeterErrorEvent(eventType string) bool {
 	return eventType == "billing.meter.error_report_triggered" || eventType == "v1.billing.meter.error_report_triggered"
 }
 
 func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries, event stripeEventEnvelope) error {
 	eventAt := stripeEventTime(int64(event.Created))
+	if isStripeMeterErrorEvent(event.Type) && len(bytes.TrimSpace(event.Data.Object)) == 0 {
+		if err := h.expandStripeThinMeterEvent(ctx, &event); err != nil {
+			return err
+		}
+	}
 	switch event.Type {
 	case "checkout.session.completed":
 		var obj stripeCheckoutCompletedObject
@@ -1554,7 +1653,7 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		}
 		teamID, err := uuid.Parse(strings.TrimSpace(obj.ClientReferenceID))
 		if err != nil {
-			return nil
+			return err
 		}
 		_, err = q.UpsertTeamBillingAccountSubscription(ctx, db.UpsertTeamBillingAccountSubscriptionParams{
 			TeamID:               teamID,
@@ -1569,9 +1668,6 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		}
 		account, err := q.GetTeamBillingAccountByStripeCustomerID(ctx, stringPtr(obj.Customer))
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil
-			}
 			return err
 		}
 		if obj.ID == "" {
@@ -1640,9 +1736,6 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		}
 		account, err := q.GetTeamBillingAccountByStripeCustomerID(ctx, stringPtr(obj.Customer))
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return nil
-			}
 			return err
 		}
 		status := strings.TrimSpace(obj.Status)

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -59,7 +59,8 @@ func DefaultReaperConfig() ReaperConfig {
 //   - The batch size bounds work per tick so a burst of expirations
 //     cannot starve the control plane for extended periods.
 func (h *Handlers) StartTimeoutReaper(ctx context.Context, cfg ReaperConfig) {
-	go h.reaperLoop(ctx, cfg)
+	logger := log.Logger
+	go h.reaperLoop(ctx, cfg, logger)
 	go h.trialEligibilityLoop(ctx, cfg.Interval)
 }
 
@@ -86,7 +87,7 @@ func (h *Handlers) trialEligibilityLoop(ctx context.Context, interval time.Durat
 	}
 }
 
-func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
+func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig, logger zerolog.Logger) {
 	parallelism := cfg.Parallelism
 	if parallelism <= 0 {
 		parallelism = 10
@@ -99,7 +100,7 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 		sweepInterval = defaultSweepInterval
 	}
 
-	log.Info().
+	logger.Info().
 		Dur("interval", cfg.Interval).
 		Dur("sweep_interval", sweepInterval).
 		Int32("batch_size", cfg.BatchSize).
@@ -111,14 +112,14 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 	// goroutine would let a slow batch hold off the sweeps — the reason they
 	// ran last in the single-ticker loop this replaced. Concurrency here is
 	// not new: every control-plane instance already runs both loops.
-	go h.sweepLoop(ctx, sweepInterval)
+	go h.sweepLoop(ctx, sweepInterval, logger)
 
 	ticker := time.NewTicker(cfg.Interval)
 	defer ticker.Stop()
 
 	runTick := func() {
-		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism) })
-		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism) })
+		sentrylog.RunSafe("reaper", func() { h.reapOnce(ctx, cfg.BatchSize, parallelism, logger) })
+		sentrylog.RunSafe("auto-delete", func() { h.reapAutoDeleteOnce(ctx, cfg.BatchSize, parallelism, logger) })
 	}
 
 	// Run once immediately so a control plane restart does not delay
@@ -128,7 +129,7 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info().Msg("timeout reaper exiting")
+			logger.Info().Msg("timeout reaper exiting")
 			return
 		case <-ticker.C:
 			runTick()
@@ -139,14 +140,14 @@ func (h *Handlers) reaperLoop(ctx context.Context, cfg ReaperConfig) {
 // sweepLoop runs the DB-only maintenance sweeps: backstops for cleanup the
 // request path already performs, each scanning accumulated history to usually
 // find nothing.
-func (h *Handlers) sweepLoop(ctx context.Context, interval time.Duration) {
+func (h *Handlers) sweepLoop(ctx context.Context, interval time.Duration, logger zerolog.Logger) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	runSweeps := func() {
-		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx) })
-		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx) })
-		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx) })
+		sentrylog.RunSafe("interval-sweep", func() { h.sweepOrphanedIntervals(ctx, logger) })
+		sentrylog.RunSafe("revocation-cleanup", func() { h.cleanupExpiredRevocations(ctx, logger) })
+		sentrylog.RunSafe("snapshot-row-sweep", func() { h.sweepOrphanedSnapshotRows(ctx, logger) })
 	}
 
 	// Immediately, so a restart after a crash cleans up without waiting a
@@ -165,40 +166,40 @@ func (h *Handlers) sweepLoop(ctx context.Context, interval time.Duration) {
 
 // sweepOrphanedIntervals closes intervals left open on no-longer-active
 // sandboxes — defense-in-depth for WAU accuracy, off the request path.
-func (h *Handlers) sweepOrphanedIntervals(ctx context.Context) {
+func (h *Handlers) sweepOrphanedIntervals(ctx context.Context, logger zerolog.Logger) {
 	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	n, err := h.DB.CloseOrphanedActiveIntervals(qctx)
 	if err != nil {
-		log.Error().Err(err).Msg("reaper: CloseOrphanedActiveIntervals failed")
+		logger.Error().Err(err).Msg("reaper: CloseOrphanedActiveIntervals failed")
 		return
 	}
 	if n > 0 {
-		log.Warn().Int64("closed", n).Msg("reaper: closed orphaned active intervals")
+		logger.Warn().Int64("closed", n).Msg("reaper: closed orphaned active intervals")
 	}
 }
 
 // cleanupExpiredRevocations deletes sandbox_revocation and revoked_proxy_token
 // rows past their TTL — once no live JWT can carry them, the entries are moot.
-func (h *Handlers) cleanupExpiredRevocations(ctx context.Context) {
+func (h *Handlers) cleanupExpiredRevocations(ctx context.Context, logger zerolog.Logger) {
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	n, err := h.DB.DeleteExpiredSandboxRevocations(queryCtx)
 	if err != nil {
-		log.Warn().Err(err).Msg("reaper: cleanup revocations failed")
+		logger.Warn().Err(err).Msg("reaper: cleanup revocations failed")
 		return
 	}
 	if n > 0 {
-		log.Info().Int64("reaped", n).Msg("reaper: deleted expired sandbox revocations")
+		logger.Info().Int64("reaped", n).Msg("reaper: deleted expired sandbox revocations")
 	}
 
 	tn, err := h.DB.DeleteExpiredRevokedProxyTokens(queryCtx)
 	if err != nil {
-		log.Warn().Err(err).Msg("reaper: cleanup revoked proxy tokens failed")
+		logger.Warn().Err(err).Msg("reaper: cleanup revoked proxy tokens failed")
 		return
 	}
 	if tn > 0 {
-		log.Info().Int64("reaped", tn).Msg("reaper: deleted expired revoked proxy tokens")
+		logger.Info().Int64("reaped", tn).Msg("reaper: deleted expired revoked proxy tokens")
 	}
 }
 
@@ -225,7 +226,7 @@ dispatch:
 	wg.Wait()
 }
 
-func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism int) {
+func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism int, logger zerolog.Logger) {
 	// Atomically claim expired active sandboxes and mark them 'pausing' in one
 	// CTE+UPDATE. FOR UPDATE SKIP LOCKED inside the query ensures that
 	// concurrent reaper replicas skip rows already being processed.
@@ -235,7 +236,7 @@ func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism in
 	expired, err := h.DB.ClaimExpiredSandboxes(queryCtx, batchSize)
 	queryCancel()
 	if err != nil {
-		log.Error().Err(err).Msg("reaper: ClaimExpiredSandboxes failed")
+		logger.Error().Err(err).Msg("reaper: ClaimExpiredSandboxes failed")
 		return
 	}
 
@@ -243,10 +244,10 @@ func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism in
 		return
 	}
 
-	log.Info().Int("count", len(expired)).Msg("reaper: pausing expired sandboxes")
+	logger.Info().Int("count", len(expired)).Msg("reaper: pausing expired sandboxes")
 
 	dispatchBounded(ctx, expired, parallelism, func(sbx db.ClaimExpiredSandboxesRow) {
-		h.pauseExpired(ctx, sbx)
+		h.pauseExpired(ctx, sbx, logger)
 	})
 }
 
@@ -255,16 +256,16 @@ func (h *Handlers) reapOnce(ctx context.Context, batchSize int32, parallelism in
 // shutdown between the soft-delete claim and cleanupSandboxSnapshots).
 // Row deletion also unblocks the vm reconciler's disk scan, which reclaims
 // the now-orphaned files.
-func (h *Handlers) sweepOrphanedSnapshotRows(ctx context.Context) {
+func (h *Handlers) sweepOrphanedSnapshotRows(ctx context.Context, logger zerolog.Logger) {
 	qctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	n, err := h.DB.DeleteSnapshotsOfDestroyedSandboxes(qctx)
 	if err != nil {
-		log.Warn().Err(err).Msg("reaper: DeleteSnapshotsOfDestroyedSandboxes failed")
+		logger.Warn().Err(err).Msg("reaper: DeleteSnapshotsOfDestroyedSandboxes failed")
 		return
 	}
 	if n > 0 {
-		log.Warn().Int64("deleted", n).Msg("reaper: removed snapshot rows orphaned by unfinished destroy teardown")
+		logger.Warn().Int64("deleted", n).Msg("reaper: removed snapshot rows orphaned by unfinished destroy teardown")
 	}
 }
 
@@ -274,7 +275,7 @@ func (h *Handlers) sweepOrphanedSnapshotRows(ctx context.Context) {
 // best-effort teardown of VM state and artifacts — same contract as the
 // user-initiated DeleteSandbox, where the vm reconciler backstops any teardown
 // step that fails.
-func (h *Handlers) reapAutoDeleteOnce(ctx context.Context, batchSize int32, parallelism int) {
+func (h *Handlers) reapAutoDeleteOnce(ctx context.Context, batchSize int32, parallelism int, logger zerolog.Logger) {
 	queryCtx, queryCancel := context.WithTimeout(ctx, 10*time.Second)
 	due, err := h.DB.ClaimAutoDeleteSandboxes(queryCtx, db.ClaimAutoDeleteSandboxesParams{
 		BatchSize:           batchSize,
@@ -282,7 +283,7 @@ func (h *Handlers) reapAutoDeleteOnce(ctx context.Context, batchSize int32, para
 	})
 	queryCancel()
 	if err != nil {
-		log.Error().Err(err).Msg("reaper: ClaimAutoDeleteSandboxes failed")
+		logger.Error().Err(err).Msg("reaper: ClaimAutoDeleteSandboxes failed")
 		return
 	}
 
@@ -290,10 +291,10 @@ func (h *Handlers) reapAutoDeleteOnce(ctx context.Context, batchSize int32, para
 		return
 	}
 
-	log.Info().Int("count", len(due)).Msg("reaper: deleting expired paused sandboxes")
+	logger.Info().Int("count", len(due)).Msg("reaper: deleting expired paused sandboxes")
 
 	dispatchBounded(ctx, due, parallelism, func(sbx db.ClaimAutoDeleteSandboxesRow) {
-		h.teardownAutoDeleted(ctx, sbx)
+		h.teardownAutoDeleted(ctx, sbx, logger)
 	})
 }
 
@@ -305,8 +306,8 @@ const autoDeleteTeardownTimeout = 2 * time.Minute
 
 // teardownAutoDeleted reclaims VM state for one sandbox already soft-deleted
 // by ClaimAutoDeleteSandboxes, via the same teardown path as DeleteSandbox.
-func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDeleteSandboxesRow) {
-	l := log.With().
+func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDeleteSandboxesRow, logger zerolog.Logger) {
+	l := logger.With().
 		Str("sandbox_id", sbx.ID.String()).
 		Str("host_id", sbx.HostID).
 		Str("team_id", sbx.TeamID.String()).
@@ -339,11 +340,11 @@ func (h *Handlers) teardownAutoDeleted(ctx context.Context, sbx db.ClaimAutoDele
 // Failure handling:
 //   - Step 1 fails → VM is still running → revert DB to 'active'.
 //   - Step 2 fails → VM is stopped → call rollbackPausedVM (resume + revert).
-func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxesRow) {
-	h.pauseClaimed(ctx, sbx, "timeout", "timeout_pause", "timeout_paused", "reaper: sandbox paused due to timeout")
+func (h *Handlers) pauseExpired(ctx context.Context, sbx db.ClaimExpiredSandboxesRow, logger zerolog.Logger) {
+	h.pauseClaimed(ctx, sbx, "timeout", "timeout_pause", "timeout_paused", "reaper: sandbox paused due to timeout", logger)
 }
 
-func (h *Handlers) pauseBillingIneligible(ctx context.Context, sbx db.ClaimBillingIneligibleSandboxesRow) {
+func (h *Handlers) pauseBillingIneligible(ctx context.Context, sbx db.ClaimBillingIneligibleSandboxesRow, logger zerolog.Logger) {
 	h.pauseClaimed(ctx, db.ClaimExpiredSandboxesRow{
 		ID:            sbx.ID,
 		TeamID:        sbx.TeamID,
@@ -351,11 +352,11 @@ func (h *Handlers) pauseBillingIneligible(ctx context.Context, sbx db.ClaimBilli
 		SnapshotID:    sbx.SnapshotID,
 		HostID:        sbx.HostID,
 		NetworkConfig: sbx.NetworkConfig,
-	}, "billing_ineligible", "billing_ineligible_pause", "billing_ineligible_paused", "billing: sandbox paused after eligibility loss")
+	}, "billing_ineligible", "billing_ineligible_pause", "billing_ineligible_paused", "billing: sandbox paused after eligibility loss", logger)
 }
 
-func (h *Handlers) pauseClaimed(ctx context.Context, sbx db.ClaimExpiredSandboxesRow, trigger, transition, activity, successMessage string) {
-	l := log.With().
+func (h *Handlers) pauseClaimed(ctx context.Context, sbx db.ClaimExpiredSandboxesRow, trigger, transition, activity, successMessage string, logger zerolog.Logger) {
+	l := logger.With().
 		Str("sandbox_id", sbx.ID.String()).
 		Str("host_id", sbx.HostID).
 		Str("team_id", sbx.TeamID.String()).

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -162,7 +162,7 @@ func TestReaper_NothingExpired(t *testing.T) {
 		}},
 	)
 
-	h.reapOnce(context.Background(), 10, 1)
+	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
 	if atomic.LoadInt32(&pauseCalled) != 0 {
 		t.Fatal("PauseInstance should not be called when no sandboxes are expired")
@@ -195,7 +195,7 @@ func TestReaper_VMDSucceeds(t *testing.T) {
 		}},
 	)
 
-	h.reapOnce(context.Background(), 10, 1)
+	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
 	if pausedID != row.ID.String() {
 		t.Fatalf("expected PauseInstance called with %s, got %q", row.ID, pausedID)
@@ -235,7 +235,7 @@ func TestReaper_VMDFails(t *testing.T) {
 		}},
 	)
 
-	h.reapOnce(context.Background(), 10, 1)
+	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
 	// Both sandboxes are attempted, and pauseWithRetry retries each failure
 	// once (a timed-out pause may have completed on the host), so 2 sandboxes
@@ -266,7 +266,7 @@ func TestReaper_DBError(t *testing.T) {
 		}},
 	)
 
-	h.reapOnce(context.Background(), 10, 1)
+	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
 	if atomic.LoadInt32(&pauseCalled) != 0 {
 		t.Fatal("PauseInstance should not be called when DB query fails")
@@ -293,7 +293,7 @@ func TestReaper_BatchSizeRespected(t *testing.T) {
 		&stubVMD{},
 	)
 
-	h.reapOnce(context.Background(), 7, 1)
+	h.reapOnce(context.Background(), 7, 1, zerolog.Nop())
 
 	if got := atomic.LoadInt32(&capturedLimit); got != 7 {
 		t.Fatalf("expected batch size 7 passed to query, got %d", got)
@@ -325,7 +325,7 @@ func TestReaper_ContextCancelledMidBatch(t *testing.T) {
 		}},
 	)
 
-	h.reapOnce(ctx, 10, 1)
+	h.reapOnce(ctx, 10, 1, zerolog.Nop())
 
 	// The loop checks ctx.Done() between each sandbox. After cancel() the loop
 	// should exit before processing all 5.

--- a/internal/api/stripe_webhook_observability_test.go
+++ b/internal/api/stripe_webhook_observability_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/superserve-ai/sandbox/internal/config"
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+func TestHandleStripeWebhookLogsNotOwnedRoutingDecision(t *testing.T) {
+	now := time.Date(2026, 8, 22, 18, 0, 0, 0, time.UTC)
+	teamID := uuid.New()
+
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_not_owned_log",
+		"type":    "checkout.session.completed",
+		"created": now.Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"client_reference_id": teamID.String(),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal webhook payload: %v", err)
+	}
+
+	var buf bytes.Buffer
+	oldLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.InfoLevel)
+	t.Cleanup(func() {
+		log.Logger = oldLogger
+	})
+
+	h := &Handlers{
+		Config: &config.Config{StripeWebhookSecret: "whsec_snapshot"},
+		Now:    func() time.Time { return now },
+		Pool:   &pgxpool.Pool{},
+		DB: db.New(&mockDBTX{
+			queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+				if strings.Contains(sql, "FROM team WHERE id = $1") {
+					return &mockRow{scanFn: func(dest ...any) error { return pgx.ErrNoRows }}
+				}
+				return &mockRow{scanFn: func(dest ...any) error {
+					return pgx.ErrNoRows
+				}}
+			},
+			execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+				t.Fatalf("unexpected billing mutation for not_owned webhook")
+				return pgconn.CommandTag{}, nil
+			},
+		}),
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/stripe/webhook", h.HandleStripeWebhook)
+
+	req := httptest.NewRequest(http.MethodPost, "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeWebhookTestSignature(payload, now, "whsec_snapshot"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"status":"ignored"`) {
+		t.Fatalf("response body = %q, want ignored status", w.Body.String())
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		`"routing_decision":"not_owned"`,
+		`"event_id":"evt_not_owned_log"`,
+		`"event_type":"checkout.session.completed"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("log output %q missing %q", out, want)
+		}
+	}
+}

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,10 +49,20 @@ type fakeStripeClient struct {
 
 type thinEventStripeClient struct {
 	*fakeStripeClient
-	retrieved json.RawMessage
+	retrieved         json.RawMessage
+	retrieveCalls     int
+	retrieveErrOnCall int
+	retrieveErr       error
 }
 
 func (f *thinEventStripeClient) RetrieveEvent(context.Context, string) (json.RawMessage, error) {
+	f.retrieveCalls++
+	if f.retrieveErrOnCall > 0 && f.retrieveCalls >= f.retrieveErrOnCall {
+		if f.retrieveErr != nil {
+			return nil, f.retrieveErr
+		}
+		return nil, errors.New("Stripe event retrieval failed")
+	}
 	return f.retrieved, nil
 }
 
@@ -251,6 +262,48 @@ func stripeSubscriptionWebhookPayload(t *testing.T, eventID, eventType, subscrip
 	return payload
 }
 
+func stripeCheckoutWebhookPayload(t *testing.T, eventID, clientReferenceID, customerID, subscriptionID string, created time.Time) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"id":      eventID,
+		"type":    "checkout.session.completed",
+		"created": created.Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":                  "cs_" + eventID,
+				"customer":            customerID,
+				"subscription":        subscriptionID,
+				"client_reference_id": clientReferenceID,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal checkout webhook payload: %v", err)
+	}
+	return payload
+}
+
+func stripeInvoiceWebhookPayload(t *testing.T, eventID, eventType, customerID, subscriptionID, status string, created time.Time) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"id":      eventID,
+		"type":    eventType,
+		"created": created.Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":           "in_" + eventID,
+				"customer":     customerID,
+				"subscription": subscriptionID,
+				"status":       status,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal invoice webhook payload: %v", err)
+	}
+	return payload
+}
+
 func doRequest(r *gin.Engine, req *http.Request) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -271,6 +324,32 @@ func exportAttemptCount(t *testing.T, teamID uuid.UUID, status string) int {
 	return n
 }
 
+func billingUsageExportRowCount(t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM billing_usage_export
+		WHERE team_id = $1
+	`, teamID).Scan(&n); err != nil {
+		t.Fatalf("count billing usage export rows: %v", err)
+	}
+	return n
+}
+
+func teamBillingAccountRowCount(t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM team_billing_account
+		WHERE team_id = $1
+	`, teamID).Scan(&n); err != nil {
+		t.Fatalf("count billing account rows: %v", err)
+	}
+	return n
+}
+
 func billingPeriodStatus(t *testing.T, teamID uuid.UUID, periodStart, periodEnd time.Time) string {
 	t.Helper()
 	var status string
@@ -282,6 +361,32 @@ func billingPeriodStatus(t *testing.T, teamID uuid.UUID, periodStart, periodEnd 
 		t.Fatalf("read billing period status: %v", err)
 	}
 	return status
+}
+
+func billingPeriodRowCount(t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM team_billing_period
+		WHERE team_id = $1
+	`, teamID).Scan(&n); err != nil {
+		t.Fatalf("count billing period rows: %v", err)
+	}
+	return n
+}
+
+func teamCreditGrantRowCount(t *testing.T, teamID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := testPool.QueryRow(context.Background(), `
+		SELECT COUNT(*)
+		FROM team_credit_grant
+		WHERE team_id = $1
+	`, teamID).Scan(&n); err != nil {
+		t.Fatalf("count credit grant rows: %v", err)
+	}
+	return n
 }
 
 func teamBillingUsageExportedAtValid(t *testing.T, teamID uuid.UUID, periodStart, periodEnd time.Time) bool {
@@ -933,6 +1038,505 @@ func TestIntegration_StripeWebhookDuplicateDeliveryIsSafe(t *testing.T) {
 	}
 }
 
+func TestIntegration_StripeWebhookIgnoresForeignOwnedEvents(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
+	before, err := testQueries.GetTeamBillingAccount(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load billing account before foreign webhooks: %v", err)
+	}
+	beforeUsageExports, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports before foreign webhooks: %v", err)
+	}
+	beforeBillingPeriod, err := testQueries.GetTeamBillingPeriod(ctx, db.GetTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing period before foreign webhooks: %v", err)
+	}
+	beforeCreditGrants, err := testQueries.ListTeamCreditGrants(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load credit grants before foreign webhooks: %v", err)
+	}
+	r := newBillingRouter(t, &fakeStripeClient{})
+	createdAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	foreignTeamID := uuid.New()
+	foreignCustomerID := "cus_" + foreignTeamID.String()
+	if _, err := testQueries.GetTeamBillingAccountByStripeCustomerID(ctx, &foreignCustomerID); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("foreign Stripe customer should be absent before webhook delivery, got err=%v", err)
+	}
+	beforeForeignAccounts := teamBillingAccountRowCount(t, foreignTeamID)
+	beforeForeignUsageExports := billingUsageExportRowCount(t, foreignTeamID)
+	beforeForeignBillingPeriods := billingPeriodRowCount(t, foreignTeamID)
+	beforeForeignCreditGrants := teamCreditGrantRowCount(t, foreignTeamID)
+	assertForeignStateUnchanged := func(label string) {
+		t.Helper()
+		if got := teamBillingAccountRowCount(t, foreignTeamID); got != beforeForeignAccounts {
+			t.Fatalf("%s: foreign team_billing_account row count changed from %d to %d", label, beforeForeignAccounts, got)
+		}
+		if got := billingUsageExportRowCount(t, foreignTeamID); got != beforeForeignUsageExports {
+			t.Fatalf("%s: foreign billing_usage_export row count changed from %d to %d", label, beforeForeignUsageExports, got)
+		}
+		if got := billingPeriodRowCount(t, foreignTeamID); got != beforeForeignBillingPeriods {
+			t.Fatalf("%s: foreign team_billing_period row count changed from %d to %d", label, beforeForeignBillingPeriods, got)
+		}
+		if got := teamCreditGrantRowCount(t, foreignTeamID); got != beforeForeignCreditGrants {
+			t.Fatalf("%s: foreign team_credit_grant row count changed from %d to %d", label, beforeForeignCreditGrants, got)
+		}
+		if _, err := testQueries.GetTeamBillingAccountByStripeCustomerID(ctx, &foreignCustomerID); !errors.Is(err, pgx.ErrNoRows) {
+			t.Fatalf("%s: foreign Stripe customer should remain absent after webhook delivery, got err=%v", label, err)
+		}
+	}
+
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name:    "checkout",
+			payload: stripeCheckoutWebhookPayload(t, "evt_foreign_checkout", foreignTeamID.String(), foreignCustomerID, "sub_foreign_checkout", createdAt),
+		},
+		{
+			name:    "subscription-created",
+			payload: stripeSubscriptionWebhookPayload(t, "evt_foreign_subscription_created", "customer.subscription.created", "sub_foreign_subscription_created", foreignCustomerID, "active", createdAt, createdAt, createdAt.Add(time.Hour)),
+		},
+		{
+			name:    "subscription-updated",
+			payload: stripeSubscriptionWebhookPayload(t, "evt_foreign_subscription_updated", "customer.subscription.updated", "sub_foreign_subscription_updated", foreignCustomerID, "active", createdAt, createdAt, createdAt.Add(time.Hour)),
+		},
+		{
+			name:    "subscription-deleted",
+			payload: stripeSubscriptionWebhookPayload(t, "evt_foreign_subscription_deleted", "customer.subscription.deleted", "sub_foreign_subscription_deleted", foreignCustomerID, "canceled", createdAt, createdAt, createdAt.Add(time.Hour)),
+		},
+		{
+			name:    "invoice-finalized",
+			payload: stripeInvoiceWebhookPayload(t, "evt_foreign_invoice_finalized", "invoice.finalized", foreignCustomerID, "sub_foreign_invoice_finalized", "open", createdAt),
+		},
+		{
+			name:    "invoice-failed",
+			payload: stripeInvoiceWebhookPayload(t, "evt_foreign_invoice_failed", "invoice.payment_failed", foreignCustomerID, "sub_foreign_invoice_failed", "open", createdAt),
+		},
+		{
+			name:    "invoice-paid",
+			payload: stripeInvoiceWebhookPayload(t, "evt_foreign_invoice_paid", "invoice.payment_succeeded", foreignCustomerID, "sub_foreign_invoice_paid", "paid", createdAt),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(tc.payload)))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Stripe-Signature", stripeSignature(t, tc.payload, time.Now().UTC()))
+			w := doRequest(r, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("foreign %s webhook: expected 200, got %d: %s", tc.name, w.Code, w.Body.String())
+			}
+			assertForeignStateUnchanged(tc.name)
+		})
+	}
+
+	after, err := testQueries.GetTeamBillingAccount(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load billing account after foreign webhooks: %v", err)
+	}
+	if derefString(after.StripeCustomerID) != derefString(before.StripeCustomerID) {
+		t.Fatalf("stripe customer id changed from %q to %q", derefString(before.StripeCustomerID), derefString(after.StripeCustomerID))
+	}
+	if derefString(after.StripeSubscriptionID) != derefString(before.StripeSubscriptionID) {
+		t.Fatalf("stripe subscription id changed from %q to %q", derefString(before.StripeSubscriptionID), derefString(after.StripeSubscriptionID))
+	}
+	if derefString(after.StripeSubscriptionStatus) != derefString(before.StripeSubscriptionStatus) {
+		t.Fatalf("stripe subscription status changed from %q to %q", derefString(before.StripeSubscriptionStatus), derefString(after.StripeSubscriptionStatus))
+	}
+	if derefString(after.StripeInvoiceStatus) != derefString(before.StripeInvoiceStatus) {
+		t.Fatalf("stripe invoice status changed from %q to %q", derefString(before.StripeInvoiceStatus), derefString(after.StripeInvoiceStatus))
+	}
+	if after.StripeSubscriptionEventAt.Valid != before.StripeSubscriptionEventAt.Valid || (after.StripeSubscriptionEventAt.Valid && !after.StripeSubscriptionEventAt.Time.Equal(before.StripeSubscriptionEventAt.Time)) {
+		t.Fatalf("subscription event at changed from %v to %v", before.StripeSubscriptionEventAt, after.StripeSubscriptionEventAt)
+	}
+	if after.CurrentPeriodStart.Valid != before.CurrentPeriodStart.Valid || (after.CurrentPeriodStart.Valid && !after.CurrentPeriodStart.Time.Equal(before.CurrentPeriodStart.Time)) {
+		t.Fatalf("current period start changed from %v to %v", before.CurrentPeriodStart, after.CurrentPeriodStart)
+	}
+	if after.CurrentPeriodEnd.Valid != before.CurrentPeriodEnd.Valid || (after.CurrentPeriodEnd.Valid && !after.CurrentPeriodEnd.Time.Equal(before.CurrentPeriodEnd.Time)) {
+		t.Fatalf("current period end changed from %v to %v", before.CurrentPeriodEnd, after.CurrentPeriodEnd)
+	}
+	if after.CancelAtPeriodEnd != before.CancelAtPeriodEnd {
+		t.Fatalf("cancel_at_period_end changed from %v to %v", before.CancelAtPeriodEnd, after.CancelAtPeriodEnd)
+	}
+	if after.StripeActivationCreditGrantedAt.Valid != before.StripeActivationCreditGrantedAt.Valid || (after.StripeActivationCreditGrantedAt.Valid && !after.StripeActivationCreditGrantedAt.Time.Equal(before.StripeActivationCreditGrantedAt.Time)) {
+		t.Fatalf("stripe activation credit grant timestamp changed from %v to %v", before.StripeActivationCreditGrantedAt, after.StripeActivationCreditGrantedAt)
+	}
+	if derefString(after.StripeActivationCreditGrantID) != derefString(before.StripeActivationCreditGrantID) {
+		t.Fatalf("stripe activation credit grant id changed from %q to %q", derefString(before.StripeActivationCreditGrantID), derefString(after.StripeActivationCreditGrantID))
+	}
+	afterUsageExports, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports after foreign webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterUsageExports, beforeUsageExports) {
+		t.Fatalf("billing_usage_export rows changed from %#v to %#v", beforeUsageExports, afterUsageExports)
+	}
+	afterBillingPeriod, err := testQueries.GetTeamBillingPeriod(ctx, db.GetTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing period after foreign webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterBillingPeriod, beforeBillingPeriod) {
+		t.Fatalf("team_billing_period row changed from %#v to %#v", beforeBillingPeriod, afterBillingPeriod)
+	}
+	afterCreditGrants, err := testQueries.ListTeamCreditGrants(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load credit grants after foreign webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterCreditGrants, beforeCreditGrants) {
+		t.Fatalf("team_credit_grant rows changed from %#v to %#v", beforeCreditGrants, afterCreditGrants)
+	}
+	if got := teamBillingAccountRowCount(t, foreignTeamID); got != beforeForeignAccounts {
+		t.Fatalf("foreign team_billing_account row count changed from %d to %d", beforeForeignAccounts, got)
+	}
+	if got := billingUsageExportRowCount(t, foreignTeamID); got != beforeForeignUsageExports {
+		t.Fatalf("foreign billing_usage_export row count changed from %d to %d", beforeForeignUsageExports, got)
+	}
+	if got := billingPeriodRowCount(t, foreignTeamID); got != beforeForeignBillingPeriods {
+		t.Fatalf("foreign team_billing_period row count changed from %d to %d", beforeForeignBillingPeriods, got)
+	}
+	if got := teamCreditGrantRowCount(t, foreignTeamID); got != beforeForeignCreditGrants {
+		t.Fatalf("foreign team_credit_grant row count changed from %d to %d", beforeForeignCreditGrants, got)
+	}
+	if _, err := testQueries.GetTeamBillingAccountByStripeCustomerID(ctx, &foreignCustomerID); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("foreign Stripe customer should remain absent after webhook delivery, got err=%v", err)
+	}
+}
+
+func TestIntegration_StripeWebhookPersistsFailureAfterRollback(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	r := newBillingRouter(t, &fakeStripeClient{})
+
+	createdAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	periodStart := createdAt.Add(2 * time.Hour)
+	periodEnd := createdAt.Add(time.Hour)
+	customerID := "cus_" + teamID.String()
+	payload := stripeSubscriptionWebhookPayload(t, "evt_processing_failure", "customer.subscription.updated", "sub_"+teamID.String(), customerID, "active", createdAt, periodStart, periodEnd)
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC()))
+	w := doRequest(r, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("failing webhook: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var lastError string
+	var processedAt pgtype.Timestamptz
+	if err := testPool.QueryRow(ctx, `
+		SELECT last_error, processed_at
+		FROM stripe_webhook_event
+		WHERE event_id = $1
+	`, "evt_processing_failure").Scan(&lastError, &processedAt); err != nil {
+		t.Fatalf("load failed webhook row: %v", err)
+	}
+	if !strings.Contains(lastError, "team_billing_account_period_valid") {
+		t.Fatalf("failed webhook last_error = %v, want original constraint failure", lastError)
+	}
+	if processedAt.Valid {
+		t.Fatalf("failed webhook processed_at = %v, want nil", processedAt)
+	}
+}
+
+func TestIntegration_StripeWebhookPersistsFailureAfterProcessedMarkRollback(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	r := newBillingRouter(t, &fakeStripeClient{})
+
+	_, err := testPool.Exec(ctx, `
+		CREATE OR REPLACE FUNCTION test_fail_stripe_webhook_mark_processed()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			IF NEW.processed_at IS DISTINCT FROM OLD.processed_at THEN
+				RAISE EXCEPTION 'forced stripe webhook processed_at update failure';
+			END IF;
+			RETURN NEW;
+		END;
+		$$;
+	`)
+	if err != nil {
+		t.Fatalf("create mark-processed failure trigger function: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DROP TRIGGER IF EXISTS test_fail_stripe_webhook_mark_processed_trg ON stripe_webhook_event`)
+		_, _ = testPool.Exec(context.Background(), `DROP FUNCTION IF EXISTS test_fail_stripe_webhook_mark_processed()`)
+	})
+	if _, err := testPool.Exec(ctx, `
+		CREATE TRIGGER test_fail_stripe_webhook_mark_processed_trg
+		BEFORE UPDATE ON stripe_webhook_event
+		FOR EACH ROW
+		EXECUTE FUNCTION test_fail_stripe_webhook_mark_processed()
+	`); err != nil {
+		t.Fatalf("create mark-processed failure trigger: %v", err)
+	}
+
+	createdAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	periodStart := createdAt.Add(2 * time.Hour)
+	periodEnd := createdAt.Add(3 * time.Hour)
+	customerID := "cus_" + teamID.String()
+	payload := stripeSubscriptionWebhookPayload(t, "evt_mark_processed_failure", "customer.subscription.updated", "sub_"+teamID.String(), customerID, "active", createdAt, periodStart, periodEnd)
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC()))
+	w := doRequest(r, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("mark-processed failing webhook: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var lastError string
+	var processedAt pgtype.Timestamptz
+	if err := testPool.QueryRow(ctx, `
+		SELECT last_error, processed_at
+		FROM stripe_webhook_event
+		WHERE event_id = $1
+	`, "evt_mark_processed_failure").Scan(&lastError, &processedAt); err != nil {
+		t.Fatalf("load mark-processed failed webhook row: %v", err)
+	}
+	if !strings.Contains(lastError, "forced stripe webhook processed_at update failure") {
+		t.Fatalf("failed webhook last_error = %v, want original processed_at failure", lastError)
+	}
+	if processedAt.Valid {
+		t.Fatalf("failed webhook processed_at = %v, want nil", processedAt)
+	}
+}
+
+func TestIntegration_StripeWebhookPersistsFailureAfterCommitRollback(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	r := newBillingRouter(t, &fakeStripeClient{})
+
+	_, err := testPool.Exec(ctx, `
+		CREATE OR REPLACE FUNCTION test_fail_stripe_webhook_commit()
+		RETURNS trigger
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+			IF NEW.event_id = 'evt_commit_failure' AND NEW.processed_at IS DISTINCT FROM OLD.processed_at THEN
+				RAISE EXCEPTION 'forced stripe webhook commit failure';
+			END IF;
+			RETURN NEW;
+		END;
+		$$;
+	`)
+	if err != nil {
+		t.Fatalf("create commit failure trigger function: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = testPool.Exec(context.Background(), `DROP TRIGGER IF EXISTS test_fail_stripe_webhook_commit_trg ON stripe_webhook_event`)
+		_, _ = testPool.Exec(context.Background(), `DROP FUNCTION IF EXISTS test_fail_stripe_webhook_commit()`)
+	})
+	if _, err := testPool.Exec(ctx, `
+		CREATE CONSTRAINT TRIGGER test_fail_stripe_webhook_commit_trg
+		AFTER UPDATE ON stripe_webhook_event
+		DEFERRABLE INITIALLY DEFERRED
+		FOR EACH ROW
+		EXECUTE FUNCTION test_fail_stripe_webhook_commit()
+	`); err != nil {
+		t.Fatalf("create commit failure trigger: %v", err)
+	}
+
+	createdAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	periodStart := createdAt.Add(2 * time.Hour)
+	periodEnd := createdAt.Add(3 * time.Hour)
+	customerID := "cus_" + teamID.String()
+	payload := stripeSubscriptionWebhookPayload(t, "evt_commit_failure", "customer.subscription.updated", "sub_"+teamID.String(), customerID, "active", createdAt, periodStart, periodEnd)
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC()))
+	w := doRequest(r, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("commit failing webhook: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var lastError string
+	var processedAt pgtype.Timestamptz
+	if err := testPool.QueryRow(ctx, `
+		SELECT last_error, processed_at
+		FROM stripe_webhook_event
+		WHERE event_id = $1
+	`, "evt_commit_failure").Scan(&lastError, &processedAt); err != nil {
+		t.Fatalf("load commit-failed webhook row: %v", err)
+	}
+	if !strings.Contains(lastError, "forced stripe webhook commit failure") {
+		t.Fatalf("failed webhook last_error = %v, want original commit failure", lastError)
+	}
+	if processedAt.Valid {
+		t.Fatalf("failed webhook processed_at = %v, want nil", processedAt)
+	}
+}
+
+func TestIntegration_StripeThinMeterErrorFailsOnMalformedExpansion(t *testing.T) {
+	stripe := &thinEventStripeClient{fakeStripeClient: &fakeStripeClient{}, retrieved: []byte(`{"data":{}}`)}
+	r := newBillingRouter(t, stripe)
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_thin_meter_error_invalid",
+		"type":    "v1.billing.meter.error_report_triggered",
+		"created": time.Now().UTC().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal thin meter error payload: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC(), testStripeMeterErrorWebhookSecret))
+	w := doRequest(r, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("malformed thin meter webhook: expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestIntegration_StripeThinMeterErrorIgnoresForeignTeam(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
+	beforeUsageExports := billingUsageExportRowCount(t, teamID)
+	beforeBillingPeriods := billingPeriodRowCount(t, teamID)
+	beforeCreditGrants := teamCreditGrantRowCount(t, teamID)
+	seedValue := pgtype.Numeric{}
+	if err := seedValue.Scan("0"); err != nil {
+		t.Fatalf("seed billing usage export value: %v", err)
+	}
+	seededExport, err := testQueries.CreateBillingUsageExport(context.Background(), db.CreateBillingUsageExportParams{
+		TeamID:                     teamID,
+		PeriodStart:                periodStart,
+		PeriodEnd:                  periodEnd,
+		ResourceType:               "cpu",
+		StripeCustomerID:           nil,
+		StripeMeterEventIdentifier: "thin-meter-foreign-export-check",
+		StripeIdempotencyKey:       nil,
+		StripeEventName:            "meter_usage_reported",
+		Value:                      seedValue,
+		Status:                     "pending",
+		Error:                      nil,
+		SentAt:                     pgtype.Timestamptz{},
+	})
+	if err != nil {
+		t.Fatalf("seed billing usage export: %v", err)
+	}
+	beforeUsageExports = billingUsageExportRowCount(t, teamID)
+	beforeUsageExportRows, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports before foreign webhook: %v", err)
+	}
+	foreignTeamID := uuid.New()
+	beforeForeignAccounts := teamBillingAccountRowCount(t, foreignTeamID)
+	beforeForeignUsageExports := billingUsageExportRowCount(t, foreignTeamID)
+	beforeForeignBillingPeriods := billingPeriodRowCount(t, foreignTeamID)
+	beforeForeignCreditGrants := teamCreditGrantRowCount(t, foreignTeamID)
+	identifier := fmt.Sprintf("team:%s:period:%d,%d:meter:cpu", foreignTeamID.String(), periodStart.Unix(), periodEnd.Unix())
+	fullData, err := json.Marshal(map[string]any{
+		"identifier":                identifier,
+		"developer_message_summary": "foreign meter error",
+	})
+	if err != nil {
+		t.Fatalf("marshal foreign meter error payload: %v", err)
+	}
+	retrieved, err := json.Marshal(map[string]json.RawMessage{"data": fullData})
+	if err != nil {
+		t.Fatalf("marshal foreign meter error retrieval payload: %v", err)
+	}
+	stripe := &thinEventStripeClient{fakeStripeClient: &fakeStripeClient{}, retrieved: retrieved}
+	r := newBillingRouter(t, stripe)
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_foreign_meter_error",
+		"type":    "v1.billing.meter.error_report_triggered",
+		"created": time.Now().UTC().Unix(),
+	})
+	if err != nil {
+		t.Fatalf("marshal foreign meter error webhook payload: %v", err)
+	}
+	signedAt := time.Now().UTC()
+	req := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(t, payload, signedAt, testStripeMeterErrorWebhookSecret))
+	w := doRequest(r, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("foreign thin meter webhook: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := billingPeriodStatus(t, teamID, periodStart, periodEnd); got != "approved" {
+		t.Fatalf("foreign thin meter webhook changed local billing period status to %q", got)
+	}
+	afterExport, err := testQueries.GetBillingUsageExportByIdentifier(context.Background(), seededExport.StripeMeterEventIdentifier)
+	if err != nil {
+		t.Fatalf("load seeded billing usage export after foreign webhook: %v", err)
+	}
+	if afterExport.Status != seededExport.Status {
+		t.Fatalf("billing_usage_export status changed from %q to %q", seededExport.Status, afterExport.Status)
+	}
+	if derefString(afterExport.Error) != derefString(seededExport.Error) {
+		t.Fatalf("billing_usage_export error changed from %q to %q", derefString(seededExport.Error), derefString(afterExport.Error))
+	}
+	if afterExport.CreatedAt != seededExport.CreatedAt {
+		t.Fatalf("billing_usage_export created_at changed from %v to %v", seededExport.CreatedAt, afterExport.CreatedAt)
+	}
+	if afterExport.UpdatedAt != seededExport.UpdatedAt {
+		t.Fatalf("billing_usage_export updated_at changed from %v to %v", seededExport.UpdatedAt, afterExport.UpdatedAt)
+	}
+	if afterExport.SentAt.Valid != seededExport.SentAt.Valid || (afterExport.SentAt.Valid && !afterExport.SentAt.Time.Equal(seededExport.SentAt.Time)) {
+		t.Fatalf("billing_usage_export sent_at changed from %v to %v", seededExport.SentAt, afterExport.SentAt)
+	}
+	if derefString(afterExport.StripeIdempotencyKey) != derefString(seededExport.StripeIdempotencyKey) {
+		t.Fatalf("billing_usage_export idempotency key changed from %q to %q", derefString(seededExport.StripeIdempotencyKey), derefString(afterExport.StripeIdempotencyKey))
+	}
+	afterUsageExportRows, err := testQueries.ListBillingUsageExportsForPeriod(context.Background(), db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports after foreign webhook: %v", err)
+	}
+	if !reflect.DeepEqual(afterUsageExportRows, beforeUsageExportRows) {
+		t.Fatalf("billing_usage_export rows changed from %#v to %#v", beforeUsageExportRows, afterUsageExportRows)
+	}
+	if got := billingUsageExportRowCount(t, teamID); got != beforeUsageExports {
+		t.Fatalf("billing_usage_export row count changed from %d to %d", beforeUsageExports, got)
+	}
+	if got := billingPeriodRowCount(t, teamID); got != beforeBillingPeriods {
+		t.Fatalf("team_billing_period row count changed from %d to %d", beforeBillingPeriods, got)
+	}
+	if got := teamCreditGrantRowCount(t, teamID); got != beforeCreditGrants {
+		t.Fatalf("team_credit_grant row count changed from %d to %d", beforeCreditGrants, got)
+	}
+	if got := teamBillingAccountRowCount(t, foreignTeamID); got != beforeForeignAccounts {
+		t.Fatalf("foreign team_billing_account row count changed from %d to %d", beforeForeignAccounts, got)
+	}
+	if got := billingUsageExportRowCount(t, foreignTeamID); got != beforeForeignUsageExports {
+		t.Fatalf("foreign billing_usage_export row count changed from %d to %d", beforeForeignUsageExports, got)
+	}
+	if got := billingPeriodRowCount(t, foreignTeamID); got != beforeForeignBillingPeriods {
+		t.Fatalf("foreign team_billing_period row count changed from %d to %d", beforeForeignBillingPeriods, got)
+	}
+	if got := teamCreditGrantRowCount(t, foreignTeamID); got != beforeForeignCreditGrants {
+		t.Fatalf("foreign team_credit_grant row count changed from %d to %d", beforeForeignCreditGrants, got)
+	}
+}
+
 func TestIntegration_StripeThinMeterErrorReconcilesByIdempotencyKey(t *testing.T) {
 	ctx := context.Background()
 	teamID, periodID, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
@@ -971,6 +1575,13 @@ func TestIntegration_StripeThinMeterErrorReconcilesByIdempotencyKey(t *testing.T
 	if got := exportAttemptCount(t, teamID, "failed"); got == 0 {
 		t.Fatal("thin meter webhook did not mark the matched export failed")
 	}
+	stripe.retrieveErrOnCall = 2
+	dupReq := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
+	dupReq.Header.Set("Content-Type", "application/json")
+	dupReq.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC(), testStripeMeterErrorWebhookSecret))
+	if w := doRequest(r, dupReq); w.Code != http.StatusOK {
+		t.Fatalf("duplicate thin meter webhook: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
 	invalidReq := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(payload)))
 	invalidReq.Header.Set("Content-Type", "application/json")
 	invalidReq.Header.Set("Stripe-Signature", stripeSignature(t, payload, time.Now().UTC(), "whsec_unconfigured"))
@@ -981,7 +1592,27 @@ func TestIntegration_StripeThinMeterErrorReconcilesByIdempotencyKey(t *testing.T
 
 func TestIntegration_StripeWebhookIgnoresForeignOrStaleSubscriptionEvents(t *testing.T) {
 	ctx := context.Background()
-	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	teamID, _, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
+	beforeUsageExports, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports before foreign/stale webhooks: %v", err)
+	}
+	beforeBillingPeriod, err := testQueries.GetTeamBillingPeriod(ctx, db.GetTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing period before foreign/stale webhooks: %v", err)
+	}
+	beforeCreditGrants, err := testQueries.ListTeamCreditGrants(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load credit grants before foreign/stale webhooks: %v", err)
+	}
 	r := newBillingRouter(t, &fakeStripeClient{})
 
 	currentCreated := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
@@ -1030,6 +1661,35 @@ func TestIntegration_StripeWebhookIgnoresForeignOrStaleSubscriptionEvents(t *tes
 	}
 	if !account.StripeSubscriptionEventAt.Valid || !account.StripeSubscriptionEventAt.Time.Equal(currentCreated) {
 		t.Fatalf("subscription event at = %v, want %v", account.StripeSubscriptionEventAt, currentCreated)
+	}
+	afterUsageExports, err := testQueries.ListBillingUsageExportsForPeriod(ctx, db.ListBillingUsageExportsForPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing usage exports after foreign/stale webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterUsageExports, beforeUsageExports) {
+		t.Fatalf("billing_usage_export rows changed from %#v to %#v", beforeUsageExports, afterUsageExports)
+	}
+	afterBillingPeriod, err := testQueries.GetTeamBillingPeriod(ctx, db.GetTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: periodStart,
+		PeriodEnd:   periodEnd,
+	})
+	if err != nil {
+		t.Fatalf("load billing period after foreign/stale webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterBillingPeriod, beforeBillingPeriod) {
+		t.Fatalf("team_billing_period row changed from %#v to %#v", beforeBillingPeriod, afterBillingPeriod)
+	}
+	afterCreditGrants, err := testQueries.ListTeamCreditGrants(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load credit grants after foreign/stale webhooks: %v", err)
+	}
+	if !reflect.DeepEqual(afterCreditGrants, beforeCreditGrants) {
+		t.Fatalf("team_credit_grant rows changed from %#v to %#v", beforeCreditGrants, afterCreditGrants)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a shared Stripe webhook routing gate before billing mutation transactions
- Treat wrong-cell owned events as 200 no-ops
- Persist failed webhook state outside aborted processing transactions

## Testing

- `go test -tags integration ./internal/integration -run 'Stripe|Billing'`
- `go test ./internal/api/...`

## Testing

- `codex-workflow validate`
