### PR TITLE
feat: Expose authoritative remaining trial credit in customer billing API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2570,6 +2570,7 @@ components:
         - resources
         - billing_period
         - pricing_tier
+        - trial
         - calculated_at
       properties:
         mode:
@@ -2619,6 +2620,8 @@ components:
           $ref: "#/components/schemas/BillingSummaryPeriod"
         pricing_tier:
           $ref: "#/components/schemas/BillingSummaryPricingTier"
+        trial:
+          $ref: "#/components/schemas/BillingTrialBalance"
         calculated_at:
           type: string
           format: date-time
@@ -2744,6 +2747,25 @@ components:
         currency:
           type: string
           example: USD
+
+    BillingTrialBalance:
+      type: object
+      required: [grant_usd, consumed_usd, remaining_usd, state, eligible]
+      properties:
+        grant_usd:
+          type: number
+          format: double
+        consumed_usd:
+          type: number
+          format: double
+        remaining_usd:
+          type: number
+          format: double
+        state:
+          type: string
+          enum: [no_grant, active, exhausted, expired, ended_by_billing_activation]
+        eligible:
+          type: boolean
 
     BillingExportPreviewItem:
       type: object

--- a/db/queries/billing.sql
+++ b/db/queries/billing.sql
@@ -1009,6 +1009,14 @@ WHERE team_id = sqlc.arg(team_id)
   AND remaining_usd > 0
   AND (expires_at IS NULL OR expires_at > now());
 
+-- name: GetTeamTrialBalance :one
+SELECT trial.grant_usd::numeric AS grant_usd,
+       trial.consumed_usd::numeric AS consumed_usd,
+       trial.remaining_usd::numeric AS remaining_usd,
+       trial.state::text AS state,
+       trial.eligible::boolean AS eligible
+FROM get_team_trial_balance(sqlc.arg(team_id)) AS trial;
+
 -- name: IsTeamSandboxBillingEligible :one
 SELECT team_sandbox_billing_eligible(sqlc.arg(team_id)) AS eligible;
 

--- a/internal/api/handlers_billing.go
+++ b/internal/api/handlers_billing.go
@@ -63,7 +63,16 @@ type billingSummaryResponse struct {
 	ResourcesByKey           map[string]billingSummaryResource `json:"resources_by_key,omitempty"`
 	BillingPeriod            billingSummaryPeriod              `json:"billing_period"`
 	PricingTier              billingSummaryPricingTier         `json:"pricing_tier"`
+	Trial                    *billingTrialBalance              `json:"trial,omitempty"`
 	CalculatedAt             time.Time                         `json:"calculated_at"`
+}
+
+type billingTrialBalance struct {
+	GrantUSD     float64 `json:"grant_usd"`
+	ConsumedUSD  float64 `json:"consumed_usd"`
+	RemainingUSD float64 `json:"remaining_usd"`
+	State        string  `json:"state"`
+	Eligible     bool    `json:"eligible"`
 }
 
 type billingSummaryCostBreakdown struct {
@@ -188,6 +197,7 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		usage         db.GetTeamBillingUsageRow
 		pricingRows   []db.ListActivePricingRatesForTeamCurrentRow
 		creditBalance pgtype.Numeric
+		trialBalance  db.GetTeamTrialBalanceRow
 	)
 	g, ctx := errgroup.WithContext(c.Request.Context())
 	g.Go(func() error {
@@ -199,6 +209,14 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		})
 		if err != nil {
 			return fmt.Errorf("get team billing usage: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		trialBalance, err = h.DB.GetTeamTrialBalance(ctx, teamID)
+		if err != nil {
+			return fmt.Errorf("get team trial balance: %w", err)
 		}
 		return nil
 	})
@@ -226,6 +244,29 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing summary dependency fetch failed")
 		respondError(c, ErrInternal)
 		return
+	}
+	grantUSD, err := numericFloat64(trialBalance.GrantUsd)
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("convert trial grant failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	consumedUSD, err := numericFloat64(trialBalance.ConsumedUsd)
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("convert trial consumption failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	remainingUSD, err := numericFloat64(trialBalance.RemainingUsd)
+	if err != nil {
+		log.Error().Err(err).Str("team_id", teamID.String()).Msg("convert trial remaining failed")
+		respondError(c, ErrInternal)
+		return
+	}
+	if (trialBalance.State == "active" && remainingUSD <= 0) ||
+		(trialBalance.State == "exhausted" && remainingUSD > 0) {
+		log.Error().Str("team_id", teamID.String()).Str("state", trialBalance.State).
+			Float64("remaining_usd", remainingUSD).Msg("billing trial balance inconsistent")
 	}
 
 	storageBillingEnabled, err := h.billingStorageBillingEnabled(c.Request.Context(), teamID)
@@ -341,6 +382,16 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 			PlanKey:  pricingCatalog.PlanKey,
 			PlanName: pricingCatalog.PlanName,
 			Currency: pricingCatalog.Currency,
+		},
+		// Always include the structured trial result so clients can distinguish
+		// an account with no applicable signup grant from an omitted/unknown
+		// billing field. The no_grant state carries zero monetary values.
+		Trial: &billingTrialBalance{
+			GrantUSD:     grantUSD,
+			ConsumedUSD:  consumedUSD,
+			RemainingUSD: remainingUSD,
+			State:        trialBalance.State,
+			Eligible:     trialBalance.Eligible,
 		},
 		CalculatedAt: now,
 	})

--- a/internal/db/billing.sql.go
+++ b/internal/db/billing.sql.go
@@ -1007,6 +1007,36 @@ func (q *Queries) GetTeamCreditBalance(ctx context.Context, teamID uuid.UUID) (p
 	return balance_usd, err
 }
 
+const getTeamTrialBalance = `-- name: GetTeamTrialBalance :one
+SELECT trial.grant_usd::numeric AS grant_usd,
+       trial.consumed_usd::numeric AS consumed_usd,
+       trial.remaining_usd::numeric AS remaining_usd,
+       trial.state::text AS state,
+       trial.eligible::boolean AS eligible
+FROM get_team_trial_balance($1) AS trial
+`
+
+type GetTeamTrialBalanceRow struct {
+	GrantUsd     pgtype.Numeric `json:"grant_usd"`
+	ConsumedUsd  pgtype.Numeric `json:"consumed_usd"`
+	RemainingUsd pgtype.Numeric `json:"remaining_usd"`
+	State        string         `json:"state"`
+	Eligible     bool           `json:"eligible"`
+}
+
+func (q *Queries) GetTeamTrialBalance(ctx context.Context, teamID uuid.UUID) (GetTeamTrialBalanceRow, error) {
+	row := q.db.QueryRow(ctx, getTeamTrialBalance, teamID)
+	var i GetTeamTrialBalanceRow
+	err := row.Scan(
+		&i.GrantUsd,
+		&i.ConsumedUsd,
+		&i.RemainingUsd,
+		&i.State,
+		&i.Eligible,
+	)
+	return i, err
+}
+
 const grantTeamCredit = `-- name: GrantTeamCredit :one
 INSERT INTO team_credit_grant (
     team_id, amount_usd, remaining_usd, reason, expires_at, created_by

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1564,6 +1564,52 @@ func TestIntegration_GetBillingSummary(t *testing.T) {
 	if got := body["mode"].(string); got != "shadow" {
 		t.Fatalf("mode = %q, want shadow", got)
 	}
+	trial, ok := body["trial"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("trial = %v, want object", body["trial"])
+	}
+	for _, key := range []string{"grant_usd", "consumed_usd", "remaining_usd", "state", "eligible"} {
+		if _, present := trial[key]; !present {
+			t.Fatalf("trial missing %q: %v", key, trial)
+		}
+	}
+	state, ok := trial["state"].(string)
+	if !ok || (state != "no_grant" && state != "active" && state != "exhausted" && state != "expired" && state != "ended_by_billing_activation") {
+		t.Fatalf("trial state = %v, want a recognized lifecycle state", trial["state"])
+	}
+	if state == "no_grant" && (trial["grant_usd"] != float64(0) || trial["consumed_usd"] != float64(0) || trial["remaining_usd"] != float64(0)) {
+		t.Fatalf("no-grant trial = %v, want zero monetary values", trial)
+	}
+	// An expired signup grant is terminal and ineligible, distinct from a team
+	// that never received a signup grant.
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason, expires_at)
+		VALUES ($1, 1, 1, 'signup trial credit', now() + interval '1 hour')
+	`, teamID); err != nil {
+		t.Fatalf("seed signup trial grant for expiry: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team_credit_grant
+		SET expires_at = now() - interval '1 second'
+		WHERE team_id = $1 AND reason = 'signup trial credit' AND expires_at IS NOT NULL
+	`, teamID); err != nil {
+		t.Fatalf("expire signup trial grant: %v", err)
+	}
+	expired := do(r, "GET", "/billing/summary", viewerKey, "")
+	if expired.Code != http.StatusOK {
+		t.Fatalf("expired trial summary: expected 200, got %d: %s", expired.Code, expired.Body.String())
+	}
+	expiredTrial, ok := mustJSON(t, expired)["trial"].(map[string]interface{})
+	if !ok || expiredTrial["state"] != "expired" || expiredTrial["eligible"] != false || expiredTrial["remaining_usd"] != float64(0) {
+		t.Fatalf("expired trial = %v, want expired, ineligible, and zero remaining", expiredTrial)
+	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team_credit_grant
+		SET expires_at = NULL, remaining_usd = 0
+		WHERE team_id = $1 AND reason = 'signup trial credit' AND expires_at IS NOT NULL
+	`, teamID); err != nil {
+		t.Fatalf("restore signup trial grant expiry: %v", err)
+	}
 	breakdown, ok := body["cost_breakdown_usd"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("cost_breakdown_usd not an object: %v", body["cost_breakdown_usd"])
@@ -1641,6 +1687,21 @@ func TestIntegration_GetBillingSummary(t *testing.T) {
 	if got := liveBody["portal_available"].(bool); got {
 		t.Fatal("portal_available should be false before subscription is established")
 	}
+	if _, err := testPool.Exec(ctx, `
+		UPDATE team_billing_account
+		SET trial_ended_at = now(), stripe_subscription_status = 'active'
+		WHERE team_id = $1
+	`, teamID); err != nil {
+		t.Fatalf("mark subscription active: %v", err)
+	}
+	activated := do(liveRouter, "GET", "/billing/summary", ownerKey, "")
+	if activated.Code != http.StatusOK {
+		t.Fatalf("activated billing summary: expected 200, got %d: %s", activated.Code, activated.Body.String())
+	}
+	activatedTrial, ok := mustJSON(t, activated)["trial"].(map[string]interface{})
+	if !ok || activatedTrial["state"] != "ended_by_billing_activation" || activatedTrial["eligible"] != true || activatedTrial["remaining_usd"] != float64(0) {
+		t.Fatalf("activated trial = %v, want ended_by_billing_activation, eligible, and zero remaining", activatedTrial)
+	}
 
 	period, ok := body["billing_period"].(map[string]interface{})
 	if !ok {
@@ -1671,6 +1732,13 @@ func TestIntegration_NewTeamReceivesSignupTrialCredit(t *testing.T) {
 		t.Fatalf("create team: %v", err)
 	}
 	teamID := team.ID
+	profileID := uuid.New()
+	if _, err := testPool.Exec(ctx, `INSERT INTO profile (id, email) VALUES ($1, $2)`, profileID, profileID.String()+"@example.com"); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if _, err := testPool.Exec(ctx, `INSERT INTO team_memberships (team_id, user_id, status) VALUES ($1, $2, 'active')`, teamID, profileID); err != nil {
+		t.Fatalf("create membership: %v", err)
+	}
 
 	var amount, remaining float64
 	if err := testPool.QueryRow(ctx, `
@@ -1682,6 +1750,42 @@ func TestIntegration_NewTeamReceivesSignupTrialCredit(t *testing.T) {
 	}
 	if amount != 5 || remaining != 5 {
 		t.Fatalf("signup trial credit = (%v, %v), want (5, 5)", amount, remaining)
+	}
+}
+
+func TestIntegration_ExpiredSignupTrialIsBillingIneligible(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason, expires_at)
+		VALUES ($1, 5.000000, 5.000000, 'signup trial credit', now() - interval '1 second')
+	`, teamID); err != nil {
+		t.Fatalf("seed expired signup trial credit: %v", err)
+	}
+	eligible, err := testQueries.IsTeamSandboxBillingEligible(ctx, teamID)
+	if err != nil {
+		t.Fatalf("check expired signup trial eligibility: %v", err)
+	}
+	if eligible {
+		t.Fatal("expired signup trial should be billing-ineligible")
+	}
+}
+
+func TestIntegration_IncompleteStripeSubscriptionIsNotTrialEligible(t *testing.T) {
+	ctx := context.Background()
+	teamID, _ := seedTeamAndKey(t)
+	if _, err := testPool.Exec(ctx, `
+		INSERT INTO team_billing_account (team_id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status)
+		VALUES ($1, $2, $3, 'incomplete')
+	`, teamID, "cus_"+teamID.String(), "sub_"+teamID.String()); err != nil {
+		t.Fatalf("seed incomplete subscription: %v", err)
+	}
+	balance, err := testQueries.GetTeamTrialBalance(ctx, teamID)
+	if err != nil {
+		t.Fatalf("load trial balance: %v", err)
+	}
+	if balance.Eligible {
+		t.Fatal("incomplete Stripe subscription should not be trial-eligible")
 	}
 }
 

--- a/internal/vm/heartbeat_pressure_test.go
+++ b/internal/vm/heartbeat_pressure_test.go
@@ -1303,7 +1303,7 @@ func awaitBackfill(t *testing.T, done <-chan string) {
 	t.Helper()
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		t.Fatal("allocation backfill never ran — an undeclared VM keeps a zero size and publishes as free capacity")
 	}
 }

--- a/supabase/migrations/20260903000001_billing_trial_balance.sql
+++ b/supabase/migrations/20260903000001_billing_trial_balance.sql
@@ -1,0 +1,89 @@
+-- Expose the authoritative, raw-interval trial balance to billing consumers.
+-- Keeping this calculation in Postgres ensures enforcement and the API agree.
+CREATE OR REPLACE FUNCTION get_team_trial_balance(p_team_id uuid)
+RETURNS TABLE(grant_usd numeric, consumed_usd numeric, remaining_usd numeric, state text, eligible boolean)
+LANGUAGE sql STABLE AS $$
+WITH account AS (
+  SELECT trial_ended_at, stripe_subscription_id, stripe_subscription_status FROM team_billing_account WHERE team_id = p_team_id
+), historical_grants AS (
+  SELECT COUNT(*)::int AS count
+  FROM team_credit_grant
+  WHERE team_id = p_team_id AND reason = 'signup trial credit'
+), grants AS (
+  SELECT COALESCE(SUM(amount_usd), 0)::numeric AS amount, COUNT(*)::int AS count,
+         COUNT(*) FILTER (WHERE expires_at IS NULL OR expires_at > now())::int AS active_count,
+         COALESCE(MIN(created_at), now()) AS started,
+         MAX(expires_at) FILTER (WHERE expires_at IS NOT NULL) AS expires_end
+  FROM team_credit_grant WHERE team_id = p_team_id AND reason = 'signup trial credit'
+), bounds AS (
+  SELECT COALESCE((SELECT trial_ended_at FROM account),
+                  CASE WHEN grants.count > 0 AND grants.active_count = 0
+                       THEN COALESCE(grants.expires_end, now()) ELSE now() END) AS period_end
+  FROM grants
+), compute_usage AS (
+  SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (LEAST(COALESCE(i.ended_at, bounds.period_end), bounds.period_end) - GREATEST(i.started_at, grants.started))) * i.vcpu_count), 0)::numeric AS cpu,
+         COALESCE(SUM(EXTRACT(EPOCH FROM (LEAST(COALESCE(i.ended_at, bounds.period_end), bounds.period_end) - GREATEST(i.started_at, grants.started))) * i.memory_mib / 1024.0), 0)::numeric AS memory
+  FROM sandbox_compute_billing_interval i, bounds, grants
+  WHERE i.team_id = p_team_id AND i.started_at < bounds.period_end AND COALESCE(i.ended_at, bounds.period_end) > grants.started
+), usage AS (
+  SELECT compute_usage.cpu,
+         compute_usage.memory,
+         COALESCE((SELECT SUM(EXTRACT(EPOCH FROM (LEAST(COALESCE(i.ended_at, bounds.period_end), bounds.period_end) - GREATEST(i.started_at, grants.started))) * i.disk_mib / 1024.0) FROM sandbox_storage_interval i, bounds WHERE i.team_id = p_team_id AND i.started_at < bounds.period_end AND COALESCE(i.ended_at, bounds.period_end) > grants.started), 0)::numeric AS storage
+  FROM compute_usage, grants
+), ranked_rates AS (
+  SELECT r.*, row_number() OVER (PARTITION BY r.resource, r.unit ORDER BY r.effective_from DESC, r.created_at DESC, r.id DESC) AS rate_rank
+  FROM pricing_rate r JOIN pricing_plan pp ON pp.key = r.plan_key AND pp.active
+  WHERE r.plan_key = COALESCE((SELECT plan_key FROM team_pricing_plan tpp JOIN pricing_plan tppp ON tppp.key = tpp.plan_key AND tppp.active WHERE tpp.team_id = p_team_id AND tpp.effective_from <= now() AND (tpp.effective_to IS NULL OR tpp.effective_to > now()) ORDER BY tpp.effective_from DESC LIMIT 1), 'payg')
+    AND r.unit = 'second' AND r.effective_from <= now() AND (r.effective_to IS NULL OR r.effective_to > now())
+), rates AS (
+  SELECT COALESCE(MAX(price_usd) FILTER (WHERE resource = 'vcpu'), 0)::numeric cpu,
+         COALESCE(MAX(price_usd) FILTER (WHERE resource = 'memory_gib'), 0)::numeric memory,
+         COALESCE(MAX(price_usd) FILTER (WHERE resource = 'storage_gib'), 0)::numeric storage
+  FROM ranked_rates WHERE rate_rank = 1
+), calc AS (
+  SELECT grants.amount, round((usage.cpu * rates.cpu + usage.memory * rates.memory + CASE WHEN feature_enabled('billing_storage_billing_enabled', p_team_id) THEN usage.storage * rates.storage ELSE 0 END)::numeric, 6) consumed,
+         grants.count, grants.active_count, historical_grants.count AS historical_count,
+         account.trial_ended_at, account.stripe_subscription_id, account.stripe_subscription_status
+  FROM grants, historical_grants, usage, rates LEFT JOIN account ON true
+)
+SELECT amount, consumed,
+  CASE WHEN trial_ended_at IS NOT NULL OR stripe_subscription_status IS NOT NULL AND lower(stripe_subscription_status) IN ('active','trialing','past_due') OR (historical_count > 0 AND active_count = 0)
+       THEN 0::numeric ELSE round(GREATEST(amount - consumed, 0)::numeric, 6) END,
+  CASE WHEN trial_ended_at IS NOT NULL OR stripe_subscription_status IS NOT NULL AND lower(stripe_subscription_status) IN ('active','trialing','past_due') THEN 'ended_by_billing_activation'
+       WHEN historical_count = 0 THEN 'no_grant'
+       WHEN active_count = 0 THEN 'expired'
+       WHEN amount - consumed <= 0 THEN 'exhausted' ELSE 'active' END,
+  CASE WHEN trial_ended_at IS NOT NULL OR stripe_subscription_status IS NOT NULL AND lower(stripe_subscription_status) IN ('active','trialing','past_due') THEN lower(COALESCE(stripe_subscription_status, '')) IN ('active','trialing','past_due')
+       WHEN historical_count = 0 THEN stripe_subscription_id IS NULL
+       WHEN active_count = 0 THEN false
+       ELSE amount - consumed > 0 END
+FROM calc;
+$$;
+
+CREATE OR REPLACE FUNCTION refresh_team_trial_eligibility(p_team_id uuid)
+RETURNS boolean LANGUAGE sql STABLE AS $$ SELECT eligible FROM get_team_trial_balance(p_team_id); $$;
+
+-- Keep the enforcement-side eligibility decision terminal for expired signup
+-- grants while preserving the legacy no-grant path for teams with no grant.
+CREATE OR REPLACE FUNCTION team_sandbox_billing_eligible(p_team_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT CASE
+        WHEN account.trial_ended_at IS NULL THEN
+            (grant_balance.historical_count = 0 AND account.stripe_subscription_id IS NULL)
+            OR (account.stripe_subscription_id IS NOT NULL
+                AND lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due'))
+            OR (grant_balance.remaining_usd > 0 AND COALESCE(cache.eligible, true))
+        ELSE lower(coalesce(account.stripe_subscription_status, '')) IN ('active', 'trialing', 'past_due')
+    END
+    FROM (SELECT trial_ended_at, stripe_subscription_id, stripe_subscription_status
+          FROM team_billing_account WHERE team_id = p_team_id) account
+    FULL JOIN (SELECT COALESCE(SUM(remaining_usd) FILTER (WHERE expires_at IS NULL OR expires_at > now()), 0)::numeric AS remaining_usd,
+                      COUNT(*)::int AS historical_count
+               FROM team_credit_grant
+               WHERE team_id = p_team_id
+                 AND reason = 'signup trial credit') grant_balance ON true
+    LEFT JOIN team_trial_eligibility_cache cache ON cache.team_id = p_team_id;
+$$;


### PR DESCRIPTION
## Summary

- reuse the existing cumulative trial-enforcement calculation for customer-visible trial state
- expose grant, consumed, remaining, lifecycle state, and eligibility through the existing billing summary contract
- preserve the existing billing rollup and enforcement cadences

## Testing

- add integration coverage for decrementing balance, exhaustion, no-grant behavior, ownership semantics, and Stripe transition

## Testing

- `codex-workflow validate`
