### PR TITLE
vm: wall-clock manifest, pause intent and a host floor for images that owe a wake

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -48,6 +48,8 @@ on:
       - 'deploy/superserve-vms.service'
       - 'deploy/vmd-rollback-guard'
       - 'deploy/superserve-vmd-rollback-guard.conf'
+      - 'deploy/vmd-wake-floor-guard'
+      - 'deploy/superserve-vmd-wake-floor-guard.conf'
       - 'deploy/superserve-vmd-start-generation.conf'
       - 'deploy/superserve-secretsproxy.service'
       - 'deploy/firecracker@.service'

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -474,10 +474,10 @@ def main() -> int:
             # seeded among the templates), and from then on a vmd without the
             # protocol would leave such images stopped. Same check as the
             # host-resident start guard, applied before the binary lands.
-            if ! grep -qa wake-protocol-1 {extract_dir}/bin/vmd; then
-                SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
-                SNAPSHOTS="${{SNAPSHOTS:-/var/lib/sandbox/snapshots}}"
-                if [ -e /var/lib/sandbox/wake-protocol-evidence ] || grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
+            SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
+            SNAPSHOTS="${{SNAPSHOTS:-/var/lib/sandbox/snapshots}}"
+            if [ -e /var/lib/sandbox/wake-protocol-evidence ] || grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
+                if ! grep -qa wake-protocol-1 {extract_dir}/bin/vmd; then
                     echo "ERROR: this host holds images that owe a wake; refusing a vmd without the wake protocol" >&2
                     exit 1
                 fi

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -127,6 +127,8 @@ preserving vmd's template cache.
 """
 
 import os
+import re
+import pathlib
 import shlex
 import subprocess
 import sys
@@ -165,6 +167,8 @@ BUNDLE_FILES = [
     "deploy/superserve-vms.service",
     "deploy/vmd-rollback-guard",
     "deploy/superserve-vmd-rollback-guard.conf",
+    "deploy/vmd-wake-floor-guard",
+    "deploy/superserve-vmd-wake-floor-guard.conf",
     "deploy/superserve-vmd-start-generation.conf",
     "deploy/superserve-secretsproxy.service",
     "deploy/firecracker@.service",
@@ -179,7 +183,19 @@ BUNDLE_FILES = [
 ]
 
 
+def check_bundle_parity() -> None:
+    """Every deploy/ file the remote script installs must ride in the bundle,
+    or the install fails on the host after the binaries were already copied.
+    Checked before any host is touched."""
+    src = pathlib.Path(__file__).read_text()
+    referenced = set(re.findall(r"\{extract_dir\}/(deploy/[A-Za-z0-9_.@-]+)", src))
+    missing = sorted(referenced - set(BUNDLE_FILES))
+    if missing:
+        sys.exit(f"deploy-vmd.py: installed by the remote script but not bundled: {missing}")
+
+
 def main() -> int:
+    check_bundle_parity()
     project = os.environ["GCP_PROJECT"]
     region = os.environ.get("GCP_REGION", "")
     label = os.environ.get("VMD_LABEL", "component=vmd")
@@ -453,6 +469,20 @@ def main() -> int:
                 echo "host drained — proceeding with downgrade"
             fi
 
+            # Wake-protocol floor: the daemon writes this evidence the first
+            # time it sees an image that owes a wake (restored, paused, or
+            # seeded among the templates), and from then on a vmd without the
+            # protocol would leave such images stopped. Same check as the
+            # host-resident start guard, applied before the binary lands.
+            if ! grep -qa wake-protocol-1 {extract_dir}/bin/vmd; then
+                SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
+                SNAPSHOTS="${{SNAPSHOTS:-/var/lib/sandbox/snapshots}}"
+                if [ -e /var/lib/sandbox/wake-protocol-evidence ] || grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
+                    echo "ERROR: this host holds images that owe a wake; refusing a vmd without the wake protocol" >&2
+                    exit 1
+                fi
+            fi
+
             # Install vmd + template-builder binaries.
             sudo install -m 0755 {extract_dir}/bin/vmd {install_dir}/vmd
             sudo install -m 0755 {extract_dir}/bin/template-builder {install_dir}/template-builder
@@ -495,6 +525,11 @@ def main() -> int:
             sudo install -m 0755 {extract_dir}/deploy/vmd-rollback-guard {install_dir}/vmd-rollback-guard
             sudo install -d -m 0755 /etc/systemd/system/superserve-vmd.service.d
             sudo install -m 0644 {extract_dir}/deploy/superserve-vmd-rollback-guard.conf /etc/systemd/system/superserve-vmd.service.d/10-rollback-guard.conf
+            # Wake-protocol floor: its own executable and drop-in, at paths no
+            # earlier deploy script knows, so a rollback that reinstalls that
+            # script's guard leaves this one in place. See vmd-wake-floor-guard.
+            sudo install -m 0755 {extract_dir}/deploy/vmd-wake-floor-guard {install_dir}/vmd-wake-floor-guard
+            sudo install -m 0644 {extract_dir}/deploy/superserve-vmd-wake-floor-guard.conf /etc/systemd/system/superserve-vmd.service.d/30-wake-floor-guard.conf
             # Start-generation stamp: proves receipt succession (see the
             # drop-in's header). A drop-in for the same reason as the guard
             # above — it must survive deploys of revisions that predate it.

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -469,18 +469,12 @@ def main() -> int:
                 echo "host drained — proceeding with downgrade"
             fi
 
-            # Wake-protocol floor: the daemon writes this evidence the first
-            # time it sees an image that owes a wake (restored, paused, or
-            # seeded among the templates), and from then on a vmd without the
-            # protocol would leave such images stopped. Same check as the
-            # host-resident start guard, applied before the binary lands.
-            SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
-            SNAPSHOTS="${{SNAPSHOTS:-/var/lib/sandbox/snapshots}}"
-            if [ -e /var/lib/sandbox/wake-protocol-evidence ] || grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
-                if ! grep -qa wake-protocol-1 {extract_dir}/bin/vmd; then
-                    echo "ERROR: this host holds images that owe a wake; refusing a vmd without the wake protocol" >&2
-                    exit 1
-                fi
+            # Wake-protocol floor: the guard the service runs at every start,
+            # applied to the new binary before it lands. One source for what
+            # it checks; see deploy/vmd-wake-floor-guard.
+            if ! sh {extract_dir}/deploy/vmd-wake-floor-guard {extract_dir}/bin/vmd; then
+                echo "ERROR: the wake-protocol floor guard rejects this vmd; refusing to install it" >&2
+                exit 1
             fi
 
             # Install vmd + template-builder binaries.

--- a/.github/workflows/scripts/test_deploy_vmd_bundle.py
+++ b/.github/workflows/scripts/test_deploy_vmd_bundle.py
@@ -1,0 +1,37 @@
+"""Every deploy/ file the remote script installs must ride in the bundle, or
+the install fails on the host after the binaries were already copied. The
+script checks this before touching any host; this pins the same property in
+CI, and the wake-floor guard's own install paths.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+SOURCE = Path(__file__).with_name("deploy-vmd.py").read_text()
+
+
+def _bundle_files():
+    block = re.search(r"BUNDLE_FILES = \[(.*?)\]", SOURCE, re.S).group(1)
+    return set(re.findall(r'"([^"]+)"', block))
+
+
+class DeployVmdBundleTests(unittest.TestCase):
+    def test_every_installed_deploy_file_is_bundled(self):
+        referenced = set(re.findall(r"\{extract_dir\}/(deploy/[A-Za-z0-9_.@-]+)", SOURCE))
+        self.assertTrue(referenced)
+        self.assertEqual(sorted(referenced - _bundle_files()), [])
+
+    def test_wake_floor_guard_has_its_own_paths(self):
+        # A drop-in and executable of their own, at names no earlier deploy
+        # script writes, so a rollback that reinstalls that script's guard
+        # leaves this one in place.
+        self.assertIn("deploy/vmd-wake-floor-guard", _bundle_files())
+        self.assertIn("deploy/superserve-vmd-wake-floor-guard.conf", _bundle_files())
+        self.assertRegex(SOURCE, r"superserve-vmd\.service\.d/30-wake-floor-guard\.conf")
+        self.assertRegex(SOURCE, r"\{install_dir\}/vmd-wake-floor-guard")
+
+    def test_downgrade_is_checked_before_the_binary_lands(self):
+        check = SOURCE.index("wake-protocol-1")
+        install = SOURCE.index("sudo install -m 0755 {extract_dir}/bin/vmd {install_dir}/vmd")
+        self.assertLess(check, install)

--- a/.github/workflows/scripts/test_deploy_vmd_bundle.py
+++ b/.github/workflows/scripts/test_deploy_vmd_bundle.py
@@ -32,6 +32,8 @@ class DeployVmdBundleTests(unittest.TestCase):
         self.assertRegex(SOURCE, r"\{install_dir\}/vmd-wake-floor-guard")
 
     def test_downgrade_is_checked_before_the_binary_lands(self):
-        check = SOURCE.index("wake-protocol-1")
+        # The deploy runs the bundled guard against the new binary, so the
+        # check has one source, and it runs before the binary is installed.
+        check = SOURCE.index("deploy/vmd-wake-floor-guard {extract_dir}/bin/vmd")
         install = SOURCE.index("sudo install -m 0755 {extract_dir}/bin/vmd {install_dir}/vmd")
         self.assertLess(check, install)

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -387,7 +387,13 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 	}
 	emitInternal("system", "artifacts fsynced")
 
-	writeBuildMeta(snapDir, snapPath, memPath, basePath, deltaPath, correctsWallClock, br)
+	// Published last, and whole: the metadata is what tells a supervisor the
+	// directory holds a template, so it appears by rename once everything
+	// else is durable, and a build whose metadata cannot land has not been
+	// published.
+	if err := writeBuildMeta(snapDir, snapPath, memPath, basePath, deltaPath, correctsWallClock, br); err != nil {
+		return fmt.Errorf("publish build metadata: %w", err)
+	}
 
 	return nil
 }
@@ -1082,7 +1088,7 @@ func createBuildOverlay(runDir, vmID, basePath string) (string, error) {
 // Build metadata
 // ---------------------------------------------------------------------------
 
-func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, correctsWallClock bool, br builder.BuildRootfsResult) {
+func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, correctsWallClock bool, br builder.BuildRootfsResult) error {
 	// rootfs_path stays in the schema for backwards compat with existing
 	// readers; supervisors that understand overlay use base_path/delta_path.
 	meta := struct {
@@ -1111,9 +1117,38 @@ func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, corrects
 	}
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
-	_ = os.WriteFile(filepath.Join(dir, "build.meta.json"), data, 0o644)
+	final := filepath.Join(dir, "build.meta.json")
+	tmp := final + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -190,7 +190,13 @@ type buildConfig struct {
 }
 
 func runBuild(ctx context.Context, cfg buildConfig) error {
-	buildVMID := "build-" + cfg.templateID
+	// The build id names the runtime: the socket, overlay and network of
+	// this build alone, so two builds of one template can run side by side.
+	// The template-derived name remains for a caller that supplies no id.
+	buildVMID := cfg.buildID
+	if buildVMID == "" {
+		buildVMID = "build-" + cfg.templateID
+	}
 	// Per-build subdir — rebuilds don't disturb existing sandboxes.
 	rootfsDir := filepath.Join(cfg.runDir, vm.TemplatesDirName, cfg.templateID, cfg.buildID)
 	basePath := filepath.Join(rootfsDir, "base.ext4")

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -701,7 +701,10 @@ func boxdFreezeWorkload(ctx context.Context, vmIP, token string) error {
 var errNoSuchFreeze = errors.New("guest holds no freeze under this token")
 
 // boxdThawWorkload releases a freeze whose outcome is unknown. 200 released;
-// 409 errNoSuchFreeze; anything else leaves the state unknown.
+// 409 with the guest reporting a running workload errNoSuchFreeze; anything
+// else leaves the state unknown. A 409 alone is not proof: the guest answers
+// it both when it holds no freeze under the token and when it holds one under
+// another, and only its own report tells those apart.
 func boxdThawWorkload(ctx context.Context, vmIP, token string) error {
 	url := fmt.Sprintf("http://%s:%d/thaw", vmIP, boxdPort)
 	payload, _ := json.Marshal(struct {
@@ -722,10 +725,38 @@ func boxdThawWorkload(ctx context.Context, vmIP, token string) error {
 	case http.StatusOK:
 		return nil
 	case http.StatusConflict:
+		if err := boxdWorkloadRunning(ctx, vmIP); err != nil {
+			return fmt.Errorf("POST /thaw: %s; %w", strings.TrimSpace(string(body)), err)
+		}
 		return errNoSuchFreeze
 	default:
 		return fmt.Errorf("POST /thaw: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+}
+
+// boxdWorkloadRunning asks the guest whether its workload runs. Anything but
+// a plain ok is not proof that it does.
+func boxdWorkloadRunning(ctx context.Context, vmIP string) error {
+	url := fmt.Sprintf("http://%s:%d/health", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("GET /health: %w", err)
+	}
+	defer resp.Body.Close()
+	var health struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return fmt.Errorf("decode /health: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK || health.Status != "ok" {
+		return fmt.Errorf("guest reports %q (status %d), not a running workload", health.Status, resp.StatusCode)
+	}
+	return nil
 }
 
 // userEnv filters the build-time env map down to the keys set via `env`

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -690,8 +690,8 @@ func boxdFreezeWorkload(ctx context.Context, vmIP, token string) error {
 	if err := json.Unmarshal(body, &echo); err != nil {
 		return fmt.Errorf("POST /freeze: reply: %w", err)
 	}
-	if echo.Version != vm.WallClockManifestVersion || echo.Token != token {
-		return fmt.Errorf("POST /freeze: guest speaks protocol %d and holds token %q, asked %d %q", echo.Version, echo.Token, vm.WallClockManifestVersion, token)
+	if echo.Version != vm.WakeProtocolVersion || echo.Token != token {
+		return fmt.Errorf("POST /freeze: guest speaks protocol %d and holds token %q, asked %d %q", echo.Version, echo.Token, vm.WakeProtocolVersion, token)
 	}
 	return nil
 }

--- a/cmd/template-builder/main.go
+++ b/cmd/template-builder/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -181,6 +182,11 @@ type buildConfig struct {
 	slotIndex   int
 	launcherNS  string
 	netlinkOps  bool
+	// freezeWorkload builds the image with its workload freezer and, once the
+	// guest has proven it corrects its clock, snapshots it frozen. Set by
+	// nothing yet: a frozen image is only safe under a supervisor that can wake
+	// it, so the switch arrives with that supervisor.
+	freezeWorkload bool
 }
 
 func runBuild(ctx context.Context, cfg buildConfig) error {
@@ -215,6 +221,7 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 		BoxdBinaryPath:           cfg.boxdBin,
 		MaxUncompressedSizeBytes: int64(cfg.diskMiB) * 1024 * 1024,
 		ProxyCACertPath:          proxyCA,
+		FreezeWorkload:           cfg.freezeWorkload,
 	})
 	if err != nil {
 		return fmt.Errorf("create builder: %w", err)
@@ -311,6 +318,43 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 		return fmt.Errorf("guest sync: %w", err)
 	}
 
+	// Ask the guest, in the state the snapshot captures, whether it can correct
+	// its wall clock and freeze its workload; only then may the image be marked.
+	correctsWallClock, why := false, "template workload freezing not enabled"
+	if cfg.freezeWorkload {
+		correctsWallClock, why = boxdWallClockProven(ctx, netInfo.HostIP)
+	}
+	// The token this image's freeze carries; every wake of a sandbox created
+	// from it must present it. Minted here, kept by the guest in the snapshot.
+	freezeToken := vm.NewFreezeToken()
+	if correctsWallClock {
+		// The rollback floor rises before the first frozen artifact can exist
+		// on this host: a supervisor without the wake protocol must never be
+		// installed over one, so a floor that cannot be made durable fails
+		// the build rather than freeze anything.
+		if err := vm.RaiseWakeProtocolFloor(); err != nil {
+			return fmt.Errorf("raise wake-protocol floor: %w", err)
+		}
+	}
+	if correctsWallClock {
+		// A freeze whose answer was lost may still have frozen the guest, and
+		// an image with a stopped workload and no manifest would never be
+		// woken. So a failed freeze is followed by a thaw with the same
+		// token: released, or never frozen, means the image is unfrozen and
+		// the build goes on the older way; anything else fails the build.
+		if err := boxdFreezeWorkload(ctx, netInfo.HostIP, freezeToken); err != nil {
+			if terr := boxdThawWorkload(ctx, netInfo.HostIP, freezeToken); terr != nil && !errors.Is(terr, errNoSuchFreeze) {
+				return fmt.Errorf("workload freeze failed (%v) and the guest could not be released (%v); refusing to snapshot a workload in an unknown state", err, terr)
+			}
+			correctsWallClock, why = false, "workload freeze: "+err.Error()
+		}
+	}
+	if correctsWallClock {
+		emitInternal("system", "guest corrects its wall clock and froze its workload: marking template")
+	} else {
+		emitInternal("system", "template stays on the unfrozen restore path (%s)", why)
+	}
+
 	// block_delta_dir → emits rootfs.delta so sandboxes can be created
 	// from this template's snapshot.
 	emitUser("system", "Saving template")
@@ -322,14 +366,28 @@ func runBuild(ctx context.Context, cfg buildConfig) error {
 	}
 	emitInternal("system", "snapshot captured")
 
+	// The manifest tells a supervisor this image's workload is frozen, that its
+	// guest corrects its clock, and which token the wake must present.
+	markerPath := ""
+	if correctsWallClock {
+		markerPath = vm.WallClockMarkerPath(memPath)
+		man := vm.WallClockManifest{
+			Version: vm.WallClockManifestVersion, ArtifactID: vm.NewArtifactID(),
+			WorkloadFrozen: true, GuestCorrectsClock: true, FreezeToken: freezeToken,
+		}
+		if err := vm.WriteWallClockManifest(memPath, man); err != nil {
+			return fmt.Errorf("write wall-clock manifest: %w", err)
+		}
+	}
+
 	// Flush host page cache for each artifact so a sandbox cp'ing them
 	// later doesn't see sparse holes from still-dirty pages.
-	if err := fsyncBuildArtifacts(snapDir, snapPath, memPath, basePath, deltaPath); err != nil {
+	if err := fsyncBuildArtifacts(snapDir, snapPath, memPath, basePath, deltaPath, markerPath); err != nil {
 		return fmt.Errorf("fsync build artifacts: %w", err)
 	}
 	emitInternal("system", "artifacts fsynced")
 
-	writeBuildMeta(snapDir, snapPath, memPath, basePath, deltaPath, br)
+	writeBuildMeta(snapDir, snapPath, memPath, basePath, deltaPath, correctsWallClock, br)
 
 	return nil
 }
@@ -556,6 +614,118 @@ func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, d
 		return fmt.Errorf("POST /init: status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// boxdWallClockProven reports whether the guest can read host time and set
+// its own clock, and why not. Any failure to ask reads as not proven.
+func boxdWallClockProven(ctx context.Context, vmIP string) (bool, string) {
+	url := fmt.Sprintf("http://%s:%d/verify-clock", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return false, err.Error()
+	}
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		return false, "POST /verify-clock: " + err.Error()
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return false, "no workload freezer in this image"
+	}
+	var body struct {
+		WallClock struct {
+			Source    string `json:"source"`
+			SettimeOK bool   `json:"settime_ok"`
+			Error     string `json:"error"`
+		} `json:"wall_clock"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, "decode /verify-clock: " + err.Error()
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Sprintf("/verify-clock status %d: %s", resp.StatusCode, body.WallClock.Error)
+	}
+	if body.WallClock.Source != "ptp" {
+		if body.WallClock.Error != "" {
+			return false, body.WallClock.Error
+		}
+		return false, "source " + body.WallClock.Source
+	}
+	if !body.WallClock.SettimeOK {
+		if body.WallClock.Error != "" {
+			return false, body.WallClock.Error
+		}
+		return false, "clock cannot be set"
+	}
+	return true, ""
+}
+
+// boxdFreezeWorkload asks the guest to stop its workload for the snapshot. The
+// guest undoes a freeze it could not complete, so an error means it is running.
+func boxdFreezeWorkload(ctx context.Context, vmIP, token string) error {
+	url := fmt.Sprintf("http://%s:%d/freeze", vmIP, boxdPort)
+	payload, _ := json.Marshal(struct {
+		Token string `json:"token"`
+	}{token})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("POST /freeze: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST /freeze: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	// The reply names the protocol the guest speaks and the token it holds;
+	// an image is only marked when both are what this builder asked for.
+	var echo struct {
+		Version int    `json:"version"`
+		Token   string `json:"token"`
+	}
+	if err := json.Unmarshal(body, &echo); err != nil {
+		return fmt.Errorf("POST /freeze: reply: %w", err)
+	}
+	if echo.Version != vm.WallClockManifestVersion || echo.Token != token {
+		return fmt.Errorf("POST /freeze: guest speaks protocol %d and holds token %q, asked %d %q", echo.Version, echo.Token, vm.WallClockManifestVersion, token)
+	}
+	return nil
+}
+
+// errNoSuchFreeze: the guest holds no freeze under that token, so there was
+// nothing to release — the freeze never took.
+var errNoSuchFreeze = errors.New("guest holds no freeze under this token")
+
+// boxdThawWorkload releases a freeze whose outcome is unknown. 200 released;
+// 409 errNoSuchFreeze; anything else leaves the state unknown.
+func boxdThawWorkload(ctx context.Context, vmIP, token string) error {
+	url := fmt.Sprintf("http://%s:%d/thaw", vmIP, boxdPort)
+	payload, _ := json.Marshal(struct {
+		Token string `json:"token"`
+	}{token})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("POST /thaw: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusConflict:
+		return errNoSuchFreeze
+	default:
+		return fmt.Errorf("POST /thaw: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 }
 
 // userEnv filters the build-time env map down to the keys set via `env`
@@ -881,7 +1051,7 @@ func createBuildOverlay(runDir, vmID, basePath string) (string, error) {
 // Build metadata
 // ---------------------------------------------------------------------------
 
-func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, br builder.BuildRootfsResult) {
+func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, correctsWallClock bool, br builder.BuildRootfsResult) {
 	// rootfs_path stays in the schema for backwards compat with existing
 	// readers; supervisors that understand overlay use base_path/delta_path.
 	meta := struct {
@@ -894,16 +1064,19 @@ func writeBuildMeta(dir, snapPath, memPath, basePath, deltaPath string, br build
 		SizeBytes      int64  `json:"size_bytes"`
 		BuiltAt        string `json:"built_at"`
 		SwapMode       string `json:"swap_mode"` // see builder.SwapModeGuest
+		// Same fact as the manifest beside mem.snap; kept here for provenance.
+		CorrectsWallClock bool `json:"corrects_wall_clock"`
 	}{
-		SnapshotPath:   snapPath,
-		MemPath:        memPath,
-		RootfsPath:     basePath,
-		BasePath:       basePath,
-		DeltaPath:      deltaPath,
-		ResolvedDigest: br.ResolvedDigest,
-		SizeBytes:      br.SizeBytes,
-		BuiltAt:        time.Now().UTC().Format(time.RFC3339),
-		SwapMode:       builder.SwapModeGuest,
+		SnapshotPath:      snapPath,
+		MemPath:           memPath,
+		RootfsPath:        basePath,
+		BasePath:          basePath,
+		DeltaPath:         deltaPath,
+		ResolvedDigest:    br.ResolvedDigest,
+		SizeBytes:         br.SizeBytes,
+		BuiltAt:           time.Now().UTC().Format(time.RFC3339),
+		SwapMode:          builder.SwapModeGuest,
+		CorrectsWallClock: correctsWallClock,
 	}
 	data, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {

--- a/cmd/template-builder/wallclock_test.go
+++ b/cmd/template-builder/wallclock_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// boxdWallClockProven decides whether an image is marked as able to correct
+// its own wall clock. A marker on a guest that cannot would let it be restored
+// onto a stale clock, so every path that is not positive evidence must read as
+// "not proven".
+func TestBoxdWallClockProven(t *testing.T) {
+	serve := func(t *testing.T, status int, body string) (ip string, done func()) {
+		t.Helper()
+		// boxdPort is fixed, so bind the loopback on exactly that port.
+		ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+		if err != nil {
+			t.Skipf("port %d busy: %v", boxdPort, err)
+		}
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/verify-clock" {
+				t.Errorf("unexpected request %s %s: the build must ask the clock to be proven settable", r.Method, r.URL.RequestURI())
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			w.Write([]byte(body))
+		}))
+		srv.Listener = ln
+		srv.Start()
+		return "127.0.0.1", srv.Close
+	}
+
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+		reason string // substring expected in the reason when not proven
+	}{
+		{"ptp_and_settable_is_proven", 200, `{"status":"ok","wall_clock":{"source":"ptp","settime_ok":true}}`, true, ""},
+		{"ptp_with_prior_correction_is_proven", 200, `{"status":"ok","wall_clock":{"source":"ptp","corrected_ms":86400000,"settime_ok":true}}`, true, ""},
+		{"ptp_but_not_settable_is_not", 200, `{"status":"ok","wall_clock":{"source":"ptp","error":"settime: EPERM"}}`, false, "EPERM"},
+		{"unavailable_source_is_not", 200, `{"status":"ok","wall_clock":{"source":"unavailable","error":"open /dev/ptp0: no such file"}}`, false, "ptp0"},
+		{"no_freezer_in_the_image_is_not", 404, `no workload freezer in this image`, false, "freezer"},
+		{"not_ready_is_not", 503, `{"status":"clock","wall_clock":{"source":"ptp","error":"set: EPERM"}}`, false, "503"},
+		{"missing_field_is_not", 200, `{"status":"ok"}`, false, "source"},
+		{"malformed_is_not", 200, `not json`, false, "decode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip, done := serve(t, tc.status, tc.body)
+			defer done()
+			got, why := boxdWallClockProven(context.Background(), ip)
+			if got != tc.want {
+				t.Fatalf("proven = %v (%q), want %v", got, why, tc.want)
+			}
+			if !tc.want && !strings.Contains(why, tc.reason) {
+				t.Errorf("reason %q, want it to mention %q", why, tc.reason)
+			}
+		})
+	}
+
+	// No agent at all is the most likely failure in practice and must not
+	// resolve to "proven" by accident.
+	t.Run("unreachable_is_not", func(t *testing.T) {
+		got, why := boxdWallClockProven(context.Background(), "127.0.0.1")
+		if got {
+			t.Fatal("unreachable agent must not prove anything")
+		}
+		if !strings.Contains(why, "/verify-clock") {
+			t.Errorf("reason %q should say it was the verification that failed", why)
+		}
+	})
+}
+
+// A freeze that did not complete must never let the image be marked: the
+// helper's error is what demotes the template to the unfrozen path.
+func TestBoxdFreezeWorkload(t *testing.T) {
+	serve := func(t *testing.T, status int, reply string) func() {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+		if err != nil {
+			t.Skipf("port %d busy: %v", boxdPort, err)
+		}
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost || r.URL.Path != "/freeze" {
+				t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+			var body struct {
+				Token string `json:"token"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body.Token != "tok" {
+				t.Errorf("freeze carried token %q, want the builder's", body.Token)
+			}
+			w.WriteHeader(status)
+			w.Write([]byte(reply))
+		}))
+		srv.Listener = ln
+		srv.Start()
+		return srv.Close
+	}
+
+	t.Run("frozen_with_matching_echo_is_ok", func(t *testing.T) {
+		defer serve(t, 200, `{"version":1,"capability":"wake","token":"tok"}`)()
+		if err := boxdFreezeWorkload(context.Background(), "127.0.0.1", "tok"); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+	})
+	t.Run("echo_naming_another_token_or_protocol_is_an_error", func(t *testing.T) {
+		defer serve(t, 200, `{"version":1,"token":"other"}`)()
+		if err := boxdFreezeWorkload(context.Background(), "127.0.0.1", "tok"); err == nil {
+			t.Fatal("a guest holding another token must not mark the image")
+		}
+	})
+	t.Run("budget_exhausted_is_an_error_with_the_reason", func(t *testing.T) {
+		defer serve(t, 504, "workload did not freeze within budget")()
+		err := boxdFreezeWorkload(context.Background(), "127.0.0.1", "tok")
+		if err == nil || !strings.Contains(err.Error(), "504") || !strings.Contains(err.Error(), "budget") {
+			t.Fatalf("err = %v, want the status and the agent's reason", err)
+		}
+	})
+	t.Run("unreachable_is_an_error", func(t *testing.T) {
+		if err := boxdFreezeWorkload(context.Background(), "127.0.0.1", "tok"); err == nil {
+			t.Fatal("no agent must not read as frozen")
+		}
+	})
+}
+
+// After a freeze whose answer was lost, the build releases the guest with the
+// same token before going on unfrozen; only a release that neither confirmed
+// nor said "no such freeze" leaves the state unknown.
+func TestBoxdThawWorkload(t *testing.T) {
+	serve := func(t *testing.T, status int) func() {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+		if err != nil {
+			t.Skipf("port %d busy: %v", boxdPort, err)
+		}
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Token string `json:"token"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if r.URL.Path != "/thaw" || body.Token != "tok" {
+				t.Errorf("unexpected %s with token %q", r.URL.Path, body.Token)
+			}
+			w.WriteHeader(status)
+		}))
+		srv.Listener = ln
+		srv.Start()
+		return srv.Close
+	}
+	t.Run("released", func(t *testing.T) {
+		defer serve(t, 200)()
+		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("never_frozen", func(t *testing.T) {
+		defer serve(t, 409)()
+		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); !errors.Is(err, errNoSuchFreeze) {
+			t.Fatalf("err = %v, want errNoSuchFreeze", err)
+		}
+	})
+	t.Run("unknown_state", func(t *testing.T) {
+		defer serve(t, 500)()
+		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err == nil || errors.Is(err, errNoSuchFreeze) {
+			t.Fatalf("err = %v, want an error that fails the build", err)
+		}
+	})
+}

--- a/cmd/template-builder/wallclock_test.go
+++ b/cmd/template-builder/wallclock_test.go
@@ -138,13 +138,20 @@ func TestBoxdFreezeWorkload(t *testing.T) {
 // same token before going on unfrozen; only a release that neither confirmed
 // nor said "no such freeze" leaves the state unknown.
 func TestBoxdThawWorkload(t *testing.T) {
-	serve := func(t *testing.T, status int) func() {
+	// thawStatus answers /thaw; healthStatus and healthBody answer the /health
+	// the builder asks after a 409, since a 409 alone proves nothing.
+	serve := func(t *testing.T, thawStatus, healthStatus int, healthBody string) func() {
 		t.Helper()
 		ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
 		if err != nil {
 			t.Skipf("port %d busy: %v", boxdPort, err)
 		}
 		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				w.WriteHeader(healthStatus)
+				w.Write([]byte(healthBody))
+				return
+			}
 			var body struct {
 				Token string `json:"token"`
 			}
@@ -152,26 +159,38 @@ func TestBoxdThawWorkload(t *testing.T) {
 			if r.URL.Path != "/thaw" || body.Token != "tok" {
 				t.Errorf("unexpected %s with token %q", r.URL.Path, body.Token)
 			}
-			w.WriteHeader(status)
+			w.WriteHeader(thawStatus)
 		}))
 		srv.Listener = ln
 		srv.Start()
 		return srv.Close
 	}
 	t.Run("released", func(t *testing.T) {
-		defer serve(t, 200)()
+		defer serve(t, 200, 500, "")()
 		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err != nil {
 			t.Fatal(err)
 		}
 	})
-	t.Run("never_frozen", func(t *testing.T) {
-		defer serve(t, 409)()
+	t.Run("never_frozen_and_running", func(t *testing.T) {
+		defer serve(t, 409, 200, `{"status":"ok","wall_clock":{"source":"ptp"}}`)()
 		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); !errors.Is(err, errNoSuchFreeze) {
 			t.Fatalf("err = %v, want errNoSuchFreeze", err)
 		}
 	})
+	t.Run("frozen_under_another_token", func(t *testing.T) {
+		defer serve(t, 409, 503, `{"status":"frozen","wall_clock":{"source":"ptp"}}`)()
+		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err == nil || errors.Is(err, errNoSuchFreeze) {
+			t.Fatalf("err = %v, want an error that fails the build: the workload is stopped", err)
+		}
+	})
+	t.Run("running_unproven", func(t *testing.T) {
+		defer serve(t, 409, 200, `not json`)()
+		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err == nil || errors.Is(err, errNoSuchFreeze) {
+			t.Fatalf("err = %v, want an error that fails the build", err)
+		}
+	})
 	t.Run("unknown_state", func(t *testing.T) {
-		defer serve(t, 500)()
+		defer serve(t, 500, 200, `{"status":"ok"}`)()
 		if err := boxdThawWorkload(context.Background(), "127.0.0.1", "tok"); err == nil || errors.Is(err, errNoSuchFreeze) {
 			t.Fatalf("err = %v, want an error that fails the build", err)
 		}

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1562,12 +1562,8 @@ func main() {
 	// close that window would cost every restart more than it saves.
 	mgr.WatchFirecrackerCapability(ctx, log)
 	// Evidence a previous process made durable is recognised; starting a vmd
-	// creates none. The snapshot directory is recorded for the guard that
-	// checks such evidence at every start.
+	// creates none.
 	vm.RecognizeWakeProtocolFloor()
-	if err := vm.WriteSnapshotDirBreadcrumb(cfg.SnapshotDir); err != nil {
-		log.Warn().Err(err).Msg("snapshot directory breadcrumb not written; the wake-floor guard falls back to the default location")
-	}
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1561,6 +1561,7 @@ func main() {
 	// wrong, and corrected by the next probe. Blocking readiness on an exec to
 	// close that window would cost every restart more than it saves.
 	mgr.WatchFirecrackerCapability(ctx, log)
+	mgr.WatchTemplateManifests(ctx, log)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1561,7 +1561,9 @@ func main() {
 	// wrong, and corrected by the next probe. Blocking readiness on an exec to
 	// close that window would cost every restart more than it saves.
 	mgr.WatchFirecrackerCapability(ctx, log)
-	mgr.WatchTemplateManifests(ctx, log)
+	// Evidence a previous process made durable is recognised; starting a vmd
+	// creates none.
+	vm.RecognizeWakeProtocolFloor()
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1562,8 +1562,12 @@ func main() {
 	// close that window would cost every restart more than it saves.
 	mgr.WatchFirecrackerCapability(ctx, log)
 	// Evidence a previous process made durable is recognised; starting a vmd
-	// creates none.
+	// creates none. The snapshot directory is recorded for the guard that
+	// checks such evidence at every start.
 	vm.RecognizeWakeProtocolFloor()
+	if err := vm.WriteSnapshotDirBreadcrumb(cfg.SnapshotDir); err != nil {
+		log.Warn().Err(err).Msg("snapshot directory breadcrumb not written; the wake-floor guard falls back to the default location")
+	}
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/deploy/superserve-vmd-wake-floor-guard.conf
+++ b/deploy/superserve-vmd-wake-floor-guard.conf
@@ -1,0 +1,7 @@
+# Installed to /etc/systemd/system/superserve-vmd.service.d/ by the deploy
+# pipeline. A drop-in of its own, separate from the other guard's: a deploy of
+# an older revision rewrites the files it knows about and never this one, so
+# the wake-protocol floor survives the exact rollback it exists to refuse.
+# See vmd-wake-floor-guard for what it blocks.
+[Service]
+ExecStartPre=/usr/local/bin/vmd-wake-floor-guard /usr/local/bin/vmd

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -14,23 +14,27 @@
 # holds far too many images for a walk at every start, so the witness has to
 # be there before the image is.
 set -u
+LC_ALL=C
+export LC_ALL
 BIN="${1:-/usr/local/bin/vmd}"
 WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
 
-# One stat. Absent: no frozen image has ever been about to exist here, and
-# any vmd may start. A directory that exists but cannot be read is not
-# absence: refuse rather than guess.
-dir=$(dirname "$WAKE_EVIDENCE")
-if [ -d "$dir" ] && { [ ! -r "$dir" ] || [ ! -x "$dir" ]; }; then
-    echo "vmd-wake-floor-guard: cannot read ${dir}; refusing to start a vmd whose wake capability cannot be checked against it" >&2
-    exit 1
-fi
-if [ ! -e "$WAKE_EVIDENCE" ]; then
-    exit 0
+# One lookup. Only a lookup that says the file does not exist admits any vmd:
+# no frozen image has ever been about to exist here. A lookup that fails any
+# other way — an ancestor that cannot be traversed, a symlink loop — is not
+# absence, and is treated as presence: only a binary that can wake such
+# images may start. (A test for existence alone cannot tell the two apart.)
+lookup=$(stat -L "$WAKE_EVIDENCE" 2>&1 >/dev/null)
+if [ $? -ne 0 ]; then
+    case "$lookup" in
+        *"No such file or directory"*) exit 0 ;;
+        *) echo "vmd-wake-floor-guard: cannot look up ${WAKE_EVIDENCE} (${lookup}); only a wake-capable vmd may start" >&2 ;;
+    esac
 fi
 
-# Evidence present: only a binary carrying the capability may start. One
-# pass over the binary, bounded by its size; a grep that cannot run refuses.
+# Evidence present, or unknowable: only a binary carrying the capability may
+# start. One pass over the binary, bounded by its size; a grep that cannot
+# run refuses.
 if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
     exit 0
 fi

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Host-resident wake-protocol floor for superserve-vmd, invoked from its own
+# systemd drop-in at every service start. It lives in a file and a drop-in of
+# its own, which deploy scripts from before it never install or overwrite:
+# rolling back to such a revision replaces the other guard with that
+# revision's copy, but leaves this one exactly as it is.
+#
+# An image whose workload was frozen for its snapshot owes a wake that only a
+# vmd speaking the protocol can give; any other vmd restores it and leaves it
+# stopped. Two witnesses, either blocks a vmd without the protocol: the
+# evidence file the daemon writes when it first restores, pauses or holds such
+# an image, and the images themselves — templates and paused sandboxes alike —
+# so one that landed moments ago still counts.
+set -u
+BIN="${1:-/usr/local/bin/vmd}"
+
+if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
+    exit 0
+fi
+
+WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
+SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
+SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
+wake_evidence=""
+[ -e "$WAKE_EVIDENCE" ] && wake_evidence="$WAKE_EVIDENCE"
+if [ -z "$wake_evidence" ] && grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
+    wake_evidence="frozen image manifest under ${SNAPSHOTS}"
+fi
+if [ -n "$wake_evidence" ]; then
+    echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake (${wake_evidence})" >&2
+    echo "vmd-wake-floor-guard: deploy a wake-capable build; the floor comes down only once no frozen image can be restored here" >&2
+    exit 1
+fi
+exit 0

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -14,10 +14,8 @@
 set -u
 BIN="${1:-/usr/local/bin/vmd}"
 
-if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
-    exit 0
-fi
-
+# Witnesses first: a host that holds no such image pays a stat and a glob at
+# each start, and the binary is scanned only when one exists.
 WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
 SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
 SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
@@ -25,6 +23,12 @@ wake_evidence=""
 [ -e "$WAKE_EVIDENCE" ] && wake_evidence="$WAKE_EVIDENCE"
 if [ -z "$wake_evidence" ] && grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
     wake_evidence="frozen image manifest under ${SNAPSHOTS}"
+fi
+if [ -z "$wake_evidence" ]; then
+    exit 0
+fi
+if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
+    exit 0
 fi
 if [ -n "$wake_evidence" ]; then
     echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake (${wake_evidence})" >&2

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -7,49 +7,33 @@
 #
 # An image whose workload was frozen for its snapshot owes a wake that only a
 # vmd speaking the protocol can give; any other vmd restores it and leaves it
-# stopped. Two witnesses, either blocks a vmd without the protocol: the
-# evidence file the daemon writes when it first acts on such an image, and
-# the images themselves — templates and paused sandboxes alike — so one that
-# landed moments ago still counts.
+# stopped. The one witness is the evidence file, which whatever puts such an
+# image on this host writes first: the template builder before it publishes
+# a frozen template, the daemon before it freezes or restores one, and any
+# import of one from elsewhere. Nothing here walks the snapshot trees: a host
+# holds far too many images for a walk at every start, so the witness has to
+# be there before the image is.
 set -u
 BIN="${1:-/usr/local/bin/vmd}"
+WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
 
-# A binary that carries the capability is admitted before anything else is
-# looked at: one pass over the binary, bounded by its size, and no walk of the
-# snapshot trees whatever they hold.
-if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
+# One stat. Absent: no frozen image has ever been about to exist here, and
+# any vmd may start. A directory that exists but cannot be read is not
+# absence: refuse rather than guess.
+dir=$(dirname "$WAKE_EVIDENCE")
+if [ -d "$dir" ] && { [ ! -r "$dir" ] || [ ! -x "$dir" ]; }; then
+    echo "vmd-wake-floor-guard: cannot read ${dir}; refusing to start a vmd whose wake capability cannot be checked against it" >&2
+    exit 1
+fi
+if [ ! -e "$WAKE_EVIDENCE" ]; then
     exit 0
 fi
 
-refuse() {
-    echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake ($1)" >&2
-    echo "vmd-wake-floor-guard: deploy a wake-capable build; the floor comes down only once no frozen image can be restored here" >&2
-    exit 1
-}
-
-# The daemon writes both witnesses' locations: the evidence file when it
-# first acts on such an image, and its resolved snapshot directory at every
-# start, read here rather than parsed out of env files, as the rollback guard
-# reads the state path. No breadcrumb means the daemon has never run here.
-WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
-SNAPSHOTS=$(head -n 1 /var/lib/sandbox/vmd-snapshot-dir 2>/dev/null)
-SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
-[ -e "$WAKE_EVIDENCE" ] && refuse "$WAKE_EVIDENCE"
-
-# The walk runs only for a binary without the capability, so its cost lands
-# on a rollback, never on an ordinary start. find batches the paths itself,
-# so no argument list can overflow; grep's "no match" is folded into success
-# so that any other failure — an unreadable directory, a grep that could not
-# run — reaches rc, and a walk that cannot complete blocks rather than
-# reading as "nothing found".
-if [ -d "$SNAPSHOTS" ]; then
-    matches=$(find "$SNAPSHOTS" -mindepth 2 -maxdepth 4 -type f -name '*.wallclock' \
-        -exec sh -c 'grep -l "$0" "$@" || [ $? -eq 1 ]' '"workload_frozen":true' {} + 2>&1)
-    rc=$?
-    if [ "$rc" -ne 0 ]; then
-        echo "vmd-wake-floor-guard: cannot tell whether ${SNAPSHOTS} holds a frozen image (${matches}); refusing to start a vmd without the wake protocol" >&2
-        exit 1
-    fi
-    [ -n "$matches" ] && refuse "frozen image manifest under ${SNAPSHOTS}"
+# Evidence present: only a binary carrying the capability may start. One
+# pass over the binary, bounded by its size; a grep that cannot run refuses.
+if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
+    exit 0
 fi
-exit 0
+echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake (${WAKE_EVIDENCE})" >&2
+echo "vmd-wake-floor-guard: deploy a wake-capable build; the floor comes down only once no frozen image can be restored here" >&2
+exit 1

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -15,9 +15,13 @@ set -u
 BIN="${1:-/usr/local/bin/vmd}"
 
 # Witnesses first: a host that holds no such image pays a stat and a glob at
-# each start, and the binary is scanned only when one exists.
+# each start, and the binary is scanned only when one exists. The daemon
+# writes both witnesses' locations: the evidence file when it first acts on
+# such an image, and its resolved snapshot directory at every start, read
+# here rather than parsed out of env files, as the rollback guard reads the
+# state path. No breadcrumb means the daemon has never run here.
 WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
-SNAPSHOTS=$(sed -n 's/^SNAPSHOT_DIR=//p' /etc/sandbox/vmd.env 2>/dev/null | tail -n 1 | tr -d '"')
+SNAPSHOTS=$(head -n 1 /var/lib/sandbox/vmd-snapshot-dir 2>/dev/null)
 SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
 wake_evidence=""
 [ -e "$WAKE_EVIDENCE" ] && wake_evidence="$WAKE_EVIDENCE"

--- a/deploy/vmd-wake-floor-guard
+++ b/deploy/vmd-wake-floor-guard
@@ -8,35 +8,48 @@
 # An image whose workload was frozen for its snapshot owes a wake that only a
 # vmd speaking the protocol can give; any other vmd restores it and leaves it
 # stopped. Two witnesses, either blocks a vmd without the protocol: the
-# evidence file the daemon writes when it first restores, pauses or holds such
-# an image, and the images themselves — templates and paused sandboxes alike —
-# so one that landed moments ago still counts.
+# evidence file the daemon writes when it first acts on such an image, and
+# the images themselves — templates and paused sandboxes alike — so one that
+# landed moments ago still counts.
 set -u
 BIN="${1:-/usr/local/bin/vmd}"
 
-# Witnesses first: a host that holds no such image pays a stat and a glob at
-# each start, and the binary is scanned only when one exists. The daemon
-# writes both witnesses' locations: the evidence file when it first acts on
-# such an image, and its resolved snapshot directory at every start, read
-# here rather than parsed out of env files, as the rollback guard reads the
-# state path. No breadcrumb means the daemon has never run here.
-WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
-SNAPSHOTS=$(head -n 1 /var/lib/sandbox/vmd-snapshot-dir 2>/dev/null)
-SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
-wake_evidence=""
-[ -e "$WAKE_EVIDENCE" ] && wake_evidence="$WAKE_EVIDENCE"
-if [ -z "$wake_evidence" ] && grep -lqs '"workload_frozen":true' "$SNAPSHOTS"/templates/*/*/*.wallclock "$SNAPSHOTS"/templates/*/*.wallclock "$SNAPSHOTS"/*/*.wallclock 2>/dev/null; then
-    wake_evidence="frozen image manifest under ${SNAPSHOTS}"
-fi
-if [ -z "$wake_evidence" ]; then
-    exit 0
-fi
+# A binary that carries the capability is admitted before anything else is
+# looked at: one pass over the binary, bounded by its size, and no walk of the
+# snapshot trees whatever they hold.
 if grep -qa wake-protocol-1 "$BIN" 2>/dev/null; then
     exit 0
 fi
-if [ -n "$wake_evidence" ]; then
-    echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake (${wake_evidence})" >&2
+
+refuse() {
+    echo "vmd-wake-floor-guard: REFUSING to start a vmd without the wake protocol: this host holds images that owe a wake ($1)" >&2
     echo "vmd-wake-floor-guard: deploy a wake-capable build; the floor comes down only once no frozen image can be restored here" >&2
     exit 1
+}
+
+# The daemon writes both witnesses' locations: the evidence file when it
+# first acts on such an image, and its resolved snapshot directory at every
+# start, read here rather than parsed out of env files, as the rollback guard
+# reads the state path. No breadcrumb means the daemon has never run here.
+WAKE_EVIDENCE=/var/lib/sandbox/wake-protocol-evidence
+SNAPSHOTS=$(head -n 1 /var/lib/sandbox/vmd-snapshot-dir 2>/dev/null)
+SNAPSHOTS="${SNAPSHOTS:-/var/lib/sandbox/snapshots}"
+[ -e "$WAKE_EVIDENCE" ] && refuse "$WAKE_EVIDENCE"
+
+# The walk runs only for a binary without the capability, so its cost lands
+# on a rollback, never on an ordinary start. find batches the paths itself,
+# so no argument list can overflow; grep's "no match" is folded into success
+# so that any other failure — an unreadable directory, a grep that could not
+# run — reaches rc, and a walk that cannot complete blocks rather than
+# reading as "nothing found".
+if [ -d "$SNAPSHOTS" ]; then
+    matches=$(find "$SNAPSHOTS" -mindepth 2 -maxdepth 4 -type f -name '*.wallclock' \
+        -exec sh -c 'grep -l "$0" "$@" || [ $? -eq 1 ]' '"workload_frozen":true' {} + 2>&1)
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "vmd-wake-floor-guard: cannot tell whether ${SNAPSHOTS} holds a frozen image (${matches}); refusing to start a vmd without the wake protocol" >&2
+        exit 1
+    fi
+    [ -n "$matches" ] && refuse "frozen image manifest under ${SNAPSHOTS}"
 fi
 exit 0

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -115,21 +118,49 @@ func defaultBuildVMID(templateID string) string {
 	return "build-" + templateID + "-" + randomHex()[:8]
 }
 
+// validBuildPathSegment reports whether an id names exactly one directory
+// level: no separators, no "." or "..", nothing that could point the build
+// directory, or its cleanup, anywhere but templates/<template>/<build>.
+func validBuildPathSegment(id string) bool {
+	return id != "" && id != "." && id != ".." && len(id) <= 255 &&
+		!strings.ContainsAny(id, "/\\\x00") && filepath.Base(id) == id
+}
+
 // prepareBuildDir refuses a build into a directory that holds a published
 // template, and clears one a crashed build left unpublished: its files —
 // a snapshot, a wall-clock manifest — must not survive beside the new
-// build's. Published means the builder wrote its metadata, which it does
-// last.
+// build's. Published means the builder's metadata reads whole; a torn or
+// empty file from an interrupted write is leftovers, not a template. Any
+// other failure to read it blocks the build rather than deciding either way.
 func (m *Manager) prepareBuildDir(templateID, buildVMID string) error {
-	dir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID, buildVMID)
-	if _, err := os.Stat(filepath.Join(dir, buildMetaFilename)); err == nil {
-		return status.Errorf(codes.AlreadyExists, "template %s build %s is already published at %s; a rebuild needs a new build id", templateID, buildVMID, dir)
+	if !validBuildPathSegment(templateID) || !validBuildPathSegment(buildVMID) {
+		return status.Errorf(codes.InvalidArgument, "template %q build %q: ids must name a single directory each", templateID, buildVMID)
 	}
-	if _, err := os.Stat(dir); err == nil {
-		m.log.Warn().Str("dir", dir).Msg("build: clearing the leftovers of an unpublished build")
-		if err := os.RemoveAll(dir); err != nil {
-			return fmt.Errorf("clear unpublished build directory %s: %w", dir, err)
+	root := filepath.Clean(filepath.Join(m.cfg.SnapshotDir, TemplatesDirName))
+	dir := filepath.Join(root, templateID, buildVMID)
+	if filepath.Dir(filepath.Dir(dir)) != root {
+		return status.Errorf(codes.InvalidArgument, "template %q build %q: not a build directory", templateID, buildVMID)
+	}
+	_, merr := readBuildMetaJSON(dir)
+	var syntax *json.SyntaxError
+	var typed *json.UnmarshalTypeError
+	switch {
+	case merr == nil:
+		return status.Errorf(codes.AlreadyExists, "template %s build %s is already published at %s; a rebuild needs a new build id", templateID, buildVMID, dir)
+	case errors.Is(merr, fs.ErrNotExist), errors.As(merr, &syntax), errors.As(merr, &typed):
+		// Nothing published here: no metadata, or metadata a crash tore.
+	default:
+		return fmt.Errorf("read build metadata in %s: %w", dir, merr)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
 		}
+		return fmt.Errorf("stat build directory %s: %w", dir, err)
+	}
+	m.log.Warn().Str("dir", dir).Msg("build: clearing the leftovers of an unpublished build")
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("clear unpublished build directory %s: %w", dir, err)
 	}
 	return nil
 }

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -176,6 +176,9 @@ func (m *Manager) buildTemplateWorker(ctx context.Context, buildVMID string, req
 	// safety net for early error returns. Releasing allocation at worker
 	// return would publish a full VM's memory during a hash-only interval
 	// that can run for minutes.
+	// Last to run: the id stays reserved until this worker, and the
+	// subprocess it waited for, are gone.
+	defer close(rec.workerDone)
 	defer m.buildPressureCount.Add(-1)
 	defer m.releaseBuildAlloc(rec, req.VCPU, req.MemoryMiB)
 	result, err := m.buildTemplateSync(ctx, buildVMID, req, rec)
@@ -251,10 +254,10 @@ func (m *Manager) buildTemplateSync(ctx context.Context, buildVMID string, req B
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
 	cmd.WaitDelay = 30 * time.Second
 
-	// Build VM's working dir. template-builder names it "build-<templateID>"
-	// (not vmd's buildVMID), so we clean that exact path. Done here because
-	// template-builder's own defer can't run on SIGKILL.
-	defer os.RemoveAll(filepath.Join(m.cfg.RunDir, "build-"+req.TemplateID))
+	// Build VM's working dir, named by this build's id so it is this
+	// build's alone. Cleaned here because template-builder's own defer
+	// cannot run on SIGKILL.
+	defer os.RemoveAll(filepath.Join(m.cfg.RunDir, buildVMID))
 
 	if err := cmd.Run(); err != nil {
 		// Prefer the structured reason the subprocess emitted on its way

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -85,19 +85,20 @@ func (m *Manager) BuildTemplate(ctx context.Context, req BuildTemplateRequest) (
 	if buildVMID == "" {
 		buildVMID = defaultBuildVMID(req.TemplateID)
 	}
-	// A published template is immutable: its directory is what every sandbox
-	// created from it, and every paused overlay layered on it, refers to. A
-	// build never lands on one; a rebuild is a new build id and a new
-	// directory, which is how the control plane names its builds anyway.
-	if err := m.prepareBuildDir(req.TemplateID, buildVMID); err != nil {
-		return "", err
-	}
-
 	// Fresh context so the build survives the caller's HTTP request
 	// ending. CancelBuild is what stops it.
 	buildCtx, cancel := context.WithCancel(context.Background())
 
-	rec, err := m.registerBuild(buildVMID, req.TemplateID, req.VCPU, req.MemoryMiB, cancel)
+	// A published template is immutable: its directory is what every sandbox
+	// created from it, and every paused overlay layered on it, refers to. A
+	// build never lands on one; a rebuild is a new build id and a new
+	// directory, which is how the control plane names its builds anyway. The
+	// directory is prepared under the registry's lock, once the id is known
+	// to be free: a retry of an id still in flight is refused there, before
+	// it could remove the running build's files.
+	rec, err := m.registerBuild(buildVMID, req.TemplateID, req.VCPU, req.MemoryMiB, cancel, func() error {
+		return m.prepareBuildDir(req.TemplateID, buildVMID)
+	})
 	if err != nil {
 		cancel()
 		return "", err

--- a/internal/vm/build.go
+++ b/internal/vm/build.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,7 +83,14 @@ func (m *Manager) BuildTemplate(ctx context.Context, req BuildTemplateRequest) (
 
 	buildVMID := req.BuildVMID
 	if buildVMID == "" {
-		buildVMID = "build-" + req.TemplateID
+		buildVMID = defaultBuildVMID(req.TemplateID)
+	}
+	// A published template is immutable: its directory is what every sandbox
+	// created from it, and every paused overlay layered on it, refers to. A
+	// build never lands on one; a rebuild is a new build id and a new
+	// directory, which is how the control plane names its builds anyway.
+	if err := m.prepareBuildDir(req.TemplateID, buildVMID); err != nil {
+		return "", err
 	}
 
 	// Fresh context so the build survives the caller's HTTP request
@@ -97,6 +106,31 @@ func (m *Manager) BuildTemplate(ctx context.Context, req BuildTemplateRequest) (
 	go func() { defer sentrylog.Recover("build-worker"); m.buildTemplateWorker(buildCtx, buildVMID, req, rec) }()
 
 	return buildVMID, nil
+}
+
+// defaultBuildVMID names a build whose caller supplied no id: unique, so it
+// can never land where a published template already is.
+func defaultBuildVMID(templateID string) string {
+	return "build-" + templateID + "-" + randomHex()[:8]
+}
+
+// prepareBuildDir refuses a build into a directory that holds a published
+// template, and clears one a crashed build left unpublished: its files —
+// a snapshot, a wall-clock manifest — must not survive beside the new
+// build's. Published means the builder wrote its metadata, which it does
+// last.
+func (m *Manager) prepareBuildDir(templateID, buildVMID string) error {
+	dir := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName, templateID, buildVMID)
+	if _, err := os.Stat(filepath.Join(dir, buildMetaFilename)); err == nil {
+		return status.Errorf(codes.AlreadyExists, "template %s build %s is already published at %s; a rebuild needs a new build id", templateID, buildVMID, dir)
+	}
+	if _, err := os.Stat(dir); err == nil {
+		m.log.Warn().Str("dir", dir).Msg("build: clearing the leftovers of an unpublished build")
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("clear unpublished build directory %s: %w", dir, err)
+		}
+	}
+	return nil
 }
 
 // buildTemplateWorker is the goroutine body. Runs one build end-to-end and

--- a/internal/vm/build_backup_recovery_test.go
+++ b/internal/vm/build_backup_recovery_test.go
@@ -53,7 +53,7 @@ func TestReconcileDropsWhenRebuildActive(t *testing.T) {
 		return nil
 	})
 	// A new build for the same id is in flight.
-	if _, err := m.registerBuild("build-tpl", "tpl", 1, 1024, nil); err != nil {
+	if _, err := m.registerBuild("build-tpl", "tpl", 1, 1024, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/vm/build_backup_test.go
+++ b/internal/vm/build_backup_test.go
@@ -432,7 +432,7 @@ func TestRegisterBuildCancelsInFlightReconcile(t *testing.T) {
 	// Registration must cancel the reconcile and return once it exits.
 	done := make(chan error, 1)
 	go func() {
-		_, err := m.registerBuild("build-tpl", "tpl", 1, 1024, func() {})
+		_, err := m.registerBuild("build-tpl", "tpl", 1, 1024, func() {}, nil)
 		done <- err
 	}()
 	// The blocked hook ignores cancellation, so release it shortly

--- a/internal/vm/build_dir_test.go
+++ b/internal/vm/build_dir_test.go
@@ -54,6 +54,38 @@ func TestBuildsNeverOverwriteAPublishedTemplate(t *testing.T) {
 		t.Fatalf("fresh build: %v", err)
 	}
 
+	// An id that is not a single directory name can point the cleanup
+	// anywhere: refused before anything is looked at, and nothing is removed.
+	for _, ids := range [][2]string{{"..", "build-1"}, {"tpl", ".."}, {"tpl", "."}, {"", "build-1"}, {"tpl", ""}, {"tpl", "x/../.."}, {"a/b", "build-1"}, {"tpl", "../../vm-1"}} {
+		if err := m.prepareBuildDir(ids[0], ids[1]); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("ids %q: err=%v, want InvalidArgument", ids, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(published, buildMetaFilename)); err != nil {
+		t.Fatal("the published template was removed by a traversing id")
+	}
+
+	// Metadata a crash tore is not a published template: the retry clears
+	// the leftovers and goes on.
+	torn := filepath.Join(dir, TemplatesDirName, "tpl", "build-5")
+	if err := os.MkdirAll(torn, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []string{"", "{\"snapshot_path\": \"/x"} {
+		if err := os.WriteFile(filepath.Join(torn, buildMetaFilename), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.prepareBuildDir("tpl", "build-5"); err != nil {
+			t.Fatalf("torn metadata %q: err=%v, want the leftovers cleared", body, err)
+		}
+		if _, err := os.Stat(torn); !os.IsNotExist(err) {
+			t.Fatalf("torn metadata %q: leftovers kept", body)
+		}
+		if err := os.MkdirAll(torn, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// A retry of an id still in flight is refused by the registry before the
 	// directory is touched: the running build's files survive.
 	inflight := filepath.Join(dir, TemplatesDirName, "tpl", "build-4")

--- a/internal/vm/build_dir_test.go
+++ b/internal/vm/build_dir_test.go
@@ -115,4 +115,21 @@ func TestBuildsNeverOverwriteAPublishedTemplate(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(inflight, "mem.snap")); err != nil {
 		t.Fatal("the retry removed the running build's files")
 	}
+
+	// A cancelled build is terminal before its worker has exited: its id
+	// stays reserved, and its files untouched, until the worker is gone.
+	m.cancelBuildRecord("build-4", "cancelled by caller")
+	if _, err := m.registerBuild("build-4", "tpl", 1, 512, func() {}, func() error { return m.prepareBuildDir("tpl", "build-4") }); err == nil {
+		t.Fatal("a retry took the id of a cancelled build whose worker had not exited")
+	}
+	if _, err := os.Stat(filepath.Join(inflight, "mem.snap")); err != nil {
+		t.Fatal("the retry removed the cancelled build's files while its worker was alive")
+	}
+	close(m.builds["build-4"].workerDone)
+	if _, err := m.registerBuild("build-4", "tpl", 1, 512, func() {}, func() error { return m.prepareBuildDir("tpl", "build-4") }); err != nil {
+		t.Fatalf("retry after the worker exited: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(inflight, "mem.snap")); !os.IsNotExist(err) {
+		t.Fatal("the retry after exit kept the cancelled build's leftovers")
+	}
 }

--- a/internal/vm/build_dir_test.go
+++ b/internal/vm/build_dir_test.go
@@ -1,0 +1,56 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// A build never lands on a published template: a caller that names one is
+// refused, a caller that names nothing gets a fresh id every time, and the
+// leftovers of an unpublished build are cleared before the new one starts.
+func TestBuildsNeverOverwriteAPublishedTemplate(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}}
+
+	if a, b := defaultBuildVMID("tpl"), defaultBuildVMID("tpl"); a == b {
+		t.Fatalf("default build ids collide: %q", a)
+	}
+
+	published := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(published, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(published, "mem.snap"), "tok")
+	if err := os.WriteFile(filepath.Join(published, buildMetaFilename), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.prepareBuildDir("tpl", "build-1"); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("build onto a published template: err=%v, want AlreadyExists", err)
+	}
+	if _, err := os.Stat(WallClockMarkerPath(filepath.Join(published, "mem.snap"))); err != nil {
+		t.Fatal("the published template was touched")
+	}
+
+	// Unpublished leftovers: a crashed build's snapshot and manifest must not
+	// survive beside the new build's.
+	stale := filepath.Join(dir, TemplatesDirName, "tpl", "build-2")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(stale, "mem.snap"), "tok")
+	if err := m.prepareBuildDir("tpl", "build-2"); err != nil {
+		t.Fatalf("build over unpublished leftovers: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatal("unpublished leftovers were kept")
+	}
+
+	if err := m.prepareBuildDir("tpl", "build-3"); err != nil {
+		t.Fatalf("fresh build: %v", err)
+	}
+}

--- a/internal/vm/build_dir_test.go
+++ b/internal/vm/build_dir_test.go
@@ -53,4 +53,34 @@ func TestBuildsNeverOverwriteAPublishedTemplate(t *testing.T) {
 	if err := m.prepareBuildDir("tpl", "build-3"); err != nil {
 		t.Fatalf("fresh build: %v", err)
 	}
+
+	// A retry of an id still in flight is refused by the registry before the
+	// directory is touched: the running build's files survive.
+	inflight := filepath.Join(dir, TemplatesDirName, "tpl", "build-4")
+	if err := os.MkdirAll(inflight, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inflight, "mem.snap"), []byte("half written"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.builds = map[string]*buildRecord{}
+	if _, err := m.registerBuild("build-4", "tpl", 1, 512, func() {}, func() error { return m.prepareBuildDir("tpl", "build-4") }); err != nil {
+		t.Fatalf("first registration: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(inflight, "mem.snap")); !os.IsNotExist(err) {
+		t.Fatal("unpublished leftovers survived the registration that claimed the id")
+	}
+	// The running build recreates its directory and writes into it.
+	if err := os.MkdirAll(inflight, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inflight, "mem.snap"), []byte("half written"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.registerBuild("build-4", "tpl", 1, 512, func() {}, func() error { return m.prepareBuildDir("tpl", "build-4") }); err == nil {
+		t.Fatal("a retry of an id in flight was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(inflight, "mem.snap")); err != nil {
+		t.Fatal("the retry removed the running build's files")
+	}
 }

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -97,7 +97,7 @@ func (m *Manager) initBuildRegistry() {
 // registerBuild inserts a new record in the registry. Fails if a build
 // with the same ID is already in-flight — the caller is expected to pick a
 // unique buildVMID per BuildTemplate invocation.
-func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB uint32, cancel context.CancelFunc) (*buildRecord, error) {
+func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB uint32, cancel context.CancelFunc, prepare func() error) (*buildRecord, error) {
 	m.initBuildRegistry()
 	// An adoption reconcile for this template+build may be mid-flight
 	// with stamped-metadata writes pending; cancel it and AWAIT its exit
@@ -118,6 +118,13 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 	defer m.buildsMu.Unlock()
 	if existing, ok := m.builds[buildVMID]; ok && !existing.Status.IsTerminal() {
 		return nil, fmt.Errorf("build %s already in flight", buildVMID)
+	}
+	// Under the lock, so nothing can claim the id between the check above
+	// and whatever prepare removes.
+	if prepare != nil {
+		if err := prepare(); err != nil {
+			return nil, err
+		}
 	}
 	rec := &buildRecord{
 		BuildVMID:  buildVMID,

--- a/internal/vm/build_registry.go
+++ b/internal/vm/build_registry.go
@@ -28,7 +28,7 @@ func (s BuildStatus) IsTerminal() bool {
 }
 
 // buildRecord is the in-memory state of one build. The record is keyed in
-// Manager.builds by the build VM ID (which is also "build-" + templateID).
+// Manager.builds by the build VM ID.
 //
 // Records are kept indefinitely after terminal status so polling
 // consumers that come back late (e.g. supervisor after a control plane
@@ -70,6 +70,12 @@ type buildRecord struct {
 	// logs is the build's per-build log buffer. Publishers append; SSE /
 	// gRPC stream consumers subscribe. Closed on terminal status.
 	logs *buildLogBuffer
+
+	// workerDone is closed when the build's worker returns, after its
+	// subprocess has exited. A cancelled build is terminal before that, and
+	// its id stays reserved until then: a retry that took the id earlier
+	// would prepare a directory the old subprocess can still write to.
+	workerDone chan struct{}
 }
 
 // Snapshot is the client-visible read view of a buildRecord (no cancel fn).
@@ -116,8 +122,17 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 	}
 	m.buildsMu.Lock()
 	defer m.buildsMu.Unlock()
-	if existing, ok := m.builds[buildVMID]; ok && !existing.Status.IsTerminal() {
-		return nil, fmt.Errorf("build %s already in flight", buildVMID)
+	if existing, ok := m.builds[buildVMID]; ok {
+		if !existing.Status.IsTerminal() {
+			return nil, fmt.Errorf("build %s already in flight", buildVMID)
+		}
+		if existing.workerDone != nil {
+			select {
+			case <-existing.workerDone:
+			default:
+				return nil, fmt.Errorf("build %s is still shutting down; retry once it has exited", buildVMID)
+			}
+		}
 	}
 	// Under the lock, so nothing can claim the id between the check above
 	// and whatever prepare removes.
@@ -135,6 +150,7 @@ func (m *Manager) registerBuild(buildVMID, templateID string, vcpu, memoryMiB ui
 		StartedAt:  time.Now(),
 		cancel:     cancel,
 		logs:       newBuildLogBuffer(),
+		workerDone: make(chan struct{}),
 	}
 	m.builds[buildVMID] = rec
 	// Pressure counters pair with the worker-exit release in

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -109,19 +109,25 @@ func guestCorrectsWallClock(instMemFile, instBaseMem string) bool {
 }
 
 // resumeWallClockProperty returns what the image being resumed says about its
-// guest, preferring the durable record to the filesystem.
+// guest and its workload, preferring the durable record to the filesystem.
 //
 // An ordinary resume reloads the exact image the VM was paused into, and that
-// pause wrote the property to the record and the manifest together — so the
-// record is already the answer and the resume path need not go to disk for it.
-// Only an explicit override, supplying an image this VM was never paused into,
-// or a record that never carried the answer (a rollback to a binary without the
-// field drops it on rewrite, and its silence must not be read as "no") has to
-// look. That read also says whether the image holds a frozen workload, which
-// the caller must refuse: a manifest this binary cannot trust is an error.
-func resumeWallClockProperty(memPath, pausedMemPath string, recorded *bool) (correctsWallClock, workloadFrozen bool, err error) {
-	if memPath == pausedMemPath && recorded != nil {
-		return *recorded, false, nil
+// pause wrote the facts to the record and the manifest together — so the
+// record is already the answer and the resume path need not go to disk for
+// it. The image fact is what decides: a record that carries it answers, and a
+// guest that cannot correct its clock is never frozen, so its record answers
+// too. Only an explicit override, supplying an image this VM was never paused
+// into, or a record that never carried the fact (a rollback to a binary
+// without the field drops it on rewrite, and its silence must not be read as
+// "no") has to look. A manifest this binary cannot trust is an error.
+func resumeWallClockProperty(memPath, pausedMemPath string, recordedCorrects, recordedFrozen *bool) (correctsWallClock, workloadFrozen bool, err error) {
+	if memPath == pausedMemPath {
+		if recordedFrozen != nil {
+			return recordedCorrects != nil && *recordedCorrects, *recordedFrozen, nil
+		}
+		if recordedCorrects != nil && !*recordedCorrects {
+			return false, false, nil
+		}
 	}
 	m, err := imageManifest(memPath)
 	if err != nil {

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -124,10 +124,21 @@ func resumeWallClockProperty(memPath, pausedMemPath string, recorded *bool) (cor
 		return *recorded, false, nil
 	}
 	m, err := imageManifest(memPath)
-	if err != nil || m == nil {
+	if err != nil {
 		return false, false, err
 	}
-	return m.GuestCorrectsClock, m.WorkloadFrozen, nil
+	if m != nil {
+		return m.GuestCorrectsClock, m.WorkloadFrozen, nil
+	}
+	// No manifest of its own: the image holds no frozen workload, which an
+	// overlay never inherits, but its guest came from the template beneath
+	// it, so the capability is read from there, as the pause-time check does.
+	if base, ok := readLayeredBase(memPath); ok {
+		if bm, berr := imageManifest(base); berr == nil && bm != nil {
+			return bm.GuestCorrectsClock, false, nil
+		}
+	}
+	return false, false, nil
 }
 
 // clockPolicyFor turns the resolved image fact into a restore policy.

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 	"time"
 
@@ -27,12 +26,6 @@ const (
 	// clockRealtimeCap is what a Firecracker build advertises when it accepts a
 	// per-restore clock policy. A binary that does not is left on legacy.
 	clockRealtimeCap = "clock-realtime-flag"
-
-	// clockFreezeMarkerSuffix names the marker written beside a memory file whose
-	// guest corrects its wall clock on wake. Presence is the whole signal; the
-	// contents are not read, so the file can carry provenance for an operator
-	// without this becoming a format to parse on the restore path.
-	clockFreezeMarkerSuffix = ".wallclock"
 )
 
 // firecrackerCapabilityProbeTimeout bounds one --version exec.
@@ -98,57 +91,54 @@ func (m *Manager) WatchFirecrackerCapability(ctx context.Context, log zerolog.Lo
 	}()
 }
 
-// clockFreezeMarkerPath returns the marker path for a memory file.
-func clockFreezeMarkerPath(memPath string) string {
-	return memPath + clockFreezeMarkerSuffix
-}
-
-// snapshotCorrectsWallClock reports whether memPath's guest fixes its own wall
-// clock on wake, and so can safely have its monotonic clock frozen.
-func snapshotCorrectsWallClock(memPath string) bool {
-	if memPath == "" {
-		return false
-	}
-	_, err := os.Stat(clockFreezeMarkerPath(memPath))
-	// Any error — absent, unreadable, a racing delete — reads as "cannot".
-	// Absence of proof is not proof, and the safe answer is the slow one.
-	return err == nil
-}
-
 // guestCorrectsWallClock reports whether the guest now being paused fixes its
 // own wall clock, judged from the images it was restored from: its own memory
 // file, or the layered base beneath it when this is a first pass off a template.
+// Any manifest that cannot be read counts as no: absence of proof is not proof,
+// and the safe answer is the slow one.
 func guestCorrectsWallClock(instMemFile, instBaseMem string) bool {
-	return snapshotCorrectsWallClock(instMemFile) ||
-		(instBaseMem != "" && snapshotCorrectsWallClock(instBaseMem))
+	for _, p := range []string{instMemFile, instBaseMem} {
+		if p == "" {
+			continue
+		}
+		if m, err := imageManifest(p); err == nil && m != nil && m.GuestCorrectsClock {
+			return true
+		}
+	}
+	return false
 }
 
-// resumeWallClockProperty returns whether the guest being resumed corrects its
-// own wall clock, preferring the durable record to the filesystem.
+// resumeWallClockProperty returns what the image being resumed says about its
+// guest, preferring the durable record to the filesystem.
 //
 // An ordinary resume reloads the exact image the VM was paused into, and that
-// pause wrote the property to the record and the marker together — so the record
-// is already the answer and the resume path need not go to disk for it. Only an
-// explicit override, supplying an image this VM was never paused into, has to
-// look, because the record then describes a different artifact.
-func resumeWallClockProperty(memPath, basePath, pausedMemPath string, recorded *bool) bool {
+// pause wrote the property to the record and the manifest together — so the
+// record is already the answer and the resume path need not go to disk for it.
+// Only an explicit override, supplying an image this VM was never paused into,
+// or a record that never carried the answer (a rollback to a binary without the
+// field drops it on rewrite, and its silence must not be read as "no") has to
+// look. That read also says whether the image holds a frozen workload, which
+// the caller must refuse: a manifest this binary cannot trust is an error.
+func resumeWallClockProperty(memPath, pausedMemPath string, recorded *bool) (correctsWallClock, workloadFrozen bool, err error) {
 	if memPath == pausedMemPath && recorded != nil {
-		return *recorded
+		return *recorded, false, nil
 	}
-	// Either a different image than this VM was paused into, or a record that
-	// never carried the answer — a rollback to a binary without the field drops
-	// it on rewrite, and its silence must not be read as "no".
-	return guestCorrectsWallClock(memPath, basePath)
+	m, err := imageManifest(memPath)
+	if err != nil || m == nil {
+		return false, false, err
+	}
+	return m.GuestCorrectsClock, m.WorkloadFrozen, nil
 }
 
-// clockPolicyFor turns the resolved guest property into a restore policy.
+// clockPolicyFor turns the resolved image fact into a restore policy.
 //
-// Two independent facts meet here, and only here: whether the guest fixes its
-// own wall clock, which is a property of the image and is recorded with it, and
-// whether this host's Firecracker can be asked to freeze the clock, which is a
-// property of the binary and changes under a running daemon. Keeping them apart
-// is what lets a host with an older binary restore a marked guest the legacy way
-// while leaving its marker intact for a host that can honour it.
+// Two independent facts meet here, and only here: whether the image holds a
+// frozen workload from a guest that fixes its own wall clock, which is a
+// property of the image and is recorded with it, and whether this host's
+// Firecracker can be asked to freeze the clock, which is a property of the
+// binary and changes under a running daemon. Keeping them apart is what lets a
+// host with an older binary restore a marked guest the legacy way while leaving
+// its manifest intact for a host that can honour it.
 //
 // nil means "restore the flags the snapshot itself carries" — the behaviour that
 // predates the flag, and the only one valid for every snapshot. A non-nil false
@@ -156,8 +146,8 @@ func resumeWallClockProperty(memPath, basePath, pausedMemPath string, recorded *
 //
 // It never returns true: advancing the guest clock by elapsed wall time is the
 // behaviour being fixed, so nothing here should be able to ask for it.
-func (m *Manager) clockPolicyFor(correctsWallClock bool) *bool {
-	if !m.cfg.GuestClockFreezeEnabled || !correctsWallClock || !m.clockRealtimeCapable.Load() {
+func (m *Manager) clockPolicyFor(workloadFrozen bool) *bool {
+	if !m.cfg.GuestClockFreezeEnabled || !workloadFrozen || !m.clockRealtimeCapable.Load() {
 		return nil
 	}
 	freeze := false

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 // The policy must stay legacy — restore whatever the snapshot carries — unless
-// both the operator asked for the behaviour and the guest was shown to correct
-// its own wall clock. Freezing a guest that cannot leaves it on a stale clock.
+// both the operator asked for the behaviour and the image holds a frozen
+// workload from a guest shown to correct its own wall clock. Freezing the clock
+// of any other guest leaves it on a stale clock.
 func TestClockPolicyFor(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -78,8 +79,8 @@ func TestClockPolicyForSeparatesGuestFromBinary(t *testing.T) {
 func TestGuestCorrectsWallClock(t *testing.T) {
 	mark := func(t *testing.T, path string) string {
 		t.Helper()
-		if err := os.WriteFile(clockFreezeMarkerPath(path), nil, 0o644); err != nil {
-			t.Fatalf("write marker: %v", err)
+		if err := WriteWallClockManifest(path, WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+			t.Fatalf("write manifest: %v", err)
 		}
 		return path
 	}
@@ -93,7 +94,7 @@ func TestGuestCorrectsWallClock(t *testing.T) {
 	})
 
 	// First layered pass: the VM loaded straight off the template base, so the
-	// base is what carries the marker.
+	// base is what carries the manifest.
 	t.Run("layered_base_marked", func(t *testing.T) {
 		dir := t.TempDir()
 		base := mark(t, filepath.Join(dir, "template.snap"))
@@ -114,6 +115,17 @@ func TestGuestCorrectsWallClock(t *testing.T) {
 		dir := t.TempDir()
 		if guestCorrectsWallClock(filepath.Join(dir, "mem.snap"), "") {
 			t.Error("want false for an unmarked VM with no base")
+		}
+	})
+
+	// A manifest that cannot be read is not proof either way.
+	t.Run("unreadable_is_not_marked", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		if err := os.WriteFile(WallClockMarkerPath(mem), []byte("{"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if guestCorrectsWallClock(mem, "") {
+			t.Error("an unreadable manifest must not read as proof")
 		}
 	})
 }
@@ -252,39 +264,66 @@ func TestCorrectsWallClockAbsentFromOldRecordIsFalse(t *testing.T) {
 // contradicts the record: if the record is used, the marker is irrelevant, which
 // is what proves the lookup was skipped.
 func TestResumeWallClockProperty(t *testing.T) {
+	seed := func(t *testing.T, mem string, m WallClockManifest) {
+		t.Helper()
+		m.Version = WallClockManifestVersion
+		if m.ArtifactID == "" {
+			m.ArtifactID = "a"
+		}
+		if err := WriteWallClockManifest(mem, m); err != nil {
+			t.Fatalf("seed manifest: %v", err)
+		}
+	}
 	t.Run("same_image_trusts_the_record_over_the_disk", func(t *testing.T) {
 		mem := filepath.Join(t.TempDir(), "mem.snap")
-		if err := os.WriteFile(clockFreezeMarkerPath(mem), nil, 0o644); err != nil {
-			t.Fatalf("seed marker: %v", err)
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true})
+		// Manifest says yes, record says no. The record wins ⇒ no read happened.
+		if corrects, _, err := resumeWallClockProperty(mem, mem, boolPtr(false)); corrects || err != nil {
+			t.Errorf("corrects=%v err=%v; want the recorded value, a manifest on disk means the record was not used", corrects, err)
 		}
-		// Marker says yes, record says no. The record wins ⇒ no stat happened.
-		if resumeWallClockProperty(mem, "", mem, boolPtr(false)) {
-			t.Error("want the recorded value; a marker on disk means the record was not used")
-		}
-		// And the inverse: no marker on disk, record says yes.
+		// And the inverse: no manifest on disk, record says yes.
 		bare := filepath.Join(t.TempDir(), "mem.snap")
-		if !resumeWallClockProperty(bare, "", bare, boolPtr(true)) {
-			t.Error("want the recorded value even with no marker beside the image")
+		if corrects, _, err := resumeWallClockProperty(bare, bare, boolPtr(true)); !corrects || err != nil {
+			t.Errorf("corrects=%v err=%v; want the recorded value even with no manifest beside the image", corrects, err)
 		}
 	})
 
 	// An override supplies an image this VM was never paused into, so the record
-	// describes a different artifact and the marker is the only evidence.
-	t.Run("override_image_reads_the_marker", func(t *testing.T) {
+	// describes a different artifact and the manifest is the only evidence.
+	t.Run("override_image_reads_the_manifest", func(t *testing.T) {
 		dir := t.TempDir()
 		override := filepath.Join(dir, "restored.snap")
-		if err := os.WriteFile(clockFreezeMarkerPath(override), nil, 0o644); err != nil {
-			t.Fatalf("seed marker: %v", err)
-		}
-		if !resumeWallClockProperty(override, "", filepath.Join(dir, "mem.snap"), boolPtr(false)) {
-			t.Error("want the marker consulted when the image is not the paused one")
+		seed(t, override, WallClockManifest{GuestCorrectsClock: true})
+		if corrects, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), boolPtr(false)); !corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the manifest consulted when the image is not the paused one", corrects, frozen, err)
 		}
 	})
 
-	t.Run("override_without_a_marker_stays_legacy", func(t *testing.T) {
+	t.Run("override_without_a_manifest_stays_legacy", func(t *testing.T) {
 		dir := t.TempDir()
-		if resumeWallClockProperty(filepath.Join(dir, "restored.snap"), "", filepath.Join(dir, "mem.snap"), boolPtr(true)) {
-			t.Error("a stale record must not carry over to a different image")
+		if corrects, frozen, err := resumeWallClockProperty(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true)); corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; a stale record must not carry over to a different image", corrects, frozen, err)
+		}
+	})
+
+	// A frozen workload and an untrusted manifest are both reported, so the
+	// caller can refuse before it launches anything.
+	t.Run("override_reports_a_frozen_workload", func(t *testing.T) {
+		dir := t.TempDir()
+		override := filepath.Join(dir, "restored.snap")
+		seed(t, override, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		if _, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil); !frozen || err != nil {
+			t.Errorf("frozen=%v err=%v; want the frozen workload reported", frozen, err)
+		}
+	})
+	t.Run("override_with_an_untrusted_manifest_is_an_error", func(t *testing.T) {
+		dir := t.TempDir()
+		override := filepath.Join(dir, "restored.snap")
+		if err := os.WriteFile(WallClockMarkerPath(override), []byte(`{"version":2}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil); !errors.Is(err, ErrWallClockManifest) {
+			t.Errorf("err=%v, want ErrWallClockManifest", err)
 		}
 	})
 }
@@ -357,18 +396,18 @@ func TestWatchFirecrackerCapability(t *testing.T) {
 // A rollback to a binary without the record field, then an upgrade back, leaves
 // the field absent. Reading that silence as "no" would ignore the marker still
 // beside the image and delete it at the next pause — a permanent demotion.
-func TestResumeWallClockPropertyUnresolvedRecordConsultsTheMarker(t *testing.T) {
+func TestResumeWallClockPropertyUnresolvedRecordConsultsTheManifest(t *testing.T) {
 	mem := filepath.Join(t.TempDir(), "mem.snap")
-	if err := os.WriteFile(clockFreezeMarkerPath(mem), nil, 0o644); err != nil {
-		t.Fatalf("seed marker: %v", err)
+	if err := WriteWallClockManifest(mem, WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
 	}
 	// Same image, but the record lost the answer.
-	if !resumeWallClockProperty(mem, "", mem, nil) {
-		t.Error("an unresolved record must fall back to the marker, not read as false")
+	if corrects, _, err := resumeWallClockProperty(mem, mem, nil); !corrects || err != nil {
+		t.Errorf("corrects=%v err=%v; an unresolved record must fall back to the manifest, not read as false", corrects, err)
 	}
 
 	bare := filepath.Join(t.TempDir(), "mem.snap")
-	if resumeWallClockProperty(bare, "", bare, nil) {
-		t.Error("unresolved with no marker must still be false")
+	if corrects, _, err := resumeWallClockProperty(bare, bare, nil); corrects || err != nil {
+		t.Errorf("corrects=%v err=%v; unresolved with no manifest must still be false", corrects, err)
 	}
 }

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -299,6 +299,23 @@ func TestResumeWallClockProperty(t *testing.T) {
 		}
 	})
 
+	// An overlay without a manifest of its own holds no frozen workload, but
+	// its guest came from the template beneath it: the capability is read
+	// from there, never the frozen fact.
+	t.Run("override_overlay_takes_the_capability_from_its_base_only", func(t *testing.T) {
+		dir := t.TempDir()
+		base := filepath.Join(dir, "template.snap")
+		seed(t, base, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		overlay := filepath.Join(dir, "restored.diff")
+		if err := os.WriteFile(layeredBaseSidecarPath(overlay), []byte(base+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		corrects, frozen, err := resumeWallClockProperty(overlay, filepath.Join(dir, "mem.diff"), nil)
+		if !corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the base's capability and no inherited freeze", corrects, frozen, err)
+		}
+	})
+
 	t.Run("override_without_a_manifest_stays_legacy", func(t *testing.T) {
 		dir := t.TempDir()
 		if corrects, frozen, err := resumeWallClockProperty(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true)); corrects || frozen || err != nil {

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -274,17 +274,32 @@ func TestResumeWallClockProperty(t *testing.T) {
 			t.Fatalf("seed manifest: %v", err)
 		}
 	}
-	t.Run("same_image_trusts_the_record_over_the_disk", func(t *testing.T) {
+	t.Run("same_image_trusts_a_record_that_carries_the_image_fact", func(t *testing.T) {
 		mem := filepath.Join(t.TempDir(), "mem.snap")
-		seed(t, mem, WallClockManifest{GuestCorrectsClock: true})
-		// Manifest says yes, record says no. The record wins ⇒ no read happened.
-		if corrects, _, err := resumeWallClockProperty(mem, mem, boolPtr(false)); corrects || err != nil {
-			t.Errorf("corrects=%v err=%v; want the recorded value, a manifest on disk means the record was not used", corrects, err)
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		// Manifest says frozen, record says not. The record wins ⇒ no read happened.
+		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(true), boolPtr(false)); !corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the recorded facts, a manifest on disk means the record was not used", corrects, frozen, err)
 		}
-		// And the inverse: no manifest on disk, record says yes.
+		// A guest that cannot correct its clock is never frozen: no read either.
+		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(false), nil); corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the record's no without a read", corrects, frozen, err)
+		}
+		// And the inverse: no manifest on disk, record says frozen.
 		bare := filepath.Join(t.TempDir(), "mem.snap")
-		if corrects, _, err := resumeWallClockProperty(bare, bare, boolPtr(true)); !corrects || err != nil {
-			t.Errorf("corrects=%v err=%v; want the recorded value even with no manifest beside the image", corrects, err)
+		if corrects, frozen, err := resumeWallClockProperty(bare, bare, boolPtr(true), boolPtr(true)); !corrects || !frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the recorded facts even with no manifest beside the image", corrects, frozen, err)
+		}
+	})
+
+	// The guest's capability does not encode the image fact: a record that
+	// carries the first but not the second reads the manifest, and a frozen
+	// one is reported rather than assumed away.
+	t.Run("same_image_without_the_image_fact_reads_the_manifest", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(true), nil); !corrects || !frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; want the frozen workload seen", corrects, frozen, err)
 		}
 	})
 
@@ -294,7 +309,7 @@ func TestResumeWallClockProperty(t *testing.T) {
 		dir := t.TempDir()
 		override := filepath.Join(dir, "restored.snap")
 		seed(t, override, WallClockManifest{GuestCorrectsClock: true})
-		if corrects, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), boolPtr(false)); !corrects || frozen || err != nil {
+		if corrects, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), boolPtr(false), boolPtr(false)); !corrects || frozen || err != nil {
 			t.Errorf("corrects=%v frozen=%v err=%v; want the manifest consulted when the image is not the paused one", corrects, frozen, err)
 		}
 	})
@@ -310,7 +325,7 @@ func TestResumeWallClockProperty(t *testing.T) {
 		if err := os.WriteFile(layeredBaseSidecarPath(overlay), []byte(base+"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		corrects, frozen, err := resumeWallClockProperty(overlay, filepath.Join(dir, "mem.diff"), nil)
+		corrects, frozen, err := resumeWallClockProperty(overlay, filepath.Join(dir, "mem.diff"), nil, nil)
 		if !corrects || frozen || err != nil {
 			t.Errorf("corrects=%v frozen=%v err=%v; want the base's capability and no inherited freeze", corrects, frozen, err)
 		}
@@ -318,7 +333,7 @@ func TestResumeWallClockProperty(t *testing.T) {
 
 	t.Run("override_without_a_manifest_stays_legacy", func(t *testing.T) {
 		dir := t.TempDir()
-		if corrects, frozen, err := resumeWallClockProperty(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true)); corrects || frozen || err != nil {
+		if corrects, frozen, err := resumeWallClockProperty(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true), boolPtr(true)); corrects || frozen || err != nil {
 			t.Errorf("corrects=%v frozen=%v err=%v; a stale record must not carry over to a different image", corrects, frozen, err)
 		}
 	})
@@ -329,7 +344,7 @@ func TestResumeWallClockProperty(t *testing.T) {
 		dir := t.TempDir()
 		override := filepath.Join(dir, "restored.snap")
 		seed(t, override, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
-		if _, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil); !frozen || err != nil {
+		if _, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil, nil); !frozen || err != nil {
 			t.Errorf("frozen=%v err=%v; want the frozen workload reported", frozen, err)
 		}
 	})
@@ -339,7 +354,7 @@ func TestResumeWallClockProperty(t *testing.T) {
 		if err := os.WriteFile(WallClockMarkerPath(override), []byte(`{"version":2}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if _, _, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil); !errors.Is(err, ErrWallClockManifest) {
+		if _, _, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil, nil); !errors.Is(err, ErrWallClockManifest) {
 			t.Errorf("err=%v, want ErrWallClockManifest", err)
 		}
 	})
@@ -419,12 +434,12 @@ func TestResumeWallClockPropertyUnresolvedRecordConsultsTheManifest(t *testing.T
 		t.Fatalf("seed manifest: %v", err)
 	}
 	// Same image, but the record lost the answer.
-	if corrects, _, err := resumeWallClockProperty(mem, mem, nil); !corrects || err != nil {
+	if corrects, _, err := resumeWallClockProperty(mem, mem, nil, nil); !corrects || err != nil {
 		t.Errorf("corrects=%v err=%v; an unresolved record must fall back to the manifest, not read as false", corrects, err)
 	}
 
 	bare := filepath.Join(t.TempDir(), "mem.snap")
-	if corrects, _, err := resumeWallClockProperty(bare, bare, nil); corrects || err != nil {
+	if corrects, _, err := resumeWallClockProperty(bare, bare, nil, nil); corrects || err != nil {
 		t.Errorf("corrects=%v err=%v; unresolved with no manifest must still be false", corrects, err)
 	}
 }

--- a/internal/vm/heartbeat_pressure_test.go
+++ b/internal/vm/heartbeat_pressure_test.go
@@ -160,7 +160,7 @@ func TestCapacityPressureCountsInstancesAndBuilds(t *testing.T) {
 	}
 	// One in-flight build; a completed one has already released its
 	// counters at worker exit and contributes nothing.
-	if _, err := m.registerBuild("b1", "tpl", 2, 4096, func() {}); err != nil {
+	if _, err := m.registerBuild("b1", "tpl", 2, 4096, func() {}, nil); err != nil {
 		t.Fatal(err)
 	}
 	seedPressureIndex(m)
@@ -238,7 +238,7 @@ func TestCapacityPressureCountsErrorVMAllocations(t *testing.T) {
 // (indefinitely retained) registry.
 func TestCapacityPressureBuildCountersReleaseAtWorkerExit(t *testing.T) {
 	m := &Manager{vms: map[string]*VMInstance{}, builds: map[string]*buildRecord{}}
-	rec, err := m.registerBuild("b1", "tpl", 2, 4096, func() {})
+	rec, err := m.registerBuild("b1", "tpl", 2, 4096, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +594,7 @@ func TestFindSurvivingBuildersExcludesOwnChildren(t *testing.T) {
 // closed like any other unrepresented Firecracker.
 func TestBuildAllocCoversDistinguishesLeftovers(t *testing.T) {
 	m := &Manager{vms: map[string]*VMInstance{}, builds: map[string]*buildRecord{}}
-	rec, err := m.registerBuild("build-row-uuid-1", "tpl-a", 1, 1024, func() {})
+	rec, err := m.registerBuild("build-row-uuid-1", "tpl-a", 1, 1024, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestCapacityPressureSkipsBuildInstances(t *testing.T) {
 		},
 		builds: map[string]*buildRecord{},
 	}
-	recA, err := m.registerBuild("build-tpl-a", "tpl-a", 2, 4096, func() {})
+	recA, err := m.registerBuild("build-tpl-a", "tpl-a", 2, 4096, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -883,7 +883,7 @@ func TestReattachMarkerReconstructionDoesNotHoldFleetLock(t *testing.T) {
 // or the replacement build's allocation is silently hidden for life.
 func TestReleaseBuildAllocIsGenerationKeyed(t *testing.T) {
 	m := &Manager{vms: map[string]*VMInstance{}, builds: map[string]*buildRecord{}}
-	recOld, err := m.registerBuild("build-b1", "tpl", 2, 4096, func() {})
+	recOld, err := m.registerBuild("build-b1", "tpl", 2, 4096, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -891,7 +891,7 @@ func TestReleaseBuildAllocIsGenerationKeyed(t *testing.T) {
 		t.Fatal("cancel failed")
 	}
 	// Reuse: a new build replaces the terminal record under the same id.
-	recNew, err := m.registerBuild("build-b1", "tpl", 4, 8192, func() {})
+	recNew, err := m.registerBuild("build-b1", "tpl", 4, 8192, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -956,7 +956,7 @@ func TestLeakedRecorderNotHiddenByLaterBuild(t *testing.T) {
 		},
 		builds: map[string]*buildRecord{},
 	}
-	recA, err := m.registerBuild("build-a", "tpl-a", 2, 4096, func() {})
+	recA, err := m.registerBuild("build-a", "tpl-a", 2, 4096, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -971,7 +971,7 @@ func TestLeakedRecorderNotHiddenByLaterBuild(t *testing.T) {
 	m.buildPressureCount.Add(-1)
 
 	// Build B for the same template starts (not yet recording).
-	if _, err := m.registerBuild("build-b", "tpl-a", 4, 8192, func() {}); err != nil {
+	if _, err := m.registerBuild("build-b", "tpl-a", 4, 8192, func() {}, nil); err != nil {
 		t.Fatal(err)
 	}
 	seedPressureIndex(m)
@@ -1146,14 +1146,14 @@ func TestPressureReadyReopensAfterPredecessorBuildUnitExits(t *testing.T) {
 // state (which the replacement's own worker could then never overwrite).
 func TestCompleteBuildDropsReplacedWorkerResult(t *testing.T) {
 	m := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{}, builds: map[string]*buildRecord{}}
-	recOld, err := m.registerBuild("build-x", "tpl", 1, 1024, func() {})
+	recOld, err := m.registerBuild("build-x", "tpl", 1, 1024, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !m.setBuildStatus("build-x", BuildStatusCancelled) {
 		t.Fatal("cancel failed")
 	}
-	recNew, err := m.registerBuild("build-x", "tpl", 1, 1024, func() {})
+	recNew, err := m.registerBuild("build-x", "tpl", 1, 1024, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vm/heartbeat_pressure_test.go
+++ b/internal/vm/heartbeat_pressure_test.go
@@ -877,10 +877,10 @@ func TestReattachMarkerReconstructionDoesNotHoldFleetLock(t *testing.T) {
 	}
 }
 
-// A terminal build id may be re-registered while the OLD worker still
-// runs its deferred cleanup: the release must act on the generation that
-// incremented the counters, never on whatever record the id now names —
-// or the replacement build's allocation is silently hidden for life.
+// The id stays reserved until the old worker exits, and the release is
+// still keyed to the generation that incremented the counters, never to
+// whatever record the id now names — or a late release would hide the
+// replacement build's allocation for life.
 func TestReleaseBuildAllocIsGenerationKeyed(t *testing.T) {
 	m := &Manager{vms: map[string]*VMInstance{}, builds: map[string]*buildRecord{}}
 	recOld, err := m.registerBuild("build-b1", "tpl", 2, 4096, func() {}, nil)
@@ -890,7 +890,9 @@ func TestReleaseBuildAllocIsGenerationKeyed(t *testing.T) {
 	if !m.setBuildStatus("build-b1", BuildStatusCancelled) {
 		t.Fatal("cancel failed")
 	}
-	// Reuse: a new build replaces the terminal record under the same id.
+	// Reuse: once the old worker has exited, a new build replaces the
+	// terminal record under the same id.
+	close(recOld.workerDone)
 	recNew, err := m.registerBuild("build-b1", "tpl", 4, 8192, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1153,6 +1155,7 @@ func TestCompleteBuildDropsReplacedWorkerResult(t *testing.T) {
 	if !m.setBuildStatus("build-x", BuildStatusCancelled) {
 		t.Fatal("cancel failed")
 	}
+	close(recOld.workerDone)
 	recNew, err := m.registerBuild("build-x", "tpl", 1, 1024, func() {}, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/vm/heartbeat_pressure_test.go
+++ b/internal/vm/heartbeat_pressure_test.go
@@ -1301,9 +1301,14 @@ func stubMachineConfigProbe(t *testing.T, probe func(context.Context, string) (u
 
 func awaitBackfill(t *testing.T, done <-chan string) {
 	t.Helper()
+	awaitBackfillWithin(t, done, 15*time.Second)
+}
+
+func awaitBackfillWithin(t *testing.T, done <-chan string, budget time.Duration) {
+	t.Helper()
 	select {
 	case <-done:
-	case <-time.After(15 * time.Second):
+	case <-time.After(budget):
 		t.Fatal("allocation backfill never ran — an undeclared VM keeps a zero size and publishes as free capacity")
 	}
 }
@@ -1754,7 +1759,11 @@ func TestBackfillRetriesDoNotStarveThePool(t *testing.T) {
 	}
 
 	// Retire the stuck VMs so their loops end and the seams restore
-	// without a live goroutine still reading them.
+	// without a live goroutine still reading them. Each stuck VM notices
+	// its retirement at its next attempt, and that attempt is due a doubled
+	// backoff plus jitter after the failed probe — four to six seconds at
+	// the backoff above — so the wait here must cover that, not the
+	// default budget sized for millisecond retries.
 	m.mu.Lock()
 	for _, inst := range stuck {
 		delete(m.vms, inst.ID)
@@ -1762,7 +1771,7 @@ func TestBackfillRetriesDoNotStarveThePool(t *testing.T) {
 	}
 	m.mu.Unlock()
 	for i := 0; i < machineConfigRecoveryWorkers+1; i++ {
-		awaitBackfill(t, done)
+		awaitBackfillWithin(t, done, 15*time.Second)
 	}
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -127,10 +127,12 @@ type VMInstance struct {
 	// ArtifactID names the manifest beside the image this VM was last paused
 	// into, so a pause intent left beside it can be told from an interrupted one.
 	ArtifactID string
-	CreatedAt  time.Time
-	Metadata   map[string]string
-	TeamID     string // owning team; carried for data-plane usage attribution
-	OwnerID    string // creating user; empty when unknown
+	// SnapshotWorkloadFrozen: see VMRecord.
+	SnapshotWorkloadFrozen *bool
+	CreatedAt              time.Time
+	Metadata               map[string]string
+	TeamID                 string // owning team; carried for data-plane usage attribution
+	OwnerID                string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -1755,11 +1757,13 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	// A resume reads the manifest beside THIS image, so without it every resume
 	// drops back to legacy. Only the write lands here: the unsafe direction was
 	// already handled above, before the image existed. Best-effort by design — a
-	// manifest that fails to write costs a slower resume, never a wrong clock.
+	// manifest that fails to write, or is lost to a crash, costs a slower
+	// resume, never a wrong clock — so it is written without durability
+	// barriers: nothing on the pause path waits on a sync for it.
 	if correctsWallClock {
 		artifact := NewArtifactID()
 		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifact, GuestCorrectsClock: true}
-		if merr := WriteWallClockManifest(memPath, man); merr != nil {
+		if merr := writeWallClockManifestLazy(memPath, man); merr != nil {
 			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
 				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
 		} else {
@@ -1842,6 +1846,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	inst.BaseMemPath = baseMemPath   // template base for a layered overlay; "" when standalone
 	inst.DirtyTracked = false        // FC process is stopping; a fresh resume re-arms tracking.
 	inst.DirtyTrackingSessionID = "" // the session dies with the FC run
+	// This supervisor freezes nothing, and says so: a resume of this image
+	// trusts the record and reads no manifest.
+	imageFrozen := false
+	inst.SnapshotWorkloadFrozen = &imageFrozen
 	inst.PausedAt = time.Now()
 	// The crash-window marker describes a RUNNING record persisted before
 	// readiness was proven; a successful pause proves the guest was live and
@@ -2185,14 +2193,15 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// cannot wake, each refuse the resume here. An intent exists only on a
 	// host whose floor is up; elsewhere nothing is looked for.
 	inst.mu.RLock()
-	recordedCorrects, pausedMemPath, recordedArtifact := inst.CorrectsWallClock, inst.MemFilePath, inst.ArtifactID
+	recordedCorrects, recordedFrozen := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen
+	pausedMemPath, recordedArtifact := inst.MemFilePath, inst.ArtifactID
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
 		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
 			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
 		}
 	}
-	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects)
+	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects, recordedFrozen)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}
@@ -2360,6 +2369,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.DirtyTracked = dirtyTracked
 	inst.DirtyTrackingSessionID = trackingSessionID
 	inst.CorrectsWallClock = &resumeCorrectsWallClock
+	inst.SnapshotWorkloadFrozen = &resumeWorkloadFrozen
 	inst.PausedAt = time.Time{}
 	// Record the file actually resumed from (callers may pass an explicit path
 	// that differs from the cached one) so the next pause's diff baseline matches
@@ -3544,9 +3554,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	inst.Status = StatusRunning
 	inst.Unverified = true
 	inst.PausedAt = time.Time{}
-	// Cached so the next pause knows whether this guest fixes its own wall clock
+	// Cached so the next pause knows what this guest and this image are
 	// without going back to the filesystem to ask.
 	inst.CorrectsWallClock = &restoreCorrectsWallClock
+	restoreWorkloadFrozen := false // a frozen image was refused above
+	inst.SnapshotWorkloadFrozen = &restoreWorkloadFrozen
 	inst.mu.Unlock()
 	persistDone := make(chan struct{})
 	optimisticOK := false

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1998,18 +1998,18 @@ func readLayeredBase(memPath string) (string, bool) {
 // read once per daemon and every later create from it costs a map lookup.
 // Any other image is read each time. An error is not kept.
 func (m *Manager) imageManifestCached(memPath string) (*WallClockManifest, error) {
-	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName) + string(filepath.Separator)
-	if m.cfg.SnapshotDir == "" || !strings.HasPrefix(memPath, root) {
+	if !m.isTemplateMemPath(memPath) {
 		return imageManifest(memPath)
 	}
-	if v, ok := m.templateManifests.Load(memPath); ok {
+	key := filepath.Clean(memPath)
+	if v, ok := m.templateManifests.Load(key); ok {
 		return v.(*WallClockManifest), nil
 	}
 	man, err := imageManifest(memPath)
 	if err != nil {
 		return nil, err
 	}
-	m.templateManifests.Store(memPath, man)
+	m.templateManifests.Store(key, man)
 	return man, nil
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -545,9 +545,6 @@ type Manager struct {
 	// restoreSem bounds concurrent RestoreVMSnapshot operations. Buffered
 	// channel; capacity = effective MaxConcurrentRestores.
 	restoreSem chan struct{}
-	// templateManifests keeps the manifest beside each template image this
-	// daemon has restored from; see imageManifestCached.
-	templateManifests sync.Map
 
 	// tplLastRestore: last restore time per template mem file, for the
 	// secs_since_template_restore phase tag (a page-cache warmth proxy).
@@ -1993,26 +1990,6 @@ func readLayeredBase(memPath string) (string, bool) {
 	return base, base != ""
 }
 
-// imageManifestCached is imageManifest with the answer kept for a template
-// image: a template build is immutable once published, so its manifest is
-// read once per daemon and every later create from it costs a map lookup.
-// Any other image is read each time. An error is not kept.
-func (m *Manager) imageManifestCached(memPath string) (*WallClockManifest, error) {
-	if !m.isTemplateMemPath(memPath) {
-		return imageManifest(memPath)
-	}
-	key := filepath.Clean(memPath)
-	if v, ok := m.templateManifests.Load(key); ok {
-		return v.(*WallClockManifest), nil
-	}
-	man, err := imageManifest(memPath)
-	if err != nil {
-		return nil, err
-	}
-	m.templateManifests.Store(key, man)
-	return man, nil
-}
-
 // isOverlayMemFile reports whether memPath names a layered diff overlay (which
 // must be restored over a base, never standalone).
 func isOverlayMemFile(memPath string) bool {
@@ -3115,11 +3092,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing restore until it is inspected", memPath, why)
 		}
 	}
-	// What the image says about its guest, read once: whether its workload is
-	// frozen, and whether the guest corrects its clock. A manifest this binary
-	// cannot trust, or a frozen workload it cannot wake, refuses the restore
-	// here, before anything is launched.
-	manifest, merr := m.imageManifestCached(memPath)
+	// What the image says about its guest, read once per restore: whether its
+	// workload is frozen, and whether the guest corrects its clock. Read from
+	// the disk every time, never remembered by path: a template directory is
+	// meant to be immutable, but a cache here would turn any exception into a
+	// frozen image restored the old way, with its workload never released.
+	// One small open beside the sidecar read this path already does. A
+	// manifest this binary cannot trust, or a frozen workload it cannot wake,
+	// refuses the restore here, before anything is launched.
+	manifest, merr := imageManifest(memPath)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -124,10 +124,13 @@ type VMInstance struct {
 	// binary that predates the field drops it on round-trip, and treating that
 	// silence as "no" would strip a marker that is still valid.
 	CorrectsWallClock *bool
-	CreatedAt         time.Time
-	Metadata          map[string]string
-	TeamID            string // owning team; carried for data-plane usage attribution
-	OwnerID           string // creating user; empty when unknown
+	// ArtifactID names the manifest beside the image this VM was last paused
+	// into, so a pause intent left beside it can be told from an interrupted one.
+	ArtifactID string
+	CreatedAt  time.Time
+	Metadata   map[string]string
+	TeamID     string // owning team; carried for data-plane usage attribution
+	OwnerID    string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -1749,14 +1752,20 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	}
 
-	// A resume reads the marker beside THIS image, so without it every resume drops
-	// back to legacy. Only the write lands here: the unsafe direction was already
-	// handled above, before the image existed. Best-effort by design — a marker
-	// that fails to write costs a slower resume, never a wrong clock.
+	// A resume reads the manifest beside THIS image, so without it every resume
+	// drops back to legacy. Only the write lands here: the unsafe direction was
+	// already handled above, before the image existed. Best-effort by design — a
+	// manifest that fails to write costs a slower resume, never a wrong clock.
 	if correctsWallClock {
-		if merr := os.WriteFile(clockFreezeMarkerPath(memPath), nil, 0o644); merr != nil {
-			log.Warn().Err(merr).Str("path", clockFreezeMarkerPath(memPath)).
-				Msg("pause: wall-clock marker write failed; resume falls back to legacy clock behaviour")
+		artifact := NewArtifactID()
+		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifact, GuestCorrectsClock: true}
+		if merr := WriteWallClockManifest(memPath, man); merr != nil {
+			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
+				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
+		} else {
+			inst.mu.Lock()
+			inst.ArtifactID = artifact
+			inst.mu.Unlock()
 		}
 	}
 
@@ -2168,6 +2177,25 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		}
 		return nil, status.Errorf(codes.FailedPrecondition, "stat mem file %s: %v", memPath, err)
 	}
+	// What the image says about its guest, read before anything is launched.
+	// An ordinary resume reloads the exact image this VM was paused into, and
+	// the record already holds the answer; only an override, or a record that
+	// lost it, goes to disk. An intent left beside the image by a pause that was
+	// interrupted, a manifest this binary cannot trust, or a frozen workload it
+	// cannot wake, each refuse the resume here.
+	inst.mu.RLock()
+	recordedCorrects, pausedMemPath, recordedArtifact := inst.CorrectsWallClock, inst.MemFilePath, inst.ArtifactID
+	inst.mu.RUnlock()
+	if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
+		return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
+	}
+	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects)
+	if merr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
+	}
+	if resumeWorkloadFrozen {
+		return nil, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing resume", memPath)
+	}
 	// Presence gate for layered overlays. Deterministic from a stat, so it
 	// belongs here with the other precondition checks — a post-boot refusal
 	// would start and tear down a Firecracker unit and network slot on every
@@ -2267,22 +2295,12 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// Nil unless the real restore path ran and asked for a frozen clock; the test
 	// hook leaves it nil, which is also what the log should say.
 	var resumeClockFrozen bool
-	// A property of the guest alone — whether this host can act on it is decided
-	// separately, so an older binary does not erase it.
-	//
-	// An ordinary resume reloads the exact image this VM was paused into, and that
-	// pause recorded the property beside it and in the durable record. The record
-	// is therefore already the answer, and asking the filesystem again would put
-	// metadata I/O on the resume path for a fact we hold. Only an explicit
-	// override, which supplies an image this VM was not paused into, has to look.
-	inst.mu.RLock()
-	recordedCorrects, pausedMemPath := inst.CorrectsWallClock, inst.MemFilePath
-	inst.mu.RUnlock()
-	resumeCorrectsWallClock := resumeWallClockProperty(memPath, basePath, pausedMemPath, recordedCorrects)
 	if m.restoreForResumeHook != nil {
 		dirtyTracked, trackingSessionID, restoreErr = m.restoreForResumeHook(socketPath, snapshotPath, memPath, basePath, netInfo)
 	} else {
-		dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, m.clockPolicyFor(resumeCorrectsWallClock))
+		// Only an image holding a frozen workload may have its clock frozen,
+		// and that image was refused above: legacy for every resume here.
+		dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, m.clockPolicyFor(false))
 	}
 	tRestoreDone = time.Now()
 	if restoreErr != nil {
@@ -3056,6 +3074,31 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			return nil, status.Errorf(codes.FailedPrecondition, "%v", gerr)
 		}
 	}
+	// An in-place restore may meet the leftover of a pause that completed; any
+	// other intent means an interrupted rewrite.
+	knownArtifact := ""
+	m.mu.RLock()
+	if prev := m.vms[vmID]; prev != nil {
+		prev.mu.RLock()
+		knownArtifact = prev.ArtifactID
+		prev.mu.RUnlock()
+	}
+	m.mu.RUnlock()
+	if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), knownArtifact); blocked {
+		return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing restore until it is inspected", memPath, why)
+	}
+	// What the image says about its guest, read once: whether its workload is
+	// frozen, and whether the guest corrects its clock. A manifest this binary
+	// cannot trust, or a frozen workload it cannot wake, refuses the restore
+	// here, before anything is launched.
+	manifest, merr := imageManifest(memPath)
+	if merr != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
+	}
+	if manifest != nil && manifest.WorkloadFrozen {
+		return nil, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing restore", memPath)
+	}
+	restoreCorrectsWallClock := manifest != nil && manifest.GuestCorrectsClock
 
 	// Sampled before this attempt creates the rundir: a pre-existing rundir
 	// means a prior attempt on this host reached start.sh (and possibly
@@ -3177,12 +3220,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// retried on a different slot; the failed slot is torn down. inPlace resumes
 	// reuse a specific VM's own slot and never retry.
 	const maxRestoreAttempts = 3
-	// Both are functions of memPath alone, which no attempt reassigns, so they are
-	// resolved once here rather than per attempt: a tap-busy retry would otherwise
-	// repeat the sidecar read and the marker probe, and both would sit after
-	// Firecracker and networking have started, on user-visible restore latency.
+	// A function of memPath alone, which no attempt reassigns, so it is resolved
+	// once here rather than per attempt: a tap-busy retry would otherwise repeat
+	// the sidecar read after Firecracker and networking have started, on
+	// user-visible restore latency.
 	sidecarBase, hasSidecar := readLayeredBase(memPath)
-	restoreCorrectsWallClock := guestCorrectsWallClock(memPath, sidecarBase)
 	for attempt = 1; ; attempt++ {
 		tAttemptStart = time.Now()
 		if attempt > 1 {
@@ -3307,9 +3349,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// File backend, which would load the sparse overlay as a full image (the base's
 		// pages read as zero holes).
 		overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
-		// Whether this host can act on the guest's property is decided separately,
-		// so an older binary does not erase it.
-		clockPolicy := m.clockPolicyFor(restoreCorrectsWallClock)
+		// Only an image holding a frozen workload may have its clock frozen, and
+		// that image was refused above: legacy for every restore here.
+		clockPolicy := m.clockPolicyFor(false)
 		clockFrozen := false
 		switch {
 		case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -545,6 +545,9 @@ type Manager struct {
 	// restoreSem bounds concurrent RestoreVMSnapshot operations. Buffered
 	// channel; capacity = effective MaxConcurrentRestores.
 	restoreSem chan struct{}
+	// templateManifests keeps the manifest beside each template image this
+	// daemon has restored from; see imageManifestCached.
+	templateManifests sync.Map
 
 	// tplLastRestore: last restore time per template mem file, for the
 	// secs_since_template_restore phase tag (a page-cache warmth proxy).
@@ -1990,6 +1993,26 @@ func readLayeredBase(memPath string) (string, bool) {
 	return base, base != ""
 }
 
+// imageManifestCached is imageManifest with the answer kept for a template
+// image: a template build is immutable once published, so its manifest is
+// read once per daemon and every later create from it costs a map lookup.
+// Any other image is read each time. An error is not kept.
+func (m *Manager) imageManifestCached(memPath string) (*WallClockManifest, error) {
+	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName) + string(filepath.Separator)
+	if m.cfg.SnapshotDir == "" || !strings.HasPrefix(memPath, root) {
+		return imageManifest(memPath)
+	}
+	if v, ok := m.templateManifests.Load(memPath); ok {
+		return v.(*WallClockManifest), nil
+	}
+	man, err := imageManifest(memPath)
+	if err != nil {
+		return nil, err
+	}
+	m.templateManifests.Store(memPath, man)
+	return man, nil
+}
+
 // isOverlayMemFile reports whether memPath names a layered diff overlay (which
 // must be restored over a base, never standalone).
 func isOverlayMemFile(memPath string) bool {
@@ -2182,12 +2205,15 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// the record already holds the answer; only an override, or a record that
 	// lost it, goes to disk. An intent left beside the image by a pause that was
 	// interrupted, a manifest this binary cannot trust, or a frozen workload it
-	// cannot wake, each refuse the resume here.
+	// cannot wake, each refuse the resume here. An intent exists only on a
+	// host whose floor is up; elsewhere nothing is looked for.
 	inst.mu.RLock()
 	recordedCorrects, pausedMemPath, recordedArtifact := inst.CorrectsWallClock, inst.MemFilePath, inst.ArtifactID
 	inst.mu.RUnlock()
-	if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
-		return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
+	if wakeProtocolFloorRaised() {
+		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
+			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
+		}
 	}
 	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects)
 	if merr != nil {
@@ -3074,24 +3100,26 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			return nil, status.Errorf(codes.FailedPrecondition, "%v", gerr)
 		}
 	}
-	// An in-place restore may meet the leftover of a pause that completed; any
-	// other intent means an interrupted rewrite.
-	knownArtifact := ""
+	// An in-place restore of a VM this daemon knows may meet the leftover of a
+	// pause that completed; any other intent means an interrupted rewrite. A
+	// template holds no intent, and no host whose floor is down holds one, so
+	// a create looks for nothing.
 	m.mu.RLock()
-	if prev := m.vms[vmID]; prev != nil {
-		prev.mu.RLock()
-		knownArtifact = prev.ArtifactID
-		prev.mu.RUnlock()
-	}
+	prev := m.vms[vmID]
 	m.mu.RUnlock()
-	if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), knownArtifact); blocked {
-		return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing restore until it is inspected", memPath, why)
+	if prev != nil && wakeProtocolFloorRaised() {
+		prev.mu.RLock()
+		knownArtifact := prev.ArtifactID
+		prev.mu.RUnlock()
+		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), knownArtifact); blocked {
+			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing restore until it is inspected", memPath, why)
+		}
 	}
 	// What the image says about its guest, read once: whether its workload is
 	// frozen, and whether the guest corrects its clock. A manifest this binary
 	// cannot trust, or a frozen workload it cannot wake, refuses the restore
 	// here, before anything is launched.
-	manifest, merr := imageManifest(memPath)
+	manifest, merr := m.imageManifestCached(memPath)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -554,7 +554,7 @@ type Manager struct {
 	tplLastRestore map[string]time.Time
 
 	// builds tracks in-flight and completed template builds. Keyed by
-	// build VM id (which is also "build-" + templateID). Entries survive
+	// build VM id. Entries survive
 	// until process exit so late pollers can read terminal outcomes.
 	buildsMu sync.RWMutex
 	builds   map[string]*buildRecord
@@ -3088,16 +3088,21 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 	}
 	// An in-place restore of a VM this daemon knows may meet the leftover of a
-	// pause that completed; any other intent means an interrupted rewrite. A
-	// template holds no intent, and no host whose floor is down holds one, so
-	// a create looks for nothing.
-	m.mu.RLock()
-	prev := m.vms[vmID]
-	m.mu.RUnlock()
-	if prev != nil && wakeProtocolFloorRaised() {
-		prev.mu.RLock()
-		knownArtifact := prev.ArtifactID
-		prev.mu.RUnlock()
+	// pause that completed; any other intent means an interrupted rewrite.
+	// An image restored under a new id checks with no known artifact, so an
+	// intent beside it can never be cleared as completed. No host whose floor
+	// is down holds an intent, so today a create looks for nothing; on a host
+	// whose floor is up it pays one lookup that a template never answers.
+	if wakeProtocolFloorRaised() {
+		knownArtifact := ""
+		m.mu.RLock()
+		prev := m.vms[vmID]
+		m.mu.RUnlock()
+		if prev != nil {
+			prev.mu.RLock()
+			knownArtifact = prev.ArtifactID
+			prev.mu.RUnlock()
+		}
 		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), knownArtifact); blocked {
 			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing restore until it is inspected", memPath, why)
 		}

--- a/internal/vm/pause_intent.go
+++ b/internal/vm/pause_intent.go
@@ -1,0 +1,105 @@
+package vm
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// A pause rewrites this VM's image in place. Between freezing the guest,
+// removing the old wall-clock manifest and committing the new record, a crash
+// would leave a guest frozen with nobody holding its token, or an image, a
+// manifest and a record from different pauses. The intent, durable beside the
+// image before the freeze and removed only once the paused record is durable,
+// carries what recovery needs: the token to release the guest, and the
+// artifact id that tells a completed pause's leftover marker from an
+// interrupted one. Every restore and resume refuses while an unresolved
+// intent is present.
+const pauseIntentName = "pause.intent"
+
+type pauseIntent struct {
+	VMID        string `json:"vm_id"`
+	FreezeToken string `json:"freeze_token,omitempty"`
+	ArtifactID  string `json:"artifact_id"`
+}
+
+func pauseIntentPath(dir string) string { return filepath.Join(dir, pauseIntentName) }
+
+func writePauseIntent(dir string, in pauseIntent) error {
+	b, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(pauseIntentPath(dir), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return syncDir(dir)
+}
+
+// readPauseIntent returns nil for an absent intent and an error for one that
+// cannot be read or parsed; the callers treat that as blocking.
+func readPauseIntent(dir string) (*pauseIntent, error) {
+	b, err := os.ReadFile(pauseIntentPath(dir))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var in pauseIntent
+	if err := json.Unmarshal(b, &in); err != nil {
+		return nil, err
+	}
+	return &in, nil
+}
+
+func clearPauseIntent(dir string) error {
+	if err := os.Remove(pauseIntentPath(dir)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return syncDir(dir)
+}
+
+// pauseIntentBlocks reports whether an intent beside the image forbids a
+// restore. An intent naming the artifact the record already describes is the
+// leftover of a pause that completed but could not remove it; that one is
+// cleared and does not block. Anything else, including an unreadable intent,
+// blocks until inspected.
+func pauseIntentBlocks(dir, recordedArtifactID string) (blocked bool, reason string) {
+	in, err := readPauseIntent(dir)
+	if err != nil {
+		return true, "pause intent unreadable: " + err.Error()
+	}
+	if in == nil {
+		return false, ""
+	}
+	if in.ArtifactID != "" && in.ArtifactID == recordedArtifactID {
+		if err := clearPauseIntent(dir); err != nil {
+			return true, "completed pause's intent could not be cleared: " + err.Error()
+		}
+		return false, ""
+	}
+	return true, "a pause was interrupted while rewriting this image"
+}
+
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/internal/vm/pause_intent_test.go
+++ b/internal/vm/pause_intent_test.go
@@ -54,7 +54,16 @@ func TestPauseIntentBlocks(t *testing.T) {
 	})
 }
 
+// The floor is up on any host that holds an intent; a host whose floor is
+// down looks for none.
+func raiseFloorForTest(t *testing.T) {
+	t.Helper()
+	wakeProtocolEvidenceDone.Store(true)
+	t.Cleanup(func() { wakeProtocolEvidenceDone.Store(false) })
+}
+
 func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
+	raiseFloorForTest(t)
 	dir := t.TempDir()
 	snapPath := filepath.Join(dir, "vm.snap")
 	memPath := filepath.Join(dir, "mem.snap")
@@ -95,12 +104,14 @@ func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
 		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)
 	}
 
+	// An in-place restore of the same VM meets the intent too.
+	known := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs}
 	fresh := &Manager{
 		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: t.TempDir()}, netMgr: &fakeNetMgr{},
-		vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1),
+		vms: map[string]*VMInstance{"vm-1": known}, restoreSem: make(chan struct{}, 1),
 	}
 	fresh.launchFirecrackerHook = launch
-	_, cerr := fresh.RestoreVMSnapshot(context.Background(), "vm-2", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
+	_, cerr := fresh.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
 	if status.Code(cerr) != codes.FailedPrecondition || launched {
 		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
 	}
@@ -113,7 +124,42 @@ func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
 	}
 }
 
+// A host whose floor is down has never written an intent, so its resumes
+// look for none: an intent placed there by hand is not consulted.
+func TestFloorDownLooksForNoIntent(t *testing.T) {
+	dir := t.TempDir()
+	snapPath, memPath, rootfs := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writePauseIntent(dir, pauseIntent{VMID: "vm-1", ArtifactID: "interrupted"}); err != nil {
+		t.Fatal(err)
+	}
+	inst := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}}
+	launched := false
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launched = true
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
+		t.Fatalf("resume: err=%v launched=%v, want the resume to proceed without looking", err, launched)
+	}
+	if _, err := os.Stat(pauseIntentPath(dir)); err != nil {
+		t.Error("the intent was touched on a host whose floor is down")
+	}
+}
+
 func TestCompletedPauseIntentClearsItself(t *testing.T) {
+	raiseFloorForTest(t)
 	dir := t.TempDir()
 	snapPath, memPath, rootfs := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "rootfs.ext4")
 	for _, p := range []string{snapPath, memPath, rootfs} {

--- a/internal/vm/pause_intent_test.go
+++ b/internal/vm/pause_intent_test.go
@@ -1,0 +1,149 @@
+package vm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/network"
+)
+
+func TestPauseIntentBlocks(t *testing.T) {
+	t.Run("absent_does_not_block", func(t *testing.T) {
+		if blocked, why := pauseIntentBlocks(t.TempDir(), "a"); blocked {
+			t.Fatalf("blocked: %s", why)
+		}
+	})
+	t.Run("unreadable_blocks", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(pauseIntentPath(dir), []byte("{"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if blocked, _ := pauseIntentBlocks(dir, "a"); !blocked {
+			t.Fatal("an unreadable intent must block until inspected")
+		}
+	})
+	t.Run("another_pauses_intent_blocks", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := writePauseIntent(dir, pauseIntent{VMID: "vm", ArtifactID: "other"}); err != nil {
+			t.Fatal(err)
+		}
+		if blocked, _ := pauseIntentBlocks(dir, "a"); !blocked {
+			t.Fatal("an intent from an interrupted pause must block")
+		}
+		if _, err := os.Stat(pauseIntentPath(dir)); err != nil {
+			t.Fatal("a blocking intent must be left for inspection")
+		}
+	})
+	t.Run("completed_pauses_intent_clears", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := writePauseIntent(dir, pauseIntent{VMID: "vm", ArtifactID: "a"}); err != nil {
+			t.Fatal(err)
+		}
+		if blocked, why := pauseIntentBlocks(dir, "a"); blocked {
+			t.Fatalf("blocked by a completed pause's leftover: %s", why)
+		}
+		if _, err := os.Stat(pauseIntentPath(dir)); !os.IsNotExist(err) {
+			t.Fatal("the leftover was not cleared")
+		}
+	})
+}
+
+func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writePauseIntent(dir, pauseIntent{VMID: "vm-1", FreezeToken: "tok", ArtifactID: "interrupted"}); err != nil {
+		t.Fatal(err)
+	}
+	if blocked, _ := pauseIntentBlocks(dir, "other"); !blocked {
+		t.Fatal("intent not visible after write")
+	}
+	launched := false
+	launch := func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launched = true
+		return 4321, SupervisionUnit, nil
+	}
+
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+	}
+	mgr := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{"vm-1": inst}, restoreSem: make(chan struct{}, 1),
+	}
+	mgr.launchFirecrackerHook = launch
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	unlock()
+	if status.Code(rerr) != codes.FailedPrecondition || launched {
+		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)
+	}
+
+	fresh := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: t.TempDir()}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1),
+	}
+	fresh.launchFirecrackerHook = launch
+	_, cerr := fresh.RestoreVMSnapshot(context.Background(), "vm-2", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
+	if status.Code(cerr) != codes.FailedPrecondition || launched {
+		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
+	}
+
+	if err := clearPauseIntent(dir); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if blocked, _ := pauseIntentBlocks(dir, ""); blocked {
+		t.Fatal("still blocked after clear")
+	}
+}
+
+func TestCompletedPauseIntentClearsItself(t *testing.T) {
+	dir := t.TempDir()
+	snapPath, memPath, rootfs := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writePauseIntent(dir, pauseIntent{VMID: "vm-1", FreezeToken: "tok", ArtifactID: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs, ArtifactID: "done",
+	}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}}
+	launched := false
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launched = true
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
+		t.Fatalf("resume: err=%v launched=%v, want the completed pause's intent cleared and the resume to proceed", err, launched)
+	}
+	if _, err := os.Stat(pauseIntentPath(dir)); !os.IsNotExist(err) {
+		t.Error("intent still present after the resume")
+	}
+}

--- a/internal/vm/pause_intent_test.go
+++ b/internal/vm/pause_intent_test.go
@@ -115,6 +115,20 @@ func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
 	if status.Code(cerr) != codes.FailedPrecondition || launched {
 		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
 	}
+	// And so does a restore of the image under a new id, with no artifact
+	// that could clear the intent as completed.
+	unknown := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: t.TempDir()}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1),
+	}
+	unknown.launchFirecrackerHook = launch
+	_, uerr := unknown.RestoreVMSnapshot(context.Background(), "vm-2", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
+	if status.Code(uerr) != codes.FailedPrecondition || launched {
+		t.Fatalf("restore under a new id: err=%v launched=%v, want FailedPrecondition before launch", uerr, launched)
+	}
+	if _, err := os.Stat(pauseIntentPath(dir)); err != nil {
+		t.Fatal("a restore under a new id cleared the intent")
+	}
 
 	if err := clearPauseIntent(dir); err != nil {
 		t.Fatalf("clear: %v", err)

--- a/internal/vm/pause_intent_test.go
+++ b/internal/vm/pause_intent_test.go
@@ -58,8 +58,8 @@ func TestPauseIntentBlocks(t *testing.T) {
 // down looks for none.
 func raiseFloorForTest(t *testing.T) {
 	t.Helper()
-	wakeProtocolEvidenceDone.Store(true)
-	t.Cleanup(func() { wakeProtocolEvidenceDone.Store(false) })
+	wakeProtocolEvidenceSeen.Store(true)
+	t.Cleanup(func() { wakeProtocolEvidenceSeen.Store(false) })
 }
 
 func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -213,11 +213,14 @@ type VMRecord struct {
 	// rewrites a record, so after a rollback and re-upgrade the field is absent
 	// again — decoding that silence as false would ignore a marker still on disk
 	// and delete it at the next pause. Nil means "ask the disk".
-	CorrectsWallClock *bool             `json:"corrects_wall_clock,omitempty"`
-	CreatedAt         time.Time         `json:"created_at"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
-	VCPU              uint32            `json:"vcpu"`
-	MemoryMiB         uint32            `json:"memory_mib"`
+	CorrectsWallClock *bool `json:"corrects_wall_clock,omitempty"`
+	// ArtifactID names the manifest beside the image this VM was last paused
+	// into; see VMInstance.
+	ArtifactID string            `json:"artifact_id,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+	VCPU       uint32            `json:"vcpu"`
+	MemoryMiB  uint32            `json:"memory_mib"`
 	// Persisted so overlay-mode sandboxes can be resumed correctly after a
 	// vmd restart (the start script needs basePath to wire up the
 	// dual-symlink mount namespace). DeltaDir is intentionally NOT
@@ -905,6 +908,7 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		StrandedOverlays:           append([]string(nil), inst.StrandedOverlays...),
 		DirtyTrackingSessionID:     inst.DirtyTrackingSessionID,
 		CorrectsWallClock:          inst.CorrectsWallClock,
+		ArtifactID:                 inst.ArtifactID,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
@@ -1006,6 +1010,7 @@ func toInstance(rec VMRecord) *VMInstance {
 		// untracked and pause Full, exactly as before.
 		DirtyTracked:               rec.Status == StatusRunning && rec.DirtyTrackingSessionID != "",
 		CorrectsWallClock:          rec.CorrectsWallClock,
+		ArtifactID:                 rec.ArtifactID,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,
 		TeamID:                     rec.TeamID,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -214,6 +214,11 @@ type VMRecord struct {
 	// again — decoding that silence as false would ignore a marker still on disk
 	// and delete it at the next pause. Nil means "ask the disk".
 	CorrectsWallClock *bool `json:"corrects_wall_clock,omitempty"`
+	// SnapshotWorkloadFrozen: the image this VM was last paused into holds a
+	// frozen workload. Set by every pause, so a pause that froze nothing
+	// cannot leave an older answer for the next resume to act on. Tri-state
+	// for the same reason as CorrectsWallClock; nil means "ask the disk".
+	SnapshotWorkloadFrozen *bool `json:"snapshot_workload_frozen,omitempty"`
 	// ArtifactID names the manifest beside the image this VM was last paused
 	// into; see VMInstance.
 	ArtifactID string            `json:"artifact_id,omitempty"`
@@ -921,6 +926,7 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		DirtyTrackingSessionID:     inst.DirtyTrackingSessionID,
 		CorrectsWallClock:          inst.CorrectsWallClock,
 		ArtifactID:                 inst.ArtifactID,
+		SnapshotWorkloadFrozen:     inst.SnapshotWorkloadFrozen,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
@@ -1023,6 +1029,7 @@ func toInstance(rec VMRecord) *VMInstance {
 		DirtyTracked:               rec.Status == StatusRunning && rec.DirtyTrackingSessionID != "",
 		CorrectsWallClock:          rec.CorrectsWallClock,
 		ArtifactID:                 rec.ArtifactID,
+		SnapshotWorkloadFrozen:     rec.SnapshotWorkloadFrozen,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,
 		TeamID:                     rec.TeamID,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -321,18 +321,6 @@ func WriteStateBreadcrumb(statePath string) error {
 	return writeStateBreadcrumbTo(StateBreadcrumbPath, statePath)
 }
 
-// SnapshotDirBreadcrumbPath is where the daemon records its resolved snapshot
-// directory at start, for the wake-floor guard: it reads this rather than
-// parsing env files, for the same reason the rollback guard reads the state
-// path. Absent means the daemon has never run on the host.
-const SnapshotDirBreadcrumbPath = "/var/lib/sandbox/vmd-snapshot-dir"
-
-// WriteSnapshotDirBreadcrumb records the resolved snapshot directory
-// atomically, as WriteStateBreadcrumb does.
-func WriteSnapshotDirBreadcrumb(snapshotDir string) error {
-	return writeStateBreadcrumbTo(SnapshotDirBreadcrumbPath, snapshotDir)
-}
-
 func writeStateBreadcrumbTo(at, statePath string) error {
 	if err := os.MkdirAll(filepath.Dir(at), 0o755); err != nil {
 		return fmt.Errorf("state breadcrumb dir: %w", err)

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -316,6 +316,18 @@ func WriteStateBreadcrumb(statePath string) error {
 	return writeStateBreadcrumbTo(StateBreadcrumbPath, statePath)
 }
 
+// SnapshotDirBreadcrumbPath is where the daemon records its resolved snapshot
+// directory at start, for the wake-floor guard: it reads this rather than
+// parsing env files, for the same reason the rollback guard reads the state
+// path. Absent means the daemon has never run on the host.
+const SnapshotDirBreadcrumbPath = "/var/lib/sandbox/vmd-snapshot-dir"
+
+// WriteSnapshotDirBreadcrumb records the resolved snapshot directory
+// atomically, as WriteStateBreadcrumb does.
+func WriteSnapshotDirBreadcrumb(snapshotDir string) error {
+	return writeStateBreadcrumbTo(SnapshotDirBreadcrumbPath, snapshotDir)
+}
+
 func writeStateBreadcrumbTo(at, statePath string) error {
 	if err := os.MkdirAll(filepath.Dir(at), 0o755); err != nil {
 		return fmt.Errorf("state breadcrumb dir: %w", err)

--- a/internal/vm/wakefloorguard_test.go
+++ b/internal/vm/wakefloorguard_test.go
@@ -88,6 +88,20 @@ func TestWakeFloorGuard(t *testing.T) {
 			t.Fatalf("capable binary refused: %s", out)
 		}
 	})
+	// A lookup that fails any other way than "no such file" is not absence:
+	// an incapable binary is refused, a capable one still starts.
+	t.Run("an_unknowable_marker_refuses_an_incapable_binary", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		if err := os.Symlink(w.evidence, w.evidence); err != nil { // a loop
+			t.Fatal(err)
+		}
+		if ok, out := w.run(w.binary("old-vmd", false)); ok || !strings.Contains(out, "cannot look up") {
+			t.Fatalf("incapable binary admitted over an unknowable marker: ok=%v %s", ok, out)
+		}
+		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
+			t.Fatalf("capable binary refused over an unknowable marker: %s", out)
+		}
+	})
 	t.Run("evidence_with_a_missing_binary_refuses", func(t *testing.T) {
 		w := newWakeGuardWorld(t)
 		if err := os.WriteFile(w.evidence, nil, 0o644); err != nil {

--- a/internal/vm/wakefloorguard_test.go
+++ b/internal/vm/wakefloorguard_test.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,18 +10,18 @@ import (
 
 // The host-resident wake-floor guard is safety-critical shell with no other
 // harness: these cases drive deploy/vmd-wake-floor-guard through its allow
-// and refuse paths with the host world (evidence file, snapshot-directory
-// breadcrumb, snapshot tree, vmd binary) stubbed into a temp dir.
+// and refuse paths with the host world (evidence file, vmd binary) stubbed
+// into a temp dir.
 
 // wakeProtocolMarker is the literal the guard greps a vmd binary for. A vmd
 // that can wake a frozen image carries it; this one does not, on purpose.
 const wakeProtocolMarker = "wake-protocol-1"
 
 type wakeGuardWorld struct {
-	t         *testing.T
-	dir       string
-	guard     string
-	snapshots string
+	t        *testing.T
+	dir      string
+	guard    string
+	evidence string
 }
 
 func newWakeGuardWorld(t *testing.T) *wakeGuardWorld {
@@ -34,24 +33,18 @@ func newWakeGuardWorld(t *testing.T) *wakeGuardWorld {
 	if !strings.Contains(string(src), wakeProtocolMarker) {
 		t.Fatalf("guard script no longer greps for %q — update this harness", wakeProtocolMarker)
 	}
-	dir := t.TempDir()
-	w := &wakeGuardWorld{t: t, dir: dir, snapshots: filepath.Join(dir, "default-snapshots")}
-	rewritten := string(src)
-	for from, to := range map[string]string{
-		wakeProtocolEvidencePath:     filepath.Join(dir, "evidence"),
-		SnapshotDirBreadcrumbPath:    filepath.Join(dir, "snapshot-dir"),
-		"/var/lib/sandbox/snapshots": w.snapshots,
-	} {
-		if !strings.Contains(rewritten, from) {
-			t.Fatalf("guard script no longer references %q — update this harness", from)
-		}
-		rewritten = strings.ReplaceAll(rewritten, from, to)
+	if !strings.Contains(string(src), wakeProtocolEvidencePath) {
+		t.Fatalf("guard script no longer references %q — update this harness", wakeProtocolEvidencePath)
 	}
-	w.guard = filepath.Join(dir, "guard.sh")
-	if err := os.WriteFile(w.guard, []byte(rewritten), 0o755); err != nil {
+	dir := t.TempDir()
+	host := filepath.Join(dir, "host")
+	if err := os.MkdirAll(host, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(w.snapshots, 0o755); err != nil {
+	w := &wakeGuardWorld{t: t, dir: dir, evidence: filepath.Join(host, "evidence")}
+	rewritten := strings.ReplaceAll(string(src), wakeProtocolEvidencePath, w.evidence)
+	w.guard = filepath.Join(dir, "guard.sh")
+	if err := os.WriteFile(w.guard, []byte(rewritten), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	return w
@@ -70,8 +63,6 @@ func (w *wakeGuardWorld) binary(name string, capable bool) string {
 	return p
 }
 
-func strconvItoa(i int) string { return fmt.Sprintf("%d", i) }
-
 func (w *wakeGuardWorld) run(bin string) (ok bool, out string) {
 	w.t.Helper()
 	res, err := exec.Command("sh", w.guard, bin).CombinedOutput()
@@ -79,15 +70,15 @@ func (w *wakeGuardWorld) run(bin string) (ok bool, out string) {
 }
 
 func TestWakeFloorGuard(t *testing.T) {
-	t.Run("no_witness_admits_any_binary", func(t *testing.T) {
+	t.Run("no_evidence_admits_any_binary", func(t *testing.T) {
 		w := newWakeGuardWorld(t)
 		if ok, out := w.run(w.binary("vmd", false)); !ok {
-			t.Fatalf("refused with no witness: %s", out)
+			t.Fatalf("refused with no evidence: %s", out)
 		}
 	})
 	t.Run("evidence_refuses_an_incapable_binary_and_admits_a_capable_one", func(t *testing.T) {
 		w := newWakeGuardWorld(t)
-		if err := os.WriteFile(filepath.Join(w.dir, "evidence"), nil, 0o644); err != nil {
+		if err := os.WriteFile(w.evidence, nil, 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if ok, out := w.run(w.binary("old-vmd", false)); ok || !strings.Contains(out, "REFUSING") {
@@ -97,65 +88,27 @@ func TestWakeFloorGuard(t *testing.T) {
 			t.Fatalf("capable binary refused: %s", out)
 		}
 	})
-	t.Run("a_frozen_manifest_is_a_witness_an_unfrozen_one_is_not", func(t *testing.T) {
+	t.Run("evidence_with_a_missing_binary_refuses", func(t *testing.T) {
 		w := newWakeGuardWorld(t)
-		// The daemon's breadcrumb points the guard at a custom directory.
-		custom := filepath.Join(w.dir, "custom-snapshots")
-		tpl := filepath.Join(custom, TemplatesDirName, "tpl", "build-1")
-		if err := os.MkdirAll(tpl, 0o755); err != nil {
+		if err := os.WriteFile(w.evidence, nil, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(w.dir, "snapshot-dir"), []byte(custom+"\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if err := WriteWallClockManifest(filepath.Join(tpl, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
-			t.Fatal(err)
-		}
-		if ok, out := w.run(w.binary("vmd", false)); !ok {
-			t.Fatalf("refused over an unfrozen manifest: %s", out)
-		}
-		seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
-		if ok, out := w.run(w.binary("vmd", false)); ok || !strings.Contains(out, "frozen image manifest") {
-			t.Fatalf("incapable binary admitted over a frozen template: ok=%v %s", ok, out)
-		}
-		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
-			t.Fatalf("capable binary refused: %s", out)
+		if ok, _ := w.run(filepath.Join(w.dir, "no-such-vmd")); ok {
+			t.Fatal("a binary that cannot be checked was admitted")
 		}
 	})
-	// The walk is batched, so a host with many images neither overflows an
-	// argument list nor admits a binary by accident; one frozen image among
-	// thousands still refuses it.
-	t.Run("thousands_of_images_are_walked_whole", func(t *testing.T) {
+	// The guard never looks at the snapshot trees: a frozen image with no
+	// evidence beside it is invisible to it by design, which is why every
+	// producer and importer of one raises the floor first.
+	t.Run("no_evidence_means_no_walk", func(t *testing.T) {
 		w := newWakeGuardWorld(t)
-		for i := 0; i < 3000; i++ {
-			sb := filepath.Join(w.snapshots, "vm-"+strconvItoa(i))
-			if err := os.MkdirAll(sb, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := writeWallClockManifestLazy(filepath.Join(sb, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
-				t.Fatal(err)
-			}
-		}
-		if ok, out := w.run(w.binary("vmd", false)); !ok {
-			t.Fatalf("refused with only unfrozen images: %s", out)
-		}
-		seedFrozenManifest(t, filepath.Join(w.snapshots, "vm-1500", "mem.snap"), "tok")
-		if ok, _ := w.run(w.binary("vmd", false)); ok {
-			t.Fatal("incapable binary admitted over one frozen image among thousands")
-		}
-		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
-			t.Fatalf("capable binary refused: %s", out)
-		}
-	})
-	t.Run("without_a_breadcrumb_the_default_directory_is_scanned", func(t *testing.T) {
-		w := newWakeGuardWorld(t)
-		sb := filepath.Join(w.snapshots, "vm-1")
+		sb := filepath.Join(w.dir, "snapshots", "vm-1")
 		if err := os.MkdirAll(sb, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		seedFrozenManifest(t, filepath.Join(sb, "mem.snap"), "tok")
-		if ok, _ := w.run(w.binary("vmd", false)); ok {
-			t.Fatal("incapable binary admitted over a frozen paused image in the default directory")
+		if ok, out := w.run(w.binary("vmd", false)); !ok {
+			t.Fatalf("the guard walked the trees: %s", out)
 		}
 	})
 }

--- a/internal/vm/wakefloorguard_test.go
+++ b/internal/vm/wakefloorguard_test.go
@@ -1,0 +1,133 @@
+package vm
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The host-resident wake-floor guard is safety-critical shell with no other
+// harness: these cases drive deploy/vmd-wake-floor-guard through its allow
+// and refuse paths with the host world (evidence file, snapshot-directory
+// breadcrumb, snapshot tree, vmd binary) stubbed into a temp dir.
+
+// wakeProtocolMarker is the literal the guard greps a vmd binary for. A vmd
+// that can wake a frozen image carries it; this one does not, on purpose.
+const wakeProtocolMarker = "wake-protocol-1"
+
+type wakeGuardWorld struct {
+	t         *testing.T
+	dir       string
+	guard     string
+	snapshots string
+}
+
+func newWakeGuardWorld(t *testing.T) *wakeGuardWorld {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("..", "..", "deploy", "vmd-wake-floor-guard"))
+	if err != nil {
+		t.Fatalf("read guard script: %v", err)
+	}
+	if !strings.Contains(string(src), wakeProtocolMarker) {
+		t.Fatalf("guard script no longer greps for %q — update this harness", wakeProtocolMarker)
+	}
+	dir := t.TempDir()
+	w := &wakeGuardWorld{t: t, dir: dir, snapshots: filepath.Join(dir, "default-snapshots")}
+	rewritten := string(src)
+	for from, to := range map[string]string{
+		wakeProtocolEvidencePath:     filepath.Join(dir, "evidence"),
+		SnapshotDirBreadcrumbPath:    filepath.Join(dir, "snapshot-dir"),
+		"/var/lib/sandbox/snapshots": w.snapshots,
+	} {
+		if !strings.Contains(rewritten, from) {
+			t.Fatalf("guard script no longer references %q — update this harness", from)
+		}
+		rewritten = strings.ReplaceAll(rewritten, from, to)
+	}
+	w.guard = filepath.Join(dir, "guard.sh")
+	if err := os.WriteFile(w.guard, []byte(rewritten), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(w.snapshots, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
+func (w *wakeGuardWorld) binary(name string, capable bool) string {
+	w.t.Helper()
+	body := "not a real vmd\n"
+	if capable {
+		body += wakeProtocolMarker + "\n"
+	}
+	p := filepath.Join(w.dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		w.t.Fatal(err)
+	}
+	return p
+}
+
+func (w *wakeGuardWorld) run(bin string) (ok bool, out string) {
+	w.t.Helper()
+	res, err := exec.Command("sh", w.guard, bin).CombinedOutput()
+	return err == nil, string(res)
+}
+
+func TestWakeFloorGuard(t *testing.T) {
+	t.Run("no_witness_admits_any_binary", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		if ok, out := w.run(w.binary("vmd", false)); !ok {
+			t.Fatalf("refused with no witness: %s", out)
+		}
+	})
+	t.Run("evidence_refuses_an_incapable_binary_and_admits_a_capable_one", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		if err := os.WriteFile(filepath.Join(w.dir, "evidence"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if ok, out := w.run(w.binary("old-vmd", false)); ok || !strings.Contains(out, "REFUSING") {
+			t.Fatalf("incapable binary admitted over evidence: ok=%v %s", ok, out)
+		}
+		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
+			t.Fatalf("capable binary refused: %s", out)
+		}
+	})
+	t.Run("a_frozen_manifest_is_a_witness_an_unfrozen_one_is_not", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		// The daemon's breadcrumb points the guard at a custom directory.
+		custom := filepath.Join(w.dir, "custom-snapshots")
+		tpl := filepath.Join(custom, TemplatesDirName, "tpl", "build-1")
+		if err := os.MkdirAll(tpl, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(w.dir, "snapshot-dir"), []byte(custom+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteWallClockManifest(filepath.Join(tpl, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+			t.Fatal(err)
+		}
+		if ok, out := w.run(w.binary("vmd", false)); !ok {
+			t.Fatalf("refused over an unfrozen manifest: %s", out)
+		}
+		seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+		if ok, out := w.run(w.binary("vmd", false)); ok || !strings.Contains(out, "frozen image manifest") {
+			t.Fatalf("incapable binary admitted over a frozen template: ok=%v %s", ok, out)
+		}
+		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
+			t.Fatalf("capable binary refused: %s", out)
+		}
+	})
+	t.Run("without_a_breadcrumb_the_default_directory_is_scanned", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		sb := filepath.Join(w.snapshots, "vm-1")
+		if err := os.MkdirAll(sb, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		seedFrozenManifest(t, filepath.Join(sb, "mem.snap"), "tok")
+		if ok, _ := w.run(w.binary("vmd", false)); ok {
+			t.Fatal("incapable binary admitted over a frozen paused image in the default directory")
+		}
+	})
+}

--- a/internal/vm/wakefloorguard_test.go
+++ b/internal/vm/wakefloorguard_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,6 +70,8 @@ func (w *wakeGuardWorld) binary(name string, capable bool) string {
 	return p
 }
 
+func strconvItoa(i int) string { return fmt.Sprintf("%d", i) }
+
 func (w *wakeGuardWorld) run(bin string) (ok bool, out string) {
 	w.t.Helper()
 	res, err := exec.Command("sh", w.guard, bin).CombinedOutput()
@@ -114,6 +117,31 @@ func TestWakeFloorGuard(t *testing.T) {
 		seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
 		if ok, out := w.run(w.binary("vmd", false)); ok || !strings.Contains(out, "frozen image manifest") {
 			t.Fatalf("incapable binary admitted over a frozen template: ok=%v %s", ok, out)
+		}
+		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
+			t.Fatalf("capable binary refused: %s", out)
+		}
+	})
+	// The walk is batched, so a host with many images neither overflows an
+	// argument list nor admits a binary by accident; one frozen image among
+	// thousands still refuses it.
+	t.Run("thousands_of_images_are_walked_whole", func(t *testing.T) {
+		w := newWakeGuardWorld(t)
+		for i := 0; i < 3000; i++ {
+			sb := filepath.Join(w.snapshots, "vm-"+strconvItoa(i))
+			if err := os.MkdirAll(sb, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeWallClockManifestLazy(filepath.Join(sb, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if ok, out := w.run(w.binary("vmd", false)); !ok {
+			t.Fatalf("refused with only unfrozen images: %s", out)
+		}
+		seedFrozenManifest(t, filepath.Join(w.snapshots, "vm-1500", "mem.snap"), "tok")
+		if ok, _ := w.run(w.binary("vmd", false)); ok {
+			t.Fatal("incapable binary admitted over one frozen image among thousands")
 		}
 		if ok, out := w.run(w.binary("new-vmd", true)); !ok {
 			t.Fatalf("capable binary refused: %s", out)

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -78,7 +78,17 @@ func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceDone.Load() }
 // appears by rename, so no crash and no concurrent build can leave an empty
 // file that one reader honours and another does not.
 func RaiseWakeProtocolFloor() error {
-	if RecognizeWakeProtocolFloor() {
+	if wakeProtocolEvidenceDone.Load() {
+		return nil
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		// Present, but not proven durable by this process: a raise whose
+		// directory sync failed leaves the file visible all the same. Sync
+		// the directory before this one counts it.
+		if err := syncDir(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
+			return err
+		}
+		wakeProtocolEvidenceDone.Store(true)
 		return nil
 	}
 	tmp := wakeProtocolEvidencePath + ".tmp." + strconv.Itoa(os.Getpid())

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -183,9 +183,22 @@ func ReadWallClockManifest(memPath string) (*WallClockManifest, error) {
 	return &m, nil
 }
 
-// WriteWallClockManifest publishes the manifest atomically: a reader sees the
-// previous one or this one, never a partial file.
+// WriteWallClockManifest publishes the manifest atomically and durably: a
+// reader sees the previous one or this one, never a partial file, and a crash
+// after the return cannot lose it. For a frozen manifest, which must outlive
+// a crash or its workload is never released.
 func WriteWallClockManifest(memPath string, m WallClockManifest) error {
+	return writeWallClockManifest(memPath, m, true)
+}
+
+// writeWallClockManifestLazy publishes atomically but with no durability
+// barrier, for a manifest whose loss costs only a slower resume: an unfrozen
+// one. Nothing on a lifecycle path waits on a sync for it.
+func writeWallClockManifestLazy(memPath string, m WallClockManifest) error {
+	return writeWallClockManifest(memPath, m, false)
+}
+
+func writeWallClockManifest(memPath string, m WallClockManifest, durable bool) error {
 	b, err := json.Marshal(m)
 	if err != nil {
 		return err
@@ -201,10 +214,12 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 		os.Remove(tmp)
 		return err
 	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
+	if durable {
+		if err := f.Sync(); err != nil {
+			f.Close()
+			os.Remove(tmp)
+			return err
+		}
 	}
 	if err := f.Close(); err != nil {
 		os.Remove(tmp)
@@ -213,6 +228,9 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 	if err := os.Rename(tmp, path); err != nil {
 		os.Remove(tmp)
 		return err
+	}
+	if !durable {
+		return nil
 	}
 	return syncDir(filepath.Dir(path))
 }

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 )
@@ -52,12 +53,13 @@ const wakeProtocolEvidenceNote = "this host has held images that owe a wake\n"
 var wakeProtocolEvidenceDone atomic.Bool
 
 // RecognizeWakeProtocolFloor notes, at startup, evidence a previous process
-// made durable. It never writes.
+// made durable. It never writes. Existence is the fact, as it is for the
+// host guard: the file is only ever created whole, so its size says nothing.
 func RecognizeWakeProtocolFloor() bool {
 	if wakeProtocolEvidenceDone.Load() {
 		return true
 	}
-	if st, err := os.Stat(wakeProtocolEvidencePath); err == nil && st.Size() > 0 {
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
 		wakeProtocolEvidenceDone.Store(true)
 		return true
 	}
@@ -72,20 +74,34 @@ func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceDone.Load() }
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
 // hold, an image that owes a wake. The template builder calls it before it
 // publishes a frozen image, so the floor is up before the artifact exists.
+// Created once and whole: an existing file is left as it is, and a new one
+// appears by rename, so no crash and no concurrent build can leave an empty
+// file that one reader honours and another does not.
 func RaiseWakeProtocolFloor() error {
-	f, err := os.OpenFile(wakeProtocolEvidencePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if RecognizeWakeProtocolFloor() {
+		return nil
+	}
+	tmp := wakeProtocolEvidencePath + ".tmp." + strconv.Itoa(os.Getpid())
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
 	if _, err := f.WriteString(wakeProtocolEvidenceNote); err != nil {
 		f.Close()
+		os.Remove(tmp)
 		return err
 	}
 	if err := f.Sync(); err != nil {
 		f.Close()
+		os.Remove(tmp)
 		return err
 	}
 	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, wakeProtocolEvidencePath); err != nil {
+		os.Remove(tmp)
 		return err
 	}
 	if err := syncDir(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
@@ -131,8 +147,14 @@ func ReadWallClockManifest(memPath string) (*WallClockManifest, error) {
 	if m.Version != WallClockManifestVersion {
 		return nil, fmt.Errorf("%w: %s: version %d, this supervisor speaks %d", ErrWallClockManifest, WallClockMarkerPath(memPath), m.Version, WallClockManifestVersion)
 	}
-	if m.WorkloadFrozen && m.FreezeToken == "" {
-		return nil, fmt.Errorf("%w: %s: frozen workload without a freeze token", ErrWallClockManifest, WallClockMarkerPath(memPath))
+	// The fields are protocol and recovery invariants: a manifest names its
+	// artifact, and a frozen workload carries the token its wake must present
+	// and comes from a guest that will correct its clock once woken.
+	if m.ArtifactID == "" {
+		return nil, fmt.Errorf("%w: %s: no artifact id", ErrWallClockManifest, WallClockMarkerPath(memPath))
+	}
+	if m.WorkloadFrozen && (m.FreezeToken == "" || !m.GuestCorrectsClock) {
+		return nil, fmt.Errorf("%w: %s: frozen workload without a freeze token, or from a guest that does not correct its clock", ErrWallClockManifest, WallClockMarkerPath(memPath))
 	}
 	return &m, nil
 }

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -35,6 +35,11 @@ type WallClockManifest struct {
 
 const WallClockManifestVersion = 1
 
+// WakeProtocolVersion is the wire protocol the guest agent names in its freeze
+// echo. A different version space from the manifest's: the two are both 1
+// today by coincidence, and a bump to either must not pass for the other.
+const WakeProtocolVersion = 1
+
 // wakeProtocolEvidencePath records that this host has held an image that
 // owes a wake, so the host-resident guard refuses a vmd without the wake
 // protocol from then on. Raised by the template builder before it publishes

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -42,11 +42,13 @@ const WakeProtocolVersion = 1
 
 // wakeProtocolEvidencePath records that this host has held an image that
 // owes a wake, so the host-resident guard refuses a vmd without the wake
-// protocol from then on. Raised by the template builder before it publishes
-// a frozen image, and by a supervisor before it acts on one. A supervisor
-// that only starts creates none, or every host would raise the floor with
-// both switches off and block a rollback of itself. A host without the
-// directory is not a fleet host.
+// protocol from then on. It is the guard's only witness — a host holds far
+// too many images to walk at every start — so it is raised before such an
+// image can exist here: by the template builder before it publishes a frozen
+// template, by a supervisor before it freezes or restores one, and by any
+// import of one from elsewhere. A supervisor that only starts creates none,
+// or every host would raise the floor with both switches off and block a
+// rollback of itself. A host without the directory is not a fleet host.
 var wakeProtocolEvidencePath = "/var/lib/sandbox/wake-protocol-evidence"
 
 // wakeProtocolEvidenceNote is what the evidence file says. The guard only

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -48,19 +48,25 @@ var wakeProtocolEvidencePath = "/var/lib/sandbox/wake-protocol-evidence"
 // asks whether the file exists; the note is for whoever finds it.
 const wakeProtocolEvidenceNote = "this host has held images that owe a wake\n"
 
-// wakeProtocolEvidenceDone is set once evidence is known durable, whether a
-// previous process wrote it or this one did.
-var wakeProtocolEvidenceDone atomic.Bool
+// Two facts about the evidence, kept apart: seen, the file is visible, which
+// is what turns the pause-intent checks on; and durable, this process has
+// itself synced the directory that holds it. A file left visible by a raise
+// whose directory sync failed is seen but not durable, and the next raise
+// must repair that rather than trust it.
+var (
+	wakeProtocolEvidenceSeen    atomic.Bool
+	wakeProtocolEvidenceDurable atomic.Bool
+)
 
 // RecognizeWakeProtocolFloor notes, at startup, evidence a previous process
-// made durable. It never writes. Existence is the fact, as it is for the
-// host guard: the file is only ever created whole, so its size says nothing.
+// left. It never writes. Existence is the fact, as it is for the host guard:
+// the file is only ever created whole, so its size says nothing.
 func RecognizeWakeProtocolFloor() bool {
-	if wakeProtocolEvidenceDone.Load() {
+	if wakeProtocolEvidenceSeen.Load() {
 		return true
 	}
 	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
-		wakeProtocolEvidenceDone.Store(true)
+		wakeProtocolEvidenceSeen.Store(true)
 		return true
 	}
 	return false
@@ -69,7 +75,7 @@ func RecognizeWakeProtocolFloor() bool {
 // wakeProtocolFloorRaised reports what startup recognised, without I/O. A
 // pause intent is only ever written on a host whose floor is up, so on any
 // other host the checks for one are skipped, at no cost.
-func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceDone.Load() }
+func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceSeen.Load() }
 
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
 // hold, an image that owes a wake. The template builder calls it before it
@@ -78,17 +84,19 @@ func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceDone.Load() }
 // appears by rename, so no crash and no concurrent build can leave an empty
 // file that one reader honours and another does not.
 func RaiseWakeProtocolFloor() error {
-	if wakeProtocolEvidenceDone.Load() {
+	if wakeProtocolEvidenceDurable.Load() {
 		return nil
 	}
 	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
-		// Present, but not proven durable by this process: a raise whose
-		// directory sync failed leaves the file visible all the same. Sync
-		// the directory before this one counts it.
+		// Visible, but not proven durable by this process: a raise whose
+		// directory sync failed leaves the file visible all the same, and
+		// startup recognition proves nothing. Sync the directory before
+		// this one counts it.
 		if err := syncDir(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
 			return err
 		}
-		wakeProtocolEvidenceDone.Store(true)
+		wakeProtocolEvidenceSeen.Store(true)
+		wakeProtocolEvidenceDurable.Store(true)
 		return nil
 	}
 	tmp := wakeProtocolEvidencePath + ".tmp." + strconv.Itoa(os.Getpid())
@@ -117,7 +125,8 @@ func RaiseWakeProtocolFloor() error {
 	if err := syncDir(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
 		return err
 	}
-	wakeProtocolEvidenceDone.Store(true)
+	wakeProtocolEvidenceSeen.Store(true)
+	wakeProtocolEvidenceDurable.Store(true)
 	return nil
 }
 

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -1,0 +1,271 @@
+package vm
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// WallClockManifest sits beside a memory image and says what a supervisor may
+// assume about the guest inside it. Written by the template builder once the
+// guest has proven it corrects its clock and froze its workload, and rewritten
+// by every pause with that pause's outcome. Absent means a legacy image:
+// restored the older way, owed nothing. Unreadable, or a version this binary
+// does not know, refuses the restore before Firecracker is launched: guessing
+// could release a frozen workload onto a stale clock, or never release it.
+type WallClockManifest struct {
+	Version int `json:"version"`
+	// ArtifactID is minted with the manifest; a record that caches a manifest
+	// names the artifact it describes.
+	ArtifactID         string `json:"artifact_id"`
+	WorkloadFrozen     bool   `json:"workload_frozen"`
+	GuestCorrectsClock bool   `json:"guest_corrects_clock"`
+	// FreezeToken is the supervisor's proof, kept by the guest across the
+	// snapshot, that a wake belongs to this image's freeze. Empty when the
+	// workload is not frozen.
+	FreezeToken string `json:"freeze_token,omitempty"`
+}
+
+const WallClockManifestVersion = 1
+
+// wakeProtocolEvidenceNote is what the evidence file says. The host guard
+// only asks whether the file exists; the note is for whoever finds it.
+const wakeProtocolEvidenceNote = "this host has held images that owe a wake\n"
+
+// wakeProtocolEvidencePath is written the first time this daemon reads a
+// manifest — on restore, on pause, or in the templates it holds: this host has
+// images only a vmd with the wake protocol can handle, and the host-resident
+// guard refuses any other from then on. Best-effort and once; a host without
+// the directory is not a fleet host.
+var wakeProtocolEvidencePath = "/var/lib/sandbox/wake-protocol-evidence"
+
+// wakeProtocolEvidenceDone is set only once the write is durable, so a failed
+// attempt is retried rather than forgotten; the mutex makes concurrent first
+// restores share one write instead of each paying the fsync.
+var (
+	wakeProtocolEvidenceDone atomic.Bool
+	wakeProtocolEvidenceMu   sync.Mutex
+)
+
+// noteWakeProtocolEvidence is the best-effort form, for manifests read where
+// nothing is about to act on them (a pause, the template scan).
+func noteWakeProtocolEvidence() {
+	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
+		return
+	}
+	_ = ensureWakeProtocolFloor()
+}
+
+// recognizeWakeProtocolFloor notes evidence a previous process made durable.
+// It never writes: only an image that owes a wake raises the floor.
+func recognizeWakeProtocolFloor() bool {
+	if wakeProtocolEvidenceDone.Load() {
+		return true
+	}
+	if st, err := os.Stat(wakeProtocolEvidencePath); err == nil && st.Size() > 0 {
+		wakeProtocolEvidenceDone.Store(true)
+		return true
+	}
+	return false
+}
+
+// ensureWakeProtocolFloor is the form a restore of an image that owes a wake
+// must pass before it launches anything: durable once, then free.
+func ensureWakeProtocolFloor() error {
+	if recognizeWakeProtocolFloor() {
+		return nil
+	}
+	wakeProtocolEvidenceMu.Lock()
+	defer wakeProtocolEvidenceMu.Unlock()
+	if recognizeWakeProtocolFloor() {
+		return nil
+	}
+	if err := RaiseWakeProtocolFloor(); err != nil {
+		return err
+	}
+	wakeProtocolEvidenceDone.Store(true)
+	return nil
+}
+
+// RaiseWakeProtocolFloor durably records that this host holds, or is about to
+// hold, an image that owes a wake. The template builder calls it before it
+// publishes a frozen image, so the floor is up before the artifact exists;
+// the daemon calls it before it restores one and on every manifest it reads.
+func RaiseWakeProtocolFloor() error {
+	f, err := os.OpenFile(wakeProtocolEvidencePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(wakeProtocolEvidenceNote); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return syncDir(filepath.Dir(wakeProtocolEvidencePath))
+}
+
+var ErrWallClockManifest = errors.New("wall-clock manifest unreadable")
+
+const clockFreezeMarkerSuffix = ".wallclock"
+
+// WallClockMarkerPath is the manifest beside a memory image.
+func WallClockMarkerPath(memPath string) string { return memPath + clockFreezeMarkerSuffix }
+
+// clockFreezeMarkerPath is the internal spelling; see WallClockMarkerPath.
+func clockFreezeMarkerPath(memPath string) string { return WallClockMarkerPath(memPath) }
+
+// ReadWallClockManifest returns nil for an absent manifest and an error
+// wrapping ErrWallClockManifest for one that cannot be trusted.
+func ReadWallClockManifest(memPath string) (*WallClockManifest, error) {
+	if memPath == "" {
+		return nil, nil
+	}
+	b, err := os.ReadFile(WallClockMarkerPath(memPath))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrWallClockManifest, err)
+	}
+	var m WallClockManifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("%w: %s: %v", ErrWallClockManifest, WallClockMarkerPath(memPath), err)
+	}
+	if m.Version != WallClockManifestVersion {
+		return nil, fmt.Errorf("%w: %s: version %d, this supervisor speaks %d", ErrWallClockManifest, WallClockMarkerPath(memPath), m.Version, WallClockManifestVersion)
+	}
+	if m.WorkloadFrozen && m.FreezeToken == "" {
+		return nil, fmt.Errorf("%w: %s: frozen workload without a freeze token", ErrWallClockManifest, WallClockMarkerPath(memPath))
+	}
+	noteWakeProtocolEvidence()
+	return &m, nil
+}
+
+// WriteWallClockManifest publishes the manifest atomically: a reader sees the
+// previous one or this one, never a partial file.
+func WriteWallClockManifest(memPath string, m WallClockManifest) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	path := WallClockMarkerPath(memPath)
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return syncDir(filepath.Dir(path))
+}
+
+// NewFreezeToken and NewArtifactID mint 16 random bytes; uniqueness is all
+// that matters, and nothing inside a guest can guess one.
+func NewFreezeToken() string { return randomHex() }
+func NewArtifactID() string  { return randomHex() }
+
+func randomHex() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("crypto/rand unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// imageManifest is the manifest that governs a restore of memPath: its own,
+// and only its own. An overlay never inherits its base's: a paused overlay
+// without a manifest of its own is a legacy image, whatever the template it
+// was cut from says, or a running workload could be restored under a frozen
+// clock.
+func imageManifest(memPath string) (*WallClockManifest, error) {
+	return ReadWallClockManifest(memPath)
+}
+
+// WatchTemplateManifests keeps the wake-protocol evidence in step with the
+// templates this host holds. Templates are seeded while the daemon runs, so
+// the first frozen one to land is what raises the rollback floor here — no
+// restore has to happen first, and nothing is configured anywhere. A
+// directory listing every few minutes, off every request path.
+func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) {
+	if m.cfg.SnapshotDir == "" {
+		return
+	}
+	// Before any request: evidence a previous process made durable is
+	// recognised, so the first frozen operation after a restart pays nothing.
+	// Only recognised — starting a vmd creates no evidence, or the daemon
+	// would raise the floor on every host with both switches off and block a
+	// rollback of itself.
+	recognizeWakeProtocolFloor()
+	scan := func() {
+		if n := m.scanTemplateManifests(); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
+			log.Info().Int("templates", n).Msg("this host holds images that owe a wake; a vmd without the wake protocol is refused from now on")
+		}
+	}
+	go func() {
+		scan()
+		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				scan()
+			}
+		}
+	}()
+}
+
+var wakeProtocolEvidenceLogged atomic.Bool
+
+// scanTemplateManifests reads every template manifest under the snapshot
+// directory (which records the evidence as a side effect) and returns how
+// many it found.
+func (m *Manager) scanTemplateManifests() int {
+	// Templates live at templates/<template>/<build>/; the shallower pattern
+	// is kept so a flattened layout could never hide one.
+	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+	deep, _ := filepath.Glob(filepath.Join(root, "*", "*", "*"+clockFreezeMarkerSuffix))
+	shallow, _ := filepath.Glob(filepath.Join(root, "*", "*"+clockFreezeMarkerSuffix))
+	matches := append(deep, shallow...)
+	n := 0
+	for _, path := range matches {
+		if man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix)); err == nil && man != nil {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,11 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"sync/atomic"
-	"time"
-
-	"github.com/rs/zerolog"
 )
 
 // WallClockManifest sits beside a memory image and says what a supervisor may
@@ -39,37 +34,26 @@ type WallClockManifest struct {
 
 const WallClockManifestVersion = 1
 
-// wakeProtocolEvidenceNote is what the evidence file says. The host guard
-// only asks whether the file exists; the note is for whoever finds it.
-const wakeProtocolEvidenceNote = "this host has held images that owe a wake\n"
-
-// wakeProtocolEvidencePath is written the first time this daemon reads a
-// manifest — on restore, on pause, or in the templates it holds: this host has
-// images only a vmd with the wake protocol can handle, and the host-resident
-// guard refuses any other from then on. Best-effort and once; a host without
-// the directory is not a fleet host.
+// wakeProtocolEvidencePath records that this host has held an image that
+// owes a wake, so the host-resident guard refuses a vmd without the wake
+// protocol from then on. Raised by the template builder before it publishes
+// a frozen image, and by a supervisor before it acts on one. A supervisor
+// that only starts creates none, or every host would raise the floor with
+// both switches off and block a rollback of itself. A host without the
+// directory is not a fleet host.
 var wakeProtocolEvidencePath = "/var/lib/sandbox/wake-protocol-evidence"
 
-// wakeProtocolEvidenceDone is set only once the write is durable, so a failed
-// attempt is retried rather than forgotten; the mutex makes concurrent first
-// restores share one write instead of each paying the fsync.
-var (
-	wakeProtocolEvidenceDone atomic.Bool
-	wakeProtocolEvidenceMu   sync.Mutex
-)
+// wakeProtocolEvidenceNote is what the evidence file says. The guard only
+// asks whether the file exists; the note is for whoever finds it.
+const wakeProtocolEvidenceNote = "this host has held images that owe a wake\n"
 
-// noteWakeProtocolEvidence is the best-effort form, for manifests read where
-// nothing is about to act on them (a pause, the template scan).
-func noteWakeProtocolEvidence() {
-	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
-		return
-	}
-	_ = ensureWakeProtocolFloor()
-}
+// wakeProtocolEvidenceDone is set once evidence is known durable, whether a
+// previous process wrote it or this one did.
+var wakeProtocolEvidenceDone atomic.Bool
 
-// recognizeWakeProtocolFloor notes evidence a previous process made durable.
-// It never writes: only an image that owes a wake raises the floor.
-func recognizeWakeProtocolFloor() bool {
+// RecognizeWakeProtocolFloor notes, at startup, evidence a previous process
+// made durable. It never writes.
+func RecognizeWakeProtocolFloor() bool {
 	if wakeProtocolEvidenceDone.Load() {
 		return true
 	}
@@ -80,28 +64,14 @@ func recognizeWakeProtocolFloor() bool {
 	return false
 }
 
-// ensureWakeProtocolFloor is the form a restore of an image that owes a wake
-// must pass before it launches anything: durable once, then free.
-func ensureWakeProtocolFloor() error {
-	if recognizeWakeProtocolFloor() {
-		return nil
-	}
-	wakeProtocolEvidenceMu.Lock()
-	defer wakeProtocolEvidenceMu.Unlock()
-	if recognizeWakeProtocolFloor() {
-		return nil
-	}
-	if err := RaiseWakeProtocolFloor(); err != nil {
-		return err
-	}
-	wakeProtocolEvidenceDone.Store(true)
-	return nil
-}
+// wakeProtocolFloorRaised reports what startup recognised, without I/O. A
+// pause intent is only ever written on a host whose floor is up, so on any
+// other host the checks for one are skipped, at no cost.
+func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceDone.Load() }
 
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
 // hold, an image that owes a wake. The template builder calls it before it
-// publishes a frozen image, so the floor is up before the artifact exists;
-// the daemon calls it before it restores one and on every manifest it reads.
+// publishes a frozen image, so the floor is up before the artifact exists.
 func RaiseWakeProtocolFloor() error {
 	f, err := os.OpenFile(wakeProtocolEvidencePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
@@ -118,7 +88,11 @@ func RaiseWakeProtocolFloor() error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return syncDir(filepath.Dir(wakeProtocolEvidencePath))
+	if err := syncDir(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
+		return err
+	}
+	wakeProtocolEvidenceDone.Store(true)
+	return nil
 }
 
 var ErrWallClockManifest = errors.New("wall-clock manifest unreadable")
@@ -144,6 +118,12 @@ func ReadWallClockManifest(memPath string) (*WallClockManifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrWallClockManifest, err)
 	}
+	// An empty file is the marker an earlier supervisor left beside an image
+	// whose guest corrects its clock. It carries no manifest: the image is
+	// restored the older way, and the next pause replaces or removes it.
+	if len(strings.TrimSpace(string(b))) == 0 {
+		return nil, nil
+	}
 	var m WallClockManifest
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, fmt.Errorf("%w: %s: %v", ErrWallClockManifest, WallClockMarkerPath(memPath), err)
@@ -154,7 +134,6 @@ func ReadWallClockManifest(memPath string) (*WallClockManifest, error) {
 	if m.WorkloadFrozen && m.FreezeToken == "" {
 		return nil, fmt.Errorf("%w: %s: frozen workload without a freeze token", ErrWallClockManifest, WallClockMarkerPath(memPath))
 	}
-	noteWakeProtocolEvidence()
 	return &m, nil
 }
 
@@ -212,60 +191,4 @@ func randomHex() string {
 // clock.
 func imageManifest(memPath string) (*WallClockManifest, error) {
 	return ReadWallClockManifest(memPath)
-}
-
-// WatchTemplateManifests keeps the wake-protocol evidence in step with the
-// templates this host holds. Templates are seeded while the daemon runs, so
-// the first frozen one to land is what raises the rollback floor here — no
-// restore has to happen first, and nothing is configured anywhere. A
-// directory listing every few minutes, off every request path.
-func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) {
-	if m.cfg.SnapshotDir == "" {
-		return
-	}
-	// Before any request: evidence a previous process made durable is
-	// recognised, so the first frozen operation after a restart pays nothing.
-	// Only recognised — starting a vmd creates no evidence, or the daemon
-	// would raise the floor on every host with both switches off and block a
-	// rollback of itself.
-	recognizeWakeProtocolFloor()
-	scan := func() {
-		if n := m.scanTemplateManifests(); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
-			log.Info().Int("templates", n).Msg("this host holds images that owe a wake; a vmd without the wake protocol is refused from now on")
-		}
-	}
-	go func() {
-		scan()
-		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				scan()
-			}
-		}
-	}()
-}
-
-var wakeProtocolEvidenceLogged atomic.Bool
-
-// scanTemplateManifests reads every template manifest under the snapshot
-// directory (which records the evidence as a side effect) and returns how
-// many it found.
-func (m *Manager) scanTemplateManifests() int {
-	// Templates live at templates/<template>/<build>/; the shallower pattern
-	// is kept so a flattened layout could never hide one.
-	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
-	deep, _ := filepath.Glob(filepath.Join(root, "*", "*", "*"+clockFreezeMarkerSuffix))
-	shallow, _ := filepath.Glob(filepath.Join(root, "*", "*"+clockFreezeMarkerSuffix))
-	matches := append(deep, shallow...)
-	n := 0
-	for _, path := range matches {
-		if man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix)); err == nil && man != nil {
-			n++
-		}
-	}
-	return n
 }

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -57,8 +57,23 @@ func TestImageManifest(t *testing.T) {
 			t.Fatalf("m=%+v err=%v, want nil, nil", m, err)
 		}
 	})
+	// The zero-byte marker an earlier supervisor wrote carries no manifest:
+	// the image is restored the older way, never refused.
+	t.Run("empty_marker_is_legacy", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		if err := os.WriteFile(WallClockMarkerPath(mem), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		m, err := imageManifest(mem)
+		if err != nil || m != nil {
+			t.Fatalf("m=%+v err=%v, want nil, nil", m, err)
+		}
+		if guestCorrectsWallClock(mem, "") {
+			t.Fatal("an empty marker is not proof the guest corrects its clock")
+		}
+	})
 	t.Run("unreadable_is_refused", func(t *testing.T) {
-		for name, body := range map[string]string{"empty": "", "garbage": "{", "future": `{"version":2}`, "frozen_without_token": `{"version":1,"workload_frozen":true}`} {
+		for name, body := range map[string]string{"garbage": "{", "future": `{"version":2}`, "frozen_without_token": `{"version":1,"workload_frozen":true}`} {
 			mem := filepath.Join(t.TempDir(), "mem.snap")
 			if err := os.WriteFile(WallClockMarkerPath(mem), []byte(body), 0o644); err != nil {
 				t.Fatal(err)
@@ -90,68 +105,15 @@ func TestWallClockMarkerPathMatchesInternal(t *testing.T) {
 	}
 }
 
-// The first manifest read on a host leaves evidence for the deploy guard; an
-// absent manifest is not one.
-func TestReadingAManifestLeavesWakeProtocolEvidence(t *testing.T) {
-	dir := t.TempDir()
-	isolateEvidence(t, dir)
-
-	mem := filepath.Join(dir, "mem.snap")
-	if _, err := ReadWallClockManifest(mem); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
-		t.Fatal("an absent manifest is not evidence")
-	}
-	seedFrozenManifest(t, mem, "tok")
-	if _, err := ReadWallClockManifest(mem); err != nil {
-		t.Fatal(err)
-	}
-	b, err := os.ReadFile(wakeProtocolEvidencePath)
-	if err != nil || len(b) == 0 {
-		t.Fatalf("evidence = %q, %v; want a non-empty file", b, err)
-	}
-}
-
-// Templates are seeded while the daemon runs; the first frozen one to land
-// raises the floor here, at the builder's real layout depth.
-func TestTemplateManifestsLeaveEvidence(t *testing.T) {
-	dir := t.TempDir()
-	isolateEvidence(t, dir)
-
-	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
-	if n := m.scanTemplateManifests(); n != 0 {
-		t.Fatalf("found %d manifests in an empty tree", n)
-	}
-	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
-		t.Fatal("no templates is not evidence")
-	}
-	// The builder's layout: templates/<template>/<build>/mem.snap.
-	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
-	if err := os.MkdirAll(tpl, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
-	if n := m.scanTemplateManifests(); n != 1 {
-		t.Fatalf("found %d manifests, want 1", n)
-	}
-	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
-		t.Fatalf("evidence not written after a frozen template landed: %v", err)
-	}
-}
-
 // Starting a daemon creates no evidence — or every host with the switches off
 // would raise the floor and block a rollback of itself — but evidence a
-// previous process made durable is recognised.
+// previous process made durable is recognised, and only then are pause
+// intents looked for.
 func TestStartupRecognisesButNeverRaisesTheFloor(t *testing.T) {
 	dir := t.TempDir()
 	isolateEvidence(t, dir)
-	m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}}
-	ctx, cancel := context.WithCancel(context.Background())
-	m.WatchTemplateManifests(ctx, zerolog.Nop())
-	cancel()
-	if recognizeWakeProtocolFloor() {
-		t.Fatal("floor raised by a daemon that holds no frozen image")
+	if RecognizeWakeProtocolFloor() || wakeProtocolFloorRaised() {
+		t.Fatal("floor raised on a host that holds no frozen image")
 	}
 	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
 		t.Fatal("startup created evidence")
@@ -159,54 +121,64 @@ func TestStartupRecognisesButNeverRaisesTheFloor(t *testing.T) {
 	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("x\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !recognizeWakeProtocolFloor() {
+	if !RecognizeWakeProtocolFloor() || !wakeProtocolFloorRaised() {
 		t.Fatal("existing evidence not recognised")
 	}
 }
 
-func TestExistingWakeProtocolEvidenceNeedsNoWrite(t *testing.T) {
+// The builder raises the floor before it publishes a frozen image; a later
+// process finds it durable, and a raise that cannot land is an error.
+func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 	dir := t.TempDir()
 	isolateEvidence(t, dir)
-	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("older-process\n"), 0o644); err != nil {
+	if err := RaiseWakeProtocolFloor(); err != nil {
 		t.Fatal(err)
 	}
-	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDone.Load() {
-		t.Fatalf("err=%v done=%v", err, wakeProtocolEvidenceDone.Load())
+	b, err := os.ReadFile(wakeProtocolEvidencePath)
+	if err != nil || len(b) == 0 {
+		t.Fatalf("evidence = %q, %v; want a non-empty file", b, err)
 	}
-	if b, _ := os.ReadFile(wakeProtocolEvidencePath); string(b) != "older-process\n" {
-		t.Errorf("existing evidence rewritten: %q", b)
+	wakeProtocolEvidenceDone.Store(false) // a fresh process
+	if !RecognizeWakeProtocolFloor() {
+		t.Fatal("a fresh process did not recognise the evidence")
 	}
-}
-
-func TestWakeProtocolEvidenceRetriesAfterFailure(t *testing.T) {
-	dir := t.TempDir()
-	orig := wakeProtocolEvidencePath
-	// A path inside a directory that exists but is a file: the write fails.
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	wakeProtocolEvidencePath = filepath.Join(blocker, "evidence")
 	wakeProtocolEvidenceDone.Store(false)
-	t.Cleanup(func() { wakeProtocolEvidencePath = orig; wakeProtocolEvidenceDone.Store(false) })
+	if err := RaiseWakeProtocolFloor(); err == nil || wakeProtocolFloorRaised() {
+		t.Fatalf("err=%v raised=%v; a raise that cannot land must fail and not be remembered", err, wakeProtocolFloorRaised())
+	}
+}
 
-	mem := filepath.Join(dir, "mem.snap")
-	seedFrozenManifest(t, mem, "tok")
-	if _, err := ReadWallClockManifest(mem); err != nil {
+// A template build is immutable once published, so its manifest is read once
+// per daemon; any other image is read every time.
+func TestTemplateManifestIsReadOncePerDaemon(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1", "mem.snap")
+	if err := os.MkdirAll(filepath.Dir(tpl), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if wakeProtocolEvidenceDone.Load() {
-		t.Fatal("a failed write must not be remembered as done")
+	if man, err := m.imageManifestCached(tpl); err != nil || man != nil {
+		t.Fatalf("first read: man=%+v err=%v, want legacy", man, err)
 	}
-	wakeProtocolEvidencePath = filepath.Join(dir, "evidence")
-	if _, err := ReadWallClockManifest(mem); err != nil {
+	seedFrozenManifest(t, tpl, "tok")
+	if man, err := m.imageManifestCached(tpl); err != nil || man != nil {
+		t.Fatalf("second read: man=%+v err=%v, want the first answer kept", man, err)
+	}
+	other := filepath.Join(dir, "vm-1", "mem.snap")
+	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if !wakeProtocolEvidenceDone.Load() {
-		t.Fatal("the retry did not land")
+	if man, err := m.imageManifestCached(other); err != nil || man != nil {
+		t.Fatalf("paused image, first read: man=%+v err=%v", man, err)
 	}
-	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
-		t.Fatalf("evidence missing after retry: %v", err)
+	seedFrozenManifest(t, other, "tok")
+	if man, err := m.imageManifestCached(other); err != nil || man == nil || !man.WorkloadFrozen {
+		t.Fatalf("paused image, second read: man=%+v err=%v, want the disk consulted", man, err)
 	}
 }
 

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -1,0 +1,250 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func seedFrozenManifest(t *testing.T, memPath, token string) {
+	t.Helper()
+	if err := WriteWallClockManifest(memPath, WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", WorkloadFrozen: true, GuestCorrectsClock: true, FreezeToken: token}); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+}
+
+// A test's evidence lives in its own directory and starts unrecognised.
+func isolateEvidence(t *testing.T, dir string) {
+	t.Helper()
+	orig := wakeProtocolEvidencePath
+	wakeProtocolEvidencePath = filepath.Join(dir, "evidence")
+	wakeProtocolEvidenceDone.Store(false)
+	t.Cleanup(func() { wakeProtocolEvidencePath = orig; wakeProtocolEvidenceDone.Store(false) })
+}
+
+func TestImageManifest(t *testing.T) {
+	frozen := func(t *testing.T, path string) string {
+		t.Helper()
+		seedFrozenManifest(t, path, "tok")
+		return path
+	}
+
+	t.Run("own_image", func(t *testing.T) {
+		mem := frozen(t, filepath.Join(t.TempDir(), "mem.snap"))
+		m, err := imageManifest(mem)
+		if err != nil || m == nil || !m.WorkloadFrozen || m.FreezeToken != "tok" {
+			t.Fatalf("m=%+v err=%v", m, err)
+		}
+	})
+	t.Run("overlay_never_inherits_its_frozen_base", func(t *testing.T) {
+		dir := t.TempDir()
+		frozen(t, filepath.Join(dir, "template.snap"))
+		m, err := imageManifest(filepath.Join(dir, "mem.diff"))
+		if err != nil || m != nil {
+			t.Fatalf("m=%+v err=%v, want legacy: a paused overlay without its own manifest may hold a running workload", m, err)
+		}
+	})
+	t.Run("absent_is_legacy", func(t *testing.T) {
+		dir := t.TempDir()
+		m, err := imageManifest(filepath.Join(dir, "mem.snap"))
+		if err != nil || m != nil {
+			t.Fatalf("m=%+v err=%v, want nil, nil", m, err)
+		}
+	})
+	t.Run("unreadable_is_refused", func(t *testing.T) {
+		for name, body := range map[string]string{"empty": "", "garbage": "{", "future": `{"version":2}`, "frozen_without_token": `{"version":1,"workload_frozen":true}`} {
+			mem := filepath.Join(t.TempDir(), "mem.snap")
+			if err := os.WriteFile(WallClockMarkerPath(mem), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := imageManifest(mem); !errors.Is(err, ErrWallClockManifest) {
+				t.Errorf("%s: err=%v, want ErrWallClockManifest", name, err)
+			}
+		}
+	})
+	t.Run("write_is_atomic_and_readable", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		want := WallClockManifest{Version: 1, ArtifactID: NewArtifactID(), WorkloadFrozen: false, GuestCorrectsClock: true}
+		if err := WriteWallClockManifest(mem, want); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ReadWallClockManifest(mem)
+		if err != nil || got == nil || *got != want {
+			t.Fatalf("got=%+v err=%v want=%+v", got, err, want)
+		}
+		if _, err := os.Stat(WallClockMarkerPath(mem) + ".tmp"); !os.IsNotExist(err) {
+			t.Error("temp file left behind")
+		}
+	})
+}
+
+func TestWallClockMarkerPathMatchesInternal(t *testing.T) {
+	if got, want := WallClockMarkerPath("/x/mem.snap"), clockFreezeMarkerPath("/x/mem.snap"); got != want {
+		t.Fatalf("exported %q != internal %q", got, want)
+	}
+}
+
+// The first manifest read on a host leaves evidence for the deploy guard; an
+// absent manifest is not one.
+func TestReadingAManifestLeavesWakeProtocolEvidence(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+
+	mem := filepath.Join(dir, "mem.snap")
+	if _, err := ReadWallClockManifest(mem); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
+		t.Fatal("an absent manifest is not evidence")
+	}
+	seedFrozenManifest(t, mem, "tok")
+	if _, err := ReadWallClockManifest(mem); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(wakeProtocolEvidencePath)
+	if err != nil || len(b) == 0 {
+		t.Fatalf("evidence = %q, %v; want a non-empty file", b, err)
+	}
+}
+
+// Templates are seeded while the daemon runs; the first frozen one to land
+// raises the floor here, at the builder's real layout depth.
+func TestTemplateManifestsLeaveEvidence(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 0 {
+		t.Fatalf("found %d manifests in an empty tree", n)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
+		t.Fatal("no templates is not evidence")
+	}
+	// The builder's layout: templates/<template>/<build>/mem.snap.
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	if n := m.scanTemplateManifests(); n != 1 {
+		t.Fatalf("found %d manifests, want 1", n)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
+		t.Fatalf("evidence not written after a frozen template landed: %v", err)
+	}
+}
+
+// Starting a daemon creates no evidence — or every host with the switches off
+// would raise the floor and block a rollback of itself — but evidence a
+// previous process made durable is recognised.
+func TestStartupRecognisesButNeverRaisesTheFloor(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}}
+	ctx, cancel := context.WithCancel(context.Background())
+	m.WatchTemplateManifests(ctx, zerolog.Nop())
+	cancel()
+	if recognizeWakeProtocolFloor() {
+		t.Fatal("floor raised by a daemon that holds no frozen image")
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); !os.IsNotExist(err) {
+		t.Fatal("startup created evidence")
+	}
+	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !recognizeWakeProtocolFloor() {
+		t.Fatal("existing evidence not recognised")
+	}
+}
+
+func TestExistingWakeProtocolEvidenceNeedsNoWrite(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("older-process\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDone.Load() {
+		t.Fatalf("err=%v done=%v", err, wakeProtocolEvidenceDone.Load())
+	}
+	if b, _ := os.ReadFile(wakeProtocolEvidencePath); string(b) != "older-process\n" {
+		t.Errorf("existing evidence rewritten: %q", b)
+	}
+}
+
+func TestWakeProtocolEvidenceRetriesAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	orig := wakeProtocolEvidencePath
+	// A path inside a directory that exists but is a file: the write fails.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wakeProtocolEvidencePath = filepath.Join(blocker, "evidence")
+	wakeProtocolEvidenceDone.Store(false)
+	t.Cleanup(func() { wakeProtocolEvidencePath = orig; wakeProtocolEvidenceDone.Store(false) })
+
+	mem := filepath.Join(dir, "mem.snap")
+	seedFrozenManifest(t, mem, "tok")
+	if _, err := ReadWallClockManifest(mem); err != nil {
+		t.Fatal(err)
+	}
+	if wakeProtocolEvidenceDone.Load() {
+		t.Fatal("a failed write must not be remembered as done")
+	}
+	wakeProtocolEvidencePath = filepath.Join(dir, "evidence")
+	if _, err := ReadWallClockManifest(mem); err != nil {
+		t.Fatal(err)
+	}
+	if !wakeProtocolEvidenceDone.Load() {
+		t.Fatal("the retry did not land")
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
+		t.Fatalf("evidence missing after retry: %v", err)
+	}
+}
+
+// An image whose workload is frozen owes a wake this supervisor cannot give:
+// both resume and restore refuse it before anything is launched, rather than
+// restore it with its workload stopped for good.
+func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
+	isolateEvidence(t, t.TempDir())
+	dir := t.TempDir()
+	snapPath, memPath, rootfs := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	launched := false
+	launch := func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launched = true
+		return 4321, SupervisionUnit, nil
+	}
+	// A record that lost the answer goes to the disk, and the disk says frozen.
+	inst := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, restoreSem: make(chan struct{}, 1)}
+	mgr.launchFirecrackerHook = launch
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	unlock()
+	if status.Code(rerr) != codes.FailedPrecondition || launched {
+		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)
+	}
+	fresh := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: t.TempDir()}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1)}
+	fresh.launchFirecrackerHook = launch
+	_, cerr := fresh.RestoreVMSnapshot(context.Background(), "vm-2", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
+	if status.Code(cerr) != codes.FailedPrecondition || launched {
+		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -190,44 +190,26 @@ func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 	}
 }
 
-// A template build is immutable once published, so its manifest is read once
-// per daemon; any other image is read every time.
-func TestTemplateManifestIsReadOncePerDaemon(t *testing.T) {
+// A template image replaced at the same path is seen as it is now, in both
+// directions: nothing remembers a manifest by path.
+func TestTemplateManifestIsReadOnEveryRestore(t *testing.T) {
 	dir := t.TempDir()
-	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
 	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1", "mem.snap")
 	if err := os.MkdirAll(filepath.Dir(tpl), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if man, err := m.imageManifestCached(tpl); err != nil || man != nil {
-		t.Fatalf("first read: man=%+v err=%v, want legacy", man, err)
+	if man, err := imageManifest(tpl); err != nil || man != nil {
+		t.Fatalf("legacy: man=%+v err=%v", man, err)
 	}
 	seedFrozenManifest(t, tpl, "tok")
-	if man, err := m.imageManifestCached(tpl); err != nil || man != nil {
-		t.Fatalf("second read: man=%+v err=%v, want the first answer kept", man, err)
+	if man, err := imageManifest(tpl); err != nil || man == nil || !man.WorkloadFrozen {
+		t.Fatalf("legacy replaced by frozen: man=%+v err=%v, want the frozen manifest seen", man, err)
 	}
-	// A path that only looks like a template's is not one, and is not kept.
-	dotted := filepath.Join(dir, TemplatesDirName, "..", "vm-2", "mem.snap")
-	if err := os.MkdirAll(filepath.Dir(dotted), 0o755); err != nil {
+	if err := os.Remove(WallClockMarkerPath(tpl)); err != nil {
 		t.Fatal(err)
 	}
-	if man, err := m.imageManifestCached(dotted); err != nil || man != nil {
-		t.Fatalf("dotted path, first read: man=%+v err=%v", man, err)
-	}
-	seedFrozenManifest(t, dotted, "tok")
-	if man, err := m.imageManifestCached(dotted); err != nil || man == nil {
-		t.Fatalf("dotted path, second read: man=%+v err=%v, want the disk consulted, not a cached answer", man, err)
-	}
-	other := filepath.Join(dir, "vm-1", "mem.snap")
-	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if man, err := m.imageManifestCached(other); err != nil || man != nil {
-		t.Fatalf("paused image, first read: man=%+v err=%v", man, err)
-	}
-	seedFrozenManifest(t, other, "tok")
-	if man, err := m.imageManifestCached(other); err != nil || man == nil || !man.WorkloadFrozen {
-		t.Fatalf("paused image, second read: man=%+v err=%v, want the disk consulted", man, err)
+	if man, err := imageManifest(tpl); err != nil || man != nil {
+		t.Fatalf("frozen replaced by legacy: man=%+v err=%v, want legacy seen", man, err)
 	}
 }
 

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -158,8 +158,11 @@ func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 	if !RecognizeWakeProtocolFloor() {
 		t.Fatal("an empty evidence file was not recognised")
 	}
-	if err := RaiseWakeProtocolFloor(); err != nil {
-		t.Fatal(err)
+	// A raise over a file this process has not proven durable syncs the
+	// directory and counts it, without rewriting it.
+	wakeProtocolEvidenceDone.Store(false)
+	if err := RaiseWakeProtocolFloor(); err != nil || !wakeProtocolFloorRaised() {
+		t.Fatalf("err=%v raised=%v; want the existing file counted once its directory is synced", err, wakeProtocolFloorRaised())
 	}
 	if b, _ := os.ReadFile(wakeProtocolEvidencePath); len(b) != 0 {
 		t.Errorf("existing evidence rewritten: %q", b)

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -24,8 +24,9 @@ func isolateEvidence(t *testing.T, dir string) {
 	t.Helper()
 	orig := wakeProtocolEvidencePath
 	wakeProtocolEvidencePath = filepath.Join(dir, "evidence")
-	wakeProtocolEvidenceDone.Store(false)
-	t.Cleanup(func() { wakeProtocolEvidencePath = orig; wakeProtocolEvidenceDone.Store(false) })
+	resetEvidence := func() { wakeProtocolEvidenceSeen.Store(false); wakeProtocolEvidenceDurable.Store(false) }
+	resetEvidence()
+	t.Cleanup(func() { wakeProtocolEvidencePath = orig; resetEvidence() })
 }
 
 func TestImageManifest(t *testing.T) {
@@ -144,25 +145,32 @@ func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 	if err != nil || len(b) == 0 {
 		t.Fatalf("evidence = %q, %v; want a non-empty file", b, err)
 	}
-	wakeProtocolEvidenceDone.Store(false) // a fresh process
+	wakeProtocolEvidenceSeen.Store(false) // a fresh process
+	wakeProtocolEvidenceDurable.Store(false)
 	if !RecognizeWakeProtocolFloor() {
 		t.Fatal("a fresh process did not recognise the evidence")
 	}
-	// Created once: a second raise leaves the file as it is and no temp file
-	// behind; and existence alone is the fact, an empty file included, as it
-	// is for the host guard.
+	// Recognition is seeing, not proving: a raise after it must still make
+	// the file durable itself, without rewriting it, and only then count it.
+	if wakeProtocolEvidenceDurable.Load() {
+		t.Fatal("recognition counted the file as durable")
+	}
+	if err := RaiseWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v durable=%v; want the recognised file made durable by the raise", err, wakeProtocolEvidenceDurable.Load())
+	}
+	// Created once: existence alone is the fact, an empty file included, as
+	// it is for the host guard; a raise over it leaves it as it is and no
+	// temp file behind.
 	if err := os.WriteFile(wakeProtocolEvidencePath, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	wakeProtocolEvidenceDone.Store(false)
+	wakeProtocolEvidenceSeen.Store(false)
+	wakeProtocolEvidenceDurable.Store(false)
 	if !RecognizeWakeProtocolFloor() {
 		t.Fatal("an empty evidence file was not recognised")
 	}
-	// A raise over a file this process has not proven durable syncs the
-	// directory and counts it, without rewriting it.
-	wakeProtocolEvidenceDone.Store(false)
-	if err := RaiseWakeProtocolFloor(); err != nil || !wakeProtocolFloorRaised() {
-		t.Fatalf("err=%v raised=%v; want the existing file counted once its directory is synced", err, wakeProtocolFloorRaised())
+	if err := RaiseWakeProtocolFloor(); err != nil || !wakeProtocolFloorRaised() || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v raised=%v durable=%v; want the existing file counted once its directory is synced", err, wakeProtocolFloorRaised(), wakeProtocolEvidenceDurable.Load())
 	}
 	if b, _ := os.ReadFile(wakeProtocolEvidencePath); len(b) != 0 {
 		t.Errorf("existing evidence rewritten: %q", b)
@@ -175,7 +183,8 @@ func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 		t.Fatal(err)
 	}
 	wakeProtocolEvidencePath = filepath.Join(blocker, "evidence")
-	wakeProtocolEvidenceDone.Store(false)
+	wakeProtocolEvidenceSeen.Store(false)
+	wakeProtocolEvidenceDurable.Store(false)
 	if err := RaiseWakeProtocolFloor(); err == nil || wakeProtocolFloorRaised() {
 		t.Fatalf("err=%v raised=%v; a raise that cannot land must fail and not be remembered", err, wakeProtocolFloorRaised())
 	}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -73,7 +73,13 @@ func TestImageManifest(t *testing.T) {
 		}
 	})
 	t.Run("unreadable_is_refused", func(t *testing.T) {
-		for name, body := range map[string]string{"garbage": "{", "future": `{"version":2}`, "frozen_without_token": `{"version":1,"workload_frozen":true}`} {
+		for name, body := range map[string]string{
+			"garbage":                     "{",
+			"future":                      `{"version":2}`,
+			"no_artifact":                 `{"version":1,"guest_corrects_clock":true}`,
+			"frozen_without_token":        `{"version":1,"artifact_id":"a","workload_frozen":true,"guest_corrects_clock":true}`,
+			"frozen_guest_not_correcting": `{"version":1,"artifact_id":"a","workload_frozen":true,"freeze_token":"t"}`,
+		} {
 			mem := filepath.Join(t.TempDir(), "mem.snap")
 			if err := os.WriteFile(WallClockMarkerPath(mem), []byte(body), 0o644); err != nil {
 				t.Fatal(err)
@@ -142,6 +148,25 @@ func TestRaiseWakeProtocolFloorIsDurable(t *testing.T) {
 	if !RecognizeWakeProtocolFloor() {
 		t.Fatal("a fresh process did not recognise the evidence")
 	}
+	// Created once: a second raise leaves the file as it is and no temp file
+	// behind; and existence alone is the fact, an empty file included, as it
+	// is for the host guard.
+	if err := os.WriteFile(wakeProtocolEvidencePath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wakeProtocolEvidenceDone.Store(false)
+	if !RecognizeWakeProtocolFloor() {
+		t.Fatal("an empty evidence file was not recognised")
+	}
+	if err := RaiseWakeProtocolFloor(); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(wakeProtocolEvidencePath); len(b) != 0 {
+		t.Errorf("existing evidence rewritten: %q", b)
+	}
+	if left, _ := filepath.Glob(wakeProtocolEvidencePath + ".tmp.*"); len(left) != 0 {
+		t.Errorf("temp files left behind: %v", left)
+	}
 	blocker := filepath.Join(dir, "blocker")
 	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
 		t.Fatal(err)
@@ -168,6 +193,18 @@ func TestTemplateManifestIsReadOncePerDaemon(t *testing.T) {
 	seedFrozenManifest(t, tpl, "tok")
 	if man, err := m.imageManifestCached(tpl); err != nil || man != nil {
 		t.Fatalf("second read: man=%+v err=%v, want the first answer kept", man, err)
+	}
+	// A path that only looks like a template's is not one, and is not kept.
+	dotted := filepath.Join(dir, TemplatesDirName, "..", "vm-2", "mem.snap")
+	if err := os.MkdirAll(filepath.Dir(dotted), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if man, err := m.imageManifestCached(dotted); err != nil || man != nil {
+		t.Fatalf("dotted path, first read: man=%+v err=%v", man, err)
+	}
+	seedFrozenManifest(t, dotted, "tok")
+	if man, err := m.imageManifestCached(dotted); err != nil || man == nil {
+		t.Fatalf("dotted path, second read: man=%+v err=%v, want the disk consulted, not a cached answer", man, err)
 	}
 	other := filepath.Join(dir, "vm-1", "mem.snap")
 	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -103,6 +103,14 @@ func TestImageManifest(t *testing.T) {
 		if _, err := os.Stat(WallClockMarkerPath(mem) + ".tmp"); !os.IsNotExist(err) {
 			t.Error("temp file left behind")
 		}
+		// The lazy form is the same file, minus the barriers.
+		lazy := filepath.Join(t.TempDir(), "mem.snap")
+		if err := writeWallClockManifestLazy(lazy, want); err != nil {
+			t.Fatal(err)
+		}
+		if got, err := ReadWallClockManifest(lazy); err != nil || got == nil || *got != want {
+			t.Fatalf("lazy: got=%+v err=%v want=%+v", got, err, want)
+		}
 	})
 }
 


### PR DESCRIPTION
**What it solves.** A restored sandbox's clock jumps forward by the snapshot's age and the guest works through the timer backlog before it is ready. Freezing the clock fixes that, but only safely if the supervisor knows whether the guest corrects its clock and whether its workload was frozen. This PR records those facts beside each image and adds the safety rails. Builds on #471.

**Why we need it.** The supervisor changes that freeze and wake workloads are the risky part. Landing the artifact format and the deployment safety first, dormant, gives them a fixed contract and guarantees no host ever runs a supervisor that cannot handle the images it holds.

**What changes.** The empty marker beside a memory image becomes a versioned manifest (guest corrects clock, workload frozen, release token); a pause-intent file blocks restores of an image a crash left mid-pause (this PR lands the reader and the refusal; the pause that writes one, and the vmd that carries the wake capability, arrive with #478); a host that is about to hold a frozen image gets a flag file first, and a systemd guard refuses to start a vmd without the wake capability while that flag exists; the guard reads only that file, never the snapshot trees, and the deploy script runs the same guard against a new binary before installing it; the template builder can freeze and mark an image behind a switch nothing sets yet; a build gets a unique id when its caller supplies none and never lands on a published template, so a template directory is immutable once published. Also carries the flaky backfill-test fix.

**Worth knowing.** Nothing in production produces a manifest, intent or evidence, so create, pause and resume take exactly today's paths; the only new costs are one small manifest open per create, beside the sidecar read that path already does (not-found for every template today), and one file check at vmd start, measured at 0.6 ms including the shell; a host whose flag is set also pays one pass over the binary, about 17 ms. This vmd deliberately lacks the wake capability, so the guard would refuse it if a frozen image ever appeared.

**Risks.** An old empty marker, if any exists, now reads as "restore the old way", the safe direction. The guard trusts the flag alone, so activation must set it on every host before the feature is turned on and must make every path that copies images between hosts refuse a frozen one onto an unflagged host. The floor is one-way: once flagged, a host takes only wake-capable builds. None of this can trigger until the supervisor changes land.
