### PR TITLE
api: cache the per-create billing eligibility gate and coalesce its background rechecks

### DIFF
--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -803,13 +803,22 @@ ORDER BY s.team_id
 LIMIT sqlc.arg(batch_limit);
 
 -- name: ListTeamsWithActiveIneligibleSandboxes :many
-SELECT DISTINCT s.team_id
-FROM sandbox s
-WHERE s.destroyed_at IS NULL
-  AND s.status = 'active'
-  AND NOT team_sandbox_billing_eligible(s.team_id)
-  AND s.team_id > COALESCE(sqlc.narg(after_team_id)::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
-ORDER BY s.team_id
+-- MATERIALIZED fence, same reason as the rollup's interval_team_set: dedupe
+-- the active-team set first so team_sandbox_billing_eligible() runs once per
+-- team. Inlined in the WHERE clause the planner may evaluate it per active
+-- sandbox row — the function does three reads, and this sweep runs on a
+-- timer against every control-plane instance.
+WITH active_teams AS MATERIALIZED (
+    SELECT DISTINCT s.team_id
+    FROM sandbox s
+    WHERE s.destroyed_at IS NULL
+      AND s.status = 'active'
+      AND s.team_id > COALESCE(sqlc.narg(after_team_id)::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+)
+SELECT team_id
+FROM active_teams
+WHERE NOT team_sandbox_billing_eligible(team_id)
+ORDER BY team_id
 LIMIT sqlc.arg(batch_limit);
 
 -- name: ActivateTeamBilling :exec

--- a/internal/api/billing_elig_cache.go
+++ b/internal/api/billing_elig_cache.go
@@ -37,6 +37,11 @@ const (
 	// evictSamplePerPut caps how many entries a put inspects for expiry, so
 	// eviction cost never scales with team cardinality on the request path.
 	evictSamplePerPut = 8
+	// billingEligCacheMaxEntries is a hard memory bound: teams actively
+	// creating within one TTL window number in the hundreds, so thousands of
+	// live entries means churn the sampled eviction hasn't caught up with.
+	// Evicting an arbitrary entry is safe — this cache only saves a read.
+	billingEligCacheMaxEntries = 4096
 )
 
 type billingEligEntry struct {
@@ -87,6 +92,15 @@ func (c *billingEligCache) put(teamID uuid.UUID, eligible bool, checked time.Tim
 		if checked.Sub(e.checked) > e.ttl() {
 			delete(c.m, k)
 		}
+	}
+	// Hard cap, enforced after the expiry sample: drop arbitrary entries
+	// (random map order) until the insert fits. O(1) amortized — the map can
+	// exceed the cap by at most one entry per put.
+	for k := range c.m {
+		if len(c.m) < billingEligCacheMaxEntries {
+			break
+		}
+		delete(c.m, k)
 	}
 	c.m[teamID] = billingEligEntry{eligible: eligible, checked: checked}
 	c.mu.Unlock()

--- a/internal/api/billing_elig_cache.go
+++ b/internal/api/billing_elig_cache.go
@@ -34,6 +34,9 @@ const (
 	// billingEligQueryTimeout bounds the shared flight's read; the query is
 	// three indexed lookups, so anything slower is the DB misbehaving.
 	billingEligQueryTimeout = 5 * time.Second
+	// evictSamplePerPut caps how many entries a put inspects for expiry, so
+	// eviction cost never scales with team cardinality on the request path.
+	evictSamplePerPut = 8
 )
 
 type billingEligEntry struct {
@@ -70,10 +73,17 @@ func (c *billingEligCache) put(teamID uuid.UUID, eligible bool, checked time.Tim
 	if c.m == nil {
 		c.m = make(map[uuid.UUID]billingEligEntry)
 	}
-	// Lazy sweep: teams that stop creating are never read again, so puts
-	// evict their expired entries. At most one put per team per TTL and the
-	// map is one entry per recently-active team, so this stays cheap.
+	// Bounded lazy eviction: teams that stop creating are never read again,
+	// so puts reclaim expired entries — but only a small random sample each
+	// (map iteration order is random), keeping this critical section O(1)
+	// no matter how many teams churn through. Puts outnumber expiries in
+	// steady state (at most one put per active team per TTL), so sampled
+	// reclamation keeps the map proportional to recently-active teams.
+	sampled := 0
 	for k, e := range c.m {
+		if sampled++; sampled > evictSamplePerPut {
+			break
+		}
 		if checked.Sub(e.checked) > e.ttl() {
 			delete(c.m, k)
 		}
@@ -93,6 +103,12 @@ func (h *Handlers) teamBillingEligibleCached(ctx context.Context, teamID uuid.UU
 		return eligible, nil
 	}
 	ch := c.group.DoChan(teamID.String(), func() (interface{}, error) {
+		// Re-check under the flight: a caller that missed while a previous
+		// flight was completing enters a fresh flight after it — without
+		// this, back-to-back flights double-read what the first just cached.
+		if eligible, ok := c.get(teamID, time.Now()); ok {
+			return eligible, nil
+		}
 		start := time.Now()
 		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), billingEligQueryTimeout)
 		defer cancel()

--- a/internal/api/billing_elig_cache.go
+++ b/internal/api/billing_elig_cache.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// billingEligCache is an in-process, TTL-bounded cache of per-team sandbox
+// billing eligibility, fronting IsTeamSandboxBillingEligible on the
+// create/resume request paths. The synchronous check is a fast-fail gate,
+// not the enforcement — trialEligibilityLoop and reconcileActivatedSandbox
+// pause ineligible teams on their own cadence regardless — so a
+// bounded-stale answer here loses nothing while removing a DB round trip
+// from every create.
+//
+// Both verdicts are cached, with asymmetric TTLs. Invalidation is
+// deliberately TTL-only: a Stripe webhook lands on ONE control-plane
+// replica, so an in-process invalidation hook could never reach the
+// others — the short ineligible TTL is what actually bounds the
+// "just paid, still blocked" window on every replica.
+const (
+	// billingEligibleTTL bounds how long an ineligible-turning team can keep
+	// passing the gate; the enforcement loops reclaim its sandboxes on the
+	// same order of delay, so the gate never outlives the safety net by much.
+	billingEligibleTTL = 30 * time.Second
+	// billingIneligibleTTL is short so a team that just paid stops seeing
+	// 402s within a few seconds on every replica, webhook or not.
+	billingIneligibleTTL = 3 * time.Second
+	// billingEligQueryTimeout bounds the shared flight's read; the query is
+	// three indexed lookups, so anything slower is the DB misbehaving.
+	billingEligQueryTimeout = 5 * time.Second
+)
+
+type billingEligEntry struct {
+	eligible bool
+	checked  time.Time // stamped from query start, so a slow read can't stretch the window
+}
+
+// billingEligCache's zero value is ready to use.
+type billingEligCache struct {
+	group singleflight.Group
+	mu    sync.Mutex
+	m     map[uuid.UUID]billingEligEntry
+}
+
+func (e billingEligEntry) ttl() time.Duration {
+	if e.eligible {
+		return billingEligibleTTL
+	}
+	return billingIneligibleTTL
+}
+
+func (c *billingEligCache) get(teamID uuid.UUID, now time.Time) (eligible, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, exists := c.m[teamID]
+	if !exists || now.Sub(e.checked) > e.ttl() {
+		return false, false
+	}
+	return e.eligible, true
+}
+
+func (c *billingEligCache) put(teamID uuid.UUID, eligible bool, checked time.Time) {
+	c.mu.Lock()
+	if c.m == nil {
+		c.m = make(map[uuid.UUID]billingEligEntry)
+	}
+	// Lazy sweep: teams that stop creating are never read again, so puts
+	// evict their expired entries. At most one put per team per TTL and the
+	// map is one entry per recently-active team, so this stays cheap.
+	for k, e := range c.m {
+		if checked.Sub(e.checked) > e.ttl() {
+			delete(c.m, k)
+		}
+	}
+	c.m[teamID] = billingEligEntry{eligible: eligible, checked: checked}
+	c.mu.Unlock()
+}
+
+// teamBillingEligibleCached answers from the cache when fresh, else runs one
+// shared read per team: the flight is detached and bounded (it may outlive
+// its caller and must not inherit a long request deadline), while each
+// waiter still selects on its own ctx so a hung-up client returns
+// immediately. Errors are never cached.
+func (h *Handlers) teamBillingEligibleCached(ctx context.Context, teamID uuid.UUID) (bool, error) {
+	c := &h.billingElig
+	if eligible, ok := c.get(teamID, time.Now()); ok {
+		return eligible, nil
+	}
+	ch := c.group.DoChan(teamID.String(), func() (interface{}, error) {
+		start := time.Now()
+		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), billingEligQueryTimeout)
+		defer cancel()
+		eligible, err := h.DB.IsTeamSandboxBillingEligible(qctx, teamID)
+		if err == nil {
+			c.put(teamID, eligible, start)
+		}
+		return eligible, err
+	})
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return false, res.Err
+		}
+		return res.Val.(bool), nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}

--- a/internal/api/billing_elig_cache_test.go
+++ b/internal/api/billing_elig_cache_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// eligMockHandlers returns a Handlers whose DB answers every eligibility read
+// with the current value of *answer, counting reads in *reads. block, when
+// non-nil, holds each read until it is closed.
+func eligMockHandlers(reads *atomic.Int64, answer *atomic.Bool, block chan struct{}) *Handlers {
+	mock := &mockDBTX{
+		queryRowFn: func(ctx context.Context, sql string, args ...any) pgx.Row {
+			reads.Add(1)
+			if block != nil {
+				<-block
+			}
+			return &mockRow{scanFn: func(dest ...any) error {
+				*(dest[0].(*bool)) = answer.Load()
+				return nil
+			}}
+		},
+	}
+	return &Handlers{DB: db.New(mock)}
+}
+
+// Within the TTL every verdict — eligible and ineligible alike — is served
+// from cache: the create path pays the DB read once per team per window.
+func TestBillingEligCacheServesBothVerdicts(t *testing.T) {
+	for _, eligible := range []bool{true, false} {
+		var reads atomic.Int64
+		var answer atomic.Bool
+		answer.Store(eligible)
+		h := eligMockHandlers(&reads, &answer, nil)
+		teamID := uuid.New()
+
+		for i := 0; i < 5; i++ {
+			got, err := h.teamBillingEligibleCached(context.Background(), teamID)
+			if err != nil || got != eligible {
+				t.Fatalf("eligible=%v call %d: got=%v err=%v", eligible, i, got, err)
+			}
+		}
+		if got := reads.Load(); got != 1 {
+			t.Fatalf("eligible=%v: DB reads = %d, want 1", eligible, got)
+		}
+	}
+}
+
+// A burst of concurrent cold-cache checks for one team shares a single
+// flight — the pattern the 100-way create benchmark exercises.
+func TestBillingEligCacheCoalescesBurst(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	block := make(chan struct{})
+	h := eligMockHandlers(&reads, &answer, block)
+	teamID := uuid.New()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if got, err := h.teamBillingEligibleCached(context.Background(), teamID); err != nil || !got {
+				t.Errorf("got=%v err=%v", got, err)
+			}
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let every goroutine reach the flight
+	close(block)
+	wg.Wait()
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("DB reads = %d, want 1 (concurrent misses must share one flight)", got)
+	}
+}
+
+// The post-activation recheck is coalesced per team the same way: a create
+// burst's worth of concurrent rechecks costs one DB read, not one per create.
+func TestReconcileActivatedSandboxCoalesces(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true) // eligible: the pause sweep must not run (it would add reads)
+	block := make(chan struct{})
+	h := eligMockHandlers(&reads, &answer, block)
+	teamID := uuid.New()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.reconcileActivatedSandbox(context.Background(), teamID)
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let every goroutine join the flight
+	close(block)
+	wg.Wait()
+	if got := reads.Load(); got != 1 {
+		t.Fatalf("DB reads = %d, want 1 (burst rechecks must share one flight)", got)
+	}
+}

--- a/internal/api/billing_elig_cache_test.go
+++ b/internal/api/billing_elig_cache_test.go
@@ -107,3 +107,24 @@ func TestReconcileActivatedSandboxCoalesces(t *testing.T) {
 		t.Fatalf("DB reads = %d, want 1 (burst rechecks must share one flight)", got)
 	}
 }
+
+// The map may never exceed its hard cap: memory stays bounded no matter how
+// many unique teams churn through faster than expiry-based eviction reclaims.
+func TestBillingEligCacheHardCap(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := eligMockHandlers(&reads, &answer, nil)
+
+	for i := 0; i < billingEligCacheMaxEntries+100; i++ {
+		if _, err := h.teamBillingEligibleCached(context.Background(), uuid.New()); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	h.billingElig.mu.Lock()
+	n := len(h.billingElig.m)
+	h.billingElig.mu.Unlock()
+	if n > billingEligCacheMaxEntries {
+		t.Fatalf("cache holds %d entries, cap is %d", n, billingEligCacheMaxEntries)
+	}
+}

--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -77,29 +77,31 @@ func (h *Handlers) reconcileActiveIneligibleTeams(ctx context.Context) {
 }
 
 func (h *Handlers) reconcileActivatedSandbox(ctx context.Context, teamID uuid.UUID) {
-	// Coalesced per team: the question — "did this team go ineligible while
-	// we were creating" — is per-team, so a concurrent create burst shares
-	// one fresh read (never the request-path cache; this is the safety net)
-	// instead of one per sandbox. Followers ride the leader's flight, so
-	// every activation still triggers a check, and the pause sweep already
-	// covers the whole team.
-	_, _, _ = h.activationRecheck.Do(teamID.String(), func() (interface{}, error) {
-		eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
-		if err != nil {
-			// No per-team retry: reads fail here exactly when the DB is
-			// already struggling, and high create churn would bank one
-			// untracked retry per team, all firing together 30s later. The
-			// 30s sweep (trialEligibilityLoop → reconcileActiveIneligibleTeams)
-			// already re-covers every team on the same timescale a retry
-			// would, with bounded, paced concurrency.
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed; 30s sweep will re-cover")
-			return nil, nil
-		}
-		if !eligible {
-			h.pauseBillingIneligibleTeam(ctx, teamID)
-		}
-		return nil, nil
+	// Only the eligibility READ is coalesced: it is per-team, so a concurrent
+	// create burst shares one fresh look (never the request-path cache; this
+	// is the safety net) instead of one per sandbox. The pause claim stays
+	// with each caller — inside the flight, a sandbox activating after the
+	// leader's claim snapshot would join the flight and never be claimed
+	// until the next sweep. Each caller runs after its own activation
+	// committed, so its own claim always covers its own sandbox; concurrent
+	// claims partition safely (FOR UPDATE SKIP LOCKED), and the ineligible
+	// case is rare enough that their cost is irrelevant.
+	verdict, err, _ := h.activationRecheck.Do(teamID.String(), func() (interface{}, error) {
+		return h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
 	})
+	if err != nil {
+		// No per-team retry: reads fail here exactly when the DB is already
+		// struggling, and high create churn would bank one untracked retry
+		// per team, all firing together 30s later. The 30s sweep
+		// (trialEligibilityLoop → reconcileActiveIneligibleTeams) already
+		// re-covers every team on the same timescale a retry would, with
+		// bounded, paced concurrency.
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed; 30s sweep will re-cover")
+		return
+	}
+	if !verdict.(bool) {
+		h.pauseBillingIneligibleTeam(ctx, teamID)
+	}
 }
 
 // pauseBillingIneligibleTeam claims and pauses active sandboxes after Stripe

--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -77,14 +77,23 @@ func (h *Handlers) reconcileActiveIneligibleTeams(ctx context.Context) {
 }
 
 func (h *Handlers) reconcileActivatedSandbox(ctx context.Context, teamID uuid.UUID) {
-	eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
-	if err != nil {
-		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed")
-		return
-	}
-	if !eligible {
-		h.pauseBillingIneligibleTeam(ctx, teamID)
-	}
+	// Coalesced per team: the question — "did this team go ineligible while
+	// we were creating" — is per-team, so a concurrent create burst shares
+	// one fresh read (never the request-path cache; this is the safety net)
+	// instead of one per sandbox. Followers ride the leader's flight, so
+	// every activation still triggers a check, and the pause sweep already
+	// covers the whole team.
+	_, _, _ = h.activationRecheck.Do(teamID.String(), func() (interface{}, error) {
+		eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed")
+			return nil, nil
+		}
+		if !eligible {
+			h.pauseBillingIneligibleTeam(ctx, teamID)
+		}
+		return nil, nil
+	})
 }
 
 // pauseBillingIneligibleTeam claims and pauses active sandboxes after Stripe

--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -86,13 +86,13 @@ func (h *Handlers) reconcileActivatedSandbox(ctx context.Context, teamID uuid.UU
 	_, _, _ = h.activationRecheck.Do(teamID.String(), func() (interface{}, error) {
 		eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
 		if err != nil {
-			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed")
-			// Every overlapping activation shares this verdict, so a
-			// transient failure must not silently drop the whole burst's
-			// recheck. The delayed retry claims-and-pauses directly — the
-			// claim query is self-gating on eligibility, so retrying an
-			// eligible team pauses nothing.
-			h.retryBillingEligibilityReconciliation(teamID)
+			// No per-team retry: reads fail here exactly when the DB is
+			// already struggling, and high create churn would bank one
+			// untracked retry per team, all firing together 30s later. The
+			// 30s sweep (trialEligibilityLoop → reconcileActiveIneligibleTeams)
+			// already re-covers every team on the same timescale a retry
+			// would, with bounded, paced concurrency.
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed; 30s sweep will re-cover")
 			return nil, nil
 		}
 		if !eligible {

--- a/internal/api/billing_reconciliation.go
+++ b/internal/api/billing_reconciliation.go
@@ -87,6 +87,12 @@ func (h *Handlers) reconcileActivatedSandbox(ctx context.Context, teamID uuid.UU
 		eligible, err := h.DB.IsTeamSandboxBillingEligible(ctx, teamID)
 		if err != nil {
 			log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing: activation eligibility check failed")
+			// Every overlapping activation shares this verdict, so a
+			// transient failure must not silently drop the whole burst's
+			// recheck. The delayed retry claims-and-pauses directly — the
+			// claim query is self-gating on eligibility, so retrying an
+			// eligible team pauses nothing.
+			h.retryBillingEligibilityReconciliation(teamID)
 			return nil, nil
 		}
 		if !eligible {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -175,6 +175,14 @@ type Handlers struct {
 	// diagnosticGroup coalesces concurrent capability rejection snapshots for
 	// the same host and required capability set.
 	diagnosticGroup singleflight.Group
+
+	// billingElig caches the per-team eligibility gate consulted on every
+	// create/resume (see billing_elig_cache.go). Zero value is ready to use.
+	billingElig billingEligCache
+
+	// activationRecheck coalesces the per-team post-activation eligibility
+	// recheck: a 100-create burst asks the same question 100 times.
+	activationRecheck singleflight.Group
 }
 
 // asyncBookkeeping runs fire-and-forget post-VMD work in a background

--- a/internal/api/handlers_billing.go
+++ b/internal/api/handlers_billing.go
@@ -551,7 +551,7 @@ func (h *Handlers) requireBillingEligible(c *gin.Context, teamID uuid.UUID) bool
 		return true
 	}
 	started := time.Now()
-	eligible, err := h.DB.IsTeamSandboxBillingEligible(c.Request.Context(), teamID)
+	eligible, err := h.teamBillingEligibleCached(c.Request.Context(), teamID)
 	log.Debug().Str("team_id", teamID.String()).Int64("billing_eligibility_ms", time.Since(started).Milliseconds()).Msg("billing eligibility check")
 	if err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("read sandbox billing eligibility failed")

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -61,17 +61,8 @@ func DefaultReaperConfig() ReaperConfig {
 func (h *Handlers) StartTimeoutReaper(ctx context.Context, cfg ReaperConfig) {
 	logger := log.Logger
 	go h.reaperLoop(ctx, cfg, logger)
-	// Decoupled from the reaper's 30s tick: eligibility moves at
-	// dollars-per-hour granularity, and each pass aggregates a month of
-	// billing intervals per trial team — 30s bought nothing but DB load.
-	go h.trialEligibilityLoop(ctx, billingEligibilityRefreshInterval)
+	go h.trialEligibilityLoop(ctx, cfg.Interval)
 }
-
-// billingEligibilityRefreshInterval paces the trial-eligibility sweep. The
-// bound on how long an ineligible team keeps running is this interval plus
-// the pause saga, which stays far inside the 90-day revocation horizon the
-// sweep ultimately protects.
-const billingEligibilityRefreshInterval = 5 * time.Minute
 
 func (h *Handlers) trialEligibilityLoop(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -61,8 +61,17 @@ func DefaultReaperConfig() ReaperConfig {
 func (h *Handlers) StartTimeoutReaper(ctx context.Context, cfg ReaperConfig) {
 	logger := log.Logger
 	go h.reaperLoop(ctx, cfg, logger)
-	go h.trialEligibilityLoop(ctx, cfg.Interval)
+	// Decoupled from the reaper's 30s tick: eligibility moves at
+	// dollars-per-hour granularity, and each pass aggregates a month of
+	// billing intervals per trial team — 30s bought nothing but DB load.
+	go h.trialEligibilityLoop(ctx, billingEligibilityRefreshInterval)
 }
+
+// billingEligibilityRefreshInterval paces the trial-eligibility sweep. The
+// bound on how long an ineligible team keeps running is this interval plus
+// the pause saga, which stays far inside the 90-day revocation horizon the
+// sweep ultimately protects.
+const billingEligibilityRefreshInterval = 5 * time.Minute
 
 func (h *Handlers) trialEligibilityLoop(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -1389,23 +1389,32 @@ func (q *Queries) ListTeamCreditGrants(ctx context.Context, teamID uuid.UUID) ([
 }
 
 const listTeamsWithActiveIneligibleSandboxes = `-- name: ListTeamsWithActiveIneligibleSandboxes :many
-SELECT DISTINCT s.team_id
-FROM sandbox s
-WHERE s.destroyed_at IS NULL
-  AND s.status = 'active'
-  AND NOT team_sandbox_billing_eligible(s.team_id)
-  AND s.team_id > COALESCE($1::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
-ORDER BY s.team_id
-LIMIT $2
+WITH active_teams AS MATERIALIZED (
+    SELECT DISTINCT s.team_id
+    FROM sandbox s
+    WHERE s.destroyed_at IS NULL
+      AND s.status = 'active'
+      AND s.team_id > COALESCE($2::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
+)
+SELECT team_id
+FROM active_teams
+WHERE NOT team_sandbox_billing_eligible(team_id)
+ORDER BY team_id
+LIMIT $1
 `
 
 type ListTeamsWithActiveIneligibleSandboxesParams struct {
-	AfterTeamID pgtype.UUID `json:"after_team_id"`
 	BatchLimit  int32       `json:"batch_limit"`
+	AfterTeamID pgtype.UUID `json:"after_team_id"`
 }
 
+// MATERIALIZED fence, same reason as the rollup's interval_team_set: dedupe
+// the active-team set first so team_sandbox_billing_eligible() runs once per
+// team. Inlined in the WHERE clause the planner may evaluate it per active
+// sandbox row — the function does three reads, and this sweep runs on a
+// timer against every control-plane instance.
 func (q *Queries) ListTeamsWithActiveIneligibleSandboxes(ctx context.Context, arg ListTeamsWithActiveIneligibleSandboxesParams) ([]uuid.UUID, error) {
-	rows, err := q.db.Query(ctx, listTeamsWithActiveIneligibleSandboxes, arg.AfterTeamID, arg.BatchLimit)
+	rows, err := q.db.Query(ctx, listTeamsWithActiveIneligibleSandboxes, arg.BatchLimit, arg.AfterTeamID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fronts the per-team billing eligibility check with a TTL cache (eligible 30s / ineligible 3s, singleflighted, hard-capped), so create and resume stop paying a DB round trip per request; enforcement is unchanged — the 30s sweep and the coalesced post-activation recheck still bound how long an ineligible team can run.
Also dedupes the sweep's scan so the eligibility function runs once per active team instead of once per active sandbox row.