### PR TITLE
feat: 2. Publish VMD host capabilities and heartbeat to Supabase

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -174,7 +174,9 @@ func main() {
 }
 
 type proxyHealthResponse struct {
-	Capabilities []string `json:"capabilities"`
+	Capabilities  []string `json:"capabilities"`
+	FilesEnabled  bool     `json:"files_enabled"`
+	ResolverReady bool     `json:"resolver_ready"`
 }
 
 func newProxyMux(proxyHandler *proxy.Handler) *http.ServeMux {
@@ -186,7 +188,9 @@ func newProxyMux(proxyHandler *proxy.Handler) *http.ServeMux {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(proxyHealthResponse{
-			Capabilities: proxyHandler.PreviewCapabilities(),
+			Capabilities:  proxyHandler.PreviewCapabilities(),
+			FilesEnabled:  proxyHandler.FilesEnabled(),
+			ResolverReady: proxyHandler.ResolverReady(r.Context()),
 		})
 	})
 	mux.Handle("/", proxyHandler)

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -61,6 +61,29 @@ func TestProxyHealthAdvertisesPreviewTokensOnlyWithAuthSeed(t *testing.T) {
 	}
 }
 
+func TestProxyHealthReportsFilesEnabled(t *testing.T) {
+	seed := []byte("preview-test-seed-that-is-at-least-thirty-two-bytes")
+	for _, enabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "disabled", true: "enabled"}[enabled], func(t *testing.T) {
+			h := proxy.NewHandler([]string{"sandbox.test"}, nil, zerolog.Nop()).WithAuth(seed)
+			if enabled {
+				h.WithFiles()
+			}
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/health", nil)
+			req.Host = "127.0.0.1:5007"
+			newProxyMux(h).ServeHTTP(w, req)
+			var health proxyHealthResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &health); err != nil {
+				t.Fatalf("decode health response: %v", err)
+			}
+			if health.FilesEnabled != enabled {
+				t.Fatalf("files_enabled = %v, want %v", health.FilesEnabled, enabled)
+			}
+		})
+	}
+}
+
 func TestProxyDomains(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1216,6 +1216,7 @@ func main() {
 	// Bind and serve BEFORE the reattach so a restart doesn't refuse connections
 	// during it; requests are gated Unavailable until startupReady flips.
 	startupReady := &atomic.Bool{}
+	localHTTPReady := &atomic.Bool{}
 	notReady := func() error {
 		return status.Error(codes.Unavailable, "vmd is starting up (reattaching VMs), retry shortly")
 	}
@@ -1614,6 +1615,8 @@ func main() {
 				PressureReady:   pressureReady,
 				MaxSandboxes:    envInt32Fatal(log, "VMD_MAX_SANDBOXES"),
 				MaxNetworkSlots: envInt32Fatal(log, "VMD_MAX_NETWORK_SLOTS"),
+				LifecycleReady:  startupReady.Load,
+				ResolverReady:   func() bool { return startupReady.Load() && localHTTPReady.Load() },
 			}, log)
 			return nil
 		})
@@ -1637,6 +1640,7 @@ func main() {
 	// Listens on localhost:9090. The edge proxy queries this to resolve
 	// instanceID → vmIP before forwarding data-plane traffic.
 	localHTTP := vm.NewLocalHTTPServer(mgr, log)
+	localHTTP.SetReadySignal(localHTTPReady)
 	lc.start("local http server", func() error {
 		if localLis != nil {
 			return localHTTP.Serve(ctx, localLis)

--- a/internal/preview/policy.go
+++ b/internal/preview/policy.go
@@ -44,6 +44,16 @@ const (
 	// depends on, HostCapabilityPortTokens.
 	HostCapabilityPortBrowserAuth = "preview_port_browser_auth_v1"
 
+	// Host operational capabilities describe technical host abilities and are
+	// published independently from control-plane status and capacity.
+	HostCapabilityCanCreate       = "can_create"
+	HostCapabilityCanResume       = "can_resume"
+	HostCapabilityCanPause        = "can_pause"
+	HostCapabilityCanDestroy      = "can_destroy"
+	HostCapabilityCanProxyTraffic = "can_proxy_traffic"
+	HostCapabilityCanReadFiles    = "can_read_files"
+	HostCapabilityCanWriteFiles   = "can_write_files"
+
 	// Published preview ports exclude privileged ports and boxd's reserved
 	// service port. Keeping this vocabulary shared prevents the API, VMD,
 	// and durable schema from disagreeing about what can be published.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -172,6 +172,19 @@ func (h *Handler) PreviewCapabilities() []string {
 	return capabilities
 }
 
+// FilesEnabled reports whether the authenticated /files bridge is enabled.
+// It is a read-only snapshot used by the local health endpoint; it performs
+// no sandbox I/O.
+func (h *Handler) FilesEnabled() bool {
+	return h.filesEnabled
+}
+
+// ResolverReady verifies the configured resolver endpoint without touching a sandbox.
+func (h *Handler) ResolverReady(ctx context.Context) bool {
+	resolver, ok := h.resolver.(interface{ Ready(context.Context) error })
+	return ok && resolver.Ready(ctx) == nil
+}
+
 // WithAnalytics enables data-plane usage events (exec/files).
 func (h *Handler) WithAnalytics(a *analytics.Client) *Handler {
 	h.analytics = a

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -103,6 +103,26 @@ type VMDResolver struct {
 	group singleflight.Group
 }
 
+// Ready verifies that the configured VMD endpoint is reachable. A 404 is
+// expected for the synthetic instance, but still proves the resolver path.
+func (r *VMDResolver) Ready(ctx context.Context) error {
+	probeCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, r.vmdAddr+"/instances/__healthcheck__", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("resolver probe returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // WithPreviewTokens declares that the owning proxy handler has a valid seed
 // and can enforce HostCapabilityPortTokens. Configure it once at startup.
 func (r *VMDResolver) WithPreviewTokens() *VMDResolver {

--- a/internal/vm/heartbeat.go
+++ b/internal/vm/heartbeat.go
@@ -39,7 +39,6 @@ type HeartbeatConfig struct {
 	Region            string
 	CapacityMemoryMib int32
 	CapacityVcpus     int32
-
 	// Pressure, when set, is sampled after each SUCCESSFUL heartbeat and
 	// published to the separate best-effort pressure endpoint — never
 	// inside the heartbeat body, so no pressure outcome can ever affect
@@ -57,6 +56,10 @@ type HeartbeatConfig struct {
 	// limits published alongside pressure; 0 means unset (no cap).
 	MaxSandboxes    int32
 	MaxNetworkSlots int32
+	// LifecycleReady gates lifecycle capability publication until VMD is ready.
+	LifecycleReady func() bool
+	// ResolverReady gates proxy, file, and preview capability publication.
+	ResolverReady func() bool
 }
 
 // pressureProbeEvery is how many beats a publisher that found the
@@ -274,8 +277,26 @@ type heartbeatRequest struct {
 }
 
 type proxyHealthResponse struct {
-	Capabilities []string `json:"capabilities"`
+	Capabilities  []string `json:"capabilities"`
+	FilesEnabled  bool     `json:"files_enabled"`
+	ResolverReady bool     `json:"resolver_ready"`
 }
+
+type proxyHealthState struct {
+	PreviewCapabilities []string
+	FilesEnabled        bool
+	ResolverReady       bool
+}
+
+const (
+	capabilityCanCreate       = preview.HostCapabilityCanCreate
+	capabilityCanResume       = preview.HostCapabilityCanResume
+	capabilityCanPause        = preview.HostCapabilityCanPause
+	capabilityCanDestroy      = preview.HostCapabilityCanDestroy
+	capabilityCanProxyTraffic = preview.HostCapabilityCanProxyTraffic
+	capabilityCanReadFiles    = preview.HostCapabilityCanReadFiles
+	capabilityCanWriteFiles   = preview.HostCapabilityCanWriteFiles
+)
 
 type heartbeatStorageCache struct {
 	mu           sync.RWMutex
@@ -336,12 +357,28 @@ func (c *heartbeatStorageCache) store(measurements []heartbeatStorageMeasurement
 
 func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig, url, token, proxyHealthURL string, storage []heartbeatStorageMeasurement, log zerolog.Logger) (bool, bool) {
 	started := time.Now()
-	capabilities, err := proxyPreviewCapabilities(ctx, client, proxyHealthURL)
+	proxyState, err := proxyHealthCapabilities(ctx, client, proxyHealthURL)
 	if err != nil {
 		log.Warn().Err(err).
+			Str("host_id", cfg.HostID).
 			Dur("duration", time.Since(started)).
-			Msg("proxy capability probe failed; advertising no preview capabilities")
-		capabilities = nil
+			Msg("proxy health probe failed; advertising no proxy or file capabilities")
+		proxyState = proxyHealthState{}
+	}
+	capabilities := make([]string, 0, 7)
+	lifecycleReady := cfg.LifecycleReady != nil && cfg.LifecycleReady()
+	resolverReady := cfg.ResolverReady != nil && cfg.ResolverReady()
+	if lifecycleReady {
+		capabilities = append(capabilities, capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy)
+	}
+	if err == nil {
+		if resolverReady && proxyState.ResolverReady {
+			capabilities = append(capabilities, capabilityCanProxyTraffic)
+			if proxyState.FilesEnabled {
+				capabilities = append(capabilities, capabilityCanReadFiles, capabilityCanWriteFiles)
+			}
+		}
+		capabilities = append(capabilities, proxyState.PreviewCapabilities...)
 	}
 	return postHeartbeat(ctx, client, cfg, url, token, capabilities, storage, log, started)
 }
@@ -498,34 +535,39 @@ func measureOverlayStorage(runDir string) ([]heartbeatStorageMeasurement, error)
 }
 
 func proxyPreviewCapabilities(ctx context.Context, client *http.Client, healthURL string) ([]string, error) {
+	state, err := proxyHealthCapabilities(ctx, client, healthURL)
+	return state.PreviewCapabilities, err
+}
+
+func proxyHealthCapabilities(ctx context.Context, client *http.Client, healthURL string) (proxyHealthState, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, healthURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build proxy health request: %w", err)
+		return proxyHealthState{}, fmt.Errorf("build proxy health request: %w", err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request proxy health: %w", err)
+		return proxyHealthState{}, fmt.Errorf("request proxy health: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("proxy health returned %d", resp.StatusCode)
+		return proxyHealthState{}, fmt.Errorf("proxy health returned %d", resp.StatusCode)
 	}
 	var health proxyHealthResponse
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<10)).Decode(&health); err != nil {
 		if err == io.EOF {
-			return nil, nil
+			return proxyHealthState{}, nil
 		}
-		return nil, fmt.Errorf("decode proxy health: %w", err)
+		return proxyHealthState{}, fmt.Errorf("decode proxy health: %w", err)
 	}
 	advertised := make(map[string]bool, len(health.Capabilities))
 	for _, capability := range health.Capabilities {
 		advertised[capability] = true
 	}
 	if !advertised[preview.HostCapabilityPorts] {
-		return nil, nil
+		return proxyHealthState{FilesEnabled: health.FilesEnabled, ResolverReady: health.ResolverReady}, nil
 	}
 	out := []string{preview.HostCapabilityPorts}
 	if advertised[preview.HostCapabilityPortAccess] {
@@ -537,5 +579,5 @@ func proxyPreviewCapabilities(ctx context.Context, client *http.Client, healthUR
 			}
 		}
 	}
-	return out, nil
+	return proxyHealthState{PreviewCapabilities: out, FilesEnabled: health.FilesEnabled, ResolverReady: health.ResolverReady}, nil
 }

--- a/internal/vm/heartbeat_test.go
+++ b/internal/vm/heartbeat_test.go
@@ -24,7 +24,7 @@ func TestSendHeartbeatAdvertisesVerifiedPreviewCapabilities(t *testing.T) {
 		switch r.URL.Path {
 		case "/health":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(proxyHealthResponse{Capabilities: []string{
+			_ = json.NewEncoder(w).Encode(proxyHealthResponse{FilesEnabled: true, ResolverReady: true, Capabilities: []string{
 				preview.HostCapabilityPorts, preview.HostCapabilityPortAccess,
 				preview.HostCapabilityPortTokens, preview.HostCapabilityPortBrowserAuth,
 			}})
@@ -43,6 +43,8 @@ func TestSendHeartbeatAdvertisesVerifiedPreviewCapabilities(t *testing.T) {
 
 	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{
 		HostID:            "host-a",
+		LifecycleReady:    func() bool { return true },
+		ResolverReady:     func() bool { return true },
 		VMDAddr:           "10.0.0.2:50051",
 		ProxyAddr:         "10.0.0.2:5007",
 		Region:            "region-a",
@@ -57,6 +59,9 @@ func TestSendHeartbeatAdvertisesVerifiedPreviewCapabilities(t *testing.T) {
 		t.Fatalf("authorization = %q", gotAuthorization)
 	}
 	want := []string{
+		capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy,
+		capabilityCanProxyTraffic,
+		capabilityCanReadFiles, capabilityCanWriteFiles,
 		preview.HostCapabilityPorts, preview.HostCapabilityPortAccess,
 		preview.HostCapabilityPortTokens, preview.HostCapabilityPortBrowserAuth,
 	}
@@ -179,11 +184,12 @@ func TestSendHeartbeatOmitsCapabilityForOldOrUnavailableProxy(t *testing.T) {
 		name         string
 		healthStatus int
 		healthBody   string
+		want         []string
 	}{
-		{name: "old proxy empty health", healthStatus: http.StatusOK},
-		{name: "proxy unavailable", healthStatus: http.StatusServiceUnavailable},
-		{name: "wrong protocol", healthStatus: http.StatusOK, healthBody: `{"capabilities":["other"]}`},
-		{name: "access without base", healthStatus: http.StatusOK, healthBody: `{"capabilities":["preview_port_access_v1"]}`},
+		{name: "old proxy empty health", healthStatus: http.StatusOK, want: []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}},
+		{name: "proxy unavailable", healthStatus: http.StatusServiceUnavailable, want: []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}},
+		{name: "wrong protocol", healthStatus: http.StatusOK, healthBody: `{"capabilities":["other"]}`, want: []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}},
+		{name: "access without base", healthStatus: http.StatusOK, healthBody: `{"capabilities":["preview_port_access_v1"]}`, want: []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}},
 	}
 
 	for _, tt := range tests {
@@ -205,11 +211,62 @@ func TestSendHeartbeatOmitsCapabilityForOldOrUnavailableProxy(t *testing.T) {
 			}))
 			defer server.Close()
 
-			sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a"}, server.URL+"/internal/hosts/host-a/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
-			if len(got.Capabilities) != 0 {
-				t.Fatalf("capabilities = %#v, want empty", got.Capabilities)
+			sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a", LifecycleReady: func() bool { return true }, ResolverReady: func() bool { return true }}, server.URL+"/internal/hosts/host-a/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
+			if !reflect.DeepEqual(got.Capabilities, tt.want) {
+				t.Fatalf("capabilities = %#v, want %#v", got.Capabilities, tt.want)
 			}
 		})
+	}
+}
+
+func TestSendHeartbeatOmitsLifecycleCapabilitiesBeforeReady(t *testing.T) {
+	var got heartbeatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(proxyHealthResponse{})
+			return
+		}
+		if r.URL.Path == "/heartbeat" {
+			_ = json.NewDecoder(r.Body).Decode(&got)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{
+		HostID: "host-a", LifecycleReady: func() bool { return false },
+	}, server.URL+"/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
+
+	if reflect.DeepEqual(got.Capabilities, []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}) {
+		t.Fatalf("lifecycle capabilities = %#v, want omitted before readiness", got.Capabilities)
+	}
+	for _, capability := range got.Capabilities {
+		if capability == capabilityCanCreate || capability == capabilityCanResume || capability == capabilityCanPause || capability == capabilityCanDestroy {
+			t.Fatalf("lifecycle capability %q published before readiness", capability)
+		}
+	}
+}
+
+func TestSendHeartbeatKeepsLifecycleCapabilitiesWhenResolverIsNotReady(t *testing.T) {
+	var got heartbeatRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_ = json.NewEncoder(w).Encode(proxyHealthResponse{})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{
+		HostID: "host-a", LifecycleReady: func() bool { return true }, ResolverReady: func() bool { return false },
+	}, server.URL+"/heartbeat", "", server.URL+"/health", nil, zerolog.Nop())
+	want := []string{capabilityCanCreate, capabilityCanResume, capabilityCanPause, capabilityCanDestroy}
+	if !reflect.DeepEqual(got.Capabilities, want) {
+		t.Fatalf("capabilities = %#v, want %#v", got.Capabilities, want)
 	}
 }
 
@@ -336,7 +393,7 @@ func TestSendHeartbeatRetriesWithoutStorageOnCompatibilityError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok, accepted := sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a"}, server.URL+"/heartbeat", "", server.URL+"/health", []heartbeatStorageMeasurement{{SandboxID: "sandbox-a", AllocatedBytes: 1}}, zerolog.Nop())
+	ok, accepted := sendHeartbeat(context.Background(), server.Client(), HeartbeatConfig{HostID: "host-a", LifecycleReady: func() bool { return true }, ResolverReady: func() bool { return true }}, server.URL+"/heartbeat", "", server.URL+"/health", []heartbeatStorageMeasurement{{SandboxID: "sandbox-a", AllocatedBytes: 1}}, zerolog.Nop())
 	if !ok {
 		t.Fatal("heartbeat should succeed after retrying without storage")
 	}

--- a/internal/vm/local_http.go
+++ b/internal/vm/local_http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -24,7 +25,11 @@ type LocalHTTPServer struct {
 	mgr    *Manager
 	log    zerolog.Logger
 	server *http.Server
+	ready  *atomic.Bool
 }
+
+// SetReadySignal records when the resolver has started serving requests.
+func (s *LocalHTTPServer) SetReadySignal(ready *atomic.Bool) { s.ready = ready }
 
 // NewLocalHTTPServer creates a LocalHTTPServer backed by the given Manager.
 func NewLocalHTTPServer(mgr *Manager, log zerolog.Logger) *LocalHTTPServer {
@@ -67,6 +72,10 @@ func (s *LocalHTTPServer) ListenAndServe(ctx context.Context, addr string) error
 // caller guarantees the listener is loopback-only.
 func (s *LocalHTTPServer) Serve(ctx context.Context, lis net.Listener) error {
 	s.log.Info().Str("addr", lis.Addr().String()).Msg("local HTTP server listening")
+	if s.ready != nil {
+		s.ready.Store(true)
+		defer s.ready.Store(false)
+	}
 
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
## Summary

- publish explicit lifecycle operational capabilities from the running VMD service
- expose proxy/files operational state through the existing proxy health probe
- preserve preview protocol capabilities and host self-description
- keep status/capacity separate from technical capability
- keep lifecycle capabilities gated until VMD is ready to serve lifecycle RPCs

## Testing

- extend focused proxy health and VMD heartbeat tests
- verify Linux compilation with `GOOS=linux go test -c ./internal/vm`
