### PR TITLE
feat: align billing to subscription anniversaries

### DIFF
--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -426,11 +426,29 @@ FOR UPDATE;
 
 -- name: UpsertTeamBillingPeriod :one
 INSERT INTO team_billing_period (team_id, period_start, period_end, status)
-VALUES (
+SELECT
     sqlc.arg(team_id),
     sqlc.arg(period_start),
     sqlc.arg(period_end),
     sqlc.arg(status)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM team_billing_period billed
+    WHERE billed.team_id = sqlc.arg(team_id)
+      AND (billed.period_start, billed.period_end) <>
+          (sqlc.arg(period_start), sqlc.arg(period_end))
+      AND (
+          billed.status = 'exported'
+          OR billed.exported_at IS NOT NULL
+          OR (
+              billed.finalized_at IS NOT NULL
+              AND (billed.blocked_reason IS NULL OR billed.blocked_reason NOT IN (
+                  'reporting_only_calendar_period', 'discarded_before_billing_cutover'
+              ))
+          )
+      )
+      AND tstzrange(billed.period_start, billed.period_end, '[)') &&
+          tstzrange(sqlc.arg(period_start), sqlc.arg(period_end), '[)')
 )
 ON CONFLICT (team_id, period_start, period_end) DO UPDATE
 SET status = CASE
@@ -582,12 +600,12 @@ WHERE billing_period_anomaly.id = sqlc.arg(id)
 RETURNING *;
 
 -- name: GetTeamBillingAccount :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, commercial_billing_anchor, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, checkout_initializing_at, checkout_session_id
 FROM team_billing_account
 WHERE team_id = sqlc.arg(team_id);
 
 -- name: GetTeamBillingAccountByStripeCustomerID :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, commercial_billing_anchor, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, checkout_initializing_at, checkout_session_id
 FROM team_billing_account
 WHERE stripe_customer_id = sqlc.arg(stripe_customer_id);
 
@@ -599,6 +617,55 @@ SET stripe_customer_id = EXCLUDED.stripe_customer_id,
     updated_at = now()
 RETURNING *;
 
+-- name: ClaimTeamCommercialBillingAnchor :one
+SELECT claim_team_commercial_billing_anchor(sqlc.arg(team_id), sqlc.arg(anchor))::timestamptz AS commercial_billing_anchor;
+
+-- name: BeginTeamBillingCheckout :one
+UPDATE team_billing_account
+SET checkout_initializing_at = now(),
+    checkout_anchor_snapshot = commercial_billing_anchor,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = sqlc.arg(team_id)
+  AND (checkout_initializing_at IS NULL OR checkout_initializing_at < now() - interval '32 minutes')
+RETURNING *;
+
+-- name: FinishTeamBillingCheckout :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = sqlc.arg(team_id);
+
+-- name: FinishTeamBillingCheckoutIfStartedBefore :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    updated_at = now()
+WHERE team_id = sqlc.arg(team_id)
+  AND checkout_initializing_at <= sqlc.arg(event_at)
+  AND checkout_session_id = sqlc.arg(session_id);
+
+-- name: SetTeamBillingCheckoutSession :exec
+UPDATE team_billing_account
+SET checkout_session_id = sqlc.arg(session_id), updated_at = now()
+WHERE team_id = sqlc.arg(team_id)
+  AND checkout_initializing_at IS NOT NULL;
+
+-- name: FinishTeamBillingCheckoutForSubscription :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = sqlc.arg(team_id)
+  AND stripe_subscription_id = sqlc.arg(subscription_id)
+  AND checkout_initializing_at IS NOT NULL;
+
+-- name: EstablishBillingCutover :one
+SELECT establish_billing_cutover(sqlc.arg(cutover), sqlc.arg(preserved_team_ids)::uuid[])::int AS team_count;
+
 -- name: UpsertTeamBillingAccountSubscription :one
 INSERT INTO team_billing_account (
     team_id,
@@ -609,6 +676,7 @@ INSERT INTO team_billing_account (
     stripe_subscription_event_at,
     current_period_start,
     current_period_end,
+    commercial_billing_anchor,
     cancel_at_period_end
 )
 VALUES (
@@ -620,6 +688,7 @@ VALUES (
     sqlc.narg(stripe_subscription_event_at),
     sqlc.narg(current_period_start),
     sqlc.narg(current_period_end),
+    COALESCE(sqlc.narg(commercial_billing_anchor)::timestamptz, sqlc.narg(current_period_start)::timestamptz),
     COALESCE(sqlc.narg(cancel_at_period_end), false)
 )
 ON CONFLICT (team_id) DO UPDATE
@@ -630,6 +699,7 @@ SET stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, team_billing_acco
     stripe_subscription_event_at = COALESCE(EXCLUDED.stripe_subscription_event_at, team_billing_account.stripe_subscription_event_at),
     current_period_start = COALESCE(EXCLUDED.current_period_start, team_billing_account.current_period_start),
     current_period_end = COALESCE(EXCLUDED.current_period_end, team_billing_account.current_period_end),
+    commercial_billing_anchor = COALESCE(team_billing_account.commercial_billing_anchor, EXCLUDED.commercial_billing_anchor),
     cancel_at_period_end = COALESCE(sqlc.narg(cancel_at_period_end), team_billing_account.cancel_at_period_end),
     updated_at = now()
 RETURNING *;

--- a/internal/api/handlers_billing.go
+++ b/internal/api/handlers_billing.go
@@ -161,6 +161,17 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 
 	now := time.Now().UTC()
 	periodStart, periodEnd := billing.CurrentBillingPeriod(now)
+	account, accountErr := h.DB.GetTeamBillingAccount(c.Request.Context(), teamID)
+	if accountErr != nil && !errors.Is(accountErr, pgx.ErrNoRows) {
+		log.Error().Err(accountErr).Str("team_id", teamID.String()).Msg("load billing account failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	if accountErr == nil && account.CommercialBillingAnchor.Valid {
+		if start, end, anchored := billing.AnniversaryPeriod(account.CommercialBillingAnchor.Time, now); anchored {
+			periodStart, periodEnd = start, end
+		}
+	}
 	period, err := h.DB.GetActiveTeamBillingPeriod(c.Request.Context(), teamID)
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {
@@ -168,7 +179,7 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 			respondError(c, ErrInternal)
 			return
 		}
-	} else {
+	} else if !(accountErr == nil && account.CommercialBillingAnchor.Valid) {
 		periodStart = period.PeriodStart
 		periodEnd = period.PeriodEnd
 	}
@@ -177,7 +188,6 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		usage         db.GetTeamBillingUsageRow
 		pricingRows   []db.ListActivePricingRatesForTeamCurrentRow
 		creditBalance pgtype.Numeric
-		account       db.GetTeamBillingAccountRow
 	)
 	g, ctx := errgroup.WithContext(c.Request.Context())
 	g.Go(func() error {
@@ -214,13 +224,6 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 	})
 	if err := g.Wait(); err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing summary dependency fetch failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
-	account, err = h.DB.GetTeamBillingAccount(c.Request.Context(), teamID)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		log.Error().Err(err).Str("team_id", teamID.String()).Msg("load billing account failed")
 		respondError(c, ErrInternal)
 		return
 	}

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/superserve-ai/sandbox/internal/authz"
+	"github.com/superserve-ai/sandbox/internal/billing"
 	"github.com/superserve-ai/sandbox/internal/config"
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -77,7 +78,9 @@ type StripeCreateCheckoutSessionParams struct {
 	CancelURL         string
 	ClientReferenceID string
 	PriceIDs          []string
+	BackdateStartDate *time.Time
 	IdempotencyKey    string
+	ExpiresAt         *time.Time
 }
 
 type StripeCheckoutSession struct {
@@ -130,21 +133,22 @@ type billingUsageResponse struct {
 }
 
 type billingPeriodResponse struct {
-	PeriodID           string     `json:"period_id"`
-	PeriodStart        time.Time  `json:"period_start"`
-	PeriodEnd          time.Time  `json:"period_end"`
-	Status             string     `json:"status"`
-	BlockedReason      *string    `json:"blocked_reason,omitempty"`
-	ApprovedAt         *time.Time `json:"approved_at,omitempty"`
-	ExportedAt         *time.Time `json:"exported_at,omitempty"`
-	FinalizedAt        *time.Time `json:"finalized_at,omitempty"`
-	CancelAtPeriodEnd  *bool      `json:"cancel_at_period_end,omitempty"`
-	StripeCustomerID   *string    `json:"stripe_customer_id,omitempty"`
-	StripeSubscription *string    `json:"stripe_subscription_id,omitempty"`
-	SubscriptionStatus *string    `json:"stripe_subscription_status,omitempty"`
-	InvoiceStatus      *string    `json:"stripe_invoice_status,omitempty"`
-	CurrentPeriodStart *time.Time `json:"current_period_start,omitempty"`
-	CurrentPeriodEnd   *time.Time `json:"current_period_end,omitempty"`
+	PeriodID                string     `json:"period_id"`
+	PeriodStart             time.Time  `json:"period_start"`
+	PeriodEnd               time.Time  `json:"period_end"`
+	Status                  string     `json:"status"`
+	BlockedReason           *string    `json:"blocked_reason,omitempty"`
+	ApprovedAt              *time.Time `json:"approved_at,omitempty"`
+	ExportedAt              *time.Time `json:"exported_at,omitempty"`
+	FinalizedAt             *time.Time `json:"finalized_at,omitempty"`
+	CancelAtPeriodEnd       *bool      `json:"cancel_at_period_end,omitempty"`
+	StripeCustomerID        *string    `json:"stripe_customer_id,omitempty"`
+	StripeSubscription      *string    `json:"stripe_subscription_id,omitempty"`
+	SubscriptionStatus      *string    `json:"stripe_subscription_status,omitempty"`
+	InvoiceStatus           *string    `json:"stripe_invoice_status,omitempty"`
+	CurrentPeriodStart      *time.Time `json:"current_period_start,omitempty"`
+	CurrentPeriodEnd        *time.Time `json:"current_period_end,omitempty"`
+	CommercialBillingAnchor *time.Time `json:"commercial_billing_anchor,omitempty"`
 }
 
 type billingExportPreviewResponse struct {
@@ -183,6 +187,15 @@ type billingExportAttemptRecord struct {
 type billingCheckoutSessionRequest struct {
 	SuccessURL string `json:"success_url"`
 	CancelURL  string `json:"cancel_url"`
+}
+
+type commercialBillingAnchorRequest struct {
+	Anchor *time.Time `json:"anchor"`
+}
+
+type billingCutoverRequest struct {
+	CutoverAt        time.Time   `json:"cutover_at" binding:"required"`
+	PreservedTeamIDs []uuid.UUID `json:"preserved_team_ids"`
 }
 
 type billingPortalSessionRequest struct {
@@ -323,6 +336,12 @@ func (c *stripeHTTPClient) CreateCheckoutSession(ctx context.Context, params Str
 	form.Set("client_reference_id", params.ClientReferenceID)
 	for i, priceID := range params.PriceIDs {
 		form.Set(fmt.Sprintf("line_items[%d][price]", i), priceID)
+	}
+	if params.BackdateStartDate != nil {
+		form.Set("subscription_data[backdate_start_date]", strconv.FormatInt(params.BackdateStartDate.UTC().Unix(), 10))
+	}
+	if params.ExpiresAt != nil {
+		form.Set("expires_at", strconv.FormatInt(params.ExpiresAt.UTC().Unix(), 10))
 	}
 	var resp struct {
 		ID  string `json:"id"`
@@ -519,6 +538,14 @@ func (h *Handlers) getTeamBillingUsage(c *gin.Context, platform bool) {
 		respondErrorMsg(c, "bad_request", err.Error(), http.StatusBadRequest)
 		return
 	}
+	if strings.TrimSpace(c.Query("period_start")) == "" && strings.TrimSpace(c.Query("period_end")) == "" {
+		periodStart, periodEnd, err = h.authoritativeBillingPeriod(c.Request.Context(), teamID, h.nowUTC())
+		if err != nil {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("load authoritative billing period failed")
+			respondError(c, ErrInternal)
+			return
+		}
+	}
 	usage, period, err := h.readBillingSnapshot(c.Request.Context(), teamID, periodStart, periodEnd)
 	if err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("read billing snapshot failed")
@@ -547,14 +574,6 @@ func (h *Handlers) listTeamBillingPeriods(c *gin.Context, platform bool) {
 	if !ok {
 		return
 	}
-	now := h.nowUTC()
-	currentStart, currentEnd := currentBillingPeriod(now)
-	if _, _, err := h.upsertBillingSnapshot(c.Request.Context(), teamID, currentStart, currentEnd); err != nil {
-		log.Error().Err(err).Str("team_id", teamID.String()).Msg("seed current billing period failed")
-		respondError(c, ErrInternal)
-		return
-	}
-
 	limitCount := int32(12)
 	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
 		n, err := strconv.Atoi(raw)
@@ -563,6 +582,34 @@ func (h *Handlers) listTeamBillingPeriods(c *gin.Context, platform bool) {
 			return
 		}
 		limitCount = int32(n)
+	}
+
+	periodStart, periodEnd, err := h.authoritativeBillingPeriod(c.Request.Context(), teamID, h.nowUTC())
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("load authoritative billing period failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	// A calendar fallback is only a reporting window until a commercial
+	// anchor is established. Seeding it here could claim the calendar start
+	// and block a later sales-assisted cutover.
+	account, accountErr := h.DB.GetTeamBillingAccount(c.Request.Context(), teamID)
+	if accountErr != nil && !errors.Is(accountErr, pgx.ErrNoRows) {
+		log.Error().Err(accountErr).Str("team_id", teamID.String()).Msg("load billing account failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	if accountErr == nil && account.CommercialBillingAnchor.Valid {
+		if _, err := h.DB.UpsertTeamBillingPeriod(c.Request.Context(), db.UpsertTeamBillingPeriodParams{
+			TeamID:      teamID,
+			PeriodStart: periodStart,
+			PeriodEnd:   periodEnd,
+			Status:      h.periodStatusForWindow(periodEnd, h.nowUTC()),
+		}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			log.Error().Err(err).Str("team_id", teamID.String()).Msg("seed authoritative billing period failed")
+			respondError(c, ErrInternal)
+			return
+		}
 	}
 
 	periods, err := h.DB.ListTeamBillingPeriods(c.Request.Context(), db.ListTeamBillingPeriodsParams{
@@ -575,7 +622,6 @@ func (h *Handlers) listTeamBillingPeriods(c *gin.Context, platform bool) {
 		return
 	}
 
-	account, _ := h.DB.GetTeamBillingAccount(c.Request.Context(), teamID)
 	resp := make([]billingPeriodResponse, 0, len(periods))
 	for _, period := range periods {
 		resp = append(resp, billingPeriodResponseFromDB(period, account))
@@ -671,12 +717,26 @@ func (h *Handlers) ApproveTeamBillingPeriod(c *gin.Context) {
 		respondErrorMsg(c, "conflict", "cannot approve an open billing period", http.StatusConflict)
 		return
 	}
-	if _, _, err := h.upsertBillingSnapshot(c.Request.Context(), teamID, periodStart, periodEnd); err != nil {
+	if h.Pool == nil {
+		respondErrorMsg(c, "service_unavailable", "billing transactions are not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := c.Request.Context()
+	tx, err := h.Pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("begin billing period approval transaction failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := h.DB.WithTx(tx)
+	if _, _, err := h.upsertBillingSnapshotWithQueries(ctx, q, teamID, periodStart, periodEnd); err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("prepare billing period approval failed")
 		respondError(c, ErrInternal)
 		return
 	}
-	period, err := h.DB.ApproveTeamBillingPeriod(c.Request.Context(), db.ApproveTeamBillingPeriodParams{
+	period, err := q.ApproveTeamBillingPeriod(ctx, db.ApproveTeamBillingPeriodParams{
 		ApprovedBy:  pgtype.UUID{Bytes: actorID, Valid: true},
 		TeamID:      teamID,
 		PeriodStart: periodStart,
@@ -688,6 +748,11 @@ func (h *Handlers) ApproveTeamBillingPeriod(c *gin.Context) {
 			return
 		}
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("approve billing period failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	if err := tx.Commit(ctx); err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("commit billing period approval transaction failed")
 		respondError(c, ErrInternal)
 		return
 	}
@@ -1288,20 +1353,107 @@ func (h *Handlers) CreateStripeCheckoutSession(c *gin.Context) {
 		respondError(c, ErrInternal)
 		return
 	}
+	// Refresh after customer provisioning so a concurrent cutover is reflected.
+	account, err = h.DB.GetTeamBillingAccount(c.Request.Context(), teamID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("refresh billing account before checkout failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	checkoutAccount, err := h.DB.BeginTeamBillingCheckout(c.Request.Context(), teamID)
+	if err != nil {
+		respondErrorMsg(c, "conflict", "another checkout is already initializing", http.StatusConflict)
+		return
+	}
+	account.CommercialBillingAnchor = checkoutAccount.CommercialBillingAnchor
+	// The normal flow creates the subscription at the commercial start.
+	expiresAt := h.nowUTC().Add(31 * time.Minute)
 	session, err := h.Stripe.CreateCheckoutSession(c.Request.Context(), StripeCreateCheckoutSessionParams{
 		CustomerID:        customerID,
 		SuccessURL:        successURL,
 		CancelURL:         cancelURL,
 		ClientReferenceID: teamID.String(),
 		PriceIDs:          priceIDs,
-		IdempotencyKey:    checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs),
+		// Ordinary Checkout creates the subscription at activation time. Any
+		// Delayed-subscription recovery is intentionally outside this Checkout path.
+		IdempotencyKey: checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs, nil) + "-expires-" + strconv.FormatInt(expiresAt.Unix(), 10),
+		// Leave a one-minute margin over Stripe's 30-minute minimum for
+		// request latency between this timestamp and session creation.
+		ExpiresAt: &expiresAt,
 	})
 	if err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("create Stripe checkout session failed")
 		respondErrorMsg(c, "bad_gateway", "Stripe checkout session creation failed", http.StatusBadGateway)
 		return
 	}
+	if err := h.DB.SetTeamBillingCheckoutSession(c.Request.Context(), db.SetTeamBillingCheckoutSessionParams{TeamID: teamID, SessionID: stringPtr(session.ID)}); err != nil {
+		respondError(c, ErrInternal)
+		return
+	}
 	c.JSON(http.StatusOK, billingSessionResponse{ID: session.ID, URL: session.URL})
+}
+
+// EstablishCommercialBillingAnchor is the sales-assisted cutover operation.
+// It is deliberately separate from Checkout so the commercial start can be
+// recorded before Stripe creates a backdated subscription.
+func (h *Handlers) EstablishCommercialBillingAnchor(c *gin.Context) {
+	_, ok := h.requirePlatformBilling(c, platformBillingWritePermission)
+	if !ok {
+		return
+	}
+	teamID, err := internalTeamID(c)
+	if err != nil {
+		return
+	}
+	var req commercialBillingAnchorRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		respondErrorMsg(c, "bad_request", "invalid commercial billing anchor request", http.StatusBadRequest)
+		return
+	}
+	anchor := h.nowUTC()
+	if req.Anchor != nil {
+		anchor = req.Anchor.UTC()
+	}
+	anchor = anchor.Truncate(time.Second)
+	if anchor.After(h.nowUTC()) {
+		respondErrorMsg(c, "bad_request", "commercial billing anchor cannot be in the future", http.StatusBadRequest)
+		return
+	}
+	claimed, err := h.DB.ClaimTeamCommercialBillingAnchor(c.Request.Context(), db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("establish commercial billing anchor failed")
+		respondErrorMsg(c, "conflict", "commercial billing anchor could not be established", http.StatusConflict)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"team_id": teamID.String(), "commercial_billing_anchor": claimed.UTC()})
+}
+
+// EstablishBillingCutover sets the one production cutover boundary for all
+// existing teams, excluding explicitly preserved accounts.
+func (h *Handlers) EstablishBillingCutover(c *gin.Context) {
+	_, ok := h.requirePlatformBilling(c, platformBillingWritePermission)
+	if !ok {
+		return
+	}
+	var req billingCutoverRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.CutoverAt.IsZero() {
+		respondErrorMsg(c, "bad_request", "cutover_at is required", http.StatusBadRequest)
+		return
+	}
+	cutover := req.CutoverAt.UTC().Truncate(time.Second)
+	count, err := h.DB.EstablishBillingCutover(c.Request.Context(), db.EstablishBillingCutoverParams{
+		Cutover:          cutover,
+		PreservedTeamIds: req.PreservedTeamIDs,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("establish billing cutover failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"cutover_at": cutover, "teams_updated": count})
 }
 
 func (h *Handlers) CreateStripeCustomerPortalSession(c *gin.Context) {
@@ -1579,7 +1731,7 @@ func (h *Handlers) rollbackAndPersistStripeWebhookFailure(ctx context.Context, t
 
 func (h *Handlers) resolveStripeWebhookRouting(ctx context.Context, event *stripeEventEnvelope) (stripeWebhookRoutingDecision, error) {
 	switch event.Type {
-	case "checkout.session.completed":
+	case "checkout.session.completed", "checkout.session.expired":
 		var obj stripeCheckoutCompletedObject
 		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
 			return stripeWebhookRoutingDecisionInvalid, err
@@ -1655,12 +1807,29 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		if err != nil {
 			return err
 		}
+		account, err := q.GetTeamBillingAccount(ctx, teamID)
+		if err != nil {
+			return err
+		}
+		if account.CheckoutSessionID == nil || *account.CheckoutSessionID != obj.ID {
+			return nil
+		}
 		_, err = q.UpsertTeamBillingAccountSubscription(ctx, db.UpsertTeamBillingAccountSubscriptionParams{
 			TeamID:               teamID,
 			StripeCustomerID:     stringPtr(obj.Customer),
 			StripeSubscriptionID: stringPtr(obj.Subscription),
 		})
 		return err
+	case "checkout.session.expired":
+		var obj stripeCheckoutCompletedObject
+		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
+			return err
+		}
+		teamID, err := uuid.Parse(strings.TrimSpace(obj.ClientReferenceID))
+		if err != nil {
+			return err
+		}
+		return q.FinishTeamBillingCheckoutIfStartedBefore(ctx, db.FinishTeamBillingCheckoutIfStartedBeforeParams{TeamID: teamID, EventAt: pgtype.Timestamptz{Time: eventAt, Valid: true}, SessionID: stringPtr(obj.ID)})
 	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted", "customer.subscription.paused", "customer.subscription.resumed":
 		var obj stripeSubscriptionObject
 		if err := json.Unmarshal(event.Data.Object, &obj); err != nil {
@@ -1679,10 +1848,17 @@ func (h *Handlers) processStripeWebhookEvent(ctx context.Context, q *db.Queries,
 		if account.StripeSubscriptionEventAt.Valid && !eventAt.After(account.StripeSubscriptionEventAt.Time.UTC()) {
 			return nil
 		}
-		if event.Type != "customer.subscription.created" {
-			if account.StripeSubscriptionID == nil || *account.StripeSubscriptionID != obj.ID {
-				return nil
-			}
+		if event.Type != "customer.subscription.created" &&
+			(account.StripeSubscriptionID == nil || *account.StripeSubscriptionID != obj.ID) {
+			return nil
+		}
+		// While Checkout is reserved, a created event for an older subscription
+		// must not replace the subscription recorded by the current attempt.
+		// Outside Checkout, retain normal event-time ordering for subscription
+		// reconciliation (including first-time imports of an existing account).
+		if event.Type == "customer.subscription.created" && account.CheckoutInitializingAt.Valid &&
+			(account.StripeSubscriptionID == nil || *account.StripeSubscriptionID != obj.ID) {
+			return nil
 		}
 		start, end, ok := stripeSubscriptionPeriodBounds(obj)
 		terminalStatus := strings.EqualFold(obj.Status, "unpaid") || strings.EqualFold(obj.Status, "canceled") || strings.EqualFold(obj.Status, "paused") || event.Type == "customer.subscription.deleted"
@@ -2048,6 +2224,9 @@ func (h *Handlers) ensureStripeCustomer(ctx context.Context, teamID uuid.UUID) (
 type billingSnapshotQuerier interface {
 	UpsertTeamBillingUsage(context.Context, db.UpsertTeamBillingUsageParams) (db.UpsertTeamBillingUsageRow, error)
 	UpsertTeamBillingPeriod(context.Context, db.UpsertTeamBillingPeriodParams) (db.TeamBillingPeriod, error)
+	GetTeamBillingAccount(context.Context, uuid.UUID) (db.GetTeamBillingAccountRow, error)
+	ClaimTeamCommercialBillingAnchor(context.Context, db.ClaimTeamCommercialBillingAnchorParams) (time.Time, error)
+	ApproveTeamBillingPeriod(context.Context, db.ApproveTeamBillingPeriodParams) (db.TeamBillingPeriod, error)
 }
 
 func (h *Handlers) upsertBillingSnapshot(ctx context.Context, teamID uuid.UUID, periodStart, periodEnd time.Time) (db.TeamBillingUsage, db.TeamBillingPeriod, error) {
@@ -2056,6 +2235,20 @@ func (h *Handlers) upsertBillingSnapshot(ctx context.Context, teamID uuid.UUID, 
 		return db.TeamBillingUsage{}, db.TeamBillingPeriod{}, err
 	}
 	return billingTeamUsageFromUpsertRow(usageRow), period, nil
+}
+
+func (h *Handlers) authoritativeBillingPeriod(ctx context.Context, teamID uuid.UUID, at time.Time) (time.Time, time.Time, error) {
+	account, err := h.DB.GetTeamBillingAccount(ctx, teamID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return time.Time{}, time.Time{}, err
+	}
+	if err == nil && account.CommercialBillingAnchor.Valid {
+		if start, end, ok := billing.AnniversaryPeriod(account.CommercialBillingAnchor.Time, at); ok {
+			return start, end, nil
+		}
+	}
+	start, end := currentBillingPeriod(at)
+	return start, end, nil
 }
 
 func (h *Handlers) readBillingSnapshot(ctx context.Context, teamID uuid.UUID, periodStart, periodEnd time.Time) (db.TeamBillingUsage, db.TeamBillingPeriod, error) {
@@ -2105,6 +2298,25 @@ func (h *Handlers) readBillingSnapshot(ctx context.Context, teamID uuid.UUID, pe
 }
 
 func (h *Handlers) upsertBillingSnapshotWithQueries(ctx context.Context, q billingSnapshotQuerier, teamID uuid.UUID, periodStart, periodEnd time.Time) (db.UpsertTeamBillingUsageRow, db.TeamBillingPeriod, error) {
+	account, err := q.GetTeamBillingAccount(ctx, teamID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return db.UpsertTeamBillingUsageRow{}, db.TeamBillingPeriod{}, err
+	}
+	if err != nil || !account.CommercialBillingAnchor.Valid {
+		_, expectedEnd, ok := billing.AnniversaryPeriod(periodStart.UTC(), periodStart.UTC())
+		if !ok || !periodEnd.UTC().Equal(expectedEnd) {
+			return db.UpsertTeamBillingUsageRow{}, db.TeamBillingPeriod{}, fmt.Errorf("first billing period must span exactly one month")
+		}
+		if _, err := q.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+			TeamID: teamID,
+			Anchor: periodStart.UTC(),
+		}); err != nil {
+			return db.UpsertTeamBillingUsageRow{}, db.TeamBillingPeriod{}, err
+		}
+	} else if expectedStart, expectedEnd, ok := billing.AnniversaryPeriod(account.CommercialBillingAnchor.Time, periodStart); !ok ||
+		!expectedStart.Equal(periodStart.UTC()) || !expectedEnd.Equal(periodEnd.UTC()) {
+		return db.UpsertTeamBillingUsageRow{}, db.TeamBillingPeriod{}, fmt.Errorf("billing period does not match commercial anchor")
+	}
 	usage, err := q.UpsertTeamBillingUsage(ctx, db.UpsertTeamBillingUsageParams{
 		TeamID:      teamID,
 		PeriodStart: pgtype.Timestamptz{Time: periodStart.UTC(), Valid: true},
@@ -2283,6 +2495,7 @@ func billingPeriodResponseFromDB(period db.TeamBillingPeriod, account db.GetTeam
 		resp.InvoiceStatus = account.StripeInvoiceStatus
 		resp.CurrentPeriodStart = timePtrFromPG(account.CurrentPeriodStart)
 		resp.CurrentPeriodEnd = timePtrFromPG(account.CurrentPeriodEnd)
+		resp.CommercialBillingAnchor = timePtrFromPG(account.CommercialBillingAnchor)
 		resp.CancelAtPeriodEnd = &account.CancelAtPeriodEnd
 	}
 	return resp
@@ -2598,13 +2811,13 @@ func stripeMeterRoundedValue(value float64) float64 {
 }
 
 func stripeSubscriptionPeriodBounds(obj stripeSubscriptionObject) (int64, int64, bool) {
-	if obj.CurrentPeriodStart > 0 && obj.CurrentPeriodEnd > 0 {
-		return obj.CurrentPeriodStart, obj.CurrentPeriodEnd, true
-	}
 	for _, item := range obj.Items.Data {
 		if item.CurrentPeriodStart > 0 && item.CurrentPeriodEnd > 0 {
 			return item.CurrentPeriodStart, item.CurrentPeriodEnd, true
 		}
+	}
+	if obj.CurrentPeriodStart > 0 && obj.CurrentPeriodEnd > 0 {
+		return obj.CurrentPeriodStart, obj.CurrentPeriodEnd, true
 	}
 	return 0, 0, false
 }
@@ -2616,7 +2829,11 @@ func stripeEventTime(v int64) time.Time {
 	return time.Unix(v, 0).UTC()
 }
 
-func checkoutSessionIdempotencyKey(teamID uuid.UUID, customerID, successURL, cancelURL string, priceIDs []string) string {
+func checkoutSessionIdempotencyKey(teamID uuid.UUID, customerID, successURL, cancelURL string, priceIDs []string, backdateStartDate *time.Time) string {
+	backdate := "none"
+	if backdateStartDate != nil {
+		backdate = strconv.FormatInt(backdateStartDate.UTC().Unix(), 10)
+	}
 	raw := strings.Join([]string{
 		"checkout-v2",
 		teamID.String(),
@@ -2624,6 +2841,7 @@ func checkoutSessionIdempotencyKey(teamID uuid.UUID, customerID, successURL, can
 		successURL,
 		cancelURL,
 		strings.Join(priceIDs, ","),
+		backdate,
 	}, "|")
 
 	sum := sha256.Sum256([]byte(raw))

--- a/internal/api/handlers_billing_stripe_test.go
+++ b/internal/api/handlers_billing_stripe_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -82,6 +83,30 @@ func (r *stripeMeterEventRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+type stripeCheckoutSessionRoundTripper struct {
+	backdateStartDate string
+	clientReferenceID string
+}
+
+func (r *stripeCheckoutSessionRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+	r.backdateStartDate = form.Get("subscription_data[backdate_start_date]")
+	r.clientReferenceID = form.Get("client_reference_id")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"id":"cs_test_123","url":"https://checkout.stripe.test/session"}`)),
 		Header:     make(http.Header),
 		Request:    req,
 	}, nil
@@ -172,6 +197,88 @@ func TestStripeReportMeterEventUsesSeparateIdentifierAndIdempotencyKey(t *testin
 	}
 	if transport.identifier == transport.idempotencyKey {
 		t.Fatal("logical identifier and HTTP idempotency key must be distinct")
+	}
+}
+
+func TestStripeCreateCheckoutSessionSendsBackdateStartDate(t *testing.T) {
+	transport := &stripeCheckoutSessionRoundTripper{}
+	client := &stripeHTTPClient{
+		baseURL:    "https://stripe.example.test",
+		secretKey:  "sk_test_example",
+		apiVersion: "2025-06-30",
+		httpClient: &http.Client{Transport: transport},
+	}
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+	if _, err := client.CreateCheckoutSession(t.Context(), StripeCreateCheckoutSessionParams{
+		CustomerID:        "cus_example",
+		SuccessURL:        "https://app.superserve.test/billing/success",
+		CancelURL:         "https://app.superserve.test/billing/cancel",
+		ClientReferenceID: "team_example",
+		PriceIDs:          []string{"price_cpu"},
+		BackdateStartDate: &anchor,
+		IdempotencyKey:    "checkout:test",
+	}); err != nil {
+		t.Fatalf("create checkout session: %v", err)
+	}
+	if transport.backdateStartDate != strconv.FormatInt(anchor.Unix(), 10) {
+		t.Fatalf("subscription backdate_start_date = %q, want %d", transport.backdateStartDate, anchor.Unix())
+	}
+	if transport.clientReferenceID != "team_example" {
+		t.Fatalf("client reference id = %q, want %q", transport.clientReferenceID, "team_example")
+	}
+}
+
+func TestCheckoutSessionIdempotencyKeyIncludesBackdateStartDate(t *testing.T) {
+	teamID := uuid.MustParse("00000000-0000-0000-0000-000000000042")
+	customerID := "cus_example"
+	successURL := "https://app.superserve.test/billing/success"
+	cancelURL := "https://app.superserve.test/billing/cancel"
+	priceIDs := []string{"price_cpu"}
+	first := checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs, nil)
+	if got := checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs, nil); got != first {
+		t.Fatalf("same checkout payload produced %q, want %q", got, first)
+	}
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+	withAnchor := checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs, &anchor)
+	if withAnchor == first {
+		t.Fatal("checkout idempotency key ignored backdate start date")
+	}
+	if got := checkoutSessionIdempotencyKey(teamID, customerID, successURL, cancelURL, priceIDs, &anchor); got != withAnchor {
+		t.Fatalf("same checkout payload with backdate produced %q, want %q", got, withAnchor)
+	}
+}
+
+func TestStripeSubscriptionPeriodBoundsPrefersItemBounds(t *testing.T) {
+	obj := stripeSubscriptionObject{
+		CurrentPeriodStart: 100,
+		CurrentPeriodEnd:   200,
+		Items: stripeSubscriptionObjectItems{
+			Data: []stripeSubscriptionItem{{
+				CurrentPeriodStart: 300,
+				CurrentPeriodEnd:   400,
+			}},
+		},
+	}
+	start, end, ok := stripeSubscriptionPeriodBounds(obj)
+	if !ok {
+		t.Fatal("expected item-level subscription period bounds")
+	}
+	if start != 300 || end != 400 {
+		t.Fatalf("subscription period bounds = (%d, %d), want (300, 400)", start, end)
+	}
+}
+
+func TestStripeSubscriptionPeriodBoundsFallsBackToTopLevel(t *testing.T) {
+	obj := stripeSubscriptionObject{
+		CurrentPeriodStart: 100,
+		CurrentPeriodEnd:   200,
+	}
+	start, end, ok := stripeSubscriptionPeriodBounds(obj)
+	if !ok {
+		t.Fatal("expected top-level subscription period bounds")
+	}
+	if start != 100 || end != 200 {
+		t.Fatalf("subscription period bounds = (%d, %d), want (100, 200)", start, end)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -149,6 +149,8 @@ func SetupRouter(ctx context.Context, h *Handlers, pool *pgxpool.Pool) *gin.Engi
 		internal.GET("/billing", h.ListPlatformBilling)
 		internal.GET("/teams/:team_id/billing/usage", h.GetPlatformTeamBillingUsage)
 		internal.GET("/teams/:team_id/billing/periods", h.ListPlatformTeamBillingPeriods)
+		internal.POST("/billing/cutover", h.EstablishBillingCutover)
+		internal.POST("/teams/:team_id/billing/anchor", h.EstablishCommercialBillingAnchor)
 		internal.GET("/teams/:team_id/billing/periods/:period_id/export-preview", h.GetPlatformTeamBillingExportPreview)
 		internal.POST("/teams/:team_id/billing/periods/:period_id/approve", h.ApproveTeamBillingPeriod)
 		internal.POST("/teams/:team_id/billing/periods/:period_id/export", h.ExportTeamBillingPeriod)

--- a/internal/billing/anniversary.go
+++ b/internal/billing/anniversary.go
@@ -1,0 +1,37 @@
+package billing
+
+import "time"
+
+// AnniversaryPeriod returns the monthly commercial billing period containing
+// at. The anchor is the authoritative commercial start. For anchors on a day
+// that does not exist in a target month, the boundary is clamped to that
+// month's final day (for example Jan 31 -> Feb 28/29).
+//
+// The first period begins exactly at anchor. Times before anchor are not part
+// of paid billing and return ok=false.
+func AnniversaryPeriod(anchor, at time.Time) (start, end time.Time, ok bool) {
+	anchor = anchor.UTC()
+	at = at.UTC()
+	if at.Before(anchor) {
+		return time.Time{}, time.Time{}, false
+	}
+
+	months := (at.Year()-anchor.Year())*12 + int(at.Month()-anchor.Month())
+	start = anniversaryBoundary(anchor, months)
+	if start.After(at) {
+		months--
+		start = anniversaryBoundary(anchor, months)
+	}
+	end = anniversaryBoundary(anchor, months+1)
+	return start, end, true
+}
+
+func anniversaryBoundary(anchor time.Time, monthOffset int) time.Time {
+	first := time.Date(anchor.Year(), anchor.Month(), 1, anchor.Hour(), anchor.Minute(), anchor.Second(), anchor.Nanosecond(), time.UTC).AddDate(0, monthOffset, 0)
+	lastDay := time.Date(first.Year(), first.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
+	day := anchor.Day()
+	if day > lastDay {
+		day = lastDay
+	}
+	return time.Date(first.Year(), first.Month(), day, anchor.Hour(), anchor.Minute(), anchor.Second(), anchor.Nanosecond(), time.UTC)
+}

--- a/internal/billing/anniversary_test.go
+++ b/internal/billing/anniversary_test.go
@@ -1,0 +1,125 @@
+package billing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnniversaryPeriod(t *testing.T) {
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		at        time.Time
+		wantStart time.Time
+		wantEnd   time.Time
+		wantOK    bool
+	}{
+		{
+			name:   "before commercial start is not billable",
+			at:     anchor.Add(-time.Nanosecond),
+			wantOK: false,
+		},
+		{
+			name:      "commercial start",
+			at:        anchor,
+			wantStart: anchor,
+			wantEnd:   time.Date(2026, 9, 21, 17, 0, 0, 0, time.UTC),
+			wantOK:    true,
+		},
+		{
+			name:      "inside first period",
+			at:        time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+			wantStart: anchor,
+			wantEnd:   time.Date(2026, 9, 21, 17, 0, 0, 0, time.UTC),
+			wantOK:    true,
+		},
+		{
+			name:      "exact anniversary advances period",
+			at:        time.Date(2026, 9, 21, 17, 0, 0, 0, time.UTC),
+			wantStart: time.Date(2026, 9, 21, 17, 0, 0, 0, time.UTC),
+			wantEnd:   time.Date(2026, 10, 21, 17, 0, 0, 0, time.UTC),
+			wantOK:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStart, gotEnd, gotOK := AnniversaryPeriod(anchor, tc.at)
+			if gotOK != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if !gotStart.Equal(tc.wantStart) {
+				t.Fatalf("start = %s, want %s", gotStart, tc.wantStart)
+			}
+			if !gotEnd.Equal(tc.wantEnd) {
+				t.Fatalf("end = %s, want %s", gotEnd, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestAnniversaryPeriodMonthEndAnchor(t *testing.T) {
+	anchor := time.Date(2026, 1, 31, 12, 0, 0, 0, time.UTC)
+
+	febStart, febEnd, ok := AnniversaryPeriod(anchor, time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC))
+	if !ok {
+		t.Fatal("expected February to be billable")
+	}
+	if !febStart.Equal(anchor) {
+		t.Fatalf("February start = %s, want %s", febStart, anchor)
+	}
+	wantFebEnd := time.Date(2026, 2, 28, 12, 0, 0, 0, time.UTC)
+	if !febEnd.Equal(wantFebEnd) {
+		t.Fatalf("February end = %s, want %s", febEnd, wantFebEnd)
+	}
+
+	marStart, marEnd, ok := AnniversaryPeriod(anchor, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+	if !ok {
+		t.Fatal("expected March to be billable")
+	}
+	if !marStart.Equal(wantFebEnd) {
+		t.Fatalf("March start = %s, want %s", marStart, wantFebEnd)
+	}
+	wantMarEnd := time.Date(2026, 3, 31, 12, 0, 0, 0, time.UTC)
+	if !marEnd.Equal(wantMarEnd) {
+		t.Fatalf("March end = %s, want %s", marEnd, wantMarEnd)
+	}
+
+	aprilStart, aprilEnd, ok := AnniversaryPeriod(anchor, time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+	if !ok {
+		t.Fatal("expected April to be billable")
+	}
+	if !aprilStart.Equal(wantMarEnd) {
+		t.Fatalf("April start = %s, want %s", aprilStart, wantMarEnd)
+	}
+	wantAprilEnd := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	if !aprilEnd.Equal(wantAprilEnd) {
+		t.Fatalf("April end = %s, want %s", aprilEnd, wantAprilEnd)
+	}
+}
+
+func TestAnniversaryPeriodNormalizesToUTC(t *testing.T) {
+	location := time.FixedZone("CDT", -5*60*60)
+	anchor := time.Date(2026, 8, 21, 12, 0, 0, 123, location)
+	at := time.Date(2026, 9, 21, 12, 0, 0, 123, location)
+
+	start, end, ok := AnniversaryPeriod(anchor, at)
+	if !ok {
+		t.Fatal("expected anniversary boundary to be billable")
+	}
+	wantStart := time.Date(2026, 9, 21, 17, 0, 0, 123, time.UTC)
+	wantEnd := time.Date(2026, 10, 21, 17, 0, 0, 123, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Fatalf("start = %s, want %s", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Fatalf("end = %s, want %s", end, wantEnd)
+	}
+	if start.Location() != time.UTC || end.Location() != time.UTC {
+		t.Fatalf("period locations = %v/%v, want UTC/UTC", start.Location(), end.Location())
+	}
+}

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -163,6 +163,43 @@ func (q *Queries) AssignTeamPricingPlan(ctx context.Context, arg AssignTeamPrici
 	return i, err
 }
 
+const beginTeamBillingCheckout = `-- name: BeginTeamBillingCheckout :one
+UPDATE team_billing_account
+SET checkout_initializing_at = now(),
+    checkout_anchor_snapshot = commercial_billing_anchor,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = $1
+  AND (checkout_initializing_at IS NULL OR checkout_initializing_at < now() - interval '32 minutes')
+RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, commercial_billing_anchor, checkout_initializing_at, checkout_anchor_snapshot, checkout_session_id
+`
+
+func (q *Queries) BeginTeamBillingCheckout(ctx context.Context, teamID uuid.UUID) (TeamBillingAccount, error) {
+	row := q.db.QueryRow(ctx, beginTeamBillingCheckout, teamID)
+	var i TeamBillingAccount
+	err := row.Scan(
+		&i.TeamID,
+		&i.StripeCustomerID,
+		&i.StripeSubscriptionID,
+		&i.StripeSubscriptionStatus,
+		&i.CurrentPeriodStart,
+		&i.CurrentPeriodEnd,
+		&i.CancelAtPeriodEnd,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.StripeInvoiceStatus,
+		&i.StripeSubscriptionEventAt,
+		&i.TrialEndedAt,
+		&i.StripeActivationCreditGrantedAt,
+		&i.StripeActivationCreditGrantID,
+		&i.CommercialBillingAnchor,
+		&i.CheckoutInitializingAt,
+		&i.CheckoutAnchorSnapshot,
+		&i.CheckoutSessionID,
+	)
+	return i, err
+}
+
 const blockTeamBillingPeriod = `-- name: BlockTeamBillingPeriod :one
 UPDATE team_billing_period
 SET status = 'blocked',
@@ -210,6 +247,22 @@ func (q *Queries) BlockTeamBillingPeriod(ctx context.Context, arg BlockTeamBilli
 		&i.NetInvoiceAmountUsd,
 	)
 	return i, err
+}
+
+const claimTeamCommercialBillingAnchor = `-- name: ClaimTeamCommercialBillingAnchor :one
+SELECT claim_team_commercial_billing_anchor($1, $2)::timestamptz AS commercial_billing_anchor
+`
+
+type ClaimTeamCommercialBillingAnchorParams struct {
+	TeamID uuid.UUID `json:"team_id"`
+	Anchor time.Time `json:"anchor"`
+}
+
+func (q *Queries) ClaimTeamCommercialBillingAnchor(ctx context.Context, arg ClaimTeamCommercialBillingAnchorParams) (time.Time, error) {
+	row := q.db.QueryRow(ctx, claimTeamCommercialBillingAnchor, arg.TeamID, arg.Anchor)
+	var commercial_billing_anchor time.Time
+	err := row.Scan(&commercial_billing_anchor)
+	return commercial_billing_anchor, err
 }
 
 const createBillingPeriodAnomaly = `-- name: CreateBillingPeriodAnomaly :one
@@ -376,6 +429,78 @@ func (q *Queries) CreateStripeWebhookEvent(ctx context.Context, arg CreateStripe
 	return i, err
 }
 
+const establishBillingCutover = `-- name: EstablishBillingCutover :one
+SELECT establish_billing_cutover($1, $2::uuid[])::int AS team_count
+`
+
+type EstablishBillingCutoverParams struct {
+	Cutover          time.Time   `json:"cutover"`
+	PreservedTeamIds []uuid.UUID `json:"preserved_team_ids"`
+}
+
+func (q *Queries) EstablishBillingCutover(ctx context.Context, arg EstablishBillingCutoverParams) (int32, error) {
+	row := q.db.QueryRow(ctx, establishBillingCutover, arg.Cutover, arg.PreservedTeamIds)
+	var team_count int32
+	err := row.Scan(&team_count)
+	return team_count, err
+}
+
+const finishTeamBillingCheckout = `-- name: FinishTeamBillingCheckout :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = $1
+`
+
+func (q *Queries) FinishTeamBillingCheckout(ctx context.Context, teamID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, finishTeamBillingCheckout, teamID)
+	return err
+}
+
+const finishTeamBillingCheckoutForSubscription = `-- name: FinishTeamBillingCheckoutForSubscription :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    checkout_session_id = NULL,
+    updated_at = now()
+WHERE team_id = $1
+  AND stripe_subscription_id = $2
+  AND checkout_initializing_at IS NOT NULL
+`
+
+type FinishTeamBillingCheckoutForSubscriptionParams struct {
+	TeamID         uuid.UUID `json:"team_id"`
+	SubscriptionID *string   `json:"subscription_id"`
+}
+
+func (q *Queries) FinishTeamBillingCheckoutForSubscription(ctx context.Context, arg FinishTeamBillingCheckoutForSubscriptionParams) error {
+	_, err := q.db.Exec(ctx, finishTeamBillingCheckoutForSubscription, arg.TeamID, arg.SubscriptionID)
+	return err
+}
+
+const finishTeamBillingCheckoutIfStartedBefore = `-- name: FinishTeamBillingCheckoutIfStartedBefore :exec
+UPDATE team_billing_account
+SET checkout_initializing_at = NULL,
+    checkout_anchor_snapshot = NULL,
+    updated_at = now()
+WHERE team_id = $1
+  AND checkout_initializing_at <= $2
+  AND checkout_session_id = $3
+`
+
+type FinishTeamBillingCheckoutIfStartedBeforeParams struct {
+	TeamID    uuid.UUID          `json:"team_id"`
+	EventAt   pgtype.Timestamptz `json:"event_at"`
+	SessionID *string            `json:"session_id"`
+}
+
+func (q *Queries) FinishTeamBillingCheckoutIfStartedBefore(ctx context.Context, arg FinishTeamBillingCheckoutIfStartedBeforeParams) error {
+	_, err := q.db.Exec(ctx, finishTeamBillingCheckoutIfStartedBefore, arg.TeamID, arg.EventAt, arg.SessionID)
+	return err
+}
+
 const getActiveTeamBillingPeriod = `-- name: GetActiveTeamBillingPeriod :one
 SELECT team_id, period_start, period_end, status, blocked_reason, blocked_at, approved_by, approved_at, exported_at, finalized_at, created_at, updated_at, gross_charges_usd, credits_applied_usd, net_invoice_amount_usd
 FROM team_billing_period
@@ -535,7 +660,7 @@ func (q *Queries) GetTeamActivePricingPlan(ctx context.Context, teamID uuid.UUID
 }
 
 const getTeamBillingAccount = `-- name: GetTeamBillingAccount :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, commercial_billing_anchor, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, checkout_initializing_at, checkout_session_id
 FROM team_billing_account
 WHERE team_id = $1
 `
@@ -549,12 +674,15 @@ type GetTeamBillingAccountRow struct {
 	StripeSubscriptionEventAt       pgtype.Timestamptz `json:"stripe_subscription_event_at"`
 	CurrentPeriodStart              pgtype.Timestamptz `json:"current_period_start"`
 	CurrentPeriodEnd                pgtype.Timestamptz `json:"current_period_end"`
+	CommercialBillingAnchor         pgtype.Timestamptz `json:"commercial_billing_anchor"`
 	CancelAtPeriodEnd               bool               `json:"cancel_at_period_end"`
 	CreatedAt                       time.Time          `json:"created_at"`
 	UpdatedAt                       time.Time          `json:"updated_at"`
 	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
 	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
 	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
+	CheckoutInitializingAt          pgtype.Timestamptz `json:"checkout_initializing_at"`
+	CheckoutSessionID               *string            `json:"checkout_session_id"`
 }
 
 func (q *Queries) GetTeamBillingAccount(ctx context.Context, teamID uuid.UUID) (GetTeamBillingAccountRow, error) {
@@ -569,18 +697,21 @@ func (q *Queries) GetTeamBillingAccount(ctx context.Context, teamID uuid.UUID) (
 		&i.StripeSubscriptionEventAt,
 		&i.CurrentPeriodStart,
 		&i.CurrentPeriodEnd,
+		&i.CommercialBillingAnchor,
 		&i.CancelAtPeriodEnd,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.TrialEndedAt,
 		&i.StripeActivationCreditGrantedAt,
 		&i.StripeActivationCreditGrantID,
+		&i.CheckoutInitializingAt,
+		&i.CheckoutSessionID,
 	)
 	return i, err
 }
 
 const getTeamBillingAccountByStripeCustomerID = `-- name: GetTeamBillingAccountByStripeCustomerID :one
-SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+SELECT team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_invoice_status, stripe_subscription_event_at, current_period_start, current_period_end, commercial_billing_anchor, cancel_at_period_end, created_at, updated_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, checkout_initializing_at, checkout_session_id
 FROM team_billing_account
 WHERE stripe_customer_id = $1
 `
@@ -594,12 +725,15 @@ type GetTeamBillingAccountByStripeCustomerIDRow struct {
 	StripeSubscriptionEventAt       pgtype.Timestamptz `json:"stripe_subscription_event_at"`
 	CurrentPeriodStart              pgtype.Timestamptz `json:"current_period_start"`
 	CurrentPeriodEnd                pgtype.Timestamptz `json:"current_period_end"`
+	CommercialBillingAnchor         pgtype.Timestamptz `json:"commercial_billing_anchor"`
 	CancelAtPeriodEnd               bool               `json:"cancel_at_period_end"`
 	CreatedAt                       time.Time          `json:"created_at"`
 	UpdatedAt                       time.Time          `json:"updated_at"`
 	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
 	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
 	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
+	CheckoutInitializingAt          pgtype.Timestamptz `json:"checkout_initializing_at"`
+	CheckoutSessionID               *string            `json:"checkout_session_id"`
 }
 
 func (q *Queries) GetTeamBillingAccountByStripeCustomerID(ctx context.Context, stripeCustomerID *string) (GetTeamBillingAccountByStripeCustomerIDRow, error) {
@@ -614,12 +748,15 @@ func (q *Queries) GetTeamBillingAccountByStripeCustomerID(ctx context.Context, s
 		&i.StripeSubscriptionEventAt,
 		&i.CurrentPeriodStart,
 		&i.CurrentPeriodEnd,
+		&i.CommercialBillingAnchor,
 		&i.CancelAtPeriodEnd,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.TrialEndedAt,
 		&i.StripeActivationCreditGrantedAt,
 		&i.StripeActivationCreditGrantID,
+		&i.CheckoutInitializingAt,
+		&i.CheckoutSessionID,
 	)
 	return i, err
 }
@@ -1997,6 +2134,23 @@ func (q *Queries) SetFeatureFlag(ctx context.Context, arg SetFeatureFlagParams) 
 	return i, err
 }
 
+const setTeamBillingCheckoutSession = `-- name: SetTeamBillingCheckoutSession :exec
+UPDATE team_billing_account
+SET checkout_session_id = $1, updated_at = now()
+WHERE team_id = $2
+  AND checkout_initializing_at IS NOT NULL
+`
+
+type SetTeamBillingCheckoutSessionParams struct {
+	SessionID *string   `json:"session_id"`
+	TeamID    uuid.UUID `json:"team_id"`
+}
+
+func (q *Queries) SetTeamBillingCheckoutSession(ctx context.Context, arg SetTeamBillingCheckoutSessionParams) error {
+	_, err := q.db.Exec(ctx, setTeamBillingCheckoutSession, arg.SessionID, arg.TeamID)
+	return err
+}
+
 const setTeamFeatureFlag = `-- name: SetTeamFeatureFlag :one
 INSERT INTO team_feature_flag (team_id, key, enabled)
 VALUES ($1, $2, $3)
@@ -2121,7 +2275,7 @@ VALUES ($1, $2)
 ON CONFLICT (team_id) DO UPDATE
 SET stripe_customer_id = EXCLUDED.stripe_customer_id,
     updated_at = now()
-RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, commercial_billing_anchor, checkout_initializing_at, checkout_anchor_snapshot, checkout_session_id
 `
 
 type UpsertTeamBillingAccountCustomerParams struct {
@@ -2147,6 +2301,10 @@ func (q *Queries) UpsertTeamBillingAccountCustomer(ctx context.Context, arg Upse
 		&i.TrialEndedAt,
 		&i.StripeActivationCreditGrantedAt,
 		&i.StripeActivationCreditGrantID,
+		&i.CommercialBillingAnchor,
+		&i.CheckoutInitializingAt,
+		&i.CheckoutAnchorSnapshot,
+		&i.CheckoutSessionID,
 	)
 	return i, err
 }
@@ -2161,6 +2319,7 @@ INSERT INTO team_billing_account (
     stripe_subscription_event_at,
     current_period_start,
     current_period_end,
+    commercial_billing_anchor,
     cancel_at_period_end
 )
 VALUES (
@@ -2172,7 +2331,8 @@ VALUES (
     $6,
     $7,
     $8,
-    COALESCE($9, false)
+    COALESCE($9::timestamptz, $7::timestamptz),
+    COALESCE($10, false)
 )
 ON CONFLICT (team_id) DO UPDATE
 SET stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, team_billing_account.stripe_customer_id),
@@ -2182,9 +2342,10 @@ SET stripe_customer_id = COALESCE(EXCLUDED.stripe_customer_id, team_billing_acco
     stripe_subscription_event_at = COALESCE(EXCLUDED.stripe_subscription_event_at, team_billing_account.stripe_subscription_event_at),
     current_period_start = COALESCE(EXCLUDED.current_period_start, team_billing_account.current_period_start),
     current_period_end = COALESCE(EXCLUDED.current_period_end, team_billing_account.current_period_end),
-    cancel_at_period_end = COALESCE($9, team_billing_account.cancel_at_period_end),
+    commercial_billing_anchor = COALESCE(team_billing_account.commercial_billing_anchor, EXCLUDED.commercial_billing_anchor),
+    cancel_at_period_end = COALESCE($10, team_billing_account.cancel_at_period_end),
     updated_at = now()
-RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id
+RETURNING team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at, stripe_invoice_status, stripe_subscription_event_at, trial_ended_at, stripe_activation_credit_granted_at, stripe_activation_credit_grant_id, commercial_billing_anchor, checkout_initializing_at, checkout_anchor_snapshot, checkout_session_id
 `
 
 type UpsertTeamBillingAccountSubscriptionParams struct {
@@ -2196,6 +2357,7 @@ type UpsertTeamBillingAccountSubscriptionParams struct {
 	StripeSubscriptionEventAt pgtype.Timestamptz `json:"stripe_subscription_event_at"`
 	CurrentPeriodStart        pgtype.Timestamptz `json:"current_period_start"`
 	CurrentPeriodEnd          pgtype.Timestamptz `json:"current_period_end"`
+	CommercialBillingAnchor   pgtype.Timestamptz `json:"commercial_billing_anchor"`
 	CancelAtPeriodEnd         interface{}        `json:"cancel_at_period_end"`
 }
 
@@ -2209,6 +2371,7 @@ func (q *Queries) UpsertTeamBillingAccountSubscription(ctx context.Context, arg 
 		arg.StripeSubscriptionEventAt,
 		arg.CurrentPeriodStart,
 		arg.CurrentPeriodEnd,
+		arg.CommercialBillingAnchor,
 		arg.CancelAtPeriodEnd,
 	)
 	var i TeamBillingAccount
@@ -2227,17 +2390,39 @@ func (q *Queries) UpsertTeamBillingAccountSubscription(ctx context.Context, arg 
 		&i.TrialEndedAt,
 		&i.StripeActivationCreditGrantedAt,
 		&i.StripeActivationCreditGrantID,
+		&i.CommercialBillingAnchor,
+		&i.CheckoutInitializingAt,
+		&i.CheckoutAnchorSnapshot,
+		&i.CheckoutSessionID,
 	)
 	return i, err
 }
 
 const upsertTeamBillingPeriod = `-- name: UpsertTeamBillingPeriod :one
 INSERT INTO team_billing_period (team_id, period_start, period_end, status)
-VALUES (
+SELECT
     $1,
     $2,
     $3,
     $4
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM team_billing_period billed
+    WHERE billed.team_id = $1
+      AND (billed.period_start, billed.period_end) <>
+          ($2, $3)
+      AND (
+          billed.status = 'exported'
+          OR billed.exported_at IS NOT NULL
+          OR (
+              billed.finalized_at IS NOT NULL
+              AND (billed.blocked_reason IS NULL OR billed.blocked_reason NOT IN (
+                  'reporting_only_calendar_period', 'discarded_before_billing_cutover'
+              ))
+          )
+      )
+      AND tstzrange(billed.period_start, billed.period_end, '[)') &&
+          tstzrange($2, $3, '[)')
 )
 ON CONFLICT (team_id, period_start, period_end) DO UPDATE
 SET status = CASE

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -750,6 +750,11 @@ type TeamBillingAccount struct {
 	TrialEndedAt                    pgtype.Timestamptz `json:"trial_ended_at"`
 	StripeActivationCreditGrantedAt pgtype.Timestamptz `json:"stripe_activation_credit_granted_at"`
 	StripeActivationCreditGrantID   *string            `json:"stripe_activation_credit_grant_id"`
+	// Authoritative Superserve commercial billing start. May predate Stripe subscription creation and must not be overwritten by Checkout time.
+	CommercialBillingAnchor pgtype.Timestamptz `json:"commercial_billing_anchor"`
+	CheckoutInitializingAt  pgtype.Timestamptz `json:"checkout_initializing_at"`
+	CheckoutAnchorSnapshot  pgtype.Timestamptz `json:"checkout_anchor_snapshot"`
+	CheckoutSessionID       *string            `json:"checkout_session_id"`
 }
 
 type TeamBillingPeriod struct {

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -72,7 +72,9 @@ func (f *fakeStripeClient) CreateCustomer(_ context.Context, params api.StripeCr
 	f.customerCalls = append(f.customerCalls, params)
 	id := f.nextCustomerID
 	if id == "" {
-		id = "cus_test_default"
+		// Keep the fixture's Stripe customer IDs unique across integration tests;
+		// the database enforces uniqueness globally, while each test uses its own team.
+		id = "cus_test_" + params.TeamID.String()
 	}
 	return api.StripeCustomer{ID: id}, nil
 }
@@ -270,7 +272,7 @@ func stripeCheckoutWebhookPayload(t *testing.T, eventID, clientReferenceID, cust
 		"created": created.Unix(),
 		"data": map[string]any{
 			"object": map[string]any{
-				"id":                  "cs_" + eventID,
+				"id":                  "cs_test_123",
 				"customer":            customerID,
 				"subscription":        subscriptionID,
 				"client_reference_id": clientReferenceID,
@@ -428,6 +430,35 @@ func TestIntegration_ShadowBillingSkipsStripeCalls(t *testing.T) {
 	}
 }
 
+func TestIntegration_ExportTeamBillingPeriodClaimsCommercialAnchor(t *testing.T) {
+	ctx := context.Background()
+	teamID, periodID, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, false)
+	adminID := seedPlatformAdminProfile(t)
+	stripe := &fakeStripeClient{}
+	r := newBillingRouter(t, stripe)
+
+	w := doInternal(r, "POST", "/internal/teams/"+teamID.String()+"/billing/periods/"+periodID+"/export", adminID.String(), "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("shadow export with anchor claim: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := len(stripe.reportCalls); got != 0 {
+		t.Fatalf("stripe report calls = %d, want 0 in shadow mode", got)
+	}
+	account, err := testQueries.GetTeamBillingAccount(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load billing account after export: %v", err)
+	}
+	if !account.CommercialBillingAnchor.Valid {
+		t.Fatal("commercial billing anchor was not claimed during export")
+	}
+	if !account.CommercialBillingAnchor.Time.Equal(periodStart) {
+		t.Fatalf("commercial billing anchor = %s, want %s", account.CommercialBillingAnchor.Time, periodStart)
+	}
+	if got := billingPeriodStatus(t, teamID, periodStart, periodEnd); got != "exported" {
+		t.Fatalf("period status after shadow export = %q, want exported", got)
+	}
+}
+
 func TestIntegration_LiveBillingSendsStripeEventsAndIsIdempotent(t *testing.T) {
 	teamID, periodID, periodStart, periodEnd := seedBillingPeriodForStripe(t, true, true)
 	adminID := seedPlatformAdminProfile(t)
@@ -577,6 +608,78 @@ func TestIntegration_CreateStripeCheckoutSessionUsesConfiguredPrice(t *testing.T
 	}
 	if got := stripe.checkoutCalls[0].IdempotencyKey; got == "" {
 		t.Fatal("checkout idempotency key was not set")
+	}
+}
+
+func TestIntegration_CreateStripeCheckoutSessionWithCommercialAnchorUsesCurrentActivation(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey, _ := seedTeamAndKeyWithRole(t, "team_owner")
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_feature_flag (team_id, key, enabled)
+		VALUES ($1, 'billing_export_enabled', true)
+		ON CONFLICT (team_id, key) DO UPDATE SET enabled = EXCLUDED.enabled
+	`, teamID); err != nil {
+		t.Fatalf("enable billing export: %v", err)
+	}
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+	if _, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	}); err != nil {
+		t.Fatalf("claim commercial billing anchor: %v", err)
+	}
+
+	stripe := &fakeStripeClient{nextCheckoutURL: "https://checkout.stripe.test/session"}
+	r := newBillingRouter(t, stripe)
+
+	w := do(r, "POST", "/stripe/checkout-session", apiKey, `{"success_url":"https://app.superserve.test/billing/success","cancel_url":"https://app.superserve.test/billing/cancel"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("checkout session with commercial anchor: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := len(stripe.checkoutCalls); got != 1 {
+		t.Fatalf("checkout calls = %d, want 1", got)
+	}
+	if stripe.checkoutCalls[0].BackdateStartDate != nil {
+		t.Fatalf("checkout backdate_start_date = %v, want nil for normal activation", stripe.checkoutCalls[0].BackdateStartDate)
+	}
+
+	customerID := "cus_test_" + teamID.String()
+	subscriptionID := "sub_" + teamID.String()
+	checkoutCreatedAt := anchor.Add(2 * time.Hour)
+	checkoutPayload := stripeCheckoutWebhookPayload(t, "evt_checkout_completed", teamID.String(), customerID, subscriptionID, checkoutCreatedAt)
+	checkoutReq := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(checkoutPayload)))
+	checkoutReq.Header.Set("Content-Type", "application/json")
+	checkoutReq.Header.Set("Stripe-Signature", stripeSignature(t, checkoutPayload, time.Now().UTC()))
+	if checkoutResp := doRequest(r, checkoutReq); checkoutResp.Code != http.StatusOK {
+		t.Fatalf("checkout webhook: expected 200, got %d: %s", checkoutResp.Code, checkoutResp.Body.String())
+	}
+
+	periodStart := anchor
+	periodEnd := anchor.AddDate(0, 1, 0)
+	subscriptionCreatedAt := checkoutCreatedAt.Add(time.Minute)
+	subscriptionPayload := stripeSubscriptionWebhookPayload(t, "evt_subscription_created", "customer.subscription.created", subscriptionID, customerID, "active", subscriptionCreatedAt, periodStart, periodEnd)
+	subscriptionReq := httptest.NewRequest("POST", "/stripe/webhook", strings.NewReader(string(subscriptionPayload)))
+	subscriptionReq.Header.Set("Content-Type", "application/json")
+	subscriptionReq.Header.Set("Stripe-Signature", stripeSignature(t, subscriptionPayload, time.Now().UTC()))
+	if subscriptionResp := doRequest(r, subscriptionReq); subscriptionResp.Code != http.StatusOK {
+		t.Fatalf("subscription created webhook: expected 200, got %d: %s", subscriptionResp.Code, subscriptionResp.Body.String())
+	}
+
+	account, err := testQueries.GetTeamBillingAccount(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load billing account after subscription activation: %v", err)
+	}
+	if !account.CommercialBillingAnchor.Valid || !account.CommercialBillingAnchor.Time.Equal(anchor) {
+		t.Fatalf("commercial billing anchor = %v, want %s", account.CommercialBillingAnchor, anchor)
+	}
+	if account.StripeSubscriptionID == nil || *account.StripeSubscriptionID != subscriptionID {
+		t.Fatalf("stripe subscription id = %q, want %q", derefString(account.StripeSubscriptionID), subscriptionID)
+	}
+	if !account.CurrentPeriodStart.Valid || !account.CurrentPeriodStart.Time.Equal(periodStart) {
+		t.Fatalf("current period start = %v, want %s", account.CurrentPeriodStart, periodStart)
+	}
+	if !account.CurrentPeriodEnd.Valid || !account.CurrentPeriodEnd.Time.Equal(periodEnd) {
+		t.Fatalf("current period end = %v, want %s", account.CurrentPeriodEnd, periodEnd)
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1847,6 +1847,179 @@ func TestIntegration_GetBillingSummaryUsesActiveBillingPeriod(t *testing.T) {
 	}
 }
 
+func TestIntegration_GetBillingSummaryUsesCommercialBillingAnchor(t *testing.T) {
+	ctx := context.Background()
+	teamID, ownerKey := seedTeamAndKey(t)
+	r := newRouter(t)
+
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+	reportingStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	reportingEnd := reportingStart.AddDate(0, 1, 0)
+	if _, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	}); err != nil {
+		t.Fatalf("claim commercial billing anchor: %v", err)
+	}
+	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: reportingStart,
+		PeriodEnd:   reportingEnd,
+		Status:      "open",
+	}); err != nil {
+		t.Fatalf("upsert reporting billing period: %v", err)
+	}
+
+	w := do(r, "GET", "/billing/summary", ownerKey, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("billing summary with commercial anchor: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	body := mustJSON(t, w)
+	period, ok := body["billing_period"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("billing_period not an object: %v", body["billing_period"])
+	}
+	gotStart, err := time.Parse(time.RFC3339, period["start"].(string))
+	if err != nil {
+		t.Fatalf("parse billing period start: %v", err)
+	}
+	if !gotStart.Equal(anchor) {
+		t.Fatalf("billing summary period start = %s, want %s", gotStart, anchor)
+	}
+	gotEnd, err := time.Parse(time.RFC3339, period["end"].(string))
+	if err != nil {
+		t.Fatalf("parse billing period end: %v", err)
+	}
+	if !gotEnd.Equal(anchor.AddDate(0, 1, 0)) {
+		t.Fatalf("billing summary period end = %s, want %s", gotEnd, anchor.AddDate(0, 1, 0))
+	}
+}
+
+func TestIntegration_ClaimTeamCommercialBillingAnchorIsIdempotentAndConflictSafe(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _ := seedTeamAndKeyWithRole(t, "viewer")
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+
+	got, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	})
+	if err != nil {
+		t.Fatalf("first commercial billing anchor claim: %v", err)
+	}
+	if !got.Equal(anchor) {
+		t.Fatalf("first commercial billing anchor claim = %s, want %s", got, anchor)
+	}
+
+	retry, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	})
+	if err != nil {
+		t.Fatalf("idempotent commercial billing anchor claim: %v", err)
+	}
+	if !retry.Equal(anchor) {
+		t.Fatalf("idempotent commercial billing anchor claim = %s, want %s", retry, anchor)
+	}
+
+	if _, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor.Add(time.Hour),
+	}); err == nil {
+		t.Fatal("conflicting commercial billing anchor claim succeeded, want failure")
+	}
+
+	account, err := testQueries.GetTeamBillingAccount(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load team billing account: %v", err)
+	}
+	if !account.CommercialBillingAnchor.Valid {
+		t.Fatal("commercial billing anchor was not persisted")
+	}
+	if !account.CommercialBillingAnchor.Time.Equal(anchor) {
+		t.Fatalf("commercial billing anchor = %s, want %s", account.CommercialBillingAnchor.Time, anchor)
+	}
+}
+
+func TestIntegration_ClaimTeamCommercialBillingAnchorPreservesLegacyPeriod(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _ := seedTeamAndKeyWithRole(t, "viewer")
+	anchor := time.Date(2026, 8, 21, 17, 0, 0, 0, time.UTC)
+	legacyStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	legacyEnd := legacyStart.AddDate(0, 1, 0)
+
+	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: legacyStart,
+		PeriodEnd:   legacyEnd,
+		Status:      "open",
+	}); err != nil {
+		t.Fatalf("seed legacy billing period: %v", err)
+	}
+
+	if _, err := testQueries.ClaimTeamCommercialBillingAnchor(ctx, db.ClaimTeamCommercialBillingAnchorParams{
+		TeamID: teamID,
+		Anchor: anchor,
+	}); err != nil {
+		t.Fatalf("claim commercial billing anchor: %v", err)
+	}
+
+	var status string
+	var finalizedAt *time.Time
+	if err := testPool.QueryRow(ctx, `
+		SELECT status, finalized_at
+		FROM team_billing_period
+		WHERE team_id = $1 AND period_start = $2 AND period_end = $3
+	`, teamID, legacyStart, legacyEnd).Scan(&status, &finalizedAt); err != nil {
+		t.Fatalf("load reconciled legacy billing period: %v", err)
+	}
+	if status != "open" || finalizedAt != nil {
+		t.Fatalf("legacy billing period status/finalized_at = %q/%v, want open/null", status, finalizedAt)
+	}
+
+	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: anchor,
+		PeriodEnd:   anchor.AddDate(0, 1, 0),
+		Status:      "open",
+	}); err == nil {
+		t.Fatal("overlapping anniversary billing period insert succeeded, want failure")
+	}
+}
+
+func TestIntegration_UpsertTeamBillingPeriodRejectsOverlap(t *testing.T) {
+	ctx := context.Background()
+	teamID, _, _ := seedTeamAndKeyWithRole(t, "viewer")
+	firstStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	firstEnd := firstStart.AddDate(0, 1, 0)
+	secondStart := firstStart.Add(20 * 24 * time.Hour)
+	secondEnd := secondStart.AddDate(0, 1, 0)
+
+	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: firstStart,
+		PeriodEnd:   firstEnd,
+		Status:      "open",
+	}); err != nil {
+		t.Fatalf("seed first billing period: %v", err)
+	}
+
+	if _, err := testQueries.UpsertTeamBillingPeriod(ctx, db.UpsertTeamBillingPeriodParams{
+		TeamID:      teamID,
+		PeriodStart: secondStart,
+		PeriodEnd:   secondEnd,
+		Status:      "open",
+	}); err == nil {
+		t.Fatal("overlapping billing period insert succeeded, want failure")
+	} else {
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "23P01" {
+			t.Fatalf("overlapping billing period error = %v, want PostgreSQL 23P01", err)
+		}
+	}
+}
+
 func TestIntegration_GetBillingSummaryDeniesUserAdmin(t *testing.T) {
 	_, apiKey, _ := seedTeamAndKeyWithRole(t, "user_admin")
 	r := newRouter(t)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3901,6 +3901,8 @@ type machineConfigRecovery struct {
 	tracked map[*VMInstance]struct{} // queued or in flight; dedupes re-requests
 	ready   chan recoveryItem
 	wake    chan struct{}
+	probe   func(context.Context, string) (uint32, uint32, error)
+	done    func(string)
 	started bool
 }
 
@@ -3925,6 +3927,8 @@ func (m *Manager) backfillMachineConfigAsync(inst *VMInstance) {
 	m.recovery.mu.Lock()
 	if !m.recovery.started {
 		m.recovery.started = true
+		m.recovery.probe = machineConfigProbe
+		m.recovery.done = machineConfigBackfillDone
 		m.recovery.ready = make(chan recoveryItem)
 		m.recovery.wake = make(chan struct{}, 1)
 		m.recovery.tracked = make(map[*VMInstance]struct{})
@@ -4019,7 +4023,7 @@ func (m *Manager) recoveryWorker() {
 		inst.mu.RUnlock()
 
 		ctx, cancel := context.WithTimeout(context.Background(), machineConfigProbeTimeout)
-		vcpu, memoryMiB, err := machineConfigProbe(ctx, socket)
+		vcpu, memoryMiB, err := m.recovery.probe(ctx, socket)
 		cancel()
 		if err == nil && vcpu > 0 && memoryMiB > 0 {
 			m.applyMachineConfig(inst, vcpu, memoryMiB)
@@ -4077,8 +4081,8 @@ func (m *Manager) recoveryFinished(inst *VMInstance) {
 	m.recovery.mu.Lock()
 	delete(m.recovery.tracked, inst)
 	m.recovery.mu.Unlock()
-	if machineConfigBackfillDone != nil {
-		machineConfigBackfillDone(inst.ID)
+	if m.recovery.done != nil {
+		m.recovery.done(inst.ID)
 	}
 	m.backfillMachineConfigAsync(inst)
 }

--- a/supabase/migrations/20260730000002_grafana_readonly_role.sql
+++ b/supabase/migrations/20260730000002_grafana_readonly_role.sql
@@ -26,6 +26,8 @@ BEGIN
             throwaway_password
         );
     END IF;
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
 END
 $$;
 

--- a/supabase/migrations/20260827000001_billing_commercial_anchor.sql
+++ b/supabase/migrations/20260827000001_billing_commercial_anchor.sql
@@ -1,0 +1,263 @@
+-- Persist the Superserve commercial billing anchor independently of
+-- Stripe subscription activation. This anchor may predate Checkout for
+-- sales-assisted conversions and must survive later subscription webhooks.
+
+ALTER TABLE team_billing_account
+    ADD COLUMN commercial_billing_anchor timestamptz;
+
+ALTER TABLE team_billing_account
+    ADD COLUMN checkout_initializing_at timestamptz,
+    ADD COLUMN checkout_anchor_snapshot timestamptz,
+    ADD COLUMN checkout_session_id text;
+
+COMMENT ON COLUMN team_billing_account.commercial_billing_anchor IS
+    'Authoritative Superserve commercial billing start. May predate Stripe subscription creation and must not be overwritten by Checkout time.';
+
+CREATE INDEX idx_team_billing_account_commercial_anchor
+    ON team_billing_account(commercial_billing_anchor)
+    WHERE commercial_billing_anchor IS NOT NULL;
+
+-- Claim the commercial anchor exactly once. Repeating the same claim is
+-- idempotent; attempting to move an established anchor fails rather than
+-- silently changing the commercial cutover after usage may already be billable.
+CREATE OR REPLACE FUNCTION claim_team_commercial_billing_anchor(
+    p_team_id uuid,
+    p_anchor timestamptz
+)
+RETURNS timestamptz
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_anchor timestamptz;
+    v_existing_anchor timestamptz;
+BEGIN
+    IF p_anchor IS NULL THEN
+        RAISE EXCEPTION 'commercial billing anchor cannot be null';
+    END IF;
+    p_anchor := date_trunc('second', p_anchor);
+
+    SELECT commercial_billing_anchor
+    INTO v_existing_anchor
+    FROM team_billing_account
+    WHERE team_id = p_team_id
+    FOR UPDATE;
+
+    IF EXISTS (SELECT 1 FROM team_billing_account WHERE team_id = p_team_id AND checkout_initializing_at > now() - interval '32 minutes') THEN
+        RAISE EXCEPTION 'checkout is initializing for this team';
+    END IF;
+
+    INSERT INTO team_billing_account (team_id, commercial_billing_anchor)
+    VALUES (p_team_id, p_anchor)
+    ON CONFLICT (team_id) DO UPDATE
+    SET commercial_billing_anchor = COALESCE(
+            team_billing_account.commercial_billing_anchor,
+            EXCLUDED.commercial_billing_anchor
+        ),
+        updated_at = now()
+    WHERE team_billing_account.checkout_initializing_at IS NULL
+       OR team_billing_account.checkout_initializing_at < now() - interval '32 minutes'
+    RETURNING commercial_billing_anchor INTO v_anchor;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'checkout is initializing for this team';
+    END IF;
+
+    IF v_anchor IS DISTINCT FROM p_anchor THEN
+        RAISE EXCEPTION
+            'commercial billing anchor already established for team % at %',
+            p_team_id,
+            v_anchor;
+    END IF;
+
+    RETURN v_anchor;
+END;
+$$;
+
+COMMENT ON FUNCTION claim_team_commercial_billing_anchor(uuid, timestamptz) IS
+    'Atomically establishes a team commercial billing anchor once. Same-value retries are idempotent; conflicting attempts fail.';
+
+CREATE OR REPLACE FUNCTION establish_billing_cutover(
+    p_cutover timestamptz,
+    p_preserved_team_ids uuid[] DEFAULT '{}'
+)
+RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_count integer;
+    v_team_id uuid;
+BEGIN
+    IF p_cutover IS NULL THEN
+        RAISE EXCEPTION 'billing cutover cannot be null';
+    END IF;
+    p_cutover := date_trunc('second', p_cutover);
+    IF p_cutover > now() THEN
+        RAISE EXCEPTION 'billing cutover cannot be in the future';
+    END IF;
+    -- A dead Checkout process can leave its reservation behind. Reclaim
+    -- expired reservations in the same transaction so the cleanup and anchor
+    -- assignment predicates observe the same state as the lease check.
+    UPDATE team_billing_account
+    SET checkout_initializing_at = NULL,
+        checkout_anchor_snapshot = NULL,
+        updated_at = now()
+    WHERE checkout_initializing_at < now() - interval '32 minutes';
+    INSERT INTO team_billing_account (team_id)
+    SELECT t.id
+    FROM team t
+    WHERE NOT (t.id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+    ON CONFLICT (team_id) DO NOTHING;
+    FOR v_team_id IN
+        SELECT a.team_id
+        FROM team_billing_account a
+        WHERE NOT (a.team_id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+        ORDER BY a.team_id
+        FOR UPDATE
+    LOOP
+        NULL;
+    END LOOP;
+    IF EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(p_preserved_team_ids, '{}')) AS preserved(team_id)
+        LEFT JOIN team_billing_account a ON a.team_id = preserved.team_id
+        WHERE a.commercial_billing_anchor IS NULL
+    ) THEN
+        RAISE EXCEPTION 'preserved teams must have an established commercial billing anchor';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM team_billing_account a
+        WHERE a.commercial_billing_anchor IS NULL
+          AND a.checkout_initializing_at > now() - interval '32 minutes'
+          AND NOT (a.team_id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+    ) THEN
+        RAISE EXCEPTION 'cannot establish billing cutover while checkout is initializing';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM team_billing_period p
+        WHERE p.team_id <> ALL(COALESCE(p_preserved_team_ids, '{}'))
+          AND NOT EXISTS (
+              SELECT 1 FROM team_billing_account existing
+              WHERE existing.team_id = p.team_id
+                AND existing.commercial_billing_anchor IS NOT NULL
+          )
+          AND p.status = 'exporting'
+          AND EXISTS (
+              SELECT 1 FROM billing_usage_export e
+              WHERE e.team_id = p.team_id AND e.period_start = p.period_start
+                AND e.period_end = p.period_end AND e.sent_at IS NOT NULL
+          )
+    ) THEN
+        RAISE EXCEPTION 'cannot discard partially exported billing periods during cutover';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM team_billing_period p
+        WHERE p.team_id <> ALL(COALESCE(p_preserved_team_ids, '{}'))
+          AND EXISTS (
+              SELECT 1 FROM team_billing_account a
+              WHERE a.team_id = p.team_id
+                AND a.commercial_billing_anchor IS NULL
+          )
+          AND p.status = 'exporting'
+    ) THEN
+        RAISE EXCEPTION 'cannot cut over while billing periods are exporting';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM team_billing_period p
+        JOIN team_billing_account a ON a.team_id = p.team_id
+        WHERE a.commercial_billing_anchor = p_cutover
+          AND p.status = 'exported'
+          AND tstzrange(p.period_start, p.period_end, '[)') &&
+              tstzrange(p_cutover, p_cutover + interval '1 month', '[)')
+    ) THEN
+        RAISE EXCEPTION 'billing cutover overlaps an exported period';
+    END IF;
+
+    UPDATE team_billing_period p
+    SET status = 'finalized', blocked_reason = 'discarded_before_billing_cutover', blocked_at = NULL,
+        gross_charges_usd = 0, credits_applied_usd = 0, net_invoice_amount_usd = 0,
+        finalized_at = now(), updated_at = now()
+    WHERE p.team_id <> ALL(COALESCE(p_preserved_team_ids, '{}'))
+      AND NOT EXISTS (
+          SELECT 1 FROM team_billing_account existing
+          WHERE existing.team_id = p.team_id
+            AND existing.commercial_billing_anchor IS NOT NULL
+      )
+      AND p.finalized_at IS NULL
+      AND p.status IN ('open', 'validating', 'blocked', 'approved', 'exporting')
+      AND NOT (
+          p.status = 'exporting'
+          AND EXISTS (
+              SELECT 1 FROM billing_usage_export e
+              WHERE e.team_id = p.team_id
+                AND e.period_start = p.period_start
+                AND e.period_end = p.period_end
+                AND e.sent_at IS NOT NULL
+          )
+      );
+
+    SELECT count(*) INTO v_count
+    FROM team t
+    LEFT JOIN team_billing_account a ON a.team_id = t.id
+    WHERE NOT (t.id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+      AND a.commercial_billing_anchor IS NULL
+      AND a.checkout_initializing_at IS NULL;
+
+    UPDATE team_billing_account a
+    SET commercial_billing_anchor = p_cutover, updated_at = now()
+    WHERE a.commercial_billing_anchor IS NULL
+      AND a.checkout_initializing_at IS NULL
+      AND NOT (a.team_id = ANY(COALESCE(p_preserved_team_ids, '{}')));
+
+    INSERT INTO team_billing_account (team_id, commercial_billing_anchor)
+    SELECT t.id, p_cutover
+    FROM team t
+    LEFT JOIN team_billing_account a ON a.team_id = t.id
+    WHERE a.team_id IS NULL
+      AND NOT (t.id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+    ON CONFLICT (team_id) DO NOTHING;
+
+    INSERT INTO team_billing_period (team_id, period_start, period_end, status)
+    SELECT a.team_id, p_cutover, p_cutover + interval '1 month', 'open'
+    FROM team_billing_account a
+    WHERE a.commercial_billing_anchor = p_cutover
+      AND NOT (a.team_id = ANY(COALESCE(p_preserved_team_ids, '{}')))
+    ON CONFLICT (team_id, period_start, period_end) DO NOTHING;
+    RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION establish_billing_cutover(timestamptz, uuid[]) IS
+    'Establishes the production billing cutover for all existing non-preserved teams without overwriting an existing anchor.';
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM team_billing_period a
+        JOIN team_billing_period b
+          ON b.team_id = a.team_id
+         AND (b.period_start, b.period_end) > (a.period_start, a.period_end)
+         AND b.finalized_at IS NULL
+         AND b.status IN ('open', 'validating', 'blocked', 'approved', 'exporting')
+        WHERE a.finalized_at IS NULL
+          AND a.status IN ('open', 'validating', 'blocked', 'approved', 'exporting')
+          AND tstzrange(a.period_start, a.period_end, '[)') &&
+              tstzrange(b.period_start, b.period_end, '[)')
+    ) THEN
+        RAISE EXCEPTION 'cannot install billing period overlap constraint until legacy overlaps are cleared';
+    END IF;
+END;
+$$;
+ALTER TABLE team_billing_period
+    ADD CONSTRAINT team_billing_period_authoritative_no_overlap
+    EXCLUDE USING gist (
+        team_id WITH =,
+        tstzrange(period_start, period_end, '[)') WITH &&
+    ) WHERE (
+        finalized_at IS NULL
+        AND status IN ('open', 'validating', 'blocked', 'approved', 'exporting')
+    );

--- a/supabase/migrations/20260827000002_billing_trial_eligibility_cumulative.sql
+++ b/supabase/migrations/20260827000002_billing_trial_eligibility_cumulative.sql
@@ -1,23 +1,5 @@
--- Persist the transition away from the Superserve trial. Billing eligibility
--- is intentionally derived from normalized subscription state after this
--- transition; the trial balance must never make a former Stripe customer
--- eligible again.
-ALTER TABLE team_billing_account
-    ADD COLUMN trial_ended_at timestamptz,
-    ADD COLUMN stripe_activation_credit_granted_at timestamptz,
-    ADD COLUMN stripe_activation_credit_grant_id text;
-
-CREATE TABLE team_trial_eligibility_cache (
-    team_id uuid PRIMARY KEY REFERENCES team(id) ON DELETE CASCADE,
-    eligible boolean NOT NULL,
-    updated_at timestamptz NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_team_credit_grant_team_reason_expiry
-    ON team_credit_grant (team_id, reason, expires_at);
-
-ALTER TABLE team_trial_eligibility_cache ENABLE ROW LEVEL SECURITY;
-
+-- Apply the cumulative signup-credit eligibility calculation to databases
+-- where the original trial-eligibility migration has already run.
 CREATE OR REPLACE FUNCTION refresh_team_trial_eligibility(p_team_id uuid)
 RETURNS boolean
 LANGUAGE sql
@@ -118,74 +100,4 @@ AS $$
     LEFT JOIN account ON true
     CROSS JOIN grant_balance
     CROSS JOIN charges;
-$$;
-
-CREATE OR REPLACE FUNCTION team_sandbox_billing_eligible(p_team_id uuid)
-RETURNS boolean
-LANGUAGE sql
-STABLE
-AS $$
-    SELECT CASE
-        WHEN account.trial_ended_at IS NULL THEN
-            (grant_balance.grant_count = 0 AND account.stripe_subscription_id IS NULL)
-            OR (account.stripe_subscription_id IS NOT NULL
-                AND lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due'))
-            OR (grant_balance.remaining_usd > 0 AND COALESCE(cache.eligible, true))
-        ELSE lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
-    END
-    FROM (SELECT trial_ended_at, stripe_subscription_id, stripe_subscription_status
-          FROM team_billing_account WHERE team_id = p_team_id) account
-    FULL JOIN (SELECT COALESCE(SUM(remaining_usd), 0)::numeric AS remaining_usd,
-                      COUNT(*)::int AS grant_count
-               FROM team_credit_grant
-               WHERE team_id = p_team_id
-                 AND reason = 'signup trial credit'
-                 AND (expires_at IS NULL OR expires_at > now())) grant_balance ON true
-    LEFT JOIN team_trial_eligibility_cache cache ON cache.team_id = p_team_id;
-$$;
-
-CREATE OR REPLACE FUNCTION grant_signup_trial_credit()
-RETURNS trigger
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
-    VALUES (NEW.id, 5.000000, 5.000000, 'signup trial credit');
-    INSERT INTO team_trial_eligibility_cache (team_id, eligible)
-    VALUES (NEW.id, true)
-    ON CONFLICT (team_id) DO UPDATE SET eligible = true, updated_at = now();
-    RETURN NEW;
-END;
-$$;
-
-DROP TRIGGER IF EXISTS team_signup_trial_credit ON team;
-CREATE TRIGGER team_signup_trial_credit
-AFTER INSERT ON team
-FOR EACH ROW
-EXECUTE FUNCTION grant_signup_trial_credit();
-
-CREATE OR REPLACE FUNCTION activate_team_billing(p_team_id uuid, p_stripe_grant_id text)
-RETURNS void
-LANGUAGE sql
-AS $$
-    WITH marked AS (
-        UPDATE team_billing_account
-        SET trial_ended_at = COALESCE(trial_ended_at, now()),
-            stripe_activation_credit_granted_at = COALESCE(stripe_activation_credit_granted_at, now()),
-            stripe_activation_credit_grant_id = COALESCE(stripe_activation_credit_grant_id, p_stripe_grant_id),
-            updated_at = now()
-        WHERE team_id = p_team_id
-          AND lower(coalesce(stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
-          AND stripe_activation_credit_granted_at IS NULL
-        RETURNING team_id
-    ), zeroed AS (
-        UPDATE team_credit_grant g
-        SET remaining_usd = 0,
-            updated_at = now()
-        FROM marked
-        WHERE g.team_id = marked.team_id
-          AND g.reason = 'signup trial credit'
-        RETURNING g.team_id
-    )
-    SELECT 1 FROM marked;
 $$;


### PR DESCRIPTION
## Summary

- Align usage rollups and Stripe exports to subscription anniversary periods.
- Persist an explicit commercial billing anchor independent of Stripe activation.
- Provide an authorized cutover operation for existing accounts and preserve explicitly anchored accounts.
- Create ordinary Checkout subscriptions at activation time; do not implicitly backdate or preload usage.
- Enforce authoritative anniversary periods and prevent overlapping live periods.

## Rollout

This is a production billing cutover. Existing non-preserved accounts receive the deployment cutover anchor; the explicitly preserved account must have its verified commercial anchor established before bulk cutover. Future sales-assisted activation is operator-assisted: establish the anchor and create the intended subscription at commercial start, then collect payment later on that subscription.

Delayed subscription recovery and historical meter-event preload are intentionally outside this normal Checkout path and are not implemented by this change.

## Testing

Unit, integration, build, vet, SQL generation, migration-order, and infrastructure checks run in CI.
