### PR TITLE
vmd: freeze on pause, wake on restore, recover on restart, behind the switches nothing sets

### DIFF
--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -561,8 +561,11 @@ func main() {
 		switch os.Args[1] {
 		case "capabilities":
 			// Advertised so rollback tooling can detect a downgrade to a binary
-			// that lacks cgroup supervision. Env-free by design.
+			// that lacks cgroup supervision, or the wake protocol frozen images
+			// depend on. Env-free by design; the literals are what the deploy
+			// guard greps the binary for, so they must stay verbatim.
 			fmt.Println("cgroup-supervision")
+			fmt.Println(vm.WakeProtocolCapability)
 			return
 		case "drain-check":
 			os.Exit(runDrainCheck())
@@ -707,6 +710,14 @@ func main() {
 	// Off by default: it only does anything for a snapshot whose guest corrects
 	// its own wall clock, and forcing legacy is the way back if one misbehaves.
 	guestClockFreezeEnabled := envOrDefault("VMD_GUEST_CLOCK_FREEZE", "false") == "true"
+	// Pause-side wait for the guest to stop its workload before a frozen-clock
+	// snapshot; only paid when the restore would freeze the clock.
+	guestFreezeBudget := 500 * time.Millisecond
+	if v := envOrDefault("VMD_GUEST_FREEZE_BUDGET_MS", ""); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			guestFreezeBudget = time.Duration(ms) * time.Millisecond
+		}
+	}
 	// Tri-state: "auto" (default) lets vmd enforce only after its convergence
 	// sweep proves every layered overlay has a presence side-car; "always"
 	// forces enforcement (fresh migration-target hosts); "never" is the
@@ -881,6 +892,7 @@ func main() {
 		DirtyTrackingSessionEnabled:         dirtyTrackingSessionEnabled,
 		HandlerDeathAbortEnabled:            handlerDeathAbortEnabled,
 		GuestClockFreezeEnabled:             guestClockFreezeEnabled,
+		GuestFreezeBudget:                   guestFreezeBudget,
 		RequirePresenceSidecar:              requirePresenceSidecar,
 		PausedNetworkReclaimEnabled:         pausedNetworkReclaimEnabled,
 		PausedNetworkSlotHeadroomPercent:    pausedNetworkSlotHeadroomPercent,
@@ -1564,6 +1576,7 @@ func main() {
 	// Evidence a previous process made durable is recognised; starting a vmd
 	// creates none.
 	vm.RecognizeWakeProtocolFloor()
+	mgr.WatchTemplateManifests(ctx, log)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1576,6 +1576,7 @@ func main() {
 	// Evidence a previous process made durable is recognised; starting a vmd
 	// creates none.
 	vm.RecognizeWakeProtocolFloor()
+	vm.PrimeWakeProtocolFloor(log)
 	mgr.WatchTemplateManifests(ctx, log)
 
 	// ---- Background full reattach ----

--- a/cmd/vmd/main.go
+++ b/cmd/vmd/main.go
@@ -1577,7 +1577,6 @@ func main() {
 	// creates none.
 	vm.RecognizeWakeProtocolFloor()
 	vm.PrimeWakeProtocolFloor(log)
-	mgr.WatchTemplateManifests(ctx, log)
 
 	// ---- Background full reattach ----
 	// Off the critical path (requests load their VM on demand); proactively
@@ -1593,6 +1592,11 @@ func main() {
 		case <-ctx.Done():
 			return
 		}
+		// The template watch is fleet-sized filesystem work as well: two
+		// globs and a manifest read per template, so it starts here, after
+		// readiness. A frozen restore that arrives first raises the floor
+		// itself.
+		mgr.WatchTemplateManifests(ctx, log)
 		// O(N) reattach, off the critical path — timed here (not via the
 		// single-goroutine marks) and flagged concurrent, distinct message, so
 		// its phase_ms is never summed into the partition. count sizes a

--- a/cmd/vmd/main_test.go
+++ b/cmd/vmd/main_test.go
@@ -3,11 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/superserve-ai/sandbox/internal/vm"
 )
 
 func TestLoadConfigRequiresExplicitHostID(t *testing.T) {
@@ -325,5 +330,45 @@ func TestPublishesCapacityPressureRequiresBothHalves(t *testing.T) {
 					tc.advertiseAddr, tc.controlPlaneURL, got, tc.want)
 			}
 		})
+	}
+}
+
+// The host guard greps the vmd binary for the wake-protocol capability. A
+// fabricated binary can only show the shell logic works; this shows a binary
+// linked from this package carries the literal the guard looks for. The test
+// binary links the same code that prints it, so it stands in for the build.
+func TestWakeFloorGuardAdmitsThisBinary(t *testing.T) {
+	const evidencePath = "/var/lib/sandbox/wake-protocol-evidence"
+	src, err := os.ReadFile(filepath.Join("..", "..", "deploy", "vmd-wake-floor-guard"))
+	if err != nil {
+		t.Fatalf("read guard script: %v", err)
+	}
+	if !strings.Contains(string(src), vm.WakeProtocolCapability) || !strings.Contains(string(src), evidencePath) {
+		t.Fatalf("guard script no longer greps for %q beside %q; update this test", vm.WakeProtocolCapability, evidencePath)
+	}
+	dir := t.TempDir()
+	evidence := filepath.Join(dir, "evidence")
+	if err := os.WriteFile(evidence, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	guard := filepath.Join(dir, "guard.sh")
+	if err := os.WriteFile(guard, []byte(strings.ReplaceAll(string(src), evidencePath, evidence)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("sh", guard, self).CombinedOutput(); err != nil {
+		t.Fatalf("the guard refused a binary built from this package with the floor up: %v\n%s", err, out)
+	}
+	// The same guard must still refuse a binary without the literal, or the
+	// admission above proves nothing.
+	other := filepath.Join(dir, "older-vmd")
+	if err := os.WriteFile(other, []byte("not a wake-capable vmd\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("sh", guard, other).Run(); err == nil {
+		t.Fatal("the guard admitted a binary without the capability while the floor was up")
 	}
 }

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -241,7 +241,13 @@ func (m *Manager) freezeGuestForPause(ctx context.Context, ip, token string, log
 	}
 	tctx, tcancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 	defer tcancel()
-	if terr := boxdThawGuest(tctx, ip, token); terr != nil && !errors.Is(terr, ErrGuestTokenMismatch) {
+	terr := boxdThawGuest(tctx, ip, token)
+	if errors.Is(terr, ErrGuestTokenMismatch) {
+		// The guest holds no freeze under this token, which says nothing about
+		// an earlier one: only a workload confirmed running is unfrozen.
+		terr = boxdGuestRunning(tctx, ip)
+	}
+	if terr != nil {
 		return false, fmt.Errorf("guest workload state unknown after failed freeze (%v); thaw not confirmed: %w", ferr, terr)
 	}
 	log.Warn().Err(ferr).Msg("pause: guest workload not frozen; this image will wake the slower way")

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -108,8 +110,8 @@ func guestCorrectsWallClock(instMemFile, instBaseMem string) bool {
 	return false
 }
 
-// resumeWallClockProperty returns what the image being resumed says about its
-// guest and its workload, preferring the durable record to the filesystem.
+// resumeImageFacts returns what the image being resumed says about its guest
+// and its workload, preferring the durable record to the filesystem.
 //
 // An ordinary resume reloads the exact image the VM was paused into, and that
 // pause wrote the facts to the record and the manifest together — so the
@@ -119,32 +121,33 @@ func guestCorrectsWallClock(instMemFile, instBaseMem string) bool {
 // too. Only an explicit override, supplying an image this VM was never paused
 // into, or a record that never carried the fact (a rollback to a binary
 // without the field drops it on rewrite, and its silence must not be read as
-// "no") has to look. A manifest this binary cannot trust is an error.
-func resumeWallClockProperty(memPath, pausedMemPath string, recordedCorrects, recordedFrozen *bool) (correctsWallClock, workloadFrozen bool, err error) {
+// "no") has to look. A manifest this binary cannot trust is an error the
+// caller must refuse on.
+func resumeImageFacts(memPath, pausedMemPath string, recordedCorrects, recordedFrozen *bool, recordedToken string) (correctsWallClock, workloadFrozen bool, token string, err error) {
 	if memPath == pausedMemPath {
 		if recordedFrozen != nil {
-			return recordedCorrects != nil && *recordedCorrects, *recordedFrozen, nil
+			return recordedCorrects != nil && *recordedCorrects, *recordedFrozen, recordedToken, nil
 		}
 		if recordedCorrects != nil && !*recordedCorrects {
-			return false, false, nil
+			return false, false, "", nil
 		}
 	}
 	m, err := imageManifest(memPath)
 	if err != nil {
-		return false, false, err
+		return false, false, "", err
 	}
 	if m != nil {
-		return m.GuestCorrectsClock, m.WorkloadFrozen, nil
+		return m.GuestCorrectsClock, m.WorkloadFrozen, m.FreezeToken, nil
 	}
 	// No manifest of its own: the image holds no frozen workload, which an
 	// overlay never inherits, but its guest came from the template beneath
 	// it, so the capability is read from there, as the pause-time check does.
 	if base, ok := readLayeredBase(memPath); ok {
 		if bm, berr := imageManifest(base); berr == nil && bm != nil {
-			return bm.GuestCorrectsClock, false, nil
+			return bm.GuestCorrectsClock, false, "", nil
 		}
 	}
-	return false, false, nil
+	return false, false, "", nil
 }
 
 // clockPolicyFor turns the resolved image fact into a restore policy.
@@ -164,7 +167,7 @@ func resumeWallClockProperty(memPath, pausedMemPath string, recordedCorrects, re
 // It never returns true: advancing the guest clock by elapsed wall time is the
 // behaviour being fixed, so nothing here should be able to ask for it.
 func (m *Manager) clockPolicyFor(workloadFrozen bool) *bool {
-	if !m.cfg.GuestClockFreezeEnabled || !workloadFrozen || !m.clockRealtimeCapable.Load() {
+	if !m.cfg.GuestClockFreezeEnabled || !workloadFrozen || !m.clockRealtimeCapable.Load() || m.guestClockUnready.Load() {
 		return nil
 	}
 	freeze := false
@@ -184,11 +187,19 @@ func (m *Manager) clockPolicyFor(workloadFrozen bool) *bool {
 // Reports whether the restore that succeeded actually carried the policy, so a
 // caller logging the outcome describes what happened rather than what was asked
 // for — after a fallback those differ.
-func (m *Manager) restoreWithClockFallback(policy *bool, restore func(clockRealtime *bool) error) (usedPolicy bool, err error) {
+// beforeLegacy, if set, runs before the legacy restore, which is skipped if it
+// fails. The restore path makes the changed policy durable there, so a crash
+// after the legacy load cannot recover the guest as clock-frozen.
+func (m *Manager) restoreWithClockFallback(policy *bool, beforeLegacy func() error, restore func(clockRealtime *bool) error) (usedPolicy bool, err error) {
 	// A refusal seen by any earlier attempt — including this restore's own
 	// session fallback, which re-enters here — already settled the answer;
 	// spend no request rediscovering it.
 	if policy != nil && !m.clockRealtimeCapable.Load() {
+		if beforeLegacy != nil {
+			if err := beforeLegacy(); err != nil {
+				return false, err
+			}
+		}
 		policy = nil
 	}
 	err = restore(policy)
@@ -198,5 +209,49 @@ func (m *Manager) restoreWithClockFallback(policy *bool, restore func(clockRealt
 	if m.clockRealtimeCapable.CompareAndSwap(true, false) {
 		m.log.Warn().Msg("firecracker rejected the clock option; falling back to legacy clock behaviour for every restore")
 	}
+	if beforeLegacy != nil {
+		if err := beforeLegacy(); err != nil {
+			return false, err
+		}
+	}
 	return false, restore(nil)
+}
+
+// defaultGuestFreezeBudget bounds the pause-side wait for the guest to stop
+// its workload. Only ever paid when the restore would freeze the clock.
+const defaultGuestFreezeBudget = 500 * time.Millisecond
+
+// freezeGuestForPause freezes the workload ahead of a snapshot. A failed freeze
+// is ambiguous, so the guest is thawed and that must confirm, else the pause
+// aborts. A retry, if any, mints a new token: the guest refuses a released one.
+func (m *Manager) freezeGuestForPause(ctx context.Context, ip, token string, log zerolog.Logger) (frozen bool, err error) {
+	budget := m.cfg.GuestFreezeBudget
+	if budget <= 0 {
+		budget = defaultGuestFreezeBudget
+	}
+	fctx, cancel := context.WithTimeout(ctx, budget)
+	echo, ferr := boxdFreezeGuest(fctx, ip, token)
+	cancel()
+	if ferr == nil && (echo.Token != token || echo.Version != WakeProtocolVersion) {
+		// The guest froze, but not as this protocol understands it: release it.
+		ferr = fmt.Errorf("freeze reply names protocol %d token %q, asked %d %q", echo.Version, echo.Token, WakeProtocolVersion, token)
+	}
+	if ferr == nil {
+		return true, nil
+	}
+	tctx, tcancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer tcancel()
+	if terr := boxdThawGuest(tctx, ip, token); terr != nil && !errors.Is(terr, ErrGuestTokenMismatch) {
+		return false, fmt.Errorf("guest workload state unknown after failed freeze (%v); thaw not confirmed: %w", ferr, terr)
+	}
+	log.Warn().Err(ferr).Msg("pause: guest workload not frozen; this image will wake the slower way")
+	return false, nil
+}
+
+// noteGuestClockUnready latches this host to unfrozen restores: host time is a
+// host property, so the caller's retry takes the path that does not need it.
+func (m *Manager) noteGuestClockUnready(log zerolog.Logger, cause error) {
+	if m.guestClockUnready.CompareAndSwap(false, true) {
+		log.Error().Err(cause).Msg("guest could not correct its clock; this host will restore with the clock unfrozen until vmd restarts")
+	}
 }

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -244,8 +244,11 @@ func (m *Manager) freezeGuestForPause(ctx context.Context, ip, token string, log
 	terr := boxdThawGuest(tctx, ip, token)
 	if errors.Is(terr, ErrGuestTokenMismatch) {
 		// The guest holds no freeze under this token, which says nothing about
-		// an earlier one: only a workload confirmed running is unfrozen.
-		terr = boxdGuestRunning(tctx, ip)
+		// an earlier one: only a workload confirmed running is unfrozen. Its
+		// own budget: a thaw that spent this one must not fail the check.
+		rctx, rcancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		terr = boxdGuestRunning(rctx, ip)
+		rcancel()
 	}
 	if terr != nil {
 		return false, fmt.Errorf("guest workload state unknown after failed freeze (%v); thaw not confirmed: %w", ferr, terr)

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -481,6 +481,28 @@ func TestFreezeGuestForPause(t *testing.T) {
 		}
 	})
 
+	// The running check after a mismatch has its own budget: a thaw that
+	// spent most of the shared one must not make the check fail on time.
+	t.Run("running_check_after_a_slow_thaw_has_its_own_budget", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(ctx context.Context, _, _ string) error {
+			time.Sleep(1500 * time.Millisecond)
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		boxdGuestRunning = func(ctx context.Context, _ string) error {
+			if dl, ok := ctx.Deadline(); !ok || time.Until(dl) < time.Second {
+				return errors.New("no time left to confirm")
+			}
+			return nil
+		}
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want the running workload confirmed with a fresh budget", frozen, err)
+		}
+	})
+
 	// The same mismatch from a guest still frozen under an earlier token must
 	// not be read as running: a snapshot of that guest marked unfrozen would
 	// never be woken. The pause aborts instead.

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -144,7 +145,7 @@ func TestRestoreWithClockFallback(t *testing.T) {
 
 		var sent []*bool
 		freeze := false
-		used, err := m.restoreWithClockFallback(&freeze, func(clock *bool) error {
+		used, err := m.restoreWithClockFallback(&freeze, nil, func(clock *bool) error {
 			sent = append(sent, clock)
 			if clock != nil {
 				return unknownField
@@ -177,7 +178,7 @@ func TestRestoreWithClockFallback(t *testing.T) {
 		boom := errors.New("load snapshot: connection refused")
 		calls := 0
 		freeze := false
-		used, err := m.restoreWithClockFallback(&freeze, func(*bool) error {
+		used, err := m.restoreWithClockFallback(&freeze, nil, func(*bool) error {
 			calls++
 			return boom
 		})
@@ -200,7 +201,7 @@ func TestRestoreWithClockFallback(t *testing.T) {
 		m := &Manager{log: zerolog.Nop()}
 		m.clockRealtimeCapable.Store(true)
 		calls := 0
-		_, err := m.restoreWithClockFallback(nil, func(*bool) error {
+		_, err := m.restoreWithClockFallback(nil, nil, func(*bool) error {
 			calls++
 			return unknownField
 		})
@@ -219,7 +220,7 @@ func TestRestoreWithClockFallbackReportsPolicyUsed(t *testing.T) {
 	m := &Manager{log: zerolog.Nop()}
 	m.clockRealtimeCapable.Store(true)
 	freeze := false
-	used, err := m.restoreWithClockFallback(&freeze, func(*bool) error { return nil })
+	used, err := m.restoreWithClockFallback(&freeze, nil, func(*bool) error { return nil })
 	if err != nil {
 		t.Fatalf("restore: %v", err)
 	}
@@ -263,7 +264,7 @@ func TestCorrectsWallClockAbsentFromOldRecordIsFalse(t *testing.T) {
 // durable record rather than the filesystem. Each case seeds a marker that
 // contradicts the record: if the record is used, the marker is irrelevant, which
 // is what proves the lookup was skipped.
-func TestResumeWallClockProperty(t *testing.T) {
+func TestResumeImageFacts(t *testing.T) {
 	seed := func(t *testing.T, mem string, m WallClockManifest) {
 		t.Helper()
 		m.Version = WallClockManifestVersion
@@ -276,19 +277,21 @@ func TestResumeWallClockProperty(t *testing.T) {
 	}
 	t.Run("same_image_trusts_a_record_that_carries_the_image_fact", func(t *testing.T) {
 		mem := filepath.Join(t.TempDir(), "mem.snap")
-		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "disk"})
 		// Manifest says frozen, record says not. The record wins ⇒ no read happened.
-		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(true), boolPtr(false)); !corrects || frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the recorded facts, a manifest on disk means the record was not used", corrects, frozen, err)
+		corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(false), boolPtr(false), "")
+		if corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the recorded facts, a manifest on disk means the record was not used", corrects, frozen, token, err)
 		}
 		// A guest that cannot correct its clock is never frozen: no read either.
-		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(false), nil); corrects || frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the record's no without a read", corrects, frozen, err)
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(false), nil, ""); corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the record's no without a read", corrects, frozen, token, err)
 		}
-		// And the inverse: no manifest on disk, record says frozen.
+		// And the inverse: no manifest on disk, record says frozen under a token.
 		bare := filepath.Join(t.TempDir(), "mem.snap")
-		if corrects, frozen, err := resumeWallClockProperty(bare, bare, boolPtr(true), boolPtr(true)); !corrects || !frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the recorded facts even with no manifest beside the image", corrects, frozen, err)
+		corrects, frozen, token, err = resumeImageFacts(bare, bare, boolPtr(true), boolPtr(true), "rec")
+		if !corrects || !frozen || token != "rec" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the recorded facts even with no manifest beside the image", corrects, frozen, token, err)
 		}
 	})
 
@@ -298,8 +301,8 @@ func TestResumeWallClockProperty(t *testing.T) {
 	t.Run("same_image_without_the_image_fact_reads_the_manifest", func(t *testing.T) {
 		mem := filepath.Join(t.TempDir(), "mem.snap")
 		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
-		if corrects, frozen, err := resumeWallClockProperty(mem, mem, boolPtr(true), nil); !corrects || !frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the frozen workload seen", corrects, frozen, err)
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(true), nil, ""); !corrects || !frozen || token != "tok" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the frozen workload seen", corrects, frozen, token, err)
 		}
 	})
 
@@ -308,9 +311,10 @@ func TestResumeWallClockProperty(t *testing.T) {
 	t.Run("override_image_reads_the_manifest", func(t *testing.T) {
 		dir := t.TempDir()
 		override := filepath.Join(dir, "restored.snap")
-		seed(t, override, WallClockManifest{GuestCorrectsClock: true})
-		if corrects, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), boolPtr(false), boolPtr(false)); !corrects || frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the manifest consulted when the image is not the paused one", corrects, frozen, err)
+		seed(t, override, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "disk"})
+		corrects, frozen, token, err := resumeImageFacts(override, filepath.Join(dir, "mem.snap"), boolPtr(false), boolPtr(false), "rec")
+		if !corrects || !frozen || token != "disk" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the manifest consulted when the image is not the paused one", corrects, frozen, token, err)
 		}
 	})
 
@@ -325,36 +329,42 @@ func TestResumeWallClockProperty(t *testing.T) {
 		if err := os.WriteFile(layeredBaseSidecarPath(overlay), []byte(base+"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		corrects, frozen, err := resumeWallClockProperty(overlay, filepath.Join(dir, "mem.diff"), nil, nil)
-		if !corrects || frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; want the base's capability and no inherited freeze", corrects, frozen, err)
+		corrects, frozen, token, err := resumeImageFacts(overlay, filepath.Join(dir, "mem.diff"), nil, nil, "")
+		if !corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the base's capability and no inherited freeze", corrects, frozen, token, err)
 		}
 	})
 
 	t.Run("override_without_a_manifest_stays_legacy", func(t *testing.T) {
 		dir := t.TempDir()
-		if corrects, frozen, err := resumeWallClockProperty(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true), boolPtr(true)); corrects || frozen || err != nil {
-			t.Errorf("corrects=%v frozen=%v err=%v; a stale record must not carry over to a different image", corrects, frozen, err)
+		corrects, frozen, token, err := resumeImageFacts(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true), boolPtr(true), "rec")
+		if corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; a stale record must not carry over to a different image", corrects, frozen, token, err)
 		}
 	})
 
-	// A frozen workload and an untrusted manifest are both reported, so the
-	// caller can refuse before it launches anything.
-	t.Run("override_reports_a_frozen_workload", func(t *testing.T) {
-		dir := t.TempDir()
-		override := filepath.Join(dir, "restored.snap")
-		seed(t, override, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
-		if _, frozen, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil, nil); !frozen || err != nil {
-			t.Errorf("frozen=%v err=%v; want the frozen workload reported", frozen, err)
+	// A record that lost the image fact goes to the disk, even for the same
+	// image: a rollback to a binary without the field drops it on rewrite.
+	t.Run("unresolved_record_consults_the_manifest", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true})
+		corrects, frozen, _, err := resumeImageFacts(mem, mem, nil, nil, "")
+		if !corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; an unresolved record must fall back to the manifest", corrects, frozen, err)
+		}
+		bare := filepath.Join(t.TempDir(), "mem.snap")
+		if corrects, frozen, _, err := resumeImageFacts(bare, bare, nil, nil, ""); corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; unresolved with no manifest must still be legacy", corrects, frozen, err)
 		}
 	})
+
 	t.Run("override_with_an_untrusted_manifest_is_an_error", func(t *testing.T) {
 		dir := t.TempDir()
 		override := filepath.Join(dir, "restored.snap")
 		if err := os.WriteFile(WallClockMarkerPath(override), []byte(`{"version":2}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if _, _, err := resumeWallClockProperty(override, filepath.Join(dir, "mem.snap"), nil, nil); !errors.Is(err, ErrWallClockManifest) {
+		if _, _, _, err := resumeImageFacts(override, filepath.Join(dir, "mem.snap"), nil, nil, ""); !errors.Is(err, ErrWallClockManifest) {
 			t.Errorf("err=%v, want ErrWallClockManifest", err)
 		}
 	})
@@ -425,21 +435,101 @@ func TestWatchFirecrackerCapability(t *testing.T) {
 	})
 }
 
-// A rollback to a binary without the record field, then an upgrade back, leaves
-// the field absent. Reading that silence as "no" would ignore the marker still
-// beside the image and delete it at the next pause — a permanent demotion.
-func TestResumeWallClockPropertyUnresolvedRecordConsultsTheManifest(t *testing.T) {
-	mem := filepath.Join(t.TempDir(), "mem.snap")
-	if err := WriteWallClockManifest(mem, WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
-		t.Fatalf("seed manifest: %v", err)
-	}
-	// Same image, but the record lost the answer.
-	if corrects, _, err := resumeWallClockProperty(mem, mem, nil, nil); !corrects || err != nil {
-		t.Errorf("corrects=%v err=%v; an unresolved record must fall back to the manifest, not read as false", corrects, err)
-	}
+func TestFreezeGuestForPause(t *testing.T) {
+	origF, origT := boxdFreezeGuest, boxdThawGuest
+	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest = origF, origT })
+	m := &Manager{log: zerolog.Nop()}
 
-	bare := filepath.Join(t.TempDir(), "mem.snap")
-	if corrects, _, err := resumeWallClockProperty(bare, bare, nil, nil); corrects || err != nil {
-		t.Errorf("corrects=%v err=%v; unresolved with no manifest must still be false", corrects, err)
+	t.Run("frozen", func(t *testing.T) {
+		boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+			return freezeEcho{Version: 1, Token: token}, nil
+		}
+		thawed := false
+		boxdThawGuest = func(context.Context, string, string) error { thawed = true; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || !frozen || thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; want frozen, no error, no thaw", frozen, err, thawed)
+		}
+	})
+
+	t.Run("refused_then_thaw_confirmed_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("504: budget")
+		}
+		thawed := false
+		boxdThawGuest = func(context.Context, string, string) error { thawed = true; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen || !thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; want unfrozen, no error, thaw issued", frozen, err, thawed)
+		}
+	})
+
+	// A freeze the guest never took answers the follow-up thaw with a token
+	// mismatch: nothing to release, the pause goes on unfrozen.
+	t.Run("never_frozen_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error {
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want unfrozen and no error", frozen, err)
+		}
+	})
+
+	t.Run("echo_naming_another_protocol_or_token_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{Version: 1, Token: "other"}, nil
+		}
+		thawed := false
+		boxdThawGuest = func(_ context.Context, _, token string) error { thawed = token == "tok"; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen || !thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; a guest that froze under another token must be released with ours", frozen, err, thawed)
+		}
+	})
+
+	t.Run("thaw_unconfirmed_aborts_the_pause", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error { return errors.New("500: thaw not confirmed") }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err == nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want an error that aborts the pause", frozen, err)
+		}
+	})
+
+	t.Run("call_is_bounded_by_the_budget", func(t *testing.T) {
+		m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{GuestFreezeBudget: 300 * time.Millisecond}}
+		var seen time.Duration
+		boxdFreezeGuest = func(ctx context.Context, _, token string) (freezeEcho, error) {
+			dl, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("freeze must carry a deadline; it sits on the pause path")
+			}
+			seen = time.Until(dl)
+			return freezeEcho{Version: 1, Token: token}, nil
+		}
+		m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if seen <= 0 || seen > 300*time.Millisecond {
+			t.Errorf("deadline %v from now, want within (0, 300ms]", seen)
+		}
+	})
+}
+
+// A guest that could not correct its clock latches the host: every later
+// restore takes the unfrozen path until vmd restarts.
+func TestGuestClockUnreadyLatchesHostToLegacy(t *testing.T) {
+	m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{GuestClockFreezeEnabled: true}}
+	m.clockRealtimeCapable.Store(true)
+	if m.clockPolicyFor(true) == nil {
+		t.Fatal("precondition: policy should freeze before the latch")
+	}
+	m.noteGuestClockUnready(zerolog.Nop(), errors.New("no ptp"))
+	if m.clockPolicyFor(true) != nil {
+		t.Error("policy still freezes after the host was latched")
 	}
 }

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -436,8 +436,8 @@ func TestWatchFirecrackerCapability(t *testing.T) {
 }
 
 func TestFreezeGuestForPause(t *testing.T) {
-	origF, origT := boxdFreezeGuest, boxdThawGuest
-	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest = origF, origT })
+	origF, origT, origR := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning
+	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest, boxdGuestRunning = origF, origT, origR })
 	m := &Manager{log: zerolog.Nop()}
 
 	t.Run("frozen", func(t *testing.T) {
@@ -465,7 +465,8 @@ func TestFreezeGuestForPause(t *testing.T) {
 	})
 
 	// A freeze the guest never took answers the follow-up thaw with a token
-	// mismatch: nothing to release, the pause goes on unfrozen.
+	// mismatch: once the workload is confirmed running there is nothing to
+	// release, and the pause goes on unfrozen.
 	t.Run("never_frozen_demotes", func(t *testing.T) {
 		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
 			return freezeEcho{}, errors.New("connection reset")
@@ -473,9 +474,27 @@ func TestFreezeGuestForPause(t *testing.T) {
 		boxdThawGuest = func(context.Context, string, string) error {
 			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
 		}
+		boxdGuestRunning = func(context.Context, string) error { return nil }
 		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
 		if err != nil || frozen {
 			t.Fatalf("frozen=%v err=%v; want unfrozen and no error", frozen, err)
+		}
+	})
+
+	// The same mismatch from a guest still frozen under an earlier token must
+	// not be read as running: a snapshot of that guest marked unfrozen would
+	// never be woken. The pause aborts instead.
+	t.Run("mismatch_without_a_running_workload_aborts_the_pause", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error {
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		boxdGuestRunning = func(context.Context, string) error { return errors.New(`guest workload status "frozen"`) }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err == nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want an error that aborts the pause", frozen, err)
 		}
 	})
 

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -496,6 +496,36 @@ func UnpauseVM(socketPath string) error {
 	return nil
 }
 
+// UnpauseVMContext resumes a paused VM's vCPUs within ctx. A bare request over
+// a context-honouring dial, as VMState: it runs on failure and recovery paths,
+// where a stuck API must not hang the caller. A VM that is not paused refuses
+// it, which callers treat as nothing to do.
+func UnpauseVMContext(ctx context.Context, socketPath string) error {
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+		DisableKeepAlives: true,
+	}
+	defer tr.CloseIdleConnections()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "http://localhost/vm", strings.NewReader(`{"state":"Resumed"}`))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Transport: tr}).Do(req)
+	if err != nil {
+		return fmt.Errorf("unpause VM: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("unpause VM: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
 // LoadSnapshotNoResume loads a snapshot but leaves the vCPUs paused — used to
 // re-snapshot it (SnapshotPausedVM) and verify the memory round-trips. The TAP
 // override mirrors RestoreSnapshot* so device restore succeeds.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1666,7 +1666,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	willFreeze := correctsWallClock && m.cfg.GuestClockFreezeEnabled && m.clockRealtimeCapable.Load() && !m.guestClockUnready.Load()
 	if willFreeze {
 		tFreeze = time.Now()
-		if err := ensureWakeProtocolFloor(); err != nil {
+		if err := m.ensureWakeFloorTimed("pause"); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record the rollback floor before freezing: %w", err))
 		}
 	}
@@ -2333,7 +2333,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	if resumeWorkloadFrozen {
 		// The floor rises before this host acts on an image that owes a wake,
 		// or a rollback could later meet the image with nothing to witness it.
-		if err := ensureWakeProtocolFloor(); err != nil {
+		if err := m.ensureWakeFloorTimed("resume"); err != nil {
 			return nil, status.Errorf(codes.Unavailable, "image %q owes a wake and the rollback floor could not be recorded on this host: %v", memPath, err)
 		}
 	}
@@ -3412,7 +3412,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	if restoreWorkloadFrozen {
 		// The floor rises before this host acts on an image that owes a wake,
 		// or a rollback could later meet the image with nothing to witness it.
-		if err := ensureWakeProtocolFloor(); err != nil {
+		if err := m.ensureWakeFloorTimed("restore"); err != nil {
 			return nil, status.Errorf(codes.Unavailable, "image %q owes a wake and the rollback floor could not be recorded on this host: %v", memPath, err)
 		}
 	}
@@ -8329,6 +8329,20 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 // inst.mu.
 func (inst *VMInstance) dropWakeImage() {
 	inst.WakeToken, inst.WakeSnapshotPath, inst.WakeMemPath = "", "", ""
+}
+
+// ensureWakeFloorTimed is ensureWakeProtocolFloor on a request path: free
+// once the floor is durable, which startup priming normally makes it before
+// any request; when a request does have to prove it, the time it spent is
+// attributed to the operation as its own phase rather than hidden in it.
+func (m *Manager) ensureWakeFloorTimed(op string) error {
+	if wakeProtocolEvidenceDurable.Load() {
+		return nil
+	}
+	t := time.Now()
+	err := ensureWakeProtocolFloor()
+	m.recordPhases(op, "", map[string]time.Duration{"wake_floor": time.Since(t)})
+	return err
 }
 
 // releaseFrozenGuest thaws a workload a pause froze, after making sure the

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -4972,10 +4972,11 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	m.mu.RUnlock()
 	// A request arriving while the startup pass still owes this VM its wake
 	// waits for that outcome rather than adopting a frozen guest — for as
-	// long as a wake can take, not the flight's own short budget: giving up
-	// early would report a live VM as missing and invite a replacement.
+	// long as a wake can take behind everything queued ahead of it in the
+	// bounded pool, not the flight's own short budget: giving up early would
+	// report a live VM as missing and invite a replacement.
 	if pw := m.pendingWake(rec.ID); pw != nil && !cleanupStale {
-		wait := time.NewTimer(boxdResumeReadyBudget + 5*time.Second)
+		wait := time.NewTimer(pendingWakeWaitBound(m.pendingWakeCount()))
 		defer wait.Stop()
 		select {
 		case <-pw.done:
@@ -8452,6 +8453,24 @@ func (m *Manager) pendingWake(id string) *pendingWake {
 	m.pendingWakeMu.Lock()
 	defer m.pendingWakeMu.Unlock()
 	return m.pendingWakes[id]
+}
+
+func (m *Manager) pendingWakeCount() int {
+	m.pendingWakeMu.Lock()
+	defer m.pendingWakeMu.Unlock()
+	return len(m.pendingWakes)
+}
+
+// pendingWakeWaitBound is how long a request may wait for a queued wake: the
+// pool serves queued wakes wakeRecoveryWorkers at a time, each bounded by
+// the wake's own budget, so a wake queued behind n others is served within
+// that many rounds of it.
+func pendingWakeWaitBound(queued int) time.Duration {
+	rounds := (queued + wakeRecoveryWorkers - 1) / wakeRecoveryWorkers
+	if rounds < 1 {
+		rounds = 1
+	}
+	return time.Duration(rounds) * (boxdResumeReadyBudget + 5*time.Second)
 }
 
 func (m *Manager) queuePendingWake(inst *VMInstance, unlock func()) {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1881,19 +1881,44 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			if merr != nil {
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("write wall-clock manifest: %w", merr))
 			}
-		} else if merr := writeWallClockManifestLazy(memPath, man); merr != nil {
-			// The image is unfrozen, so no manifest is safe for it; a stale
-			// frozen one is not: a restore would present its token to a guest
-			// that already answered it and run the clock uncorrected. The
-			// stale one goes, or the pause fails.
-			if rerr := os.Remove(clockFreezeMarkerPath(memPath)); rerr != nil && !os.IsNotExist(rerr) {
-				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("wall-clock manifest write failed (%v) and the stale one could not be cleared: %w", merr, rerr))
+		} else {
+			// Unfrozen. Where no manifest exists the write is lazy: lost to a
+			// crash, it costs the next resume a slower path, never a wrong
+			// clock. Where one exists it is REPLACED durably: the one there
+			// may say frozen under a token this guest already answered, and
+			// a crash that let it survive beside this image would have a
+			// restore present that token and run the clock uncorrected.
+			_, serr := os.Stat(clockFreezeMarkerPath(memPath))
+			replacing := serr == nil
+			var merr error
+			if replacing {
+				tManifest := time.Now()
+				merr = WriteWallClockManifest(memPath, man)
+				manifestDur = time.Since(tManifest)
+			} else {
+				merr = writeWallClockManifestLazy(memPath, man)
 			}
-			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
-				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
+			if merr != nil {
+				// No manifest is safe for an unfrozen image; a stale frozen
+				// one is not. The stale one goes, durably, or the pause fails.
+				if rerr := removeWallClockManifestDurably(memPath); rerr != nil {
+					return "", "", nil, m.handleVMError(vmID, fmt.Errorf("wall-clock manifest write failed (%v) and the stale one could not be cleared: %w", merr, rerr))
+				}
+				log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
+					Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
+			}
 		}
-	} else if merr := os.Remove(clockFreezeMarkerPath(memPath)); merr != nil && !os.IsNotExist(merr) {
-		return "", "", nil, m.handleVMError(vmID, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
+	} else {
+		// A guest that cannot correct its clock gets no manifest; one an
+		// earlier image left here goes, durably, for the reason above.
+		tManifest := time.Now()
+		merr := removeWallClockManifestDurably(memPath)
+		if d := time.Since(tManifest); d > time.Millisecond {
+			manifestDur = d
+		}
+		if merr != nil {
+			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
+		}
 	}
 
 	snapshotOK = true
@@ -5031,7 +5056,10 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		case <-pw.done:
 			return published()
 		case <-wait.C:
-			return nil, false
+			// The pool may have published the VM and be held only in the
+			// durable write that follows, which no round bounds: a VM in
+			// the map is served.
+			return published()
 		}
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -135,12 +135,14 @@ type VMInstance struct {
 	WakeOwedFromPaused bool
 	// FreezeToken is the token the image's freeze carries; a wake must present it.
 	FreezeToken string
-	// WakeToken: see VMRecord.
-	WakeToken string
-	CreatedAt time.Time
-	Metadata  map[string]string
-	TeamID    string // owning team; carried for data-plane usage attribution
-	OwnerID   string // creating user; empty when unknown
+	// WakeToken, WakeSnapshotPath, WakeMemPath: see VMRecord.
+	WakeToken        string
+	WakeSnapshotPath string
+	WakeMemPath      string
+	CreatedAt        time.Time
+	Metadata         map[string]string
+	TeamID           string // owning team; carried for data-plane usage attribution
+	OwnerID          string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -2422,7 +2424,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		// next. The in-flight token goes with it.
 		restamped := inst.IP != entryIP || inst.Namespace != entryNS || inst.WakeToken != ""
 		inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace = entrySocket, entryIP, entryTAP, entryMAC, entryNS
-		inst.WakeToken = ""
+		inst.dropWakeImage()
 		inst.mu.Unlock()
 		if !revert && !restamped {
 			return
@@ -2472,6 +2474,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			inst.MACAddress = netInfo.MACAddress
 			inst.Namespace = nsName
 			inst.WakeToken = resumeToken
+			inst.WakeSnapshotPath, inst.WakeMemPath = snapshotPath, memPath
 			inst.mu.Unlock()
 			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil, true)
 			published = true
@@ -2549,7 +2552,8 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 					// Durably Error, never retried: the artifacts are retained,
 					// and nothing is owed, so recovery cannot return it to Paused.
 					inst.mu.Lock()
-					inst.WakePending, inst.WakeOwedFromPaused, inst.WakeToken = false, false, ""
+					inst.WakePending, inst.WakeOwedFromPaused = false, false
+					inst.dropWakeImage()
 					inst.mu.Unlock()
 					m.setStatus(vmID, StatusError)
 					return nil, status.Errorf(codes.FailedPrecondition, "image %q: %v", memPath, werr)
@@ -2598,7 +2602,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.CorrectsWallClock = &resumeCorrectsWallClock
 	inst.SnapshotWorkloadFrozen = &resumeWorkloadFrozen
 	inst.FreezeToken = resumeToken
-	inst.WakeToken = ""
+	inst.dropWakeImage()
 	inst.PausedAt = time.Time{}
 	// Record the file actually resumed from (callers may pass an explicit path
 	// that differs from the cached one) so the next pause's diff baseline matches
@@ -3958,7 +3962,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// Terminal: the Error written below must not owe a wake, or
 			// recovery would read it as a resume to return to Paused.
 			inst.mu.Lock()
-			inst.WakePending, inst.WakeOwedFromPaused, inst.WakeToken = false, false, ""
+			inst.WakePending, inst.WakeOwedFromPaused = false, false
+			inst.dropWakeImage()
 			inst.mu.Unlock()
 		}
 		// Emit the exhausted readiness wait immediately, before teardown, so
@@ -4089,7 +4094,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	inst.Unverified = false
 	inst.WakePending = false
 	inst.WakeOwedFromPaused = false
-	inst.WakeToken = ""
+	inst.dropWakeImage()
 	// A frozen image kept its pause timestamp through the launch, so a
 	// failure could return it to Paused in its place in the reclaim order.
 	inst.PausedAt = time.Time{}
@@ -5109,7 +5114,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 				log.Warn().Msg("resume interrupted before its launch — record returns to Paused")
 				rec.Status = StatusPaused
 				rec.WakePending, rec.ClockFrozen, rec.WakeOwedFromPaused, rec.Unverified = false, false, false, false
-				rec.WakeToken = ""
+				rec.WakeToken, rec.WakeSnapshotPath, rec.WakeMemPath = "", "", ""
 				if wrote, perr := m.state.PutIfPresent(rec); perr != nil || !wrote {
 					log.Warn().Err(perr).Bool("present", wrote).Msg("interrupted resume's record could not be returned to Paused")
 					return nil, false
@@ -8239,6 +8244,7 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 	ctx := context.WithoutCancel(callerCtx)
 	inst.mu.RLock()
 	pending, frozen, token := inst.WakePending, inst.ClockFrozen, inst.WakeToken
+	wakeSnap, wakeMem := inst.WakeSnapshotPath, inst.WakeMemPath
 	inst.mu.RUnlock()
 	if !pending {
 		return adoptionBoxdReady(ctx, m, ip)
@@ -8249,12 +8255,40 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 		}
 		return err
 	}
+	// The image this wake was owed for is the one running now. A resume
+	// from an override that died before its commit commits here, as its own
+	// commit would have: a retry of it then finds the sandbox up instead of
+	// relaunching over it. Its facts come from its manifest; one read, on
+	// the recovery path only.
+	var image *WallClockManifest
+	if wakeMem != "" {
+		image, _ = imageManifest(wakeMem)
+	}
 	inst.mu.Lock()
 	inst.WakePending = false
 	inst.WakeOwedFromPaused = false
-	inst.WakeToken = ""
+	if wakeMem != "" {
+		inst.SnapshotPath, inst.MemFilePath, inst.FreezeToken = wakeSnap, wakeMem, token
+		inst.BaseMemPath, _ = readLayeredBase(wakeMem)
+		frozen := true
+		inst.SnapshotWorkloadFrozen = &frozen
+		inst.CorrectsWallClock = nil // unresolved: the next pause asks the disk
+		if image != nil {
+			corrects := image.GuestCorrectsClock
+			inst.CorrectsWallClock = &corrects
+			inst.SnapshotWorkloadFrozen = &image.WorkloadFrozen
+			inst.ArtifactID = image.ArtifactID
+		}
+	}
+	inst.dropWakeImage()
 	inst.mu.Unlock()
 	return nil
+}
+
+// dropWakeImage forgets the image an owed wake was for. The caller holds
+// inst.mu.
+func (inst *VMInstance) dropWakeImage() {
+	inst.WakeToken, inst.WakeSnapshotPath, inst.WakeMemPath = "", "", ""
 }
 
 // releaseFrozenGuest thaws a workload a pause froze, after making sure the
@@ -8485,7 +8519,7 @@ func (m *Manager) parkUnservable(inst *VMInstance, terminal bool) {
 	if !terminal && inst.WakePending && inst.WakeOwedFromPaused {
 		inst.Status = StatusPaused
 		inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
-		inst.WakeToken = ""
+		inst.dropWakeImage()
 	} else {
 		inst.Status = StatusError
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2535,7 +2535,9 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		inst.mu.Lock()
 		inst.ClockFrozen = false
 		inst.mu.Unlock()
-		if !m.persistState(inst) {
+		// Fenced like the wake-owed write: a destroy landing here must not
+		// be resurrected, and a VM that is gone gets no legacy load.
+		if !m.persistWhileTracked(inst) {
 			return fmt.Errorf("vm %s: clock policy could not be made durable before the legacy restore", vmID)
 		}
 		return nil
@@ -3834,7 +3836,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			inst.mu.Lock()
 			inst.ClockFrozen = false
 			inst.mu.Unlock()
-			if !m.persistState(inst) {
+			// Fenced like the wake-owed write: a destroy landing here must
+			// not be resurrected, and a VM that is gone gets no legacy load.
+			if !m.persistWhileTracked(inst) {
 				return fmt.Errorf("vm %s: clock policy could not be made durable before the legacy restore", vmID)
 			}
 			return nil

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1706,6 +1706,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		guestFrozen, ferr = m.freezeGuestForPause(ctx, instIP, freezeToken, log)
 		freezeDur = time.Since(tFreeze)
 		if ferr != nil {
+			// The guest may be frozen and could not be shown released: it
+			// must not be served as running. The intent keeps its token.
+			m.markUnservable(inst, log)
 			return "", "", nil, m.handleVMError(vmID, ferr)
 		}
 	}
@@ -1720,6 +1723,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			}
 			if terr := m.releaseFrozenGuest(ctx, socketPath, instIP, freezeToken); terr != nil {
 				log.Error().Err(terr).Msg("pause: snapshot failed and the guest workload could not be thawed")
+				m.markUnservable(inst, log)
 			}
 		}()
 	}
@@ -8442,6 +8446,19 @@ func (m *Manager) failAfterSnapshot(inst *VMInstance, socketPath string, err err
 	m.parkUnservable(inst, true)
 	_, _ = m.persistStateIfPresent(inst)
 	return fmt.Errorf("%w; the guest could not be resumed and was parked as error", err)
+}
+
+// markUnservable records, durably, that this guest's workload may be frozen
+// with no confirmed release: Error, so it is not served as running, with its
+// process, intent and artifacts kept for a release that still has the token.
+func (m *Manager) markUnservable(inst *VMInstance, log zerolog.Logger) {
+	inst.mu.Lock()
+	inst.Status = StatusError
+	inst.mu.Unlock()
+	if _, err := m.persistStateIfPresent(inst); err != nil {
+		log.Error().Err(err).Msg("pause: guest with an unconfirmed release could not be recorded as error")
+	}
+	log.Error().Msg("pause: guest workload may still be frozen and could not be released; recorded as error")
 }
 
 // abandonDirtyBaseline forgets a dirty-tracking baseline a snapshot consumed

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2893,6 +2893,15 @@ func (m *Manager) VerifySnapshot(ctx context.Context, vmID string) (string, erro
 
 // CreateVMSnapshot captures a point-in-time snapshot of a running VM.
 func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string) (snapshotPath, memPath string, err error) {
+	// Under the VM's lifecycle lock, like a pause: the intent read below must
+	// not take a pause in flight for an abandoned one and release the guest
+	// that pause is freezing, and the image is of a guest no concurrent
+	// lifecycle op is moving. Unrelated sandboxes are not serialized.
+	unlockOp, err := m.lockVMOp(ctx, vmID)
+	if err != nil {
+		return "", "", err
+	}
+	defer unlockOp()
 	inst, err := m.getInstance(vmID)
 	if err != nil {
 		return "", "", err
@@ -2921,9 +2930,7 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	// clearing DirtyTracked and the unpause below. Failing here has done nothing
 	// yet.
 	//
-	// This path holds no vm-op lock, so any provenance read here could describe a
-	// state a concurrent pause or resume has already moved on from. An ad-hoc
-	// image is therefore never marked: restores from it take legacy behaviour,
+	// An ad-hoc image is never marked: restores from it take legacy behaviour,
 	// which is slower and always correct. Callers may also hand in a directory
 	// that already holds an image, so clear rather than assume.
 	if merr := os.Remove(clockFreezeMarkerPath(memPath)); merr != nil && !os.IsNotExist(merr) {
@@ -2941,9 +2948,8 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	// ad-hoc snapshot. Forces the next pause back to Full.
 	//
 	// Not persisted, deliberately: DirtyTracked is not in VMRecord, so a write
-	// here would duplicate the durable record while clobbering fields a
-	// concurrent lifecycle op just changed — this path holds no vm-op lock.
-	// Persisting from here needs that lock; see TestToRecordIgnoresDirtyTracked.
+	// here would only duplicate the durable record; see
+	// TestToRecordIgnoresDirtyTracked.
 	// The session id gets the same in-memory-only clear: skipping the guarded
 	// Diff it would fail saves one rejected RPC, and a stale PERSISTED session
 	// (this clear not landing durably before a vmd restart) is exactly what the

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1710,14 +1710,6 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			}
 		}()
 	}
-	if !guestFrozen {
-		for _, candidate := range []string{overlayPath, fullPath} {
-			if merr := os.Remove(clockFreezeMarkerPath(candidate)); merr != nil && !os.IsNotExist(merr) {
-				return "", "", nil, m.handleVMError(vmID, fmt.Errorf(
-					"clear stale wall-clock marker for %q: %w", candidate, merr))
-			}
-		}
-	}
 	layered := m.cfg.IncrementalSnapshotEnabled && dirtyTracked && instBaseMem != "" &&
 		(instMemFile == instBaseMem || overlayPath == instMemFile)
 	baseMemPath := ""
@@ -1857,13 +1849,18 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	}
 
-	// The manifest lands only after the image exists; the stale one was cleared
-	// before. A frozen image's manifest is mandatory and durable: an overlay
-	// that lost it would read as legacy on another host and its workload would
-	// never be woken, so the deferred thaw releases the guest on this failure.
-	// An unfrozen image's manifest only spares the next resume a slower path,
-	// so it is written without durability barriers and a failure is logged:
-	// nothing on the ordinary pause path waits on a sync for it.
+	// The manifest lands only after the image exists, and only beside the
+	// image this pause wrote: the manifest of an image it did not touch keeps
+	// describing that image, which is still the last good one if this pause
+	// failed or died before here. A frozen image's manifest is mandatory and
+	// durable: an overlay that lost it would read as legacy on another host
+	// and its workload would never be woken, so the deferred thaw releases
+	// the guest on this failure. An unfrozen image's manifest only spares the
+	// next resume a slower path, so it is written without durability barriers
+	// and a failure is logged: nothing on the ordinary pause path waits on a
+	// sync for it. A guest that cannot correct its clock gets no manifest, so
+	// one an earlier image left at this path is removed: a stale frozen one
+	// beside this unfrozen image would send a wake nothing answers.
 	if correctsWallClock {
 		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifactID, WorkloadFrozen: guestFrozen, GuestCorrectsClock: true}
 		if guestFrozen {
@@ -1875,6 +1872,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
 				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
 		}
+	} else if merr := os.Remove(clockFreezeMarkerPath(memPath)); merr != nil && !os.IsNotExist(merr) {
+		return "", "", nil, m.handleVMError(vmID, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
 	}
 
 	snapshotOK = true

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2292,6 +2292,11 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.mu.RLock()
 	recordedCorrects, recordedFrozen, recordedToken := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen, inst.FreezeToken
 	pausedMemPath, recordedArtifact, entryUnverified := inst.MemFilePath, inst.ArtifactID, inst.Unverified
+	// The identity the record carried in: a frozen resume stamps this run's
+	// slot and token on it before the launch, and a resume that does not
+	// commit hands them back, since its slot is released and the image the
+	// record names is still the one it was paused into.
+	entrySocket, entryIP, entryTAP, entryMAC, entryNS := inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
 		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
@@ -2408,9 +2413,17 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			inst.ClockFrozen = false
 			inst.WakeOwedFromPaused = false
 		}
+		// Whatever verdict the record got, it must not keep this run's
+		// identity: the slot goes back to the pool once this returns, and a
+		// retry that found it here would claim whatever sandbox holds it
+		// next; the token belongs to an image it may not have resumed from.
+		restamped := inst.IP != entryIP || inst.Namespace != entryNS || inst.FreezeToken != recordedToken
+		inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace = entrySocket, entryIP, entryTAP, entryMAC, entryNS
+		inst.FreezeToken = recordedToken
 		inst.mu.Unlock()
-		if revert {
-			// Best-effort: an undurable revert is re-derived by the next attempt.
+		if revert || restamped {
+			// Durable before the deferred teardown releases the slot; an
+			// undurable revert is re-derived by the next attempt.
 			_, _ = m.persistStateIfPresent(inst)
 		}
 	}()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -135,10 +135,12 @@ type VMInstance struct {
 	WakeOwedFromPaused bool
 	// FreezeToken is the token the image's freeze carries; a wake must present it.
 	FreezeToken string
-	CreatedAt   time.Time
-	Metadata    map[string]string
-	TeamID      string // owning team; carried for data-plane usage attribution
-	OwnerID     string // creating user; empty when unknown
+	// WakeToken: see VMRecord.
+	WakeToken string
+	CreatedAt time.Time
+	Metadata  map[string]string
+	TeamID    string // owning team; carried for data-plane usage attribution
+	OwnerID   string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -2293,9 +2295,10 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	recordedCorrects, recordedFrozen, recordedToken := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen, inst.FreezeToken
 	pausedMemPath, recordedArtifact, entryUnverified := inst.MemFilePath, inst.ArtifactID, inst.Unverified
 	// The identity the record carried in: a frozen resume stamps this run's
-	// slot and token on it before the launch, and a resume that does not
-	// commit hands them back, since its slot is released and the image the
-	// record names is still the one it was paused into.
+	// slot on it before the launch, and a resume that does not commit hands
+	// it back, since the slot is released. The token of the image being
+	// loaded rides WakeToken until the commit, so the record's own image and
+	// token stay paired whatever happens in between.
 	entrySocket, entryIP, entryTAP, entryMAC, entryNS := inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
@@ -2416,15 +2419,21 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		// Whatever verdict the record got, it must not keep this run's
 		// identity: the slot goes back to the pool once this returns, and a
 		// retry that found it here would claim whatever sandbox holds it
-		// next; the token belongs to an image it may not have resumed from.
-		restamped := inst.IP != entryIP || inst.Namespace != entryNS || inst.FreezeToken != recordedToken
+		// next. The in-flight token goes with it.
+		restamped := inst.IP != entryIP || inst.Namespace != entryNS || inst.WakeToken != ""
 		inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace = entrySocket, entryIP, entryTAP, entryMAC, entryNS
-		inst.FreezeToken = recordedToken
+		inst.WakeToken = ""
 		inst.mu.Unlock()
-		if revert || restamped {
-			// Durable before the deferred teardown releases the slot; an
-			// undurable revert is re-derived by the next attempt.
-			_, _ = m.persistStateIfPresent(inst)
+		if !revert && !restamped {
+			return
+		}
+		// Durable before the deferred teardown releases the slot. If the
+		// write fails the durable record still names the slot, so the slot
+		// stays this sandbox's until a write succeeds: leaked for now, never
+		// claimed from another sandbox after a restart.
+		if _, perr := m.persistStateIfPresent(inst); perr != nil {
+			needsNetworkCleanup = false
+			log.Error().Err(perr).Msg("resume rollback could not be made durable; keeping the network slot reserved for this sandbox")
 		}
 	}()
 	// If this Firecracker refuses the clock option, the record must say the
@@ -2462,7 +2471,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			inst.TAPDevice = netInfo.TAPDevice
 			inst.MACAddress = netInfo.MACAddress
 			inst.Namespace = nsName
-			inst.FreezeToken = resumeToken
+			inst.WakeToken = resumeToken
 			inst.mu.Unlock()
 			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil, true)
 			published = true
@@ -2540,7 +2549,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 					// Durably Error, never retried: the artifacts are retained,
 					// and nothing is owed, so recovery cannot return it to Paused.
 					inst.mu.Lock()
-					inst.WakePending, inst.WakeOwedFromPaused = false, false
+					inst.WakePending, inst.WakeOwedFromPaused, inst.WakeToken = false, false, ""
 					inst.mu.Unlock()
 					m.setStatus(vmID, StatusError)
 					return nil, status.Errorf(codes.FailedPrecondition, "image %q: %v", memPath, werr)
@@ -2589,6 +2598,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.CorrectsWallClock = &resumeCorrectsWallClock
 	inst.SnapshotWorkloadFrozen = &resumeWorkloadFrozen
 	inst.FreezeToken = resumeToken
+	inst.WakeToken = ""
 	inst.PausedAt = time.Time{}
 	// Record the file actually resumed from (callers may pass an explicit path
 	// that differs from the cached one) so the next pause's diff baseline matches
@@ -3579,6 +3589,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		inst.SnapshotWorkloadFrozen = &restoreWorkloadFrozen
 		inst.FreezeToken = restoreToken
 		inst.ArtifactID = restoreArtifactID
+		if restoreWorkloadFrozen {
+			inst.WakeToken = restoreToken
+		}
 		inst.mu.Unlock()
 		// Only a frozen image owes a wake, so only then must the record say so
 		// before the vCPUs can run (see persistWakeOwed). An unfrozen image
@@ -3945,7 +3958,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// Terminal: the Error written below must not owe a wake, or
 			// recovery would read it as a resume to return to Paused.
 			inst.mu.Lock()
-			inst.WakePending, inst.WakeOwedFromPaused = false, false
+			inst.WakePending, inst.WakeOwedFromPaused, inst.WakeToken = false, false, ""
 			inst.mu.Unlock()
 		}
 		// Emit the exhausted readiness wait immediately, before teardown, so
@@ -4076,6 +4089,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	inst.Unverified = false
 	inst.WakePending = false
 	inst.WakeOwedFromPaused = false
+	inst.WakeToken = ""
 	// A frozen image kept its pause timestamp through the launch, so a
 	// failure could return it to Paused in its place in the reclaim order.
 	inst.PausedAt = time.Time{}
@@ -5095,6 +5109,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 				log.Warn().Msg("resume interrupted before its launch — record returns to Paused")
 				rec.Status = StatusPaused
 				rec.WakePending, rec.ClockFrozen, rec.WakeOwedFromPaused, rec.Unverified = false, false, false, false
+				rec.WakeToken = ""
 				if wrote, perr := m.state.PutIfPresent(rec); perr != nil || !wrote {
 					log.Warn().Err(perr).Bool("present", wrote).Msg("interrupted resume's record could not be returned to Paused")
 					return nil, false
@@ -8223,7 +8238,7 @@ var adoptionBoxdReady = func(ctx context.Context, m *Manager, ip string) error {
 func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VMInstance) error {
 	ctx := context.WithoutCancel(callerCtx)
 	inst.mu.RLock()
-	pending, frozen, token := inst.WakePending, inst.ClockFrozen, inst.FreezeToken
+	pending, frozen, token := inst.WakePending, inst.ClockFrozen, inst.WakeToken
 	inst.mu.RUnlock()
 	if !pending {
 		return adoptionBoxdReady(ctx, m, ip)
@@ -8237,6 +8252,7 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 	inst.mu.Lock()
 	inst.WakePending = false
 	inst.WakeOwedFromPaused = false
+	inst.WakeToken = ""
 	inst.mu.Unlock()
 	return nil
 }
@@ -8469,6 +8485,7 @@ func (m *Manager) parkUnservable(inst *VMInstance, terminal bool) {
 	if !terminal && inst.WakePending && inst.WakeOwedFromPaused {
 		inst.Status = StatusPaused
 		inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
+		inst.WakeToken = ""
 	} else {
 		inst.Status = StatusError
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1508,7 +1508,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	// in the pause distributions — those are the pauses worth seeing. The
 	// already-paused retry guard (before either) still deliberately emits
 	// nothing.
-	var freezeDur time.Duration
+	var freezeDur, manifestDur time.Duration
 	var tFreeze time.Time
 	defer func() {
 		if tSnapshot.IsZero() && tFreeze.IsZero() {
@@ -1520,6 +1520,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 		if freezeDur > 0 {
 			phases["freeze"] = freezeDur
+		}
+		if manifestDur > 0 {
+			phases["manifest"] = manifestDur
 		}
 		if snapshotDur > 0 {
 			phases["snapshot"] = snapshotDur
@@ -1870,10 +1873,22 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifactID, WorkloadFrozen: guestFrozen, GuestCorrectsClock: true}
 		if guestFrozen {
 			man.FreezeToken = freezeToken
-			if merr := WriteWallClockManifest(memPath, man); merr != nil {
+			// A file and a directory sync while the guest is stopped: timed
+			// as its own phase, so a storage stall here has a name.
+			tManifest := time.Now()
+			merr := WriteWallClockManifest(memPath, man)
+			manifestDur = time.Since(tManifest)
+			if merr != nil {
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("write wall-clock manifest: %w", merr))
 			}
 		} else if merr := writeWallClockManifestLazy(memPath, man); merr != nil {
+			// The image is unfrozen, so no manifest is safe for it; a stale
+			// frozen one is not: a restore would present its token to a guest
+			// that already answered it and run the clock uncorrected. The
+			// stale one goes, or the pause fails.
+			if rerr := os.Remove(clockFreezeMarkerPath(memPath)); rerr != nil && !os.IsNotExist(rerr) {
+				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("wall-clock manifest write failed (%v) and the stale one could not be cleared: %w", merr, rerr))
+			}
 			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
 				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -129,9 +129,10 @@ type VMInstance struct {
 	ArtifactID string
 	// SnapshotWorkloadFrozen: see VMRecord.
 	SnapshotWorkloadFrozen *bool
-	// WakePending / ClockFrozen: see VMRecord.
-	WakePending bool
-	ClockFrozen bool
+	// WakePending / ClockFrozen / WakeOwedFromPaused: see VMRecord.
+	WakePending        bool
+	ClockFrozen        bool
+	WakeOwedFromPaused bool
 	// FreezeToken is the token the image's freeze carries; a wake must present it.
 	FreezeToken string
 	CreatedAt   time.Time
@@ -1682,9 +1683,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			if snapshotOK {
 				return
 			}
-			tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-			defer cancel()
-			if terr := boxdThawGuest(tctx, instIP, freezeToken); terr != nil {
+			if terr := m.releaseFrozenGuest(ctx, socketPath, instIP, freezeToken); terr != nil {
 				log.Error().Err(terr).Msg("pause: snapshot failed and the guest workload could not be thawed")
 			}
 		}()
@@ -2407,6 +2406,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			inst.Unverified = entryUnverified
 			inst.WakePending = false
 			inst.ClockFrozen = false
+			inst.WakeOwedFromPaused = false
 		}
 		inst.mu.Unlock()
 		if revert {
@@ -2429,7 +2429,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			if m.cgroupLaunch(resumeExisting) {
 				predicted = SupervisionCgroup
 			}
-			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil)
+			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil, true)
 			published = true
 		}
 		// freshUnit=false: a resume replaces a paused VM's slot, never a brand-new
@@ -2510,6 +2510,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			}
 			inst.mu.Lock()
 			inst.WakePending = false
+			inst.WakeOwedFromPaused = false
 			inst.mu.Unlock()
 		}
 		break
@@ -3281,11 +3282,17 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// intent beside it can never be cleared as completed. No host whose floor
 	// is down holds an intent, so today a create looks for nothing; on a host
 	// whose floor is up it pays one lookup that a template never answers.
+	m.mu.RLock()
+	prev := m.vms[vmID]
+	m.mu.RUnlock()
+	restoreFromPaused := false
+	if prev != nil {
+		prev.mu.RLock()
+		restoreFromPaused = prev.Status == StatusPaused
+		prev.mu.RUnlock()
+	}
 	if wakeProtocolFloorRaised() {
 		knownArtifact := ""
-		m.mu.RLock()
-		prev := m.vms[vmID]
-		m.mu.RUnlock()
 		if prev != nil {
 			prev.mu.RLock()
 			knownArtifact = prev.ArtifactID
@@ -3535,7 +3542,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// keeps the older ordering below, unchanged.
 		var joinWakeOwed func(Supervision) bool
 		if restoreWorkloadFrozen {
-			joinWakeOwed = m.persistWakeOwed(inst, predictedSupervision, clockPolicy != nil)
+			joinWakeOwed = m.persistWakeOwed(inst, predictedSupervision, clockPolicy != nil, restoreFromPaused)
 		}
 		m.beginLaunchAttempt(inst)
 		pid, supervision, startErr = m.launchFirecracker(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, existingSupervision, inPlace || priorRunDir, freshUnit && attempt == 1)
@@ -4008,6 +4015,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	inst.mu.Lock()
 	inst.Unverified = false
 	inst.WakePending = false
+	inst.WakeOwedFromPaused = false
 	inst.mu.Unlock()
 	// Persist-then-verify: checking AFTER the write leaves no window — a
 	// concurrent DestroyVM either erased the record itself or is caught here,
@@ -5015,6 +5023,21 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			fullyDown = vmUnitFullyDown(rec.ID)
 		}
 		if fullyDown {
+			if rec.WakePending && rec.WakeOwedFromPaused {
+				// A resume that published its wake-owed record and died before
+				// its Firecracker launched. The paused image is intact, so the
+				// sandbox returns to Paused rather than being reaped as a
+				// failed create; the record is rewritten before it is read as
+				// Paused, so a second restart sees the same thing.
+				log.Warn().Msg("resume interrupted before its launch — record returns to Paused")
+				rec.Status = StatusPaused
+				rec.WakePending, rec.ClockFrozen, rec.WakeOwedFromPaused, rec.Unverified = false, false, false, false
+				if wrote, perr := m.state.PutIfPresent(rec); perr != nil || !wrote {
+					log.Warn().Err(perr).Bool("present", wrote).Msg("interrupted resume's record could not be returned to Paused")
+					return nil, false
+				}
+				return m.reattachRecord(ctx, rec, cleanupStale)
+			}
 			log.Warn().Msg("VM in BoltDB but not running — cleaning up stale record")
 			// Cold-booted VMs (old build path) ran with Setsid and no unit, so
 			// they survive vmd restarts as orphans holding TAP fds — SIGKILL by
@@ -8150,9 +8173,27 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 	}
 	inst.mu.Lock()
 	inst.WakePending = false
+	inst.WakeOwedFromPaused = false
 	inst.mu.Unlock()
 	return nil
 }
+
+// releaseFrozenGuest thaws a workload a pause froze, after making sure the
+// guest can answer: a snapshot pauses the vCPUs first, so a release after a
+// snapshot that then failed, or after a crash between the two, meets a guest
+// that cannot run boxd until Firecracker resumes it. The unpause is
+// best-effort — a guest never paused refuses it — and the thaw is the verdict.
+func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token string) error {
+	if socketPath != "" {
+		_ = fcUnpauseVM(socketPath)
+	}
+	tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+	return boxdThawGuest(tctx, ip, token)
+}
+
+// fcUnpauseVM is a seam over the Firecracker resume call.
+var fcUnpauseVM = UnpauseVM
 
 // persistWakeOwed publishes Running with a wake owed and starts the durable
 // write so it overlaps the launch. A crash after the load must find a record
@@ -8162,7 +8203,10 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 // reports whether the record is durable; the caller must not load the
 // snapshot otherwise. The status is set directly: setStatus would persist
 // synchronously, on the launch path.
-func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clockFrozen bool) (join func(actual Supervision) bool) {
+//
+// fromPaused says the record was Paused before this began, so recovery may
+// return it there; a create's record has nowhere to return to.
+func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clockFrozen, fromPaused bool) (join func(actual Supervision) bool) {
 	inst.mu.Lock()
 	inst.Status = StatusRunning
 	inst.Unverified = true
@@ -8170,6 +8214,7 @@ func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clock
 	inst.Supervision = predicted
 	inst.WakePending = true
 	inst.ClockFrozen = clockFrozen
+	inst.WakeOwedFromPaused = fromPaused
 	inst.mu.Unlock()
 	done := make(chan struct{})
 	ok := false
@@ -8305,9 +8350,7 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 		return true
 	}
 	if in.FreezeToken != "" && inst.IP != "" {
-		tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-		terr := boxdThawGuest(tctx, inst.IP, in.FreezeToken)
-		cancel()
+		terr := m.releaseFrozenGuest(ctx, inst.SocketPath, inst.IP, in.FreezeToken)
 		// A token the guest never froze under means the crash came before
 		// the freeze: nothing to release.
 		if terr != nil && !errors.Is(terr, ErrGuestTokenMismatch) {
@@ -8340,14 +8383,20 @@ func (m *Manager) publishRecovered(inst *VMInstance) {
 }
 
 // parkUnservable stops a guest whose state recovery could not settle — a
-// freeze it could not release, a wake it did not answer — and marks it Error.
-// Stopped first, and confirmed as far as the stop can confirm: a guest in an
-// unknown state must not keep running behind an Error record until a grace
-// period reaps it.
+// freeze it could not release, a wake it did not answer. Stopped first, and
+// confirmed as far as the stop can confirm: a guest in an unknown state must
+// not keep running behind a record until a grace period reaps it. A resume
+// that never completed returns to Paused, as its own failure path would:
+// its image is intact and its workload never ran. Anything else is Error.
 func (m *Manager) parkUnservable(inst *VMInstance) {
 	m.stopUnitDuringRestoreError(inst.ID)
 	inst.mu.Lock()
-	inst.Status = StatusError
+	if inst.WakePending && inst.WakeOwedFromPaused {
+		inst.Status = StatusPaused
+		inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
+	} else {
+		inst.Status = StatusError
+	}
 	inst.mu.Unlock()
 }
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3398,9 +3398,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	prev := m.vms[vmID]
 	m.mu.RUnlock()
 	restoreFromPaused := false
+	var prevPausedAt time.Time
 	if prev != nil {
 		prev.mu.RLock()
 		restoreFromPaused = prev.Status == StatusPaused
+		prevPausedAt = prev.PausedAt
 		prev.mu.RUnlock()
 	}
 	if wakeProtocolFloorRaised() {
@@ -3483,8 +3485,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		Supervision:  prevSupervision,
 		SnapshotPath: snapshotPath,
 		MemFilePath:  memPath,
-		TeamID:       teamID,
-		OwnerID:      ownerID,
+		// Kept through the launch: a failure returns a restore from a paused
+		// record to Paused in its place in the reclaim order; the commit clears it.
+		PausedAt: prevPausedAt,
+		TeamID:   teamID,
+		OwnerID:  ownerID,
 
 		PreviewAccess:              previewAccess,
 		PreviewPorts:               clonePreviewPorts(previewPorts),
@@ -4016,11 +4021,22 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	if wakeErr != nil {
 		err := wakeErr
+		// The verdict this failure leaves behind. A wake the guest refused
+		// as another freeze's is terminal: Error, owing nothing, or recovery
+		// would read it as a resume to return to Paused. A wake that merely
+		// did not happen on an image the record was paused into leaves that
+		// image intact: the record returns to Paused, as a resume's failure
+		// does, rather than to an Error a restart would reap as stale.
+		verdict := StatusError
 		if errors.Is(err, ErrGuestTokenMismatch) {
-			// Terminal: the Error written below must not owe a wake, or
-			// recovery would read it as a resume to return to Paused.
 			inst.mu.Lock()
 			inst.WakePending, inst.WakeOwedFromPaused = false, false
+			inst.dropWakeImage()
+			inst.mu.Unlock()
+		} else if restoreFromPaused {
+			verdict = StatusPaused
+			inst.mu.Lock()
+			inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
 			inst.dropWakeImage()
 			inst.mu.Unlock()
 		}
@@ -4057,11 +4073,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if stillTracked {
 			// Mark the failure in-memory BEFORE returning: only the durable
 			// write may be deferred. A same-ID retry that wins the lifecycle
-			// lock right after this RPC returns must see Error — a lingering
-			// Running/Unverified corpse would route it into re-verifying a
-			// stopped VM instead of relaunching.
+			// lock right after this RPC returns must see the verdict — a
+			// lingering Running/Unverified corpse would route it into
+			// re-verifying a stopped VM instead of relaunching.
 			inst.mu.Lock()
-			inst.Status = StatusError
+			inst.Status = verdict
 			inst.mu.Unlock()
 		}
 		go func() {
@@ -4100,7 +4116,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				// construction.
 				m.persistState(cur)
 			} else {
-				m.setStatus(vmID, StatusError)
+				m.setStatus(vmID, verdict)
 			}
 			// DestroyVM bypasses the lifecycle lock, so its record delete
 			// can interleave anywhere around EITHER write above and be

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2502,7 +2502,11 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 				}
 				if errors.Is(werr, ErrGuestTokenMismatch) {
 					// This image and its record describe different snapshots.
-					// Durably Error, never retried: the artifacts are retained.
+					// Durably Error, never retried: the artifacts are retained,
+					// and nothing is owed, so recovery cannot return it to Paused.
+					inst.mu.Lock()
+					inst.WakePending, inst.WakeOwedFromPaused = false, false
+					inst.mu.Unlock()
 					m.setStatus(vmID, StatusError)
 					return nil, status.Errorf(codes.FailedPrecondition, "image %q: %v", memPath, werr)
 				}
@@ -3893,6 +3897,13 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	if wakeErr != nil {
 		err := wakeErr
+		if errors.Is(err, ErrGuestTokenMismatch) {
+			// Terminal: the Error written below must not owe a wake, or
+			// recovery would read it as a resume to return to Paused.
+			inst.mu.Lock()
+			inst.WakePending, inst.WakeOwedFromPaused = false, false
+			inst.mu.Unlock()
+		}
 		// Emit the exhausted readiness wait immediately, before teardown, so
 		// the sample measures the probe (not unit stop + resource release +
 		// persist join) and the concurrent-destroy return below can't skip it.
@@ -4016,6 +4027,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	inst.Unverified = false
 	inst.WakePending = false
 	inst.WakeOwedFromPaused = false
+	// A frozen image kept its pause timestamp through the launch, so a
+	// failure could return it to Paused in its place in the reclaim order.
+	inst.PausedAt = time.Time{}
 	inst.mu.Unlock()
 	// Persist-then-verify: checking AFTER the write leaves no window — a
 	// concurrent DestroyVM either erased the record itself or is caught here,
@@ -5023,7 +5037,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			fullyDown = vmUnitFullyDown(rec.ID)
 		}
 		if fullyDown {
-			if rec.WakePending && rec.WakeOwedFromPaused {
+			if rec.Status == StatusRunning && rec.Unverified && rec.WakePending && rec.WakeOwedFromPaused {
 				// A resume that published its wake-owed record and died before
 				// its Firecracker launched. The paused image is intact, so the
 				// sandbox returns to Paused rather than being reaped as a
@@ -5170,7 +5184,7 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	// it. Neither may be served as Running until resolved.
 	if rec.Status == StatusRunning && !m.recoverPauseIntent(ctx, inst, log) {
 		rec.Status = StatusError
-		m.parkUnservable(inst)
+		m.parkUnservable(inst, true)
 	}
 	if rec.Status == StatusRunning && inst.WakePending {
 		if cleanupStale {
@@ -5188,9 +5202,9 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 			m.queuePendingWake(inst, unlock)
 			return nil, false
 		}
-		if !m.completeOwedWake(ctx, inst, log) {
+		if err := m.completeOwedWake(ctx, inst, log); err != nil {
 			rec.Status = StatusError
-			m.parkUnservable(inst)
+			m.parkUnservable(inst, errors.Is(err, ErrGuestTokenMismatch))
 		}
 	}
 
@@ -8184,16 +8198,21 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 // that cannot run boxd until Firecracker resumes it. The unpause is
 // best-effort — a guest never paused refuses it — and the thaw is the verdict.
 func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token string) error {
+	// Each step bounded on its own: a stuck Firecracker API must neither hang
+	// this caller nor eat the thaw's budget.
+	base := context.WithoutCancel(ctx)
 	if socketPath != "" {
-		_ = fcUnpauseVM(socketPath)
+		uctx, cancel := context.WithTimeout(base, 2*time.Second)
+		_ = fcUnpauseVM(uctx, socketPath)
+		cancel()
 	}
-	tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	tctx, cancel := context.WithTimeout(base, 2*time.Second)
 	defer cancel()
 	return boxdThawGuest(tctx, ip, token)
 }
 
 // fcUnpauseVM is a seam over the Firecracker resume call.
-var fcUnpauseVM = UnpauseVM
+var fcUnpauseVM = UnpauseVMContext
 
 // persistWakeOwed publishes Running with a wake owed and starts the durable
 // write so it overlaps the launch. A crash after the load must find a record
@@ -8202,7 +8221,8 @@ var fcUnpauseVM = UnpauseVM
 // write, re-persists if the launch landed in another supervision mode, and
 // reports whether the record is durable; the caller must not load the
 // snapshot otherwise. The status is set directly: setStatus would persist
-// synchronously, on the launch path.
+// synchronously, on the launch path. PausedAt is kept: a failure returns a
+// resume to Paused in its place in the reclaim order, and the commit clears it.
 //
 // fromPaused says the record was Paused before this began, so recovery may
 // return it there; a create's record has nowhere to return to.
@@ -8210,7 +8230,6 @@ func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clock
 	inst.mu.Lock()
 	inst.Status = StatusRunning
 	inst.Unverified = true
-	inst.PausedAt = time.Time{}
 	inst.Supervision = predicted
 	inst.WakePending = true
 	inst.ClockFrozen = clockFrozen
@@ -8305,10 +8324,10 @@ func (m *Manager) drainPendingWakes(ctx context.Context) int {
 				log.Info().Msg("reattach: a request replaced this VM before its wake completed; recovery instance abandoned")
 				return
 			}
-			if m.completeOwedWake(ctx, pw.inst, log) {
+			if err := m.completeOwedWake(ctx, pw.inst, log); err == nil {
 				woken.Add(1)
 			} else {
-				m.parkUnservable(pw.inst)
+				m.parkUnservable(pw.inst, errors.Is(err, ErrGuestTokenMismatch))
 			}
 			m.publishRecovered(pw.inst)
 		}(pw)
@@ -8317,18 +8336,18 @@ func (m *Manager) drainPendingWakes(ctx context.Context) int {
 	return int(woken.Load())
 }
 
-// completeOwedWake sends the wake a reattached record still owes. True once
-// the guest is awake; false leaves the instance owing it, for Error.
-func (m *Manager) completeOwedWake(ctx context.Context, inst *VMInstance, log zerolog.Logger) bool {
+// completeOwedWake sends the wake a reattached record still owes. Nil once
+// the guest is awake; the error otherwise, with the instance still owing it.
+func (m *Manager) completeOwedWake(ctx context.Context, inst *VMInstance, log zerolog.Logger) error {
 	if err := m.verifyBoxdReady(ctx, inst.IP, inst); err != nil {
-		log.Error().Err(err).Msg("reattach: guest still owes its wake and could not be woken; parking as error")
-		return false
+		log.Error().Err(err).Msg("reattach: guest still owes its wake and could not be woken; parking")
+		return err
 	}
 	inst.mu.Lock()
 	inst.Unverified = false
 	inst.mu.Unlock()
 	log.Info().Msg("reattach: completed the wake a restore owed this guest")
-	return true
+	return nil
 }
 
 // recoverPauseIntent releases a guest that a pause froze and then died
@@ -8387,11 +8406,12 @@ func (m *Manager) publishRecovered(inst *VMInstance) {
 // confirmed as far as the stop can confirm: a guest in an unknown state must
 // not keep running behind a record until a grace period reaps it. A resume
 // that never completed returns to Paused, as its own failure path would:
-// its image is intact and its workload never ran. Anything else is Error.
-func (m *Manager) parkUnservable(inst *VMInstance) {
+// its image is intact and its workload never ran. A terminal verdict — a
+// wake the guest refused as another freeze's — and anything else is Error.
+func (m *Manager) parkUnservable(inst *VMInstance, terminal bool) {
 	m.stopUnitDuringRestoreError(inst.ID)
 	inst.mu.Lock()
-	if inst.WakePending && inst.WakeOwedFromPaused {
+	if !terminal && inst.WakePending && inst.WakeOwedFromPaused {
 		inst.Status = StatusPaused
 		inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
 	} else {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -8419,17 +8419,29 @@ func (m *Manager) ensureWakeFloorTimed(op string) error {
 
 // failAfterSnapshot is the error return for a pause that fails after its
 // snapshot: Firecracker left the vCPUs paused and the record says Running,
-// so the guest is resumed first, best-effort, before the error. The snapshot
-// consumed the dirty bitmap, so the retry must be Full: a Diff would hold
-// only the pages dirtied since, and the abandoned overlay's would be lost.
+// so the guest is resumed first. An unpause that did not confirm leaves the
+// guest's state unknown, so only a guest that answers stays recorded
+// Running; otherwise it is parked as Error, its artifacts kept. The snapshot
+// consumed the dirty bitmap, so the retry must be Full.
 func (m *Manager) failAfterSnapshot(inst *VMInstance, socketPath string, err error) error {
 	m.abandonDirtyBaseline(inst)
 	uctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if uerr := fcUnpauseVM(uctx, socketPath); uerr != nil {
-		m.log.Error().Err(uerr).Str("vm_id", inst.ID).Msg("pause failed after its snapshot and the guest could not be resumed")
+	uerr := fcUnpauseVM(uctx, socketPath)
+	cancel()
+	if uerr == nil {
+		return m.handleVMError(inst.ID, err)
 	}
-	return m.handleVMError(inst.ID, err)
+	inst.mu.RLock()
+	ip := inst.IP
+	inst.mu.RUnlock()
+	if perr := boxdHealthProbe(context.Background(), ip, 5*time.Second); perr == nil {
+		m.log.Warn().Err(uerr).Str("vm_id", inst.ID).Msg("pause failed after its snapshot; the unpause did not confirm but the guest answers")
+		return m.handleVMError(inst.ID, err)
+	}
+	m.log.Error().Err(uerr).Str("vm_id", inst.ID).Msg("pause failed after its snapshot and the guest neither resumed nor answers; parking as error")
+	m.parkUnservable(inst, true)
+	_, _ = m.persistStateIfPresent(inst)
+	return fmt.Errorf("%w; the guest could not be resumed and was parked as error", err)
 }
 
 // abandonDirtyBaseline forgets a dirty-tracking baseline a snapshot consumed

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1498,22 +1498,27 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	var snapshotType string
 	var tSnapshot time.Time
 	var snapshotDur, stopDur time.Duration
-	// Deferred, gated on snapshot work having begun: a CreateSnapshot that
-	// burns seconds and then fails must land in the pause distributions —
-	// those are among the slowest pauses. The already-paused retry guard
-	// (before tSnapshot) still deliberately emits nothing.
+	// Deferred, gated on freeze or snapshot work having begun: a freeze that
+	// fails, or a CreateSnapshot that burns seconds and then fails, must land
+	// in the pause distributions — those are the pauses worth seeing. The
+	// already-paused retry guard (before either) still deliberately emits
+	// nothing.
 	var freezeDur time.Duration
+	var tFreeze time.Time
 	defer func() {
-		if tSnapshot.IsZero() {
+		if tSnapshot.IsZero() && tFreeze.IsZero() {
 			return
 		}
 		phases := map[string]time.Duration{"total": time.Since(tPause)}
+		if freezeDur == 0 && !tFreeze.IsZero() {
+			freezeDur = time.Since(tFreeze) // died inside the freeze
+		}
 		if freezeDur > 0 {
 			phases["freeze"] = freezeDur
 		}
 		if snapshotDur > 0 {
 			phases["snapshot"] = snapshotDur
-		} else {
+		} else if !tSnapshot.IsZero() {
 			phases["snapshot"] = time.Since(tSnapshot)
 		}
 		if stopDur > 0 {
@@ -1607,6 +1612,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	instBaseMem := inst.BaseMemPath
 	instMemFile := inst.MemFilePath
 	recordedCorrects := inst.CorrectsWallClock
+	recordedArtifact := inst.ArtifactID
 	instIP := inst.IP
 	diskPath := inst.DiskPath
 	diskBasePath := inst.Config.BasePath
@@ -1659,8 +1665,24 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	// able to release it.
 	willFreeze := correctsWallClock && m.cfg.GuestClockFreezeEnabled && m.clockRealtimeCapable.Load() && !m.guestClockUnready.Load()
 	if willFreeze {
+		tFreeze = time.Now()
 		if err := ensureWakeProtocolFloor(); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record the rollback floor before freezing: %w", err))
+		}
+		// An intent already here may name a freeze an earlier pause left in
+		// place: its reply lost and its thaw unconfirmed. That token is the
+		// only way to release the guest, so it is resolved before a new one
+		// replaces it; a pause refused here keeps it. The leftover of a pause
+		// that completed names this record's artifact and is simply rewritten.
+		prior, perr := readPauseIntent(snapshotDir)
+		if perr != nil {
+			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("read the earlier pause intent: %w", perr))
+		}
+		if prior != nil && prior.FreezeToken != "" && prior.ArtifactID != recordedArtifact {
+			if rerr := m.releaseOrConfirmRunning(ctx, "", instIP, prior.FreezeToken); rerr != nil {
+				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("an earlier pause's freeze could not be released: %w", rerr))
+			}
+			log.Warn().Msg("pause: released a guest an earlier pause had left frozen")
 		}
 		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, FreezeToken: freezeToken, ArtifactID: artifactID}); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
@@ -1670,7 +1692,6 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	// freeze the clock; otherwise the freeze buys nothing.
 	guestFrozen := false
 	if willFreeze {
-		tFreeze := time.Now()
 		var ferr error
 		guestFrozen, ferr = m.freezeGuestForPause(ctx, instIP, freezeToken, log)
 		freezeDur = time.Since(tFreeze)
@@ -8310,6 +8331,20 @@ func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token 
 	return boxdThawGuest(tctx, ip, token)
 }
 
+// releaseOrConfirmRunning releases a workload frozen under token or, when the
+// guest holds no freeze under it, confirms the workload runs: a thaw refused
+// for one token says nothing about a freeze under an earlier one, and only a
+// workload confirmed running owes nothing.
+func (m *Manager) releaseOrConfirmRunning(ctx context.Context, socketPath, ip, token string) error {
+	err := m.releaseFrozenGuest(ctx, socketPath, ip, token)
+	if errors.Is(err, ErrGuestTokenMismatch) {
+		rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		err = boxdGuestRunning(rctx, ip)
+		cancel()
+	}
+	return err
+}
+
 // fcUnpauseVM is a seam over the Firecracker resume call.
 var fcUnpauseVM = UnpauseVMContext
 
@@ -8468,15 +8503,7 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 		return true
 	}
 	if in.FreezeToken != "" && inst.IP != "" {
-		terr := m.releaseFrozenGuest(ctx, inst.SocketPath, inst.IP, in.FreezeToken)
-		if errors.Is(terr, ErrGuestTokenMismatch) {
-			// A token the guest never froze under means the crash came before
-			// the freeze, unless the guest is still frozen under an earlier
-			// one: only a workload confirmed running owes nothing.
-			rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-			terr = boxdGuestRunning(rctx, inst.IP)
-			cancel()
-		}
+		terr := m.releaseOrConfirmRunning(ctx, inst.SocketPath, inst.IP, in.FreezeToken)
 		if terr != nil {
 			log.Error().Err(terr).Msg("reattach: a pause left this guest frozen and it could not be released; parking as error")
 			return false

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1669,21 +1669,18 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		if err := ensureWakeProtocolFloor(); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record the rollback floor before freezing: %w", err))
 		}
-		// An intent already here may name a freeze an earlier pause left in
-		// place: its reply lost and its thaw unconfirmed. That token is the
-		// only way to release the guest, so it is resolved before a new one
-		// replaces it; a pause refused here keeps it. The leftover of a pause
-		// that completed names this record's artifact and is simply rewritten.
-		prior, perr := readPauseIntent(snapshotDir)
-		if perr != nil {
-			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("read the earlier pause intent: %w", perr))
-		}
-		if prior != nil && prior.FreezeToken != "" && prior.ArtifactID != recordedArtifact {
-			if rerr := m.releaseOrConfirmRunning(ctx, "", instIP, prior.FreezeToken); rerr != nil {
-				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("an earlier pause's freeze could not be released: %w", rerr))
-			}
-			log.Warn().Msg("pause: released a guest an earlier pause had left frozen")
-		}
+	}
+	// Whatever this pause plans, an image of this guest is published only
+	// once a freeze an earlier pause may have left is resolved: a custom
+	// directory, or a host that cannot freeze today, does not turn a frozen
+	// workload into an unfrozen image. A pause refused here leaves that
+	// intent, and its token, for the next attempt.
+	if err := m.resolveOutstandingFreeze(ctx, vmID, socketPath, instIP, recordedArtifact, log); err != nil {
+		return "", "", nil, m.handleVMError(vmID, err)
+	}
+	if willFreeze {
+		// Durable BEFORE the freeze: a crash after it must find the token,
+		// or the guest stays frozen with nobody able to release it.
 		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, FreezeToken: freezeToken, ArtifactID: artifactID}); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
 		}
@@ -2903,6 +2900,14 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID, fmt.Sprintf("snap-%d", time.Now().Unix()))
+	}
+	// An ad-hoc image is never marked, so it restores without a wake: it may
+	// only be taken of a guest no earlier pause left frozen.
+	inst.mu.RLock()
+	adHocSocket, adHocIP, adHocArtifact := inst.SocketPath, inst.IP, inst.ArtifactID
+	inst.mu.RUnlock()
+	if err := m.resolveOutstandingFreeze(ctx, vmID, adHocSocket, adHocIP, adHocArtifact, m.log.With().Str("vm_id", vmID).Logger()); err != nil {
+		return "", "", err
 	}
 	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
 		return "", "", fmt.Errorf("create snapshot dir: %w", err)
@@ -8329,6 +8334,38 @@ func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token 
 	tctx, cancel := context.WithTimeout(base, 2*time.Second)
 	defer cancel()
 	return boxdThawGuest(tctx, ip, token)
+}
+
+// resolveOutstandingFreeze releases, or confirms released, a workload an
+// earlier pause of this VM may have left frozen (its reply lost, its thaw
+// unconfirmed), before any image of the guest can be published as unfrozen.
+// The intent that pause left is the only holder of its token; it is cleared
+// once nothing is frozen under it, and kept when that cannot be shown. The
+// leftover of a pause that completed names this record's artifact and is
+// nothing to resolve. Intents exist only on a host whose floor is up, so a
+// host with the floor down looks for nothing.
+func (m *Manager) resolveOutstandingFreeze(ctx context.Context, vmID, socketPath, ip, recordedArtifact string, log zerolog.Logger) error {
+	if !wakeProtocolFloorRaised() {
+		return nil
+	}
+	dir := filepath.Join(m.cfg.SnapshotDir, vmID)
+	prior, err := readPauseIntent(dir)
+	if err != nil {
+		return fmt.Errorf("read the earlier pause intent: %w", err)
+	}
+	if prior == nil || prior.FreezeToken == "" || prior.ArtifactID == recordedArtifact {
+		return nil
+	}
+	// The vCPUs may still be paused from that pause's snapshot attempt; the
+	// guest cannot answer a thaw until Firecracker resumes them.
+	if err := m.releaseOrConfirmRunning(ctx, socketPath, ip, prior.FreezeToken); err != nil {
+		return fmt.Errorf("an earlier pause's freeze could not be released: %w", err)
+	}
+	log.Warn().Msg("released a guest an earlier pause had left frozen")
+	if err := clearPauseIntent(dir); err != nil {
+		return fmt.Errorf("clear the earlier pause intent: %w", err)
+	}
+	return nil
 }
 
 // releaseOrConfirmRunning releases a workload frozen under token or, when the

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3003,6 +3003,20 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	snapshotPath = filepath.Join(snapshotDir, "vmstate.snap")
 	memPath = filepath.Join(snapshotDir, "mem.snap")
 
+	// A directory reused over a frozen image: the image is replaced before
+	// its manifest goes, and a crash or a failed resume in between would leave
+	// the old frozen manifest governing the new unfrozen image. The rewrite is
+	// journalled first, so a restore refuses the image until the manifest is
+	// gone; the journal is cleared with it. Only a host with frozen images
+	// can hold such a manifest.
+	journalled := false
+	if wakeProtocolFloorRaised() && m.frozenManifestAt(memPath) {
+		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, ArtifactID: NewArtifactID()}); err != nil {
+			return "", "", fmt.Errorf("record the ad-hoc rewrite of %q: %w", memPath, err)
+		}
+		journalled = true
+	}
+
 	// Before the snapshot, not after: CreateSnapshot consumes Firecracker's dirty
 	// bitmap and leaves the VM paused, so returning past that point would skip
 	// clearing DirtyTracked and the unpause below. Failing here has done nothing
@@ -3048,6 +3062,11 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 		return "", "", fmt.Errorf("clear wall-clock manifest for ad-hoc snapshot %q: %w", memPath, merr)
 	} else if merr != nil {
 		m.log.Warn().Err(merr).Str("vm_id", vmID).Msg("ad-hoc snapshot: a stale marker could not be removed")
+	}
+	if journalled {
+		if err := clearPauseIntent(snapshotDir); err != nil {
+			return "", "", fmt.Errorf("clear the ad-hoc rewrite journal for %q: %w", memPath, err)
+		}
 	}
 
 	return snapshotPath, memPath, nil
@@ -3636,6 +3655,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// The Running write that overlaps the readiness wait; joined before the
 	// record is trusted, and by the failure worker before it writes Error.
 	var persistDone chan struct{}
+	// Whether a wake-owed record was published for an attempt: a failure
+	// before the wake then returns a restore from a paused record to Paused.
+	wakeOwedPublished := false
 	for attempt = 1; ; attempt++ {
 		tAttemptStart = time.Now()
 		if attempt > 1 {
@@ -3722,6 +3744,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		var joinWakeOwed func(Supervision) bool
 		if restoreWorkloadFrozen {
 			joinWakeOwed = m.persistWakeOwed(inst, predictedSupervision, clockPolicy != nil, restoreFromPaused)
+			wakeOwedPublished = true
 		}
 		m.beginLaunchAttempt(inst)
 		pid, supervision, startErr = m.launchFirecracker(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, existingSupervision, inPlace || priorRunDir, freshUnit && attempt == 1)
@@ -3744,7 +3767,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		if startErr != nil {
 			tFailBoundary = time.Now()
 			m.releaseFailedRestore(vmID, inPlace, false, cleanupAfterRestoreFailure)
-			m.setStatus(vmID, StatusError)
+			m.setStatus(vmID, m.preWakeFailureStatus(inst, wakeOwedPublished && restoreFromPaused))
 			return nil, fmt.Errorf("start firecracker: %w", startErr)
 		}
 		if joinWakeOwed != nil && !optimisticOK {
@@ -3756,7 +3779,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			tFailBoundary = time.Now()
 			m.stopUnitDuringRestoreError(vmID)
 			m.releaseFailedRestore(vmID, inPlace, false, cleanupAfterRestoreFailure)
-			m.setStatus(vmID, StatusError)
+			m.setStatus(vmID, m.preWakeFailureStatus(inst, wakeOwedPublished && restoreFromPaused))
 			return nil, fmt.Errorf("vm %s: wake record could not be made durable before the load", vmID)
 		}
 		publishLaunchPID(inst, pid, supervision)
@@ -4031,7 +4054,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// cleanup or it leaks. See stopUnitDuringRestoreError comment.
 		m.stopUnitDuringRestoreError(vmID)
 		m.releaseFailedRestore(vmID, inPlace, isTapDeviceBusyErr(restoreErr), cleanupAfterRestoreFailure)
-		m.setStatus(vmID, StatusError)
+		m.setStatus(vmID, m.preWakeFailureStatus(inst, wakeOwedPublished && restoreFromPaused))
 		// armLayered may have set DirtyTracked=true on inst before the restore call;
 		// clear it on failure so a lingering instance can't later take a Diff against a
 		// baseline that never loaded. (The VM is StatusError + unit stopped, so this is
@@ -8490,6 +8513,21 @@ func (m *Manager) markUnservable(inst *VMInstance, log zerolog.Logger) {
 		log.Error().Err(err).Msg("pause: guest with an unconfirmed release could not be recorded as error")
 	}
 	log.Error().Msg("pause: guest workload may still be frozen and could not be released; recorded as error")
+}
+
+// preWakeFailureStatus is the status a restore failure before the wake
+// leaves. A wake-owed record published for a paused image returns to Paused,
+// owing nothing: the image is intact, and an Error record a restart would
+// reap as stale. Anything else is Error.
+func (m *Manager) preWakeFailureStatus(inst *VMInstance, returnToPaused bool) VMStatus {
+	if !returnToPaused {
+		return StatusError
+	}
+	inst.mu.Lock()
+	inst.WakePending, inst.ClockFrozen, inst.WakeOwedFromPaused, inst.Unverified = false, false, false, false
+	inst.dropWakeImage()
+	inst.mu.Unlock()
+	return StatusPaused
 }
 
 // abandonDirtyBaseline forgets a dirty-tracking baseline a snapshot consumed

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -8452,6 +8452,9 @@ func (m *Manager) failAfterSnapshot(inst *VMInstance, socketPath string, err err
 // with no confirmed release: Error, so it is not served as running, with its
 // process, intent and artifacts kept for a release that still has the token.
 func (m *Manager) markUnservable(inst *VMInstance, log zerolog.Logger) {
+	// The process stays: capacity must keep charging it behind the Error
+	// record until a confirmed stop or the reconciler's reap clears this.
+	m.vmStopUnconfirmed.Store(inst.ID, struct{}{})
 	inst.mu.Lock()
 	inst.Status = StatusError
 	inst.mu.Unlock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1692,6 +1692,20 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, FreezeToken: freezeToken, ArtifactID: artifactID}); err != nil {
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
 		}
+	} else if wakeProtocolFloorRaised() && snapshotDir == filepath.Join(m.cfg.SnapshotDir, vmID) && m.frozenManifestAt(overlayPath, fullPath) {
+		// An unfrozen pause about to overwrite an image whose manifest says
+		// frozen: the image is rewritten before that manifest is replaced,
+		// and a crash between the two would leave a frozen manifest beside
+		// an image that is not. The intent names the rewrite, so a restore
+		// refuses the image until recovery has removed the stale manifest.
+		// Only a host with frozen images can hold such a manifest, so only
+		// there is this looked for.
+		if artifactID == "" {
+			artifactID = NewArtifactID()
+		}
+		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, ArtifactID: artifactID}); err != nil {
+			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
+		}
 	}
 	// Freeze the workload before the image exists — only when the restore would
 	// freeze the clock; otherwise the freeze buys nothing.
@@ -8427,6 +8441,21 @@ func (m *Manager) ensureWakeFloorTimed(op string) error {
 	return err
 }
 
+// frozenManifestAt reports whether any of the paths carries a manifest that
+// says frozen. A stat first: absent manifests, the common case, cost one
+// lookup each and no read.
+func (m *Manager) frozenManifestAt(paths ...string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(WallClockMarkerPath(p)); err != nil {
+			continue
+		}
+		if man, err := ReadWallClockManifest(p); err == nil && man != nil && man.WorkloadFrozen {
+			return true
+		}
+	}
+	return false
+}
+
 // releaseFrozenGuest thaws a workload a pause froze, after making sure the
 // guest can answer: a snapshot pauses the vCPUs first, so a release after a
 // snapshot that then failed, or after a crash between the two, meets a guest
@@ -8720,6 +8749,17 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 	}
 	if in == nil {
 		return true
+	}
+	if in.FreezeToken == "" {
+		// An unfrozen rewrite that was interrupted: the images here are
+		// unfrozen or torn, so a manifest beside them that says frozen is
+		// stale either way and must not outlive the intent.
+		for _, name := range []string{"mem.diff", "mem.snap"} {
+			if err := removeWallClockManifestDurably(filepath.Join(dir, name)); err != nil {
+				log.Error().Err(err).Msg("reattach: a stale frozen manifest beside an interrupted rewrite could not be removed; parking as error")
+				return false
+			}
+		}
 	}
 	if in.FreezeToken != "" && inst.IP != "" {
 		terr := m.releaseOrConfirmRunning(ctx, inst.SocketPath, inst.IP, in.FreezeToken)

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1877,6 +1877,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			merr := WriteWallClockManifest(memPath, man)
 			manifestDur = time.Since(tManifest)
 			if merr != nil {
+				// The deferred thaw resumes and releases the guest; the
+				// consumed baseline is dropped here so the retry is Full.
+				m.abandonDirtyBaseline(inst)
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("write wall-clock manifest: %w", merr))
 			}
 		} else {
@@ -1898,8 +1901,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 				// one is not. The stale one goes, durably, or the pause
 				// fails; a marker that was not a frozen manifest and will not
 				// go is harmless and only logged.
-				if frozen, rerr := removeWallClockManifest(memPath); rerr != nil && frozen {
-					return "", "", nil, m.failAfterSnapshot(vmID, socketPath, fmt.Errorf("wall-clock manifest write failed (%v) and the stale frozen one could not be cleared: %w", merr, rerr))
+				if blocking, rerr := removeWallClockManifest(memPath); rerr != nil && blocking {
+					return "", "", nil, m.failAfterSnapshot(inst, socketPath, fmt.Errorf("wall-clock manifest write failed (%v) and the stale one could not be cleared: %w", merr, rerr))
 				} else if rerr != nil {
 					log.Warn().Err(rerr).Str("path", WallClockMarkerPath(memPath)).Msg("pause: a stale marker could not be removed")
 				}
@@ -1909,16 +1912,16 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	} else {
 		// No manifest for a guest that cannot correct its clock; a stale one
-		// goes, durably. A marker that was never a frozen manifest and will
-		// not go is harmless. The vCPUs are paused from the snapshot on: a
+		// goes, durably. A marker that will not go fails the pause unless it
+		// is known harmless. The vCPUs are paused from the snapshot on: a
 		// failure here must not strand them.
 		tManifest := time.Now()
-		frozen, merr := removeWallClockManifest(memPath)
+		blocking, merr := removeWallClockManifest(memPath)
 		if d := time.Since(tManifest); d > time.Millisecond {
 			manifestDur = d
 		}
-		if merr != nil && frozen {
-			return "", "", nil, m.failAfterSnapshot(vmID, socketPath, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
+		if merr != nil && blocking {
+			return "", "", nil, m.failAfterSnapshot(inst, socketPath, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
 		} else if merr != nil {
 			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).Msg("pause: a stale marker could not be removed")
 		}
@@ -8416,14 +8419,26 @@ func (m *Manager) ensureWakeFloorTimed(op string) error {
 
 // failAfterSnapshot is the error return for a pause that fails after its
 // snapshot: Firecracker left the vCPUs paused and the record says Running,
-// so the guest is resumed first, best-effort, before the error.
-func (m *Manager) failAfterSnapshot(vmID, socketPath string, err error) error {
+// so the guest is resumed first, best-effort, before the error. The snapshot
+// consumed the dirty bitmap, so the retry must be Full: a Diff would hold
+// only the pages dirtied since, and the abandoned overlay's would be lost.
+func (m *Manager) failAfterSnapshot(inst *VMInstance, socketPath string, err error) error {
+	m.abandonDirtyBaseline(inst)
 	uctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if uerr := fcUnpauseVM(uctx, socketPath); uerr != nil {
-		m.log.Error().Err(uerr).Str("vm_id", vmID).Msg("pause failed after its snapshot and the guest could not be resumed")
+		m.log.Error().Err(uerr).Str("vm_id", inst.ID).Msg("pause failed after its snapshot and the guest could not be resumed")
 	}
-	return m.handleVMError(vmID, err)
+	return m.handleVMError(inst.ID, err)
+}
+
+// abandonDirtyBaseline forgets a dirty-tracking baseline a snapshot consumed
+// and this pause then abandoned: the next pause must be Full.
+func (m *Manager) abandonDirtyBaseline(inst *VMInstance) {
+	inst.mu.Lock()
+	inst.DirtyTracked = false
+	inst.DirtyTrackingSessionID = ""
+	inst.mu.Unlock()
 }
 
 // frozenManifestAt reports whether any of the paths carries a manifest that
@@ -8726,6 +8741,17 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 		for _, name := range []string{"mem.diff", "mem.snap"} {
 			if _, err := removeWallClockManifest(filepath.Join(dir, name)); err != nil {
 				log.Error().Err(err).Msg("reattach: a stale frozen manifest beside an interrupted rewrite could not be removed; parking as error")
+				return false
+			}
+		}
+		// The snapshot may have paused the vCPUs before the crash: resume
+		// them and confirm the guest answers, or it is not served as running.
+		if inst.SocketPath != "" && inst.IP != "" {
+			uctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+			_ = fcUnpauseVM(uctx, inst.SocketPath)
+			cancel()
+			if err := boxdHealthProbe(context.WithoutCancel(ctx), inst.IP, 5*time.Second); err != nil {
+				log.Error().Err(err).Msg("reattach: guest did not answer after an interrupted rewrite; parking as error")
 				return false
 			}
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1503,11 +1503,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	var snapshotType string
 	var tSnapshot time.Time
 	var snapshotDur, stopDur time.Duration
-	// Deferred, gated on freeze or snapshot work having begun: a freeze that
-	// fails, or a CreateSnapshot that burns seconds and then fails, must land
-	// in the pause distributions — those are the pauses worth seeing. The
-	// already-paused retry guard (before either) still deliberately emits
-	// nothing.
+	// Deferred, gated on freeze or snapshot work having begun: a failed
+	// freeze or a slow failed snapshot must land in the pause distributions.
+	// The already-paused retry guard still emits nothing.
 	var freezeDur, manifestDur time.Duration
 	var tFreeze time.Time
 	defer func() {
@@ -1666,11 +1664,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	if correctsWallClock {
 		freezeToken, artifactID = NewFreezeToken(), NewArtifactID()
 	}
-	// Only a pause that will freeze the guest records its intent (see
-	// pause_intent.go), and only once this host's floor is up: recovery looks
-	// for intents on such hosts alone. Durable BEFORE the freeze: a crash
-	// after it must find the token, or the guest stays frozen with nobody
-	// able to release it.
+	// Only a pause that will freeze records its intent (see pause_intent.go),
+	// and only once the floor is up: recovery looks for intents there alone.
+	// Durable before the freeze, or a crash leaves a guest nobody can release.
 	willFreeze := correctsWallClock && m.cfg.GuestClockFreezeEnabled && m.clockRealtimeCapable.Load() && !m.guestClockUnready.Load()
 	if willFreeze {
 		tFreeze = time.Now()
@@ -1678,11 +1674,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record the rollback floor before freezing: %w", err))
 		}
 	}
-	// Whatever this pause plans, an image of this guest is published only
-	// once a freeze an earlier pause may have left is resolved: a custom
-	// directory, or a host that cannot freeze today, does not turn a frozen
-	// workload into an unfrozen image. A pause refused here leaves that
-	// intent, and its token, for the next attempt.
+	// Whatever this pause plans, a freeze an earlier pause left is resolved
+	// first: a custom directory or a host that cannot freeze must not publish
+	// a frozen workload as unfrozen. A refusal keeps that intent for the retry.
 	if err := m.resolveOutstandingFreeze(ctx, vmID, socketPath, instIP, recordedArtifact, log); err != nil {
 		return "", "", nil, m.handleVMError(vmID, err)
 	}
@@ -1693,13 +1687,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
 		}
 	} else if wakeProtocolFloorRaised() && snapshotDir == filepath.Join(m.cfg.SnapshotDir, vmID) && m.frozenManifestAt(overlayPath, fullPath) {
-		// An unfrozen pause about to overwrite an image whose manifest says
-		// frozen: the image is rewritten before that manifest is replaced,
-		// and a crash between the two would leave a frozen manifest beside
-		// an image that is not. The intent names the rewrite, so a restore
-		// refuses the image until recovery has removed the stale manifest.
-		// Only a host with frozen images can hold such a manifest, so only
-		// there is this looked for.
+		// An unfrozen pause overwriting an image whose manifest says frozen:
+		// the image is rewritten before the manifest is replaced, so the
+		// rewrite is recorded and a restore refuses the image until recovery
+		// removes the stale manifest. Only a host with frozen images holds one.
 		if artifactID == "" {
 			artifactID = NewArtifactID()
 		}
@@ -1871,18 +1862,11 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	}
 
-	// The manifest lands only after the image exists, and only beside the
-	// image this pause wrote: the manifest of an image it did not touch keeps
-	// describing that image, which is still the last good one if this pause
-	// failed or died before here. A frozen image's manifest is mandatory and
-	// durable: an overlay that lost it would read as legacy on another host
-	// and its workload would never be woken, so the deferred thaw releases
-	// the guest on this failure. An unfrozen image's manifest only spares the
-	// next resume a slower path, so it is written without durability barriers
-	// and a failure is logged: nothing on the ordinary pause path waits on a
-	// sync for it. A guest that cannot correct its clock gets no manifest, so
-	// one an earlier image left at this path is removed: a stale frozen one
-	// beside this unfrozen image would send a wake nothing answers.
+	// The manifest lands after the image, beside the image this pause wrote
+	// only: an untouched image keeps its own, still the last good one if this
+	// pause dies here. Frozen: mandatory and durable, or an overlay would read
+	// as legacy elsewhere and never be woken; the deferred thaw releases the
+	// guest on failure.
 	if correctsWallClock {
 		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifactID, WorkloadFrozen: guestFrozen, GuestCorrectsClock: true}
 		if guestFrozen {
@@ -1896,12 +1880,9 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("write wall-clock manifest: %w", merr))
 			}
 		} else {
-			// Unfrozen. Where no manifest exists the write is lazy: lost to a
-			// crash, it costs the next resume a slower path, never a wrong
-			// clock. Where one exists it is REPLACED durably: the one there
-			// may say frozen under a token this guest already answered, and
-			// a crash that let it survive beside this image would have a
-			// restore present that token and run the clock uncorrected.
+			// Unfrozen: lazy where no manifest exists, since losing it costs
+			// only a slower resume; replaced durably where one exists, since
+			// it may say frozen under a token this guest already answered.
 			_, serr := os.Stat(clockFreezeMarkerPath(memPath))
 			replacing := serr == nil
 			var merr error
@@ -1927,11 +1908,10 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			}
 		}
 	} else {
-		// A guest that cannot correct its clock gets no manifest; one an
-		// earlier image left here goes, durably, for the reason above. A
-		// marker that was not a frozen manifest and will not go is harmless:
-		// the image reads as legacy either way. The vCPUs are paused from
-		// the snapshot on, so a failure here must not strand them.
+		// No manifest for a guest that cannot correct its clock; a stale one
+		// goes, durably. A marker that was never a frozen manifest and will
+		// not go is harmless. The vCPUs are paused from the snapshot on: a
+		// failure here must not strand them.
 		tManifest := time.Now()
 		frozen, merr := removeWallClockManifest(memPath)
 		if d := time.Since(tManifest); d > time.Millisecond {
@@ -2382,10 +2362,8 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	recordedCorrects, recordedFrozen, recordedToken := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen, inst.FreezeToken
 	pausedMemPath, recordedArtifact, entryUnverified := inst.MemFilePath, inst.ArtifactID, inst.Unverified
 	// The identity the record carried in: a frozen resume stamps this run's
-	// slot on it before the launch, and a resume that does not commit hands
-	// it back, since the slot is released. The token of the image being
-	// loaded rides WakeToken until the commit, so the record's own image and
-	// token stay paired whatever happens in between.
+	// slot before the launch and hands it back if it does not commit. The
+	// loaded image's token rides WakeToken until the commit.
 	entrySocket, entryIP, entryTAP, entryMAC, entryNS := inst.SocketPath, inst.IP, inst.TAPDevice, inst.MACAddress, inst.Namespace
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
@@ -2977,11 +2955,9 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	if snapshotDir == "" {
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID, fmt.Sprintf("snap-%d", time.Now().Unix()))
 	}
-	// An ad-hoc image is never marked, so it restores without a wake: it may
-	// only be taken of a running guest no earlier pause left frozen. A paused
-	// record's Firecracker may have outlived a failed stop, its workload
-	// frozen for the image that pause published; an image of it from here
-	// would never be woken.
+	// An ad-hoc image is never marked, so it restores without a wake: only a
+	// running guest no earlier pause left frozen may be captured. A paused
+	// record's Firecracker may have outlived a failed stop, workload frozen.
 	inst.mu.RLock()
 	adHocStatus := inst.Status
 	adHocSocket, adHocIP, adHocArtifact := inst.SocketPath, inst.IP, inst.ArtifactID
@@ -3465,13 +3441,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 	}
 	// What the image says about its guest, read once per restore: whether its
-	// workload is frozen (and so owes a wake with this token) and whether the
-	// guest corrects its clock. Read from the disk every time, never
-	// remembered by path: a template directory is meant to be immutable, but
-	// a cache here would turn any exception into a frozen image restored the
-	// old way, with its workload never released. One small open beside the
-	// sidecar read this path already does. A manifest this binary cannot
-	// trust refuses the restore here, before anything is launched.
+	// workload is frozen and whether the guest corrects its clock. Read from
+	// disk every time, never cached by path: a cache would turn any exception
+	// into a frozen image restored the old way. One small open beside the
+	// sidecar read here; an untrusted manifest refuses before any launch.
 	manifest, merr := imageManifest(memPath)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
@@ -4069,12 +4042,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	if wakeErr != nil {
 		err := wakeErr
-		// The verdict this failure leaves behind. A wake the guest refused
-		// as another freeze's is terminal: Error, owing nothing, or recovery
-		// would read it as a resume to return to Paused. A wake that merely
-		// did not happen on an image the record was paused into leaves that
-		// image intact: the record returns to Paused, as a resume's failure
-		// does, rather than to an Error a restart would reap as stale.
+		// The verdict this failure leaves. A wake refused as another freeze's
+		// is terminal: Error, owing nothing. A wake that merely did not happen
+		// on the image the record was paused into returns it to Paused, as a
+		// resume's failure does, not to an Error a restart would reap.
 		verdict := StatusError
 		if errors.Is(err, ErrGuestTokenMismatch) {
 			inst.mu.Lock()
@@ -5053,11 +5024,10 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		return inst, true
 	}
 	m.mu.RUnlock()
-	// A request arriving while the startup pass still owes this VM its wake
-	// waits for that outcome rather than adopting a frozen guest — for as
-	// long as a wake can take behind everything queued ahead of it in the
-	// bounded pool, not the flight's own short budget: giving up early would
-	// report a live VM as missing and invite a replacement.
+	// A request meeting a wake the startup pass still owes waits for the
+	// outcome rather than adopting a frozen guest: as long as a wake can take
+	// behind everything queued ahead of it, since giving up early would
+	// report a live VM as missing.
 	if pw := m.pendingWake(rec.ID); pw != nil && !cleanupStale {
 		published := func() (*VMInstance, bool) {
 			m.mu.RLock()
@@ -5244,10 +5214,8 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		if fullyDown {
 			if rec.Status == StatusRunning && rec.Unverified && rec.WakePending && rec.WakeOwedFromPaused {
 				// A resume that published its wake-owed record and died before
-				// its Firecracker launched. The paused image is intact, so the
-				// sandbox returns to Paused rather than being reaped as a
-				// failed create; the record is rewritten before it is read as
-				// Paused, so a second restart sees the same thing.
+				// its launch: the paused image is intact, so the record returns
+				// to Paused instead of being reaped, rewritten before it is read.
 				log.Warn().Msg("resume interrupted before its launch — record returns to Paused")
 				rec.Status = StatusPaused
 				rec.WakePending, rec.ClockFrozen, rec.WakeOwedFromPaused, rec.Unverified = false, false, false, false
@@ -5394,11 +5362,10 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	}
 	if rec.Status == StatusRunning && inst.WakePending {
 		if cleanupStale {
-			// The startup pass queues it for the pool after the pass, holding
-			// the VM's lifecycle lock from here until the pool publishes the
-			// outcome: a restore or resume for this id waits on that lock,
-			// never on the pool. If a request already holds the lock, its own
-			// lazy reattach completes the wake inline; nothing to queue.
+			// Queued for the pool after the pass, holding the lifecycle lock
+			// until the pool publishes the outcome, so a restore or resume for
+			// this id waits on the lock, never on the pool. A request already
+			// holding the lock completes the wake inline.
 			unlock, ok := m.tryLockVMOp(inst.ID)
 			if !ok {
 				log.Info().Msg("reattach: a request holds this VM's lock; leaving its owed wake to that request")
@@ -5538,12 +5505,10 @@ func (m *Manager) reattachByID(vmID string, cleanupStale bool) *VMInstance {
 		return got, nil
 	})
 	if errors.Is(err, errReattachDeferred) && !cleanupStale {
-		// The startup pass found this VM's lifecycle lock held and left its
-		// owed wake to whoever holds it — a caller that joined this very
-		// flight. That caller must not read the deferral as "no such VM": it
-		// reattaches itself, completing the wake inline. Through a flight of
-		// its own, so every joiner of the deferred one shares a single
-		// recovery instead of each running one against the same guest.
+		// The startup pass found this VM's lock held and left its owed wake to
+		// the holder, a caller that joined this flight: it reattaches itself,
+		// completing the wake inline through a flight of its own, so joiners
+		// share one recovery.
 		v2, _, _ := m.reattachSF.Do(vmID+"\x00retry", func() (any, error) {
 			rec, gerr := m.state.Get(vmID)
 			if gerr != nil || rec == nil {
@@ -8400,11 +8365,10 @@ func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VM
 		}
 		return err
 	}
-	// The image this wake was owed for is the one running now. A resume
-	// from an override that died before its commit commits here, as its own
-	// commit would have: a retry of it then finds the sandbox up instead of
-	// relaunching over it. Its facts come from its manifest; one read, on
-	// the recovery path only.
+	// The image this wake was owed for is the one running now: a resume
+	// from an override that died before its commit commits here, so a retry
+	// finds the sandbox up instead of relaunching over it. One manifest
+	// read, on the recovery path only.
 	var image *WallClockManifest
 	if wakeMem != "" {
 		image, _ = imageManifest(wakeMem)
@@ -8451,11 +8415,8 @@ func (m *Manager) ensureWakeFloorTimed(op string) error {
 }
 
 // failAfterSnapshot is the error return for a pause that fails after its
-// snapshot landed: Firecracker left the vCPUs paused for the snapshot, and
-// a pause that returns an error keeps the VM recorded Running, so the guest
-// is resumed first — a stopped sandbox that reads as running is the one
-// outcome this must never leave. Best-effort: a guest that cannot be
-// resumed is reported as the error it already was.
+// snapshot: Firecracker left the vCPUs paused and the record says Running,
+// so the guest is resumed first, best-effort, before the error.
 func (m *Manager) failAfterSnapshot(vmID, socketPath string, err error) error {
 	uctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -8480,11 +8441,9 @@ func (m *Manager) frozenManifestAt(paths ...string) bool {
 	return false
 }
 
-// releaseFrozenGuest thaws a workload a pause froze, after making sure the
-// guest can answer: a snapshot pauses the vCPUs first, so a release after a
-// snapshot that then failed, or after a crash between the two, meets a guest
-// that cannot run boxd until Firecracker resumes it. The unpause is
-// best-effort — a guest never paused refuses it — and the thaw is the verdict.
+// releaseFrozenGuest thaws a workload a pause froze, after resuming the
+// vCPUs a snapshot may have paused so the guest can answer. The unpause is
+// best-effort; the thaw is the verdict.
 func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token string) error {
 	// Each step bounded on its own: a stuck Firecracker API must neither hang
 	// this caller nor eat the thaw's budget.
@@ -8500,13 +8459,10 @@ func (m *Manager) releaseFrozenGuest(ctx context.Context, socketPath, ip, token 
 }
 
 // resolveOutstandingFreeze releases, or confirms released, a workload an
-// earlier pause of this VM may have left frozen (its reply lost, its thaw
-// unconfirmed), before any image of the guest can be published as unfrozen.
-// The intent that pause left is the only holder of its token; it is cleared
-// once nothing is frozen under it, and kept when that cannot be shown. The
-// leftover of a pause that completed names this record's artifact and is
-// nothing to resolve. Intents exist only on a host whose floor is up, so a
-// host with the floor down looks for nothing.
+// earlier pause may have left frozen, before any image of the guest is
+// published as unfrozen. Its intent is cleared once nothing is frozen under
+// it and kept otherwise; a completed pause's leftover names the record's
+// artifact and is nothing to resolve. Only a host whose floor is up holds intents.
 func (m *Manager) resolveOutstandingFreeze(ctx context.Context, vmID, socketPath, ip, recordedArtifact string, log zerolog.Logger) error {
 	if !wakeProtocolFloorRaised() {
 		return nil
@@ -8549,17 +8505,11 @@ func (m *Manager) releaseOrConfirmRunning(ctx context.Context, socketPath, ip, t
 var fcUnpauseVM = UnpauseVMContext
 
 // persistWakeOwed publishes Running with a wake owed and starts the durable
-// write so it overlaps the launch. A crash after the load must find a record
-// that owes a wake, or recovery could adopt an older verified record over a
-// guest whose workload is still frozen. The returned join waits for the
-// write, re-persists if the launch landed in another supervision mode, and
-// reports whether the record is durable; the caller must not load the
-// snapshot otherwise. The status is set directly: setStatus would persist
-// synchronously, on the launch path. PausedAt is kept: a failure returns a
-// resume to Paused in its place in the reclaim order, and the commit clears it.
-//
-// fromPaused says the record was Paused before this began, so recovery may
-// return it there; a create's record has nowhere to return to.
+// write under the launch: a crash after the load must find a record owing a
+// wake. The join waits for the write, re-persists if the launch landed in
+// another supervision mode, and reports durability; the caller must not load
+// otherwise. PausedAt is kept so a failure returns a resume to its place.
+// fromPaused says recovery may return the record to Paused.
 func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clockFrozen, fromPaused bool) (join func(actual Supervision) bool) {
 	inst.mu.Lock()
 	inst.Status = StatusRunning
@@ -8585,14 +8535,11 @@ func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clock
 	}
 }
 
-// persistWhileTracked writes the record and then checks the instance still
-// owns its id. DestroyVM takes no lifecycle lock, so its record delete can
-// land on either side of this write; a write that landed after it would
-// resurrect a VM the user destroyed, and the early failure paths of a launch
-// never write again to notice. Checking AFTER the write leaves no window: a
-// destroy either erased the record itself or is caught here, and the write
-// is erased in turn. Reports false when the VM is gone, so the caller
-// aborts a launch that has nothing to run for.
+// persistWhileTracked writes the record, then checks the instance still owns
+// its id: DestroyVM takes no lifecycle lock, so its delete can land either
+// side of this write, and a write landing after it would resurrect the VM.
+// Checked after the write there is no window; the write is erased and false
+// returned when the VM is gone.
 func (m *Manager) persistWhileTracked(inst *VMInstance) bool {
 	ok := m.persistState(inst)
 	m.mu.RLock()
@@ -8756,11 +8703,9 @@ func (m *Manager) completeOwedWake(ctx context.Context, inst *VMInstance, log ze
 	return nil
 }
 
-// recoverPauseIntent releases a guest that a pause froze and then died
-// before finishing. True when nothing is owed or the guest is released;
-// false when a frozen guest could not be released and must not be served.
-// Only a host whose floor is up ever holds an intent, so elsewhere nothing
-// is looked for.
+// recoverPauseIntent releases a guest a pause froze and then died before
+// finishing. True when nothing is owed or the guest is released; false when
+// a frozen guest could not be released and must not be served.
 func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log zerolog.Logger) bool {
 	if !wakeProtocolFloorRaised() {
 		return true
@@ -8816,13 +8761,10 @@ func (m *Manager) publishRecovered(inst *VMInstance) {
 	}
 }
 
-// parkUnservable stops a guest whose state recovery could not settle — a
-// freeze it could not release, a wake it did not answer. Stopped first, and
-// confirmed as far as the stop can confirm: a guest in an unknown state must
-// not keep running behind a record until a grace period reaps it. A resume
-// that never completed returns to Paused, as its own failure path would:
-// its image is intact and its workload never ran. A terminal verdict — a
-// wake the guest refused as another freeze's — and anything else is Error.
+// parkUnservable stops a guest whose recovery could not settle, confirmed as
+// far as the stop can, so an unknown guest never runs on behind a record. A
+// resume that never completed returns to Paused, its image intact; a refused
+// wake, or anything else, is Error.
 func (m *Manager) parkUnservable(inst *VMInstance, terminal bool) {
 	m.stopUnitDuringRestoreError(inst.ID)
 	inst.mu.Lock()

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2911,10 +2911,17 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 		snapshotDir = filepath.Join(m.cfg.SnapshotDir, vmID, fmt.Sprintf("snap-%d", time.Now().Unix()))
 	}
 	// An ad-hoc image is never marked, so it restores without a wake: it may
-	// only be taken of a guest no earlier pause left frozen.
+	// only be taken of a running guest no earlier pause left frozen. A paused
+	// record's Firecracker may have outlived a failed stop, its workload
+	// frozen for the image that pause published; an image of it from here
+	// would never be woken.
 	inst.mu.RLock()
+	adHocStatus := inst.Status
 	adHocSocket, adHocIP, adHocArtifact := inst.SocketPath, inst.IP, inst.ArtifactID
 	inst.mu.RUnlock()
+	if adHocStatus != StatusRunning {
+		return "", "", status.Errorf(codes.FailedPrecondition, "vm %s is %v; an ad-hoc snapshot needs a running VM", vmID, adHocStatus)
+	}
 	if err := m.resolveOutstandingFreeze(ctx, vmID, adHocSocket, adHocIP, adHocArtifact, m.log.With().Str("vm_id", vmID).Logger()); err != nil {
 		return "", "", err
 	}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2414,6 +2414,17 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			_, _ = m.persistStateIfPresent(inst)
 		}
 	}()
+	// If this Firecracker refuses the clock option, the record must say the
+	// clock ran before the legacy retry can run the vCPUs.
+	demote := func() error {
+		inst.mu.Lock()
+		inst.ClockFrozen = false
+		inst.mu.Unlock()
+		if !m.persistState(inst) {
+			return fmt.Errorf("vm %s: clock policy could not be made durable before the legacy restore", vmID)
+		}
+		return nil
+	}
 	// Two passes at most: a frozen-clock restore whose guest cannot correct its
 	// clock is relaunched unfrozen. Only Firecracker is torn down between
 	// passes; the slot, the network, and this frame's cleanup are kept.
@@ -2429,6 +2440,17 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			if m.cgroupLaunch(resumeExisting) {
 				predicted = SupervisionCgroup
 			}
+			// The record recovery would act on must name this launch's guest:
+			// the slot this resume took and the token the image resolved to,
+			// stamped before the write that owes the wake, not after it.
+			inst.mu.Lock()
+			inst.SocketPath = socketPath
+			inst.IP = netInfo.HostIP
+			inst.TAPDevice = netInfo.TAPDevice
+			inst.MACAddress = netInfo.MACAddress
+			inst.Namespace = nsName
+			inst.FreezeToken = resumeToken
+			inst.mu.Unlock()
 			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil, true)
 			published = true
 		}
@@ -2464,7 +2486,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		if m.restoreForResumeHook != nil {
 			dirtyTracked, trackingSessionID, restoreErr = m.restoreForResumeHook(socketPath, snapshotPath, memPath, basePath, netInfo)
 		} else {
-			dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, resumePolicy)
+			dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, resumePolicy, demote)
 		}
 		tRestoreDone = time.Now()
 		if restoreErr != nil {
@@ -2635,8 +2657,9 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 // whether dirty-page tracking was armed so the caller can decide if the next pause
 // may write a Diff.
 // clockPolicy is resolved by the caller so the resume log can report what was
-// asked for without stat-ing the marker a second time.
-func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo, clockPolicy *bool) (dirtyTracked bool, trackingSessionID string, clockFrozen bool, err error) {
+// asked for without stat-ing the marker a second time; beforeLegacy runs
+// before the legacy retry if this Firecracker refuses the option.
+func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo, clockPolicy *bool, beforeLegacy func() error) (dirtyTracked bool, trackingSessionID string, clockFrozen bool, err error) {
 	useUffd := m.cfg.ResumeUffdEnabled && m.cfg.UffdEnabled && netInfo != nil && netInfo.TAPDevice != ""
 	if !useUffd {
 		// A layered overlay can only be served by the UFFD layered backend. If this
@@ -2646,7 +2669,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 		if basePath != "" {
 			return false, "", false, fmt.Errorf("layered overlay %q requires UFFD resume (resume-uffd + uffd + tap); refusing File-backend restore", memPath)
 		}
-		used, rerr := m.restoreWithClockFallback(clockPolicy, nil, func(clock *bool) error {
+		used, rerr := m.restoreWithClockFallback(clockPolicy, beforeLegacy, func(clock *bool) error {
 			return RestoreSnapshot(socketPath, snapshotPath, memPath, "", clock)
 		})
 		return false, "", used, rerr
@@ -2661,7 +2684,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 		sessionID = newTrackingSessionID()
 	}
 	armed, used, rerr := m.restoreWithSessionFallback(sessionID, func(sid string) (bool, error) {
-		return m.restoreWithClockFallback(clockPolicy, nil, func(clock *bool) error {
+		return m.restoreWithClockFallback(clockPolicy, beforeLegacy, func(clock *bool) error {
 			return RestoreSnapshotUffdInternalWithOverrides(
 				socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 				m.cfg.HandlerDeathAbortEnabled, sid, clock,
@@ -3464,6 +3487,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		tBoxdStart         time.Time
 		optimisticOK       bool
 	)
+	// The Running write that overlaps the readiness wait; joined before the
+	// record is trusted, and by the failure worker before it writes Error.
+	var persistDone chan struct{}
 	for attempt = 1; ; attempt++ {
 		tAttemptStart = time.Now()
 		if attempt > 1 {
@@ -3746,7 +3772,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// An unfrozen image publishes Running after the load, the write
 			// overlapping the readiness wait; a crash here leaves an unverified
 			// record, which adoption re-verifies before trusting.
-			var persistDone chan struct{}
+			persistDone = nil
 			if !restoreWorkloadFrozen {
 				inst.mu.Lock()
 				inst.Status = StatusRunning
@@ -3793,10 +3819,15 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				wakeErr = boxdHealthProbe(ctx, hostIP, readiness)
 			}
 			stopDiag()
-			if persistDone != nil {
+			// The write overlapping the wait must land before the vCPUs are
+			// trusted or the same instance is relaunched. A failed restore
+			// joins it in its detached worker instead, so a stalled store
+			// delays neither the teardown nor the reply.
+			retryUnfrozen := wakeErr != nil && !clockRetried && restoreClockFrozen && errors.Is(wakeErr, ErrGuestClockUnready)
+			if (wakeErr == nil || retryUnfrozen) && persistDone != nil {
 				<-persistDone
 			}
-			if wakeErr == nil || clockRetried || !restoreClockFrozen || !errors.Is(wakeErr, ErrGuestClockUnready) {
+			if !retryUnfrozen {
 				break
 			}
 			// The guest could not correct a frozen clock. The host is latched now,
@@ -3946,6 +3977,11 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		go func() {
 			defer sentrylog.Recover("restore-error-persist")
+			// The optimistic Running write may still be in flight; it lands
+			// before the Error write below so it cannot overwrite it.
+			if persistDone != nil {
+				<-persistDone
+			}
 			// The identity check and the Error write must be atomic against
 			// a same-ID retry, which serializes on the lifecycle lock: held
 			// here, the map entry cannot be replaced between check and
@@ -8370,9 +8406,15 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 	}
 	if in.FreezeToken != "" && inst.IP != "" {
 		terr := m.releaseFrozenGuest(ctx, inst.SocketPath, inst.IP, in.FreezeToken)
-		// A token the guest never froze under means the crash came before
-		// the freeze: nothing to release.
-		if terr != nil && !errors.Is(terr, ErrGuestTokenMismatch) {
+		if errors.Is(terr, ErrGuestTokenMismatch) {
+			// A token the guest never froze under means the crash came before
+			// the freeze, unless the guest is still frozen under an earlier
+			// one: only a workload confirmed running owes nothing.
+			rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+			terr = boxdGuestRunning(rctx, inst.IP)
+			cancel()
+		}
+		if terr != nil {
 			log.Error().Err(terr).Msg("reattach: a pause left this guest frozen and it could not be released; parking as error")
 			return false
 		}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -2534,7 +2534,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		if err != nil {
 			return nil, fmt.Errorf("start firecracker for restore: %w", err)
 		}
-		if !durable && !m.persistState(inst) {
+		if !durable && !m.persistWhileTracked(inst) {
 			// Fail closed: the vCPUs must not run ahead of the record that
 			// owes their wake.
 			m.stopUnitDuringRestoreError(vmID)
@@ -3692,7 +3692,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			return nil, fmt.Errorf("start firecracker: %w", startErr)
 		}
 		if joinWakeOwed != nil && !optimisticOK {
-			optimisticOK = m.persistState(inst)
+			optimisticOK = m.persistWhileTracked(inst)
 		}
 		if joinWakeOwed != nil && !optimisticOK {
 			// Fail closed: the vCPUs must not run ahead of the record that
@@ -7285,9 +7285,17 @@ func (m *Manager) releaseFailedRestore(vmID string, inPlace, tapBusy bool, clean
 // firecracker process leaks. Mode-aware: cgroup mode's kill waits for the
 // group to empty by construction (so the slot-recycle-races-tap concern the
 // unit path handles with a MainPID SIGKILL is already covered).
+// restoreErrorStopBudget bounds the stop of what a failed launch started,
+// and restoreErrorProcessWait the wait for its process to go, on the error
+// paths of restore and resume and in wake recovery.
+const (
+	restoreErrorStopBudget  = 10 * time.Second
+	restoreErrorProcessWait = 2 * time.Second
+)
+
 func (m *Manager) stopUnitDuringRestoreError(vmID string) {
 	supervision := m.supervisionForVM(vmID)
-	stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	stopCtx, cancel := context.WithTimeout(context.Background(), restoreErrorStopBudget)
 	defer cancel()
 	stopErr := m.stopVM(stopCtx, vmID, supervision)
 	if stopErr != nil {
@@ -8485,15 +8493,35 @@ func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clock
 	go func() {
 		defer sentrylog.Recover("wake-owed-persist")
 		defer close(done)
-		ok = m.persistState(inst)
+		ok = m.persistWhileTracked(inst)
 	}()
 	return func(actual Supervision) bool {
 		<-done
 		if !ok || actual != predicted {
-			ok = m.persistState(inst)
+			ok = m.persistWhileTracked(inst)
 		}
 		return ok
 	}
+}
+
+// persistWhileTracked writes the record and then checks the instance still
+// owns its id. DestroyVM takes no lifecycle lock, so its record delete can
+// land on either side of this write; a write that landed after it would
+// resurrect a VM the user destroyed, and the early failure paths of a launch
+// never write again to notice. Checking AFTER the write leaves no window: a
+// destroy either erased the record itself or is caught here, and the write
+// is erased in turn. Reports false when the VM is gone, so the caller
+// aborts a launch that has nothing to run for.
+func (m *Manager) persistWhileTracked(inst *VMInstance) bool {
+	ok := m.persistState(inst)
+	m.mu.RLock()
+	tracked := m.vms[inst.ID] == inst
+	m.mu.RUnlock()
+	if !tracked {
+		m.deleteState(inst.ID)
+		return false
+	}
+	return ok
 }
 
 // pendingWake is a reattached instance that owes its guest a wake. The startup
@@ -8550,16 +8578,20 @@ func (m *Manager) noteWakeDrainStarted() {
 // pendingWakeWaitBoundFor is a seam over pendingWakeWaitBound for tests.
 var pendingWakeWaitBoundFor = pendingWakeWaitBound
 
+// wakeRecoveryRound is how long one queued wake can occupy a pool worker:
+// the wake's own budget and then, if it failed, the teardown of what was
+// launched — the bounded stop and the wait for its process — with a margin.
+const wakeRecoveryRound = boxdResumeReadyBudget + restoreErrorStopBudget + restoreErrorProcessWait + 5*time.Second
+
 // pendingWakeWaitBound is how long a request may wait for a queued wake: the
-// pool serves queued wakes wakeRecoveryWorkers at a time, each bounded by
-// the wake's own budget, so a wake queued behind n others is served within
-// that many rounds of it.
+// pool serves queued wakes wakeRecoveryWorkers at a time, each within a
+// round, so a wake queued behind n others is served within that many rounds.
 func pendingWakeWaitBound(queued int) time.Duration {
 	rounds := (queued + wakeRecoveryWorkers - 1) / wakeRecoveryWorkers
 	if rounds < 1 {
 		rounds = 1
 	}
-	return time.Duration(rounds) * (boxdResumeReadyBudget + 5*time.Second)
+	return time.Duration(rounds) * wakeRecoveryRound
 }
 
 func (m *Manager) queuePendingWake(inst *VMInstance, unlock func()) {

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -129,10 +129,15 @@ type VMInstance struct {
 	ArtifactID string
 	// SnapshotWorkloadFrozen: see VMRecord.
 	SnapshotWorkloadFrozen *bool
-	CreatedAt              time.Time
-	Metadata               map[string]string
-	TeamID                 string // owning team; carried for data-plane usage attribution
-	OwnerID                string // creating user; empty when unknown
+	// WakePending / ClockFrozen: see VMRecord.
+	WakePending bool
+	ClockFrozen bool
+	// FreezeToken is the token the image's freeze carries; a wake must present it.
+	FreezeToken string
+	CreatedAt   time.Time
+	Metadata    map[string]string
+	TeamID      string // owning team; carried for data-plane usage attribution
+	OwnerID     string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -357,6 +362,10 @@ type ManagerConfig struct {
 	// rather than hanging silently. Independent of the snapshot flags. Default false.
 	HandlerDeathAbortEnabled bool
 
+	// GuestFreezeBudget bounds the pause-side wait for a guest to stop its
+	// workload before a frozen-clock snapshot. Zero means the default.
+	GuestFreezeBudget time.Duration
+
 	// GuestClockFreezeEnabled lets a restore ask Firecracker to freeze the guest's
 	// monotonic clock across the snapshot instead of advancing it by the time the
 	// snapshot sat unused. Only takes effect for a snapshot whose guest can correct
@@ -475,6 +484,8 @@ type Manager struct {
 	launchFirecrackerHook func(ctx context.Context, vmID, socketPath, perVMRootfs, basePath, netNS string, existing Supervision, hadPriorLife, freshUnit bool) (pid int, supervision Supervision, err error)
 	// restoreForResumeHook is a test seam for the snapshot restore step.
 	restoreForResumeHook func(socketPath, snapshotPath, memPath, basePath string, netInfo *network.VMNetInfo) (dirtyTracked bool, trackingSessionID string, err error)
+	// restoreSnapshotHook is the restore path's.
+	restoreSnapshotHook func(socketPath, snapshotPath, memPath string, clockRealtime *bool) error
 	// pausedNetworkControllerState bounds pause-network reclamation cadence.
 	pausedNetworkControllerMu      sync.Mutex
 	pausedNetworkControllerLastRun time.Time
@@ -705,6 +716,16 @@ type Manager struct {
 	// older Firecracker under a running daemon, and the first restore it refuses
 	// clears this for good.
 	clockRealtimeCapable atomic.Bool
+	// guestClockUnready latches this host to unfrozen restores after a guest
+	// reported it could not correct its clock. See noteGuestClockUnready.
+	guestClockUnready atomic.Bool
+	// pendingWakes are reattached records that owe a wake, held back from
+	// m.vms until the startup pool completes it. See queuePendingWake.
+	pendingWakeMu sync.Mutex
+	pendingWakes  map[string]*pendingWake
+	// reattachDeferred marks ids whose startup reattach was left to the
+	// request holding their lifecycle lock; see reattachByID.
+	reattachDeferred sync.Map
 	// dirtyTrackingSessionCapable is the same probe for the guarded-session
 	// fields, demoted on the first refusal exactly like the clock flag.
 	dirtyTrackingSessionCapable atomic.Bool
@@ -1476,11 +1497,15 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	// burns seconds and then fails must land in the pause distributions —
 	// those are among the slowest pauses. The already-paused retry guard
 	// (before tSnapshot) still deliberately emits nothing.
+	var freezeDur time.Duration
 	defer func() {
 		if tSnapshot.IsZero() {
 			return
 		}
 		phases := map[string]time.Duration{"total": time.Since(tPause)}
+		if freezeDur > 0 {
+			phases["freeze"] = freezeDur
+		}
 		if snapshotDur > 0 {
 			phases["snapshot"] = snapshotDur
 		} else {
@@ -1577,6 +1602,7 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	instBaseMem := inst.BaseMemPath
 	instMemFile := inst.MemFilePath
 	recordedCorrects := inst.CorrectsWallClock
+	instIP := inst.IP
 	diskPath := inst.DiskPath
 	diskBasePath := inst.Config.BasePath
 	inst.mu.RUnlock()
@@ -1607,7 +1633,63 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	if recordedCorrects == nil {
 		correctsWallClock = guestCorrectsWallClock(instMemFile, instBaseMem)
 	}
-	if !correctsWallClock {
+	// Recovery after a crash looks for a pause's intent in this VM's own
+	// snapshot directory and nowhere else, so a pause into a caller-supplied
+	// directory freezes nothing and writes no manifest: the older path, correct.
+	if correctsWallClock && snapshotDir != filepath.Join(m.cfg.SnapshotDir, vmID) {
+		log.Info().Str("dir", snapshotDir).Msg("pause: custom snapshot directory; pausing unfrozen")
+		correctsWallClock = false
+	}
+	// The token this freeze carries; the guest keeps it across the snapshot and
+	// the wake must present it. The artifact id names the manifest this pause
+	// will write, in the intent and in the record alike.
+	freezeToken, artifactID := "", ""
+	if correctsWallClock {
+		freezeToken, artifactID = NewFreezeToken(), NewArtifactID()
+	}
+	// Only a pause that will freeze the guest records its intent (see
+	// pause_intent.go), and only once this host's floor is up: recovery looks
+	// for intents on such hosts alone. Durable BEFORE the freeze: a crash
+	// after it must find the token, or the guest stays frozen with nobody
+	// able to release it.
+	willFreeze := correctsWallClock && m.cfg.GuestClockFreezeEnabled && m.clockRealtimeCapable.Load() && !m.guestClockUnready.Load()
+	if willFreeze {
+		if err := ensureWakeProtocolFloor(); err != nil {
+			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record the rollback floor before freezing: %w", err))
+		}
+		if err := writePauseIntent(snapshotDir, pauseIntent{VMID: vmID, FreezeToken: freezeToken, ArtifactID: artifactID}); err != nil {
+			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("record pause intent: %w", err))
+		}
+	}
+	// Freeze the workload before the image exists — only when the restore would
+	// freeze the clock; otherwise the freeze buys nothing.
+	guestFrozen := false
+	if willFreeze {
+		tFreeze := time.Now()
+		var ferr error
+		guestFrozen, ferr = m.freezeGuestForPause(ctx, instIP, freezeToken, log)
+		freezeDur = time.Since(tFreeze)
+		if ferr != nil {
+			return "", "", nil, m.handleVMError(vmID, ferr)
+		}
+	}
+	// The manifest says what this image holds: an unfrozen one restores the
+	// unfrozen way. What the guest can do is not rewritten by what this pause did.
+	snapshotOK := false
+	if guestFrozen {
+		// A failed snapshot leaves the VM running; do not leave it frozen.
+		defer func() {
+			if snapshotOK {
+				return
+			}
+			tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+			defer cancel()
+			if terr := boxdThawGuest(tctx, instIP, freezeToken); terr != nil {
+				log.Error().Err(terr).Msg("pause: snapshot failed and the guest workload could not be thawed")
+			}
+		}()
+	}
+	if !guestFrozen {
 		for _, candidate := range []string{overlayPath, fullPath} {
 			if merr := os.Remove(clockFreezeMarkerPath(candidate)); merr != nil && !os.IsNotExist(merr) {
 				return "", "", nil, m.handleVMError(vmID, fmt.Errorf(
@@ -1754,24 +1836,27 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	}
 
-	// A resume reads the manifest beside THIS image, so without it every resume
-	// drops back to legacy. Only the write lands here: the unsafe direction was
-	// already handled above, before the image existed. Best-effort by design — a
-	// manifest that fails to write, or is lost to a crash, costs a slower
-	// resume, never a wrong clock — so it is written without durability
-	// barriers: nothing on the pause path waits on a sync for it.
+	// The manifest lands only after the image exists; the stale one was cleared
+	// before. A frozen image's manifest is mandatory and durable: an overlay
+	// that lost it would read as legacy on another host and its workload would
+	// never be woken, so the deferred thaw releases the guest on this failure.
+	// An unfrozen image's manifest only spares the next resume a slower path,
+	// so it is written without durability barriers and a failure is logged:
+	// nothing on the ordinary pause path waits on a sync for it.
 	if correctsWallClock {
-		artifact := NewArtifactID()
-		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifact, GuestCorrectsClock: true}
-		if merr := writeWallClockManifestLazy(memPath, man); merr != nil {
+		man := WallClockManifest{Version: WallClockManifestVersion, ArtifactID: artifactID, WorkloadFrozen: guestFrozen, GuestCorrectsClock: true}
+		if guestFrozen {
+			man.FreezeToken = freezeToken
+			if merr := WriteWallClockManifest(memPath, man); merr != nil {
+				return "", "", nil, m.handleVMError(vmID, fmt.Errorf("write wall-clock manifest: %w", merr))
+			}
+		} else if merr := writeWallClockManifestLazy(memPath, man); merr != nil {
 			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
 				Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
-		} else {
-			inst.mu.Lock()
-			inst.ArtifactID = artifact
-			inst.mu.Unlock()
 		}
 	}
+
+	snapshotOK = true
 
 	// Stop the Firecracker process — snapshot is already on disk. A stop
 	// that fails must NOT fail the pause: the artifacts are valid and the
@@ -1846,10 +1931,12 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	inst.BaseMemPath = baseMemPath   // template base for a layered overlay; "" when standalone
 	inst.DirtyTracked = false        // FC process is stopping; a fresh resume re-arms tracking.
 	inst.DirtyTrackingSessionID = "" // the session dies with the FC run
-	// This supervisor freezes nothing, and says so: a resume of this image
-	// trusts the record and reads no manifest.
-	imageFrozen := false
-	inst.SnapshotWorkloadFrozen = &imageFrozen
+	inst.SnapshotWorkloadFrozen = &guestFrozen
+	inst.FreezeToken = ""
+	if guestFrozen {
+		inst.FreezeToken = freezeToken
+	}
+	inst.ArtifactID = artifactID
 	inst.PausedAt = time.Now()
 	// The crash-window marker describes a RUNNING record persisted before
 	// readiness was proven; a successful pause proves the guest was live and
@@ -1871,6 +1958,15 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 	case !wrote:
 		log.Warn().Msg("record deleted during pause stop — destroy owns the teardown")
 		return "", "", nil, status.Errorf(codes.NotFound, "vm %s destroyed during pause", vmID)
+	}
+	// The image, its manifest and the record are all durable: the rewrite is
+	// complete. An intent that cannot be removed now names the artifact the
+	// record does, which is how the next resume tells it from an interrupted
+	// one and clears it itself.
+	if willFreeze {
+		if err := clearPauseIntent(snapshotDir); err != nil {
+			log.Warn().Err(err).Str("dir", snapshotDir).Msg("pause: intent marker could not be cleared; the next resume clears it")
+		}
 	}
 
 	// Every deferral — this pause's and any earlier one — resolves now that
@@ -1909,6 +2005,8 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 
 	log.Info().
 		Str("snapshot_type", snapshotType).
+		Bool("guest_frozen", guestFrozen).
+		Int64("freeze_ms", freezeDur.Milliseconds()).
 		Int64("snapshot_ms", snapshotDur.Milliseconds()).
 		Int64("stop_ms", stopDur.Milliseconds()).
 		Int64("pause_ms", time.Since(tPause).Milliseconds()).
@@ -2129,7 +2227,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		// relaunches over a possibly-live guest. Evidence decides, with the
 		// gate restore adoption uses; success heals the marker durably.
 		tVerify = time.Now()
-		verr := m.verifyBoxdReady(ctx, existing.IP)
+		verr := m.verifyBoxdReady(ctx, existing.IP, existing)
 		verifyDur += time.Since(tVerify)
 		tVerify = time.Time{}
 		if verr != nil {
@@ -2189,24 +2287,28 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// An ordinary resume reloads the exact image this VM was paused into, and
 	// the record already holds the answer; only an override, or a record that
 	// lost it, goes to disk. An intent left beside the image by a pause that was
-	// interrupted, a manifest this binary cannot trust, or a frozen workload it
-	// cannot wake, each refuse the resume here. An intent exists only on a
-	// host whose floor is up; elsewhere nothing is looked for.
+	// interrupted, or a manifest this binary cannot trust, refuses the resume
+	// here; a frozen workload owes a wake before the resume commits. An intent
+	// exists only on a host whose floor is up; elsewhere nothing is looked for.
 	inst.mu.RLock()
-	recordedCorrects, recordedFrozen := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen
-	pausedMemPath, recordedArtifact := inst.MemFilePath, inst.ArtifactID
+	recordedCorrects, recordedFrozen, recordedToken := inst.CorrectsWallClock, inst.SnapshotWorkloadFrozen, inst.FreezeToken
+	pausedMemPath, recordedArtifact, entryUnverified := inst.MemFilePath, inst.ArtifactID, inst.Unverified
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
 		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
 			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
 		}
 	}
-	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects, recordedFrozen)
+	resumeCorrectsWallClock, resumeWorkloadFrozen, resumeToken, merr := resumeImageFacts(memPath, pausedMemPath, recordedCorrects, recordedFrozen, recordedToken)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}
 	if resumeWorkloadFrozen {
-		return nil, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing resume", memPath)
+		// The floor rises before this host acts on an image that owes a wake,
+		// or a rollback could later meet the image with nothing to witness it.
+		if err := ensureWakeProtocolFloor(); err != nil {
+			return nil, status.Errorf(codes.Unavailable, "image %q owes a wake and the rollback floor could not be recorded on this host: %v", memPath, err)
+		}
 	}
 	// Presence gate for layered overlays. Deterministic from a stat, so it
 	// belongs here with the other precondition checks — a post-boot refusal
@@ -2260,25 +2362,6 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		return nil, err
 	}
 
-	tFcStart = time.Now()
-	inst.mu.RLock()
-	resumeExisting := inst.Supervision
-	inst.mu.RUnlock()
-	// freshUnit=false: a resume replaces a paused VM's slot, never a brand-new
-	// unit, so it must always run the linger query.
-	pid, resumeSupervision, err := m.launchFirecracker(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, nsName, resumeExisting, true, false)
-	// Stamp before the error branch too: a cgroup launch that forked FC but
-	// failed socket-readiness (kill unconfirmed) leaves a live process, so the
-	// instance must say cgroup for a later destroy to kill it, not no-op a unit.
-	inst.mu.Lock()
-	inst.Supervision = resumeSupervision
-	inst.mu.Unlock()
-	if err != nil {
-		return nil, fmt.Errorf("start firecracker for restore: %w", err)
-	}
-	tFcDone = time.Now()
-
-	log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
 	// A base is needed only when memPath is itself a diff overlay. Keying on memPath
 	// (not the cached BaseMemPath) means a standalone/override resume clears any
 	// stale base, so the next pause won't wrongly diff against the old template.
@@ -2295,49 +2378,144 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			basePath = inst.BaseMemPath
 		}
 		if basePath == "" {
-			m.stopUnitDuringRestoreError(vmID)
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
 		}
 	}
-	tRestore = time.Now()
-	var dirtyTracked bool
-	var trackingSessionID string
-	var restoreErr error
-	// Nil unless the real restore path ran and asked for a frozen clock; the test
-	// hook leaves it nil, which is also what the log should say.
-	var resumeClockFrozen bool
-	if m.restoreForResumeHook != nil {
-		dirtyTracked, trackingSessionID, restoreErr = m.restoreForResumeHook(socketPath, snapshotPath, memPath, basePath, netInfo)
-	} else {
-		// Only an image holding a frozen workload may have its clock frozen,
-		// and that image was refused above: legacy for every resume here.
-		dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, m.clockPolicyFor(false))
-	}
-	tRestoreDone = time.Now()
-	if restoreErr != nil {
-		// Firecracker is already running; stop the unit before returning or it leaks.
-		m.stopUnitDuringRestoreError(vmID)
-		if errors.Is(restoreErr, ErrTornSnapshot) {
-			return nil, status.Errorf(codes.DataLoss,
-				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
-				snapshotPath, restoreErr)
+
+	var (
+		pid               int
+		dirtyTracked      bool
+		trackingSessionID string
+		restoreErr        error
+		resumeClockFrozen bool
+		syncWake          time.Duration
+	)
+	// A frozen image publishes Running with a wake owed before each launch (see
+	// persistWakeOwed). A resume that then fails leaves that record claiming a
+	// guest that never came back: put the sandbox back to Paused, unless a
+	// failure path already gave a more specific verdict.
+	published, committed := false, false
+	defer func() {
+		if !published || committed {
+			return
 		}
-		if errors.Is(restoreErr, ErrLayeredInvalidSnapshot) {
-			// Permanent: the overlay/base pairing is structurally invalid, so retrying
-			// the layered restore can't succeed. FailedPrecondition tells the caller not
-			// to retry (vs the generic Internal below, which it may).
-			return nil, status.Errorf(codes.FailedPrecondition,
-				"snapshot %q has an invalid layered overlay/base pairing; do not retry: %v",
-				snapshotPath, restoreErr)
+		inst.mu.Lock()
+		revert := inst.Status == StatusRunning && inst.Unverified
+		if revert {
+			inst.Status = StatusPaused
+			inst.Unverified = entryUnverified
+			inst.WakePending = false
+			inst.ClockFrozen = false
 		}
-		return nil, fmt.Errorf("restore snapshot: %w", restoreErr)
+		inst.mu.Unlock()
+		if revert {
+			// Best-effort: an undurable revert is re-derived by the next attempt.
+			_, _ = m.persistStateIfPresent(inst)
+		}
+	}()
+	// Two passes at most: a frozen-clock restore whose guest cannot correct its
+	// clock is relaunched unfrozen. Only Firecracker is torn down between
+	// passes; the slot, the network, and this frame's cleanup are kept.
+	for pass := 0; ; pass++ {
+		tFcStart = time.Now()
+		inst.mu.RLock()
+		resumeExisting := inst.Supervision
+		inst.mu.RUnlock()
+		resumePolicy := m.clockPolicyFor(resumeWorkloadFrozen)
+		var joinWakeOwed func(Supervision) bool
+		if resumeWorkloadFrozen {
+			predicted := SupervisionUnit
+			if m.cgroupLaunch(resumeExisting) {
+				predicted = SupervisionCgroup
+			}
+			joinWakeOwed = m.persistWakeOwed(inst, predicted, resumePolicy != nil)
+			published = true
+		}
+		// freshUnit=false: a resume replaces a paused VM's slot, never a brand-new
+		// unit, so it must always run the linger query.
+		var resumeSupervision = resumeExisting
+		var err error
+		pid, resumeSupervision, err = m.launchFirecracker(ctx, vmID, socketPath, rootfsPath, inst.Config.BasePath, nsName, resumeExisting, true, false)
+		// Stamp before the error branch too: a cgroup launch that forked FC but
+		// failed socket-readiness (kill unconfirmed) leaves a live process, so the
+		// instance must say cgroup for a later destroy to kill it, not no-op a unit.
+		inst.mu.Lock()
+		inst.Supervision = resumeSupervision
+		inst.mu.Unlock()
+		durable := true
+		if joinWakeOwed != nil {
+			durable = joinWakeOwed(resumeSupervision)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("start firecracker for restore: %w", err)
+		}
+		if !durable && !m.persistState(inst) {
+			// Fail closed: the vCPUs must not run ahead of the record that
+			// owes their wake.
+			m.stopUnitDuringRestoreError(vmID)
+			return nil, fmt.Errorf("vm %s: wake record could not be made durable before the load", vmID)
+		}
+		tFcDone = time.Now()
+
+		log.Info().Str("snapshot_path", snapshotPath).Msg("restoring VM from snapshot")
+		tRestore = time.Now()
+		resumeClockFrozen = false
+		if m.restoreForResumeHook != nil {
+			dirtyTracked, trackingSessionID, restoreErr = m.restoreForResumeHook(socketPath, snapshotPath, memPath, basePath, netInfo)
+		} else {
+			dirtyTracked, trackingSessionID, resumeClockFrozen, restoreErr = m.restoreForResume(socketPath, snapshotPath, memPath, basePath, netInfo, resumePolicy)
+		}
+		tRestoreDone = time.Now()
+		if restoreErr != nil {
+			// Firecracker is already running; stop the unit before returning or it leaks.
+			m.stopUnitDuringRestoreError(vmID)
+			if errors.Is(restoreErr, ErrTornSnapshot) {
+				return nil, status.Errorf(codes.DataLoss,
+					"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
+					snapshotPath, restoreErr)
+			}
+			if errors.Is(restoreErr, ErrLayeredInvalidSnapshot) {
+				// Permanent: the overlay/base pairing is structurally invalid, so retrying
+				// the layered restore can't succeed. FailedPrecondition tells the caller not
+				// to retry (vs the generic Internal below, which it may).
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"snapshot %q has an invalid layered overlay/base pairing; do not retry: %v",
+					snapshotPath, restoreErr)
+			}
+			return nil, fmt.Errorf("restore snapshot: %w", restoreErr)
+		}
+
+		// An image with a frozen workload is not resumed until the guest has
+		// released it, correcting its clock first if that was frozen too. If it
+		// cannot, the second pass relaunches with the clock running — the host is
+		// latched, so the policy resolves to legacy — and still owes the release.
+		if resumeWorkloadFrozen {
+			tWake := time.Now()
+			werr := boxdWakeGuest(context.WithoutCancel(ctx), netInfo.HostIP, boxdResumeReadyBudget, resumeClockFrozen, resumeToken)
+			syncWake = time.Since(tWake)
+			if werr != nil {
+				m.stopUnitDuringRestoreError(vmID)
+				if errors.Is(werr, ErrGuestClockUnready) && pass == 0 {
+					m.noteGuestClockUnready(log, werr)
+					continue
+				}
+				if errors.Is(werr, ErrGuestTokenMismatch) {
+					// This image and its record describe different snapshots.
+					// Durably Error, never retried: the artifacts are retained.
+					m.setStatus(vmID, StatusError)
+					return nil, status.Errorf(codes.FailedPrecondition, "image %q: %v", memPath, werr)
+				}
+				return nil, status.Errorf(codes.Unavailable, "guest did not wake after restore: %v", werr)
+			}
+			inst.mu.Lock()
+			inst.WakePending = false
+			inst.mu.Unlock()
+		}
+		break
 	}
 
-	inst.mu.RLock()
-	wasUnverified := inst.Unverified
-	inst.mu.RUnlock()
-	if wasUnverified {
+	if entryUnverified {
 		// The relaunch of an unverified crash-window record verifies readiness
 		// synchronously (as its adoption above does): clearing the marker
 		// blind would let a same-artifact restore retry adopt an unready VM without
@@ -2347,7 +2525,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		// snapshot, so this teardown discards nothing of value — but only a
 		// GENUINE verdict may reach it; see verifyBoxdReady.
 		tVerify = time.Now()
-		verr := m.verifyBoxdReady(ctx, netInfo.HostIP)
+		verr := m.verifyBoxdReady(ctx, netInfo.HostIP, inst)
 		verifyDur += time.Since(tVerify)
 		tVerify = time.Time{}
 		if verr != nil {
@@ -2370,6 +2548,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.DirtyTrackingSessionID = trackingSessionID
 	inst.CorrectsWallClock = &resumeCorrectsWallClock
 	inst.SnapshotWorkloadFrozen = &resumeWorkloadFrozen
+	inst.FreezeToken = resumeToken
 	inst.PausedAt = time.Time{}
 	// Record the file actually resumed from (callers may pass an explicit path
 	// that differs from the cached one) so the next pause's diff baseline matches
@@ -2382,6 +2561,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	if cerr := m.commitResumeState(inst); cerr != nil {
 		return nil, cerr
 	}
+	committed = true
 	// A legacy paused record is the one case reattach cannot recover:
 	// it skips paused VMs because a paused VM has no Firecracker to ask.
 	// Resume is when one becomes askable again, so without this such a
@@ -2414,7 +2594,15 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	probeStart := time.Now()
 	vmIP := inst.IP
 	probe := boxdHealthProbe
+	if resumeWorkloadFrozen {
+		// Readiness was proven by the wake; the detached probe has nothing to add.
+		log.Info().Int64("wait_boxd_ms", syncWake.Milliseconds()).Msg("guest awake after resume")
+		m.recordPhases("resume", "", map[string]time.Duration{"wait_boxd": syncWake})
+	}
 	go func() {
+		if resumeWorkloadFrozen {
+			return
+		}
 		defer sentrylog.Recover("resume-boxd-probe")
 		probeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -2453,7 +2641,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 		if basePath != "" {
 			return false, "", false, fmt.Errorf("layered overlay %q requires UFFD resume (resume-uffd + uffd + tap); refusing File-backend restore", memPath)
 		}
-		used, rerr := m.restoreWithClockFallback(clockPolicy, func(clock *bool) error {
+		used, rerr := m.restoreWithClockFallback(clockPolicy, nil, func(clock *bool) error {
 			return RestoreSnapshot(socketPath, snapshotPath, memPath, "", clock)
 		})
 		return false, "", used, rerr
@@ -2468,7 +2656,7 @@ func (m *Manager) restoreForResume(socketPath, snapshotPath, memPath, basePath s
 		sessionID = newTrackingSessionID()
 	}
 	armed, used, rerr := m.restoreWithSessionFallback(sessionID, func(sid string) (bool, error) {
-		return m.restoreWithClockFallback(clockPolicy, func(clock *bool) error {
+		return m.restoreWithClockFallback(clockPolicy, nil, func(clock *bool) error {
 			return RestoreSnapshotUffdInternalWithOverrides(
 				socketPath, snapshotPath, memPath, basePath, "", "", "eth0", netInfo.TAPDevice, "", trackDirty,
 				m.cfg.HandlerDeathAbortEnabled, sid, clock,
@@ -2941,7 +3129,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// passes. Verified records adopt without this gate: readiness was
 			// proven once, and a wedged boxd here must not demote a live VM.
 			tVerify := time.Now()
-			err := m.verifyBoxdReady(ctx, existing.IP)
+			err := m.verifyBoxdReady(ctx, existing.IP, existing)
 			// Emitted here, success and failure alike: this branch returns
 			// before the phase defer below is registered, and a crash-window
 			// adoption can wait out the whole probe budget.
@@ -3108,21 +3296,30 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 	}
 	// What the image says about its guest, read once per restore: whether its
-	// workload is frozen, and whether the guest corrects its clock. Read from
-	// the disk every time, never remembered by path: a template directory is
-	// meant to be immutable, but a cache here would turn any exception into a
-	// frozen image restored the old way, with its workload never released.
-	// One small open beside the sidecar read this path already does. A
-	// manifest this binary cannot trust, or a frozen workload it cannot wake,
-	// refuses the restore here, before anything is launched.
+	// workload is frozen (and so owes a wake with this token) and whether the
+	// guest corrects its clock. Read from the disk every time, never
+	// remembered by path: a template directory is meant to be immutable, but
+	// a cache here would turn any exception into a frozen image restored the
+	// old way, with its workload never released. One small open beside the
+	// sidecar read this path already does. A manifest this binary cannot
+	// trust refuses the restore here, before anything is launched.
 	manifest, merr := imageManifest(memPath)
 	if merr != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}
-	if manifest != nil && manifest.WorkloadFrozen {
-		return nil, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing restore", memPath)
+	restoreWorkloadFrozen := manifest != nil && manifest.WorkloadFrozen
+	restoreGuestCorrects := manifest != nil && manifest.GuestCorrectsClock
+	if restoreWorkloadFrozen {
+		// The floor rises before this host acts on an image that owes a wake,
+		// or a rollback could later meet the image with nothing to witness it.
+		if err := ensureWakeProtocolFloor(); err != nil {
+			return nil, status.Errorf(codes.Unavailable, "image %q owes a wake and the rollback floor could not be recorded on this host: %v", memPath, err)
+		}
 	}
-	restoreCorrectsWallClock := manifest != nil && manifest.GuestCorrectsClock
+	restoreToken, restoreArtifactID := "", ""
+	if manifest != nil {
+		restoreToken, restoreArtifactID = manifest.FreezeToken, manifest.ArtifactID
+	}
 
 	// Sampled before this attempt creates the rundir: a pre-existing rundir
 	// means a prior attempt on this host reached start.sh (and possibly
@@ -3235,9 +3432,9 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 
 	// Loop-carried across restore attempts: only what the post-loop code reads.
 	var (
-		hostIP     string
-		pid        int
-		restoreErr error
+		hostIP, tapDevice, macAddr, nsName string
+		pid                                int
+		restoreErr                         error
 	)
 
 	// A fresh restore that fails with a still-held tap0 (isTapDeviceBusyErr) is
@@ -3249,14 +3446,19 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// the sidecar read after Firecracker and networking have started, on
 	// user-visible restore latency.
 	sidecarBase, hasSidecar := readLayeredBase(memPath)
+	var (
+		restoreClockFrozen bool
+		clockRetried       bool
+		wakeErr            error
+		tBoxdStart         time.Time
+		optimisticOK       bool
+	)
 	for attempt = 1; ; attempt++ {
 		tAttemptStart = time.Now()
 		if attempt > 1 {
 			restorePhasesRecorded = false
 			tNetReady, tFcReady = time.Time{}, time.Time{}
 		}
-		var tapDevice, macAddr, nsName string
-		hostIP = ""
 		if inPlace {
 			existingNet := m.netMgr.GetVMNetInfo(vmID)
 			if existingNet != nil {
@@ -3312,6 +3514,29 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// survives into the new attempt points at a stopped (possibly
 		// recycled) process — which stall capture would then inspect and
 		// report as this VM's.
+		// Whether this host can act on the image's fact is decided separately,
+		// so an older binary does not erase it; and per attempt, since a
+		// relaunch after an uncorrectable clock finds the host latched.
+		clockPolicy := m.clockPolicyFor(restoreWorkloadFrozen)
+		predictedSupervision := SupervisionUnit
+		if m.cgroupLaunch(existingSupervision) {
+			predictedSupervision = SupervisionCgroup
+		}
+		// Cached so the next pause knows what this guest and this image are
+		// without going back to the filesystem to ask.
+		inst.mu.Lock()
+		inst.CorrectsWallClock = &restoreGuestCorrects
+		inst.SnapshotWorkloadFrozen = &restoreWorkloadFrozen
+		inst.FreezeToken = restoreToken
+		inst.ArtifactID = restoreArtifactID
+		inst.mu.Unlock()
+		// Only a frozen image owes a wake, so only then must the record say so
+		// before the vCPUs can run (see persistWakeOwed). An unfrozen image
+		// keeps the older ordering below, unchanged.
+		var joinWakeOwed func(Supervision) bool
+		if restoreWorkloadFrozen {
+			joinWakeOwed = m.persistWakeOwed(inst, predictedSupervision, clockPolicy != nil)
+		}
 		m.beginLaunchAttempt(inst)
 		pid, supervision, startErr = m.launchFirecracker(ctx, vmID, socketPath, diskPath, resourceLimits.BasePath, nsName, existingSupervision, inPlace || priorRunDir, freshUnit && attempt == 1)
 		// Stamp the chosen mode NOW, before the error branch: a launch that
@@ -3322,11 +3547,31 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		inst.mu.Lock()
 		inst.Supervision = supervision
 		inst.mu.Unlock()
+		// Joined before the load: the record must owe the wake before the
+		// vCPUs can run. Normally it landed under the launch.
+		tJoin := time.Now()
+		var persistJoin time.Duration
+		if joinWakeOwed != nil {
+			optimisticOK = joinWakeOwed(supervision)
+			persistJoin = time.Since(tJoin)
+		}
 		if startErr != nil {
 			tFailBoundary = time.Now()
 			m.releaseFailedRestore(vmID, inPlace, false, cleanupAfterRestoreFailure)
 			m.setStatus(vmID, StatusError)
 			return nil, fmt.Errorf("start firecracker: %w", startErr)
+		}
+		if joinWakeOwed != nil && !optimisticOK {
+			optimisticOK = m.persistState(inst)
+		}
+		if joinWakeOwed != nil && !optimisticOK {
+			// Fail closed: the vCPUs must not run ahead of the record that
+			// owes their wake.
+			tFailBoundary = time.Now()
+			m.stopUnitDuringRestoreError(vmID)
+			m.releaseFailedRestore(vmID, inPlace, false, cleanupAfterRestoreFailure)
+			m.setStatus(vmID, StatusError)
+			return nil, fmt.Errorf("vm %s: wake record could not be made durable before the load", vmID)
 		}
 		publishLaunchPID(inst, pid, supervision)
 		tFcReady = time.Now()
@@ -3351,6 +3596,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			Float64("mem_psi_avg10", memPSI).
 			Float64("io_psi_avg10", ioPSI).
 			Int("attempt", attempt).
+			Int64("persist_join_ms", persistJoin.Milliseconds()).
 			Msg("restoring snapshot")
 		restorePhasesRecorded = true
 		attemptPhases := map[string]time.Duration{
@@ -3373,11 +3619,23 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// File backend, which would load the sparse overlay as a full image (the base's
 		// pages read as zero holes).
 		overlayNeedsLayered := isOverlayMemFile(memPath) || hasSidecar
-		// Only an image holding a frozen workload may have its clock frozen, and
-		// that image was refused above: legacy for every restore here.
-		clockPolicy := m.clockPolicyFor(false)
-		clockFrozen := false
+		// If this Firecracker refuses the option, the record must say the clock
+		// ran before the legacy retry can run the vCPUs.
+		demote := func() error {
+			inst.mu.Lock()
+			inst.ClockFrozen = false
+			inst.mu.Unlock()
+			if !m.persistState(inst) {
+				return fmt.Errorf("vm %s: clock policy could not be made durable before the legacy restore", vmID)
+			}
+			return nil
+		}
+		restoreClockFrozen = false
 		switch {
+		case m.restoreSnapshotHook != nil:
+			restoreClockFrozen, attemptErr = m.restoreWithClockFallback(clockPolicy, demote, func(clock *bool) error {
+				return m.restoreSnapshotHook(socketPath, snapshotPath, memPath, clock)
+			})
 		case overlayNeedsLayered && !(useUffd && m.cfg.ResumeUffdEnabled):
 			attemptErr = fmt.Errorf(
 				"layered overlay %q requires UFFD layered restore (uffd + resume-uffd); refusing File-backend restore",
@@ -3434,8 +3692,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			}
 			if attemptErr == nil {
 				var armed string
-				armed, clockFrozen, attemptErr = m.restoreWithSessionFallback(trackingSessionID, func(sid string) (bool, error) {
-					return m.restoreWithClockFallback(clockPolicy, func(clock *bool) error {
+				armed, restoreClockFrozen, attemptErr = m.restoreWithSessionFallback(trackingSessionID, func(sid string) (bool, error) {
+					return m.restoreWithClockFallback(clockPolicy, demote, func(clock *bool) error {
 						return RestoreSnapshotUffdInternalWithOverrides(
 							socketPath, snapshotPath, memPath, basePath, accessLogPath, recordToPath, "eth0", tapDevice, plan.deltaDir, armLayered,
 							m.cfg.HandlerDeathAbortEnabled, sid, clock,
@@ -3449,12 +3707,12 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 				}
 			}
 		case inPlace:
-			clockFrozen, attemptErr = m.restoreWithClockFallback(clockPolicy, func(clock *bool) error {
+			restoreClockFrozen, attemptErr = m.restoreWithClockFallback(clockPolicy, demote, func(clock *bool) error {
 				return RestoreSnapshot(socketPath, snapshotPath, memPath, plan.deltaDir, clock)
 			})
 		default:
 			// UFFD disabled but fresh restore — File backend with network overrides.
-			clockFrozen, attemptErr = m.restoreWithClockFallback(clockPolicy, func(clock *bool) error {
+			restoreClockFrozen, attemptErr = m.restoreWithClockFallback(clockPolicy, demote, func(clock *bool) error {
 				return RestoreSnapshotWithOverrides(socketPath, snapshotPath, memPath, "eth0", tapDevice, plan.deltaDir, clock)
 			})
 		}
@@ -3466,7 +3724,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// only symptom of the gates disagreeing is a readiness number that
 			// looks the same as before, which is indistinguishable from the
 			// feature being off.
-			Bool("guest_clock_frozen", clockFrozen).
+			Bool("guest_clock_frozen", restoreClockFrozen).
 			Msg("snapshot loaded")
 		// Failed attempts included: a slow failing load (tap-busy retry,
 		// terminal failure) must appear in the distribution, not vanish.
@@ -3474,7 +3732,78 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		restoreErr = attemptErr
 
 		if restoreErr == nil {
-			break
+			// An unfrozen image publishes Running after the load, the write
+			// overlapping the readiness wait; a crash here leaves an unverified
+			// record, which adoption re-verifies before trusting.
+			var persistDone chan struct{}
+			if !restoreWorkloadFrozen {
+				inst.mu.Lock()
+				inst.Status = StatusRunning
+				inst.Unverified = true
+				inst.PausedAt = time.Time{}
+				inst.mu.Unlock()
+				done := make(chan struct{})
+				persistDone = done
+				go func() {
+					defer sentrylog.Recover("restore-persist")
+					defer close(done)
+					optimisticOK = m.persistState(inst)
+				}()
+			}
+			tBoxdStart = time.Now()
+			// Same window as first boot: a restore that has to fault its memory and
+			// overlay from cold storage (first resume of a migrated VM, page cache
+			// evicted) legitimately needs more than a warm same-host resume, and a
+			// timeout here is destructive — the error path below tears down the VM.
+			//
+			// The window is clamped to the RPC deadline less the WORST-CASE error
+			// path — the verdict returns only after teardown, so the reserve must
+			// cover it: the 10s bounded unit stop, the 2s surviving-unit resolve,
+			// and a reply margin. Then the DEFINITIVE verdict always reaches the
+			// caller in-band even when setup ate into the budget and the stop is
+			// stuck at its bound: an honest early error beats letting the caller's
+			// deadline win the race — a bare DeadlineExceeded reads as transient
+			// and gets retried into this VM's torn-down state.
+			readiness := 30 * time.Second
+			if dl, ok := ctx.Deadline(); ok {
+				if remaining := time.Until(dl) - bootVerdictReserve; remaining < readiness {
+					readiness = remaining
+				}
+			}
+			// Diagnostics fire from inside the readiness window if the guest is still
+			// unready after a few seconds — the teardown capture proved the guest
+			// itself is what stalls, and answering why needs signals that exist only
+			// while it runs. Cancelled on the healthy path, where the whole cost is a
+			// timer that never fires.
+			stopDiag := m.armEarlyStallDiagnostics(vmID, pid)
+			if restoreWorkloadFrozen {
+				wakeErr = boxdWakeGuest(ctx, hostIP, readiness, restoreClockFrozen, restoreToken)
+			} else {
+				wakeErr = boxdHealthProbe(ctx, hostIP, readiness)
+			}
+			stopDiag()
+			if persistDone != nil {
+				<-persistDone
+			}
+			if wakeErr == nil || clockRetried || !restoreClockFrozen || !errors.Is(wakeErr, ErrGuestClockUnready) {
+				break
+			}
+			// The guest could not correct a frozen clock. The host is latched now,
+			// so the same instance relaunches with the clock running — on the slot,
+			// overlay and record it already owns. None of them may be released and
+			// recreated: an in-place overlay recreated from scratch is truncated.
+			clockRetried = true
+			m.noteGuestClockUnready(log, wakeErr)
+			m.recordPhases("restore", "", map[string]time.Duration{"wait_boxd": time.Since(tBoxdStart)})
+			m.stopUnitDuringRestoreError(vmID)
+			if !vmDeadForRetry(m, vmID) {
+				log.Warn().Msg("VM not confirmed dead after stop — not relaunching")
+				break
+			}
+			inst.mu.Lock()
+			inst.DirtyTracked = false
+			inst.mu.Unlock()
+			continue
 		}
 		// Retriable only for a fresh-restore tap0 busy. The overlay and inst are
 		// kept for the next attempt; terminal cleanup lives below the loop.
@@ -3499,6 +3828,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		// Full teardown, not recycle: a fast recycle could return this same busy
 		// slot to the pool and the next attempt could re-claim it.
 		m.netMgr.TeardownVM(vmID)
+		tapDevice, macAddr, hostIP, nsName = "", "", "", ""
 		inst.mu.Lock()
 		inst.DirtyTracked = false
 		inst.DirtyTrackingSessionID = ""
@@ -3542,36 +3872,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		return nil, fmt.Errorf("restore snapshot: %w", restoreErr)
 	}
 
-	// Running means the vCPUs are live, which is what lets the persist overlap
-	// the wait below; readiness is still verified there and still fails the
-	// restore. This deliberately adopts the resume path's weaker guarantee —
-	// resume has always published Running before readiness (its probe is
-	// detached telemetry) — where restore previously published only after.
-	// The window itself is not routable: the control plane hands out no usable
-	// sandbox until this RPC returns and it activates the row. What the marker
-	// bounds is the durable case — a crash here leaves a Running record whose
-	// readiness was never proven, and both restore and resume adoption
-	// re-verify such records before adopting them.
-	// The status is set directly — setStatus would
-	// persist synchronously, serializing the very fsync the goroutine
-	// overlaps with the boxd wait.
-	inst.mu.Lock()
-	inst.Status = StatusRunning
-	inst.Unverified = true
-	inst.PausedAt = time.Time{}
-	// Cached so the next pause knows what this guest and this image are
-	// without going back to the filesystem to ask.
-	inst.CorrectsWallClock = &restoreCorrectsWallClock
-	restoreWorkloadFrozen := false // a frozen image was refused above
-	inst.SnapshotWorkloadFrozen = &restoreWorkloadFrozen
-	inst.mu.Unlock()
-	persistDone := make(chan struct{})
-	optimisticOK := false
-	go func() {
-		defer sentrylog.Recover("restore-persist")
-		defer close(persistDone)
-		optimisticOK = m.persistState(inst)
-	}()
 	// Callers declare the allocation, so this normally does nothing at
 	// all — backfillMachineConfigAsync returns immediately once the size
 	// is known, spawning nothing. It covers the rollout window where a
@@ -3584,35 +3884,8 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		m.backfillMachineConfigAsync(inst)
 	}
 
-	tBoxdStart := time.Now()
-	// Same window as first boot: a restore that has to fault its memory and
-	// overlay from cold storage (first resume of a migrated VM, page cache
-	// evicted) legitimately needs more than a warm same-host resume, and a
-	// timeout here is destructive — the error path below tears down the VM.
-	//
-	// The window is clamped to the RPC deadline less the WORST-CASE error
-	// path — the verdict returns only after teardown, so the reserve must
-	// cover it: the 10s bounded unit stop, the 2s surviving-unit resolve,
-	// and a reply margin. Then the DEFINITIVE verdict always reaches the
-	// caller in-band even when setup ate into the budget and the stop is
-	// stuck at its bound: an honest early error beats letting the caller's
-	// deadline win the race — a bare DeadlineExceeded reads as transient
-	// and gets retried into this VM's torn-down state.
-	readiness := 30 * time.Second
-	if dl, ok := ctx.Deadline(); ok {
-		if remaining := time.Until(dl) - bootVerdictReserve; remaining < readiness {
-			readiness = remaining
-		}
-	}
-	// Diagnostics fire from inside the readiness window if the guest is still
-	// unready after a few seconds — the teardown capture proved the guest
-	// itself is what stalls, and answering why needs signals that exist only
-	// while it runs. Cancelled on the healthy path, where the whole cost is a
-	// timer that never fires.
-	stopDiag := m.armEarlyStallDiagnostics(vmID, pid)
-	err := m.waitForBoxd(ctx, hostIP, readiness)
-	stopDiag()
-	if err != nil {
+	if wakeErr != nil {
+		err := wakeErr
 		// Emit the exhausted readiness wait immediately, before teardown, so
 		// the sample measures the probe (not unit stop + resource release +
 		// persist join) and the concurrent-destroy return below can't skip it.
@@ -3655,7 +3928,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 		}
 		go func() {
 			defer sentrylog.Recover("restore-error-persist")
-			<-persistDone
 			// The identity check and the Error write must be atomic against
 			// a same-ID retry, which serializes on the lifecycle lock: held
 			// here, the map entry cannot be replaced between check and
@@ -3708,6 +3980,10 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 			// transient and the control plane retries a destroyed sandbox.
 			return nil, status.Errorf(codes.NotFound, "vm %s was destroyed during restore", vmID)
 		}
+		if errors.Is(err, ErrGuestTokenMismatch) {
+			// The artifacts are retained for inspection; nothing retries this.
+			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %v", memPath, err)
+		}
 		return nil, fmt.Errorf("boxd not ready after restore: %w", err)
 	}
 	tBoxdReady := time.Now()
@@ -3719,7 +3995,6 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	// secs_since_template_restore reflects real warmth for either backend.
 	m.markTemplateRestored(warmthPath)
 
-	<-persistDone
 	if !optimisticOK && !m.persistState(inst) {
 		// The record could not be made durable, so the VM would be invisible
 		// to the next reattach — a zombie unit after any vmd restart. Fail
@@ -3732,6 +4007,7 @@ func (m *Manager) restoreVMSnapshot(ctx context.Context, vmID, snapshotPath, mem
 	}
 	inst.mu.Lock()
 	inst.Unverified = false
+	inst.WakePending = false
 	inst.mu.Unlock()
 	// Persist-then-verify: checking AFTER the write leaves no window — a
 	// concurrent DestroyVM either erased the record itself or is caught here,
@@ -4342,6 +4618,7 @@ func (m *Manager) ReattachAll(ctx context.Context) (reattached, stale int) {
 			stale++
 		}
 	}
+	reattached += m.drainPendingWakes(ctx)
 
 	// Reconstruct unconfirmed-stop markers the previous process took to
 	// its grave: vmStopUnconfirmed is in-memory, so a restart after a
@@ -4564,6 +4841,23 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		return inst, true
 	}
 	m.mu.RUnlock()
+	// A request arriving while the startup pass still owes this VM its wake
+	// waits for that outcome rather than adopting a frozen guest — for as
+	// long as a wake can take, not the flight's own short budget: giving up
+	// early would report a live VM as missing and invite a replacement.
+	if pw := m.pendingWake(rec.ID); pw != nil && !cleanupStale {
+		wait := time.NewTimer(boxdResumeReadyBudget + 5*time.Second)
+		defer wait.Stop()
+		select {
+		case <-pw.done:
+			m.mu.RLock()
+			inst, ok := m.vms[rec.ID]
+			m.mu.RUnlock()
+			return inst, ok
+		case <-wait.C:
+			return nil, false
+		}
+	}
 
 	log := m.log.With().Str("vm_id", rec.ID).Logger()
 
@@ -4848,6 +5142,35 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 		}
 	}
 
+	// A live guest may still owe something from the process that died: a
+	// pause that froze it and never finished, or a restore that never woke
+	// it. Neither may be served as Running until resolved.
+	if rec.Status == StatusRunning && !m.recoverPauseIntent(ctx, inst, log) {
+		rec.Status = StatusError
+		m.parkUnservable(inst)
+	}
+	if rec.Status == StatusRunning && inst.WakePending {
+		if cleanupStale {
+			// The startup pass queues it for the pool after the pass, holding
+			// the VM's lifecycle lock from here until the pool publishes the
+			// outcome: a restore or resume for this id waits on that lock,
+			// never on the pool. If a request already holds the lock, its own
+			// lazy reattach completes the wake inline; nothing to queue.
+			unlock, ok := m.tryLockVMOp(inst.ID)
+			if !ok {
+				log.Info().Msg("reattach: a request holds this VM's lock; leaving its owed wake to that request")
+				m.reattachDeferred.Store(inst.ID, struct{}{})
+				return nil, false
+			}
+			m.queuePendingWake(inst, unlock)
+			return nil, false
+		}
+		if !m.completeOwedWake(ctx, inst, log) {
+			rec.Status = StatusError
+			m.parkUnservable(inst)
+		}
+	}
+
 	// Publish, re-checking under the write lock in case another caller won the
 	// race while we restored network state; if so, keep theirs.
 	m.mu.Lock()
@@ -4945,7 +5268,7 @@ func (m *Manager) reattachByID(vmID string, cleanupStale bool) *VMInstance {
 	if m.state == nil {
 		return nil
 	}
-	v, _, _ := m.reattachSF.Do(vmID, func() (any, error) {
+	v, err, _ := m.reattachSF.Do(vmID, func() (any, error) {
 		m.mu.RLock()
 		inst, ok := m.vms[vmID]
 		m.mu.RUnlock()
@@ -4964,11 +5287,40 @@ func (m *Manager) reattachByID(vmID string, cleanupStale bool) *VMInstance {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		got, _ := m.reattachRecord(ctx, *rec, cleanupStale)
+		if got == nil {
+			if _, deferred := m.reattachDeferred.LoadAndDelete(vmID); deferred {
+				return (*VMInstance)(nil), errReattachDeferred
+			}
+		}
 		return got, nil
 	})
+	if errors.Is(err, errReattachDeferred) && !cleanupStale {
+		// The startup pass found this VM's lifecycle lock held and left its
+		// owed wake to whoever holds it — a caller that joined this very
+		// flight. That caller must not read the deferral as "no such VM": it
+		// reattaches itself, completing the wake inline. Through a flight of
+		// its own, so every joiner of the deferred one shares a single
+		// recovery instead of each running one against the same guest.
+		v2, _, _ := m.reattachSF.Do(vmID+"\x00retry", func() (any, error) {
+			rec, gerr := m.state.Get(vmID)
+			if gerr != nil || rec == nil {
+				return (*VMInstance)(nil), nil
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), boxdResumeReadyBudget+5*time.Second)
+			defer cancel()
+			got, _ := m.reattachRecord(ctx, *rec, false)
+			return got, nil
+		})
+		inst, _ := v2.(*VMInstance)
+		return inst
+	}
 	inst, _ := v.(*VMInstance)
 	return inst
 }
+
+// errReattachDeferred: the startup pass left a VM's owed wake to the request
+// holding its lifecycle lock. See reattachByID.
+var errReattachDeferred = errors.New("reattach deferred to the lifecycle lock holder")
 
 // SweepStartupOrphanNamespaces removes host network namespaces (ns-N / veth-N)
 // that no live BoltDB record claims — leaked by crashed template builds or a
@@ -7779,8 +8131,224 @@ var adoptionBoxdReady = func(ctx context.Context, m *Manager, ip string) error {
 // of it, so an inherited ctx always expires first and every attempt would end
 // "no verdict", leaving the record unchanged for the next attempt to repeat.
 // The wall-clock bound inside waitForBoxd still caps the wait.
-func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string) error {
-	return adoptionBoxdReady(context.WithoutCancel(callerCtx), m, ip)
+//
+// A record still owing a wake gets one, with the policy its restore used: a
+// health poll would accept a stopped workload as ready.
+func (m *Manager) verifyBoxdReady(callerCtx context.Context, ip string, inst *VMInstance) error {
+	ctx := context.WithoutCancel(callerCtx)
+	inst.mu.RLock()
+	pending, frozen, token := inst.WakePending, inst.ClockFrozen, inst.FreezeToken
+	inst.mu.RUnlock()
+	if !pending {
+		return adoptionBoxdReady(ctx, m, ip)
+	}
+	if err := boxdWakeGuest(ctx, ip, 30*time.Second, frozen, token); err != nil {
+		if errors.Is(err, ErrGuestClockUnready) {
+			m.noteGuestClockUnready(m.log.With().Str("vm_id", inst.ID).Logger(), err)
+		}
+		return err
+	}
+	inst.mu.Lock()
+	inst.WakePending = false
+	inst.mu.Unlock()
+	return nil
+}
+
+// persistWakeOwed publishes Running with a wake owed and starts the durable
+// write so it overlaps the launch. A crash after the load must find a record
+// that owes a wake, or recovery could adopt an older verified record over a
+// guest whose workload is still frozen. The returned join waits for the
+// write, re-persists if the launch landed in another supervision mode, and
+// reports whether the record is durable; the caller must not load the
+// snapshot otherwise. The status is set directly: setStatus would persist
+// synchronously, on the launch path.
+func (m *Manager) persistWakeOwed(inst *VMInstance, predicted Supervision, clockFrozen bool) (join func(actual Supervision) bool) {
+	inst.mu.Lock()
+	inst.Status = StatusRunning
+	inst.Unverified = true
+	inst.PausedAt = time.Time{}
+	inst.Supervision = predicted
+	inst.WakePending = true
+	inst.ClockFrozen = clockFrozen
+	inst.mu.Unlock()
+	done := make(chan struct{})
+	ok := false
+	go func() {
+		defer sentrylog.Recover("wake-owed-persist")
+		defer close(done)
+		ok = m.persistState(inst)
+	}()
+	return func(actual Supervision) bool {
+		<-done
+		if !ok || actual != predicted {
+			ok = m.persistState(inst)
+		}
+		return ok
+	}
+}
+
+// pendingWake is a reattached instance that owes its guest a wake. The startup
+// pass finds them faster than a wake can be completed, so they are queued and
+// resolved by a bounded pool after the pass; a request for one waits on done.
+type pendingWake struct {
+	inst *VMInstance
+	done chan struct{}
+	// unlock releases the VM's lifecycle lock, held since the startup pass
+	// queued it, once the outcome is published.
+	unlock func()
+}
+
+const wakeRecoveryWorkers = 4
+
+func (m *Manager) pendingWake(id string) *pendingWake {
+	m.pendingWakeMu.Lock()
+	defer m.pendingWakeMu.Unlock()
+	return m.pendingWakes[id]
+}
+
+func (m *Manager) queuePendingWake(inst *VMInstance, unlock func()) {
+	m.pendingWakeMu.Lock()
+	defer m.pendingWakeMu.Unlock()
+	if m.pendingWakes == nil {
+		m.pendingWakes = map[string]*pendingWake{}
+	}
+	if _, queued := m.pendingWakes[inst.ID]; queued {
+		unlock()
+		return
+	}
+	m.pendingWakes[inst.ID] = &pendingWake{inst: inst, done: make(chan struct{}), unlock: unlock}
+}
+
+// drainPendingWakes completes every queued wake through a bounded pool and
+// publishes each outcome: Running once woken, Error otherwise — never a frozen
+// guest presented as ready. Returns how many were published Running.
+func (m *Manager) drainPendingWakes(ctx context.Context) int {
+	m.pendingWakeMu.Lock()
+	queued := make([]*pendingWake, 0, len(m.pendingWakes))
+	for _, pw := range m.pendingWakes {
+		queued = append(queued, pw)
+	}
+	m.pendingWakeMu.Unlock()
+	if len(queued) == 0 {
+		return 0
+	}
+	var woken atomic.Int32
+	sem := make(chan struct{}, wakeRecoveryWorkers)
+	var wg sync.WaitGroup
+	for _, pw := range queued {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(pw *pendingWake) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer sentrylog.Recover("wake-recovery")
+			defer func() {
+				m.pendingWakeMu.Lock()
+				delete(m.pendingWakes, pw.inst.ID)
+				m.pendingWakeMu.Unlock()
+				close(pw.done)
+				pw.unlock()
+			}()
+			log := m.log.With().Str("vm_id", pw.inst.ID).Logger()
+			// The lifecycle lock has been held since the startup pass queued
+			// this VM, so no restore or resume for the id can have run
+			// meanwhile; the map check below is belt and braces.
+			m.mu.RLock()
+			_, taken := m.vms[pw.inst.ID]
+			m.mu.RUnlock()
+			if taken {
+				log.Info().Msg("reattach: a request replaced this VM before its wake completed; recovery instance abandoned")
+				return
+			}
+			if m.completeOwedWake(ctx, pw.inst, log) {
+				woken.Add(1)
+			} else {
+				m.parkUnservable(pw.inst)
+			}
+			m.publishRecovered(pw.inst)
+		}(pw)
+	}
+	wg.Wait()
+	return int(woken.Load())
+}
+
+// completeOwedWake sends the wake a reattached record still owes. True once
+// the guest is awake; false leaves the instance owing it, for Error.
+func (m *Manager) completeOwedWake(ctx context.Context, inst *VMInstance, log zerolog.Logger) bool {
+	if err := m.verifyBoxdReady(ctx, inst.IP, inst); err != nil {
+		log.Error().Err(err).Msg("reattach: guest still owes its wake and could not be woken; parking as error")
+		return false
+	}
+	inst.mu.Lock()
+	inst.Unverified = false
+	inst.mu.Unlock()
+	log.Info().Msg("reattach: completed the wake a restore owed this guest")
+	return true
+}
+
+// recoverPauseIntent releases a guest that a pause froze and then died
+// before finishing. True when nothing is owed or the guest is released;
+// false when a frozen guest could not be released and must not be served.
+// Only a host whose floor is up ever holds an intent, so elsewhere nothing
+// is looked for.
+func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log zerolog.Logger) bool {
+	if !wakeProtocolFloorRaised() {
+		return true
+	}
+	dir := filepath.Join(m.cfg.SnapshotDir, inst.ID)
+	in, err := readPauseIntent(dir)
+	if err != nil {
+		log.Error().Err(err).Msg("reattach: pause intent unreadable; parking as error")
+		return false
+	}
+	if in == nil {
+		return true
+	}
+	if in.FreezeToken != "" && inst.IP != "" {
+		tctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		terr := boxdThawGuest(tctx, inst.IP, in.FreezeToken)
+		cancel()
+		// A token the guest never froze under means the crash came before
+		// the freeze: nothing to release.
+		if terr != nil && !errors.Is(terr, ErrGuestTokenMismatch) {
+			log.Error().Err(terr).Msg("reattach: a pause left this guest frozen and it could not be released; parking as error")
+			return false
+		}
+		log.Warn().Msg("reattach: released a guest an interrupted pause had frozen")
+	}
+	if cerr := clearPauseIntent(dir); cerr != nil {
+		log.Warn().Err(cerr).Msg("reattach: interrupted pause's intent could not be cleared; the next pause rewrites it")
+	}
+	return true
+}
+
+// publishRecovered publishes an instance the wake pool resolved, durably —
+// only if nothing else took the id meanwhile: the record belongs to whoever
+// owns the map entry, and a stale instance must never write over it.
+func (m *Manager) publishRecovered(inst *VMInstance) {
+	m.mu.Lock()
+	if _, present := m.vms[inst.ID]; present {
+		m.mu.Unlock()
+		return
+	}
+	m.vms[inst.ID] = inst
+	m.indexVM(inst.ID, inst)
+	m.mu.Unlock()
+	if wrote, perr := m.persistStateIfPresent(inst); perr == nil && !wrote {
+		m.undoReattach(inst.ID)
+	}
+}
+
+// parkUnservable stops a guest whose state recovery could not settle — a
+// freeze it could not release, a wake it did not answer — and marks it Error.
+// Stopped first, and confirmed as far as the stop can confirm: a guest in an
+// unknown state must not keep running behind an Error record until a grace
+// period reaps it.
+func (m *Manager) parkUnservable(inst *VMInstance) {
+	m.stopUnitDuringRestoreError(inst.ID)
+	inst.mu.Lock()
+	inst.Status = StatusError
+	inst.mu.Unlock()
 }
 
 // commitResumeState persists a resumed instance and verifies the VM was not

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -1914,9 +1914,13 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 			}
 			if merr != nil {
 				// No manifest is safe for an unfrozen image; a stale frozen
-				// one is not. The stale one goes, durably, or the pause fails.
-				if rerr := removeWallClockManifestDurably(memPath); rerr != nil {
-					return "", "", nil, m.handleVMError(vmID, fmt.Errorf("wall-clock manifest write failed (%v) and the stale one could not be cleared: %w", merr, rerr))
+				// one is not. The stale one goes, durably, or the pause
+				// fails; a marker that was not a frozen manifest and will not
+				// go is harmless and only logged.
+				if frozen, rerr := removeWallClockManifest(memPath); rerr != nil && frozen {
+					return "", "", nil, m.failAfterSnapshot(vmID, socketPath, fmt.Errorf("wall-clock manifest write failed (%v) and the stale frozen one could not be cleared: %w", merr, rerr))
+				} else if rerr != nil {
+					log.Warn().Err(rerr).Str("path", WallClockMarkerPath(memPath)).Msg("pause: a stale marker could not be removed")
 				}
 				log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).
 					Msg("pause: wall-clock manifest write failed; resume falls back to legacy clock behaviour")
@@ -1924,14 +1928,19 @@ func (m *Manager) PauseVM(ctx context.Context, vmID, snapshotDir, pauseToken str
 		}
 	} else {
 		// A guest that cannot correct its clock gets no manifest; one an
-		// earlier image left here goes, durably, for the reason above.
+		// earlier image left here goes, durably, for the reason above. A
+		// marker that was not a frozen manifest and will not go is harmless:
+		// the image reads as legacy either way. The vCPUs are paused from
+		// the snapshot on, so a failure here must not strand them.
 		tManifest := time.Now()
-		merr := removeWallClockManifestDurably(memPath)
+		frozen, merr := removeWallClockManifest(memPath)
 		if d := time.Since(tManifest); d > time.Millisecond {
 			manifestDur = d
 		}
-		if merr != nil {
-			return "", "", nil, m.handleVMError(vmID, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
+		if merr != nil && frozen {
+			return "", "", nil, m.failAfterSnapshot(vmID, socketPath, fmt.Errorf("clear stale wall-clock manifest for %q: %w", memPath, merr))
+		} else if merr != nil {
+			log.Warn().Err(merr).Str("path", WallClockMarkerPath(memPath)).Msg("pause: a stale marker could not be removed")
 		}
 	}
 
@@ -8441,6 +8450,21 @@ func (m *Manager) ensureWakeFloorTimed(op string) error {
 	return err
 }
 
+// failAfterSnapshot is the error return for a pause that fails after its
+// snapshot landed: Firecracker left the vCPUs paused for the snapshot, and
+// a pause that returns an error keeps the VM recorded Running, so the guest
+// is resumed first — a stopped sandbox that reads as running is the one
+// outcome this must never leave. Best-effort: a guest that cannot be
+// resumed is reported as the error it already was.
+func (m *Manager) failAfterSnapshot(vmID, socketPath string, err error) error {
+	uctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if uerr := fcUnpauseVM(uctx, socketPath); uerr != nil {
+		m.log.Error().Err(uerr).Str("vm_id", vmID).Msg("pause failed after its snapshot and the guest could not be resumed")
+	}
+	return m.handleVMError(vmID, err)
+}
+
 // frozenManifestAt reports whether any of the paths carries a manifest that
 // says frozen. A stat first: absent manifests, the common case, cost one
 // lookup each and no read.
@@ -8755,7 +8779,7 @@ func (m *Manager) recoverPauseIntent(ctx context.Context, inst *VMInstance, log 
 		// unfrozen or torn, so a manifest beside them that says frozen is
 		// stale either way and must not outlive the intent.
 		for _, name := range []string{"mem.diff", "mem.snap"} {
-			if err := removeWallClockManifestDurably(filepath.Join(dir, name)); err != nil {
+			if _, err := removeWallClockManifest(filepath.Join(dir, name)); err != nil {
 				log.Error().Err(err).Msg("reattach: a stale frozen manifest beside an interrupted rewrite could not be removed; parking as error")
 				return false
 			}

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -3008,13 +3008,6 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 	// clearing DirtyTracked and the unpause below. Failing here has done nothing
 	// yet.
 	//
-	// An ad-hoc image is never marked: restores from it take legacy behaviour,
-	// which is slower and always correct. Callers may also hand in a directory
-	// that already holds an image, so clear rather than assume.
-	if merr := os.Remove(clockFreezeMarkerPath(memPath)); merr != nil && !os.IsNotExist(merr) {
-		return "", "", fmt.Errorf("clear wall-clock marker for ad-hoc snapshot %q: %w", memPath, merr)
-	}
-
 	if err := CreateSnapshot(inst.SocketPath, snapshotPath, memPath, "", SnapshotNormal); err != nil {
 		return "", "", fmt.Errorf("create snapshot: %w", err)
 	}
@@ -3041,6 +3034,20 @@ func (m *Manager) CreateVMSnapshot(ctx context.Context, vmID, snapshotDir string
 
 	if err := UnpauseVM(inst.SocketPath); err != nil {
 		return snapshotPath, memPath, fmt.Errorf("resume after snapshot: %w", err)
+	}
+
+	// An ad-hoc image is never marked: restores from it take legacy behaviour,
+	// slower and always correct. A manifest an earlier image left at this path
+	// goes only now, after the image is replaced: a snapshot that failed left
+	// the earlier image, and its manifest must stay with it. One that will
+	// not go and is not known harmless would send a wake nothing answers, so
+	// the image is withdrawn rather than published beside it.
+	if blocking, merr := removeWallClockManifest(memPath); merr != nil && blocking {
+		_ = os.Remove(memPath)
+		_ = os.Remove(snapshotPath)
+		return "", "", fmt.Errorf("clear wall-clock manifest for ad-hoc snapshot %q: %w", memPath, merr)
+	} else if merr != nil {
+		m.log.Warn().Err(merr).Str("vm_id", vmID).Msg("ad-hoc snapshot: a stale marker could not be removed")
 	}
 
 	return snapshotPath, memPath, nil

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -728,6 +728,11 @@ type Manager struct {
 	// m.vms until the startup pool completes it. See queuePendingWake.
 	pendingWakeMu sync.Mutex
 	pendingWakes  map[string]*pendingWake
+	// wakeDrainStarted closes when the pool begins serving queued wakes,
+	// after the startup pass has scanned every record; a request waiting
+	// on a queued wake counts its bound from then, not from the scan.
+	wakeDrainStarted chan struct{}
+	wakeDrainBegun   bool
 	// reattachDeferred marks ids whose startup reattach was left to the
 	// request holding their lifecycle lock; see reattachByID.
 	reattachDeferred sync.Map
@@ -4975,14 +4980,25 @@ func (m *Manager) reattachRecord(ctx context.Context, rec VMRecord, cleanupStale
 	// bounded pool, not the flight's own short budget: giving up early would
 	// report a live VM as missing and invite a replacement.
 	if pw := m.pendingWake(rec.ID); pw != nil && !cleanupStale {
-		wait := time.NewTimer(pendingWakeWaitBound(m.pendingWakeCount()))
-		defer wait.Stop()
-		select {
-		case <-pw.done:
+		published := func() (*VMInstance, bool) {
 			m.mu.RLock()
 			inst, ok := m.vms[rec.ID]
 			m.mu.RUnlock()
 			return inst, ok
+		}
+		// The pool starts only once the startup pass has scanned every
+		// record, and that scan is not bounded by the queue: wait for the
+		// pool to start, then for it to reach this wake.
+		select {
+		case <-pw.done:
+			return published()
+		case <-m.wakeDrainStartedCh():
+		}
+		wait := time.NewTimer(pendingWakeWaitBoundFor(m.pendingWakeCount()))
+		defer wait.Stop()
+		select {
+		case <-pw.done:
+			return published()
 		case <-wait.C:
 			return nil, false
 		}
@@ -8474,6 +8490,35 @@ func (m *Manager) pendingWakeCount() int {
 	return len(m.pendingWakes)
 }
 
+// wakeDrainStartedCh is closed once the pool has begun serving queued wakes.
+func (m *Manager) wakeDrainStartedCh() <-chan struct{} {
+	m.pendingWakeMu.Lock()
+	defer m.pendingWakeMu.Unlock()
+	if m.wakeDrainStarted == nil {
+		m.wakeDrainStarted = make(chan struct{})
+		if m.wakeDrainBegun {
+			close(m.wakeDrainStarted)
+		}
+	}
+	return m.wakeDrainStarted
+}
+
+func (m *Manager) noteWakeDrainStarted() {
+	m.pendingWakeMu.Lock()
+	defer m.pendingWakeMu.Unlock()
+	if m.wakeDrainBegun {
+		return
+	}
+	m.wakeDrainBegun = true
+	if m.wakeDrainStarted == nil {
+		m.wakeDrainStarted = make(chan struct{})
+	}
+	close(m.wakeDrainStarted)
+}
+
+// pendingWakeWaitBoundFor is a seam over pendingWakeWaitBound for tests.
+var pendingWakeWaitBoundFor = pendingWakeWaitBound
+
 // pendingWakeWaitBound is how long a request may wait for a queued wake: the
 // pool serves queued wakes wakeRecoveryWorkers at a time, each bounded by
 // the wake's own budget, so a wake queued behind n others is served within
@@ -8503,6 +8548,7 @@ func (m *Manager) queuePendingWake(inst *VMInstance, unlock func()) {
 // publishes each outcome: Running once woken, Error otherwise — never a frozen
 // guest presented as ready. Returns how many were published Running.
 func (m *Manager) drainPendingWakes(ctx context.Context) int {
+	m.noteWakeDrainStarted()
 	m.pendingWakeMu.Lock()
 	queued := make([]*pendingWake, 0, len(m.pendingWakes))
 	for _, pw := range m.pendingWakes {

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -2051,7 +2051,7 @@ func TestVerifyBoxdReadyDetachedFromCaller(t *testing.T) {
 	defer func() { adoptionBoxdReady = orig }()
 
 	m := &Manager{log: zerolog.Nop()}
-	if err := m.verifyBoxdReady(callerCtx, "192.0.2.5"); err != nil {
+	if err := m.verifyBoxdReady(callerCtx, "192.0.2.5", &VMInstance{}); err != nil {
 		t.Fatalf("healthy gate must pass, got %v", err)
 	}
 	if gateCtxDone {
@@ -2371,7 +2371,7 @@ func TestVerifyBoxdReadyReachesVerdictUnderShorterCallerDeadline(t *testing.T) {
 	defer cancel()
 
 	m := &Manager{log: zerolog.Nop()}
-	err := m.verifyBoxdReady(callerCtx, "192.0.2.5")
+	err := m.verifyBoxdReady(callerCtx, "192.0.2.5", &VMInstance{})
 	if err == nil {
 		t.Fatal("a silent guest must produce a verdict, not be swallowed")
 	}

--- a/internal/vm/session_policy_test.go
+++ b/internal/vm/session_policy_test.go
@@ -398,7 +398,7 @@ func TestRestoreForResume_SessionRequiresCapability(t *testing.T) {
 	net := &network.VMNetInfo{TAPDevice: "tap0"}
 	for _, capable := range []bool{false, true} {
 		m := resumeManager(t, capable)
-		tracked, armed, _, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", net, nil)
+		tracked, armed, _, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", net, nil, nil)
 		if err != nil || !tracked {
 			t.Fatalf("capable=%v: restore failed or untracked: %v", capable, err)
 		}
@@ -423,7 +423,7 @@ func TestRestoreForResume_UnknownSessionFieldFallsBack(t *testing.T) {
 		return http.StatusNoContent, ""
 	})
 	m := resumeManager(t, true)
-	tracked, armed, _, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, nil)
+	tracked, armed, _, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, nil, nil)
 	if err != nil {
 		t.Fatalf("the unguarded retry must succeed: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestRestoreForResume_DoubleRollbackRetriesEachFieldOnce(t *testing.T) {
 	m := resumeManager(t, true)
 	m.clockRealtimeCapable.Store(true)
 	freeze := false
-	_, armed, usedClock, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, &freeze)
+	_, armed, usedClock, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, &freeze, nil)
 	if err != nil || armed != "" || usedClock {
 		t.Fatalf("the bare retry must succeed with nothing armed, got err=%v armed=%q clock=%v", err, armed, usedClock)
 	}
@@ -619,3 +619,42 @@ func TestIsUnknownSessionFieldErr(t *testing.T) {
 type fakeErr struct{ s string }
 
 func (e *fakeErr) Error() string { return e.s }
+
+// If this Firecracker refuses the clock option, the hook runs between the
+// refusal and the legacy retry, and a hook that fails stops the retry: the
+// record must say the clock ran before the vCPUs can.
+func TestRestoreForResume_RunsTheHookBeforeTheLegacyRetry(t *testing.T) {
+	refuseClock := func(_, body string) (int, string) {
+		if strings.Contains(body, `"clock_realtime"`) {
+			return http.StatusBadRequest, unknownFieldPayload("clock_realtime")
+		}
+		return http.StatusNoContent, ""
+	}
+	fc := startSnapshotAPIFake(t, refuseClock)
+	m := resumeManager(t, true)
+	m.clockRealtimeCapable.Store(true)
+	freeze := false
+	requestsAtHook := -1
+	hook := func() error { requestsAtHook = len(fc.snapshotBodies()); return nil }
+	_, _, usedClock, err := m.restoreForResume(fc.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, &freeze, hook)
+	if err != nil || usedClock {
+		t.Fatalf("err=%v usedClock=%v; want a legacy success", err, usedClock)
+	}
+	if requestsAtHook != 1 {
+		t.Fatalf("hook ran after %d requests, want after the refused one only", requestsAtHook)
+	}
+	if bodies := fc.snapshotBodies(); len(bodies) != 2 || strings.Contains(bodies[1], `"clock_realtime"`) {
+		t.Fatalf("want two requests, the second without the option: %v", bodies)
+	}
+
+	fc2 := startSnapshotAPIFake(t, refuseClock)
+	m2 := resumeManager(t, true)
+	m2.clockRealtimeCapable.Store(true)
+	_, _, _, err = m2.restoreForResume(fc2.socketPath, "/tmp/snap", "/tmp/mem", "", &network.VMNetInfo{TAPDevice: "tap0"}, &freeze, func() error { return io.ErrUnexpectedEOF })
+	if err == nil || !strings.Contains(err.Error(), io.ErrUnexpectedEOF.Error()) {
+		t.Fatalf("err=%v, want the hook's error", err)
+	}
+	if n := len(fc2.snapshotBodies()); n != 1 {
+		t.Fatalf("the legacy retry ran after a failed hook: %d requests", n)
+	}
+}

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -228,6 +228,11 @@ type VMRecord struct {
 	WakePending bool   `json:"wake_pending,omitempty"`
 	ClockFrozen bool   `json:"clock_frozen,omitempty"`
 	FreezeToken string `json:"freeze_token,omitempty"`
+	// WakeOwedFromPaused: the record owing the wake was Paused before this
+	// resume began, so its image is intact. A crash before the launch, or a
+	// wake that never completes, returns it to Paused; a create in the same
+	// state is a failed create and is reaped.
+	WakeOwedFromPaused bool `json:"wake_owed_from_paused,omitempty"`
 	// ArtifactID names the manifest beside the image this VM was last paused
 	// into; see VMInstance.
 	ArtifactID string            `json:"artifact_id,omitempty"`
@@ -927,6 +932,7 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		WakePending:                inst.WakePending,
 		ClockFrozen:                inst.ClockFrozen,
 		FreezeToken:                inst.FreezeToken,
+		WakeOwedFromPaused:         inst.WakeOwedFromPaused,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
@@ -1033,6 +1039,7 @@ func toInstance(rec VMRecord) *VMInstance {
 		WakePending:                rec.WakePending,
 		ClockFrozen:                rec.ClockFrozen,
 		FreezeToken:                rec.FreezeToken,
+		WakeOwedFromPaused:         rec.WakeOwedFromPaused,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,
 		TeamID:                     rec.TeamID,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -228,6 +228,11 @@ type VMRecord struct {
 	WakePending bool   `json:"wake_pending,omitempty"`
 	ClockFrozen bool   `json:"clock_frozen,omitempty"`
 	FreezeToken string `json:"freeze_token,omitempty"`
+	// WakeToken is the token the owed wake must present: that of the image
+	// being loaded, kept apart from FreezeToken, which describes the image the
+	// record names, until the commit. A resume from an override that dies
+	// between the two returns to Paused with its own image and token intact.
+	WakeToken string `json:"wake_token,omitempty"`
 	// WakeOwedFromPaused: the record owing the wake was Paused before this
 	// resume began, so its image is intact. A crash before the launch, or a
 	// wake that never completes, returns it to Paused; a create in the same
@@ -932,6 +937,7 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		WakePending:                inst.WakePending,
 		ClockFrozen:                inst.ClockFrozen,
 		FreezeToken:                inst.FreezeToken,
+		WakeToken:                  inst.WakeToken,
 		WakeOwedFromPaused:         inst.WakeOwedFromPaused,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
@@ -1039,6 +1045,7 @@ func toInstance(rec VMRecord) *VMInstance {
 		WakePending:                rec.WakePending,
 		ClockFrozen:                rec.ClockFrozen,
 		FreezeToken:                rec.FreezeToken,
+		WakeToken:                  rec.WakeToken,
 		WakeOwedFromPaused:         rec.WakeOwedFromPaused,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -233,6 +233,13 @@ type VMRecord struct {
 	// record names, until the commit. A resume from an override that dies
 	// between the two returns to Paused with its own image and token intact.
 	WakeToken string `json:"wake_token,omitempty"`
+	// WakeSnapshotPath / WakeMemPath name the image the owed wake is for when
+	// it is not the one the record names: a resume from an override. A wake
+	// completed by recovery commits them as the record's image, so a retry of
+	// that resume finds the sandbox up instead of relaunching it; a wake that
+	// fails drops them and the record keeps its own image.
+	WakeSnapshotPath string `json:"wake_snapshot_path,omitempty"`
+	WakeMemPath      string `json:"wake_mem_path,omitempty"`
 	// WakeOwedFromPaused: the record owing the wake was Paused before this
 	// resume began, so its image is intact. A crash before the launch, or a
 	// wake that never completes, returns it to Paused; a create in the same
@@ -938,6 +945,8 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		ClockFrozen:                inst.ClockFrozen,
 		FreezeToken:                inst.FreezeToken,
 		WakeToken:                  inst.WakeToken,
+		WakeSnapshotPath:           inst.WakeSnapshotPath,
+		WakeMemPath:                inst.WakeMemPath,
 		WakeOwedFromPaused:         inst.WakeOwedFromPaused,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
@@ -1046,6 +1055,8 @@ func toInstance(rec VMRecord) *VMInstance {
 		ClockFrozen:                rec.ClockFrozen,
 		FreezeToken:                rec.FreezeToken,
 		WakeToken:                  rec.WakeToken,
+		WakeSnapshotPath:           rec.WakeSnapshotPath,
+		WakeMemPath:                rec.WakeMemPath,
 		WakeOwedFromPaused:         rec.WakeOwedFromPaused,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -219,6 +219,15 @@ type VMRecord struct {
 	// cannot leave an older answer for the next resume to act on. Tri-state
 	// for the same reason as CorrectsWallClock; nil means "ask the disk".
 	SnapshotWorkloadFrozen *bool `json:"snapshot_workload_frozen,omitempty"`
+	// WakePending: restored but the guest has not yet been told to correct its
+	// clock and release its workload. Written with the Running record, so a
+	// daemon that crashes between the two completes the wake on recovery
+	// instead of verifying a stopped workload as ready. ClockFrozen is the
+	// policy that restore used, which the wake must carry. FreezeToken is the
+	// token the image's freeze carries; a wake or thaw must present it.
+	WakePending bool   `json:"wake_pending,omitempty"`
+	ClockFrozen bool   `json:"clock_frozen,omitempty"`
+	FreezeToken string `json:"freeze_token,omitempty"`
 	// ArtifactID names the manifest beside the image this VM was last paused
 	// into; see VMInstance.
 	ArtifactID string            `json:"artifact_id,omitempty"`
@@ -915,6 +924,9 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		CorrectsWallClock:          inst.CorrectsWallClock,
 		ArtifactID:                 inst.ArtifactID,
 		SnapshotWorkloadFrozen:     inst.SnapshotWorkloadFrozen,
+		WakePending:                inst.WakePending,
+		ClockFrozen:                inst.ClockFrozen,
+		FreezeToken:                inst.FreezeToken,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
@@ -1018,6 +1030,9 @@ func toInstance(rec VMRecord) *VMInstance {
 		CorrectsWallClock:          rec.CorrectsWallClock,
 		ArtifactID:                 rec.ArtifactID,
 		SnapshotWorkloadFrozen:     rec.SnapshotWorkloadFrozen,
+		WakePending:                rec.WakePending,
+		ClockFrozen:                rec.ClockFrozen,
+		FreezeToken:                rec.FreezeToken,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,
 		TeamID:                     rec.TeamID,

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -219,12 +219,10 @@ type VMRecord struct {
 	// cannot leave an older answer for the next resume to act on. Tri-state
 	// for the same reason as CorrectsWallClock; nil means "ask the disk".
 	SnapshotWorkloadFrozen *bool `json:"snapshot_workload_frozen,omitempty"`
-	// WakePending: restored but the guest has not yet been told to correct its
-	// clock and release its workload. Written with the Running record, so a
-	// daemon that crashes between the two completes the wake on recovery
-	// instead of verifying a stopped workload as ready. ClockFrozen is the
-	// policy that restore used, which the wake must carry. FreezeToken is the
-	// token the image's freeze carries; a wake or thaw must present it.
+	// WakePending: restored, the guest not yet told to correct its clock and
+	// release its workload; written with the Running record so a crash between
+	// the two completes the wake on recovery. ClockFrozen is the policy the
+	// restore used; FreezeToken the token the image's freeze carries.
 	WakePending bool   `json:"wake_pending,omitempty"`
 	ClockFrozen bool   `json:"clock_frozen,omitempty"`
 	FreezeToken string `json:"freeze_token,omitempty"`
@@ -233,11 +231,9 @@ type VMRecord struct {
 	// record names, until the commit. A resume from an override that dies
 	// between the two returns to Paused with its own image and token intact.
 	WakeToken string `json:"wake_token,omitempty"`
-	// WakeSnapshotPath / WakeMemPath name the image the owed wake is for when
-	// it is not the one the record names: a resume from an override. A wake
-	// completed by recovery commits them as the record's image, so a retry of
-	// that resume finds the sandbox up instead of relaunching it; a wake that
-	// fails drops them and the record keeps its own image.
+	// WakeSnapshotPath / WakeMemPath name the image an owed wake is for when
+	// it is not the record's own: a resume from an override. A wake completed
+	// by recovery commits them as the record's image; a failed one drops them.
 	WakeSnapshotPath string `json:"wake_snapshot_path,omitempty"`
 	WakeMemPath      string `json:"wake_mem_path,omitempty"`
 	// WakeOwedFromPaused: the record owing the wake was Paused before this

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
@@ -131,6 +133,176 @@ func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, h
 	}
 	return nil
 }
+
+// ErrGuestClockUnready: the guest cannot correct its clock; waiting longer
+// cannot help, and this host should restore the unfrozen way.
+var ErrGuestClockUnready = errors.New("guest clock could not be corrected")
+
+// ErrGuestThawFailed: the guest corrected its clock but could not release its
+// workload. Not a clock problem; retrying unfrozen would not help.
+var ErrGuestThawFailed = errors.New("guest workload could not be released")
+
+// ErrGuestTokenMismatch: the guest holds no freeze this wake names — a torn or
+// mismatched artifact, never retried.
+var ErrGuestTokenMismatch = errors.New("guest freeze token mismatch")
+
+// clockUnreadyPolls is how many consecutive such answers make it final: the
+// first may be mid-correction.
+const clockUnreadyPolls = 3
+
+// freezeEcho is what the guest answers a freeze with: the protocol it speaks
+// and the token it now holds, so the pause needs no separate probe.
+type freezeEcho struct {
+	Version    int    `json:"version"`
+	Capability string `json:"capability"`
+	Token      string `json:"token"`
+}
+
+// postBoxdFreeze asks the guest to stop its workload ahead of a snapshot.
+func postBoxdFreeze(ctx context.Context, vmIP, token string) (freezeEcho, error) {
+	// The guest's budget is shorter than ours, so it gives up and thaws first.
+	req := struct {
+		BudgetMs int64  `json:"budget_ms,omitempty"`
+		Token    string `json:"token"`
+	}{Token: token}
+	if dl, ok := ctx.Deadline(); ok {
+		budget := time.Until(dl) - 200*time.Millisecond
+		if budget <= 0 {
+			return freezeEcho{}, context.DeadlineExceeded
+		}
+		req.BudgetMs = budget.Milliseconds()
+	}
+	body, _ := json.Marshal(req)
+	reply, err := postBoxd(ctx, vmIP, "/freeze", body)
+	if err != nil {
+		return freezeEcho{}, err
+	}
+	var echo freezeEcho
+	if err := json.Unmarshal(reply, &echo); err != nil {
+		return freezeEcho{}, fmt.Errorf("POST /freeze: reply: %w", err)
+	}
+	return echo, nil
+}
+
+// postBoxdThaw undoes a freeze whose snapshot did not happen. A refusal that
+// the token names no freeze the guest holds is ErrGuestTokenMismatch.
+func postBoxdThaw(ctx context.Context, vmIP, token string) error {
+	body, _ := json.Marshal(struct {
+		Token string `json:"token"`
+	}{token})
+	_, err := postBoxd(ctx, vmIP, "/thaw", body)
+	var se *boxdStatusError
+	if errors.As(err, &se) && se.Code == http.StatusConflict {
+		return fmt.Errorf("%w: %s", ErrGuestTokenMismatch, se.Body)
+	}
+	return err
+}
+
+// boxdStatusError is a non-200 answer from the guest agent.
+type boxdStatusError struct {
+	Path string
+	Code int
+	Body string
+}
+
+func (e *boxdStatusError) Error() string {
+	return fmt.Sprintf("POST %s: status %d: %s", e.Path, e.Code, e.Body)
+}
+
+func postBoxd(ctx context.Context, vmIP, path string, body []byte) ([]byte, error) {
+	url := fmt.Sprintf("http://%s:%d%s", vmIP, boxdPort, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create %s request: %w", path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := boxdHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	reply, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return nil, &boxdStatusError{Path: path, Code: resp.StatusCode, Body: strings.TrimSpace(string(reply))}
+	}
+	return reply, nil
+}
+
+// waitForGuestWake tells a restored guest to correct its clock and release its
+// workload, and waits for it to confirm. clockFrozen is the policy the restore
+// used, so the guest knows whether correction is required. Returns
+// ErrGuestClockUnready as soon as the guest reports it cannot, so the caller
+// can retry the restore the unfrozen way instead of waiting out the budget.
+func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, clockFrozen bool, token string) error {
+	url := fmt.Sprintf("http://%s:%d/wake", vmIP, boxdPort)
+	body, _ := json.Marshal(struct {
+		ClockFrozen bool   `json:"clock_frozen"`
+		Token       string `json:"token"`
+	}{clockFrozen, token})
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	const maxProbeInterval = 10 * time.Millisecond
+	interval := time.Millisecond
+	var lastErr error
+	clockUnready := 0
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err == nil {
+			reply, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			err = fmt.Errorf("unexpected status %d", resp.StatusCode)
+			if resp.StatusCode == http.StatusConflict {
+				// Definitive: the guest holds no freeze this token names, so
+				// this image and this wake describe different snapshots.
+				return fmt.Errorf("%w: %s", ErrGuestTokenMismatch, strings.TrimSpace(string(reply)))
+			}
+			if resp.StatusCode == http.StatusServiceUnavailable {
+				var r struct {
+					Status    string `json:"status"`
+					WallClock struct {
+						Error string `json:"error"`
+					} `json:"wall_clock"`
+				}
+				if json.Unmarshal(reply, &r) == nil && (r.Status == "clock" || r.Status == "thaw") {
+					if clockUnready++; clockUnready >= clockUnreadyPolls {
+						sentinel := ErrGuestClockUnready
+						if r.Status == "thaw" {
+							sentinel = ErrGuestThawFailed
+						}
+						return fmt.Errorf("%w (%s)", sentinel, r.WallClock.Error)
+					}
+				}
+			}
+		}
+		lastErr = err
+		time.Sleep(interval)
+		interval = min(interval*2, maxProbeInterval)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("guest not awake after %s: %w", timeout, lastErr)
+	}
+	return fmt.Errorf("guest not awake after %s", timeout)
+}
+
+// Seams so the pause and restore paths can be tested without a guest.
+var (
+	boxdFreezeGuest = postBoxdFreeze
+	boxdThawGuest   = postBoxdThaw
+	boxdWakeGuest   = waitForGuestWake
+)
 
 // boxdFilesystemClient returns a Connect RPC client for boxd's
 // FilesystemService, used for metadata ops (Remove, Move, etc.) inside

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -198,6 +198,37 @@ func postBoxdThaw(ctx context.Context, vmIP, token string) error {
 	return err
 }
 
+// guestWorkloadRunning asks the guest whether its workload runs. Health
+// answers ok only while nothing is frozen, so a thaw refused for a token the
+// guest does not hold is read as "never frozen" only once this confirms it:
+// the guest may still be frozen under an earlier token.
+func guestWorkloadRunning(ctx context.Context, vmIP string) error {
+	url := fmt.Sprintf("http://%s:%d/health", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create /health request: %w", err)
+	}
+	resp, err := boxdHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET /health: %w", err)
+	}
+	defer resp.Body.Close()
+	reply, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return &boxdStatusError{Path: "/health", Code: resp.StatusCode, Body: strings.TrimSpace(string(reply))}
+	}
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(reply, &body); err != nil {
+		return fmt.Errorf("decode /health: %w", err)
+	}
+	if body.Status != "ok" {
+		return fmt.Errorf("guest workload status %q", body.Status)
+	}
+	return nil
+}
+
 // boxdStatusError is a non-200 answer from the guest agent.
 type boxdStatusError struct {
 	Path string
@@ -299,9 +330,10 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 
 // Seams so the pause and restore paths can be tested without a guest.
 var (
-	boxdFreezeGuest = postBoxdFreeze
-	boxdThawGuest   = postBoxdThaw
-	boxdWakeGuest   = waitForGuestWake
+	boxdFreezeGuest  = postBoxdFreeze
+	boxdThawGuest    = postBoxdThaw
+	boxdWakeGuest    = waitForGuestWake
+	boxdGuestRunning = guestWorkloadRunning
 )
 
 // boxdFilesystemClient returns a Connect RPC client for boxd's

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -280,7 +280,12 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 	const maxProbeInterval = 10 * time.Millisecond
 	interval := time.Millisecond
 	var lastErr error
-	clockUnready := 0
+	// Consecutive answers of one kind make the verdict; anything in between —
+	// a transport error, another status, a body that does not parse, or the
+	// other kind — starts the count over. The first may be mid-correction,
+	// and a verdict assembled from answers that were not consecutive would
+	// park a guest that was recovering.
+	streakKind, streak := "", 0
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -288,6 +293,7 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := client.Do(req)
+		kind, detail := "", ""
 		if err == nil {
 			reply, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			resp.Body.Close()
@@ -308,14 +314,20 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 					} `json:"wall_clock"`
 				}
 				if json.Unmarshal(reply, &r) == nil && (r.Status == "clock" || r.Status == "thaw") {
-					if clockUnready++; clockUnready >= clockUnreadyPolls {
-						sentinel := ErrGuestClockUnready
-						if r.Status == "thaw" {
-							sentinel = ErrGuestThawFailed
-						}
-						return fmt.Errorf("%w (%s)", sentinel, r.WallClock.Error)
-					}
+					kind, detail = r.Status, r.WallClock.Error
 				}
+			}
+		}
+		if kind != streakKind {
+			streakKind, streak = kind, 0
+		}
+		if kind != "" {
+			if streak++; streak >= clockUnreadyPolls {
+				sentinel := ErrGuestClockUnready
+				if kind == "thaw" {
+					sentinel = ErrGuestThawFailed
+				}
+				return fmt.Errorf("%w (%s)", sentinel, detail)
 			}
 		}
 		lastErr = err

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -267,10 +267,8 @@ func postBoxd(ctx context.Context, vmIP, path string, body []byte) ([]byte, erro
 }
 
 // waitForGuestWake tells a restored guest to correct its clock and release its
-// workload, and waits for it to confirm. clockFrozen is the policy the restore
-// used, so the guest knows whether correction is required. Returns
-// ErrGuestClockUnready as soon as the guest reports it cannot, so the caller
-// can retry the restore the unfrozen way instead of waiting out the budget.
+// workload, and waits for it to confirm. Returns ErrGuestClockUnready as soon
+// as the guest reports it cannot, so the caller retries the unfrozen way.
 func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, clockFrozen bool, token string) error {
 	url := fmt.Sprintf("http://%s:%d/wake", vmIP, boxdPort)
 	body, _ := json.Marshal(struct {
@@ -285,11 +283,9 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 	const maxProbeInterval = 10 * time.Millisecond
 	interval := time.Millisecond
 	var lastErr error
-	// Consecutive answers of one kind make the verdict; anything in between —
-	// a transport error, another status, a body that does not parse, or the
-	// other kind — starts the count over. The first may be mid-correction,
-	// and a verdict assembled from answers that were not consecutive would
-	// park a guest that was recovering.
+	// Consecutive answers of one kind make the verdict; anything else in
+	// between starts the count over. The first may be mid-correction, and
+	// non-consecutive failures would park a guest that was recovering.
 	streakKind, streak := "", 0
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -166,11 +166,16 @@ func postBoxdFreeze(ctx context.Context, vmIP, token string) (freezeEcho, error)
 		Token    string `json:"token"`
 	}{Token: token}
 	if dl, ok := ctx.Deadline(); ok {
-		budget := time.Until(dl) - 200*time.Millisecond
+		// The reserve is what the guest's reply needs to reach us after it
+		// gives up; it never eats the whole budget, so a short budget still
+		// asks the guest for most of it rather than nothing.
+		remaining := time.Until(dl)
+		reserve := min(200*time.Millisecond, remaining/4)
+		budget := remaining - reserve
 		if budget <= 0 {
 			return freezeEcho{}, context.DeadlineExceeded
 		}
-		req.BudgetMs = budget.Milliseconds()
+		req.BudgetMs = max(budget.Milliseconds(), 1)
 	}
 	body, _ := json.Marshal(req)
 	reply, err := postBoxd(ctx, vmIP, "/freeze", body)

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -977,3 +977,128 @@ func TestRequestJoiningADeferredStartupFlightReattachesItself(t *testing.T) {
 		t.Errorf("reattaches = %d, want 2 (eager + one shared retry)", n)
 	}
 }
+
+// A resume publishes its wake-owed record before it launches Firecracker. A
+// crash in that window must not reap the sandbox as a failed create: the
+// paused image is intact, so the record returns to Paused. A create's record
+// in the same state has nowhere to return to and is reaped as before.
+func TestInterruptedResumeReturnsToPaused(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return true }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+	for _, tc := range []struct {
+		name       string
+		fromPaused bool
+		wantKept   bool
+	}{
+		{"resume_returns_to_paused", true, true},
+		{"create_is_reaped", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { store.Close() })
+			snapPath, memPath := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap")
+			for _, p := range []string{snapPath, memPath} {
+				if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath}
+			if err := store.Put(rec); err != nil {
+				t.Fatal(err)
+			}
+			mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+			inst, _ := mgr.reattachRecord(context.Background(), rec, true)
+			got, _ := store.Get("vm-1")
+			if !tc.wantKept {
+				if got != nil {
+					t.Fatalf("record kept: %+v; a failed create must be reaped", got)
+				}
+				return
+			}
+			if got == nil || got.Status != StatusPaused || got.WakePending || got.Unverified || got.WakeOwedFromPaused {
+				t.Fatalf("record = %+v, want Paused with nothing owed", got)
+			}
+			if inst != nil {
+				inst.mu.RLock()
+				defer inst.mu.RUnlock()
+				if inst.Status != StatusPaused {
+					t.Errorf("instance status %v, want Paused", inst.Status)
+				}
+			}
+		})
+	}
+}
+
+// A reattached resume whose guest will not wake goes back to Paused with
+// nothing owed, as the resume's own failure path would. (A create in the
+// same state is parked as Error with its wake still owed; see the lazy-path
+// test above.)
+func TestUnwakeableReattachedResumeReturnsToPaused(t *testing.T) {
+	origWake := boxdWakeGuest
+	t.Cleanup(func() { boxdWakeGuest = origWake })
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return errors.New("no answer") }
+	dir := t.TempDir()
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+		t.Fatal(err)
+	}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+	inst := mgr.reattachByID("vm-1", false)
+	if inst == nil {
+		t.Fatal("a parked record must still be tracked")
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != StatusPaused || inst.WakePending || inst.WakeOwedFromPaused {
+		t.Errorf("status=%v wakePending=%v fromPaused=%v, want Paused and nothing owed", inst.Status, inst.WakePending, inst.WakeOwedFromPaused)
+	}
+	if rec, _ := store.Get("vm-1"); rec == nil || rec.Status != StatusPaused || rec.WakePending {
+		t.Errorf("record = %+v, want Paused and durable", rec)
+	}
+}
+
+// A snapshot pauses the vCPUs before it writes, so a release after a
+// snapshot that then failed, or after a crash between the two, must resume
+// Firecracker before the guest can answer the thaw.
+func TestReleaseOfAFrozenGuestUnpausesFirecrackerFirst(t *testing.T) {
+	origUnpause, origThaw := fcUnpauseVM, boxdThawGuest
+	t.Cleanup(func() { fcUnpauseVM, boxdThawGuest = origUnpause, origThaw })
+	var order []string
+	fcUnpauseVM = func(socket string) error { order = append(order, "unpause:"+socket); return nil }
+	boxdThawGuest = func(_ context.Context, _, token string) error { order = append(order, "thaw:"+token); return nil }
+	m := &Manager{log: zerolog.Nop()}
+	if err := m.releaseFrozenGuest(context.Background(), "/run/vm.sock", "10.0.0.2", "tok"); err != nil {
+		t.Fatal(err)
+	}
+	if len(order) != 2 || order[0] != "unpause:/run/vm.sock" || order[1] != "thaw:tok" {
+		t.Fatalf("order = %v, want the unpause before the thaw", order)
+	}
+	// Recovery after a crash takes the same path, with the record's socket.
+	raiseFloorForTest(t)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "tok", ArtifactID: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	order = nil
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}}
+	inst := &VMInstance{ID: "vm-1", IP: "10.0.0.2", SocketPath: "/run/vm-1.sock"}
+	if !mgr.recoverPauseIntent(context.Background(), inst, zerolog.Nop()) {
+		t.Fatal("recovery reported the guest could not be released")
+	}
+	if len(order) != 2 || order[0] != "unpause:/run/vm-1.sock" || order[1] != "thaw:tok" {
+		t.Fatalf("recovery order = %v, want the unpause before the thaw", order)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -243,10 +243,11 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 		}
 	}
 	frozen := true
+	pausedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	inst := &VMInstance{
 		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
 		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
-		SnapshotWorkloadFrozen: &frozen,
+		SnapshotWorkloadFrozen: &frozen, PausedAt: pausedAt,
 	}
 	mgr := &Manager{
 		log:    zerolog.Nop(),
@@ -276,6 +277,9 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 	defer inst.mu.RUnlock()
 	if inst.Status != StatusPaused || inst.WakePending || inst.Unverified {
 		t.Errorf("after failure: status=%v wakePending=%v unverified=%v, want Paused and nothing owed", inst.Status, inst.WakePending, inst.Unverified)
+	}
+	if !inst.PausedAt.Equal(pausedAt) {
+		t.Errorf("PausedAt = %v, want the original %v kept for the reclaim order", inst.PausedAt, pausedAt)
 	}
 }
 
@@ -1007,7 +1011,8 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath}
+			pausedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, PausedAt: pausedAt}
 			if err := store.Put(rec); err != nil {
 				t.Fatal(err)
 			}
@@ -1022,6 +1027,9 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 			}
 			if got == nil || got.Status != StatusPaused || got.WakePending || got.Unverified || got.WakeOwedFromPaused {
 				t.Fatalf("record = %+v, want Paused with nothing owed", got)
+			}
+			if !got.PausedAt.Equal(pausedAt) {
+				t.Errorf("PausedAt = %v, want the original %v kept for the reclaim order", got.PausedAt, pausedAt)
 			}
 			if inst != nil {
 				inst.mu.RLock()
@@ -1073,7 +1081,13 @@ func TestReleaseOfAFrozenGuestUnpausesFirecrackerFirst(t *testing.T) {
 	origUnpause, origThaw := fcUnpauseVM, boxdThawGuest
 	t.Cleanup(func() { fcUnpauseVM, boxdThawGuest = origUnpause, origThaw })
 	var order []string
-	fcUnpauseVM = func(socket string) error { order = append(order, "unpause:"+socket); return nil }
+	fcUnpauseVM = func(ctx context.Context, socket string) error {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("the unpause must be bounded: a stuck Firecracker API must not hang cleanup or recovery")
+		}
+		order = append(order, "unpause:"+socket)
+		return nil
+	}
 	boxdThawGuest = func(_ context.Context, _, token string) error { order = append(order, "thaw:"+token); return nil }
 	m := &Manager{log: zerolog.Nop()}
 	if err := m.releaseFrozenGuest(context.Background(), "/run/vm.sock", "10.0.0.2", "tok"); err != nil {
@@ -1101,4 +1115,76 @@ func TestReleaseOfAFrozenGuestUnpausesFirecrackerFirst(t *testing.T) {
 	if len(order) != 2 || order[0] != "unpause:/run/vm-1.sock" || order[1] != "thaw:tok" {
 		t.Fatalf("recovery order = %v, want the unpause before the thaw", order)
 	}
+}
+
+// A stuck Firecracker API bounds the release: the unpause gives up on its
+// own budget and the thaw is still attempted.
+func TestReleaseOfAFrozenGuestIsBoundedByAStuckFirecracker(t *testing.T) {
+	origUnpause, origThaw := fcUnpauseVM, boxdThawGuest
+	t.Cleanup(func() { fcUnpauseVM, boxdThawGuest = origUnpause, origThaw })
+	fcUnpauseVM = func(ctx context.Context, _ string) error { <-ctx.Done(); return ctx.Err() }
+	thawed := false
+	boxdThawGuest = func(context.Context, string, string) error { thawed = true; return nil }
+	m := &Manager{log: zerolog.Nop()}
+	start := time.Now()
+	if err := m.releaseFrozenGuest(context.Background(), "/run/vm.sock", "10.0.0.2", "tok"); err != nil || !thawed {
+		t.Fatalf("err=%v thawed=%v; want the thaw attempted after the unpause gave up", err, thawed)
+	}
+	if took := time.Since(start); took > 5*time.Second {
+		t.Fatalf("release took %v; the unpause must be bounded", took)
+	}
+}
+
+// A token mismatch is terminal. The Error a resume writes owes nothing, so a
+// restart does not return it to Paused; a reattached wake the guest refuses
+// as another freeze's is Error, not Paused, however the resume began.
+func TestTokenMismatchStaysErrorThroughRecovery(t *testing.T) {
+	origWake, origDown := boxdWakeGuest, vmUnitFullyDown
+	t.Cleanup(func() { boxdWakeGuest, vmUnitFullyDown = origWake, origDown })
+
+	t.Run("error_record_with_no_unit_is_not_returned_to_paused", func(t *testing.T) {
+		vmUnitFullyDown = func(string) bool { return true }
+		dir := t.TempDir()
+		store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { store.Close() })
+		// What an older write could have left: Error, yet still owing.
+		rec := VMRecord{ID: "vm-1", Status: StatusError, WakePending: true, WakeOwedFromPaused: true, FreezeToken: "tok", Supervision: SupervisionUnit}
+		if err := store.Put(rec); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+		mgr.reattachRecord(context.Background(), rec, true)
+		if got, _ := store.Get("vm-1"); got != nil && got.Status == StatusPaused {
+			t.Fatalf("record = %+v; a terminal Error must not become Paused", got)
+		}
+	})
+
+	t.Run("refused_wake_on_a_reattached_resume_is_error", func(t *testing.T) {
+		vmUnitFullyDown = func(string) bool { return false }
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error {
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		dir := t.TempDir()
+		store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { store.Close() })
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+		inst := mgr.reattachByID("vm-1", false)
+		if inst == nil {
+			t.Fatal("a parked record must still be tracked")
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusError {
+			t.Errorf("status %v, want Error: a refused wake is terminal even for a resume", inst.Status)
+		}
+	})
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1,0 +1,979 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/network"
+)
+
+// A guest that reports it cannot correct its clock must fail the wait fast and
+// typed, so the restore can be retried the unfrozen way instead of waiting out
+// the budget with the customer's processes frozen.
+func TestWaitForGuestWakeFailsFastOnUncorrectableClock(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	calls := 0
+	var sawPolicy bool
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wake" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var b struct {
+			ClockFrozen bool `json:"clock_frozen"`
+		}
+		_ = jsonDecode(r, &b)
+		sawPolicy = b.ClockFrozen
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"status":"clock","wall_clock":{"source":"unavailable","error":"open /dev/ptp0: no such file"}}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	start := time.Now()
+	err = waitForGuestWake(context.Background(), "127.0.0.1", 10*time.Second, true, "tok")
+	if !errors.Is(err, ErrGuestClockUnready) {
+		t.Fatalf("err = %v, want ErrGuestClockUnready", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Errorf("took %v; must not wait out the budget", time.Since(start))
+	}
+	if calls < clockUnreadyPolls {
+		t.Errorf("gave up after %d polls, want at least %d", calls, clockUnreadyPolls)
+	}
+	if !sawPolicy {
+		t.Error("the guest must be told the clock was frozen")
+	}
+}
+
+func TestWaitForGuestWakeReadyIsNil(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok","wall_clock":{"source":"ptp"}}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	if err := waitForGuestWake(context.Background(), "127.0.0.1", 2*time.Second, false, "tok"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func jsonDecode(r *http.Request, v any) error { return json.NewDecoder(r.Body).Decode(v) }
+
+// A record that still owes a wake must get one on recovery — with the policy
+// its restore used — never a health poll, which would take a stopped workload
+// for a ready sandbox.
+func TestVerifyBoxdReadyCompletesAPendingWake(t *testing.T) {
+	origWake, origAdopt := boxdWakeGuest, adoptionBoxdReady
+	t.Cleanup(func() { boxdWakeGuest, adoptionBoxdReady = origWake, origAdopt })
+	m := &Manager{log: zerolog.Nop()}
+
+	t.Run("pending_wake_is_sent_with_its_policy", func(t *testing.T) {
+		var sawFrozen *bool
+		var sawToken string
+		boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, token string) error {
+			sawFrozen = &frozen
+			sawToken = token
+			return nil
+		}
+		adoptionBoxdReady = func(context.Context, *Manager, string) error {
+			t.Fatal("a pending wake must not be verified by health")
+			return nil
+		}
+		inst := &VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, FreezeToken: "tok"}
+		if err := m.verifyBoxdReady(context.Background(), "10.0.0.2", inst); err != nil {
+			t.Fatalf("verify: %v", err)
+		}
+		if sawFrozen == nil || !*sawFrozen || sawToken != "tok" {
+			t.Error("wake not sent, or sent without the frozen policy and the record's token")
+		}
+		if inst.WakePending {
+			t.Error("WakePending still set after a completed wake")
+		}
+	})
+
+	t.Run("no_pending_wake_uses_health", func(t *testing.T) {
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error {
+			t.Fatal("no wake owed; must not send one")
+			return nil
+		}
+		called := false
+		adoptionBoxdReady = func(context.Context, *Manager, string) error { called = true; return nil }
+		if err := m.verifyBoxdReady(context.Background(), "10.0.0.2", &VMInstance{ID: "vm"}); err != nil || !called {
+			t.Fatalf("err=%v called=%v; want health verification", err, called)
+		}
+	})
+
+	t.Run("uncorrectable_clock_latches_the_host_and_fails", func(t *testing.T) {
+		m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{GuestClockFreezeEnabled: true}}
+		m.clockRealtimeCapable.Store(true)
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return ErrGuestClockUnready }
+		inst := &VMInstance{ID: "vm", WakePending: true, ClockFrozen: true}
+		if err := m.verifyBoxdReady(context.Background(), "10.0.0.2", inst); !errors.Is(err, ErrGuestClockUnready) {
+			t.Fatalf("err = %v, want ErrGuestClockUnready", err)
+		}
+		if !inst.WakePending {
+			t.Error("a failed wake must leave WakePending set")
+		}
+		if m.clockPolicyFor(true) != nil {
+			t.Error("host not latched to unfrozen restores")
+		}
+	})
+}
+
+// The wake state must survive a daemon restart, or recovery cannot know it
+// owes one.
+func TestWakeStateSurvivesRecordRoundTrip(t *testing.T) {
+	frozen := true
+	rec := toRecord(&VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok", ArtifactID: "a"})
+	if !rec.WakePending || !rec.ClockFrozen || rec.SnapshotWorkloadFrozen == nil || !*rec.SnapshotWorkloadFrozen || rec.FreezeToken != "tok" || rec.ArtifactID != "a" {
+		t.Fatalf("toRecord dropped wake state: %+v", rec)
+	}
+	got := toInstance(rec)
+	if !got.WakePending || !got.ClockFrozen || got.SnapshotWorkloadFrozen == nil || !*got.SnapshotWorkloadFrozen || got.FreezeToken != "tok" || got.ArtifactID != "a" {
+		t.Errorf("toInstance dropped wake state: pending=%v frozen=%v image=%v", got.WakePending, got.ClockFrozen, got.SnapshotWorkloadFrozen)
+	}
+}
+
+// An image holding a frozen workload owes a wake before the resume commits,
+// whether or not this restore froze the clock — with the policy off, the
+// workload is still stopped in the image.
+func TestResumeWakesFrozenWorkloadBeforeCommit(t *testing.T) {
+	useTempFloor(t)
+	origWake := boxdWakeGuest
+	t.Cleanup(func() { boxdWakeGuest = origWake })
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	frozen := true
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+		SnapshotWorkloadFrozen: &frozen,
+	}
+	mgr := &Manager{
+		log:    zerolog.Nop(),
+		cfg:    ManagerConfig{RunDir: dir},
+		netMgr: &fakeNetMgr{},
+		vms:    map[string]*VMInstance{"vm-1": inst},
+	}
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
+	wakes := 0
+	var sawFrozen, owedAtWake bool
+	boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, _ string) error {
+		wakes++
+		sawFrozen = frozen
+		inst.mu.RLock()
+		owedAtWake = inst.WakePending && inst.Unverified
+		inst.mu.RUnlock()
+		return nil
+	}
+
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if wakes != 1 {
+		t.Fatalf("wakes = %d, want exactly one synchronous wake", wakes)
+	}
+	if sawFrozen {
+		t.Error("the clock was not frozen; the wake must say so")
+	}
+	if !owedAtWake {
+		t.Error("the record must owe the wake while the workload is still frozen")
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != StatusRunning || inst.Unverified || inst.WakePending {
+		t.Errorf("after resume: status=%v unverified=%v wakePending=%v", inst.Status, inst.Unverified, inst.WakePending)
+	}
+}
+
+// A frozen resume that fails after publishing its wake-owed record puts the
+// sandbox back to Paused, so the record does not advertise a guest that never
+// came back.
+func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
+	useTempFloor(t)
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	frozen := true
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+		SnapshotWorkloadFrozen: &frozen,
+	}
+	mgr := &Manager{
+		log:    zerolog.Nop(),
+		cfg:    ManagerConfig{RunDir: dir},
+		netMgr: &fakeNetMgr{},
+		vms:    map[string]*VMInstance{"vm-1": inst},
+	}
+	var owedAtLaunch bool
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		inst.mu.RLock()
+		owedAtLaunch = inst.Status == StatusRunning && inst.WakePending
+		inst.mu.RUnlock()
+		return 0, SupervisionUnit, errors.New("launch failed")
+	}
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err == nil {
+		t.Fatal("want the launch failure")
+	}
+	if !owedAtLaunch {
+		t.Error("the wake-owed record must be published before the launch")
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != StatusPaused || inst.WakePending || inst.Unverified {
+		t.Errorf("after failure: status=%v wakePending=%v unverified=%v, want Paused and nothing owed", inst.Status, inst.WakePending, inst.Unverified)
+	}
+}
+
+// An in-place restore whose guest cannot correct a frozen clock relaunches
+// with the clock running on the overlay, slot and record it already owns.
+// Recreating the overlay would truncate it.
+func TestRestoreInPlaceClockFallbackKeepsOverlayAndSlot(t *testing.T) {
+	useTempFloor(t)
+	origWake, origDead := boxdWakeGuest, vmDeadForRetry
+	t.Cleanup(func() { boxdWakeGuest, vmDeadForRetry = origWake, origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	overlay := filepath.Join(dir, "vm-1", "overlay.ext4")
+	if err := os.MkdirAll(filepath.Dir(overlay), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const data = "customer data"
+	if err := os.WriteFile(overlay, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeNetMgr{}
+	prev := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: overlay,
+	}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		cfg:        ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true},
+		netMgr:     fake,
+		vms:        map[string]*VMInstance{"vm-1": prev},
+		restoreSem: make(chan struct{}, 1),
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	launches := 0
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launches++
+		return 4321, SupervisionUnit, nil
+	}
+	var policies []*bool
+	mgr.restoreSnapshotHook = func(_, _, _ string, clock *bool) error {
+		policies = append(policies, clock)
+		return nil
+	}
+	wakes := 0
+	boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, token string) error {
+		wakes++
+		if token != "tok" {
+			t.Errorf("wake %d carried token %q, want the manifest's", wakes, token)
+		}
+		if wakes == 1 {
+			if !frozen {
+				t.Error("first wake must carry the frozen policy")
+			}
+			return ErrGuestClockUnready
+		}
+		if frozen {
+			t.Error("the relaunch must run the clock")
+		}
+		return nil
+	}
+
+	inst, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if launches != 2 || wakes != 2 {
+		t.Fatalf("launches=%d wakes=%d, want 2 and 2", launches, wakes)
+	}
+	if len(policies) != 2 || policies[0] == nil || *policies[0] || policies[1] != nil {
+		t.Fatalf("clock policies = %v, want frozen then legacy", policies)
+	}
+	if got, _ := os.ReadFile(overlay); string(got) != data {
+		t.Fatalf("overlay = %q, want the original contents", got)
+	}
+	if len(fake.setupCalls) != 1 || len(fake.teardownCalls) != 0 || len(fake.cleanupVMCalls) != 0 {
+		t.Fatalf("network setup=%v teardown=%v cleanup=%v; the slot must be kept", fake.setupCalls, fake.teardownCalls, fake.cleanupVMCalls)
+	}
+	mgr.mu.RLock()
+	tracked := mgr.vms["vm-1"] == inst
+	mgr.mu.RUnlock()
+	if !tracked {
+		t.Fatal("instance was untracked between passes")
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != StatusRunning || inst.WakePending || inst.ClockFrozen {
+		t.Errorf("status=%v wakePending=%v clockFrozen=%v", inst.Status, inst.WakePending, inst.ClockFrozen)
+	}
+	if inst.CorrectsWallClock == nil || !*inst.CorrectsWallClock {
+		t.Error("the image property must survive the fallback")
+	}
+	if !mgr.guestClockUnready.Load() {
+		t.Error("host not latched")
+	}
+}
+
+// The vCPUs must not run ahead of the record that owes their wake: a restore
+// whose record cannot be made durable fails before the load.
+func TestRestoreAbortsBeforeLoadWithoutDurableWakeRecord(t *testing.T) {
+	useTempFloor(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+	rw, err := OpenStateStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rw.Close()
+	store, err := OpenStateStoreReadOnly(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Only a frozen image owes a wake, and so only a frozen image has a record
+	// that must be durable before the load.
+	seedFrozenManifest(t, memPath, "tok")
+	fake := &fakeNetMgr{}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		cfg:        ManagerConfig{RunDir: dir},
+		netMgr:     fake,
+		state:      store,
+		vms:        map[string]*VMInstance{},
+		restoreSem: make(chan struct{}, 1),
+	}
+	launches := 0
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		launches++
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreSnapshotHook = func(string, string, string, *bool) error {
+		t.Error("snapshot loaded without a durable wake record")
+		return nil
+	}
+
+	_, err = mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath, DeltaDir: filepath.Join(dir, "delta")}, nil, "team", "owner", "", nil, 0)
+	if err == nil || launches != 1 {
+		t.Fatalf("err=%v launches=%d, want a failure after one launch", err, launches)
+	}
+	if len(fake.cleanupVMCalls) != 1 {
+		t.Errorf("cleanup calls = %v, want the slot released", fake.cleanupVMCalls)
+	}
+}
+
+// When Firecracker refuses the clock option, the record must say the clock ran
+// before the legacy retry can run the vCPUs.
+func TestRestoreLegacyRetrySeesDurableClockPolicy(t *testing.T) {
+	useTempFloor(t)
+	origWake := boxdWakeGuest
+	t.Cleanup(func() { boxdWakeGuest = origWake })
+	boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, _ string) error {
+		if frozen {
+			t.Error("the legacy restore ran the clock; the wake must say so")
+		}
+		return nil
+	}
+
+	dir := t.TempDir()
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		cfg:        ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true},
+		netMgr:     &fakeNetMgr{},
+		state:      store,
+		vms:        map[string]*VMInstance{},
+		restoreSem: make(chan struct{}, 1),
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		return 4321, SupervisionUnit, nil
+	}
+	unknownField := errors.New("load snapshot: [PUT /snapshot/load][400] Bad Request: unknown field `clock_realtime`")
+	var durableAtRetry *VMRecord
+	mgr.restoreSnapshotHook = func(_, _, _ string, clock *bool) error {
+		if clock != nil {
+			return unknownField
+		}
+		durableAtRetry, _ = store.Get("vm-1")
+		return nil
+	}
+
+	inst, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath, DeltaDir: filepath.Join(dir, "delta")}, nil, "team", "owner", "", nil, 0)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if durableAtRetry == nil || durableAtRetry.ClockFrozen || !durableAtRetry.WakePending {
+		t.Fatalf("record at the legacy retry = %+v, want durable, clock running, wake owed", durableAtRetry)
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.ClockFrozen {
+		t.Error("instance still claims a frozen clock")
+	}
+}
+
+// A guest that can correct its clock, paused without freezing, must be resumed
+// the legacy way: the image fact says unfrozen even though the guest fact says
+// capable, and only the image fact may freeze a clock or owe a wake.
+func TestResumeOfUnfrozenPauseDoesNotFreezeOrWake(t *testing.T) {
+	origWake := boxdWakeGuest
+	t.Cleanup(func() { boxdWakeGuest = origWake })
+	// The detached readiness probe after the commit may poll the wake endpoint;
+	// a wake before the commit, or one claiming a frozen clock, may not happen.
+	var mu sync.Mutex
+	var beforeCommit, frozenWakes int
+	var inst *VMInstance
+	boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, _ string) error {
+		inst.mu.RLock()
+		st := inst.Status
+		inst.mu.RUnlock()
+		mu.Lock()
+		defer mu.Unlock()
+		if st != StatusRunning {
+			beforeCommit++
+		}
+		if frozen {
+			frozenWakes++
+		}
+		return nil
+	}
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	corrects, frozen := true, false
+	inst = &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+		CorrectsWallClock: &corrects, SnapshotWorkloadFrozen: &frozen,
+	}
+	mgr := &Manager{
+		log:    zerolog.Nop(),
+		cfg:    ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true},
+		netMgr: &fakeNetMgr{},
+		vms:    map[string]*VMInstance{"vm-1": inst},
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
+
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	mu.Lock()
+	if beforeCommit != 0 || frozenWakes != 0 {
+		t.Errorf("wakes before commit=%d claiming frozen=%d; an unfrozen image owes neither", beforeCommit, frozenWakes)
+	}
+	mu.Unlock()
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.CorrectsWallClock == nil || !*inst.CorrectsWallClock {
+		t.Error("the guest fact must survive an unfrozen resume")
+	}
+	if inst.SnapshotWorkloadFrozen == nil || *inst.SnapshotWorkloadFrozen {
+		t.Error("the image fact must say unfrozen")
+	}
+}
+
+// A guest a crashed pause left frozen is released on reattach with the token
+// the intent carries; a token the guest never froze under means the crash came
+// first, and nothing is owed. A guest that cannot be released is not served.
+func TestReattachReleasesAGuestAnInterruptedPauseFroze(t *testing.T) {
+	raiseFloorForTest(t)
+	origThaw := boxdThawGuest
+	t.Cleanup(func() { boxdThawGuest = origThaw })
+	cases := []struct {
+		name       string
+		thaw       error
+		wantStatus VMStatus
+		wantIntent bool
+	}{
+		{"released", nil, StatusRunning, false},
+		{"never_frozen", fmt.Errorf("%w: status token", ErrGuestTokenMismatch), StatusRunning, false},
+		{"unreachable", errors.New("connection refused"), StatusError, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { store.Close() })
+			vmDir := filepath.Join(dir, "vm-1")
+			if err := os.MkdirAll(vmDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "tok", ArtifactID: "a"}); err != nil {
+				t.Fatal(err)
+			}
+			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2"}
+			if err := store.Put(rec); err != nil {
+				t.Fatal(err)
+			}
+			var sawToken string
+			boxdThawGuest = func(_ context.Context, _ string, token string) error { sawToken = token; return tc.thaw }
+			mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+			inst := mgr.reattachByID("vm-1", false)
+			if inst == nil || sawToken != "tok" {
+				t.Fatalf("inst=%v token=%q, want the record published and the intent's token presented", inst, sawToken)
+			}
+			inst.mu.RLock()
+			st := inst.Status
+			inst.mu.RUnlock()
+			if st != tc.wantStatus {
+				t.Errorf("status %v, want %v", st, tc.wantStatus)
+			}
+			_, serr := os.Stat(pauseIntentPath(vmDir))
+			if present := serr == nil; present != tc.wantIntent {
+				t.Errorf("intent present=%v, want %v", present, tc.wantIntent)
+			}
+		})
+	}
+}
+
+// A record that owes a wake is not served until the wake completes: a request
+// arriving through the lazy path completes it inline, the startup pass queues it
+// for the pool, and a request during that wait sees the pool's outcome.
+func TestReattachCompletesOwedWakesBeforeServing(t *testing.T) {
+	origWake := boxdWakeGuest
+	t.Cleanup(func() { boxdWakeGuest = origWake })
+	newStore := func(t *testing.T) (*Manager, *StateStore) {
+		t.Helper()
+		dir := t.TempDir()
+		store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { store.Close() })
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+			t.Fatal(err)
+		}
+		return &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}, store
+	}
+
+	t.Run("lazy_path_wakes_inline", func(t *testing.T) {
+		mgr, store := newStore(t)
+		var sawFrozen bool
+		var sawToken string
+		boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, frozen bool, token string) error {
+			sawFrozen, sawToken = frozen, token
+			return nil
+		}
+		inst := mgr.reattachByID("vm-1", false)
+		if inst == nil || !sawFrozen || sawToken != "tok" {
+			t.Fatalf("inst=%v frozen=%v token=%q, want the wake sent with the record's policy and token", inst, sawFrozen, sawToken)
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusRunning || inst.WakePending || inst.Unverified {
+			t.Errorf("status=%v wakePending=%v unverified=%v", inst.Status, inst.WakePending, inst.Unverified)
+		}
+		if rec, _ := store.Get("vm-1"); rec == nil || rec.WakePending {
+			t.Error("the completed wake was not made durable")
+		}
+	})
+
+	t.Run("lazy_path_parks_a_guest_that_will_not_wake", func(t *testing.T) {
+		mgr, _ := newStore(t)
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return errors.New("no answer") }
+		inst := mgr.reattachByID("vm-1", false)
+		if inst == nil {
+			t.Fatal("a parked record must still be tracked, as Error")
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusError {
+			t.Errorf("status %v, want Error", inst.Status)
+		}
+	})
+
+	t.Run("startup_pass_queues_and_the_pool_resolves", func(t *testing.T) {
+		mgr, store := newStore(t)
+		// The startup pass checks the unit is live before anything else; make
+		// it so, with the API socket present, as the other startup-pass tests do.
+		origDown := vmUnitFullyDown
+		vmUnitFullyDown = func(string) bool { return false }
+		t.Cleanup(func() { vmUnitFullyDown = origDown })
+		socket := filepath.Join(t.TempDir(), "firecracker.sock")
+		if err := os.WriteFile(socket, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rec, _ := store.Get("vm-1")
+		rec.SocketPath = socket
+		if err := store.Put(*rec); err != nil {
+			t.Fatal(err)
+		}
+		wakes := 0
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { wakes++; return nil }
+		if inst, ok := mgr.reattachRecord(context.Background(), *rec, true); inst != nil || ok {
+			t.Fatal("the startup pass must not publish a guest that owes a wake")
+		}
+		if mgr.pendingWake("vm-1") == nil {
+			t.Fatal("not queued")
+		}
+		// The lifecycle lock is held for the worker: a restore for this id
+		// would wait on it, not on the pool.
+		if _, ok := mgr.tryLockVMOp("vm-1"); ok {
+			t.Fatal("lifecycle lock not reserved while the wake is pending")
+		}
+		// A request during the wait sees the pool's outcome.
+		got := make(chan *VMInstance, 1)
+		go func() { got <- mgr.reattachByID("vm-1", false) }()
+		if n := mgr.drainPendingWakes(context.Background()); n != 1 || wakes != 1 {
+			t.Fatalf("drained=%d wakes=%d, want one guest woken once", n, wakes)
+		}
+		select {
+		case inst := <-got:
+			if inst == nil || inst.WakePending {
+				t.Fatalf("request got %v, want the woken instance", inst)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("request never saw the pool's outcome")
+		}
+		if mgr.pendingWake("vm-1") != nil {
+			t.Error("still queued after resolution")
+		}
+		if unlock, ok := mgr.tryLockVMOp("vm-1"); !ok {
+			t.Error("lifecycle lock not released after the pool published")
+		} else {
+			unlock()
+		}
+	})
+
+	t.Run("startup_pass_leaves_a_locked_vm_to_its_request", func(t *testing.T) {
+		mgr, store := newStore(t)
+		origDown := vmUnitFullyDown
+		vmUnitFullyDown = func(string) bool { return false }
+		t.Cleanup(func() { vmUnitFullyDown = origDown })
+		socket := filepath.Join(t.TempDir(), "firecracker.sock")
+		if err := os.WriteFile(socket, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rec, _ := store.Get("vm-1")
+		rec.SocketPath = socket
+		unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer unlock()
+		if inst, ok := mgr.reattachRecord(context.Background(), *rec, true); inst != nil || ok || mgr.pendingWake("vm-1") != nil {
+			t.Fatalf("inst=%v ok=%v queued=%v; a VM whose lock a request holds must not be queued", inst, ok, mgr.pendingWake("vm-1") != nil)
+		}
+	})
+
+	t.Run("pool_abandons_an_instance_a_request_replaced", func(t *testing.T) {
+		mgr, store := newStore(t)
+		boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error {
+			t.Error("a replaced instance must not be woken")
+			return nil
+		}
+		rec, _ := store.Get("vm-1")
+		stale := toInstance(*rec)
+		unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		mgr.queuePendingWake(stale, unlock)
+		// A request won the id first: the replacement owns map and record.
+		replacement := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.9"}
+		mgr.vms["vm-1"] = replacement
+		if err := store.Put(toRecord(replacement)); err != nil {
+			t.Fatal(err)
+		}
+		if n := mgr.drainPendingWakes(context.Background()); n != 0 {
+			t.Fatalf("drained %d, want the stale instance abandoned", n)
+		}
+		if mgr.vms["vm-1"] != replacement {
+			t.Error("the replacement was displaced")
+		}
+		if got, _ := store.Get("vm-1"); got == nil || got.IP != "10.0.0.9" || got.WakePending {
+			t.Errorf("record = %+v; the stale instance must not be persisted over the replacement", got)
+		}
+	})
+}
+
+// A wake the guest refuses as belonging to another freeze means the image and
+// its record describe different snapshots. The restore fails as a
+// precondition, the VM is durably Error, and the artifacts stay for inspection.
+func TestTokenMismatchFailsRestoreAndResumeWithoutRetry(t *testing.T) {
+	useTempFloor(t)
+	origWake, origDead := boxdWakeGuest, vmDeadForRetry
+	t.Cleanup(func() { boxdWakeGuest, vmDeadForRetry = origWake, origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+	wakes := 0
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error {
+		wakes++
+		return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+	}
+	newDir := func(t *testing.T) (dir, snapPath, memPath string) {
+		dir = t.TempDir()
+		snapPath, memPath = filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap")
+		for _, p := range []string{snapPath, memPath, filepath.Join(dir, "base.ext4")} {
+			if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		seedFrozenManifest(t, memPath, "tok")
+		return dir, snapPath, memPath
+	}
+
+	t.Run("restore", func(t *testing.T) {
+		dir, snapPath, memPath := newDir(t)
+		mgr := &Manager{
+			log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true}, netMgr: &fakeNetMgr{},
+			vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1),
+		}
+		mgr.clockRealtimeCapable.Store(true)
+		mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+			return 4321, SupervisionUnit, nil
+		}
+		mgr.restoreSnapshotHook = func(string, string, string, *bool) error { return nil }
+		wakes = 0
+		_, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: filepath.Join(dir, "base.ext4"), DeltaDir: filepath.Join(dir, "delta")}, nil, "team", "owner", "", nil, 0)
+		if status.Code(err) != codes.FailedPrecondition || wakes != 1 {
+			t.Fatalf("err=%v wakes=%d, want FailedPrecondition after one wake", err, wakes)
+		}
+		for _, p := range []string{snapPath, memPath, WallClockMarkerPath(memPath)} {
+			if _, serr := os.Stat(p); serr != nil {
+				t.Errorf("artifact %s not retained: %v", p, serr)
+			}
+		}
+		mgr.mu.RLock()
+		inst := mgr.vms["vm-1"]
+		mgr.mu.RUnlock()
+		if inst != nil {
+			inst.mu.RLock()
+			st := inst.Status
+			inst.mu.RUnlock()
+			if st != StatusError {
+				t.Errorf("status %v, want Error", st)
+			}
+		}
+	})
+
+	t.Run("resume", func(t *testing.T) {
+		dir, snapPath, memPath := newDir(t)
+		frozen := true
+		inst := &VMInstance{
+			ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+			SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: filepath.Join(dir, "base.ext4"),
+			SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok",
+		}
+		mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}}
+		mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+			return 4321, SupervisionUnit, nil
+		}
+		mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
+		unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer unlock()
+		wakes = 0
+		_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+		if status.Code(rerr) != codes.FailedPrecondition || wakes != 1 {
+			t.Fatalf("err=%v wakes=%d, want FailedPrecondition after one wake", rerr, wakes)
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusError {
+			t.Errorf("status %v, want Error and not reverted to Paused", inst.Status)
+		}
+	})
+}
+
+// useTempFloor points the rollback-floor evidence at a temp file: a frozen
+// restore refuses to launch until the floor is durable, and the test host has
+// no fleet directory to record it in.
+func useTempFloor(t *testing.T) {
+	t.Helper()
+	isolateEvidence(t, t.TempDir())
+}
+
+// The eager pass and a request share one flight per VM. When the pass finds
+// the request holding the lifecycle lock and leaves the wake to it, the
+// request must not read that as "no such VM": it reattaches itself.
+func TestRequestJoiningADeferredStartupFlightReattachesItself(t *testing.T) {
+	origWake, origHook := boxdWakeGuest, reattachHook
+	t.Cleanup(func() { boxdWakeGuest, reattachHook = origWake, origHook })
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return nil }
+
+	dir := t.TempDir()
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	socket := filepath.Join(dir, "firecracker.sock")
+	if err := os.WriteFile(socket, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2", SocketPath: socket}); err != nil {
+		t.Fatal(err)
+	}
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+
+	// The request holds the lock, as restore and resume do before reattaching.
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	// Hold the eager flight open at its start until the requests have joined
+	// it, counting every reattach that runs.
+	started, release := make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	var reattaches atomic.Int32
+	reattachHook = func(string) {
+		reattaches.Add(1)
+		once.Do(func() { close(started); <-release })
+	}
+	eager := make(chan *VMInstance, 1)
+	go func() { eager <- mgr.reattachByID("vm-1", true) }()
+	<-started
+	lazy := make(chan *VMInstance, 2)
+	go func() { lazy <- mgr.reattachByID("vm-1", false) }()
+	go func() { lazy <- mgr.reattachByID("vm-1", false) }()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	if got := <-eager; got != nil {
+		t.Fatalf("eager pass published %v over a locked VM", got)
+	}
+	var got []*VMInstance
+	for i := 0; i < 2; i++ {
+		select {
+		case inst := <-lazy:
+			got = append(got, inst)
+		case <-time.After(5 * time.Second):
+			t.Fatal("a request never got its instance")
+		}
+	}
+	for _, inst := range got {
+		if inst == nil {
+			t.Fatal("a request read the deferral as a missing VM")
+		}
+		inst.mu.RLock()
+		st, pending := inst.Status, inst.WakePending
+		inst.mu.RUnlock()
+		if st != StatusRunning || pending {
+			t.Errorf("status=%v wakePending=%v, want woken and Running", st, pending)
+		}
+	}
+	if got[0] != got[1] {
+		t.Error("the two requests got different instances")
+	}
+	// The eager attempt plus exactly one shared recovery: joiners never each
+	// run their own against the same guest.
+	if n := reattaches.Load(); n != 2 {
+		t.Errorf("reattaches = %d, want 2 (eager + one shared retry)", n)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1771,3 +1771,45 @@ func TestAdHocSnapshotWaitsForAPauseInFlight(t *testing.T) {
 		t.Fatalf("thaws=%d; a completed pause's leftover intent is nothing to release", thaws)
 	}
 }
+
+// A pause whose stop of Firecracker fails records Paused over a process that
+// may still hold the guest, its workload frozen for the image the pause
+// published. An ad-hoc snapshot of it, never marked, would restore without a
+// wake: only a running VM may be snapshotted this way.
+func TestAdHocSnapshotRefusesAPausedVM(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Cgroup-supervised with no cgroup on this host: the pause's stop cannot
+	// be confirmed, which is the case where Firecracker may survive.
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	inst.mu.RLock()
+	st := inst.Status
+	inst.mu.RUnlock()
+	if st != StatusPaused {
+		t.Fatalf("status after the pause %v, want Paused", st)
+	}
+	before := len(fc.snapshotBodies())
+	_, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", filepath.Join(dir, "adhoc"))
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("err=%v, want FailedPrecondition for a paused VM", err)
+	}
+	if got := len(fc.snapshotBodies()); got != before {
+		t.Fatalf("snapshot requests went from %d to %d; a refused snapshot must send none", before, got)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -69,6 +69,57 @@ func TestWaitForGuestWakeFailsFastOnUncorrectableClock(t *testing.T) {
 	}
 }
 
+// The verdict needs consecutive answers of one kind: an answer of another
+// kind, or another status, in between starts the count over, so a guest
+// that was recovering is not parked on failures that were not consecutive.
+func TestWaitForGuestWakeVerdictNeedsAConsecutiveStreak(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		answers []int // 0: clock, 1: thaw, 2: HTTP 500
+		want    error
+		calls   int
+	}{
+		{"a_thaw_answer_breaks_a_clock_streak", []int{0, 0, 1, 0, 0, 0}, ErrGuestClockUnready, 6},
+		{"another_status_breaks_the_streak", []int{1, 1, 2, 1, 1, 1}, ErrGuestThawFailed, 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+			if err != nil {
+				t.Skipf("port %d busy: %v", boxdPort, err)
+			}
+			calls := 0
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				i := calls
+				calls++
+				if i >= len(tc.answers) {
+					i = len(tc.answers) - 1
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch tc.answers[i] {
+				case 0:
+					w.WriteHeader(http.StatusServiceUnavailable)
+					w.Write([]byte(`{"status":"clock","wall_clock":{"error":"no ptp"}}`))
+				case 1:
+					w.WriteHeader(http.StatusServiceUnavailable)
+					w.Write([]byte(`{"status":"thaw","wall_clock":{"error":"cgroup busy"}}`))
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+			srv.Listener = ln
+			srv.Start()
+			defer srv.Close()
+			err = waitForGuestWake(context.Background(), "127.0.0.1", 10*time.Second, true, "tok")
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			if calls != tc.calls {
+				t.Fatalf("verdict after %d answers, want %d: the streak must restart at the interruption", calls, tc.calls)
+			}
+		})
+	}
+}
+
 func TestWaitForGuestWakeReadyIsNil(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
 	if err != nil {

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1423,9 +1423,11 @@ func TestFrozenResumeRollbackThatCannotPersistKeepsTheSlot(t *testing.T) {
 // the already-running check and relaunch over the recovered guest.
 func TestRecoveredOverrideResumeCommitsTheImageItWoke(t *testing.T) {
 	useTempFloor(t)
-	origWake, origDown := boxdWakeGuest, vmUnitFullyDown
-	t.Cleanup(func() { boxdWakeGuest, vmUnitFullyDown = origWake, origDown })
+	origWake, origDown, origDead := boxdWakeGuest, vmUnitFullyDown, vmDeadForRetry
+	t.Cleanup(func() { boxdWakeGuest, vmUnitFullyDown, vmDeadForRetry = origWake, origDown, origDead })
+	// The recovered guest's process is alive for the retry's liveness check.
 	vmUnitFullyDown = func(string) bool { return false }
+	vmDeadForRetry = func(*Manager, string) bool { return false }
 
 	dir := t.TempDir()
 	own := filepath.Join(dir, "mem.snap")

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1956,3 +1956,59 @@ func TestUnfrozenPauseKeepsTheOldManifestUntilItsSnapshotLands(t *testing.T) {
 		t.Fatalf("manifest=%+v err=%v; the replaced image is unfrozen and must carry no manifest", man, err)
 	}
 }
+
+// A request that meets a queued wake early in the startup pass waits for
+// the pool to start before its bound runs: the scan ahead of the pool is
+// not counted in the queue, and giving up during it would report a live,
+// recoverable VM as missing.
+func TestRequestForAQueuedWakeWaitsForThePoolToStart(t *testing.T) {
+	origWake, origBound := boxdWakeGuest, pendingWakeWaitBoundFor
+	t.Cleanup(func() { boxdWakeGuest, pendingWakeWaitBoundFor = origWake, origBound })
+	pendingWakeWaitBoundFor = func(int) time.Duration { return 50 * time.Millisecond }
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return nil }
+
+	dir := t.TempDir()
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2"}
+	if err := store.Put(rec); err != nil {
+		t.Fatal(err)
+	}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.queuePendingWake(toInstance(rec), unlock)
+
+	type outcome struct {
+		inst *VMInstance
+		ok   bool
+	}
+	got := make(chan outcome, 1)
+	go func() {
+		inst, ok := mgr.reattachRecord(context.Background(), rec, false)
+		got <- outcome{inst, ok}
+	}()
+	// Well past the bound, the pool has not started: the request must still
+	// be waiting rather than have reported the VM missing.
+	select {
+	case o := <-got:
+		t.Fatalf("request returned inst=%v ok=%v before the pool started", o.inst, o.ok)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if n := mgr.drainPendingWakes(context.Background()); n != 1 {
+		t.Fatalf("drained %d, want the queued wake served", n)
+	}
+	select {
+	case o := <-got:
+		if o.inst == nil || !o.ok {
+			t.Fatalf("request got inst=%v ok=%v, want the recovered VM", o.inst, o.ok)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("request never returned after the pool served its wake")
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2219,3 +2219,37 @@ func TestDestroyDuringAFrozenResumeLeavesNoRecord(t *testing.T) {
 		t.Fatalf("record = %+v; a destroyed VM's record was resurrected by the wake-owed write", rec)
 	}
 }
+
+// An unfrozen pause that replaces an existing manifest replaces it durably
+// and times it: the one there may say frozen under a token already answered.
+func TestUnfrozenPauseReplacingAManifestDoesSoDurably(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, memSnap, "A")
+	corrects := true
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+	sink := &phaseSink{}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, recorder: sink, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	man, err := ReadWallClockManifest(memSnap)
+	if err != nil || man == nil || man.WorkloadFrozen || man.FreezeToken != "" {
+		t.Fatalf("manifest=%+v err=%v; want the frozen manifest replaced by an unfrozen one", man, err)
+	}
+	if !sink.has("pause", "manifest") {
+		t.Fatalf("phases = %+v; a durable replacement must be timed", sink.phases)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2903,3 +2903,64 @@ func TestAdHocSnapshotOverAFrozenImageJournalsTheRewrite(t *testing.T) {
 		t.Fatalf("manifest=%+v err=%v; an ad-hoc image is never marked", man, err)
 	}
 }
+
+// A clock demotion written while a destroy takes the VM must not resurrect
+// its record, and the legacy load must not run for a VM that is gone.
+func TestClockDemotionDuringDestroyLeavesNoRecord(t *testing.T) {
+	useTempFloor(t)
+	origDead := vmDeadForRetry
+	t.Cleanup(func() { vmDeadForRetry = origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	overlay := filepath.Join(dir, "vm-1", "overlay.ext4")
+	if err := os.MkdirAll(filepath.Dir(overlay), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{snapPath, memPath, basePath, overlay} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	mgr := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1), state: store,
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		return 4321, SupervisionUnit, nil
+	}
+	loads := 0
+	mgr.restoreSnapshotHook = func(_, _, _ string, clock *bool) error {
+		loads++
+		if clock != nil {
+			// The destroy lands as Firecracker refuses the option: the
+			// demotion that follows must find the VM gone.
+			mgr.mu.Lock()
+			delete(mgr.vms, "vm-1")
+			mgr.mu.Unlock()
+			mgr.deleteState("vm-1")
+			return errors.New(unknownClockFieldMarker)
+		}
+		t.Error("the legacy load ran for a destroyed VM")
+		return nil
+	}
+	if _, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0); err == nil {
+		t.Fatal("want the restore to fail once the VM is gone")
+	}
+	if loads != 1 {
+		t.Fatalf("loads = %d, want the refused one only", loads)
+	}
+	if rec, gerr := store.Get("vm-1"); gerr == nil && rec != nil {
+		t.Fatalf("record = %+v; the demotion resurrected a destroyed VM", rec)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -262,7 +262,8 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 	inst := &VMInstance{
 		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
 		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
-		SnapshotWorkloadFrozen: &frozen, PausedAt: pausedAt,
+		SnapshotWorkloadFrozen: &frozen, PausedAt: pausedAt, FreezeToken: "rec",
+		IP: "10.9.9.9", // an earlier run's slot, long released
 	}
 	mgr := &Manager{
 		log:    zerolog.Nop(),
@@ -287,6 +288,42 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 	}
 	if !owedAtLaunch {
 		t.Error("the wake-owed record must be published before the launch")
+	}
+	// The slot this run took goes back to the pool: the record must not keep
+	// naming it, or a retry would claim whatever sandbox holds it next.
+	inst.mu.RLock()
+	ip, ns, token := inst.IP, inst.Namespace, inst.FreezeToken
+	inst.mu.RUnlock()
+	if ip != "10.9.9.9" || ns != "" || token != "rec" {
+		t.Errorf("after the failure: ip=%q ns=%q token=%q; want the entry identity back", ip, ns, token)
+	}
+
+	// An override resolves its token from its own manifest; a failed resume
+	// from it must hand the record's own token back with the record's image,
+	// or the next ordinary resume presents the wrong token.
+	override := filepath.Join(dir, "other.snap")
+	if err := os.WriteFile(override, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, override, "disk")
+	var tokenAtLaunch string
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		inst.mu.RLock()
+		tokenAtLaunch = inst.FreezeToken
+		inst.mu.RUnlock()
+		return 0, SupervisionUnit, errors.New("launch failed")
+	}
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", override, nil); err == nil {
+		t.Fatal("want the launch failure")
+	}
+	inst.mu.RLock()
+	mem, token := inst.MemFilePath, inst.FreezeToken
+	inst.mu.RUnlock()
+	if tokenAtLaunch != "disk" {
+		t.Errorf("token at launch %q, want the override's", tokenAtLaunch)
+	}
+	if mem != memPath || token != "rec" {
+		t.Errorf("after the failed override resume: mem=%q token=%q; want the record's own image and token", mem, token)
 	}
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1075,7 +1075,7 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 			// What a resume from an override leaves if vmd dies before its
 			// launch: the record's own image and token, and the override's
 			// token in flight.
-			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "rec", WakeToken: "disk", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, PausedAt: pausedAt}
+			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "rec", WakeToken: "disk", WakeSnapshotPath: filepath.Join(dir, "other-vm.snap"), WakeMemPath: filepath.Join(dir, "other.snap"), WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, PausedAt: pausedAt}
 			if err := store.Put(rec); err != nil {
 				t.Fatal(err)
 			}
@@ -1091,8 +1091,8 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 			if got == nil || got.Status != StatusPaused || got.WakePending || got.Unverified || got.WakeOwedFromPaused {
 				t.Fatalf("record = %+v, want Paused with nothing owed", got)
 			}
-			if got.FreezeToken != "rec" || got.WakeToken != "" {
-				t.Errorf("tokens freeze=%q wake=%q; want the record's own token kept and the in-flight one dropped", got.FreezeToken, got.WakeToken)
+			if got.FreezeToken != "rec" || got.WakeToken != "" || got.MemFilePath != memPath || got.WakeMemPath != "" {
+				t.Errorf("record = %+v; want its own image and token kept and the in-flight image dropped", got)
 			}
 			if !got.PausedAt.Equal(pausedAt) {
 				t.Errorf("PausedAt = %v, want the original %v kept for the reclaim order", got.PausedAt, pausedAt)
@@ -1414,5 +1414,71 @@ func TestFrozenResumeRollbackThatCannotPersistKeepsTheSlot(t *testing.T) {
 	defer inst.mu.RUnlock()
 	if inst.Status != StatusPaused {
 		t.Errorf("status %v, want Paused in memory", inst.Status)
+	}
+}
+
+// A resume from an override that died after loading the override and before
+// its commit: recovery wakes the override's guest, and the record must then
+// name the override as its image, or a retry of the same resume would miss
+// the already-running check and relaunch over the recovered guest.
+func TestRecoveredOverrideResumeCommitsTheImageItWoke(t *testing.T) {
+	useTempFloor(t)
+	origWake, origDown := boxdWakeGuest, vmUnitFullyDown
+	t.Cleanup(func() { boxdWakeGuest, vmUnitFullyDown = origWake, origDown })
+	vmUnitFullyDown = func(string) bool { return false }
+
+	dir := t.TempDir()
+	own := filepath.Join(dir, "mem.snap")
+	ownSnap := filepath.Join(dir, "vm.snap")
+	override := filepath.Join(dir, "other.snap")
+	overrideSnap := filepath.Join(dir, "other-vm.snap")
+	for _, p := range []string{own, ownSnap, override, overrideSnap} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, override, "disk")
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	rec := VMRecord{
+		ID: "vm-1", Status: StatusRunning, Unverified: true, Supervision: SupervisionUnit, IP: "10.0.0.2",
+		SnapshotPath: ownSnap, MemFilePath: own, FreezeToken: "rec",
+		WakePending: true, ClockFrozen: true, WakeOwedFromPaused: true,
+		WakeToken: "disk", WakeSnapshotPath: overrideSnap, WakeMemPath: override,
+	}
+	if err := store.Put(rec); err != nil {
+		t.Fatal(err)
+	}
+	var sawToken string
+	boxdWakeGuest = func(_ context.Context, _ string, _ time.Duration, _ bool, token string) error {
+		sawToken = token
+		return nil
+	}
+	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
+	inst := mgr.reattachByID("vm-1", false)
+	if inst == nil || sawToken != "disk" {
+		t.Fatalf("inst=%v token=%q, want the override's guest woken with its token", inst, sawToken)
+	}
+	got, _ := store.Get("vm-1")
+	if got == nil || got.Status != StatusRunning || got.WakePending || got.MemFilePath != override || got.SnapshotPath != overrideSnap || got.FreezeToken != "disk" || got.WakeMemPath != "" || got.WakeToken != "" {
+		t.Fatalf("record = %+v; want the override committed as the record's image, nothing in flight", got)
+	}
+
+	// The lost reply's retry names the override: the sandbox is already up.
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		t.Fatal("the retry relaunched a recovered guest")
+		return 0, SupervisionUnit, nil
+	}
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	again, err := mgr.resumeVMLocked(context.Background(), "vm-1", overrideSnap, override, nil)
+	if err != nil || again != inst {
+		t.Fatalf("retry: err=%v same=%v; want the running instance returned as is", err, again == inst)
 	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1910,3 +1910,49 @@ func TestFreezeRequestKeepsAPositiveGuestBudget(t *testing.T) {
 		t.Fatalf("guest budget %dms, want positive and below the caller's 100ms", seen)
 	}
 }
+
+// A pause that will not freeze leaves the manifest of the last good image in
+// place until its own snapshot has replaced that image: a pause that fails
+// first must not turn a frozen image into one a restore reads as legacy.
+func TestUnfrozenPauseKeepsTheOldManifestUntilItsSnapshotLands(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+
+	fail := true
+	fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+		if fail {
+			return http.StatusInternalServerError, `{"fault_message":"disk full"}`
+		}
+		return http.StatusNoContent, ""
+	})
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The image this VM was resumed from holds a frozen workload.
+	seedFrozenManifest(t, memSnap, "A")
+	corrects := false
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+		t.Fatal("want the snapshot failure")
+	}
+	if man, err := ReadWallClockManifest(memSnap); err != nil || man == nil || !man.WorkloadFrozen {
+		t.Fatalf("manifest=%+v err=%v; the last good image's manifest must survive a failed pause", man, err)
+	}
+
+	fail = false
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if man, err := ReadWallClockManifest(memSnap); err != nil || man != nil {
+		t.Fatalf("manifest=%+v err=%v; the replaced image is unfrozen and must carry no manifest", man, err)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2387,18 +2387,37 @@ func TestPauseFailingAfterItsSnapshotResumesTheVCPUs(t *testing.T) {
 		if os.Geteuid() == 0 {
 			t.Skip("needs a directory the process cannot write; root can")
 		}
-		m, _, vmDir, memSnap := newVM(t, false, false)
-		seedFrozenManifest(t, memSnap, "A")
-		if err := os.Chmod(vmDir, 0o555); err != nil {
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
+		// The directory turns read-only under the snapshot itself: the intent
+		// before it lands, the manifest's removal after it cannot.
+		fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+			_ = os.Chmod(vmDir, 0o555)
+			return http.StatusNoContent, ""
+		})
 		t.Cleanup(func() { os.Chmod(vmDir, 0o755) })
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		seedFrozenManifest(t, memSnap, "A")
+		corrects := false
+		inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+		m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
 		unpaused = nil
 		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
 			t.Fatal("want the pause refused: a frozen manifest beside an unfrozen image cannot stay")
 		}
-		if len(unpaused) == 0 {
-			t.Fatal("the vCPUs must be resumed before the error returns")
+		if len(unpaused) == 0 || unpaused[0] != fc.socketPath {
+			t.Fatalf("unpause calls = %v; the vCPUs must be resumed before the error returns", unpaused)
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusRunning {
+			t.Fatalf("status %v, want Running: the pause did not commit", inst.Status)
 		}
 	})
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2012,3 +2012,79 @@ func TestRequestForAQueuedWakeWaitsForThePoolToStart(t *testing.T) {
 		t.Fatal("request never returned after the pool served its wake")
 	}
 }
+
+// An unfrozen pause whose manifest write fails must not leave an old frozen
+// manifest beside its new image: a restore would present that token to a
+// guest that already answered it and run the clock uncorrected. The stale
+// manifest goes, and the image reads as legacy.
+func TestUnfrozenPauseWhoseManifestWriteFailsLeavesNoStaleFrozenOne(t *testing.T) {
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, memSnap, "A")
+	// The writer's temporary file cannot be created: a directory sits at its path.
+	if err := os.Mkdir(WallClockMarkerPath(memSnap)+".tmp", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	corrects := true
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if man, err := ReadWallClockManifest(memSnap); err != nil || man != nil {
+		t.Fatalf("manifest=%+v err=%v; the stale frozen manifest must be gone when the new one could not be written", man, err)
+	}
+}
+
+// A frozen pause's durable manifest write is timed as its own phase.
+func TestFrozenPauseRecordsTheManifestPhase(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origF, origT, origDown := boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown
+	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown = origF, origT, origDown })
+	vmUnitFullyDown = func(string) bool { return false }
+	boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+		return freezeEcho{Version: WakeProtocolVersion, Token: token}, nil
+	}
+	boxdThawGuest = func(context.Context, string, string) error { return nil }
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corrects := true
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+	sink := &phaseSink{}
+	m := &Manager{
+		log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, recorder: sink,
+		cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true},
+	}
+	m.clockRealtimeCapable.Store(true)
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	if man, err := ReadWallClockManifest(memSnap); err != nil || man == nil || !man.WorkloadFrozen {
+		t.Fatalf("manifest=%+v err=%v; want the frozen image's manifest written", man, err)
+	}
+	if !sink.has("pause", "manifest") || !sink.has("pause", "freeze") {
+		t.Fatalf("phases = %+v; want the durable manifest write and the freeze recorded", sink.phases)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2088,3 +2088,77 @@ func TestFrozenPauseRecordsTheManifestPhase(t *testing.T) {
 		t.Fatalf("phases = %+v; want the durable manifest write and the freeze recorded", sink.phases)
 	}
 }
+
+// A restore of a VM from the image it was paused into whose wake merely does
+// not happen returns the record to Paused: the image is intact, and an Error
+// record owing nothing would be reaped as stale by the next restart. A wake
+// the guest refuses as another freeze's stays terminal.
+func TestFrozenRestoreOfAPausedVMFailingItsWakeReturnsToPaused(t *testing.T) {
+	useTempFloor(t)
+	origWake, origDead := boxdWakeGuest, vmDeadForRetry
+	t.Cleanup(func() { boxdWakeGuest, vmDeadForRetry = origWake, origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error { return errors.New("no answer") }
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	overlay := filepath.Join(dir, "vm-1", "overlay.ext4")
+	if err := os.MkdirAll(filepath.Dir(overlay), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlay, []byte("customer data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	pausedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	prev := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: overlay, PausedAt: pausedAt,
+	}
+	if err := store.Put(toRecord(prev)); err != nil {
+		t.Fatal(err)
+	}
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		cfg:        ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true},
+		netMgr:     &fakeNetMgr{},
+		vms:        map[string]*VMInstance{"vm-1": prev},
+		restoreSem: make(chan struct{}, 1),
+		state:      store,
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreSnapshotHook = func(_, _, _ string, _ *bool) error { return nil }
+
+	if _, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0); err == nil {
+		t.Fatal("want the wake failure")
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		rec, gerr := store.Get("vm-1")
+		if gerr == nil && rec != nil && rec.Status == StatusPaused {
+			if rec.WakePending || rec.WakeOwedFromPaused || rec.WakeToken != "" || !rec.PausedAt.Equal(pausedAt) {
+				t.Fatalf("record = %+v; want Paused owing nothing, in its place in the reclaim order", rec)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("durable record never returned to Paused: rec=%+v err=%v", rec, gerr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1864,3 +1864,49 @@ func TestAdHocSnapshotRefusesAPausedVM(t *testing.T) {
 		t.Fatalf("snapshot requests went from %d to %d; a refused snapshot must send none", before, got)
 	}
 }
+
+// A request that meets a queued wake waits for the pool to reach it: behind
+// n others it is served within ceil(n/workers) rounds of a wake's budget.
+func TestPendingWakeWaitBoundCoversTheQueue(t *testing.T) {
+	round := boxdResumeReadyBudget + 5*time.Second
+	for _, tc := range []struct {
+		queued int
+		rounds int
+	}{{0, 1}, {1, 1}, {wakeRecoveryWorkers, 1}, {wakeRecoveryWorkers + 1, 2}, {3*wakeRecoveryWorkers + 1, 4}} {
+		if got := pendingWakeWaitBound(tc.queued); got != time.Duration(tc.rounds)*round {
+			t.Errorf("queued=%d: bound %v, want %d rounds of %v", tc.queued, got, tc.rounds, round)
+		}
+	}
+}
+
+// A short freeze budget still reaches the guest as a positive budget: the
+// reserve for the reply scales down with it instead of consuming it whole.
+func TestFreezeRequestKeepsAPositiveGuestBudget(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	var seen int64 = -1
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b struct {
+			BudgetMs int64  `json:"budget_ms"`
+			Token    string `json:"token"`
+		}
+		_ = jsonDecode(r, &b)
+		seen = b.BudgetMs
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":1,"capability":"wake","token":"` + b.Token + `"}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	echo, err := postBoxdFreeze(ctx, "127.0.0.1", "tok")
+	if err != nil || echo.Token != "tok" {
+		t.Fatalf("echo=%+v err=%v; want the freeze sent and echoed under a 100ms budget", echo, err)
+	}
+	if seen <= 0 || seen >= 100 {
+		t.Fatalf("guest budget %dms, want positive and below the caller's 100ms", seen)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1501,7 +1501,10 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 	var unpaused []string
 	fcUnpauseVM = func(_ context.Context, socket string) error { unpaused = append(unpaused, socket); return nil }
 
-	newPause := func(t *testing.T) (*Manager, string) {
+	// Cgroup-supervised: an error on this path asks whether the VM is dead,
+	// and a cgroup the host never had reads as alive everywhere, while a
+	// unit systemd never had reads as dead where systemd is present.
+	newPause := func(t *testing.T) (*Manager, string, string) {
 		t.Helper()
 		fc := startSnapshotAPIFake(t, nil)
 		dir := t.TempDir()
@@ -1519,7 +1522,7 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 		}
 		corrects := true
 		inst := &VMInstance{
-			ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2",
+			ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2",
 			SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects, ArtifactID: "current",
 		}
 		m := &Manager{
@@ -1527,11 +1530,11 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 			cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true},
 		}
 		m.clockRealtimeCapable.Store(true)
-		return m, vmDir
+		return m, vmDir, fc.socketPath
 	}
 
 	t.Run("an_unconfirmed_release_refuses_the_pause_and_keeps_the_token", func(t *testing.T) {
-		m, vmDir := newPause(t)
+		m, vmDir, socket := newPause(t)
 		unpaused = nil
 		var thawed []string
 		boxdThawGuest = func(_ context.Context, _, token string) error {
@@ -1550,7 +1553,7 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 		}
 		// The earlier attempt may have left the vCPUs paused; the guest cannot
 		// answer until Firecracker resumes them.
-		if len(unpaused) != 1 || unpaused[0] != m.vms["vm-1"].SocketPath {
+		if len(unpaused) != 1 || unpaused[0] != socket {
 			t.Fatalf("unpause calls = %v, want one on the VM's socket before the thaw", unpaused)
 		}
 		in, err := readPauseIntent(vmDir)
@@ -1562,7 +1565,7 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 	// A pause that will not freeze — a custom directory here — must still not
 	// publish a frozen guest as an unfrozen image.
 	t.Run("a_pause_that_will_not_freeze_resolves_it_or_is_refused", func(t *testing.T) {
-		m, vmDir := newPause(t)
+		m, vmDir, _ := newPause(t)
 		custom := t.TempDir()
 		boxdThawGuest = func(context.Context, string, string) error { return errors.New("connection refused") }
 		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
@@ -1584,7 +1587,7 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 	})
 
 	t.Run("a_confirmed_release_lets_the_pause_go_on_under_a_new_token", func(t *testing.T) {
-		m, vmDir := newPause(t)
+		m, vmDir, _ := newPause(t)
 		var thawed []string
 		boxdThawGuest = func(_ context.Context, _, token string) error { thawed = append(thawed, token); return nil }
 		frozeUnder := ""
@@ -1693,7 +1696,7 @@ func TestAdHocSnapshotResolvesAnEarlierFreezeOrRefuses(t *testing.T) {
 	if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "A", ArtifactID: "earlier"}); err != nil {
 		t.Fatal(err)
 	}
-	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2", SocketPath: fc.socketPath, ArtifactID: "current"}
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, ArtifactID: "current"}
 	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
 
 	var thawed []string

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/superserve-ai/sandbox/internal/telemetry"
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -1482,5 +1483,160 @@ func TestRecoveredOverrideResumeCommitsTheImageItWoke(t *testing.T) {
 	again, err := mgr.resumeVMLocked(context.Background(), "vm-1", overrideSnap, override, nil)
 	if err != nil || again != inst {
 		t.Fatalf("retry: err=%v same=%v; want the running instance returned as is", err, again == inst)
+	}
+}
+
+// A pause whose freeze reply was lost and whose thaw could not be confirmed
+// leaves the guest frozen under its token, recorded in the intent. A retry
+// must resolve that freeze before it writes an intent with a new token, or
+// the old token, the only way to release the guest, is gone.
+func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
+	useTempFloor(t)
+	origF, origT, origR, origDown := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown
+	t.Cleanup(func() {
+		boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown = origF, origT, origR, origDown
+	})
+	vmUnitFullyDown = func(string) bool { return false }
+
+	newPause := func(t *testing.T) (*Manager, string) {
+		t.Helper()
+		fc := startSnapshotAPIFake(t, nil)
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// What the earlier pause left: its intent, under its token.
+		if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "A", ArtifactID: "earlier"}); err != nil {
+			t.Fatal(err)
+		}
+		corrects := true
+		inst := &VMInstance{
+			ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2",
+			SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects, ArtifactID: "current",
+		}
+		m := &Manager{
+			log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst},
+			cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true},
+		}
+		m.clockRealtimeCapable.Store(true)
+		return m, vmDir
+	}
+
+	t.Run("an_unconfirmed_release_refuses_the_pause_and_keeps_the_token", func(t *testing.T) {
+		m, vmDir := newPause(t)
+		var thawed []string
+		boxdThawGuest = func(_ context.Context, _, token string) error {
+			thawed = append(thawed, token)
+			return errors.New("connection refused")
+		}
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			t.Error("a new freeze was sent while an earlier one was unresolved")
+			return freezeEcho{}, errors.New("unexpected")
+		}
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the pause refused")
+		}
+		if len(thawed) != 1 || thawed[0] != "A" {
+			t.Fatalf("thaws = %v, want exactly the earlier token presented", thawed)
+		}
+		in, err := readPauseIntent(vmDir)
+		if err != nil || in == nil || in.FreezeToken != "A" {
+			t.Fatalf("intent = %+v err=%v; the earlier token must survive a refused pause", in, err)
+		}
+	})
+
+	t.Run("a_confirmed_release_lets_the_pause_go_on_under_a_new_token", func(t *testing.T) {
+		m, vmDir := newPause(t)
+		var thawed []string
+		boxdThawGuest = func(_ context.Context, _, token string) error { thawed = append(thawed, token); return nil }
+		frozeUnder := ""
+		boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+			frozeUnder = token
+			return freezeEcho{Version: WakeProtocolVersion, Token: token}, nil
+		}
+		boxdGuestRunning = func(context.Context, string) error { return nil }
+		_, _, _, _ = m.PauseVM(context.Background(), "vm-1", vmDir, "")
+		if len(thawed) == 0 || thawed[0] != "A" {
+			t.Fatalf("thaws = %v, want the earlier token released first", thawed)
+		}
+		if frozeUnder == "" || frozeUnder == "A" {
+			t.Fatalf("froze under %q, want a fresh token after the release", frozeUnder)
+		}
+		if in, _ := readPauseIntent(vmDir); in != nil && in.FreezeToken == "A" {
+			t.Fatal("the intent still names the released freeze")
+		}
+	})
+}
+
+// phaseSink records the latency phases a manager emits.
+type phaseSink struct {
+	telemetry.Recorder
+	mu     sync.Mutex
+	phases []telemetry.LatencyPhase
+}
+
+func (p *phaseSink) RecordLatencyPhase(_ context.Context, ph telemetry.LatencyPhase) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.phases = append(p.phases, ph)
+}
+
+func (p *phaseSink) has(op, phase string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, ph := range p.phases {
+		if ph.Op == op && ph.Phase == phase {
+			return true
+		}
+	}
+	return false
+}
+
+// A pause that fails inside its freeze is one of the pauses worth seeing:
+// its phases land in the distributions like a failed snapshot's do.
+func TestFailedFreezeLandsInPausePhases(t *testing.T) {
+	useTempFloor(t)
+	origF, origT, origDown := boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown
+	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown = origF, origT, origDown })
+	vmUnitFullyDown = func(string) bool { return false }
+	boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+		return freezeEcho{}, errors.New("connection reset")
+	}
+	boxdThawGuest = func(context.Context, string, string) error { return errors.New("connection refused") }
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corrects := true
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2",
+		SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects,
+	}
+	sink := &phaseSink{}
+	m := &Manager{
+		log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, recorder: sink,
+		cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true},
+	}
+	m.clockRealtimeCapable.Store(true)
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+		t.Fatal("want the pause to fail inside its freeze")
+	}
+	if !sink.has("pause", "freeze") || !sink.has("pause", "total") {
+		t.Fatalf("phases = %+v; want the failed pause's freeze and total recorded", sink.phases)
+	}
+	if sink.has("pause", "snapshot") {
+		t.Fatalf("phases = %+v; a pause that never snapshotted must not report a snapshot phase", sink.phases)
 	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1718,3 +1718,56 @@ func TestAdHocSnapshotResolvesAnEarlierFreezeOrRefuses(t *testing.T) {
 		t.Fatalf("intent = %+v; a resolved intent must be cleared", in)
 	}
 }
+
+// An ad-hoc snapshot takes the VM's lifecycle lock: while a pause is in
+// flight, its fresh intent must not be read as an abandoned freeze and the
+// guest that pause is freezing released. The snapshot waits for the pause.
+func TestAdHocSnapshotWaitsForAPauseInFlight(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origT, origUnpause := boxdThawGuest, fcUnpauseVM
+	t.Cleanup(func() { boxdThawGuest, fcUnpauseVM = origT, origUnpause })
+	fcUnpauseVM = func(context.Context, string) error { return nil }
+	thaws := 0
+	boxdThawGuest = func(context.Context, string, string) error { thaws++; return nil }
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, ArtifactID: "current"}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+
+	// A pause in flight: it holds the lock and has just recorded its intent.
+	unlock, err := m.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "B", ArtifactID: "next"}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	if _, _, err := m.CreateVMSnapshot(ctx, "vm-1", filepath.Join(dir, "adhoc")); err == nil {
+		t.Fatal("the snapshot ran beside a pause in flight")
+	}
+	if thaws != 0 || len(fc.snapshotBodies()) != 0 {
+		t.Fatalf("thaws=%d requests=%d; the pause's guest must be left alone", thaws, len(fc.snapshotBodies()))
+	}
+	if in, _ := readPauseIntent(vmDir); in == nil || in.FreezeToken != "B" {
+		t.Fatal("the pause's intent was cleared by the snapshot")
+	}
+	// The pause completes: its intent names the record's artifact now.
+	inst.mu.Lock()
+	inst.ArtifactID = "next"
+	inst.mu.Unlock()
+	unlock()
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", filepath.Join(dir, "adhoc")); err != nil {
+		t.Fatalf("snapshot after the pause: %v", err)
+	}
+	if thaws != 0 {
+		t.Fatalf("thaws=%d; a completed pause's leftover intent is nothing to release", thaws)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1868,7 +1868,10 @@ func TestAdHocSnapshotRefusesAPausedVM(t *testing.T) {
 // A request that meets a queued wake waits for the pool to reach it: behind
 // n others it is served within ceil(n/workers) rounds of a wake's budget.
 func TestPendingWakeWaitBoundCoversTheQueue(t *testing.T) {
-	round := boxdResumeReadyBudget + 5*time.Second
+	round := wakeRecoveryRound
+	if round <= boxdResumeReadyBudget+restoreErrorStopBudget {
+		t.Fatalf("round %v must cover the wake budget and a failed wake's teardown", round)
+	}
 	for _, tc := range []struct {
 		queued int
 		rounds int
@@ -2160,5 +2163,59 @@ func TestFrozenRestoreOfAPausedVMFailingItsWakeReturnsToPaused(t *testing.T) {
 			t.Fatalf("durable record never returned to Paused: rec=%+v err=%v", rec, gerr)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A destroy that lands around the wake-owed write must win: the write is
+// erased again and the launch aborted, never a record resurrected for a VM
+// the user destroyed.
+func TestDestroyDuringAFrozenResumeLeavesNoRecord(t *testing.T) {
+	useTempFloor(t)
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	frozen := true
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+		SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok",
+	}
+	if err := store.Put(toRecord(inst)); err != nil {
+		t.Fatal(err)
+	}
+	mgr := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{"vm-1": inst}, state: store,
+	}
+	// The destroy lands under the launch, after the wake-owed write began:
+	// the record is gone and the id no longer this instance's.
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		mgr.mu.Lock()
+		delete(mgr.vms, "vm-1")
+		mgr.mu.Unlock()
+		mgr.deleteState("vm-1")
+		return 0, SupervisionUnit, errors.New("launch failed")
+	}
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err == nil {
+		t.Fatal("want the resume to fail")
+	}
+	if rec, gerr := store.Get("vm-1"); gerr == nil && rec != nil {
+		t.Fatalf("record = %+v; a destroyed VM's record was resurrected by the wake-owed write", rec)
 	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2686,3 +2686,71 @@ func TestRecoveryOfAnUnfrozenRewriteResumesTheVCPUs(t *testing.T) {
 		}
 	})
 }
+
+// A pause whose freeze cannot be undone with confidence leaves a guest that
+// may be frozen: it is recorded Error, not served as running, with its intent
+// and token kept for a later release.
+func TestPauseWithAnUnconfirmedThawRecordsTheGuestAsError(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origF, origT, origR, origDown, origUnpause := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown, fcUnpauseVM
+	t.Cleanup(func() {
+		boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown, fcUnpauseVM = origF, origT, origR, origDown, origUnpause
+	})
+	vmUnitFullyDown = func(string) bool { return false }
+	fcUnpauseVM = func(context.Context, string) error { return nil }
+	boxdThawGuest = func(context.Context, string, string) error { return errors.New("connection refused") }
+
+	newVM := func(t *testing.T) (*Manager, *VMInstance, string, string) {
+		t.Helper()
+		fc := startSnapshotAPIFake(t, nil)
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		corrects := true
+		inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+		m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true}}
+		m.clockRealtimeCapable.Store(true)
+		return m, inst, vmDir, memSnap
+	}
+	check := func(t *testing.T, m *Manager, inst *VMInstance, vmDir string) {
+		t.Helper()
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the pause to fail")
+		}
+		inst.mu.RLock()
+		st := inst.Status
+		inst.mu.RUnlock()
+		if st != StatusError {
+			t.Fatalf("status %v, want Error: a guest that may be frozen must not be served as running", st)
+		}
+		if in, err := readPauseIntent(vmDir); err != nil || in == nil || in.FreezeToken == "" {
+			t.Fatalf("intent = %+v err=%v; the token must be kept for a later release", in, err)
+		}
+	}
+
+	t.Run("freeze_reply_lost_and_thaw_unconfirmed", func(t *testing.T) {
+		m, inst, vmDir, _ := newVM(t)
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		check(t, m, inst, vmDir)
+	})
+
+	t.Run("manifest_unpublished_and_the_deferred_thaw_fails", func(t *testing.T) {
+		m, inst, vmDir, memSnap := newVM(t)
+		boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+			return freezeEcho{Version: WakeProtocolVersion, Token: token}, nil
+		}
+		if err := os.MkdirAll(filepath.Join(WallClockMarkerPath(memSnap), "x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		check(t, m, inst, vmDir)
+	})
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2374,6 +2374,39 @@ func TestPauseFailingAfterItsSnapshotResumesTheVCPUs(t *testing.T) {
 		}
 	})
 
+	// An unpause that does not confirm leaves the guest's state unknown: a
+	// guest that answers stays Running; one that does not is parked.
+	t.Run("an_unconfirmed_unpause_parks_a_guest_that_does_not_answer", func(t *testing.T) {
+		origProbe := boxdHealthProbe
+		t.Cleanup(func() { boxdHealthProbe = origProbe })
+		for _, tc := range []struct {
+			name   string
+			answer error
+			want   VMStatus
+		}{
+			{"answers", nil, StatusRunning},
+			{"silent", errors.New("no answer"), StatusError},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				m, inst, vmDir, memSnap := newVM(t, false, false)
+				stuckMarker(t, memSnap)
+				fcUnpauseVM = func(context.Context, string) error { return errors.New("firecracker api timeout") }
+				t.Cleanup(func() {
+					fcUnpauseVM = func(_ context.Context, socket string) error { unpaused = append(unpaused, socket); return nil }
+				})
+				boxdHealthProbe = func(context.Context, string, time.Duration) error { return tc.answer }
+				if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+					t.Fatal("want the pause refused")
+				}
+				inst.mu.RLock()
+				defer inst.mu.RUnlock()
+				if inst.Status != tc.want {
+					t.Fatalf("status %v, want %v", inst.Status, tc.want)
+				}
+			})
+		}
+	})
+
 	// An empty marker that will not go is harmless: a restore reads it as
 	// legacy. The pause completes.
 	t.Run("legacy_pause_survives_an_empty_marker_that_will_not_go", func(t *testing.T) {

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -1492,11 +1492,14 @@ func TestRecoveredOverrideResumeCommitsTheImageItWoke(t *testing.T) {
 // the old token, the only way to release the guest, is gone.
 func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 	useTempFloor(t)
-	origF, origT, origR, origDown := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown
+	raiseFloorForTest(t)
+	origF, origT, origR, origDown, origUnpause := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown, fcUnpauseVM
 	t.Cleanup(func() {
-		boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown = origF, origT, origR, origDown
+		boxdFreezeGuest, boxdThawGuest, boxdGuestRunning, vmUnitFullyDown, fcUnpauseVM = origF, origT, origR, origDown, origUnpause
 	})
 	vmUnitFullyDown = func(string) bool { return false }
+	var unpaused []string
+	fcUnpauseVM = func(_ context.Context, socket string) error { unpaused = append(unpaused, socket); return nil }
 
 	newPause := func(t *testing.T) (*Manager, string) {
 		t.Helper()
@@ -1529,6 +1532,7 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 
 	t.Run("an_unconfirmed_release_refuses_the_pause_and_keeps_the_token", func(t *testing.T) {
 		m, vmDir := newPause(t)
+		unpaused = nil
 		var thawed []string
 		boxdThawGuest = func(_ context.Context, _, token string) error {
 			thawed = append(thawed, token)
@@ -1544,9 +1548,38 @@ func TestPauseResolvesAnEarlierFreezeBeforeReplacingItsIntent(t *testing.T) {
 		if len(thawed) != 1 || thawed[0] != "A" {
 			t.Fatalf("thaws = %v, want exactly the earlier token presented", thawed)
 		}
+		// The earlier attempt may have left the vCPUs paused; the guest cannot
+		// answer until Firecracker resumes them.
+		if len(unpaused) != 1 || unpaused[0] != m.vms["vm-1"].SocketPath {
+			t.Fatalf("unpause calls = %v, want one on the VM's socket before the thaw", unpaused)
+		}
 		in, err := readPauseIntent(vmDir)
 		if err != nil || in == nil || in.FreezeToken != "A" {
 			t.Fatalf("intent = %+v err=%v; the earlier token must survive a refused pause", in, err)
+		}
+	})
+
+	// A pause that will not freeze — a custom directory here — must still not
+	// publish a frozen guest as an unfrozen image.
+	t.Run("a_pause_that_will_not_freeze_resolves_it_or_is_refused", func(t *testing.T) {
+		m, vmDir := newPause(t)
+		custom := t.TempDir()
+		boxdThawGuest = func(context.Context, string, string) error { return errors.New("connection refused") }
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			t.Error("a custom-directory pause froze the guest")
+			return freezeEcho{}, errors.New("unexpected")
+		}
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", custom, ""); err == nil {
+			t.Fatal("want the pause refused while the earlier freeze is unresolved")
+		}
+		if in, _ := readPauseIntent(vmDir); in == nil || in.FreezeToken != "A" {
+			t.Fatal("the earlier intent must survive the refused pause")
+		}
+		// Released: the pause goes on unfrozen, and the spent intent is gone.
+		boxdThawGuest = func(context.Context, string, string) error { return nil }
+		_, _, _, _ = m.PauseVM(context.Background(), "vm-1", custom, "")
+		if in, _ := readPauseIntent(vmDir); in != nil {
+			t.Fatalf("intent = %+v after the release; a resolved intent must be cleared", in)
 		}
 	})
 
@@ -1638,5 +1671,47 @@ func TestFailedFreezeLandsInPausePhases(t *testing.T) {
 	}
 	if sink.has("pause", "snapshot") {
 		t.Fatalf("phases = %+v; a pause that never snapshotted must not report a snapshot phase", sink.phases)
+	}
+}
+
+// An ad-hoc snapshot is never marked, so it restores without a wake: taken of
+// a guest an earlier pause left frozen, it would publish a stopped workload
+// for good. It resolves that freeze first, or refuses.
+func TestAdHocSnapshotResolvesAnEarlierFreezeOrRefuses(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origT, origUnpause := boxdThawGuest, fcUnpauseVM
+	t.Cleanup(func() { boxdThawGuest, fcUnpauseVM = origT, origUnpause })
+	fcUnpauseVM = func(context.Context, string) error { return nil }
+
+	fc := startSnapshotAPIFake(t, nil)
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", FreezeToken: "A", ArtifactID: "earlier"}); err != nil {
+		t.Fatal(err)
+	}
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionUnit, IP: "10.0.0.2", SocketPath: fc.socketPath, ArtifactID: "current"}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+
+	var thawed []string
+	boxdThawGuest = func(_ context.Context, _, token string) error {
+		thawed = append(thawed, token)
+		return errors.New("connection refused")
+	}
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", filepath.Join(dir, "adhoc")); err == nil {
+		t.Fatal("want the snapshot refused while the earlier freeze is unresolved")
+	}
+	if len(thawed) != 1 || thawed[0] != "A" || len(fc.snapshotBodies()) != 0 {
+		t.Fatalf("thaws=%v requests=%d; want the earlier token presented and no snapshot taken", thawed, len(fc.snapshotBodies()))
+	}
+	boxdThawGuest = func(context.Context, string, string) error { return nil }
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", filepath.Join(dir, "adhoc")); err != nil {
+		t.Fatalf("snapshot after the release: %v", err)
+	}
+	if in, _ := readPauseIntent(vmDir); in != nil {
+		t.Fatalf("intent = %+v; a resolved intent must be cleared", in)
 	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2253,3 +2253,56 @@ func TestUnfrozenPauseReplacingAManifestDoesSoDurably(t *testing.T) {
 		t.Fatalf("phases = %+v; a durable replacement must be timed", sink.phases)
 	}
 }
+
+// An unfrozen pause that overwrites an image whose manifest says frozen
+// records an intent first: a crash between the rewrite and the manifest's
+// replacement then leaves an intent a restore refuses on, and recovery
+// removes the stale manifest before it clears the intent.
+func TestUnfrozenOverwriteOfAFrozenImageIsCoveredByAnIntent(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origDown := vmUnitFullyDown
+	vmUnitFullyDown = func(string) bool { return false }
+	t.Cleanup(func() { vmUnitFullyDown = origDown })
+
+	fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+		return http.StatusInternalServerError, `{"fault_message":"disk full"}`
+	})
+	dir := t.TempDir()
+	vmDir := filepath.Join(dir, "vm-1")
+	if err := os.MkdirAll(vmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memSnap := filepath.Join(vmDir, "mem.snap")
+	if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, memSnap, "A")
+	corrects := false
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects, ArtifactID: "current"}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+
+	// The rewrite dies (here: the snapshot fails) with the old manifest
+	// still beside the image, and the intent recorded.
+	if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+		t.Fatal("want the snapshot failure")
+	}
+	in, err := readPauseIntent(vmDir)
+	if err != nil || in == nil || in.FreezeToken != "" || in.ArtifactID == "" || in.ArtifactID == "current" {
+		t.Fatalf("intent = %+v err=%v; want an intent naming the rewrite, without a token", in, err)
+	}
+	if blocked, _ := pauseIntentBlocks(vmDir, "current"); !blocked {
+		t.Fatal("a restore of the image must be refused while the rewrite's intent stands")
+	}
+
+	// Recovery after a restart: the stale frozen manifest goes, then the intent.
+	if !m.recoverPauseIntent(context.Background(), inst, zerolog.Nop()) {
+		t.Fatal("recovery must succeed for a rewrite that froze nothing")
+	}
+	if man, err := ReadWallClockManifest(memSnap); err != nil || man != nil {
+		t.Fatalf("manifest=%+v err=%v; the stale frozen manifest must be removed before the intent is cleared", man, err)
+	}
+	if in, _ := readPauseIntent(vmDir); in != nil {
+		t.Fatalf("intent = %+v; want it cleared after recovery", in)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -106,7 +106,7 @@ func TestVerifyBoxdReadyCompletesAPendingWake(t *testing.T) {
 			t.Fatal("a pending wake must not be verified by health")
 			return nil
 		}
-		inst := &VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, FreezeToken: "tok"}
+		inst := &VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok"}
 		if err := m.verifyBoxdReady(context.Background(), "10.0.0.2", inst); err != nil {
 			t.Fatalf("verify: %v", err)
 		}
@@ -151,7 +151,7 @@ func TestVerifyBoxdReadyCompletesAPendingWake(t *testing.T) {
 // owes one.
 func TestWakeStateSurvivesRecordRoundTrip(t *testing.T) {
 	frozen := true
-	rec := toRecord(&VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok", ArtifactID: "a"})
+	rec := toRecord(&VMInstance{ID: "vm", WakePending: true, ClockFrozen: true, SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok", WakeToken: "tok", ArtifactID: "a"})
 	if !rec.WakePending || !rec.ClockFrozen || rec.SnapshotWorkloadFrozen == nil || !*rec.SnapshotWorkloadFrozen || rec.FreezeToken != "tok" || rec.ArtifactID != "a" {
 		t.Fatalf("toRecord dropped wake state: %+v", rec)
 	}
@@ -200,7 +200,7 @@ func TestResumeWakesFrozenWorkloadBeforeCommit(t *testing.T) {
 	var owedAtLaunch bool
 	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
 		inst.mu.RLock()
-		ipAtLaunch, tokenAtLaunch, owedAtLaunch = inst.IP, inst.FreezeToken, inst.WakePending
+		ipAtLaunch, tokenAtLaunch, owedAtLaunch = inst.IP, inst.WakeToken, inst.WakePending
 		inst.mu.RUnlock()
 		return 4321, SupervisionUnit, nil
 	}
@@ -240,6 +240,9 @@ func TestResumeWakesFrozenWorkloadBeforeCommit(t *testing.T) {
 	defer inst.mu.RUnlock()
 	if inst.Status != StatusRunning || inst.Unverified || inst.WakePending {
 		t.Errorf("after resume: status=%v unverified=%v wakePending=%v", inst.Status, inst.Unverified, inst.WakePending)
+	}
+	if inst.FreezeToken != "tok" || inst.WakeToken != "" {
+		t.Errorf("after resume: freeze=%q wake=%q; want the committed token and nothing in flight", inst.FreezeToken, inst.WakeToken)
 	}
 }
 
@@ -292,10 +295,10 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 	// The slot this run took goes back to the pool: the record must not keep
 	// naming it, or a retry would claim whatever sandbox holds it next.
 	inst.mu.RLock()
-	ip, ns, token := inst.IP, inst.Namespace, inst.FreezeToken
+	ip, ns, token, inflight := inst.IP, inst.Namespace, inst.FreezeToken, inst.WakeToken
 	inst.mu.RUnlock()
-	if ip != "10.9.9.9" || ns != "" || token != "rec" {
-		t.Errorf("after the failure: ip=%q ns=%q token=%q; want the entry identity back", ip, ns, token)
+	if ip != "10.9.9.9" || ns != "" || token != "rec" || inflight != "" {
+		t.Errorf("after the failure: ip=%q ns=%q token=%q inflight=%q; want the entry identity back and nothing in flight", ip, ns, token, inflight)
 	}
 
 	// An override resolves its token from its own manifest; a failed resume
@@ -309,7 +312,7 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 	var tokenAtLaunch string
 	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
 		inst.mu.RLock()
-		tokenAtLaunch = inst.FreezeToken
+		tokenAtLaunch = inst.WakeToken
 		inst.mu.RUnlock()
 		return 0, SupervisionUnit, errors.New("launch failed")
 	}
@@ -317,13 +320,13 @@ func TestFrozenResumeFailureRevertsToPaused(t *testing.T) {
 		t.Fatal("want the launch failure")
 	}
 	inst.mu.RLock()
-	mem, token := inst.MemFilePath, inst.FreezeToken
+	mem, token, inflight := inst.MemFilePath, inst.FreezeToken, inst.WakeToken
 	inst.mu.RUnlock()
 	if tokenAtLaunch != "disk" {
-		t.Errorf("token at launch %q, want the override's", tokenAtLaunch)
+		t.Errorf("token in flight at launch %q, want the override's", tokenAtLaunch)
 	}
-	if mem != memPath || token != "rec" {
-		t.Errorf("after the failed override resume: mem=%q token=%q; want the record's own image and token", mem, token)
+	if mem != memPath || token != "rec" || inflight != "" {
+		t.Errorf("after the failed override resume: mem=%q token=%q inflight=%q; want the record's own image and token", mem, token, inflight)
 	}
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()
@@ -711,7 +714,7 @@ func TestReattachCompletesOwedWakesBeforeServing(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() { store.Close() })
-		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
 			t.Fatal(err)
 		}
 		return &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}, store
@@ -974,7 +977,7 @@ func TestRequestJoiningADeferredStartupFlightReattachesItself(t *testing.T) {
 	if err := os.WriteFile(socket, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2", SocketPath: socket}); err != nil {
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok", Supervision: SupervisionUnit, IP: "10.0.0.2", SocketPath: socket}); err != nil {
 		t.Fatal(err)
 	}
 	origDown := vmUnitFullyDown
@@ -1069,7 +1072,10 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 				}
 			}
 			pausedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
-			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, PausedAt: pausedAt}
+			// What a resume from an override leaves if vmd dies before its
+			// launch: the record's own image and token, and the override's
+			// token in flight.
+			rec := VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "rec", WakeToken: "disk", WakeOwedFromPaused: tc.fromPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, PausedAt: pausedAt}
 			if err := store.Put(rec); err != nil {
 				t.Fatal(err)
 			}
@@ -1084,6 +1090,9 @@ func TestInterruptedResumeReturnsToPaused(t *testing.T) {
 			}
 			if got == nil || got.Status != StatusPaused || got.WakePending || got.Unverified || got.WakeOwedFromPaused {
 				t.Fatalf("record = %+v, want Paused with nothing owed", got)
+			}
+			if got.FreezeToken != "rec" || got.WakeToken != "" {
+				t.Errorf("tokens freeze=%q wake=%q; want the record's own token kept and the in-flight one dropped", got.FreezeToken, got.WakeToken)
 			}
 			if !got.PausedAt.Equal(pausedAt) {
 				t.Errorf("PausedAt = %v, want the original %v kept for the reclaim order", got.PausedAt, pausedAt)
@@ -1113,7 +1122,7 @@ func TestUnwakeableReattachedResumeReturnsToPaused(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { store.Close() })
-	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+	if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
 		t.Fatal(err)
 	}
 	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
@@ -1208,7 +1217,7 @@ func TestTokenMismatchStaysErrorThroughRecovery(t *testing.T) {
 		}
 		t.Cleanup(func() { store.Close() })
 		// What an older write could have left: Error, yet still owing.
-		rec := VMRecord{ID: "vm-1", Status: StatusError, WakePending: true, WakeOwedFromPaused: true, FreezeToken: "tok", Supervision: SupervisionUnit}
+		rec := VMRecord{ID: "vm-1", Status: StatusError, WakePending: true, WakeOwedFromPaused: true, FreezeToken: "tok", WakeToken: "tok", Supervision: SupervisionUnit}
 		if err := store.Put(rec); err != nil {
 			t.Fatal(err)
 		}
@@ -1230,7 +1239,7 @@ func TestTokenMismatchStaysErrorThroughRecovery(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() { store.Close() })
-		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
+		if err := store.Put(VMRecord{ID: "vm-1", Status: StatusRunning, Unverified: true, WakePending: true, ClockFrozen: true, FreezeToken: "tok", WakeToken: "tok", WakeOwedFromPaused: true, Supervision: SupervisionUnit, IP: "10.0.0.2"}); err != nil {
 			t.Fatal(err)
 		}
 		mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
@@ -1335,5 +1344,75 @@ func TestFailedRestoreDoesNotWaitOnTheStore(t *testing.T) {
 			t.Fatalf("durable record never reached Error after the store was released: rec=%+v err=%v", rec, gerr)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A rollback that cannot be made durable leaves a record naming this run's
+// slot. The slot then stays reserved for this sandbox rather than going back
+// to the pool, where the next sandbox to receive it could be claimed by a
+// retry after a restart.
+func TestFrozenResumeRollbackThatCannotPersistKeepsTheSlot(t *testing.T) {
+	useTempFloor(t)
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	rootfs := filepath.Join(dir, "rootfs.ext4")
+	for _, p := range []string{snapPath, memPath, rootfs} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			store.Close()
+		}
+	})
+	frozen := true
+	inst := &VMInstance{
+		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
+		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
+		SnapshotWorkloadFrozen: &frozen, FreezeToken: "rec",
+	}
+	if err := store.Put(toRecord(inst)); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeNetMgr{}
+	mgr := &Manager{
+		log:    zerolog.Nop(),
+		cfg:    ManagerConfig{RunDir: dir},
+		netMgr: fake,
+		vms:    map[string]*VMInstance{"vm-1": inst},
+		state:  store,
+	}
+	// The store dies under the resume: the launch fails and the rollback's
+	// write cannot land.
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		store.Close()
+		closed = true
+		return 0, SupervisionUnit, errors.New("launch failed")
+	}
+	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err == nil {
+		t.Fatal("want the launch failure")
+	}
+	if len(fake.setupCalls) != 1 {
+		t.Fatalf("setup calls = %v, want the slot taken once", fake.setupCalls)
+	}
+	if len(fake.teardownCalls) != 0 {
+		t.Fatalf("teardown calls = %v; the slot must stay reserved while the durable record still names it", fake.teardownCalls)
+	}
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if inst.Status != StatusPaused {
+		t.Errorf("status %v, want Paused in memory", inst.Status)
 	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -181,15 +182,26 @@ func TestResumeWakesFrozenWorkloadBeforeCommit(t *testing.T) {
 	inst := &VMInstance{
 		ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit,
 		SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs,
-		SnapshotWorkloadFrozen: &frozen,
+		SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok",
+		IP: "10.9.9.9", // the slot of an earlier run; this resume takes a new one
 	}
+	fake := &fakeNetMgr{}
+	slot, _ := fake.SetupVM(context.Background(), "probe", nil)
 	mgr := &Manager{
 		log:    zerolog.Nop(),
 		cfg:    ManagerConfig{RunDir: dir},
-		netMgr: &fakeNetMgr{},
+		netMgr: fake,
 		vms:    map[string]*VMInstance{"vm-1": inst},
 	}
+	// The launch runs after the record owes the wake and before the guest is
+	// woken: what recovery would read after a crash here must already name
+	// this run's slot and token.
+	var ipAtLaunch, tokenAtLaunch string
+	var owedAtLaunch bool
 	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		inst.mu.RLock()
+		ipAtLaunch, tokenAtLaunch, owedAtLaunch = inst.IP, inst.FreezeToken, inst.WakePending
+		inst.mu.RUnlock()
 		return 4321, SupervisionUnit, nil
 	}
 	mgr.restoreForResumeHook = func(string, string, string, string, *network.VMNetInfo) (bool, string, error) { return false, "", nil }
@@ -220,6 +232,9 @@ func TestResumeWakesFrozenWorkloadBeforeCommit(t *testing.T) {
 	}
 	if !owedAtWake {
 		t.Error("the record must owe the wake while the workload is still frozen")
+	}
+	if !owedAtLaunch || ipAtLaunch != slot.HostIP || tokenAtLaunch != "tok" {
+		t.Errorf("at launch: owed=%v ip=%q token=%q; want the owed record to name this run's slot %q and token", owedAtLaunch, ipAtLaunch, tokenAtLaunch, slot.HostIP)
 	}
 	inst.mu.RLock()
 	defer inst.mu.RUnlock()
@@ -585,20 +600,24 @@ func TestResumeOfUnfrozenPauseDoesNotFreezeOrWake(t *testing.T) {
 
 // A guest a crashed pause left frozen is released on reattach with the token
 // the intent carries; a token the guest never froze under means the crash came
-// first, and nothing is owed. A guest that cannot be released is not served.
+// first, and nothing is owed, once the workload is confirmed running. A guest
+// that cannot be released, or is frozen under another token, is not served.
 func TestReattachReleasesAGuestAnInterruptedPauseFroze(t *testing.T) {
 	raiseFloorForTest(t)
-	origThaw := boxdThawGuest
-	t.Cleanup(func() { boxdThawGuest = origThaw })
+	origThaw, origRunning := boxdThawGuest, boxdGuestRunning
+	t.Cleanup(func() { boxdThawGuest, boxdGuestRunning = origThaw, origRunning })
+	mismatch := fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
 	cases := []struct {
 		name       string
 		thaw       error
+		running    error
 		wantStatus VMStatus
 		wantIntent bool
 	}{
-		{"released", nil, StatusRunning, false},
-		{"never_frozen", fmt.Errorf("%w: status token", ErrGuestTokenMismatch), StatusRunning, false},
-		{"unreachable", errors.New("connection refused"), StatusError, true},
+		{"released", nil, nil, StatusRunning, false},
+		{"never_frozen", mismatch, nil, StatusRunning, false},
+		{"frozen_under_another_token", mismatch, errors.New(`guest workload status "frozen"`), StatusError, true},
+		{"unreachable", errors.New("connection refused"), nil, StatusError, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -621,6 +640,7 @@ func TestReattachReleasesAGuestAnInterruptedPauseFroze(t *testing.T) {
 			}
 			var sawToken string
 			boxdThawGuest = func(_ context.Context, _ string, token string) error { sawToken = token; return tc.thaw }
+			boxdGuestRunning = func(context.Context, string) error { return tc.running }
 			mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{SnapshotDir: dir}, state: store, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}}
 			inst := mgr.reattachByID("vm-1", false)
 			if inst == nil || sawToken != "tok" {
@@ -1187,4 +1207,96 @@ func TestTokenMismatchStaysErrorThroughRecovery(t *testing.T) {
 			t.Errorf("status %v, want Error: a refused wake is terminal even for a resume", inst.Status)
 		}
 	})
+}
+
+// A failed create must not wait on the state store: the Running write that
+// overlaps the readiness wait is joined by the failure worker, off the reply.
+// The writer is held from inside the launch, once that write is the only one
+// left, and the guest never answers.
+func TestFailedRestoreDoesNotWaitOnTheStore(t *testing.T) {
+	useTempFloor(t)
+	origProbe, origDead := boxdHealthProbe, vmDeadForRetry
+	t.Cleanup(func() { boxdHealthProbe, vmDeadForRetry = origProbe, origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+	boxdHealthProbe = func(context.Context, string, time.Duration) error { return errors.New("guest never answered") }
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	held := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		time.Sleep(50 * time.Millisecond) // let the failure worker's write land before the store closes
+		store.Close()
+	})
+	mgr := &Manager{
+		log:        zerolog.Nop(),
+		cfg:        ManagerConfig{RunDir: dir},
+		netMgr:     &fakeNetMgr{},
+		vms:        map[string]*VMInstance{},
+		restoreSem: make(chan struct{}, 1),
+		state:      store,
+	}
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		go func() {
+			_ = store.db.Update(func(*bolt.Tx) error {
+				close(held)
+				<-release
+				return nil
+			})
+		}()
+		<-held
+		return 4321, SupervisionUnit, nil
+	}
+	mgr.restoreSnapshotHook = func(_, _, _ string, _ *bool) error { return nil }
+
+	start := time.Now()
+	_, rerr := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0)
+	took := time.Since(start)
+	if rerr == nil {
+		t.Fatal("restore succeeded without a ready guest")
+	}
+	if took > 2*time.Second {
+		t.Fatalf("a failed restore took %v with the store held; the reply must not wait on it", took)
+	}
+	mgr.mu.RLock()
+	inst := mgr.vms["vm-1"]
+	mgr.mu.RUnlock()
+	if inst != nil {
+		inst.mu.RLock()
+		st := inst.Status
+		inst.mu.RUnlock()
+		if st != StatusError {
+			t.Fatalf("status %v after the failed restore, want Error before the reply", st)
+		}
+	}
+	// Once the store is free, the deferred write converges the record to
+	// Error: the Running write it joined first cannot land after it.
+	close(release)
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		rec, gerr := store.Get("vm-1")
+		if gerr == nil && rec != nil && rec.Status == StatusError {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("durable record never reached Error after the store was released: rec=%+v err=%v", rec, gerr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2306,3 +2306,202 @@ func TestUnfrozenOverwriteOfAFrozenImageIsCoveredByAnIntent(t *testing.T) {
 		t.Fatalf("intent = %+v; want it cleared after recovery", in)
 	}
 }
+
+// A pause that fails after its snapshot landed resumes the vCPUs before it
+// returns: Firecracker paused them for the snapshot, and a pause that
+// returns an error keeps the VM recorded Running. A marker that will not go
+// but was never a frozen manifest does not fail the pause at all.
+func TestPauseFailingAfterItsSnapshotResumesTheVCPUs(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origF, origT, origDown, origUnpause := boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown, fcUnpauseVM
+	t.Cleanup(func() {
+		boxdFreezeGuest, boxdThawGuest, vmUnitFullyDown, fcUnpauseVM = origF, origT, origDown, origUnpause
+	})
+	vmUnitFullyDown = func(string) bool { return false }
+	var unpaused []string
+	fcUnpauseVM = func(_ context.Context, socket string) error { unpaused = append(unpaused, socket); return nil }
+	boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+		return freezeEcho{Version: WakeProtocolVersion, Token: token}, nil
+	}
+	boxdThawGuest = func(context.Context, string, string) error { return nil }
+
+	newVM := func(t *testing.T, corrects bool, freezeOn bool) (*Manager, *VMInstance, string, string) {
+		t.Helper()
+		fc := startSnapshotAPIFake(t, nil)
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+		m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: freezeOn}}
+		m.clockRealtimeCapable.Store(true)
+		return m, inst, vmDir, memSnap
+	}
+	// A marker that cannot be removed and is not a manifest: a directory
+	// with something in it.
+	stuckMarker := func(t *testing.T, memSnap string) {
+		t.Helper()
+		marker := WallClockMarkerPath(memSnap)
+		if err := os.MkdirAll(filepath.Join(marker, "x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("legacy_pause_survives_a_marker_that_will_not_go", func(t *testing.T) {
+		m, inst, vmDir, memSnap := newVM(t, false, false)
+		stuckMarker(t, memSnap)
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+			t.Fatalf("pause: %v; a marker that was never a frozen manifest must not fail the pause", err)
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusPaused {
+			t.Fatalf("status %v, want Paused", inst.Status)
+		}
+	})
+
+	t.Run("a_frozen_pause_whose_manifest_cannot_land_resumes_the_guest", func(t *testing.T) {
+		m, inst, vmDir, memSnap := newVM(t, true, true)
+		stuckMarker(t, memSnap) // the manifest's rename onto it fails
+		unpaused = nil
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the manifest failure")
+		}
+		if len(unpaused) == 0 || unpaused[0] != inst.SocketPath {
+			t.Fatalf("unpause calls = %v; the vCPUs must be resumed before the error returns", unpaused)
+		}
+		inst.mu.RLock()
+		defer inst.mu.RUnlock()
+		if inst.Status != StatusRunning {
+			t.Fatalf("status %v, want Running: the pause did not commit", inst.Status)
+		}
+	})
+
+	t.Run("a_frozen_manifest_that_cannot_be_removed_fails_the_pause_and_resumes_the_guest", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("needs a directory the process cannot write; root can")
+		}
+		m, _, vmDir, memSnap := newVM(t, false, false)
+		seedFrozenManifest(t, memSnap, "A")
+		if err := os.Chmod(vmDir, 0o555); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(vmDir, 0o755) })
+		unpaused = nil
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the pause refused: a frozen manifest beside an unfrozen image cannot stay")
+		}
+		if len(unpaused) == 0 {
+			t.Fatal("the vCPUs must be resumed before the error returns")
+		}
+	})
+}
+
+// The dormancy contract: with the switches off, a legacy image's lifecycle
+// makes no guest call, writes no manifest or intent, records no new phase
+// and sends no wake. A frozen image on a host later switched off is still
+// woken (see TestResumeWakesFrozenWorkloadBeforeCommit, which runs with the
+// switch off).
+func TestDormantHostAddsNothingToALegacyLifecycle(t *testing.T) {
+	origF, origT, origW, origR, origP, origDown, origDead := boxdFreezeGuest, boxdThawGuest, boxdWakeGuest, boxdGuestRunning, boxdHealthProbe, vmUnitFullyDown, vmDeadForRetry
+	t.Cleanup(func() {
+		boxdFreezeGuest, boxdThawGuest, boxdWakeGuest, boxdGuestRunning, boxdHealthProbe, vmUnitFullyDown, vmDeadForRetry = origF, origT, origW, origR, origP, origDown, origDead
+	})
+	vmUnitFullyDown = func(string) bool { return false }
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+	boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+		t.Error("a dormant host froze a guest")
+		return freezeEcho{}, errors.New("unexpected")
+	}
+	boxdThawGuest = func(context.Context, string, string) error { t.Error("a dormant host thawed a guest"); return nil }
+	boxdWakeGuest = func(context.Context, string, time.Duration, bool, string) error {
+		t.Error("a dormant host woke a guest")
+		return nil
+	}
+	boxdGuestRunning = func(context.Context, string) error {
+		t.Error("a dormant host asked a guest whether it runs")
+		return nil
+	}
+	boxdHealthProbe = func(context.Context, string, time.Duration) error { return nil }
+
+	for _, tc := range []struct {
+		name   string
+		marker func(t *testing.T, memSnap string)
+	}{
+		{"absent_marker", func(*testing.T, string) {}},
+		{"empty_marker", func(t *testing.T, memSnap string) {
+			if err := os.WriteFile(WallClockMarkerPath(memSnap), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run("pause_"+tc.name, func(t *testing.T) {
+			fc := startSnapshotAPIFake(t, nil)
+			dir := t.TempDir()
+			vmDir := filepath.Join(dir, "vm-1")
+			if err := os.MkdirAll(vmDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			memSnap := filepath.Join(vmDir, "mem.snap")
+			if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tc.marker(t, memSnap)
+			inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap}
+			sink := &phaseSink{}
+			m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, recorder: sink, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+			if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+				t.Fatalf("pause: %v", err)
+			}
+			if _, err := os.Stat(WallClockMarkerPath(memSnap)); err == nil {
+				t.Fatal("a legacy pause left a marker beside its image")
+			}
+			if _, err := os.Stat(pauseIntentPath(vmDir)); err == nil {
+				t.Fatal("a legacy pause wrote an intent")
+			}
+			for _, phase := range []string{"freeze", "manifest", "wake_floor"} {
+				if sink.has("pause", phase) {
+					t.Fatalf("phases = %+v; a legacy pause recorded a %s phase", sink.phases, phase)
+				}
+			}
+		})
+	}
+
+	t.Run("create_sends_no_wake", func(t *testing.T) {
+		dir := t.TempDir()
+		snapPath, memPath, basePath := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "base.ext4")
+		overlay := filepath.Join(dir, "vm-1", "overlay.ext4")
+		if err := os.MkdirAll(filepath.Dir(overlay), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, p := range []string{snapPath, memPath, basePath, overlay} {
+			if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		sink := &phaseSink{}
+		m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1), recorder: sink}
+		m.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+			return 4321, SupervisionUnit, nil
+		}
+		m.restoreSnapshotHook = func(_, _, _ string, clock *bool) error {
+			if clock != nil {
+				t.Error("a dormant host asked Firecracker for a clock policy")
+			}
+			return nil
+		}
+		inst, err := m.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0)
+		if err != nil || inst == nil {
+			t.Fatalf("restore: inst=%v err=%v", inst, err)
+		}
+		if sink.has("restore", "wake_floor") {
+			t.Fatalf("phases = %+v; a legacy create proved a floor", sink.phases)
+		}
+	})
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2261,9 +2261,11 @@ func TestUnfrozenPauseReplacingAManifestDoesSoDurably(t *testing.T) {
 func TestUnfrozenOverwriteOfAFrozenImageIsCoveredByAnIntent(t *testing.T) {
 	useTempFloor(t)
 	raiseFloorForTest(t)
-	origDown := vmUnitFullyDown
+	origDown, origUnpause, origProbe := vmUnitFullyDown, fcUnpauseVM, boxdHealthProbe
 	vmUnitFullyDown = func(string) bool { return false }
-	t.Cleanup(func() { vmUnitFullyDown = origDown })
+	fcUnpauseVM = func(context.Context, string) error { return nil }
+	boxdHealthProbe = func(context.Context, string, time.Duration) error { return nil }
+	t.Cleanup(func() { vmUnitFullyDown, fcUnpauseVM, boxdHealthProbe = origDown, origUnpause, origProbe })
 
 	fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
 		return http.StatusInternalServerError, `{"fault_message":"disk full"}`
@@ -2353,16 +2355,93 @@ func TestPauseFailingAfterItsSnapshotResumesTheVCPUs(t *testing.T) {
 		}
 	}
 
-	t.Run("legacy_pause_survives_a_marker_that_will_not_go", func(t *testing.T) {
+	// A marker that will not go and cannot be read is not harmless: a restore
+	// would refuse the image. The pause is refused and the guest resumed.
+	t.Run("legacy_pause_refuses_an_unreadable_marker_that_will_not_go", func(t *testing.T) {
 		m, inst, vmDir, memSnap := newVM(t, false, false)
 		stuckMarker(t, memSnap)
-		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
-			t.Fatalf("pause: %v; a marker that was never a frozen manifest must not fail the pause", err)
+		unpaused = nil
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the pause refused: the image would carry a marker a restore cannot read")
+		}
+		if len(unpaused) != 1 || unpaused[0] != inst.SocketPath {
+			t.Fatalf("unpause calls = %v; the vCPUs must be resumed before the error returns", unpaused)
 		}
 		inst.mu.RLock()
 		defer inst.mu.RUnlock()
-		if inst.Status != StatusPaused {
-			t.Fatalf("status %v, want Paused", inst.Status)
+		if inst.Status != StatusRunning {
+			t.Fatalf("status %v, want Running", inst.Status)
+		}
+	})
+
+	// An empty marker that will not go is harmless: a restore reads it as
+	// legacy. The pause completes.
+	t.Run("legacy_pause_survives_an_empty_marker_that_will_not_go", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("needs a directory the process cannot write; root can")
+		}
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+			_ = os.Chmod(vmDir, 0o555)
+			return http.StatusNoContent, ""
+		})
+		t.Cleanup(func() { os.Chmod(vmDir, 0o755) })
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(WallClockMarkerPath(memSnap), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		corrects := false
+		inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath, MemFilePath: memSnap, CorrectsWallClock: &corrects}
+		m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+			t.Fatalf("pause: %v; an empty marker reads as legacy and must not fail the pause", err)
+		}
+	})
+
+	// The snapshot consumed the dirty bitmap: a pause that fails after it
+	// leaves the retry no baseline, so the retry is Full, not another Diff.
+	t.Run("a_retry_after_a_failure_past_the_snapshot_is_full", func(t *testing.T) {
+		fc := startSnapshotAPIFake(t, nil)
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		memSnap := filepath.Join(vmDir, "mem.snap")
+		if err := os.WriteFile(memSnap, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		corrects := true
+		inst := &VMInstance{
+			ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath,
+			MemFilePath: memSnap, CorrectsWallClock: &corrects, DirtyTracked: true, DirtyTrackingSessionID: "session-a",
+		}
+		m := &Manager{
+			log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst},
+			cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir, GuestClockFreezeEnabled: true, IncrementalSnapshotEnabled: true, DirtyTrackingSessionEnabled: true},
+		}
+		m.clockRealtimeCapable.Store(true)
+		m.dirtyTrackingSessionCapable.Store(true)
+		stuckMarker(t, memSnap) // the frozen manifest cannot land after the Diff
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err == nil {
+			t.Fatal("want the manifest failure")
+		}
+		if err := os.RemoveAll(WallClockMarkerPath(memSnap)); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, _, err := m.PauseVM(context.Background(), "vm-1", vmDir, ""); err != nil {
+			t.Fatalf("retry: %v", err)
+		}
+		bodies := fc.snapshotBodies()
+		if len(bodies) != 2 || !isDiffRequest(bodies[0]) || isDiffRequest(bodies[1]) {
+			t.Fatalf("requests = %v; want a Diff that failed past the snapshot, then a Full retry", bodies)
 		}
 	})
 
@@ -2521,6 +2600,56 @@ func TestDormantHostAddsNothingToALegacyLifecycle(t *testing.T) {
 		}
 		if sink.has("restore", "wake_floor") {
 			t.Fatalf("phases = %+v; a legacy create proved a floor", sink.phases)
+		}
+	})
+}
+
+// Recovery of an intent without a token, an unfrozen rewrite the crash
+// interrupted after the snapshot paused the vCPUs, resumes them and confirms
+// the guest answers before the VM is served as running.
+func TestRecoveryOfAnUnfrozenRewriteResumesTheVCPUs(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	origUnpause, origProbe := fcUnpauseVM, boxdHealthProbe
+	t.Cleanup(func() { fcUnpauseVM, boxdHealthProbe = origUnpause, origProbe })
+	var unpaused []string
+	fcUnpauseVM = func(_ context.Context, socket string) error { unpaused = append(unpaused, socket); return nil }
+
+	newCase := func(t *testing.T) (*Manager, *VMInstance, string) {
+		t.Helper()
+		dir := t.TempDir()
+		vmDir := filepath.Join(dir, "vm-1")
+		if err := os.MkdirAll(vmDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := writePauseIntent(vmDir, pauseIntent{VMID: "vm-1", ArtifactID: "rewrite"}); err != nil {
+			t.Fatal(err)
+		}
+		inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: "/run/vm-1/firecracker.sock", ArtifactID: "current"}
+		m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+		return m, inst, vmDir
+	}
+
+	t.Run("resumed_and_answering", func(t *testing.T) {
+		m, inst, vmDir := newCase(t)
+		boxdHealthProbe = func(context.Context, string, time.Duration) error { return nil }
+		unpaused = nil
+		if !m.recoverPauseIntent(context.Background(), inst, zerolog.Nop()) {
+			t.Fatal("recovery must succeed once the guest answers")
+		}
+		if len(unpaused) != 1 || unpaused[0] != inst.SocketPath {
+			t.Fatalf("unpause calls = %v; the vCPUs the snapshot paused must be resumed", unpaused)
+		}
+		if in, _ := readPauseIntent(vmDir); in != nil {
+			t.Fatalf("intent = %+v; want it cleared", in)
+		}
+	})
+
+	t.Run("not_answering_is_not_served", func(t *testing.T) {
+		m, inst, _ := newCase(t)
+		boxdHealthProbe = func(context.Context, string, time.Duration) error { return errors.New("no answer") }
+		if m.recoverPauseIntent(context.Background(), inst, zerolog.Nop()) {
+			t.Fatal("a guest that does not answer after the resume must not be served as running")
 		}
 	})
 }

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2733,6 +2733,11 @@ func TestPauseWithAnUnconfirmedThawRecordsTheGuestAsError(t *testing.T) {
 		if in, err := readPauseIntent(vmDir); err != nil || in == nil || in.FreezeToken == "" {
 			t.Fatalf("intent = %+v err=%v; the token must be kept for a later release", in, err)
 		}
+		// The process was kept: capacity must go on charging it behind the
+		// Error record until its stop is confirmed.
+		if _, marked := m.vmStopUnconfirmed.Load("vm-1"); !marked {
+			t.Fatal("a retained process behind an Error record must be marked as possibly alive for capacity accounting")
+		}
 	}
 
 	t.Run("freeze_reply_lost_and_thaw_unconfirmed", func(t *testing.T) {

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2759,3 +2759,43 @@ func TestPauseWithAnUnconfirmedThawRecordsTheGuestAsError(t *testing.T) {
 		check(t, m, inst, vmDir)
 	})
 }
+
+// An ad-hoc snapshot into a directory that already holds a frozen image
+// keeps that image's manifest until its own snapshot has replaced the image:
+// a snapshot that fails first must not turn a frozen image into one a
+// restore reads as legacy.
+func TestAdHocSnapshotKeepsTheOldManifestUntilItsSnapshotLands(t *testing.T) {
+	fail := true
+	fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+		if fail {
+			return http.StatusInternalServerError, `{"fault_message":"disk full"}`
+		}
+		return http.StatusNoContent, ""
+	})
+	dir := t.TempDir()
+	snapDir := filepath.Join(dir, "adhoc")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memPath := filepath.Join(snapDir, "mem.snap")
+	if err := os.WriteFile(memPath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, memPath, "A")
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", snapDir); err == nil {
+		t.Fatal("want the snapshot failure")
+	}
+	if man, err := ReadWallClockManifest(memPath); err != nil || man == nil || !man.WorkloadFrozen {
+		t.Fatalf("manifest=%+v err=%v; the earlier image's manifest must survive a failed snapshot", man, err)
+	}
+	fail = false
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", snapDir); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if man, err := ReadWallClockManifest(memPath); err != nil || man != nil {
+		t.Fatalf("manifest=%+v err=%v; an ad-hoc image is never marked", man, err)
+	}
+}

--- a/internal/vm/wake_test.go
+++ b/internal/vm/wake_test.go
@@ -2799,3 +2799,107 @@ func TestAdHocSnapshotKeepsTheOldManifestUntilItsSnapshotLands(t *testing.T) {
 		t.Fatalf("manifest=%+v err=%v; an ad-hoc image is never marked", man, err)
 	}
 }
+
+// A restore of a paused VM from a frozen image whose launch fails, after the
+// wake-owed record was published, returns the record to Paused: the image is
+// intact, and an Error record would be reaped as stale by the next restart.
+func TestFrozenRestoreOfAPausedVMFailingBeforeItsWakeReturnsToPaused(t *testing.T) {
+	useTempFloor(t)
+	origDead := vmDeadForRetry
+	t.Cleanup(func() { vmDeadForRetry = origDead })
+	vmDeadForRetry = func(*Manager, string) bool { return true }
+
+	dir := t.TempDir()
+	snapPath := filepath.Join(dir, "vm.snap")
+	memPath := filepath.Join(dir, "mem.snap")
+	basePath := filepath.Join(dir, "base.ext4")
+	for _, p := range []string{snapPath, memPath, basePath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedFrozenManifest(t, memPath, "tok")
+	overlay := filepath.Join(dir, "vm-1", "overlay.ext4")
+	if err := os.MkdirAll(filepath.Dir(overlay), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlay, []byte("customer data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStateStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	pausedAt := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	prev := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: overlay, PausedAt: pausedAt}
+	if err := store.Put(toRecord(prev)); err != nil {
+		t.Fatal(err)
+	}
+	mgr := &Manager{
+		log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir, GuestClockFreezeEnabled: true}, netMgr: &fakeNetMgr{},
+		vms: map[string]*VMInstance{"vm-1": prev}, restoreSem: make(chan struct{}, 1), state: store,
+	}
+	mgr.clockRealtimeCapable.Store(true)
+	var owedAtLaunch bool
+	mgr.launchFirecrackerHook = func(context.Context, string, string, string, string, string, Supervision, bool, bool) (int, Supervision, error) {
+		mgr.mu.RLock()
+		inst := mgr.vms["vm-1"]
+		mgr.mu.RUnlock()
+		inst.mu.RLock()
+		owedAtLaunch = inst.Status == StatusRunning && inst.WakePending && inst.WakeOwedFromPaused
+		inst.mu.RUnlock()
+		return 0, SupervisionUnit, errors.New("launch failed")
+	}
+	if _, err := mgr.RestoreVMSnapshot(context.Background(), "vm-1", snapPath, memPath, VMConfig{BasePath: basePath}, nil, "team", "owner", "", nil, 0); err == nil {
+		t.Fatal("want the launch failure")
+	}
+	if !owedAtLaunch {
+		t.Fatal("precondition: the wake-owed record must have been published before the launch")
+	}
+	rec, gerr := store.Get("vm-1")
+	if gerr != nil || rec == nil || rec.Status != StatusPaused || rec.WakePending || rec.WakeOwedFromPaused || !rec.PausedAt.Equal(pausedAt) {
+		t.Fatalf("record = %+v err=%v; want Paused, owing nothing, in its place in the reclaim order", rec, gerr)
+	}
+}
+
+// An ad-hoc snapshot over a frozen image journals the rewrite before the
+// image is replaced: a restore refuses the directory while the old manifest
+// could still govern the new image, and the journal clears with the manifest.
+func TestAdHocSnapshotOverAFrozenImageJournalsTheRewrite(t *testing.T) {
+	useTempFloor(t)
+	raiseFloorForTest(t)
+	dir := t.TempDir()
+	snapDir := filepath.Join(dir, "adhoc")
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	memPath := filepath.Join(snapDir, "mem.snap")
+	if err := os.WriteFile(memPath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, memPath, "A")
+	var journalledAtSnapshot, manifestAtSnapshot, blockedAtSnapshot bool
+	fc := startSnapshotAPIFake(t, func(_, _ string) (int, string) {
+		in, _ := readPauseIntent(snapDir)
+		journalledAtSnapshot = in != nil && in.FreezeToken == ""
+		man, _ := ReadWallClockManifest(memPath)
+		manifestAtSnapshot = man != nil && man.WorkloadFrozen
+		blockedAtSnapshot, _ = pauseIntentBlocks(snapDir, "")
+		return http.StatusNoContent, ""
+	})
+	inst := &VMInstance{ID: "vm-1", Status: StatusRunning, Supervision: SupervisionCgroup, IP: "10.0.0.2", SocketPath: fc.socketPath}
+	m := &Manager{log: zerolog.Nop(), netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, cfg: ManagerConfig{SnapshotDir: dir, RunDir: dir}}
+	if _, _, err := m.CreateVMSnapshot(context.Background(), "vm-1", snapDir); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if !journalledAtSnapshot || !manifestAtSnapshot || !blockedAtSnapshot {
+		t.Fatalf("at the snapshot: journalled=%v manifest=%v blocked=%v; the rewrite must be journalled while the old manifest still stands, and a restore refused", journalledAtSnapshot, manifestAtSnapshot, blockedAtSnapshot)
+	}
+	if in, _ := readPauseIntent(snapDir); in != nil {
+		t.Fatalf("journal = %+v after success; want it cleared with the manifest", in)
+	}
+	if man, err := ReadWallClockManifest(memPath); err != nil || man != nil {
+		t.Fatalf("manifest=%+v err=%v; an ad-hoc image is never marked", man, err)
+	}
+}

--- a/internal/vm/wakefloorguard_test.go
+++ b/internal/vm/wakefloorguard_test.go
@@ -14,8 +14,9 @@ import (
 // into a temp dir.
 
 // wakeProtocolMarker is the literal the guard greps a vmd binary for. A vmd
-// that can wake a frozen image carries it; this one does not, on purpose.
-const wakeProtocolMarker = "wake-protocol-1"
+// that can wake a frozen image carries it (see the daemon's capabilities
+// command); that a binary built from that package does is shown there.
+const wakeProtocolMarker = WakeProtocolCapability
 
 type wakeGuardWorld struct {
 	t        *testing.T

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -299,7 +299,10 @@ func imageManifest(memPath string) (*WallClockManifest, error) {
 // restore has to happen first. A directory listing at start and every few
 // minutes, off every request path.
 func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) {
-	if m.cfg.SnapshotDir == "" {
+	// Only a host that may act on frozen images watches for them. With the
+	// switch off this does no filesystem work at all; such a host's floor
+	// still rises at the first frozen image it restores.
+	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
 		return
 	}
 	scan := func() {

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -243,18 +243,18 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 }
 
 // removeWallClockManifest removes the manifest beside an image, if any. One
-// that said frozen is removed with a directory sync so a crash cannot bring
-// it back; any other marker is simply removed. Only a host whose floor is up
-// reads before removing. Nothing to remove is not an error. A marker that
-// will not go is blocking unless it is known harmless: readable and not
-// frozen, or empty. One a restore could not read would refuse the image.
+// that said frozen, or one that cannot be read and so may have, is removed
+// with a directory sync so a crash cannot bring it back; any other marker is
+// simply removed. Only a host whose floor is up reads before removing.
+// Nothing to remove is not an error. A marker that will not go is blocking
+// unless it is known harmless: readable and not frozen, or empty. One a
+// restore could not read would refuse the image.
 func removeWallClockManifest(memPath string) (blocking bool, err error) {
 	path := WallClockMarkerPath(memPath)
 	frozen := false
 	if wakeProtocolFloorRaised() {
-		if man, rerr := ReadWallClockManifest(memPath); rerr == nil && man != nil && man.WorkloadFrozen {
-			frozen = true
-		}
+		man, rerr := ReadWallClockManifest(memPath)
+		frozen = rerr != nil || (man != nil && man.WorkloadFrozen)
 	}
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -242,13 +242,15 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 	return writeWallClockManifest(memPath, m, true)
 }
 
-// removeWallClockManifest removes the manifest beside an image, if any, and
-// reports whether it said frozen: one that did is removed with a directory
-// sync so a crash cannot bring it back; any other marker is simply removed.
-// Only a host whose floor is up reads before removing. Nothing to remove is
-// not an error.
-func removeWallClockManifest(memPath string) (frozen bool, err error) {
+// removeWallClockManifest removes the manifest beside an image, if any. One
+// that said frozen is removed with a directory sync so a crash cannot bring
+// it back; any other marker is simply removed. Only a host whose floor is up
+// reads before removing. Nothing to remove is not an error. A marker that
+// will not go is blocking unless it is known harmless: readable and not
+// frozen, or empty. One a restore could not read would refuse the image.
+func removeWallClockManifest(memPath string) (blocking bool, err error) {
 	path := WallClockMarkerPath(memPath)
+	frozen := false
 	if wakeProtocolFloorRaised() {
 		if man, rerr := ReadWallClockManifest(memPath); rerr == nil && man != nil && man.WorkloadFrozen {
 			frozen = true
@@ -258,7 +260,11 @@ func removeWallClockManifest(memPath string) (frozen bool, err error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return frozen, err
+		if frozen {
+			return true, err
+		}
+		man, rerr := ReadWallClockManifest(memPath)
+		return rerr != nil || (man != nil && man.WorkloadFrozen), err
 	}
 	if !frozen {
 		return false, nil

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -88,6 +88,22 @@ func RecognizeWakeProtocolFloor() bool {
 	return false
 }
 
+// PrimeWakeProtocolFloor proves recognised evidence durable in the
+// background, so the first request that acts on an image owing a wake after
+// a restart finds the floor already durable instead of paying the directory
+// sync itself. A host without evidence primes nothing: the floor is never
+// raised here, only proven.
+func PrimeWakeProtocolFloor(log zerolog.Logger) {
+	if !wakeProtocolEvidenceSeen.Load() || wakeProtocolEvidenceDurable.Load() {
+		return
+	}
+	go func() {
+		if err := ensureWakeProtocolFloor(); err != nil {
+			log.Warn().Err(err).Msg("wake-protocol floor could not be proven durable at startup; the first frozen restore will retry")
+		}
+	}()
+}
+
 // wakeProtocolFloorRaised reports what startup recognised, without I/O. A
 // pause intent is only ever written on a host whose floor is up, so on any
 // other host the checks for one are skipped, at no cost.

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -10,7 +11,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // WallClockManifest sits beside a memory image and says what a supervisor may
@@ -39,6 +44,10 @@ const WallClockManifestVersion = 1
 // echo. A different version space from the manifest's: the two are both 1
 // today by coincidence, and a bump to either must not pass for the other.
 const WakeProtocolVersion = 1
+
+// WakeProtocolCapability is the string a vmd that can wake a frozen image
+// carries; the host guard and the deploy check grep the binary for it.
+const WakeProtocolCapability = "wake-protocol-1"
 
 // wakeProtocolEvidencePath records that this host has held an image that
 // owes a wake, so the host-resident guard refuses a vmd without the wake
@@ -83,6 +92,31 @@ func RecognizeWakeProtocolFloor() bool {
 // pause intent is only ever written on a host whose floor is up, so on any
 // other host the checks for one are skipped, at no cost.
 func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceSeen.Load() }
+
+// wakeProtocolEvidenceMu makes concurrent first raises share one write
+// instead of each paying the sync.
+var wakeProtocolEvidenceMu sync.Mutex
+
+// ensureWakeProtocolFloor is the form a supervisor uses before it acts on an
+// image that owes a wake — freezing one, restoring one: durable once, then
+// free. Never on a request path for an image that owes nothing.
+func ensureWakeProtocolFloor() error {
+	if wakeProtocolEvidenceDurable.Load() {
+		return nil
+	}
+	wakeProtocolEvidenceMu.Lock()
+	defer wakeProtocolEvidenceMu.Unlock()
+	return RaiseWakeProtocolFloor()
+}
+
+// noteWakeProtocolEvidence is the best-effort form, for the template scan: a
+// host without the directory is not a fleet host.
+func noteWakeProtocolEvidence() {
+	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
+		return
+	}
+	_ = ensureWakeProtocolFloor()
+}
 
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
 // hold, an image that owes a wake. The template builder calls it before it
@@ -257,4 +291,56 @@ func randomHex() string {
 // clock.
 func imageManifest(memPath string) (*WallClockManifest, error) {
 	return ReadWallClockManifest(memPath)
+}
+
+// WatchTemplateManifests keeps the wake-protocol evidence in step with the
+// templates this host holds. Templates are seeded while the daemon runs, so
+// the first frozen one to land is what raises the rollback floor here — no
+// restore has to happen first. A directory listing at start and every few
+// minutes, off every request path.
+func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) {
+	if m.cfg.SnapshotDir == "" {
+		return
+	}
+	scan := func() {
+		if n := m.scanTemplateManifests(); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
+			log.Info().Int("templates", n).Msg("this host holds images that owe a wake; a vmd without the wake protocol is refused from now on")
+		}
+	}
+	go func() {
+		scan()
+		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				scan()
+			}
+		}
+	}()
+}
+
+var wakeProtocolEvidenceLogged atomic.Bool
+
+// scanTemplateManifests reads every template manifest under the snapshot
+// directory, raises the floor for each frozen one, and returns how many
+// frozen ones it found.
+func (m *Manager) scanTemplateManifests() int {
+	// Templates live at templates/<template>/<build>/; the shallower pattern
+	// is kept so a flattened layout could never hide one.
+	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+	deep, _ := filepath.Glob(filepath.Join(root, "*", "*", "*"+clockFreezeMarkerSuffix))
+	shallow, _ := filepath.Glob(filepath.Join(root, "*", "*"+clockFreezeMarkerSuffix))
+	n := 0
+	for _, path := range append(deep, shallow...) {
+		man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
+		if err != nil || man == nil || !man.WorkloadFrozen {
+			continue
+		}
+		n++
+		noteWakeProtocolEvidence()
+	}
+	return n
 }

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -317,10 +317,12 @@ func imageManifest(memPath string) (*WallClockManifest, error) {
 // The returned channel closes once the watcher has stopped, after ctx ends.
 func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) (stopped <-chan struct{}) {
 	done := make(chan struct{})
-	// Only a host that may act on frozen images watches for them. With the
-	// switch off this does no filesystem work at all; such a host's floor
-	// still rises at the first frozen image it restores.
-	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
+	// Regardless of the freeze switch: a frozen template landing on a host
+	// that does not freeze is still one this daemon restores and wakes, and
+	// the floor must be up before any rollback could meet it, not only once
+	// a restore first does. The work is two globs and a manifest read per
+	// template, after readiness and off every request path.
+	if m.cfg.SnapshotDir == "" {
 		close(done)
 		return done
 	}

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -244,27 +244,30 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 	return writeWallClockManifest(memPath, m, true)
 }
 
-// removeWallClockManifestDurably removes the manifest beside an image, if
-// any. One that said frozen is removed with a directory sync, so a crash
-// cannot bring it back beside an image it does not describe; any other
-// marker is simply removed, since its return would cost nothing but a
-// slower resume. Nothing to remove is not an error.
-func removeWallClockManifestDurably(memPath string) error {
+// removeWallClockManifest removes the manifest beside an image, if any, and
+// reports whether it said frozen. One that did is removed with a directory
+// sync, so a crash cannot bring it back beside an image it does not
+// describe; any other marker is simply removed, since its return would cost
+// nothing but a slower resume. Only a host with frozen images can hold a
+// frozen manifest, so elsewhere nothing is read: the removal is the one
+// call it always was. Nothing to remove is not an error.
+func removeWallClockManifest(memPath string) (frozen bool, err error) {
 	path := WallClockMarkerPath(memPath)
-	frozen := false
-	if man, err := ReadWallClockManifest(memPath); err == nil && man != nil && man.WorkloadFrozen {
-		frozen = true
+	if wakeProtocolFloorRaised() {
+		if man, rerr := ReadWallClockManifest(memPath); rerr == nil && man != nil && man.WorkloadFrozen {
+			frozen = true
+		}
 	}
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return err
+		return frozen, err
 	}
 	if !frozen {
-		return nil
+		return false, nil
 	}
-	return syncDir(filepath.Dir(path))
+	return true, syncDir(filepath.Dir(path))
 }
 
 // writeWallClockManifestLazy publishes atomically but with no durability

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -90,10 +90,8 @@ func RecognizeWakeProtocolFloor() bool {
 }
 
 // PrimeWakeProtocolFloor proves recognised evidence durable in the
-// background, so the first request that acts on an image owing a wake after
-// a restart finds the floor already durable instead of paying the directory
-// sync itself. A host without evidence primes nothing: the floor is never
-// raised here, only proven.
+// background, so the first request needing the floor after a restart pays no
+// directory sync. Without evidence it primes nothing: proven here, never raised.
 func PrimeWakeProtocolFloor(log zerolog.Logger) {
 	if !wakeProtocolEvidenceSeen.Load() || wakeProtocolEvidenceDurable.Load() {
 		return
@@ -245,12 +243,10 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 }
 
 // removeWallClockManifest removes the manifest beside an image, if any, and
-// reports whether it said frozen. One that did is removed with a directory
-// sync, so a crash cannot bring it back beside an image it does not
-// describe; any other marker is simply removed, since its return would cost
-// nothing but a slower resume. Only a host with frozen images can hold a
-// frozen manifest, so elsewhere nothing is read: the removal is the one
-// call it always was. Nothing to remove is not an error.
+// reports whether it said frozen: one that did is removed with a directory
+// sync so a crash cannot bring it back; any other marker is simply removed.
+// Only a host whose floor is up reads before removing. Nothing to remove is
+// not an error.
 func removeWallClockManifest(memPath string) (frozen bool, err error) {
 	path := WallClockMarkerPath(memPath)
 	if wakeProtocolFloorRaised() {
@@ -336,19 +332,15 @@ func imageManifest(memPath string) (*WallClockManifest, error) {
 	return ReadWallClockManifest(memPath)
 }
 
-// WatchTemplateManifests keeps the wake-protocol evidence in step with the
-// templates this host holds. Templates are seeded while the daemon runs, so
-// the first frozen one to land is what raises the rollback floor here — no
-// restore has to happen first. A directory listing at start and every few
-// minutes, off every request path.
-// The returned channel closes once the watcher has stopped, after ctx ends.
+// WatchTemplateManifests raises the rollback floor for frozen templates as
+// they land, so no restore has to happen first: a scan at start and every few
+// minutes plus a watch on the tree, off every request path. The returned
+// channel closes once the watcher has stopped.
 func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) (stopped <-chan struct{}) {
 	done := make(chan struct{})
-	// Only a host that may act on frozen images watches for them: with the
-	// switch off this does no filesystem work at all. A frozen template must
-	// not reach such a host in the first place; that is enforced where
-	// templates are admitted, and the guard's floor rises at the first
-	// frozen image a host does restore.
+	// Only a host that may act on frozen images watches: with the switch off
+	// this does no filesystem work. A frozen template must not reach such a
+	// host, which is enforced where templates are admitted.
 	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
 		close(done)
 		return done

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -381,7 +381,10 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 				case <-t.C:
 					scan()
 				case ev := <-events:
-					if !ev.Has(fsnotify.Create) && !ev.Has(fsnotify.Rename) {
+					// Writes too: an importer that creates the path and then
+					// streams the manifest into it is complete only at its
+					// last write, and a partial file simply fails to parse.
+					if !ev.Has(fsnotify.Create) && !ev.Has(fsnotify.Rename) && !ev.Has(fsnotify.Write) {
 						continue
 					}
 					if info, serr := os.Stat(ev.Name); serr == nil && info.IsDir() {

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -364,6 +364,11 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 		// fallback for anything the watch missed; a host that cannot watch
 		// keeps the scan alone.
 		root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+		// The root is created if absent, so the watch has something to
+		// attach to before the first template lands rather than after.
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			log.Warn().Err(err).Str("path", root).Msg("template root cannot be created; frozen templates are witnessed by the periodic scan alone")
+		}
 		var events <-chan fsnotify.Event
 		var errs <-chan error
 		if w, werr := fsnotify.NewWatcher(); werr == nil {

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -245,15 +245,24 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 }
 
 // removeWallClockManifestDurably removes the manifest beside an image, if
-// any, and syncs its directory so a crash cannot bring it back beside an
-// image it does not describe. Nothing to remove is not an error.
+// any. One that said frozen is removed with a directory sync, so a crash
+// cannot bring it back beside an image it does not describe; any other
+// marker is simply removed, since its return would cost nothing but a
+// slower resume. Nothing to remove is not an error.
 func removeWallClockManifestDurably(memPath string) error {
 	path := WallClockMarkerPath(memPath)
+	frozen := false
+	if man, err := ReadWallClockManifest(memPath); err == nil && man != nil && man.WorkloadFrozen {
+		frozen = true
+	}
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
+	}
+	if !frozen {
+		return nil
 	}
 	return syncDir(filepath.Dir(path))
 }
@@ -332,12 +341,12 @@ func imageManifest(memPath string) (*WallClockManifest, error) {
 // The returned channel closes once the watcher has stopped, after ctx ends.
 func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) (stopped <-chan struct{}) {
 	done := make(chan struct{})
-	// Regardless of the freeze switch: a frozen template landing on a host
-	// that does not freeze is still one this daemon restores and wakes, and
-	// the floor must be up before any rollback could meet it, not only once
-	// a restore first does. The work is two globs and a manifest read per
-	// template, after readiness and off every request path.
-	if m.cfg.SnapshotDir == "" {
+	// Only a host that may act on frozen images watches for them: with the
+	// switch off this does no filesystem work at all. A frozen template must
+	// not reach such a host in the first place; that is enforced where
+	// templates are admitted, and the guard's floor rises at the first
+	// frozen image a host does restore.
+	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
 		close(done)
 		return done
 	}

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -314,12 +314,15 @@ func imageManifest(memPath string) (*WallClockManifest, error) {
 // the first frozen one to land is what raises the rollback floor here — no
 // restore has to happen first. A directory listing at start and every few
 // minutes, off every request path.
-func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) {
+// The returned channel closes once the watcher has stopped, after ctx ends.
+func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) (stopped <-chan struct{}) {
+	done := make(chan struct{})
 	// Only a host that may act on frozen images watches for them. With the
 	// switch off this does no filesystem work at all; such a host's floor
 	// still rises at the first frozen image it restores.
 	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
-		return
+		close(done)
+		return done
 	}
 	scan := func() {
 		if n := m.scanTemplateManifests(); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
@@ -327,6 +330,7 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 		}
 	}
 	go func() {
+		defer close(done)
 		scan()
 		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
 		defer t.Stop()
@@ -339,6 +343,7 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 			}
 		}
 	}()
+	return done
 }
 
 var wakeProtocolEvidenceLogged atomic.Bool

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/fsnotify/fsnotify"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -243,6 +244,20 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 	return writeWallClockManifest(memPath, m, true)
 }
 
+// removeWallClockManifestDurably removes the manifest beside an image, if
+// any, and syncs its directory so a crash cannot bring it back beside an
+// image it does not describe. Nothing to remove is not an error.
+func removeWallClockManifestDurably(memPath string) error {
+	path := WallClockMarkerPath(memPath)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return syncDir(filepath.Dir(path))
+}
+
 // writeWallClockManifestLazy publishes atomically but with no durability
 // barrier, for a manifest whose loss costs only a slower resume: an unfrozen
 // one. Nothing on a lifecycle path waits on a sync for it.
@@ -334,6 +349,49 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 	go func() {
 		defer close(done)
 		scan()
+		// A template lands by copy, between scans. The tree is watched so a
+		// frozen one is witnessed as it lands, with the periodic scan as the
+		// fallback for anything the watch missed; a host that cannot watch
+		// keeps the scan alone.
+		root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+		var events <-chan fsnotify.Event
+		var errs <-chan error
+		if w, werr := fsnotify.NewWatcher(); werr == nil {
+			defer w.Close()
+			watchTemplateTree(w, root)
+			events, errs = w.Events, w.Errors
+			// Anything that landed while the watches were being added.
+			scan()
+			t := time.NewTicker(firecrackerCapabilityRefreshInterval)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					scan()
+				case ev := <-events:
+					if !ev.Has(fsnotify.Create) && !ev.Has(fsnotify.Rename) {
+						continue
+					}
+					if info, serr := os.Stat(ev.Name); serr == nil && info.IsDir() {
+						// A new template or build directory: watch it, and
+						// read what may already be inside.
+						watchTemplateTree(w, ev.Name)
+						scan()
+						continue
+					}
+					if strings.HasSuffix(ev.Name, clockFreezeMarkerSuffix) {
+						if n := m.noteTemplateManifest(ev.Name); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
+							log.Info().Str("path", ev.Name).Msg("a frozen template landed; a vmd without the wake protocol is refused from now on")
+						}
+					}
+				case <-errs:
+				}
+			}
+		} else {
+			log.Warn().Err(werr).Msg("template tree cannot be watched; frozen templates are witnessed by the periodic scan alone")
+		}
 		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
 		defer t.Stop()
 		for {
@@ -346,6 +404,44 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 		}
 	}()
 	return done
+}
+
+// watchTemplateTree watches dir and every directory beneath it to the depth
+// templates live at (templates/<template>/<build>); inotify watches are not
+// recursive, so each level is added, and what is already there is added now.
+func watchTemplateTree(w *fsnotify.Watcher, dir string) {
+	_ = w.Add(dir)
+	if rel, err := filepath.Rel(filepath.Dir(dir), dir); err != nil || rel == "" {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			sub := filepath.Join(dir, e.Name())
+			_ = w.Add(sub)
+			if subs, err := os.ReadDir(sub); err == nil {
+				for _, b := range subs {
+					if b.IsDir() {
+						_ = w.Add(filepath.Join(sub, b.Name()))
+					}
+				}
+			}
+		}
+	}
+}
+
+// noteTemplateManifest reads one manifest that just landed and raises the
+// floor for a frozen one. Returns 1 if it was frozen.
+func (m *Manager) noteTemplateManifest(path string) int {
+	man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
+	if err != nil || man == nil || !man.WorkloadFrozen {
+		return 0
+	}
+	noteWakeProtocolEvidence()
+	return 1
 }
 
 var wakeProtocolEvidenceLogged atomic.Bool

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -456,3 +456,46 @@ func TestTemplateWatchWitnessesATemplateAsItLands(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// A manifest streamed into its final path, created empty and written after,
+// is witnessed at its last write, not left for the next periodic scan.
+func TestTemplateWatchWitnessesAManifestStreamedIntoPlace(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+
+	path := WallClockMarkerPath(filepath.Join(tpl, "mem.snap"))
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond) // the create is seen while the file is empty
+	body := `{"version":1,"artifact_id":"a","workload_frozen":true,"guest_corrects_clock":true,"freeze_token":"tok"}`
+	if _, err := f.WriteString(body[:20]); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond) // a partial write does not parse
+	if _, err := f.WriteString(body[20:]); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the streamed frozen manifest was not witnessed at its last write")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -221,11 +221,15 @@ func TestTemplateManifestIsReadOnEveryRestore(t *testing.T) {
 	}
 }
 
-// An image whose workload is frozen owes a wake this supervisor cannot give:
-// both resume and restore refuse it before anything is launched, rather than
-// restore it with its workload stopped for good.
-func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
-	isolateEvidence(t, t.TempDir())
+// A frozen image is only restored once the rollback floor is durable on this
+// host; a floor that cannot be written refuses the restore before any launch.
+func TestFrozenRestoreRequiresTheFloor(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	isolateEvidence(t, blocker) // a path inside a file: the raise cannot land
+
 	dir := t.TempDir()
 	snapPath, memPath, rootfs := filepath.Join(dir, "vm.snap"), filepath.Join(dir, "mem.snap"), filepath.Join(dir, "rootfs.ext4")
 	for _, p := range []string{snapPath, memPath, rootfs} {
@@ -239,8 +243,8 @@ func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
 		launched = true
 		return 4321, SupervisionUnit, nil
 	}
-	// A record that lost the answer goes to the disk, and the disk says frozen.
-	inst := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs}
+	frozen := true
+	inst := &VMInstance{ID: "vm-1", Status: StatusPaused, Supervision: SupervisionUnit, SnapshotPath: snapPath, MemFilePath: memPath, DiskPath: rootfs, SnapshotWorkloadFrozen: &frozen, FreezeToken: "tok"}
 	mgr := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: dir}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{"vm-1": inst}, restoreSem: make(chan struct{}, 1)}
 	mgr.launchFirecrackerHook = launch
 	unlock, err := mgr.lockVMOp(context.Background(), "vm-1")
@@ -249,13 +253,75 @@ func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
 	}
 	_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	unlock()
-	if status.Code(rerr) != codes.FailedPrecondition || launched {
-		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)
+	if status.Code(rerr) != codes.Unavailable || launched {
+		t.Fatalf("resume: err=%v launched=%v, want Unavailable before launch", rerr, launched)
 	}
 	fresh := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{RunDir: t.TempDir()}, netMgr: &fakeNetMgr{}, vms: map[string]*VMInstance{}, restoreSem: make(chan struct{}, 1)}
 	fresh.launchFirecrackerHook = launch
 	_, cerr := fresh.RestoreVMSnapshot(context.Background(), "vm-2", snapPath, memPath, VMConfig{}, nil, "team", "owner", "", nil, 0)
-	if status.Code(cerr) != codes.FailedPrecondition || launched {
-		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
+	if status.Code(cerr) != codes.Unavailable || launched {
+		t.Fatalf("restore: err=%v launched=%v, want Unavailable before launch", cerr, launched)
+	}
+}
+
+// Templates are seeded while the daemon runs; the first frozen one to land
+// raises the floor here, at the builder's real layout depth. An unfrozen
+// manifest raises nothing.
+func TestTemplateManifestsLeaveEvidence(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 0 {
+		t.Fatalf("found %d frozen manifests in an empty tree", n)
+	}
+	// The builder's layout: templates/<template>/<build>/mem.snap.
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteWallClockManifest(filepath.Join(tpl, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+		t.Fatal(err)
+	}
+	if n := m.scanTemplateManifests(); n != 0 || wakeProtocolFloorRaised() {
+		t.Fatalf("n=%d raised=%v; an unfrozen manifest is not evidence", n, wakeProtocolFloorRaised())
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	if n := m.scanTemplateManifests(); n != 1 {
+		t.Fatalf("found %d frozen manifests, want 1", n)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
+		t.Fatalf("evidence not written after a frozen template landed: %v", err)
+	}
+}
+
+// The daemon's own raise is durable once and then free; a raise that cannot
+// land is not remembered, so the next one tries again.
+func TestEnsureWakeProtocolFloor(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("older-process\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v durable=%v", err, wakeProtocolEvidenceDurable.Load())
+	}
+	if b, _ := os.ReadFile(wakeProtocolEvidencePath); string(b) != "older-process\n" {
+		t.Errorf("existing evidence rewritten: %q", b)
+	}
+
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wakeProtocolEvidencePath = filepath.Join(blocker, "evidence")
+	wakeProtocolEvidenceSeen.Store(false)
+	wakeProtocolEvidenceDurable.Store(false)
+	if err := ensureWakeProtocolFloor(); err == nil || wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v durable=%v; a failed raise must not be remembered as done", err, wakeProtocolEvidenceDurable.Load())
+	}
+	wakeProtocolEvidencePath = filepath.Join(dir, "evidence2")
+	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("retry: err=%v durable=%v", err, wakeProtocolEvidenceDurable.Load())
 	}
 }

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -327,11 +327,9 @@ func TestEnsureWakeProtocolFloor(t *testing.T) {
 	}
 }
 
-// A frozen template on disk raises the floor whether or not this host
-// freezes: the floor guards against a rollback meeting that template, which
-// does not depend on the switch. A host without a snapshot directory
-// watches nothing.
-func TestTemplateWatchRaisesTheFloorRegardlessOfTheSwitch(t *testing.T) {
+// A host with the switch off does no work for the watch: a frozen template
+// already on disk raises nothing until the switch is on.
+func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
 	dir := t.TempDir()
 	isolateEvidence(t, dir)
 	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
@@ -342,15 +340,18 @@ func TestTemplateWatchRaisesTheFloorRegardlessOfTheSwitch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	none := &Manager{cfg: ManagerConfig{}}
+	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
 	select {
-	case <-none.WatchTemplateManifests(ctx, zerolog.Nop()):
+	case <-off.WatchTemplateManifests(ctx, zerolog.Nop()):
 	default:
-		t.Fatal("a host without a snapshot directory must start nothing")
+		t.Fatal("a watch with the switch off must start nothing")
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		t.Fatal("the watch scanned the templates with the switch off")
 	}
 
-	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
-	stopped := off.WatchTemplateManifests(ctx, zerolog.Nop())
+	on := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := on.WatchTemplateManifests(ctx, zerolog.Nop())
 	// The watcher must be gone before the evidence path is restored by the
 	// cleanup, or it would read a path being rewritten under it.
 	defer func() { cancel(); <-stopped }()
@@ -360,7 +361,7 @@ func TestTemplateWatchRaisesTheFloorRegardlessOfTheSwitch(t *testing.T) {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("the watch never raised the floor for a frozen template with the switch off")
+			t.Fatal("the watch never raised the floor with the switch on")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -430,7 +431,7 @@ func TestTemplateWatchWitnessesATemplateAsItLands(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
 	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
 	defer func() { cancel(); <-stopped }()
 	time.Sleep(50 * time.Millisecond)

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -341,14 +341,20 @@ func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
 	defer cancel()
 
 	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
-	off.WatchTemplateManifests(ctx, zerolog.Nop())
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-off.WatchTemplateManifests(ctx, zerolog.Nop()):
+	default:
+		t.Fatal("a watch with the switch off must start nothing")
+	}
 	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
 		t.Fatal("the watch scanned the templates with the switch off")
 	}
 
 	on := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
-	on.WatchTemplateManifests(ctx, zerolog.Nop())
+	stopped := on.WatchTemplateManifests(ctx, zerolog.Nop())
+	// The watcher must be gone before the evidence path is restored by the
+	// cleanup, or it would read a path being rewritten under it.
+	defer func() { cancel(); <-stopped }()
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
@@ -323,5 +324,39 @@ func TestEnsureWakeProtocolFloor(t *testing.T) {
 	wakeProtocolEvidencePath = filepath.Join(dir, "evidence2")
 	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
 		t.Fatalf("retry: err=%v durable=%v", err, wakeProtocolEvidenceDurable.Load())
+	}
+}
+
+// A host with the switch off does no work for the watch: a frozen template
+// already on disk raises nothing until the switch is on.
+func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	off.WatchTemplateManifests(ctx, zerolog.Nop())
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		t.Fatal("the watch scanned the templates with the switch off")
+	}
+
+	on := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	on.WatchTemplateManifests(ctx, zerolog.Nop())
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the watch never raised the floor with the switch on")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -327,9 +327,11 @@ func TestEnsureWakeProtocolFloor(t *testing.T) {
 	}
 }
 
-// A host with the switch off does no work for the watch: a frozen template
-// already on disk raises nothing until the switch is on.
-func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
+// A frozen template on disk raises the floor whether or not this host
+// freezes: the floor guards against a rollback meeting that template, which
+// does not depend on the switch. A host without a snapshot directory
+// watches nothing.
+func TestTemplateWatchRaisesTheFloorRegardlessOfTheSwitch(t *testing.T) {
 	dir := t.TempDir()
 	isolateEvidence(t, dir)
 	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
@@ -340,18 +342,15 @@ func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	none := &Manager{cfg: ManagerConfig{}}
 	select {
-	case <-off.WatchTemplateManifests(ctx, zerolog.Nop()):
+	case <-none.WatchTemplateManifests(ctx, zerolog.Nop()):
 	default:
-		t.Fatal("a watch with the switch off must start nothing")
-	}
-	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
-		t.Fatal("the watch scanned the templates with the switch off")
+		t.Fatal("a host without a snapshot directory must start nothing")
 	}
 
-	on := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
-	stopped := on.WatchTemplateManifests(ctx, zerolog.Nop())
+	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	stopped := off.WatchTemplateManifests(ctx, zerolog.Nop())
 	// The watcher must be gone before the evidence path is restored by the
 	// cleanup, or it would read a path being rewritten under it.
 	defer func() { cancel(); <-stopped }()
@@ -361,7 +360,7 @@ func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("the watch never raised the floor with the switch on")
+			t.Fatal("the watch never raised the floor for a frozen template with the switch off")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -528,3 +528,32 @@ func TestTemplateWatchAttachesBeforeTheRootExists(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// A manifest that cannot be read may have described a frozen image, so its
+// removal is made durable like a frozen one's: where the directory cannot be
+// synced, the removal is reported as failed rather than as done.
+func TestRemovingAnUnreadableManifestIsDurable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs a directory the process cannot open for sync; root can")
+	}
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	raiseFloorForTest(t)
+	imgDir := filepath.Join(dir, "img")
+	if err := os.MkdirAll(imgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mem := filepath.Join(imgDir, "mem.snap")
+	if err := os.WriteFile(WallClockMarkerPath(mem), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Writable and searchable but not readable: the unlink succeeds, the
+	// directory sync cannot open it.
+	if err := os.Chmod(imgDir, 0o333); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(imgDir, 0o755) })
+	if _, err := removeWallClockManifest(mem); err == nil {
+		t.Fatal("removing an unreadable manifest without a durable sync must not report success")
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -419,3 +419,39 @@ func TestPrimeWakeProtocolFloor(t *testing.T) {
 		}
 	})
 }
+
+// A frozen template that lands after the watch started is witnessed as it
+// lands, not at the next periodic scan: the floor is up within moments.
+func TestTemplateWatchWitnessesATemplateAsItLands(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, TemplatesDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		t.Fatal("nothing had landed yet")
+	}
+	// The copy: directories first, then the manifest, renamed into place.
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the frozen template that landed was not witnessed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -360,3 +360,57 @@ func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// Recognised evidence is proven durable in the background at startup, so the
+// first request that needs the floor after a restart pays nothing; a host
+// without evidence primes nothing and raises nothing.
+func TestPrimeWakeProtocolFloor(t *testing.T) {
+	t.Run("recognised_evidence_becomes_durable_off_the_request_path", func(t *testing.T) {
+		dir := t.TempDir()
+		isolateEvidence(t, dir)
+		if err := os.WriteFile(wakeProtocolEvidencePath, []byte(wakeProtocolEvidenceNote), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !RecognizeWakeProtocolFloor() || wakeProtocolEvidenceDurable.Load() {
+			t.Fatal("precondition: seen at startup, not yet durable")
+		}
+		PrimeWakeProtocolFloor(zerolog.Nop())
+		deadline := time.Now().Add(3 * time.Second)
+		for !wakeProtocolEvidenceDurable.Load() {
+			if time.Now().After(deadline) {
+				t.Fatal("priming never proved the recognised floor durable")
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		// The request path then does no work and records no phase.
+		sink := &phaseSink{}
+		m := &Manager{recorder: sink}
+		if err := m.ensureWakeFloorTimed("restore"); err != nil || sink.has("restore", "wake_floor") {
+			t.Fatalf("err=%v phases=%+v; a durable floor must cost a request nothing", err, sink.phases)
+		}
+	})
+
+	t.Run("no_evidence_primes_nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		isolateEvidence(t, dir)
+		if RecognizeWakeProtocolFloor() {
+			t.Fatal("precondition: nothing to recognise")
+		}
+		PrimeWakeProtocolFloor(zerolog.Nop())
+		time.Sleep(50 * time.Millisecond)
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil || wakeProtocolEvidenceDurable.Load() {
+			t.Fatal("priming raised a floor on a host that had none")
+		}
+	})
+
+	// A request that does have to prove the floor attributes the cost.
+	t.Run("a_request_that_proves_it_records_the_phase", func(t *testing.T) {
+		dir := t.TempDir()
+		isolateEvidence(t, dir)
+		sink := &phaseSink{}
+		m := &Manager{recorder: sink}
+		if err := m.ensureWakeFloorTimed("pause"); err != nil || !sink.has("pause", "wake_floor") {
+			t.Fatalf("err=%v phases=%+v; the fallback must be timed as its own phase", err, sink.phases)
+		}
+	})
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -499,3 +499,32 @@ func TestTemplateWatchWitnessesAManifestStreamedIntoPlace(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// A watch started before the templates root exists still witnesses the first
+// template to land: the root is created so the watch attaches to it.
+func TestTemplateWatchAttachesBeforeTheRootExists(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a template landing under a root created after the watch started was not witnessed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
vmd learns the wake protocol: a pause of a guest that corrects its clock freezes the workload under a fresh token (floor raised and intent recorded first, thawed and paused unfrozen if the freeze fails), snapshots it and writes a frozen manifest; a restore or resume of a frozen image publishes a record that owes a wake before the vCPUs run, wakes the guest with the token once the snapshot is loaded, and relaunches with the clock running if the guest cannot correct it; on restart, a guest an interrupted pause left frozen is released and a record still owing a wake gets one through a bounded pool before it is served. The binary now carries the capability the host guard looks for.

Dormant: freezing needs both switches, and nothing sets the builder's, so no image is frozen. A contract test asserts what that means: with the switches off, a pause of a legacy image sends no guest call, writes no manifest or intent and records no new phase; a create sends no wake and asks for no clock policy; the template watch and the startup priming do nothing on a host without evidence. A frozen image on a host later switched off is still woken. The template scan runs only on a host whose switch is on, so a dormant host does no work for it.