### PR TITLE
ci: deploy a published Firecracker release to the sandbox hosts

### DIFF
--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -28,6 +28,13 @@ on:
           - staging
           - production
 
+# One rollout at a time, and never cancelled: two overlapping dispatches for
+# different versions could interleave their per-host loops and leave a cell on
+# mixed digests, with both runs reporting success.
+concurrency:
+  group: deploy-firecracker
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write
@@ -47,15 +54,19 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      - name: Install ${{ inputs.version }}
+      # The dispatch input reaches the script through the environment, never
+      # through the run body: `${{ }}` is substituted before bash parses the
+      # script, so an interpolated tag could close the quoting and run
+      # arbitrary commands on a job that has already authenticated to GCP.
+      - name: Install
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          python3 .github/workflows/scripts/deploy-firecracker.py \
-            --version '${{ inputs.version }}'
+          python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"
 
   deploy-production:
     name: Production
@@ -73,12 +84,32 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      - name: Install ${{ inputs.version }}
+      # Production is two cells, and each is discovered by its own region: a
+      # single run scoped to one region would filter the other cell out
+      # entirely and still report success, leaving it on the old binary.
+      # Both are steps in this job rather than separate jobs, because a second
+      # job referencing the production environment would double any approval
+      # gate.
+      #
+      # use4 is the primary and is unguarded: a missing GCP_REGION_USE4 must
+      # fail the deploy rather than silently skip the primary cell.
+      - name: Install on the use4 cell
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
-          GCP_REGION: ${{ vars.GCP_REGION }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          python3 .github/workflows/scripts/deploy-firecracker.py \
-            --version '${{ inputs.version }}'
+          python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"
+
+      - name: Install on the usw cell
+        if: vars.GCP_REGION_USW != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USW }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -29,6 +29,10 @@ on:
         options:
           - staging
           - production
+      target_sha256:
+        description: 'Production only: sha256 of the binary verified on staging — pins production to those exact bytes'
+        required: false
+        type: string
       rollback_sha256:
         description: 'Production only: sha256 of the binary production runs today — the one staging verified rolling back to'
         required: false
@@ -86,12 +90,17 @@ jobs:
       # Installing proves only that the binary loads. Snapshot formats are
       # versioned, and the swap sits between what was written before it and
       # what is resumed after — in both directions, rollback included.
-      - name: Require the rollback digest
+      - name: Require the pinned digests
         env:
           ROLLBACK: ${{ inputs.rollback_sha256 }}
+          TARGET: ${{ inputs.target_sha256 }}
         run: |
           if ! printf '%s' "$ROLLBACK" | grep -qE '^[0-9a-f]{64}$'; then
             echo "::error::rollback_sha256 must be the sha256 of the binary production runs today (64 lowercase hex). Without it the staging verification is not bound to the binary these hosts would actually roll back to."
+            exit 1
+          fi
+          if ! printf '%s' "$TARGET" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "::error::target_sha256 must be the sha256 verified on staging (64 lowercase hex). Release assets can be replaced, so without it production is not bound to the bytes that were tested."
             exit 1
           fi
 
@@ -128,6 +137,7 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
           EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          TARGET_SHA256: ${{ inputs.target_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION" --preflight-only
@@ -140,6 +150,7 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
           EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          TARGET_SHA256: ${{ inputs.target_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION" --preflight-only
@@ -151,6 +162,7 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
           EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          TARGET_SHA256: ${{ inputs.target_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"
@@ -163,6 +175,7 @@ jobs:
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
           EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          TARGET_SHA256: ${{ inputs.target_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -142,8 +142,11 @@ jobs:
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION" --preflight-only
 
+      # Gated on whether the cell exists, not on the value that scopes it: a
+      # region left unset must abort in the script, not skip the cell and
+      # report success with it still on the old binary.
       - name: Preflight the usw cell
-        if: vars.GCP_REGION_USW != ''
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION_USW }}
@@ -168,7 +171,7 @@ jobs:
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"
 
       - name: Install on the usw cell
-        if: vars.GCP_REGION_USW != ''
+        if: vars.CLOUD_RUN_SERVICE_USW != ''
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION_USW }}

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -4,8 +4,9 @@
 # runs identical bytes. Production never deploys without staging first.
 #
 # Running sandboxes are unaffected; PAUSED ones are not. Resuming one launches
-# a fresh Firecracker from this path, so the new binary must restore a
-# snapshot the old one wrote — hence the cross-upgrade resume gate below.
+# a fresh Firecracker from this path, so snapshots have to survive the swap in
+# both directions — the new binary must read what the old one wrote, and a
+# rollback must read what the new one wrote. Hence the staging gate below.
 
 name: Deploy Firecracker
 
@@ -24,8 +25,8 @@ on:
         options:
           - staging
           - production
-      snapshot_compat_verified:
-        description: 'Production only: a sandbox paused BEFORE this version was installed on staging was resumed successfully AFTER'
+      staging_verified:
+        description: 'Production only: on staging, (1) a fresh sandbox created under this version works, (2) a sandbox paused before the install resumed after it, and (3) a sandbox paused under this version resumes under the version you would roll back to'
         required: false
         default: false
         type: boolean
@@ -74,14 +75,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      # Deploying only proves NEW sandboxes work; the paused fleet resumes
-      # under this binary. Pause on staging, install, then resume.
-      - name: Require the cross-upgrade resume check
+      # Installing proves only that the binary loads. Snapshot formats are
+      # versioned, and the swap sits between what was written before it and
+      # what is resumed after — in both directions, rollback included.
+      - name: Require staging verification
         env:
-          VERIFIED: ${{ inputs.snapshot_compat_verified }}
+          VERIFIED: ${{ inputs.staging_verified }}
         run: |
           if [ "$VERIFIED" != "true" ]; then
-            echo "::error::snapshot_compat_verified is not set — pause a sandbox on staging BEFORE installing this version, resume it AFTER, and confirm it works before deploying to production"
+            echo "::error::staging_verified is not set. On staging, confirm all three before deploying to production: (1) a fresh sandbox created under this version works; (2) a sandbox paused BEFORE the install resumes AFTER it; (3) a sandbox paused under this version resumes under the version you would roll back to — otherwise the rollout is forward-only and rollback will strand those sandboxes."
             exit 1
           fi
 

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -2,8 +2,15 @@
 #
 # Builds nothing: it installs a release built once in the fork, so every host
 # runs identical bytes. Production never deploys without staging first, same
-# discipline as the other deploys here. A swap only affects VMs launched
-# after it, so it is safe to run during traffic.
+# discipline as the other deploys here.
+#
+# A running sandbox is unaffected — its process is already executing and keeps
+# the old inode across the rename. A PAUSED one is not: it has no process, and
+# resuming it launches a fresh Firecracker from this path, so the new binary
+# must be able to restore a snapshot the old one wrote. Snapshot formats are
+# versioned and an incompatible one is refused, which is why production
+# requires that pause-then-resume-across-the-upgrade has been proven on
+# staging rather than only that new sandboxes work.
 
 name: Deploy Firecracker
 
@@ -22,6 +29,11 @@ on:
         options:
           - staging
           - production
+      snapshot_compat_verified:
+        description: 'Production only: a sandbox paused BEFORE this version was installed on staging was resumed successfully AFTER'
+        required: false
+        default: false
+        type: boolean
 
 # One rollout at a time: overlapping dispatches could interleave their
 # per-host loops and leave a cell on mixed digests, both reporting success.
@@ -67,6 +79,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # Deploying only proves new sandboxes work. The paused fleet resumes
+      # under this binary, so refuse until a resume ACROSS the upgrade has
+      # actually been observed on staging: pause a sandbox, install, resume it.
+      - name: Require the cross-upgrade resume check
+        env:
+          VERIFIED: ${{ inputs.snapshot_compat_verified }}
+        run: |
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::snapshot_compat_verified is not set — pause a sandbox on staging BEFORE installing this version, resume it AFTER, and confirm it works before deploying to production"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: google-github-actions/auth@v2

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -29,6 +29,10 @@ on:
         options:
           - staging
           - production
+      rollback_sha256:
+        description: 'Production only: sha256 of the binary production runs today — the one staging verified rolling back to'
+        required: false
+        type: string
       staging_verified:
         description: 'Production only: on staging, (1) a fresh sandbox created under this version works, (2) a sandbox paused before the install resumed after it, and (3) a sandbox paused under this version resumes under the version you would roll back to'
         required: false
@@ -82,6 +86,15 @@ jobs:
       # Installing proves only that the binary loads. Snapshot formats are
       # versioned, and the swap sits between what was written before it and
       # what is resumed after — in both directions, rollback included.
+      - name: Require the rollback digest
+        env:
+          ROLLBACK: ${{ inputs.rollback_sha256 }}
+        run: |
+          if ! printf '%s' "$ROLLBACK" | grep -qE '^[0-9a-f]{64}$'; then
+            echo "::error::rollback_sha256 must be the sha256 of the binary production runs today (64 lowercase hex). Without it the staging verification is not bound to the binary these hosts would actually roll back to."
+            exit 1
+          fi
+
       - name: Require staging verification
         env:
           VERIFIED: ${{ inputs.staging_verified }}
@@ -105,12 +118,39 @@ jobs:
       # Steps rather than jobs — a second job on the production environment
       # would double any approval gate. use4 is unguarded, so a missing
       # region fails the deploy rather than skipping the primary cell.
+      # Both cells are checked before either is changed: a second cell found
+      # on an unexpected binary should stop the rollout, not be discovered
+      # after the first has already been swapped.
+      - name: Preflight the use4 cell
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION" --preflight-only
+
+      - name: Preflight the usw cell
+        if: vars.GCP_REGION_USW != ''
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION_USW }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION" --preflight-only
+
       - name: Install on the use4 cell
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION_USE4 }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"
@@ -122,6 +162,7 @@ jobs:
           GCP_REGION: ${{ vars.GCP_REGION_USW }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -3,6 +3,10 @@
 # Builds nothing: it installs a release built once in the fork, so every host
 # runs identical bytes. Production never deploys without staging first.
 #
+# Host discovery matches the vmd deploy exactly, so standby hosts are out of
+# scope here for the same reasons they are there; a promoted standby needs the
+# current release installed and verified before it serves traffic.
+#
 # Running sandboxes are unaffected; PAUSED ones are not. Resuming one launches
 # a fresh Firecracker from this path, so snapshots have to survive the swap in
 # both directions — the new binary must read what the old one wrote, and a

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -70,12 +70,19 @@ jobs:
 
       # Input goes through the environment, not the run body: `${{ }}` is
       # substituted before bash parses, so a tag could inject commands.
+      # The pinned digests are empty on a staging-only dispatch, where they are
+      # what this run discovers. On a production dispatch they are set, and
+      # staging is then held to the same predecessor production is moving off
+      # — otherwise the "paused before, resumed after" test would have been run
+      # against whatever staging happened to be on.
       - name: Install
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
           GCP_REGION: ${{ vars.GCP_REGION }}
           VMD_LABEL: ${{ vars.VMD_LABEL }}
           VERSION: ${{ inputs.version }}
+          EXPECTED_CURRENT_SHA256: ${{ inputs.rollback_sha256 }}
+          TARGET_SHA256: ${{ inputs.target_sha256 }}
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py --version "$VERSION"

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -1,14 +1,9 @@
 # Deploy Firecracker — the VMM binary on the sandbox hosts.
 #
-# Unlike the other deploys this one builds nothing: it installs a published
-# release built once in the fork, so every host ends up running provably
-# identical bytes. Production never deploys without staging first, same
-# discipline as the other deploys here.
-#
-# A swap only affects VMs launched after it — running and paused sandboxes
-# keep the process and artifacts they already have — so this is safe to run
-# during traffic, and a cell stays on mixed versions until its sandboxes
-# recycle.
+# Builds nothing: it installs a release built once in the fork, so every host
+# runs identical bytes. Production never deploys without staging first, same
+# discipline as the other deploys here. A swap only affects VMs launched
+# after it, so it is safe to run during traffic.
 
 name: Deploy Firecracker
 
@@ -28,9 +23,8 @@ on:
           - staging
           - production
 
-# One rollout at a time, and never cancelled: two overlapping dispatches for
-# different versions could interleave their per-host loops and leave a cell on
-# mixed digests, with both runs reporting success.
+# One rollout at a time: overlapping dispatches could interleave their
+# per-host loops and leave a cell on mixed digests, both reporting success.
 concurrency:
   group: deploy-firecracker
   cancel-in-progress: false
@@ -54,10 +48,8 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      # The dispatch input reaches the script through the environment, never
-      # through the run body: `${{ }}` is substituted before bash parses the
-      # script, so an interpolated tag could close the quoting and run
-      # arbitrary commands on a job that has already authenticated to GCP.
+      # Input goes through the environment, not the run body: `${{ }}` is
+      # substituted before bash parses, so a tag could inject commands.
       - name: Install
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}
@@ -84,15 +76,11 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      # Production is two cells, and each is discovered by its own region: a
-      # single run scoped to one region would filter the other cell out
-      # entirely and still report success, leaving it on the old binary.
-      # Both are steps in this job rather than separate jobs, because a second
-      # job referencing the production environment would double any approval
-      # gate.
-      #
-      # use4 is the primary and is unguarded: a missing GCP_REGION_USE4 must
-      # fail the deploy rather than silently skip the primary cell.
+      # Two cells, each discovered by its own region: one run scoped to a
+      # single region would filter the other out and still report success.
+      # Steps rather than jobs — a second job on the production environment
+      # would double any approval gate. use4 is unguarded, so a missing
+      # region fails the deploy rather than skipping the primary cell.
       - name: Install on the use4 cell
         env:
           GCP_PROJECT: ${{ vars.GCP_PROJECT }}

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -55,8 +55,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py \
-            --version '${{ inputs.version }}' \
-            --repo "${{ vars.FIRECRACKER_REPO }}"
+            --version '${{ inputs.version }}'
 
   deploy-production:
     name: Production
@@ -82,5 +81,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 .github/workflows/scripts/deploy-firecracker.py \
-            --version '${{ inputs.version }}' \
-            --repo "${{ vars.FIRECRACKER_REPO }}"
+            --version '${{ inputs.version }}'

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -1,16 +1,11 @@
 # Deploy Firecracker — the VMM binary on the sandbox hosts.
 #
 # Builds nothing: it installs a release built once in the fork, so every host
-# runs identical bytes. Production never deploys without staging first, same
-# discipline as the other deploys here.
+# runs identical bytes. Production never deploys without staging first.
 #
-# A running sandbox is unaffected — its process is already executing and keeps
-# the old inode across the rename. A PAUSED one is not: it has no process, and
-# resuming it launches a fresh Firecracker from this path, so the new binary
-# must be able to restore a snapshot the old one wrote. Snapshot formats are
-# versioned and an incompatible one is refused, which is why production
-# requires that pause-then-resume-across-the-upgrade has been proven on
-# staging rather than only that new sandboxes work.
+# Running sandboxes are unaffected; PAUSED ones are not. Resuming one launches
+# a fresh Firecracker from this path, so the new binary must restore a
+# snapshot the old one wrote — hence the cross-upgrade resume gate below.
 
 name: Deploy Firecracker
 
@@ -79,9 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      # Deploying only proves new sandboxes work. The paused fleet resumes
-      # under this binary, so refuse until a resume ACROSS the upgrade has
-      # actually been observed on staging: pause a sandbox, install, resume it.
+      # Deploying only proves NEW sandboxes work; the paused fleet resumes
+      # under this binary. Pause on staging, install, then resume.
       - name: Require the cross-upgrade resume check
         env:
           VERIFIED: ${{ inputs.snapshot_compat_verified }}

--- a/.github/workflows/deploy-firecracker.yml
+++ b/.github/workflows/deploy-firecracker.yml
@@ -1,0 +1,86 @@
+# Deploy Firecracker — the VMM binary on the sandbox hosts.
+#
+# Unlike the other deploys this one builds nothing: it installs a published
+# release built once in the fork, so every host ends up running provably
+# identical bytes. Production never deploys without staging first, same
+# discipline as the other deploys here.
+#
+# A swap only affects VMs launched after it — running and paused sandboxes
+# keep the process and artifacts they already have — so this is safe to run
+# during traffic, and a cell stays on mixed versions until its sandboxes
+# recycle.
+
+name: Deploy Firecracker
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to install (e.g. v1.15.0-ss1)'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment (staging always runs first)'
+        required: false
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-staging:
+    name: Staging
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install ${{ inputs.version }}
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/workflows/scripts/deploy-firecracker.py \
+            --version '${{ inputs.version }}' \
+            --repo "${{ vars.FIRECRACKER_REPO }}"
+
+  deploy-production:
+    name: Production
+    if: inputs.environment == 'production'
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Install ${{ inputs.version }}
+        env:
+          GCP_PROJECT: ${{ vars.GCP_PROJECT }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+          VMD_LABEL: ${{ vars.VMD_LABEL }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .github/workflows/scripts/deploy-firecracker.py \
+            --version '${{ inputs.version }}' \
+            --repo "${{ vars.FIRECRACKER_REPO }}"

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -105,46 +105,63 @@ def list_instances(project, region, label):
     ]
 
 
-def current_digest(inst, project):
-    """The digest a host is running right now, read without changing anything."""
+def host_digests(inst, project, expected):
+    """What a host is running, and whether it still holds a backup of
+    `expected`. Read-only, and one round trip rather than two."""
     name, zone = inst["name"], inst["zone"]
+    probe = f"""
+        live=$(sha256sum < {shlex.quote(INSTALL_PATH)} | cut -d' ' -f1)
+        backup={shlex.quote(INSTALL_PATH)}.pre-{expected[:12]}.bak
+        if [ -f "$backup" ]; then
+          echo "$live $(sha256sum < "$backup" | cut -d' ' -f1)"
+        else
+          echo "$live none"
+        fi
+    """
     r = run_or_die(
         ["gcloud", "compute", "ssh", name, f"--zone={zone}", f"--project={project}",
-         "--quiet", "--tunnel-through-iap", "--command",
-         f"sha256sum < {shlex.quote(INSTALL_PATH)} | cut -d' ' -f1"],
+         "--quiet", "--tunnel-through-iap", "--command", probe],
         f"[{name}] read installed digest",
     )
-    return (r.stdout or "").strip().splitlines()[-1].strip()
+    live, backup = (r.stdout or "").strip().splitlines()[-1].split()
+    return live, (None if backup == "none" else backup)
 
 
 HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
 
-def preflight(instances, project, expected):
-    """Require every host to be on the same digest before any is changed.
+def host_state(live, backup, expected, target):
+    """Whether a host is in a state this rollout may proceed from.
 
-    The rollback a deployment was verified against on staging is only the one
-    that exists here if the cell is actually uniform; a host that has drifted
-    would fall back to a binary nobody tested against. Checked across the whole
-    cell first, so drift stops the rollout instead of being discovered halfway.
+    Two are acceptable, which is what lets a partly-finished rollout be
+    retried: a host still on the verified rollback binary, or one already on
+    the target — provided it still holds a correct backup of that rollback
+    binary, so it has not lost the way back. Anything else is a host nobody
+    verified against, and the rollout stops rather than guessing.
     """
-    digests = {}
-    for inst in instances:
-        digests[inst["name"]] = current_digest(inst, project)
-    for name, d in sorted(digests.items()):
-        print(f"  {name}: currently {d}")
+    if live == expected:
+        return True, "on the rollback binary"
+    if live == target:
+        if backup == expected:
+            return True, "already on the target"
+        return False, (
+            f"is on the target but its backup of {expected[:12]} is "
+            + ("missing" if backup is None else f"wrong ({backup[:12]})")
+        )
+    return False, f"is on {live[:12]}, neither the rollback nor the target"
 
-    distinct = set(digests.values())
-    if len(distinct) > 1:
-        raise RuntimeError(
-            "hosts are not on a single version, so the rollback target is not "
-            "the one staging verified: " + ", ".join(f"{n}={d}" for n, d in sorted(digests.items()))
-        )
-    if expected and distinct and expected not in distinct:
-        raise RuntimeError(
-            f"hosts are on {distinct.pop()}, not the expected {expected}"
-        )
-    return digests
+
+def preflight(instances, project, expected, target):
+    """Check every host before any of them is changed."""
+    problems = []
+    for inst in instances:
+        live, backup = host_digests(inst, project, expected)
+        ok, why = host_state(live, backup, expected, target)
+        print(f"  {inst['name']}: {why}")
+        if not ok:
+            problems.append(f"{inst['name']} {why}")
+    if problems:
+        raise RuntimeError("; ".join(problems))
 
 
 def install_script(version, digest):
@@ -276,7 +293,12 @@ def main() -> int:
             print(f"EXPECTED_CURRENT_SHA256 is not a sha256 digest: {expected!r}",
                   file=sys.stderr)
             return 1
-        preflight(instances, project, expected)
+        if expected:
+            preflight(instances, project, expected, digest)
+        elif args.preflight_only:
+            print("EXPECTED_CURRENT_SHA256 is unset — nothing to preflight against",
+                  file=sys.stderr)
+            return 1
         if args.preflight_only:
             print("preflight only — nothing installed")
             return 0

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -81,10 +81,11 @@ def fetch_release(version, workdir):
     return binary, digest
 
 
-def list_instances(project, region, label):
+def list_instances(project, region, label, running_only=True):
+    status = " AND status=RUNNING" if running_only else ""
     result = subprocess.run(
         ["gcloud", "compute", "instances", "list", f"--project={project}",
-         f"--filter=labels.{label} AND status=RUNNING",
+         f"--filter=labels.{label}{status}",
          "--format=csv[no-heading](name,zone)"],
         capture_output=True, text=True, check=True,
     )
@@ -95,9 +96,12 @@ def list_instances(project, region, label):
     ]
     # Scope by zone basename rather than in the gcloud filter: matching zone
     # URIs in a filter is easy to get subtly wrong, and a deploy that silently
-    # skips a host is exactly the drift this script exists to prevent.
+    # skips a host is exactly the drift this script exists to prevent. The
+    # zone's region must match exactly — a prefix test lets a truncated value
+    # like "us" pull in every region at once.
     return [
-        i for i in instances if i["zone"].split("/")[-1].startswith(f"{region}-")
+        i for i in instances
+        if i["zone"].split("/")[-1].rsplit("-", 1)[0] == region
     ]
 
 
@@ -137,19 +141,33 @@ if [ "$(sha256sum < "$live" | cut -d' ' -f1)" = "$digest" ]; then
 fi
 
 # Named after the digest it preserves, not the version installed: a
-# per-version name is wrong on redeploy, where `cp -n` keeps the older file
-# and the real predecessor is lost.
-backup="$live.pre-$(sha256sum < "$live" | cut -c1-12).bak"
+# per-version name is wrong on redeploy, where an existing file would be kept
+# and the real predecessor lost.
+live_digest=$(sha256sum < "$live" | cut -d' ' -f1)
+backup="$live.pre-${{live_digest:0:12}}.bak"
 
-# Chained: a failed backup must not be followed by an install that
-# overwrites what it should have preserved. `cp -n`, not `--update=none`
-# (needs coreutils >= 9.3). Writes alongside and renames — writing to the
-# live path exposes a half-written binary and fails with ETXTBSY.
+# Temp file then rename, and recreate unless the existing one already holds
+# the right bytes: skipping on path existence alone would accept a partial
+# file from an interrupted copy.
+if [ ! -f "$backup" ] || [ "$(sha256sum < "$backup" | cut -d' ' -f1)" != "$live_digest" ]; then
+  sudo rm -f "$backup.tmp"
+  sudo cp "$live" "$backup.tmp"
+  sudo mv -f "$backup.tmp" "$backup"
+fi
+
+# Only install against a backup proven to hold what it replaces.
+backup_digest=$(sha256sum < "$backup" | cut -d' ' -f1)
+if [ "$backup_digest" != "$live_digest" ]; then
+  echo "backup $backup holds $backup_digest, not the live $live_digest — abort"
+  exit 1
+fi
+
+# Write alongside and rename: writing to the live path exposes a half-written
+# binary to a launching sandbox and fails with ETXTBSY while one is running.
 incoming="$live.incoming"
 sudo rm -f "$incoming"
-sudo cp -n "$live" "$backup" \\
-  && sudo install -m 0755 "$staged" "$incoming" \\
-  && sudo mv -f "$incoming" "$live"
+sudo install -m 0755 "$staged" "$incoming"
+sudo mv -f "$incoming" "$live"
 
 # Prove the swap landed, and that what landed still runs here.
 installed=$(sha256sum < "$live" | cut -d' ' -f1)
@@ -199,6 +217,14 @@ def main() -> int:
 
         instances = list_instances(project, region, label)
         where = f"{project} ({region})"
+
+        # Discovery is RUNNING-only — a stopped host cannot be reached — so a
+        # cold standby keeps whatever binary it has. Name it, or promotion
+        # quietly puts an untracked binary into service.
+        for inst in list_instances(project, region, label, running_only=False):
+            if inst not in instances:
+                print(f"NOTE: {inst['name']} is not running and was skipped — "
+                      f"install {args.version} on it before promoting it")
         if not instances:
             print(f"No instances with label {label} found in {where}", file=sys.stderr)
             return 1

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -55,7 +55,7 @@ def sha256_of(path):
     return h.hexdigest()
 
 
-def fetch_release(version, workdir):
+def fetch_release(version, workdir, expected_digest=""):
     """Download and unpack the release, returning (binary_path, sha256).
 
     The digest is taken from the unpacked binary and cross-checked against the
@@ -77,6 +77,14 @@ def fetch_release(version, workdir):
     if digest != published:
         raise RuntimeError(
             f"release {version} digest mismatch: unpacked {digest}, published {published}"
+        )
+    # Release assets can be replaced after the fact, and each cell downloads
+    # independently, so agreeing with the checksum published beside them only
+    # proves the pair is self-consistent. Pinning the digest verified on
+    # staging is what stops untested bytes reaching production.
+    if expected_digest and digest != expected_digest:
+        raise RuntimeError(
+            f"release {version} is {digest}, not the verified {expected_digest}"
         )
     print(f"{version}: sha256 {digest}")
     return binary, digest
@@ -139,16 +147,19 @@ def host_state(live, backup, expected, target):
     binary, so it has not lost the way back. Anything else is a host nobody
     verified against, and the rollout stops rather than guessing.
     """
-    if live == expected:
-        return True, "on the rollback binary"
     if live == target:
-        if backup == expected:
-            return True, "already on the target"
-        return False, (
-            f"is on the target but its backup of {expected[:12]} is "
-            + ("missing" if backup is None else f"wrong ({backup[:12]})")
-        )
-    return False, f"is on {live[:12]}, neither the rollback nor the target"
+        # Nothing to do here, whichever direction this is. A host that was
+        # never updated is already at the target during a rollback, and would
+        # have no backup of the binary it never ran; requiring one would let
+        # an untouched host block the rollback of the hosts that were changed.
+        note = "already on the target"
+        if backup != expected:
+            note += "; no local backup of {} (break-glass only — a rollback " \
+                    "installs a release)".format(expected[:12])
+        return True, note
+    if live == expected:
+        return True, "on the expected binary"
+    return False, f"is on {live[:12]}, neither the expected binary nor the target"
 
 
 def preflight(instances, project, expected, target):
@@ -279,7 +290,11 @@ def main() -> int:
         return 1
 
     with tempfile.TemporaryDirectory() as workdir:
-        binary, digest = fetch_release(args.version, workdir)
+        target = os.environ.get("TARGET_SHA256", "").strip()
+        if target and not HEX64.match(target):
+            print(f"TARGET_SHA256 is not a sha256 digest: {target!r}", file=sys.stderr)
+            return 1
+        binary, digest = fetch_release(args.version, workdir, target)
 
         instances = list_instances(project, region, label)
         where = f"{project} ({region})"

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -140,17 +140,12 @@ if [ "$(sha256sum < "$live" | cut -d' ' -f1)" = "$digest" ]; then
   exit 0
 fi
 
-# Back up, then install, CHAINED: if the backup fails the install must not
-# run, or it overwrites the very binary the backup was meant to preserve.
-# `cp -n` rather than `--update=none`, which needs coreutils >= 9.3 and so
-# fails outright on the older hosts.
-#
-# The install itself writes a temporary file alongside the live one and
-# renames it into place. Writing to the live pathname directly would expose a
-# window where a launching sandbox execs a half-written binary, and would fail
-# outright with ETXTBSY while any sandbox is running from it. A rename within
-# the same directory is atomic: processes already running keep the old inode,
-# and every exec after it sees a complete binary.
+# Backup CHAINED to install: a failed backup must not be followed by an
+# install that overwrites the binary it was meant to preserve. `cp -n`, not
+# `--update=none`, which needs coreutils >= 9.3.
+# The install writes alongside and renames: writing to the live path exposes
+# a half-written binary to a launching sandbox, and fails with ETXTBSY while
+# one is running from it. A rename in the same directory is atomic.
 incoming="$live.incoming"
 sudo rm -f "$incoming"
 sudo cp -n "$live" "$backup" \\

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -96,24 +96,20 @@ def list_instances(project, region, label):
     # Scope by zone basename rather than in the gcloud filter: matching zone
     # URIs in a filter is easy to get subtly wrong, and a deploy that silently
     # skips a host is exactly the drift this script exists to prevent.
-    if region:
-        instances = [
-            i for i in instances if i["zone"].split("/")[-1].startswith(f"{region}-")
-        ]
-    return instances
+    return [
+        i for i in instances if i["zone"].split("/")[-1].startswith(f"{region}-")
+    ]
 
 
 def install_script(version, digest):
     """The remote half of a swap, in the order the checks have to happen."""
     staged = f"/tmp/firecracker-{version}"
-    backup = f"{INSTALL_PATH}.pre-{version}.bak"
     return f"""
 set -euo pipefail
 
 staged={shlex.quote(staged)}
 live={shlex.quote(INSTALL_PATH)}
 stock={shlex.quote(STOCK_BACKUP)}
-backup={shlex.quote(backup)}
 digest={shlex.quote(digest)}
 
 # Rollback floor. Without it a bad swap has nowhere to fall back to, so
@@ -139,6 +135,13 @@ if [ "$(sha256sum < "$live" | cut -d' ' -f1)" = "$digest" ]; then
   rm -f "$staged"
   exit 0
 fi
+
+# Name the backup after the digest it preserves, not the version being
+# installed. A per-version name is wrong the second time a version is
+# deployed: `cp -n` would keep the older file and the predecessor it should
+# have saved would be lost. Keyed by content, an existing file with this name
+# already holds these exact bytes, so skipping the copy is correct.
+backup="$live.pre-$(sha256sum < "$live" | cut -c1-12).bak"
 
 # Backup CHAINED to install: a failed backup must not be followed by an
 # install that overwrites the binary it was meant to preserve. `cp -n`, not
@@ -187,14 +190,20 @@ def main() -> int:
     args = ap.parse_args()
 
     project = os.environ["GCP_PROJECT"]
-    region = os.environ.get("GCP_REGION", "")
     label = os.environ["VMD_LABEL"]
+    # Required, not optional: cells share a project and a label, so an unset
+    # region silently widens discovery to every cell at once instead of the
+    # one being deployed.
+    region = os.environ.get("GCP_REGION", "").strip()
+    if not region:
+        print("GCP_REGION is unset — refusing to deploy without a region", file=sys.stderr)
+        return 1
 
     with tempfile.TemporaryDirectory() as workdir:
         binary, digest = fetch_release(args.version, workdir)
 
         instances = list_instances(project, region, label)
-        where = f"{project} ({region})" if region else project
+        where = f"{project} ({region})"
         if not instances:
             print(f"No instances with label {label} found in {where}", file=sys.stderr)
             return 1

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -144,8 +144,18 @@ fi
 # run, or it overwrites the very binary the backup was meant to preserve.
 # `cp -n` rather than `--update=none`, which needs coreutils >= 9.3 and so
 # fails outright on the older hosts.
+#
+# The install itself writes a temporary file alongside the live one and
+# renames it into place. Writing to the live pathname directly would expose a
+# window where a launching sandbox execs a half-written binary, and would fail
+# outright with ETXTBSY while any sandbox is running from it. A rename within
+# the same directory is atomic: processes already running keep the old inode,
+# and every exec after it sees a complete binary.
+incoming="$live.incoming"
+sudo rm -f "$incoming"
 sudo cp -n "$live" "$backup" \\
-  && sudo install -m 0755 "$staged" "$live"
+  && sudo install -m 0755 "$staged" "$incoming" \\
+  && sudo mv -f "$incoming" "$live"
 
 # Prove the swap landed, and that what landed still runs here.
 installed=$(sha256sum < "$live" | cut -d' ' -f1)

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -18,6 +18,11 @@ import sys
 import tarfile
 import tempfile
 
+# The one repository the binary is published from. Not configurable: there is
+# a single fork, it does not vary by environment, and an unset variable would
+# silently become an empty string.
+RELEASE_REPO = "superserve-ai/firecracker"
+
 INSTALL_PATH = "/usr/local/bin/firecracker"
 # The pre-fork stock binary. It is the floor of any rollback, so a host that
 # has lost it must not be deployed to until it is restored.
@@ -49,14 +54,14 @@ def sha256_of(path):
     return h.hexdigest()
 
 
-def fetch_release(repo, version, workdir):
+def fetch_release(version, workdir):
     """Download and unpack the release, returning (binary_path, sha256).
 
     The digest is taken from the unpacked binary and cross-checked against the
     published .sha256, so a tampered or truncated download cannot reach a host.
     """
     run_or_die(
-        ["gh", "release", "download", version, "--repo", repo,
+        ["gh", "release", "download", version, "--repo", RELEASE_REPO,
          "--pattern", "firecracker.tar.gz", "--pattern", "firecracker.sha256",
          "--dir", workdir],
         f"download release {version}",
@@ -174,7 +179,6 @@ def deploy_to(inst, project, binary, version, digest):
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--version", required=True, help="release tag to install")
-    ap.add_argument("--repo", required=True, help="owner/name the release is published in")
     args = ap.parse_args()
 
     project = os.environ["GCP_PROJECT"]
@@ -182,7 +186,7 @@ def main() -> int:
     label = os.environ["VMD_LABEL"]
 
     with tempfile.TemporaryDirectory() as workdir:
-        binary, digest = fetch_release(args.repo, args.version, workdir)
+        binary, digest = fetch_release(args.version, workdir)
 
         instances = list_instances(project, region, label)
         where = f"{project} ({region})" if region else project

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -136,19 +136,15 @@ if [ "$(sha256sum < "$live" | cut -d' ' -f1)" = "$digest" ]; then
   exit 0
 fi
 
-# Name the backup after the digest it preserves, not the version being
-# installed. A per-version name is wrong the second time a version is
-# deployed: `cp -n` would keep the older file and the predecessor it should
-# have saved would be lost. Keyed by content, an existing file with this name
-# already holds these exact bytes, so skipping the copy is correct.
+# Named after the digest it preserves, not the version installed: a
+# per-version name is wrong on redeploy, where `cp -n` keeps the older file
+# and the real predecessor is lost.
 backup="$live.pre-$(sha256sum < "$live" | cut -c1-12).bak"
 
-# Backup CHAINED to install: a failed backup must not be followed by an
-# install that overwrites the binary it was meant to preserve. `cp -n`, not
-# `--update=none`, which needs coreutils >= 9.3.
-# The install writes alongside and renames: writing to the live path exposes
-# a half-written binary to a launching sandbox, and fails with ETXTBSY while
-# one is running from it. A rename in the same directory is atomic.
+# Chained: a failed backup must not be followed by an install that
+# overwrites what it should have preserved. `cp -n`, not `--update=none`
+# (needs coreutils >= 9.3). Writes alongside and renames — writing to the
+# live path exposes a half-written binary and fails with ETXTBSY.
 incoming="$live.incoming"
 sudo rm -f "$incoming"
 sudo cp -n "$live" "$backup" \\
@@ -191,9 +187,8 @@ def main() -> int:
 
     project = os.environ["GCP_PROJECT"]
     label = os.environ["VMD_LABEL"]
-    # Required, not optional: cells share a project and a label, so an unset
-    # region silently widens discovery to every cell at once instead of the
-    # one being deployed.
+    # Required: cells share a project and a label, so an unset region widens
+    # discovery to every cell at once.
     region = os.environ.get("GCP_REGION", "").strip()
     if not region:
         print("GCP_REGION is unset — refusing to deploy without a region", file=sys.stderr)

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -81,11 +81,10 @@ def fetch_release(version, workdir):
     return binary, digest
 
 
-def list_instances(project, region, label, running_only=True):
-    status = " AND status=RUNNING" if running_only else ""
+def list_instances(project, region, label):
     result = subprocess.run(
         ["gcloud", "compute", "instances", "list", f"--project={project}",
-         f"--filter=labels.{label}{status}",
+         f"--filter=labels.{label} AND status=RUNNING",
          "--format=csv[no-heading](name,zone)"],
         capture_output=True, text=True, check=True,
     )
@@ -105,6 +104,44 @@ def list_instances(project, region, label, running_only=True):
     ]
 
 
+def current_digest(inst, project):
+    """The digest a host is running right now, read without changing anything."""
+    name, zone = inst["name"], inst["zone"]
+    r = run_or_die(
+        ["gcloud", "compute", "ssh", name, f"--zone={zone}", f"--project={project}",
+         "--quiet", "--tunnel-through-iap", "--command",
+         f"sha256sum < {shlex.quote(INSTALL_PATH)} | cut -d' ' -f1"],
+        f"[{name}] read installed digest",
+    )
+    return (r.stdout or "").strip().splitlines()[-1].strip()
+
+
+def preflight(instances, project, expected):
+    """Require every host to be on the same digest before any is changed.
+
+    The rollback a deployment was verified against on staging is only the one
+    that exists here if the cell is actually uniform; a host that has drifted
+    would fall back to a binary nobody tested against. Checked across the whole
+    cell first, so drift stops the rollout instead of being discovered halfway.
+    """
+    digests = {}
+    for inst in instances:
+        digests[inst["name"]] = current_digest(inst, project)
+    for name, d in sorted(digests.items()):
+        print(f"  {name}: currently {d}")
+
+    distinct = set(digests.values())
+    if len(distinct) > 1:
+        raise RuntimeError(
+            "hosts are not on a single version, so the rollback target is not "
+            "the one staging verified: " + ", ".join(f"{n}={d}" for n, d in sorted(digests.items()))
+        )
+    if expected and distinct and expected not in distinct:
+        raise RuntimeError(
+            f"hosts are on {distinct.pop()}, not the expected {expected}"
+        )
+
+
 def install_script(version, digest):
     """The remote half of a swap, in the order the checks have to happen."""
     staged = f"/tmp/firecracker-{version}"
@@ -119,6 +156,9 @@ digest={shlex.quote(digest)}
 # Rollback floor. Without it a bad swap has nowhere to fall back to, so
 # refuse before touching anything.
 test -f "$stock" || {{ echo "stock backup $stock missing — abort"; exit 1; }}
+# Existence is not usability: a truncated or non-executable floor leaves the
+# host with no deep rollback at all.
+"$stock" --version >/dev/null 2>&1 || {{ echo "stock backup $stock does not run — abort"; exit 1; }}
 
 # The bytes that arrived are the bytes that were built.
 echo "$digest  $staged" | sha256sum -c -
@@ -218,17 +258,11 @@ def main() -> int:
         instances = list_instances(project, region, label)
         where = f"{project} ({region})"
 
-        # Discovery is RUNNING-only — a stopped host cannot be reached — so a
-        # cold standby keeps whatever binary it has. Name it, or promotion
-        # quietly puts an untracked binary into service.
-        for inst in list_instances(project, region, label, running_only=False):
-            if inst not in instances:
-                print(f"NOTE: {inst['name']} is not running and was skipped — "
-                      f"install {args.version} on it before promoting it")
         if not instances:
             print(f"No instances with label {label} found in {where}", file=sys.stderr)
             return 1
         print(f"Installing {args.version} on {len(instances)} instance(s) in {where}")
+        preflight(instances, project, os.environ.get("EXPECTED_CURRENT_SHA256", "").strip())
 
         # Sequential, and stopping on the first failure: a swap only affects
         # VMs launched after it, so there is nothing to gain from racing, and

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Install a published Firecracker release on every host in a cell.
+
+This builds nothing. The binary is a release artifact built once, and every
+host installs those exact bytes after verifying the digest — so fleet
+uniformity is a property of the process rather than something to audit
+afterwards. Hosts are visited one at a time: a swap only affects VMs launched
+after it, so there is no rush, and stopping on the first failure leaves the
+rest of the cell untouched.
+"""
+
+import argparse
+import hashlib
+import os
+import shlex
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+INSTALL_PATH = "/usr/local/bin/firecracker"
+# The pre-fork stock binary. It is the floor of any rollback, so a host that
+# has lost it must not be deployed to until it is restored.
+STOCK_BACKUP = f"{INSTALL_PATH}.v1.15.0.bak"
+# Every launch is gated on this capability, so a binary that stopped
+# advertising it would disable direct spawn on the next daemon restart
+# rather than failing at install time.
+REQUIRED_CAPABILITY = "serial-console-cap"
+
+
+def run_or_die(cmd, context):
+    """Run a subprocess, surfacing both streams on failure. Logs reach the
+    GitHub Actions UI directly — no need to inspect the runner."""
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"{context} failed (exit={r.returncode}): {' '.join(cmd[:4])}…\n"
+            f"--- stderr ---\n{(r.stderr or '').strip() or '(empty)'}\n"
+            f"--- stdout ---\n{(r.stdout or '').strip() or '(empty)'}"
+        )
+    return r
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fetch_release(repo, version, workdir):
+    """Download and unpack the release, returning (binary_path, sha256).
+
+    The digest is taken from the unpacked binary and cross-checked against the
+    published .sha256, so a tampered or truncated download cannot reach a host.
+    """
+    run_or_die(
+        ["gh", "release", "download", version, "--repo", repo,
+         "--pattern", "firecracker.tar.gz", "--pattern", "firecracker.sha256",
+         "--dir", workdir],
+        f"download release {version}",
+    )
+    with tarfile.open(os.path.join(workdir, "firecracker.tar.gz")) as tf:
+        tf.extract("firecracker", path=workdir)
+    binary = os.path.join(workdir, "firecracker")
+
+    digest = sha256_of(binary)
+    with open(os.path.join(workdir, "firecracker.sha256")) as f:
+        published = f.read().split()[0]
+    if digest != published:
+        raise RuntimeError(
+            f"release {version} digest mismatch: unpacked {digest}, published {published}"
+        )
+    print(f"{version}: sha256 {digest}")
+    return binary, digest
+
+
+def list_instances(project, region, label):
+    result = subprocess.run(
+        ["gcloud", "compute", "instances", "list", f"--project={project}",
+         f"--filter=labels.{label} AND status=RUNNING",
+         "--format=csv[no-heading](name,zone)"],
+        capture_output=True, text=True, check=True,
+    )
+    instances = [
+        {"name": parts[0], "zone": parts[1]}
+        for line in result.stdout.strip().splitlines() if line.strip()
+        for parts in [line.strip().split(",")]
+    ]
+    # Scope by zone basename rather than in the gcloud filter: matching zone
+    # URIs in a filter is easy to get subtly wrong, and a deploy that silently
+    # skips a host is exactly the drift this script exists to prevent.
+    if region:
+        instances = [
+            i for i in instances if i["zone"].split("/")[-1].startswith(f"{region}-")
+        ]
+    return instances
+
+
+def install_script(version, digest):
+    """The remote half of a swap, in the order the checks have to happen."""
+    staged = f"/tmp/firecracker-{version}"
+    backup = f"{INSTALL_PATH}.pre-{version}.bak"
+    return f"""
+set -euo pipefail
+
+staged={shlex.quote(staged)}
+live={shlex.quote(INSTALL_PATH)}
+stock={shlex.quote(STOCK_BACKUP)}
+backup={shlex.quote(backup)}
+digest={shlex.quote(digest)}
+
+# Rollback floor. Without it a bad swap has nowhere to fall back to, so
+# refuse before touching anything.
+test -f "$stock" || {{ echo "stock backup $stock missing — abort"; exit 1; }}
+
+# The bytes that arrived are the bytes that were built.
+echo "$digest  $staged" | sha256sum -c -
+
+# Loader pre-check, deliberately while still in /tmp: a binary linked against
+# a newer glibc than this host provides fails here, with the live binary
+# untouched. This is the failure that is otherwise discovered by a sandbox
+# that will not start.
+chmod +x "$staged"
+"$staged" --version
+"$staged" --version | grep -qE '^[[:space:]]*capability: {REQUIRED_CAPABILITY}[[:space:]]*$' \\
+  || {{ echo "staged binary does not advertise {REQUIRED_CAPABILITY} — abort"; exit 1; }}
+
+# Already at this version: nothing to do, and re-running must not manufacture
+# a second backup of a binary that is already the target.
+if [ "$(sha256sum < "$live" | cut -d' ' -f1)" = "$digest" ]; then
+  echo "already at $digest — nothing to do"
+  rm -f "$staged"
+  exit 0
+fi
+
+# Back up, then install, CHAINED: if the backup fails the install must not
+# run, or it overwrites the very binary the backup was meant to preserve.
+# `cp -n` rather than `--update=none`, which needs coreutils >= 9.3 and so
+# fails outright on the older hosts.
+sudo cp -n "$live" "$backup" \\
+  && sudo install -m 0755 "$staged" "$live"
+
+# Prove the swap landed, and that what landed still runs here.
+installed=$(sha256sum < "$live" | cut -d' ' -f1)
+test "$installed" = "$digest" || {{ echo "post-install digest $installed != $digest"; exit 1; }}
+"$live" --version
+"$live" --version | grep -qE '^[[:space:]]*capability: {REQUIRED_CAPABILITY}[[:space:]]*$'
+rm -f "$staged"
+echo "installed $digest (previous binary saved at $backup)"
+"""
+
+
+def deploy_to(inst, project, binary, version, digest):
+    name, zone = inst["name"], inst["zone"]
+    tag = f"{name}/{zone.split('/')[-1]}"
+    staged = f"/tmp/firecracker-{version}"
+
+    run_or_die(
+        ["gcloud", "compute", "scp", binary, f"{name}:{staged}",
+         f"--zone={zone}", f"--project={project}", "--quiet", "--tunnel-through-iap"],
+        f"[{tag}] upload binary",
+    )
+    r = run_or_die(
+        ["gcloud", "compute", "ssh", name, f"--zone={zone}", f"--project={project}",
+         "--quiet", "--tunnel-through-iap", "--command", install_script(version, digest)],
+        f"[{tag}] install",
+    )
+    for line in (r.stdout or "").strip().splitlines():
+        print(f"[{tag}] {line}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--version", required=True, help="release tag to install")
+    ap.add_argument("--repo", required=True, help="owner/name the release is published in")
+    args = ap.parse_args()
+
+    project = os.environ["GCP_PROJECT"]
+    region = os.environ.get("GCP_REGION", "")
+    label = os.environ["VMD_LABEL"]
+
+    with tempfile.TemporaryDirectory() as workdir:
+        binary, digest = fetch_release(args.repo, args.version, workdir)
+
+        instances = list_instances(project, region, label)
+        where = f"{project} ({region})" if region else project
+        if not instances:
+            print(f"No instances with label {label} found in {where}", file=sys.stderr)
+            return 1
+        print(f"Installing {args.version} on {len(instances)} instance(s) in {where}")
+
+        # Sequential, and stopping on the first failure: a swap only affects
+        # VMs launched after it, so there is nothing to gain from racing, and
+        # a host that refuses the binary should halt the rollout rather than
+        # let it continue into the rest of the cell.
+        for inst in instances:
+            deploy_to(inst, project, binary, args.version, digest)
+
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/deploy-firecracker.py
+++ b/.github/workflows/scripts/deploy-firecracker.py
@@ -11,6 +11,7 @@ rest of the cell untouched.
 
 import argparse
 import hashlib
+import re
 import os
 import shlex
 import subprocess
@@ -116,6 +117,9 @@ def current_digest(inst, project):
     return (r.stdout or "").strip().splitlines()[-1].strip()
 
 
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
 def preflight(instances, project, expected):
     """Require every host to be on the same digest before any is changed.
 
@@ -140,6 +144,7 @@ def preflight(instances, project, expected):
         raise RuntimeError(
             f"hosts are on {distinct.pop()}, not the expected {expected}"
         )
+    return digests
 
 
 def install_script(version, digest):
@@ -241,6 +246,10 @@ def deploy_to(inst, project, binary, version, digest):
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--version", required=True, help="release tag to install")
+    # Lets every cell be checked before any of them is changed, rather than
+    # discovering the second cell's state after the first has been mutated.
+    ap.add_argument("--preflight-only", action="store_true",
+                    help="verify what the hosts are running and exit")
     args = ap.parse_args()
 
     project = os.environ["GCP_PROJECT"]
@@ -262,7 +271,15 @@ def main() -> int:
             print(f"No instances with label {label} found in {where}", file=sys.stderr)
             return 1
         print(f"Installing {args.version} on {len(instances)} instance(s) in {where}")
-        preflight(instances, project, os.environ.get("EXPECTED_CURRENT_SHA256", "").strip())
+        expected = os.environ.get("EXPECTED_CURRENT_SHA256", "").strip()
+        if expected and not HEX64.match(expected):
+            print(f"EXPECTED_CURRENT_SHA256 is not a sha256 digest: {expected!r}",
+                  file=sys.stderr)
+            return 1
+        preflight(instances, project, expected)
+        if args.preflight_only:
+            print("preflight only — nothing installed")
+            return 0
 
         # Sequential, and stopping on the first failure: a swap only affects
         # VMs launched after it, so there is nothing to gain from racing, and

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -1,5 +1,6 @@
 import hashlib
 import importlib.util
+import unittest.mock
 import os
 import tempfile
 import unittest
@@ -80,6 +81,33 @@ class InstallScriptSafetyTest(unittest.TestCase):
         # Re-running must not manufacture a second backup of a binary that is
         # already the target.
         self.assertIn("already at $digest", self.script)
+
+
+    def test_backup_is_named_after_the_digest_it_preserves(self):
+        # A per-version name is wrong the second time a version is deployed:
+        # `cp -n` keeps the older file and the real predecessor is lost.
+        self.assertRegex(
+            self.commands,
+            r'backup="\$live\.pre-\$\(sha256sum < "\$live"',
+            "the backup name must derive from the live binary's digest",
+        )
+        self.assertNotIn("pre-v1.2.3.bak", self.commands)
+
+
+class RegionTest(unittest.TestCase):
+    def test_an_unset_region_is_refused(self):
+        # Cells share a project and a label, so no region means every cell at
+        # once rather than the one being deployed.
+        import io
+        import contextlib
+        env = {"GCP_PROJECT": "p", "VMD_LABEL": "l", "GCP_REGION": "  "}
+        with unittest.mock.patch.dict(os.environ, env, clear=True), \
+                unittest.mock.patch("sys.argv", ["x", "--version", "v1"]):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = deploy_firecracker.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("GCP_REGION is unset", err.getvalue())
 
 
 class DigestTest(unittest.TestCase):

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -1,0 +1,80 @@
+import hashlib
+import importlib.util
+import os
+import tempfile
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "deploy_firecracker",
+    os.path.join(os.path.dirname(__file__), "deploy-firecracker.py"),
+)
+deploy_firecracker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_firecracker)
+
+
+class InstallScriptSafetyTest(unittest.TestCase):
+    """The install script's invariants, each of which has a failure mode that
+    is silent rather than loud if it regresses."""
+
+    def setUp(self):
+        self.script = deploy_firecracker.install_script("v1.2.3", "a" * 64)
+        # Comments legitimately name the pitfalls they warn about, so
+        # command-level assertions look at executable lines only.
+        self.commands = "\n".join(
+            line for line in self.script.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+
+    def test_backup_is_chained_to_install(self):
+        # An un-chained backup lets a FAILED backup be followed by an install
+        # that overwrites the binary the backup was meant to preserve.
+        self.assertRegex(
+            self.commands,
+            r"cp -n[^\n]*\\\n\s*&& sudo install",
+            "backup must be &&-chained to the install",
+        )
+
+    def test_backup_does_not_use_update_none(self):
+        # `--update=none` needs coreutils >= 9.3 and fails on the older hosts.
+        self.assertNotIn("--update=none", self.commands)
+
+    def test_refuses_without_the_stock_backup(self):
+        self.assertIn(deploy_firecracker.STOCK_BACKUP, self.script)
+        self.assertRegex(self.script, r'test -f "\$stock" \|\|')
+
+    def test_verifies_digest_before_and_after_install(self):
+        # Before: the bytes that arrived are the bytes that were built.
+        self.assertIn("sha256sum -c -", self.script)
+        # After: the swap actually landed.
+        self.assertIn("post-install digest", self.script)
+
+    def test_checks_capability_while_still_staged(self):
+        # The loader/capability pre-check must happen against the staged copy,
+        # so a binary this host cannot run is rejected with the live one intact.
+        staged_check = self.script.index('"$staged" --version')
+        install = self.script.index("sudo install")
+        self.assertLess(staged_check, install)
+        self.assertIn(deploy_firecracker.REQUIRED_CAPABILITY, self.script)
+
+    def test_is_idempotent_when_already_at_the_target(self):
+        # Re-running must not manufacture a second backup of a binary that is
+        # already the target.
+        self.assertIn("already at $digest", self.script)
+
+
+class DigestTest(unittest.TestCase):
+    def test_sha256_of_matches_hashlib(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"firecracker bytes")
+            path = f.name
+        try:
+            self.assertEqual(
+                deploy_firecracker.sha256_of(path),
+                hashlib.sha256(b"firecracker bytes").hexdigest(),
+            )
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -120,6 +120,39 @@ class RegionTest(unittest.TestCase):
         self.assertIn("GCP_REGION is unset", err.getvalue())
 
 
+class PreflightStateTest(unittest.TestCase):
+    """A rollout that stopped halfway must still be completable."""
+
+    A = "a" * 64   # the verified rollback binary
+    B = "b" * 64   # the target release
+    C = "c" * 64   # anything else
+
+    def test_a_host_not_yet_updated_is_accepted(self):
+        ok, _ = deploy_firecracker.host_state(self.A, None, self.A, self.B)
+        self.assertTrue(ok)
+
+    def test_a_host_already_updated_is_accepted_when_it_can_still_roll_back(self):
+        # The retry case: the first cell installed, the second failed. Both
+        # states have to pass or the rollout can never be finished.
+        ok, _ = deploy_firecracker.host_state(self.B, self.A, self.A, self.B)
+        self.assertTrue(ok)
+
+    def test_an_updated_host_that_lost_its_backup_is_refused(self):
+        ok, why = deploy_firecracker.host_state(self.B, None, self.A, self.B)
+        self.assertFalse(ok)
+        self.assertIn("missing", why)
+
+    def test_an_updated_host_with_a_wrong_backup_is_refused(self):
+        ok, why = deploy_firecracker.host_state(self.B, self.C, self.A, self.B)
+        self.assertFalse(ok)
+        self.assertIn("wrong", why)
+
+    def test_an_unknown_binary_is_refused(self):
+        ok, why = deploy_firecracker.host_state(self.C, self.A, self.A, self.B)
+        self.assertFalse(ok)
+        self.assertIn("neither", why)
+
+
 class ExpectedDigestTest(unittest.TestCase):
     def test_a_malformed_expected_digest_is_refused(self):
         # A pinned rollback digest that is not a digest would otherwise be

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -137,15 +137,23 @@ class PreflightStateTest(unittest.TestCase):
         ok, _ = deploy_firecracker.host_state(self.B, self.A, self.A, self.B)
         self.assertTrue(ok)
 
-    def test_an_updated_host_that_lost_its_backup_is_refused(self):
+    def test_a_host_at_the_target_passes_without_a_local_backup(self):
+        # During a ROLLBACK the untouched hosts are already at the target and
+        # never had the binary being rolled back from, so they cannot hold a
+        # backup of it. Demanding one would let them block the rollback of the
+        # hosts that were actually changed.
         ok, why = deploy_firecracker.host_state(self.B, None, self.A, self.B)
-        self.assertFalse(ok)
-        self.assertIn("missing", why)
+        self.assertTrue(ok)
+        self.assertIn("break-glass", why)
 
-    def test_an_updated_host_with_a_wrong_backup_is_refused(self):
-        ok, why = deploy_firecracker.host_state(self.B, self.C, self.A, self.B)
-        self.assertFalse(ok)
-        self.assertIn("wrong", why)
+    def test_a_rollback_across_a_partly_updated_cell_is_accepted(self):
+        # Rolling back from B to A: the updated host is on B (the expected
+        # binary), the untouched one is already on A (the target). Both must
+        # pass or the rollback cannot run.
+        updated, _ = deploy_firecracker.host_state(self.B, self.A, self.B, self.A)
+        untouched, _ = deploy_firecracker.host_state(self.A, None, self.B, self.A)
+        self.assertTrue(updated)
+        self.assertTrue(untouched)
 
     def test_an_unknown_binary_is_refused(self):
         ok, why = deploy_firecracker.host_state(self.C, self.A, self.A, self.B)

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -26,14 +26,24 @@ class InstallScriptSafetyTest(unittest.TestCase):
             if not line.lstrip().startswith("#")
         )
 
-    def test_backup_is_chained_to_install(self):
-        # An un-chained backup lets a FAILED backup be followed by an install
-        # that overwrites the binary the backup was meant to preserve.
+    def test_install_is_gated_on_a_verified_backup(self):
+        # The install must not proceed unless the backup provably holds the
+        # bytes it is about to replace: an interrupted or out-of-space copy
+        # can leave a partial file, and overwriting the live binary against it
+        # destroys the only good copy.
+        verify = self.commands.index('"$backup_digest" != "$live_digest"')
+        install = self.commands.index('mv -f "$incoming" "$live"')
+        self.assertLess(verify, install, "backup must be verified before install")
         self.assertRegex(
-            self.commands,
-            r"cp -n[^\n]*\\\n\s*&& sudo install",
-            "backup must be &&-chained to the install",
+            self.commands, r'backup_digest" != "\$live_digest"[^\n]*\n[^\n]*\n\s*exit 1',
+            "a mismatched backup must abort",
         )
+
+    def test_backup_is_written_atomically(self):
+        # A backup written straight to its final name can be left partial and
+        # then trusted by the next run, which skips an existing path.
+        self.assertRegex(self.commands, r'cp "\$live" "\$backup\.tmp"')
+        self.assertRegex(self.commands, r'mv -f "\$backup\.tmp" "\$backup"')
 
     def test_replaces_the_live_binary_by_rename(self):
         # Writing to the live pathname directly exposes a window where a
@@ -88,7 +98,7 @@ class InstallScriptSafetyTest(unittest.TestCase):
         # `cp -n` keeps the older file and the real predecessor is lost.
         self.assertRegex(
             self.commands,
-            r'backup="\$live\.pre-\$\(sha256sum < "\$live"',
+            r'backup="\$live\.pre-\$\{live_digest:0:12\}\.bak"',
             "the backup name must derive from the live binary's digest",
         )
         self.assertNotIn("pre-v1.2.3.bak", self.commands)

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -120,6 +120,31 @@ class RegionTest(unittest.TestCase):
         self.assertIn("GCP_REGION is unset", err.getvalue())
 
 
+class ExpectedDigestTest(unittest.TestCase):
+    def test_a_malformed_expected_digest_is_refused(self):
+        # A pinned rollback digest that is not a digest would otherwise be
+        # compared against real ones and never match, or worse be empty and
+        # silently skip the binding entirely.
+        import io
+        import contextlib
+        env = {
+            "GCP_PROJECT": "p", "VMD_LABEL": "l", "GCP_REGION": "us-east4",
+            "EXPECTED_CURRENT_SHA256": "not-a-digest",
+        }
+        with unittest.mock.patch.dict(os.environ, env, clear=True), \
+                unittest.mock.patch("sys.argv", ["x", "--version", "v1"]), \
+                unittest.mock.patch.object(
+                    deploy_firecracker, "fetch_release", return_value=("/tmp/x", "a" * 64)), \
+                unittest.mock.patch.object(
+                    deploy_firecracker, "list_instances",
+                    return_value=[{"name": "h", "zone": "us-east4-a"}]):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                rc = deploy_firecracker.main()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a sha256 digest", err.getvalue())
+
+
 class DigestTest(unittest.TestCase):
     def test_sha256_of_matches_hashlib(self):
         with tempfile.NamedTemporaryFile(delete=False) as f:

--- a/.github/workflows/scripts/test_deploy_firecracker.py
+++ b/.github/workflows/scripts/test_deploy_firecracker.py
@@ -34,6 +34,26 @@ class InstallScriptSafetyTest(unittest.TestCase):
             "backup must be &&-chained to the install",
         )
 
+    def test_replaces_the_live_binary_by_rename(self):
+        # Writing to the live pathname directly exposes a window where a
+        # launching sandbox execs a half-written binary, and fails with
+        # ETXTBSY while any sandbox is running from it.
+        self.assertRegex(
+            self.commands,
+            r'install -m 0755 "\$staged" "\$incoming"',
+            "install must write a temporary file, not the live path",
+        )
+        self.assertRegex(
+            self.commands,
+            r'mv -f "\$incoming" "\$live"',
+            "the temporary file must be renamed over the live path",
+        )
+        self.assertNotRegex(
+            self.commands,
+            r'install -m 0755 "\$staged" "\$live"',
+            "must never install straight onto the live path",
+        )
+
     def test_backup_does_not_use_update_none(self):
         # `--update=none` needs coreutils >= 9.3 and fails on the older hosts.
         self.assertNotIn("--update=none", self.commands)


### PR DESCRIPTION
Installs a published Firecracker release across a cell — fetching a fixed, digest-verified artifact rather than building, so every host provably runs the same bytes.

Per host: refuse if the rollback binary is missing, verify the digest, loader pre-check while still in `/tmp`, back up (written atomically, named by the digest it preserves, and verified before anything is overwritten), install by atomic rename, re-verify. Sequential, stopping on the first failure.

Snapshots have to survive the swap in both directions, so production is gated on `staging_verified`: a fresh create under the new version, a pre-install pause resuming after, and a pause under the new version resuming under the rollback target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
