### PR TITLE
feat: add abuse control-plane trust and quarantine controls

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -32,6 +32,7 @@ on:
       # matches no path is not a skipped job but no job at all. The
       # deploy-trigger-coverage CI check enforces this against `go list -deps`.
       - 'cmd/controlplane/**'
+      - 'internal/abuse/**'
       - 'internal/analytics/**'
       - 'internal/api/**'
       - 'internal/auth/**'

--- a/internal/abuse/control.go
+++ b/internal/abuse/control.go
@@ -1,0 +1,181 @@
+// Package abuse contains the authoritative, cache-independent abuse state
+// contract consumed by reconciliation and lifecycle caches.
+package abuse
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+type Action string
+
+const (
+	ActionSignup Action = "signup"
+	ActionCreate Action = "create"
+	ActionResume Action = "resume"
+)
+
+type Request struct {
+	UserID, TeamID uuid.UUID
+	IP, Domain     string
+	// AuthProvider identifies the provider for the corporate identity represented
+	// by Domain. A matching active association grants the same trust precedence
+	// as an explicitly verified team.
+	AuthProvider  string
+	Action        Action
+	GlobalEnabled bool
+}
+type Decision struct {
+	Allowed       bool
+	Reason        string
+	RestrictionID *uuid.UUID
+	// ExpiresAt lets downstream caches stop serving a denial when the
+	// authoritative restriction expires without a state-change row.
+	ExpiresAt  *time.Time
+	Generation int64
+}
+
+// IsTrustedIdentity checks the runtime-managed provider/domain association.
+// Resolve applies a matching active association as a trust signal for the
+// request; it is not a user record or deploy-time list.
+func IsTrustedIdentity(ctx context.Context, q db.DBTX, provider, domain string) (bool, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	var err error
+	domain, err = NormalizeDomain(domain)
+	if err != nil || provider == "" {
+		return false, err
+	}
+	var ok bool
+	err = q.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM abuse_trusted_identities WHERE auth_provider=$1 AND domain=$2 AND revoked_at IS NULL)`, provider, domain).Scan(&ok)
+	return ok, err
+}
+
+// NormalizeIP accepts exactly one address and deliberately rejects CIDR.
+func NormalizeIP(value string) (string, error) {
+	v := strings.TrimSpace(value)
+	if strings.Contains(v, "/") {
+		return "", fmt.Errorf("CIDR is not supported")
+	}
+	ip := net.ParseIP(v)
+	if ip == nil {
+		return "", fmt.Errorf("invalid IP address")
+	}
+	return ip.String(), nil
+}
+func NormalizeDomain(value string) (string, error) {
+	v := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(value), "."))
+	if v == "" || strings.ContainsAny(v, "*/") || strings.Contains(v, "..") {
+		return "", fmt.Errorf("invalid exact domain")
+	}
+	for _, label := range strings.Split(v, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", fmt.Errorf("invalid exact domain")
+		}
+	}
+	return v, nil
+}
+
+// Resolve reads current state on every call. Verified teams and approved
+// corporate identities take precedence over restrictions, and released/expired
+// rows are never applicable.
+func Resolve(ctx context.Context, q db.DBTX, req Request) (Decision, error) {
+	if !isSupportedAction(req.Action) {
+		return Decision{}, fmt.Errorf("unsupported abuse action %q", req.Action)
+	}
+	if !req.GlobalEnabled {
+		return Decision{Allowed: true, Reason: "global_off"}, nil
+	}
+	// Capture the invalidation token before reading trust state. If a trust or
+	// identity mutation races this evaluation, the decision retains the older
+	// token and downstream caches are forced to re-evaluate it.
+	generation, err := currentGeneration(ctx, q, req.TeamID)
+	if err != nil {
+		return Decision{}, err
+	}
+	var verified bool
+	if err := q.QueryRow(ctx, `SELECT COALESCE(verified,false) AND revoked_at IS NULL FROM abuse_team_trust WHERE team_id=$1`, req.TeamID).Scan(&verified); err != nil && err != pgx.ErrNoRows {
+		return Decision{}, err
+	}
+	if verified {
+		return currentDecision(ctx, q, req, true, generation)
+	}
+	if req.AuthProvider != "" && req.Domain != "" {
+		trusted, err := IsTrustedIdentity(ctx, q, req.AuthProvider, req.Domain)
+		if err != nil {
+			return Decision{}, err
+		}
+		if trusted {
+			decision, err := currentDecision(ctx, q, req, true, generation)
+			if err == nil {
+				decision.Reason = "trusted_identity"
+			}
+			return decision, err
+		}
+	}
+	return currentDecision(ctx, q, req, false, generation)
+}
+
+func isSupportedAction(action Action) bool {
+	switch action {
+	case ActionSignup, ActionCreate, ActionResume:
+		return true
+	default:
+		return false
+	}
+}
+
+func currentGeneration(ctx context.Context, q db.DBTX, teamID uuid.UUID) (int64, error) {
+	var generation int64
+	if err := q.QueryRow(ctx, `SELECT COALESCE(MAX(id),0) FROM abuse_state_changes WHERE team_id=$1 OR team_id IS NULL`, teamID).Scan(&generation); err != nil {
+		return 0, err
+	}
+	return generation, nil
+}
+
+func currentDecision(ctx context.Context, q db.DBTX, req Request, verified bool, generation int64) (Decision, error) {
+	var id uuid.UUID
+	if verified {
+		return Decision{Allowed: true, Reason: "verified_team", Generation: generation}, nil
+	}
+	var ipValue, domainValue string
+	if req.IP != "" {
+		ip, err := NormalizeIP(req.IP)
+		if err != nil {
+			return Decision{}, err
+		}
+		ipValue = ip
+	}
+	if req.Domain != "" {
+		domain, err := NormalizeDomain(req.Domain)
+		if err != nil {
+			return Decision{}, err
+		}
+		domainValue = domain
+	}
+	if req.UserID == uuid.Nil && req.TeamID == uuid.Nil && ipValue == "" && domainValue == "" {
+		return Decision{Allowed: true, Reason: "no_restriction", Generation: generation}, nil
+	}
+	// Subject references and canonical values are checked independently so an
+	// IP can never satisfy a domain restriction (or vice versa).
+	var expiresAt *time.Time
+	err := q.QueryRow(ctx, `SELECT id,expires_at FROM abuse_restrictions WHERE action=$1 AND released_at IS NULL AND (expires_at IS NULL OR expires_at > now()) AND ((subject_type='user' AND subject_user_id=$2) OR (subject_type='team' AND subject_team_id=$3) OR (subject_type='ip' AND subject_value=$4) OR (subject_type='domain' AND subject_value=$5)) ORDER BY created_at DESC LIMIT 1`, string(req.Action), req.UserID, req.TeamID, ipValue, domainValue).Scan(&id, &expiresAt)
+	if err == nil {
+		return Decision{Allowed: false, Reason: "active_restriction", RestrictionID: &id, ExpiresAt: expiresAt, Generation: generation}, nil
+	}
+	if err != pgx.ErrNoRows {
+		return Decision{}, err
+	}
+	return Decision{Allowed: true, Reason: "no_restriction", Generation: generation}, nil
+}
+
+// ActiveAt is useful to workers re-checking state immediately before action.
+func ActiveAt(expires *time.Time, released *time.Time, now time.Time) bool {
+	return released == nil && (expires == nil || expires.After(now))
+}

--- a/internal/api/rbac_platform_abuse.go
+++ b/internal/api/rbac_platform_abuse.go
@@ -1,0 +1,489 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/superserve-ai/sandbox/internal/abuse"
+	"github.com/superserve-ai/sandbox/internal/authz"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type abuseMutation struct {
+	Source   string          `json:"source"`
+	Reason   string          `json:"reason"`
+	Evidence json.RawMessage `json:"evidence"`
+}
+type abuseRestrictionInput struct {
+	SubjectType  string     `json:"subject_type"`
+	SubjectValue string     `json:"subject_value"`
+	UserID       *uuid.UUID `json:"user_id"`
+	TeamID       *uuid.UUID `json:"team_id"`
+	Action       string     `json:"action"`
+	ExpiresAt    *time.Time `json:"expires_at"`
+	abuseMutation
+}
+
+// All abuse mutations serialize state-change ID allocation with commit order.
+// Without this, a later transaction can commit a larger sequence value first,
+// causing generation readers to miss the earlier transaction when it commits.
+const abuseMutationLockKey int64 = 0x53534142555345
+
+func (h *Handlers) withAbuseMutation(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := h.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, abuseMutationLockKey); err != nil {
+		return err
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (h *Handlers) requireAbuse(c *gin.Context, write bool) (uuid.UUID, bool) {
+	actor, err := internalActorID(c)
+	if err != nil {
+		return uuid.Nil, false
+	}
+	if err = h.requirePlatformAdminGoogleSession(c.Request.Context(), h.Pool, actor); err != nil {
+		if errors.Is(err, authz.ErrSessionNotEligible) || errors.Is(err, pgx.ErrNoRows) {
+			respondError(c, ErrForbidden)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return uuid.Nil, false
+	}
+	perm := "platform:abuse:read"
+	if write {
+		perm = "platform:abuse:write"
+	}
+	if err = h.rbacService().RequirePlatformPermission(c.Request.Context(), actor, perm); err != nil {
+		if errors.Is(err, authz.ErrPermissionDenied) || errors.Is(err, authz.ErrScopeMismatch) {
+			respondError(c, ErrForbidden)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return uuid.Nil, false
+	}
+	return actor, true
+}
+func (h *Handlers) GetPlatformAbuseTeamTrust(c *gin.Context) {
+	team, err := internalTeamID(c)
+	if err != nil {
+		return
+	}
+	if _, ok := h.requireAbuse(c, false); !ok {
+		return
+	}
+	var out struct {
+		TeamID    uuid.UUID       `json:"team_id"`
+		Verified  bool            `json:"verified"`
+		Source    string          `json:"source"`
+		Reason    *string         `json:"reason,omitempty"`
+		Evidence  json.RawMessage `json:"evidence"`
+		UpdatedAt time.Time       `json:"updated_at"`
+	}
+	err = h.Pool.QueryRow(c, `SELECT team_id,verified,source,reason,evidence,updated_at FROM abuse_team_trust WHERE team_id=$1`, team).Scan(&out.TeamID, &out.Verified, &out.Source, &out.Reason, &out.Evidence, &out.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		out.TeamID = team
+		out.Evidence = json.RawMessage(`{}`)
+	} else if err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (h *Handlers) SetPlatformAbuseTeamTrust(c *gin.Context) {
+	team, err := internalTeamID(c)
+	if err != nil {
+		return
+	}
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	var in struct {
+		Verified bool `json:"verified"`
+		abuseMutation
+	}
+	if c.ShouldBindJSON(&in) != nil {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	ev := in.Evidence
+	if len(ev) == 0 {
+		ev = []byte(`{}`)
+	}
+	source := strings.TrimSpace(in.Source)
+	if source == "" {
+		source = "platform_admin"
+	}
+	err = h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(c, `INSERT INTO abuse_team_trust(team_id,verified,source,reason,evidence,updated_at,revoked_at) VALUES($1,$2,$3,$4,$5,now(),CASE WHEN $2 THEN NULL ELSE now() END) ON CONFLICT(team_id) DO UPDATE SET verified=EXCLUDED.verified,source=EXCLUDED.source,reason=EXCLUDED.reason,evidence=EXCLUDED.evidence,updated_at=now(),revoked_at=EXCLUDED.revoked_at`, team, in.Verified, source, in.Reason, ev); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(team_id,reason) VALUES($1,'team trust changed')`, team); err != nil {
+			return err
+		}
+		auditValue, err := json.Marshal(struct {
+			Verified bool            `json:"verified"`
+			Source   string          `json:"source"`
+			Reason   string          `json:"reason,omitempty"`
+			Evidence json.RawMessage `json:"evidence"`
+		}{in.Verified, source, in.Reason, ev})
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,team_id,event_type,new_value,metadata) VALUES($1,$2,'abuse.team_trust.changed',$3,$4)`, actor, team, auditValue, `{"source":"platform_admin"}`)
+		return err
+	})
+	if err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handlers) ListPlatformAbuseRestrictions(c *gin.Context) {
+	if _, ok := h.requireAbuse(c, false); !ok {
+		return
+	}
+	rows, err := h.Pool.Query(c, `SELECT id,subject_type,subject_value,subject_user_id,subject_team_id,action,source,reason,evidence,created_at,expires_at,released_at FROM abuse_restrictions WHERE released_at IS NULL AND (expires_at IS NULL OR expires_at>now()) ORDER BY created_at DESC`)
+	if err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	defer rows.Close()
+	out := []gin.H{}
+	for rows.Next() {
+		var id uuid.UUID
+		var typ, val, act, src, reason string
+		var uid, tid *uuid.UUID
+		var ev []byte
+		var created time.Time
+		var exp, rel *time.Time
+		if err := rows.Scan(&id, &typ, &val, &uid, &tid, &act, &src, &reason, &ev, &created, &exp, &rel); err != nil {
+			respondError(c, ErrInternal)
+			return
+		}
+		out = append(out, gin.H{"id": id, "subject_type": typ, "subject_value": val, "user_id": uid, "team_id": tid, "action": act, "source": src, "reason": reason, "evidence": json.RawMessage(ev), "created_at": created, "expires_at": exp, "released_at": rel})
+	}
+	if err := rows.Err(); err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+func (h *Handlers) CreatePlatformAbuseRestriction(c *gin.Context) {
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	var in abuseRestrictionInput
+	if c.ShouldBindJSON(&in) != nil || in.Reason == "" {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	switch in.SubjectType {
+	case "user":
+		if in.UserID == nil {
+			respondError(c, ErrBadRequest)
+			return
+		}
+		// UUID-backed subjects use the typed ID as their canonical value so
+		// listings, audit records, and resolution cannot disagree.
+		in.SubjectValue = in.UserID.String()
+	case "team":
+		if in.TeamID == nil {
+			respondError(c, ErrBadRequest)
+			return
+		}
+		in.SubjectValue = in.TeamID.String()
+	case "ip":
+		var err error
+		in.SubjectValue, err = abuse.NormalizeIP(in.SubjectValue)
+		if err != nil {
+			respondError(c, ErrBadRequest)
+			return
+		}
+	case "domain":
+		var err error
+		in.SubjectValue, err = abuse.NormalizeDomain(in.SubjectValue)
+		if err != nil {
+			respondError(c, ErrBadRequest)
+			return
+		}
+	default:
+		respondError(c, ErrBadRequest)
+		return
+	}
+	if in.SubjectValue == "" || in.Action == "" {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	id := uuid.New()
+	ev := in.Evidence
+	if len(ev) == 0 {
+		ev = []byte(`{}`)
+	}
+	source := strings.TrimSpace(in.Source)
+	if source == "" {
+		source = "platform_admin"
+	}
+	auditValue, err := json.Marshal(struct {
+		ID           uuid.UUID       `json:"id"`
+		SubjectType  string          `json:"subject_type"`
+		SubjectValue string          `json:"subject_value"`
+		UserID       *uuid.UUID      `json:"user_id,omitempty"`
+		TeamID       *uuid.UUID      `json:"team_id,omitempty"`
+		Action       string          `json:"action"`
+		Source       string          `json:"source"`
+		Reason       string          `json:"reason"`
+		Evidence     json.RawMessage `json:"evidence"`
+		ExpiresAt    *time.Time      `json:"expires_at,omitempty"`
+	}{id, in.SubjectType, in.SubjectValue, in.UserID, in.TeamID, in.Action, source, in.Reason, ev, in.ExpiresAt})
+	if err != nil {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	err = h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(c, `INSERT INTO abuse_restrictions(id,subject_type,subject_value,subject_user_id,subject_team_id,action,source,reason,evidence,created_by,expires_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`, id, in.SubjectType, in.SubjectValue, in.UserID, in.TeamID, in.Action, source, in.Reason, ev, actor, in.ExpiresAt); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(team_id,reason) VALUES($1,'restriction changed')`, in.TeamID); err != nil {
+			return err
+		}
+		_, err := tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,team_id,event_type,new_value,metadata) VALUES($1,$2,'abuse.restriction.created',$3,$4)`, actor, in.TeamID, auditValue, `{"source":"platform_admin"}`)
+		return err
+	})
+	if err != nil {
+		if isAbuseValidationError(err) {
+			respondError(c, ErrBadRequest)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+
+// isAbuseValidationError identifies database errors caused by invalid input
+// or violated abuse-control constraints. Unexpected transaction/store errors
+// must remain internal failures so callers can retry them appropriately.
+func isAbuseValidationError(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return strings.HasPrefix(pgErr.Code, "22") || strings.HasPrefix(pgErr.Code, "23")
+}
+
+func (h *Handlers) ReleasePlatformAbuseRestriction(c *gin.Context) {
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	id, err := parseUUIDParam(c, "restriction_id")
+	if err != nil {
+		return
+	}
+	err = h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		result, err := tx.Exec(c, `UPDATE abuse_restrictions SET released_at=now(),released_by=$2,updated_at=now() WHERE id=$1 AND released_at IS NULL`, id, actor)
+		if err != nil {
+			return err
+		}
+		if result.RowsAffected() != 1 {
+			return ErrConflict
+		}
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(reason) VALUES('restriction released')`); err != nil {
+			return err
+		}
+		auditValue, err := json.Marshal(struct {
+			ID       uuid.UUID `json:"id"`
+			Released bool      `json:"released"`
+		}{id, true})
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,event_type,new_value) VALUES($1,'abuse.restriction.released',$2)`, actor, auditValue)
+		return err
+	})
+	if err != nil {
+		if errors.Is(err, ErrConflict) {
+			respondError(c, err)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+func (h *Handlers) RecordPlatformAbuseRefresh(c *gin.Context) {
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	var in struct {
+		TeamID *uuid.UUID `json:"team_id"`
+		Reason string     `json:"reason"`
+	}
+	if c.ShouldBindJSON(&in) != nil {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	err := h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(team_id,reason) VALUES($1,COALESCE(NULLIF($2,''),'refresh requested'))`, in.TeamID, in.Reason); err != nil {
+			return err
+		}
+		_, err := tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,team_id,event_type,metadata) VALUES($1,$2,'abuse.state.refresh_requested',$3)`, actor, in.TeamID, []byte(`{"source":"platform_admin"}`))
+		return err
+	})
+	if err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handlers) ListPlatformAbuseTrustedIdentities(c *gin.Context) {
+	if _, ok := h.requireAbuse(c, false); !ok {
+		return
+	}
+	rows, err := h.Pool.Query(c, `SELECT id,auth_provider,domain,source,evidence,created_at,updated_at,revoked_at FROM abuse_trusted_identities ORDER BY domain`)
+	if err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	defer rows.Close()
+	out := []gin.H{}
+	for rows.Next() {
+		var id uuid.UUID
+		var p, d, s string
+		var ev []byte
+		var cr, up time.Time
+		var rv *time.Time
+		if err := rows.Scan(&id, &p, &d, &s, &ev, &cr, &up, &rv); err != nil {
+			respondError(c, ErrInternal)
+			return
+		}
+		out = append(out, gin.H{"id": id, "auth_provider": p, "domain": d, "source": s, "evidence": json.RawMessage(ev), "created_at": cr, "updated_at": up, "revoked_at": rv})
+	}
+	if err := rows.Err(); err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}
+func (h *Handlers) AddPlatformAbuseTrustedIdentity(c *gin.Context) {
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	var in struct {
+		AuthProvider string          `json:"auth_provider"`
+		Domain       string          `json:"domain"`
+		Source       string          `json:"source"`
+		Evidence     json.RawMessage `json:"evidence"`
+	}
+	if c.ShouldBindJSON(&in) != nil {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	p := strings.ToLower(strings.TrimSpace(in.AuthProvider))
+	d, e := abuse.NormalizeDomain(in.Domain)
+	if p == "" || e != nil {
+		respondError(c, ErrBadRequest)
+		return
+	}
+	if len(in.Evidence) == 0 {
+		in.Evidence = []byte(`{}`)
+	}
+	source := strings.TrimSpace(in.Source)
+	if source == "" {
+		source = "platform_admin"
+	}
+	id := uuid.New()
+	e = h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(c, `INSERT INTO abuse_trusted_identities(id,auth_provider,domain,source,evidence) VALUES($1,$2,$3,$4,$5)`, id, p, d, source, in.Evidence); err != nil {
+			return err
+		}
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(reason) VALUES('trusted identity changed')`); err != nil {
+			return err
+		}
+		auditValue, err := json.Marshal(struct {
+			ID           uuid.UUID       `json:"id"`
+			State        string          `json:"state"`
+			AuthProvider string          `json:"auth_provider"`
+			Domain       string          `json:"domain"`
+			Source       string          `json:"source"`
+			Evidence     json.RawMessage `json:"evidence"`
+		}{id, "active", p, d, source, in.Evidence})
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,event_type,new_value) VALUES($1,'abuse.trusted_identity.created',$2)`, actor, auditValue)
+		return err
+	})
+	if e != nil {
+		if isAbuseValidationError(e) {
+			respondError(c, ErrBadRequest)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"id": id})
+}
+func (h *Handlers) RevokePlatformAbuseTrustedIdentity(c *gin.Context) {
+	actor, ok := h.requireAbuse(c, true)
+	if !ok {
+		return
+	}
+	id, e := parseUUIDParam(c, "identity_id")
+	if e != nil {
+		return
+	}
+	e = h.withAbuseMutation(c, func(tx pgx.Tx) error {
+		result, err := tx.Exec(c, `UPDATE abuse_trusted_identities SET revoked_at=now(),updated_at=now() WHERE id=$1 AND revoked_at IS NULL`, id)
+		if err != nil {
+			return err
+		}
+		if result.RowsAffected() != 1 {
+			return ErrConflict
+		}
+		if _, err := tx.Exec(c, `INSERT INTO abuse_state_changes(reason) VALUES('trusted identity changed')`); err != nil {
+			return err
+		}
+		auditValue, err := json.Marshal(struct {
+			ID      uuid.UUID `json:"id"`
+			State   string    `json:"state"`
+			Revoked bool      `json:"revoked"`
+		}{id, "revoked", true})
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(c, `INSERT INTO audit_logs(actor_user_id,event_type,new_value) VALUES($1,'abuse.trusted_identity.revoked',$2)`, actor, auditValue)
+		return err
+	})
+	if e != nil {
+		if errors.Is(e, ErrConflict) {
+			respondError(c, ErrConflict)
+		} else {
+			respondError(c, ErrInternal)
+		}
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -116,6 +116,17 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 	{
 		operator.GET("/hosts", h.HostList)
 		operator.POST("/hosts/:host_id/status", h.HostUpdateStatus)
+		// Abuse controls require the operator credential; the host-shared
+		// internal token must not be sufficient to grant or remove trust.
+		operator.GET("/abuse/teams/:team_id/trust", h.GetPlatformAbuseTeamTrust)
+		operator.PUT("/abuse/teams/:team_id/trust", h.SetPlatformAbuseTeamTrust)
+		operator.GET("/abuse/restrictions", h.ListPlatformAbuseRestrictions)
+		operator.POST("/abuse/restrictions", h.CreatePlatformAbuseRestriction)
+		operator.POST("/abuse/restrictions/:restriction_id/release", h.ReleasePlatformAbuseRestriction)
+		operator.POST("/abuse/refresh", h.RecordPlatformAbuseRefresh)
+		operator.GET("/abuse/trusted-identities", h.ListPlatformAbuseTrustedIdentities)
+		operator.POST("/abuse/trusted-identities", h.AddPlatformAbuseTrustedIdentity)
+		operator.POST("/abuse/trusted-identities/:identity_id/revoke", h.RevokePlatformAbuseTrustedIdentity)
 	}
 
 	// Internal endpoints — authenticated via a shared token (not per-team

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -151,6 +151,54 @@ func (ns NullTemplateStatus) Value() (driver.Value, error) {
 	return string(ns.TemplateStatus), nil
 }
 
+type AbuseRestriction struct {
+	ID            uuid.UUID          `json:"id"`
+	SubjectType   string             `json:"subject_type"`
+	SubjectValue  string             `json:"subject_value"`
+	SubjectUserID pgtype.UUID        `json:"subject_user_id"`
+	SubjectTeamID pgtype.UUID        `json:"subject_team_id"`
+	Action        string             `json:"action"`
+	Source        string             `json:"source"`
+	Reason        string             `json:"reason"`
+	Evidence      []byte             `json:"evidence"`
+	CreatedBy     pgtype.UUID        `json:"created_by"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
+	ExpiresAt     pgtype.Timestamptz `json:"expires_at"`
+	ReleasedAt    pgtype.Timestamptz `json:"released_at"`
+	ReleasedBy    pgtype.UUID        `json:"released_by"`
+}
+
+type AbuseStateChange struct {
+	ID         int64       `json:"id"`
+	TeamID     pgtype.UUID `json:"team_id"`
+	Generation int64       `json:"generation"`
+	Reason     string      `json:"reason"`
+	CreatedAt  time.Time   `json:"created_at"`
+}
+
+type AbuseTeamTrust struct {
+	TeamID    uuid.UUID          `json:"team_id"`
+	Verified  bool               `json:"verified"`
+	Source    string             `json:"source"`
+	Reason    *string            `json:"reason"`
+	Evidence  []byte             `json:"evidence"`
+	CreatedAt time.Time          `json:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at"`
+	RevokedAt pgtype.Timestamptz `json:"revoked_at"`
+}
+
+type AbuseTrustedIdentity struct {
+	ID           uuid.UUID          `json:"id"`
+	AuthProvider string             `json:"auth_provider"`
+	Domain       string             `json:"domain"`
+	Source       string             `json:"source"`
+	Evidence     []byte             `json:"evidence"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
+	RevokedAt    pgtype.Timestamptz `json:"revoked_at"`
+}
+
 type Activity struct {
 	ID           uuid.UUID   `json:"id"`
 	SandboxID    pgtype.UUID `json:"sandbox_id"`

--- a/internal/integration/abuse_control_plane_test.go
+++ b/internal/integration/abuse_control_plane_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestPlatformAbuseControlPlaneRoutes(t *testing.T) {
+	ctx := context.Background()
+	teamID := mustCreateTeam(t, ctx, "abuse-control-"+uuid.NewString()[:8])
+	adminID := seedPlatformAdminProfile(t)
+	nonAdminID := seedSuperserveEmailProfile(t)
+	r := newInternalRouter(t)
+
+	// Internal authentication and the dedicated permission are both required,
+	// even for read-only abuse-control operations.
+	if w := doInternal(r, http.MethodGet, "/internal/abuse/teams/"+teamID.String()+"/trust", nonAdminID.String(), ""); w.Code != http.StatusForbidden {
+		t.Fatalf("non-admin trust read status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+
+	trustPath := "/internal/abuse/teams/" + teamID.String() + "/trust"
+	if w := doInternal(r, http.MethodPut, trustPath, nonAdminID.String(), `{"verified":true}`); w.Code != http.StatusForbidden {
+		t.Fatalf("non-admin trust write status = %d, want 403: %s", w.Code, w.Body.String())
+	}
+	if w := doInternal(r, http.MethodPut, trustPath, adminID.String(), `{"verified":true,"reason":"approved team","evidence":{"source":"review"}}`); w.Code != http.StatusNoContent {
+		t.Fatalf("set team trust status = %d, want 204: %s", w.Code, w.Body.String())
+	}
+	trustRead := doInternal(r, http.MethodGet, trustPath, adminID.String(), "")
+	if trustRead.Code != http.StatusOK {
+		t.Fatalf("get team trust status = %d, want 200: %s", trustRead.Code, trustRead.Body.String())
+	}
+	var trust struct {
+		Verified bool `json:"verified"`
+	}
+	if err := json.Unmarshal(trustRead.Body.Bytes(), &trust); err != nil {
+		t.Fatalf("decode team trust: %v", err)
+	}
+	if !trust.Verified {
+		t.Fatal("team trust readback is not verified")
+	}
+	if auditEventCount(t, ctx, teamID, "abuse.team_trust.changed") == 0 {
+		t.Fatal("expected team trust audit row")
+	}
+
+	create := doInternal(r, http.MethodPost, "/internal/abuse/restrictions", adminID.String(), `{"subject_type":"ip","subject_value":"192.0.2.10","action":"create","reason":"test restriction","evidence":{"case":"integration"}}`)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create restriction status = %d, want 201: %s", create.Code, create.Body.String())
+	}
+	var created struct {
+		ID uuid.UUID `json:"id"`
+	}
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil || created.ID == uuid.Nil {
+		t.Fatalf("decode created restriction: %v, body=%s", err, create.Body.String())
+	}
+	list := doInternal(r, http.MethodGet, "/internal/abuse/restrictions", adminID.String(), "")
+	var activeRestrictions []struct {
+		ID uuid.UUID `json:"id"`
+	}
+	if list.Code != http.StatusOK || json.Unmarshal(list.Body.Bytes(), &activeRestrictions) != nil || len(activeRestrictions) == 0 {
+		t.Fatalf("restriction list status/body = %d/%s, want active restriction", list.Code, list.Body.String())
+	}
+	var restrictionAudit int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM audit_logs WHERE actor_user_id=$1 AND event_type='abuse.restriction.created'`, adminID).Scan(&restrictionAudit); err != nil {
+		t.Fatalf("count restriction audit rows: %v", err)
+	}
+	if restrictionAudit == 0 {
+		t.Fatal("expected restriction creation audit row")
+	}
+
+	releasePath := "/internal/abuse/restrictions/" + created.ID.String() + "/release"
+	if w := doInternal(r, http.MethodPost, releasePath, adminID.String(), ""); w.Code != http.StatusNoContent {
+		t.Fatalf("release restriction status = %d, want 204: %s", w.Code, w.Body.String())
+	}
+	listAfterRelease := doInternal(r, http.MethodGet, "/internal/abuse/restrictions", adminID.String(), "")
+	var releasedRestrictions []struct {
+		ID uuid.UUID `json:"id"`
+	}
+	if listAfterRelease.Code != http.StatusOK || json.Unmarshal(listAfterRelease.Body.Bytes(), &releasedRestrictions) != nil || len(releasedRestrictions) != 0 {
+		t.Fatalf("released restriction list = %d/%s, want empty", listAfterRelease.Code, listAfterRelease.Body.String())
+	}
+	var releaseAudit int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM audit_logs WHERE actor_user_id=$1 AND event_type='abuse.restriction.released'`, adminID).Scan(&releaseAudit); err != nil {
+		t.Fatalf("count release audit rows: %v", err)
+	}
+	if releaseAudit == 0 {
+		t.Fatal("expected restriction release audit row")
+	}
+
+	identity := doInternal(r, http.MethodPost, "/internal/abuse/trusted-identities", adminID.String(), `{"auth_provider":"Google","domain":"example.test","evidence":{"approved":true}}`)
+	if identity.Code != http.StatusCreated {
+		t.Fatalf("add trusted identity status = %d, want 201: %s", identity.Code, identity.Body.String())
+	}
+	var createdIdentity struct {
+		ID uuid.UUID `json:"id"`
+	}
+	if err := json.Unmarshal(identity.Body.Bytes(), &createdIdentity); err != nil || createdIdentity.ID == uuid.Nil {
+		t.Fatalf("decode trusted identity: %v, body=%s", err, identity.Body.String())
+	}
+	if w := doInternal(r, http.MethodPost, "/internal/abuse/trusted-identities/"+createdIdentity.ID.String()+"/revoke", adminID.String(), ""); w.Code != http.StatusNoContent {
+		t.Fatalf("revoke trusted identity status = %d, want 204: %s", w.Code, w.Body.String())
+	}
+	if w := doInternal(r, http.MethodPost, "/internal/abuse/refresh", adminID.String(), fmt.Sprintf(`{"team_id":%q,"reason":"refresh after change"}`, teamID)); w.Code != http.StatusNoContent {
+		t.Fatalf("record refresh status = %d, want 204: %s", w.Code, w.Body.String())
+	}
+	var refreshAudit int
+	if err := testPool.QueryRow(ctx, `SELECT COUNT(*) FROM audit_logs WHERE team_id=$1 AND event_type='abuse.state.refresh_requested'`, teamID).Scan(&refreshAudit); err != nil {
+		t.Fatalf("count refresh audit rows: %v", err)
+	}
+	if refreshAudit == 0 {
+		t.Fatal("expected refresh audit row")
+	}
+}

--- a/internal/integration/rbac_phase1_test.go
+++ b/internal/integration/rbac_phase1_test.go
@@ -65,6 +65,8 @@ func TestRbacSeedData(t *testing.T) {
 		"platform:team_users:write",
 		"platform:team_roles:write",
 		"platform:billing:write",
+		"platform:abuse:read",
+		"platform:abuse:write",
 	}
 	var gotPerms []string
 	rows, err = testPool.Query(ctx, `SELECT name FROM permissions ORDER BY name`)
@@ -100,6 +102,8 @@ func TestRbacSeedData(t *testing.T) {
 			"platform:team_users:write",
 			"platform:team_roles:write",
 			"platform:billing:write",
+			"platform:abuse:read",
+			"platform:abuse:write",
 			"billing:read",
 			"billing:write",
 			"users:read",

--- a/internal/integration/rbac_phase2b_test.go
+++ b/internal/integration/rbac_phase2b_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const internalRBACToken = "integration-rbac-phase2b-token"
+const operatorRBACToken = "integration-operator-rbac-phase2b-token"
 
 func newInternalRouter(t *testing.T) *gin.Engine {
 	return newInternalRouterWithNow(t, nil)
@@ -28,6 +29,7 @@ func newInternalRouter(t *testing.T) *gin.Engine {
 func newInternalRouterWithNow(t *testing.T, now func() time.Time) *gin.Engine {
 	t.Helper()
 	t.Setenv("INTERNAL_API_TOKEN", internalRBACToken)
+	t.Setenv("OPERATOR_API_TOKEN", operatorRBACToken)
 	return newRouterWithNow(t, now)
 }
 
@@ -38,7 +40,11 @@ func doInternal(r *gin.Engine, method, path, actorID, body string) *httptest.Res
 	}
 	req := httptest.NewRequest(method, path, bodyReader)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+internalRBACToken)
+	token := internalRBACToken
+	if strings.HasPrefix(path, "/internal/abuse/") {
+		token = operatorRBACToken
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 	if actorID != "" {
 		req.Header.Set("X-Actor-User-Id", actorID)
 	}

--- a/supabase/migrations/20260826000001_abuse_control_plane.sql
+++ b/supabase/migrations/20260826000001_abuse_control_plane.sql
@@ -1,0 +1,95 @@
+-- Durable abuse control-plane state.  Enforcement consumers read these tables
+-- directly; no lifecycle cache or worker is owned by this migration.
+CREATE TABLE IF NOT EXISTS abuse_team_trust (
+    team_id uuid PRIMARY KEY REFERENCES team(id) ON DELETE CASCADE,
+    verified boolean NOT NULL DEFAULT false,
+    source text NOT NULL DEFAULT 'platform_admin',
+    reason text,
+    evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS abuse_trusted_identities (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    auth_provider text NOT NULL,
+    domain text NOT NULL,
+    source text NOT NULL DEFAULT 'platform_admin',
+    evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    revoked_at timestamptz
+);
+-- A revoked association remains auditable while allowing the same identity to
+-- be trusted again through a new active row.
+ALTER TABLE abuse_trusted_identities
+    DROP CONSTRAINT IF EXISTS abuse_trusted_identities_auth_provider_domain_key;
+CREATE UNIQUE INDEX IF NOT EXISTS abuse_trusted_identity_active_unique
+    ON abuse_trusted_identities (auth_provider, domain)
+    WHERE revoked_at IS NULL;
+ALTER TABLE abuse_trusted_identities ADD CONSTRAINT abuse_trusted_identity_canonical
+    CHECK (auth_provider = lower(trim(auth_provider)) AND domain = lower(trim(domain))
+           AND domain <> '' AND domain NOT LIKE '%*%' AND domain NOT LIKE '%/%');
+
+CREATE TABLE IF NOT EXISTS abuse_restrictions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    subject_type text NOT NULL,
+    subject_value text NOT NULL,
+    subject_user_id uuid,
+    subject_team_id uuid REFERENCES team(id) ON DELETE CASCADE,
+    action text NOT NULL,
+    source text NOT NULL,
+    reason text NOT NULL,
+    evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_by uuid,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz,
+    released_at timestamptz,
+    released_by uuid,
+    CONSTRAINT abuse_restriction_subject_type CHECK (subject_type IN ('user','team','ip','domain')),
+    CONSTRAINT abuse_restriction_action CHECK (action IN ('signup','create','resume')),
+    CONSTRAINT abuse_restriction_subject_shape CHECK (
+      (subject_type = 'user' AND subject_user_id IS NOT NULL AND subject_team_id IS NULL) OR
+      (subject_type = 'team' AND subject_team_id IS NOT NULL AND subject_user_id IS NULL) OR
+      (subject_type IN ('ip','domain') AND subject_user_id IS NULL AND subject_team_id IS NULL)
+    ),
+    CONSTRAINT abuse_restriction_exact_subject CHECK (
+      (subject_type <> 'ip' OR (subject_value NOT LIKE '%/%' AND subject_value NOT LIKE '%*%')) AND
+      (subject_type <> 'domain' OR (subject_value = lower(trim(subject_value)) AND subject_value NOT LIKE '%*%' AND subject_value NOT LIKE '%/%'))
+    )
+);
+CREATE INDEX IF NOT EXISTS idx_abuse_restrictions_active
+ ON abuse_restrictions(subject_type, subject_value, action)
+ WHERE released_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_abuse_restrictions_team_active
+ ON abuse_restrictions(subject_team_id, action) WHERE released_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_abuse_restrictions_user_active
+ ON abuse_restrictions(subject_user_id, action) WHERE released_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS abuse_state_changes (
+    id bigserial PRIMARY KEY,
+    team_id uuid REFERENCES team(id) ON DELETE CASCADE,
+    generation bigint NOT NULL DEFAULT 1,
+    reason text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_abuse_state_changes_cursor ON abuse_state_changes(id);
+
+-- These tables hold sensitive trust, restriction, and evidence state.  Keep
+-- them inaccessible to anon/authenticated clients; control-plane handlers use
+-- the service role after platform authorization.
+ALTER TABLE abuse_team_trust ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_trusted_identities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_restrictions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE abuse_state_changes ENABLE ROW LEVEL SECURITY;
+
+INSERT INTO permissions (name, description) VALUES
+ ('platform:abuse:read', 'Inspect abuse trust and restrictions'),
+ ('platform:abuse:write', 'Mutate abuse trust and restrictions')
+ON CONFLICT (name) DO UPDATE SET description = EXCLUDED.description, updated_at = now();
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'platform_admin' AND p.name IN ('platform:abuse:read','platform:abuse:write')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- add durable team trust, trusted corporate identity associations, and contextual abuse restrictions
- protect abuse-control operations with dedicated operator authentication and audited admin mutations
- expose the authoritative state/invalidation contract consumed by later phases without implementing the lifecycle cache

## Testing

- focused integration coverage for trust precedence, restriction actions, authorization, auditing, and reversibility
- `go test ./internal/api -run '^$'`\n- `git diff --check`\n\nKnown limitation: the full unit suite requires local listener permissions unavailable in this sandbox.