### PR TITLE
feat: Expose authoritative Stripe credit balance in customer billing API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2594,6 +2594,7 @@ components:
         credits_applied_usd:
           type: number
           format: double
+          nullable: true
           description: Credits applied against the current period charges.
         # Phase 1 exposes float USD values for billing UI display. Invoice-grade
         # exports should use decimal/cents fields before becoming customer-visible
@@ -2601,11 +2602,36 @@ components:
         credits_remaining_usd:
           type: number
           format: double
+          nullable: true
           description: Credits still available after applying current period charges.
         expected_invoice_amount_usd:
           type: number
           format: double
+          nullable: true
           description: Expected invoice amount after credits.
+        stripe_credit_balance_usd:
+          type: number
+          format: double
+          nullable: true
+          description: Stripe-authoritative aggregate remaining credit; null when unavailable.
+        stripe_credits_applied_usd:
+          type: number
+          format: double
+          nullable: true
+        stripe_remaining_credit_usd:
+          type: number
+          format: double
+          nullable: true
+        credit_source:
+          type: string
+          enum: [local_trial, stripe]
+        credit_status:
+          type: string
+          enum: [available, unavailable]
+        credit_observed_at:
+          type: string
+          format: date-time
+          nullable: true
         cost_breakdown_usd:
           $ref: "#/components/schemas/BillingSummaryCostBreakdown"
         resources:

--- a/internal/api/handlers_billing.go
+++ b/internal/api/handlers_billing.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -55,9 +56,15 @@ type billingSummaryResponse struct {
 	PortalAvailable          bool                              `json:"portal_available"`
 	PaymentSetupRequired     bool                              `json:"payment_setup_required"`
 	CurrentChargesUSD        float64                           `json:"current_charges_usd"`
-	CreditsAppliedUSD        float64                           `json:"credits_applied_usd"`
-	CreditsRemainingUSD      float64                           `json:"credits_remaining_usd"`
-	ExpectedInvoiceAmountUSD float64                           `json:"expected_invoice_amount_usd"`
+	CreditsAppliedUSD        *float64                          `json:"credits_applied_usd"`
+	CreditsRemainingUSD      *float64                          `json:"credits_remaining_usd"`
+	ExpectedInvoiceAmountUSD *float64                          `json:"expected_invoice_amount_usd"`
+	StripeCreditBalanceUSD   *float64                          `json:"stripe_credit_balance_usd,omitempty"`
+	StripeCreditsAppliedUSD  *float64                          `json:"stripe_credits_applied_usd,omitempty"`
+	StripeRemainingCreditUSD *float64                          `json:"stripe_remaining_credit_usd,omitempty"`
+	CreditSource             string                            `json:"credit_source"`
+	CreditStatus             string                            `json:"credit_status"`
+	CreditObservedAt         *time.Time                        `json:"credit_observed_at,omitempty"`
 	CostBreakdownUSD         billingSummaryCostBreakdown       `json:"cost_breakdown_usd"`
 	Resources                []billingSummaryResource          `json:"resources"`
 	ResourcesByKey           map[string]billingSummaryResource `json:"resources_by_key,omitempty"`
@@ -200,7 +207,16 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		trialBalance  db.GetTeamTrialBalanceRow
 	)
 	g, ctx := errgroup.WithContext(c.Request.Context())
+	hasEstablishedSubscription := billingAccountHasEstablishedSubscription(account)
+	// Stripe remains authoritative for credit state after activation, including
+	// when the subscription has since been canceled. Keep this separate from
+	// the active-subscription predicate so canceled accounts can still use
+	// checkout/portal semantics based on their current status.
+	hasStripeCreditState := billingAccountHasStripeCreditState(account)
 	g.Go(func() error {
+		// Usage remains required for every account: Stripe owns credit state after
+		// activation, but current charges and the resource breakdown still come
+		// from the live Superserve usage rollup.
 		var err error
 		usage, err = h.DB.GetTeamBillingUsage(ctx, db.GetTeamBillingUsageParams{
 			TeamID:      teamID,
@@ -232,14 +248,16 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		}
 		return nil
 	})
-	g.Go(func() error {
-		var err error
-		creditBalance, err = h.DB.GetTeamCreditBalance(ctx, teamID)
-		if err != nil {
-			return fmt.Errorf("get team credit balance: %w", err)
-		}
-		return nil
-	})
+	if !hasStripeCreditState {
+		g.Go(func() error {
+			var err error
+			creditBalance, err = h.DB.GetTeamCreditBalance(ctx, teamID)
+			if err != nil {
+				return fmt.Errorf("get team credit balance: %w", err)
+			}
+			return nil
+		})
+	}
 	if err := g.Wait(); err != nil {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("billing summary dependency fetch failed")
 		respondError(c, ErrInternal)
@@ -331,12 +349,14 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 	}
 
 	creditsAvailable, err := numericFloat64(creditBalance)
-	if err != nil {
+	if err != nil && !hasStripeCreditState {
 		log.Error().Err(err).Str("team_id", teamID.String()).Msg("convert credit balance failed")
 		respondError(c, ErrInternal)
 		return
 	}
-	hasEstablishedSubscription := billingAccountHasEstablishedSubscription(account)
+	if hasStripeCreditState {
+		creditsAvailable = 0
+	}
 	checkoutAvailable := false
 	if canManageBilling && mode == billingModeLive && h.Stripe != nil && !hasEstablishedSubscription {
 		if _, err := billingCheckoutPriceIDs(resourceStates); err == nil {
@@ -353,10 +373,68 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		creditsAvailable,
 		storageBillingEnabled,
 	)
-	paymentSetupRequired := mode == billingModeLive &&
-		!hasEstablishedSubscription &&
-		charges.CreditsRemainingUSD <= 0
 	summaryResources := billingSummaryResourcesFromState(resourceStates, vcpuSeconds, memoryGibSeconds, storageGibSeconds, charges)
+	creditSource, creditStatus := "local_trial", "available"
+	var stripeBalance, stripeApplied, stripeRemaining *float64
+	var creditsApplied, creditsRemaining, expectedInvoice *float64
+	var observed *time.Time
+	if hasStripeCreditState {
+		creditSource, creditStatus = "stripe", "unavailable"
+		// Keep every credit-derived estimate unavailable until Stripe's
+		// authoritative balance has been read successfully. In particular, do
+		// not expose the local zero-credit arithmetic as a payable estimate when
+		// the Stripe dependency is unavailable.
+		if reader, ok := h.Stripe.(stripeCreditBalanceReader); ok && account.StripeCustomerID != nil {
+			cb, e := reader.GetCustomerCreditBalance(c.Request.Context(), *account.StripeCustomerID)
+			if e == nil {
+				v := cb.AvailableUSD
+				stripeBalance = &v
+				// Keep the applied amount clamped to both the current charges and
+				// the available balance. This is the same amount used for the
+				// derived remaining/payable values below.
+				available := math.Max(v, 0)
+				applied := math.Min(math.Max(charges.CurrentChargesUSD, 0), available)
+				// This endpoint returns Stripe's post-application balance. Keep
+				// estimates in that same accounting view; subtracting local gross
+				// usage here would charge the period twice.
+				if cb.IncludesCurrentPeriodUsage {
+					applied = 0
+					remaining := available
+					stripeApplied, stripeRemaining = &applied, &remaining
+				} else {
+					remaining := math.Max(v-applied, 0)
+					stripeApplied, stripeRemaining = &applied, &remaining
+					payable := stripeExpectedInvoiceAmount(charges.CurrentChargesUSD, applied)
+					expectedInvoice = &payable
+				}
+				creditStatus = "available"
+				observed = &cb.ObservedAt
+			} else {
+				// Stripe is the source of truth after activation. Never fall back to
+				// the local pre-Stripe calculation when its balance read fails.
+				creditsApplied, creditsRemaining, expectedInvoice = nil, nil, nil
+				log.Warn().Err(e).Str("team_id", teamID.String()).Msg("stripe credit balance unavailable")
+			}
+		}
+	}
+	if !hasStripeCreditState {
+		creditsApplied = &charges.CreditsAppliedUSD
+		creditsRemaining = &charges.CreditsRemainingUSD
+		expectedInvoice = &charges.ExpectedInvoiceAmountUSD
+	}
+	// Stripe is authoritative for activated accounts, so determine whether
+	// payment setup is required only after its remaining balance has been read.
+	paymentSetupRequired := false
+	if hasStripeCreditState {
+		// An unavailable Stripe balance cannot establish whether setup is
+		// required; specifically, do not fall back to the local zero-credit
+		// arithmetic used while Stripe is authoritative.
+		paymentSetupRequired = stripeRemaining != nil && *stripeRemaining <= 0 &&
+			mode == billingModeLive && !hasEstablishedSubscription
+	} else {
+		paymentSetupRequired = mode == billingModeLive &&
+			!hasEstablishedSubscription && charges.CreditsRemainingUSD <= 0
+	}
 
 	setPrivateBillingCacheHeaders(c)
 	c.JSON(http.StatusOK, billingSummaryResponse{
@@ -367,9 +445,10 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		PortalAvailable:          canManageBilling && mode == billingModeLive && h.Stripe != nil && hasEstablishedSubscription,
 		PaymentSetupRequired:     paymentSetupRequired,
 		CurrentChargesUSD:        charges.CurrentChargesUSD,
-		CreditsAppliedUSD:        charges.CreditsAppliedUSD,
-		CreditsRemainingUSD:      charges.CreditsRemainingUSD,
-		ExpectedInvoiceAmountUSD: charges.ExpectedInvoiceAmountUSD,
+		CreditsAppliedUSD:        creditsApplied,
+		CreditsRemainingUSD:      creditsRemaining,
+		ExpectedInvoiceAmountUSD: expectedInvoice,
+		StripeCreditBalanceUSD:   stripeBalance, StripeCreditsAppliedUSD: stripeApplied, StripeRemainingCreditUSD: stripeRemaining, CreditSource: creditSource, CreditStatus: creditStatus, CreditObservedAt: observed,
 		CostBreakdownUSD: billingSummaryCostBreakdown{
 			Compute: charges.Breakdown.ComputeUSD,
 			Memory:  charges.Breakdown.MemoryUSD,
@@ -395,6 +474,23 @@ func (h *Handlers) GetBillingSummary(c *gin.Context) {
 		},
 		CalculatedAt: now,
 	})
+}
+
+func stripeExpectedInvoiceAmount(currentChargesUSD, appliedCreditUSD float64) float64 {
+	return math.Max(currentChargesUSD-appliedCreditUSD, 0)
+}
+
+func billingAccountHasStripeCreditState(account db.GetTeamBillingAccountRow) bool {
+	if billingAccountHasEstablishedSubscription(account) {
+		return true
+	}
+	if account.StripeCustomerID == nil || strings.TrimSpace(*account.StripeCustomerID) == "" {
+		return false
+	}
+	if account.StripeActivationCreditGrantID != nil && strings.TrimSpace(*account.StripeActivationCreditGrantID) != "" {
+		return true
+	}
+	return account.TrialEndedAt.Valid
 }
 
 func (h *Handlers) requireBillingRead(c *gin.Context) (uuid.UUID, bool) {

--- a/internal/api/handlers_billing_stripe.go
+++ b/internal/api/handlers_billing_stripe.go
@@ -48,6 +48,20 @@ type StripeBillingClient interface {
 	ReportMeterEvent(ctx context.Context, params StripeReportMeterEventParams) error
 }
 
+type StripeCreditBalance struct {
+	AvailableUSD float64
+	ObservedAt   time.Time
+	// IncludesCurrentPeriodUsage states whether Stripe has already applied or
+	// reserved this period's usage in AvailableUSD. The credit balance summary
+	// endpoint is post-application, so callers must not subtract local usage
+	// from it again.
+	IncludesCurrentPeriodUsage bool
+}
+
+type stripeCreditBalanceReader interface {
+	GetCustomerCreditBalance(context.Context, string) (StripeCreditBalance, error)
+}
+
 type stripeEventRetriever interface {
 	RetrieveEvent(ctx context.Context, eventID string) (json.RawMessage, error)
 }
@@ -325,6 +339,51 @@ func (c *stripeHTTPClient) CreateBillingCreditGrant(ctx context.Context, params 
 		return StripeBillingCreditGrant{}, err
 	}
 	return StripeBillingCreditGrant{ID: resp.ID}, nil
+}
+
+// GetCustomerCreditBalance reads Stripe's authoritative aggregate credit balance.
+func (c *stripeHTTPClient) GetCustomerCreditBalance(ctx context.Context, customerID string) (StripeCreditBalance, error) {
+	var resp struct {
+		Balances []struct {
+			AvailableBalance struct {
+				Monetary *struct {
+					Currency string `json:"currency"`
+					Value    int64  `json:"value"`
+				} `json:"monetary"`
+			} `json:"available_balance"`
+		} `json:"balances"`
+	}
+	// credit_balance_summary is Stripe's aggregate view: it applies the
+	// applicability filter and excludes expired grants server-side. Unlike the
+	// credit-grants list API, this response is not capped at the first page, so
+	// iterating every returned balance preserves credits when a customer has
+	// more than 100 grants.
+	path := "/v1/billing/credit_balance_summary?customer=" + url.QueryEscape(customerID) + "&filter[type]=applicability_scope&filter[applicability_scope][price_type]=metered"
+	if err := c.doForm(ctx, http.MethodGet, path, nil, &resp, ""); err != nil {
+		return StripeCreditBalance{}, err
+	}
+	var cents int64
+	seenUSD := false
+	for _, b := range resp.Balances {
+		// Stripe may omit the monetary object when a balance is not
+		// representable. Treat that as an unavailable read, not as a known
+		// zero: decoding a missing object into a value struct would silently
+		// turn malformed/partial responses into an authoritative zero.
+		if b.AvailableBalance.Monetary == nil {
+			return StripeCreditBalance{}, fmt.Errorf("stripe credit balance summary contained an unrepresentable balance")
+		}
+		if b.AvailableBalance.Monetary.Currency == "usd" {
+			cents += b.AvailableBalance.Monetary.Value
+			seenUSD = true
+		}
+	}
+	if !seenUSD {
+		return StripeCreditBalance{}, fmt.Errorf("stripe credit balance summary contained no usable usd balance")
+	}
+	// The credit balance summary is an aggregate grant balance only. Current
+	// period meter usage is exported separately when the period closes, so this
+	// read must not claim that active-period usage has already been reflected.
+	return StripeCreditBalance{AvailableUSD: float64(cents) / 100, ObservedAt: time.Now().UTC(), IncludesCurrentPeriodUsage: false}, nil
 }
 
 func (c *stripeHTTPClient) CreateCheckoutSession(ctx context.Context, params StripeCreateCheckoutSessionParams) (StripeCheckoutSession, error) {

--- a/internal/api/handlers_billing_stripe_test.go
+++ b/internal/api/handlers_billing_stripe_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -91,6 +92,106 @@ func (r *stripeMeterEventRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 type stripeCheckoutSessionRoundTripper struct {
 	backdateStartDate string
 	clientReferenceID string
+}
+
+type stripeCreditBalanceRoundTripper struct {
+	status int
+	body   string
+}
+
+func (r *stripeCreditBalanceRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path != "/v1/billing/credit_balance_summary" || req.URL.Query().Get("customer") != "cus_example" || req.URL.Query().Get("filter[type]") != "applicability_scope" || req.URL.Query().Get("filter[applicability_scope][price_type]") != "metered" {
+		return nil, fmt.Errorf("unexpected credit balance request: %s", req.URL.String())
+	}
+	status := r.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(r.body)), Header: make(http.Header), Request: req}, nil
+}
+
+func TestStripeCreditBalanceAggregatesApplicableGrants(t *testing.T) {
+	transport := &stripeCreditBalanceRoundTripper{body: `{"balances":[{"available_balance":{"monetary":{"currency":"usd","value":2000}}},{"available_balance":{"monetary":{"currency":"usd","value":1200000}}},{"available_balance":{"monetary":{"currency":"eur","value":9000}}}]}`}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	got, err := client.GetCustomerCreditBalance(t.Context(), "cus_example")
+	if err != nil {
+		t.Fatalf("get credit balance: %v", err)
+	}
+	if got.AvailableUSD != 12020 {
+		t.Fatalf("available credit = %v, want 12020", got.AvailableUSD)
+	}
+	if got.ObservedAt.IsZero() {
+		t.Fatal("expected observation timestamp")
+	}
+	if got.IncludesCurrentPeriodUsage {
+		t.Fatal("credit balance summary must not claim active-period usage is reflected")
+	}
+}
+
+func TestStripeCreditBalancePreservesKnownZero(t *testing.T) {
+	transport := &stripeCreditBalanceRoundTripper{body: `{"balances":[{"available_balance":{"monetary":{"currency":"usd","value":0}}}]}`}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	got, err := client.GetCustomerCreditBalance(t.Context(), "cus_example")
+	if err != nil {
+		t.Fatalf("get credit balance: %v", err)
+	}
+	if got.AvailableUSD != 0 {
+		t.Fatalf("available credit = %v, want 0", got.AvailableUSD)
+	}
+}
+
+func TestStripeCreditBalanceDoesNotTruncateAggregateBalances(t *testing.T) {
+	var balances strings.Builder
+	balances.WriteString(`{"balances":[`)
+	for i := 0; i < 101; i++ {
+		if i > 0 {
+			balances.WriteByte(',')
+		}
+		balances.WriteString(`{"available_balance":{"monetary":{"currency":"usd","value":100}}}`)
+	}
+	balances.WriteString(`]}`)
+	transport := &stripeCreditBalanceRoundTripper{body: balances.String()}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	got, err := client.GetCustomerCreditBalance(t.Context(), "cus_example")
+	if err != nil {
+		t.Fatalf("get credit balance: %v", err)
+	}
+	if got.AvailableUSD != 101 {
+		t.Fatalf("available credit = %v, want 101", got.AvailableUSD)
+	}
+}
+
+func TestStripeCreditBalancePropagatesFetchFailure(t *testing.T) {
+	transport := &stripeCreditBalanceRoundTripper{status: http.StatusBadGateway, body: `{"error":"unavailable"}`}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	if _, err := client.GetCustomerCreditBalance(t.Context(), "cus_example"); err == nil {
+		t.Fatal("expected fetch failure")
+	}
+}
+
+func TestStripeCreditBalanceRejectsMissingMonetaryBalance(t *testing.T) {
+	transport := &stripeCreditBalanceRoundTripper{body: `{"balances":[{"available_balance":{}}]}`}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	if _, err := client.GetCustomerCreditBalance(t.Context(), "cus_example"); err == nil {
+		t.Fatal("expected malformed balance response to be unavailable")
+	}
+}
+
+func TestStripeCreditBalanceRejectsPartiallyMalformedBalances(t *testing.T) {
+	transport := &stripeCreditBalanceRoundTripper{body: `{"balances":[{"available_balance":{"monetary":{"currency":"usd","value":2000}}},{"available_balance":{}}]}`}
+	client := &stripeHTTPClient{baseURL: "https://stripe.example.test", secretKey: "sk_test_example", apiVersion: "2025-06-30", httpClient: &http.Client{Transport: transport}}
+	if _, err := client.GetCustomerCreditBalance(t.Context(), "cus_example"); err == nil {
+		t.Fatal("expected partially malformed balance response to be unavailable")
+	}
+}
+
+func TestStripeExpectedInvoiceAmountClampsPayableEstimate(t *testing.T) {
+	if got := stripeExpectedInvoiceAmount(30, 20); got != 10 {
+		t.Fatalf("expected payable estimate = %v, want 10", got)
+	}
+	if got := stripeExpectedInvoiceAmount(20, 30); got != 0 {
+		t.Fatalf("expected payable estimate = %v, want 0", got)
+	}
 }
 
 func (r *stripeCheckoutSessionRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/integration/billing_stripe_integration_test.go
+++ b/internal/integration/billing_stripe_integration_test.go
@@ -40,11 +40,22 @@ type fakeStripeClient struct {
 	portalCalls      []api.StripeCreateCustomerPortalSessionParams
 	customerCalls    []api.StripeCreateCustomerParams
 	creditGrantCalls []api.StripeCreateBillingCreditGrantParams
+	creditBalance    api.StripeCreditBalance
+	creditBalanceErr error
 	reportErr        error
 	reportErrAt      int
 	nextCustomerID   string
 	nextCheckoutURL  string
 	nextPortalURL    string
+}
+
+func (f *fakeStripeClient) GetCustomerCreditBalance(_ context.Context, _ string) (api.StripeCreditBalance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.creditBalanceErr != nil {
+		return api.StripeCreditBalance{}, f.creditBalanceErr
+	}
+	return f.creditBalance, nil
 }
 
 type thinEventStripeClient struct {
@@ -215,6 +226,106 @@ func seedBillingPeriodForStripe(t *testing.T, approved bool, exportEnabled bool)
 
 func apiPeriodID(start, end time.Time) string {
 	return start.Format(time.RFC3339) + "," + end.Format(time.RFC3339)
+}
+
+// TestIntegration_GetBillingSummaryStripeCredits exercises the Stripe-authoritative
+// branch with aggregate balances that differ from any local audit grant.
+func TestIntegration_GetBillingSummaryStripeCredits(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stripe float64
+		local  float64
+	}{
+		{name: "zero", stripe: 0, local: 95},
+		{name: "partial", stripe: 20.5, local: 95},
+		{name: "full", stripe: 95, local: 1},
+		{name: "multiple grants aggregate", stripe: 145, local: 95},
+		{name: "large grant", stripe: 12000, local: 95},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+			viewerKey := seedKeyForExistingTeamWithRole(t, teamID, "viewer")
+			if _, err := testPool.Exec(ctx, `
+				INSERT INTO team_credit_grant (team_id, amount_usd, remaining_usd, reason)
+				VALUES ($1, $2, $2, 'audit-only local fixture')`, teamID, tc.local); err != nil {
+				t.Fatalf("seed local audit credit: %v", err)
+			}
+			stripe := &fakeStripeClient{creditBalance: api.StripeCreditBalance{AvailableUSD: tc.stripe, ObservedAt: time.Now().UTC(), IncludesCurrentPeriodUsage: false}}
+			w := do(newBillingRouter(t, stripe), "GET", "/billing/summary", viewerKey, "")
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+			body := mustJSON(t, w)
+			if body["credit_source"] != "stripe" || body["credit_status"] != "available" {
+				t.Fatalf("credit state = %v/%v, want stripe/available", body["credit_source"], body["credit_status"])
+			}
+			if got := body["stripe_credit_balance_usd"].(float64); math.Abs(got-tc.stripe) > 1e-9 {
+				t.Fatalf("stripe balance = %v, want %v", got, tc.stripe)
+			}
+			charges := body["current_charges_usd"].(float64)
+			wantApplied := math.Min(math.Max(charges, 0), math.Max(tc.stripe, 0))
+			wantRemaining := math.Max(tc.stripe-wantApplied, 0)
+			if got := body["stripe_credits_applied_usd"].(float64); math.Abs(got-wantApplied) > 1e-9 {
+				t.Fatalf("stripe applied = %v, want %v", got, wantApplied)
+			}
+			if got := body["stripe_remaining_credit_usd"].(float64); math.Abs(got-wantRemaining) > 1e-9 {
+				t.Fatalf("stripe remaining = %v, want %v", got, wantRemaining)
+			}
+			if _, ok := body["credits_remaining_usd"]; ok && body["credits_remaining_usd"] != nil {
+				t.Fatalf("post-activation local estimate should remain unavailable: %v", body["credits_remaining_usd"])
+			}
+		})
+	}
+}
+
+func TestIntegration_GetBillingSummaryStripeCreditReaderFailureDegrades(t *testing.T) {
+	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	viewerKey := seedKeyForExistingTeamWithRole(t, teamID, "viewer")
+	stripe := &fakeStripeClient{creditBalanceErr: errors.New("credit balance unavailable")}
+	w := do(newBillingRouter(t, stripe), "GET", "/billing/summary", viewerKey, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := mustJSON(t, w)
+	if body["current_charges_usd"] == nil {
+		t.Fatal("expected non-Stripe charges when Stripe credit read fails")
+	}
+	for _, field := range []string{"stripe_credit_balance_usd", "credits_applied_usd", "credits_remaining_usd", "expected_invoice_amount_usd"} {
+		if value, ok := body[field]; ok && value != nil {
+			t.Fatalf("%s = %v, want null when Stripe credit is unavailable", field, value)
+		}
+	}
+	if body["credit_status"] != "unavailable" {
+		t.Fatalf("credit_status = %v, want unavailable", body["credit_status"])
+	}
+}
+
+func TestIntegration_GetBillingSummaryStripeCreditAlreadyReflectsCurrentPeriod(t *testing.T) {
+	teamID, _, _, _ := seedBillingPeriodForStripe(t, true, true)
+	viewerKey := seedKeyForExistingTeamWithRole(t, teamID, "viewer")
+	stripe := &fakeStripeClient{creditBalance: api.StripeCreditBalance{AvailableUSD: 20, ObservedAt: time.Now().UTC(), IncludesCurrentPeriodUsage: true}}
+	w := do(newBillingRouter(t, stripe), "GET", "/billing/summary", viewerKey, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := mustJSON(t, w)
+	if body["stripe_credit_balance_usd"] != float64(20) {
+		t.Fatalf("stripe balance = %v, want 20", body["stripe_credit_balance_usd"])
+	}
+	if got := body["stripe_credits_applied_usd"].(float64); got != 0 {
+		t.Fatalf("stripe applied = %v, want 0", got)
+	}
+	if got := body["stripe_remaining_credit_usd"].(float64); got != 20 {
+		t.Fatalf("stripe remaining = %v, want 20", got)
+	}
+	// Stripe's available balance already reflects current-period usage; do not
+	// subtract it again in a local payable estimate.
+	for _, field := range []string{"credits_applied_usd", "credits_remaining_usd", "expected_invoice_amount_usd"} {
+		if value, ok := body[field]; ok && value != nil {
+			t.Fatalf("%s = %v, want null for Stripe-authoritative accounting", field, value)
+		}
+	}
 }
 
 func stripeSignature(t *testing.T, payload []byte, ts time.Time, secret ...string) string {


### PR DESCRIPTION
## Summary

- add Stripe credit-balance reads to the existing billing integration
- switch post-activation `/billing/summary` credit state from local `team_credit_grant` to Stripe-authoritative aggregate credit state
- preserve explicit 0 vs unavailable/null semantics and prevent local/Stripe double counting
- expose Stripe-consistent credit/payable estimates and source/freshness metadata

## Testing

- extend billing integration coverage for zero, partial, fully-covered, large, multiple-grant, unavailable, and accounting-boundary cases
- validate the OpenAPI billing summary contract

## Testing

- `codex-workflow validate`
