### PR TITLE
vmd: diagnose a stalled guest while it is still running

### DIFF
--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3079,7 +3079,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			readiness = remaining
 		}
 	}
-	if err := m.waitForBoxd(ctx, hostIP, readiness); err != nil {
+	// Diagnostics fire from inside the readiness window if the guest is still
+	// unready after a few seconds — the teardown capture proved the guest
+	// itself is what stalls, and answering why needs signals that exist only
+	// while it runs. Cancelled on the healthy path, where the whole cost is a
+	// timer that never fires.
+	stopDiag := m.armEarlyStallDiagnostics(vmID, pid)
+	err := m.waitForBoxd(ctx, hostIP, readiness)
+	stopDiag()
+	if err != nil {
 		// Emit the exhausted readiness wait immediately, before teardown, so
 		// the sample measures the probe (not unit stop + resource release +
 		// persist join) and the concurrent-destroy return below can't skip it.

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -49,8 +49,16 @@ var stallDiagSem = make(chan struct{}, 2)
 // healthy restore it stops a timer that never fired, which is this feature's
 // entire cost there.
 func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
+	// Cancellation runs through a context, not the timer: Stop cannot recall
+	// a callback that already fired, so a restore that becomes ready just
+	// after the threshold would otherwise be profiled and logged as stalled —
+	// a false specimen in the very data this exists to produce.
+	ctx, cancel := context.WithCancel(context.Background())
 	timer := time.AfterFunc(stallDiagAfter, func() {
 		defer sentrylog.Recover("stall-diag-arm")
+		if ctx.Err() != nil {
+			return
+		}
 		select {
 		case stallDiagSem <- struct{}{}:
 		default:
@@ -59,32 +67,45 @@ func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 			return
 		}
 		defer func() { <-stallDiagSem }()
-		m.runStallDiagnostics(vmID, m.resolveFCPID(vmID, launchPID))
+		m.runStallDiagnostics(ctx, vmID, m.resolveFCPID(vmID, launchPID))
 	})
-	return func() { timer.Stop() }
+	return func() {
+		timer.Stop()
+		cancel()
+	}
 }
 
 // runStallDiagnostics collects the live-VM evidence and logs it. A probe that
 // fails contributes an empty field rather than aborting the rest.
-func (m *Manager) runStallDiagnostics(vmID string, pid int) {
+func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid int) {
 	if pid <= 0 || !pidIsVMFirecracker(pid, vmID) {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), stallDiagBudget)
+	ctx, cancel := context.WithTimeout(parent, stallDiagBudget)
 	defer cancel()
+	deadline, _ := ctx.Deadline()
 	started := time.Now()
 
-	before, kvmDir := readKVMCounters(pid)
+	before, kvmDir := readKVMCounters(pid, deadline)
 	select {
 	case <-time.After(stallDiagSettle):
 	case <-ctx.Done():
 		return
 	}
-	after, _ := readKVMCounters(pid)
+	after, _ := readKVMCounters(pid, deadline)
 	deltas := counterDeltas(before, after)
 
 	guestIPs := sampleGuestIPs(ctx, pid)
-	threads := captureProcState(pid, vmID)
+	threads, _ := captureProcStateBounded(pid, vmID, nil)
+	if threads == nil {
+		threads = &procStallState{PID: pid, UffdPending: -1, UffdTotal: -1}
+	}
+
+	// The guest may have come up while the battery ran; publishing then would
+	// record a healthy restore as a stall.
+	if ctx.Err() != nil {
+		return
+	}
 
 	ev := m.log.Warn().Str("vm_id", vmID).
 		Int("fc_pid", pid).
@@ -126,7 +147,7 @@ func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int
 // readKVMCounters reads every per-VM and per-vCPU counter KVM exposes for
 // this process. Names carry their vcpu directory as a prefix, since telling
 // the spinning vCPU from the halted one is the entire point.
-func readKVMCounters(pid int) (map[string]int64, string) {
+func readKVMCounters(pid int, deadline time.Time) (map[string]int64, string) {
 	out := map[string]int64{}
 	base, err := kvmDebugDirFor(pid)
 	if err != nil {
@@ -141,11 +162,11 @@ func readKVMCounters(pid int) (map[string]int64, string) {
 			if e.IsDir() {
 				continue
 			}
-			raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
-			if err != nil {
-				continue
+			raw, ok := readProcFileBy(filepath.Join(dir, e.Name()), deadline)
+			if !ok {
+				return // out of budget; report what was gathered
 			}
-			if n, err := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64); err == nil {
+			if n, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); err == nil {
 				out[prefix+e.Name()] = n
 			}
 		}
@@ -178,13 +199,43 @@ func kvmDebugDirFor(pid int) (string, error) {
 	return "", os.ErrNotExist
 }
 
-// counterDeltas keeps only counters that moved: what is still ticking (or
-// conspicuously not) is the signal, and dropping the hundreds of static
-// counters is what makes it readable.
+// alwaysReportCounters are reported even when they did not move. A zero here
+// is a finding, not noise: an exit count that stays flat while a vCPU burns
+// CPU says the guest is looping without ever leaving guest mode, and a halt
+// wakeup that never increments says nothing is being delivered to the halted
+// one. Omitting them would make "did not move" indistinguishable from "not
+// available".
+var alwaysReportCounters = map[string]bool{
+	"exits":                true,
+	"halt_exits":           true,
+	"halt_wakeup":          true,
+	"halt_successful_poll": true,
+	"halt_attempted_poll":  true,
+	"irq_injections":       true,
+	"irq_window_exits":     true,
+	"nmi_injections":       true,
+	"mmio_exits":           true,
+	"signal_exits":         true,
+	"insn_emulation":       true,
+	"request_irq_exits":    true,
+	"guest_mode":           true,
+}
+
+// counterDeltas reports counters that moved, plus the allowlist above whether
+// they moved or not. Dropping the hundreds of remaining static counters is
+// what keeps the result readable.
 func counterDeltas(before, after map[string]int64) map[string]int64 {
 	deltas := map[string]int64{}
 	for k, a := range after {
-		if b, ok := before[k]; ok && a != b {
+		b, ok := before[k]
+		if !ok {
+			continue
+		}
+		name := k
+		if i := strings.LastIndex(k, "/"); i >= 0 {
+			name = k[i+1:]
+		}
+		if a != b || alwaysReportCounters[name] {
 			deltas[k] = a - b
 		}
 	}
@@ -211,12 +262,32 @@ func formatDeltas(deltas map[string]int64) string {
 	return strings.Join(parts, " ")
 }
 
-var guestIPPattern = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s`)
+// guestSampleLine matches a perf script line of the form "<ip> <dso>", where
+// the dso identifies which address space the sample came from.
+var guestSampleLine = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s+(\S.*)$`)
 
-// sampleGuestIPs profiles the stalled process and returns distinct guest
-// instruction pointers, most frequent first. Addresses rather than symbols:
-// the shipped guest kernel is stripped, so resolution happens offline against
-// a kallsyms dump from a live guest of the same image.
+// guestDSO reports whether a perf dso field denotes guest address space.
+// perf labels guest samples with a guest-specific dso; anything else is a
+// host address inside Firecracker or the kernel.
+func guestDSO(dso string) bool {
+	return strings.Contains(strings.ToLower(dso), "guest")
+}
+
+// sampleGuestIPs profiles the stalled VM and returns distinct GUEST
+// instruction pointers, most frequent first.
+//
+// Two things make this trustworthy rather than merely plausible. It records
+// through `perf kvm --guest`, which is the interface built for guest
+// profiling — plain `perf record` on the pid samples the host side and would
+// hand back Firecracker and KVM addresses. And it keeps only samples perf
+// attributes to guest address space, so an address is either provably from
+// the guest or absent: reporting a host address as a guest RIP would send a
+// reader to resolve it against guest symbols and arrive at confident
+// nonsense, which is worse than reporting nothing.
+//
+// Addresses rather than symbols because the shipped guest kernel is stripped;
+// resolution happens offline against a kallsyms dump from a live guest of the
+// same image.
 func sampleGuestIPs(ctx context.Context, pid int) []string {
 	tmp, err := os.MkdirTemp("", "stalldiag")
 	if err != nil {
@@ -225,21 +296,23 @@ func sampleGuestIPs(ctx context.Context, pid int) []string {
 	defer os.RemoveAll(tmp)
 	data := filepath.Join(tmp, "perf.data")
 
-	rec := exec.CommandContext(ctx, "perf", "record", "-e", "cpu-clock", "-F", "97",
-		"--pid", strconv.Itoa(pid), "-o", data, "--", "sleep",
+	rec := exec.CommandContext(ctx, "perf", "kvm", "--guest", "record",
+		"-p", strconv.Itoa(pid), "-o", data, "--", "sleep",
 		strconv.Itoa(int(stallDiagPerfWindow/time.Second)))
 	if err := rec.Run(); err != nil {
 		return nil
 	}
-	script := exec.CommandContext(ctx, "perf", "script", "-i", data, "-F", "ip")
+	script := exec.CommandContext(ctx, "perf", "script", "-i", data, "-F", "ip,dso")
 	out, err := script.Output()
 	if err != nil {
 		return nil
 	}
 
 	counts := map[string]int{}
-	for _, m := range guestIPPattern.FindAllStringSubmatch(string(out), -1) {
-		counts[m[1]]++
+	for _, m := range guestSampleLine.FindAllStringSubmatch(string(out), -1) {
+		if guestDSO(m[2]) {
+			counts[m[1]]++
+		}
 	}
 	ips := make([]string, 0, len(counts))
 	for ip := range counts {

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -157,7 +157,8 @@ func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas, gauges map[st
 	}
 }
 
-// readKVMCounters reads every counter KVM exposes for this process.
+// readKVMCounters reads the allowlisted counters KVM exposes for this
+// process; see kvmReadable for why the set is explicit.
 //
 // The useful counters (exits, halt_wakeup, irq_injections, ...) live at the
 // VM level and are aggregated across vCPUs; the per-vCPU directories carry
@@ -178,7 +179,7 @@ func readKVMCounters(pid int, deadline time.Time) (map[string]int64, string) {
 			return
 		}
 		for _, e := range entries {
-			if e.IsDir() {
+			if e.IsDir() || !kvmReadable(e.Name()) {
 				continue
 			}
 			raw, ok := readProcFileBy(filepath.Join(dir, e.Name()), deadline)
@@ -235,19 +236,65 @@ var kvmGauges = map[string]bool{
 	"lapic_timer_advance_ns": true,
 }
 
+// alwaysReportCounters are reported even when they did not move. A zero here
+// is a finding, not noise: an exit count that stays flat while a vCPU burns
+// CPU says the guest is looping without ever leaving guest mode, and a halt
+// wakeup that never increments says nothing is reaching the halted one.
+// Omitting them would make "did not move" indistinguishable from "not
+// available". The tlb-flush and notify entries speak to whether one vCPU is
+// waiting on another to acknowledge an interrupt.
 var alwaysReportCounters = map[string]bool{
-	"exits":                true,
-	"halt_exits":           true,
-	"halt_wakeup":          true,
-	"halt_successful_poll": true,
-	"halt_attempted_poll":  true,
-	"irq_injections":       true,
-	"irq_window_exits":     true,
-	"nmi_injections":       true,
-	"mmio_exits":           true,
-	"signal_exits":         true,
-	"insn_emulation":       true,
-	"request_irq_exits":    true,
+	"exits":                     true,
+	"halt_exits":                true,
+	"halt_wakeup":               true,
+	"halt_successful_poll":      true,
+	"halt_attempted_poll":       true,
+	"irq_injections":            true,
+	"irq_window_exits":          true,
+	"nmi_injections":            true,
+	"request_irq_exits":         true,
+	"mmio_exits":                true,
+	"signal_exits":              true,
+	"insn_emulation":            true,
+	"remote_tlb_flush":          true,
+	"remote_tlb_flush_requests": true,
+	"notify_window_exits":       true,
+}
+
+// kvmExtraCounters are plain counters reported only when they move.
+var kvmExtraCounters = map[string]bool{
+	"irq_exits":           true,
+	"io_exits":            true,
+	"tlb_flush":           true,
+	"req_event":           true,
+	"blocking":            true,
+	"host_state_reload":   true,
+	"hypercalls":          true,
+	"nmi_window_exits":    true,
+	"halt_poll_invalid":   true,
+	"insn_emulation_fail": true,
+	"preemption_reported": true,
+	"preemption_other":    true,
+	"nx_lpage_splits":     true,
+	"pf_taken":            true,
+	"pf_fixed":            true,
+	"pf_fast":             true,
+	"pf_guest":            true,
+	"pf_spurious":         true,
+	"pf_emulate":          true,
+}
+
+// kvmReadable gates which debugfs entries are OPENED at all.
+//
+// Not every entry there is a cheap integer. Reading mmu_rmaps_stat takes
+// slots_lock and the MMU *write* lock and walks each memslot's reverse maps —
+// work proportional to guest memory, performed while blocking the guest's own
+// fault handling. Parsing the result and discarding it would be far too late:
+// the cost is paid at open. The *_hist entries are likewise not single
+// integers. A battery only ever runs against a VM that is already unwell, so
+// entries are named explicitly rather than discovered.
+func kvmReadable(name string) bool {
+	return alwaysReportCounters[name] || kvmGauges[name] || kvmExtraCounters[name]
 }
 
 // counterDeltas reports counters that moved, plus the allowlist above whether

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -1,30 +1,14 @@
 package vm
 
-// stall_diag.go — diagnostics gathered WHILE a guest is still stuck, rather
-// than at the moment it is killed.
+// stall_diag.go — diagnostics gathered while a guest is still stuck, rather
+// than at teardown (stall_proc.go).
 //
-// The teardown capture (stall_proc.go) answered where the stall is not: with
-// the memory handler idle and zero unresolved faults, the guest itself is the
-// thing that is stuck — one vCPU spinning in guest mode, another halted
-// waiting for an interrupt. Answering *why* needs signals that only exist
-// while the VM runs, and that take longer to collect than a teardown path can
-// afford.
-//
-// The timing is the whole idea. A healthy guest answers in tens of
-// milliseconds, so by a few seconds the outcome is already decided — yet vmd
-// then sits idle until the readiness deadline. Firing diagnostics into that
-// dead time costs the request nothing (it is not on the reply path at all)
-// and buys the better part of half a minute to work with, which is what makes
-// the slower, more decisive probes possible:
-//
-//   - KVM counters sampled twice: whether the spinning vCPU is exiting at all,
-//     and whether the halted one is being woken. A flat exit count means a
-//     tight guest loop; a flat halt_wakeup means nothing is arriving.
-//   - guest instruction pointers: which code the guest is actually looping in.
-//   - thread stacks re-read over time: whether the state is frozen or moving.
-//
-// Everything here is read-only with respect to the VM. Nothing interferes
-// with a guest that might still recover.
+// A healthy guest answers in tens of milliseconds, so once a readiness wait
+// has run for seconds the outcome is already decided and vmd is simply idle
+// until the deadline. Running the probes in that dead window keeps them off
+// the reply path entirely and leaves time for ones a teardown path could not
+// afford. Everything here is read-only with respect to the VM: nothing
+// interferes with a guest that might still recover.
 
 import (
 	"context"
@@ -42,37 +26,28 @@ import (
 )
 
 const (
-	// stallDiagAfter is how long a readiness wait must run before the guest
-	// is treated as stuck. Healthy restores finish about three orders of
-	// magnitude faster, and nothing has ever been observed recovering between
-	// a couple of seconds and the deadline, so this only ever fires on a
-	// guest that is already lost.
+	// Healthy restores finish three orders of magnitude faster than this, and
+	// no restore has been observed recovering between a couple of seconds and
+	// the deadline, so this only fires on a guest that is already lost.
 	stallDiagAfter = 5 * time.Second
 
-	// stallDiagSettle separates the two counter samples. Long enough that a
-	// slow-moving counter still shows movement, short enough to leave the
-	// rest of the window for the profile.
-	stallDiagSettle = 2 * time.Second
-
-	// stallDiagPerfWindow is how long the guest is profiled for instruction
-	// pointers. It runs inside the readiness window with room to spare.
+	stallDiagSettle     = 2 * time.Second
 	stallDiagPerfWindow = 3 * time.Second
 
-	// stallDiagBudget caps the whole battery so it can never outlive the
-	// readiness window and collide with teardown.
+	// Caps the battery so it can never outlive the readiness window and
+	// collide with teardown.
 	stallDiagBudget = 20 * time.Second
 )
 
-// stallDiagSem bounds concurrent diagnostic batteries. These are heavier than
-// the teardown capture — a profiler subprocess and several seconds of
-// sampling — so a burst of stalls must not turn diagnosis into load on a host
-// that is already unwell. Saturated attempts are skipped, not queued.
+// stallDiagSem bounds concurrent batteries: these run a profiler subprocess
+// for seconds, so a burst of stalls must not turn diagnosis into load on a
+// host that is already unwell. Saturated attempts are skipped, not queued.
 var stallDiagSem = make(chan struct{}, 2)
 
-// armEarlyStallDiagnostics schedules the battery to run if the guest is still
-// unready after stallDiagAfter. The returned func cancels it and is safe to
-// call on every path — on a healthy restore it stops a timer that never fired,
-// which is the entire cost of this feature on the happy path.
+// armEarlyStallDiagnostics schedules the battery for a guest still unready
+// after stallDiagAfter. The returned cancel is safe on every path; on a
+// healthy restore it stops a timer that never fired, which is this feature's
+// entire cost there.
 func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 	timer := time.AfterFunc(stallDiagAfter, func() {
 		defer sentrylog.Recover("stall-diag-arm")
@@ -89,9 +64,8 @@ func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 	return func() { timer.Stop() }
 }
 
-// runStallDiagnostics collects the live-VM evidence and logs it. Best-effort
-// throughout: a probe that fails contributes an empty field rather than
-// aborting the rest, because a partial answer still narrows the question.
+// runStallDiagnostics collects the live-VM evidence and logs it. A probe that
+// fails contributes an empty field rather than aborting the rest.
 func (m *Manager) runStallDiagnostics(vmID string, pid int) {
 	if pid <= 0 || !pidIsVMFirecracker(pid, vmID) {
 		return
@@ -127,8 +101,7 @@ func (m *Manager) runStallDiagnostics(vmID string, pid int) {
 	m.writeStallDiagDump(vmID, pid, deltas, guestIPs, threads)
 }
 
-// writeStallDiagDump preserves the full battery next to the other forensics
-// so a later reader has the raw numbers, not just the summary line.
+// writeStallDiagDump preserves the raw numbers next to the other forensics.
 func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int64, guestIPs []string, threads *procStallState) {
 	if !m.forensicsOK {
 		return
@@ -151,8 +124,8 @@ func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int
 }
 
 // readKVMCounters reads every per-VM and per-vCPU counter KVM exposes for
-// this process. Names are prefixed by their vcpu directory so a spinning and
-// a halted vCPU stay distinguishable — which is the entire point.
+// this process. Names carry their vcpu directory as a prefix, since telling
+// the spinning vCPU from the halted one is the entire point.
 func readKVMCounters(pid int) (map[string]int64, string) {
 	out := map[string]int64{}
 	base, err := kvmDebugDirFor(pid)
@@ -188,8 +161,8 @@ func readKVMCounters(pid int) (map[string]int64, string) {
 	return out, base
 }
 
-// kvmDebugDirFor finds the debugfs directory KVM created for this process.
-// The name is "<pid>-<instance>", so the pid alone is not a complete key.
+// kvmDebugDirFor finds KVM's debugfs directory for this process. The name is
+// "<pid>-<instance>", so matching must include the separator.
 func kvmDebugDirFor(pid int) (string, error) {
 	root := "/sys/kernel/debug/kvm"
 	entries, err := os.ReadDir(root)
@@ -205,9 +178,9 @@ func kvmDebugDirFor(pid int) (string, error) {
 	return "", os.ErrNotExist
 }
 
-// counterDeltas keeps only counters that MOVED. A stalled VM's interesting
-// signal is what is still ticking (or conspicuously not), and dropping the
-// hundreds of static counters is what makes the result readable.
+// counterDeltas keeps only counters that moved: what is still ticking (or
+// conspicuously not) is the signal, and dropping the hundreds of static
+// counters is what makes it readable.
 func counterDeltas(before, after map[string]int64) map[string]int64 {
 	deltas := map[string]int64{}
 	for k, a := range after {
@@ -238,17 +211,12 @@ func formatDeltas(deltas map[string]int64) string {
 	return strings.Join(parts, " ")
 }
 
-// guestIPPattern matches the instruction pointers perf reports for samples
-// taken while the CPU was in guest mode.
 var guestIPPattern = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s`)
 
-// sampleGuestIPs profiles the stalled process and returns the distinct guest
-// instruction pointers seen, most frequent first.
-//
-// Addresses rather than symbols on purpose: the shipped guest kernel is
-// stripped, so resolution happens offline against a kallsyms dump from a live
-// guest of the same image. Recording raw pointers keeps the host path simple
-// and the evidence durable.
+// sampleGuestIPs profiles the stalled process and returns distinct guest
+// instruction pointers, most frequent first. Addresses rather than symbols:
+// the shipped guest kernel is stripped, so resolution happens offline against
+// a kallsyms dump from a live guest of the same image.
 func sampleGuestIPs(ctx context.Context, pid int) []string {
 	tmp, err := os.MkdirTemp("", "stalldiag")
 	if err != nil {

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -62,6 +62,12 @@ func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 	// after the threshold would otherwise be profiled and logged as stalled —
 	// a false specimen in the very data this exists to produce.
 	ctx, cancel := context.WithCancel(context.Background())
+	// settled decides, exactly once, whether this restore is published as a
+	// stall. Checking the context before writing is not enough: readiness can
+	// complete in the window between that check and the write, and the
+	// callback would still record a healthy restore as stalled. Whichever of
+	// the two arrives first claims the outcome.
+	var settled atomic.Bool
 	timer := time.AfterFunc(stallDiagAfter, func() {
 		defer sentrylog.Recover("stall-diag-arm")
 		if ctx.Err() != nil {
@@ -75,17 +81,20 @@ func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 			return
 		}
 		defer func() { <-stallDiagSem }()
-		m.runStallDiagnostics(ctx, vmID, m.resolveFCPID(vmID, launchPID))
+		m.runStallDiagnostics(ctx, &settled, vmID, m.resolveFCPID(vmID, launchPID))
 	})
 	return func() {
 		timer.Stop()
+		// Claim the outcome before cancelling, so a battery about to publish
+		// loses the race rather than winning it.
+		settled.CompareAndSwap(false, true)
 		cancel()
 	}
 }
 
 // runStallDiagnostics collects the live-VM evidence and logs it. A probe that
 // fails contributes an empty field rather than aborting the rest.
-func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid int) {
+func (m *Manager) runStallDiagnostics(parent context.Context, settled *atomic.Bool, vmID string, pid int) {
 	if pid <= 0 || !pidIsVMFirecracker(pid, vmID) {
 		return
 	}
@@ -127,9 +136,10 @@ func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid i
 		}
 	}
 
-	// The guest may have come up while the battery ran; publishing then would
-	// record a healthy restore as a stall.
-	if ctx.Err() != nil {
+	// The guest may have come up while the battery ran. Claiming the outcome
+	// is what makes the decision final: if readiness already claimed it, this
+	// restore was healthy and must not be recorded as a stall.
+	if settled != nil && !settled.CompareAndSwap(false, true) {
 		return
 	}
 
@@ -400,7 +410,16 @@ func perfIsUsable() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "perf", "--version").CombinedOutput()
-	ok := err == nil && !strings.Contains(string(out), "linux-tools")
+	if err != nil {
+		// Could not run it at all — a fork failure or timeout under the very
+		// host pressure that accompanies a stall. That says nothing durable
+		// about perf, so it is not cached: caching it would silently disable
+		// guest profiling for the rest of this process's life.
+		return false
+	}
+	// A command that ran gives a deterministic answer: the distribution stub
+	// prints an "install linux-tools-<kernel>" notice instead of profiling.
+	ok := !strings.Contains(string(out), "linux-tools")
 	perfUsable.Store(&ok)
 	return ok
 }

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -35,6 +35,13 @@ const (
 	stallDiagSettle     = 2 * time.Second
 	stallDiagPerfWindow = 3 * time.Second
 
+	// A stall means the host may already be struggling, so the profile is
+	// deliberately coarse: ~100 Hz is ample to identify a loop the guest has
+	// been spinning in for seconds, and the size cap bounds the write even if
+	// the rate assumption is ever wrong.
+	stallDiagPerfHz      = "97"
+	stallDiagPerfMaxSize = "32M"
+
 	// Caps the battery so it can never outlive the readiness window and
 	// collide with teardown.
 	stallDiagBudget = 20 * time.Second
@@ -113,6 +120,7 @@ func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid i
 		Dur("stuck_for", time.Since(started)+stallDiagAfter).
 		Str("kvm_dir", kvmDir).
 		Str("kvm_deltas", formatDeltas(deltas)).
+		Str("kvm_gauges", formatGauges(latestGauges(after))).
 		Str("guest_ips", strings.Join(guestIPs, ",")).
 		Bool("uffd_found", threads.UffdFound).
 		Int64("uffd_pending", threads.UffdPending).
@@ -120,11 +128,11 @@ func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid i
 		Str("thread_state", threads.threadSummary())
 	ev.Msg("guest still not ready — live diagnostics")
 
-	m.writeStallDiagDump(vmID, pid, deltas, guestIPs, threads)
+	m.writeStallDiagDump(vmID, pid, deltas, latestGauges(after), guestIPs, threads)
 }
 
 // writeStallDiagDump preserves the raw numbers next to the other forensics.
-func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int64, guestIPs []string, threads *procStallState) {
+func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas, gauges map[string]int64, guestIPs []string, threads *procStallState) {
 	if !m.forensicsOK {
 		return
 	}
@@ -134,6 +142,10 @@ func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int
 	fmt.Fprintf(&b, "vm: %s\npid: %d\n\n--- kvm counter deltas over %s ---\n", vmID, pid, stallDiagSettle)
 	for _, k := range sortedKeys(deltas) {
 		fmt.Fprintf(&b, "  %-32s %d\n", k, deltas[k])
+	}
+	fmt.Fprintf(&b, "\n--- kvm gauges (current values) ---\n")
+	for _, k := range sortedKeys(gauges) {
+		fmt.Fprintf(&b, "  %-32s %d\n", k, gauges[k])
 	}
 	fmt.Fprintf(&b, "\n--- guest instruction pointers ---\n")
 	for _, ip := range guestIPs {
@@ -212,6 +224,17 @@ func kvmDebugDirFor(pid int) (string, error) {
 // wakeup that never increments says nothing is being delivered to the halted
 // one. Omitting them would make "did not move" indistinguishable from "not
 // available".
+// kvmGauges hold a current value rather than a running total, so a delta of
+// zero says "unchanged", not "idle" — guest_mode 1→1 and 0→0 are opposite
+// findings that subtract to the same number. They are reported as values.
+var kvmGauges = map[string]bool{
+	"guest_mode":             true,
+	"pid":                    true,
+	"tsc-offset":             true,
+	"tsc-scaling-ratio":      true,
+	"lapic_timer_advance_ns": true,
+}
+
 var alwaysReportCounters = map[string]bool{
 	"exits":                true,
 	"halt_exits":           true,
@@ -225,7 +248,6 @@ var alwaysReportCounters = map[string]bool{
 	"signal_exits":         true,
 	"insn_emulation":       true,
 	"request_irq_exits":    true,
-	"guest_mode":           true,
 }
 
 // counterDeltas reports counters that moved, plus the allowlist above whether
@@ -238,15 +260,34 @@ func counterDeltas(before, after map[string]int64) map[string]int64 {
 		if !ok {
 			continue
 		}
-		name := k
-		if i := strings.LastIndex(k, "/"); i >= 0 {
-			name = k[i+1:]
+		name := baseName(k)
+		if kvmGauges[name] {
+			continue // reported as a value; see latestGauges
 		}
 		if a != b || alwaysReportCounters[name] {
 			deltas[k] = a - b
 		}
 	}
 	return deltas
+}
+
+// latestGauges returns the current value of each gauge — which vCPU is in
+// guest mode, the thread each vCPU runs on, and the clock offsets.
+func latestGauges(sample map[string]int64) map[string]int64 {
+	out := map[string]int64{}
+	for k, v := range sample {
+		if kvmGauges[baseName(k)] {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func baseName(key string) string {
+	if i := strings.LastIndex(key, "/"); i >= 0 {
+		return key[i+1:]
+	}
+	return key
 }
 
 func sortedKeys(m map[string]int64) []string {
@@ -256,6 +297,18 @@ func sortedKeys(m map[string]int64) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// formatGauges renders current values (no sign), unlike deltas.
+func formatGauges(g map[string]int64) string {
+	if len(g) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(g))
+	for _, k := range sortedKeys(g) {
+		parts = append(parts, fmt.Sprintf("%s=%d", k, g[k]))
+	}
+	return strings.Join(parts, " ")
 }
 
 func formatDeltas(deltas map[string]int64) string {
@@ -325,6 +378,7 @@ func sampleGuestIPs(ctx context.Context, pid int) []string {
 		return nil
 	}
 	rec := exec.CommandContext(ctx, "perf", "kvm", "--guest", "record",
+		"-F", stallDiagPerfHz, "--max-size", stallDiagPerfMaxSize,
 		"-p", strconv.Itoa(pid), "-o", data, "--", "sleep",
 		strconv.Itoa(int(stallDiagPerfWindow/time.Second)))
 	if err := rec.Run(); err != nil {

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -100,13 +100,31 @@ func (m *Manager) runStallDiagnostics(parent context.Context, vmID string, pid i
 	case <-ctx.Done():
 		return
 	}
+	// Re-check identity after the settle, before anything reads or profiles
+	// again. The process may have exited during those seconds and the kernel
+	// is free to hand its number to another Firecracker — whose counters and
+	// guest addresses would then be recorded under this VM's id. Abandoning
+	// the battery is the right trade: no evidence beats wrong evidence.
+	if ctx.Err() != nil || !pidIsVMFirecracker(pid, vmID) {
+		return
+	}
 	after, _ := readKVMCounters(pid, deadline)
 	deltas := counterDeltas(before, after)
 
-	guestIPs := sampleGuestIPs(ctx, pid)
-	threads, _ := captureProcStateBounded(pid, vmID, nil)
-	if threads == nil {
-		threads = &procStallState{PID: pid, UffdPending: -1, UffdTotal: -1}
+	var guestIPs []string
+	if ctx.Err() == nil {
+		guestIPs = sampleGuestIPs(ctx, pid)
+	}
+
+	// Only after profiling, and only if still wanted: this capture takes a
+	// slot in the semaphore the teardown path shares, so starting one for a
+	// battery that is already cancelled can make a genuine timeout skip its
+	// own capture as saturated.
+	threads := &procStallState{PID: pid, UffdPending: -1, UffdTotal: -1}
+	if ctx.Err() == nil {
+		if st, _ := captureProcStateBounded(pid, vmID, nil); st != nil {
+			threads = st
+		}
 	}
 
 	// The guest may have come up while the battery ran; publishing then would

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -52,6 +52,28 @@ const (
 // host that is already unwell. Saturated attempts are skipped, not queued.
 var stallDiagSem = make(chan struct{}, 2)
 
+// A host-wide stall can leave hundreds of restores unready at once, and one
+// warning per skipped restore would itself become load on a struggling host.
+// Skips are counted and reported as one aggregate warning per interval.
+var (
+	stallDiagSkips    atomic.Int64
+	stallDiagLastWarn atomic.Int64
+)
+
+const stallDiagWarnEvery = 30 * time.Second
+
+// claimSkipWarn records one saturated skip and reports whether this caller
+// should emit the aggregate warning, returning the skips it covers.
+func claimSkipWarn(now time.Time) (int64, bool) {
+	stallDiagSkips.Add(1)
+	last := stallDiagLastWarn.Load()
+	if now.UnixNano()-last < int64(stallDiagWarnEvery) ||
+		!stallDiagLastWarn.CompareAndSwap(last, now.UnixNano()) {
+		return 0, false
+	}
+	return stallDiagSkips.Swap(0), true
+}
+
 // armEarlyStallDiagnostics schedules the battery for a guest still unready
 // after stallDiagAfter. The returned cancel is safe on every path; on a
 // healthy restore it stops a timer that never fired, which is this feature's
@@ -76,8 +98,11 @@ func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
 		select {
 		case stallDiagSem <- struct{}{}:
 		default:
-			m.log.Warn().Str("vm_id", vmID).
-				Msg("guest slow to become ready — diagnostics skipped (concurrent batteries saturated)")
+			// vm_id is a sample, not the full set; skipped carries the count.
+			if n, ok := claimSkipWarn(time.Now()); ok {
+				m.log.Warn().Int64("skipped", n).Str("vm_id", vmID).
+					Msg("guests slow to become ready — diagnostics skipped (concurrent batteries saturated)")
+			}
 			return
 		}
 		defer func() { <-stallDiagSem }()
@@ -247,12 +272,6 @@ func kvmDebugDirFor(pid int) (string, error) {
 	return "", os.ErrNotExist
 }
 
-// alwaysReportCounters are reported even when they did not move. A zero here
-// is a finding, not noise: an exit count that stays flat while a vCPU burns
-// CPU says the guest is looping without ever leaving guest mode, and a halt
-// wakeup that never increments says nothing is being delivered to the halted
-// one. Omitting them would make "did not move" indistinguishable from "not
-// available".
 // kvmGauges hold a current value rather than a running total, so a delta of
 // zero says "unchanged", not "idle" — guest_mode 1→1 and 0→0 are opposite
 // findings that subtract to the same number. They are reported as values.
@@ -403,18 +422,20 @@ func formatDeltas(deltas map[string]int64) string {
 // subprocess discovering that every time.
 var perfUsable atomic.Pointer[bool]
 
-func perfIsUsable() bool {
+// perfIsUsable derives its probe from the battery's context so cancellation
+// reaches the subprocess instead of leaving it to run out its own clock.
+func perfIsUsable(parent context.Context) bool {
 	if cached := perfUsable.Load(); cached != nil {
 		return *cached
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "perf", "--version").CombinedOutput()
 	if err != nil {
-		// Could not run it at all — a fork failure or timeout under the very
-		// host pressure that accompanies a stall. That says nothing durable
-		// about perf, so it is not cached: caching it would silently disable
-		// guest profiling for the rest of this process's life.
+		// Could not run it at all — cancelled, a fork failure, or a timeout
+		// under the very host pressure that accompanies a stall. That says
+		// nothing durable about perf, so it is not cached: caching it would
+		// silently disable guest profiling for the rest of this process's life.
 		return false
 	}
 	// A command that ran gives a deterministic answer: the distribution stub
@@ -451,16 +472,15 @@ func guestDSO(dso string) bool {
 // resolution happens offline against a kallsyms dump from a live guest of the
 // same image.
 func sampleGuestIPs(ctx context.Context, pid int) []string {
+	if !perfIsUsable(ctx) {
+		return nil
+	}
 	tmp, err := os.MkdirTemp("", "stalldiag")
 	if err != nil {
 		return nil
 	}
 	defer os.RemoveAll(tmp)
 	data := filepath.Join(tmp, "perf.data")
-
-	if !perfIsUsable() {
-		return nil
-	}
 	rec := exec.CommandContext(ctx, "perf", "kvm", "--guest", "record",
 		"-F", stallDiagPerfHz, "--max-size", stallDiagPerfMaxSize,
 		"-p", strconv.Itoa(pid), "-o", data, "--", "sleep",

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
@@ -144,9 +145,15 @@ func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int
 	}
 }
 
-// readKVMCounters reads every per-VM and per-vCPU counter KVM exposes for
-// this process. Names carry their vcpu directory as a prefix, since telling
-// the spinning vCPU from the halted one is the entire point.
+// readKVMCounters reads every counter KVM exposes for this process.
+//
+// The useful counters (exits, halt_wakeup, irq_injections, ...) live at the
+// VM level and are aggregated across vCPUs; the per-vCPU directories carry
+// only a handful of values. That is still enough: a flat VM-wide exit count
+// while a vCPU burns CPU proves a loop that never leaves guest mode, and the
+// per-vCPU guest_mode and pid entries say which vCPU is executing and map it
+// to the thread stacks captured alongside. Names keep their directory as a
+// prefix so the two levels stay distinguishable.
 func readKVMCounters(pid int, deadline time.Time) (map[string]int64, string) {
 	out := map[string]int64{}
 	base, err := kvmDebugDirFor(pid)
@@ -262,6 +269,24 @@ func formatDeltas(deltas map[string]int64) string {
 	return strings.Join(parts, " ")
 }
 
+// perfUsable caches whether perf can actually profile. Distributions ship a
+// wrapper at the usual path that only prints an "install linux-tools-<kernel>"
+// notice, so presence on PATH proves nothing and a stall must not spend a
+// subprocess discovering that every time.
+var perfUsable atomic.Pointer[bool]
+
+func perfIsUsable() bool {
+	if cached := perfUsable.Load(); cached != nil {
+		return *cached
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "perf", "--version").CombinedOutput()
+	ok := err == nil && !strings.Contains(string(out), "linux-tools")
+	perfUsable.Store(&ok)
+	return ok
+}
+
 // guestSampleLine matches a perf script line of the form "<ip> <dso>", where
 // the dso identifies which address space the sample came from.
 var guestSampleLine = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s+(\S.*)$`)
@@ -296,6 +321,9 @@ func sampleGuestIPs(ctx context.Context, pid int) []string {
 	defer os.RemoveAll(tmp)
 	data := filepath.Join(tmp, "perf.data")
 
+	if !perfIsUsable() {
+		return nil
+	}
 	rec := exec.CommandContext(ctx, "perf", "kvm", "--guest", "record",
 		"-p", strconv.Itoa(pid), "-o", data, "--", "sleep",
 		strconv.Itoa(int(stallDiagPerfWindow/time.Second)))

--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -1,0 +1,293 @@
+package vm
+
+// stall_diag.go — diagnostics gathered WHILE a guest is still stuck, rather
+// than at the moment it is killed.
+//
+// The teardown capture (stall_proc.go) answered where the stall is not: with
+// the memory handler idle and zero unresolved faults, the guest itself is the
+// thing that is stuck — one vCPU spinning in guest mode, another halted
+// waiting for an interrupt. Answering *why* needs signals that only exist
+// while the VM runs, and that take longer to collect than a teardown path can
+// afford.
+//
+// The timing is the whole idea. A healthy guest answers in tens of
+// milliseconds, so by a few seconds the outcome is already decided — yet vmd
+// then sits idle until the readiness deadline. Firing diagnostics into that
+// dead time costs the request nothing (it is not on the reply path at all)
+// and buys the better part of half a minute to work with, which is what makes
+// the slower, more decisive probes possible:
+//
+//   - KVM counters sampled twice: whether the spinning vCPU is exiting at all,
+//     and whether the halted one is being woken. A flat exit count means a
+//     tight guest loop; a flat halt_wakeup means nothing is arriving.
+//   - guest instruction pointers: which code the guest is actually looping in.
+//   - thread stacks re-read over time: whether the state is frozen or moving.
+//
+// Everything here is read-only with respect to the VM. Nothing interferes
+// with a guest that might still recover.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/sentrylog"
+)
+
+const (
+	// stallDiagAfter is how long a readiness wait must run before the guest
+	// is treated as stuck. Healthy restores finish about three orders of
+	// magnitude faster, and nothing has ever been observed recovering between
+	// a couple of seconds and the deadline, so this only ever fires on a
+	// guest that is already lost.
+	stallDiagAfter = 5 * time.Second
+
+	// stallDiagSettle separates the two counter samples. Long enough that a
+	// slow-moving counter still shows movement, short enough to leave the
+	// rest of the window for the profile.
+	stallDiagSettle = 2 * time.Second
+
+	// stallDiagPerfWindow is how long the guest is profiled for instruction
+	// pointers. It runs inside the readiness window with room to spare.
+	stallDiagPerfWindow = 3 * time.Second
+
+	// stallDiagBudget caps the whole battery so it can never outlive the
+	// readiness window and collide with teardown.
+	stallDiagBudget = 20 * time.Second
+)
+
+// stallDiagSem bounds concurrent diagnostic batteries. These are heavier than
+// the teardown capture — a profiler subprocess and several seconds of
+// sampling — so a burst of stalls must not turn diagnosis into load on a host
+// that is already unwell. Saturated attempts are skipped, not queued.
+var stallDiagSem = make(chan struct{}, 2)
+
+// armEarlyStallDiagnostics schedules the battery to run if the guest is still
+// unready after stallDiagAfter. The returned func cancels it and is safe to
+// call on every path — on a healthy restore it stops a timer that never fired,
+// which is the entire cost of this feature on the happy path.
+func (m *Manager) armEarlyStallDiagnostics(vmID string, launchPID int) func() {
+	timer := time.AfterFunc(stallDiagAfter, func() {
+		defer sentrylog.Recover("stall-diag-arm")
+		select {
+		case stallDiagSem <- struct{}{}:
+		default:
+			m.log.Warn().Str("vm_id", vmID).
+				Msg("guest slow to become ready — diagnostics skipped (concurrent batteries saturated)")
+			return
+		}
+		defer func() { <-stallDiagSem }()
+		m.runStallDiagnostics(vmID, m.resolveFCPID(vmID, launchPID))
+	})
+	return func() { timer.Stop() }
+}
+
+// runStallDiagnostics collects the live-VM evidence and logs it. Best-effort
+// throughout: a probe that fails contributes an empty field rather than
+// aborting the rest, because a partial answer still narrows the question.
+func (m *Manager) runStallDiagnostics(vmID string, pid int) {
+	if pid <= 0 || !pidIsVMFirecracker(pid, vmID) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), stallDiagBudget)
+	defer cancel()
+	started := time.Now()
+
+	before, kvmDir := readKVMCounters(pid)
+	select {
+	case <-time.After(stallDiagSettle):
+	case <-ctx.Done():
+		return
+	}
+	after, _ := readKVMCounters(pid)
+	deltas := counterDeltas(before, after)
+
+	guestIPs := sampleGuestIPs(ctx, pid)
+	threads := captureProcState(pid, vmID)
+
+	ev := m.log.Warn().Str("vm_id", vmID).
+		Int("fc_pid", pid).
+		Dur("stuck_for", time.Since(started)+stallDiagAfter).
+		Str("kvm_dir", kvmDir).
+		Str("kvm_deltas", formatDeltas(deltas)).
+		Str("guest_ips", strings.Join(guestIPs, ",")).
+		Bool("uffd_found", threads.UffdFound).
+		Int64("uffd_pending", threads.UffdPending).
+		Int64("uffd_total", threads.UffdTotal).
+		Str("thread_state", threads.threadSummary())
+	ev.Msg("guest still not ready — live diagnostics")
+
+	m.writeStallDiagDump(vmID, pid, deltas, guestIPs, threads)
+}
+
+// writeStallDiagDump preserves the full battery next to the other forensics
+// so a later reader has the raw numbers, not just the summary line.
+func (m *Manager) writeStallDiagDump(vmID string, pid int, deltas map[string]int64, guestIPs []string, threads *procStallState) {
+	if !m.forensicsOK {
+		return
+	}
+	dir := filepath.Join(m.cfg.RunDir, stallForensicsDirName)
+	path := filepath.Join(dir, fmt.Sprintf("%d-%s.livediag.txt", time.Now().Unix(), vmID))
+	var b strings.Builder
+	fmt.Fprintf(&b, "vm: %s\npid: %d\n\n--- kvm counter deltas over %s ---\n", vmID, pid, stallDiagSettle)
+	for _, k := range sortedKeys(deltas) {
+		fmt.Fprintf(&b, "  %-32s %d\n", k, deltas[k])
+	}
+	fmt.Fprintf(&b, "\n--- guest instruction pointers ---\n")
+	for _, ip := range guestIPs {
+		fmt.Fprintf(&b, "  %s\n", ip)
+	}
+	fmt.Fprintf(&b, "\n--- threads ---\n%s", threads.dump())
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err == nil {
+		pruneOldest(dir, stallForensicsKeep)
+	}
+}
+
+// readKVMCounters reads every per-VM and per-vCPU counter KVM exposes for
+// this process. Names are prefixed by their vcpu directory so a spinning and
+// a halted vCPU stay distinguishable — which is the entire point.
+func readKVMCounters(pid int) (map[string]int64, string) {
+	out := map[string]int64{}
+	base, err := kvmDebugDirFor(pid)
+	if err != nil {
+		return out, ""
+	}
+	readInto := func(dir, prefix string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			if n, err := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64); err == nil {
+				out[prefix+e.Name()] = n
+			}
+		}
+	}
+	readInto(base, "vm/")
+	if entries, err := os.ReadDir(base); err == nil {
+		for _, e := range entries {
+			if e.IsDir() && strings.HasPrefix(e.Name(), "vcpu") {
+				readInto(filepath.Join(base, e.Name()), e.Name()+"/")
+			}
+		}
+	}
+	return out, base
+}
+
+// kvmDebugDirFor finds the debugfs directory KVM created for this process.
+// The name is "<pid>-<instance>", so the pid alone is not a complete key.
+func kvmDebugDirFor(pid int) (string, error) {
+	root := "/sys/kernel/debug/kvm"
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", err
+	}
+	want := strconv.Itoa(pid) + "-"
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), want) {
+			return filepath.Join(root, e.Name()), nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+// counterDeltas keeps only counters that MOVED. A stalled VM's interesting
+// signal is what is still ticking (or conspicuously not), and dropping the
+// hundreds of static counters is what makes the result readable.
+func counterDeltas(before, after map[string]int64) map[string]int64 {
+	deltas := map[string]int64{}
+	for k, a := range after {
+		if b, ok := before[k]; ok && a != b {
+			deltas[k] = a - b
+		}
+	}
+	return deltas
+}
+
+func sortedKeys(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func formatDeltas(deltas map[string]int64) string {
+	if len(deltas) == 0 {
+		return "none-moved"
+	}
+	parts := make([]string, 0, len(deltas))
+	for _, k := range sortedKeys(deltas) {
+		parts = append(parts, fmt.Sprintf("%s=%+d", k, deltas[k]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// guestIPPattern matches the instruction pointers perf reports for samples
+// taken while the CPU was in guest mode.
+var guestIPPattern = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s`)
+
+// sampleGuestIPs profiles the stalled process and returns the distinct guest
+// instruction pointers seen, most frequent first.
+//
+// Addresses rather than symbols on purpose: the shipped guest kernel is
+// stripped, so resolution happens offline against a kallsyms dump from a live
+// guest of the same image. Recording raw pointers keeps the host path simple
+// and the evidence durable.
+func sampleGuestIPs(ctx context.Context, pid int) []string {
+	tmp, err := os.MkdirTemp("", "stalldiag")
+	if err != nil {
+		return nil
+	}
+	defer os.RemoveAll(tmp)
+	data := filepath.Join(tmp, "perf.data")
+
+	rec := exec.CommandContext(ctx, "perf", "record", "-e", "cpu-clock", "-F", "97",
+		"--pid", strconv.Itoa(pid), "-o", data, "--", "sleep",
+		strconv.Itoa(int(stallDiagPerfWindow/time.Second)))
+	if err := rec.Run(); err != nil {
+		return nil
+	}
+	script := exec.CommandContext(ctx, "perf", "script", "-i", data, "-F", "ip")
+	out, err := script.Output()
+	if err != nil {
+		return nil
+	}
+
+	counts := map[string]int{}
+	for _, m := range guestIPPattern.FindAllStringSubmatch(string(out), -1) {
+		counts[m[1]]++
+	}
+	ips := make([]string, 0, len(counts))
+	for ip := range counts {
+		ips = append(ips, ip)
+	}
+	sort.Slice(ips, func(i, j int) bool {
+		if counts[ips[i]] != counts[ips[j]] {
+			return counts[ips[i]] > counts[ips[j]]
+		}
+		return ips[i] < ips[j]
+	})
+	if len(ips) > 12 {
+		ips = ips[:12]
+	}
+	for i, ip := range ips {
+		ips[i] = fmt.Sprintf("%s:%d", ip, counts[ip])
+	}
+	return ips
+}

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -69,6 +69,20 @@ func TestKVMDebugDirMatchesTheWholePIDToken(t *testing.T) {
 	}
 }
 
+func TestPerfStubIsNotTreatedAsUsable(t *testing.T) {
+	// Distributions ship a wrapper at perf's usual path that only prints an
+	// "install linux-tools-<kernel>" notice. Presence on PATH proves nothing,
+	// and profiling through the stub yields no samples at all.
+	stub := "perf not found for kernel 6.8.0-1063-gcp\n\nYou may need to install the following packages for this specific kernel:\n    linux-tools-6.8.0-1063-gcp\n"
+	if !strings.Contains(stub, "linux-tools") {
+		t.Fatal("test fixture no longer resembles the stub output")
+	}
+	real := "perf version 6.8.12\n"
+	if strings.Contains(real, "linux-tools") {
+		t.Fatal("a working perf must not be mistaken for the stub")
+	}
+}
+
 func TestOnlyGuestSamplesAreReported(t *testing.T) {
 	// A host address reported as a guest RIP would be resolved against guest
 	// symbols and yield confident nonsense — worse than reporting nothing.

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -68,6 +68,24 @@ func TestExpensiveKVMEntriesAreNeverOpened(t *testing.T) {
 	}
 }
 
+func TestBatteryAbandonsAProcessThatChangedIdentity(t *testing.T) {
+	// The settle interval gives the stalled process time to exit, and the
+	// kernel may hand its number to another Firecracker. Recording that
+	// process's counters and guest addresses under this VM's id would be
+	// worse than recording nothing, so the battery abandons instead.
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	m.runStallDiagnostics(context.Background(), "00000000-0000-0000-0000-000000000000", os.Getpid())
+
+	// A cancelled battery must not start the shared-semaphore capture at all;
+	// stealing a slot there can make a genuine timeout skip its own capture.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m.runStallDiagnostics(ctx, "any-vm", os.Getpid())
+	if len(stallProcSem) != 0 {
+		t.Fatalf("cancelled battery left %d proc-capture slots held", len(stallProcSem))
+	}
+}
+
 func TestGaugesAreReportedAsValuesNotDeltas(t *testing.T) {
 	// guest_mode and pid hold a current value, not a running total. As deltas
 	// they are actively misleading: 1→1 and 0→0 both subtract to zero, which

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -47,6 +47,45 @@ func TestCounterDeltasKeepMovementAndTheProofOfStillness(t *testing.T) {
 	}
 }
 
+func TestGaugesAreReportedAsValuesNotDeltas(t *testing.T) {
+	// guest_mode and pid hold a current value, not a running total. As deltas
+	// they are actively misleading: 1→1 and 0→0 both subtract to zero, which
+	// would leave the executing vCPU unidentifiable and drop the vCPU→thread
+	// mapping entirely.
+	before := map[string]int64{
+		"vcpu0/guest_mode": 1, "vcpu1/guest_mode": 0,
+		"vcpu0/pid": 4242, "vcpu1/pid": 4243,
+		"vm/exits": 100,
+	}
+	after := map[string]int64{
+		"vcpu0/guest_mode": 1, "vcpu1/guest_mode": 0,
+		"vcpu0/pid": 4242, "vcpu1/pid": 4243,
+		"vm/exits": 100,
+	}
+
+	d := counterDeltas(before, after)
+	for k := range d {
+		if strings.Contains(k, "guest_mode") || strings.Contains(k, "pid") {
+			t.Fatalf("gauge %q leaked into deltas, where it cannot be interpreted", k)
+		}
+	}
+
+	g := latestGauges(after)
+	if g["vcpu0/guest_mode"] != 1 || g["vcpu1/guest_mode"] != 0 {
+		t.Fatalf("guest_mode values lost: %v", g)
+	}
+	if g["vcpu0/pid"] != 4242 || g["vcpu1/pid"] != 4243 {
+		t.Fatalf("vcpu→thread mapping lost: %v", g)
+	}
+	// Rendered without a sign, unlike deltas.
+	if s := formatGauges(g); !strings.Contains(s, "vcpu0/guest_mode=1") {
+		t.Fatalf("gauges rendered as %q", s)
+	}
+	if formatGauges(nil) != "none" {
+		t.Fatal("empty gauges must render as none")
+	}
+}
+
 func TestKVMDebugDirMatchesTheWholePIDToken(t *testing.T) {
 	// KVM names its directories "<pid>-<instance>", so a prefix match on the
 	// bare pid would also match pid 12345 for pid 1234.

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -172,6 +172,42 @@ func TestKVMDebugDirMatchesTheWholePIDToken(t *testing.T) {
 	}
 }
 
+func TestSaturationWarningsAreAggregated(t *testing.T) {
+	// A host-wide stall can leave hundreds of restores unready at once; one
+	// warning per skipped restore would itself be load on a struggling host,
+	// so skips accumulate into one counted warning per interval.
+	stallDiagSkips.Store(0)
+	stallDiagLastWarn.Store(0)
+	base := time.Unix(1000, 0)
+
+	if n, ok := claimSkipWarn(base); !ok || n != 1 {
+		t.Fatalf("first skip should warn with count 1, got %d %v", n, ok)
+	}
+	for i := 0; i < 400; i++ {
+		if _, ok := claimSkipWarn(base.Add(time.Second)); ok {
+			t.Fatal("skips within the interval must not each warn")
+		}
+	}
+	if n, ok := claimSkipWarn(base.Add(stallDiagWarnEvery + time.Second)); !ok || n != 401 {
+		t.Fatalf("next interval should warn with the accumulated 401 skips, got %d %v", n, ok)
+	}
+}
+
+func TestCancelledPerfProbeIsNotCached(t *testing.T) {
+	// A probe that never ran — cancelled by readiness completing — says
+	// nothing durable about perf. Caching its failure would silently disable
+	// guest profiling for the rest of the process's life.
+	perfUsable.Store(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if perfIsUsable(ctx) {
+		t.Fatal("a cancelled probe must not report perf as usable")
+	}
+	if perfUsable.Load() != nil {
+		t.Fatal("a probe that never ran must not be cached")
+	}
+}
+
 func TestPerfStubIsNotTreatedAsUsable(t *testing.T) {
 	// Distributions ship a wrapper at perf's usual path that only prints an
 	// "install linux-tools-<kernel>" notice. Presence on PATH proves nothing,

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,18 +11,27 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func TestCounterDeltasKeepOnlyWhatMoved(t *testing.T) {
-	// A stalled VM's signal is what is still ticking — or conspicuously not.
-	// Hundreds of static counters would bury it, so only movement survives.
+func TestCounterDeltasKeepMovementAndTheProofOfStillness(t *testing.T) {
+	// Movement is signal, but so is its absence: a vCPU burning CPU while its
+	// exit count stays flat proves a loop that never leaves guest mode. So
+	// allowlisted counters are reported at zero, while the hundreds of other
+	// static counters are dropped to keep the result readable.
 	before := map[string]int64{"vcpu0/exits": 100, "vcpu1/exits": 50, "vm/fpu_reload": 7}
 	after := map[string]int64{"vcpu0/exits": 100, "vcpu1/exits": 4050, "vm/fpu_reload": 7}
 
 	d := counterDeltas(before, after)
-	if len(d) != 1 {
-		t.Fatalf("expected only the moving counter, got %v", d)
-	}
 	if d["vcpu1/exits"] != 4000 {
 		t.Fatalf("delta = %d, want 4000", d["vcpu1/exits"])
+	}
+	got, ok := d["vcpu0/exits"]
+	if !ok {
+		t.Fatal("a flat exit count must be reported — it is the proof of a tight guest loop")
+	}
+	if got != 0 {
+		t.Fatalf("flat counter reported as %d, want 0", got)
+	}
+	if _, ok := d["vm/fpu_reload"]; ok {
+		t.Fatal("static non-allowlisted counter was not dropped")
 	}
 	// A counter absent from the first sample cannot yield a meaningful delta.
 	if got := counterDeltas(map[string]int64{}, after); len(got) != 0 {
@@ -59,32 +69,66 @@ func TestKVMDebugDirMatchesTheWholePIDToken(t *testing.T) {
 	}
 }
 
-func TestGuestIPPatternExtractsAddresses(t *testing.T) {
-	sample := "          ffffffff810a2b40\n          ffffffff810a2b40\n          7f9c0a1b2c3d\nnot-an-address\n"
-	m := guestIPPattern.FindAllStringSubmatch(sample, -1)
-	if len(m) != 3 {
-		t.Fatalf("extracted %d addresses, want 3: %v", len(m), m)
+func TestOnlyGuestSamplesAreReported(t *testing.T) {
+	// A host address reported as a guest RIP would be resolved against guest
+	// symbols and yield confident nonsense — worse than reporting nothing.
+	sample := "" +
+		"    ffffffff810a2b40 [guest.kernel.kallsyms]\n" +
+		"    ffffffff810a2b40 [guest.kernel.kallsyms]\n" +
+		"    00007f9c0a1b2c3d /usr/local/bin/firecracker\n" +
+		"    ffffffff81abcdef [kernel.kallsyms]\n"
+
+	var guest, host int
+	for _, m := range guestSampleLine.FindAllStringSubmatch(sample, -1) {
+		if guestDSO(m[2]) {
+			guest++
+		} else {
+			host++
+		}
 	}
-	if m[0][1] != "ffffffff810a2b40" {
-		t.Fatalf("first address = %q", m[0][1])
+	if guest != 2 {
+		t.Fatalf("guest samples = %d, want 2", guest)
+	}
+	if host != 2 {
+		t.Fatalf("host samples = %d, want 2 (they must be recognized and excluded)", host)
+	}
+	if guestDSO("/usr/local/bin/firecracker") || guestDSO("[kernel.kallsyms]") {
+		t.Fatal("host dso classified as guest")
+	}
+	if !guestDSO("[guest.kernel.kallsyms]") {
+		t.Fatal("guest dso not recognized")
 	}
 }
 
 func TestArmedDiagnosticsAreCancelledOnTheHappyPath(t *testing.T) {
-	// The entire cost on a successful restore must be a timer that never
-	// fires: an unknown pid would make the battery a no-op anyway, but the
-	// contract is that cancelling is always safe and immediate.
+	// Cancelling must be safe on every path and repeatable, since restore
+	// paths may cancel more than once.
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
 	stop := m.armEarlyStallDiagnostics("vm-that-succeeds", 0)
 	stop()
-	stop() // idempotent: restore paths may cancel more than once
+	stop()
 	time.Sleep(10 * time.Millisecond)
+}
+
+func TestCancellationSuppressesABatteryAlreadyInFlight(t *testing.T) {
+	// A restore that becomes ready just after the threshold would otherwise be
+	// profiled and logged as stalled — timer.Stop cannot recall a callback
+	// that already fired, so the context is what must suppress it.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	// A cancelled context must stop the battery before it profiles anything,
+	// even when handed a live pid.
+	m.runStallDiagnostics(ctx, "not-this-vm", os.Getpid())
+	if ctx.Err() == nil {
+		t.Fatal("test setup: context should be cancelled")
+	}
 }
 
 func TestDiagnosticsRefuseAForeignPID(t *testing.T) {
 	// Same identity rule as the teardown capture: profiling and counter reads
 	// must never be aimed at a process that is not this VM's firecracker.
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
-	m.runStallDiagnostics("00000000-0000-0000-0000-000000000000", os.Getpid())
-	m.runStallDiagnostics("any-vm", 0)
+	m.runStallDiagnostics(context.Background(), "00000000-0000-0000-0000-000000000000", os.Getpid())
+	m.runStallDiagnostics(context.Background(), "any-vm", 0)
 }

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -1,0 +1,90 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestCounterDeltasKeepOnlyWhatMoved(t *testing.T) {
+	// A stalled VM's signal is what is still ticking — or conspicuously not.
+	// Hundreds of static counters would bury it, so only movement survives.
+	before := map[string]int64{"vcpu0/exits": 100, "vcpu1/exits": 50, "vm/fpu_reload": 7}
+	after := map[string]int64{"vcpu0/exits": 100, "vcpu1/exits": 4050, "vm/fpu_reload": 7}
+
+	d := counterDeltas(before, after)
+	if len(d) != 1 {
+		t.Fatalf("expected only the moving counter, got %v", d)
+	}
+	if d["vcpu1/exits"] != 4000 {
+		t.Fatalf("delta = %d, want 4000", d["vcpu1/exits"])
+	}
+	// A counter absent from the first sample cannot yield a meaningful delta.
+	if got := counterDeltas(map[string]int64{}, after); len(got) != 0 {
+		t.Fatalf("counters without a baseline produced deltas: %v", got)
+	}
+	// The rendered form must name the vcpu, since distinguishing the spinning
+	// vCPU from the halted one is the entire purpose.
+	if s := formatDeltas(d); !strings.Contains(s, "vcpu1/exits=+4000") {
+		t.Fatalf("formatted deltas lost the vcpu identity: %q", s)
+	}
+	if s := formatDeltas(nil); s != "none-moved" {
+		t.Fatalf("empty deltas rendered as %q", s)
+	}
+}
+
+func TestKVMDebugDirMatchesTheWholePIDToken(t *testing.T) {
+	// KVM names its directories "<pid>-<instance>", so a prefix match on the
+	// bare pid would also match pid 12345 for pid 1234.
+	root := t.TempDir()
+	for _, name := range []string{"1234-15", "12345-15", "999-1"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Exercise the same matching rule the real lookup uses.
+	entries, _ := os.ReadDir(root)
+	var got []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "1234-") {
+			got = append(got, e.Name())
+		}
+	}
+	if len(got) != 1 || got[0] != "1234-15" {
+		t.Fatalf("pid token matching selected %v", got)
+	}
+}
+
+func TestGuestIPPatternExtractsAddresses(t *testing.T) {
+	sample := "          ffffffff810a2b40\n          ffffffff810a2b40\n          7f9c0a1b2c3d\nnot-an-address\n"
+	m := guestIPPattern.FindAllStringSubmatch(sample, -1)
+	if len(m) != 3 {
+		t.Fatalf("extracted %d addresses, want 3: %v", len(m), m)
+	}
+	if m[0][1] != "ffffffff810a2b40" {
+		t.Fatalf("first address = %q", m[0][1])
+	}
+}
+
+func TestArmedDiagnosticsAreCancelledOnTheHappyPath(t *testing.T) {
+	// The entire cost on a successful restore must be a timer that never
+	// fires: an unknown pid would make the battery a no-op anyway, but the
+	// contract is that cancelling is always safe and immediate.
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	stop := m.armEarlyStallDiagnostics("vm-that-succeeds", 0)
+	stop()
+	stop() // idempotent: restore paths may cancel more than once
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestDiagnosticsRefuseAForeignPID(t *testing.T) {
+	// Same identity rule as the teardown capture: profiling and counter reads
+	// must never be aimed at a process that is not this VM's firecracker.
+	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
+	m.runStallDiagnostics("00000000-0000-0000-0000-000000000000", os.Getpid())
+	m.runStallDiagnostics("any-vm", 0)
+}

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -74,15 +75,39 @@ func TestBatteryAbandonsAProcessThatChangedIdentity(t *testing.T) {
 	// process's counters and guest addresses under this VM's id would be
 	// worse than recording nothing, so the battery abandons instead.
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
-	m.runStallDiagnostics(context.Background(), "00000000-0000-0000-0000-000000000000", os.Getpid())
+	m.runStallDiagnostics(context.Background(), nil, "00000000-0000-0000-0000-000000000000", os.Getpid())
 
 	// A cancelled battery must not start the shared-semaphore capture at all;
 	// stealing a slot there can make a genuine timeout skip its own capture.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	m.runStallDiagnostics(ctx, "any-vm", os.Getpid())
+	m.runStallDiagnostics(ctx, nil, "any-vm", os.Getpid())
 	if len(stallProcSem) != 0 {
 		t.Fatalf("cancelled battery left %d proc-capture slots held", len(stallProcSem))
+	}
+}
+
+func TestPublicationIsClaimedExactlyOnce(t *testing.T) {
+	// Readiness can complete in the window between the battery's last context
+	// check and its write, so the outcome is decided by a claim rather than a
+	// check: whoever arrives first wins, and the loser stays silent.
+	var settled atomic.Bool
+
+	// Readiness wins: the battery must not publish.
+	if !settled.CompareAndSwap(false, true) {
+		t.Fatal("first claim should succeed")
+	}
+	if settled.CompareAndSwap(false, true) {
+		t.Fatal("a second claim must fail — the outcome is already decided")
+	}
+
+	// Fresh restore, battery wins: readiness then finds it already claimed.
+	var other atomic.Bool
+	if !other.CompareAndSwap(false, true) {
+		t.Fatal("battery should be able to claim an unclaimed outcome")
+	}
+	if other.CompareAndSwap(false, true) {
+		t.Fatal("readiness must not re-claim after the battery published")
 	}
 }
 
@@ -211,7 +236,7 @@ func TestCancellationSuppressesABatteryAlreadyInFlight(t *testing.T) {
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
 	// A cancelled context must stop the battery before it profiles anything,
 	// even when handed a live pid.
-	m.runStallDiagnostics(ctx, "not-this-vm", os.Getpid())
+	m.runStallDiagnostics(ctx, nil, "not-this-vm", os.Getpid())
 	if ctx.Err() == nil {
 		t.Fatal("test setup: context should be cancelled")
 	}
@@ -221,6 +246,6 @@ func TestDiagnosticsRefuseAForeignPID(t *testing.T) {
 	// Same identity rule as the teardown capture: profiling and counter reads
 	// must never be aimed at a process that is not this VM's firecracker.
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}}
-	m.runStallDiagnostics(context.Background(), "00000000-0000-0000-0000-000000000000", os.Getpid())
-	m.runStallDiagnostics(context.Background(), "any-vm", 0)
+	m.runStallDiagnostics(context.Background(), nil, "00000000-0000-0000-0000-000000000000", os.Getpid())
+	m.runStallDiagnostics(context.Background(), nil, "any-vm", 0)
 }

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -47,6 +47,27 @@ func TestCounterDeltasKeepMovementAndTheProofOfStillness(t *testing.T) {
 	}
 }
 
+func TestExpensiveKVMEntriesAreNeverOpened(t *testing.T) {
+	// Reading mmu_rmaps_stat takes the KVM MMU write lock and walks every
+	// memslot's reverse maps, blocking the guest's own fault handling. The
+	// cost is paid at open, so filtering after parsing would be too late.
+	// The *_hist entries are not single integers either.
+	for _, name := range []string{"mmu_rmaps_stat", "halt_poll_success_hist", "halt_poll_fail_hist", "halt_wait_hist"} {
+		if kvmReadable(name) {
+			t.Fatalf("%q would be opened; it is not a cheap integer", name)
+		}
+	}
+	// Entries the diagnosis depends on, all verified present on the hosts.
+	for _, name := range []string{
+		"exits", "halt_wakeup", "irq_injections", "remote_tlb_flush",
+		"remote_tlb_flush_requests", "notify_window_exits", "guest_mode", "pid",
+	} {
+		if !kvmReadable(name) {
+			t.Fatalf("%q must be readable — the diagnosis depends on it", name)
+		}
+	}
+}
+
 func TestGaugesAreReportedAsValuesNotDeltas(t *testing.T) {
 	// guest_mode and pid hold a current value, not a running total. As deltas
 	// they are actively misleading: 1→1 and 0→0 both subtract to zero, which


### PR DESCRIPTION
The teardown capture answered where the stall is *not*: the memory handler sits idle with zero unresolved faults, so the guest itself is what hangs — one vCPU spinning in guest mode, another halted waiting for an interrupt. Answering *why* needs signals that exist only while the VM runs.

This fires diagnostics from inside the readiness window instead of at teardown. A healthy guest answers in tens of milliseconds, so after a few seconds the outcome is already decided, yet vmd currently sits idle until the deadline. Using that dead time costs the request nothing — it is not on the reply path — and leaves most of a minute for probes a teardown path could never afford:

- KVM counters sampled twice, reported as deltas per vCPU: whether the spinning vCPU is exiting at all, and whether the halted one is ever woken. A flat exit count means a tight guest loop; a flat halt_wakeup means nothing is arriving.
- guest instruction pointers, sampled with perf: which code the guest is actually looping in. Raw addresses, resolved offline against a symbol dump, since the shipped guest kernel is stripped.
- thread stacks and fault counters re-read for correlation.

Read-only with respect to the VM — nothing interferes with a guest that might still recover. Concurrency is capped and saturated attempts are skipped rather than queued, the whole battery is bounded well inside the readiness window, and on a successful restore the entire cost is a timer that never fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)