### PR TITLE
resume: emit lookup, claim, vmd, post, and revert phases; skip the binding read when there were never bindings

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -762,6 +762,37 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	sandboxID := sandbox.ID
 	l := sandboxLogger(sandboxID.String(), sandbox.HostID)
 
+	// Phase stamps, registered before ANY return so failed resumes land in
+	// the histograms too (create's discipline): claim is everything before
+	// the boot RPC (policy reads, the resuming claim, snapshot lookup); vmd
+	// is the boot RPC with its retry and the stateless fallback; post is
+	// the policy/egress/secret reapply. A stage that errored before its
+	// end-stamp reports its elapsed time. total stays with the callers,
+	// which own the request-level clock.
+	tStart := time.Now()
+	var tVmdStart, tVmdEnd, tPostDone time.Time
+	defer func() {
+		phases := map[string]time.Duration{}
+		if !tVmdStart.IsZero() {
+			phases["claim"] = tVmdStart.Sub(tStart)
+		} else {
+			phases["claim"] = time.Since(tStart)
+		}
+		switch {
+		case !tVmdEnd.IsZero():
+			phases["vmd"] = tVmdEnd.Sub(tVmdStart)
+		case !tVmdStart.IsZero():
+			phases["vmd"] = time.Since(tVmdStart)
+		}
+		switch {
+		case !tPostDone.IsZero():
+			phases["post"] = tPostDone.Sub(tVmdEnd)
+		case !tVmdEnd.IsZero():
+			phases["post"] = time.Since(tVmdEnd)
+		}
+		RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID, phases)
+	}()
+
 	if !sandbox.SnapshotID.Valid {
 		l.Error().Msg("paused sandbox has no snapshot_id")
 		respondError(c, ErrInternal)
@@ -904,6 +935,12 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// retry, and the stateless fallback all draw down the same 2×vmdTimeout
 	// budget, so a resume holds the row mid-transition for a bounded window
 	// no matter which path it walks.
+
+	// stateless records that the VM came up through the RestoreSnapshot
+	// fallback rather than ResumeInstance; post-boot steps the resume request
+	// already carries (egress rules) are only replayed on that path.
+	stateless := false
+	tVmdStart = time.Now()
 	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdBootTimeout)
 	defer bootCancel()
 	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), sandbox.HostID, func(ctx context.Context) (string, uint32, uint32, error) {
@@ -911,6 +948,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	})
 	if err != nil {
 		if isVMDNotFound(err) {
+			stateless = true
 			l.Warn().Err(err).
 				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
@@ -947,6 +985,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			return "", false
 		}
 	}
+	tVmdEnd = time.Now()
 
 	// Older vmd builds may return 0 for vcpu/mem on both the Resume and
 	// Restore paths (ResourceLimits field was added later). Fall back to
@@ -1052,33 +1091,46 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	// Apply egress rules before committing to 'active' so "active ⇒ rules
-	// applied" holds by construction.
-	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
-		l.Error().Err(err).Msg("reapply network config on resume failed")
-		pauseAndRevert()
-		respondError(c, ErrInternal)
-		return "", false
-	}
-
-	// Re-apply the current binding set before committing to 'active', so a secret
-	// attached or detached while paused takes effect — the snapshot froze the old
-	// JWT. Skipped when there are no bindings, keeping the secret-less resume a
-	// single round trip. The fresh IP binds the re-minted JWT.
-	sandbox.IpAddress = ipAddr
-	if meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID); merr != nil {
-		l.Error().Err(merr).Msg("load secret bindings on resume failed")
-		pauseAndRevert()
-		respondError(c, ErrInternal)
-		return "", false
-	} else if len(meta) > 0 {
-		if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
-			l.Error().Err(aerr).Msg("reapply secret bindings on resume failed")
+	// Egress rules must be in place before committing to 'active' so
+	// "active ⇒ rules applied" holds by construction. ResumeInstance carries
+	// them and the daemon applies them before Firecracker starts, so only
+	// the stateless fallback, whose restore request has no egress field,
+	// needs the separate push.
+	if stateless {
+		if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
+			l.Error().Err(err).Msg("reapply network config on resume failed")
 			pauseAndRevert()
 			respondError(c, ErrInternal)
 			return "", false
 		}
 	}
+
+	// Re-apply the current binding set before committing to 'active', so a secret
+	// attached or detached while paused takes effect — the snapshot froze the old
+	// JWT. The fresh IP binds the re-minted JWT. had_secret_bindings is set by
+	// trigger on the first attach and never cleared, and the claim read it
+	// under the advisory lock attach takes, so a false proves the binding set
+	// is empty and the secret-less resume skips the read entirely. NULL
+	// predates the column and reads as unknown.
+	sandbox.IpAddress = ipAddr
+	if sandbox.HadSecretBindings == nil || *sandbox.HadSecretBindings {
+		meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID)
+		if merr != nil {
+			l.Error().Err(merr).Msg("load secret bindings on resume failed")
+			pauseAndRevert()
+			respondError(c, ErrInternal)
+			return "", false
+		}
+		if len(meta) > 0 {
+			if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
+				l.Error().Err(aerr).Msg("reapply secret bindings on resume failed")
+				pauseAndRevert()
+				respondError(c, ErrInternal)
+				return "", false
+			}
+		}
+	}
+	tPostDone = time.Now()
 
 	// Fire-and-forget: the resuming→active bookkeeping write is off the hot
 	// path. BeginResume's claim owns the row and every other transition is
@@ -1115,6 +1167,12 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
+	l.Info().
+		Int64("claim_ms", tVmdStart.Sub(tStart).Milliseconds()).
+		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
+		Int64("post_ms", tPostDone.Sub(tVmdEnd).Milliseconds()).
+		Bool("stateless", stateless).
+		Msg("ResumeSandbox phases")
 	return currentPolicy.Access, true
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -766,29 +766,44 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// the histograms too (create's discipline): claim is everything before
 	// the boot RPC (policy reads, the resuming claim, snapshot lookup); vmd
 	// is the boot RPC with its retry and the stateless fallback; post is
-	// the policy/egress/secret reapply. A stage that errored before its
-	// end-stamp reports its elapsed time. total stays with the callers,
-	// which own the request-level clock.
+	// the policy/egress/secret reapply. Every stage is stamped the moment
+	// its work returns, success or not, and a compensation that runs before
+	// the reply (revert to paused, re-pause) is reported as its own revert
+	// phase: a re-pause snapshots the guest and must not read as post time.
+	// total stays with the callers, which own the request-level clock.
 	tStart := time.Now()
-	var tVmdStart, tVmdEnd, tPostDone time.Time
+	var tVmdStart, tVmdEnd, tPostStart, tPostDone, tRevertStart time.Time
+	// markRevert is called only on the synchronous failure paths; the
+	// detached activate goroutine compensates after the reply and must not
+	// touch these stamps.
+	markRevert := func() {
+		if tRevertStart.IsZero() {
+			tRevertStart = time.Now()
+		}
+	}
 	defer func() {
+		stageEnd := time.Now()
+		if !tRevertStart.IsZero() {
+			stageEnd = tRevertStart
+		}
 		phases := map[string]time.Duration{}
-		if !tVmdStart.IsZero() {
-			phases["claim"] = tVmdStart.Sub(tStart)
+		if tVmdStart.IsZero() {
+			phases["claim"] = stageEnd.Sub(tStart)
 		} else {
-			phases["claim"] = time.Since(tStart)
+			phases["claim"] = tVmdStart.Sub(tStart)
 		}
-		switch {
-		case !tVmdEnd.IsZero():
+		if !tVmdEnd.IsZero() {
 			phases["vmd"] = tVmdEnd.Sub(tVmdStart)
-		case !tVmdStart.IsZero():
-			phases["vmd"] = time.Since(tVmdStart)
 		}
-		switch {
-		case !tPostDone.IsZero():
-			phases["post"] = tPostDone.Sub(tVmdEnd)
-		case !tVmdEnd.IsZero():
-			phases["post"] = time.Since(tVmdEnd)
+		if !tPostStart.IsZero() {
+			if tPostDone.IsZero() {
+				phases["post"] = stageEnd.Sub(tPostStart)
+			} else {
+				phases["post"] = tPostDone.Sub(tPostStart)
+			}
+		}
+		if !tRevertStart.IsZero() {
+			phases["revert"] = time.Since(tRevertStart)
 		}
 		RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID, phases)
 	}()
@@ -895,6 +910,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	})
 	if err != nil {
 		l.Error().Err(err).Msg("DB GetSnapshot failed")
+		markRevert()
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return "", false
@@ -922,6 +938,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
 	if vmdLookupErr != nil {
 		l.Error().Err(vmdLookupErr).Msg("resolve VMD for resume failed")
+		markRevert()
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return "", false
@@ -935,20 +952,15 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// retry, and the stateless fallback all draw down the same 2×vmdTimeout
 	// budget, so a resume holds the row mid-transition for a bounded window
 	// no matter which path it walks.
-
-	// stateless records that the VM came up through the RestoreSnapshot
-	// fallback rather than ResumeInstance; post-boot steps the resume request
-	// already carries (egress rules) are only replayed on that path.
-	stateless := false
 	tVmdStart = time.Now()
 	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdBootTimeout)
 	defer bootCancel()
 	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), sandbox.HostID, func(ctx context.Context) (string, uint32, uint32, error) {
 		return vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath, sandbox.NetworkConfig)
 	})
+	tVmdEnd = time.Now()
 	if err != nil {
 		if isVMDNotFound(err) {
-			stateless = true
 			l.Warn().Err(err).
 				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
@@ -967,12 +979,14 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 				// exists; declaring it spares the daemon a probe.
 				vmdclient.ResourceLimits{VCPU: uint32(sandbox.VcpuCount), MemoryMiB: uint32(sandbox.MemoryMib)})
 			fcancel()
+			tVmdEnd = time.Now()
 			if err != nil {
 				l.Error().Err(err).Msg("VMD RestoreSnapshot fallback failed")
 				// Deliberately no destroy for a boot that may land late: the
 				// row reverts to paused, so a follow-up resume on this ID
 				// adopts the live VM (instant resume), and the reconciler
 				// reaps the paused-row/active-VM state if no retry comes.
+				markRevert()
 				revertToPaused()
 				respondError(c, ErrInternal)
 				return "", false
@@ -980,12 +994,13 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		} else {
 			l.Error().Err(err).Msg("VMD ResumeInstance failed")
 			// Same deliberate no-destroy as the fallback branch above.
+			markRevert()
 			revertToPaused()
 			respondError(c, ErrInternal)
 			return "", false
 		}
 	}
-	tVmdEnd = time.Now()
+	tPostStart = time.Now()
 
 	// Older vmd builds may return 0 for vcpu/mem on both the Resume and
 	// Restore paths (ResourceLimits field was added later). Fall back to
@@ -1059,11 +1074,17 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// the stateless restore while VMD returns NotFound to the mutation push; this
 	// final authoritative snapshot closes that window. If a later mutation wins,
 	// VMD's monotonic revision check rejects this older snapshot.
-	currentPolicy, policyErr := h.loadPreviewPolicySnapshot(postCtx, sandboxID, teamID)
-	if policyErr != nil {
-		l.Error().Err(policyErr).Msg("reload preview policy after resume failed")
+	// failPost is the post-stage failure path: the VM is up, so the row is
+	// re-paused rather than destroyed (see pauseAndRevert).
+	failPost := func(err error, msg string) {
+		markRevert()
+		l.Error().Err(err).Msg(msg)
 		pauseAndRevert()
 		respondError(c, ErrInternal)
+	}
+	currentPolicy, policyErr := h.loadPreviewPolicySnapshot(postCtx, sandboxID, teamID)
+	if policyErr != nil {
+		failPost(policyErr, "reload preview policy after resume failed")
 		return "", false
 	}
 	// A private publication may have changed while the VM was restoring. Gate
@@ -1072,6 +1093,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// concurrently-added browser policy on a downgraded host.
 	if currentPolicy.requiresBrowserCapability() {
 		if capabilityErr := validateHostPreviewBrowserCapabilities(postCtx, h.DB, sandbox.HostID); capabilityErr != nil {
+			markRevert()
 			pauseAndRevert()
 			h.handlePreviewMutationResult(c, sandboxID, "ReapplyPreviewBrowserAuthAfterResume", capabilityErr)
 			return "", false
@@ -1084,25 +1106,20 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			// never take this fallback.
 			l.Warn().Msg("vmd lacks preview policy update for legacy resume")
 		} else {
-			l.Error().Err(policyErr).Msg("reapply preview policy after resume failed")
-			pauseAndRevert()
-			respondError(c, ErrInternal)
+			failPost(policyErr, "reapply preview policy after resume failed")
 			return "", false
 		}
 	}
 
-	// Egress rules must be in place before committing to 'active' so
-	// "active ⇒ rules applied" holds by construction. ResumeInstance carries
-	// them and the daemon applies them before Firecracker starts, so only
-	// the stateless fallback, whose restore request has no egress field,
-	// needs the separate push.
-	if stateless {
-		if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
-			l.Error().Err(err).Msg("reapply network config on resume failed")
-			pauseAndRevert()
-			respondError(c, ErrInternal)
-			return "", false
-		}
+	// Apply egress rules before committing to 'active' so "active ⇒ rules
+	// applied" holds by construction. ResumeInstance carries the same rules,
+	// but the daemon's retry-adoption branch returns a running VM without
+	// applying them and its in-memory proxy rules do not survive a restart,
+	// so this replay stays until the daemon applies rules on adoption and
+	// acknowledges it in the response.
+	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
+		failPost(err, "reapply network config on resume failed")
+		return "", false
 	}
 
 	// Re-apply the current binding set before committing to 'active', so a secret
@@ -1116,16 +1133,12 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	if sandbox.HadSecretBindings == nil || *sandbox.HadSecretBindings {
 		meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID)
 		if merr != nil {
-			l.Error().Err(merr).Msg("load secret bindings on resume failed")
-			pauseAndRevert()
-			respondError(c, ErrInternal)
+			failPost(merr, "load secret bindings on resume failed")
 			return "", false
 		}
 		if len(meta) > 0 {
 			if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
-				l.Error().Err(aerr).Msg("reapply secret bindings on resume failed")
-				pauseAndRevert()
-				respondError(c, ErrInternal)
+				failPost(aerr, "reapply secret bindings on resume failed")
 				return "", false
 			}
 		}
@@ -1167,12 +1180,6 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
-	l.Info().
-		Int64("claim_ms", tVmdStart.Sub(tStart).Milliseconds()).
-		Int64("vmd_ms", tVmdEnd.Sub(tVmdStart).Milliseconds()).
-		Int64("post_ms", tPostDone.Sub(tVmdEnd).Milliseconds()).
-		Bool("stateless", stateless).
-		Msg("ResumeSandbox phases")
 	return currentPolicy.Access, true
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1340,11 +1340,14 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	// settle window and then 409s is among the slowest resume requests and
 	// must land in the total distribution. Transition counts/results come
 	// from the SandboxLifecycleTelemetry middleware; this emits total and
-	// lookup, which ends at the resume claim and includes any settle wait.
+	// lookup, which ends at the resume claim, or at the reply when the
+	// request never gets there, so a settle-window 409 lands in lookup too.
 	// HostID is empty until the row loads.
 	defer func() {
 		phases := map[string]time.Duration{"total": time.Since(tResume)}
-		if !tLookupDone.IsZero() {
+		if tLookupDone.IsZero() {
+			phases["lookup"] = phases["total"]
+		} else {
 			phases["lookup"] = tLookupDone.Sub(tResume)
 		}
 		RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID, phases)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -727,11 +727,18 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 			}
 			// The resume returns the post-restore access it pushed to VMD, so
 			// the response reports exactly what the VM enforces.
+			// lookup runs from the auth boundary to here: the row read and any
+			// starting/resuming settle wait above. total is unchanged and
+			// measures the resume work alone, so on this path it excludes
+			// lookup, where the explicit endpoint's total includes it. This
+			// route is not a lifecycle op for the auth middleware, so claiming
+			// the series here silences nothing.
+			tAuth := PhaseStart(c)
 			tResume := time.Now()
 			resumedAccess, ok := h.resumePausedSandbox(c, &sandbox, teamID)
 			// Emitted for failures too — auto-resume totals must not censor.
 			RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID,
-				map[string]time.Duration{"total": time.Since(tResume)})
+				map[string]time.Duration{"total": time.Since(tResume), "lookup": tResume.Sub(tAuth)})
 			if !ok {
 				return nil, ""
 			}
@@ -1341,14 +1348,22 @@ func (h *Handlers) ActivateSandbox(c *gin.Context) {
 func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	tResume := PhaseStart(c)
 	var sandbox db.Sandbox
+	var tLookupDone time.Time
 	// Registered before ANY return: a resume that burns the whole pausing
 	// settle window and then 409s is among the slowest resume requests and
 	// must land in the total distribution. Transition counts/results come
-	// from the SandboxLifecycleTelemetry middleware; this emits only the
-	// phase-series total. HostID is empty until the row loads.
+	// from the SandboxLifecycleTelemetry middleware; this emits the
+	// phase-series total and lookup. lookup runs from the auth boundary to
+	// the resume claim (auth, the row read, and any pausing-settle wait,
+	// which RecordResumeSettleWait also reports on its own), so lookup +
+	// claim + vmd + post + revert partitions total. HostID is empty until
+	// the row loads.
 	defer func() {
-		RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID,
-			map[string]time.Duration{"total": time.Since(tResume)})
+		phases := map[string]time.Duration{"total": time.Since(tResume)}
+		if !tLookupDone.IsZero() {
+			phases["lookup"] = tLookupDone.Sub(tResume)
+		}
+		RecordLatencyPhases(c.Request.Context(), "resume", sandbox.HostID, phases)
 	}()
 	sandboxID, err := parseSandboxID(c)
 	if err != nil {
@@ -1448,6 +1463,7 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 		return
 	}
 
+	tLookupDone = time.Now()
 	if _, ok := h.resumePausedSandbox(c, &sandbox, teamID); !ok {
 		return
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -727,12 +727,9 @@ func (h *Handlers) loadActiveOrResumeSandbox(c *gin.Context) (*db.Sandbox, strin
 			}
 			// The resume returns the post-restore access it pushed to VMD, so
 			// the response reports exactly what the VM enforces.
-			// lookup runs from the auth boundary to here: the row read and any
-			// starting/resuming settle wait above. total is unchanged and
-			// measures the resume work alone, so on this path it excludes
-			// lookup, where the explicit endpoint's total includes it. This
-			// route is not a lifecycle op for the auth middleware, so claiming
-			// the series here silences nothing.
+			// lookup ends here, from the auth boundary. total covers the resume
+			// work alone on this path (the explicit endpoint's includes lookup).
+			// The route is not a lifecycle op, so PhaseStart silences nothing.
 			tAuth := PhaseStart(c)
 			tResume := time.Now()
 			resumedAccess, ok := h.resumePausedSandbox(c, &sandbox, teamID)
@@ -769,20 +766,15 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	sandboxID := sandbox.ID
 	l := sandboxLogger(sandboxID.String(), sandbox.HostID)
 
-	// Phase stamps, registered before ANY return so failed resumes land in
-	// the histograms too (create's discipline): claim is everything before
-	// the boot RPC (policy reads, the resuming claim, snapshot lookup); vmd
-	// is the boot RPC with its retry and the stateless fallback; post is
-	// the policy/egress/secret reapply. Every stage is stamped the moment
-	// its work returns, success or not, and a compensation that runs before
-	// the reply (revert to paused, re-pause) is reported as its own revert
-	// phase: a re-pause snapshots the guest and must not read as post time.
-	// total stays with the callers, which own the request-level clock.
+	// Registered before ANY return so failed resumes land in the histograms
+	// too. claim = before the boot RPC, vmd = the boot RPC (retry and
+	// stateless fallback included), post = the reapply steps, revert = any
+	// compensation run before the reply, kept separate because a re-pause
+	// snapshots the guest. total is emitted by the callers.
 	tStart := time.Now()
 	var tVmdStart, tVmdEnd, tPostStart, tPostDone, tRevertStart time.Time
-	// markRevert is called only on the synchronous failure paths; the
-	// detached activate goroutine compensates after the reply and must not
-	// touch these stamps.
+	// Synchronous failure paths only: the detached activate goroutine
+	// compensates after the reply and must not touch these stamps.
 	markRevert := func() {
 		if tRevertStart.IsZero() {
 			tRevertStart = time.Now()
@@ -1081,8 +1073,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// the stateless restore while VMD returns NotFound to the mutation push; this
 	// final authoritative snapshot closes that window. If a later mutation wins,
 	// VMD's monotonic revision check rejects this older snapshot.
-	// failPost is the post-stage failure path: the VM is up, so the row is
-	// re-paused rather than destroyed (see pauseAndRevert).
+	// Post-stage failure: the VM is up, so re-pause rather than destroy.
 	failPost := func(err error, msg string) {
 		markRevert()
 		l.Error().Err(err).Msg(msg)
@@ -1120,10 +1111,8 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 
 	// Apply egress rules before committing to 'active' so "active ⇒ rules
 	// applied" holds by construction. ResumeInstance carries the same rules,
-	// but the daemon's retry-adoption branch returns a running VM without
-	// applying them and its in-memory proxy rules do not survive a restart,
-	// so this replay stays until the daemon applies rules on adoption and
-	// acknowledges it in the response.
+	// but the daemon's retry adoption returns a running VM without applying
+	// them, and its proxy rules do not survive a restart.
 	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
 		failPost(err, "reapply network config on resume failed")
 		return "", false
@@ -1131,11 +1120,9 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 
 	// Re-apply the current binding set before committing to 'active', so a secret
 	// attached or detached while paused takes effect — the snapshot froze the old
-	// JWT. The fresh IP binds the re-minted JWT. had_secret_bindings is set by
-	// trigger on the first attach and never cleared, and the claim read it
-	// under the advisory lock attach takes, so a false proves the binding set
-	// is empty and the secret-less resume skips the read entirely. NULL
-	// predates the column and reads as unknown.
+	// JWT. The fresh IP binds the re-minted JWT. had_secret_bindings is
+	// trigger-set on first attach, never cleared, and was read under the lock
+	// attach takes, so false proves an empty set; NULL predates the column.
 	sandbox.IpAddress = ipAddr
 	if sandbox.HadSecretBindings == nil || *sandbox.HadSecretBindings {
 		meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID)
@@ -1352,12 +1339,9 @@ func (h *Handlers) ResumeSandbox(c *gin.Context) {
 	// Registered before ANY return: a resume that burns the whole pausing
 	// settle window and then 409s is among the slowest resume requests and
 	// must land in the total distribution. Transition counts/results come
-	// from the SandboxLifecycleTelemetry middleware; this emits the
-	// phase-series total and lookup. lookup runs from the auth boundary to
-	// the resume claim (auth, the row read, and any pausing-settle wait,
-	// which RecordResumeSettleWait also reports on its own), so lookup +
-	// claim + vmd + post + revert partitions total. HostID is empty until
-	// the row loads.
+	// from the SandboxLifecycleTelemetry middleware; this emits total and
+	// lookup, which ends at the resume claim and includes any settle wait.
+	// HostID is empty until the row loads.
 	defer func() {
 		phases := map[string]time.Duration{"total": time.Since(tResume)}
 		if !tLookupDone.IsZero() {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1657,9 +1657,8 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 // paused, and never flip status to active.
 // A resume that gets the VM up but then fails to reapply egress rules must
 // re-pause the VM (preserving the overlay), never destroy it.
-// The separate egress push only runs on the stateless fallback: the resume
-// request itself carries the rules and the daemon applies them before the
-// VM starts, so this drives ResumeInstance to NotFound to reach the push.
+// A post-stage failure re-pauses the VM before replying; the phase series
+// must report that compensation as revert, not as post time.
 func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
@@ -1671,12 +1670,13 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
 	}
 
+	rec := &captureTelemetryRecorder{}
+	SetTelemetryRecorder(rec)
+	t.Cleanup(func() { SetTelemetryRecorder(nil) })
+
 	var destroyCalled, pauseCalled, updateNetworkCalled, finalizeCalled, activateCalled int32
 	vmd := &stubVMD{
 		resumeFn: func(context.Context, string, string, string, []byte) (string, error) {
-			return "", status.Error(codes.NotFound, "vm absent after vmd restart")
-		},
-		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "10.0.0.5", nil
 		},
 		destroyFn: func(context.Context, string, bool) error {
@@ -1739,14 +1739,24 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	if got := atomic.LoadInt32(&activateCalled); got != 0 {
 		t.Errorf("ActivateSandbox calls = %d, want 0 (network failed before commit)", got)
 	}
+	phases := map[string]bool{}
+	for _, p := range rec.phases {
+		if p.Op == "resume" {
+			phases[p.Phase] = true
+		}
+	}
+	for _, want := range []string{"claim", "vmd", "post", "revert"} {
+		if !phases[want] {
+			t.Errorf("failed resume must record phase %q; got %v", want, phases)
+		}
+	}
 }
 
-// A tracked resume carries the egress rules in the ResumeInstance request
-// and the daemon applies them before Firecracker starts; the control plane
-// must not spend a second host round trip re-sending the same rules. The
-// phase emission is asserted here too: claim, vmd, and post must land for
-// a successful resume alongside the caller-owned total.
-func TestResumeSandbox_TrackedResumeCarriesRulesAndSkipsReapply(t *testing.T) {
+// A successful resume records claim, vmd, and post alongside the
+// caller-owned total, and no revert. The persisted egress rules ride the
+// ResumeInstance request itself, which is what will let the post-boot
+// replay go once the daemon acknowledges applying them.
+func TestResumeSandbox_EmitsPhasesAndCarriesRulesInResumeRequest(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	snapshotID := uuid.New()
@@ -1762,16 +1772,11 @@ func TestResumeSandbox_TrackedResumeCarriesRulesAndSkipsReapply(t *testing.T) {
 	SetTelemetryRecorder(rec)
 	t.Cleanup(func() { SetTelemetryRecorder(nil) })
 
-	var updateNetworkCalled int32
 	var resumeNetworkConfig []byte
 	vmd := &stubVMD{
 		resumeFn: func(_ context.Context, _, _, _ string, networkConfig []byte) (string, error) {
 			resumeNetworkConfig = networkConfig
 			return "10.0.0.5", nil
-		},
-		updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
-			atomic.AddInt32(&updateNetworkCalled, 1)
-			return nil
 		},
 	}
 
@@ -1803,9 +1808,6 @@ func TestResumeSandbox_TrackedResumeCarriesRulesAndSkipsReapply(t *testing.T) {
 	if len(resumeNetworkConfig) == 0 {
 		t.Fatal("ResumeInstance must carry the persisted egress rules")
 	}
-	if got := atomic.LoadInt32(&updateNetworkCalled); got != 0 {
-		t.Errorf("UpdateSandboxNetwork calls = %d, want 0 (rules already applied by the resume request)", got)
-	}
 	got := map[string]bool{}
 	for _, p := range rec.phases {
 		if p.Op == "resume" && p.HostID == "host-a" {
@@ -1816,6 +1818,9 @@ func TestResumeSandbox_TrackedResumeCarriesRulesAndSkipsReapply(t *testing.T) {
 		if !got[want] {
 			t.Errorf("resume phase %q not recorded; got %v", want, got)
 		}
+	}
+	if got["revert"] {
+		t.Error("a successful resume must not record a revert phase")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1753,9 +1753,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 }
 
 // A successful resume records lookup, claim, vmd, and post alongside the
-// caller-owned total, and no revert. The persisted egress rules ride the
-// ResumeInstance request itself, which is what will let the post-boot
-// replay go once the daemon acknowledges applying them.
+// caller-owned total, and no revert; the egress rules ride the request.
 func TestResumeSandbox_EmitsPhasesAndCarriesRulesInResumeRequest(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
@@ -1824,9 +1822,8 @@ func TestResumeSandbox_EmitsPhasesAndCarriesRulesInResumeRequest(t *testing.T) {
 	}
 }
 
-// had_secret_bindings=false proves the binding set is empty, so the resume
-// must not spend a round trip on the binding read or a guest round trip on
-// an inject.
+// had_secret_bindings=false proves the binding set is empty: no binding
+// read, no inject.
 func TestResumeSandbox_NoBindingsSkipsBindingRead(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1752,7 +1752,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	}
 }
 
-// A successful resume records claim, vmd, and post alongside the
+// A successful resume records lookup, claim, vmd, and post alongside the
 // caller-owned total, and no revert. The persisted egress rules ride the
 // ResumeInstance request itself, which is what will let the post-boot
 // replay go once the daemon acknowledges applying them.
@@ -1814,7 +1814,7 @@ func TestResumeSandbox_EmitsPhasesAndCarriesRulesInResumeRequest(t *testing.T) {
 			got[p.Phase] = true
 		}
 	}
-	for _, want := range []string{"claim", "vmd", "post", "total"} {
+	for _, want := range []string{"lookup", "claim", "vmd", "post", "total"} {
 		if !got[want] {
 			t.Errorf("resume phase %q not recorded; got %v", want, got)
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1657,6 +1657,9 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 // paused, and never flip status to active.
 // A resume that gets the VM up but then fails to reapply egress rules must
 // re-pause the VM (preserving the overlay), never destroy it.
+// The separate egress push only runs on the stateless fallback: the resume
+// request itself carries the rules and the daemon applies them before the
+// VM starts, so this drives ResumeInstance to NotFound to reach the push.
 func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
@@ -1671,6 +1674,9 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	var destroyCalled, pauseCalled, updateNetworkCalled, finalizeCalled, activateCalled int32
 	vmd := &stubVMD{
 		resumeFn: func(context.Context, string, string, string, []byte) (string, error) {
+			return "", status.Error(codes.NotFound, "vm absent after vmd restart")
+		},
+		restoreFn: func(context.Context, string, string, string) (string, error) {
 			return "10.0.0.5", nil
 		},
 		destroyFn: func(context.Context, string, bool) error {
@@ -1732,6 +1738,145 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&activateCalled); got != 0 {
 		t.Errorf("ActivateSandbox calls = %d, want 0 (network failed before commit)", got)
+	}
+}
+
+// A tracked resume carries the egress rules in the ResumeInstance request
+// and the daemon applies them before Firecracker starts; the control plane
+// must not spend a second host round trip re-sending the same rules. The
+// phase emission is asserted here too: claim, vmd, and post must land for
+// a successful resume alongside the caller-owned total.
+func TestResumeSandbox_TrackedResumeCarriesRulesAndSkipsReapply(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	sb.HostID = "host-a"
+	sb.NetworkConfig = []byte(`{"egress":{"allowed_cidrs":["10.0.0.0/8"]}}`)
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
+	}
+
+	rec := &captureTelemetryRecorder{}
+	SetTelemetryRecorder(rec)
+	t.Cleanup(func() { SetTelemetryRecorder(nil) })
+
+	var updateNetworkCalled int32
+	var resumeNetworkConfig []byte
+	vmd := &stubVMD{
+		resumeFn: func(_ context.Context, _, _, _ string, networkConfig []byte) (string, error) {
+			resumeNetworkConfig = networkConfig
+			return "10.0.0.5", nil
+		},
+		updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
+			atomic.AddInt32(&updateNetworkCalled, 1)
+			return nil
+		},
+	}
+
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	h.WaitAsyncBookkeeping()
+
+	if len(resumeNetworkConfig) == 0 {
+		t.Fatal("ResumeInstance must carry the persisted egress rules")
+	}
+	if got := atomic.LoadInt32(&updateNetworkCalled); got != 0 {
+		t.Errorf("UpdateSandboxNetwork calls = %d, want 0 (rules already applied by the resume request)", got)
+	}
+	got := map[string]bool{}
+	for _, p := range rec.phases {
+		if p.Op == "resume" && p.HostID == "host-a" {
+			got[p.Phase] = true
+		}
+	}
+	for _, want := range []string{"claim", "vmd", "post", "total"} {
+		if !got[want] {
+			t.Errorf("resume phase %q not recorded; got %v", want, got)
+		}
+	}
+}
+
+// had_secret_bindings=false proves the binding set is empty, so the resume
+// must not spend a round trip on the binding read or a guest round trip on
+// an inject.
+func TestResumeSandbox_NoBindingsSkipsBindingRead(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	noBindings := false
+	sb.HadSecretBindings = &noBindings
+	snap := db.Snapshot{ID: snapshotID, SandboxID: sandboxID, TeamID: teamID, Path: "/snapshots/test/vmstate.snap", Trigger: "pause"}
+
+	var injectCalled bool
+	vmd := &stubVMD{
+		resumeFn: func(_ context.Context, _, _, _ string, _ []byte) (string, error) { return "10.0.0.5", nil },
+		injectEnvFn: func(context.Context, string, map[string]string, string) error {
+			injectCalled = true
+			return nil
+		},
+	}
+
+	var bindingReads int32
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "'resuming'"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			case strings.Contains(sql, "FROM snapshot"):
+				return snapshotRow(snap)
+			default:
+				return activityRow()
+			}
+		},
+		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+			if strings.Contains(sql, "ListSandboxSecretBindingMeta") {
+				atomic.AddInt32(&bindingReads, 1)
+			}
+			return &scanRows{}, nil
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, "v1")}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	h.WaitAsyncBookkeeping()
+	if got := atomic.LoadInt32(&bindingReads); got != 0 {
+		t.Errorf("ListSandboxSecretBindingMeta reads = %d, want 0", got)
+	}
+	if injectCalled {
+		t.Error("no bindings to reapply; InjectSandboxEnv must not be called")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1488,6 +1488,10 @@ func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
 	teamID := uuid.New()
 	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusPausing}
 
+	rec := &captureTelemetryRecorder{}
+	SetTelemetryRecorder(rec)
+	t.Cleanup(func() { SetTelemetryRecorder(nil) })
+
 	var reads int32
 	mock := &mockDBTX{
 		queryRowFn: func(context.Context, string, ...any) pgx.Row {
@@ -1501,6 +1505,22 @@ func TestResumeSandbox_PersistentPausing_409(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+	// The whole settle window is lookup time; a 409 must not censor it.
+	var lookup, total time.Duration
+	for _, p := range rec.phases {
+		if p.Op != "resume" {
+			continue
+		}
+		switch p.Phase {
+		case "lookup":
+			lookup = p.Duration
+		case "total":
+			total = p.Duration
+		}
+	}
+	if lookup < pausingSettleWindow || lookup != total {
+		t.Errorf("lookup = %v, total = %v; a settle-window 409 must record lookup = total >= %v", lookup, total, pausingSettleWindow)
 	}
 	// A fixed 50ms poll over this 1s window would read ~20 times; the
 	// backed-off poll (50ms doubling up to 500ms) should land around 6 and

--- a/internal/api/telemetry_test.go
+++ b/internal/api/telemetry_test.go
@@ -16,6 +16,7 @@ import (
 
 type captureTelemetryRecorder struct {
 	transitions []telemetry.SandboxTransition
+	phases      []telemetry.LatencyPhase
 }
 
 func (r *captureTelemetryRecorder) RecordSandboxTransition(_ context.Context, t telemetry.SandboxTransition) {
@@ -24,8 +25,10 @@ func (r *captureTelemetryRecorder) RecordSandboxTransition(_ context.Context, t 
 
 func (r *captureTelemetryRecorder) RecordSandboxResumeSettleWait(context.Context, telemetry.SandboxResumeSettleWait) {
 }
-func (r *captureTelemetryRecorder) RecordVMDCall(context.Context, telemetry.VMDCall)           {}
-func (r *captureTelemetryRecorder) RecordLatencyPhase(context.Context, telemetry.LatencyPhase) {}
+func (r *captureTelemetryRecorder) RecordVMDCall(context.Context, telemetry.VMDCall) {}
+func (r *captureTelemetryRecorder) RecordLatencyPhase(_ context.Context, p telemetry.LatencyPhase) {
+	r.phases = append(r.phases, p)
+}
 func (r *captureTelemetryRecorder) RecordHostResolution(context.Context, telemetry.HostResolution) {
 }
 func (r *captureTelemetryRecorder) RecordCapacityShadow(context.Context, telemetry.CapacityShadow) {


### PR DESCRIPTION
Resume now emits lookup, claim, vmd, post, and revert phases the way create does, so the control-plane share of resume latency is measurable per stage and a failed resume's compensation is reported on its own rather than inflating the stage it follows. On the explicit endpoint the stage phases partition total; on the auto-resume path total is unchanged and measures the resume work alone.
The secret-binding read is skipped when had_secret_bindings is false on the claimed row; the flag is trigger-set, never cleared, and read under the same advisory lock binding mutations take.
The post-boot egress replay is unchanged: the daemon's retry-adoption branch returns a running VM without applying rules and its proxy rules do not survive a restart, so dropping the replay waits for the daemon to apply rules on adoption and acknowledge it in the response.