### PR TITLE
vmd: hold fleet-sized background work until the daemon is ready to serve

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1455,9 +1455,8 @@ func main() {
 	go func() {
 		defer sentrylog.Recover("startup reattach")
 		// Held until readiness: requests load their VM on demand, so nothing
-		// waits on this pass, while running it during startup both contends
-		// for RTNL and emits one line per record — enough, on a large host,
-		// to push the readiness line past journald's rate limit.
+		// waits on this pass (see the fleet-sized background work comment
+		// above for why it must not run during startup).
 		select {
 		case <-postReady:
 		case <-ctx.Done():
@@ -1748,11 +1747,9 @@ func main() {
 	startupReady.Store(true)
 	st.mark("ready", true, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
-	// Released only after the readiness line is emitted: the work behind it
-	// logs per record, and on a large host that burst is enough to exhaust
-	// journald's rate limit. Anything published after this point can be
-	// dropped; the readiness line cannot, because the deploy readiness check
-	// reads it from the journal.
+	// Released only after the readiness line is emitted: the deploy
+	// readiness check reads that line from the journal, so nothing the
+	// background work logs may come ahead of it.
 	close(postReady)
 
 	// Leak gauge for network namespaces — independent of the launcher path.

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -213,21 +213,38 @@ func publishesCapacityPressure(advertiseAddr, controlPlaneURL string) bool {
 	return advertiseAddr != "" && controlPlaneURL != ""
 }
 
-func advertisedVMDAddr(interfaceName string, grpcPort int, explicit string) (string, error) {
+// hostIPOnce memoizes hostInterfaceAddress. Both advertised endpoints derive
+// from the same interface, and the lookup dumps the host's interface and
+// address tables — tables that grow with every VM and pooled slot on the box
+// — so it runs at most once per process, and not at all when both endpoints
+// are configured explicitly.
+func hostIPOnce(interfaceName string) func() (string, error) {
+	var (
+		once sync.Once
+		ip   string
+		err  error
+	)
+	return func() (string, error) {
+		once.Do(func() { ip, err = hostInterfaceAddress(interfaceName) })
+		return ip, err
+	}
+}
+
+func advertisedVMDAddr(hostIP func() (string, error), grpcPort int, explicit string) (string, error) {
 	if explicit != "" {
 		if _, _, err := net.SplitHostPort(explicit); err != nil {
 			return "", err
 		}
 		return explicit, nil
 	}
-	ip, err := hostInterfaceAddress(interfaceName)
+	ip, err := hostIP()
 	if err != nil {
 		return "", err
 	}
 	return net.JoinHostPort(ip, strconv.Itoa(grpcPort)), nil
 }
 
-func advertisedProxyAddr(interfaceName, proxyHealthURL, explicit string) (string, error) {
+func advertisedProxyAddr(hostIP func() (string, error), proxyHealthURL, explicit string) (string, error) {
 	if explicit != "" {
 		if _, _, err := net.SplitHostPort(explicit); err != nil {
 			return "", err
@@ -246,7 +263,7 @@ func advertisedProxyAddr(interfaceName, proxyHealthURL, explicit string) (string
 		return "", err
 	}
 	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
-		ip, err := hostInterfaceAddress(interfaceName)
+		ip, err := hostIP()
 		if err != nil {
 			return "", err
 		}
@@ -1381,6 +1398,29 @@ func main() {
 		mgr.StartMountCountSampler(ctx, time.Minute)
 	}
 
+	// ---- Fleet-sized background work ----
+	// Slot refill, slot adoption, and the full reattach each walk the whole
+	// inventory: their cost grows with records, slots, and interfaces, while
+	// everything before readiness is bounded. Run concurrently with startup
+	// they compete for the kernel's single global RTNL lock and delay the
+	// readiness the daemon is trying to announce, and their per-record logs
+	// can bury the readiness line under journald's rate limit. Holding them
+	// behind readiness keeps startup proportional to nothing but itself.
+	//
+	// Requests cannot be served during the wait — the gRPC interceptors
+	// reject everything with Unavailable until startupReady flips — so the
+	// deferral delays no caller. A daemon that shuts down before readiness
+	// never opens it; every waiter also selects on context cancellation, so
+	// none of them are left parked.
+	postReady := make(chan struct{})
+	deferFleetWork := envOrDefault("VMD_DEFER_FLEET_WORK_UNTIL_READY", "true") != "false"
+	var poolStartGate <-chan struct{}
+	if deferFleetWork {
+		poolStartGate = postReady
+	} else {
+		close(postReady)
+	}
+
 	// ---- Pre-allocate network slots ----
 	// Warm buffer of network namespaces so creation claims off the hot path.
 	// StartPool returns immediately and fills in the background, so the gate
@@ -1390,6 +1430,7 @@ func main() {
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
 		NewSize:           netPoolFresh,
 		RecycleSize:       netPoolRecycle,
+		StartGate:         poolStartGate,
 		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
 		AbandonOnStop:     adoptNetPool,
 	})
@@ -1420,6 +1461,15 @@ func main() {
 	// service — a completing lc service trips lifecycle shutdown.
 	go func() {
 		defer sentrylog.Recover("startup reattach")
+		// Held until readiness: requests load their VM on demand, so nothing
+		// waits on this pass, while running it during startup both contends
+		// for RTNL and emits one line per record — enough, on a large host,
+		// to push the readiness line past journald's rate limit.
+		select {
+		case <-postReady:
+		case <-ctx.Done():
+			return
+		}
 		// O(N) reattach, off the critical path — timed here (not via the
 		// single-goroutine marks) and flagged concurrent, distinct message, so
 		// its phase_ms is never summed into the partition. count sizes a
@@ -1575,17 +1625,12 @@ func main() {
 		if proxyHealthURL == "" {
 			proxyHealthURL = "http://127.0.0.1:5007/health"
 		}
-		vmdAddr, err := advertisedVMDAddr(cfg.HostInterface, cfg.GRPCPort, cfg.VMDAdvertiseAddr)
-		if err != nil {
-			log.Warn().Err(err).Str("host_interface", cfg.HostInterface).
-				Int("grpc_port", cfg.GRPCPort).
-				Msg("unable to resolve advertised VMD address; heartbeat will omit host self-description")
-		}
-		proxyAddr, err := advertisedProxyAddr(cfg.HostInterface, proxyHealthURL, cfg.ProxyAdvertiseAddr)
-		if err != nil {
-			log.Warn().Err(err).Str("proxy_health_url", proxyHealthURL).
-				Msg("unable to derive advertised proxy address; heartbeat will omit host self-description")
-		}
+		// Both endpoints derive from one host-interface lookup, and that
+		// lookup dumps the host's interface and address tables — whose size
+		// grows with the fleet. hostIP resolves at most once, and only if
+		// something actually needs it: two explicit advertise settings
+		// resolve nothing at all.
+		hostIP := hostIPOnce(cfg.HostInterface)
 		// Pressure publication is wired ONLY on the explicit advertise
 		// setting — never on the resolved vmdAddr, which now falls back
 		// to deriving an address from the host interface. Keying on the
@@ -1599,6 +1644,21 @@ func main() {
 			pressureReady = mgr.PressureReady
 		}
 		lc.start("heartbeat", func() error {
+			// Resolved here rather than on the startup goroutine: the lookup
+			// is fleet-sized, and its only consumer is this heartbeat. A
+			// failure still omits self-description and warns; it has never
+			// been a reason to hold up readiness.
+			vmdAddr, err := advertisedVMDAddr(hostIP, cfg.GRPCPort, cfg.VMDAdvertiseAddr)
+			if err != nil {
+				log.Warn().Err(err).Str("host_interface", cfg.HostInterface).
+					Int("grpc_port", cfg.GRPCPort).
+					Msg("unable to resolve advertised VMD address; heartbeat will omit host self-description")
+			}
+			proxyAddr, err := advertisedProxyAddr(hostIP, proxyHealthURL, cfg.ProxyAdvertiseAddr)
+			if err != nil {
+				log.Warn().Err(err).Str("proxy_health_url", proxyHealthURL).
+					Msg("unable to derive advertised proxy address; heartbeat will omit host self-description")
+			}
 			vm.StartHeartbeat(ctx, vm.HeartbeatConfig{
 				ControlPlaneURL:   cfg.ControlPlaneURL,
 				HostID:            cfg.HostID,
@@ -1695,6 +1755,14 @@ func main() {
 	startupReady.Store(true)
 	st.mark("ready", true, -1)
 	log.Info().Msg("startup complete — gRPC serving requests")
+	// Released only after the readiness line is emitted: the work behind it
+	// logs per record, and on a large host that burst is enough to exhaust
+	// journald's rate limit. Anything published after this point can be
+	// dropped; the readiness line cannot, because the deploy readiness check
+	// reads it from the journal.
+	if deferFleetWork {
+		close(postReady)
+	}
 
 	// Leak gauge for network namespaces — independent of the launcher path.
 	// Started AFTER readiness (and so after StartPool): its immediate first

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -213,19 +213,19 @@ func publishesCapacityPressure(advertiseAddr, controlPlaneURL string) bool {
 	return advertiseAddr != "" && controlPlaneURL != ""
 }
 
-// hostIPOnce memoizes hostInterfaceAddress. Both advertised endpoints derive
-// from the same interface, and the lookup dumps the host's interface and
-// address tables — tables that grow with every VM and pooled slot on the box
-// — so it runs at most once per process, and not at all when both endpoints
-// are configured explicitly.
-func hostIPOnce(interfaceName string) func() (string, error) {
+// hostIPOnce memoizes a host-address resolver. Both advertised endpoints
+// derive from the same interface, and the lookup dumps the host's interface
+// and address tables — tables that grow with every VM and pooled slot on the
+// box — so it runs at most once per process, and not at all when both
+// endpoints are configured explicitly.
+func hostIPOnce(resolve func() (string, error)) func() (string, error) {
 	var (
 		once sync.Once
 		ip   string
 		err  error
 	)
 	return func() (string, error) {
-		once.Do(func() { ip, err = hostInterfaceAddress(interfaceName) })
+		once.Do(func() { ip, err = resolve() })
 		return ip, err
 	}
 }
@@ -1623,7 +1623,7 @@ func main() {
 		// grows with the fleet. hostIP resolves at most once, and only if
 		// something actually needs it: two explicit advertise settings
 		// resolve nothing at all.
-		hostIP := hostIPOnce(cfg.HostInterface)
+		hostIP := hostIPOnce(func() (string, error) { return hostInterfaceAddress(cfg.HostInterface) })
 		// Pressure publication is wired ONLY on the explicit advertise
 		// setting — never on the resolved vmdAddr, which now falls back
 		// to deriving an address from the host interface. Keying on the

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1413,13 +1413,6 @@ func main() {
 	// never opens it; every waiter also selects on context cancellation, so
 	// none of them are left parked.
 	postReady := make(chan struct{})
-	deferFleetWork := envOrDefault("VMD_DEFER_FLEET_WORK_UNTIL_READY", "true") != "false"
-	var poolStartGate <-chan struct{}
-	if deferFleetWork {
-		poolStartGate = postReady
-	} else {
-		close(postReady)
-	}
 
 	// ---- Pre-allocate network slots ----
 	// Warm buffer of network namespaces so creation claims off the hot path.
@@ -1430,7 +1423,7 @@ func main() {
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
 		NewSize:           netPoolFresh,
 		RecycleSize:       netPoolRecycle,
-		StartGate:         poolStartGate,
+		StartGate:         postReady,
 		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
 		AbandonOnStop:     adoptNetPool,
 	})
@@ -1760,9 +1753,7 @@ func main() {
 	// journald's rate limit. Anything published after this point can be
 	// dropped; the readiness line cannot, because the deploy readiness check
 	// reads it from the journal.
-	if deferFleetWork {
-		close(postReady)
-	}
+	close(postReady)
 
 	// Leak gauge for network namespaces — independent of the launcher path.
 	// Started AFTER readiness (and so after StartPool): its immediate first

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -106,15 +105,7 @@ func TestAdvertisedAddrsShareOneHostLookup(t *testing.T) {
 		resolved++
 		return "10.0.0.3", nil
 	}
-	memo := func() func() (string, error) {
-		var once sync.Once
-		var ip string
-		var err error
-		return func() (string, error) {
-			once.Do(func() { ip, err = hostIP() })
-			return ip, err
-		}
-	}()
+	memo := hostIPOnce(hostIP)
 
 	vmdAddr, err := advertisedVMDAddr(memo, 50051, "")
 	if err != nil {

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -69,7 +70,15 @@ func TestLoadConfigUsesHeartbeatOverrides(t *testing.T) {
 }
 
 func TestAdvertisedAddrsPreferExplicitOverrides(t *testing.T) {
-	vmdAddr, err := advertisedVMDAddr("does-not-matter", 50051, "10.0.0.2:50051")
+	// The host lookup dumps fleet-sized kernel tables, so explicit settings
+	// must satisfy both endpoints without it ever running.
+	resolved := 0
+	hostIP := func() (string, error) {
+		resolved++
+		return "", fmt.Errorf("host lookup must not run when both addresses are explicit")
+	}
+
+	vmdAddr, err := advertisedVMDAddr(hostIP, 50051, "10.0.0.2:50051")
 	if err != nil {
 		t.Fatalf("advertisedVMDAddr: %v", err)
 	}
@@ -77,12 +86,52 @@ func TestAdvertisedAddrsPreferExplicitOverrides(t *testing.T) {
 		t.Fatalf("advertisedVMDAddr = %q, want explicit override", vmdAddr)
 	}
 
-	proxyAddr, err := advertisedProxyAddr("does-not-matter", "http://127.0.0.1:5007/health", "10.0.0.2:5007")
+	proxyAddr, err := advertisedProxyAddr(hostIP, "http://127.0.0.1:5007/health", "10.0.0.2:5007")
 	if err != nil {
 		t.Fatalf("advertisedProxyAddr: %v", err)
 	}
 	if proxyAddr != "10.0.0.2:5007" {
 		t.Fatalf("advertisedProxyAddr = %q, want explicit override", proxyAddr)
+	}
+	if resolved != 0 {
+		t.Fatalf("host interface resolved %d times, want 0", resolved)
+	}
+}
+
+// Both endpoints derive from the same interface; the lookup behind them must
+// run once no matter how many callers need it.
+func TestAdvertisedAddrsShareOneHostLookup(t *testing.T) {
+	resolved := 0
+	hostIP := func() (string, error) {
+		resolved++
+		return "10.2.0.3", nil
+	}
+	memo := func() func() (string, error) {
+		var once sync.Once
+		var ip string
+		var err error
+		return func() (string, error) {
+			once.Do(func() { ip, err = hostIP() })
+			return ip, err
+		}
+	}()
+
+	vmdAddr, err := advertisedVMDAddr(memo, 50051, "")
+	if err != nil {
+		t.Fatalf("advertisedVMDAddr: %v", err)
+	}
+	proxyAddr, err := advertisedProxyAddr(memo, "http://127.0.0.1:5007/health", "")
+	if err != nil {
+		t.Fatalf("advertisedProxyAddr: %v", err)
+	}
+	if vmdAddr != "10.2.0.3:50051" {
+		t.Fatalf("advertisedVMDAddr = %q, want derived host address", vmdAddr)
+	}
+	if proxyAddr != "10.2.0.3:5007" {
+		t.Fatalf("advertisedProxyAddr = %q, want derived host address", proxyAddr)
+	}
+	if resolved != 1 {
+		t.Fatalf("host interface resolved %d times, want 1", resolved)
 	}
 }
 

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -104,7 +104,7 @@ func TestAdvertisedAddrsShareOneHostLookup(t *testing.T) {
 	resolved := 0
 	hostIP := func() (string, error) {
 		resolved++
-		return "10.2.0.3", nil
+		return "10.0.0.3", nil
 	}
 	memo := func() func() (string, error) {
 		var once sync.Once
@@ -124,10 +124,10 @@ func TestAdvertisedAddrsShareOneHostLookup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("advertisedProxyAddr: %v", err)
 	}
-	if vmdAddr != "10.2.0.3:50051" {
+	if vmdAddr != "10.0.0.3:50051" {
 		t.Fatalf("advertisedVMDAddr = %q, want derived host address", vmdAddr)
 	}
-	if proxyAddr != "10.2.0.3:5007" {
+	if proxyAddr != "10.0.0.3:5007" {
 		t.Fatalf("advertisedProxyAddr = %q, want derived host address", proxyAddr)
 	}
 	if resolved != 1 {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -135,6 +136,15 @@ type Manager struct {
 	ops slotNetOps
 	// useNetlinkOps selects the netlink backend at construction.
 	useNetlinkOps bool
+
+	// foregroundOps counts in-flight request-path network operations
+	// (SetupVM, ReattachVM, cleanup). Background producers consult it to
+	// yield: every network mutation on the host serializes on the kernel's
+	// single RTNL lock, so a slot build running flat-out adds latency to
+	// whatever request-path operation is holding a caller open. The counter
+	// is advisory — nothing blocks on it — and it costs one atomic add per
+	// operation.
+	foregroundOps atomic.Int64
 
 	mu      sync.Mutex
 	devices map[string]*VMNetInfo
@@ -384,6 +394,8 @@ func (m *Manager) SetProxyPorts(http, tls, other uint16) {
 // The host reaches the VM at hostIP:<port>. NAT inside the namespace
 // translates to 169.254.0.21:<port>. No guest IP reconfig needed.
 func (m *Manager) SetupVM(ctx context.Context, vmID string, cfg *Config) (*VMNetInfo, error) {
+	m.foregroundOps.Add(1)
+	defer m.foregroundOps.Add(-1)
 	// Try the pre-allocated pool first; fall back to on-demand setup.
 	if m.pool != nil {
 		if info := m.pool.Claim(vmID); info != nil {
@@ -615,6 +627,8 @@ func (m *Manager) CleanupVM(vmID string) { m.cleanupVM(vmID, true) }
 func (m *Manager) TeardownVM(vmID string) { m.cleanupVM(vmID, false) }
 
 func (m *Manager) cleanupVM(vmID string, recycle bool) {
+	m.foregroundOps.Add(1)
+	defer m.foregroundOps.Add(-1)
 	m.mu.Lock()
 	info, ok := m.devices[vmID]
 	if ok {
@@ -798,6 +812,8 @@ func (m *Manager) Forget(vmID string) {
 // customer's subsequent UpdateFirewallRules calls apply to the existing
 // kernel state.
 func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
+	m.foregroundOps.Add(1)
+	defer m.foregroundOps.Add(-1)
 	idx, ok := slotFromNamespace(namespace)
 	if !ok {
 		return fmt.Errorf("reattach %s: cannot parse slot from namespace %q", vmID, namespace)

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -138,16 +138,11 @@ type Manager struct {
 	useNetlinkOps bool
 
 	// foregroundOps counts in-flight network operations a caller is actively
-	// waiting on: SetupVM (create) and EnsureVMSlot (resume rebuilding its
-	// retained slot). Background producers consult it to yield: every
-	// network mutation on the host serializes on the kernel's single RTNL
-	// lock, so a slot build running flat-out adds latency to whatever
-	// request-path operation is holding a caller open. Deliberately NOT
-	// counted: reattach (only ever called by the background startup pass)
-	// and cleanup (shared by request destroys and the reconciler's
-	// continuous background reaping — counting it would keep producers
-	// yielding to background churn). The counter is advisory — nothing
-	// blocks on it — and costs one atomic add per operation.
+	// waiting on — SetupVM (create) and EnsureVMSlot (resume) — so
+	// background producers can yield the RTNL lock to them. Deliberately
+	// NOT counted: reattach (only ever called by the background startup
+	// pass) and cleanup (shared with the reconciler's continuous reaping).
+	// Advisory only; nothing blocks on it.
 	foregroundOps atomic.Int64
 
 	mu      sync.Mutex

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -137,13 +137,17 @@ type Manager struct {
 	// useNetlinkOps selects the netlink backend at construction.
 	useNetlinkOps bool
 
-	// foregroundOps counts in-flight request-path network operations
-	// (SetupVM, ReattachVM, cleanup). Background producers consult it to
-	// yield: every network mutation on the host serializes on the kernel's
-	// single RTNL lock, so a slot build running flat-out adds latency to
-	// whatever request-path operation is holding a caller open. The counter
-	// is advisory — nothing blocks on it — and it costs one atomic add per
-	// operation.
+	// foregroundOps counts in-flight network operations a caller is actively
+	// waiting on: SetupVM (create) and EnsureVMSlot (resume rebuilding its
+	// retained slot). Background producers consult it to yield: every
+	// network mutation on the host serializes on the kernel's single RTNL
+	// lock, so a slot build running flat-out adds latency to whatever
+	// request-path operation is holding a caller open. Deliberately NOT
+	// counted: reattach (only ever called by the background startup pass)
+	// and cleanup (shared by request destroys and the reconciler's
+	// continuous background reaping — counting it would keep producers
+	// yielding to background churn). The counter is advisory — nothing
+	// blocks on it — and costs one atomic add per operation.
 	foregroundOps atomic.Int64
 
 	mu      sync.Mutex
@@ -627,8 +631,10 @@ func (m *Manager) CleanupVM(vmID string) { m.cleanupVM(vmID, true) }
 func (m *Manager) TeardownVM(vmID string) { m.cleanupVM(vmID, false) }
 
 func (m *Manager) cleanupVM(vmID string, recycle bool) {
-	m.foregroundOps.Add(1)
-	defer m.foregroundOps.Add(-1)
+	// Not counted in foregroundOps: reached from request destroys AND from
+	// the reconciler's background reaping through the same entry points, and
+	// the reconciler churns continuously — counting it would keep producers
+	// yielding to background work.
 	m.mu.Lock()
 	info, ok := m.devices[vmID]
 	if ok {
@@ -812,8 +818,9 @@ func (m *Manager) Forget(vmID string) {
 // customer's subsequent UpdateFirewallRules calls apply to the existing
 // kernel state.
 func (m *Manager) ReattachVM(vmID, namespace, hostIP, macAddress string) error {
-	m.foregroundOps.Add(1)
-	defer m.foregroundOps.Add(-1)
+	// Not counted in foregroundOps: the only caller is the startup reattach
+	// pass, which is itself background work — counting it would make the
+	// producers yield to each other.
 	idx, ok := slotFromNamespace(namespace)
 	if !ok {
 		return fmt.Errorf("reattach %s: cannot parse slot from namespace %q", vmID, namespace)
@@ -903,6 +910,8 @@ func (m *Manager) ReserveSlotsAbove(reservations map[string]string) {
 // so a rebuild preserves the VM's network identity. Per-customer egress
 // rules are NOT restored here; the caller reapplies them.
 func (m *Manager) EnsureVMSlot(ctx context.Context, vmID, namespace, hostIP, macAddress string) (*VMNetInfo, error) {
+	m.foregroundOps.Add(1)
+	defer m.foregroundOps.Add(-1)
 	idx, ok := slotFromNamespace(namespace)
 	if !ok {
 		return nil, fmt.Errorf("ensure %s: cannot parse slot from namespace %q", vmID, namespace)

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -30,6 +30,13 @@ type PoolConfig struct {
 	// and the next process adopts the slots via AdoptOrphanSlots. Off by
 	// default (legacy teardown).
 	AbandonOnStop bool
+	// StartGate holds the refill and adoption workers until it is closed.
+	// Both walk the whole slot inventory over netlink, and every netlink
+	// operation takes the kernel's single global RTNL lock — so while they
+	// run, any other caller needing that lock queues behind them. Deferring
+	// them until the daemon can serve requests keeps work proportional to
+	// the fleet off the startup path. Nil starts them immediately.
+	StartGate <-chan struct{}
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
@@ -45,8 +52,11 @@ type Pool struct {
 	fresh    chan *preallocSlot // pre-allocated from scratch
 	recycled chan *preallocSlot // returned from destroyed sandboxes
 	stopCh   chan struct{}
-	wg       sync.WaitGroup
-	drainMu  sync.RWMutex
+	// startGate delays the refill and adoption workers; see PoolConfig.
+	// Nil means "already open".
+	startGate <-chan struct{}
+	wg        sync.WaitGroup
+	drainMu   sync.RWMutex
 	// refillDrainGate is closed while the controller is draining warm inventory.
 	// Refill workers select on it before handing a built slot to the pool so a
 	// send that was already blocked when drain started can still abort instead
@@ -230,6 +240,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		fresh:             make(chan *preallocSlot, newSize),
 		recycled:          make(chan *preallocSlot, recycleSize),
 		stopCh:            make(chan struct{}),
+		startGate:         cfg.StartGate,
 		refillDrainGate:   make(chan struct{}),
 		resetTapOnRecycle: cfg.ResetTapOnRecycle,
 		abandonOnStop:     cfg.AbandonOnStop,
@@ -255,11 +266,37 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		// inline build against the imminent refill (the same synchronous
 		// publication StartAdoption makes for its phase). The worker inherits
 		// the declaration and relinquishes it on backoff, pause, or exit.
-		p.refillActive.Add(1)
+		//
+		// Behind a start gate the refill is NOT imminent — nothing is built
+		// until the gate opens — so the declaration would make a claimant
+		// wait on a producer that has not started. There the worker declares
+		// itself once it is past the gate and genuinely producing, and a
+		// claimant arriving first correctly takes the bounded inline path.
+		if p.startGate == nil {
+			p.refillActive.Add(1)
+		}
 		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 	}
 
 	return p
+}
+
+// waitForStart blocks until the start gate opens. It reports false when the
+// pool was stopped or the context cancelled while waiting, so a daemon that
+// shuts down before the gate opens never leaves a worker parked on it.
+// A nil gate is already open.
+func (p *Pool) waitForStart(ctx context.Context) bool {
+	if p.startGate == nil {
+		return true
+	}
+	select {
+	case <-p.startGate:
+		return true
+	case <-p.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // Claim takes a slot from the pool and assigns it to the given VM ID.
@@ -975,6 +1012,13 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 	go func() {
 		defer p.wg.Done()
 		defer sentrylog.Recover("netpool-adopt")
+		if !p.waitForStart(ctx) {
+			// Nothing was scanned, so the phase must not stay latched at
+			// scanning — a claimant would wait on a pass that will never run.
+			p.adoptPhase.Store(adoptPhaseIdle)
+			p.signalProgress()
+			return
+		}
 		p.AdoptOrphanSlots(ctx)
 	}()
 	return true
@@ -1181,14 +1225,23 @@ const (
 
 func (p *Pool) refillLoop(ctx context.Context) {
 	defer p.wg.Done()
+	if !p.waitForStart(ctx) {
+		return
+	}
+	// Past the gate the worker is genuinely producing, so it publishes the
+	// declaration StartPool skipped (see there for why a gated pool must not
+	// declare it up front). Ungated, StartPool already published it.
+	if p.startGate != nil {
+		p.refillActive.Add(1)
+	}
 	// The worker's active declaration is continuous across successful
 	// iterations — decrementing between two builds would let a delivery
 	// broadcast wake claimants into the instant where the count reads zero,
 	// and they would bail to inline builds against a producer that is
 	// committed to its next slot. Zero is exposed only at backoff, pause,
 	// and shutdown, when the pool genuinely promises nothing. The initial
-	// declaration was published synchronously by StartPool; this loop only
-	// ever relinquishes and re-acquires it.
+	// declaration was published synchronously by StartPool (or, when gated,
+	// just above); this loop only ever relinquishes and re-acquires it.
 	active := true
 	deactivate := func() {
 		if active {

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -55,6 +55,17 @@ type Pool struct {
 	// startGate delays the refill and adoption workers; see PoolConfig.
 	// Nil means "already open".
 	startGate <-chan struct{}
+	// claimWaiters counts callers currently inside ClaimWait; producers
+	// never yield to the foreground while it is non-zero (the foreground is
+	// waiting on them).
+	claimWaiters atomic.Int64
+	// bgSlotSem meters concurrent background slot operations (adoption and
+	// refill share it). A gated pool starts it at one token and ramps to
+	// full over refillRampStep intervals, so the post-restart RTNL load
+	// arrives gradually across BOTH producers rather than as a burst of
+	// every worker at once. Nil (tests, ungated legacy construction) meters
+	// nothing.
+	bgSlotSem chan struct{}
 	wg        sync.WaitGroup
 	drainMu   sync.RWMutex
 	// refillDrainGate is closed while the controller is draining warm inventory.
@@ -264,6 +275,15 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	if newSize < workers {
 		workers = newSize
 	}
+	// One shared concurrency budget across both background producers —
+	// adoption and refill — granted gradually after the gate (see
+	// rampBGSlots), so neither can burst the RTNL lock alone the moment the
+	// daemon starts serving. Created before any worker spawns so every
+	// reader sees the same channel.
+	p.bgSlotSem = make(chan struct{}, workers+adoptConcurrency)
+	p.wg.Add(1)
+	go func() { defer sentrylog.Recover("netpool-ramp"); p.rampBGSlots(ctx, workers+adoptConcurrency) }()
+
 	for i := 0; i < workers; i++ {
 		p.wg.Add(1)
 		// Declared active before the goroutine is even scheduled — a create
@@ -280,8 +300,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		if p.startGate == nil {
 			p.refillActive.Add(1)
 		}
-		worker := i
-		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx, worker) }()
+		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
 	}
 
 	return p
@@ -306,13 +325,13 @@ func (p *Pool) waitForStart(ctx context.Context) bool {
 }
 
 const (
-	// refillRampStep staggers gated refill workers after the gate opens:
-	// worker i starts i steps later. The gate opens at the same instant the
-	// daemon begins serving, and every slot build competes with request-path
-	// operations for the kernel's single RTNL lock — releasing the whole
-	// crew at once would aim that contention exactly at the post-restart
-	// burst. Full concurrency arrives within workers×step; ungated pools
-	// (no restart in progress) are never staggered.
+	// refillRampStep is the interval at which a gated pool's background
+	// concurrency budget (bgSlotSem) grows by one token after the gate
+	// opens. The gate opens at the same instant the daemon begins serving,
+	// and every slot operation competes with request-path work for the
+	// kernel's single RTNL lock — granting the whole budget at once would
+	// aim that contention exactly at the post-restart burst. Ungated pools
+	// (no restart in progress) get the full budget immediately.
 	refillRampStep = 2 * time.Second
 	// yieldPoll and yieldCapPerOp bound the foreground-priority pause a
 	// producer takes between slots. The cap keeps continuous request
@@ -324,18 +343,72 @@ const (
 
 // yieldToForeground briefly pauses a background producer while request-path
 // network operations are in flight, giving their RTNL acquisitions priority
-// over slot production. It never yields while the pool is out of stock: an
-// empty pool means the in-flight request may itself be waiting on this
-// producer, and yielding to a claimant is priority inversion. Bounded by
-// yieldCapPerOp so producers always make progress under sustained traffic;
-// returns early on shutdown.
+// over slot production. It never yields while a claimant is waiting on the
+// pool: that foreground caller is waiting on this producer, and yielding to
+// it would be priority inversion. Bounded by yieldCapPerOp so producers
+// always make progress under sustained traffic; returns early on shutdown.
 func (p *Pool) yieldToForeground(ctx context.Context) {
 	deadline := time.Now().Add(yieldCapPerOp)
 	for p.mgr.foregroundOps.Load() > 0 &&
-		len(p.fresh)+len(p.recycled) > 0 &&
+		p.claimWaiters.Load() == 0 &&
 		time.Now().Before(deadline) {
 		select {
 		case <-time.After(yieldPoll):
+		case <-p.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// acquireBGSlot takes one background-concurrency token (and yields to any
+// in-flight foreground work first). Reports false on shutdown/cancellation.
+// A nil semaphore meters nothing — tests and legacy construction.
+func (p *Pool) acquireBGSlot(ctx context.Context) bool {
+	p.yieldToForeground(ctx)
+	if p.bgSlotSem == nil {
+		return true
+	}
+	select {
+	case <-p.bgSlotSem:
+		return true
+	case <-p.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (p *Pool) releaseBGSlot() {
+	if p.bgSlotSem != nil {
+		p.bgSlotSem <- struct{}{}
+	}
+}
+
+// rampBGSlots grants the background concurrency budget: everything at once
+// for an ungated pool, one token per refillRampStep after the gate opens for
+// a gated one. Runs in the pool wait group so Stop joins it.
+func (p *Pool) rampBGSlots(ctx context.Context, total int) {
+	defer p.wg.Done()
+	if !p.waitForStart(ctx) {
+		return
+	}
+	granted := 0
+	if p.startGate == nil {
+		for ; granted < total; granted++ {
+			p.bgSlotSem <- struct{}{}
+		}
+		return
+	}
+	for granted < total {
+		p.bgSlotSem <- struct{}{}
+		granted++
+		if granted == total {
+			return
+		}
+		select {
+		case <-time.After(refillRampStep):
 		case <-p.stopCh:
 			return
 		case <-ctx.Done():
@@ -485,6 +558,11 @@ func (p *Pool) finalClaim(ctx context.Context, vmID string) *VMNetInfo {
 }
 
 func (p *Pool) ClaimWait(ctx context.Context, vmID string) *VMNetInfo {
+	// Declared for the producers' yield logic: while anyone is in here, the
+	// foreground is waiting on the pool itself, and producers must run flat
+	// out rather than politely yielding to the very caller they'd unblock.
+	p.claimWaiters.Add(1)
+	defer p.claimWaiters.Add(-1)
 	start := time.Now()
 	for {
 		// Checked before every claim attempt, not only in the select: a
@@ -982,7 +1060,16 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				defer workers.Done()
 				defer sentrylog.Recover("netpool-adopt")
 				for idx := range work {
+					// Metered by the shared background budget; a failed
+					// acquire means shutdown — the slot stays claimed in
+					// the kernel, the same abandoned state a mid-pass
+					// shutdown leaves for the next boot to adopt.
+					if !p.acquireBGSlot(ctx) {
+						nSkipped.Add(1)
+						continue
+					}
 					p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped, &nTimeouts)
+					p.releaseBGSlot()
 				}
 			}()
 		}
@@ -1000,9 +1087,6 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				break feed
 			default:
 			}
-			// Pacing point for the whole crew: the feed is the one place
-			// every adoption worker's next slot flows through.
-			p.yieldToForeground(ctx)
 			if nTimeouts.Load() >= adoptTimeoutAbort {
 				// The host is wedged, not the slots: each timeout strands a
 				// pinned thread, so stop dispatching. Unlike a shutdown break
@@ -1284,22 +1368,10 @@ const (
 	refillStopped
 )
 
-func (p *Pool) refillLoop(ctx context.Context, worker int) {
+func (p *Pool) refillLoop(ctx context.Context) {
 	defer p.wg.Done()
 	if !p.waitForStart(ctx) {
 		return
-	}
-	// Gated workers ramp in staggered rather than all at once; see
-	// refillRampStep. The sleep is interruptible so shutdown mid-ramp
-	// doesn't hang the join.
-	if p.startGate != nil && worker > 0 {
-		select {
-		case <-time.After(time.Duration(worker) * refillRampStep):
-		case <-p.stopCh:
-			return
-		case <-ctx.Done():
-			return
-		}
 	}
 	// Past the gate the worker is genuinely producing, so it publishes the
 	// declaration StartPool skipped (see there for why a gated pool must not
@@ -1347,7 +1419,6 @@ func (p *Pool) refillLoop(ctx context.Context, worker int) {
 			active = true
 			p.refillActive.Add(1)
 		}
-		p.yieldToForeground(ctx)
 		switch p.refillStep(ctx, deactivate) {
 		case refillStopped:
 			return
@@ -1377,7 +1448,14 @@ func (p *Pool) refillLoop(ctx context.Context, worker int) {
 // it before tearing the doomed slot down, because cleanup can block for
 // seconds and a discarding worker is not a producer anyone should wait on.
 func (p *Pool) refillStep(ctx context.Context, deactivate func()) refillOutcome {
+	// Metered: the build is the RTNL-heavy part. The token is returned
+	// before the delivery send below — a worker parked on a full pool must
+	// not hold concurrency budget the other producers could use.
+	if !p.acquireBGSlot(ctx) {
+		return refillStopped
+	}
 	slot, err := p.allocate(ctx)
+	p.releaseBGSlot()
 	if err != nil {
 		if ctx.Err() != nil {
 			return refillStopped

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -211,6 +211,11 @@ var abandonStopWait = 10 * time.Second
 // Adoption pass phases (Pool.adoptPhase).
 const (
 	adoptPhaseIdle int32 = iota
+	// adoptPhasePending is a pass claimed but parked behind the start gate:
+	// it holds the duplicate-start guard without reading as a producer, so
+	// a claimant arriving before the gate opens builds inline instead of
+	// spending its wait budget on a pass that has not begun.
+	adoptPhasePending
 	adoptPhaseScanning
 	adoptPhaseVerifying
 )
@@ -275,7 +280,8 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		if p.startGate == nil {
 			p.refillActive.Add(1)
 		}
-		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx) }()
+		worker := i
+		go func() { defer sentrylog.Recover("netpool-refill"); p.refillLoop(ctx, worker) }()
 	}
 
 	return p
@@ -296,6 +302,45 @@ func (p *Pool) waitForStart(ctx context.Context) bool {
 		return false
 	case <-ctx.Done():
 		return false
+	}
+}
+
+const (
+	// refillRampStep staggers gated refill workers after the gate opens:
+	// worker i starts i steps later. The gate opens at the same instant the
+	// daemon begins serving, and every slot build competes with request-path
+	// operations for the kernel's single RTNL lock — releasing the whole
+	// crew at once would aim that contention exactly at the post-restart
+	// burst. Full concurrency arrives within workers×step; ungated pools
+	// (no restart in progress) are never staggered.
+	refillRampStep = 2 * time.Second
+	// yieldPoll and yieldCapPerOp bound the foreground-priority pause a
+	// producer takes between slots. The cap keeps continuous request
+	// traffic from starving the producers: yielding is a courtesy with a
+	// ceiling, after which the producer proceeds regardless.
+	yieldPoll     = 25 * time.Millisecond
+	yieldCapPerOp = 500 * time.Millisecond
+)
+
+// yieldToForeground briefly pauses a background producer while request-path
+// network operations are in flight, giving their RTNL acquisitions priority
+// over slot production. It never yields while the pool is out of stock: an
+// empty pool means the in-flight request may itself be waiting on this
+// producer, and yielding to a claimant is priority inversion. Bounded by
+// yieldCapPerOp so producers always make progress under sustained traffic;
+// returns early on shutdown.
+func (p *Pool) yieldToForeground(ctx context.Context) {
+	deadline := time.Now().Add(yieldCapPerOp)
+	for p.mgr.foregroundOps.Load() > 0 &&
+		len(p.fresh)+len(p.recycled) > 0 &&
+		time.Now().Before(deadline) {
+		select {
+		case <-time.After(yieldPoll):
+		case <-p.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 
@@ -378,8 +423,12 @@ func (p *Pool) producing() bool {
 // adoptionTrusted reports whether claimants should treat the adoption pass as
 // a producer worth waiting on: a pass is running and hasn't tripped the
 // no-yield escape. Trust is reversible — a later delivery restores it.
+// A pending pass (parked behind the start gate) is not running and earns no
+// trust: nothing it could deliver exists yet.
 func (p *Pool) adoptionTrusted() bool {
-	return p.adoptPhase.Load() != adoptPhaseIdle && p.adoptStreak.Load() < p.adoptEscapeStreak
+	phase := p.adoptPhase.Load()
+	running := phase == adoptPhaseScanning || phase == adoptPhaseVerifying
+	return running && p.adoptStreak.Load() < p.adoptEscapeStreak
 }
 
 // progressCh returns the channel the next progress broadcast will close.
@@ -951,6 +1000,9 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				break feed
 			default:
 			}
+			// Pacing point for the whole crew: the feed is the one place
+			// every adoption worker's next slot flows through.
+			p.yieldToForeground(ctx)
 			if nTimeouts.Load() >= adoptTimeoutAbort {
 				// The host is wedged, not the slots: each timeout strands a
 				// pinned thread, so stop dispatching. Unlike a shutdown break
@@ -1004,7 +1056,15 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 // builds against the imminent churn. The pass is tracked in the pool wait
 // group so Stop cannot outlive its state. A duplicate start is a no-op.
 func (p *Pool) StartAdoption(ctx context.Context) bool {
-	if !p.adoptPhase.CompareAndSwap(adoptPhaseIdle, adoptPhaseScanning) {
+	// A gated pass enters pending, not scanning: it holds the duplicate-start
+	// guard, but producing()/adoptionTrusted() ignore it, so no claimant
+	// spends its wait budget on work parked behind the gate. The pass
+	// promotes itself to scanning only once it is genuinely running.
+	claimed := adoptPhaseScanning
+	if p.startGate != nil {
+		claimed = adoptPhasePending
+	}
+	if !p.adoptPhase.CompareAndSwap(adoptPhaseIdle, claimed) {
 		p.log.Warn().Msg("pool: adoption already running — duplicate start ignored")
 		return false
 	}
@@ -1013,12 +1073,13 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 		defer p.wg.Done()
 		defer sentrylog.Recover("netpool-adopt")
 		if !p.waitForStart(ctx) {
-			// Nothing was scanned, so the phase must not stay latched at
-			// scanning — a claimant would wait on a pass that will never run.
+			// Nothing was scanned, so the phase must not stay latched — a
+			// later StartAdoption (or direct pass) must find it idle.
 			p.adoptPhase.Store(adoptPhaseIdle)
 			p.signalProgress()
 			return
 		}
+		p.adoptPhase.CompareAndSwap(adoptPhasePending, adoptPhaseScanning)
 		p.AdoptOrphanSlots(ctx)
 	}()
 	return true
@@ -1223,10 +1284,22 @@ const (
 	refillStopped
 )
 
-func (p *Pool) refillLoop(ctx context.Context) {
+func (p *Pool) refillLoop(ctx context.Context, worker int) {
 	defer p.wg.Done()
 	if !p.waitForStart(ctx) {
 		return
+	}
+	// Gated workers ramp in staggered rather than all at once; see
+	// refillRampStep. The sleep is interruptible so shutdown mid-ramp
+	// doesn't hang the join.
+	if p.startGate != nil && worker > 0 {
+		select {
+		case <-time.After(time.Duration(worker) * refillRampStep):
+		case <-p.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
 	}
 	// Past the gate the worker is genuinely producing, so it publishes the
 	// declaration StartPool skipped (see there for why a gated pool must not
@@ -1274,6 +1347,7 @@ func (p *Pool) refillLoop(ctx context.Context) {
 			active = true
 			p.refillActive.Add(1)
 		}
+		p.yieldToForeground(ctx)
 		switch p.refillStep(ctx, deactivate) {
 		case refillStopped:
 			return

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -30,12 +30,10 @@ type PoolConfig struct {
 	// and the next process adopts the slots via AdoptOrphanSlots. Off by
 	// default (legacy teardown).
 	AbandonOnStop bool
-	// StartGate holds the refill and adoption workers until it is closed.
-	// Both walk the whole slot inventory over netlink, and every netlink
-	// operation takes the kernel's single global RTNL lock — so while they
-	// run, any other caller needing that lock queues behind them. Deferring
-	// them until the daemon can serve requests keeps work proportional to
-	// the fleet off the startup path. Nil starts them immediately.
+	// StartGate holds the refill and adoption workers until it is closed,
+	// keeping their RTNL-heavy inventory walks off the startup path (see
+	// the fleet-sized background work comment in cmd/vmd). Nil starts them
+	// immediately.
 	StartGate <-chan struct{}
 }
 
@@ -59,12 +57,9 @@ type Pool struct {
 	// never yield to the foreground while it is non-zero (the foreground is
 	// waiting on them).
 	claimWaiters atomic.Int64
-	// bgSlotSem meters concurrent background slot operations (adoption and
-	// refill share it). A gated pool starts it at one token and ramps to
-	// full over refillRampStep intervals, so the post-restart RTNL load
-	// arrives gradually across BOTH producers rather than as a burst of
-	// every worker at once. Nil (tests, ungated legacy construction) meters
-	// nothing.
+	// bgSlotSem is the shared concurrency budget for background slot work
+	// (adoption and refill together); rampBGSlots grants it. Nil meters
+	// nothing (tests).
 	bgSlotSem chan struct{}
 	wg        sync.WaitGroup
 	drainMu   sync.RWMutex
@@ -291,12 +286,9 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		// inline build against the imminent refill (the same synchronous
 		// publication StartAdoption makes for its phase). The worker inherits
 		// the declaration and relinquishes it on backoff, pause, or exit.
-		//
-		// Behind a start gate the refill is NOT imminent — nothing is built
-		// until the gate opens — so the declaration would make a claimant
-		// wait on a producer that has not started. There the worker declares
-		// itself once it is past the gate and genuinely producing, and a
-		// claimant arriving first correctly takes the bounded inline path.
+		// Behind a start gate the refill is NOT imminent, so the worker
+		// declares itself only once past the gate; a claimant arriving
+		// first correctly takes the bounded inline path.
 		if p.startGate == nil {
 			p.refillActive.Add(1)
 		}
@@ -326,12 +318,10 @@ func (p *Pool) waitForStart(ctx context.Context) bool {
 
 const (
 	// refillRampStep is the interval at which a gated pool's background
-	// concurrency budget (bgSlotSem) grows by one token after the gate
-	// opens. The gate opens at the same instant the daemon begins serving,
-	// and every slot operation competes with request-path work for the
-	// kernel's single RTNL lock — granting the whole budget at once would
-	// aim that contention exactly at the post-restart burst. Ungated pools
-	// (no restart in progress) get the full budget immediately.
+	// concurrency budget grows by one token after the gate opens — the gate
+	// opens the instant the daemon begins serving, so the budget arrives
+	// gradually instead of as a burst aimed at the first requests. Ungated
+	// pools get the full budget immediately.
 	refillRampStep = 2 * time.Second
 	// yieldPoll and yieldCapPerOp bound the foreground-priority pause a
 	// producer takes between slots. The cap keeps continuous request

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -360,6 +360,17 @@ func (p *Pool) yieldToForeground(ctx context.Context) {
 // semaphore meters nothing — tests and legacy construction.
 func (p *Pool) withBGSlot(ctx context.Context, fn func()) bool {
 	p.yieldToForeground(ctx)
+	// Checked before the select: with a token and a cancellation both
+	// ready, select would pick arms at random and could start one more
+	// operation into a shutdown.
+	select {
+	case <-p.stopCh:
+		return false
+	default:
+	}
+	if ctx.Err() != nil {
+		return false
+	}
 	if p.bgSlotSem == nil {
 		fn()
 		return true

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -352,28 +352,28 @@ func (p *Pool) yieldToForeground(ctx context.Context) {
 	}
 }
 
-// acquireBGSlot takes one background-concurrency token (and yields to any
-// in-flight foreground work first). Reports false on shutdown/cancellation.
-// A nil semaphore meters nothing — tests and legacy construction.
-func (p *Pool) acquireBGSlot(ctx context.Context) bool {
+// withBGSlot runs fn under one background-concurrency token, yielding to any
+// in-flight foreground work first. Reports false — without running fn — on
+// shutdown or cancellation. The token is released even when fn panics: the
+// workers' panic recovery keeps the daemon up, and a token leaked past it
+// would shrink the budget for the rest of the process's life. A nil
+// semaphore meters nothing — tests and legacy construction.
+func (p *Pool) withBGSlot(ctx context.Context, fn func()) bool {
 	p.yieldToForeground(ctx)
 	if p.bgSlotSem == nil {
+		fn()
 		return true
 	}
 	select {
 	case <-p.bgSlotSem:
-		return true
 	case <-p.stopCh:
 		return false
 	case <-ctx.Done():
 		return false
 	}
-}
-
-func (p *Pool) releaseBGSlot() {
-	if p.bgSlotSem != nil {
-		p.bgSlotSem <- struct{}{}
-	}
+	defer func() { p.bgSlotSem <- struct{}{} }()
+	fn()
+	return true
 }
 
 // rampBGSlots grants the background concurrency budget: everything at once
@@ -898,7 +898,18 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 			defer workers.Done()
 			defer sentrylog.Recover("netpool-receipt-adopt")
 			for idx := range work {
-				slot, timedOut := p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
+				// Metered like every other background slot path — "fast"
+				// is per-slot cost, not license to burst RTNL: on a clean
+				// restart this is the path that adopts most of the fleet.
+				// A refused token means shutdown; the index stays claimed
+				// for the next boot, like a mid-pass shutdown.
+				var slot *preallocSlot
+				var timedOut bool
+				if !p.withBGSlot(ctx, func() {
+					slot, timedOut = p.fastAdoptVouched(idx, nsSet, vethSet, occupied)
+				}) {
+					continue
+				}
 				if timedOut {
 					// The abandoned validator may still be mutating this
 					// namespace; the index must not re-enter ANY path this
@@ -1050,16 +1061,15 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 				defer workers.Done()
 				defer sentrylog.Recover("netpool-adopt")
 				for idx := range work {
-					// Metered by the shared background budget; a failed
-					// acquire means shutdown — the slot stays claimed in
+					// Metered by the shared background budget; a refused
+					// token means shutdown — the slot stays claimed in
 					// the kernel, the same abandoned state a mid-pass
 					// shutdown leaves for the next boot to adopt.
-					if !p.acquireBGSlot(ctx) {
+					if !p.withBGSlot(ctx, func() {
+						p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped, &nTimeouts)
+					}) {
 						nSkipped.Add(1)
-						continue
 					}
-					p.adoptOne(ctx, idx, &nAdopted, &nInvalid, &nSkipped, &nTimeouts)
-					p.releaseBGSlot()
 				}
 			}()
 		}
@@ -1441,11 +1451,11 @@ func (p *Pool) refillStep(ctx context.Context, deactivate func()) refillOutcome 
 	// Metered: the build is the RTNL-heavy part. The token is returned
 	// before the delivery send below — a worker parked on a full pool must
 	// not hold concurrency budget the other producers could use.
-	if !p.acquireBGSlot(ctx) {
+	var slot *preallocSlot
+	var err error
+	if !p.withBGSlot(ctx, func() { slot, err = p.allocate(ctx) }) {
 		return refillStopped
 	}
-	slot, err := p.allocate(ctx)
-	p.releaseBGSlot()
 	if err != nil {
 		if ctx.Err() != nil {
 			return refillStopped

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -898,11 +898,9 @@ func (p *Pool) adoptFromReceipt(ctx context.Context, candidates []int) (remainin
 			defer workers.Done()
 			defer sentrylog.Recover("netpool-receipt-adopt")
 			for idx := range work {
-				// Metered like every other background slot path — "fast"
-				// is per-slot cost, not license to burst RTNL: on a clean
-				// restart this is the path that adopts most of the fleet.
-				// A refused token means shutdown; the index stays claimed
-				// for the next boot, like a mid-pass shutdown.
+				// Metered: on a clean restart this path adopts most of the
+				// fleet. A refused token means shutdown; the index stays
+				// claimed for the next boot, like a mid-pass shutdown.
 				var slot *preallocSlot
 				var timedOut bool
 				if !p.withBGSlot(ctx, func() {

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1349,3 +1349,30 @@ func TestBGSlotBudgetRampsAfterGate(t *testing.T) {
 		t.Fatal("ramp feeder did not exit on stop")
 	}
 }
+
+// A panic inside metered work must not leak the token: the workers' panic
+// recovery keeps the daemon alive, and a leaked token would shrink the
+// background budget for the rest of the process's life.
+func TestWithBGSlotReturnsTokenOnPanic(t *testing.T) {
+	p := &Pool{
+		log:       zerolog.Nop(),
+		stopCh:    make(chan struct{}),
+		bgSlotSem: make(chan struct{}, 1),
+	}
+	p.bgSlotSem <- struct{}{} // full budget: one token
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected the panic to propagate")
+			}
+		}()
+		p.withBGSlot(context.Background(), func() { panic("boom") })
+	}()
+
+	select {
+	case <-p.bgSlotSem:
+	default:
+		t.Fatal("token not returned after panic")
+	}
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1254,7 +1254,7 @@ func TestGatedRefillDeclaresNoProducerBeforeRelease(t *testing.T) {
 	p := &Pool{log: zerolog.Nop(), stopCh: make(chan struct{}), startGate: make(chan struct{})}
 	ctx, cancel := context.WithCancel(context.Background())
 	p.wg.Add(1)
-	go p.refillLoop(ctx)
+	go p.refillLoop(ctx, 0)
 
 	time.Sleep(20 * time.Millisecond)
 	if got := p.refillActive.Load(); got != 0 {
@@ -1271,5 +1271,45 @@ func TestGatedRefillDeclaresNoProducerBeforeRelease(t *testing.T) {
 	}
 	if got := p.refillActive.Load(); got != 0 {
 		t.Fatalf("refillActive = %d after exit, want 0", got)
+	}
+}
+
+// A gated adoption pass holds the duplicate-start guard but must not read as
+// a producer while parked: a claimant that trusts it waits out the adoption
+// budget on work that has not begun.
+func TestGatedAdoptionNotProducingBeforeRelease(t *testing.T) {
+	gate := make(chan struct{})
+	p := &Pool{
+		log:               zerolog.Nop(),
+		stopCh:            make(chan struct{}),
+		startGate:         gate,
+		adoptEscapeStreak: defaultAdoptEscapeStreak,
+	}
+
+	if !p.StartAdoption(context.Background()) {
+		t.Fatal("first StartAdoption must claim the pass")
+	}
+	if p.StartAdoption(context.Background()) {
+		t.Fatal("duplicate StartAdoption must be refused while parked")
+	}
+	if p.adoptionTrusted() {
+		t.Fatal("a parked adoption pass must not be trusted")
+	}
+	if p.producing() {
+		t.Fatal("a parked adoption pass must not read as producing")
+	}
+
+	// Shutdown before the gate ever opens: the pass must resolve to idle so
+	// nothing later waits on it — and a fresh start must be claimable again.
+	close(p.stopCh)
+	waited := make(chan struct{})
+	go func() { p.wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("parked adoption did not exit on stop")
+	}
+	if got := p.adoptPhase.Load(); got != adoptPhaseIdle {
+		t.Fatalf("adoptPhase = %d after stop, want idle", got)
 	}
 }

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1355,20 +1355,27 @@ func TestBGSlotBudgetRampsAfterGate(t *testing.T) {
 // background budget for the rest of the process's life.
 func TestWithBGSlotReturnsTokenOnPanic(t *testing.T) {
 	p := &Pool{
+		mgr:       &Manager{}, // yieldToForeground reads its counters
 		log:       zerolog.Nop(),
 		stopCh:    make(chan struct{}),
 		bgSlotSem: make(chan struct{}, 1),
 	}
 	p.bgSlotSem <- struct{}{} // full budget: one token
 
+	ran := false
 	func() {
 		defer func() {
-			if recover() == nil {
-				t.Fatal("expected the panic to propagate")
+			// Specifically fn's panic — anything else means the panic fired
+			// before the token was even acquired and the test proved nothing.
+			if r := recover(); r != "boom" {
+				t.Fatalf("recovered %v, want the fn panic", r)
 			}
 		}()
-		p.withBGSlot(context.Background(), func() { panic("boom") })
+		p.withBGSlot(context.Background(), func() { ran = true; panic("boom") })
 	}()
+	if !ran {
+		t.Fatal("fn never ran — the token was never at risk")
+	}
 
 	select {
 	case <-p.bgSlotSem:

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1170,3 +1170,106 @@ func BenchmarkClaimWaitBurst(b *testing.B) {
 		close(p.stopCh)
 	}
 }
+
+// The start gate holds fleet-sized background work until the daemon is ready
+// to serve. It must release on the gate, and it must not strand a worker when
+// the daemon shuts down before readiness is ever announced.
+func TestPoolWaitForStart(t *testing.T) {
+	newPool := func(gate <-chan struct{}) *Pool {
+		return &Pool{log: zerolog.Nop(), stopCh: make(chan struct{}), startGate: gate}
+	}
+
+	t.Run("nil gate is already open", func(t *testing.T) {
+		if !newPool(nil).waitForStart(context.Background()) {
+			t.Fatal("nil gate must not block")
+		}
+	})
+
+	t.Run("closed gate releases", func(t *testing.T) {
+		gate := make(chan struct{})
+		close(gate)
+		if !newPool(gate).waitForStart(context.Background()) {
+			t.Fatal("closed gate must release")
+		}
+	})
+
+	t.Run("releases when the gate opens later", func(t *testing.T) {
+		gate := make(chan struct{})
+		p := newPool(gate)
+		done := make(chan bool, 1)
+		go func() { done <- p.waitForStart(context.Background()) }()
+		select {
+		case <-done:
+			t.Fatal("released before the gate opened")
+		case <-time.After(20 * time.Millisecond):
+		}
+		close(gate)
+		select {
+		case ok := <-done:
+			if !ok {
+				t.Fatal("waitForStart reported failure after the gate opened")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("still parked after the gate opened")
+		}
+	})
+
+	t.Run("stop releases the waiter", func(t *testing.T) {
+		p := newPool(make(chan struct{})) // never opened
+		done := make(chan bool, 1)
+		go func() { done <- p.waitForStart(context.Background()) }()
+		close(p.stopCh)
+		select {
+		case ok := <-done:
+			if ok {
+				t.Fatal("stop must report the gate never opened")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("shutdown before readiness stranded a worker")
+		}
+	})
+
+	t.Run("context cancellation releases the waiter", func(t *testing.T) {
+		p := newPool(make(chan struct{})) // never opened
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan bool, 1)
+		go func() { done <- p.waitForStart(ctx) }()
+		cancel()
+		select {
+		case ok := <-done:
+			if ok {
+				t.Fatal("cancellation must report the gate never opened")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("cancellation stranded a worker")
+		}
+	})
+}
+
+// A gated pool must not advertise itself as producing before it can produce:
+// a claimant that sees a producer waits for it, and nothing is built until
+// the gate opens. Declaring early would trade a bounded inline build for a
+// stall on a worker that has not started.
+func TestGatedRefillDeclaresNoProducerBeforeRelease(t *testing.T) {
+	p := &Pool{log: zerolog.Nop(), stopCh: make(chan struct{}), startGate: make(chan struct{})}
+	ctx, cancel := context.WithCancel(context.Background())
+	p.wg.Add(1)
+	go p.refillLoop(ctx)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := p.refillActive.Load(); got != 0 {
+		t.Fatalf("refillActive = %d while gated, want 0", got)
+	}
+
+	cancel()
+	waited := make(chan struct{})
+	go func() { p.wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("gated worker did not exit on cancellation")
+	}
+	if got := p.refillActive.Load(); got != 0 {
+		t.Fatalf("refillActive = %d after exit, want 0", got)
+	}
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1254,7 +1254,7 @@ func TestGatedRefillDeclaresNoProducerBeforeRelease(t *testing.T) {
 	p := &Pool{log: zerolog.Nop(), stopCh: make(chan struct{}), startGate: make(chan struct{})}
 	ctx, cancel := context.WithCancel(context.Background())
 	p.wg.Add(1)
-	go p.refillLoop(ctx, 0)
+	go p.refillLoop(ctx)
 
 	time.Sleep(20 * time.Millisecond)
 	if got := p.refillActive.Load(); got != 0 {
@@ -1311,5 +1311,41 @@ func TestGatedAdoptionNotProducingBeforeRelease(t *testing.T) {
 	}
 	if got := p.adoptPhase.Load(); got != adoptPhaseIdle {
 		t.Fatalf("adoptPhase = %d after stop, want idle", got)
+	}
+}
+
+// The background concurrency budget stays at zero while the gate is closed,
+// grants its first token promptly on release, and its feeder joins cleanly on
+// stop mid-ramp.
+func TestBGSlotBudgetRampsAfterGate(t *testing.T) {
+	gate := make(chan struct{})
+	p := &Pool{
+		log:       zerolog.Nop(),
+		stopCh:    make(chan struct{}),
+		startGate: gate,
+		bgSlotSem: make(chan struct{}, 3),
+	}
+	p.wg.Add(1)
+	go p.rampBGSlots(context.Background(), 3)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := len(p.bgSlotSem); got != 0 {
+		t.Fatalf("budget = %d tokens while gated, want 0", got)
+	}
+
+	close(gate)
+	select {
+	case <-p.bgSlotSem:
+	case <-time.After(time.Second):
+		t.Fatal("no token granted after the gate opened")
+	}
+
+	close(p.stopCh)
+	waited := make(chan struct{})
+	go func() { p.wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("ramp feeder did not exit on stop")
 	}
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -4518,7 +4518,12 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			inst.Supervision = fresh.Supervision
 			inst.mu.Unlock()
 		}
-		log.Info().Msg("reattached paused VM")
+		// Debug, not Info: paused records dominate a large host's store, and
+		// one line per record is enough volume to trip journald's rate limit
+		// and suppress whatever the daemon logs next — including request
+		// errors. The pass already logs its count up front and its totals on
+		// completion; per-record detail is for debugging, not the journal.
+		log.Debug().Msg("reattached paused VM")
 	} else {
 		// Only a deletion undoes the reattach (see persistStateIfPresent).
 		if wrote, perr := m.persistStateIfPresent(inst); perr == nil && !wrote {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -4518,12 +4518,11 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			inst.Supervision = fresh.Supervision
 			inst.mu.Unlock()
 		}
-		// Debug, not Info: paused records dominate a large host's store, and
-		// one line per record is enough volume to trip journald's rate limit
-		// and suppress whatever the daemon logs next — including request
-		// errors. The pass already logs its count up front and its totals on
-		// completion; per-record detail is for debugging, not the journal.
-		log.Debug().Msg("reattached paused VM")
+		// Deliberately no per-record log: paused records dominate a large
+		// host's store, and one line per record is enough volume to trip
+		// journald's rate limit and suppress whatever the daemon logs next —
+		// including request errors. The pass logs its count up front and its
+		// totals on completion; anomalies on this path log above.
 	} else {
 		// Only a deletion undoes the reattach (see persistStateIfPresent).
 		if wrote, perr := m.persistStateIfPresent(inst); perr == nil && !wrote {


### PR DESCRIPTION
Slot refill, slot adoption, and the full reattach each walk the whole inventory, and every netlink operation they issue takes the kernel's single global RTNL lock — so running them during startup delays the readiness they compete with, and their per-record logs can push the readiness line past journald's rate limit.

A `postReady` barrier now holds all three until readiness is announced, released after the readiness line is logged. Requests can't be served during the wait (the gRPC interceptors reject everything with `Unavailable` until `startupReady` flips), so nothing is delayed that a caller was waiting on. Behind the gate the pool no longer declares itself as producing, so an early create takes the bounded inline path instead of stalling on a worker that hasn't started.

Also resolves the host interface once instead of twice, and off the startup goroutine: both advertised endpoints derive from the same lookup, which dumps interface and address tables that grow with the fleet.
