### PR TITLE
resume: one-statement claim carrying the snapshot paths, preview policy, ports, and base path

### DIFF
--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -494,13 +494,18 @@ RETURNING *;
 -- The paused→resuming claim plus the boot inputs in one round trip:
 -- snapshot paths, preview policy with published ports, template base path.
 -- The advisory lock is the one attach/detach take before re-reading
--- status; taken before the update and held to statement end, so the
--- returned row already reflects a binding mutation that beat the claim.
+-- status; held to statement end, so the returned row already reflects a
+-- binding mutation that beat the claim. It rides a FROM item joined on
+-- the row key: the planner keeps a volatile target there, whereas an
+-- EXISTS subquery has its target list dropped and never takes the lock.
 -- LEFT joins keep the row when the snapshot or policy row is missing.
 -- 0 rows: not paused, or another resume claimed it.
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 FROM (
+  SELECT @id::uuid AS id
+  FROM (SELECT pg_advisory_xact_lock(hashtext(@lock_key::text)::bigint)) locked
+) lk, (
   SELECT sb.id,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
@@ -526,9 +531,8 @@ FROM (
   ) pp ON true
   WHERE sb.id = @id AND sb.team_id = @team_id
 ) x
-WHERE sandbox.id = x.id
+WHERE sandbox.id = lk.id AND sandbox.id = x.id
   AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
-  AND EXISTS (SELECT pg_advisory_xact_lock(hashtext(@lock_key::text)::bigint))
 RETURNING sqlc.embed(sandbox),
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -490,6 +490,55 @@ SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
 RETURNING *;
 
+-- name: ClaimResume :one
+-- The resume claim and everything the boot RPC needs in one round trip:
+-- paused→resuming, the snapshot's artifact paths, the preview policy with
+-- its published ports, and the template base path for rows that predate
+-- base_path pinning. The advisory lock is the one attach and detach take
+-- before re-reading status. It is acquired before the row is updated and
+-- released at statement end, so the returned row and the binding set agree:
+-- a mutation holding the lock lands first and shows in the row, or arrives
+-- later and sees 'resuming'. The side joins are LEFT so a missing snapshot
+-- row (NULL snap_path) or a legacy sandbox with no policy row still returns
+-- the claimed row for the caller to handle. 0 rows means another resume
+-- claimed it or it is not paused.
+UPDATE sandbox
+SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
+FROM (
+  SELECT sb.id,
+         s.path AS snap_path,
+         s.mem_path AS snap_mem_path,
+         COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
+         COALESCE(p.access, 'legacy_public')::text AS wire_access,
+         COALESCE(p.revision, 0)::bigint AS revision,
+         COALESCE(pp.ports, '{}')::int[] AS port_numbers,
+         COALESCE(pp.accesses, '{}')::text[] AS port_accesses,
+         COALESCE(pp.token_versions, '{}')::bigint[] AS port_token_versions,
+         t.base_path AS template_base_path
+  FROM sandbox sb
+  LEFT JOIN snapshot s ON s.id = sb.snapshot_id AND s.team_id = sb.team_id
+  LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = sb.id
+  LEFT JOIN template t ON t.id = sb.template_id
+  LEFT JOIN LATERAL (
+    SELECT array_agg(pp.port ORDER BY pp.port) AS ports,
+           array_agg(pp.access ORDER BY pp.port) AS accesses,
+           array_agg(g.token_version ORDER BY pp.port) AS token_versions
+    FROM sandbox_published_port pp
+    JOIN sandbox_preview_port_token_generation g
+      ON g.sandbox_id = pp.sandbox_id AND g.port = pp.port
+    WHERE pp.sandbox_id = sb.id AND g.token_version > 0
+  ) pp ON true
+  WHERE sb.id = @id AND sb.team_id = @team_id
+) x
+WHERE sandbox.id = x.id
+  AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
+  AND EXISTS (SELECT pg_advisory_xact_lock(hashtext(@lock_key::text)::bigint))
+RETURNING sqlc.embed(sandbox),
+          x.snap_path, x.snap_mem_path,
+          x.access, x.wire_access, x.revision,
+          x.port_numbers, x.port_accesses, x.port_token_versions,
+          x.template_base_path;
+
 -- name: RevertResumeToPaused :exec
 -- Compensate a failed resume attempt by flipping status back to 'paused'.
 -- Guarded on status = 'resuming' so we never clobber a concurrent transition

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -491,17 +491,13 @@ WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
 RETURNING *;
 
 -- name: ClaimResume :one
--- The resume claim and everything the boot RPC needs in one round trip:
--- paused→resuming, the snapshot's artifact paths, the preview policy with
--- its published ports, and the template base path for rows that predate
--- base_path pinning. The advisory lock is the one attach and detach take
--- before re-reading status. It is acquired before the row is updated and
--- released at statement end, so the returned row and the binding set agree:
--- a mutation holding the lock lands first and shows in the row, or arrives
--- later and sees 'resuming'. The side joins are LEFT so a missing snapshot
--- row (NULL snap_path) or a legacy sandbox with no policy row still returns
--- the claimed row for the caller to handle. 0 rows means another resume
--- claimed it or it is not paused.
+-- The paused→resuming claim plus the boot inputs in one round trip:
+-- snapshot paths, preview policy with published ports, template base path.
+-- The advisory lock is the one attach/detach take before re-reading
+-- status; taken before the update and held to statement end, so the
+-- returned row already reflects a binding mutation that beat the claim.
+-- LEFT joins keep the row when the snapshot or policy row is missing.
+-- 0 rows: not paused, or another resume claimed it.
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 FROM (

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -222,6 +222,8 @@ WHERE id = $1 AND team_id = $5 AND destroyed_at IS NULL;
 WITH activated AS (
   UPDATE sandbox
   SET status = 'active',
+      -- The claim left the paused deadline on the row; it ends here.
+      auto_delete_at = NULL,
       vcpu_count = $2,
       memory_mib = $3,
       ip_address = $4,
@@ -499,17 +501,17 @@ RETURNING *;
 -- the row key: the planner keeps a volatile target there, whereas an
 -- EXISTS subquery has its target list dropped and never takes the lock.
 -- LEFT joins keep the row when the snapshot or policy row is missing.
--- prior_auto_delete_at is the deadline the claim clears, handed back by a
--- revert that never reached the daemon.
+-- The auto-delete deadline stays on the row: the reaper acts on paused rows
+-- only, a failed resume returns the row to paused with the deadline it had,
+-- and activation clears it.
 -- 0 rows: not paused, or another resume claimed it.
 UPDATE sandbox
-SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
+SET status = 'resuming', updated_at = now()
 FROM (
   SELECT @id::uuid AS id
   FROM (SELECT pg_advisory_xact_lock(hashtext(@lock_key::text)::bigint)) locked
 ) lk, (
   SELECT sb.id,
-         sb.auto_delete_at AS prior_auto_delete_at,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
@@ -540,7 +542,7 @@ RETURNING sqlc.embed(sandbox),
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
-          x.template_base_path, x.prior_auto_delete_at;
+          x.template_base_path;
 
 -- name: RevertResumeToPaused :exec
 -- Compensate a failed resume attempt by flipping status back to 'paused'.
@@ -548,18 +550,11 @@ RETURNING sqlc.embed(sandbox),
 -- (e.g., ActivateSandbox has already flipped to 'active').
 UPDATE sandbox
 SET status = 'paused',
-    -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
-    -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands back the deadline the claim saw instead, so
-    -- retrying it cannot postpone deletion. It is restored only while the
-    -- row is untouched since the claim: an auto-delete patch, even one that
-    -- repeats the value, bumps updated_at and leaves the deadline NULL for
-    -- the return to paused, so it is armed from the current window here.
-    auto_delete_at = CASE
-      WHEN updated_at = sqlc.narg('claimed_updated_at')::timestamptz
-      THEN sqlc.narg('prior_auto_delete_at')::timestamptz
-      ELSE now() + make_interval(secs => auto_delete_seconds)
-    END,
+    -- The claim leaves the deadline in place, so a failed resume returns the
+    -- row to paused with the deadline it had and retrying cannot postpone
+    -- deletion. An auto-delete patch made while resuming leaves the deadline
+    -- NULL for the return to paused, so it is armed from the window here.
+    auto_delete_at = COALESCE(auto_delete_at, now() + make_interval(secs => auto_delete_seconds)),
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -550,10 +550,15 @@ UPDATE sandbox
 SET status = 'paused',
     -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
     -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands the prior deadline back instead, so retrying
-    -- it cannot postpone deletion.
-    auto_delete_at = COALESCE(sqlc.narg('prior_auto_delete_at')::timestamptz,
-                             now() + make_interval(secs => auto_delete_seconds)),
+    -- reached the daemon hands back the deadline and window the claim saw
+    -- instead, so retrying it cannot postpone deletion. A window patched
+    -- while the row was resuming wins: the patch left the deadline NULL for
+    -- the return to paused, so it is armed from the new window here.
+    auto_delete_at = CASE
+      WHEN auto_delete_seconds IS NOT DISTINCT FROM sqlc.narg('prior_auto_delete_seconds')::int
+      THEN sqlc.narg('prior_auto_delete_at')::timestamptz
+      ELSE now() + make_interval(secs => auto_delete_seconds)
+    END,
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -550,12 +550,13 @@ UPDATE sandbox
 SET status = 'paused',
     -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
     -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands back the deadline and window the claim saw
-    -- instead, so retrying it cannot postpone deletion. A window patched
-    -- while the row was resuming wins: the patch left the deadline NULL for
-    -- the return to paused, so it is armed from the new window here.
+    -- reached the daemon hands back the deadline the claim saw instead, so
+    -- retrying it cannot postpone deletion. It is restored only while the
+    -- row is untouched since the claim: an auto-delete patch, even one that
+    -- repeats the value, bumps updated_at and leaves the deadline NULL for
+    -- the return to paused, so it is armed from the current window here.
     auto_delete_at = CASE
-      WHEN auto_delete_seconds IS NOT DISTINCT FROM sqlc.narg('prior_auto_delete_seconds')::int
+      WHEN updated_at = sqlc.narg('claimed_updated_at')::timestamptz
       THEN sqlc.narg('prior_auto_delete_at')::timestamptz
       ELSE now() + make_interval(secs => auto_delete_seconds)
     END,

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -499,6 +499,8 @@ RETURNING *;
 -- the row key: the planner keeps a volatile target there, whereas an
 -- EXISTS subquery has its target list dropped and never takes the lock.
 -- LEFT joins keep the row when the snapshot or policy row is missing.
+-- prior_auto_delete_at is the deadline the claim clears, handed back by a
+-- revert that never reached the daemon.
 -- 0 rows: not paused, or another resume claimed it.
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
@@ -507,6 +509,7 @@ FROM (
   FROM (SELECT pg_advisory_xact_lock(hashtext(@lock_key::text)::bigint)) locked
 ) lk, (
   SELECT sb.id,
+         sb.auto_delete_at AS prior_auto_delete_at,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
@@ -537,7 +540,7 @@ RETURNING sqlc.embed(sandbox),
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
-          x.template_base_path;
+          x.template_base_path, x.prior_auto_delete_at;
 
 -- name: RevertResumeToPaused :exec
 -- Compensate a failed resume attempt by flipping status back to 'paused'.
@@ -545,9 +548,12 @@ RETURNING sqlc.embed(sandbox),
 -- (e.g., ActivateSandbox has already flipped to 'active').
 UPDATE sandbox
 SET status = 'paused',
-    -- Re-arm the auto-delete deadline cleared by BeginResume; the sandbox is
-    -- paused again, so it gets a fresh window.
-    auto_delete_at = now() + make_interval(secs => auto_delete_seconds),
+    -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
+    -- paused again, so it gets a fresh window. A resume refused before it
+    -- reached the daemon hands the prior deadline back instead, so retrying
+    -- it cannot postpone deletion.
+    auto_delete_at = COALESCE(sqlc.narg('prior_auto_delete_at')::timestamptz,
+                             now() + make_interval(secs => auto_delete_seconds)),
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming';
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -813,66 +813,15 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		return "", false
 	}
 
-	// Resolve the effective policy before claiming the sandbox. A missing
-	// side-table row is an older control plane's legacy sandbox; strict
-	// sandboxes may only resume while their host proves enforcement support.
-	// The snapshot is also the fallback payload if VMD lost its in-memory VM.
-	resumePolicy, err := h.loadPreviewPolicySnapshot(c.Request.Context(), sandboxID, teamID)
-	if err != nil {
-		l.Error().Err(err).Msg("load preview policy for resume failed")
-		respondError(c, ErrInternal)
-		return "", false
-	}
-	if resumePolicy.requiresBrowserCapability() {
-		if !h.requireHostPreviewPortBrowserAuth(c, sandbox.HostID) {
-			return "", false
-		}
-		// A Phase 2 VMD may still hold a raw-private snapshot at the previous
-		// revision. Advance under the sandbox row lock before restoring so the
-		// browser-authenticated per-port entries always have a strictly newer
-		// ordering key.
-		resumePolicy, err = h.applyPreviewMutationValidated(c.Request.Context(), sandboxID, teamID, func(*db.Queries) error {
-			return nil
-		}, func(q *db.Queries, _ previewPolicySnapshot) error {
-			return validateHostPreviewBrowserCapabilities(c.Request.Context(), q, sandbox.HostID)
-		})
-		if err != nil {
-			if !h.handlePreviewMutationResult(c, sandboxID, "ActivatePreviewBrowserAuthForResume", err) {
-				return "", false
-			}
-		}
-	} else if resumePolicy.Access != preview.AccessLegacyPublic && !h.requireHostPreviewPorts(c, sandbox.HostID) {
-		return "", false
-	}
-	resumeVMDAccess := resumePolicy.vmdAccess()
-
-	// Serialize the paused→resuming claim with attach/detach via a DB advisory
-	// lock (held only for the claim). Both take the same lock and re-read status
-	// under it, so across API instances a mutation can't read a stale 'paused' and
-	// land a binding this resume won't pick up. Once the claim flips status to
-	// 'resuming', those handlers see it under the lock and reject with 409.
-	claimResume := func(q *db.Queries) (db.Sandbox, error) {
-		if h.Pool != nil {
-			if lerr := q.LockSandboxForSecretWrites(c.Request.Context(), sandboxID.String()); lerr != nil {
-				return db.Sandbox{}, lerr
-			}
-		}
-		return q.BeginResume(c.Request.Context(), db.BeginResumeParams{ID: sandboxID, TeamID: teamID})
-	}
-	var (
-		claimed db.Sandbox
-	)
-	if h.Pool == nil {
-		claimed, err = claimResume(h.DB)
-	} else {
-		var tx pgx.Tx
-		if tx, err = h.Pool.Begin(c.Request.Context()); err == nil {
-			defer tx.Rollback(c.Request.Context())
-			if claimed, err = claimResume(h.DB.WithTx(tx)); err == nil {
-				err = tx.Commit(c.Request.Context())
-			}
-		}
-	}
+	// One round trip for the claim and everything the boot RPC needs: the
+	// advisory lock attach and detach take, paused→resuming, and the row with
+	// its snapshot paths, preview policy, published ports, and template base
+	// path (see ClaimResume).
+	claimed, err := h.DB.ClaimResume(c.Request.Context(), db.ClaimResumeParams{
+		ID:      sandboxID,
+		TeamID:  teamID,
+		LockKey: sandboxID.String(),
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			// Someone else is already resuming, or the sandbox is no longer
@@ -885,11 +834,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			h.respondQuotaExceeded(c, teamID)
 			return "", false
 		}
-		l.Error().Err(err).Msg("DB BeginResume failed")
+		l.Error().Err(err).Msg("DB ClaimResume failed")
 		respondError(c, ErrInternal)
 		return "", false
 	}
-	*sandbox = claimed
+	*sandbox = claimed.Sandbox
 
 	revertCtx := context.WithoutCancel(c.Request.Context())
 	revertToPaused := func() {
@@ -903,20 +852,55 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	snapshot, err := h.DB.GetSnapshot(c.Request.Context(), db.GetSnapshotParams{
-		ID:     sandbox.SnapshotID.Bytes,
-		TeamID: teamID,
-	})
-	if err != nil {
-		l.Error().Err(err).Msg("DB GetSnapshot failed")
+	// Strict sandboxes may only resume while their host proves enforcement
+	// support; a missing policy row is an older control plane's legacy
+	// sandbox. The policy rides the claim, so a refusal here reverts it. The
+	// snapshot is also the fallback payload if VMD lost its in-memory VM.
+	resumePolicy := previewPolicySnapshot{
+		Access:     claimed.Access,
+		WireAccess: claimed.WireAccess,
+		Revision:   claimed.Revision,
+		Ports:      claimedPortPolicies(claimed.PortNumbers, claimed.PortAccesses, claimed.PortTokenVersions),
+	}
+	if resumePolicy.requiresBrowserCapability() {
+		if !h.requireHostPreviewPortBrowserAuth(c, sandbox.HostID) {
+			markRevert()
+			revertToPaused()
+			return "", false
+		}
+		// A Phase 2 VMD may still hold a raw-private snapshot at the previous
+		// revision. Advance under the sandbox row lock before restoring so the
+		// browser-authenticated per-port entries always have a strictly newer
+		// ordering key.
+		resumePolicy, err = h.applyPreviewMutationValidated(c.Request.Context(), sandboxID, teamID, func(*db.Queries) error {
+			return nil
+		}, func(q *db.Queries, _ previewPolicySnapshot) error {
+			return validateHostPreviewBrowserCapabilities(c.Request.Context(), q, sandbox.HostID)
+		})
+		if err != nil {
+			if !h.handlePreviewMutationResult(c, sandboxID, "ActivatePreviewBrowserAuthForResume", err) {
+				markRevert()
+				revertToPaused()
+				return "", false
+			}
+		}
+	} else if resumePolicy.Access != preview.AccessLegacyPublic && !h.requireHostPreviewPorts(c, sandbox.HostID) {
+		markRevert()
+		revertToPaused()
+		return "", false
+	}
+	resumeVMDAccess := resumePolicy.vmdAccess()
+
+	// NULL snap_path: the snapshot row is gone despite a set snapshot_id.
+	if claimed.SnapPath == nil {
+		l.Error().Msg("snapshot row missing for the paused sandbox")
 		markRevert()
 		revertToPaused()
 		respondError(c, ErrInternal)
 		return "", false
 	}
-
-	snapshotPath := snapshot.Path
-	memPath := resolveMemPath(snapshot)
+	snapshotPath := *claimed.SnapPath
+	memPath := resolveMemPath(db.Snapshot{Path: snapshotPath, MemPath: claimed.SnapMemPath})
 
 	// Overlay-mode sandboxes need basePath for the mount-namespace symlink.
 	// Read sandbox.base_path first (pinned at create) so a template rebuild
@@ -924,14 +908,8 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	var resumeBasePath string
 	if sandbox.BasePath != nil {
 		resumeBasePath = *sandbox.BasePath
-	} else if sandbox.TemplateID.Valid {
-		tpl, tplErr := h.DB.GetTemplateForOwner(c.Request.Context(), db.GetTemplateForOwnerParams{
-			ID:     sandbox.TemplateID.Bytes,
-			TeamID: teamID,
-		})
-		if tplErr == nil && tpl.BasePath != nil {
-			resumeBasePath = *tpl.BasePath
-		}
+	} else if claimed.TemplateBasePath != nil {
+		resumeBasePath = *claimed.TemplateBasePath
 	}
 
 	vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -813,10 +813,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		return "", false
 	}
 
-	// One round trip for the claim and everything the boot RPC needs: the
-	// advisory lock attach and detach take, paused→resuming, and the row with
-	// its snapshot paths, preview policy, published ports, and template base
-	// path (see ClaimResume).
+	// One statement for the claim and the boot inputs; see ClaimResume.
 	claimed, err := h.DB.ClaimResume(c.Request.Context(), db.ClaimResumeParams{
 		ID:      sandboxID,
 		TeamID:  teamID,

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -843,11 +843,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		defer rcancel()
 		params := db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}
 		// Never reached the daemon: the deadline the claim cleared stands, so
-		// retrying a refused resume cannot postpone auto-delete. The window
-		// goes with it so a patch made meanwhile is honored over the deadline.
+		// retrying a refused resume cannot postpone auto-delete. The claim's
+		// updated_at goes with it so a patch made meanwhile wins instead.
 		if tVmdStart.IsZero() {
 			params.PriorAutoDeleteAt = claimed.PriorAutoDeleteAt
-			params.PriorAutoDeleteSeconds = claimed.Sandbox.AutoDeleteSeconds
+			params.ClaimedUpdatedAt = pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true}
 		}
 		if err := h.DB.RevertResumeToPaused(rctx, params); err != nil {
 			l.Error().Err(err).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -841,15 +841,10 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	revertToPaused := func() {
 		rctx, rcancel := context.WithTimeout(revertCtx, asyncTimeout)
 		defer rcancel()
-		params := db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}
-		// Never reached the daemon: the deadline the claim cleared stands, so
-		// retrying a refused resume cannot postpone auto-delete. The claim's
-		// updated_at goes with it so a patch made meanwhile wins instead.
-		if tVmdStart.IsZero() {
-			params.PriorAutoDeleteAt = claimed.PriorAutoDeleteAt
-			params.ClaimedUpdatedAt = pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true}
-		}
-		if err := h.DB.RevertResumeToPaused(rctx, params); err != nil {
+		if err := h.DB.RevertResumeToPaused(rctx, db.RevertResumeToPausedParams{
+			ID:     sandboxID,
+			TeamID: teamID,
+		}); err != nil {
 			l.Error().Err(err).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")
 		}
 	}
@@ -1776,7 +1771,9 @@ func (h *Handlers) sandboxToResponse(s db.Sandbox) sandboxResponse {
 	if s.AutoDeleteSeconds != nil {
 		resp.AutoDeleteSeconds = s.AutoDeleteSeconds
 	}
-	if s.AutoDeleteAt.Valid {
+	// The deadline rides through a resume on the row; it is reported only
+	// while it can fire.
+	if s.Status == db.SandboxStatusPaused && s.AutoDeleteAt.Valid {
 		resp.AutoDeleteAt = &s.AutoDeleteAt.Time
 	}
 	if len(s.NetworkConfig) > 0 {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -843,9 +843,11 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		defer rcancel()
 		params := db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}
 		// Never reached the daemon: the deadline the claim cleared stands, so
-		// retrying a refused resume cannot postpone auto-delete.
+		// retrying a refused resume cannot postpone auto-delete. The window
+		// goes with it so a patch made meanwhile is honored over the deadline.
 		if tVmdStart.IsZero() {
 			params.PriorAutoDeleteAt = claimed.PriorAutoDeleteAt
+			params.PriorAutoDeleteSeconds = claimed.Sandbox.AutoDeleteSeconds
 		}
 		if err := h.DB.RevertResumeToPaused(rctx, params); err != nil {
 			l.Error().Err(err).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -841,10 +841,13 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	revertToPaused := func() {
 		rctx, rcancel := context.WithTimeout(revertCtx, asyncTimeout)
 		defer rcancel()
-		if err := h.DB.RevertResumeToPaused(rctx, db.RevertResumeToPausedParams{
-			ID:     sandboxID,
-			TeamID: teamID,
-		}); err != nil {
+		params := db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}
+		// Never reached the daemon: the deadline the claim cleared stands, so
+		// retrying a refused resume cannot postpone auto-delete.
+		if tVmdStart.IsZero() {
+			params.PriorAutoDeleteAt = claimed.PriorAutoDeleteAt
+		}
+		if err := h.DB.RevertResumeToPaused(rctx, params); err != nil {
 			l.Error().Err(err).Msg("RevertResumeToPaused failed — sandbox may be stuck in 'resuming'")
 		}
 	}

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -122,6 +122,19 @@ func publishedPortPolicies(ports []db.ListPublishedPortsRow) map[int32]vmdclient
 	return out
 }
 
+// claimedPortPolicies is publishedPortPolicies over the parallel arrays the
+// resume claim aggregates its ports into.
+func claimedPortPolicies(ports []int32, accesses []string, tokenVersions []int64) map[int32]vmdclient.PortPolicy {
+	rows := make([]db.ListPublishedPortsRow, 0, len(ports))
+	for i, port := range ports {
+		if i >= len(accesses) || i >= len(tokenVersions) {
+			break
+		}
+		rows = append(rows, db.ListPublishedPortsRow{Port: port, Access: accesses[i], TokenVersion: tokenVersions[i]})
+	}
+	return publishedPortPolicies(rows)
+}
+
 // vmdPorts strips credential generations from non-tokenized modes. The
 // control-plane snapshot retains them so API publication responses can report
 // the durable generation for public ports too, but public wire records have no

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -982,6 +982,45 @@ func snapshotRow(s db.Snapshot) *mockRow {
 	}}
 }
 
+// claimResumeRow mocks ClaimResume's RETURNING: the sandbox columns, then
+// the joined snapshot paths, policy, aggregated ports, and template base
+// path. A nil snap models a missing snapshot row.
+func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision int64, ports ...publishedPortResponse) *mockRow {
+	return &mockRow{scanFn: func(dest ...any) error {
+		if err := sandboxRow(sb).scanFn(dest[:26]...); err != nil {
+			return err
+		}
+		var snapPath, snapMemPath *string
+		if snap != nil {
+			p := snap.Path
+			snapPath, snapMemPath = &p, snap.MemPath
+		}
+		*dest[26].(**string) = snapPath
+		*dest[27].(**string) = snapMemPath
+		if access == "" {
+			access = preview.AccessLegacyPublic
+		}
+		*dest[28].(*string) = access
+		*dest[29].(*string) = access
+		*dest[30].(*int64) = revision
+		numbers, accesses, versions := []int32{}, []string{}, []int64{}
+		for _, port := range ports {
+			version := port.TokenVersion
+			if version == 0 {
+				version = 1
+			}
+			numbers = append(numbers, port.Port)
+			accesses = append(accesses, port.Access)
+			versions = append(versions, version)
+		}
+		*dest[31].(*[]int32) = numbers
+		*dest[32].(*[]string) = accesses
+		*dest[33].(*[]int64) = versions
+		*dest[34].(**string) = nil
+		return nil
+	}}
+}
+
 // finalizePauseRow mocks the single-column RETURNING of FinalizePause.
 func finalizePauseRow(snapshotID uuid.UUID) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
@@ -1059,7 +1098,7 @@ func TestResumeSandbox_LegacyPolicyToleratesOldVMD(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb) // BeginResume RETURNING *
+				return claimResumeRow(sb, &snap, preview.AccessLegacyPublic, 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -1109,7 +1148,6 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
 	}
 
-	var policyReads int
 	var restored, reconciled previewPolicySnapshot
 	vmd := &stubVMD{
 		resumeFn: func(context.Context, string, string, string, []byte) (string, error) {
@@ -1130,17 +1168,11 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 			case strings.Contains(sql, "-- name: GetSandbox :one"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
-				policyReads++
-				if policyReads == 1 {
-					return previewPolicyRow(preview.AccessPublic, 7)
-				}
 				return previewPolicyRow(preview.AccessPublic, 8)
 			case (strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one")):
 				return scalarBoolRow(true)
-			case strings.Contains(sql, "-- name: BeginResume :one"):
-				return sandboxRow(sb)
-			case strings.Contains(sql, "-- name: GetSnapshot :one"):
-				return snapshotRow(snap)
+			case strings.Contains(sql, "-- name: ClaimResume :one"):
+				return claimResumeRow(sb, &snap, preview.AccessPublic, 7, publishedPortResponse{Port: 3000, Access: preview.AccessPublic})
 			default:
 				return activityRow()
 			}
@@ -1148,9 +1180,6 @@ func TestResumeSandbox_NotFoundRestoreReceivesPolicyAndReconcilesLatest(t *testi
 		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
 			switch {
 			case strings.Contains(sql, "-- name: ListPublishedPorts :many"):
-				if policyReads == 1 {
-					return previewPortRows(3000), nil
-				}
 				return previewPortRows(8080), nil
 			case strings.Contains(sql, "-- name: ListSandboxSecretBindingMeta :many"):
 				return emptyRows{}, nil
@@ -1225,10 +1254,10 @@ func TestResumeSandbox_PrivatePolicyRequiresBrowserChainAndRestoresBrowserPorts(
 			case strings.Contains(sql, "-- name: AdvanceSandboxPreviewPolicy :one"):
 				revisionBumps++
 				return previewPolicyRow(preview.AccessPrivate, 8)
-			case strings.Contains(sql, "-- name: BeginResume :one"):
-				return sandboxRow(sb)
-			case strings.Contains(sql, "-- name: GetSnapshot :one"):
-				return snapshotRow(snap)
+			case strings.Contains(sql, "-- name: ClaimResume :one"):
+				return claimResumeRow(sb, &snap, preview.AccessPrivate, 8, publishedPortResponse{
+					Port: 3000, Access: preview.AccessPrivate, TokenVersion: 12,
+				})
 			default:
 				return activityRow()
 			}
@@ -1298,7 +1327,7 @@ func TestResumeSandbox_ReappliesSecretBindings(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -1435,7 +1464,7 @@ func TestResumeSandbox_SettlesPausingToPaused(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):
@@ -1652,7 +1681,7 @@ func TestResumeSandbox_VMDError(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			default:
@@ -1720,7 +1749,7 @@ func TestResumeSandbox_NetworkReapplyFailure_PausesNotDestroys(t *testing.T) {
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):
@@ -1802,7 +1831,7 @@ func TestResumeSandbox_EmitsPhasesAndCarriesRulesInResumeRequest(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):
@@ -1867,7 +1896,7 @@ func TestResumeSandbox_NoBindingsSkipsBindingRead(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -1938,7 +1967,7 @@ func TestResumeSandbox_ActivateFailure_PausesNotDestroys(t *testing.T) {
 				atomic.AddInt32(&finalizeCalled, 1)
 				return uuidRow(snapshotID)
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM snapshot"):
 				return snapshotRow(snap)
 			case strings.Contains(sql, "FROM sandbox"):
@@ -2042,7 +2071,7 @@ func TestActivateSandbox_PausedResumesAndReturns200(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):
@@ -2189,7 +2218,7 @@ func TestResumeSandbox_ActivityLogFailure_StillReturns200(t *testing.T) {
 		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
 			switch {
 			case strings.Contains(sql, "'resuming'"):
-				return sandboxRow(sb)
+				return claimResumeRow(sb, &snap, "", 0)
 			case strings.Contains(sql, "FROM sandbox"):
 				return sandboxRow(sb)
 			case strings.Contains(sql, "FROM snapshot"):

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -982,9 +982,8 @@ func snapshotRow(s db.Snapshot) *mockRow {
 	}}
 }
 
-// claimResumeRow mocks ClaimResume's RETURNING: the sandbox columns, then
-// the joined snapshot paths, policy, aggregated ports, and template base
-// path. A nil snap models a missing snapshot row.
+// claimResumeRow mocks ClaimResume's RETURNING; a nil snap models a
+// missing snapshot row.
 func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision int64, ports ...publishedPortResponse) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
 		if err := sandboxRow(sb).scanFn(dest[:26]...); err != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4210,6 +4210,8 @@ func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
 	sb.HostID = "host-without-ports-" + uuid.NewString()
 	deadline := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
 	sb.AutoDeleteAt = pgtype.Timestamptz{Time: deadline, Valid: true}
+	window := int32(3600)
+	sb.AutoDeleteSeconds = &window
 	snap := db.Snapshot{
 		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
@@ -4254,11 +4256,14 @@ func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
 	if reached {
 		t.Fatal("refused resume reached the daemon")
 	}
-	if len(reverted) != 3 {
-		t.Fatalf("revert args = %v, want id, team, prior deadline", reverted)
+	if len(reverted) != 4 {
+		t.Fatalf("revert args = %v, want id, team, prior window, prior deadline", reverted)
 	}
-	got, ok := reverted[2].(pgtype.Timestamptz)
+	if secs, ok := reverted[2].(*int32); !ok || secs == nil || *secs != window {
+		t.Fatalf("revert window = %v, want %d", reverted[2], window)
+	}
+	got, ok := reverted[3].(pgtype.Timestamptz)
 	if !ok || !got.Valid || !got.Time.Equal(deadline) {
-		t.Fatalf("revert deadline = %v, want %v", reverted[2], deadline)
+		t.Fatalf("revert deadline = %v, want %v", reverted[3], deadline)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1016,6 +1016,7 @@ func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision in
 		*dest[32].(*[]string) = accesses
 		*dest[33].(*[]int64) = versions
 		*dest[34].(**string) = nil
+		*dest[35].(*pgtype.Timestamptz) = sb.AutoDeleteAt
 		return nil
 	}}
 }
@@ -4195,5 +4196,69 @@ func TestCreateSandboxDeclaresResourceLimitsToVMD(t *testing.T) {
 	if vmd.restoreLimits.VCPU != uint32(tpl.Vcpu) || vmd.restoreLimits.MemoryMiB != uint32(tpl.MemoryMib) {
 		t.Fatalf("declared allocation = %d/%d, want the shape the row is inserted with (%d/%d)",
 			vmd.restoreLimits.VCPU, vmd.restoreLimits.MemoryMiB, tpl.Vcpu, tpl.MemoryMib)
+	}
+}
+
+// A resume the host capability gate refuses never reaches the daemon, so its
+// revert hands the claim's cleared deadline back rather than re-arming it;
+// otherwise retrying the refused resume would postpone auto-delete forever.
+func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
+	sandboxID := uuid.New()
+	teamID := uuid.New()
+	snapshotID := uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	sb.HostID = "host-without-ports-" + uuid.NewString()
+	deadline := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	sb.AutoDeleteAt = pgtype.Timestamptz{Time: deadline, Valid: true}
+	snap := db.Snapshot{
+		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
+		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
+	}
+
+	var reverted []any
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: ClaimResume :one"):
+				return claimResumeRow(sb, &snap, preview.AccessPublic, 3)
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+				return scalarBoolRow(false)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		queryFn: func(context.Context, string, ...any) (pgx.Rows, error) {
+			return emptyRows{}, nil
+		},
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "-- name: RevertResumeToPaused :exec") {
+				reverted = args
+			}
+			return pgconn.NewCommandTag(""), nil
+		},
+	}
+	reached := false
+	vmd := &stubVMD{resumeFn: func(context.Context, string, string, string, []byte) (string, error) {
+		reached = true
+		return "10.0.0.2", nil
+	}}
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+	if reached {
+		t.Fatal("refused resume reached the daemon")
+	}
+	if len(reverted) != 3 {
+		t.Fatalf("revert args = %v, want id, team, prior deadline", reverted)
+	}
+	got, ok := reverted[2].(pgtype.Timestamptz)
+	if !ok || !got.Valid || !got.Time.Equal(deadline) {
+		t.Fatalf("revert deadline = %v, want %v", reverted[2], deadline)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4210,8 +4210,7 @@ func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
 	sb.HostID = "host-without-ports-" + uuid.NewString()
 	deadline := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
 	sb.AutoDeleteAt = pgtype.Timestamptz{Time: deadline, Valid: true}
-	window := int32(3600)
-	sb.AutoDeleteSeconds = &window
+	sb.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
 	snap := db.Snapshot{
 		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
@@ -4257,10 +4256,10 @@ func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
 		t.Fatal("refused resume reached the daemon")
 	}
 	if len(reverted) != 4 {
-		t.Fatalf("revert args = %v, want id, team, prior window, prior deadline", reverted)
+		t.Fatalf("revert args = %v, want id, team, claim updated_at, prior deadline", reverted)
 	}
-	if secs, ok := reverted[2].(*int32); !ok || secs == nil || *secs != window {
-		t.Fatalf("revert window = %v, want %d", reverted[2], window)
+	if at, ok := reverted[2].(pgtype.Timestamptz); !ok || !at.Valid || !at.Time.Equal(sb.UpdatedAt) {
+		t.Fatalf("revert claim updated_at = %v, want %v", reverted[2], sb.UpdatedAt)
 	}
 	got, ok := reverted[3].(pgtype.Timestamptz)
 	if !ok || !got.Valid || !got.Time.Equal(deadline) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1016,7 +1016,6 @@ func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision in
 		*dest[32].(*[]string) = accesses
 		*dest[33].(*[]int64) = versions
 		*dest[34].(**string) = nil
-		*dest[35].(*pgtype.Timestamptz) = sb.AutoDeleteAt
 		return nil
 	}}
 }
@@ -4199,18 +4198,15 @@ func TestCreateSandboxDeclaresResourceLimitsToVMD(t *testing.T) {
 	}
 }
 
-// A resume the host capability gate refuses never reaches the daemon, so its
-// revert hands the claim's cleared deadline back rather than re-arming it;
-// otherwise retrying the refused resume would postpone auto-delete forever.
-func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
+// A resume the host capability gate refuses never reaches the daemon and
+// reverts the claim; the revert carries no deadline because the claim leaves
+// it on the row, so retrying the refused resume cannot postpone auto-delete.
+func TestResumeSandbox_CapabilityRefusalRevertsWithoutReachingDaemon(t *testing.T) {
 	sandboxID := uuid.New()
 	teamID := uuid.New()
 	snapshotID := uuid.New()
 	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
 	sb.HostID = "host-without-ports-" + uuid.NewString()
-	deadline := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
-	sb.AutoDeleteAt = pgtype.Timestamptz{Time: deadline, Valid: true}
-	sb.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
 	snap := db.Snapshot{
 		ID: snapshotID, SandboxID: sandboxID, TeamID: teamID,
 		Path: "/snapshots/test/vmstate.snap", Trigger: "pause",
@@ -4255,14 +4251,7 @@ func TestResumeSandbox_CapabilityRefusalKeepsAutoDeleteDeadline(t *testing.T) {
 	if reached {
 		t.Fatal("refused resume reached the daemon")
 	}
-	if len(reverted) != 4 {
-		t.Fatalf("revert args = %v, want id, team, claim updated_at, prior deadline", reverted)
-	}
-	if at, ok := reverted[2].(pgtype.Timestamptz); !ok || !at.Valid || !at.Time.Equal(sb.UpdatedAt) {
-		t.Fatalf("revert claim updated_at = %v, want %v", reverted[2], sb.UpdatedAt)
-	}
-	got, ok := reverted[3].(pgtype.Timestamptz)
-	if !ok || !got.Valid || !got.Time.Equal(deadline) {
-		t.Fatalf("revert deadline = %v, want %v", reverted[3], deadline)
+	if len(reverted) != 2 {
+		t.Fatalf("revert args = %v, want id and team only", reverted)
 	}
 }

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -543,6 +543,118 @@ func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]Cla
 	return items, nil
 }
 
+const claimResume = `-- name: ClaimResume :one
+UPDATE sandbox
+SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
+FROM (
+  SELECT sb.id,
+         s.path AS snap_path,
+         s.mem_path AS snap_mem_path,
+         COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
+         COALESCE(p.access, 'legacy_public')::text AS wire_access,
+         COALESCE(p.revision, 0)::bigint AS revision,
+         COALESCE(pp.ports, '{}')::int[] AS port_numbers,
+         COALESCE(pp.accesses, '{}')::text[] AS port_accesses,
+         COALESCE(pp.token_versions, '{}')::bigint[] AS port_token_versions,
+         t.base_path AS template_base_path
+  FROM sandbox sb
+  LEFT JOIN snapshot s ON s.id = sb.snapshot_id AND s.team_id = sb.team_id
+  LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = sb.id
+  LEFT JOIN template t ON t.id = sb.template_id
+  LEFT JOIN LATERAL (
+    SELECT array_agg(pp.port ORDER BY pp.port) AS ports,
+           array_agg(pp.access ORDER BY pp.port) AS accesses,
+           array_agg(g.token_version ORDER BY pp.port) AS token_versions
+    FROM sandbox_published_port pp
+    JOIN sandbox_preview_port_token_generation g
+      ON g.sandbox_id = pp.sandbox_id AND g.port = pp.port
+    WHERE pp.sandbox_id = sb.id AND g.token_version > 0
+  ) pp ON true
+  WHERE sb.id = $2 AND sb.team_id = $3
+) x
+WHERE sandbox.id = x.id
+  AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
+  AND EXISTS (SELECT pg_advisory_xact_lock(hashtext($1::text)::bigint))
+RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcpu_count, sandbox.memory_mib, sandbox.host_id, sandbox.ip_address, sandbox.pid, sandbox.snapshot_id, sandbox.created_at, sandbox.updated_at, sandbox.destroyed_at, sandbox.network_config, sandbox.timeout_seconds, sandbox.metadata, sandbox.template_id, sandbox.snapshot_path, sandbox.mem_path, sandbox.base_path, sandbox.delta_path, sandbox.disk_mib, sandbox.auto_delete_seconds, sandbox.auto_delete_at, sandbox.failed_at, sandbox.had_secret_bindings,
+          x.snap_path, x.snap_mem_path,
+          x.access, x.wire_access, x.revision,
+          x.port_numbers, x.port_accesses, x.port_token_versions,
+          x.template_base_path
+`
+
+type ClaimResumeParams struct {
+	LockKey string    `json:"lock_key"`
+	ID      uuid.UUID `json:"id"`
+	TeamID  uuid.UUID `json:"team_id"`
+}
+
+type ClaimResumeRow struct {
+	Sandbox           Sandbox  `json:"sandbox"`
+	SnapPath          *string  `json:"snap_path"`
+	SnapMemPath       *string  `json:"snap_mem_path"`
+	Access            string   `json:"access"`
+	WireAccess        string   `json:"wire_access"`
+	Revision          int64    `json:"revision"`
+	PortNumbers       []int32  `json:"port_numbers"`
+	PortAccesses      []string `json:"port_accesses"`
+	PortTokenVersions []int64  `json:"port_token_versions"`
+	TemplateBasePath  *string  `json:"template_base_path"`
+}
+
+// The resume claim and everything the boot RPC needs in one round trip:
+// paused→resuming, the snapshot's artifact paths, the preview policy with
+// its published ports, and the template base path for rows that predate
+// base_path pinning. The advisory lock is the one attach and detach take
+// before re-reading status. It is acquired before the row is updated and
+// released at statement end, so the returned row and the binding set agree:
+// a mutation holding the lock lands first and shows in the row, or arrives
+// later and sees 'resuming'. The side joins are LEFT so a missing snapshot
+// row (NULL snap_path) or a legacy sandbox with no policy row still returns
+// the claimed row for the caller to handle. 0 rows means another resume
+// claimed it or it is not paused.
+func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (ClaimResumeRow, error) {
+	row := q.db.QueryRow(ctx, claimResume, arg.LockKey, arg.ID, arg.TeamID)
+	var i ClaimResumeRow
+	err := row.Scan(
+		&i.Sandbox.ID,
+		&i.Sandbox.TeamID,
+		&i.Sandbox.Name,
+		&i.Sandbox.Status,
+		&i.Sandbox.VcpuCount,
+		&i.Sandbox.MemoryMib,
+		&i.Sandbox.HostID,
+		&i.Sandbox.IpAddress,
+		&i.Sandbox.Pid,
+		&i.Sandbox.SnapshotID,
+		&i.Sandbox.CreatedAt,
+		&i.Sandbox.UpdatedAt,
+		&i.Sandbox.DestroyedAt,
+		&i.Sandbox.NetworkConfig,
+		&i.Sandbox.TimeoutSeconds,
+		&i.Sandbox.Metadata,
+		&i.Sandbox.TemplateID,
+		&i.Sandbox.SnapshotPath,
+		&i.Sandbox.MemPath,
+		&i.Sandbox.BasePath,
+		&i.Sandbox.DeltaPath,
+		&i.Sandbox.DiskMib,
+		&i.Sandbox.AutoDeleteSeconds,
+		&i.Sandbox.AutoDeleteAt,
+		&i.Sandbox.FailedAt,
+		&i.Sandbox.HadSecretBindings,
+		&i.SnapPath,
+		&i.SnapMemPath,
+		&i.Access,
+		&i.WireAccess,
+		&i.Revision,
+		&i.PortNumbers,
+		&i.PortAccesses,
+		&i.PortTokenVersions,
+		&i.TemplateBasePath,
+	)
+	return i, err
+}
+
 const countActiveSandboxesAtBasePath = `-- name: CountActiveSandboxesAtBasePath :one
 SELECT COUNT(*)::bigint FROM sandbox
 WHERE base_path = $1 AND destroyed_at IS NULL

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -601,17 +601,13 @@ type ClaimResumeRow struct {
 	TemplateBasePath  *string  `json:"template_base_path"`
 }
 
-// The resume claim and everything the boot RPC needs in one round trip:
-// paused→resuming, the snapshot's artifact paths, the preview policy with
-// its published ports, and the template base path for rows that predate
-// base_path pinning. The advisory lock is the one attach and detach take
-// before re-reading status. It is acquired before the row is updated and
-// released at statement end, so the returned row and the binding set agree:
-// a mutation holding the lock lands first and shows in the row, or arrives
-// later and sees 'resuming'. The side joins are LEFT so a missing snapshot
-// row (NULL snap_path) or a legacy sandbox with no policy row still returns
-// the claimed row for the caller to handle. 0 rows means another resume
-// claimed it or it is not paused.
+// The paused→resuming claim plus the boot inputs in one round trip:
+// snapshot paths, preview policy with published ports, template base path.
+// The advisory lock is the one attach/detach take before re-reading
+// status; taken before the update and held to statement end, so the
+// returned row already reflects a binding mutation that beat the claim.
+// LEFT joins keep the row when the snapshot or policy row is missing.
+// 0 rows: not paused, or another resume claimed it.
 func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (ClaimResumeRow, error) {
 	row := q.db.QueryRow(ctx, claimResume, arg.LockKey, arg.ID, arg.TeamID)
 	var i ClaimResumeRow

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -547,6 +547,9 @@ const claimResume = `-- name: ClaimResume :one
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 FROM (
+  SELECT $1::uuid AS id
+  FROM (SELECT pg_advisory_xact_lock(hashtext($2::text)::bigint)) locked
+) lk, (
   SELECT sb.id,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
@@ -570,11 +573,10 @@ FROM (
       ON g.sandbox_id = pp.sandbox_id AND g.port = pp.port
     WHERE pp.sandbox_id = sb.id AND g.token_version > 0
   ) pp ON true
-  WHERE sb.id = $2 AND sb.team_id = $3
+  WHERE sb.id = $1 AND sb.team_id = $3
 ) x
-WHERE sandbox.id = x.id
+WHERE sandbox.id = lk.id AND sandbox.id = x.id
   AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
-  AND EXISTS (SELECT pg_advisory_xact_lock(hashtext($1::text)::bigint))
 RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcpu_count, sandbox.memory_mib, sandbox.host_id, sandbox.ip_address, sandbox.pid, sandbox.snapshot_id, sandbox.created_at, sandbox.updated_at, sandbox.destroyed_at, sandbox.network_config, sandbox.timeout_seconds, sandbox.metadata, sandbox.template_id, sandbox.snapshot_path, sandbox.mem_path, sandbox.base_path, sandbox.delta_path, sandbox.disk_mib, sandbox.auto_delete_seconds, sandbox.auto_delete_at, sandbox.failed_at, sandbox.had_secret_bindings,
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,
@@ -583,8 +585,8 @@ RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcp
 `
 
 type ClaimResumeParams struct {
-	LockKey string    `json:"lock_key"`
 	ID      uuid.UUID `json:"id"`
+	LockKey string    `json:"lock_key"`
 	TeamID  uuid.UUID `json:"team_id"`
 }
 
@@ -604,12 +606,14 @@ type ClaimResumeRow struct {
 // The paused→resuming claim plus the boot inputs in one round trip:
 // snapshot paths, preview policy with published ports, template base path.
 // The advisory lock is the one attach/detach take before re-reading
-// status; taken before the update and held to statement end, so the
-// returned row already reflects a binding mutation that beat the claim.
+// status; held to statement end, so the returned row already reflects a
+// binding mutation that beat the claim. It rides a FROM item joined on
+// the row key: the planner keeps a volatile target there, whereas an
+// EXISTS subquery has its target list dropped and never takes the lock.
 // LEFT joins keep the row when the snapshot or policy row is missing.
 // 0 rows: not paused, or another resume claimed it.
 func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (ClaimResumeRow, error) {
-	row := q.db.QueryRow(ctx, claimResume, arg.LockKey, arg.ID, arg.TeamID)
+	row := q.db.QueryRow(ctx, claimResume, arg.ID, arg.LockKey, arg.TeamID)
 	var i ClaimResumeRow
 	err := row.Scan(
 		&i.Sandbox.ID,

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -2489,25 +2489,36 @@ UPDATE sandbox
 SET status = 'paused',
     -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
     -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands the prior deadline back instead, so retrying
-    -- it cannot postpone deletion.
-    auto_delete_at = COALESCE($3::timestamptz,
-                             now() + make_interval(secs => auto_delete_seconds)),
+    -- reached the daemon hands back the deadline and window the claim saw
+    -- instead, so retrying it cannot postpone deletion. A window patched
+    -- while the row was resuming wins: the patch left the deadline NULL for
+    -- the return to paused, so it is armed from the new window here.
+    auto_delete_at = CASE
+      WHEN auto_delete_seconds IS NOT DISTINCT FROM $3::int
+      THEN $4::timestamptz
+      ELSE now() + make_interval(secs => auto_delete_seconds)
+    END,
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
 `
 
 type RevertResumeToPausedParams struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
+	ID                     uuid.UUID          `json:"id"`
+	TeamID                 uuid.UUID          `json:"team_id"`
+	PriorAutoDeleteSeconds *int32             `json:"prior_auto_delete_seconds"`
+	PriorAutoDeleteAt      pgtype.Timestamptz `json:"prior_auto_delete_at"`
 }
 
 // Compensate a failed resume attempt by flipping status back to 'paused'.
 // Guarded on status = 'resuming' so we never clobber a concurrent transition
 // (e.g., ActivateSandbox has already flipped to 'active').
 func (q *Queries) RevertResumeToPaused(ctx context.Context, arg RevertResumeToPausedParams) error {
-	_, err := q.db.Exec(ctx, revertResumeToPaused, arg.ID, arg.TeamID, arg.PriorAutoDeleteAt)
+	_, err := q.db.Exec(ctx, revertResumeToPaused,
+		arg.ID,
+		arg.TeamID,
+		arg.PriorAutoDeleteSeconds,
+		arg.PriorAutoDeleteAt,
+	)
 	return err
 }
 

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -18,6 +18,8 @@ const activateSandbox = `-- name: ActivateSandbox :exec
 WITH activated AS (
   UPDATE sandbox
   SET status = 'active',
+      -- The claim left the paused deadline on the row; it ends here.
+      auto_delete_at = NULL,
       vcpu_count = $2,
       memory_mib = $3,
       ip_address = $4,
@@ -545,13 +547,12 @@ func (q *Queries) ClaimExpiredSandboxes(ctx context.Context, limit int32) ([]Cla
 
 const claimResume = `-- name: ClaimResume :one
 UPDATE sandbox
-SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
+SET status = 'resuming', updated_at = now()
 FROM (
   SELECT $1::uuid AS id
   FROM (SELECT pg_advisory_xact_lock(hashtext($2::text)::bigint)) locked
 ) lk, (
   SELECT sb.id,
-         sb.auto_delete_at AS prior_auto_delete_at,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
@@ -582,7 +583,7 @@ RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcp
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
-          x.template_base_path, x.prior_auto_delete_at
+          x.template_base_path
 `
 
 type ClaimResumeParams struct {
@@ -592,17 +593,16 @@ type ClaimResumeParams struct {
 }
 
 type ClaimResumeRow struct {
-	Sandbox           Sandbox            `json:"sandbox"`
-	SnapPath          *string            `json:"snap_path"`
-	SnapMemPath       *string            `json:"snap_mem_path"`
-	Access            string             `json:"access"`
-	WireAccess        string             `json:"wire_access"`
-	Revision          int64              `json:"revision"`
-	PortNumbers       []int32            `json:"port_numbers"`
-	PortAccesses      []string           `json:"port_accesses"`
-	PortTokenVersions []int64            `json:"port_token_versions"`
-	TemplateBasePath  *string            `json:"template_base_path"`
-	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
+	Sandbox           Sandbox  `json:"sandbox"`
+	SnapPath          *string  `json:"snap_path"`
+	SnapMemPath       *string  `json:"snap_mem_path"`
+	Access            string   `json:"access"`
+	WireAccess        string   `json:"wire_access"`
+	Revision          int64    `json:"revision"`
+	PortNumbers       []int32  `json:"port_numbers"`
+	PortAccesses      []string `json:"port_accesses"`
+	PortTokenVersions []int64  `json:"port_token_versions"`
+	TemplateBasePath  *string  `json:"template_base_path"`
 }
 
 // The paused→resuming claim plus the boot inputs in one round trip:
@@ -613,8 +613,9 @@ type ClaimResumeRow struct {
 // the row key: the planner keeps a volatile target there, whereas an
 // EXISTS subquery has its target list dropped and never takes the lock.
 // LEFT joins keep the row when the snapshot or policy row is missing.
-// prior_auto_delete_at is the deadline the claim clears, handed back by a
-// revert that never reached the daemon.
+// The auto-delete deadline stays on the row: the reaper acts on paused rows
+// only, a failed resume returns the row to paused with the deadline it had,
+// and activation clears it.
 // 0 rows: not paused, or another resume claimed it.
 func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (ClaimResumeRow, error) {
 	row := q.db.QueryRow(ctx, claimResume, arg.ID, arg.LockKey, arg.TeamID)
@@ -655,7 +656,6 @@ func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (Claim
 		&i.PortAccesses,
 		&i.PortTokenVersions,
 		&i.TemplateBasePath,
-		&i.PriorAutoDeleteAt,
 	)
 	return i, err
 }
@@ -2487,39 +2487,25 @@ func (q *Queries) RevertPauseToActive(ctx context.Context, arg RevertPauseToActi
 const revertResumeToPaused = `-- name: RevertResumeToPaused :exec
 UPDATE sandbox
 SET status = 'paused',
-    -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
-    -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands back the deadline the claim saw instead, so
-    -- retrying it cannot postpone deletion. It is restored only while the
-    -- row is untouched since the claim: an auto-delete patch, even one that
-    -- repeats the value, bumps updated_at and leaves the deadline NULL for
-    -- the return to paused, so it is armed from the current window here.
-    auto_delete_at = CASE
-      WHEN updated_at = $3::timestamptz
-      THEN $4::timestamptz
-      ELSE now() + make_interval(secs => auto_delete_seconds)
-    END,
+    -- The claim leaves the deadline in place, so a failed resume returns the
+    -- row to paused with the deadline it had and retrying cannot postpone
+    -- deletion. An auto-delete patch made while resuming leaves the deadline
+    -- NULL for the return to paused, so it is armed from the window here.
+    auto_delete_at = COALESCE(auto_delete_at, now() + make_interval(secs => auto_delete_seconds)),
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
 `
 
 type RevertResumeToPausedParams struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	ClaimedUpdatedAt  pgtype.Timestamptz `json:"claimed_updated_at"`
-	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
+	ID     uuid.UUID `json:"id"`
+	TeamID uuid.UUID `json:"team_id"`
 }
 
 // Compensate a failed resume attempt by flipping status back to 'paused'.
 // Guarded on status = 'resuming' so we never clobber a concurrent transition
 // (e.g., ActivateSandbox has already flipped to 'active').
 func (q *Queries) RevertResumeToPaused(ctx context.Context, arg RevertResumeToPausedParams) error {
-	_, err := q.db.Exec(ctx, revertResumeToPaused,
-		arg.ID,
-		arg.TeamID,
-		arg.ClaimedUpdatedAt,
-		arg.PriorAutoDeleteAt,
-	)
+	_, err := q.db.Exec(ctx, revertResumeToPaused, arg.ID, arg.TeamID)
 	return err
 }
 

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -551,6 +551,7 @@ FROM (
   FROM (SELECT pg_advisory_xact_lock(hashtext($2::text)::bigint)) locked
 ) lk, (
   SELECT sb.id,
+         sb.auto_delete_at AS prior_auto_delete_at,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
@@ -581,7 +582,7 @@ RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcp
           x.snap_path, x.snap_mem_path,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
-          x.template_base_path
+          x.template_base_path, x.prior_auto_delete_at
 `
 
 type ClaimResumeParams struct {
@@ -591,16 +592,17 @@ type ClaimResumeParams struct {
 }
 
 type ClaimResumeRow struct {
-	Sandbox           Sandbox  `json:"sandbox"`
-	SnapPath          *string  `json:"snap_path"`
-	SnapMemPath       *string  `json:"snap_mem_path"`
-	Access            string   `json:"access"`
-	WireAccess        string   `json:"wire_access"`
-	Revision          int64    `json:"revision"`
-	PortNumbers       []int32  `json:"port_numbers"`
-	PortAccesses      []string `json:"port_accesses"`
-	PortTokenVersions []int64  `json:"port_token_versions"`
-	TemplateBasePath  *string  `json:"template_base_path"`
+	Sandbox           Sandbox            `json:"sandbox"`
+	SnapPath          *string            `json:"snap_path"`
+	SnapMemPath       *string            `json:"snap_mem_path"`
+	Access            string             `json:"access"`
+	WireAccess        string             `json:"wire_access"`
+	Revision          int64              `json:"revision"`
+	PortNumbers       []int32            `json:"port_numbers"`
+	PortAccesses      []string           `json:"port_accesses"`
+	PortTokenVersions []int64            `json:"port_token_versions"`
+	TemplateBasePath  *string            `json:"template_base_path"`
+	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
 }
 
 // The paused→resuming claim plus the boot inputs in one round trip:
@@ -611,6 +613,8 @@ type ClaimResumeRow struct {
 // the row key: the planner keeps a volatile target there, whereas an
 // EXISTS subquery has its target list dropped and never takes the lock.
 // LEFT joins keep the row when the snapshot or policy row is missing.
+// prior_auto_delete_at is the deadline the claim clears, handed back by a
+// revert that never reached the daemon.
 // 0 rows: not paused, or another resume claimed it.
 func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (ClaimResumeRow, error) {
 	row := q.db.QueryRow(ctx, claimResume, arg.ID, arg.LockKey, arg.TeamID)
@@ -651,6 +655,7 @@ func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (Claim
 		&i.PortAccesses,
 		&i.PortTokenVersions,
 		&i.TemplateBasePath,
+		&i.PriorAutoDeleteAt,
 	)
 	return i, err
 }
@@ -2482,23 +2487,27 @@ func (q *Queries) RevertPauseToActive(ctx context.Context, arg RevertPauseToActi
 const revertResumeToPaused = `-- name: RevertResumeToPaused :exec
 UPDATE sandbox
 SET status = 'paused',
-    -- Re-arm the auto-delete deadline cleared by BeginResume; the sandbox is
-    -- paused again, so it gets a fresh window.
-    auto_delete_at = now() + make_interval(secs => auto_delete_seconds),
+    -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
+    -- paused again, so it gets a fresh window. A resume refused before it
+    -- reached the daemon hands the prior deadline back instead, so retrying
+    -- it cannot postpone deletion.
+    auto_delete_at = COALESCE($3::timestamptz,
+                             now() + make_interval(secs => auto_delete_seconds)),
     updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
 `
 
 type RevertResumeToPausedParams struct {
-	ID     uuid.UUID `json:"id"`
-	TeamID uuid.UUID `json:"team_id"`
+	ID                uuid.UUID          `json:"id"`
+	TeamID            uuid.UUID          `json:"team_id"`
+	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
 }
 
 // Compensate a failed resume attempt by flipping status back to 'paused'.
 // Guarded on status = 'resuming' so we never clobber a concurrent transition
 // (e.g., ActivateSandbox has already flipped to 'active').
 func (q *Queries) RevertResumeToPaused(ctx context.Context, arg RevertResumeToPausedParams) error {
-	_, err := q.db.Exec(ctx, revertResumeToPaused, arg.ID, arg.TeamID)
+	_, err := q.db.Exec(ctx, revertResumeToPaused, arg.ID, arg.TeamID, arg.PriorAutoDeleteAt)
 	return err
 }
 

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -2489,12 +2489,13 @@ UPDATE sandbox
 SET status = 'paused',
     -- Re-arm the auto-delete deadline cleared by the claim; the sandbox is
     -- paused again, so it gets a fresh window. A resume refused before it
-    -- reached the daemon hands back the deadline and window the claim saw
-    -- instead, so retrying it cannot postpone deletion. A window patched
-    -- while the row was resuming wins: the patch left the deadline NULL for
-    -- the return to paused, so it is armed from the new window here.
+    -- reached the daemon hands back the deadline the claim saw instead, so
+    -- retrying it cannot postpone deletion. It is restored only while the
+    -- row is untouched since the claim: an auto-delete patch, even one that
+    -- repeats the value, bumps updated_at and leaves the deadline NULL for
+    -- the return to paused, so it is armed from the current window here.
     auto_delete_at = CASE
-      WHEN auto_delete_seconds IS NOT DISTINCT FROM $3::int
+      WHEN updated_at = $3::timestamptz
       THEN $4::timestamptz
       ELSE now() + make_interval(secs => auto_delete_seconds)
     END,
@@ -2503,10 +2504,10 @@ WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'resuming'
 `
 
 type RevertResumeToPausedParams struct {
-	ID                     uuid.UUID          `json:"id"`
-	TeamID                 uuid.UUID          `json:"team_id"`
-	PriorAutoDeleteSeconds *int32             `json:"prior_auto_delete_seconds"`
-	PriorAutoDeleteAt      pgtype.Timestamptz `json:"prior_auto_delete_at"`
+	ID                uuid.UUID          `json:"id"`
+	TeamID            uuid.UUID          `json:"team_id"`
+	ClaimedUpdatedAt  pgtype.Timestamptz `json:"claimed_updated_at"`
+	PriorAutoDeleteAt pgtype.Timestamptz `json:"prior_auto_delete_at"`
 }
 
 // Compensate a failed resume attempt by flipping status back to 'paused'.
@@ -2516,7 +2517,7 @@ func (q *Queries) RevertResumeToPaused(ctx context.Context, arg RevertResumeToPa
 	_, err := q.db.Exec(ctx, revertResumeToPaused,
 		arg.ID,
 		arg.TeamID,
-		arg.PriorAutoDeleteSeconds,
+		arg.ClaimedUpdatedAt,
 		arg.PriorAutoDeleteAt,
 	)
 	return err

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// seedPausedSandbox creates and pauses a sandbox through the API and waits
+// for the pause to finalize, so the row is claimable.
+func seedPausedSandbox(t *testing.T, apiKey string) uuid.UUID {
+	t.Helper()
+	r := newRouter(t)
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"claim-box"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+	pw := do(r, "POST", "/sandboxes/"+sid+"/pause", apiKey, "")
+	if pw.Code != http.StatusNoContent {
+		t.Fatalf("pause: %d %s", pw.Code, pw.Body.String())
+	}
+	waitBookkeeping()
+	id, err := uuid.Parse(sid)
+	if err != nil {
+		t.Fatalf("parse sandbox id %q: %v", sid, err)
+	}
+	return id
+}
+
+// The claim must block on the advisory lock a secret attach holds; a claim
+// that skipped the lock could flip the row to resuming under an in-flight
+// attach and resume a guest that never receives the new binding. Mocked
+// handler tests cannot see this; only the planner can drop the lock call.
+func TestIntegration_ClaimResume_WaitsForAttachLock(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	sandboxID := seedPausedSandbox(t, apiKey)
+
+	holder, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder tx: %v", err)
+	}
+	defer holder.Rollback(ctx)
+	if err := testQueries.WithTx(holder).LockSandboxForSecretWrites(ctx, sandboxID.String()); err != nil {
+		t.Fatalf("take attach lock: %v", err)
+	}
+
+	type result struct {
+		row db.ClaimResumeRow
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		row, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
+			ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
+		})
+		done <- result{row, err}
+	}()
+
+	select {
+	case res := <-done:
+		t.Fatalf("claim returned while the attach lock was held (err=%v)", res.err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release attach lock: %v", err)
+	}
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("claim after lock release: %v", res.err)
+		}
+		if res.row.Sandbox.Status != db.SandboxStatusResuming {
+			t.Errorf("claimed status = %q, want resuming", res.row.Sandbox.Status)
+		}
+		if res.row.SnapPath == nil || *res.row.SnapPath != "/snapshots/disk.snap" {
+			t.Errorf("claimed snap_path = %v, want the paused snapshot's path", res.row.SnapPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("claim did not proceed after the attach lock was released")
+	}
+}
+
+// The claim holds the attach lock for its own transaction, visible in
+// pg_locks, so a concurrent attach waits on it rather than the reverse
+// only.
+func TestIntegration_ClaimResume_HoldsAttachLock(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	sandboxID := seedPausedSandbox(t, apiKey)
+
+	tx, err := testPool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := testQueries.WithTx(tx).ClaimResume(ctx, db.ClaimResumeParams{
+		ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
+	}); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	var held int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid()`,
+	).Scan(&held); err != nil {
+		t.Fatalf("read pg_locks: %v", err)
+	}
+	if held == 0 {
+		t.Fatal("ClaimResume did not take the attach advisory lock")
+	}
+}

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -145,8 +146,8 @@ func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
 
 	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
 		ID: sandboxID, TeamID: teamID,
-		PriorAutoDeleteSeconds: claimed.Sandbox.AutoDeleteSeconds,
-		PriorAutoDeleteAt:      claimed.PriorAutoDeleteAt,
+		ClaimedUpdatedAt:  pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true},
+		PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
 	}); err != nil {
 		t.Fatalf("revert: %v", err)
 	}
@@ -162,7 +163,7 @@ func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
 
 // A window patched between the claim and a pre-daemon revert wins over the
 // deadline the claim saw: disabling auto-delete leaves no deadline, and a
-// new window arms a fresh deadline from it.
+// new or repeated window arms a fresh deadline from it.
 func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
@@ -188,8 +189,8 @@ func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
 		}
 		if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
 			ID: sandboxID, TeamID: teamID,
-			PriorAutoDeleteSeconds: claimed.Sandbox.AutoDeleteSeconds,
-			PriorAutoDeleteAt:      claimed.PriorAutoDeleteAt,
+			ClaimedUpdatedAt:  pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true},
+			PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
 		}); err != nil {
 			t.Fatalf("revert: %v", err)
 		}
@@ -212,13 +213,14 @@ func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
 		t.Fatalf("disabled while resuming, after revert seconds=%v at=%v, want none", row.AutoDeleteSeconds, row.AutoDeleteAt.Time)
 	}
 
-	wider := int32(7200)
-	claimed := claimThenPatch(&wider)
-	row := read()
-	if row.AutoDeleteSeconds == nil || *row.AutoDeleteSeconds != wider {
-		t.Fatalf("after revert seconds=%v, want %d", row.AutoDeleteSeconds, wider)
-	}
-	if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) || row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
-		t.Fatalf("widened while resuming, after revert at=%v, want a fresh deadline in the future", row.AutoDeleteAt.Time)
+	for _, window := range []int32{7200, 3600} {
+		claimed := claimThenPatch(&window)
+		row := read()
+		if row.AutoDeleteSeconds == nil || *row.AutoDeleteSeconds != window {
+			t.Fatalf("after revert seconds=%v, want %d", row.AutoDeleteSeconds, window)
+		}
+		if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) || row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
+			t.Fatalf("window %d patched while resuming, after revert at=%v, want a fresh deadline in the future", window, row.AutoDeleteAt.Time)
+		}
 	}
 }

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -144,7 +144,9 @@ func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
 	}
 
 	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
-		ID: sandboxID, TeamID: teamID, PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
+		ID: sandboxID, TeamID: teamID,
+		PriorAutoDeleteSeconds: claimed.Sandbox.AutoDeleteSeconds,
+		PriorAutoDeleteAt:      claimed.PriorAutoDeleteAt,
 	}); err != nil {
 		t.Fatalf("revert: %v", err)
 	}
@@ -155,5 +157,68 @@ func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
 	if row.Status != db.SandboxStatusPaused || !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
 		t.Fatalf("after revert status=%s auto_delete_at=%v, want paused with %v",
 			row.Status, row.AutoDeleteAt.Time, claimed.PriorAutoDeleteAt.Time)
+	}
+}
+
+// A window patched between the claim and a pre-daemon revert wins over the
+// deadline the claim saw: disabling auto-delete leaves no deadline, and a
+// new window arms a fresh deadline from it.
+func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	sandboxID := seedPausedSandbox(t, apiKey)
+
+	claimThenPatch := func(patched *int32) db.ClaimResumeRow {
+		t.Helper()
+		if _, err := testPool.Exec(ctx,
+			`UPDATE sandbox SET auto_delete_seconds = 3600, auto_delete_at = now() - interval '1 hour' WHERE id = $1`, sandboxID,
+		); err != nil {
+			t.Fatalf("seed window: %v", err)
+		}
+		claimed, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
+			ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
+		})
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		if _, err := testQueries.UpdateSandboxAutoDelete(ctx, db.UpdateSandboxAutoDeleteParams{
+			ID: sandboxID, TeamID: teamID, AutoDeleteSeconds: patched,
+		}); err != nil {
+			t.Fatalf("patch window: %v", err)
+		}
+		if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
+			ID: sandboxID, TeamID: teamID,
+			PriorAutoDeleteSeconds: claimed.Sandbox.AutoDeleteSeconds,
+			PriorAutoDeleteAt:      claimed.PriorAutoDeleteAt,
+		}); err != nil {
+			t.Fatalf("revert: %v", err)
+		}
+		return claimed
+	}
+	read := func() db.Sandbox {
+		t.Helper()
+		row, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if row.Status != db.SandboxStatusPaused {
+			t.Fatalf("status = %s, want paused", row.Status)
+		}
+		return row
+	}
+
+	claimThenPatch(nil)
+	if row := read(); row.AutoDeleteSeconds != nil || row.AutoDeleteAt.Valid {
+		t.Fatalf("disabled while resuming, after revert seconds=%v at=%v, want none", row.AutoDeleteSeconds, row.AutoDeleteAt.Time)
+	}
+
+	wider := int32(7200)
+	claimed := claimThenPatch(&wider)
+	row := read()
+	if row.AutoDeleteSeconds == nil || *row.AutoDeleteSeconds != wider {
+		t.Fatalf("after revert seconds=%v, want %d", row.AutoDeleteSeconds, wider)
+	}
+	if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) || row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
+		t.Fatalf("widened while resuming, after revert at=%v, want a fresh deadline in the future", row.AutoDeleteAt.Time)
 	}
 }

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -119,9 +118,10 @@ func TestIntegration_ClaimResume_HoldsAttachLock(t *testing.T) {
 	}
 }
 
-// A revert handed the prior deadline leaves it exactly as the claim found
-// it; only a revert without one re-arms a fresh window.
-func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
+// The claim leaves the auto-delete deadline on the row, and a revert leaves
+// it as it found it, so a resume that fails before reaching the daemon
+// cannot postpone deletion.
+func TestIntegration_ClaimResume_LeavesDeadlineForRevert(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
 	sandboxID := seedPausedSandbox(t, apiKey)
@@ -137,49 +137,42 @@ func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("claim: %v", err)
 	}
-	if !claimed.PriorAutoDeleteAt.Valid || !claimed.PriorAutoDeleteAt.Time.Before(time.Now()) {
-		t.Fatalf("claim returned prior deadline %v, want the past one it cleared", claimed.PriorAutoDeleteAt)
-	}
-	if claimed.Sandbox.AutoDeleteAt.Valid {
-		t.Fatalf("claim left auto_delete_at = %v, want cleared", claimed.Sandbox.AutoDeleteAt.Time)
+	if !claimed.Sandbox.AutoDeleteAt.Valid || !claimed.Sandbox.AutoDeleteAt.Time.Before(time.Now()) {
+		t.Fatalf("claim left auto_delete_at = %v, want the past deadline untouched", claimed.Sandbox.AutoDeleteAt)
 	}
 
-	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
-		ID: sandboxID, TeamID: teamID,
-		ClaimedUpdatedAt:  pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true},
-		PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
-	}); err != nil {
+	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}); err != nil {
 		t.Fatalf("revert: %v", err)
 	}
 	row, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if row.Status != db.SandboxStatusPaused || !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
+	if row.Status != db.SandboxStatusPaused || !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.Equal(claimed.Sandbox.AutoDeleteAt.Time) {
 		t.Fatalf("after revert status=%s auto_delete_at=%v, want paused with %v",
-			row.Status, row.AutoDeleteAt.Time, claimed.PriorAutoDeleteAt.Time)
+			row.Status, row.AutoDeleteAt.Time, claimed.Sandbox.AutoDeleteAt.Time)
 	}
 }
 
-// A window patched between the claim and a pre-daemon revert wins over the
-// deadline the claim saw: disabling auto-delete leaves no deadline, and a
-// new or repeated window arms a fresh deadline from it.
-func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
+// An auto-delete patch made while the row is resuming leaves the deadline
+// NULL for the return to paused, so the revert arms it from the patched
+// window: disabling leaves no deadline, a new or repeated window arms a
+// fresh one.
+func TestIntegration_RevertResumeToPaused_ArmsPatchedWindow(t *testing.T) {
 	ctx := context.Background()
 	teamID, apiKey := seedTeamAndKey(t)
 	sandboxID := seedPausedSandbox(t, apiKey)
 
-	claimThenPatch := func(patched *int32) db.ClaimResumeRow {
+	claimPatchRevert := func(patched *int32) {
 		t.Helper()
 		if _, err := testPool.Exec(ctx,
 			`UPDATE sandbox SET auto_delete_seconds = 3600, auto_delete_at = now() - interval '1 hour' WHERE id = $1`, sandboxID,
 		); err != nil {
 			t.Fatalf("seed window: %v", err)
 		}
-		claimed, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
+		if _, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
 			ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatalf("claim: %v", err)
 		}
 		if _, err := testQueries.UpdateSandboxAutoDelete(ctx, db.UpdateSandboxAutoDeleteParams{
@@ -187,14 +180,9 @@ func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("patch window: %v", err)
 		}
-		if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
-			ID: sandboxID, TeamID: teamID,
-			ClaimedUpdatedAt:  pgtype.Timestamptz{Time: claimed.Sandbox.UpdatedAt, Valid: true},
-			PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
-		}); err != nil {
+		if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{ID: sandboxID, TeamID: teamID}); err != nil {
 			t.Fatalf("revert: %v", err)
 		}
-		return claimed
 	}
 	read := func() db.Sandbox {
 		t.Helper()
@@ -208,18 +196,18 @@ func TestIntegration_RevertResumeToPaused_PatchedWindowWins(t *testing.T) {
 		return row
 	}
 
-	claimThenPatch(nil)
+	claimPatchRevert(nil)
 	if row := read(); row.AutoDeleteSeconds != nil || row.AutoDeleteAt.Valid {
 		t.Fatalf("disabled while resuming, after revert seconds=%v at=%v, want none", row.AutoDeleteSeconds, row.AutoDeleteAt.Time)
 	}
 
 	for _, window := range []int32{7200, 3600} {
-		claimed := claimThenPatch(&window)
+		claimPatchRevert(&window)
 		row := read()
 		if row.AutoDeleteSeconds == nil || *row.AutoDeleteSeconds != window {
 			t.Fatalf("after revert seconds=%v, want %d", row.AutoDeleteSeconds, window)
 		}
-		if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) || row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
+		if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) {
 			t.Fatalf("window %d patched while resuming, after revert at=%v, want a fresh deadline in the future", window, row.AutoDeleteAt.Time)
 		}
 	}

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -117,3 +117,43 @@ func TestIntegration_ClaimResume_HoldsAttachLock(t *testing.T) {
 		t.Fatal("ClaimResume did not take the attach advisory lock")
 	}
 }
+
+// A revert handed the prior deadline leaves it exactly as the claim found
+// it; only a revert without one re-arms a fresh window.
+func TestIntegration_RevertResumeToPaused_KeepsPriorDeadline(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	sandboxID := seedPausedSandbox(t, apiKey)
+	if _, err := testPool.Exec(ctx,
+		`UPDATE sandbox SET auto_delete_at = now() - interval '1 hour' WHERE id = $1`, sandboxID,
+	); err != nil {
+		t.Fatalf("seed deadline: %v", err)
+	}
+
+	claimed, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
+		ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
+	})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed.PriorAutoDeleteAt.Valid || !claimed.PriorAutoDeleteAt.Time.Before(time.Now()) {
+		t.Fatalf("claim returned prior deadline %v, want the past one it cleared", claimed.PriorAutoDeleteAt)
+	}
+	if claimed.Sandbox.AutoDeleteAt.Valid {
+		t.Fatalf("claim left auto_delete_at = %v, want cleared", claimed.Sandbox.AutoDeleteAt.Time)
+	}
+
+	if err := testQueries.RevertResumeToPaused(ctx, db.RevertResumeToPausedParams{
+		ID: sandboxID, TeamID: teamID, PriorAutoDeleteAt: claimed.PriorAutoDeleteAt,
+	}); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	row, err := testQueries.GetSandbox(ctx, db.GetSandboxParams{ID: sandboxID, TeamID: teamID})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if row.Status != db.SandboxStatusPaused || !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.Equal(claimed.PriorAutoDeleteAt.Time) {
+		t.Fatalf("after revert status=%s auto_delete_at=%v, want paused with %v",
+			row.Status, row.AutoDeleteAt.Time, claimed.PriorAutoDeleteAt.Time)
+	}
+}


### PR DESCRIPTION
The resume claim is now a single ClaimResume statement: it takes the same advisory lock attach and detach take, flips paused to resuming, and returns the snapshot paths, preview policy with published ports, and template base path in one round trip, replacing the policy reads, the four-statement claim transaction, the snapshot read, and the template fallback read.
The lock rides a FROM item joined on the row key, because Postgres drops the target list of an EXISTS subquery and would never call it; two integration tests prove it, one blocking the claim behind a held attach lock, one reading pg_locks from inside the claiming transaction.
The host capability checks run after the claim on the returned policy and revert it on refusal; the post-restore policy reapply is unchanged. The claim phase, now on main, measures the change.