### PR TITLE
vmd: hand the startup pool deficit to adoption before refill builds anything

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1507,16 +1507,21 @@ func main() {
 	// below isn't held for the fill; creates fall back to on-demand until warm.
 	netPoolFresh, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_FRESH_SIZE", "256"))
 	netPoolRecycle, _ := strconv.Atoi(envOrDefault("VMD_NET_POOL_RECYCLE_SIZE", "256"))
+	// One predicate decides both the plan and the call: PlanStartupAdoption
+	// parks refill behind a pass the caller promises to start, so the two
+	// must never diverge.
+	adoptionPlanned := adoptNetPool && slotsReserved && sweepSafe
 	netPool := netMgr.StartPool(ctx, network.PoolConfig{
-		NewSize:           netPoolFresh,
-		RecycleSize:       netPoolRecycle,
-		StartGate:         postReady,
-		ResetTapOnRecycle: envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
-		AbandonOnStop:     adoptNetPool,
+		NewSize:             netPoolFresh,
+		RecycleSize:         netPoolRecycle,
+		StartGate:           postReady,
+		PlanStartupAdoption: adoptionPlanned,
+		ResetTapOnRecycle:   envOrDefault("VMD_RECYCLE_TAP_RESET", "false") == "true",
+		AbandonOnStop:       adoptNetPool,
 	})
 	lc.addCloser("network pool", func(_ context.Context) error { netPool.Stop(); return nil })
 	switch {
-	case adoptNetPool && slotsReserved && sweepSafe:
+	case adoptionPlanned:
 		// Adopt the slots the previous run abandoned (or crashed out of):
 		// the pool starts warm within seconds instead of refilling from
 		// scratch. StartAdoption marks the pass underway before returning,

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -86,9 +86,9 @@ type Pool struct {
 	// refillWake nudges workers held at the inventory target the moment a
 	// claim creates a deficit, so refill responds to a drain immediately
 	// instead of on the next hold poll — and a claimant arriving behind a
-	// burst finds a producer, not an inline build. Capacity one: a single
-	// token restarts the crew, extra nudges drop. Nil (tests) falls back
-	// to the poll.
+	// burst finds a producer, not an inline build. One token of capacity
+	// per worker (see StartPool): deeper drains wake more of the crew.
+	// Nil (tests) falls back to the poll.
 	refillWake chan struct{}
 	wg         sync.WaitGroup
 	drainMu    sync.RWMutex
@@ -289,7 +289,6 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		recycled:            make(chan *preallocSlot, recycleSize),
 		stopCh:              make(chan struct{}),
 		startupAdoptionDone: make(chan struct{}),
-		refillWake:          make(chan struct{}, 1),
 		startGate:           cfg.StartGate,
 		refillDrainGate:     make(chan struct{}),
 		resetTapOnRecycle:   cfg.ResetTapOnRecycle,
@@ -309,6 +308,12 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	if newSize < workers {
 		workers = newSize
 	}
+	// One wake token per worker: a burst that drains the pool sends one
+	// nudge per deficit-opening claim, so the whole held crew resumes in
+	// proportion to the drain instead of single file — a lone token would
+	// serialize refill for up to a hold poll exactly when concurrency
+	// matters most.
+	p.refillWake = make(chan struct{}, workers)
 	// One shared concurrency budget across both background producers —
 	// adoption and refill — granted gradually after the gate (see
 	// rampBGSlots), so neither can burst the RTNL lock alone the moment the

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -198,6 +198,10 @@ const (
 	// per-attempt luck, so retrying immediately burns a core and floods the
 	// log with thousands of identical lines a second without fixing anything.
 	refillFailureBackoff = 2 * time.Second
+	// refillHoldPoll is how often a held refill worker re-checks total warm
+	// inventory (see the hold in refillLoop). A claim draining the surplus
+	// resumes building within one tick.
+	refillHoldPoll = 500 * time.Millisecond
 	// refillConcurrency is the number of refill workers rebuilding the fresh
 	// pool. A single worker refills at one slot per build-time, which cannot
 	// catch a drained pool back up while claims keep arriving; builds stay
@@ -1513,6 +1517,25 @@ func (p *Pool) refillLoop(ctx context.Context) {
 			deactivate()
 			select {
 			case <-time.After(refillFailureBackoff):
+			case <-p.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		// The refill target is total warm inventory, not fresh-channel
+		// occupancy: a recovered slot sitting in recycled serves a claim
+		// exactly as well as a fresh build, so building "up to target" on
+		// top of a stocked recycled channel duplicates, at full price,
+		// inventory the pool already holds. Matters most after a
+		// receiptless restart, where full adoption places everything it
+		// recovers into recycled. Held workers are not producers; claims
+		// draining the surplus reopen building within a poll tick.
+		if len(p.fresh)+len(p.recycled) >= p.newSize {
+			deactivate()
+			select {
+			case <-time.After(refillHoldPoll):
 			case <-p.stopCh:
 				return
 			case <-ctx.Done():

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -128,7 +128,14 @@ type Pool struct {
 	// slot. Workers declare themselves active for the whole construction-
 	// through-delivery span and inactive during backoff sleeps, so claimants
 	// read actual producer state instead of inferring liveness from timing.
+	// Also the heartbeat's provisioning floor (Manager.SlotPressure) — it
+	// must count real in-flight work only, never readiness to work.
 	refillActive atomic.Int64
+	// refillHeld counts workers parked at the inventory target: not
+	// building (so excluded from provisioning pressure), but one wake from
+	// it — so producing() counts them and claimants wait instead of
+	// building inline.
+	refillHeld atomic.Int64
 
 	// adoptPhase is the adoption pass's lifecycle: idle → scanning (orphan
 	// scan, zero output possible) → verifying (workers judging candidates) →
@@ -562,12 +569,13 @@ func (p *Pool) producing() bool {
 	// While the pressure controller has refill paused, in-flight workers'
 	// output is predestined for the discard arms — active or not, they can
 	// deliver nothing, so claimants must not wait on them. The handoff
-	// bridge counts as production for the same reason held workers do:
-	// refill is committed and moments away (see refillHandoffBridge).
+	// bridge and held workers count as production for the same reason:
+	// refill is committed and moments away (see refillHandoffBridge and
+	// refillHeld).
 	if p.refillHandoffBridge.Load() > 0 {
 		return true
 	}
-	return p.refillActive.Load() > 0 && !p.refillIsPaused()
+	return (p.refillActive.Load() > 0 || p.refillHeld.Load() > 0) && !p.refillIsPaused()
 }
 
 // adoptionTrusted reports whether claimants should treat the adoption pass as
@@ -1625,25 +1633,33 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		// receiptless restart, where full adoption places everything it
 		// recovers into recycled.
 		//
-		// Held workers STAY declared active — the same truthfulness as a
-		// worker parked on a full channel with a slot in hand: one wake
-		// from producing. Deactivating here would open a window where a
-		// burst drains the pool and the next claimant reads zero producers
-		// before any woken worker re-declares, sending it to an inline
-		// build against workers already waking.
+		// Held workers move to refillHeld, not refillActive: claimants
+		// still see a producer (producing() counts held — one wake from
+		// building), but the heartbeat's provisioning floor no longer
+		// reports settled workers as in-flight work. The held→active
+		// transition below publishes active BEFORE releasing held, so no
+		// claimant can observe the pool with neither.
 		if len(p.fresh)+len(p.recycled) >= p.newSize {
-			if !active {
-				active = true
-				p.refillActive.Add(1)
+			deactivate()
+			p.refillHeld.Add(1)
+			for {
+				select {
+				case <-p.refillWake: // a claim opened a deficit
+				case <-time.After(refillHoldPoll):
+				case <-p.stopCh:
+					p.refillHeld.Add(-1)
+					return
+				case <-ctx.Done():
+					p.refillHeld.Add(-1)
+					return
+				}
+				if len(p.fresh)+len(p.recycled) < p.newSize {
+					break
+				}
 			}
-			select {
-			case <-p.refillWake: // a claim opened a deficit
-			case <-time.After(refillHoldPoll):
-			case <-p.stopCh:
-				return
-			case <-ctx.Done():
-				return
-			}
+			active = true
+			p.refillActive.Add(1)
+			p.refillHeld.Add(-1)
 			continue
 		}
 		if !active {

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -85,6 +85,11 @@ type Pool struct {
 	// parked). Refill measures the remaining deficit only after it.
 	startupAdoptionDone chan struct{}
 	startupAdoptionOnce sync.Once
+	// startupAdoptionResolvedAt is the handoff instant (unix nanos, zero
+	// until resolved). ClaimWait re-anchors the pool budget here for
+	// claimants that had been waiting on adoption — see the budget
+	// computation for why.
+	startupAdoptionResolvedAt atomic.Int64
 	// refillHandoffBridge keeps producing() true across the instant of the
 	// handoff on a gated pool: the channel close releases the workers, but
 	// until the scheduler runs one, refillActive is still zero — and a
@@ -532,6 +537,11 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 			// queueing behind it.
 			p.wakeRefillOnDeficit()
 			p.cleanup(slot)
+			// And again after cleanup: at the slot ceiling, the early wake
+			// can rouse workers into an allocator that still owns this
+			// index — they fail into backoff, and without a second nudge
+			// nothing tells them the index just became reusable.
+			p.wakeRefillOnDeficit()
 			continue
 		}
 		tNsChecked := time.Now()
@@ -667,10 +677,21 @@ func (p *Pool) ClaimWait(ctx context.Context, vmID string) *VMNetInfo {
 			return p.finalClaim(ctx, vmID)
 		}
 		budget := poolClaimWaitBudget
+		anchor := start
 		if p.adoptionTrusted() {
 			budget = adoptionClaimWaitBudget
+		} else if ns := p.startupAdoptionResolvedAt.Load(); ns > 0 {
+			// A claimant that outlived the adoption pass must not have its
+			// (shorter) pool budget backdated to its own arrival: the wait
+			// so far was spent on adoption, and refill only became the
+			// producer at the handoff. Re-anchoring there gives the
+			// released workers the pool budget they were promised instead
+			// of a bill that is already overdrawn.
+			if resolved := time.Unix(0, ns); resolved.After(anchor) {
+				anchor = resolved
+			}
 		}
-		remaining := budget - time.Since(start)
+		remaining := budget - time.Since(anchor)
 		if remaining <= 0 {
 			return p.finalClaim(ctx, vmID)
 		}
@@ -1313,6 +1334,7 @@ func (p *Pool) finishStartupAdoption() {
 		// so the count is exact; an ungated boot may include a build that
 		// was already in flight at the reset — harmless overcount.
 		p.postHandoffBuilds.Store(0)
+		p.startupAdoptionResolvedAt.Store(time.Now().UnixNano())
 		close(p.startupAdoptionDone)
 		p.log.Info().Dur("held_refill_for", time.Since(p.startupAdoptionBegan)).
 			Msg("pool: startup adoption handoff resolved — refill released")
@@ -1738,9 +1760,14 @@ func (p *Pool) refillStep(ctx context.Context, deactivate func()) refillOutcome 
 }
 
 // pauseAfterFailure waits out the retry backoff, reporting false when the pool
-// is shutting down and the caller should give up instead of retrying.
+// is shutting down and the caller should give up instead of retrying. A wake
+// cuts the backoff short: it means pool state changed under the failure — a
+// claim opened a deficit or a discarded slot's index became reusable — and
+// the failure's cause may be gone with it.
 func (p *Pool) pauseAfterFailure(ctx context.Context) bool {
 	select {
+	case <-p.refillWake:
+		return true
 	case <-time.After(refillFailureBackoff):
 		return true
 	case <-p.stopCh:

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -35,6 +35,14 @@ type PoolConfig struct {
 	// the fleet-sized background work comment in cmd/vmd). Nil starts them
 	// immediately.
 	StartGate <-chan struct{}
+	// PlanStartupAdoption declares — before any refill worker spawns — that
+	// the caller will run StartAdoption, so refill defers to it (see
+	// startupAdoptionPlanned). Required for the handoff on an UNGATED pool:
+	// its workers start immediately and check the plan exactly once, so a
+	// plan established only inside StartAdoption arrives too late for them.
+	// A caller that sets this MUST call StartAdoption, or refill stays
+	// parked until shutdown.
+	PlanStartupAdoption bool
 }
 
 // Pool pre-allocates network namespaces, veth pairs, TAP devices, and
@@ -322,6 +330,12 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	// serialize refill for up to a hold poll exactly when concurrency
 	// matters most.
 	p.refillWake = make(chan struct{}, workers)
+	// Settled before any worker spawns — the one ordering that works for
+	// ungated pools, whose workers read the plan immediately and only once.
+	if cfg.PlanStartupAdoption {
+		p.startupAdoptionPlanned.Store(true)
+		p.startupAdoptionBegan = time.Now()
+	}
 	// One shared concurrency budget across both background producers —
 	// adoption and refill — granted gradually after the gate (see
 	// rampBGSlots), so neither can burst the RTNL lock alone the moment the
@@ -1103,6 +1117,12 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 	// — the stray-veth sweep delivers nothing a claimant could wait for.
 	p.adoptPhase.CompareAndSwap(adoptPhaseIdle, adoptPhaseScanning)
 	defer func() {
+		// The handoff resolves BEFORE the idle phase is published: on a
+		// panic this deferred cleanup runs ahead of the caller's outer
+		// finish, and a claimant woken by the signalProgress below must
+		// see the bridge, not a gap with no producer at all. Idempotent —
+		// on the normal path the explicit pre-sweep finish already ran.
+		p.finishStartupAdoption()
 		p.adoptPhase.Store(adoptPhaseIdle)
 		p.adoptStreak.Store(0)
 		p.signalProgress()
@@ -1233,12 +1253,14 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 		p.log.Warn().Msg("pool: adoption already running — duplicate start ignored")
 		return false
 	}
-	// Synchronous, before the goroutine and before the start gate can open:
-	// StartAdoption is a startup call and gated refill workers park on the
-	// gate until readiness, so the flag is settled before any of them can
-	// read it. finishStartupAdoption is the only release.
-	p.startupAdoptionPlanned.Store(true)
-	p.startupAdoptionBegan = time.Now()
+	// Synchronous, before the goroutine and before the start gate can open —
+	// sufficient for GATED pools, whose workers park on the gate until
+	// readiness. An ungated pool's workers are already past their one plan
+	// check by now; PoolConfig.PlanStartupAdoption is the only ordering
+	// that covers them. finishStartupAdoption is the only release.
+	if p.startupAdoptionPlanned.CompareAndSwap(false, true) {
+		p.startupAdoptionBegan = time.Now()
+	}
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -67,16 +67,24 @@ type Pool struct {
 	// few namespace entries; building one from scratch is a namespace, a
 	// veth pair, a tap, and a firewall program — so if both producers wake
 	// at the same gate, refill duplicates at full price exactly the
-	// inventory adoption is restoring. Written only by StartAdoption,
-	// before the start gate opens (see there); never afterwards.
-	startupAdoptionPlanned bool
+	// inventory adoption is restoring. Written only by StartAdoption (see
+	// there); atomic because an ungated pool's workers may already be
+	// running when that write lands.
+	startupAdoptionPlanned atomic.Bool
 	// startupAdoptionDone is the one-shot handoff: closed on every exit of
 	// the boot adoption pass. Refill measures the remaining deficit only
 	// after it.
 	startupAdoptionDone chan struct{}
 	startupAdoptionOnce sync.Once
-	wg                  sync.WaitGroup
-	drainMu             sync.RWMutex
+	// startupAdoptionBegan and postHandoffBuilds record the handoff's two
+	// numbers of interest: how long recovery held refill, and how many
+	// fresh builds followed anyway. Together they make a restart's log
+	// prove (or disprove) that recovery restored the pool without refill
+	// duplicating it.
+	startupAdoptionBegan time.Time
+	postHandoffBuilds    atomic.Int64
+	wg                   sync.WaitGroup
+	drainMu              sync.RWMutex
 	// refillDrainGate is closed while the controller is draining warm inventory.
 	// Refill workers select on it before handing a built slot to the pool so a
 	// send that was already blocked when drain started can still abort instead
@@ -164,6 +172,10 @@ var pidsInNsFunc = pidsInNs
 // resetTapFunc is a seam over Manager.resetTap so tests can drive the
 // recycle-vs-teardown decision without building a real netns + tap device.
 var resetTapFunc = (*Manager).resetTap
+
+// poolAllocateFunc is a seam over Pool.allocate so tests can count and stub
+// fresh slot builds without kernel namespaces.
+var poolAllocateFunc = (*Pool).allocate
 
 const (
 	// defaultVerifyPollInterval trades a small amount of slot-reuse latency
@@ -1180,7 +1192,8 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 	// StartAdoption is a startup call and gated refill workers park on the
 	// gate until readiness, so the flag is settled before any of them can
 	// read it. finishStartupAdoption is the only release.
-	p.startupAdoptionPlanned = true
+	p.startupAdoptionPlanned.Store(true)
+	p.startupAdoptionBegan = time.Now()
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
@@ -1209,7 +1222,28 @@ func (p *Pool) finishStartupAdoption() {
 	if p.startupAdoptionDone == nil {
 		return
 	}
-	p.startupAdoptionOnce.Do(func() { close(p.startupAdoptionDone) })
+	p.startupAdoptionOnce.Do(func() {
+		close(p.startupAdoptionDone)
+		// Zeroed at the handoff so the summary below counts only builds
+		// after it, even on boots where refill ran alongside the pass.
+		p.postHandoffBuilds.Store(0)
+		p.log.Info().Dur("held_refill_for", time.Since(p.startupAdoptionBegan)).
+			Msg("pool: startup adoption handoff resolved — refill released")
+		// One delayed summary so a restart's log answers "did refill
+		// duplicate the recovery?" without host forensics. Builds after
+		// a clean recovery should be near the claims consumed during it,
+		// bounded by the worker count — never hundreds.
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			select {
+			case <-time.After(time.Minute):
+				p.log.Info().Int64("fresh_builds", p.postHandoffBuilds.Load()).
+					Msg("pool: fresh builds in the first minute after adoption handoff")
+			case <-p.stopCh:
+			}
+		}()
+	})
 }
 
 // waitForStartupAdoption blocks a refill worker until the boot adoption pass
@@ -1217,7 +1251,7 @@ func (p *Pool) finishStartupAdoption() {
 // was planned — fresh boot, adoption skipped, tests. Reports false on
 // shutdown/cancellation.
 func (p *Pool) waitForStartupAdoption(ctx context.Context) bool {
-	if !p.startupAdoptionPlanned || p.startupAdoptionDone == nil {
+	if !p.startupAdoptionPlanned.Load() || p.startupAdoptionDone == nil {
 		return true
 	}
 	select {
@@ -1521,7 +1555,7 @@ func (p *Pool) refillStep(ctx context.Context, deactivate func()) refillOutcome 
 	// not hold concurrency budget the other producers could use.
 	var slot *preallocSlot
 	var err error
-	if !p.withBGSlot(ctx, func() { slot, err = p.allocate(ctx) }) {
+	if !p.withBGSlot(ctx, func() { slot, err = poolAllocateFunc(p, ctx) }) {
 		return refillStopped
 	}
 	if err != nil {
@@ -1531,6 +1565,7 @@ func (p *Pool) refillStep(ctx context.Context, deactivate func()) refillOutcome 
 		p.log.Error().Err(err).Msg("pool refill failed")
 		return refillFailed
 	}
+	p.postHandoffBuilds.Add(1)
 	if p.refillIsPaused() {
 		deactivate()
 		p.cleanup(slot)

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -72,10 +72,18 @@ type Pool struct {
 	// running when that write lands.
 	startupAdoptionPlanned atomic.Bool
 	// startupAdoptionDone is the one-shot handoff: closed on every exit of
-	// the boot adoption pass. Refill measures the remaining deficit only
-	// after it.
+	// the boot adoption pass, and early when the pass trips its no-yield
+	// escape (a distrusted pass must not keep the fallback producer
+	// parked). Refill measures the remaining deficit only after it.
 	startupAdoptionDone chan struct{}
 	startupAdoptionOnce sync.Once
+	// refillHandoffBridge keeps producing() true across the instant of the
+	// handoff on a gated pool: the channel close releases the workers, but
+	// until the scheduler runs one, refillActive is still zero — and a
+	// claimant woken in that window would take an inline build against
+	// workers already waking. Set by finishStartupAdoption, cleared by the
+	// first worker to declare itself.
+	refillHandoffBridge atomic.Int64
 	// startupAdoptionBegan and postHandoffBuilds record the handoff's two
 	// numbers of interest: how long recovery held refill, and how many
 	// fresh builds followed anyway. Together they make a restart's log
@@ -539,7 +547,12 @@ func (p *Pool) producing() bool {
 	}
 	// While the pressure controller has refill paused, in-flight workers'
 	// output is predestined for the discard arms — active or not, they can
-	// deliver nothing, so claimants must not wait on them.
+	// deliver nothing, so claimants must not wait on them. The handoff
+	// bridge counts as production for the same reason held workers do:
+	// refill is committed and moments away (see refillHandoffBridge).
+	if p.refillHandoffBridge.Load() > 0 {
+		return true
+	}
 	return p.refillActive.Load() > 0 && !p.refillIsPaused()
 }
 
@@ -1178,15 +1191,18 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 		invalid, skipped = nInvalid.Load(), nSkipped.Load()
 	}
 
+	// Inventory work is done — release refill BEFORE dropping the adoption
+	// phase and BEFORE the stray-veth sweep. Order matters twice over: the
+	// finish raises the handoff bridge, so a claimant woken by the
+	// signalProgress below sees a producer at every instant of the
+	// transfer; and the sweep's per-interface deletions can block for
+	// seconds while delivering nothing a claimant could wait for — holding
+	// the handoff across it would leave the pool with no producer at all
+	// while requests are already being served. The goroutine's deferred
+	// finish stays as the backstop for every other exit path.
+	p.finishStartupAdoption()
 	p.adoptPhase.Store(adoptPhaseIdle)
 	p.signalProgress()
-	// Inventory work is done — release refill BEFORE the stray-veth sweep.
-	// The sweep's per-interface deletions can block for seconds and deliver
-	// nothing a claimant could wait for; holding the handoff across it
-	// would leave the pool with no producer at all while requests are
-	// already being served. The goroutine's deferred finish stays as the
-	// backstop for every other exit path.
-	p.finishStartupAdoption()
 	p.mgr.SweepStrayHostVeths()
 	// Emitted on every completion path — including the receipt fast path
 	// adopting all slots, or no orphans at all — so startup timing always has
@@ -1252,6 +1268,13 @@ func (p *Pool) finishStartupAdoption() {
 		return
 	}
 	p.startupAdoptionOnce.Do(func() {
+		// The bridge is raised BEFORE the close: from the claimants' side
+		// the producer role must transfer atomically — adoption may stop
+		// counting the instant this returns, so refill has to already
+		// count. Gated only; an ungated pool's workers declared long ago.
+		if p.startGate != nil {
+			p.refillHandoffBridge.Store(1)
+		}
 		// Zeroed BEFORE the close: the close wakes the refill workers, and
 		// a build landing between the two would be erased from the summary.
 		// On gated boots (production) workers are parked until the close,
@@ -1325,6 +1348,13 @@ func (p *Pool) adoptYieldedNothing() {
 	if p.adoptStreak.Add(1) == p.adoptEscapeStreak {
 		p.log.Warn().Int64("consecutive_without_delivery", p.adoptEscapeStreak).
 			Msg("pool: adoption yielding no inventory — claimants no longer waiting on the pass")
+		// A pass claimants no longer trust must not keep the fallback
+		// producer parked either: on an invalid-heavy fleet the remainder
+		// of the pass can run for minutes, and every create in that span
+		// would otherwise build inline. Refill wakes now and the
+		// total-inventory hold keeps the two producers from overfilling
+		// if the pass later delivers again.
+		p.finishStartupAdoption()
 		p.signalProgress()
 	}
 }
@@ -1522,9 +1552,12 @@ func (p *Pool) refillLoop(ctx context.Context) {
 	}
 	// Past the gate the worker is genuinely producing, so it publishes the
 	// declaration StartPool skipped (see there for why a gated pool must not
-	// declare it up front). Ungated, StartPool already published it.
+	// declare it up front) and lowers the handoff bridge — its declaration
+	// now carries what the bridge was holding. Ungated, StartPool already
+	// published it.
 	if p.startGate != nil {
 		p.refillActive.Add(1)
+		p.refillHandoffBridge.Store(0)
 	}
 	// The worker's active declaration is continuous across successful
 	// iterations — decrementing between two builds would let a delivery

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -63,18 +63,16 @@ type Pool struct {
 	bgSlotSem chan struct{}
 	// startupAdoptionPlanned hands the startup deficit to adoption: while a
 	// boot-time adoption pass is planned, refill workers wait for it to
-	// finish before building anything. Reusing an abandoned slot costs a
+	// resolve before building anything. Reusing an abandoned slot costs a
 	// few namespace entries; building one from scratch is a namespace, a
-	// veth pair, a tap, and a firewall program — so when both producers
-	// wake at the same gate, letting them race means refill duplicates, at
-	// full price, exactly the inventory adoption is already restoring.
-	// Written before the start gate opens (StartAdoption runs during
-	// startup; workers park on the gate until readiness), so gated workers
-	// always observe it; never written afterwards.
+	// veth pair, a tap, and a firewall program — so if both producers wake
+	// at the same gate, refill duplicates at full price exactly the
+	// inventory adoption is restoring. Written only by StartAdoption,
+	// before the start gate opens (see there); never afterwards.
 	startupAdoptionPlanned bool
-	// startupAdoptionDone is the one-shot handoff: closed when the boot
-	// adoption pass finishes — complete, aborted, cancelled, panicked, or
-	// never released. Refill measures the remaining deficit only after it.
+	// startupAdoptionDone is the one-shot handoff: closed on every exit of
+	// the boot adoption pass. Refill measures the remaining deficit only
+	// after it.
 	startupAdoptionDone chan struct{}
 	startupAdoptionOnce sync.Once
 	wg                  sync.WaitGroup
@@ -1178,11 +1176,10 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 		p.log.Warn().Msg("pool: adoption already running — duplicate start ignored")
 		return false
 	}
-	// Synchronous, before the goroutine and — decisively — before the start
-	// gate can open: StartAdoption is a startup call, and gated refill
-	// workers park on the gate until readiness, so by the time any of them
-	// can read this flag it is settled. From here refill defers to this
-	// pass; finishStartupAdoption is the only release.
+	// Synchronous, before the goroutine and before the start gate can open:
+	// StartAdoption is a startup call and gated refill workers park on the
+	// gate until readiness, so the flag is settled before any of them can
+	// read it. finishStartupAdoption is the only release.
 	p.startupAdoptionPlanned = true
 	p.wg.Add(1)
 	go func() {
@@ -1216,10 +1213,9 @@ func (p *Pool) finishStartupAdoption() {
 }
 
 // waitForStartupAdoption blocks a refill worker until the boot adoption pass
-// has resolved, so the two producers never solve the same deficit twice:
-// adoption restores the previous run's slots at reuse cost while refill
-// would rebuild them at full cost. Immediate when no pass was planned (fresh
-// boot, adoption skipped, tests). Reports false on shutdown/cancellation.
+// has resolved (see startupAdoptionPlanned for why). Immediate when no pass
+// was planned — fresh boot, adoption skipped, tests. Reports false on
+// shutdown/cancellation.
 func (p *Pool) waitForStartupAdoption(ctx context.Context) bool {
 	if !p.startupAdoptionPlanned || p.startupAdoptionDone == nil {
 		return true
@@ -1439,10 +1435,9 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		return
 	}
 	// Adoption owns the startup deficit; refill is the fallback. Waiting
-	// here (still undeclared — a parked worker is not a producer) means the
-	// deficit refill eventually measures through the channels is the REAL
-	// one: what adoption could not restore, plus whatever claims consumed
-	// meanwhile. Skipped entirely when no boot adoption was planned.
+	// here — still undeclared, a parked worker is not a producer — means
+	// the deficit refill later measures through the channels is what
+	// adoption could not restore plus what claims consumed meanwhile.
 	if !p.waitForStartupAdoption(ctx) {
 		return
 	}

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -83,8 +83,15 @@ type Pool struct {
 	// duplicating it.
 	startupAdoptionBegan time.Time
 	postHandoffBuilds    atomic.Int64
-	wg                   sync.WaitGroup
-	drainMu              sync.RWMutex
+	// refillWake nudges workers held at the inventory target the moment a
+	// claim creates a deficit, so refill responds to a drain immediately
+	// instead of on the next hold poll — and a claimant arriving behind a
+	// burst finds a producer, not an inline build. Capacity one: a single
+	// token restarts the crew, extra nudges drop. Nil (tests) falls back
+	// to the poll.
+	refillWake chan struct{}
+	wg         sync.WaitGroup
+	drainMu    sync.RWMutex
 	// refillDrainGate is closed while the controller is draining warm inventory.
 	// Refill workers select on it before handing a built slot to the pool so a
 	// send that was already blocked when drain started can still abort instead
@@ -282,6 +289,7 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 		recycled:            make(chan *preallocSlot, recycleSize),
 		stopCh:              make(chan struct{}),
 		startupAdoptionDone: make(chan struct{}),
+		refillWake:          make(chan struct{}, 1),
 		startGate:           cfg.StartGate,
 		refillDrainGate:     make(chan struct{}),
 		resetTapOnRecycle:   cfg.ResetTapOnRecycle,
@@ -495,6 +503,16 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 		p.mgr.assignSlotLocked(slot.idx, vmID)
 		p.mgr.mu.Unlock()
 		tDone := time.Now()
+
+		// A successful claim may have opened a deficit; nudge any worker
+		// held at the inventory target. Non-blocking single-token send —
+		// nanoseconds on the claim path, never a wait.
+		if p.refillWake != nil && len(p.fresh)+len(p.recycled) < p.newSize {
+			select {
+			case p.refillWake <- struct{}{}:
+			default:
+			}
+		}
 
 		p.log.Info().
 			Str("vm_id", vmID).
@@ -1535,6 +1553,7 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		if len(p.fresh)+len(p.recycled) >= p.newSize {
 			deactivate()
 			select {
+			case <-p.refillWake: // a claim opened a deficit
 			case <-time.After(refillHoldPoll):
 			case <-p.stopCh:
 				return

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -1223,10 +1223,13 @@ func (p *Pool) finishStartupAdoption() {
 		return
 	}
 	p.startupAdoptionOnce.Do(func() {
-		close(p.startupAdoptionDone)
-		// Zeroed at the handoff so the summary below counts only builds
-		// after it, even on boots where refill ran alongside the pass.
+		// Zeroed BEFORE the close: the close wakes the refill workers, and
+		// a build landing between the two would be erased from the summary.
+		// On gated boots (production) workers are parked until the close,
+		// so the count is exact; an ungated boot may include a build that
+		// was already in flight at the reset — harmless overcount.
 		p.postHandoffBuilds.Store(0)
+		close(p.startupAdoptionDone)
 		p.log.Info().Dur("held_refill_for", time.Since(p.startupAdoptionBegan)).
 			Msg("pool: startup adoption handoff resolved — refill released")
 		// One delayed summary so a restart's log answers "did refill

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -498,6 +498,9 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 				Int("slot", slot.idx).
 				Msg("pool: discarded phantom slot (kernel netns missing)")
 			p.cleanup(slot)
+			// The discard opened a deficit just like a successful claim
+			// would; held workers must hear about this one too.
+			p.wakeRefillOnDeficit()
 			continue
 		}
 		tNsChecked := time.Now()
@@ -509,15 +512,7 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 		p.mgr.mu.Unlock()
 		tDone := time.Now()
 
-		// A successful claim may have opened a deficit; nudge any worker
-		// held at the inventory target. Non-blocking single-token send —
-		// nanoseconds on the claim path, never a wait.
-		if p.refillWake != nil && len(p.fresh)+len(p.recycled) < p.newSize {
-			select {
-			case p.refillWake <- struct{}{}:
-			default:
-			}
-		}
+		p.wakeRefillOnDeficit()
 
 		p.log.Info().
 			Str("vm_id", vmID).
@@ -1185,6 +1180,13 @@ func (p *Pool) AdoptOrphanSlots(ctx context.Context) (adopted, invalid, skipped 
 
 	p.adoptPhase.Store(adoptPhaseIdle)
 	p.signalProgress()
+	// Inventory work is done — release refill BEFORE the stray-veth sweep.
+	// The sweep's per-interface deletions can block for seconds and deliver
+	// nothing a claimant could wait for; holding the handoff across it
+	// would leave the pool with no producer at all while requests are
+	// already being served. The goroutine's deferred finish stays as the
+	// backstop for every other exit path.
+	p.finishStartupAdoption()
 	p.mgr.SweepStrayHostVeths()
 	// Emitted on every completion path — including the receipt fast path
 	// adopting all slots, or no orphans at all — so startup timing always has
@@ -1274,6 +1276,19 @@ func (p *Pool) finishStartupAdoption() {
 			}
 		}()
 	})
+}
+
+// wakeRefillOnDeficit nudges workers held at the inventory target when a
+// popped slot — claimed or discarded as a phantom — has opened a deficit.
+// Non-blocking send, nanoseconds on the claim path; extra nudges beyond the
+// crew-sized capacity drop.
+func (p *Pool) wakeRefillOnDeficit() {
+	if p.refillWake != nil && len(p.fresh)+len(p.recycled) < p.newSize {
+		select {
+		case p.refillWake <- struct{}{}:
+		default:
+		}
+	}
 }
 
 // waitForStartupAdoption blocks a refill worker until the boot adoption pass

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -61,8 +61,24 @@ type Pool struct {
 	// (adoption and refill together); rampBGSlots grants it. Nil meters
 	// nothing (tests).
 	bgSlotSem chan struct{}
-	wg        sync.WaitGroup
-	drainMu   sync.RWMutex
+	// startupAdoptionPlanned hands the startup deficit to adoption: while a
+	// boot-time adoption pass is planned, refill workers wait for it to
+	// finish before building anything. Reusing an abandoned slot costs a
+	// few namespace entries; building one from scratch is a namespace, a
+	// veth pair, a tap, and a firewall program — so when both producers
+	// wake at the same gate, letting them race means refill duplicates, at
+	// full price, exactly the inventory adoption is already restoring.
+	// Written before the start gate opens (StartAdoption runs during
+	// startup; workers park on the gate until readiness), so gated workers
+	// always observe it; never written afterwards.
+	startupAdoptionPlanned bool
+	// startupAdoptionDone is the one-shot handoff: closed when the boot
+	// adoption pass finishes — complete, aborted, cancelled, panicked, or
+	// never released. Refill measures the remaining deficit only after it.
+	startupAdoptionDone chan struct{}
+	startupAdoptionOnce sync.Once
+	wg                  sync.WaitGroup
+	drainMu             sync.RWMutex
 	// refillDrainGate is closed while the controller is draining warm inventory.
 	// Refill workers select on it before handing a built slot to the pool so a
 	// send that was already blocked when drain started can still abort instead
@@ -245,17 +261,18 @@ func (m *Manager) StartPool(ctx context.Context, cfg PoolConfig) *Pool {
 	}
 
 	p := &Pool{
-		mgr:               m,
-		log:               m.log.With().Str("component", "net_pool").Logger(),
-		newSize:           newSize,
-		fresh:             make(chan *preallocSlot, newSize),
-		recycled:          make(chan *preallocSlot, recycleSize),
-		stopCh:            make(chan struct{}),
-		startGate:         cfg.StartGate,
-		refillDrainGate:   make(chan struct{}),
-		resetTapOnRecycle: cfg.ResetTapOnRecycle,
-		abandonOnStop:     cfg.AbandonOnStop,
-		resetSem:          make(chan struct{}, resetTapConcurrency),
+		mgr:                 m,
+		log:                 m.log.With().Str("component", "net_pool").Logger(),
+		newSize:             newSize,
+		fresh:               make(chan *preallocSlot, newSize),
+		recycled:            make(chan *preallocSlot, recycleSize),
+		stopCh:              make(chan struct{}),
+		startupAdoptionDone: make(chan struct{}),
+		startGate:           cfg.StartGate,
+		refillDrainGate:     make(chan struct{}),
+		resetTapOnRecycle:   cfg.ResetTapOnRecycle,
+		abandonOnStop:       cfg.AbandonOnStop,
+		resetSem:            make(chan struct{}, resetTapConcurrency),
 	}
 	p.adoptEscapeStreak = defaultAdoptEscapeStreak
 	m.pool = p
@@ -1161,10 +1178,20 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 		p.log.Warn().Msg("pool: adoption already running — duplicate start ignored")
 		return false
 	}
+	// Synchronous, before the goroutine and — decisively — before the start
+	// gate can open: StartAdoption is a startup call, and gated refill
+	// workers park on the gate until readiness, so by the time any of them
+	// can read this flag it is settled. From here refill defers to this
+	// pass; finishStartupAdoption is the only release.
+	p.startupAdoptionPlanned = true
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
 		defer sentrylog.Recover("netpool-adopt")
+		// Unconditional: every exit — completion, abort, cancellation,
+		// panic, or a gate that never opened — must release the refill
+		// workers waiting on the handoff.
+		defer p.finishStartupAdoption()
 		if !p.waitForStart(ctx) {
 			// Nothing was scanned, so the phase must not stay latched — a
 			// later StartAdoption (or direct pass) must find it idle.
@@ -1176,6 +1203,35 @@ func (p *Pool) StartAdoption(ctx context.Context) bool {
 		p.AdoptOrphanSlots(ctx)
 	}()
 	return true
+}
+
+// finishStartupAdoption resolves the startup handoff to refill. Idempotent;
+// safe to call on every adoption exit path. A nil channel (pool constructed
+// directly, outside StartPool) has no waiters and needs no resolution.
+func (p *Pool) finishStartupAdoption() {
+	if p.startupAdoptionDone == nil {
+		return
+	}
+	p.startupAdoptionOnce.Do(func() { close(p.startupAdoptionDone) })
+}
+
+// waitForStartupAdoption blocks a refill worker until the boot adoption pass
+// has resolved, so the two producers never solve the same deficit twice:
+// adoption restores the previous run's slots at reuse cost while refill
+// would rebuild them at full cost. Immediate when no pass was planned (fresh
+// boot, adoption skipped, tests). Reports false on shutdown/cancellation.
+func (p *Pool) waitForStartupAdoption(ctx context.Context) bool {
+	if !p.startupAdoptionPlanned || p.startupAdoptionDone == nil {
+		return true
+	}
+	select {
+	case <-p.startupAdoptionDone:
+		return true
+	case <-p.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // adoptDelivered and adoptYieldedNothing maintain the pass's trust streak
@@ -1380,6 +1436,14 @@ const (
 func (p *Pool) refillLoop(ctx context.Context) {
 	defer p.wg.Done()
 	if !p.waitForStart(ctx) {
+		return
+	}
+	// Adoption owns the startup deficit; refill is the fallback. Waiting
+	// here (still undeclared — a parked worker is not a producer) means the
+	// deficit refill eventually measures through the channels is the REAL
+	// one: what adoption could not restore, plus whatever claims consumed
+	// meanwhile. Skipped entirely when no boot adoption was planned.
+	if !p.waitForStartupAdoption(ctx) {
 		return
 	}
 	// Past the gate the worker is genuinely producing, so it publishes the

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -526,10 +526,12 @@ func (p *Pool) Claim(vmID string) *VMNetInfo {
 				Str("namespace", slot.info.Namespace).
 				Int("slot", slot.idx).
 				Msg("pool: discarded phantom slot (kernel netns missing)")
-			p.cleanup(slot)
 			// The discard opened a deficit just like a successful claim
-			// would; held workers must hear about this one too.
+			// would; held workers hear about it BEFORE the teardown below,
+			// which can block — replacement overlaps cleanup instead of
+			// queueing behind it.
 			p.wakeRefillOnDeficit()
+			p.cleanup(slot)
 			continue
 		}
 		tNsChecked := time.Now()
@@ -1640,8 +1642,11 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		// transition below publishes active BEFORE releasing held, so no
 		// claimant can observe the pool with neither.
 		if len(p.fresh)+len(p.recycled) >= p.newSize {
-			deactivate()
+			// Held is published BEFORE active is dropped: deactivate()
+			// broadcasts to claimants, and one woken by it must never see
+			// both counters at zero with a wake already queued.
 			p.refillHeld.Add(1)
+			deactivate()
 			for {
 				select {
 				case <-p.refillWake: // a claim opened a deficit

--- a/internal/network/pool.go
+++ b/internal/network/pool.go
@@ -1548,10 +1548,19 @@ func (p *Pool) refillLoop(ctx context.Context) {
 		// top of a stocked recycled channel duplicates, at full price,
 		// inventory the pool already holds. Matters most after a
 		// receiptless restart, where full adoption places everything it
-		// recovers into recycled. Held workers are not producers; claims
-		// draining the surplus reopen building within a poll tick.
+		// recovers into recycled.
+		//
+		// Held workers STAY declared active — the same truthfulness as a
+		// worker parked on a full channel with a slot in hand: one wake
+		// from producing. Deactivating here would open a window where a
+		// burst drains the pool and the next claimant reads zero producers
+		// before any woken worker re-declares, sending it to an inline
+		// build against workers already waking.
 		if len(p.fresh)+len(p.recycled) >= p.newSize {
-			deactivate()
+			if !active {
+				active = true
+				p.refillActive.Add(1)
+			}
 			select {
 			case <-p.refillWake: // a claim opened a deficit
 			case <-time.After(refillHoldPoll):

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1728,6 +1728,35 @@ func TestEachDeficitClaimDepositsAWakeToken(t *testing.T) {
 	}
 }
 
+// An ungated pool's workers start immediately and read the adoption plan
+// exactly once, so the plan must arrive through PoolConfig — a plan set only
+// inside StartAdoption lands after their check and the handoff silently
+// stops applying.
+func TestConfigPlannedAdoptionParksUngatedRefill(t *testing.T) {
+	builds := stubPoolAllocate(t)
+	m := newTestManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := m.StartPool(ctx, PoolConfig{NewSize: 2, RecycleSize: 2, PlanStartupAdoption: true})
+	defer p.Stop()
+
+	time.Sleep(30 * time.Millisecond)
+	if got := builds.Load(); got != 0 {
+		t.Fatalf("ungated refill built %d slots despite a planned adoption, want 0", got)
+	}
+
+	p.finishStartupAdoption()
+	deadline := time.After(2 * time.Second)
+	for builds.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("refill never resumed after the handoff resolved")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
 // The producer role must transfer atomically from the claimants' viewpoint:
 // the instant the handoff resolves — before any released worker is scheduled
 // — producing() must already be true, or a claimant woken by adoption's

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1686,6 +1686,48 @@ func TestClaimWakesHeldRefillWorkers(t *testing.T) {
 	}
 }
 
+// A drain deeper than one slot must wake held workers in proportion: every
+// deficit-opening claim deposits its own wake token, so a burst releases the
+// crew rather than one worker. A coalescing single-token channel would
+// serialize refill behind one worker for up to a hold poll, exactly when
+// concurrency matters most.
+func TestEachDeficitClaimDepositsAWakeToken(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+
+	const capacity, crew = 4, 3
+	p := &Pool{
+		mgr:               m,
+		log:               zerolog.Nop(),
+		newSize:           capacity,
+		fresh:             make(chan *preallocSlot, capacity),
+		recycled:          make(chan *preallocSlot, capacity),
+		stopCh:            make(chan struct{}),
+		refillWake:        make(chan struct{}, crew),
+		refillDrainGate:   make(chan struct{}),
+		adoptEscapeStreak: defaultAdoptEscapeStreak,
+	}
+	for i := 0; i < capacity; i++ {
+		ns := fmt.Sprintf("ns-%d", i)
+		touchNS(t, dir, ns)
+		m.assignSlotLocked(i, poolOwner)
+		p.fresh <- &preallocSlot{idx: i, info: &VMNetInfo{Namespace: ns}}
+	}
+
+	// No workers running: the tokens accumulate, making the per-claim
+	// deposit directly observable.
+	for i := 0; i < capacity; i++ {
+		if info := p.Claim(fmt.Sprintf("vm-drain-%d", i)); info == nil {
+			t.Fatalf("claim %d from a stocked pool failed", i)
+		}
+	}
+	// Every claim opened or deepened the deficit; each must have deposited
+	// a token, saturating the crew-sized channel — not coalescing to one.
+	if got := len(p.refillWake); got != crew {
+		t.Fatalf("wake tokens = %d after draining the pool, want %d (one per held worker)", got, crew)
+	}
+}
+
 // StartAdoption's planned-flag write must be race-safe against concurrent
 // handoff readers — the interleaving an ungated pool's already-running
 // workers produce. The readers here call waitForStartupAdoption directly

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1383,3 +1383,101 @@ func TestWithBGSlotReturnsTokenOnPanic(t *testing.T) {
 		t.Fatal("token not returned after panic")
 	}
 }
+
+// Adoption owns the startup deficit; refill is the fallback. While a boot
+// adoption pass is planned but unresolved, a refill worker must not get past
+// the handoff — otherwise both producers solve the same deficit and refill
+// rebuilds, at full cost, the very slots adoption is restoring.
+func TestRefillDefersToStartupAdoption(t *testing.T) {
+	newPool := func() *Pool {
+		return &Pool{
+			log:                 zerolog.Nop(),
+			stopCh:              make(chan struct{}),
+			startGate:           make(chan struct{}),
+			startupAdoptionDone: make(chan struct{}),
+			adoptEscapeStreak:   defaultAdoptEscapeStreak,
+		}
+	}
+
+	t.Run("no pass planned: immediate", func(t *testing.T) {
+		p := newPool()
+		if !p.waitForStartupAdoption(context.Background()) {
+			t.Fatal("refill must proceed when no boot adoption was planned")
+		}
+	})
+
+	t.Run("nil handoff channel: immediate", func(t *testing.T) {
+		p := &Pool{log: zerolog.Nop(), stopCh: make(chan struct{})}
+		p.startupAdoptionPlanned = true
+		if !p.waitForStartupAdoption(context.Background()) {
+			t.Fatal("a pool without a handoff channel has no waiters to hold")
+		}
+	})
+
+	t.Run("planned pass holds refill until resolved", func(t *testing.T) {
+		p := newPool()
+		if !p.StartAdoption(context.Background()) {
+			t.Fatal("StartAdoption must claim the pass")
+		}
+		done := make(chan bool, 1)
+		go func() { done <- p.waitForStartupAdoption(context.Background()) }()
+		select {
+		case <-done:
+			t.Fatal("refill released while the pass was still parked")
+		case <-time.After(20 * time.Millisecond):
+		}
+		// The pass is parked behind the never-opened gate; stopping resolves
+		// the handoff through the unconditional defer.
+		close(p.stopCh)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("handoff never resolved after the pass exited")
+		}
+	})
+
+	t.Run("refill worker allocates nothing before handoff", func(t *testing.T) {
+		gate := make(chan struct{})
+		p := newPool()
+		p.startGate = gate
+		p.startupAdoptionPlanned = true
+		ctx, cancel := context.WithCancel(context.Background())
+		p.wg.Add(1)
+		go p.refillLoop(ctx)
+
+		close(gate) // gate opens; handoff still unresolved
+		time.Sleep(20 * time.Millisecond)
+		// Past the handoff the worker's first act is declaring refillActive;
+		// zero means it never reached the build loop, so no allocation was
+		// possible.
+		if got := p.refillActive.Load(); got != 0 {
+			t.Fatalf("refillActive = %d while adoption unresolved, want 0", got)
+		}
+
+		cancel()
+		waited := make(chan struct{})
+		go func() { p.wg.Wait(); close(waited) }()
+		select {
+		case <-waited:
+		case <-time.After(time.Second):
+			t.Fatal("parked refill worker did not exit on cancellation")
+		}
+	})
+
+	t.Run("cancellation resolves the handoff", func(t *testing.T) {
+		p := newPool()
+		ctx, cancel := context.WithCancel(context.Background())
+		if !p.StartAdoption(ctx) {
+			t.Fatal("StartAdoption must claim the pass")
+		}
+		cancel() // pass parked behind the gate exits via ctx
+		select {
+		case <-p.startupAdoptionDone:
+		case <-time.After(time.Second):
+			t.Fatal("handoff unresolved after cancellation")
+		}
+		// Idempotent: repeated finishes must not panic.
+		p.finishStartupAdoption()
+		p.finishStartupAdoption()
+	})
+}

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1658,6 +1658,11 @@ func TestClaimWakesHeldRefillWorkers(t *testing.T) {
 	if got := builds.Load(); got != 0 {
 		t.Fatalf("refill built %d slots at target, want 0", got)
 	}
+	// Held is still declared: a claimant racing the wake must see a
+	// producer, not fall back to an inline build.
+	if got := p.refillActive.Load(); got != 1 {
+		t.Fatalf("refillActive = %d while held at target, want 1", got)
+	}
 
 	if info := p.Claim("vm-wake"); info == nil {
 		t.Fatal("claim from a stocked pool failed")

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1735,6 +1735,56 @@ func TestEachDeficitClaimDepositsAWakeToken(t *testing.T) {
 	}
 }
 
+// A claimant that outlived a trusted adoption pass gets the pool budget
+// re-anchored at the handoff: its wait so far was spent on adoption, and
+// backdating the shorter refill budget to its arrival would make it bail to
+// an inline build at the exact moment refill becomes available.
+func TestClaimBudgetReanchorsAtHandoff(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+
+	p := &Pool{
+		mgr:                 m,
+		log:                 zerolog.Nop(),
+		newSize:             2,
+		fresh:               make(chan *preallocSlot, 2),
+		recycled:            make(chan *preallocSlot, 2),
+		stopCh:              make(chan struct{}),
+		startGate:           make(chan struct{}),
+		startupAdoptionDone: make(chan struct{}),
+		adoptEscapeStreak:   defaultAdoptEscapeStreak,
+	}
+	p.startupAdoptionPlanned.Store(true)
+	p.adoptPhase.Store(adoptPhaseScanning) // trusted pass under way
+
+	got := make(chan *VMNetInfo, 1)
+	go func() { got <- p.ClaimWait(context.Background(), "vm-late") }()
+
+	// The claimant waits out more than the whole pool budget under the
+	// trusted pass, then the pass hands off with the pool still empty.
+	time.Sleep(poolClaimWaitBudget + 200*time.Millisecond)
+	p.finishStartupAdoption() // bridge up, resolvedAt stamped
+	p.adoptPhase.Store(adoptPhaseIdle)
+	p.signalProgress()
+
+	// Refill "delivers" shortly after the handoff — well inside the
+	// re-anchored pool budget, far outside the backdated one.
+	time.Sleep(300 * time.Millisecond)
+	touchNS(t, dir, "ns-late")
+	m.assignSlotLocked(1, poolOwner)
+	p.fresh <- &preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-late"}}
+	p.signalProgress()
+
+	select {
+	case info := <-got:
+		if info == nil {
+			t.Fatal("claimant bailed to inline build — pool budget was not re-anchored at the handoff")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("claimant never returned")
+	}
+}
+
 // An ungated pool's workers start immediately and read the adoption plan
 // exactly once, so the plan must arrive through PoolConfig — a plan set only
 // inside StartAdoption lands after their check and the handoff silently

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1728,6 +1728,65 @@ func TestEachDeficitClaimDepositsAWakeToken(t *testing.T) {
 	}
 }
 
+// The producer role must transfer atomically from the claimants' viewpoint:
+// the instant the handoff resolves — before any released worker is scheduled
+// — producing() must already be true, or a claimant woken by adoption's
+// completion takes an inline build against workers that are already waking.
+func TestHandoffBridgesProducerVisibility(t *testing.T) {
+	p := &Pool{
+		log:                 zerolog.Nop(),
+		stopCh:              make(chan struct{}),
+		startGate:           make(chan struct{}),
+		startupAdoptionDone: make(chan struct{}),
+		adoptEscapeStreak:   defaultAdoptEscapeStreak,
+	}
+	p.startupAdoptionPlanned.Store(true)
+
+	if p.producing() {
+		t.Fatal("nothing declared yet — must not read as producing")
+	}
+	p.finishStartupAdoption()
+	if !p.producing() {
+		t.Fatal("handoff resolved with zero scheduled workers — the bridge must hold producer visibility")
+	}
+
+	// The first worker to declare itself takes over from the bridge.
+	p.refillActive.Add(1)
+	p.refillHandoffBridge.Store(0)
+	if !p.producing() {
+		t.Fatal("declared worker must carry production after the bridge drops")
+	}
+}
+
+// A pass that trips the no-yield escape loses claimant trust; it must lose
+// its hold on the fallback producer at the same moment, or every create for
+// the remainder of a fleet-sized pass builds inline.
+func TestEscapeStreakReleasesTheHandoff(t *testing.T) {
+	p := &Pool{
+		log:                 zerolog.Nop(),
+		stopCh:              make(chan struct{}),
+		startGate:           make(chan struct{}),
+		startupAdoptionDone: make(chan struct{}),
+		adoptEscapeStreak:   3,
+	}
+	p.startupAdoptionPlanned.Store(true)
+
+	for i := 0; i < 2; i++ {
+		p.adoptYieldedNothing()
+		select {
+		case <-p.startupAdoptionDone:
+			t.Fatalf("handoff released after %d misses, before the escape streak", i+1)
+		default:
+		}
+	}
+	p.adoptYieldedNothing() // trips the escape
+	select {
+	case <-p.startupAdoptionDone:
+	default:
+		t.Fatal("escape streak tripped but the handoff stayed unresolved")
+	}
+}
+
 // Discarding a phantom slot opens a deficit exactly like a successful claim;
 // it must deposit a wake token too, or held workers sleep out the hold poll
 // while a claimant waits on them.

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1570,6 +1570,56 @@ func TestRefillBuildsOnlyTheDeficitAfterAdoption(t *testing.T) {
 			}
 		})
 	}
+
+	// The receiptless-restart shape: full adoption places everything it
+	// recovers into the recycled channel, and none of it into fresh. That
+	// inventory serves claims just as well, so refill must build nothing.
+	t.Run("recovery into recycled only", func(t *testing.T) {
+		builds := stubPoolAllocate(t)
+		gate := make(chan struct{})
+		p := &Pool{
+			mgr:                 &Manager{},
+			log:                 zerolog.Nop(),
+			newSize:             capacity,
+			fresh:               make(chan *preallocSlot, capacity),
+			recycled:            make(chan *preallocSlot, capacity),
+			stopCh:              make(chan struct{}),
+			startGate:           gate,
+			startupAdoptionDone: make(chan struct{}),
+			refillDrainGate:     make(chan struct{}),
+			adoptEscapeStreak:   defaultAdoptEscapeStreak,
+		}
+		p.startupAdoptionPlanned.Store(true)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		for i := 0; i < workers; i++ {
+			p.wg.Add(1)
+			go p.refillLoop(ctx)
+		}
+
+		close(gate)
+		for i := 0; i < capacity; i++ {
+			p.recycled <- &preallocSlot{idx: 2000 + i, adopted: true}
+		}
+		p.finishStartupAdoption()
+
+		time.Sleep(100 * time.Millisecond)
+		if got := builds.Load(); got != 0 {
+			t.Fatalf("refill built %d slots atop a fully recycled recovery, want 0", got)
+		}
+		if got := len(p.fresh); got != 0 {
+			t.Fatalf("fresh holds %d slots, want 0 — inventory already at target", got)
+		}
+
+		close(p.stopCh)
+		waited := make(chan struct{})
+		go func() { p.wg.Wait(); close(waited) }()
+		select {
+		case <-waited:
+		case <-time.After(2 * time.Second):
+			t.Fatal("workers did not join after stop")
+		}
+	})
 }
 
 // StartAdoption's planned-flag write must be race-safe against concurrent

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1728,6 +1728,34 @@ func TestEachDeficitClaimDepositsAWakeToken(t *testing.T) {
 	}
 }
 
+// Discarding a phantom slot opens a deficit exactly like a successful claim;
+// it must deposit a wake token too, or held workers sleep out the hold poll
+// while a claimant waits on them.
+func TestPhantomDiscardDepositsAWakeToken(t *testing.T) {
+	withTestNetnsDir(t) // no ns file: the pooled slot is a phantom
+	m := newTestManager()
+
+	p := &Pool{
+		mgr:               m,
+		log:               zerolog.Nop(),
+		newSize:           1,
+		fresh:             make(chan *preallocSlot, 1),
+		recycled:          make(chan *preallocSlot, 1),
+		stopCh:            make(chan struct{}),
+		refillWake:        make(chan struct{}, 1),
+		adoptEscapeStreak: defaultAdoptEscapeStreak,
+	}
+	m.assignSlotLocked(1, poolOwner)
+	p.fresh <- &preallocSlot{idx: 1, info: &VMNetInfo{Namespace: "ns-1"}, vethName: "veth-1"}
+
+	if got := p.Claim("vm-x"); got != nil {
+		t.Fatalf("expected nil (only a phantom available), got %+v", got)
+	}
+	if got := len(p.refillWake); got != 1 {
+		t.Fatalf("wake tokens = %d after a phantom discard, want 1", got)
+	}
+}
+
 // StartAdoption's planned-flag write must be race-safe against concurrent
 // handoff readers — the interleaving an ungated pool's already-running
 // workers produce. The readers here call waitForStartupAdoption directly

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1622,6 +1622,65 @@ func TestRefillBuildsOnlyTheDeficitAfterAdoption(t *testing.T) {
 	})
 }
 
+// A claim that opens a deficit must wake held refill workers immediately —
+// not on the next hold poll — so a claimant arriving behind a burst finds a
+// producer instead of falling back to an inline build.
+func TestClaimWakesHeldRefillWorkers(t *testing.T) {
+	dir := withTestNetnsDir(t)
+	m := newTestManager()
+	builds := stubPoolAllocate(t)
+
+	const capacity = 2
+	p := &Pool{
+		mgr:               m,
+		log:               zerolog.Nop(),
+		newSize:           capacity,
+		fresh:             make(chan *preallocSlot, capacity),
+		recycled:          make(chan *preallocSlot, capacity),
+		stopCh:            make(chan struct{}),
+		refillWake:        make(chan struct{}, 1),
+		refillDrainGate:   make(chan struct{}),
+		adoptEscapeStreak: defaultAdoptEscapeStreak,
+	}
+	for i := 0; i < capacity; i++ {
+		ns := fmt.Sprintf("ns-%d", i)
+		touchNS(t, dir, ns)
+		m.assignSlotLocked(i, poolOwner)
+		p.fresh <- &preallocSlot{idx: i, info: &VMNetInfo{Namespace: ns}}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.refillActive.Add(1) // ungated declaration, mirroring StartPool
+	p.wg.Add(1)
+	go p.refillLoop(ctx)
+
+	time.Sleep(30 * time.Millisecond) // worker reaches the hold at target
+	if got := builds.Load(); got != 0 {
+		t.Fatalf("refill built %d slots at target, want 0", got)
+	}
+
+	if info := p.Claim("vm-wake"); info == nil {
+		t.Fatal("claim from a stocked pool failed")
+	}
+	deadline := time.After(200 * time.Millisecond) // well under refillHoldPoll
+	for builds.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("no build within 200ms of the deficit — the wake never fired")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	close(p.stopCh)
+	waited := make(chan struct{})
+	go func() { p.wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not join after stop")
+	}
+}
+
 // StartAdoption's planned-flag write must be race-safe against concurrent
 // handoff readers — the interleaving an ungated pool's already-running
 // workers produce. The readers here call waitForStartupAdoption directly

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1408,7 +1408,7 @@ func TestRefillDefersToStartupAdoption(t *testing.T) {
 
 	t.Run("nil handoff channel: immediate", func(t *testing.T) {
 		p := &Pool{log: zerolog.Nop(), stopCh: make(chan struct{})}
-		p.startupAdoptionPlanned = true
+		p.startupAdoptionPlanned.Store(true)
 		if !p.waitForStartupAdoption(context.Background()) {
 			t.Fatal("a pool without a handoff channel has no waiters to hold")
 		}
@@ -1440,7 +1440,7 @@ func TestRefillDefersToStartupAdoption(t *testing.T) {
 		gate := make(chan struct{})
 		p := newPool()
 		p.startGate = gate
-		p.startupAdoptionPlanned = true
+		p.startupAdoptionPlanned.Store(true)
 		ctx, cancel := context.WithCancel(context.Background())
 		p.wg.Add(1)
 		go p.refillLoop(ctx)
@@ -1480,4 +1480,131 @@ func TestRefillDefersToStartupAdoption(t *testing.T) {
 		p.finishStartupAdoption()
 		p.finishStartupAdoption()
 	})
+}
+
+// stubPoolAllocate replaces fresh slot construction with a counter that
+// returns inert slots (nil info short-circuits every cleanup path), so tests
+// can measure exactly how many builds refill performs.
+func stubPoolAllocate(t *testing.T) *atomic.Int64 {
+	t.Helper()
+	var builds atomic.Int64
+	old := poolAllocateFunc
+	poolAllocateFunc = func(p *Pool, ctx context.Context) (*preallocSlot, error) {
+		builds.Add(1)
+		return &preallocSlot{idx: int(builds.Load())}, nil
+	}
+	t.Cleanup(func() { poolAllocateFunc = old })
+	return &builds
+}
+
+// The incident regression: after a recovery pass that restores the whole
+// pool, refill must build at most one in-hand slot per worker — never the
+// pool-sized burst the producer race caused. With K slots consumed during
+// recovery, the bound is K plus the worker count.
+func TestRefillBuildsOnlyTheDeficitAfterAdoption(t *testing.T) {
+	const capacity, workers, claimed = 8, 4, 3
+	for _, tc := range []struct {
+		name     string
+		consume  int
+		maxBuild int64
+	}{
+		{"perfect recovery, no claims", 0, workers},
+		{"perfect recovery, K claims", claimed, claimed + workers},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builds := stubPoolAllocate(t)
+			gate := make(chan struct{})
+			p := &Pool{
+				mgr:                 &Manager{}, // yieldToForeground reads its counters
+				log:                 zerolog.Nop(),
+				newSize:             capacity,
+				fresh:               make(chan *preallocSlot, capacity),
+				recycled:            make(chan *preallocSlot, capacity),
+				stopCh:              make(chan struct{}),
+				startGate:           gate,
+				startupAdoptionDone: make(chan struct{}),
+				refillDrainGate:     make(chan struct{}),
+				adoptEscapeStreak:   defaultAdoptEscapeStreak,
+			}
+			p.startupAdoptionPlanned.Store(true)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			for i := 0; i < workers; i++ {
+				p.wg.Add(1)
+				go p.refillLoop(ctx)
+			}
+
+			close(gate)
+			time.Sleep(20 * time.Millisecond)
+			if got := builds.Load(); got != 0 {
+				t.Fatalf("refill built %d slots before the handoff, want 0", got)
+			}
+
+			// The recovery pass restores the full pool, minus what claims
+			// consumed while it ran, then hands off.
+			for i := 0; i < capacity-tc.consume; i++ {
+				p.fresh <- &preallocSlot{idx: 1000 + i}
+			}
+			p.finishStartupAdoption()
+
+			deadline := time.After(2 * time.Second)
+			for len(p.fresh) < capacity {
+				select {
+				case <-deadline:
+					t.Fatalf("pool never refilled: fresh=%d builds=%d", len(p.fresh), builds.Load())
+				case <-time.After(5 * time.Millisecond):
+				}
+			}
+			time.Sleep(50 * time.Millisecond) // let parked overshoot settle
+			if got := builds.Load(); got > tc.maxBuild {
+				t.Fatalf("refill built %d slots, want <= %d", got, tc.maxBuild)
+			}
+
+			close(p.stopCh)
+			waited := make(chan struct{})
+			go func() { p.wg.Wait(); close(waited) }()
+			select {
+			case <-waited:
+			case <-time.After(2 * time.Second):
+				t.Fatal("workers did not join after stop")
+			}
+		})
+	}
+}
+
+// On an ungated pool, StartAdoption's planned-flag write can land while
+// refill workers are already past the gate and reading it — the flag must be
+// race-safe under that interleaving (run with -race).
+func TestStartAdoptionPlannedFlagIsRaceSafe(t *testing.T) {
+	p := &Pool{
+		log:                 zerolog.Nop(),
+		stopCh:              make(chan struct{}),
+		startGate:           make(chan struct{}), // never opened: the pass parks harmlessly
+		startupAdoptionDone: make(chan struct{}),
+		adoptEscapeStreak:   defaultAdoptEscapeStreak,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			p.waitForStartupAdoption(ctx) // races the Store below
+		}()
+	}
+	if !p.StartAdoption(ctx) {
+		t.Fatal("StartAdoption must claim the pass")
+	}
+	cancel() // releases any reader that observed the flag set
+	readers.Wait()
+
+	close(p.stopCh)
+	waited := make(chan struct{})
+	go func() { p.wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parked adoption did not join after stop")
+	}
 }

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1658,10 +1658,17 @@ func TestClaimWakesHeldRefillWorkers(t *testing.T) {
 	if got := builds.Load(); got != 0 {
 		t.Fatalf("refill built %d slots at target, want 0", got)
 	}
-	// Held is still declared: a claimant racing the wake must see a
-	// producer, not fall back to an inline build.
-	if got := p.refillActive.Load(); got != 1 {
-		t.Fatalf("refillActive = %d while held at target, want 1", got)
+	// Held is visible to claimants but NOT to the provisioning floor: a
+	// claimant racing the wake must see a producer, while the heartbeat
+	// must not report a settled worker as in-flight work.
+	if got := p.refillHeld.Load(); got != 1 {
+		t.Fatalf("refillHeld = %d while held at target, want 1", got)
+	}
+	if got := p.refillActive.Load(); got != 0 {
+		t.Fatalf("refillActive = %d while held at target, want 0 (held is not provisioning)", got)
+	}
+	if !p.producing() {
+		t.Fatal("held worker must still read as a producer to claimants")
 	}
 
 	if info := p.Claim("vm-wake"); info == nil {

--- a/internal/network/pool_test.go
+++ b/internal/network/pool_test.go
@@ -1572,9 +1572,11 @@ func TestRefillBuildsOnlyTheDeficitAfterAdoption(t *testing.T) {
 	}
 }
 
-// On an ungated pool, StartAdoption's planned-flag write can land while
-// refill workers are already past the gate and reading it — the flag must be
-// race-safe under that interleaving (run with -race).
+// StartAdoption's planned-flag write must be race-safe against concurrent
+// handoff readers — the interleaving an ungated pool's already-running
+// workers produce. The readers here call waitForStartupAdoption directly
+// (the adoption pass itself stays parked behind an unopened gate), so this
+// validates the concurrent flag access, not the full ungated StartPool flow.
 func TestStartAdoptionPlannedFlagIsRaceSafe(t *testing.T) {
 	p := &Pool{
 		log:                 zerolog.Nop(),


### PR DESCRIPTION
After a restart, the boot adoption pass and the refill workers wake at the same gate and independently set out to fill the same empty pool: adoption re-places the previous run's slots while refill, seeing empty channels, builds brand-new ones. The duplicated builds are pure waste — a namespace, veth pair, tap, and firewall program each — and their kernel work runs concurrently with live restores.

Adoption now owns the startup deficit. `StartAdoption` marks the pass before the gate can open, and refill workers wait on a one-shot handoff that every adoption exit resolves — completion, abort, cancellation, panic, or shutdown before release. Refill then measures the remaining deficit through the channels and builds only what adoption could not restore plus what claims consumed meanwhile.

Boots without an adoption pass are unaffected: the handoff resolves immediately and refill remains the sole producer.
