### PR TITLE
vmd: read stalled-guest RIPs from the kvm_entry tracepoint

### DIFF
--- a/internal/vm/stall_diag.go
+++ b/internal/vm/stall_diag.go
@@ -35,11 +35,9 @@ const (
 	stallDiagSettle     = 2 * time.Second
 	stallDiagPerfWindow = 3 * time.Second
 
-	// A stall means the host may already be struggling, so the profile is
-	// deliberately coarse: ~100 Hz is ample to identify a loop the guest has
-	// been spinning in for seconds, and the size cap bounds the write even if
-	// the rate assumption is ever wrong.
-	stallDiagPerfHz      = "97"
+	// kvm_entry fires per VM entry — a few thousand per second on a spinning
+	// vCPU — so the size cap bounds the recording even if a guest exits far
+	// more often than any observed stall.
 	stallDiagPerfMaxSize = "32M"
 
 	// Caps the battery so it can never outlive the readiness window and
@@ -440,33 +438,33 @@ func perfIsUsable(parent context.Context) bool {
 	}
 	// A command that ran gives a deterministic answer: the distribution stub
 	// prints an "install linux-tools-<kernel>" notice instead of profiling.
+	// Only the positive verdict is cached — perf can be installed out-of-band
+	// under a running daemon, and re-probing a stub costs one cheap
+	// subprocess per stall.
 	ok := !strings.Contains(string(out), "linux-tools")
-	perfUsable.Store(&ok)
+	if ok {
+		perfUsable.Store(&ok)
+	}
 	return ok
 }
 
-// guestSampleLine matches a perf script line of the form "<ip> <dso>", where
-// the dso identifies which address space the sample came from.
-var guestSampleLine = regexp.MustCompile(`(?m)^\s*([0-9a-f]{6,16})\s+(\S.*)$`)
+// kvmEntryLine matches one perf-script kvm:kvm_entry event, capturing which
+// vCPU entered guest mode and the guest RIP it entered at. The comma between
+// the fields is optional: the tracepoint's print format differs across kernel
+// versions ("vcpu 0 rip 0x..." vs "vcpu 0, rip 0x...").
+var kvmEntryLine = regexp.MustCompile(`kvm_entry:\s+vcpu (\d+),?\s+rip 0x([0-9a-f]+)`)
 
-// guestDSO reports whether a perf dso field denotes guest address space.
-// perf labels guest samples with a guest-specific dso; anything else is a
-// host address inside Firecracker or the kernel.
-func guestDSO(dso string) bool {
-	return strings.Contains(strings.ToLower(dso), "guest")
-}
-
-// sampleGuestIPs profiles the stalled VM and returns distinct GUEST
-// instruction pointers, most frequent first.
+// sampleGuestIPs records where the guest is executing and returns distinct
+// per-vCPU guest instruction pointers, most frequent first, each rendered as
+// "v<cpu>:<rip>:<count>".
 //
-// Two things make this trustworthy rather than merely plausible. It records
-// through `perf kvm --guest`, which is the interface built for guest
-// profiling — plain `perf record` on the pid samples the host side and would
-// hand back Firecracker and KVM addresses. And it keeps only samples perf
-// attributes to guest address space, so an address is either provably from
-// the guest or absent: reporting a host address as a guest RIP would send a
-// reader to resolve it against guest symbols and arrive at confident
-// nonsense, which is worse than reporting nothing.
+// It reads the kvm:kvm_entry tracepoint rather than sampling with the PMU:
+// KVM logs the guest RIP on every VM entry, entirely host-side, so this works
+// where guest PMU sampling is not virtualized and `perf kvm --guest record`
+// returns zero samples. A stalled vCPU still enters thousands of times a
+// second — the host timer tick alone forces exits — so the address it spins
+// at clusters sharply, and the halted vCPU's wake/halt cycle shows up as a
+// separate, sparser cluster under its own vcpu id.
 //
 // Addresses rather than symbols because the shipped guest kernel is stripped;
 // resolution happens offline against a kallsyms dump from a live guest of the
@@ -481,24 +479,22 @@ func sampleGuestIPs(ctx context.Context, pid int) []string {
 	}
 	defer os.RemoveAll(tmp)
 	data := filepath.Join(tmp, "perf.data")
-	rec := exec.CommandContext(ctx, "perf", "kvm", "--guest", "record",
-		"-F", stallDiagPerfHz, "--max-size", stallDiagPerfMaxSize,
+	rec := exec.CommandContext(ctx, "perf", "record", "-e", "kvm:kvm_entry",
+		"--max-size", stallDiagPerfMaxSize,
 		"-p", strconv.Itoa(pid), "-o", data, "--", "sleep",
 		strconv.Itoa(int(stallDiagPerfWindow/time.Second)))
 	if err := rec.Run(); err != nil {
 		return nil
 	}
-	script := exec.CommandContext(ctx, "perf", "script", "-i", data, "-F", "ip,dso")
+	script := exec.CommandContext(ctx, "perf", "script", "-i", data)
 	out, err := script.Output()
 	if err != nil {
 		return nil
 	}
 
 	counts := map[string]int{}
-	for _, m := range guestSampleLine.FindAllStringSubmatch(string(out), -1) {
-		if guestDSO(m[2]) {
-			counts[m[1]]++
-		}
+	for _, m := range kvmEntryLine.FindAllStringSubmatch(string(out), -1) {
+		counts["v"+m[1]+":"+m[2]]++
 	}
 	ips := make([]string, 0, len(counts))
 	for ip := range counts {

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -222,34 +222,34 @@ func TestPerfStubIsNotTreatedAsUsable(t *testing.T) {
 	}
 }
 
-func TestOnlyGuestSamplesAreReported(t *testing.T) {
-	// A host address reported as a guest RIP would be resolved against guest
-	// symbols and yield confident nonsense — worse than reporting nothing.
-	sample := "" +
-		"    ffffffff810a2b40 [guest.kernel.kallsyms]\n" +
-		"    ffffffff810a2b40 [guest.kernel.kallsyms]\n" +
-		"    00007f9c0a1b2c3d /usr/local/bin/firecracker\n" +
-		"    ffffffff81abcdef [kernel.kallsyms]\n"
+func TestKvmEntryLinesYieldPerVcpuRIPs(t *testing.T) {
+	// The tracepoint stream interleaves entries from every vCPU with other
+	// kvm events. Only kvm_entry lines carry a guest RIP; counting anything
+	// else (kvm_exit reasons, msr writes) would corrupt the histogram, and
+	// losing the vcpu id would merge the spinning vCPU's cluster with the
+	// halted one's — the distinction is the entire finding.
+	// First three lines are verbatim perf-script output from a production
+	// host; the comma variant covers kernels whose print format includes it.
+	out := "" +
+		"       fc_vcpu 1  599500 [039] 1377662.550600: kvm:kvm_entry:  vcpu 1 rip 0xffffffff81036706\n" +
+		"       fc_vcpu 1  599500 [039] 1377662.550637: kvm:kvm_entry:  vcpu 1 rip 0xffffffff81036706\n" +
+		"       fc_vcpu 0  599499 [002] 1377662.550644: kvm:kvm_entry:  vcpu 0 rip 0xffffffff815cf36e\n" +
+		" fc_vcpu 1 2335220 [069] 12345.679150: kvm:kvm_entry: vcpu 1, rip 0xffffffff81036706\n" +
+		" fc_vcpu 1 2335220 [069] 12345.679200: kvm:kvm_exit: reason EXTERNAL_INTERRUPT rip 0xffffffff81036706 info1 0\n" +
+		" fc_vcpu 1 2335220 [069] 12345.679300: kvm:kvm_msr: msr_write 6e0 = 0x1fb1e5ac1f9\n"
 
-	var guest, host int
-	for _, m := range guestSampleLine.FindAllStringSubmatch(sample, -1) {
-		if guestDSO(m[2]) {
-			guest++
-		} else {
-			host++
-		}
+	counts := map[string]int{}
+	for _, m := range kvmEntryLine.FindAllStringSubmatch(out, -1) {
+		counts["v"+m[1]+":"+m[2]]++
 	}
-	if guest != 2 {
-		t.Fatalf("guest samples = %d, want 2", guest)
+	if counts["v1:ffffffff81036706"] != 3 {
+		t.Fatalf("spinning vCPU cluster = %d, want 3 (both print formats must count)", counts["v1:ffffffff81036706"])
 	}
-	if host != 2 {
-		t.Fatalf("host samples = %d, want 2 (they must be recognized and excluded)", host)
+	if counts["v0:ffffffff815cf36e"] != 1 {
+		t.Fatalf("halted vCPU entry = %d, want 1", counts["v0:ffffffff815cf36e"])
 	}
-	if guestDSO("/usr/local/bin/firecracker") || guestDSO("[kernel.kallsyms]") {
-		t.Fatal("host dso classified as guest")
-	}
-	if !guestDSO("[guest.kernel.kallsyms]") {
-		t.Fatal("guest dso not recognized")
+	if len(counts) != 2 {
+		t.Fatalf("non-entry events leaked into the histogram: %v", counts)
 	}
 }
 

--- a/internal/vm/stall_diag_test.go
+++ b/internal/vm/stall_diag_test.go
@@ -228,25 +228,25 @@ func TestKvmEntryLinesYieldPerVcpuRIPs(t *testing.T) {
 	// else (kvm_exit reasons, msr writes) would corrupt the histogram, and
 	// losing the vcpu id would merge the spinning vCPU's cluster with the
 	// halted one's — the distinction is the entire finding.
-	// First three lines are verbatim perf-script output from a production
-	// host; the comma variant covers kernels whose print format includes it.
+	// Both print formats perf emits for this tracepoint: some kernels write
+	// "vcpu N rip 0x...", others "vcpu N, rip 0x...". Both must count.
 	out := "" +
-		"       fc_vcpu 1  599500 [039] 1377662.550600: kvm:kvm_entry:  vcpu 1 rip 0xffffffff81036706\n" +
-		"       fc_vcpu 1  599500 [039] 1377662.550637: kvm:kvm_entry:  vcpu 1 rip 0xffffffff81036706\n" +
-		"       fc_vcpu 0  599499 [002] 1377662.550644: kvm:kvm_entry:  vcpu 0 rip 0xffffffff815cf36e\n" +
-		" fc_vcpu 1 2335220 [069] 12345.679150: kvm:kvm_entry: vcpu 1, rip 0xffffffff81036706\n" +
-		" fc_vcpu 1 2335220 [069] 12345.679200: kvm:kvm_exit: reason EXTERNAL_INTERRUPT rip 0xffffffff81036706 info1 0\n" +
-		" fc_vcpu 1 2335220 [069] 12345.679300: kvm:kvm_msr: msr_write 6e0 = 0x1fb1e5ac1f9\n"
+		"       fc_vcpu 1   11111 [007] 1000.000100: kvm:kvm_entry:  vcpu 1 rip 0xffffffffaaaa1111\n" +
+		"       fc_vcpu 1   11111 [007] 1000.000200: kvm:kvm_entry:  vcpu 1 rip 0xffffffffaaaa1111\n" +
+		"       fc_vcpu 0   11110 [003] 1000.000300: kvm:kvm_entry:  vcpu 0 rip 0xffffffffbbbb2222\n" +
+		" fc_vcpu 1 11111 [007] 1000.000400: kvm:kvm_entry: vcpu 1, rip 0xffffffffaaaa1111\n" +
+		" fc_vcpu 1 11111 [007] 1000.000500: kvm:kvm_exit: reason EXTERNAL_INTERRUPT rip 0xffffffffaaaa1111 info1 0\n" +
+		" fc_vcpu 1 11111 [007] 1000.000600: kvm:kvm_msr: msr_write 6e0 = 0x1234abcd\n"
 
 	counts := map[string]int{}
 	for _, m := range kvmEntryLine.FindAllStringSubmatch(out, -1) {
 		counts["v"+m[1]+":"+m[2]]++
 	}
-	if counts["v1:ffffffff81036706"] != 3 {
-		t.Fatalf("spinning vCPU cluster = %d, want 3 (both print formats must count)", counts["v1:ffffffff81036706"])
+	if counts["v1:ffffffffaaaa1111"] != 3 {
+		t.Fatalf("spinning vCPU cluster = %d, want 3 (both print formats must count)", counts["v1:ffffffffaaaa1111"])
 	}
-	if counts["v0:ffffffff815cf36e"] != 1 {
-		t.Fatalf("halted vCPU entry = %d, want 1", counts["v0:ffffffff815cf36e"])
+	if counts["v0:ffffffffbbbb2222"] != 1 {
+		t.Fatalf("halted vCPU entry = %d, want 1", counts["v0:ffffffffbbbb2222"])
 	}
 	if len(counts) != 2 {
 		t.Fatalf("non-entry events leaked into the histogram: %v", counts)


### PR DESCRIPTION
## What

Replaces the guest instruction-pointer sampling in the stall diagnostics: instead of `perf kvm --guest record` (PMU sampling), record the `kvm:kvm_entry` tracepoint and histogram the guest RIP per vCPU.

## Why

Guest PMU sampling is not virtualized on our hosts — `perf kvm --guest record` runs cleanly but captures zero guest samples, which is why the `guest_ips` field of every stall specimen so far has been empty. The `kvm_entry` tracepoint is host-side: KVM logs the guest RIP on every VM entry, no guest PMU involved. A stalled vCPU still enters thousands of times per second (the host timer tick alone forces exits), so the address it spins at clusters sharply — validated against a live guest before writing this change.

Reporting is now per-vCPU (`v<cpu>:<rip>:<count>`), which separates the spinning vCPU's cluster from the halted one's — the distinction the diagnosis rests on.

Also: a perf probe that reaches the distribution stub is no longer cached negatively, so installing the real perf under a running daemon takes effect on the next stall instead of requiring a restart.

## Testing

- The parsing regex was validated against real `perf script` output before writing the fixture — the tracepoint's print format varies across kernel versions (`vcpu N rip 0x...` vs `vcpu N, rip 0x...`), and the test covers both.
- Full `internal/vm` suite in a linux container: pass.
- `GOOS=linux go vet` and full build: clean.