### PR TITLE
infra: re-enable backup_coverage_alerts now that the metric is confirmed live

### DIFF
--- a/infra/envs/production/us-east4/main.tf
+++ b/infra/envs/production/us-east4/main.tf
@@ -380,21 +380,11 @@ module "observability" {
   # under us-central1 labeling before the host swap, so the legacy
   # value stays scoped: host rows relabeled or restored under it must
   # not fall outside the alert.
-  #
-  # Left null for now (was the object below): creating these alert_policy
-  # resources requires backup_uncovered_paused_sandboxes to already exist
-  # as a Cloud Monitoring metric type, but the controlplane code that
-  # emits it deploys through this same Terraform CD run's api job, which
-  # is itself gated on this apply succeeding. Deadlock: apply fails on
-  # "Cannot find metric" -> api deploy never runs -> metric never gets
-  # emitted -> apply keeps failing. Re-enable once a later deploy (with
-  # this block still null) has shipped the emitting code and the metric
-  # is confirmed present in Cloud Monitoring.
-  # backup_coverage_alerts = {
-  #   enabled        = false
-  #   display_prefix = "Backup coverage / us-east4"
-  #   regions        = ["us-east4", "us-central1"]
-  # }
+  backup_coverage_alerts = {
+    enabled        = false
+    display_prefix = "Backup coverage / us-east4"
+    regions        = ["us-east4", "us-central1"]
+  }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount
   # table) and live network namespaces accumulating. Both degrade latency

--- a/infra/envs/production/us-west2/main.tf
+++ b/infra/envs/production/us-west2/main.tf
@@ -395,21 +395,11 @@ module "observability" {
   # one-field flip once the cell's backfill backlog converges to zero.
   # regions lists the host table's region column values in this cell's
   # database, NOT GCP region names; "usw" is the only value present.
-  #
-  # Left null for now (was the object below): creating these alert_policy
-  # resources requires backup_uncovered_paused_sandboxes to already exist
-  # as a Cloud Monitoring metric type, but the controlplane code that
-  # emits it deploys through this same Terraform CD run's api job, which
-  # is itself gated on this apply succeeding. Deadlock: apply fails on
-  # "Cannot find metric" -> api deploy never runs -> metric never gets
-  # emitted -> apply keeps failing. Re-enable once a later deploy (with
-  # this block still null) has shipped the emitting code and the metric
-  # is confirmed present in Cloud Monitoring.
-  # backup_coverage_alerts = {
-  #   enabled        = false
-  #   display_prefix = "Backup coverage / us-west2"
-  #   regions        = ["usw"]
-  # }
+  backup_coverage_alerts = {
+    enabled        = false
+    display_prefix = "Backup coverage / us-west2"
+    regions        = ["usw"]
+  }
   # Launch-path health for the same host: the pruned launcher mount namespace
   # being unavailable (VM starts fall back to walking the full host mount
   # table) and live network namespaces accumulating. Both degrade latency

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -382,21 +382,11 @@ module "observability" {
   # region-scoped companion condition) before it matters. regions lists
   # the host table's region column values in this cell's database, not
   # GCP region names; "us-central1" is the only value present.
-  #
-  # Left null for now (was the object below): creating these alert_policy
-  # resources requires backup_uncovered_paused_sandboxes to already exist
-  # as a Cloud Monitoring metric type, but the controlplane code that
-  # emits it deploys through this same Terraform CD run's api job, which
-  # is itself gated on this apply succeeding. Deadlock: apply fails on
-  # "Cannot find metric" -> api deploy never runs -> metric never gets
-  # emitted -> apply keeps failing. Re-enable once a later deploy (with
-  # this block still null) has shipped the emitting code and the metric
-  # is confirmed present in Cloud Monitoring.
-  # backup_coverage_alerts = {
-  #   enabled        = false
-  #   display_prefix = "Backup coverage / staging"
-  #   regions        = ["us-central1"]
-  # }
+  backup_coverage_alerts = {
+    enabled        = false
+    display_prefix = "Backup coverage / staging"
+    regions        = ["us-central1"]
+  }
   # Root-filesystem (OS disk) utilization, same policies as the production
   # cells so staging validates the query shape first. Module defaults:
   # warn at 85% sustained 30 minutes, page at 95%.


### PR DESCRIPTION
## Summary
- #409 shipped the coverage sampler + disabled-by-default `backup_coverage_alerts` policies. Applying it deadlocked Terraform CD: the alert_policy resources require `backup_uncovered_paused_sandboxes` to already exist as a Cloud Monitoring metric type, but the controlplane code that emits it deploys through this same gated apply.
- #443 nulled `backup_coverage_alerts` in all three environments to break the deadlock and let the emitting code ship, leaving the original blocks commented out in place.
- This PR uncomments them now that the metric is confirmed live: verified fresh, continuous data points (15s cadence) in Cloud Monitoring for staging (rayai-dev) and both production cells (rayai-prod, us-east4 and usw2) before restoring.

## Technical decisions / tradeoffs
- Values restored unchanged from the original #409 config (`enabled = false`, same display_prefix/regions) — this is a pure re-enable, not a config change. Policies stay disabled by default; flipping them on is a separate step gated on the cell's backfill backlog converging to zero.

## Testing
- `terraform validate` clean on all three environments.
- Confirmed via the Cloud Monitoring API that `backup_uncovered_paused_sandboxes` has recent points in all three projects/regions before restoring the alert_policy blocks that reference it.
- Local Codex review: clean, no findings.