### PR TITLE
vmd: enforce host capacity locally with an id-keyed admission ledger

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -29,6 +29,7 @@ on:
       # Every internal package the host binaries import must be listed, or a
       # change to it merges without deploying. Enforced by the
       # deploy-trigger-coverage CI check against `go list -deps`.
+      - 'internal/admission/**'
       - 'internal/backup/**'
       - 'internal/blocklist/**'
       - 'internal/builder/**'

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -498,6 +498,12 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 		VmId:         vmID,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
+		// Fixed here rather than taken from the caller: this RPC only ever
+		// resumes. Declared all the same, because a daemon enforcing local
+		// capacity refuses an undeclared intent on every boot path, and a
+		// client that set it on one path but not the other would fail on
+		// whichever it forgot.
+		AdmissionIntent: vmdpb.AdmissionIntent_ADMISSION_INTENT_RESUME,
 	}
 	if len(networkConfig) > 0 {
 		var persisted struct {
@@ -536,7 +542,7 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 // instance from the snapshot files, bypassing any in-memory state. For
 // sandboxes with secrets the caller passes envVars=nil and pushes env via
 // InjectSandboxEnv after minting a JWT against the returned source IP.
-func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits vmdclient.ResourceLimits) (string, uint32, uint32, string, error) {
+func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits vmdclient.ResourceLimits, intent vmdclient.AdmissionIntent) (string, uint32, uint32, string, error) {
 	resp, err := c.client.RestoreSnapshot(ctx, &vmdpb.RestoreSnapshotRequest{
 		VmId:                  vmID,
 		SnapshotPath:          snapshotPath,
@@ -555,6 +561,10 @@ func (c *grpcVMDClient) RestoreSnapshot(ctx context.Context, vmID, snapshotPath,
 		// counted as unsized until that lands. Omitted (zero) only by
 		// callers that do not know the shape.
 		ResourceLimits: restoreResourceLimits(limits),
+		// Declared, never inferred: this same RPC serves both a create
+		// and the stateless-resume fallback below, and a daemon
+		// enforcing capacity has no way to tell them apart.
+		AdmissionIntent: admissionIntentToProto(intent),
 	})
 	if err != nil {
 		return "", 0, 0, "", fmt.Errorf("gRPC RestoreSnapshot: %w", err)
@@ -936,4 +946,18 @@ func (s *deadHostClientStream) RecvMsg(m any) error {
 		s.onDead()
 	}
 	return err
+}
+
+// admissionIntentToProto maps the control plane's intent onto the wire
+// enum. The two are separate types so call sites in internal/api do not
+// depend on generated protobuf code; this is the only place they meet.
+func admissionIntentToProto(i vmdclient.AdmissionIntent) vmdpb.AdmissionIntent {
+	switch i {
+	case vmdclient.IntentCreate:
+		return vmdpb.AdmissionIntent_ADMISSION_INTENT_CREATE
+	case vmdclient.IntentResume:
+		return vmdpb.AdmissionIntent_ADMISSION_INTENT_RESUME
+	default:
+		return vmdpb.AdmissionIntent_ADMISSION_INTENT_UNSPECIFIED
+	}
 }

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1747,10 +1747,14 @@ func main() {
 		// Builders orphaned by the previous daemon (deploy restarts kill
 		// only the main process) hold unsizable build-VM memory; the
 		// pressure gate stays closed until the async discovery completes
-		// and every survivor exits. Skipped when pressure publication is
-		// not configured: the /proc walk buys nothing for a host that
-		// never publishes.
-		if publishesPressure {
+		// and every survivor exits.
+		//
+		// Needed by local admission as well as by publication, and for a
+		// sharper reason: admission reconstruction counts builders from
+		// the live registry, which a survivor is absent from until this
+		// scan finds it. Skipping the walk on a host that enforces limits
+		// would open the gate blind to work already running.
+		if publishesPressure || localAdmission {
 			mgr.ScanSurvivingBuildersAsync(cfg.TemplateBuilderBin)
 		}
 		proxyHealthURL := os.Getenv("PROXY_HEALTH_URL")

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -677,6 +677,15 @@ func main() {
 		log.Info().Uint64("port", port).Msg("guest DNS redirect enabled")
 	}
 
+	// Host-local capacity admission. Read once and shared by the three
+	// places that must agree: the gate itself, the slot allocator policy,
+	// and the capability this host advertises. Its own setting, never
+	// inferred from VMD_MAX_SANDBOXES or VMD_MAX_NETWORK_SLOTS being set —
+	// those are already configured on production hosts to feed pressure
+	// publication, so deriving enablement from them would switch
+	// enforcement on fleet-wide the moment this ships.
+	localAdmission := envOrDefault("VMD_LOCAL_ADMISSION_ENABLED", "false") == "true"
+
 	// ---- Network manager + host firewall ----
 	// preliminary: sentry init, config parse, tool lookups, dir creation, and
 	// egress/DNS option wiring — everything before the network manager builds.
@@ -684,6 +693,15 @@ func main() {
 	netMgrOpts = append(netMgrOpts,
 		network.WithHostID(cfg.HostID),
 		network.WithSecretsProxyAddr(cfg.SecretsProxySandboxDst, cfg.SecretsProxySandboxPort))
+	// Slot policy travels with local admission, not on its own: the two are
+	// halves of one limit, and a host that enforces sandbox counts while
+	// minting slots without bound is enforcing neither. Left unset — and so
+	// unlimited — on any host that has not opted in, whatever
+	// VMD_MAX_NETWORK_SLOTS happens to say for pressure publication.
+	if localAdmission {
+		netMgrOpts = append(netMgrOpts,
+			network.WithOperatorSlotLimit(int(envInt32Fatal(log, "VMD_MAX_NETWORK_SLOTS"))))
+	}
 	netMgr, err := network.NewManager(ctx, cfg.HostInterface, log, netMgrOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize network manager")
@@ -898,7 +916,7 @@ func main() {
 		// configured on production hosts to feed pressure publication, so
 		// inferring enablement from it would switch enforcement on across
 		// the whole fleet the moment this ships.
-		LocalAdmission: envOrDefault("VMD_LOCAL_ADMISSION_ENABLED", "false") == "true",
+		LocalAdmission: localAdmission,
 		MaxSandboxes:   int(envInt32Fatal(log, "VMD_MAX_SANDBOXES")),
 	}, netMgr, log)
 	if err != nil {
@@ -1788,8 +1806,11 @@ func main() {
 				// endpoint after each successful heartbeat; in-memory
 				// counters only. The limits are operator admission knobs;
 				// 0 (unset) means no cap.
-				Pressure:        pressureSample,
-				PressureReady:   pressureReady,
+				Pressure:      pressureSample,
+				PressureReady: pressureReady,
+				// Advertised so placement can tell a host that enforces its
+				// own limits from one that only reports its load.
+				LocalAdmission:  localAdmission,
 				MaxSandboxes:    envInt32Fatal(log, "VMD_MAX_SANDBOXES"),
 				MaxNetworkSlots: envInt32Fatal(log, "VMD_MAX_NETWORK_SLOTS"),
 				LifecycleReady:  startupReady.Load,

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -893,6 +893,13 @@ func main() {
 		LauncherNSPath:                      os.Getenv("VMD_LAUNCHER_NS_PATH"),
 		DirectSpawn:                         envOrDefault("VMD_DIRECT_SPAWN", "false") == "true",
 		PressureAccounting:                  publishesPressure,
+		// Host-local capacity admission. Its own setting, deliberately not
+		// derived from VMD_MAX_SANDBOXES being set: that value is already
+		// configured on production hosts to feed pressure publication, so
+		// inferring enablement from it would switch enforcement on across
+		// the whole fleet the moment this ships.
+		LocalAdmission: envOrDefault("VMD_LOCAL_ADMISSION_ENABLED", "false") == "true",
+		MaxSandboxes:   int(envInt32Fatal(log, "VMD_MAX_SANDBOXES")),
 	}, netMgr, log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize VM manager")
@@ -1583,6 +1590,12 @@ func main() {
 		if reattached > 0 || stale > 0 {
 			log.Info().Int("reattached", reattached).Int("stale", stale).Msg("startup reattach complete")
 		}
+		// Opens host-local admission once the daemon knows what this host
+		// is already carrying. Started here rather than before serving
+		// begins because the listening socket survives a restart: calls
+		// can already be queued on it, and the gate refuses them until
+		// this completes rather than admitting against an empty ledger.
+		mgr.StartAdmission(ctx)
 		// After the instance map is rebuilt: pauses that still owed their
 		// backup enqueue when the previous process exited get their
 		// rehash re-run, and completed template builds whose generation

--- a/internal/admission/gate.go
+++ b/internal/admission/gate.go
@@ -1,0 +1,338 @@
+package admission
+
+import (
+	"fmt"
+	"sync"
+)
+
+// State is the gate's lifecycle. The states exist because "is this
+// host full?" is unanswerable until the daemon knows what it is already
+// carrying, and a daemon that answers it anyway admits against an empty
+// count — which is not a limit at all.
+type State int
+
+const (
+	// StateDisabled is the default and the only state a daemon reaches
+	// without the operator opting in. Every request is admitted; the
+	// ledger is not consulted and not maintained.
+	StateDisabled State = iota
+	// StateReconstructing is where an enabled gate starts. The socket
+	// is inherited across a restart and can deliver queued requests before
+	// reattach finishes, so this state must be the initial one rather than
+	// something entered later — there is no instant at which an enabled
+	// gate is both open and ignorant.
+	StateReconstructing
+	// StateOpen admits within the operator's limits.
+	StateOpen
+	// StateDraining refuses new sandboxes while letting existing ones
+	// go on being accounted, so a drain's own pending count means
+	// something.
+	StateDraining
+)
+
+func (s State) String() string {
+	switch s {
+	case StateDisabled:
+		return "disabled"
+	case StateReconstructing:
+		return "reconstructing"
+	case StateOpen:
+		return "open"
+	case StateDraining:
+		return "draining"
+	}
+	return "unknown"
+}
+
+// Intent is why a boot is happening, as the caller declared it.
+// Mirrors the wire enum; the daemon never infers it. A sandbox that already
+// exists can arrive through the create RPC (the caller's stateless fallback,
+// taken precisely when this daemon has no record of it), so neither the RPC
+// nor "do I remember this id" separates the two.
+type Intent int
+
+const (
+	IntentUnspecified Intent = iota
+	IntentCreate
+	IntentResume
+)
+
+// ErrIntentRequired refuses a boot whose caller predates the
+// intent field, rather than guessing. Guessing "create" double-charges a
+// resuming sandbox; guessing "resume" lets a real create past the limit.
+// Both are silent, so an enabled gate makes the skew loud instead.
+var ErrIntentRequired = fmt.Errorf("admission intent required: caller must declare create or resume")
+
+// ErrHostAtCapacity rejects a create the host has no room for. Distinct
+// from every other failure on purpose: it is the one the control plane may
+// answer by placing the sandbox somewhere else, and a generic error would
+// either strand a placeable sandbox or invite retries of a genuine fault.
+var ErrHostAtCapacity = fmt.Errorf("host at configured sandbox capacity")
+
+// ErrNotReady rejects work that arrives before the gate knows what
+// the host is carrying, or after a drain has closed it.
+var ErrNotReady = fmt.Errorf("host not accepting new sandboxes")
+
+// admissionToken is one host-owned charge. Tokens are keyed by id, which is
+// what makes admission idempotent: a retried create finds its own token and
+// re-admits rather than charging twice.
+type admissionToken struct {
+	// build distinguishes a template build from a sandbox. Both hold a
+	// sandbox token — build pressure is published as provisioning
+	// sandboxes, and the ranker counts provisioning against the same
+	// limit, so a gate that ignored builds would enforce a different
+	// limit than the one ranking believes in.
+	build bool
+}
+
+// Gate enforces the operator's concurrent-sandbox limit locally.
+//
+// Counting is len(map): the ledger is keyed by sandbox id, so the count is
+// O(1) and exact at once, with no counter to drift from the thing it
+// counts. That is the property that makes this safe to hold a mutex for —
+// admission is a map lookup, a compare, and an insert, and the lock is
+// never held across Firecracker, filesystem, database, network, logging or
+// metric work.
+//
+// The ledger is authoritative while the gate is open. Capacity pressure is
+// an eventually consistent sample taken off the hot path and must never
+// lower these counts; it audits them, and an audit that finds the ledger
+// undercounting closes the gate for reconstruction rather than quietly
+// correcting it.
+type Gate struct {
+	mu     sync.Mutex
+	state  State
+	tokens map[string]admissionToken
+	// maxSandboxes is the operator's limit. Zero means unlimited, matching
+	// how the pressure publisher already reads VMD_MAX_SANDBOXES.
+	maxSandboxes int
+}
+
+// NewGate builds a gate. An enabled gate starts reconstructing and
+// admits nothing until Opened; a disabled one is inert and stays that way.
+func NewGate(enabled bool, maxSandboxes int) *Gate {
+	state := StateDisabled
+	if enabled {
+		state = StateReconstructing
+	}
+	return &Gate{
+		state:        state,
+		tokens:       make(map[string]admissionToken),
+		maxSandboxes: maxSandboxes,
+	}
+}
+
+// Enabled reports whether this gate enforces anything.
+func (g *Gate) Enabled() bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.state != StateDisabled
+}
+
+// State reports the current lifecycle state, for diagnostics and tests.
+func (g *Gate) State() State {
+	if g == nil {
+		return StateDisabled
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.state
+}
+
+// Charged reports how many tokens are held. This is the count admission
+// decisions are made against.
+func (g *Gate) Charged() int {
+	if g == nil {
+		return 0
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.tokens)
+}
+
+// Reconstruct seeds the ledger from what the host is already carrying and
+// opens the gate.
+//
+// Deliberately replaces rather than merges: a partial rebuild that kept
+// unknown ids would carry forward exactly the phantom charges reconstruction
+// exists to clear. Safe only because callers run it while the gate is closed
+// — Open is what publishes the result.
+func (g *Gate) Reconstruct(sandboxIDs, buildIDs []string) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state == StateDisabled {
+		return
+	}
+	tokens := make(map[string]admissionToken, len(sandboxIDs)+len(buildIDs))
+	for _, id := range sandboxIDs {
+		tokens[id] = admissionToken{}
+	}
+	for _, id := range buildIDs {
+		tokens[id] = admissionToken{build: true}
+	}
+	g.tokens = tokens
+}
+
+// Open moves a reconstructed gate into service. Separate from Reconstruct so
+// the transition is a deliberate act by the readiness path rather than a
+// side effect of seeding — and so a caller cannot open a gate it never
+// seeded.
+func (g *Gate) Open() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state == StateReconstructing || g.state == StateDraining {
+		g.state = StateOpen
+	}
+}
+
+// Close returns an enabled gate to reconstructing. Used by drain and by an
+// audit that finds the ledger undercounting: in both cases the safe move is
+// to stop admitting until the count can be rebuilt, never to keep serving
+// from a ledger known to be wrong.
+func (g *Gate) Close() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state != StateDisabled {
+		g.state = StateReconstructing
+	}
+}
+
+// Drain closes the gate to new sandboxes. Existing tokens stay charged, so
+// the pending count a drain waits on is the daemon's own and not an
+// estimate made elsewhere.
+func (g *Gate) Drain() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state != StateDisabled {
+		g.state = StateDraining
+	}
+}
+
+// Admit charges id and reports whether the boot may proceed.
+//
+// Idempotent by id: an id that already holds a token is re-admitted without
+// a second charge, so a retried create — or a create racing its own
+// retry — cannot consume two slots. Resume is never refused on the operator
+// limit; it is bound to this host and has nowhere else to go, and refusing
+// it would strand a paused sandbox. Physical ceilings are enforced
+// elsewhere, by the resources that actually run out.
+func (g *Gate) Admit(id string, intent Intent) error {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state == StateDisabled {
+		return nil
+	}
+	if intent == IntentUnspecified {
+		return ErrIntentRequired
+	}
+	if _, held := g.tokens[id]; held {
+		// Already ours. Re-admitting costs nothing and must not be
+		// refused even while draining: the sandbox is already here, and
+		// failing its retry would destroy work the drain is trying to
+		// let finish.
+		return nil
+	}
+	if g.state != StateOpen {
+		if intent == IntentResume && g.state == StateDraining {
+			// A drain stops new placement, not the return of sandboxes
+			// this host already owns.
+			g.tokens[id] = admissionToken{}
+			return nil
+		}
+		return ErrNotReady
+	}
+	if intent == IntentCreate && g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {
+		return ErrHostAtCapacity
+	}
+	g.tokens[id] = admissionToken{}
+	return nil
+}
+
+// AdmitBuild charges a template build. Builds are always new work, so there
+// is no resume equivalent — but they are refused for the same reason
+// creates are, because their pressure is published as provisioning
+// sandboxes and counted against this same limit.
+func (g *Gate) AdmitBuild(id string) error {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state == StateDisabled {
+		return nil
+	}
+	if _, held := g.tokens[id]; held {
+		return nil
+	}
+	if g.state != StateOpen {
+		return ErrNotReady
+	}
+	if g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {
+		return ErrHostAtCapacity
+	}
+	g.tokens[id] = admissionToken{build: true}
+	return nil
+}
+
+// Release drops id's token. Idempotent, because the failure paths that call
+// it are not mutually exclusive — a create can fail its launch and then be
+// torn down again by a reconciler, and the second release must not
+// decrement anything a later id has since claimed.
+func (g *Gate) Release(id string) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.tokens, id)
+}
+
+// Holds reports whether id is charged, for reconciliation and tests.
+func (g *Gate) Holds(id string) bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, held := g.tokens[id]
+	return held
+}
+
+// AuditUndercount reports whether an observed sandbox count exceeds what the
+// ledger is charging, which means the ledger has lost track of live work.
+//
+// One-directional on purpose. The observation is an eventually consistent
+// sample: it can be taken before a just-admitted sandbox materializes, so
+// observing FEWER than the ledger holds is normal and must never lower the
+// count. Observing MORE cannot be explained that way — something is running
+// that the gate is not charging for — and that is a correctness bug the
+// caller answers by closing the gate and reconstructing.
+func (g *Gate) AuditUndercount(observedSandboxes int) bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.state != StateOpen {
+		return false
+	}
+	return observedSandboxes > len(g.tokens)
+}

--- a/internal/admission/gate.go
+++ b/internal/admission/gate.go
@@ -16,11 +16,18 @@ const (
 	// without the operator opting in. Every request is admitted; the
 	// ledger is not consulted and not maintained.
 	StateDisabled State = iota
-	// StateReconstructing is where an enabled gate starts. The socket
-	// is inherited across a restart and can deliver queued requests before
-	// reattach finishes, so this state must be the initial one rather than
-	// something entered later — there is no instant at which an enabled
-	// gate is both open and ignorant.
+	// StateReconstructing is where an enabled gate starts, and where it
+	// returns whenever its ledger can no longer be trusted.
+	//
+	// It admits and charges without enforcing. The daemon does not know
+	// what it is holding yet, and the two ways to handle that are not
+	// symmetric: the RPC server serves throughout a restart, so refusing
+	// would deny every create and resume for the length of the rebuild —
+	// a window this host did not have before local admission existed —
+	// while admitting is no worse than a host with no limit configured,
+	// which is what every host was until now. Charging is what makes it
+	// safe: those tokens outlive the rebuild, so the ledger is already
+	// correct when the gate opens.
 	StateReconstructing
 	// StateOpen admits within the operator's limits.
 	StateOpen
@@ -69,8 +76,10 @@ var ErrIntentRequired = fmt.Errorf("admission intent required: caller must decla
 // either strand a placeable sandbox or invite retries of a genuine fault.
 var ErrHostAtCapacity = fmt.Errorf("host at configured sandbox capacity")
 
-// ErrNotReady rejects work that arrives before the gate knows what
-// the host is carrying, or after a drain has closed it.
+// ErrNotReady refuses a new sandbox on a host being drained. Rebuilding is
+// deliberately NOT one of its causes: a host that does not yet know what it
+// holds admits and charges instead, because refusing there would deny work
+// the host has room for and could serve.
 var ErrNotReady = fmt.Errorf("host not accepting new sandboxes")
 
 // admissionToken is one host-owned charge. Tokens are keyed by id, which is
@@ -243,21 +252,6 @@ func (g *Gate) Open() {
 	}
 }
 
-// Close returns an enabled gate to reconstructing. Used by drain and by an
-// audit that finds the ledger undercounting: in both cases the safe move is
-// to stop admitting until the count can be rebuilt, never to keep serving
-// from a ledger known to be wrong.
-func (g *Gate) Close() {
-	if g == nil {
-		return
-	}
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.state != StateDisabled {
-		g.state = StateReconstructing
-	}
-}
-
 // Drain closes the gate to new sandboxes. Existing tokens stay charged, so
 // the pending count a drain waits on is the daemon's own and not an
 // estimate made elsewhere.
@@ -299,14 +293,34 @@ func (g *Gate) Admit(id string, intent Intent) error {
 		// let finish.
 		return nil
 	}
-	if g.state != StateOpen {
-		if intent == IntentResume && g.state == StateDraining {
+	switch g.state {
+	case StateReconstructing:
+		// Charge, but do not enforce. The daemon does not yet know what it
+		// is holding, and the two ways to handle that are not symmetric:
+		// refusing would deny every create and resume for the whole
+		// rebuild — a window this host did not have before local admission
+		// existed, since the RPC server serves throughout it — while
+		// admitting is no worse than the behavior of a host with no limit
+		// configured at all, which is what every host was until now.
+		//
+		// Charging matters as much as admitting: these tokens carry a
+		// generation above the rebuild's snapshot, so they survive it and
+		// the ledger is already correct the moment the gate opens.
+		g.gen++
+		g.tokens[id] = admissionToken{gen: g.gen}
+		return nil
+	case StateDraining:
+		if intent == IntentResume {
 			// A drain stops new placement, not the return of sandboxes
 			// this host already owns.
 			g.gen++
 			g.tokens[id] = admissionToken{gen: g.gen}
 			return nil
 		}
+		// Creates ARE refused here, unlike during a rebuild: a drain is a
+		// deliberate operator action to move work off this host, so
+		// refusing is the whole point rather than a side effect of
+		// ignorance.
 		return ErrNotReady
 	}
 	if intent == IntentCreate && g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {
@@ -344,7 +358,14 @@ func (g *Gate) AdmitBuild(id string, owner any) error {
 		}
 		return nil
 	}
-	if g.state != StateOpen {
+	switch g.state {
+	case StateReconstructing:
+		// Same reasoning as Admit: charge without enforcing rather than
+		// fail builds for the length of a rebuild.
+		g.gen++
+		g.tokens[id] = admissionToken{build: true, gen: g.gen, owner: owner}
+		return nil
+	case StateDraining:
 		return ErrNotReady
 	}
 	if g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {

--- a/internal/admission/gate.go
+++ b/internal/admission/gate.go
@@ -83,6 +83,17 @@ type admissionToken struct {
 	// limit, so a gate that ignored builds would enforce a different
 	// limit than the one ranking believes in.
 	build bool
+	// gen is the generation this token was charged in. A rebuild replaces
+	// only tokens that existed when its snapshot of the world was taken;
+	// anything charged later is newer than the snapshot and survives, or
+	// a create admitted mid-rebuild would silently lose its charge.
+	gen uint64
+	// owner identifies WHICH holder charged this token, for ids that can
+	// be re-registered while a previous holder is still shutting down.
+	// Releasing by id alone would let the outgoing holder drop the
+	// incoming one's charge; a release must match the owner that took it.
+	// Nil for sandboxes, whose id is held by one lifecycle at a time.
+	owner any
 }
 
 // Gate enforces the operator's concurrent-sandbox limit locally.
@@ -106,6 +117,11 @@ type Gate struct {
 	// maxSandboxes is the operator's limit. Zero means unlimited, matching
 	// how the pressure publisher already reads VMD_MAX_SANDBOXES.
 	maxSandboxes int
+	// gen increments on every charge. A rebuild reads it before consulting
+	// its slower source of truth and passes it back, which is what lets
+	// the rebuild tell "this token predates my snapshot, replace it" from
+	// "this was charged while I was reading, keep it".
+	gen uint64
 }
 
 // NewGate builds a gate. An enabled gate starts reconstructing and
@@ -160,7 +176,32 @@ func (g *Gate) Charged() int {
 // unknown ids would carry forward exactly the phantom charges reconstruction
 // exists to clear. Safe only because callers run it while the gate is closed
 // — Open is what publishes the result.
-func (g *Gate) Reconstruct(sandboxIDs, buildIDs []string) {
+// BeginReconstruct marks the point a rebuild starts reading the world, and
+// returns the generation to hand back to Reconstruct.
+//
+// Rebuilding is not instantaneous — it reads a persistent store — and the
+// gate keeps admitting owned work while it runs. Without this marker a
+// rebuild would replace the ledger wholesale and discard any token charged
+// while it was reading, so a create admitted mid-rebuild would proceed
+// uncharged and the host would over-admit by exactly that many.
+func (g *Gate) BeginReconstruct() uint64 {
+	if g == nil {
+		return 0
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.gen
+}
+
+// Reconstruct replaces the ledger with what the caller observed, keeping
+// any token charged after its snapshot began.
+//
+// since must come from BeginReconstruct, taken BEFORE the caller read its
+// source of truth. Tokens at or below it predate the snapshot and are
+// authoritative from the snapshot; tokens above it were charged while the
+// caller was reading, are absent from what it saw, and must survive — they
+// are in-flight work, not stale residue.
+func (g *Gate) Reconstruct(since uint64, sandboxIDs, buildIDs []string) {
 	if g == nil {
 		return
 	}
@@ -171,10 +212,18 @@ func (g *Gate) Reconstruct(sandboxIDs, buildIDs []string) {
 	}
 	tokens := make(map[string]admissionToken, len(sandboxIDs)+len(buildIDs))
 	for _, id := range sandboxIDs {
-		tokens[id] = admissionToken{}
+		tokens[id] = admissionToken{gen: g.gen}
 	}
 	for _, id := range buildIDs {
-		tokens[id] = admissionToken{build: true}
+		tokens[id] = admissionToken{build: true, gen: g.gen}
+	}
+	// Carry forward everything charged since the snapshot started. Also
+	// keeps the newer token when both sides have the id: the live charge
+	// knows its owner, the reconstructed one does not.
+	for id, tok := range g.tokens {
+		if tok.gen > since {
+			tokens[id] = tok
+		}
 	}
 	g.tokens = tokens
 }
@@ -254,7 +303,8 @@ func (g *Gate) Admit(id string, intent Intent) error {
 		if intent == IntentResume && g.state == StateDraining {
 			// A drain stops new placement, not the return of sandboxes
 			// this host already owns.
-			g.tokens[id] = admissionToken{}
+			g.gen++
+			g.tokens[id] = admissionToken{gen: g.gen}
 			return nil
 		}
 		return ErrNotReady
@@ -262,7 +312,8 @@ func (g *Gate) Admit(id string, intent Intent) error {
 	if intent == IntentCreate && g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {
 		return ErrHostAtCapacity
 	}
-	g.tokens[id] = admissionToken{}
+	g.gen++
+	g.tokens[id] = admissionToken{gen: g.gen}
 	return nil
 }
 
@@ -270,7 +321,11 @@ func (g *Gate) Admit(id string, intent Intent) error {
 // is no resume equivalent — but they are refused for the same reason
 // creates are, because their pressure is published as provisioning
 // sandboxes and counted against this same limit.
-func (g *Gate) AdmitBuild(id string) error {
+// owner identifies the holder taking the charge, and must be presented
+// again to release it. A build id can be re-registered while the previous
+// worker is still winding down, so a release that matched on id alone would
+// let the outgoing worker drop the incoming one's charge.
+func (g *Gate) AdmitBuild(id string, owner any) error {
 	if g == nil {
 		return nil
 	}
@@ -279,7 +334,14 @@ func (g *Gate) AdmitBuild(id string) error {
 	if g.state == StateDisabled {
 		return nil
 	}
-	if _, held := g.tokens[id]; held {
+	if existing, held := g.tokens[id]; held {
+		// Re-admitting the same id under a NEW owner is a replacement, not
+		// a retry: take ownership so the outgoing holder's release cannot
+		// match, while the count stays put because the id is unchanged.
+		if existing.owner != owner {
+			g.gen++
+			g.tokens[id] = admissionToken{build: true, gen: g.gen, owner: owner}
+		}
 		return nil
 	}
 	if g.state != StateOpen {
@@ -288,7 +350,8 @@ func (g *Gate) AdmitBuild(id string) error {
 	if g.maxSandboxes > 0 && len(g.tokens) >= g.maxSandboxes {
 		return ErrHostAtCapacity
 	}
-	g.tokens[id] = admissionToken{build: true}
+	g.gen++
+	g.tokens[id] = admissionToken{build: true, gen: g.gen, owner: owner}
 	return nil
 }
 
@@ -303,6 +366,25 @@ func (g *Gate) Release(id string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	delete(g.tokens, id)
+}
+
+// ReleaseOwned drops id's token only if owner still holds it.
+//
+// The guard is the point: an id can be re-registered while its previous
+// holder is still shutting down, and that outgoing holder will release on
+// its way out. Releasing by id alone would free the INCOMING holder's
+// charge and let the host over-admit by one for as long as the replacement
+// runs. A mismatch means someone else owns the id now, so there is nothing
+// here to give back.
+func (g *Gate) ReleaseOwned(id string, owner any) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if tok, held := g.tokens[id]; held && tok.owner == owner {
+		delete(g.tokens, id)
+	}
 }
 
 // Holds reports whether id is charged, for reconciliation and tests.

--- a/internal/admission/gate_test.go
+++ b/internal/admission/gate_test.go
@@ -138,25 +138,48 @@ func TestAdmissionGateDisabledIsInertEvenWithLimitsSet(t *testing.T) {
 	}
 }
 
-// The socket survives a restart and can deliver queued requests before
-// reattach finishes. An enabled gate must therefore start closed — if it
-// admits during reconstruction it is admitting against an empty count,
-// which is no limit at all.
-func TestAdmissionGateStartsClosedAndRefusesUntilOpened(t *testing.T) {
-	g := NewGate(true, 10)
+// An enabled gate starts in reconstructing, because a restarted daemon does
+// not yet know what it is holding.
+//
+// It must NOT refuse during that window. The RPC server serves throughout a
+// restart, so work that arrives mid-rebuild succeeds today; refusing it
+// would convert every deploy into a create-and-resume outage on this host.
+// Admitting instead is no worse than a host with no limit configured, which
+// is what every host was before this existed.
+func TestAdmissionGateAdmitsWhileReconstructing(t *testing.T) {
+	g := NewGate(true, 1) // a limit of one, deliberately already "exceeded"
 	if got := g.State(); got != StateReconstructing {
 		t.Fatalf("initial state %v, want reconstructing", got)
 	}
-	if err := g.Admit("sb-1", IntentCreate); !errors.Is(err, ErrNotReady) {
-		t.Fatalf("admitted before reconstruction finished: %v", err)
+	for _, id := range []string{"sb-1", "sb-2", "sb-3"} {
+		if err := g.Admit(id, IntentCreate); err != nil {
+			t.Fatalf("%s refused during reconstruction: %v; a restart would deny every create", id, err)
+		}
 	}
-	g.Reconstruct(g.BeginReconstruct(), []string{"survivor-1", "survivor-2"}, []string{"build-1"})
+	if err := g.Admit("sb-4", IntentResume); err != nil {
+		t.Fatalf("resume refused during reconstruction: %v", err)
+	}
+}
+
+// Admitting during the rebuild is only safe because those admissions are
+// still CHARGED — they carry a generation above the rebuild's snapshot, so
+// they survive it and the ledger is correct the instant the gate opens.
+// Were they admitted uncharged, the host would open believing it had room
+// it had already given away.
+func TestAdmissionGateChargesWorkAdmittedWhileReconstructing(t *testing.T) {
+	g := NewGate(true, 10)
+	since := g.BeginReconstruct()
+	if err := g.Admit("arrived-during-rebuild", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	g.Reconstruct(since, []string{"survivor-1", "survivor-2"}, []string{"build-1"})
 	g.Open()
-	if got := g.Charged(); got != 3 {
-		t.Fatalf("reconstructed ledger holds %d, want 3 (two sandboxes and a builder)", got)
+
+	if !g.Holds("arrived-during-rebuild") {
+		t.Fatal("work admitted during the rebuild was not charged; the gate opens over-committed")
 	}
-	if err := g.Admit("sb-1", IntentCreate); err != nil {
-		t.Fatalf("refused after opening: %v", err)
+	if got := g.Charged(); got != 4 {
+		t.Fatalf("charged %d, want 4 (two survivors, a builder, and the in-flight create)", got)
 	}
 }
 

--- a/internal/admission/gate_test.go
+++ b/internal/admission/gate_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 // The whole point of the gate: N racers against room for K admit exactly K.
-// The design this replaced failed precisely here — 20 concurrent admissions
-// against room for 3 let 8 through — so this is written against the real
-// gate under real concurrency, not a serialized approximation of it.
+// Written against the real gate under real concurrency rather than a
+// serialized approximation, because a limit that is checked and then
+// committed in two steps passes every sequential test and still overshoots
+// under load — which is the only way this failure ever shows up.
 func TestAdmissionGateAdmitsExactlyItsLimitUnderRace(t *testing.T) {
 	const limit, racers = 3, 20
 	g := NewGate(true, limit)

--- a/internal/admission/gate_test.go
+++ b/internal/admission/gate_test.go
@@ -15,7 +15,7 @@ import (
 func TestAdmissionGateAdmitsExactlyItsLimitUnderRace(t *testing.T) {
 	const limit, racers = 3, 20
 	g := NewGate(true, limit)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
 	var wg sync.WaitGroup
@@ -57,7 +57,7 @@ func TestAdmissionGateAdmitsExactlyItsLimitUnderRace(t *testing.T) {
 // buys is that an already-charged id is re-admitted when a newcomer is not.
 func TestAdmissionGateReadmitsAnOwnedSandboxAtCapacity(t *testing.T) {
 	g := NewGate(true, 2)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
 	if err := g.Admit("sb-1", IntentCreate); err != nil {
@@ -86,7 +86,7 @@ func TestAdmissionGateReadmitsAnOwnedSandboxAtCapacity(t *testing.T) {
 // apply to it. A create at the same limit is still refused.
 func TestAdmissionGateNeverRefusesResumeOnOperatorLimit(t *testing.T) {
 	g := NewGate(true, 1)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
 	if err := g.Admit("sb-1", IntentCreate); err != nil {
@@ -108,7 +108,7 @@ func TestAdmissionGateNeverRefusesResumeOnOperatorLimit(t *testing.T) {
 // "resume" lets a real create past the limit — so an enabled gate refuses.
 func TestAdmissionGateRefusesUnspecifiedIntentWhenEnabled(t *testing.T) {
 	g := NewGate(true, 10)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
 	if err := g.Admit("sb-1", IntentUnspecified); !errors.Is(err, ErrIntentRequired) {
@@ -150,7 +150,7 @@ func TestAdmissionGateStartsClosedAndRefusesUntilOpened(t *testing.T) {
 	if err := g.Admit("sb-1", IntentCreate); !errors.Is(err, ErrNotReady) {
 		t.Fatalf("admitted before reconstruction finished: %v", err)
 	}
-	g.Reconstruct([]string{"survivor-1", "survivor-2"}, []string{"build-1"})
+	g.Reconstruct(g.BeginReconstruct(), []string{"survivor-1", "survivor-2"}, []string{"build-1"})
 	g.Open()
 	if got := g.Charged(); got != 3 {
 		t.Fatalf("reconstructed ledger holds %d, want 3 (two sandboxes and a builder)", got)
@@ -166,10 +166,10 @@ func TestAdmissionGateStartsClosedAndRefusesUntilOpened(t *testing.T) {
 // one placement believes in.
 func TestAdmissionGateCountsBuildersAgainstTheSandboxLimit(t *testing.T) {
 	g := NewGate(true, 2)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
-	if err := g.AdmitBuild("build-1"); err != nil {
+	if err := g.AdmitBuild("build-1", "worker-1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := g.Admit("sb-1", IntentCreate); err != nil {
@@ -182,7 +182,7 @@ func TestAdmissionGateCountsBuildersAgainstTheSandboxLimit(t *testing.T) {
 	// Separate from the assertion above, which only proves the builder's
 	// token is counted when something else asks for room — it would still
 	// pass if AdmitBuild never checked the limit at all.
-	if err := g.AdmitBuild("build-2"); !errors.Is(err, ErrHostAtCapacity) {
+	if err := g.AdmitBuild("build-2", "worker-2"); !errors.Is(err, ErrHostAtCapacity) {
 		t.Fatalf("build admitted past the limit: got %v, want ErrHostAtCapacity", err)
 	}
 }
@@ -192,7 +192,7 @@ func TestAdmissionGateCountsBuildersAgainstTheSandboxLimit(t *testing.T) {
 // create still completes.
 func TestAdmissionGateDrainRefusesNewButNotOwned(t *testing.T) {
 	g := NewGate(true, 10)
-	g.Reconstruct([]string{"existing"}, nil)
+	g.Reconstruct(g.BeginReconstruct(), []string{"existing"}, nil)
 	g.Open()
 	if err := g.Admit("in-flight", IntentCreate); err != nil {
 		t.Fatal(err)
@@ -215,7 +215,7 @@ func TestAdmissionGateDrainRefusesNewButNotOwned(t *testing.T) {
 // sandbox has since claimed.
 func TestAdmissionGateReleaseIsIdempotent(t *testing.T) {
 	g := NewGate(true, 2)
-	g.Reconstruct(nil, nil)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
 	g.Open()
 
 	if err := g.Admit("sb-1", IntentCreate); err != nil {
@@ -240,7 +240,7 @@ func TestAdmissionGateReleaseIsIdempotent(t *testing.T) {
 // gate is not charging for, which is a correctness bug.
 func TestAdmissionGateAuditOnlyReactsToUndercount(t *testing.T) {
 	g := NewGate(true, 10)
-	g.Reconstruct([]string{"a", "b", "c"}, nil)
+	g.Reconstruct(g.BeginReconstruct(), []string{"a", "b", "c"}, nil)
 	g.Open()
 
 	if g.AuditUndercount(1) {
@@ -251,5 +251,87 @@ func TestAdmissionGateAuditOnlyReactsToUndercount(t *testing.T) {
 	}
 	if !g.AuditUndercount(4) {
 		t.Fatal("audit missed an undercount: a VM is running that the gate is not charging for")
+	}
+}
+
+// A rebuild reads a persistent store, which takes time, and the gate keeps
+// admitting owned work while it reads. A create admitted in that window is
+// absent from the snapshot the rebuild is holding — so a rebuild that
+// replaced the ledger wholesale would drop its charge and let the host
+// over-admit by exactly the number of creates in flight.
+func TestReconstructKeepsTokensChargedWhileItWasReading(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct(g.BeginReconstruct(), []string{"old"}, nil)
+	g.Open()
+
+	// A rebuild begins: it captures the generation, then reads its store.
+	since := g.BeginReconstruct()
+
+	// Mid-read, a create is admitted. It cannot appear in what the rebuild
+	// is about to hand back, because that snapshot predates it.
+	if err := g.Admit("in-flight", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	// The rebuild commits what it saw: only the old sandbox.
+	g.Reconstruct(since, []string{"old"}, nil)
+
+	if !g.Holds("in-flight") {
+		t.Fatal("a create admitted during the rebuild lost its charge; the host would over-admit by one per in-flight create")
+	}
+	if !g.Holds("old") {
+		t.Fatal("the rebuild dropped a sandbox it observed")
+	}
+	if got := g.Charged(); got != 2 {
+		t.Fatalf("charged %d, want 2", got)
+	}
+}
+
+// A rebuild is authoritative for everything that predates it: a token whose
+// work is gone must not survive, or the host shrinks silently until restart.
+func TestReconstructDropsTokensItsSnapshotDoesNotContain(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct(g.BeginReconstruct(), []string{"stale-1", "stale-2", "live"}, nil)
+	g.Open()
+
+	// The store now reports only one of them; the other two are gone.
+	g.Reconstruct(g.BeginReconstruct(), []string{"live"}, nil)
+
+	if g.Holds("stale-1") || g.Holds("stale-2") {
+		t.Fatal("a rebuild kept tokens its authoritative source no longer lists; leaked capacity never returns")
+	}
+	if got := g.Charged(); got != 1 {
+		t.Fatalf("charged %d, want 1", got)
+	}
+}
+
+// A build id can be re-registered while the previous worker is still
+// winding down, and that outgoing worker releases on its way out. Releasing
+// by id alone would free the REPLACEMENT's charge and let the host
+// over-admit for as long as the replacement runs.
+func TestReleaseOwnedIgnoresASupersededHolder(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct(g.BeginReconstruct(), nil, nil)
+	g.Open()
+
+	first := "worker-a"
+	second := "worker-b"
+	if err := g.AdmitBuild("build-1", first); err != nil {
+		t.Fatal(err)
+	}
+	// The id is re-registered under a new worker before the old one exits.
+	if err := g.AdmitBuild("build-1", second); err != nil {
+		t.Fatal(err)
+	}
+	// The outgoing worker finally exits and releases.
+	g.ReleaseOwned("build-1", first)
+
+	if !g.Holds("build-1") {
+		t.Fatal("a superseded worker's release freed the replacement's charge")
+	}
+	// The replacement's own release does take effect.
+	g.ReleaseOwned("build-1", second)
+	if g.Holds("build-1") {
+		t.Fatal("the owning worker's release did not free its charge")
 	}
 }

--- a/internal/admission/gate_test.go
+++ b/internal/admission/gate_test.go
@@ -1,0 +1,254 @@
+package admission
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// The whole point of the gate: N racers against room for K admit exactly K.
+// The design this replaced failed precisely here — 20 concurrent admissions
+// against room for 3 let 8 through — so this is written against the real
+// gate under real concurrency, not a serialized approximation of it.
+func TestAdmissionGateAdmitsExactlyItsLimitUnderRace(t *testing.T) {
+	const limit, racers = 3, 20
+	g := NewGate(true, limit)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	admitted := 0
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release them together, so they actually contend
+			if err := g.Admit(fmt.Sprintf("sb-%d", i), IntentCreate); err == nil {
+				mu.Lock()
+				admitted++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if admitted != limit {
+		t.Fatalf("admitted %d of %d racers against room for %d; the limit is not being enforced atomically",
+			admitted, racers, limit)
+	}
+	if got := g.Charged(); got != limit {
+		t.Fatalf("ledger charges %d, want %d", got, limit)
+	}
+}
+
+// Idempotency by id is what makes retries safe, and the case that proves it
+// is a retry of a sandbox on a host that is already full.
+//
+// Deliberately NOT written as "admit the same id repeatedly, expect the
+// count to stay at one": a Go map assignment is idempotent by construction,
+// so that version passes whether or not the gate checks for an existing
+// token — it asserts a property of the data structure rather than of the
+// code, and would have shipped a missing check. What the check actually
+// buys is that an already-charged id is re-admitted when a newcomer is not.
+func TestAdmissionGateReadmitsAnOwnedSandboxAtCapacity(t *testing.T) {
+	g := NewGate(true, 2)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-2", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	// The host is full: a newcomer is refused...
+	if err := g.Admit("sb-3", IntentCreate); !errors.Is(err, ErrHostAtCapacity) {
+		t.Fatalf("newcomer at capacity: got %v, want ErrHostAtCapacity", err)
+	}
+	// ...but a retry of a sandbox this host already charged must still
+	// succeed, or a transient failure mid-create becomes a sandbox that can
+	// never finish booting on the host still holding its slot.
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatalf("retry of an already-admitted sandbox refused at capacity: %v", err)
+	}
+	if got := g.Charged(); got != 2 {
+		t.Fatalf("charged %d after the retry, want 2", got)
+	}
+}
+
+// A resume is bound to this host: refusing it strands a paused sandbox
+// rather than redirecting it, so the operator's sandbox limit must not
+// apply to it. A create at the same limit is still refused.
+func TestAdmissionGateNeverRefusesResumeOnOperatorLimit(t *testing.T) {
+	g := NewGate(true, 1)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-2", IntentCreate); !errors.Is(err, ErrHostAtCapacity) {
+		t.Fatalf("create past the limit: got %v, want ErrHostAtCapacity", err)
+	}
+	if err := g.Admit("sb-3", IntentResume); err != nil {
+		t.Fatalf("resume refused at the operator limit: %v; a paused sandbox would be stranded", err)
+	}
+	if !g.Holds("sb-3") {
+		t.Fatal("resume admitted but not charged; the gate would under-count real load")
+	}
+}
+
+// An unspecified intent means the caller predates the field. Guessing either
+// way is silently wrong — "create" double-charges a resuming sandbox,
+// "resume" lets a real create past the limit — so an enabled gate refuses.
+func TestAdmissionGateRefusesUnspecifiedIntentWhenEnabled(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	if err := g.Admit("sb-1", IntentUnspecified); !errors.Is(err, ErrIntentRequired) {
+		t.Fatalf("got %v, want ErrIntentRequired", err)
+	}
+	if g.Charged() != 0 {
+		t.Fatal("a refused boot was charged")
+	}
+}
+
+// The same call on a disabled gate must behave exactly as it did before this
+// existed. This is the inertness contract the rollout depends on, and it has
+// to hold even with the operator limits set — they are already set in
+// production for pressure publication.
+func TestAdmissionGateDisabledIsInertEvenWithLimitsSet(t *testing.T) {
+	g := NewGate(false, 1)
+	for i := 0; i < 10; i++ {
+		if err := g.Admit(fmt.Sprintf("sb-%d", i), IntentUnspecified); err != nil {
+			t.Fatalf("disabled gate refused a boot: %v", err)
+		}
+	}
+	if got := g.Charged(); got != 0 {
+		t.Fatalf("disabled gate charged %d tokens; it must not maintain a ledger", got)
+	}
+	if g.Enabled() {
+		t.Fatal("gate reports enabled")
+	}
+}
+
+// The socket survives a restart and can deliver queued requests before
+// reattach finishes. An enabled gate must therefore start closed — if it
+// admits during reconstruction it is admitting against an empty count,
+// which is no limit at all.
+func TestAdmissionGateStartsClosedAndRefusesUntilOpened(t *testing.T) {
+	g := NewGate(true, 10)
+	if got := g.State(); got != StateReconstructing {
+		t.Fatalf("initial state %v, want reconstructing", got)
+	}
+	if err := g.Admit("sb-1", IntentCreate); !errors.Is(err, ErrNotReady) {
+		t.Fatalf("admitted before reconstruction finished: %v", err)
+	}
+	g.Reconstruct([]string{"survivor-1", "survivor-2"}, []string{"build-1"})
+	g.Open()
+	if got := g.Charged(); got != 3 {
+		t.Fatalf("reconstructed ledger holds %d, want 3 (two sandboxes and a builder)", got)
+	}
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatalf("refused after opening: %v", err)
+	}
+}
+
+// Builders hold a sandbox token because their pressure is published as
+// provisioning sandboxes and ranking counts provisioning against this same
+// limit. A gate that ignored them would enforce a different limit than the
+// one placement believes in.
+func TestAdmissionGateCountsBuildersAgainstTheSandboxLimit(t *testing.T) {
+	g := NewGate(true, 2)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	if err := g.AdmitBuild("build-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-2", IntentCreate); !errors.Is(err, ErrHostAtCapacity) {
+		t.Fatalf("got %v, want ErrHostAtCapacity — the builder's token was not counted", err)
+	}
+	// And the reverse: a build is itself refused once the host is full.
+	// Separate from the assertion above, which only proves the builder's
+	// token is counted when something else asks for room — it would still
+	// pass if AdmitBuild never checked the limit at all.
+	if err := g.AdmitBuild("build-2"); !errors.Is(err, ErrHostAtCapacity) {
+		t.Fatalf("build admitted past the limit: got %v, want ErrHostAtCapacity", err)
+	}
+}
+
+// Drain stops new placement without breaking sandboxes the host already
+// owns: a resume of one of ours still lands, and a retry of an in-flight
+// create still completes.
+func TestAdmissionGateDrainRefusesNewButNotOwned(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct([]string{"existing"}, nil)
+	g.Open()
+	if err := g.Admit("in-flight", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	g.Drain()
+	if err := g.Admit("newcomer", IntentCreate); !errors.Is(err, ErrNotReady) {
+		t.Fatalf("drain admitted a new create: %v", err)
+	}
+	if err := g.Admit("in-flight", IntentCreate); err != nil {
+		t.Fatalf("drain broke a retry of work already admitted: %v", err)
+	}
+	if err := g.Admit("returning", IntentResume); err != nil {
+		t.Fatalf("drain refused a resume of a host-owned sandbox: %v", err)
+	}
+}
+
+// Release must be idempotent: the failure paths that call it are not
+// mutually exclusive, and a second release must not free capacity a later
+// sandbox has since claimed.
+func TestAdmissionGateReleaseIsIdempotent(t *testing.T) {
+	g := NewGate(true, 2)
+	g.Reconstruct(nil, nil)
+	g.Open()
+
+	if err := g.Admit("sb-1", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	g.Release("sb-1")
+	g.Release("sb-1") // the reconciler, after the launch path already unwound
+	if err := g.Admit("sb-2", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-3", IntentCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Admit("sb-4", IntentCreate); !errors.Is(err, ErrHostAtCapacity) {
+		t.Fatalf("got %v, want ErrHostAtCapacity — a double release freed a slot twice", err)
+	}
+}
+
+// The audit is one-directional. Pressure is sampled off the hot path and can
+// be taken before a just-admitted sandbox materializes, so seeing fewer than
+// the ledger holds is normal. Seeing more means something is running that the
+// gate is not charging for, which is a correctness bug.
+func TestAdmissionGateAuditOnlyReactsToUndercount(t *testing.T) {
+	g := NewGate(true, 10)
+	g.Reconstruct([]string{"a", "b", "c"}, nil)
+	g.Open()
+
+	if g.AuditUndercount(1) {
+		t.Fatal("audit reacted to an observation lagging the ledger; it would close the gate on every burst")
+	}
+	if g.AuditUndercount(3) {
+		t.Fatal("audit reacted to agreement")
+	}
+	if !g.AuditUndercount(4) {
+		t.Fatal("audit missed an undercount: a VM is running that the gate is not charging for")
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -927,7 +927,12 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			ipAddress, actualVcpu, actualMemMiB, _, err = vmd.RestoreSnapshot(fctx, sandboxID.String(), snapshotPath, memPath, resumeBasePath, "", sandbox.TeamID.String(), ownerIDFromContext(c), resumeVMDAccess, resumePolicy.vmdPorts(), resumePolicy.Revision, nil,
 				// The row is authoritative for a sandbox that already
 				// exists; declaring it spares the daemon a probe.
-				vmdclient.ResourceLimits{VCPU: uint32(sandbox.VcpuCount), MemoryMiB: uint32(sandbox.MemoryMib)})
+				vmdclient.ResourceLimits{VCPU: uint32(sandbox.VcpuCount), MemoryMiB: uint32(sandbox.MemoryMib)},
+				// A resume, not a create: this fallback runs for a sandbox that
+				// already exists and is bound to this host. Declaring CREATE here
+				// would charge it a second time and let a full host refuse a
+				// sandbox that has nowhere else to go.
+				vmdclient.IntentResume)
 			fcancel()
 			if err != nil {
 				l.Error().Err(err).Msg("VMD RestoreSnapshot fallback failed")
@@ -2481,7 +2486,12 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 			// Same shape the sandbox row is being inserted with (the
 			// template's, or the defaults) — declared so the daemon
 			// never has to ask Firecracker for it afterwards.
-			vmdclient.ResourceLimits{VCPU: uint32(insertVcpu), MemoryMiB: uint32(insertMemMiB)})
+			vmdclient.ResourceLimits{VCPU: uint32(insertVcpu), MemoryMiB: uint32(insertMemMiB)},
+			// A genuine create: this sandbox does not exist yet, so a host
+			// enforcing capacity may refuse it and the control plane may
+			// place it elsewhere. The stateless-resume fallback shares this
+			// RPC and declares RESUME instead.
+			vmdclient.IntentCreate)
 		previewProtocol = protocol
 		return ip, vcpu, memMiB, err
 	})

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -36,6 +36,7 @@ import (
 
 type stubVMD struct {
 	restoreLimits    vmdclient.ResourceLimits
+	restoreIntent    vmdclient.AdmissionIntent
 	destroyFn        func(ctx context.Context, id string, force bool) error
 	pauseFn          func(ctx context.Context, id, snapshotDir string) (string, string, error)
 	resumeFn         func(ctx context.Context, id, snapshotPath, memPath string, networkConfig []byte) (string, error)
@@ -88,8 +89,9 @@ func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath 
 	}
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, _ map[string]string, limits vmdclient.ResourceLimits) (string, uint32, uint32, string, error) {
+func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, _ map[string]string, limits vmdclient.ResourceLimits, intent vmdclient.AdmissionIntent) (string, uint32, uint32, string, error) {
 	s.restoreLimits = limits
+	s.restoreIntent = intent
 	protocol := preview.HostCapabilityPorts
 	if s.restorePreviewProtocol != nil {
 		protocol = *s.restorePreviewProtocol
@@ -1183,6 +1185,15 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 	if _, ok := reconciled.Ports[8080]; !ok || len(reconciled.Ports) != 1 {
 		t.Fatalf("reconciled ports = %#v, want {8080}", reconciled.Ports)
 	}
+	// This path reaches vmd through the CREATE rpc, but it is a resume: the
+	// sandbox exists and is bound to this host. Declaring CREATE here would
+	// charge it a second time on a capacity-enforcing host, and let a full
+	// host refuse a sandbox that has nowhere else to go. The daemon cannot
+	// catch the mistake — it takes this path precisely when it has no
+	// record of the sandbox — so the assertion has to live here.
+	if vmd.restoreIntent != vmdclient.IntentResume {
+		t.Errorf("stateless-resume fallback declared intent %v, want IntentResume", vmd.restoreIntent)
+	}
 }
 
 func TestResumeSandbox_PrivatePolicyRequiresBrowserChainAndRestoresBrowserPorts(t *testing.T) {
@@ -2137,6 +2148,13 @@ func TestCreateSandbox_Success(t *testing.T) {
 	}
 	if v := body["memory_mib"].(float64); v == 0 {
 		t.Error("memory_mib is 0 — VMD's reported value was not propagated to the response")
+	}
+	// A create must say so. The same RPC also serves the stateless-resume
+	// fallback, and a host enforcing local capacity refuses a boot whose
+	// intent is unset — so an undeclared create is not a cosmetic omission,
+	// it is a create that cannot land on an enforcing host.
+	if vmd.restoreIntent != vmdclient.IntentCreate {
+		t.Errorf("restore intent = %v, want IntentCreate", vmd.restoreIntent)
 	}
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -304,7 +304,7 @@ func (s *stubVMD) PauseInstance(_ context.Context, _, _, pauseToken string) (str
 func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ []byte) (string, uint32, uint32, error) {
 	return "10.0.0.1", 1, 1024, nil
 }
-func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _, _ string, _ map[int32]vmdclient.PortPolicy, _ int64, _ map[string]string, _ vmdclient.ResourceLimits) (string, uint32, uint32, string, error) {
+func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _, _ string, _ map[int32]vmdclient.PortPolicy, _ int64, _ map[string]string, _ vmdclient.ResourceLimits, _ vmdclient.AdmissionIntent) (string, uint32, uint32, string, error) {
 	return "10.0.0.1", 1, 1024, preview.HostCapabilityPorts, nil
 }
 func (s *stubVMD) InjectSandboxEnv(_ context.Context, _ string, _ map[string]string, _ string) error {

--- a/internal/network/manager.go
+++ b/internal/network/manager.go
@@ -83,6 +83,14 @@ const MaxSlots = 65000
 // ErrNoSlots is returned when no network slots are available.
 var ErrNoSlots = fmt.Errorf("no available network slots (max %d concurrent VMs)", MaxSlots)
 
+// ErrOperatorSlotLimit is returned when this host has minted as many slot
+// indexes as the operator allows. Distinct from ErrNoSlots on purpose: the
+// kernel range is not exhausted and nothing here is broken, so a caller
+// that can place the work on another host should, while one that cannot —
+// a resume, which reuses its recorded index and never reaches this — is
+// never affected.
+var ErrOperatorSlotLimit = fmt.Errorf("host at its configured network-slot limit")
+
 // reclaimCooldown bounds how often a claim at the ceiling rescans for unused
 // indexes. The scan is cheap but pointless to repeat while nothing has been
 // released, and a host at the ceiling is exactly when claims arrive fastest.
@@ -157,6 +165,9 @@ type Manager struct {
 	nextSlot   int   // next new slot (used when freeSlots is empty)
 	maxSlot    int   // new-slot ceiling; meaningful only when slotPinned (WithExactSlot)
 	slotPinned bool  // WithExactSlot: allocate exactly maxSlot or fail, never advance
+	// operatorMaxSlots caps minted indexes as operator policy, below the
+	// kernel ceiling. Zero means unlimited. See WithOperatorSlotLimit.
+	operatorMaxSlots int
 
 	// slotOwner is the single source of truth for slot allocation AND identity:
 	// slotOwner[idx] == the current owner of slot index idx, one of
@@ -233,6 +244,26 @@ type ManagerOption func(*Manager)
 // WithHostID supplies the persisted VMD host identity for network-operation logs.
 func WithHostID(hostID string) ManagerOption {
 	return func(m *Manager) { m.hostID = hostID }
+}
+
+// WithOperatorSlotLimit caps how many slot indexes this host will mint, as
+// operator policy below the kernel ceiling. Zero — the default — means no
+// policy limit and leaves behavior exactly as it was.
+//
+// Enforced inside this allocator rather than by a separate admission
+// counter because the allocator already owns the authoritative
+// slot-to-owner ledger; a second counter would be a copy of that ledger,
+// free to drift from it. Every path that mints an index — sandbox creates,
+// pool refill, template builders — arrives through the same claim, so one
+// check covers all three instead of three checks that must be kept in
+// agreement.
+//
+// Reusing a recycled or warm slot is deliberately not capped: it transfers
+// ownership of an index this host already prepared and does not grow the
+// host's footprint. That is also why resume is unaffected — it reuses the
+// index recorded in its namespace and never mints a new one.
+func WithOperatorSlotLimit(limit int) ManagerOption {
+	return func(m *Manager) { m.operatorMaxSlots = limit }
 }
 
 // WithNetlinkSlotOps selects the netlink backend for slot network operations
@@ -1173,6 +1204,15 @@ func (m *Manager) claimSlotIndex(owner string) (int, error) {
 				}
 				m.mu.Unlock()
 				return 0, ErrNoSlots
+			}
+			// Operator policy, checked only on the mint path and only
+			// after the reclaim attempt above: recycling an index this
+			// host already prepared is not growth, so a host at its policy
+			// limit can still reuse what it has. Inside the allocator lock,
+			// so concurrent claims cannot both pass the same check.
+			if m.operatorMaxSlots > 0 && !m.slotPinned && m.nextSlot > m.operatorMaxSlots {
+				m.mu.Unlock()
+				return 0, ErrOperatorSlotLimit
 			}
 			idx = m.nextSlot
 			m.nextSlot++

--- a/internal/network/slot_limit_test.go
+++ b/internal/network/slot_limit_test.go
@@ -1,0 +1,71 @@
+package network
+
+import (
+	"errors"
+	"testing"
+)
+
+// The operator limit caps how many indexes a host MINTS. Reuse of an index
+// the host already prepared is not growth and must stay allowed, which is
+// also what keeps a resume working on a host at its limit: a resume reuses
+// the index recorded in its namespace and never reaches the mint path.
+func TestOperatorSlotLimitCapsMintingButNotReuse(t *testing.T) {
+	m := &Manager{
+		slotOwner:        make(map[int]string),
+		nextSlot:         1,
+		operatorMaxSlots: 2,
+	}
+
+	first, err := m.claimSlotIndex("vm-1")
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if _, err := m.claimSlotIndex("vm-2"); err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	// Third mint is over the operator's policy.
+	if _, err := m.claimSlotIndex("vm-3"); !errors.Is(err, ErrOperatorSlotLimit) {
+		t.Fatalf("third claim: got %v, want ErrOperatorSlotLimit", err)
+	}
+
+	// Recycle the index the way reclaim does — return it to freeSlots and
+	// drop its ownership — rather than through ReleaseSlot, which also
+	// tears down real namespace and veth state this test has no business
+	// standing up. What matters here is only that a claim served from
+	// inventory is a reuse, not a mint, so the limit must not block it.
+	m.mu.Lock()
+	delete(m.slotOwner, first)
+	m.freeSlots = append(m.freeSlots, first)
+	m.mu.Unlock()
+
+	if got, err := m.claimSlotIndex("vm-4"); err != nil {
+		t.Fatalf("reuse of a recycled index refused at the operator limit: %v", err)
+	} else if got != first {
+		t.Fatalf("reuse handed out index %d, want the recycled %d", got, first)
+	}
+}
+
+// Zero means no policy limit, which is what every host that has not opted
+// in runs with — including hosts where VMD_MAX_NETWORK_SLOTS is already set
+// for pressure publication.
+func TestOperatorSlotLimitZeroIsUnlimited(t *testing.T) {
+	m := &Manager{
+		slotOwner: make(map[int]string),
+		nextSlot:  1,
+	}
+	for i := 0; i < 50; i++ {
+		if _, err := m.claimSlotIndex("vm"); err != nil {
+			t.Fatalf("claim %d refused with no operator limit set: %v", i, err)
+		}
+	}
+}
+
+// The policy refusal must stay distinguishable from kernel exhaustion: one
+// means "place this elsewhere", the other means the host's slot range is
+// genuinely used up. Collapsing them would make a policy limit read as a
+// host fault.
+func TestOperatorSlotLimitIsDistinctFromKernelExhaustion(t *testing.T) {
+	if errors.Is(ErrOperatorSlotLimit, ErrNoSlots) || errors.Is(ErrNoSlots, ErrOperatorSlotLimit) {
+		t.Fatal("operator-limit and kernel-exhaustion errors are conflated")
+	}
+}

--- a/internal/telemetry/vmd_client.go
+++ b/internal/telemetry/vmd_client.go
@@ -56,10 +56,10 @@ func (c *instrumentedVMDClient) ResumeInstance(ctx context.Context, instanceID, 
 	return c.next.ResumeInstance(ctx, instanceID, snapshotPath, memPath, networkConfig)
 }
 
-func (c *instrumentedVMDClient) RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits vmdclient.ResourceLimits) (ipAddress string, actualVcpu, actualMemMiB uint32, previewProtocol string, err error) {
+func (c *instrumentedVMDClient) RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits vmdclient.ResourceLimits, intent vmdclient.AdmissionIntent) (ipAddress string, actualVcpu, actualMemMiB uint32, previewProtocol string, err error) {
 	started := time.Now()
 	defer func() { c.record(ctx, "CreateVM", started, err) }()
-	return c.next.RestoreSnapshot(ctx, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID, previewAccess, previewPorts, previewPolicyRevision, envVars, limits)
+	return c.next.RestoreSnapshot(ctx, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID, previewAccess, previewPorts, previewPolicyRevision, envVars, limits, intent)
 }
 
 func (c *instrumentedVMDClient) InjectSandboxEnv(ctx context.Context, instanceID string, envVars map[string]string, secretsJWT string) error {

--- a/internal/vm/admission_rpc.go
+++ b/internal/vm/admission_rpc.go
@@ -1,0 +1,59 @@
+package vm
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/admission"
+	"github.com/superserve-ai/sandbox/proto/vmdpb"
+)
+
+// intentFromProto translates the wire enum into the gate's own.
+//
+// The two are separate types on purpose: the gate is the daemon's
+// capacity model and must not depend on generated protobuf code, and an
+// unrecognized wire value maps to unspecified rather than to a guess, so a
+// future sender cannot smuggle a meaning this daemon does not implement.
+func intentFromProto(i vmdpb.AdmissionIntent) admission.Intent {
+	switch i {
+	case vmdpb.AdmissionIntent_ADMISSION_INTENT_CREATE:
+		return admission.IntentCreate
+	case vmdpb.AdmissionIntent_ADMISSION_INTENT_RESUME:
+		return admission.IntentResume
+	default:
+		return admission.IntentUnspecified
+	}
+}
+
+// admissionError converts a gate refusal into the status code its caller
+// should act on. Nil passes through, so call sites read as one line.
+//
+// The codes are the contract, not decoration:
+//
+//   - ResourceExhausted says the host is full and the sandbox is placeable
+//     elsewhere. It is the only refusal a caller should answer by choosing
+//     another host, which is why it must not share a code with anything a
+//     retry to the SAME host could fix.
+//   - Unavailable says this host is not taking new sandboxes right now —
+//     still reconstructing, or draining. Retryable against another host,
+//     and against this one later.
+//   - FailedPrecondition says the caller did not declare its intent. Not
+//     retryable: the same request will fail identically until the caller is
+//     upgraded. Loud on purpose — the alternative is guessing, and both
+//     guesses are silently wrong in the case that matters.
+func admissionError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, admission.ErrHostAtCapacity):
+		return status.Error(codes.ResourceExhausted, err.Error())
+	case errors.Is(err, admission.ErrNotReady):
+		return status.Error(codes.Unavailable, err.Error())
+	case errors.Is(err, admission.ErrIntentRequired):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return err
+	}
+}

--- a/internal/vm/admission_rpc.go
+++ b/internal/vm/admission_rpc.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/superserve-ai/sandbox/internal/admission"
+	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/proto/vmdpb"
 )
 
@@ -53,6 +54,11 @@ func admissionError(err error) error {
 		return status.Error(codes.Unavailable, err.Error())
 	case errors.Is(err, admission.ErrIntentRequired):
 		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, network.ErrOperatorSlotLimit):
+		// Policy exhaustion, not kernel exhaustion: the host is fine and
+		// the sandbox is placeable elsewhere, so it carries the same code
+		// as a sandbox-count refusal rather than reading as a host fault.
+		return status.Error(codes.ResourceExhausted, err.Error())
 	default:
 		return err
 	}

--- a/internal/vm/admission_wiring.go
+++ b/internal/vm/admission_wiring.go
@@ -1,0 +1,163 @@
+package vm
+
+import (
+	"context"
+	"time"
+
+	"github.com/superserve-ai/sandbox/internal/admission"
+)
+
+// admissionReadyPoll is how often the readiness transition re-checks
+// whether the daemon has finished working out what it is carrying.
+//
+// Startup-only and bounded by reattach, so a short interval costs a handful
+// of atomic loads across a window that is already dominated by reattaching
+// VMs. Long enough not to spin, short enough that a host is not refusing
+// creates for meaningfully longer than it must.
+var admissionReadyPoll = 250 * time.Millisecond
+
+// AdmissionGate exposes the gate for the RPC surface and for drain.
+func (m *Manager) AdmissionGate() *admission.Gate { return m.admission }
+
+// StartAdmission brings the gate into service once the daemon knows what
+// this host is already running, and never before.
+//
+// Runs as a background transition rather than from a request, because the
+// listening socket survives a restart: queued calls can arrive before
+// reattach completes, and a gate that reconstructed lazily on the first one
+// would either block that request behind fleet-sized work or admit it
+// against an empty ledger. Both are worse than refusing briefly.
+//
+// A no-op when the gate is disabled, so a host that never opted in does not
+// grow a goroutine for a feature it is not running.
+func (m *Manager) StartAdmission(ctx context.Context) {
+	if !m.admission.Enabled() {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(admissionReadyPoll)
+		defer ticker.Stop()
+		for {
+			// PressureReady is exactly this condition already: reattach
+			// complete, the surviving-builder scan finished, and no
+			// leftover build cgroup or unit still possibly alive. Reused
+			// rather than duplicated — a second readiness rule would be
+			// one more thing to keep in agreement with the first.
+			if m.PressureReady() {
+				m.reconstructAdmission()
+				m.admission.Open()
+				m.log.Info().Int("charged", m.admission.Charged()).
+					Msg("host-local admission open")
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+// reconstructAdmission seeds the ledger from everything this host is
+// holding capacity for.
+//
+// Persisted records, not live instances: a sandbox paused on this host owns
+// its slot for its whole host-owned lifetime, and it has no live instance to
+// enumerate. Reading the store is what makes a restarted daemon charge for
+// the paused sandboxes it is still responsible for, rather than treating a
+// restart as a way to forget them.
+//
+// A store read failure leaves the gate closed. That refuses creates until
+// the next attempt, which is the safe direction: opening on a partial ledger
+// would admit against a count known to be too low.
+func (m *Manager) reconstructAdmission() {
+	if !m.admission.Enabled() {
+		return
+	}
+	var sandboxIDs []string
+	if m.state != nil {
+		records, err := m.state.All()
+		if err != nil {
+			m.log.Error().Err(err).
+				Msg("admission reconstruction could not read persisted records; gate stays closed")
+			return
+		}
+		for _, rec := range records {
+			// Builds are counted from the live registry below. A
+			// build-prefixed record is either that same build — which
+			// would then be charged twice — or residue of one that has
+			// already exited and holds nothing.
+			if isBuildVM(rec.ID) {
+				continue
+			}
+			sandboxIDs = append(sandboxIDs, rec.ID)
+		}
+	}
+	m.admission.Reconstruct(sandboxIDs, m.liveBuildIDs())
+}
+
+// liveBuildIDs returns builds whose subprocess may still hold capacity.
+//
+// Terminal records are skipped: the registry retains them for status
+// polling long after the worker exits, so charging them would leak a token
+// per completed build until the daemon restarted.
+func (m *Manager) liveBuildIDs() []string {
+	m.buildsMu.Lock()
+	defer m.buildsMu.Unlock()
+	var ids []string
+	for id, rec := range m.builds {
+		if rec == nil || rec.Status.IsTerminal() {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// deleteRecord removes a VM's persisted record and releases the capacity it
+// was holding.
+//
+// The two belong together: the ledger is reconstructed from persisted
+// records, so a record that disappears without its token being released
+// leaves a charge no restart could explain and no audit could attribute.
+// Every caller that retires a record routes through here for that reason —
+// a release bolted onto each call site individually is one forgotten site
+// away from a slow capacity leak.
+//
+// Release is unconditional on the delete succeeding. A record that survives
+// a failed delete keeps its token, which is the fail-closed direction: the
+// host may under-admit briefly, but it cannot over-admit against a sandbox
+// still on disk.
+func (m *Manager) deleteRecord(vmID string) error {
+	if err := m.state.Delete(vmID); err != nil {
+		return err
+	}
+	m.admission.Release(vmID)
+	return nil
+}
+
+// AuditAdmission compares the gate's ledger against an independently
+// observed sandbox count and closes the gate if the ledger is behind.
+//
+// One-directional, and that is the whole design. The observation is an
+// eventually consistent sample: it can be taken before a just-admitted
+// sandbox materializes, so seeing fewer than the ledger holds is ordinary
+// and must never lower the count. Seeing more means something is running
+// that nothing is charging for — a real correctness bug — and the answer is
+// to stop admitting and rebuild, not to quietly adopt the sample.
+func (m *Manager) AuditAdmission() {
+	if !m.admission.Enabled() {
+		return
+	}
+	p := m.CapacityPressure()
+	observed := int(p.RunningSandboxes + p.ProvisioningSandboxes + p.PausedSandboxes)
+	if !m.admission.AuditUndercount(observed) {
+		return
+	}
+	m.log.Error().Int("observed", observed).Int("charged", m.admission.Charged()).
+		Msg("admission ledger undercounts live sandboxes; closing gate to reconstruct")
+	m.admission.Close()
+	m.reconstructAdmission()
+	m.admission.Open()
+}

--- a/internal/vm/admission_wiring.go
+++ b/internal/vm/admission_wiring.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/superserve-ai/sandbox/internal/admission"
@@ -38,7 +39,14 @@ func (m *Manager) StartAdmission(ctx context.Context) {
 			// rather than duplicated — a second readiness rule would be
 			// one more thing to keep in agreement with the first.
 			if m.PressureReady() {
-				m.reconstructAdmission()
+				if err := m.reconstructAdmission(); err != nil {
+					// Stay closed and come back on the next tick. Refusing
+					// creates for another interval is recoverable; opening
+					// against a ledger we know is incomplete is not.
+					m.log.Error().Err(err).
+						Msg("admission reconstruction failed; gate stays closed, retrying")
+					break
+				}
 				m.admission.Open()
 				m.log.Info().Int("charged", m.admission.Charged()).
 					Msg("host-local admission open")
@@ -55,7 +63,7 @@ func (m *Manager) StartAdmission(ctx context.Context) {
 }
 
 // reconstructAdmission seeds the ledger from everything this host is
-// holding capacity for.
+// holding capacity for, and reports whether it managed to.
 //
 // Persisted records, not live instances: a sandbox paused on this host owns
 // its slot for its whole host-owned lifetime, and it has no live instance to
@@ -63,20 +71,24 @@ func (m *Manager) StartAdmission(ctx context.Context) {
 // the paused sandboxes it is still responsible for, rather than treating a
 // restart as a way to forget them.
 //
-// A store read failure leaves the gate closed. That refuses creates until
-// the next attempt, which is the safe direction: opening on a partial ledger
-// would admit against a count known to be too low.
-func (m *Manager) reconstructAdmission() {
+// The error is the contract. A caller that opened the gate anyway would be
+// opening an empty or partial ledger, which is not a weaker limit but no
+// limit at all — the failure mode this whole gate exists to prevent. Every
+// caller must leave the gate closed and try again.
+//
+// The generation is taken BEFORE the store read and handed back after, so a
+// create admitted while the read was in flight keeps its charge instead of
+// being erased by a snapshot that predates it.
+func (m *Manager) reconstructAdmission() error {
 	if !m.admission.Enabled() {
-		return
+		return nil
 	}
+	since := m.admission.BeginReconstruct()
 	var sandboxIDs []string
 	if m.state != nil {
 		records, err := m.state.All()
 		if err != nil {
-			m.log.Error().Err(err).
-				Msg("admission reconstruction could not read persisted records; gate stays closed")
-			return
+			return fmt.Errorf("read persisted vm records: %w", err)
 		}
 		for _, rec := range records {
 			// Builds are counted from the live registry below. A
@@ -89,7 +101,8 @@ func (m *Manager) reconstructAdmission() {
 			sandboxIDs = append(sandboxIDs, rec.ID)
 		}
 	}
-	m.admission.Reconstruct(sandboxIDs, m.liveBuildIDs())
+	m.admission.Reconstruct(since, sandboxIDs, m.liveBuildIDs())
+	return nil
 }
 
 // liveBuildIDs returns builds whose subprocess may still hold capacity.
@@ -155,27 +168,47 @@ func (m *Manager) auditAdmissionLoop(ctx context.Context) {
 	}
 }
 
-// AuditAdmission compares the gate's ledger against an independently
-// observed sandbox count and closes the gate if the ledger is behind.
+// AuditAdmission re-derives the ledger from the daemon's authoritative
+// state, and treats an undercount as urgent enough to stop admitting first.
 //
-// One-directional, and that is the whole design. The observation is an
-// eventually consistent sample: it can be taken before a just-admitted
-// sandbox materializes, so seeing fewer than the ledger holds is ordinary
-// and must never lower the count. Seeing more means something is running
-// that nothing is charging for — a real correctness bug — and the answer is
-// to stop admitting and rebuild, not to quietly adopt the sample.
+// Two different problems, handled differently:
+//
+// An UNDERCOUNT — more running than charged — means the host may be
+// admitting against a limit it has already exceeded, so the gate closes
+// before the rebuild rather than after. The comparison is one-directional
+// for that decision: capacity pressure is an eventually consistent sample
+// that can be taken before a just-admitted sandbox materializes, so seeing
+// FEWER than the ledger holds is ordinary and must never close the gate.
+//
+// An OVERCOUNT — a token whose work is long gone — is the opposite: it
+// silently shrinks the host until a restart, and no sampled comparison can
+// safely detect it. The unconditional rebuild is what collects those,
+// because it derives the ledger from persisted records and the live build
+// registry rather than adjusting it. That is safe to run while open only
+// because the rebuild is generation-bound: anything admitted while it reads
+// survives, so an in-flight create cannot lose its charge to it.
 func (m *Manager) AuditAdmission() {
 	if !m.admission.Enabled() {
 		return
 	}
 	p := m.CapacityPressure()
 	observed := int(p.RunningSandboxes + p.ProvisioningSandboxes + p.PausedSandboxes)
-	if !m.admission.AuditUndercount(observed) {
+	undercount := m.admission.AuditUndercount(observed)
+	if undercount {
+		m.log.Error().Int("observed", observed).Int("charged", m.admission.Charged()).
+			Msg("admission ledger undercounts live sandboxes; closing gate to rebuild")
+		m.admission.Close()
+	}
+	if err := m.reconstructAdmission(); err != nil {
+		// A failed rebuild leaves the gate however this call found it: still
+		// open when nothing was known to be wrong, and closed when it was.
+		// Reopening on a rebuild that failed would restore service on a
+		// ledger no more trustworthy than the one that triggered this.
+		m.log.Error().Err(err).Bool("undercount", undercount).
+			Msg("admission rebuild failed")
 		return
 	}
-	m.log.Error().Int("observed", observed).Int("charged", m.admission.Charged()).
-		Msg("admission ledger undercounts live sandboxes; closing gate to reconstruct")
-	m.admission.Close()
-	m.reconstructAdmission()
-	m.admission.Open()
+	if undercount {
+		m.admission.Open()
+	}
 }

--- a/internal/vm/admission_wiring.go
+++ b/internal/vm/admission_wiring.go
@@ -48,6 +48,7 @@ func (m *Manager) StartAdmission(ctx context.Context) {
 				m.admission.Open()
 				m.log.Info().Int("charged", m.admission.Charged()).
 					Msg("host-local admission open")
+				go m.auditAdmissionLoop(ctx)
 				return
 			}
 			select {
@@ -135,6 +136,29 @@ func (m *Manager) deleteRecord(vmID string) error {
 	}
 	m.admission.Release(vmID)
 	return nil
+}
+
+// admissionAuditInterval is how often the ledger is checked against
+// observed load. Slow on purpose: an undercount is a bug, not an expected
+// condition, and each pass walks the fleet. Frequent enough that a leak is
+// caught in minutes rather than at the next restart.
+var admissionAuditInterval = 2 * time.Minute
+
+// auditAdmissionLoop re-checks the ledger for as long as the daemon runs.
+// Its own goroutine because the check walks the fleet and must never sit on
+// a request path, and because closing the gate mid-audit has to be able to
+// happen without a caller waiting on it.
+func (m *Manager) auditAdmissionLoop(ctx context.Context) {
+	ticker := time.NewTicker(admissionAuditInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.AuditAdmission()
+		}
+	}
 }
 
 // AuditAdmission compares the gate's ledger against an independently

--- a/internal/vm/admission_wiring.go
+++ b/internal/vm/admission_wiring.go
@@ -20,11 +20,12 @@ func (m *Manager) AdmissionGate() *admission.Gate { return m.admission }
 // StartAdmission brings the gate into service once the daemon knows what
 // this host is already running, and never before.
 //
-// Runs as a background transition rather than from a request, because the
-// listening socket survives a restart: queued calls can arrive before
-// reattach completes, and a gate that reconstructed lazily on the first one
-// would either block that request behind fleet-sized work or admit it
-// against an empty ledger. Both are worse than refusing briefly.
+// Runs as a background transition rather than from a request. The RPC
+// server serves throughout a restart, so a create can arrive before reattach
+// finishes; a gate that rebuilt lazily on that first request would block it
+// behind fleet-sized work. Until this completes the gate admits and charges
+// without enforcing, so the wait costs correctness of the limit rather than
+// availability of the host.
 func (m *Manager) StartAdmission(ctx context.Context) {
 	if !m.admission.Enabled() {
 		return
@@ -40,11 +41,13 @@ func (m *Manager) StartAdmission(ctx context.Context) {
 			// one more thing to keep in agreement with the first.
 			if m.PressureReady() {
 				if err := m.reconstructAdmission(); err != nil {
-					// Stay closed and come back on the next tick. Refusing
-					// creates for another interval is recoverable; opening
-					// against a ledger we know is incomplete is not.
+					// Stay in the permissive rebuild state and retry on the
+					// next tick. Not enforcing for another interval is
+					// recoverable; opening against a ledger known to be
+					// incomplete would enforce a limit lower than reality
+					// and refuse creates this host has room for.
 					m.log.Error().Err(err).
-						Msg("admission reconstruction failed; gate stays closed, retrying")
+						Msg("admission reconstruction failed; not yet enforcing, retrying")
 					break
 				}
 				m.admission.Open()
@@ -193,22 +196,19 @@ func (m *Manager) AuditAdmission() {
 	}
 	p := m.CapacityPressure()
 	observed := int(p.RunningSandboxes + p.ProvisioningSandboxes + p.PausedSandboxes)
-	undercount := m.admission.AuditUndercount(observed)
-	if undercount {
+	if m.admission.AuditUndercount(observed) {
+		// Logged, not answered by closing the gate. Closing would drop this
+		// host into the permissive rebuild state, which enforces nothing —
+		// exactly the condition an undercount already describes. The
+		// rebuild below is the actual fix, it derives from authoritative
+		// state rather than adjusting, and it completes in a store read.
 		m.log.Error().Int("observed", observed).Int("charged", m.admission.Charged()).
-			Msg("admission ledger undercounts live sandboxes; closing gate to rebuild")
-		m.admission.Close()
+			Msg("admission ledger undercounts live sandboxes; rebuilding")
 	}
 	if err := m.reconstructAdmission(); err != nil {
-		// A failed rebuild leaves the gate however this call found it: still
-		// open when nothing was known to be wrong, and closed when it was.
-		// Reopening on a rebuild that failed would restore service on a
-		// ledger no more trustworthy than the one that triggered this.
-		m.log.Error().Err(err).Bool("undercount", undercount).
-			Msg("admission rebuild failed")
-		return
-	}
-	if undercount {
-		m.admission.Open()
+		// The previous ledger stands. Stale and enforcing beats fresh and
+		// empty: an incomplete rebuild would hand back a count lower than
+		// the truth, which is the over-admission this exists to prevent.
+		m.log.Error().Err(err).Msg("admission rebuild failed; keeping the existing ledger")
 	}
 }

--- a/internal/vm/admission_wiring.go
+++ b/internal/vm/admission_wiring.go
@@ -9,11 +9,8 @@ import (
 
 // admissionReadyPoll is how often the readiness transition re-checks
 // whether the daemon has finished working out what it is carrying.
-//
-// Startup-only and bounded by reattach, so a short interval costs a handful
-// of atomic loads across a window that is already dominated by reattaching
-// VMs. Long enough not to spin, short enough that a host is not refusing
-// creates for meaningfully longer than it must.
+// Startup-only and bounded by reattach, so the cost is a handful of atomic
+// loads across a window already dominated by reattaching VMs.
 var admissionReadyPoll = 250 * time.Millisecond
 
 // AdmissionGate exposes the gate for the RPC surface and for drain.
@@ -27,9 +24,6 @@ func (m *Manager) AdmissionGate() *admission.Gate { return m.admission }
 // reattach completes, and a gate that reconstructed lazily on the first one
 // would either block that request behind fleet-sized work or admit it
 // against an empty ledger. Both are worse than refusing briefly.
-//
-// A no-op when the gate is disabled, so a host that never opted in does not
-// grow a goroutine for a feature it is not running.
 func (m *Manager) StartAdmission(ctx context.Context) {
 	if !m.admission.Enabled() {
 		return

--- a/internal/vm/admission_wiring_test.go
+++ b/internal/vm/admission_wiring_test.go
@@ -1,0 +1,52 @@
+package vm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/admission"
+)
+
+// A rebuild that could not read the store must report it, and its caller
+// must leave the gate closed. Opening on an empty or partial ledger is not
+// a weaker limit — it is no limit at all, which is the exact failure the
+// gate exists to prevent.
+func TestReconstructAdmissionReportsStoreFailure(t *testing.T) {
+	// A closed store fails every read the way an unavailable or corrupt one
+	// does, without needing to corrupt a file on disk.
+	store, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Manager{
+		log:       zerolog.Nop(),
+		admission: admission.NewGate(true, 10),
+		state:     store,
+	}
+
+	if err := m.reconstructAdmission(); err == nil {
+		t.Fatal("reconstruction reported success against an unreadable store; the caller would open an empty ledger")
+	}
+	if got := m.admission.State(); got != admission.StateReconstructing {
+		t.Fatalf("gate state = %v, want reconstructing — a failed rebuild must not leave it open", got)
+	}
+	if got := m.admission.Charged(); got != 0 {
+		t.Fatalf("charged %d after a failed rebuild, want 0", got)
+	}
+}
+
+// With no store configured at all the rebuild is trivially complete, so it
+// must succeed rather than fail closed forever — that is the shape every
+// test-constructed Manager and every host without persisted state has.
+func TestReconstructAdmissionSucceedsWithNoStore(t *testing.T) {
+	m := &Manager{log: zerolog.Nop(), admission: admission.NewGate(true, 10)}
+	if err := m.reconstructAdmission(); err != nil {
+		t.Fatalf("reconstruction failed with no store configured: %v", err)
+	}
+}

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -111,6 +111,11 @@ func (m *Manager) buildTemplateWorker(ctx context.Context, buildVMID string, req
 	// return would publish a full VM's memory during a hash-only interval
 	// that can run for minutes.
 	defer m.buildPressureCount.Add(-1)
+	// Pairs with registerBuild's AdmitBuild. Released at worker return, not
+	// at cancellation: a cancelled build's subprocess is still alive and
+	// still holding capacity until the worker actually exits. Same boundary
+	// as the workflow count above, for the same reason.
+	defer m.admission.Release(buildVMID)
 	defer m.releaseBuildAlloc(rec, req.VCPU, req.MemoryMiB)
 	result, err := m.buildTemplateSync(ctx, buildVMID, req, rec)
 	m.completeBuild(buildVMID, rec, result, err)

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -115,7 +115,7 @@ func (m *Manager) buildTemplateWorker(ctx context.Context, buildVMID string, req
 	// at cancellation: a cancelled build's subprocess is still alive and
 	// still holding capacity until the worker actually exits. Same boundary
 	// as the workflow count above, for the same reason.
-	defer m.admission.Release(buildVMID)
+	defer m.admission.ReleaseOwned(buildVMID, rec)
 	defer m.releaseBuildAlloc(rec, req.VCPU, req.MemoryMiB)
 	result, err := m.buildTemplateSync(ctx, buildVMID, req, rec)
 	m.completeBuild(buildVMID, rec, result, err)

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -119,6 +119,15 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 	if existing, ok := m.builds[buildVMID]; ok && !existing.Status.IsTerminal() {
 		return nil, fmt.Errorf("build %s already in flight", buildVMID)
 	}
+	// Charged before the record exists, so a refused build never enters the
+	// registry and needs no unwinding. Builds hold a sandbox token because
+	// their pressure is published as provisioning sandboxes and placement
+	// ranks against that number — exempting them here would enforce a
+	// different limit than the one the scheduler believes in. Released at
+	// worker exit; see buildTemplateWorker.
+	if err := m.admission.AdmitBuild(buildVMID); err != nil {
+		return nil, err
+	}
 	rec := &buildRecord{
 		BuildVMID:  buildVMID,
 		TemplateID: templateID,

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -119,15 +119,11 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 	if existing, ok := m.builds[buildVMID]; ok && !existing.Status.IsTerminal() {
 		return nil, fmt.Errorf("build %s already in flight", buildVMID)
 	}
-	// Charged before the record exists, so a refused build never enters the
-	// registry and needs no unwinding. Builds hold a sandbox token because
-	// their pressure is published as provisioning sandboxes and placement
-	// ranks against that number — exempting them here would enforce a
-	// different limit than the one the scheduler believes in. Released at
-	// worker exit; see buildTemplateWorker.
-	if err := m.admission.AdmitBuild(buildVMID); err != nil {
-		return nil, err
-	}
+	// Builds hold a sandbox token because their pressure is published as
+	// provisioning sandboxes and placement ranks against that number —
+	// exempting them here would enforce a different limit than the one the
+	// scheduler believes in. Charged just below, once the record exists to
+	// own the charge; released at worker exit, see buildTemplateWorker.
 	rec := &buildRecord{
 		BuildVMID:  buildVMID,
 		TemplateID: templateID,
@@ -137,6 +133,17 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 		StartedAt:  time.Now(),
 		cancel:     cancel,
 		logs:       newBuildLogBuffer(),
+	}
+	// Charged against this record, not just the id: completeBuild already
+	// tolerates a replaced generation whose old worker is still winding
+	// down, and that outgoing worker releases on its way out. Keying the
+	// charge to the record makes its release a no-op once this one owns
+	// the id, instead of freeing the replacement's capacity.
+	if err := m.admission.AdmitBuild(buildVMID, rec); err != nil {
+		// Refused before publication, so a rejected build leaves no
+		// registry entry to unwind and no id a later retry has to work
+		// around.
+		return nil, err
 	}
 	m.builds[buildVMID] = rec
 	// Pressure counters pair with the worker-exit release in

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -53,11 +53,11 @@ func (a *GRPCAdapter) PauseVM(ctx context.Context, req *vmdpb.PauseVMRequest) (*
 	entries := make([]*vmdpb.ArtifactManifestEntry, 0, len(manifest))
 	for _, e := range manifest {
 		entry := &vmdpb.ArtifactManifestEntry{
-			FileName:  e.FileName,
-			Path:      e.Path,
-			SizeBytes: e.SizeBytes,
-			Sha256:    e.SHA256,
-			BasePath:  e.BasePath,
+			FileName:       e.FileName,
+			Path:           e.Path,
+			SizeBytes:      e.SizeBytes,
+			Sha256:         e.SHA256,
+			BasePath:       e.BasePath,
 			AllocatedBytes: e.AllocatedBytes,
 		}
 		entries = append(entries, entry)
@@ -83,6 +83,15 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 		return nil, err
 	}
 	defer unlockOp()
+
+	// A resume is never refused on the operator's sandbox limit — it is
+	// bound to this host and has nowhere else to go — but it is still
+	// charged, so the host's own count reflects the load it is carrying.
+	// Inside the op lock, so a resume racing its own retry cannot be
+	// charged by one attempt and released by the other.
+	if err := admissionError(a.mgr.AdmissionGate().Admit(req.GetVmId(), intentFromProto(req.GetAdmissionIntent()))); err != nil {
+		return nil, err
+	}
 
 	var resumeNetworkRules *sandboxNetworkRules
 	if netCfg := req.GetSandboxNetwork(); netCfg != nil {
@@ -178,6 +187,16 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 	}
 	if previewPortsContainTokenizedAccess(previewPorts) && req.GetPreviewPolicyRevision() <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "tokenized preview policy requires a positive preview_policy_revision")
+	}
+
+	// Admission before any launch work: a local gate exists to refuse in
+	// microseconds, before Firecracker, the filesystem or the network have
+	// been touched. The intent is the caller's because this RPC serves both
+	// a genuine create and the caller's stateless-resume fallback, and the
+	// daemon cannot tell those apart — the fallback is taken precisely when
+	// this daemon has no record of the sandbox.
+	if err := admissionError(a.mgr.AdmissionGate().Admit(req.GetVmId(), intentFromProto(req.GetAdmissionIntent()))); err != nil {
+		return nil, err
 	}
 
 	inst, err := a.mgr.RestoreVMSnapshot(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), vmCfg, netCfg, req.GetTeamId(), req.GetOwnerId(), req.GetPreviewAccess(), previewPorts, req.GetPreviewPolicyRevision())

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -106,7 +106,10 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 	}
 	inst, err := a.mgr.resumeVMLocked(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), resumeNetworkRules)
 	if err != nil {
-		return nil, err
+		// A resume reuses its recorded index and should never reach the
+		// operator's slot limit, but it can exhaust the kernel range —
+		// map here so that surfaces as capacity rather than Unknown.
+		return nil, admissionError(err)
 	}
 
 	// Resume is a no-op for secrets: the agent's HTTPS_PROXY (with its JWT) and
@@ -201,7 +204,12 @@ func (a *GRPCAdapter) RestoreSnapshot(ctx context.Context, req *vmdpb.RestoreSna
 
 	inst, err := a.mgr.RestoreVMSnapshot(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), vmCfg, netCfg, req.GetTeamId(), req.GetOwnerId(), req.GetPreviewAccess(), previewPorts, req.GetPreviewPolicyRevision())
 	if err != nil {
-		return nil, err
+		// Mapped on the way out too, not only around the gate above: the
+		// operator's slot limit is enforced inside the allocator, so it
+		// surfaces from deep in the launch rather than from admission.
+		// Returned raw it would reach the caller as Unknown — unretryable,
+		// and indistinguishable from a genuine host fault.
+		return nil, admissionError(err)
 	}
 
 	// Env vars are pushed in a separate InjectSandboxEnv call so the control

--- a/internal/vm/heartbeat.go
+++ b/internal/vm/heartbeat.go
@@ -52,6 +52,11 @@ type HeartbeatConfig struct {
 	// instance map (the control plane keeps the previous report; its age
 	// is the staleness signal). Nil means always ready.
 	PressureReady func() bool
+	// LocalAdmission declares that this daemon enforces the operator's
+	// capacity limits itself. Advertised as a capability so placement can
+	// tell an enforcing host from one that merely reports its load. False
+	// on every host that has not opted in, which is the default.
+	LocalAdmission bool
 	// MaxSandboxes and MaxNetworkSlots are operator-configured admission
 	// limits published alongside pressure; 0 means unset (no cap).
 	MaxSandboxes    int32
@@ -312,6 +317,23 @@ const (
 	// in different packages because the daemon does not import the
 	// control plane.
 	capabilityCapacityPressure = "capacity_pressure_v1"
+
+	// capabilityLocalAdmission marks a daemon that enforces the operator's
+	// capacity limits itself, refusing creates it has no room for.
+	//
+	// Separate from capacity_pressure_v1 because the two are independently
+	// deployable and a host can do the first without the second: publishing
+	// what it is carrying says nothing about whether it will refuse
+	// anything. Placement needs to tell them apart — only a host that
+	// admits locally can be relied on to hold a limit, and only such a host
+	// answers a create with a capacity refusal the caller is meant to retry
+	// elsewhere.
+	//
+	// Advertised whenever the gate is enabled, not only once it is open:
+	// "enforcing, but still reconstructing" is a state the control plane
+	// should see as enforcing-and-currently-refusing, never mistake for a
+	// daemon that does not enforce at all.
+	capabilityLocalAdmission = "local_admission_v1"
 )
 
 type heartbeatStorageCache struct {
@@ -404,6 +426,9 @@ func sendHeartbeat(ctx context.Context, client *http.Client, cfg HeartbeatConfig
 		// should read to a consumer: not describable, and not silently
 		// mistaken for a daemon that never publishes.
 		capabilities = append(capabilities, capabilityCapacityPressure)
+	}
+	if cfg.LocalAdmission {
+		capabilities = append(capabilities, capabilityLocalAdmission)
 	}
 	return postHeartbeat(ctx, client, cfg, url, token, capabilities, storage, log, started)
 }

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/superserve-ai/sandbox/internal/admission"
 	"github.com/superserve-ai/sandbox/internal/backup"
 	"github.com/superserve-ai/sandbox/internal/network"
 	"github.com/superserve-ai/sandbox/internal/presence"
@@ -374,6 +375,19 @@ type ManagerConfig struct {
 	// skipped when false, so a host that never publishes runs the
 	// startup path it ran before the feature existed.
 	PressureAccounting bool
+
+	// LocalAdmission enables host-local capacity admission.
+	//
+	// Its own setting, deliberately not derived from MaxSandboxes being
+	// non-zero: that limit is already set on production hosts to feed
+	// pressure publication, so inferring enablement from it would turn
+	// enforcement on across the fleet the moment this ships.
+	LocalAdmission bool
+
+	// MaxSandboxes is the operator's concurrent-sandbox limit, consulted
+	// only when LocalAdmission is set. Zero means unlimited, matching how
+	// the pressure publisher already reads the same operator value.
+	MaxSandboxes int
 }
 
 // ---------------------------------------------------------------------------
@@ -573,6 +587,13 @@ type Manager struct {
 	// publishes runs exactly the startup path it ran before the feature
 	// existed. Set once before ReattachAll; never mutated after.
 	pressureAccounting bool
+
+	// admission enforces the operator's concurrent-sandbox limit on this
+	// host. Nil unless the operator opted in, and every method on the gate
+	// is a no-op on a nil receiver, so the enforcement points below read
+	// identically whether or not the feature is on — inertness is a
+	// property of the gate, not of a branch at each call site.
+	admission *admission.Gate
 
 	// recovery probes allocations for VMs nobody declared a size for.
 	// Fixed worker set; see machineConfigRecovery.
@@ -813,6 +834,7 @@ func NewManager(cfg ManagerConfig, netMgr *network.Manager, log zerolog.Logger) 
 		}
 	}
 	m := &Manager{
+		admission:          admission.NewGate(cfg.LocalAdmission, cfg.MaxSandboxes),
 		forensicsOK:        forensicsQuarantineOK,
 		cfg:                cfg,
 		netMgr:             netMgr,
@@ -4499,7 +4521,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 				sigkillPID(rec.PID, 500*time.Millisecond)
 				log.Info().Int("pid", rec.PID).Msg("killed orphan Firecracker process")
 			}
-			m.state.Delete(rec.ID)
+			m.deleteRecord(rec.ID)
 			// Free this record's namespace/slot directly instead of a broad
 			// re-sweep (which would also delete the warm pool's netns).
 			m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
@@ -4563,7 +4585,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 					}
 				}
 				if confirmed {
-					if derr := m.state.Delete(rec.ID); derr == nil {
+					if derr := m.deleteRecord(rec.ID); derr == nil {
 						m.netMgr.CleanupVMOrNamespace(rec.ID, rec.Namespace)
 						return nil, false
 					} else {
@@ -6265,7 +6287,7 @@ func (m *Manager) deleteState(vmID string) {
 		}
 		return
 	}
-	if err := m.state.Delete(vmID); err != nil {
+	if err := m.deleteRecord(vmID); err != nil {
 		m.log.Error().Err(err).Str("vm_id", vmID).Msg("failed to delete VM state from BoltDB")
 	}
 }

--- a/internal/vm/reconciler.go
+++ b/internal/vm/reconciler.go
@@ -1545,7 +1545,7 @@ func (r *Reconciler) markStale(vmID string) error {
 	// Delete from BoltDB first. Deleting from the map before BoltDB would
 	// cause ReattachAll to resurrect the stale record on next restart, so a
 	// failure here abandons the whole cleanup rather than half-applying it.
-	if err := r.mgr.state.Delete(vmID); err != nil {
+	if err := r.mgr.deleteRecord(vmID); err != nil {
 		r.mgr.log.Error().Err(err).Str("vm_id", vmID).Msg("reconciler: failed to delete stale state")
 		return err
 	}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -199,7 +199,7 @@ type VMRecord struct {
 	// rewrites a record, so after a rollback and re-upgrade the field is absent
 	// again — decoding that silence as false would ignore a marker still on disk
 	// and delete it at the next pause. Nil means "ask the disk".
-	CorrectsWallClock *bool `json:"corrects_wall_clock,omitempty"`
+	CorrectsWallClock *bool             `json:"corrects_wall_clock,omitempty"`
 	CreatedAt         time.Time         `json:"created_at"`
 	Metadata          map[string]string `json:"metadata,omitempty"`
 	VCPU              uint32            `json:"vcpu"`

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -69,7 +69,15 @@ type Client interface {
 	// Firecracker, so a daemon told nothing has to ask Firecracker
 	// afterwards to describe its own host honestly. Declaring it here
 	// keeps that probe off the create path entirely.
-	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits ResourceLimits) (ipAddress string, actualVcpu, actualMemMiB uint32, previewProtocol string, err error)
+	//
+	// intent says whether this call is creating a sandbox or resuming one
+	// that already exists. It must be declared because THIS method serves
+	// both: it is the create path and it is the stateless-resume fallback,
+	// and the daemon cannot tell them apart — the fallback is taken
+	// precisely when the daemon has no record of the sandbox. A host
+	// enforcing local capacity refuses a call that leaves it unset rather
+	// than guessing, since both guesses are silently wrong.
+	RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits ResourceLimits, intent AdmissionIntent) (ipAddress string, actualVcpu, actualMemMiB uint32, previewProtocol string, err error)
 	// InjectSandboxEnv pushes env vars and the optional secrets JWT into a
 	// running sandbox's boxd. Idempotent.
 	InjectSandboxEnv(ctx context.Context, instanceID string, envVars map[string]string, secretsJWT string) error
@@ -217,3 +225,24 @@ type BuildStatusResult struct {
 	StartedAtUnix           int64
 	EndedAtUnix             int64
 }
+
+// AdmissionIntent tells a capacity-enforcing daemon why a boot is
+// happening. Defined here rather than reused from the generated protobuf so
+// the control plane's own call sites do not depend on wire types; the gRPC
+// client maps it across the boundary.
+type AdmissionIntent int
+
+const (
+	// IntentUnspecified is the zero value and is never sent deliberately.
+	// A daemon enforcing local capacity refuses it, which is what makes a
+	// caller that forgot to declare its intent fail loudly instead of
+	// being guessed at.
+	IntentUnspecified AdmissionIntent = iota
+	// IntentCreate is a sandbox that does not exist yet, and so may be
+	// refused and placed on another host.
+	IntentCreate
+	// IntentResume is a sandbox that already exists on this host. Never
+	// refused on the operator's sandbox limit: it is bound here and has
+	// nowhere else to go.
+	IntentResume
+)

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -375,6 +375,28 @@ message ArtifactManifestEntry {
 // ResumeVM (wake from snapshot)
 // ---------------------------------------------------------------------------
 
+// Why a boot is happening, as the caller understands it. The daemon cannot
+// derive this: a sandbox that already exists may still arrive through the
+// snapshot-restore RPC — the caller's stateless fallback, taken precisely
+// when the daemon has no record of the VM — so neither the RPC used nor
+// "does this daemon remember the id" separates the two. Both inferences are
+// wrong in exactly the case that matters.
+enum AdmissionIntent {
+  // Sender predates this field. Follows legacy behavior while host-local
+  // admission is off, and is refused once it is on, so an unsafe version
+  // skew surfaces as an error rather than a silent guess in one direction.
+  ADMISSION_INTENT_UNSPECIFIED = 0;
+  // A sandbox that does not exist yet. Subject to the operator's
+  // concurrent-sandbox limit, and rejectable — the caller can place it on
+  // another host.
+  ADMISSION_INTENT_CREATE = 1;
+  // A sandbox that already exists and is bound to this host. Never refused
+  // on the operator's sandbox limit: it has nowhere else to go, and
+  // refusing it would strand a paused sandbox. Physical ceilings still
+  // apply.
+  ADMISSION_INTENT_RESUME = 2;
+}
+
 message ResumeVMRequest {
   string vm_id = 1;
   string snapshot_path = 2;
@@ -383,6 +405,11 @@ message ResumeVMRequest {
   map<string, string> env_vars = 5;          // Re-inject env vars after resume.
   reserved 6;                                 // was secrets_broker (SecretsBrokerConfig)
   reserved "secrets_broker";
+  // Declared rather than assumed even here, where RESUME is the only
+  // sensible value: the daemon refuses UNSPECIFIED under local admission,
+  // so a caller that sets the field on one boot path but not the other
+  // fails on whichever it forgot. One rule for every boot-capable RPC.
+  AdmissionIntent admission_intent = 7;
 }
 
 message ResumeVMResponse {
@@ -445,6 +472,10 @@ message RestoreSnapshotRequest {
   repeated PreviewPort preview_ports = 13;
   // Monotonic generation used to reject stale full-allowlist pushes.
   int64 preview_policy_revision = 14;
+  // CREATE for a new sandbox, RESUME when this RPC is serving the caller's
+  // stateless-resume fallback for a sandbox that already exists. The daemon
+  // has no way to tell those apart on its own — see AdmissionIntent.
+  AdmissionIntent admission_intent = 15;
 }
 
 message PreviewPort {

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -21,6 +21,71 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Why a boot is happening, as the caller understands it. The daemon cannot
+// derive this: a sandbox that already exists may still arrive through the
+// snapshot-restore RPC — the caller's stateless fallback, taken precisely
+// when the daemon has no record of the VM — so neither the RPC used nor
+// "does this daemon remember the id" separates the two. Both inferences are
+// wrong in exactly the case that matters.
+type AdmissionIntent int32
+
+const (
+	// Sender predates this field. Follows legacy behavior while host-local
+	// admission is off, and is refused once it is on, so an unsafe version
+	// skew surfaces as an error rather than a silent guess in one direction.
+	AdmissionIntent_ADMISSION_INTENT_UNSPECIFIED AdmissionIntent = 0
+	// A sandbox that does not exist yet. Subject to the operator's
+	// concurrent-sandbox limit, and rejectable — the caller can place it on
+	// another host.
+	AdmissionIntent_ADMISSION_INTENT_CREATE AdmissionIntent = 1
+	// A sandbox that already exists and is bound to this host. Never refused
+	// on the operator's sandbox limit: it has nowhere else to go, and
+	// refusing it would strand a paused sandbox. Physical ceilings still
+	// apply.
+	AdmissionIntent_ADMISSION_INTENT_RESUME AdmissionIntent = 2
+)
+
+// Enum value maps for AdmissionIntent.
+var (
+	AdmissionIntent_name = map[int32]string{
+		0: "ADMISSION_INTENT_UNSPECIFIED",
+		1: "ADMISSION_INTENT_CREATE",
+		2: "ADMISSION_INTENT_RESUME",
+	}
+	AdmissionIntent_value = map[string]int32{
+		"ADMISSION_INTENT_UNSPECIFIED": 0,
+		"ADMISSION_INTENT_CREATE":      1,
+		"ADMISSION_INTENT_RESUME":      2,
+	}
+)
+
+func (x AdmissionIntent) Enum() *AdmissionIntent {
+	p := new(AdmissionIntent)
+	*p = x
+	return p
+}
+
+func (x AdmissionIntent) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AdmissionIntent) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_vmd_proto_enumTypes[0].Descriptor()
+}
+
+func (AdmissionIntent) Type() protoreflect.EnumType {
+	return &file_proto_vmd_proto_enumTypes[0]
+}
+
+func (x AdmissionIntent) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AdmissionIntent.Descriptor instead.
+func (AdmissionIntent) EnumDescriptor() ([]byte, []int) {
+	return file_proto_vmd_proto_rawDescGZIP(), []int{0}
+}
+
 type VMStatus int32
 
 const (
@@ -63,11 +128,11 @@ func (x VMStatus) String() string {
 }
 
 func (VMStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_proto_vmd_proto_enumTypes[0].Descriptor()
+	return file_proto_vmd_proto_enumTypes[1].Descriptor()
 }
 
 func (VMStatus) Type() protoreflect.EnumType {
-	return &file_proto_vmd_proto_enumTypes[0]
+	return &file_proto_vmd_proto_enumTypes[1]
 }
 
 func (x VMStatus) Number() protoreflect.EnumNumber {
@@ -76,7 +141,7 @@ func (x VMStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VMStatus.Descriptor instead.
 func (VMStatus) EnumDescriptor() ([]byte, []int) {
-	return file_proto_vmd_proto_rawDescGZIP(), []int{0}
+	return file_proto_vmd_proto_rawDescGZIP(), []int{1}
 }
 
 type BuildTemplateRequest struct {
@@ -1708,8 +1773,13 @@ type ResumeVMRequest struct {
 	MemFilePath    string                 `protobuf:"bytes,3,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
 	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,4,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`                                                      // Reapply egress rules after resume.
 	EnvVars        map[string]string      `protobuf:"bytes,5,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Re-inject env vars after resume.
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Declared rather than assumed even here, where RESUME is the only
+	// sensible value: the daemon refuses UNSPECIFIED under local admission,
+	// so a caller that sets the field on one boot path but not the other
+	// fails on whichever it forgot. One rule for every boot-capable RPC.
+	AdmissionIntent AdmissionIntent `protobuf:"varint,7,opt,name=admission_intent,json=admissionIntent,proto3,enum=superserve.vmd.v1.AdmissionIntent" json:"admission_intent,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ResumeVMRequest) Reset() {
@@ -1775,6 +1845,13 @@ func (x *ResumeVMRequest) GetEnvVars() map[string]string {
 		return x.EnvVars
 	}
 	return nil
+}
+
+func (x *ResumeVMRequest) GetAdmissionIntent() AdmissionIntent {
+	if x != nil {
+		return x.AdmissionIntent
+	}
+	return AdmissionIntent_ADMISSION_INTENT_UNSPECIFIED
 }
 
 type ResumeVMResponse struct {
@@ -2004,8 +2081,12 @@ type RestoreSnapshotRequest struct {
 	PreviewPorts  []*PreviewPort `protobuf:"bytes,13,rep,name=preview_ports,json=previewPorts,proto3" json:"preview_ports,omitempty"`
 	// Monotonic generation used to reject stale full-allowlist pushes.
 	PreviewPolicyRevision int64 `protobuf:"varint,14,opt,name=preview_policy_revision,json=previewPolicyRevision,proto3" json:"preview_policy_revision,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// CREATE for a new sandbox, RESUME when this RPC is serving the caller's
+	// stateless-resume fallback for a sandbox that already exists. The daemon
+	// has no way to tell those apart on its own — see AdmissionIntent.
+	AdmissionIntent AdmissionIntent `protobuf:"varint,15,opt,name=admission_intent,json=admissionIntent,proto3,enum=superserve.vmd.v1.AdmissionIntent" json:"admission_intent,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *RestoreSnapshotRequest) Reset() {
@@ -2127,6 +2208,13 @@ func (x *RestoreSnapshotRequest) GetPreviewPolicyRevision() int64 {
 		return x.PreviewPolicyRevision
 	}
 	return 0
+}
+
+func (x *RestoreSnapshotRequest) GetAdmissionIntent() AdmissionIntent {
+	if x != nil {
+		return x.AdmissionIntent
+	}
+	return AdmissionIntent_ADMISSION_INTENT_UNSPECIFIED
 }
 
 type PreviewPort struct {
@@ -3948,13 +4036,14 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\x12\x16\n" +
 	"\x06sha256\x18\x04 \x01(\tR\x06sha256\x12\x1b\n" +
 	"\tbase_path\x18\x05 \x01(\tR\bbasePath\x12'\n" +
-	"\x0fallocated_bytes\x18\x06 \x01(\x03R\x0eallocatedBytes\"\xdf\x02\n" +
+	"\x0fallocated_bytes\x18\x06 \x01(\x03R\x0eallocatedBytes\"\xae\x03\n" +
 	"\x0fResumeVMRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12P\n" +
 	"\x0fsandbox_network\x18\x04 \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x12J\n" +
-	"\benv_vars\x18\x05 \x03(\v2/.superserve.vmd.v1.ResumeVMRequest.EnvVarsEntryR\aenvVars\x1a:\n" +
+	"\benv_vars\x18\x05 \x03(\v2/.superserve.vmd.v1.ResumeVMRequest.EnvVarsEntryR\aenvVars\x12M\n" +
+	"\x10admission_intent\x18\a \x01(\x0e2\".superserve.vmd.v1.AdmissionIntentR\x0fadmissionIntent\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aR\x0esecrets_broker\"\xc5\x01\n" +
@@ -3973,7 +4062,7 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12&\n" +
-	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\xc0\x05\n" +
+	"\x0fcreated_at_unix\x18\x04 \x01(\x03R\rcreatedAtUnix\"\x8f\x06\n" +
 	"\x16RestoreSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
@@ -3988,7 +4077,8 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\bowner_id\x18\v \x01(\tR\aownerId\x12%\n" +
 	"\x0epreview_access\x18\f \x01(\tR\rpreviewAccess\x12C\n" +
 	"\rpreview_ports\x18\r \x03(\v2\x1e.superserve.vmd.v1.PreviewPortR\fpreviewPorts\x126\n" +
-	"\x17preview_policy_revision\x18\x0e \x01(\x03R\x15previewPolicyRevision\x1a:\n" +
+	"\x17preview_policy_revision\x18\x0e \x01(\x03R\x15previewPolicyRevision\x12M\n" +
+	"\x10admission_intent\x18\x0f \x01(\x0e2\".superserve.vmd.v1.AdmissionIntentR\x0fadmissionIntent\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x04\x10\x05R\foverlay_path\"^\n" +
@@ -4106,7 +4196,11 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x1dInvalidateSandboxRulesRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\" \n" +
-	"\x1eInvalidateSandboxRulesResponse*\x96\x01\n" +
+	"\x1eInvalidateSandboxRulesResponse*m\n" +
+	"\x0fAdmissionIntent\x12 \n" +
+	"\x1cADMISSION_INTENT_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17ADMISSION_INTENT_CREATE\x10\x01\x12\x1b\n" +
+	"\x17ADMISSION_INTENT_RESUME\x10\x02*\x96\x01\n" +
 	"\bVMStatus\x12\x19\n" +
 	"\x15VM_STATUS_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12VM_STATUS_CREATING\x10\x01\x12\x15\n" +
@@ -4152,152 +4246,155 @@ func file_proto_vmd_proto_rawDescGZIP() []byte {
 	return file_proto_vmd_proto_rawDescData
 }
 
-var file_proto_vmd_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_proto_vmd_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_proto_vmd_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
 var file_proto_vmd_proto_goTypes = []any{
-	(VMStatus)(0),                              // 0: superserve.vmd.v1.VMStatus
-	(*BuildTemplateRequest)(nil),               // 1: superserve.vmd.v1.BuildTemplateRequest
-	(*BuildStep)(nil),                          // 2: superserve.vmd.v1.BuildStep
-	(*BuildEnvOp)(nil),                         // 3: superserve.vmd.v1.BuildEnvOp
-	(*BuildUserOp)(nil),                        // 4: superserve.vmd.v1.BuildUserOp
-	(*BuildTemplateResponse)(nil),              // 5: superserve.vmd.v1.BuildTemplateResponse
-	(*GetBuildStatusRequest)(nil),              // 6: superserve.vmd.v1.GetBuildStatusRequest
-	(*GetBuildStatusResponse)(nil),             // 7: superserve.vmd.v1.GetBuildStatusResponse
-	(*CancelBuildRequest)(nil),                 // 8: superserve.vmd.v1.CancelBuildRequest
-	(*CancelBuildResponse)(nil),                // 9: superserve.vmd.v1.CancelBuildResponse
-	(*StreamBuildLogsRequest)(nil),             // 10: superserve.vmd.v1.StreamBuildLogsRequest
-	(*BuildLogEvent)(nil),                      // 11: superserve.vmd.v1.BuildLogEvent
-	(*ResourceLimits)(nil),                     // 12: superserve.vmd.v1.ResourceLimits
-	(*NetworkConfig)(nil),                      // 13: superserve.vmd.v1.NetworkConfig
-	(*SandboxNetworkConfig)(nil),               // 14: superserve.vmd.v1.SandboxNetworkConfig
-	(*SandboxNetworkEgressConfig)(nil),         // 15: superserve.vmd.v1.SandboxNetworkEgressConfig
-	(*DestroyVMRequest)(nil),                   // 16: superserve.vmd.v1.DestroyVMRequest
-	(*DestroyVMResponse)(nil),                  // 17: superserve.vmd.v1.DestroyVMResponse
-	(*ReviveVMRequest)(nil),                    // 18: superserve.vmd.v1.ReviveVMRequest
-	(*ReviveVMResponse)(nil),                   // 19: superserve.vmd.v1.ReviveVMResponse
-	(*PauseVMRequest)(nil),                     // 20: superserve.vmd.v1.PauseVMRequest
-	(*PauseVMResponse)(nil),                    // 21: superserve.vmd.v1.PauseVMResponse
-	(*ArtifactManifestEntry)(nil),              // 22: superserve.vmd.v1.ArtifactManifestEntry
-	(*ResumeVMRequest)(nil),                    // 23: superserve.vmd.v1.ResumeVMRequest
-	(*ResumeVMResponse)(nil),                   // 24: superserve.vmd.v1.ResumeVMResponse
-	(*CreateSnapshotRequest)(nil),              // 25: superserve.vmd.v1.CreateSnapshotRequest
-	(*CreateSnapshotResponse)(nil),             // 26: superserve.vmd.v1.CreateSnapshotResponse
-	(*RestoreSnapshotRequest)(nil),             // 27: superserve.vmd.v1.RestoreSnapshotRequest
-	(*PreviewPort)(nil),                        // 28: superserve.vmd.v1.PreviewPort
-	(*RestoreSnapshotResponse)(nil),            // 29: superserve.vmd.v1.RestoreSnapshotResponse
-	(*InjectSandboxEnvRequest)(nil),            // 30: superserve.vmd.v1.InjectSandboxEnvRequest
-	(*InjectSandboxEnvResponse)(nil),           // 31: superserve.vmd.v1.InjectSandboxEnvResponse
-	(*DeleteSnapshotRequest)(nil),              // 32: superserve.vmd.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),             // 33: superserve.vmd.v1.DeleteSnapshotResponse
-	(*DeleteSandboxSnapshotsRequest)(nil),      // 34: superserve.vmd.v1.DeleteSandboxSnapshotsRequest
-	(*DeleteSandboxSnapshotsResponse)(nil),     // 35: superserve.vmd.v1.DeleteSandboxSnapshotsResponse
-	(*DeleteTemplateArtifactsRequest)(nil),     // 36: superserve.vmd.v1.DeleteTemplateArtifactsRequest
-	(*DeleteTemplateArtifactsResponse)(nil),    // 37: superserve.vmd.v1.DeleteTemplateArtifactsResponse
-	(*DeleteBuildArtifactsRequest)(nil),        // 38: superserve.vmd.v1.DeleteBuildArtifactsRequest
-	(*DeleteBuildArtifactsResponse)(nil),       // 39: superserve.vmd.v1.DeleteBuildArtifactsResponse
-	(*ListBuildArtifactsRequest)(nil),          // 40: superserve.vmd.v1.ListBuildArtifactsRequest
-	(*BuildArtifactEntry)(nil),                 // 41: superserve.vmd.v1.BuildArtifactEntry
-	(*ListBuildArtifactsResponse)(nil),         // 42: superserve.vmd.v1.ListBuildArtifactsResponse
-	(*ListDirRequest)(nil),                     // 43: superserve.vmd.v1.ListDirRequest
-	(*ListDirResponse)(nil),                    // 44: superserve.vmd.v1.ListDirResponse
-	(*ListDirEntry)(nil),                       // 45: superserve.vmd.v1.ListDirEntry
-	(*GetVMInfoRequest)(nil),                   // 46: superserve.vmd.v1.GetVMInfoRequest
-	(*GetVMInfoResponse)(nil),                  // 47: superserve.vmd.v1.GetVMInfoResponse
-	(*SetupNetworkRequest)(nil),                // 48: superserve.vmd.v1.SetupNetworkRequest
-	(*SetupNetworkResponse)(nil),               // 49: superserve.vmd.v1.SetupNetworkResponse
-	(*UpdateSandboxNetworkRequest)(nil),        // 50: superserve.vmd.v1.UpdateSandboxNetworkRequest
-	(*UpdateSandboxNetworkResponse)(nil),       // 51: superserve.vmd.v1.UpdateSandboxNetworkResponse
-	(*UpdateSandboxPreviewPolicyRequest)(nil),  // 52: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
-	(*UpdateSandboxPreviewPolicyResponse)(nil), // 53: superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
-	(*InvalidateSecretRequest)(nil),            // 54: superserve.vmd.v1.InvalidateSecretRequest
-	(*InvalidateSecretResponse)(nil),           // 55: superserve.vmd.v1.InvalidateSecretResponse
-	(*RevokeSandboxRequest)(nil),               // 56: superserve.vmd.v1.RevokeSandboxRequest
-	(*RevokeSandboxResponse)(nil),              // 57: superserve.vmd.v1.RevokeSandboxResponse
-	(*InvalidateSandboxRulesRequest)(nil),      // 58: superserve.vmd.v1.InvalidateSandboxRulesRequest
-	(*InvalidateSandboxRulesResponse)(nil),     // 59: superserve.vmd.v1.InvalidateSandboxRulesResponse
-	nil,                                        // 60: superserve.vmd.v1.ReviveVMRequest.EnvVarsEntry
-	nil,                                        // 61: superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
-	nil,                                        // 62: superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
-	nil,                                        // 63: superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
-	nil,                                        // 64: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	(AdmissionIntent)(0),                       // 0: superserve.vmd.v1.AdmissionIntent
+	(VMStatus)(0),                              // 1: superserve.vmd.v1.VMStatus
+	(*BuildTemplateRequest)(nil),               // 2: superserve.vmd.v1.BuildTemplateRequest
+	(*BuildStep)(nil),                          // 3: superserve.vmd.v1.BuildStep
+	(*BuildEnvOp)(nil),                         // 4: superserve.vmd.v1.BuildEnvOp
+	(*BuildUserOp)(nil),                        // 5: superserve.vmd.v1.BuildUserOp
+	(*BuildTemplateResponse)(nil),              // 6: superserve.vmd.v1.BuildTemplateResponse
+	(*GetBuildStatusRequest)(nil),              // 7: superserve.vmd.v1.GetBuildStatusRequest
+	(*GetBuildStatusResponse)(nil),             // 8: superserve.vmd.v1.GetBuildStatusResponse
+	(*CancelBuildRequest)(nil),                 // 9: superserve.vmd.v1.CancelBuildRequest
+	(*CancelBuildResponse)(nil),                // 10: superserve.vmd.v1.CancelBuildResponse
+	(*StreamBuildLogsRequest)(nil),             // 11: superserve.vmd.v1.StreamBuildLogsRequest
+	(*BuildLogEvent)(nil),                      // 12: superserve.vmd.v1.BuildLogEvent
+	(*ResourceLimits)(nil),                     // 13: superserve.vmd.v1.ResourceLimits
+	(*NetworkConfig)(nil),                      // 14: superserve.vmd.v1.NetworkConfig
+	(*SandboxNetworkConfig)(nil),               // 15: superserve.vmd.v1.SandboxNetworkConfig
+	(*SandboxNetworkEgressConfig)(nil),         // 16: superserve.vmd.v1.SandboxNetworkEgressConfig
+	(*DestroyVMRequest)(nil),                   // 17: superserve.vmd.v1.DestroyVMRequest
+	(*DestroyVMResponse)(nil),                  // 18: superserve.vmd.v1.DestroyVMResponse
+	(*ReviveVMRequest)(nil),                    // 19: superserve.vmd.v1.ReviveVMRequest
+	(*ReviveVMResponse)(nil),                   // 20: superserve.vmd.v1.ReviveVMResponse
+	(*PauseVMRequest)(nil),                     // 21: superserve.vmd.v1.PauseVMRequest
+	(*PauseVMResponse)(nil),                    // 22: superserve.vmd.v1.PauseVMResponse
+	(*ArtifactManifestEntry)(nil),              // 23: superserve.vmd.v1.ArtifactManifestEntry
+	(*ResumeVMRequest)(nil),                    // 24: superserve.vmd.v1.ResumeVMRequest
+	(*ResumeVMResponse)(nil),                   // 25: superserve.vmd.v1.ResumeVMResponse
+	(*CreateSnapshotRequest)(nil),              // 26: superserve.vmd.v1.CreateSnapshotRequest
+	(*CreateSnapshotResponse)(nil),             // 27: superserve.vmd.v1.CreateSnapshotResponse
+	(*RestoreSnapshotRequest)(nil),             // 28: superserve.vmd.v1.RestoreSnapshotRequest
+	(*PreviewPort)(nil),                        // 29: superserve.vmd.v1.PreviewPort
+	(*RestoreSnapshotResponse)(nil),            // 30: superserve.vmd.v1.RestoreSnapshotResponse
+	(*InjectSandboxEnvRequest)(nil),            // 31: superserve.vmd.v1.InjectSandboxEnvRequest
+	(*InjectSandboxEnvResponse)(nil),           // 32: superserve.vmd.v1.InjectSandboxEnvResponse
+	(*DeleteSnapshotRequest)(nil),              // 33: superserve.vmd.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),             // 34: superserve.vmd.v1.DeleteSnapshotResponse
+	(*DeleteSandboxSnapshotsRequest)(nil),      // 35: superserve.vmd.v1.DeleteSandboxSnapshotsRequest
+	(*DeleteSandboxSnapshotsResponse)(nil),     // 36: superserve.vmd.v1.DeleteSandboxSnapshotsResponse
+	(*DeleteTemplateArtifactsRequest)(nil),     // 37: superserve.vmd.v1.DeleteTemplateArtifactsRequest
+	(*DeleteTemplateArtifactsResponse)(nil),    // 38: superserve.vmd.v1.DeleteTemplateArtifactsResponse
+	(*DeleteBuildArtifactsRequest)(nil),        // 39: superserve.vmd.v1.DeleteBuildArtifactsRequest
+	(*DeleteBuildArtifactsResponse)(nil),       // 40: superserve.vmd.v1.DeleteBuildArtifactsResponse
+	(*ListBuildArtifactsRequest)(nil),          // 41: superserve.vmd.v1.ListBuildArtifactsRequest
+	(*BuildArtifactEntry)(nil),                 // 42: superserve.vmd.v1.BuildArtifactEntry
+	(*ListBuildArtifactsResponse)(nil),         // 43: superserve.vmd.v1.ListBuildArtifactsResponse
+	(*ListDirRequest)(nil),                     // 44: superserve.vmd.v1.ListDirRequest
+	(*ListDirResponse)(nil),                    // 45: superserve.vmd.v1.ListDirResponse
+	(*ListDirEntry)(nil),                       // 46: superserve.vmd.v1.ListDirEntry
+	(*GetVMInfoRequest)(nil),                   // 47: superserve.vmd.v1.GetVMInfoRequest
+	(*GetVMInfoResponse)(nil),                  // 48: superserve.vmd.v1.GetVMInfoResponse
+	(*SetupNetworkRequest)(nil),                // 49: superserve.vmd.v1.SetupNetworkRequest
+	(*SetupNetworkResponse)(nil),               // 50: superserve.vmd.v1.SetupNetworkResponse
+	(*UpdateSandboxNetworkRequest)(nil),        // 51: superserve.vmd.v1.UpdateSandboxNetworkRequest
+	(*UpdateSandboxNetworkResponse)(nil),       // 52: superserve.vmd.v1.UpdateSandboxNetworkResponse
+	(*UpdateSandboxPreviewPolicyRequest)(nil),  // 53: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
+	(*UpdateSandboxPreviewPolicyResponse)(nil), // 54: superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
+	(*InvalidateSecretRequest)(nil),            // 55: superserve.vmd.v1.InvalidateSecretRequest
+	(*InvalidateSecretResponse)(nil),           // 56: superserve.vmd.v1.InvalidateSecretResponse
+	(*RevokeSandboxRequest)(nil),               // 57: superserve.vmd.v1.RevokeSandboxRequest
+	(*RevokeSandboxResponse)(nil),              // 58: superserve.vmd.v1.RevokeSandboxResponse
+	(*InvalidateSandboxRulesRequest)(nil),      // 59: superserve.vmd.v1.InvalidateSandboxRulesRequest
+	(*InvalidateSandboxRulesResponse)(nil),     // 60: superserve.vmd.v1.InvalidateSandboxRulesResponse
+	nil,                                        // 61: superserve.vmd.v1.ReviveVMRequest.EnvVarsEntry
+	nil,                                        // 62: superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	nil,                                        // 63: superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
+	nil,                                        // 64: superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
+	nil,                                        // 65: superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
 }
 var file_proto_vmd_proto_depIdxs = []int32{
-	2,  // 0: superserve.vmd.v1.BuildTemplateRequest.steps:type_name -> superserve.vmd.v1.BuildStep
-	3,  // 1: superserve.vmd.v1.BuildStep.env:type_name -> superserve.vmd.v1.BuildEnvOp
-	4,  // 2: superserve.vmd.v1.BuildStep.user:type_name -> superserve.vmd.v1.BuildUserOp
-	15, // 3: superserve.vmd.v1.SandboxNetworkConfig.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	60, // 4: superserve.vmd.v1.ReviveVMRequest.env_vars:type_name -> superserve.vmd.v1.ReviveVMRequest.EnvVarsEntry
-	22, // 5: superserve.vmd.v1.PauseVMResponse.manifest:type_name -> superserve.vmd.v1.ArtifactManifestEntry
-	14, // 6: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
-	61, // 7: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
-	12, // 8: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	12, // 9: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	13, // 10: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	62, // 11: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
-	28, // 12: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	12, // 13: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	63, // 14: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
-	41, // 15: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
-	45, // 16: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
-	0,  // 17: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
-	12, // 18: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	64, // 19: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
-	13, // 20: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	15, // 21: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	28, // 22: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	16, // 23: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
-	20, // 24: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
-	23, // 25: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
-	25, // 26: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
-	27, // 27: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
-	30, // 28: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
-	32, // 29: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
-	34, // 30: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
-	36, // 31: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
-	38, // 32: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
-	40, // 33: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
-	43, // 34: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
-	46, // 35: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
-	48, // 36: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
-	18, // 37: superserve.vmd.v1.VMDaemon.ReviveVM:input_type -> superserve.vmd.v1.ReviveVMRequest
-	50, // 38: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
-	52, // 39: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
-	54, // 40: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
-	56, // 41: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
-	58, // 42: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
-	1,  // 43: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
-	6,  // 44: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
-	8,  // 45: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
-	10, // 46: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
-	17, // 47: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
-	21, // 48: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
-	24, // 49: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
-	26, // 50: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
-	29, // 51: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
-	31, // 52: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
-	33, // 53: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
-	35, // 54: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
-	37, // 55: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
-	39, // 56: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
-	42, // 57: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
-	44, // 58: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
-	47, // 59: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
-	49, // 60: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
-	19, // 61: superserve.vmd.v1.VMDaemon.ReviveVM:output_type -> superserve.vmd.v1.ReviveVMResponse
-	51, // 62: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
-	53, // 63: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
-	55, // 64: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
-	57, // 65: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
-	59, // 66: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
-	5,  // 67: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
-	7,  // 68: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
-	9,  // 69: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
-	11, // 70: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
-	47, // [47:71] is the sub-list for method output_type
-	23, // [23:47] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	3,  // 0: superserve.vmd.v1.BuildTemplateRequest.steps:type_name -> superserve.vmd.v1.BuildStep
+	4,  // 1: superserve.vmd.v1.BuildStep.env:type_name -> superserve.vmd.v1.BuildEnvOp
+	5,  // 2: superserve.vmd.v1.BuildStep.user:type_name -> superserve.vmd.v1.BuildUserOp
+	16, // 3: superserve.vmd.v1.SandboxNetworkConfig.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	61, // 4: superserve.vmd.v1.ReviveVMRequest.env_vars:type_name -> superserve.vmd.v1.ReviveVMRequest.EnvVarsEntry
+	23, // 5: superserve.vmd.v1.PauseVMResponse.manifest:type_name -> superserve.vmd.v1.ArtifactManifestEntry
+	15, // 6: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
+	62, // 7: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
+	0,  // 8: superserve.vmd.v1.ResumeVMRequest.admission_intent:type_name -> superserve.vmd.v1.AdmissionIntent
+	13, // 9: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	13, // 10: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	14, // 11: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	63, // 12: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
+	29, // 13: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	0,  // 14: superserve.vmd.v1.RestoreSnapshotRequest.admission_intent:type_name -> superserve.vmd.v1.AdmissionIntent
+	13, // 15: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	64, // 16: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
+	42, // 17: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
+	46, // 18: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
+	1,  // 19: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
+	13, // 20: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	65, // 21: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	14, // 22: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	16, // 23: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	29, // 24: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	17, // 25: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
+	21, // 26: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
+	24, // 27: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
+	26, // 28: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
+	28, // 29: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
+	31, // 30: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
+	33, // 31: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
+	35, // 32: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
+	37, // 33: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
+	39, // 34: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
+	41, // 35: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
+	44, // 36: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
+	47, // 37: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
+	49, // 38: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
+	19, // 39: superserve.vmd.v1.VMDaemon.ReviveVM:input_type -> superserve.vmd.v1.ReviveVMRequest
+	51, // 40: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
+	53, // 41: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
+	55, // 42: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
+	57, // 43: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
+	59, // 44: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
+	2,  // 45: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
+	7,  // 46: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
+	9,  // 47: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
+	11, // 48: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
+	18, // 49: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
+	22, // 50: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
+	25, // 51: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
+	27, // 52: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
+	30, // 53: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
+	32, // 54: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
+	34, // 55: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
+	36, // 56: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
+	38, // 57: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
+	40, // 58: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
+	43, // 59: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
+	45, // 60: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
+	48, // 61: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
+	50, // 62: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
+	20, // 63: superserve.vmd.v1.VMDaemon.ReviveVM:output_type -> superserve.vmd.v1.ReviveVMResponse
+	52, // 64: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
+	54, // 65: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
+	56, // 66: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
+	58, // 67: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
+	60, // 68: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
+	6,  // 69: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
+	8,  // 70: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
+	10, // 71: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
+	12, // 72: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
+	49, // [49:73] is the sub-list for method output_type
+	25, // [25:49] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_proto_vmd_proto_init() }
@@ -4316,7 +4413,7 @@ func file_proto_vmd_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_vmd_proto_rawDesc), len(file_proto_vmd_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   64,
 			NumExtensions: 0,
 			NumServices:   1,


### PR DESCRIPTION
Hosts can't currently refuse work they have no room for: two API replicas can select the same host and exceed its limit before the next heartbeat corrects them. This adds the enforcement side on the host — an id-keyed ledger checked inside the create/restore RPC already on the path, so counting is `len(map)` and the mutex is held for arithmetic only.

Callers now declare whether a boot is a create or a resume, because the restore RPC serves both and the stateless-resume fallback is taken precisely when the daemon has no record of the sandbox — so neither the RPC nor "does this daemon know this id" can distinguish them. Resumes are charged but never refused on the operator's sandbox limit; network slots are capped inside the allocator on minting only, so reuse and resume are unaffected.

**Scope: this is the enforcement half only.** A refused create returns `ResourceExhausted` and the control plane does *not* yet re-place it — retry currently covers deadline and `Unavailable` against the same host, so an enabled host would surface capacity refusals as failed creates. Enabling therefore requires the retry/re-placement work first, plus a control plane that sends the intent field on every boot. Until then this is a last-line overload guard, not a placement mechanism.

A restart does not cost availability: the RPC server serves while the daemon is still working out what it holds, so during that window the gate admits and charges without enforcing rather than refusing. The limit is briefly unenforced — which is what every host does today — instead of the host briefly refusing work it has room for.

Inert unless `VMD_LOCAL_ADMISSION_ENABLED` is set — deliberately not inferred from the `VMD_MAX_*` limits, which are already configured on hosts that publish pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
