### PR TITLE
infra: null out backup_coverage_alerts to break a Terraform CD deadlock

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -380,11 +380,21 @@ module "observability" {
   # under us-central1 labeling before the host swap, so the legacy
   # value stays scoped: host rows relabeled or restored under it must
   # not fall outside the alert.
-  backup_coverage_alerts = {
-    enabled        = false
-    display_prefix = "Backup coverage / us-east4"
-    regions        = ["us-east4", "us-central1"]
-  }
+  #
+  # Left null for now (was the object below): creating these alert_policy
+  # resources requires backup_uncovered_paused_sandboxes to already exist
+  # as a Cloud Monitoring metric type, but the controlplane code that
+  # emits it deploys through this same Terraform CD run's api job, which
+  # is itself gated on this apply succeeding. Deadlock: apply fails on
+  # "Cannot find metric" -> api deploy never runs -> metric never gets
+  # emitted -> apply keeps failing. Re-enable once a later deploy (with
+  # this block still null) has shipped the emitting code and the metric
+  # is confirmed present in Cloud Monitoring.
+  # backup_coverage_alerts = {
+  #   enabled        = false
+  #   display_prefix = "Backup coverage / us-east4"
+  #   regions        = ["us-east4", "us-central1"]
+  # }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount
   # table) and live network namespaces accumulating. Both degrade latency

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -395,11 +395,21 @@ module "observability" {
   # one-field flip once the cell's backfill backlog converges to zero.
   # regions lists the host table's region column values in this cell's
   # database, NOT GCP region names; "usw" is the only value present.
-  backup_coverage_alerts = {
-    enabled        = false
-    display_prefix = "Backup coverage / us-west2"
-    regions        = ["usw"]
-  }
+  #
+  # Left null for now (was the object below): creating these alert_policy
+  # resources requires backup_uncovered_paused_sandboxes to already exist
+  # as a Cloud Monitoring metric type, but the controlplane code that
+  # emits it deploys through this same Terraform CD run's api job, which
+  # is itself gated on this apply succeeding. Deadlock: apply fails on
+  # "Cannot find metric" -> api deploy never runs -> metric never gets
+  # emitted -> apply keeps failing. Re-enable once a later deploy (with
+  # this block still null) has shipped the emitting code and the metric
+  # is confirmed present in Cloud Monitoring.
+  # backup_coverage_alerts = {
+  #   enabled        = false
+  #   display_prefix = "Backup coverage / us-west2"
+  #   regions        = ["usw"]
+  # }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount
   # table) and live network namespaces accumulating. Both degrade latency

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -382,11 +382,21 @@ module "observability" {
   # region-scoped companion condition) before it matters. regions lists
   # the host table's region column values in this cell's database, not
   # GCP region names; "us-central1" is the only value present.
-  backup_coverage_alerts = {
-    enabled        = false
-    display_prefix = "Backup coverage / staging"
-    regions        = ["us-central1"]
-  }
+  #
+  # Left null for now (was the object below): creating these alert_policy
+  # resources requires backup_uncovered_paused_sandboxes to already exist
+  # as a Cloud Monitoring metric type, but the controlplane code that
+  # emits it deploys through this same Terraform CD run's api job, which
+  # is itself gated on this apply succeeding. Deadlock: apply fails on
+  # "Cannot find metric" -> api deploy never runs -> metric never gets
+  # emitted -> apply keeps failing. Re-enable once a later deploy (with
+  # this block still null) has shipped the emitting code and the metric
+  # is confirmed present in Cloud Monitoring.
+  # backup_coverage_alerts = {
+  #   enabled        = false
+  #   display_prefix = "Backup coverage / staging"
+  #   regions        = ["us-central1"]
+  # }
   # Root-filesystem (OS disk) utilization, same policies as the production
   # cells so staging validates the query shape first. Module defaults:
   # warn at 85% sustained 30 minutes, page at 95%.


### PR DESCRIPTION
## Summary
- Merging #409 revealed a deploy-pipeline deadlock: the new `google_monitoring_alert_policy.backup_coverage` resources require `backup_uncovered_paused_sandboxes` to already exist as a Cloud Monitoring metric type, but the controlplane code that emits it deploys through this same workflow's api job, which is gated on this apply succeeding first. Apply fails on the missing metric -> api job never runs -> metric never appears -> apply keeps failing, indefinitely.
- Verified concretely: staging has 18 real paused sandboxes and it's been well over an hour since the original merge, but the metric shows zero data points anywhere in Cloud Monitoring, consistent with the emitting code never having reached Cloud Run.
- Fix: null `backup_coverage_alerts` in all three environments (its documented default — "Null omits the policy entirely") so `terraform apply` succeeds with zero coverage alert_policy resources, unblocking the gated api-deploy job so the sampler code actually ships.

## Technical decisions / tradeoffs
- Considered `-target` to apply everything except the three alert_policy resources — rejected: still needs the same api-deploy job to run afterward, and this is simpler and reversible with an obvious diff.
- Left the original `backup_coverage_alerts` blocks commented out in place (not deleted) so the follow-up re-enabling them is a one-line uncomment, not a re-author.

## Testing
- `terraform validate` clean on all three environments (this is a config-only change; no state/credentials available locally to `plan`).
- Local Codex review: clean, no findings.

Follow-up once the metric is confirmed live in Cloud Monitoring: uncomment `backup_coverage_alerts` in all three files to re-enable the disabled-by-default alert policies.