### PR TITLE
controlplane: one host-row read per cold create

### DIFF
--- a/cmd/hostctl/main.go
+++ b/cmd/hostctl/main.go
@@ -80,12 +80,13 @@ func main() {
 //	  create. The scheduler's candidate set is a hint served at any age;
 //	  what stops admission is the per-create host pre-flight, which reads
 //	  status fresh once its cache lapses: pre-flight cache TTL + grace
-//	  (10s+2s), PLUS its query bound (5s — a read that starts before the
-//	  drain commits and finishes after it can still attest a pre-drain
-//	  view), plus a cold registry resolve (2s bound) BEFORE the bounded
-//	  boot begins. The constant keeps its earlier, larger value: the
-//	  pre-flight bound is far inside it, and shrinking a wait that ops
-//	  already budget for buys nothing.
+//	  (10s+2s by default; the TTL is clamped to 30s however it is
+//	  configured, so the worst case is 32s), PLUS its query bound (5s — a
+//	  read that starts before the drain commits and finishes after it can
+//	  still attest a pre-drain view), plus a cold registry resolve (2s
+//	  bound) BEFORE the bounded boot begins: at most 39s. The constant
+//	  keeps its earlier, larger value; shrinking a wait that ops already
+//	  budget for buys nothing.
 //	drainQuietWindow — continuous zeros required AFTER that: 2×30s boot
 //	  (incl. retry) + insert/cleanup visibility margin.
 const (

--- a/cmd/hostctl/main.go
+++ b/cmd/hostctl/main.go
@@ -77,12 +77,15 @@ func main() {
 // merely a few polls:
 //
 //	drainConvergence — when the last stale replica can still ADMIT a
-//	  create: scheduler cache TTL + stale grace (30s+30s), PLUS the fill
-//	  bound (5s — a fill that reads the host set before the drain commits
-//	  and finishes after it stamps a pre-drain view as fresh at its END),
-//	  plus a 10s post-admission margin: the admitted create still runs the
-//	  capability lookup (5s bound, api.hostCapQueryTimeout) and a cold
-//	  registry resolve (2s bound) BEFORE its bounded boot begins.
+//	  create. The scheduler's candidate set is a hint served at any age;
+//	  what stops admission is the per-create host pre-flight, which reads
+//	  status fresh once its cache lapses: pre-flight cache TTL + grace
+//	  (10s+2s), PLUS its query bound (5s — a read that starts before the
+//	  drain commits and finishes after it can still attest a pre-drain
+//	  view), plus a cold registry resolve (2s bound) BEFORE the bounded
+//	  boot begins. The constant keeps its earlier, larger value: the
+//	  pre-flight bound is far inside it, and shrinking a wait that ops
+//	  already budget for buys nothing.
 //	drainQuietWindow — continuous zeros required AFTER that: 2×30s boot
 //	  (incl. retry) + insert/cleanup visibility margin.
 const (

--- a/cmd/hostctl/main.go
+++ b/cmd/hostctl/main.go
@@ -77,16 +77,11 @@ func main() {
 // merely a few polls:
 //
 //	drainConvergence — when the last stale replica can still ADMIT a
-//	  create. The scheduler's candidate set is a hint served at any age;
-//	  what stops admission is the per-create host pre-flight, which reads
-//	  status fresh once its cache lapses: pre-flight cache TTL + grace
-//	  (10s+2s by default; the TTL is clamped to 30s however it is
-//	  configured, so the worst case is 32s), PLUS its query bound (5s — a
-//	  read that starts before the drain commits and finishes after it can
-//	  still attest a pre-drain view), plus a cold registry resolve (2s
-//	  bound) BEFORE the bounded boot begins: at most 39s. The constant
-//	  keeps its earlier, larger value; shrinking a wait that ops already
-//	  budget for buys nothing.
+//	  create. The scheduler's candidate set is served at any age, so the
+//	  bound is the per-create host pre-flight: its cache TTL + grace (10s+2s
+//	  by default, TTL capped at 30s) + its 5s query bound + a 2s cold
+//	  registry resolve, at most 39s. The constant keeps its earlier, larger
+//	  value.
 //	drainQuietWindow — continuous zeros required AFTER that: 2×30s boot
 //	  (incl. retry) + insert/cleanup visibility margin.
 const (

--- a/cmd/hostctl/main.go
+++ b/cmd/hostctl/main.go
@@ -77,11 +77,9 @@ func main() {
 // merely a few polls:
 //
 //	drainConvergence — when the last stale replica can still ADMIT a
-//	  create. The scheduler's candidate set is served at any age, so the
-//	  bound is the per-create host pre-flight: its cache TTL + grace (10s+2s
-//	  by default, TTL capped at 30s) + its 5s query bound + a 2s cold
-//	  registry resolve, at most 39s. The constant keeps its earlier, larger
-//	  value.
+//	  create: the per-create host pre-flight's cache TTL + grace + query
+//	  bound + a cold registry resolve, at most 39s. The constant keeps its
+//	  earlier, larger value.
 //	drainQuietWindow — continuous zeros required AFTER that: 2×30s boot
 //	  (incl. retry) + insert/cleanup visibility margin.
 const (

--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -141,28 +141,35 @@ SELECT EXISTS (
 -- outside a mutation transaction: omitting the lock keeps concurrent checks
 -- from serializing behind the host's heartbeat writer. Transactional callers
 -- that must pin the host across a commit use HostHasCapabilities.
+--
+-- Also returns the host's VMD address (empty when the host is not active):
+-- the pre-flight already reads the row, so the caller can record it as the
+-- address verification the host registry would otherwise perform with a
+-- read of its own.
 WITH target_host AS MATERIALIZED (
-  SELECT id, last_heartbeat_at
+  SELECT id, vmd_addr, last_heartbeat_at
   FROM host
   WHERE id = sqlc.arg('host_id')
     AND status = 'active'
     AND last_heartbeat_at IS NOT NULL
 )
-SELECT EXISTS (
-  SELECT 1
-  FROM target_host h
-  WHERE NOT EXISTS (
+SELECT
+  EXISTS (
     SELECT 1
-    FROM unnest(sqlc.arg('required_capabilities')::text[]) AS required(capability)
+    FROM target_host h
     WHERE NOT EXISTS (
       SELECT 1
-      FROM host_capability hc
-      WHERE hc.host_id = h.id
-        AND hc.capability = required.capability
-        AND hc.heartbeat_at = h.last_heartbeat_at
+      FROM unnest(sqlc.arg('required_capabilities')::text[]) AS required(capability)
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM host_capability hc
+        WHERE hc.host_id = h.id
+          AND hc.capability = required.capability
+          AND hc.heartbeat_at = h.last_heartbeat_at
+      )
     )
-  )
-);
+  ) AS has_capabilities,
+  COALESCE((SELECT vmd_addr FROM target_host), '')::text AS vmd_addr;
 
 -- name: MarkHostUnhealthy :exec
 UPDATE host

--- a/db/queries/hosts.sql
+++ b/db/queries/hosts.sql
@@ -142,10 +142,8 @@ SELECT EXISTS (
 -- from serializing behind the host's heartbeat writer. Transactional callers
 -- that must pin the host across a commit use HostHasCapabilities.
 --
--- Also returns the host's VMD address (empty when the host is not active):
--- the pre-flight already reads the row, so the caller can record it as the
--- address verification the host registry would otherwise perform with a
--- read of its own.
+-- Also returns the host's VMD address (empty when the host is not active),
+-- so the caller can record this read as the registry's address verification.
 WITH target_host AS MATERIALIZED (
   SELECT id, vmd_addr, last_heartbeat_at
   FROM host

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -132,9 +132,10 @@ type HostRegistry interface {
 	// re-reads the host row. Callers that change a host's address must
 	// invalidate, or RPCs keep flowing to the previous machine.
 	Invalidate(hostID string)
-	// MarkVerified records a host row read the caller has just performed and
-	// the address it saw, so the next ClientFor need not read the row itself.
-	MarkVerified(ctx context.Context, hostID, addr string)
+	// MarkVerified records a host row read the caller has just performed —
+	// the address it saw and when the read began — so the next ClientFor
+	// need not read the row itself.
+	MarkVerified(ctx context.Context, hostID, addr string, readAt time.Time)
 }
 
 // Handlers holds shared dependencies for all route handlers.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -132,6 +132,9 @@ type HostRegistry interface {
 	// re-reads the host row. Callers that change a host's address must
 	// invalidate, or RPCs keep flowing to the previous machine.
 	Invalidate(hostID string)
+	// MarkVerified records a host row read the caller has just performed and
+	// the address it saw, so the next ClientFor need not read the row itself.
+	MarkVerified(ctx context.Context, hostID, addr string)
 }
 
 // Handlers holds shared dependencies for all route handlers.
@@ -2050,6 +2053,57 @@ func (h *Handlers) fetchSandboxSecretBindings(ctx context.Context, sandboxID uui
 	return out
 }
 
+// selectCreateHost picks the host for a new sandbox: the scheduler when one
+// is wired, else the configured default. Writes the error response and
+// returns ok=false when no host is available.
+func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
+	switch {
+	case h.Scheduler != nil:
+		hostID, err := h.Scheduler.SelectHost(c.Request.Context(), requiredCapabilities)
+		if err != nil {
+			log.Error().Err(err).Msg("scheduler SelectHost failed")
+			respondErrorMsg(c, "service_unavailable", "No hosts available", http.StatusServiceUnavailable)
+			return "", false
+		}
+		return hostID, true
+	case h.Config != nil && h.Config.DefaultHostID != "":
+		return h.Config.DefaultHostID, true
+	default:
+		return "default", true
+	}
+}
+
+// placeCreate selects a host and re-attests it after placement. The
+// scheduler's candidate set is a cached hint that may be arbitrarily stale;
+// the pre-flight reads the chosen host's current status and capabilities
+// (one row read when nothing is cached, and it doubles as the registry's
+// address verification). When that read rejects the host, the candidate set
+// is dropped and selection runs once more on a fresh load before the request
+// fails, so a host that left rotation costs one extra read, never a failed
+// create. VMD's post-boot policy attestation remains the fail-closed gate.
+// Writes the error response and returns ok=false on failure.
+func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
+	if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+		return "", false
+	}
+	SetTelemetryHostID(c, hostID)
+	if h.Scheduler != nil {
+		eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
+		if err == nil && !eligible {
+			log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; reloading candidates and selecting again")
+			h.Scheduler.Invalidate()
+			if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+				return "", false
+			}
+			SetTelemetryHostID(c, hostID)
+		}
+	}
+	if !h.requireHostPreviewCapabilities(c, hostID, requiredCapabilities...) {
+		return "", false
+	}
+	return hostID, true
+}
+
 func (h *Handlers) CreateSandbox(c *gin.Context) {
 	tHandler := time.Now()
 	// total is based on the auth boundary so it covers a slow cache miss;
@@ -2269,29 +2323,8 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	if previewAccess == preview.AccessPrivate {
 		requiredCapabilities = previewBrowserCapabilities()
 	}
-	if h.Scheduler != nil {
-		hostID, err = h.Scheduler.SelectHost(c.Request.Context(), requiredCapabilities)
-		if err != nil {
-			log.Error().Err(err).Msg("scheduler SelectHost failed")
-			respondErrorMsg(c, "service_unavailable", "No hosts available", http.StatusServiceUnavailable)
-			return
-		}
-	} else if h.Config != nil && h.Config.DefaultHostID != "" {
-		hostID = h.Config.DefaultHostID
-	} else {
-		hostID = "default"
-	}
-	SetTelemetryHostID(c, hostID)
-
-	// Re-attest after placement. The scheduler cache and the default-host path
-	// are only hints; this re-check is fresher (attestation-cache TTL vs the
-	// scheduler's candidate TTL), and VMD's post-boot policy attestation
-	// remains the fail-closed gate.
-	if previewAccess == preview.AccessPrivate {
-		if !h.requireHostPreviewPortBrowserAuth(c, hostID) {
-			return
-		}
-	} else if !h.requireHostPreviewPorts(c, hostID) {
+	var placed bool
+	if hostID, placed = h.placeCreate(c, requiredCapabilities); !placed {
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2087,18 +2087,17 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 		return "", false
 	}
 	SetTelemetryHostID(c, hostID)
-	if h.Scheduler != nil {
-		eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
-		if err == nil && !eligible {
-			log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; reloading candidates and selecting again")
-			h.Scheduler.Invalidate()
-			if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
-				return "", false
-			}
-			SetTelemetryHostID(c, hostID)
+	eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
+	if err == nil && !eligible && h.Scheduler != nil {
+		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; reloading candidates and selecting again")
+		h.Scheduler.Invalidate()
+		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+			return "", false
 		}
+		SetTelemetryHostID(c, hostID)
+		eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 	}
-	if !h.requireHostPreviewCapabilities(c, hostID, requiredCapabilities...) {
+	if !h.respondHostCapabilityResult(c, hostID, requiredCapabilities, eligible, err) {
 		return "", false
 	}
 	return hostID, true

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2094,12 +2094,17 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 	if err == nil && !eligible && h.Scheduler != nil {
 		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
+		rejected := hostID
 		h.Scheduler.Reject(hostID)
 		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}
-		SetTelemetryHostID(c, hostID)
-		eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
+		// The same host again (the default-host fallback) can only repeat
+		// the answer just given; don't pay the read twice.
+		if hostID != rejected {
+			SetTelemetryHostID(c, hostID)
+			eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
+		}
 	}
 	if !h.respondHostCapabilityResult(c, hostID, requiredCapabilities, eligible, err) {
 		return "", false

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -141,8 +141,10 @@ type HostRegistry interface {
 	Generation(hostID string) uint64
 	// MarkVerified records a host row read the caller has just performed and
 	// the address it saw, so the next ClientFor need not read the row itself.
-	// A read from before an invalidation (readGen stale) is discarded.
-	MarkVerified(ctx context.Context, hostID, addr string, readGen uint64)
+	// A read from before an invalidation (readGen stale) is discarded. The
+	// error of a resolution it had to run is returned, so the caller fails
+	// here instead of repeating the lookup at ClientFor.
+	MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) error
 }
 
 // Handlers holds shared dependencies for all route handlers.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -125,8 +125,10 @@ type Scheduler interface {
 	Invalidate()
 	// Reject drops the cached candidate set for requiredCapabilities if it
 	// still names hostID, which that set's pre-flight has just refused;
-	// state loaded since, and other capability sets, are kept.
-	Reject(hostID string, requiredCapabilities []string)
+	// state loaded since, and other capability sets, are kept. Reports
+	// whether anything was dropped, i.e. whether the next SelectHost is a
+	// fresh load.
+	Reject(hostID string, requiredCapabilities []string) bool
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -2141,13 +2143,14 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	if err == nil && !eligible && h.Scheduler != nil {
 		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
 		rejected := hostID
-		h.Scheduler.Reject(hostID, requiredCapabilities)
+		reloaded := h.Scheduler.Reject(hostID, requiredCapabilities)
 		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}
-		// The same host again (the default-host fallback) can only repeat
-		// the answer just given; don't pay the read twice.
-		if hostID != rejected {
+		// The same host from an unchanged set (the default-host fallback)
+		// can only repeat the answer just given; the same host from a fresh
+		// load may have regained eligibility and is checked again.
+		if hostID != rejected || reloaded {
 			SetTelemetryHostID(c, hostID)
 			eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -124,10 +124,8 @@ type Scheduler interface {
 	// Invalidate drops any cached host state so the next SelectHost
 	// reflects host status changes immediately.
 	Invalidate()
-	// Reject drops the candidate set gen (the one a SelectHost returned
-	// hostID from) if it is still cached and still names hostID, which its
-	// pre-flight has just refused; a set loaded since, and other capability
-	// sets, are kept.
+	// Reject drops the candidate set gen if it is still cached and still
+	// names hostID, whose pre-flight has just refused it.
 	Reject(hostID string, requiredCapabilities []string, gen uint64)
 }
 
@@ -2128,12 +2126,9 @@ func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []strin
 	}
 }
 
-// placeCreate selects a host and re-attests it: the candidate set may be
-// arbitrarily stale, so the pre-flight reads the chosen host's status and
-// capabilities (one row read when uncached, which also verifies its address
-// for the registry). A rejected host drops the candidate sets still naming
-// it and selection runs once more before the request fails. Writes the error
-// response and returns ok=false on failure.
+// placeCreate selects a host and re-attests it, since the candidate set may
+// be stale. A host that fails the pre-flight is rejected from the set and
+// selection runs once more. Writes the error response on failure.
 func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
 	var gen uint64
 	if hostID, gen, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
@@ -2148,10 +2143,8 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 		if hostID, gen, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}
-		// The same host from the same set (the default-host fallback) can
-		// only repeat the answer just given; the same host from a different
-		// set — whoever loaded it — may have regained eligibility and is
-		// checked again.
+		// The same host from the same set can only repeat the answer just
+		// given; from a newer set it may have regained eligibility.
 		if hostID != rejected || gen != rejectedGen {
 			SetTelemetryHostID(c, hostID)
 			eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -123,6 +123,9 @@ type Scheduler interface {
 	// Invalidate drops any cached host state so the next SelectHost
 	// reflects host status changes immediately.
 	Invalidate()
+	// Reject drops cached host state that still names hostID, which the
+	// create pre-flight has just refused; state loaded since is kept.
+	Reject(hostID string)
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -2076,9 +2079,9 @@ func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []strin
 // placeCreate selects a host and re-attests it: the candidate set may be
 // arbitrarily stale, so the pre-flight reads the chosen host's status and
 // capabilities (one row read when uncached, which also verifies its address
-// for the registry). A rejected host drops the candidate set and selection
-// runs once more before the request fails. Writes the error response and
-// returns ok=false on failure.
+// for the registry). A rejected host drops the candidate sets still naming
+// it and selection runs once more before the request fails. Writes the error
+// response and returns ok=false on failure.
 func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
 	if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 		return "", false
@@ -2086,8 +2089,8 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	SetTelemetryHostID(c, hostID)
 	eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 	if err == nil && !eligible && h.Scheduler != nil {
-		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; reloading candidates and selecting again")
-		h.Scheduler.Invalidate()
+		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
+		h.Scheduler.Reject(hostID)
 		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -132,10 +132,9 @@ type HostRegistry interface {
 	// re-reads the host row. Callers that change a host's address must
 	// invalidate, or RPCs keep flowing to the previous machine.
 	Invalidate(hostID string)
-	// MarkVerified records a host row read the caller has just performed —
-	// the address it saw and when the read began — so the next ClientFor
-	// need not read the row itself.
-	MarkVerified(ctx context.Context, hostID, addr string, readAt time.Time)
+	// MarkVerified records a host row read the caller has just performed and
+	// the address it saw, so the next ClientFor need not read the row itself.
+	MarkVerified(ctx context.Context, hostID, addr string)
 }
 
 // Handlers holds shared dependencies for all route handlers.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -119,16 +119,17 @@ func (h *Handlers) respondQuotaExceeded(c *gin.Context, teamID uuid.UUID) {
 
 // Scheduler selects a host for new sandboxes.
 type Scheduler interface {
-	SelectHost(ctx context.Context, requiredCapabilities []string) (hostID string, err error)
+	// SelectHost picks a host; gen identifies the candidate set it came from.
+	SelectHost(ctx context.Context, requiredCapabilities []string) (hostID string, gen uint64, err error)
 	// Invalidate drops any cached host state so the next SelectHost
 	// reflects host status changes immediately.
 	Invalidate()
-	// Reject drops the cached candidate set for requiredCapabilities if it
-	// still names hostID, which that set's pre-flight has just refused;
-	// state loaded since, and other capability sets, are kept. Reports
-	// whether anything was dropped, i.e. whether the next SelectHost is a
-	// fresh load.
-	Reject(hostID string, requiredCapabilities []string) bool
+	// Reject drops the candidate set gen (the one a SelectHost returned
+	// hostID from) if it is still cached and still names hostID, which its
+	// pre-flight has just refused; a set loaded since, and other capability
+	// sets, are kept. Reports whether anything was dropped, i.e. whether the
+	// next SelectHost is a fresh load.
+	Reject(hostID string, requiredCapabilities []string, gen uint64) bool
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -2111,20 +2112,20 @@ func (h *Handlers) fetchSandboxSecretBindings(ctx context.Context, sandboxID uui
 // selectCreateHost picks the host for a new sandbox: the scheduler when one
 // is wired, else the configured default. Writes the error response and
 // returns ok=false when no host is available.
-func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
+func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []string) (hostID string, gen uint64, ok bool) {
 	switch {
 	case h.Scheduler != nil:
-		hostID, err := h.Scheduler.SelectHost(c.Request.Context(), requiredCapabilities)
+		hostID, gen, err := h.Scheduler.SelectHost(c.Request.Context(), requiredCapabilities)
 		if err != nil {
 			log.Error().Err(err).Msg("scheduler SelectHost failed")
 			respondErrorMsg(c, "service_unavailable", "No hosts available", http.StatusServiceUnavailable)
-			return "", false
+			return "", 0, false
 		}
-		return hostID, true
+		return hostID, gen, true
 	case h.Config != nil && h.Config.DefaultHostID != "":
-		return h.Config.DefaultHostID, true
+		return h.Config.DefaultHostID, 0, true
 	default:
-		return "default", true
+		return "default", 0, true
 	}
 }
 
@@ -2135,7 +2136,8 @@ func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []strin
 // it and selection runs once more before the request fails. Writes the error
 // response and returns ok=false on failure.
 func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
-	if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+	var gen uint64
+	if hostID, gen, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 		return "", false
 	}
 	SetTelemetryHostID(c, hostID)
@@ -2143,8 +2145,8 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	if err == nil && !eligible && h.Scheduler != nil {
 		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
 		rejected := hostID
-		reloaded := h.Scheduler.Reject(hostID, requiredCapabilities)
-		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+		reloaded := h.Scheduler.Reject(hostID, requiredCapabilities, gen)
+		if hostID, _, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}
 		// The same host from an unchanged set (the default-host fallback)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -123,9 +123,10 @@ type Scheduler interface {
 	// Invalidate drops any cached host state so the next SelectHost
 	// reflects host status changes immediately.
 	Invalidate()
-	// Reject drops cached host state that still names hostID, which the
-	// create pre-flight has just refused; state loaded since is kept.
-	Reject(hostID string)
+	// Reject drops the cached candidate set for requiredCapabilities if it
+	// still names hostID, which that set's pre-flight has just refused;
+	// state loaded since, and other capability sets, are kept.
+	Reject(hostID string, requiredCapabilities []string)
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -2095,7 +2096,7 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	if err == nil && !eligible && h.Scheduler != nil {
 		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
 		rejected := hostID
-		h.Scheduler.Reject(hostID)
+		h.Scheduler.Reject(hostID, requiredCapabilities)
 		if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2073,15 +2073,12 @@ func (h *Handlers) selectCreateHost(c *gin.Context, requiredCapabilities []strin
 	}
 }
 
-// placeCreate selects a host and re-attests it after placement. The
-// scheduler's candidate set is a cached hint that may be arbitrarily stale;
-// the pre-flight reads the chosen host's current status and capabilities
-// (one row read when nothing is cached, and it doubles as the registry's
-// address verification). When that read rejects the host, the candidate set
-// is dropped and selection runs once more on a fresh load before the request
-// fails, so a host that left rotation costs one extra read, never a failed
-// create. VMD's post-boot policy attestation remains the fail-closed gate.
-// Writes the error response and returns ok=false on failure.
+// placeCreate selects a host and re-attests it: the candidate set may be
+// arbitrarily stale, so the pre-flight reads the chosen host's status and
+// capabilities (one row read when uncached, which also verifies its address
+// for the registry). A rejected host drops the candidate set and selection
+// runs once more before the request fails. Writes the error response and
+// returns ok=false on failure.
 func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (hostID string, ok bool) {
 	if hostID, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 		return "", false

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -135,9 +135,13 @@ type HostRegistry interface {
 	// re-reads the host row. Callers that change a host's address must
 	// invalidate, or RPCs keep flowing to the previous machine.
 	Invalidate(hostID string)
+	// Generation is the host's invalidation generation; capture it before
+	// reading the host row and pass it to MarkVerified with what was read.
+	Generation(hostID string) uint64
 	// MarkVerified records a host row read the caller has just performed and
 	// the address it saw, so the next ClientFor need not read the row itself.
-	MarkVerified(ctx context.Context, hostID, addr string)
+	// A read from before an invalidation (readGen stale) is discarded.
+	MarkVerified(ctx context.Context, hostID, addr string, readGen uint64)
 }
 
 // Handlers holds shared dependencies for all route handlers.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -127,9 +127,8 @@ type Scheduler interface {
 	// Reject drops the candidate set gen (the one a SelectHost returned
 	// hostID from) if it is still cached and still names hostID, which its
 	// pre-flight has just refused; a set loaded since, and other capability
-	// sets, are kept. Reports whether anything was dropped, i.e. whether the
-	// next SelectHost is a fresh load.
-	Reject(hostID string, requiredCapabilities []string, gen uint64) bool
+	// sets, are kept.
+	Reject(hostID string, requiredCapabilities []string, gen uint64)
 }
 
 // HostRegistry resolves a host ID to a VMD client.
@@ -2144,15 +2143,16 @@ func (h *Handlers) placeCreate(c *gin.Context, requiredCapabilities []string) (h
 	eligible, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 	if err == nil && !eligible && h.Scheduler != nil {
 		log.Warn().Str("host_id", hostID).Msg("scheduled host failed the pre-flight; selecting again without it")
-		rejected := hostID
-		reloaded := h.Scheduler.Reject(hostID, requiredCapabilities, gen)
-		if hostID, _, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
+		rejected, rejectedGen := hostID, gen
+		h.Scheduler.Reject(hostID, requiredCapabilities, gen)
+		if hostID, gen, ok = h.selectCreateHost(c, requiredCapabilities); !ok {
 			return "", false
 		}
-		// The same host from an unchanged set (the default-host fallback)
-		// can only repeat the answer just given; the same host from a fresh
-		// load may have regained eligibility and is checked again.
-		if hostID != rejected || reloaded {
+		// The same host from the same set (the default-host fallback) can
+		// only repeat the answer just given; the same host from a different
+		// set — whoever loaded it — may have regained eligibility and is
+		// checked again.
+		if hostID != rejected || gen != rejectedGen {
 			SetTelemetryHostID(c, hostID)
 			eligible, err = h.hostHasCapabilitiesCached(c.Request.Context(), hostID, requiredCapabilities)
 		}

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -343,6 +343,14 @@ func (h *Handlers) pushPreviewCredentialPolicy(ctx context.Context, sandbox db.S
 // transactional validateHostPreviewCapabilities on mutations.
 func (h *Handlers) requireHostPreviewCapabilities(c *gin.Context, hostID string, capabilities ...string) bool {
 	hasCapabilities, err := h.hostHasCapabilitiesCached(c.Request.Context(), hostID, capabilities)
+	return h.respondHostCapabilityResult(c, hostID, capabilities, hasCapabilities, err)
+}
+
+// respondHostCapabilityResult turns a pre-flight outcome into the response:
+// an error is a 500, a rejection a 409 with diagnostics gathered off the
+// request. Returns true when the host passed. Split from the check so a
+// caller that already holds a result never pays the read twice.
+func (h *Handlers) respondHostCapabilityResult(c *gin.Context, hostID string, capabilities []string, hasCapabilities bool, err error) bool {
 	if err != nil {
 		log.Error().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).Msg("DB HostHasCapabilities failed")
 		respondError(c, ErrInternal)

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -346,10 +346,9 @@ func (h *Handlers) requireHostPreviewCapabilities(c *gin.Context, hostID string,
 	return h.respondHostCapabilityResult(c, hostID, capabilities, hasCapabilities, err)
 }
 
-// respondHostCapabilityResult turns a pre-flight outcome into the response:
-// an error is a 500, a rejection a 409 with diagnostics gathered off the
-// request. Returns true when the host passed. Split from the check so a
-// caller that already holds a result never pays the read twice.
+// respondHostCapabilityResult turns a pre-flight outcome into the response
+// (error → 500, rejection → 409 with diagnostics gathered off the request)
+// and returns true when the host passed.
 func (h *Handlers) respondHostCapabilityResult(c *gin.Context, hostID string, capabilities []string, hasCapabilities bool, err error) bool {
 	if err != nil {
 		log.Error().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).Msg("DB HostHasCapabilities failed")

--- a/internal/api/handlers_preview.go
+++ b/internal/api/handlers_preview.go
@@ -364,7 +364,7 @@ func (h *Handlers) requireHostPreviewCapabilities(c *gin.Context, hostID string,
 // and returns true when the host passed.
 func (h *Handlers) respondHostCapabilityResult(c *gin.Context, hostID string, capabilities []string, hasCapabilities bool, err error) bool {
 	if err != nil {
-		log.Error().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).Msg("DB HostHasCapabilities failed")
+		log.Error().Err(err).Str("host_id", hostID).Strs("capabilities", capabilities).Msg("host pre-flight failed")
 		respondError(c, ErrInternal)
 		return false
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4050,3 +4050,48 @@ func TestCreateSandboxDeclaresResourceLimitsToVMD(t *testing.T) {
 			vmd.restoreLimits.VCPU, vmd.restoreLimits.MemoryMiB, tpl.Vcpu, tpl.MemoryMib)
 	}
 }
+
+// One pre-flight read per selected host, even with the cache disabled: the
+// result of the check is what the response is built from, not a second read.
+func TestPlaceCreateChecksCapabilitiesOncePerHost(t *testing.T) {
+	t.Setenv("HOST_CAPABILITY_CACHE_TTL", "0")
+	for _, tc := range []struct {
+		name       string
+		readErr    error
+		wantOK     bool
+		wantStatus int
+	}{
+		{name: "eligible", wantOK: true, wantStatus: http.StatusOK},
+		{name: "read fails", readErr: fmt.Errorf("connection reset"), wantStatus: http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var reads int
+			mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+				if !strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+					return errorRow(fmt.Errorf("unexpected query: %s", sql))
+				}
+				reads++
+				if tc.readErr != nil {
+					return errorRow(tc.readErr)
+				}
+				return &mockRow{scanFn: func(dest ...any) error {
+					*dest[0].(*bool) = true
+					*dest[1].(*string) = "10.0.0.5:50051"
+					return nil
+				}}
+			}}
+			h := &Handlers{DB: db.New(mock), Scheduler: &stubScheduler{hostID: "host-live"}}
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+			_, ok := h.placeCreate(c, []string{preview.HostCapabilityPorts})
+			if ok != tc.wantOK || w.Code != tc.wantStatus {
+				t.Fatalf("placeCreate ok=%v status=%d, want ok=%v status=%d", ok, w.Code, tc.wantOK, tc.wantStatus)
+			}
+			if reads != 1 {
+				t.Fatalf("pre-flight reads = %d, want 1", reads)
+			}
+		})
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -55,16 +55,25 @@ type stubVMD struct {
 
 type stubScheduler struct {
 	hostID   string
+	hosts    []string // when set, served in order ahead of hostID
 	err      error
 	required []string
+	selects  int
+	drops    int
 }
 
 func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, error) {
 	s.required = append([]string(nil), required...)
+	s.selects++
+	if len(s.hosts) > 0 {
+		id := s.hosts[0]
+		s.hosts = s.hosts[1:]
+		return id, s.err
+	}
 	return s.hostID, s.err
 }
 
-func (s *stubScheduler) Invalidate() {}
+func (s *stubScheduler) Invalidate() { s.drops++ }
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
 	if s.destroyFn != nil {
@@ -2252,8 +2261,47 @@ func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
 	}
-	if checks != 1 || inserted || restored {
-		t.Fatalf("post-selection result: checks=%d inserted=%v restored=%v", checks, inserted, restored)
+	// A rejected host drops the cached candidate set and selection runs once
+	// more on a fresh load; the same host coming back is re-checked and the
+	// create fails before any insert or boot.
+	if checks != 2 || scheduler.selects != 2 || scheduler.drops != 1 || inserted || restored {
+		t.Fatalf("post-selection result: checks=%d selects=%d drops=%d inserted=%v restored=%v",
+			checks, scheduler.selects, scheduler.drops, inserted, restored)
+	}
+}
+
+// A stale candidate set can name a host that has since left rotation. The
+// pre-flight rejects it, the set is dropped, and the create lands on the
+// host a fresh load returns instead of failing.
+func TestPlaceCreateReselectsWhenPreflightRejectsHost(t *testing.T) {
+	scheduler := &stubScheduler{hosts: []string{"host-gone", "host-live"}}
+	var checked []string
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+		if !strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+			return errorRow(fmt.Errorf("unexpected query: %s", sql))
+		}
+		hostID := args[1].(string)
+		checked = append(checked, hostID)
+		return &mockRow{scanFn: func(dest ...any) error {
+			*dest[0].(*bool) = hostID == "host-live"
+			*dest[1].(*string) = "10.0.0.5:50051"
+			return nil
+		}}
+	}}
+	h := &Handlers{DB: db.New(mock), Scheduler: scheduler}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+	hostID, ok := h.placeCreate(c, []string{preview.HostCapabilityPorts})
+	if !ok || hostID != "host-live" {
+		t.Fatalf("placeCreate = (%q, %v), want (host-live, true); body: %s", hostID, ok, w.Body.String())
+	}
+	if scheduler.selects != 2 || scheduler.drops != 1 {
+		t.Fatalf("selects=%d drops=%d, want 2 and 1", scheduler.selects, scheduler.drops)
+	}
+	if !reflect.DeepEqual(checked, []string{"host-gone", "host-live"}) {
+		t.Fatalf("pre-flight reads = %v, want [host-gone host-live] (the live host's second check hits the cache)", checked)
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -60,6 +60,7 @@ type stubScheduler struct {
 	required []string
 	selects  int
 	drops    int
+	rejected []string
 }
 
 func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, error) {
@@ -73,7 +74,8 @@ func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string
 	return s.hostID, s.err
 }
 
-func (s *stubScheduler) Invalidate() { s.drops++ }
+func (s *stubScheduler) Invalidate()          { s.drops++ }
+func (s *stubScheduler) Reject(hostID string) { s.drops++; s.rejected = append(s.rejected, hostID) }
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
 	if s.destroyFn != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2263,10 +2263,10 @@ func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T)
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
 	}
-	// A rejected host drops the cached candidate set and selection runs once
-	// more on a fresh load; the same host coming back is re-checked and the
+	// A rejected host is dropped from the cached candidates and selection
+	// runs once more; the same host coming back is not re-checked, and the
 	// create fails before any insert or boot.
-	if checks != 2 || scheduler.selects != 2 || scheduler.drops != 1 || inserted || restored {
+	if checks != 1 || scheduler.selects != 2 || scheduler.drops != 1 || inserted || restored {
 		t.Fatalf("post-selection result: checks=%d selects=%d drops=%d inserted=%v restored=%v",
 			checks, scheduler.selects, scheduler.drops, inserted, restored)
 	}
@@ -4095,5 +4095,38 @@ func TestPlaceCreateChecksCapabilitiesOncePerHost(t *testing.T) {
 				t.Fatalf("pre-flight reads = %d, want 1", reads)
 			}
 		})
+	}
+}
+
+// When reselection hands back the host that was just rejected — the
+// default-host fallback does this by design — the pre-flight is not run a
+// second time: the answer cannot change, and the create fails on the first.
+func TestPlaceCreateDoesNotRecheckAnUnchangedReselection(t *testing.T) {
+	scheduler := &stubScheduler{hostID: "only-host"}
+	reads := 0
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+		if strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+			reads++
+			return &mockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*bool) = false
+				*dest[1].(*string) = ""
+				return nil
+			}}
+		}
+		return &mockRow{scanFn: func(dest ...any) error { return nil }} // rejection diagnostics, off the request
+	}}
+	h := &Handlers{DB: db.New(mock), Scheduler: scheduler}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+	if _, ok := h.placeCreate(c, []string{preview.HostCapabilityPorts}); ok {
+		t.Fatal("placeCreate accepted a host that failed the pre-flight")
+	}
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	if reads != 1 || scheduler.selects != 2 {
+		t.Fatalf("pre-flight reads=%d selects=%d, want 1 and 2", reads, scheduler.selects)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -61,15 +61,18 @@ type stubScheduler struct {
 	selects  int
 	drops    int
 	rejected []string
-	// rejectDrops is what Reject reports: true means the next SelectHost is
-	// a fresh load, false the unchanged default-host fallback.
-	rejectDrops bool
+	// sameSet makes every selection come from one unchanged set, as the
+	// default-host fallback does; otherwise each is its own fresh set.
+	sameSet bool
 }
 
 func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, uint64, error) {
 	s.required = append([]string(nil), required...)
 	s.selects++
 	gen := uint64(s.selects) // each selection reads as its own candidate set
+	if s.sameSet {
+		gen = 0 // the unchanged default-host fallback
+	}
 	if len(s.hosts) > 0 {
 		id := s.hosts[0]
 		s.hosts = s.hosts[1:]
@@ -79,10 +82,9 @@ func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string
 }
 
 func (s *stubScheduler) Invalidate() { s.drops++ }
-func (s *stubScheduler) Reject(hostID string, _ []string, _ uint64) bool {
+func (s *stubScheduler) Reject(hostID string, _ []string, _ uint64) {
 	s.drops++
 	s.rejected = append(s.rejected, hostID)
-	return s.rejectDrops
 }
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
@@ -2431,7 +2433,7 @@ func TestCreateSandbox_PrivateUsesBrowserCapablePlacementAndAttestation(t *testi
 
 func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T) {
 	teamID := uuid.New()
-	scheduler := &stubScheduler{hostID: "rolled-back-host", rejectDrops: true}
+	scheduler := &stubScheduler{hostID: "rolled-back-host"}
 	var inserted, restored bool
 	var checks int
 	mock := &mockDBTX{
@@ -4305,7 +4307,7 @@ func TestPlaceCreateChecksCapabilitiesOncePerHost(t *testing.T) {
 // default-host fallback does this by design — the pre-flight is not run a
 // second time: the answer cannot change, and the create fails on the first.
 func TestPlaceCreateDoesNotRecheckAnUnchangedReselection(t *testing.T) {
-	scheduler := &stubScheduler{hostID: "only-host"}
+	scheduler := &stubScheduler{hostID: "only-host", sameSet: true}
 	reads := 0
 	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 		if strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
@@ -4396,7 +4398,7 @@ func TestResumeSandbox_CapabilityRefusalRevertsWithoutReachingDaemon(t *testing.
 // between the first pre-flight and the reload, so it is checked again and,
 // if it now passes, the create proceeds on it.
 func TestPlaceCreateRechecksTheSameHostAfterAFreshLoad(t *testing.T) {
-	scheduler := &stubScheduler{hostID: "flapping-host", rejectDrops: true}
+	scheduler := &stubScheduler{hostID: "flapping-host"}
 	reads := 0
 	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
 		if !strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -66,19 +66,20 @@ type stubScheduler struct {
 	rejectDrops bool
 }
 
-func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, error) {
+func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, uint64, error) {
 	s.required = append([]string(nil), required...)
 	s.selects++
+	gen := uint64(s.selects) // each selection reads as its own candidate set
 	if len(s.hosts) > 0 {
 		id := s.hosts[0]
 		s.hosts = s.hosts[1:]
-		return id, s.err
+		return id, gen, s.err
 	}
-	return s.hostID, s.err
+	return s.hostID, gen, s.err
 }
 
 func (s *stubScheduler) Invalidate() { s.drops++ }
-func (s *stubScheduler) Reject(hostID string, _ []string) bool {
+func (s *stubScheduler) Reject(hostID string, _ []string, _ uint64) bool {
 	s.drops++
 	s.rejected = append(s.rejected, hostID)
 	return s.rejectDrops

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -74,8 +74,11 @@ func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string
 	return s.hostID, s.err
 }
 
-func (s *stubScheduler) Invalidate()          { s.drops++ }
-func (s *stubScheduler) Reject(hostID string) { s.drops++; s.rejected = append(s.rejected, hostID) }
+func (s *stubScheduler) Invalidate() { s.drops++ }
+func (s *stubScheduler) Reject(hostID string, _ []string) {
+	s.drops++
+	s.rejected = append(s.rejected, hostID)
+}
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
 	if s.destroyFn != nil {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -61,6 +61,9 @@ type stubScheduler struct {
 	selects  int
 	drops    int
 	rejected []string
+	// rejectDrops is what Reject reports: true means the next SelectHost is
+	// a fresh load, false the unchanged default-host fallback.
+	rejectDrops bool
 }
 
 func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string, error) {
@@ -75,9 +78,10 @@ func (s *stubScheduler) SelectHost(_ context.Context, required []string) (string
 }
 
 func (s *stubScheduler) Invalidate() { s.drops++ }
-func (s *stubScheduler) Reject(hostID string, _ []string) {
+func (s *stubScheduler) Reject(hostID string, _ []string) bool {
 	s.drops++
 	s.rejected = append(s.rejected, hostID)
+	return s.rejectDrops
 }
 
 func (s *stubVMD) DestroyInstance(ctx context.Context, id string, force bool) error {
@@ -2426,7 +2430,7 @@ func TestCreateSandbox_PrivateUsesBrowserCapablePlacementAndAttestation(t *testi
 
 func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T) {
 	teamID := uuid.New()
-	scheduler := &stubScheduler{hostID: "rolled-back-host"}
+	scheduler := &stubScheduler{hostID: "rolled-back-host", rejectDrops: true}
 	var inserted, restored bool
 	var checks int
 	mock := &mockDBTX{
@@ -2462,9 +2466,9 @@ func TestCreateSandbox_RechecksCapabilitiesAfterSchedulerSelection(t *testing.T)
 		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
 	}
 	// A rejected host is dropped from the cached candidates and selection
-	// runs once more; the same host coming back is not re-checked, and the
-	// create fails before any insert or boot.
-	if checks != 1 || scheduler.selects != 2 || scheduler.drops != 1 || inserted || restored {
+	// runs once more on a fresh load; the same host coming back from that
+	// load is re-checked, and the create fails before any insert or boot.
+	if checks != 2 || scheduler.selects != 2 || scheduler.drops != 1 || inserted || restored {
 		t.Fatalf("post-selection result: checks=%d selects=%d drops=%d inserted=%v restored=%v",
 			checks, scheduler.selects, scheduler.drops, inserted, restored)
 	}
@@ -4384,5 +4388,37 @@ func TestResumeSandbox_CapabilityRefusalRevertsWithoutReachingDaemon(t *testing.
 	}
 	if len(reverted) != 2 {
 		t.Fatalf("revert args = %v, want id and team only", reverted)
+	}
+}
+
+// The same host coming back from a FRESH load may have regained eligibility
+// between the first pre-flight and the reload, so it is checked again and,
+// if it now passes, the create proceeds on it.
+func TestPlaceCreateRechecksTheSameHostAfterAFreshLoad(t *testing.T) {
+	scheduler := &stubScheduler{hostID: "flapping-host", rejectDrops: true}
+	reads := 0
+	mock := &mockDBTX{queryRowFn: func(_ context.Context, sql string, args ...any) pgx.Row {
+		if !strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one") {
+			return errorRow(fmt.Errorf("unexpected query: %s", sql))
+		}
+		reads++
+		pass := reads > 1 // eligible again by the second check
+		return &mockRow{scanFn: func(dest ...any) error {
+			*dest[0].(*bool) = pass
+			*dest[1].(*string) = "10.0.0.5:50051"
+			return nil
+		}}
+	}}
+	h := &Handlers{DB: db.New(mock), Scheduler: scheduler}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/sandboxes", nil)
+
+	hostID, ok := h.placeCreate(c, []string{preview.HostCapabilityPorts})
+	if !ok || hostID != "flapping-host" {
+		t.Fatalf("placeCreate = (%q, %v), want (flapping-host, true); body: %s", hostID, ok, w.Body.String())
+	}
+	if reads != 2 || scheduler.selects != 2 {
+		t.Fatalf("pre-flight reads=%d selects=%d, want 2 and 2", reads, scheduler.selects)
 	}
 }

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -169,12 +169,13 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 // readHostCaps performs the pre-flight read and, on an affirmative answer,
 // records the address it returned with the host registry.
 func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
+	readAt := time.Now()
 	row, err := h.DB.HostHasCapabilitiesUnlocked(ctx, params)
 	if err != nil {
 		return false, err
 	}
 	if row.HasCapabilities && h.Hosts != nil {
-		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr)
+		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, readAt)
 	}
 	return row.HasCapabilities, nil
 }

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -22,11 +22,14 @@ const hostCapQueryTimeout = 5 * time.Second
 
 // hostCapCache is an in-process, TTL-bounded, positive-only cache of host
 // capability attestations, fronting HostHasCapabilitiesUnlocked on the
-// standalone pre-flight paths. Same shape as apiKeyCache: only affirmative
-// results are cached (a missing capability or an error always re-reads, so a
-// capability 409 is always fresh), an expired entry is served for a short
-// grace while one background flight refreshes it, and concurrent misses
-// coalesce. The fail-closed gates (transactional validation, VMD's post-boot
+// standalone pre-flight paths. The read behind it is the one host-row read a
+// create pays when nothing is cached: it also returns the host's address,
+// which is handed to the host registry as that host's verification, so the
+// dispatch that follows does not read the row again. Same shape as
+// apiKeyCache: only affirmative results are cached (a missing capability or
+// an error always re-reads, so a capability 409 is always fresh), an expired
+// entry is served for a short grace while one background flight refreshes
+// it, and concurrent misses coalesce. The fail-closed gates (transactional validation, VMD's post-boot
 // attestation) do not go through this cache. Cardinality is hosts ×
 // capability sets; puts sweep expired entries, so memory tracks the active
 // fleet.
@@ -136,7 +139,7 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 		start := time.Now()
 		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostCapQueryTimeout)
 		defer cancel()
-		has, err := h.DB.HostHasCapabilitiesUnlocked(qctx, params)
+		has, err := h.readHostCaps(qctx, params)
 		switch {
 		case err != nil:
 		case has:
@@ -157,6 +160,19 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 	}
 }
 
+// readHostCaps performs the pre-flight read and, on an affirmative answer,
+// records the address it returned with the host registry.
+func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
+	row, err := h.DB.HostHasCapabilitiesUnlocked(ctx, params)
+	if err != nil {
+		return false, err
+	}
+	if row.HasCapabilities && h.Hosts != nil {
+		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr)
+	}
+	return row.HasCapabilities, nil
+}
+
 func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string, capabilities []string) (bool, error) {
 	c := &h.hostCaps
 	c.init()
@@ -168,7 +184,7 @@ func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string,
 		// unbounded read here would silently break that arithmetic.
 		qctx, cancel := context.WithTimeout(ctx, hostCapQueryTimeout)
 		defer cancel()
-		return h.DB.HostHasCapabilitiesUnlocked(qctx, params)
+		return h.readHostCaps(qctx, params)
 	}
 	sorted := append([]string(nil), capabilities...)
 	sort.Strings(sorted)

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -34,16 +34,22 @@ const hostCapQueryTimeout = 5 * time.Second
 // capability sets; puts sweep expired entries, so memory tracks the active
 // fleet.
 const (
-	// The TTL also bounds how long a just-fenced host or dropped capability
-	// can keep passing this pre-flight (the create path already tolerates the
-	// scheduler cache's 30s for placement).
+	// The TTL bounds how long a just-fenced host or dropped capability can
+	// keep passing this pre-flight. That bound is load-bearing for drains:
+	// the scheduler's candidate set is served at any age, so this cache is
+	// what stops a replica admitting creates onto a host that left rotation.
+	// hostctl's drain convergence window is derived from TTL + grace + the
+	// query bound, which is why the TTL is capped below.
 	defaultHostCapCacheTTL = 10 * time.Second
+	maxHostCapCacheTTL     = 30 * time.Second
 	hostCapCacheStaleGrace = 2 * time.Second
 )
 
 // hostCapCacheTTLFromEnv reads HOST_CAPABILITY_CACHE_TTL (a Go duration,
-// e.g. "30s"). Unset or unparsable falls back to the default; a non-positive
-// duration disables caching.
+// e.g. "5s"). Unset or unparsable falls back to the default; a non-positive
+// duration disables caching; anything above maxHostCapCacheTTL is clamped to
+// it, so an operator can shorten the admission bound but not stretch it past
+// what drain --wait budgets for.
 func hostCapCacheTTLFromEnv() time.Duration {
 	raw := os.Getenv("HOST_CAPABILITY_CACHE_TTL")
 	if raw == "" {
@@ -53,7 +59,7 @@ func hostCapCacheTTLFromEnv() time.Duration {
 	if err != nil {
 		return defaultHostCapCacheTTL
 	}
-	return d
+	return min(d, maxHostCapCacheTTL)
 }
 
 type hostCapEntry struct {

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/hostreg"
 )
 
 // hostCapQueryTimeout bounds every capability lookup, cached-miss and
@@ -131,9 +132,7 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 	c := &h.hostCaps
 	ch := c.group.DoChan(key, func() (interface{}, error) {
 		start := time.Now()
-		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostCapQueryTimeout)
-		defer cancel()
-		has, err := h.readHostCaps(qctx, params)
+		has, err := h.readHostCaps(context.WithoutCancel(ctx), params)
 		switch {
 		case err != nil:
 		case has:
@@ -154,21 +153,26 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 	}
 }
 
-// readHostCaps performs the pre-flight read and, on an affirmative answer,
-// records the address it returned with the host registry. A registry
-// resolution failure fails the pre-flight, so the create does not repeat
-// that lookup at dispatch.
+// readHostCaps performs the pre-flight read under hostCapQueryTimeout and,
+// on an affirmative answer, records the address it returned with the host
+// registry under the registry's own bound, so a read that used most of its
+// budget cannot starve the resolution wait. A resolution failure fails the
+// pre-flight, so the create does not repeat that lookup at dispatch.
 func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
 	var gen uint64
 	if h.Hosts != nil {
 		gen = h.Hosts.Generation(params.HostID) // before the read, so a reclaim during it is caught
 	}
-	row, err := h.DB.HostHasCapabilitiesUnlocked(ctx, params)
+	qctx, cancel := context.WithTimeout(ctx, hostCapQueryTimeout)
+	row, err := h.DB.HostHasCapabilitiesUnlocked(qctx, params)
+	cancel()
 	if err != nil {
 		return false, err
 	}
 	if row.HasCapabilities && h.Hosts != nil {
-		if err := h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, gen); err != nil {
+		rctx, cancel := context.WithTimeout(ctx, hostreg.ResolveTimeout)
+		defer cancel()
+		if err := h.Hosts.MarkVerified(rctx, params.HostID, row.VmdAddr, gen); err != nil {
 			return false, err
 		}
 	}
@@ -180,13 +184,7 @@ func (h *Handlers) hostHasCapabilitiesCached(ctx context.Context, hostID string,
 	c.init()
 	params := db.HostHasCapabilitiesUnlockedParams{HostID: hostID, RequiredCapabilities: capabilities}
 	if c.ttl <= 0 {
-		// Same bound as the cached fetch: this lookup sits between scheduler
-		// admission and the bounded boot work, and ops tooling (hostctl
-		// --wait) budgets a fixed post-admission margin for it — an
-		// unbounded read here would silently break that arithmetic.
-		qctx, cancel := context.WithTimeout(ctx, hostCapQueryTimeout)
-		defer cancel()
-		return h.readHostCaps(qctx, params)
+		return h.readHostCaps(ctx, params)
 	}
 	sorted := append([]string(nil), capabilities...)
 	sort.Strings(sorted)

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -155,7 +155,9 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 }
 
 // readHostCaps performs the pre-flight read and, on an affirmative answer,
-// records the address it returned with the host registry.
+// records the address it returned with the host registry. A registry
+// resolution failure fails the pre-flight, so the create does not repeat
+// that lookup at dispatch.
 func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
 	var gen uint64
 	if h.Hosts != nil {
@@ -166,7 +168,9 @@ func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabiliti
 		return false, err
 	}
 	if row.HasCapabilities && h.Hosts != nil {
-		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, gen)
+		if err := h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, gen); err != nil {
+			return false, err
+		}
 	}
 	return row.HasCapabilities, nil
 }

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -22,34 +22,29 @@ const hostCapQueryTimeout = 5 * time.Second
 
 // hostCapCache is an in-process, TTL-bounded, positive-only cache of host
 // capability attestations, fronting HostHasCapabilitiesUnlocked on the
-// standalone pre-flight paths. The read behind it is the one host-row read a
-// create pays when nothing is cached: it also returns the host's address,
-// which is handed to the host registry as that host's verification, so the
+// standalone pre-flight paths. The read behind it also returns the host's
+// address, handed to the host registry as that host's verification, so the
 // dispatch that follows does not read the row again. Same shape as
 // apiKeyCache: only affirmative results are cached (a missing capability or
 // an error always re-reads, so a capability 409 is always fresh), an expired
 // entry is served for a short grace while one background flight refreshes
-// it, and concurrent misses coalesce. The fail-closed gates (transactional validation, VMD's post-boot
-// attestation) do not go through this cache. Cardinality is hosts ×
-// capability sets; puts sweep expired entries, so memory tracks the active
-// fleet.
+// it, and concurrent misses coalesce. The fail-closed gates (transactional
+// validation, VMD's post-boot attestation) do not go through this cache.
+// Cardinality is hosts × capability sets; puts sweep expired entries, so
+// memory tracks the active fleet.
 const (
-	// The TTL bounds how long a just-fenced host or dropped capability can
-	// keep passing this pre-flight. That bound is load-bearing for drains:
-	// the scheduler's candidate set is served at any age, so this cache is
-	// what stops a replica admitting creates onto a host that left rotation.
-	// hostctl's drain convergence window is derived from TTL + grace + the
-	// query bound, which is why the TTL is capped below.
+	// The TTL bounds how long a fenced host or dropped capability can keep
+	// passing this pre-flight. With the scheduler's candidate set served at
+	// any age, this is the bound hostctl's drain convergence is derived from
+	// (TTL + grace + query bound), hence the cap below.
 	defaultHostCapCacheTTL = 10 * time.Second
 	maxHostCapCacheTTL     = 30 * time.Second
 	hostCapCacheStaleGrace = 2 * time.Second
 )
 
-// hostCapCacheTTLFromEnv reads HOST_CAPABILITY_CACHE_TTL (a Go duration,
-// e.g. "5s"). Unset or unparsable falls back to the default; a non-positive
-// duration disables caching; anything above maxHostCapCacheTTL is clamped to
-// it, so an operator can shorten the admission bound but not stretch it past
-// what drain --wait budgets for.
+// hostCapCacheTTLFromEnv reads HOST_CAPABILITY_CACHE_TTL (a Go duration).
+// Unset or unparsable falls back to the default, non-positive disables
+// caching, and anything above maxHostCapCacheTTL is clamped to it.
 func hostCapCacheTTLFromEnv() time.Duration {
 	raw := os.Getenv("HOST_CAPABILITY_CACHE_TTL")
 	if raw == "" {

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -164,12 +164,16 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 // readHostCaps performs the pre-flight read and, on an affirmative answer,
 // records the address it returned with the host registry.
 func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
+	var gen uint64
+	if h.Hosts != nil {
+		gen = h.Hosts.Generation(params.HostID) // before the read, so a reclaim during it is caught
+	}
 	row, err := h.DB.HostHasCapabilitiesUnlocked(ctx, params)
 	if err != nil {
 		return false, err
 	}
 	if row.HasCapabilities && h.Hosts != nil {
-		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr)
+		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, gen)
 	}
 	return row.HasCapabilities, nil
 }

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -21,22 +21,15 @@ import (
 const hostCapQueryTimeout = 5 * time.Second
 
 // hostCapCache is an in-process, TTL-bounded, positive-only cache of host
-// capability attestations, fronting HostHasCapabilitiesUnlocked on the
-// standalone pre-flight paths. The read behind it also returns the host's
-// address, handed to the host registry as that host's verification, so the
-// dispatch that follows does not read the row again. Same shape as
-// apiKeyCache: only affirmative results are cached (a missing capability or
-// an error always re-reads, so a capability 409 is always fresh), an expired
-// entry is served for a short grace while one background flight refreshes
-// it, and concurrent misses coalesce. The fail-closed gates (transactional
-// validation, VMD's post-boot attestation) do not go through this cache.
-// Cardinality is hosts × capability sets; puts sweep expired entries, so
-// memory tracks the active fleet.
+// capability attestations fronting HostHasCapabilitiesUnlocked on the
+// pre-flight paths; the read behind it also hands the host's address to the
+// registry as its verification. Same shape as apiKeyCache: only affirmative
+// results are cached, an expired entry is served for a short grace while one
+// flight refreshes it, and concurrent misses coalesce. Puts sweep expired
+// entries, so memory tracks the active fleet.
 const (
-	// The TTL bounds how long a fenced host or dropped capability can keep
-	// passing this pre-flight. With the scheduler's candidate set served at
-	// any age, this is the bound hostctl's drain convergence is derived from
-	// (TTL + grace + query bound), hence the cap below.
+	// The TTL bounds how long a fenced host can keep passing this pre-flight
+	// and feeds hostctl's drain convergence, hence the cap.
 	defaultHostCapCacheTTL = 10 * time.Second
 	maxHostCapCacheTTL     = 30 * time.Second
 	hostCapCacheStaleGrace = 2 * time.Second

--- a/internal/api/hostcap_cache.go
+++ b/internal/api/hostcap_cache.go
@@ -169,13 +169,12 @@ func (h *Handlers) fetchHostCaps(ctx context.Context, key string, params db.Host
 // readHostCaps performs the pre-flight read and, on an affirmative answer,
 // records the address it returned with the host registry.
 func (h *Handlers) readHostCaps(ctx context.Context, params db.HostHasCapabilitiesUnlockedParams) (bool, error) {
-	readAt := time.Now()
 	row, err := h.DB.HostHasCapabilitiesUnlocked(ctx, params)
 	if err != nil {
 		return false, err
 	}
 	if row.HasCapabilities && h.Hosts != nil {
-		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr, readAt)
+		h.Hosts.MarkVerified(ctx, params.HostID, row.VmdAddr)
 	}
 	return row.HasCapabilities, nil
 }

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -41,7 +41,7 @@ func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, e
 	return nil, fmt.Errorf("not used in this test")
 }
 func (v *verifyRecorder) Invalidate(string) {}
-func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string) {
+func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ time.Time) {
 	v.mu.Lock()
 	v.verified = append(v.verified, hostID+"="+addr)
 	v.mu.Unlock()

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -11,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
 // capMockHandlers returns a Handlers whose DB answers every capability read
@@ -21,11 +24,49 @@ func capMockHandlers(reads *atomic.Int64, answer *atomic.Bool) *Handlers {
 			reads.Add(1)
 			return &mockRow{scanFn: func(dest ...any) error {
 				*(dest[0].(*bool)) = answer.Load()
+				*(dest[1].(*string)) = "10.0.0.9:50051"
 				return nil
 			}}
 		},
 	}
 	return &Handlers{DB: db.New(mock)}
+}
+
+type verifyRecorder struct {
+	mu       sync.Mutex
+	verified []string
+}
+
+func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, error) {
+	return nil, fmt.Errorf("not used in this test")
+}
+func (v *verifyRecorder) Invalidate(string) {}
+func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string) {
+	v.mu.Lock()
+	v.verified = append(v.verified, hostID+"="+addr)
+	v.mu.Unlock()
+}
+
+// The pre-flight read is also the host registry's address verification: an
+// affirmative answer hands the address over, a negative one does not.
+func TestHostCapReadVerifiesRegistryAddress(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+	reg := &verifyRecorder{}
+	h.Hosts = reg
+
+	if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"}); err != nil || !ok {
+		t.Fatalf("positive: ok=%v err=%v", ok, err)
+	}
+	answer.Store(false)
+	if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-b", []string{"preview_ports_v1"}); err != nil || ok {
+		t.Fatalf("negative: ok=%v err=%v", ok, err)
+	}
+	if want := []string{"host-a=10.0.0.9:50051"}; !reflect.DeepEqual(reg.verified, want) {
+		t.Fatalf("verified = %v, want %v", reg.verified, want)
+	}
 }
 
 // A positive attestation must be served from cache within the TTL — the

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -245,3 +245,20 @@ func TestHostCapCacheDisabled(t *testing.T) {
 		t.Fatalf("DB reads = %d, want 3 (TTL=0 must disable caching)", got)
 	}
 }
+
+// The TTL is the drain admission bound, so configuration can shorten or
+// disable it but never stretch it past the cap.
+func TestHostCapCacheTTLClamped(t *testing.T) {
+	for raw, want := range map[string]time.Duration{
+		"":    defaultHostCapCacheTTL,
+		"5s":  5 * time.Second,
+		"0":   0,
+		"10m": maxHostCapCacheTTL,
+		"bad": defaultHostCapCacheTTL,
+	} {
+		t.Setenv("HOST_CAPABILITY_CACHE_TTL", raw)
+		if got := hostCapCacheTTLFromEnv(); got != want {
+			t.Fatalf("HOST_CAPABILITY_CACHE_TTL=%q: ttl = %v, want %v", raw, got, want)
+		}
+	}
+}

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -35,6 +35,7 @@ func capMockHandlers(reads *atomic.Int64, answer *atomic.Bool) *Handlers {
 type verifyRecorder struct {
 	mu       sync.Mutex
 	verified []string
+	err      error // returned by every MarkVerified
 }
 
 func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, error) {
@@ -42,10 +43,31 @@ func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, e
 }
 func (v *verifyRecorder) Invalidate(string)        {}
 func (v *verifyRecorder) Generation(string) uint64 { return 0 }
-func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ uint64) {
+func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ uint64) error {
 	v.mu.Lock()
 	v.verified = append(v.verified, hostID+"="+addr)
 	v.mu.Unlock()
+	return v.err
+}
+
+// A registry resolution that fails during the pre-flight fails the
+// pre-flight, uncached, so the create ends here instead of repeating the
+// same lookup at dispatch.
+func TestHostCapReadFailsWhenRegistryResolutionFails(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+	h.Hosts = &verifyRecorder{err: fmt.Errorf("row unreadable")}
+
+	for i := 0; i < 2; i++ {
+		if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"}); err == nil || ok {
+			t.Fatalf("call %d: ok=%v err=%v, want the resolution error", i, ok, err)
+		}
+	}
+	if n := reads.Load(); n != 2 {
+		t.Fatalf("reads = %d, want 2 (a failed pre-flight is not cached)", n)
+	}
 }
 
 // The pre-flight read is also the host registry's address verification: an

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -41,7 +41,7 @@ func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, e
 	return nil, fmt.Errorf("not used in this test")
 }
 func (v *verifyRecorder) Invalidate(string) {}
-func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ time.Time) {
+func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string) {
 	v.mu.Lock()
 	v.verified = append(v.verified, hostID+"="+addr)
 	v.mu.Unlock()

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/hostreg"
 	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
@@ -33,9 +34,10 @@ func capMockHandlers(reads *atomic.Int64, answer *atomic.Bool) *Handlers {
 }
 
 type verifyRecorder struct {
-	mu       sync.Mutex
-	verified []string
-	err      error // returned by every MarkVerified
+	mu        sync.Mutex
+	verified  []string
+	remaining time.Duration // budget left on the last MarkVerified's context
+	err       error         // returned by every MarkVerified
 }
 
 func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, error) {
@@ -43,11 +45,32 @@ func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, e
 }
 func (v *verifyRecorder) Invalidate(string)        {}
 func (v *verifyRecorder) Generation(string) uint64 { return 0 }
-func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ uint64) error {
+func (v *verifyRecorder) MarkVerified(ctx context.Context, hostID, addr string, _ uint64) error {
 	v.mu.Lock()
 	v.verified = append(v.verified, hostID+"="+addr)
+	if deadline, ok := ctx.Deadline(); ok {
+		v.remaining = time.Until(deadline)
+	}
 	v.mu.Unlock()
 	return v.err
+}
+
+// The registry wait gets the registry's own budget, not what is left of the
+// capability query's, so a read that ran long cannot starve the resolution.
+func TestHostCapReadGivesRegistryItsOwnBudget(t *testing.T) {
+	var reads atomic.Int64
+	var answer atomic.Bool
+	answer.Store(true)
+	h := capMockHandlers(&reads, &answer)
+	reg := &verifyRecorder{}
+	h.Hosts = reg
+
+	if ok, err := h.hostHasCapabilitiesCached(context.Background(), "host-a", []string{"preview_ports_v1"}); err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if got := reg.remaining; got <= hostreg.ResolveTimeout-time.Second || got > hostreg.ResolveTimeout {
+		t.Fatalf("registry wait budget = %v, want about %v", got, hostreg.ResolveTimeout)
+	}
 }
 
 // A registry resolution that fails during the pre-flight fails the

--- a/internal/api/hostcap_cache_test.go
+++ b/internal/api/hostcap_cache_test.go
@@ -40,8 +40,9 @@ type verifyRecorder struct {
 func (v *verifyRecorder) ClientFor(context.Context, string) (vmdclient.Client, error) {
 	return nil, fmt.Errorf("not used in this test")
 }
-func (v *verifyRecorder) Invalidate(string) {}
-func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string) {
+func (v *verifyRecorder) Invalidate(string)        {}
+func (v *verifyRecorder) Generation(string) uint64 { return 0 }
+func (v *verifyRecorder) MarkVerified(_ context.Context, hostID, addr string, _ uint64) {
 	v.mu.Lock()
 	v.verified = append(v.verified, hostID+"="+addr)
 	v.mu.Unlock()

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -112,7 +112,7 @@ func (f *fakeHostRegistry) ClientFor(context.Context, string) (vmdclient.Client,
 func (f *fakeHostRegistry) Invalidate(hostID string) {
 	f.invalidated = append(f.invalidated, hostID)
 }
-func (f *fakeHostRegistry) MarkVerified(context.Context, string, string) {}
+func (f *fakeHostRegistry) MarkVerified(context.Context, string, string, time.Time) {}
 
 // Reclaiming a silent holder's identity rewrites vmd_addr, so the cached
 // client for that host id must be evicted — it still dials the old machine

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -112,6 +112,7 @@ func (f *fakeHostRegistry) ClientFor(context.Context, string) (vmdclient.Client,
 func (f *fakeHostRegistry) Invalidate(hostID string) {
 	f.invalidated = append(f.invalidated, hostID)
 }
+func (f *fakeHostRegistry) MarkVerified(context.Context, string, string) {}
 
 // Reclaiming a silent holder's identity rewrites vmd_addr, so the cached
 // client for that host id must be evicted — it still dials the old machine

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -112,8 +112,8 @@ func (f *fakeHostRegistry) ClientFor(context.Context, string) (vmdclient.Client,
 func (f *fakeHostRegistry) Invalidate(hostID string) {
 	f.invalidated = append(f.invalidated, hostID)
 }
-func (f *fakeHostRegistry) Generation(string) uint64                             { return 0 }
-func (f *fakeHostRegistry) MarkVerified(context.Context, string, string, uint64) {}
+func (f *fakeHostRegistry) Generation(string) uint64                                   { return 0 }
+func (f *fakeHostRegistry) MarkVerified(context.Context, string, string, uint64) error { return nil }
 
 // Reclaiming a silent holder's identity rewrites vmd_addr, so the cached
 // client for that host id must be evicted — it still dials the old machine

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -112,7 +112,7 @@ func (f *fakeHostRegistry) ClientFor(context.Context, string) (vmdclient.Client,
 func (f *fakeHostRegistry) Invalidate(hostID string) {
 	f.invalidated = append(f.invalidated, hostID)
 }
-func (f *fakeHostRegistry) MarkVerified(context.Context, string, string, time.Time) {}
+func (f *fakeHostRegistry) MarkVerified(context.Context, string, string) {}
 
 // Reclaiming a silent holder's identity rewrites vmd_addr, so the cached
 // client for that host id must be evicted — it still dials the old machine

--- a/internal/api/hosts_test.go
+++ b/internal/api/hosts_test.go
@@ -112,7 +112,8 @@ func (f *fakeHostRegistry) ClientFor(context.Context, string) (vmdclient.Client,
 func (f *fakeHostRegistry) Invalidate(hostID string) {
 	f.invalidated = append(f.invalidated, hostID)
 }
-func (f *fakeHostRegistry) MarkVerified(context.Context, string, string) {}
+func (f *fakeHostRegistry) Generation(string) uint64                             { return 0 }
+func (f *fakeHostRegistry) MarkVerified(context.Context, string, string, uint64) {}
 
 // Reclaiming a silent holder's identity rewrites vmd_addr, so the cached
 // client for that host id must be evicted — it still dials the old machine

--- a/internal/api/vmd_for_host_test.go
+++ b/internal/api/vmd_for_host_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"time"
+
 	"context"
 	"errors"
 	"fmt"
@@ -21,8 +23,8 @@ func (f *routeFakeRegistry) ClientFor(context.Context, string) (vmdclient.Client
 
 // Invalidate keeps the fake compatible with the registry interface as it
 // grows an eviction method.
-func (f *routeFakeRegistry) Invalidate(string)                            {}
-func (f *routeFakeRegistry) MarkVerified(context.Context, string, string) {}
+func (f *routeFakeRegistry) Invalidate(string)                                       {}
+func (f *routeFakeRegistry) MarkVerified(context.Context, string, string, time.Time) {}
 
 // A sandbox row referencing an unregistered host is a hard error, never a
 // silent fallback to the default client: with more than one host the

--- a/internal/api/vmd_for_host_test.go
+++ b/internal/api/vmd_for_host_test.go
@@ -21,7 +21,8 @@ func (f *routeFakeRegistry) ClientFor(context.Context, string) (vmdclient.Client
 
 // Invalidate keeps the fake compatible with the registry interface as it
 // grows an eviction method.
-func (f *routeFakeRegistry) Invalidate(string) {}
+func (f *routeFakeRegistry) Invalidate(string)                            {}
+func (f *routeFakeRegistry) MarkVerified(context.Context, string, string) {}
 
 // A sandbox row referencing an unregistered host is a hard error, never a
 // silent fallback to the default client: with more than one host the

--- a/internal/api/vmd_for_host_test.go
+++ b/internal/api/vmd_for_host_test.go
@@ -21,8 +21,9 @@ func (f *routeFakeRegistry) ClientFor(context.Context, string) (vmdclient.Client
 
 // Invalidate keeps the fake compatible with the registry interface as it
 // grows an eviction method.
-func (f *routeFakeRegistry) Invalidate(string)                            {}
-func (f *routeFakeRegistry) MarkVerified(context.Context, string, string) {}
+func (f *routeFakeRegistry) Invalidate(string)                                    {}
+func (f *routeFakeRegistry) Generation(string) uint64                             { return 0 }
+func (f *routeFakeRegistry) MarkVerified(context.Context, string, string, uint64) {}
 
 // A sandbox row referencing an unregistered host is a hard error, never a
 // silent fallback to the default client: with more than one host the

--- a/internal/api/vmd_for_host_test.go
+++ b/internal/api/vmd_for_host_test.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"time"
-
 	"context"
 	"errors"
 	"fmt"
@@ -23,8 +21,8 @@ func (f *routeFakeRegistry) ClientFor(context.Context, string) (vmdclient.Client
 
 // Invalidate keeps the fake compatible with the registry interface as it
 // grows an eviction method.
-func (f *routeFakeRegistry) Invalidate(string)                                       {}
-func (f *routeFakeRegistry) MarkVerified(context.Context, string, string, time.Time) {}
+func (f *routeFakeRegistry) Invalidate(string)                            {}
+func (f *routeFakeRegistry) MarkVerified(context.Context, string, string) {}
 
 // A sandbox row referencing an unregistered host is a hard error, never a
 // silent fallback to the default client: with more than one host the

--- a/internal/api/vmd_for_host_test.go
+++ b/internal/api/vmd_for_host_test.go
@@ -21,9 +21,9 @@ func (f *routeFakeRegistry) ClientFor(context.Context, string) (vmdclient.Client
 
 // Invalidate keeps the fake compatible with the registry interface as it
 // grows an eviction method.
-func (f *routeFakeRegistry) Invalidate(string)                                    {}
-func (f *routeFakeRegistry) Generation(string) uint64                             { return 0 }
-func (f *routeFakeRegistry) MarkVerified(context.Context, string, string, uint64) {}
+func (f *routeFakeRegistry) Invalidate(string)                                          {}
+func (f *routeFakeRegistry) Generation(string) uint64                                   { return 0 }
+func (f *routeFakeRegistry) MarkVerified(context.Context, string, string, uint64) error { return nil }
 
 // A sandbox row referencing an unregistered host is a hard error, never a
 // silent fallback to the default client: with more than one host the

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -244,27 +244,29 @@ func (q *Queries) HostHasCapabilities(ctx context.Context, arg HostHasCapabiliti
 
 const hostHasCapabilitiesUnlocked = `-- name: HostHasCapabilitiesUnlocked :one
 WITH target_host AS MATERIALIZED (
-  SELECT id, last_heartbeat_at
+  SELECT id, vmd_addr, last_heartbeat_at
   FROM host
   WHERE id = $2
     AND status = 'active'
     AND last_heartbeat_at IS NOT NULL
 )
-SELECT EXISTS (
-  SELECT 1
-  FROM target_host h
-  WHERE NOT EXISTS (
+SELECT
+  EXISTS (
     SELECT 1
-    FROM unnest($1::text[]) AS required(capability)
+    FROM target_host h
     WHERE NOT EXISTS (
       SELECT 1
-      FROM host_capability hc
-      WHERE hc.host_id = h.id
-        AND hc.capability = required.capability
-        AND hc.heartbeat_at = h.last_heartbeat_at
+      FROM unnest($1::text[]) AS required(capability)
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM host_capability hc
+        WHERE hc.host_id = h.id
+          AND hc.capability = required.capability
+          AND hc.heartbeat_at = h.last_heartbeat_at
+      )
     )
-  )
-)
+  ) AS has_capabilities,
+  COALESCE((SELECT vmd_addr FROM target_host), '')::text AS vmd_addr
 `
 
 type HostHasCapabilitiesUnlockedParams struct {
@@ -272,15 +274,25 @@ type HostHasCapabilitiesUnlockedParams struct {
 	HostID               string   `json:"host_id"`
 }
 
+type HostHasCapabilitiesUnlockedRow struct {
+	HasCapabilities bool   `json:"has_capabilities"`
+	VmdAddr         string `json:"vmd_addr"`
+}
+
 // HostHasCapabilities without the row lock, for standalone pre-flight reads
 // outside a mutation transaction: omitting the lock keeps concurrent checks
 // from serializing behind the host's heartbeat writer. Transactional callers
 // that must pin the host across a commit use HostHasCapabilities.
-func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCapabilitiesUnlockedParams) (bool, error) {
+//
+// Also returns the host's VMD address (empty when the host is not active):
+// the pre-flight already reads the row, so the caller can record it as the
+// address verification the host registry would otherwise perform with a
+// read of its own.
+func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCapabilitiesUnlockedParams) (HostHasCapabilitiesUnlockedRow, error) {
 	row := q.db.QueryRow(ctx, hostHasCapabilitiesUnlocked, arg.RequiredCapabilities, arg.HostID)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
+	var i HostHasCapabilitiesUnlockedRow
+	err := row.Scan(&i.HasCapabilities, &i.VmdAddr)
+	return i, err
 }
 
 const listActiveHosts = `-- name: ListActiveHosts :many

--- a/internal/db/hosts.sql.go
+++ b/internal/db/hosts.sql.go
@@ -284,10 +284,8 @@ type HostHasCapabilitiesUnlockedRow struct {
 // from serializing behind the host's heartbeat writer. Transactional callers
 // that must pin the host across a commit use HostHasCapabilities.
 //
-// Also returns the host's VMD address (empty when the host is not active):
-// the pre-flight already reads the row, so the caller can record it as the
-// address verification the host registry would otherwise perform with a
-// read of its own.
+// Also returns the host's VMD address (empty when the host is not active),
+// so the caller can record this read as the registry's address verification.
 func (q *Queries) HostHasCapabilitiesUnlocked(ctx context.Context, arg HostHasCapabilitiesUnlockedParams) (HostHasCapabilitiesUnlockedRow, error) {
 	row := q.db.QueryRow(ctx, hostHasCapabilitiesUnlocked, arg.RequiredCapabilities, arg.HostID)
 	var i HostHasCapabilitiesUnlockedRow

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -313,20 +313,29 @@ func (r *Registry) Invalidate(hostID string) {
 // MarkVerified records a host row read the caller has just performed and
 // the address it saw, so the dispatch that follows finds a verified client
 // instead of blocking on a row read of its own. A cached client at the same
-// address has its lease renewed in place. No client yet, or a moved address,
-// resolves now (row read plus dial) under the usual generation guards; a
-// resolution failure is logged and leaves ClientFor to fail closed as before.
+// address has its lease renewed in place. A cached client at a DIFFERENT
+// address is dropped first — the row just said the host moved, so that
+// client must not survive as a within-lease fallback should the resolution
+// below fail to read — and then, as with no client at all, the host is
+// resolved now (row read plus dial) under the usual generation guards. A
+// resolution failure is logged and leaves ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
-	if e, ok := r.clients[hostID]; ok && e.addr == addr {
-		now := time.Now()
-		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
-		r.clients[hostID] = e
-		r.mu.Unlock()
-		return
+	if e, ok := r.clients[hostID]; ok {
+		if e.addr == addr {
+			now := time.Now()
+			e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
+			r.clients[hostID] = e
+			r.mu.Unlock()
+			return
+		}
+		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
+			Msg("host address changed; dropping the cached client before re-resolving")
+		delete(r.clients, hostID)
+		r.gens[hostID]++
 	}
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -18,6 +18,12 @@ import (
 // wires it to Invalidate.
 type DialFunc func(hostID, addr string, onDead func()) (vmdclient.Client, error)
 
+// observation is one read of a host row's address and when that read began.
+type observation struct {
+	addr string
+	at   time.Time
+}
+
 // addrRecheckTTL bounds how long a cached client can be dispatched through
 // without its address being re-verified against the host row. An address
 // change (a host identity reclaimed by a re-provisioned machine) is only
@@ -77,13 +83,16 @@ type Registry struct {
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
-	// observed is the address most recently reported to MarkVerified per
-	// host. Equivalent reports coalesce on it: only a report that differs
-	// from the last one supersedes a resolution in flight, so concurrent
-	// verifications of one unchanged address cannot exhaust that
-	// resolution's attempts between them.
-	observed map[string]string
-	resolve  singleflight.Group // one row-read/dial resolution in flight per host
+	// latest is the newest observation of each host's row address, from a
+	// resolution's own read or from a caller's MarkVerified, ordered by when
+	// the read STARTED. A resolution publishes only what no newer read
+	// contradicts, and a caller's report lands only if no newer read
+	// contradicts it, so an older read can never overwrite a newer one
+	// whichever side it came from — including when an address returns to
+	// an earlier value. Equal addresses never conflict, so equivalent
+	// reports cost a resolution in flight nothing.
+	latest  map[string]observation
+	resolve singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
 	// waiting on it — without this guard, every warm call in the refresh
@@ -94,11 +103,11 @@ type Registry struct {
 // New creates a Registry backed by the host table.
 func New(queries *db.Queries, dial DialFunc) *Registry {
 	return &Registry{
-		db:       queries,
-		dial:     dial,
-		clients:  make(map[string]entry),
-		gens:     make(map[string]uint64),
-		observed: make(map[string]string),
+		db:      queries,
+		dial:    dial,
+		clients: make(map[string]entry),
+		gens:    make(map[string]uint64),
+		latest:  make(map[string]observation),
 	}
 }
 
@@ -207,6 +216,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 			prev, hadPrev := r.clients[hostID]
 			r.mu.RUnlock()
 
+			readAt := time.Now()
 			host, err := r.db.GetHost(vctx, hostID)
 			if err != nil {
 				// Dispatching a cached client on a failed read is only safe
@@ -249,6 +259,11 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				r.mu.Unlock()
 				continue // invalidated mid-read; re-read the row
 			}
+			if r.contradictedLocked(hostID, host.VmdAddr, readAt) {
+				r.mu.Unlock()
+				continue // a newer read saw the host elsewhere; re-read the row
+			}
+			r.recordLocked(hostID, host.VmdAddr, readAt)
 			if e, ok := r.clients[hostID]; ok && e.addr == host.VmdAddr {
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
@@ -280,6 +295,10 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				// as it stands now.
 				r.mu.Unlock()
 				continue
+			}
+			if r.contradictedLocked(hostID, host.VmdAddr, readAt) {
+				r.mu.Unlock()
+				continue // the address moved on while we dialed; re-read the row
 			}
 			now := time.Now()
 			r.clients[hostID] = entry{
@@ -313,35 +332,38 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 func (r *Registry) Invalidate(hostID string) {
 	r.mu.Lock()
 	delete(r.clients, hostID)
-	delete(r.observed, hostID)
+	delete(r.latest, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
 
-// MarkVerified records a host row read the caller has just performed and
-// the address it saw, so the dispatch that follows finds a verified client
-// instead of blocking on a row read of its own. A cached client at the same
-// address has its lease renewed in place. Otherwise the host is resolved now
-// (row read plus dial): a cached client at a DIFFERENT address is dropped
-// first — the row just said the host moved, so that client must not survive
-// as a within-lease fallback should the resolution fail to read — and the
-// first report of an address the registry has not seen bumps the host's
-// generation, so a resolution already in flight that read the row BEFORE
-// this observation discards what it read and reads again instead of
-// publishing an older address over the newer one. Further reports of the
-// same address join that resolution without bumping again. A resolution
-// failure is logged and leaves ClientFor to fail closed.
-func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
+// MarkVerified records a host row read the caller has just performed — the
+// address it saw and when the read began — so the dispatch that follows
+// finds a verified client instead of blocking on a row read of its own. A
+// report a newer read already contradicts is dropped: that read governs. A
+// cached client at the reported address has its lease renewed in place.
+// Otherwise the host is resolved now (row read plus dial); a cached client
+// at a DIFFERENT address is dropped first, since the row just said the host
+// moved and that client must not survive as a within-lease fallback should
+// the resolution fail to read. A resolution already in flight that read an
+// older, different address re-reads before publishing (see latest), so this
+// report is never overwritten by it. A resolution failure is logged and
+// leaves ClientFor to fail closed.
+func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readAt time.Time) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
+	if r.contradictedLocked(hostID, addr, readAt) {
+		r.mu.Unlock()
+		return
+	}
+	r.recordLocked(hostID, addr, readAt)
 	if e, ok := r.clients[hostID]; ok {
 		if e.addr == addr {
 			now := time.Now()
 			e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 			r.clients[hostID] = e
-			r.observed[hostID] = addr
 			r.mu.Unlock()
 			return
 		}
@@ -349,12 +371,23 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 			Msg("host address changed; dropping the cached client before re-resolving")
 		delete(r.clients, hostID)
 	}
-	if r.observed[hostID] != addr {
-		r.observed[hostID] = addr
-		r.gens[hostID]++
-	}
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
+	}
+}
+
+// contradictedLocked reports whether a read of addr that began at readAt is
+// contradicted by a newer read that saw a different address. Caller holds mu.
+func (r *Registry) contradictedLocked(hostID, addr string, readAt time.Time) bool {
+	l, ok := r.latest[hostID]
+	return ok && l.at.After(readAt) && l.addr != addr
+}
+
+// recordLocked keeps an observation when it is at least as new as the one
+// held. Caller holds mu.
+func (r *Registry) recordLocked(hostID, addr string, readAt time.Time) {
+	if l, ok := r.latest[hostID]; !ok || !readAt.Before(l.at) {
+		r.latest[hostID] = observation{addr: addr, at: readAt}
 	}
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -313,12 +313,15 @@ func (r *Registry) Invalidate(hostID string) {
 // MarkVerified records a host row read the caller has just performed and
 // the address it saw, so the dispatch that follows finds a verified client
 // instead of blocking on a row read of its own. A cached client at the same
-// address has its lease renewed in place. A cached client at a DIFFERENT
-// address is dropped first — the row just said the host moved, so that
-// client must not survive as a within-lease fallback should the resolution
-// below fail to read — and then, as with no client at all, the host is
-// resolved now (row read plus dial) under the usual generation guards. A
-// resolution failure is logged and leaves ClientFor to fail closed.
+// address has its lease renewed in place. Otherwise the host is resolved now
+// (row read plus dial): a cached client at a DIFFERENT address is dropped
+// first — the row just said the host moved, so that client must not survive
+// as a within-lease fallback should the resolution fail to read — and in
+// both that case and the no-client case the host's generation is bumped, so
+// a resolution already in flight that read the row BEFORE this observation
+// discards what it read and reads again instead of publishing an older
+// address over the newer one. A resolution failure is logged and leaves
+// ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
@@ -335,8 +338,8 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
 			Msg("host address changed; dropping the cached client before re-resolving")
 		delete(r.clients, hostID)
-		r.gens[hostID]++
 	}
+	r.gens[hostID]++
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -309,3 +309,27 @@ func (r *Registry) Invalidate(hostID string) {
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
+
+// MarkVerified records a host row read the caller has just performed and
+// the address it saw, so the dispatch that follows finds a verified client
+// instead of blocking on a row read of its own. A cached client at the same
+// address has its lease renewed in place. No client yet, or a moved address,
+// resolves now (row read plus dial) under the usual generation guards; a
+// resolution failure is logged and leaves ClientFor to fail closed as before.
+func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
+	if addr == "" {
+		return
+	}
+	r.mu.Lock()
+	if e, ok := r.clients[hostID]; ok && e.addr == addr {
+		now := time.Now()
+		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
+		r.clients[hostID] = e
+		r.mu.Unlock()
+		return
+	}
+	r.mu.Unlock()
+	if _, err := r.resolveClient(ctx, hostID); err != nil {
+		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
+	}
+}

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -76,8 +76,14 @@ type Registry struct {
 	// address. The mutex is never held across I/O, so an invalidation can
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
-	gens    map[string]uint64
-	resolve singleflight.Group // one row-read/dial resolution in flight per host
+	gens map[string]uint64
+	// observed is the address most recently reported to MarkVerified per
+	// host. Equivalent reports coalesce on it: only a report that differs
+	// from the last one supersedes a resolution in flight, so concurrent
+	// verifications of one unchanged address cannot exhaust that
+	// resolution's attempts between them.
+	observed map[string]string
+	resolve  singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
 	// waiting on it — without this guard, every warm call in the refresh
@@ -88,10 +94,11 @@ type Registry struct {
 // New creates a Registry backed by the host table.
 func New(queries *db.Queries, dial DialFunc) *Registry {
 	return &Registry{
-		db:      queries,
-		dial:    dial,
-		clients: make(map[string]entry),
-		gens:    make(map[string]uint64),
+		db:       queries,
+		dial:     dial,
+		clients:  make(map[string]entry),
+		gens:     make(map[string]uint64),
+		observed: make(map[string]string),
 	}
 }
 
@@ -306,6 +313,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 func (r *Registry) Invalidate(hostID string) {
 	r.mu.Lock()
 	delete(r.clients, hostID)
+	delete(r.observed, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
@@ -316,12 +324,13 @@ func (r *Registry) Invalidate(hostID string) {
 // address has its lease renewed in place. Otherwise the host is resolved now
 // (row read plus dial): a cached client at a DIFFERENT address is dropped
 // first — the row just said the host moved, so that client must not survive
-// as a within-lease fallback should the resolution fail to read — and in
-// both that case and the no-client case the host's generation is bumped, so
-// a resolution already in flight that read the row BEFORE this observation
-// discards what it read and reads again instead of publishing an older
-// address over the newer one. A resolution failure is logged and leaves
-// ClientFor to fail closed.
+// as a within-lease fallback should the resolution fail to read — and the
+// first report of an address the registry has not seen bumps the host's
+// generation, so a resolution already in flight that read the row BEFORE
+// this observation discards what it read and reads again instead of
+// publishing an older address over the newer one. Further reports of the
+// same address join that resolution without bumping again. A resolution
+// failure is logged and leaves ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
@@ -332,6 +341,7 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 			now := time.Now()
 			e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 			r.clients[hostID] = e
+			r.observed[hostID] = addr
 			r.mu.Unlock()
 			return
 		}
@@ -339,7 +349,10 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 			Msg("host address changed; dropping the cached client before re-resolving")
 		delete(r.clients, hostID)
 	}
-	r.gens[hostID]++
+	if r.observed[hostID] != addr {
+		r.observed[hostID] = addr
+		r.gens[hostID]++
+	}
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -418,6 +418,12 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGe
 		delete(r.clients, hostID)
 		r.gens[hostID]++
 	} else if ok && !r.unconfirmedConflictLocked(hostID) {
+		// Renewing from the caller's read is exactly as safe as renewing
+		// from the recheck's own read: both are one row read that cannot be
+		// ordered against a reclaim committed on another replica, and both
+		// leave the same recheck-bounded window. Only a row version could
+		// order them; until one exists, this is the read the recheck would
+		// otherwise repeat.
 		now := time.Now()
 		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 		r.clients[hostID] = e

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -183,6 +183,14 @@ func (r *Registry) ClientFor(ctx context.Context, hostID string) (vmdclient.Clie
 // returning or caching the just-invalidated address. Concurrent callers for
 // one host share a single resolution.
 func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.Client, error) {
+	return r.resolveFrom(ctx, hostID, "")
+}
+
+// resolveFrom is resolveClient with an optional address the caller has just
+// read from the host row: the first attempt dials it instead of reading the
+// row again, under the same generation and report checks. A later attempt,
+// forced by a conflict, always reads.
+func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (vmdclient.Client, error) {
 	// DoChan rather than Do: the shared resolution keeps running on its
 	// detached context and still fills the cache, but each caller waits only
 	// as long as its own request lives — a canceled create/resume stops
@@ -217,37 +225,43 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 			seqAtRead := r.reportSeq[hostID]
 			r.mu.RUnlock()
 
-			host, err := r.db.GetHost(vctx, hostID)
-			if err != nil {
-				// Dispatching a cached client on a failed read is only safe
-				// while an entry exists NOW — checked after the read, not
-				// via the pre-read snapshot, so an invalidation that landed
-				// during the read is honored. Invalidated with an
-				// unreadable row: retry, then fail closed — the
-				// invalidation had a reason, and dispatching past it risks
-				// the machine that lost the identity.
-				r.mu.Lock()
-				e, ok := r.clients[hostID]
-				withinLease := ok && time.Since(e.verifiedAt) < r.unverifiedLease()
-				if withinLease {
-					// Bounded backoff: the next verification is due after
-					// the backoff, not before, and degraded suppresses
-					// refresh-ahead — so a failing DB is retried on the
-					// backoff's pace, never per call. verifiedAt (the lease
-					// clock) advances solely on successful reads, so
-					// sustained failure runs the lease out and fails closed.
-					e.nextCheckAt = time.Now().Add(r.verifyFailureBackoff())
-					e.degraded = true
-					r.clients[hostID] = e
+			var addr string
+			if attempt == 0 && knownAddr != "" {
+				addr = knownAddr
+			} else {
+				host, err := r.db.GetHost(vctx, hostID)
+				if err != nil {
+					// Dispatching a cached client on a failed read is only safe
+					// while an entry exists NOW — checked after the read, not
+					// via the pre-read snapshot, so an invalidation that landed
+					// during the read is honored. Invalidated with an
+					// unreadable row: retry, then fail closed — the
+					// invalidation had a reason, and dispatching past it risks
+					// the machine that lost the identity.
+					r.mu.Lock()
+					e, ok := r.clients[hostID]
+					withinLease := ok && time.Since(e.verifiedAt) < r.unverifiedLease()
+					if withinLease {
+						// Bounded backoff: the next verification is due after
+						// the backoff, not before, and degraded suppresses
+						// refresh-ahead — so a failing DB is retried on the
+						// backoff's pace, never per call. verifiedAt (the lease
+						// clock) advances solely on successful reads, so
+						// sustained failure runs the lease out and fails closed.
+						e.nextCheckAt = time.Now().Add(r.verifyFailureBackoff())
+						e.degraded = true
+						r.clients[hostID] = e
+					}
+					r.mu.Unlock()
+					if withinLease {
+						log.Warn().Err(err).Str("host_id", hostID).
+							Msg("host address verification failed; dispatching via cached client within lease")
+						return e.client, nil
+					}
+					lastErr = err
+					continue
 				}
-				r.mu.Unlock()
-				if withinLease {
-					log.Warn().Err(err).Str("host_id", hostID).
-						Msg("host address verification failed; dispatching via cached client within lease")
-					return e.client, nil
-				}
-				lastErr = err
-				continue
+				addr = host.VmdAddr
 			}
 
 			// If the cache holds an entry at the row's address — the common
@@ -259,7 +273,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				r.mu.Unlock()
 				continue // invalidated mid-read; re-read the row
 			}
-			if r.reportedConflictLocked(hostID, seqAtRead, host.VmdAddr) {
+			if r.reportedConflictLocked(hostID, seqAtRead, addr) {
 				// In doubt: drop the cached client before the re-read so a
 				// failed confirmation fails closed for every caller.
 				delete(r.clients, hostID)
@@ -267,7 +281,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				continue
 			}
 			seqAtDial := r.reportSeq[hostID]
-			if e, ok := r.clients[hostID]; ok && e.addr == host.VmdAddr {
+			if e, ok := r.clients[hostID]; ok && e.addr == addr {
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 				r.clients[hostID] = e
@@ -278,18 +292,18 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 
 			// No usable entry for the row's address: dial it. Covers first
 			// use, an address change, and an invalidated-but-unmoved host.
-			if hadPrev && prev.addr != host.VmdAddr {
+			if hadPrev && prev.addr != addr {
 				log.Warn().Str("host_id", hostID).Str("old_addr", prev.addr).
-					Str("new_addr", host.VmdAddr).
+					Str("new_addr", addr).
 					Msg("host address changed; re-dialing before dispatch")
 			}
-			c, err := r.dial(hostID, host.VmdAddr, func() { r.Invalidate(hostID) })
+			c, err := r.dial(hostID, addr, func() { r.Invalidate(hostID) })
 			if err != nil {
 				// No falling back to a previous client: failing loudly
 				// beats executing on a machine that may have lost the
 				// identity.
 				r.Invalidate(hostID)
-				return nil, fmt.Errorf("dial VMD at %s for host %q: %w", host.VmdAddr, hostID, err)
+				return nil, fmt.Errorf("dial VMD at %s for host %q: %w", addr, hostID, err)
 			}
 			r.mu.Lock()
 			if r.gens[hostID] != startGen {
@@ -299,7 +313,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				r.mu.Unlock()
 				continue
 			}
-			if r.reportedConflictLocked(hostID, seqAtDial, host.VmdAddr) {
+			if r.reportedConflictLocked(hostID, seqAtDial, addr) {
 				// Same as above, for a report that landed during the dial.
 				delete(r.clients, hostID)
 				r.mu.Unlock()
@@ -307,7 +321,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 			}
 			now := time.Now()
 			r.clients[hostID] = entry{
-				client: c, addr: host.VmdAddr,
+				client: c, addr: addr,
 				verifiedAt: now, nextCheckAt: now.Add(r.recheckTTL()),
 			}
 			r.mu.Unlock()
@@ -346,8 +360,9 @@ func (r *Registry) Invalidate(hostID string) {
 // MarkVerified records a host row read the caller has just performed and the
 // address it saw, so the dispatch that follows does not read the row itself.
 // A cached client at that address has its lease renewed; one at a different
-// address is dropped, never kept as a fallback, and the host is resolved now.
-// A resolution failure is logged and leaves ClientFor to fail closed.
+// address is dropped, never kept as a fallback, and the host is resolved now
+// from the reported address, with no second row read. A resolution failure
+// is logged and leaves ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
@@ -373,7 +388,7 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 		r.gens[hostID]++
 	}
 	r.mu.Unlock()
-	if _, err := r.resolveClient(ctx, hostID); err != nil {
+	if _, err := r.resolveFrom(ctx, hostID, addr); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
 	}
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -77,19 +77,13 @@ type Registry struct {
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
-	// reported is the address a caller most recently handed to MarkVerified,
-	// reportSeq counts those reports, and reportConflictSeq is the sequence of
-	// the latest report that disagreed with the one before it. Reads cannot be
-	// ordered from this side (a query that starts first can execute last), so
-	// a resolution never ranks a report against its own read by time. Reports
-	// that arrive while its read is in flight leave the address in doubt when
-	// the latest disagrees with the read or they disagreed among themselves;
-	// a doubted address drops its cached client and is re-read before anything
-	// publishes, so a failed confirmation fails closed. Identical reports set
-	// no conflict. A report that disagrees with the previous report or with
-	// the cached client is itself in doubt: confirmedSeq is the report
-	// sequence as of the last row read that published, and while the latest
-	// conflict is newer than it, no report is dialed or renewed unread.
+	// reported is the address a caller last handed to MarkVerified, reportSeq
+	// counts those reports, reportConflictSeq is the sequence of the latest
+	// report that disagreed with the one before it, and confirmedSeq is the
+	// report sequence as of the last row read that published. Reads cannot be
+	// ordered by time, so a report that conflicts with an unconfirmed read or
+	// with the cached client keeps the host in doubt: it is re-read before
+	// anything publishes, never dialed or renewed unread.
 	reported          map[string]string
 	reportSeq         map[string]uint64
 	reportConflictSeq map[string]uint64
@@ -191,9 +185,8 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 	return r.resolveFrom(ctx, hostID, "", 0)
 }
 
-// Generation is the host's current invalidation generation. A caller that
-// reads the host row captures it first and hands it to MarkVerified with
-// the address it read, so a read that predates a reclaim is never trusted.
+// Generation is the host's current invalidation generation; a caller
+// captures it before reading the host row and hands it to MarkVerified.
 func (r *Registry) Generation(hostID string) uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -201,11 +194,8 @@ func (r *Registry) Generation(hostID string) uint64 {
 }
 
 // resolveFrom is resolveClient for a caller that has just reported knownAddr
-// (valid while the host's generation is still knownGen). The report is
-// never dialed unread — another replica may have committed a reclaim after
-// the caller's read, which no process-local state can see — but if a client
-// at that address is already cached by the time this runs, it is renewed
-// without a read; otherwise the row is read as usual.
+// (valid while the host's generation is still knownGen). The report is never
+// dialed unread; it only renews a client already cached at that address.
 func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, knownGen uint64) (vmdclient.Client, error) {
 	// DoChan rather than Do: the shared resolution keeps running on its
 	// detached context and still fills the cache, but each caller waits only
@@ -233,10 +223,8 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 			defer func() { r.Observe(kind, time.Since(started), err) }()
 		}
 
-		// Two failed row reads end the resolution, as before; the third
-		// attempt exists for a conflict-driven re-read, which consumes an
-		// attempt but not a read failure, so an outage still costs exactly
-		// two reads.
+		// Two failed row reads end the resolution; the third attempt is
+		// reserved for a conflict-driven re-read, which is not a failure.
 		var lastErr error
 		readFailures := 0
 		for attempt := 0; attempt < 3 && readFailures < 2; attempt++ {
@@ -382,18 +370,12 @@ func (r *Registry) Invalidate(hostID string) {
 	r.mu.Unlock()
 }
 
-// MarkVerified records a host row read the caller has just performed — the
-// address it saw and the Generation it captured before reading — so the
-// dispatch that follows does not read the row itself. A report from before
-// an invalidation is discarded: the reclaim that bumped the generation is
-// newer than what it read. Otherwise a cached client at that address has
-// its lease renewed, unless the report disagrees with the previous report
-// or with the cached client, in which case the row is read before anything
-// is published, since either side may be the stale one; a cached client at
-// a different address is dropped, never kept as a fallback. A cold host is
-// resolved with a row read: the reported address is never dialed unread,
-// because a reclaim committed on another replica after the caller's read is
-// invisible here. A resolution failure is logged and leaves ClientFor to
+// MarkVerified records a host row read the caller has just performed (the
+// address it saw, and the Generation captured before reading) so the dispatch
+// that follows does not read the row again. A report older than the host's
+// generation is discarded. A cached client at that address is renewed; every
+// other case re-reads the row, since a reclaim committed on another replica
+// after the caller's read is invisible here. Failures leave ClientFor to
 // fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) {
 	if addr == "" {
@@ -418,12 +400,9 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGe
 		delete(r.clients, hostID)
 		r.gens[hostID]++
 	} else if ok && !r.unconfirmedConflictLocked(hostID) {
-		// Renewing from the caller's read is exactly as safe as renewing
-		// from the recheck's own read: both are one row read that cannot be
-		// ordered against a reclaim committed on another replica, and both
-		// leave the same recheck-bounded window. Only a row version could
-		// order them; until one exists, this is the read the recheck would
-		// otherwise repeat.
+		// Renewing from the caller's read is as safe as from the recheck's
+		// own: both are one row read that cannot be ordered against a
+		// reclaim on another replica. Only a row version could order them.
 		now := time.Now()
 		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 		r.clients[hostID] = e
@@ -437,10 +416,8 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGe
 	}
 }
 
-// renewIfCachedAt renews and returns the cached client at addr when one is
-// cached and no report conflict is unconfirmed. It lets a report that raced
-// a resolution which has since published that same address return without
-// a read of its own. Takes mu.
+// renewIfCachedAt renews and returns the cached client at addr, if one is
+// cached and no report conflict is unconfirmed. Takes mu.
 func (r *Registry) renewIfCachedAt(hostID, addr string) (vmdclient.Client, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -77,22 +77,22 @@ type Registry struct {
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
-	// observed is the address most recently seen for each host by ANY read:
-	// a resolution's own row read or a caller's MarkVerified. Two reads
-	// cannot be ordered from this side — a query that started first can
-	// execute last — so no observation ever wins over another on timing.
-	// Instead a report that disagrees with the last observation is a
-	// conflict: it bumps the host's generation, so a resolution in flight
-	// re-reads the row before publishing, and it drops a cached client at
-	// the contradicted address, so nothing dispatches through it while the
-	// fresh read is pending. The fresh, generation-guarded read is the only
-	// authority. Equal addresses never conflict, so equivalent reports cost
-	// a resolution in flight nothing. Residual: a read that executed before
-	// a move but was delivered after can publish the superseded address;
-	// the next read from either side — every create's pre-flight, or the
-	// recheck — reports the conflict and it is re-resolved.
-	observed map[string]string
-	resolve  singleflight.Group // one row-read/dial resolution in flight per host
+	// reported is the address a caller most recently handed to MarkVerified
+	// per host, and reportSeq counts those reports. Two row reads cannot be
+	// ordered from this side — a query that started first can execute last
+	// — so a report and a resolution's own read are never ranked on timing.
+	// Instead a resolution treats any report that arrives WHILE its read is
+	// in flight as ambiguous: after the read returns it checks whether such
+	// a report disagrees with what the read saw and, if so, reads again
+	// before publishing (and again after the dial, for reports that arrive
+	// then). A report that agrees costs nothing, so concurrent equivalent
+	// reports cannot starve a resolution; only a genuine conflict costs a
+	// re-read, and the fresh generation-guarded read is the sole authority.
+	// A report that contradicts the CACHED client drops it on the spot, so
+	// nothing dispatches through it while that read is pending.
+	reported  map[string]string
+	reportSeq map[string]uint64
+	resolve   singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
 	// waiting on it — without this guard, every warm call in the refresh
@@ -103,11 +103,12 @@ type Registry struct {
 // New creates a Registry backed by the host table.
 func New(queries *db.Queries, dial DialFunc) *Registry {
 	return &Registry{
-		db:       queries,
-		dial:     dial,
-		clients:  make(map[string]entry),
-		gens:     make(map[string]uint64),
-		observed: make(map[string]string),
+		db:        queries,
+		dial:      dial,
+		clients:   make(map[string]entry),
+		gens:      make(map[string]uint64),
+		reported:  make(map[string]string),
+		reportSeq: make(map[string]uint64),
 	}
 }
 
@@ -210,10 +211,11 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 		}
 
 		var lastErr error
-		for attempt := 0; attempt < 2; attempt++ {
+		for attempt := 0; attempt < 3; attempt++ {
 			r.mu.RLock()
 			startGen := r.gens[hostID]
 			prev, hadPrev := r.clients[hostID]
+			seqAtRead := r.reportSeq[hostID]
 			r.mu.RUnlock()
 
 			host, err := r.db.GetHost(vctx, hostID)
@@ -258,7 +260,11 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				r.mu.Unlock()
 				continue // invalidated mid-read; re-read the row
 			}
-			r.observed[hostID] = host.VmdAddr
+			if r.reportedConflictLocked(hostID, seqAtRead, host.VmdAddr) {
+				r.mu.Unlock()
+				continue // a report during the read disagrees with it; re-read the row
+			}
+			seqAtDial := r.reportSeq[hostID]
 			if e, ok := r.clients[hostID]; ok && e.addr == host.VmdAddr {
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
@@ -290,6 +296,10 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				// as it stands now.
 				r.mu.Unlock()
 				continue
+			}
+			if r.reportedConflictLocked(hostID, seqAtDial, host.VmdAddr) {
+				r.mu.Unlock()
+				continue // a report during the dial disagrees with the address dialed; re-read
 			}
 			now := time.Now()
 			r.clients[hostID] = entry{
@@ -323,33 +333,28 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 func (r *Registry) Invalidate(hostID string) {
 	r.mu.Lock()
 	delete(r.clients, hostID)
-	delete(r.observed, hostID)
+	delete(r.reported, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
 
 // MarkVerified records a host row read the caller has just performed and
 // the address it saw, so the dispatch that follows finds a verified client
-// instead of blocking on a row read of its own. A report that agrees with
-// the last observation renews a cached client at that address in place. A
-// report that disagrees is a conflict (see observed): the host's generation
-// is bumped so any resolution in flight re-reads before publishing, a
-// cached client at the contradicted address is dropped — the row just said
-// the host moved, and that client must not survive as a within-lease
-// fallback should the fresh read fail — and the host is resolved now unless
-// the cached client already sits at the reported address. A resolution
-// failure is logged and leaves ClientFor to fail closed.
+// instead of blocking on a row read of its own. The report is recorded for
+// any resolution in flight to check against (see reported). A cached client
+// at the reported address has its lease renewed in place. A cached client at
+// a DIFFERENT address is dropped — the row just said the host moved, and
+// that client must not survive as a within-lease fallback should the fresh
+// read fail — the generation is bumped so the resolution re-reads, and the
+// host is resolved now. A resolution failure is logged and leaves ClientFor
+// to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
-	last, seen := r.observed[hostID]
-	conflict := seen && last != addr
-	r.observed[hostID] = addr
-	if conflict {
-		r.gens[hostID]++
-	}
+	r.reported[hostID] = addr
+	r.reportSeq[hostID]++
 	e, ok := r.clients[hostID]
 	if ok && e.addr == addr {
 		now := time.Now()
@@ -362,12 +367,16 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
 			Msg("host address changed; dropping the cached client before re-resolving")
 		delete(r.clients, hostID)
-		if !conflict {
-			r.gens[hostID]++ // the cached address is contradicted even if no read recorded it
-		}
+		r.gens[hostID]++
 	}
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
 	}
+}
+
+// reportedConflictLocked reports whether a MarkVerified report arrived since
+// reportSeq was seq and disagrees with addr. Caller holds mu.
+func (r *Registry) reportedConflictLocked(hostID string, seq uint64, addr string) bool {
+	return r.reportSeq[hostID] != seq && r.reported[hostID] != addr
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -188,15 +188,24 @@ func (r *Registry) ClientFor(ctx context.Context, hostID string) (vmdclient.Clie
 // returning or caching the just-invalidated address. Concurrent callers for
 // one host share a single resolution.
 func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.Client, error) {
-	return r.resolveFrom(ctx, hostID, "")
+	return r.resolveFrom(ctx, hostID, "", 0)
+}
+
+// Generation is the host's current invalidation generation. A caller that
+// reads the host row captures it first and hands it to MarkVerified with
+// the address it read, so a read that predates a reclaim is never trusted.
+func (r *Registry) Generation(hostID string) uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.gens[hostID]
 }
 
 // resolveFrom is resolveClient with an optional address the caller has just
-// read from the host row: the first attempt dials it instead of reading the
-// row again, under the same generation and report checks, unless a report
-// conflict is still unconfirmed. A later attempt, forced by a conflict,
-// always reads.
-func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (vmdclient.Client, error) {
+// read from the host row, valid only while the host's generation is still
+// knownGen: the first attempt dials it instead of reading the row again,
+// under the same generation and report checks, unless a report conflict is
+// still unconfirmed. A later attempt, forced by a conflict, always reads.
+func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, knownGen uint64) (vmdclient.Client, error) {
 	// DoChan rather than Do: the shared resolution keeps running on its
 	// detached context and still fills the cache, but each caller waits only
 	// as long as its own request lives — a canceled create/resume stops
@@ -235,7 +244,7 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 			prev, hadPrev := r.clients[hostID]
 			seqAtRead := r.reportSeq[hostID]
 			seed := knownAddr
-			if attempt > 0 || r.unconfirmedConflictLocked(hostID) {
+			if attempt > 0 || startGen != knownGen || r.unconfirmedConflictLocked(hostID) {
 				seed = ""
 			}
 			r.mu.RUnlock()
@@ -380,20 +389,26 @@ func (r *Registry) Invalidate(hostID string) {
 	r.mu.Unlock()
 }
 
-// MarkVerified records a host row read the caller has just performed and the
-// address it saw, so the dispatch that follows does not read the row itself.
-// A cached client at that address has its lease renewed and a cold host is
-// dialed from the reported address with no second row read — unless the
-// report disagrees with the previous report or with the cached client, in
-// which case the row is read before anything is published, since either
-// side may be the stale one. A cached client at a different address is
-// dropped, never kept as a fallback. A resolution failure is logged and
-// leaves ClientFor to fail closed.
-func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
+// MarkVerified records a host row read the caller has just performed — the
+// address it saw and the Generation it captured before reading — so the
+// dispatch that follows does not read the row itself. A report from before
+// an invalidation is discarded: the reclaim that bumped the generation is
+// newer than what it read. Otherwise a cached client at that address has
+// its lease renewed and a cold host is dialed from the reported address with
+// no second row read — unless the report disagrees with the previous report
+// or with the cached client, in which case the row is read before anything
+// is published, since either side may be the stale one. A cached client at
+// a different address is dropped, never kept as a fallback. A resolution
+// failure is logged and leaves ClientFor to fail closed.
+func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
+	if r.gens[hostID] != readGen {
+		r.mu.Unlock()
+		return
+	}
 	seq := r.reportSeq[hostID] + 1
 	r.reportSeq[hostID] = seq
 	last, seen := r.reported[hostID]
@@ -414,8 +429,9 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 		r.mu.Unlock()
 		return
 	}
+	gen := r.gens[hostID]
 	r.mu.Unlock()
-	if _, err := r.resolveFrom(ctx, hostID, addr); err != nil {
+	if _, err := r.resolveFrom(ctx, hostID, addr, gen); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
 	}
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -78,23 +78,28 @@ type Registry struct {
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
 	// reported is the address a caller most recently handed to MarkVerified
-	// per host, and reportSeq counts those reports. Two row reads cannot be
-	// ordered from this side — a query that started first can execute last
-	// — so a report and a resolution's own read are never ranked on timing.
-	// Instead a resolution treats any report that arrives WHILE its read is
-	// in flight as ambiguous: after the read returns it checks whether such
-	// a report disagrees with what the read saw and, if so, reads again
-	// before publishing (and again after the dial, for reports that arrive
-	// then). A report that agrees costs nothing, so concurrent equivalent
-	// reports cannot starve a resolution; only a genuine conflict costs a
-	// re-read, and the fresh generation-guarded read is the sole authority.
+	// per host, reportSeq counts those reports, and reportConflictSeq is the
+	// sequence number of the latest report that DISAGREED with the one
+	// before it. Two row reads cannot be ordered from this side — a query
+	// that started first can execute last — so a report and a resolution's
+	// own read are never ranked on timing. Instead a resolution treats the
+	// reports that arrive WHILE its read is in flight as ambiguous: after
+	// the read returns it reads again before publishing if the latest such
+	// report disagrees with what the read saw, OR if those reports disagreed
+	// among themselves — a stale report that happens to echo the read must
+	// not erase an earlier one that contradicted it. The same check runs
+	// after the dial, for reports that arrive then. Identical reports set no
+	// conflict, so concurrent equivalent reports cannot starve a resolution;
+	// only a genuine conflict costs a re-read, and the fresh
+	// generation-guarded read is the sole authority.
 	// A report that contradicts the CACHED client drops it on the spot, and
 	// so does a conflict detected by a resolution, so nothing — the
 	// resolution's own within-lease fallback included — dispatches through
 	// a doubted address; if the confirming read fails, dispatch fails closed.
-	reported  map[string]string
-	reportSeq map[string]uint64
-	resolve   singleflight.Group // one row-read/dial resolution in flight per host
+	reported          map[string]string
+	reportSeq         map[string]uint64
+	reportConflictSeq map[string]uint64
+	resolve           singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
 	// waiting on it — without this guard, every warm call in the refresh
@@ -105,12 +110,13 @@ type Registry struct {
 // New creates a Registry backed by the host table.
 func New(queries *db.Queries, dial DialFunc) *Registry {
 	return &Registry{
-		db:        queries,
-		dial:      dial,
-		clients:   make(map[string]entry),
-		gens:      make(map[string]uint64),
-		reported:  make(map[string]string),
-		reportSeq: make(map[string]uint64),
+		db:                queries,
+		dial:              dial,
+		clients:           make(map[string]entry),
+		gens:              make(map[string]uint64),
+		reported:          make(map[string]string),
+		reportSeq:         make(map[string]uint64),
+		reportConflictSeq: make(map[string]uint64),
 	}
 }
 
@@ -344,6 +350,7 @@ func (r *Registry) Invalidate(hostID string) {
 	r.mu.Lock()
 	delete(r.clients, hostID)
 	delete(r.reported, hostID)
+	delete(r.reportConflictSeq, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
@@ -363,6 +370,9 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 		return
 	}
 	r.mu.Lock()
+	if last, seen := r.reported[hostID]; seen && last != addr {
+		r.reportConflictSeq[hostID] = r.reportSeq[hostID] + 1
+	}
 	r.reported[hostID] = addr
 	r.reportSeq[hostID]++
 	e, ok := r.clients[hostID]
@@ -385,8 +395,12 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	}
 }
 
-// reportedConflictLocked reports whether a MarkVerified report arrived since
-// reportSeq was seq and disagrees with addr. Caller holds mu.
+// reportedConflictLocked reports whether the MarkVerified reports that
+// arrived since reportSeq was seq leave addr in doubt: the latest disagrees
+// with it, or they disagreed among themselves. Caller holds mu.
 func (r *Registry) reportedConflictLocked(hostID string, seq uint64, addr string) bool {
-	return r.reportSeq[hostID] != seq && r.reported[hostID] != addr
+	if r.reportSeq[hostID] == seq {
+		return false
+	}
+	return r.reported[hostID] != addr || r.reportConflictSeq[hostID] > seq
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -200,11 +200,12 @@ func (r *Registry) Generation(hostID string) uint64 {
 	return r.gens[hostID]
 }
 
-// resolveFrom is resolveClient with an optional address the caller has just
-// read from the host row, valid only while the host's generation is still
-// knownGen: the first attempt dials it instead of reading the row again,
-// under the same generation and report checks, unless a report conflict is
-// still unconfirmed. A later attempt, forced by a conflict, always reads.
+// resolveFrom is resolveClient for a caller that has just reported knownAddr
+// (valid while the host's generation is still knownGen). The report is
+// never dialed unread — another replica may have committed a reclaim after
+// the caller's read, which no process-local state can see — but if a client
+// at that address is already cached by the time this runs, it is renewed
+// without a read; otherwise the row is read as usual.
 func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, knownGen uint64) (vmdclient.Client, error) {
 	// DoChan rather than Do: the shared resolution keeps running on its
 	// detached context and still fills the cache, but each caller waits only
@@ -232,10 +233,10 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 			defer func() { r.Observe(kind, time.Since(started), err) }()
 		}
 
-		// Two failed row reads end the resolution, as before this budget also
-		// covered a seeded first attempt and conflict-driven re-reads; those
-		// consume attempts but not read failures, so an outage still costs
-		// exactly two reads.
+		// Two failed row reads end the resolution, as before; the third
+		// attempt exists for a conflict-driven re-read, which consumes an
+		// attempt but not a read failure, so an outage still costs exactly
+		// two reads.
 		var lastErr error
 		readFailures := 0
 		for attempt := 0; attempt < 3 && readFailures < 2; attempt++ {
@@ -243,51 +244,47 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 			startGen := r.gens[hostID]
 			prev, hadPrev := r.clients[hostID]
 			seqAtRead := r.reportSeq[hostID]
-			seed := knownAddr
-			if attempt > 0 || startGen != knownGen || r.unconfirmedConflictLocked(hostID) {
-				seed = ""
-			}
 			r.mu.RUnlock()
-
-			var addr string
-			if seed != "" {
-				addr = seed
-			} else {
-				host, err := r.db.GetHost(vctx, hostID)
-				if err != nil {
-					// Dispatching a cached client on a failed read is only safe
-					// while an entry exists NOW — checked after the read, not
-					// via the pre-read snapshot, so an invalidation that landed
-					// during the read is honored. Invalidated with an
-					// unreadable row: retry, then fail closed — the
-					// invalidation had a reason, and dispatching past it risks
-					// the machine that lost the identity.
-					r.mu.Lock()
-					e, ok := r.clients[hostID]
-					withinLease := ok && time.Since(e.verifiedAt) < r.unverifiedLease()
-					if withinLease {
-						// Bounded backoff: the next verification is due after
-						// the backoff, not before, and degraded suppresses
-						// refresh-ahead — so a failing DB is retried on the
-						// backoff's pace, never per call. verifiedAt (the lease
-						// clock) advances solely on successful reads, so
-						// sustained failure runs the lease out and fails closed.
-						e.nextCheckAt = time.Now().Add(r.verifyFailureBackoff())
-						e.degraded = true
-						r.clients[hostID] = e
-					}
-					r.mu.Unlock()
-					if withinLease {
-						log.Warn().Err(err).Str("host_id", hostID).
-							Msg("host address verification failed; dispatching via cached client within lease")
-						return e.client, nil
-					}
-					lastErr = err
-					readFailures++
-					continue
+			if attempt == 0 && knownAddr != "" && startGen == knownGen {
+				if c, ok := r.renewIfCachedAt(hostID, knownAddr); ok {
+					return c, nil
 				}
-				addr = host.VmdAddr
 			}
+
+			host, err := r.db.GetHost(vctx, hostID)
+			if err != nil {
+				// Dispatching a cached client on a failed read is only safe
+				// while an entry exists NOW — checked after the read, not
+				// via the pre-read snapshot, so an invalidation that landed
+				// during the read is honored. Invalidated with an
+				// unreadable row: retry, then fail closed — the
+				// invalidation had a reason, and dispatching past it risks
+				// the machine that lost the identity.
+				r.mu.Lock()
+				e, ok := r.clients[hostID]
+				withinLease := ok && time.Since(e.verifiedAt) < r.unverifiedLease()
+				if withinLease {
+					// Bounded backoff: the next verification is due after
+					// the backoff, not before, and degraded suppresses
+					// refresh-ahead — so a failing DB is retried on the
+					// backoff's pace, never per call. verifiedAt (the lease
+					// clock) advances solely on successful reads, so
+					// sustained failure runs the lease out and fails closed.
+					e.nextCheckAt = time.Now().Add(r.verifyFailureBackoff())
+					e.degraded = true
+					r.clients[hostID] = e
+				}
+				r.mu.Unlock()
+				if withinLease {
+					log.Warn().Err(err).Str("host_id", hostID).
+						Msg("host address verification failed; dispatching via cached client within lease")
+					return e.client, nil
+				}
+				lastErr = err
+				readFailures++
+				continue
+			}
+			addr := host.VmdAddr
 
 			// If the cache holds an entry at the row's address — the common
 			// case, or a replacement another caller dialed — return that
@@ -310,9 +307,7 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 				r.clients[hostID] = e
-				if seed == "" {
-					r.confirmLocked(hostID, seqAtRead)
-				}
+				r.confirmLocked(hostID, seqAtRead)
 				r.mu.Unlock()
 				return e.client, nil
 			}
@@ -352,9 +347,7 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 				client: c, addr: addr,
 				verifiedAt: now, nextCheckAt: now.Add(r.recheckTTL()),
 			}
-			if seed == "" {
-				r.confirmLocked(hostID, seqAtRead)
-			}
+			r.confirmLocked(hostID, seqAtRead)
 			r.mu.Unlock()
 			return c, nil
 		}
@@ -394,12 +387,14 @@ func (r *Registry) Invalidate(hostID string) {
 // dispatch that follows does not read the row itself. A report from before
 // an invalidation is discarded: the reclaim that bumped the generation is
 // newer than what it read. Otherwise a cached client at that address has
-// its lease renewed and a cold host is dialed from the reported address with
-// no second row read — unless the report disagrees with the previous report
+// its lease renewed, unless the report disagrees with the previous report
 // or with the cached client, in which case the row is read before anything
-// is published, since either side may be the stale one. A cached client at
-// a different address is dropped, never kept as a fallback. A resolution
-// failure is logged and leaves ClientFor to fail closed.
+// is published, since either side may be the stale one; a cached client at
+// a different address is dropped, never kept as a fallback. A cold host is
+// resolved with a row read: the reported address is never dialed unread,
+// because a reclaim committed on another replica after the caller's read is
+// invisible here. A resolution failure is logged and leaves ClientFor to
+// fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) {
 	if addr == "" {
 		return
@@ -434,6 +429,23 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGe
 	if _, err := r.resolveFrom(ctx, hostID, addr, gen); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
 	}
+}
+
+// renewIfCachedAt renews and returns the cached client at addr when one is
+// cached and no report conflict is unconfirmed. It lets a report that raced
+// a resolution which has since published that same address return without
+// a read of its own. Takes mu.
+func (r *Registry) renewIfCachedAt(hostID, addr string) (vmdclient.Client, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.clients[hostID]
+	if !ok || e.addr != addr || r.unconfirmedConflictLocked(hostID) {
+		return nil, false
+	}
+	now := time.Now()
+	e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
+	r.clients[hostID] = e
+	return e.client, true
 }
 
 // unconfirmedConflictLocked reports whether the latest report conflict is

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -77,25 +77,16 @@ type Registry struct {
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
-	// reported is the address a caller most recently handed to MarkVerified
-	// per host, reportSeq counts those reports, and reportConflictSeq is the
-	// sequence number of the latest report that DISAGREED with the one
-	// before it. Two row reads cannot be ordered from this side — a query
-	// that started first can execute last — so a report and a resolution's
-	// own read are never ranked on timing. Instead a resolution treats the
-	// reports that arrive WHILE its read is in flight as ambiguous: after
-	// the read returns it reads again before publishing if the latest such
-	// report disagrees with what the read saw, OR if those reports disagreed
-	// among themselves — a stale report that happens to echo the read must
-	// not erase an earlier one that contradicted it. The same check runs
-	// after the dial, for reports that arrive then. Identical reports set no
-	// conflict, so concurrent equivalent reports cannot starve a resolution;
-	// only a genuine conflict costs a re-read, and the fresh
-	// generation-guarded read is the sole authority.
-	// A report that contradicts the CACHED client drops it on the spot, and
-	// so does a conflict detected by a resolution, so nothing — the
-	// resolution's own within-lease fallback included — dispatches through
-	// a doubted address; if the confirming read fails, dispatch fails closed.
+	// reported is the address a caller most recently handed to MarkVerified,
+	// reportSeq counts those reports, and reportConflictSeq is the sequence of
+	// the latest report that disagreed with the one before it. Reads cannot be
+	// ordered from this side (a query that starts first can execute last), so
+	// a resolution never ranks a report against its own read by time. Reports
+	// that arrive while its read is in flight leave the address in doubt when
+	// the latest disagrees with the read or they disagreed among themselves;
+	// a doubted address drops its cached client and is re-read before anything
+	// publishes, so a failed confirmation fails closed. Identical reports set
+	// no conflict.
 	reported          map[string]string
 	reportSeq         map[string]uint64
 	reportConflictSeq map[string]uint64
@@ -269,11 +260,8 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				continue // invalidated mid-read; re-read the row
 			}
 			if r.reportedConflictLocked(hostID, seqAtRead, host.VmdAddr) {
-				// A report during the read disagrees with it: the address is
-				// in doubt. Drop any cached client NOW, before the re-read —
-				// if that read fails, neither this resolution's within-lease
-				// fallback nor any concurrent ClientFor may dispatch through
-				// an address a read has contradicted.
+				// In doubt: drop the cached client before the re-read so a
+				// failed confirmation fails closed for every caller.
 				delete(r.clients, hostID)
 				r.mu.Unlock()
 				continue
@@ -355,16 +343,11 @@ func (r *Registry) Invalidate(hostID string) {
 	r.mu.Unlock()
 }
 
-// MarkVerified records a host row read the caller has just performed and
-// the address it saw, so the dispatch that follows finds a verified client
-// instead of blocking on a row read of its own. The report is recorded for
-// any resolution in flight to check against (see reported). A cached client
-// at the reported address has its lease renewed in place. A cached client at
-// a DIFFERENT address is dropped — the row just said the host moved, and
-// that client must not survive as a within-lease fallback should the fresh
-// read fail — the generation is bumped so the resolution re-reads, and the
-// host is resolved now. A resolution failure is logged and leaves ClientFor
-// to fail closed.
+// MarkVerified records a host row read the caller has just performed and the
+// address it saw, so the dispatch that follows does not read the row itself.
+// A cached client at that address has its lease renewed; one at a different
+// address is dropped, never kept as a fallback, and the host is resolved now.
+// A resolution failure is logged and leaves ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -374,17 +374,17 @@ func (r *Registry) Invalidate(hostID string) {
 // address it saw, and the Generation captured before reading) so the dispatch
 // that follows does not read the row again. A report older than the host's
 // generation is discarded. A cached client at that address is renewed; every
-// other case re-reads the row, since a reclaim committed on another replica
-// after the caller's read is invisible here. Failures leave ClientFor to
-// fail closed.
-func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) {
+// other case reads the row, since a reclaim committed on another replica
+// after the caller's read is invisible here, and that resolution's error is
+// returned so the caller fails without repeating it at dispatch.
+func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGen uint64) error {
 	if addr == "" {
-		return
+		return nil
 	}
 	r.mu.Lock()
 	if r.gens[hostID] != readGen {
 		r.mu.Unlock()
-		return
+		return nil
 	}
 	seq := r.reportSeq[hostID] + 1
 	r.reportSeq[hostID] = seq
@@ -407,13 +407,12 @@ func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readGe
 		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 		r.clients[hostID] = e
 		r.mu.Unlock()
-		return
+		return nil
 	}
 	gen := r.gens[hostID]
 	r.mu.Unlock()
-	if _, err := r.resolveFrom(ctx, hostID, addr, gen); err != nil {
-		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
-	}
+	_, err := r.resolveFrom(ctx, hostID, addr, gen)
+	return err
 }
 
 // renewIfCachedAt renews and returns the cached client at addr, if one is

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -88,8 +88,10 @@ type Registry struct {
 	// then). A report that agrees costs nothing, so concurrent equivalent
 	// reports cannot starve a resolution; only a genuine conflict costs a
 	// re-read, and the fresh generation-guarded read is the sole authority.
-	// A report that contradicts the CACHED client drops it on the spot, so
-	// nothing dispatches through it while that read is pending.
+	// A report that contradicts the CACHED client drops it on the spot, and
+	// so does a conflict detected by a resolution, so nothing — the
+	// resolution's own within-lease fallback included — dispatches through
+	// a doubted address; if the confirming read fails, dispatch fails closed.
 	reported  map[string]string
 	reportSeq map[string]uint64
 	resolve   singleflight.Group // one row-read/dial resolution in flight per host
@@ -261,8 +263,14 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				continue // invalidated mid-read; re-read the row
 			}
 			if r.reportedConflictLocked(hostID, seqAtRead, host.VmdAddr) {
+				// A report during the read disagrees with it: the address is
+				// in doubt. Drop any cached client NOW, before the re-read —
+				// if that read fails, neither this resolution's within-lease
+				// fallback nor any concurrent ClientFor may dispatch through
+				// an address a read has contradicted.
+				delete(r.clients, hostID)
 				r.mu.Unlock()
-				continue // a report during the read disagrees with it; re-read the row
+				continue
 			}
 			seqAtDial := r.reportSeq[hostID]
 			if e, ok := r.clients[hostID]; ok && e.addr == host.VmdAddr {
@@ -298,8 +306,10 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				continue
 			}
 			if r.reportedConflictLocked(hostID, seqAtDial, host.VmdAddr) {
+				// Same as above, for a report that landed during the dial.
+				delete(r.clients, hostID)
 				r.mu.Unlock()
-				continue // a report during the dial disagrees with the address dialed; re-read
+				continue
 			}
 			now := time.Now()
 			r.clients[hostID] = entry{

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -185,6 +185,10 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 	return r.resolveFrom(ctx, hostID, "", 0)
 }
 
+// ResolveTimeout bounds one host resolution (row read and dial). A caller
+// that waits on one budgets it separately from its own work.
+const ResolveTimeout = 2 * time.Second
+
 // Generation is the host's current invalidation generation; a caller
 // captures it before reading the host row and hands it to MarkVerified.
 func (r *Registry) Generation(hostID string) uint64 {
@@ -205,7 +209,7 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string, kn
 		// Detached context: singleflight followers share the leader's
 		// result, so the leader's per-request cancellation must not decide
 		// the resolution for everyone behind it.
-		vctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		vctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ResolveTimeout)
 		defer cancel()
 
 		// One observation per executed flight: kind fixed at flight start,

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -86,10 +86,14 @@ type Registry struct {
 	// the latest disagrees with the read or they disagreed among themselves;
 	// a doubted address drops its cached client and is re-read before anything
 	// publishes, so a failed confirmation fails closed. Identical reports set
-	// no conflict.
+	// no conflict. A report that disagrees with the previous report or with
+	// the cached client is itself in doubt: confirmedSeq is the report
+	// sequence as of the last row read that published, and while the latest
+	// conflict is newer than it, no report is dialed or renewed unread.
 	reported          map[string]string
 	reportSeq         map[string]uint64
 	reportConflictSeq map[string]uint64
+	confirmedSeq      map[string]uint64
 	resolve           singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
@@ -108,6 +112,7 @@ func New(queries *db.Queries, dial DialFunc) *Registry {
 		reported:          make(map[string]string),
 		reportSeq:         make(map[string]uint64),
 		reportConflictSeq: make(map[string]uint64),
+		confirmedSeq:      make(map[string]uint64),
 	}
 }
 
@@ -188,8 +193,9 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 
 // resolveFrom is resolveClient with an optional address the caller has just
 // read from the host row: the first attempt dials it instead of reading the
-// row again, under the same generation and report checks. A later attempt,
-// forced by a conflict, always reads.
+// row again, under the same generation and report checks, unless a report
+// conflict is still unconfirmed. A later attempt, forced by a conflict,
+// always reads.
 func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (vmdclient.Client, error) {
 	// DoChan rather than Do: the shared resolution keeps running on its
 	// detached context and still fills the cache, but each caller waits only
@@ -223,11 +229,15 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 			startGen := r.gens[hostID]
 			prev, hadPrev := r.clients[hostID]
 			seqAtRead := r.reportSeq[hostID]
+			seed := knownAddr
+			if attempt > 0 || r.unconfirmedConflictLocked(hostID) {
+				seed = ""
+			}
 			r.mu.RUnlock()
 
 			var addr string
-			if attempt == 0 && knownAddr != "" {
-				addr = knownAddr
+			if seed != "" {
+				addr = seed
 			} else {
 				host, err := r.db.GetHost(vctx, hostID)
 				if err != nil {
@@ -285,6 +295,9 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 				r.clients[hostID] = e
+				if seed == "" {
+					r.confirmLocked(hostID, seqAtRead)
+				}
 				r.mu.Unlock()
 				return e.client, nil
 			}
@@ -324,6 +337,9 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 				client: c, addr: addr,
 				verifiedAt: now, nextCheckAt: now.Add(r.recheckTTL()),
 			}
+			if seed == "" {
+				r.confirmLocked(hostID, seqAtRead)
+			}
 			r.mu.Unlock()
 			return c, nil
 		}
@@ -353,43 +369,63 @@ func (r *Registry) Invalidate(hostID string) {
 	delete(r.clients, hostID)
 	delete(r.reported, hostID)
 	delete(r.reportConflictSeq, hostID)
+	delete(r.confirmedSeq, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
 
 // MarkVerified records a host row read the caller has just performed and the
 // address it saw, so the dispatch that follows does not read the row itself.
-// A cached client at that address has its lease renewed; one at a different
-// address is dropped, never kept as a fallback, and the host is resolved now
-// from the reported address, with no second row read. A resolution failure
-// is logged and leaves ClientFor to fail closed.
+// A cached client at that address has its lease renewed and a cold host is
+// dialed from the reported address with no second row read — unless the
+// report disagrees with the previous report or with the cached client, in
+// which case the row is read before anything is published, since either
+// side may be the stale one. A cached client at a different address is
+// dropped, never kept as a fallback. A resolution failure is logged and
+// leaves ClientFor to fail closed.
 func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
-	if last, seen := r.reported[hostID]; seen && last != addr {
-		r.reportConflictSeq[hostID] = r.reportSeq[hostID] + 1
-	}
+	seq := r.reportSeq[hostID] + 1
+	r.reportSeq[hostID] = seq
+	last, seen := r.reported[hostID]
 	r.reported[hostID] = addr
-	r.reportSeq[hostID]++
 	e, ok := r.clients[hostID]
-	if ok && e.addr == addr {
+	if (seen && last != addr) || (ok && e.addr != addr) {
+		r.reportConflictSeq[hostID] = seq
+	}
+	if ok && e.addr != addr {
+		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
+			Msg("host address changed; dropping the cached client before re-resolving")
+		delete(r.clients, hostID)
+		r.gens[hostID]++
+	} else if ok && !r.unconfirmedConflictLocked(hostID) {
 		now := time.Now()
 		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
 		r.clients[hostID] = e
 		r.mu.Unlock()
 		return
 	}
-	if ok {
-		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
-			Msg("host address changed; dropping the cached client before re-resolving")
-		delete(r.clients, hostID)
-		r.gens[hostID]++
-	}
 	r.mu.Unlock()
 	if _, err := r.resolveFrom(ctx, hostID, addr); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
+	}
+}
+
+// unconfirmedConflictLocked reports whether the latest report conflict is
+// newer than the last row read that published. Caller holds mu.
+func (r *Registry) unconfirmedConflictLocked(hostID string) bool {
+	return r.reportConflictSeq[hostID] > r.confirmedSeq[hostID]
+}
+
+// confirmLocked records that a row read whose report snapshot was seq has
+// published: every conflict recorded at or before seq is settled by it.
+// Caller holds mu.
+func (r *Registry) confirmLocked(hostID string, seq uint64) {
+	if seq > r.confirmedSeq[hostID] {
+		r.confirmedSeq[hostID] = seq
 	}
 }
 

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -18,12 +18,6 @@ import (
 // wires it to Invalidate.
 type DialFunc func(hostID, addr string, onDead func()) (vmdclient.Client, error)
 
-// observation is one read of a host row's address and when that read began.
-type observation struct {
-	addr string
-	at   time.Time
-}
-
 // addrRecheckTTL bounds how long a cached client can be dispatched through
 // without its address being re-verified against the host row. An address
 // change (a host identity reclaimed by a re-provisioned machine) is only
@@ -83,16 +77,22 @@ type Registry struct {
 	// always land mid-resolve and be observed. Grows one counter per host
 	// id ever seen (fleet-bounded).
 	gens map[string]uint64
-	// latest is the newest observation of each host's row address, from a
-	// resolution's own read or from a caller's MarkVerified, ordered by when
-	// the read STARTED. A resolution publishes only what no newer read
-	// contradicts, and a caller's report lands only if no newer read
-	// contradicts it, so an older read can never overwrite a newer one
-	// whichever side it came from — including when an address returns to
-	// an earlier value. Equal addresses never conflict, so equivalent
-	// reports cost a resolution in flight nothing.
-	latest  map[string]observation
-	resolve singleflight.Group // one row-read/dial resolution in flight per host
+	// observed is the address most recently seen for each host by ANY read:
+	// a resolution's own row read or a caller's MarkVerified. Two reads
+	// cannot be ordered from this side — a query that started first can
+	// execute last — so no observation ever wins over another on timing.
+	// Instead a report that disagrees with the last observation is a
+	// conflict: it bumps the host's generation, so a resolution in flight
+	// re-reads the row before publishing, and it drops a cached client at
+	// the contradicted address, so nothing dispatches through it while the
+	// fresh read is pending. The fresh, generation-guarded read is the only
+	// authority. Equal addresses never conflict, so equivalent reports cost
+	// a resolution in flight nothing. Residual: a read that executed before
+	// a move but was delivered after can publish the superseded address;
+	// the next read from either side — every create's pre-flight, or the
+	// recheck — reports the conflict and it is re-resolved.
+	observed map[string]string
+	resolve  singleflight.Group // one row-read/dial resolution in flight per host
 	// refreshing holds hosts with a refresh-ahead goroutine in flight.
 	// Singleflight dedupes the underlying read but not the goroutines
 	// waiting on it — without this guard, every warm call in the refresh
@@ -103,11 +103,11 @@ type Registry struct {
 // New creates a Registry backed by the host table.
 func New(queries *db.Queries, dial DialFunc) *Registry {
 	return &Registry{
-		db:      queries,
-		dial:    dial,
-		clients: make(map[string]entry),
-		gens:    make(map[string]uint64),
-		latest:  make(map[string]observation),
+		db:       queries,
+		dial:     dial,
+		clients:  make(map[string]entry),
+		gens:     make(map[string]uint64),
+		observed: make(map[string]string),
 	}
 }
 
@@ -216,7 +216,6 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 			prev, hadPrev := r.clients[hostID]
 			r.mu.RUnlock()
 
-			readAt := time.Now()
 			host, err := r.db.GetHost(vctx, hostID)
 			if err != nil {
 				// Dispatching a cached client on a failed read is only safe
@@ -259,11 +258,7 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				r.mu.Unlock()
 				continue // invalidated mid-read; re-read the row
 			}
-			if r.contradictedLocked(hostID, host.VmdAddr, readAt) {
-				r.mu.Unlock()
-				continue // a newer read saw the host elsewhere; re-read the row
-			}
-			r.recordLocked(hostID, host.VmdAddr, readAt)
+			r.observed[hostID] = host.VmdAddr
 			if e, ok := r.clients[hostID]; ok && e.addr == host.VmdAddr {
 				now := time.Now()
 				e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
@@ -295,10 +290,6 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 				// as it stands now.
 				r.mu.Unlock()
 				continue
-			}
-			if r.contradictedLocked(hostID, host.VmdAddr, readAt) {
-				r.mu.Unlock()
-				continue // the address moved on while we dialed; re-read the row
 			}
 			now := time.Now()
 			r.clients[hostID] = entry{
@@ -332,62 +323,51 @@ func (r *Registry) resolveClient(ctx context.Context, hostID string) (vmdclient.
 func (r *Registry) Invalidate(hostID string) {
 	r.mu.Lock()
 	delete(r.clients, hostID)
-	delete(r.latest, hostID)
+	delete(r.observed, hostID)
 	r.gens[hostID]++
 	r.mu.Unlock()
 }
 
-// MarkVerified records a host row read the caller has just performed — the
-// address it saw and when the read began — so the dispatch that follows
-// finds a verified client instead of blocking on a row read of its own. A
-// report a newer read already contradicts is dropped: that read governs. A
-// cached client at the reported address has its lease renewed in place.
-// Otherwise the host is resolved now (row read plus dial); a cached client
-// at a DIFFERENT address is dropped first, since the row just said the host
-// moved and that client must not survive as a within-lease fallback should
-// the resolution fail to read. A resolution already in flight that read an
-// older, different address re-reads before publishing (see latest), so this
-// report is never overwritten by it. A resolution failure is logged and
-// leaves ClientFor to fail closed.
-func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string, readAt time.Time) {
+// MarkVerified records a host row read the caller has just performed and
+// the address it saw, so the dispatch that follows finds a verified client
+// instead of blocking on a row read of its own. A report that agrees with
+// the last observation renews a cached client at that address in place. A
+// report that disagrees is a conflict (see observed): the host's generation
+// is bumped so any resolution in flight re-reads before publishing, a
+// cached client at the contradicted address is dropped — the row just said
+// the host moved, and that client must not survive as a within-lease
+// fallback should the fresh read fail — and the host is resolved now unless
+// the cached client already sits at the reported address. A resolution
+// failure is logged and leaves ClientFor to fail closed.
+func (r *Registry) MarkVerified(ctx context.Context, hostID, addr string) {
 	if addr == "" {
 		return
 	}
 	r.mu.Lock()
-	if r.contradictedLocked(hostID, addr, readAt) {
+	last, seen := r.observed[hostID]
+	conflict := seen && last != addr
+	r.observed[hostID] = addr
+	if conflict {
+		r.gens[hostID]++
+	}
+	e, ok := r.clients[hostID]
+	if ok && e.addr == addr {
+		now := time.Now()
+		e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
+		r.clients[hostID] = e
 		r.mu.Unlock()
 		return
 	}
-	r.recordLocked(hostID, addr, readAt)
-	if e, ok := r.clients[hostID]; ok {
-		if e.addr == addr {
-			now := time.Now()
-			e.verifiedAt, e.nextCheckAt, e.degraded = now, now.Add(r.recheckTTL()), false
-			r.clients[hostID] = e
-			r.mu.Unlock()
-			return
-		}
+	if ok {
 		log.Warn().Str("host_id", hostID).Str("old_addr", e.addr).Str("new_addr", addr).
 			Msg("host address changed; dropping the cached client before re-resolving")
 		delete(r.clients, hostID)
+		if !conflict {
+			r.gens[hostID]++ // the cached address is contradicted even if no read recorded it
+		}
 	}
 	r.mu.Unlock()
 	if _, err := r.resolveClient(ctx, hostID); err != nil {
 		log.Warn().Err(err).Str("host_id", hostID).Msg("host client resolution after row verification failed")
-	}
-}
-
-// contradictedLocked reports whether a read of addr that began at readAt is
-// contradicted by a newer read that saw a different address. Caller holds mu.
-func (r *Registry) contradictedLocked(hostID, addr string, readAt time.Time) bool {
-	l, ok := r.latest[hostID]
-	return ok && l.at.After(readAt) && l.addr != addr
-}
-
-// recordLocked keeps an observation when it is at least as new as the one
-// held. Caller holds mu.
-func (r *Registry) recordLocked(hostID, addr string, readAt time.Time) {
-	if l, ok := r.latest[hostID]; !ok || !readAt.Before(l.at) {
-		r.latest[hostID] = observation{addr: addr, at: readAt}
 	}
 }

--- a/internal/hostreg/registry.go
+++ b/internal/hostreg/registry.go
@@ -223,8 +223,13 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 			defer func() { r.Observe(kind, time.Since(started), err) }()
 		}
 
+		// Two failed row reads end the resolution, as before this budget also
+		// covered a seeded first attempt and conflict-driven re-reads; those
+		// consume attempts but not read failures, so an outage still costs
+		// exactly two reads.
 		var lastErr error
-		for attempt := 0; attempt < 3; attempt++ {
+		readFailures := 0
+		for attempt := 0; attempt < 3 && readFailures < 2; attempt++ {
 			r.mu.RLock()
 			startGen := r.gens[hostID]
 			prev, hadPrev := r.clients[hostID]
@@ -269,6 +274,7 @@ func (r *Registry) resolveFrom(ctx context.Context, hostID, knownAddr string) (v
 						return e.client, nil
 					}
 					lastErr = err
+					readFailures++
 					continue
 				}
 				addr = host.VmdAddr

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -864,3 +864,76 @@ func TestMarkVerifiedSupersedesColdLookupThatReadTheOldAddress(t *testing.T) {
 		t.Fatalf("settled address = %q, want the newer .2", settled)
 	}
 }
+
+// Concurrent verifications that all report the same, unchanged address must
+// coalesce: a cold lookup has two attempts, and if every report superseded
+// it the lookup would fail with a spurious address flap on a healthy host.
+func TestConcurrentSameAddressVerificationsDoNotStarveColdLookup(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dialStarted := make(chan struct{})
+	dialRelease := make(chan struct{})
+	var once sync.Once
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		once.Do(func() {
+			close(dialStarted)
+			<-dialRelease // hold the first dial open while the reports land
+		})
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	<-dialStarted
+
+	var verified sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		verified.Add(1)
+		go func() {
+			defer verified.Done()
+			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+		}()
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for { // the first report supersedes the lookup; the others must not
+		r.mu.RLock()
+		gen := r.gens["host-a"]
+		r.mu.RUnlock()
+		if gen > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no report superseded the in-flight lookup")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	for i := 0; i < 100; i++ {
+		runtime.Gosched() // let the remaining reports reach their (no-op) check
+	}
+	close(dialRelease)
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v (equivalent reports must not exhaust the lookup)", err)
+	}
+	verified.Wait()
+	r.mu.RLock()
+	gen, settled := r.gens["host-a"], r.clients["host-a"].addr
+	r.mu.RUnlock()
+	if gen != 1 {
+		t.Fatalf("generation bumps = %d, want exactly 1 for three reports of one address", gen)
+	}
+	if settled != "10.0.0.1:50051" {
+		t.Fatalf("settled address = %q", settled)
+	}
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("post-settle ClientFor: %v", err)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -700,3 +700,55 @@ func TestObserveRecordsPerResolutionNotPerWaiter(t *testing.T) {
 		t.Fatalf("sample = %+v, want cold/success (the canceled waiter must not record an error)", samples[0])
 	}
 }
+
+// A caller that has just read the host row hands the address to the
+// registry: a cached client at that address has its lease renewed without a
+// row read of its own, so the dispatch that follows never blocks on one.
+func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var dials atomic.Int64
+	dial := func(_, _ string, _ func()) (vmdclient.Client, error) {
+		dials.Add(1)
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // cold: read + dial
+		t.Fatalf("prime: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond) // lease due; ClientFor alone would read again
+
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor after MarkVerified: %v", err)
+	}
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1 (MarkVerified must renew the lease without a read)", n)
+	}
+	if dials.Load() != 1 {
+		t.Fatalf("dials = %d, want 1", dials.Load())
+	}
+}
+
+// With no client yet, MarkVerified resolves up front (one read, one dial) so
+// the first dispatch on a fresh process finds a verified client waiting.
+func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var dials atomic.Int64
+	dial := func(_, _ string, _ func()) (vmdclient.Client, error) {
+		dials.Add(1)
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1", n)
+	}
+	if dials.Load() != 1 {
+		t.Fatalf("dials = %d, want 1", dials.Load())
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -718,7 +718,7 @@ func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
 	}
 	time.Sleep(2 * time.Millisecond) // lease due; ClientFor alone would read again
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after MarkVerified: %v", err)
 	}
@@ -741,7 +741,7 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	}
 	r := New(db.New(store), dial)
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor: %v", err)
 	}
@@ -764,7 +764,7 @@ func TestMarkVerifiedMovedAddressFailsClosedWhenReadFails(t *testing.T) {
 	}
 
 	store.setFailRead(true)
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", time.Now())
 	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
 		t.Fatal("ClientFor served the client at the old address after the row reported a move")
 	}
@@ -785,7 +785,7 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 	}
 
 	store.setAddr("10.0.0.2:50051")
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", time.Now())
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after move: %v", err)
 	}
@@ -798,10 +798,10 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 }
 
 // A cold lookup that read the row before the host moved must not publish
-// that older address over a verification that observed the move while the
-// lookup was still dialing: MarkVerified supersedes it even with no client
-// cached, so the lookup re-reads and the newest address is what settles.
-func TestMarkVerifiedSupersedesColdLookupThatReadTheOldAddress(t *testing.T) {
+// that older address over a report that observed the move while the lookup
+// was still dialing: the newer report contradicts what the lookup read, so
+// the lookup re-reads and the newest address is what settles.
+func TestMarkVerifiedNewerReportSupersedesColdLookup(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
 	var mu sync.Mutex
 	var dialed []string
@@ -826,25 +826,14 @@ func TestMarkVerifiedSupersedesColdLookupThatReadTheOldAddress(t *testing.T) {
 	}()
 	<-dialStarted // the lookup read .1 and is dialing it
 	store.setAddr("10.0.0.2:50051")
+	reportAt := time.Now() // began after the lookup's read: it is the newer observation
 
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", reportAt) // joins the lookup in flight
 		close(verified)
 	}()
-	deadline := time.Now().Add(2 * time.Second)
-	for { // MarkVerified bumps the generation before it joins; wait for that
-		r.mu.RLock()
-		gen := r.gens["host-a"]
-		r.mu.RUnlock()
-		if gen > 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("MarkVerified never superseded the in-flight lookup")
-		}
-		time.Sleep(time.Millisecond)
-	}
+	waitForLatest(t, r, "host-a", "10.0.0.2:50051")
 	close(dialRelease)
 
 	if err := <-lookup; err != nil {
@@ -857,28 +846,22 @@ func TestMarkVerifiedSupersedesColdLookupThatReadTheOldAddress(t *testing.T) {
 	if len(got) != 2 || got[0] != "10.0.0.1:50051" || got[1] != "10.0.0.2:50051" {
 		t.Fatalf("dial sequence = %v, want [.1 discarded, .2 published]", got)
 	}
-	r.mu.RLock()
-	settled := r.clients["host-a"].addr
-	r.mu.RUnlock()
-	if settled != "10.0.0.2:50051" {
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
 		t.Fatalf("settled address = %q, want the newer .2", settled)
 	}
 }
 
-// Concurrent verifications that all report the same, unchanged address must
-// coalesce: a cold lookup has two attempts, and if every report superseded
-// it the lookup would fail with a spurious address flap on a healthy host.
-func TestConcurrentSameAddressVerificationsDoNotStarveColdLookup(t *testing.T) {
+// Concurrent reports of the same, unchanged address must cost a cold lookup
+// nothing: equal addresses never conflict, so the lookup publishes on its
+// first attempt and the registry never re-reads or re-dials for them.
+func TestConcurrentSameAddressReportsDoNotDisturbColdLookup(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
-	var mu sync.Mutex
-	var dialed []string
+	var dials atomic.Int64
 	dialStarted := make(chan struct{})
 	dialRelease := make(chan struct{})
 	var once sync.Once
 	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
-		mu.Lock()
-		dialed = append(dialed, addr)
-		mu.Unlock()
+		dials.Add(1)
 		once.Do(func() {
 			close(dialStarted)
 			<-dialRelease // hold the first dial open while the reports land
@@ -899,41 +882,175 @@ func TestConcurrentSameAddressVerificationsDoNotStarveColdLookup(t *testing.T) {
 		verified.Add(1)
 		go func() {
 			defer verified.Done()
-			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
 		}()
 	}
-	deadline := time.Now().Add(2 * time.Second)
-	for { // the first report supersedes the lookup; the others must not
-		r.mu.RLock()
-		gen := r.gens["host-a"]
-		r.mu.RUnlock()
-		if gen > 0 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("no report superseded the in-flight lookup")
-		}
-		time.Sleep(time.Millisecond)
-	}
 	for i := 0; i < 100; i++ {
-		runtime.Gosched() // let the remaining reports reach their (no-op) check
+		runtime.Gosched() // let the reports reach the registry before the dial returns
 	}
 	close(dialRelease)
 
 	if err := <-lookup; err != nil {
-		t.Fatalf("ClientFor: %v (equivalent reports must not exhaust the lookup)", err)
+		t.Fatalf("ClientFor: %v (equivalent reports must not disturb the lookup)", err)
 	}
 	verified.Wait()
-	r.mu.RLock()
-	gen, settled := r.gens["host-a"], r.clients["host-a"].addr
-	r.mu.RUnlock()
-	if gen != 1 {
-		t.Fatalf("generation bumps = %d, want exactly 1 for three reports of one address", gen)
+	if n := dials.Load(); n != 1 {
+		t.Fatalf("dials = %d, want 1 (no report contradicted the lookup's read)", n)
 	}
-	if settled != "10.0.0.1:50051" {
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1", n)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.1:50051" {
 		t.Fatalf("settled address = %q", settled)
 	}
-	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
-		t.Fatalf("post-settle ClientFor: %v", err)
+}
+
+// An address the registry has held before is not an already-handled report:
+// the cached client moved to .2 through an ordinary refresh, an older lookup
+// has read .2 and not yet acted on it, and a newer read reports the host
+// back at .1. The report must win, whatever the registry has seen
+// historically: the older lookup re-reads instead of publishing .2 again.
+func TestMarkVerifiedReusedAddressStillSupersedesOlderLookup(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // .1
+		t.Fatalf("prime: %v", err)
+	}
+	store.setAddr("10.0.0.2:50051")
+	time.Sleep(2 * time.Millisecond)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // refresh adopts .2
+		t.Fatalf("refresh: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("after refresh settled = %q, want .2", settled)
+	}
+
+	// Lease due again: the next lookup reads .2 and is held inside that read
+	// (the store captured .2 before it blocked), so it has not acted on it.
+	time.Sleep(2 * time.Millisecond)
+	gate := make(chan struct{})
+	store.setGate(gate)
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatal("older lookup never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	store.setAddr("10.0.0.1:50051") // the host returns to .1 while that read is held
+	reportAt := time.Now()
+	verified := make(chan struct{})
+	go func() {
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", reportAt)
+		close(verified)
+	}()
+	waitForLatest(t, r, "host-a", "10.0.0.1:50051")
+	store.setGate(nil)
+	close(gate) // the older read returns .2, which is now contradicted
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	<-verified
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.1:50051" {
+		t.Fatalf("settled address = %q, want the newer .1 (an older lookup of .2 must not win)", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 3 || got[2] != "10.0.0.1:50051" {
+		t.Fatalf("dial sequence = %v, want [.1, .2, .1 re-read and published]", got)
+	}
+}
+
+// The renew-in-place shortcut is not exempt: the cached client is at .1, an
+// older lookup read the host at .2 and is dialing, and a newer read reports
+// .1 again. Renewing .1 is right, but the older lookup must not then publish
+// .2 over it.
+func TestMarkVerifiedSameAddressStillSupersedesOlderConflictingLookup(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dialStarted := make(chan struct{})
+	dialRelease := make(chan struct{})
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		if addr == "10.0.0.2:50051" {
+			close(dialStarted)
+			<-dialRelease
+		}
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // .1
+		t.Fatalf("prime: %v", err)
+	}
+	store.setAddr("10.0.0.2:50051")
+	time.Sleep(2 * time.Millisecond)
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a") // reads .2, dials it
+		lookup <- err
+	}()
+	<-dialStarted
+	store.setAddr("10.0.0.1:50051")
+	reportAt := time.Now()
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", reportAt) // matches the cached client: renews
+	close(dialRelease)
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.1:50051" {
+		t.Fatalf("settled address = %q, want .1 (the older .2 lookup must re-read, not publish)", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	// The re-read finds .1 already cached and renews it: no third dial.
+	if len(got) != 2 || got[1] != "10.0.0.2:50051" {
+		t.Fatalf("dial sequence = %v, want [.1, .2 discarded]", got)
+	}
+}
+
+func settledAddr(r *Registry, hostID string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.clients[hostID].addr
+}
+
+// waitForLatest blocks until the registry's newest observation of hostID is
+// addr, i.e. the report under test has been recorded.
+func waitForLatest(t *testing.T, r *Registry, hostID, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		r.mu.RLock()
+		got := r.latest[hostID].addr
+		r.mu.RUnlock()
+		if got == addr {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("report of %s never recorded (latest is %q)", addr, got)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -796,3 +796,71 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 		t.Fatalf("reads = %d, want 2 (prime + the move's re-resolution)", n)
 	}
 }
+
+// A cold lookup that read the row before the host moved must not publish
+// that older address over a verification that observed the move while the
+// lookup was still dialing: MarkVerified supersedes it even with no client
+// cached, so the lookup re-reads and the newest address is what settles.
+func TestMarkVerifiedSupersedesColdLookupThatReadTheOldAddress(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dialStarted := make(chan struct{})
+	dialRelease := make(chan struct{})
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		if addr == "10.0.0.1:50051" {
+			close(dialStarted)
+			<-dialRelease // hold the cold dial open while the move is observed
+		}
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	<-dialStarted // the lookup read .1 and is dialing it
+	store.setAddr("10.0.0.2:50051")
+
+	verified := make(chan struct{})
+	go func() {
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
+		close(verified)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for { // MarkVerified bumps the generation before it joins; wait for that
+		r.mu.RLock()
+		gen := r.gens["host-a"]
+		r.mu.RUnlock()
+		if gen > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("MarkVerified never superseded the in-flight lookup")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(dialRelease)
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	<-verified
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 2 || got[0] != "10.0.0.1:50051" || got[1] != "10.0.0.2:50051" {
+		t.Fatalf("dial sequence = %v, want [.1 discarded, .2 published]", got)
+	}
+	r.mu.RLock()
+	settled := r.clients["host-a"].addr
+	r.mu.RUnlock()
+	if settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want the newer .2", settled)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -752,3 +752,47 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 		t.Fatalf("dials = %d, want 1", dials.Load())
 	}
 }
+
+// The row just reported a new address: the client at the old one must not
+// survive as a within-lease fallback when the re-resolution's read fails.
+func TestMarkVerifiedMovedAddressFailsClosedWhenReadFails(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	dial := func(_, _ string, _ func()) (vmdclient.Client, error) { return nil, nil }
+	r := New(db.New(store), dial)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	store.setFailRead(true)
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
+		t.Fatal("ClientFor served the client at the old address after the row reported a move")
+	}
+}
+
+// A moved address re-resolves: one read, one fresh dial, and the next
+// dispatch goes to the new machine without a further read.
+func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		dialed = append(dialed, addr)
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	store.setAddr("10.0.0.2:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor after move: %v", err)
+	}
+	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
+		t.Fatalf("dialed = %v, want %v", dialed, want)
+	}
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads = %d, want 2 (prime + the move's re-resolution)", n)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -738,8 +738,8 @@ func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
 	}
 }
 
-// With no client yet, MarkVerified resolves up front (one read, one dial) so
-// the first dispatch on a fresh process finds a verified client waiting.
+// With no client yet, MarkVerified dials the reported address up front — no
+// row read of its own — so the first dispatch finds a verified client.
 func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
 	var dials atomic.Int64
@@ -753,19 +753,24 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor: %v", err)
 	}
-	if n := store.readCount(); n != 1 {
-		t.Fatalf("reads = %d, want 1", n)
+	if n := store.readCount(); n != 0 {
+		t.Fatalf("reads = %d, want 0 (the caller's read is the verification)", n)
 	}
 	if dials.Load() != 1 {
 		t.Fatalf("dials = %d, want 1", dials.Load())
 	}
 }
 
-// The row just reported a new address: the client at the old one must not
-// survive as a within-lease fallback when the re-resolution's read fails.
-func TestMarkVerifiedMovedAddressFailsClosedWhenReadFails(t *testing.T) {
+// The row just reported a new address: the client at the old one is dropped
+// and the new address is dialed from the report itself, so even with the
+// row unreadable the next dispatch goes to the new machine, never the old.
+func TestMarkVerifiedMovedAddressDialsReportWithoutRead(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
-	dial := func(_, _ string, _ func()) (vmdclient.Client, error) { return nil, nil }
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		dialed = append(dialed, addr)
+		return nil, nil
+	}
 	r := New(db.New(store), dial)
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("prime: %v", err)
@@ -773,8 +778,17 @@ func TestMarkVerifiedMovedAddressFailsClosedWhenReadFails(t *testing.T) {
 
 	store.setFailRead(true)
 	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
-	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
-		t.Fatal("ClientFor served the client at the old address after the row reported a move")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor after move: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want the reported .2", settled)
+	}
+	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
+		t.Fatalf("dialed = %v, want %v", dialed, want)
+	}
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1 (prime only)", n)
 	}
 }
 
@@ -800,8 +814,8 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
 		t.Fatalf("dialed = %v, want %v", dialed, want)
 	}
-	if n := store.readCount(); n != 2 {
-		t.Fatalf("reads = %d, want 2 (prime + the move's re-resolution)", n)
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1 (prime only; the move is dialed from the report)", n)
 	}
 }
 

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -1422,3 +1422,17 @@ func TestSequentialConflictingReportsAreConfirmedByARead(t *testing.T) {
 		t.Fatalf("ClientFor: %v", err)
 	}
 }
+
+// An ordinary resolution against a failing row read costs two reads and no
+// more; the third attempt exists for a seeded dial or a conflict re-read.
+func TestOrdinaryLookupFailureUsesTwoReads(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051", failRead: true}
+	dial := func(_, _ string, _ func()) (vmdclient.Client, error) { return nil, nil }
+	r := New(db.New(store), dial)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
+		t.Fatal("ClientFor succeeded against a failing row read")
+	}
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads = %d, want 2", n)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -1041,14 +1041,14 @@ func settledAddr(r *Registry, hostID string) string {
 	return r.clients[hostID].addr
 }
 
-// waitForObserved blocks until the registry's last observation of hostID is
+// waitForObserved blocks until the registry's last report for hostID is
 // addr, i.e. the report under test has been recorded.
 func waitForObserved(t *testing.T, r *Registry, hostID, addr string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		r.mu.RLock()
-		got := r.observed[hostID]
+		got := r.reported[hostID]
 		r.mu.RUnlock()
 		if got == addr {
 			return
@@ -1114,11 +1114,123 @@ func TestDelayedLookupThatReadsTheNewerAddressIsKept(t *testing.T) {
 	if len(got) != 2 || got[1] != "10.0.0.2:50051" {
 		t.Fatalf("dial sequence = %v, want [.1, .2]", got)
 	}
-	// And the next dispatch goes to .2 without another read.
+	// The report landed inside the read's window and disagreed with what the
+	// read returned, so the resolution read once more before publishing:
+	// prime, the delayed read, and that confirming read. The next dispatch
+	// then goes to .2 with no further read.
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("post-settle ClientFor: %v", err)
 	}
-	if n := store.readCount(); n != 2 {
-		t.Fatalf("reads = %d, want 2", n)
+	if n := store.readCount(); n != 3 {
+		t.Fatalf("reads = %d, want 3 (prime, delayed read, confirming re-read)", n)
+	}
+}
+
+// A report that arrives while a cold read is in flight is ambiguous: the
+// read may have captured an older snapshot. The registry must not publish
+// what the read saw when the report disagrees with it; it reads again, and
+// the address the read discarded is never dialed.
+func TestReportDuringColdReadForcesReRead(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	gate := make(chan struct{})
+	store.setGate(gate) // the read captures .1 and is held before it returns
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("cold lookup never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	store.setAddr("10.0.0.2:50051")
+	verified := make(chan struct{})
+	go func() {
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
+		close(verified)
+	}()
+	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
+	store.setGate(nil)
+	close(gate) // the held read now returns the stale .1
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	<-verified
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want .2", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "10.0.0.2:50051" {
+		t.Fatalf("dialed = %v, want only .2 (the stale read must not be dialed)", got)
+	}
+}
+
+// The renew-in-place path is not exempt from that window: the cached client
+// is at .1, a due read has captured .2 and is held, the host returns to .1,
+// and a report of .1 arrives. The read must not publish .2 over the
+// verified .1; it re-reads and lands on .1 with no new dial.
+func TestReportDuringReadAfterAddressReturns(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // .1
+		t.Fatalf("prime: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond) // lease due
+	store.setAddr("10.0.0.2:50051")
+	gate := make(chan struct{})
+	store.setGate(gate) // the recheck captures .2 and is held before it returns
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("recheck never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	store.setAddr("10.0.0.1:50051")                                  // the host returns to .1
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // matches the cached client: renews
+	store.setGate(nil)
+	close(gate) // the held read now returns .2
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.1:50051" {
+		t.Fatalf("settled address = %q, want the verified .1", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 1 {
+		t.Fatalf("dialed = %v, want only the priming dial (.2 must never be dialed)", got)
 	}
 }

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -1471,3 +1471,18 @@ func TestMarkVerifiedFromBeforeInvalidateIsDiscarded(t *testing.T) {
 		t.Fatalf("dialed = %v, want %v (the stale .1 must not be dialed again)", dialed, want)
 	}
 }
+
+// A cold host whose row cannot be read fails MarkVerified with the
+// resolution's own read budget, and the error is returned so the caller
+// does not run the same resolution again at dispatch.
+func TestMarkVerifiedColdFailureIsReturned(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051", failRead: true}
+	r := New(db.New(store), func(_, _ string, _ func()) (vmdclient.Client, error) { return nil, nil })
+
+	if err := r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")); err == nil {
+		t.Fatal("MarkVerified returned nil for an unreadable row")
+	}
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads = %d, want 2 (one resolution's failure budget)", n)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -726,7 +726,7 @@ func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
 	}
 	time.Sleep(2 * time.Millisecond) // lease due; ClientFor alone would read again
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a"))
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after MarkVerified: %v", err)
 	}
@@ -749,7 +749,7 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	}
 	r := New(db.New(store), dial)
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a"))
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor: %v", err)
 	}
@@ -779,7 +779,7 @@ func TestMarkVerifiedMovedAddressReadsBeforeDialing(t *testing.T) {
 	}
 
 	store.setFailRead(true)
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a"))
 	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
 		t.Fatal("ClientFor dispatched while the moved address was unconfirmed and unreadable")
 	}
@@ -812,7 +812,7 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 	}
 
 	store.setAddr("10.0.0.2:50051")
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a"))
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after move: %v", err)
 	}
@@ -856,7 +856,7 @@ func TestMarkVerifiedNewerReportSupersedesColdLookup(t *testing.T) {
 
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // joins the lookup in flight
 		close(verified)
 	}()
 	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
@@ -908,7 +908,7 @@ func TestConcurrentSameAddressReportsDoNotDisturbColdLookup(t *testing.T) {
 		verified.Add(1)
 		go func() {
 			defer verified.Done()
-			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a"))
 		}()
 	}
 	for i := 0; i < 100; i++ {
@@ -980,7 +980,7 @@ func TestMarkVerifiedReusedAddressStillSupersedesOlderLookup(t *testing.T) {
 	store.setAddr("10.0.0.1:50051") // the host returns to .1 while that read is held
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a"))
 		close(verified)
 	}()
 	waitForObserved(t, r, "host-a", "10.0.0.1:50051")
@@ -1036,7 +1036,7 @@ func TestMarkVerifiedSameAddressStillSupersedesOlderConflictingLookup(t *testing
 	}()
 	<-dialStarted
 	store.setAddr("10.0.0.1:50051")
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // matches the cached client: renews
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // matches the cached client: renews
 	close(dialRelease)
 
 	if err := <-lookup; err != nil {
@@ -1117,8 +1117,8 @@ func TestDelayedLookupThatReadsTheNewerAddressIsKept(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // executed first: still .1
-	store.setAddr("10.0.0.2:50051")                                  // the host moves
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // executed first: still .1
+	store.setAddr("10.0.0.2:50051")                                                          // the host moves
 	store.setDelay(nil)
 	close(delay) // the delayed read now executes and sees .2
 
@@ -1179,7 +1179,7 @@ func TestReportDuringColdReadForcesReRead(t *testing.T) {
 	store.setAddr("10.0.0.2:50051")
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // joins the lookup in flight
 		close(verified)
 	}()
 	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
@@ -1236,8 +1236,8 @@ func TestReportDuringReadAfterAddressReturns(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 	}
-	store.setAddr("10.0.0.1:50051")                                  // the host returns to .1
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // matches the cached client: renews
+	store.setAddr("10.0.0.1:50051")                                                          // the host returns to .1
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // matches the cached client: renews
 	store.setGate(nil)
 	close(gate) // the held read now returns .2
 
@@ -1294,8 +1294,8 @@ func TestConflictDropsCachedClientSoFailedConfirmationFailsClosed(t *testing.T) 
 		}
 		time.Sleep(time.Millisecond)
 	}
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // renews .1
-	store.setFailRead(true)                                          // the confirming re-read will fail
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // renews .1
+	store.setFailRead(true)                                                                  // the confirming re-read will fail
 	store.setGate(nil)
 	close(gate) // the held read returns .2: a conflict
 
@@ -1357,12 +1357,12 @@ func TestConflictingReportsDoNotHideEachOther(t *testing.T) {
 	reports.Add(2)
 	go func() {
 		defer reports.Done()
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // current
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // current
 	}()
 	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
 	go func() {
 		defer reports.Done()
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale, delivered late
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // stale, delivered late
 	}()
 	waitForObserved(t, r, "host-a", "10.0.0.1:50051")
 	store.setGate(nil)
@@ -1398,18 +1398,18 @@ func TestSequentialConflictingReportsAreConfirmedByARead(t *testing.T) {
 	}
 	r := New(db.New(store), dial)
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // cold: dialed from the report
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // cold: dialed from the report
 	if n := store.readCount(); n != 0 {
 		t.Fatalf("reads after the cold report = %d, want 0", n)
 	}
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale, out of order
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // stale, out of order
 	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
 		t.Fatalf("after the stale report settled = %q, want .2 confirmed by the row", settled)
 	}
 	if n := store.readCount(); n != 1 {
 		t.Fatalf("reads after the stale report = %d, want 1 (the confirmation)", n)
 	}
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale again
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // stale again
 	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
 		t.Fatalf("after the second stale report settled = %q, want .2", settled)
 	}
@@ -1434,5 +1434,39 @@ func TestOrdinaryLookupFailureUsesTwoReads(t *testing.T) {
 	}
 	if n := store.readCount(); n != 2 {
 		t.Fatalf("reads = %d, want 2", n)
+	}
+}
+
+// A report from before an invalidation is stale by construction: the
+// reclaim that bumped the generation is newer than whatever it read. The
+// caller captured the generation before its read, so the registry discards
+// the report and the next dispatch resolves from the row.
+func TestMarkVerifiedFromBeforeInvalidateIsDiscarded(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		dialed = append(dialed, addr)
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	gen := r.Generation("host-a") // captured before a read that saw .1
+	store.setAddr("10.0.0.2:50051")
+	r.Invalidate("host-a")                                                // the reclaim to .2 commits
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", gen) // that read, delivered late
+	if _, ok := func() (entry, bool) { r.mu.RLock(); defer r.mu.RUnlock(); e, ok := r.clients["host-a"]; return e, ok }(); ok {
+		t.Fatal("a report from before the invalidation repopulated the client")
+	}
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want .2 from the row", settled)
+	}
+	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
+		t.Fatalf("dialed = %v, want %v (the stale .1 must not be dialed again)", dialed, want)
 	}
 }

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -738,8 +738,9 @@ func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
 	}
 }
 
-// With no client yet, MarkVerified dials the reported address up front — no
-// row read of its own — so the first dispatch finds a verified client.
+// With no client yet, MarkVerified resolves up front — one row read, since a
+// reported address is never dialed unread — so the first dispatch finds a
+// verified client without reading again.
 func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
 	var dials atomic.Int64
@@ -753,8 +754,8 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor: %v", err)
 	}
-	if n := store.readCount(); n != 0 {
-		t.Fatalf("reads = %d, want 0 (the caller's read is the verification)", n)
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads = %d, want 1 (the registry's own read; the report is not dialed unread)", n)
 	}
 	if dials.Load() != 1 {
 		t.Fatalf("dials = %d, want 1", dials.Load())
@@ -820,7 +821,7 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 		t.Fatalf("dialed = %v, want %v", dialed, want)
 	}
 	if n := store.readCount(); n != 2 {
-		t.Fatalf("reads = %d, want 2 (prime, and the move confirmed by a read)", n)
+		t.Fatalf("reads = %d, want 2 (prime, and the move read before dialing)", n)
 	}
 }
 
@@ -1398,16 +1399,16 @@ func TestSequentialConflictingReportsAreConfirmedByARead(t *testing.T) {
 	}
 	r := New(db.New(store), dial)
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // cold: dialed from the report
-	if n := store.readCount(); n != 0 {
-		t.Fatalf("reads after the cold report = %d, want 0", n)
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", r.Generation("host-a")) // cold: read, then dialed
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads after the cold report = %d, want 1", n)
 	}
 	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // stale, out of order
 	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
 		t.Fatalf("after the stale report settled = %q, want .2 confirmed by the row", settled)
 	}
-	if n := store.readCount(); n != 1 {
-		t.Fatalf("reads after the stale report = %d, want 1 (the confirmation)", n)
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads after the stale report = %d, want 2 (the confirmation)", n)
 	}
 	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", r.Generation("host-a")) // stale again
 	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -1029,9 +1029,10 @@ func TestMarkVerifiedSameAddressStillSupersedesOlderConflictingLookup(t *testing
 	mu.Lock()
 	got := append([]string(nil), dialed...)
 	mu.Unlock()
-	// The re-read finds .1 already cached and renews it: no third dial.
-	if len(got) != 2 || got[1] != "10.0.0.2:50051" {
-		t.Fatalf("dial sequence = %v, want [.1, .2 discarded]", got)
+	// The conflict dropped the cached .1 (it was in doubt), so the confirming
+	// re-read dials .1 afresh rather than renewing it: .2 is never published.
+	if len(got) != 3 || got[1] != "10.0.0.2:50051" || got[2] != "10.0.0.1:50051" {
+		t.Fatalf("dial sequence = %v, want [.1, .2 discarded, .1 re-dialed after confirmation]", got)
 	}
 }
 
@@ -1230,7 +1231,73 @@ func TestReportDuringReadAfterAddressReturns(t *testing.T) {
 	mu.Lock()
 	got := append([]string(nil), dialed...)
 	mu.Unlock()
-	if len(got) != 1 {
-		t.Fatalf("dialed = %v, want only the priming dial (.2 must never be dialed)", got)
+	// The conflict dropped the cached .1 (in doubt until confirmed), so the
+	// re-read dials .1 again; .2 is never dialed.
+	if len(got) != 2 || got[1] != "10.0.0.1:50051" {
+		t.Fatalf("dialed = %v, want [.1, .1 re-dialed after confirmation] and never .2", got)
+	}
+}
+
+// A conflict must not leave the doubted client behind as a fallback. The
+// cached client is at .1, a due read captures .2 and is held, a report of .1
+// renews the client, the held read returns .2 — a conflict — and the
+// confirming re-read then fails. Nothing may dispatch through .1: not this
+// resolution via its within-lease fallback, and not a concurrent request.
+// Once reads work again the registry lands on the row's answer.
+func TestConflictDropsCachedClientSoFailedConfirmationFailsClosed(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // .1
+		t.Fatalf("prime: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond) // lease due
+	store.setAddr("10.0.0.2:50051")
+	gate := make(chan struct{})
+	store.setGate(gate) // the recheck captures .2 and is held
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("recheck never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // renews .1
+	store.setFailRead(true)                                          // the confirming re-read will fail
+	store.setGate(nil)
+	close(gate) // the held read returns .2: a conflict
+
+	if err := <-lookup; err == nil {
+		t.Fatal("resolution returned a client after its confirming read failed; want fail closed")
+	}
+	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
+		t.Fatal("a concurrent ClientFor was served the doubted client; want fail closed")
+	}
+	mu.Lock()
+	n := len(dialed)
+	mu.Unlock()
+	if n != 1 {
+		t.Fatalf("dials = %d, want only the priming dial while the address is in doubt", n)
+	}
+
+	store.setFailRead(false)
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor once reads work: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want .2 (the row's answer)", settled)
 	}
 }

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -23,7 +23,8 @@ type hostDB struct {
 	mu       sync.Mutex
 	addr     string
 	failRead bool
-	gate     chan struct{} // non-nil: QueryRow waits until closed
+	gate     chan struct{} // non-nil: QueryRow waits until closed (after capturing the address)
+	delay    chan struct{} // non-nil: QueryRow waits until closed BEFORE capturing the address
 	reads    atomic.Int64
 }
 
@@ -33,7 +34,8 @@ func (h *hostDB) setFailRead(v bool) {
 	h.failRead = v
 	h.mu.Unlock()
 }
-func (h *hostDB) setGate(c chan struct{}) { h.mu.Lock(); h.gate = c; h.mu.Unlock() }
+func (h *hostDB) setGate(c chan struct{})  { h.mu.Lock(); h.gate = c; h.mu.Unlock() }
+func (h *hostDB) setDelay(c chan struct{}) { h.mu.Lock(); h.delay = c; h.mu.Unlock() }
 
 type errRow struct{ err error }
 
@@ -49,6 +51,12 @@ func (h *hostDB) Query(context.Context, string, ...any) (pgx.Rows, error) {
 }
 func (h *hostDB) QueryRow(_ context.Context, _ string, args ...any) pgx.Row {
 	h.reads.Add(1)
+	h.mu.Lock()
+	delay := h.delay
+	h.mu.Unlock()
+	if delay != nil {
+		<-delay // a query that started early but executes late
+	}
 	h.mu.Lock()
 	addr, fail, gate := h.addr, h.failRead, h.gate
 	h.mu.Unlock()
@@ -718,7 +726,7 @@ func TestMarkVerifiedRenewsLeaseWithoutRead(t *testing.T) {
 	}
 	time.Sleep(2 * time.Millisecond) // lease due; ClientFor alone would read again
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after MarkVerified: %v", err)
 	}
@@ -741,7 +749,7 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	}
 	r := New(db.New(store), dial)
 
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor: %v", err)
 	}
@@ -764,7 +772,7 @@ func TestMarkVerifiedMovedAddressFailsClosedWhenReadFails(t *testing.T) {
 	}
 
 	store.setFailRead(true)
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", time.Now())
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
 	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
 		t.Fatal("ClientFor served the client at the old address after the row reported a move")
 	}
@@ -785,7 +793,7 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 	}
 
 	store.setAddr("10.0.0.2:50051")
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", time.Now())
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
 		t.Fatalf("ClientFor after move: %v", err)
 	}
@@ -826,14 +834,13 @@ func TestMarkVerifiedNewerReportSupersedesColdLookup(t *testing.T) {
 	}()
 	<-dialStarted // the lookup read .1 and is dialing it
 	store.setAddr("10.0.0.2:50051")
-	reportAt := time.Now() // began after the lookup's read: it is the newer observation
 
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051", reportAt) // joins the lookup in flight
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // joins the lookup in flight
 		close(verified)
 	}()
-	waitForLatest(t, r, "host-a", "10.0.0.2:50051")
+	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
 	close(dialRelease)
 
 	if err := <-lookup; err != nil {
@@ -882,7 +889,7 @@ func TestConcurrentSameAddressReportsDoNotDisturbColdLookup(t *testing.T) {
 		verified.Add(1)
 		go func() {
 			defer verified.Done()
-			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", time.Now())
+			r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
 		}()
 	}
 	for i := 0; i < 100; i++ {
@@ -952,13 +959,12 @@ func TestMarkVerifiedReusedAddressStillSupersedesOlderLookup(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 	store.setAddr("10.0.0.1:50051") // the host returns to .1 while that read is held
-	reportAt := time.Now()
 	verified := make(chan struct{})
 	go func() {
-		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", reportAt)
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051")
 		close(verified)
 	}()
-	waitForLatest(t, r, "host-a", "10.0.0.1:50051")
+	waitForObserved(t, r, "host-a", "10.0.0.1:50051")
 	store.setGate(nil)
 	close(gate) // the older read returns .2, which is now contradicted
 
@@ -1011,8 +1017,7 @@ func TestMarkVerifiedSameAddressStillSupersedesOlderConflictingLookup(t *testing
 	}()
 	<-dialStarted
 	store.setAddr("10.0.0.1:50051")
-	reportAt := time.Now()
-	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051", reportAt) // matches the cached client: renews
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // matches the cached client: renews
 	close(dialRelease)
 
 	if err := <-lookup; err != nil {
@@ -1036,14 +1041,14 @@ func settledAddr(r *Registry, hostID string) string {
 	return r.clients[hostID].addr
 }
 
-// waitForLatest blocks until the registry's newest observation of hostID is
+// waitForObserved blocks until the registry's last observation of hostID is
 // addr, i.e. the report under test has been recorded.
-func waitForLatest(t *testing.T, r *Registry, hostID, addr string) {
+func waitForObserved(t *testing.T, r *Registry, hostID, addr string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		r.mu.RLock()
-		got := r.latest[hostID].addr
+		got := r.observed[hostID]
 		r.mu.RUnlock()
 		if got == addr {
 			return
@@ -1052,5 +1057,68 @@ func waitForLatest(t *testing.T, r *Registry, hostID, addr string) {
 			t.Fatalf("report of %s never recorded (latest is %q)", addr, got)
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+// Start time says nothing about snapshot order: a row read that started
+// first can execute last. Here the registry's due recheck is delayed before
+// it reads, a capability read executed in the meantime reports the old
+// address, the host moves, and the delayed read then sees the NEW address.
+// That read is the newer snapshot and must be kept — nothing may discard it
+// on the grounds that another read "started later".
+func TestDelayedLookupThatReadsTheNewerAddressIsKept(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+	r.recheck = time.Millisecond
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil { // .1
+		t.Fatalf("prime: %v", err)
+	}
+	time.Sleep(2 * time.Millisecond) // lease due: the next ClientFor re-reads
+
+	delay := make(chan struct{})
+	store.setDelay(delay)
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 2 { // the recheck has started its read and is held before it
+		if time.Now().After(deadline) {
+			t.Fatal("recheck never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // executed first: still .1
+	store.setAddr("10.0.0.2:50051")                                  // the host moves
+	store.setDelay(nil)
+	close(delay) // the delayed read now executes and sees .2
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want .2 (the later-executed read is the newer snapshot)", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 2 || got[1] != "10.0.0.2:50051" {
+		t.Fatalf("dial sequence = %v, want [.1, .2]", got)
+	}
+	// And the next dispatch goes to .2 without another read.
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("post-settle ClientFor: %v", err)
+	}
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads = %d, want 2", n)
 	}
 }

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -1301,3 +1301,65 @@ func TestConflictDropsCachedClientSoFailedConfirmationFailsClosed(t *testing.T) 
 		t.Fatalf("settled address = %q, want .2 (the row's answer)", settled)
 	}
 }
+
+// Two reports that disagree with each other inside a read's window leave the
+// address in doubt even when the later one happens to echo the read. A cold
+// read captures .1 and is held; the host moves to .2 and a report says so;
+// a stale report of .1 arrives after it; the held read returns .1. The
+// registry must confirm rather than trust the echo, and lands on .2.
+func TestConflictingReportsDoNotHideEachOther(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.1:50051"}
+	var mu sync.Mutex
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		mu.Lock()
+		dialed = append(dialed, addr)
+		mu.Unlock()
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	gate := make(chan struct{})
+	store.setGate(gate) // the cold read captures .1 and is held
+	lookup := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(context.Background(), "host-a")
+		lookup <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.readCount() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("cold lookup never reached its read")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	store.setAddr("10.0.0.2:50051")
+	var reports sync.WaitGroup
+	reports.Add(2)
+	go func() {
+		defer reports.Done()
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // current
+	}()
+	waitForObserved(t, r, "host-a", "10.0.0.2:50051")
+	go func() {
+		defer reports.Done()
+		r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale, delivered late
+	}()
+	waitForObserved(t, r, "host-a", "10.0.0.1:50051")
+	store.setGate(nil)
+	close(gate) // the held read returns .1, matching the stale report
+
+	if err := <-lookup; err != nil {
+		t.Fatalf("ClientFor: %v", err)
+	}
+	reports.Wait()
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("settled address = %q, want .2 (a stale echo must not hide the conflicting report)", settled)
+	}
+	mu.Lock()
+	got := append([]string(nil), dialed...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "10.0.0.2:50051" {
+		t.Fatalf("dialed = %v, want only .2", got)
+	}
+}

--- a/internal/hostreg/registry_test.go
+++ b/internal/hostreg/registry_test.go
@@ -761,10 +761,12 @@ func TestMarkVerifiedColdResolvesOnce(t *testing.T) {
 	}
 }
 
-// The row just reported a new address: the client at the old one is dropped
-// and the new address is dialed from the report itself, so even with the
-// row unreadable the next dispatch goes to the new machine, never the old.
-func TestMarkVerifiedMovedAddressDialsReportWithoutRead(t *testing.T) {
+// A report that disagrees with the cached client is itself in doubt — the
+// cached address came from a read too, and the two cannot be ordered — so
+// the old client is dropped and the row is read before either address is
+// dialed. With the row unreadable, dispatch fails closed; once it reads,
+// the registry lands on the row's answer.
+func TestMarkVerifiedMovedAddressReadsBeforeDialing(t *testing.T) {
 	store := &hostDB{addr: "10.0.0.1:50051"}
 	var dialed []string
 	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
@@ -778,17 +780,20 @@ func TestMarkVerifiedMovedAddressDialsReportWithoutRead(t *testing.T) {
 
 	store.setFailRead(true)
 	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051")
+	if _, err := r.ClientFor(context.Background(), "host-a"); err == nil {
+		t.Fatal("ClientFor dispatched while the moved address was unconfirmed and unreadable")
+	}
+	if len(dialed) != 1 {
+		t.Fatalf("dialed = %v, want only the priming dial until the row confirms", dialed)
+	}
+
+	store.setFailRead(false)
+	store.setAddr("10.0.0.2:50051")
 	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
-		t.Fatalf("ClientFor after move: %v", err)
+		t.Fatalf("ClientFor once readable: %v", err)
 	}
 	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
-		t.Fatalf("settled address = %q, want the reported .2", settled)
-	}
-	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
-		t.Fatalf("dialed = %v, want %v", dialed, want)
-	}
-	if n := store.readCount(); n != 1 {
-		t.Fatalf("reads = %d, want 1 (prime only)", n)
+		t.Fatalf("settled address = %q, want .2", settled)
 	}
 }
 
@@ -814,8 +819,8 @@ func TestMarkVerifiedMovedAddressRedials(t *testing.T) {
 	if want := []string{"10.0.0.1:50051", "10.0.0.2:50051"}; fmt.Sprint(dialed) != fmt.Sprint(want) {
 		t.Fatalf("dialed = %v, want %v", dialed, want)
 	}
-	if n := store.readCount(); n != 1 {
-		t.Fatalf("reads = %d, want 1 (prime only; the move is dialed from the report)", n)
+	if n := store.readCount(); n != 2 {
+		t.Fatalf("reads = %d, want 2 (prime, and the move confirmed by a read)", n)
 	}
 }
 
@@ -1375,5 +1380,45 @@ func TestConflictingReportsDoNotHideEachOther(t *testing.T) {
 	mu.Unlock()
 	if len(got) != 1 || got[0] != "10.0.0.2:50051" {
 		t.Fatalf("dialed = %v, want only .2", got)
+	}
+}
+
+// Reports from unlocked reads can finish out of order across a move: a
+// report of .2 dials .2 cold, then a stale report of .1 arrives. The stale
+// report disagrees with the previous one, so it must not be dialed unread:
+// the row is read, still says .2, and .2 stays. A second stale .1 report
+// disagrees with the cached .2 and is likewise confirmed by a read, never
+// dialed.
+func TestSequentialConflictingReportsAreConfirmedByARead(t *testing.T) {
+	store := &hostDB{addr: "10.0.0.2:50051"}
+	var dialed []string
+	dial := func(_, addr string, _ func()) (vmdclient.Client, error) {
+		dialed = append(dialed, addr)
+		return nil, nil
+	}
+	r := New(db.New(store), dial)
+
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.2:50051") // cold: dialed from the report
+	if n := store.readCount(); n != 0 {
+		t.Fatalf("reads after the cold report = %d, want 0", n)
+	}
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale, out of order
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("after the stale report settled = %q, want .2 confirmed by the row", settled)
+	}
+	if n := store.readCount(); n != 1 {
+		t.Fatalf("reads after the stale report = %d, want 1 (the confirmation)", n)
+	}
+	r.MarkVerified(context.Background(), "host-a", "10.0.0.1:50051") // stale again
+	if settled := settledAddr(r, "host-a"); settled != "10.0.0.2:50051" {
+		t.Fatalf("after the second stale report settled = %q, want .2", settled)
+	}
+	for _, d := range dialed {
+		if d == "10.0.0.1:50051" {
+			t.Fatalf("dialed = %v; the stale address must never be dialed", dialed)
+		}
+	}
+	if _, err := r.ClientFor(context.Background(), "host-a"); err != nil {
+		t.Fatalf("ClientFor: %v", err)
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,11 +25,11 @@ type Scheduler interface {
 const defaultCacheTTL = 30 * time.Second
 
 // hostsFillTimeout bounds every candidate-set fill, blocking and background
-// alike. This is a published contract, not just hygiene: a fill that reads
-// the host set before a drain commits and finishes after it stamps a
-// pre-drain view as fresh, so the drain's total staleness budget is
-// TTL + grace + THIS bound. hostctl's drain convergence window is derived
-// from that sum — widening this widens what --wait must cover.
+// alike. The candidate set is a placement hint served at any age; what keeps
+// a drained or retired host from taking a create is the per-create host
+// pre-flight (status and capabilities read fresh within its own TTL), so
+// this bound is hygiene for the fill itself rather than part of the drain
+// convergence budget.
 const hostsFillTimeout = 5 * time.Second
 
 // LeastLoaded picks the active host with the fewest running sandboxes
@@ -120,17 +120,6 @@ func (s *LeastLoaded) SelectHost(ctx context.Context, requiredCapabilities []str
 	return hosts[b].ID, nil
 }
 
-// hostsStaleGrace bounds how long an expired candidate set keeps being served
-// while refreshes run (or fail) in the background. Host health flows through
-// the DB, and every capability set is keyed independently, so persistent
-// refresh failures degrade to blocking loads instead of serving stale hosts
-// forever.
-const hostsStaleGrace = 30 * time.Second
-
-// loadHosts serves a cached capability-specific candidate set — stale
-// included, up to hostsStaleGrace — and refreshes it in the background once
-// the TTL lapses. The first call for a set, a post-Invalidate call, and any
-// call past the grace window block on a fresh load.
 // fillEntry loads the candidate set and, when it comes back empty, resolves
 // the default host's status in the same fill — one query per cache fill, not
 // one per create. Status changes reach the cache through Invalidate.
@@ -154,6 +143,15 @@ func (s *LeastLoaded) fillEntry(ctx context.Context, normalized []string) (hostC
 	return entry, nil
 }
 
+// loadHosts serves a cached capability-specific candidate set at any age and
+// refreshes it in the background once the TTL lapses. Only the first call for
+// a set and a post-Invalidate call block on a fresh load. A request that
+// finds the set expired never waits for the DB: it serves what it has and
+// the refresh rides along behind it. Serving a stale set is safe because the
+// create path re-reads the chosen host's status and capabilities before
+// dispatch and re-selects after an Invalidate when that read rejects it, so
+// a host that left rotation is at most one bounded pre-flight away from
+// being dropped, however old this cache is.
 func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []string) (hostCacheEntry, error) {
 	key, normalized := capabilityCacheKey(requiredCapabilities)
 	s.mu.RLock()
@@ -161,9 +159,6 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	startGen := s.gen
 	s.mu.RUnlock()
 
-	if cached && time.Since(entry.cachedAt) >= s.ttl()+hostsStaleGrace {
-		cached = false
-	}
 	if cached {
 		if time.Since(entry.cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
 			// Detached: the refresh outlives the triggering request. On error the
@@ -195,15 +190,11 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Double-check: another blocked caller may have reloaded this capability
-	// set while we waited. A past-grace entry is what we are here to replace.
-	if entry, ok := s.cache[key]; ok && time.Since(entry.cachedAt) < s.ttl()+hostsStaleGrace {
+	// Double-check: another blocked caller may have loaded this capability
+	// set while we waited.
+	if entry, ok := s.cache[key]; ok {
 		return entry, nil
 	}
-	// Bound the blocking fill like the background refresh: fill duration
-	// extends how long a pre-drain read of the host set can be stamped as
-	// fresh after the drain commits, so ops tooling (hostctl --wait) can
-	// only budget for it if it has a hard ceiling.
 	fillCtx, fillCancel := context.WithTimeout(ctx, hostsFillTimeout)
 	fresh, err := s.fillEntry(fillCtx, normalized)
 	fillCancel()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -159,6 +159,13 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	startGen := s.gen
 	s.mu.RUnlock()
 
+	// An expired set that cannot place anything is reloaded in line rather
+	// than served: serving it would refuse a create the DB may already be
+	// able to place, and the refresh behind that refusal would only help the
+	// next one.
+	if cached && time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry) {
+		cached = false
+	}
 	if cached {
 		if time.Since(entry.cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
 			// Detached: the refresh outlives the triggering request. On error the
@@ -191,8 +198,8 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Double-check: another blocked caller may have loaded this capability
-	// set while we waited.
-	if entry, ok := s.cache[key]; ok {
+	// set while we waited; an expired unplaceable one is what we replace.
+	if entry, ok := s.cache[key]; ok && !(time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry)) {
 		return entry, nil
 	}
 	fillCtx, fillCancel := context.WithTimeout(ctx, hostsFillTimeout)
@@ -209,6 +216,18 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	}
 	s.cache[key] = fresh
 	return fresh, nil
+}
+
+// cannotPlace reports whether SelectHost would refuse every create from this
+// entry: no candidates, and no default-host fallback that would apply.
+func (s *LeastLoaded) cannotPlace(e hostCacheEntry) bool {
+	if len(e.hosts) > 0 {
+		return false
+	}
+	if s.DefaultHostID == "" {
+		return true
+	}
+	return e.defaultStatus != "missing" && e.defaultStatus != "active"
 }
 
 func capabilityCacheKey(capabilities []string) (string, []string) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -163,7 +163,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 		cached = false
 	}
 	if cached {
-		if _, busy := s.refreshing.LoadOrStore(key, struct{}{}); time.Since(entry.cachedAt) >= s.ttl() && !busy {
+		if time.Since(entry.cachedAt) >= s.ttl() && s.claimRefresh(key) {
 			// Detached: the refresh outlives the triggering request. On error the
 			// stale set stays servable and the next expired call retries.
 			qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
@@ -205,6 +205,12 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	case <-ctx.Done():
 		return hostCacheEntry{}, ctx.Err()
 	}
+}
+
+// claimRefresh reserves the refresh slot for key; false if one is running.
+func (s *LeastLoaded) claimRefresh(key string) bool {
+	_, busy := s.refreshing.LoadOrStore(key, struct{}{})
+	return !busy
 }
 
 // publish caches fresh for key under a new generation, unless it is stale:

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -48,10 +49,12 @@ type LeastLoaded struct {
 	DefaultHostID string        // fallback when no host rows exist
 	TTL           time.Duration // 0 = use defaultCacheTTL
 
-	mu         sync.RWMutex
-	cache      map[string]hostCacheEntry
-	gen        uint64      // bumped by Invalidate and blocking reloads; discards refreshes that started earlier
-	refreshing atomic.Bool // one background refresh at a time across capability sets
+	mu            sync.RWMutex
+	cache         map[string]hostCacheEntry
+	gen           uint64             // stamped on every published set; a Reject carries the set's stamp
+	invalidations uint64             // bumped by Invalidate; a load begun before it is not cached
+	refreshing    atomic.Bool        // one background refresh at a time across capability sets
+	fills         singleflight.Group // one blocking fill per capability set at a time
 }
 
 type hostCacheEntry struct {
@@ -152,7 +155,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	key, normalized := capabilityCacheKey(requiredCapabilities)
 	s.mu.RLock()
 	entry, cached := s.cache[key]
-	startGen := s.gen
+	inv := s.invalidations
 	s.mu.RUnlock()
 
 	// An expired set with nothing to place on is reloaded in line: serving
@@ -174,44 +177,54 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 						Msg("host list refresh failed; serving stale until the grace window expires")
 					return
 				}
-				s.mu.Lock()
-				// Discard results from before the latest Invalidate or blocking
-				// reload so an older query cannot replace a newer candidate set.
-				if s.gen == startGen {
-					if s.cache == nil {
-						s.cache = make(map[string]hostCacheEntry)
-					}
-					fresh.gen = startGen
-					s.cache[key] = fresh
-				}
-				s.mu.Unlock()
+				s.publish(key, fresh, inv)
 			}()
 		}
 		return entry, nil
 	}
 
+	// Blocking load: one fill per capability set at a time, run outside the
+	// mutex, so a slow fill for one set never stalls selects for the others.
+	// The flight publishes on the leader's invalidation snapshot, the most
+	// conservative one; every waiter shares its result.
+	ch := s.fills.DoChan(key, func() (any, error) {
+		fillCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
+		defer cancel()
+		fresh, err := s.fillEntry(fillCtx, normalized)
+		if err != nil {
+			return nil, err
+		}
+		return s.publish(key, fresh, inv), nil
+	})
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return hostCacheEntry{}, res.Err
+		}
+		return res.Val.(hostCacheEntry), nil
+	case <-ctx.Done():
+		return hostCacheEntry{}, ctx.Err()
+	}
+}
+
+// publish caches fresh for key under a new generation, unless an Invalidate
+// landed after the load began (invalidations moved past inv): a set read
+// before an invalidation may be what it invalidated, so it is served to the
+// request that loaded it but not cached. Returns the entry as it should be
+// served, stamped only if cached.
+func (s *LeastLoaded) publish(key string, fresh hostCacheEntry, inv uint64) hostCacheEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Double-check: another blocked caller may have loaded this capability
-	// set while we waited; an expired unplaceable one is what we replace.
-	if entry, ok := s.cache[key]; ok && !(time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry)) {
-		return entry, nil
+	if s.invalidations != inv {
+		return fresh
 	}
-	fillCtx, fillCancel := context.WithTimeout(ctx, hostsFillTimeout)
-	fresh, err := s.fillEntry(fillCtx, normalized)
-	fillCancel()
-	if err != nil {
-		return hostCacheEntry{}, err
-	}
-	// Bump the generation so any older in-flight background refresh cannot
-	// land after this blocking load and replace it with an earlier snapshot.
 	s.gen++
+	fresh.gen = s.gen
 	if s.cache == nil {
 		s.cache = make(map[string]hostCacheEntry)
 	}
-	fresh.gen = s.gen
 	s.cache[key] = fresh
-	return fresh, nil
+	return fresh
 }
 
 // cannotPlace reports whether this entry has no candidates. An empty set is
@@ -247,18 +260,14 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 // evidence, and the host is re-attested from it — so a burst of creates
 // that all drew the same stale host reloads once, not once per create.
 // Other capability sets are untouched, and a default-host fallback is never
-// reloaded for this, see names. Reports whether a set was dropped, i.e.
-// whether the next SelectHost loads fresh.
-func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen uint64) bool {
+// reloaded for this, see names.
+func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen uint64) {
 	key, _ := capabilityCacheKey(requiredCapabilities)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if entry, ok := s.cache[key]; ok && entry.gen == gen && s.names(entry, hostID) {
 		delete(s.cache, key)
-		s.gen++
-		return true
 	}
-	return false
 }
 
 // names reports whether this entry's candidate set lists hostID. The
@@ -276,7 +285,7 @@ func (s *LeastLoaded) names(e hostCacheEntry, hostID string) bool {
 
 func (s *LeastLoaded) Invalidate() {
 	s.mu.Lock()
-	s.gen++
+	s.invalidations++
 	s.cache = nil
 	s.mu.Unlock()
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,10 +25,8 @@ type Scheduler interface {
 
 const defaultCacheTTL = 30 * time.Second
 
-// hostsFillTimeout bounds every candidate-set fill, blocking and background
-// alike. The candidate set is a placement hint; the per-create host
-// pre-flight is what keeps a drained host from taking a create, so this
-// bound is not part of the drain convergence budget.
+// hostsFillTimeout bounds every candidate-set fill. The set is only a
+// placement hint; the per-create pre-flight keeps drained hosts out.
 const hostsFillTimeout = 5 * time.Second
 
 // LeastLoaded picks the active host with the fewest running sandboxes
@@ -146,10 +144,9 @@ func (s *LeastLoaded) fillEntry(ctx context.Context, normalized []string) (hostC
 }
 
 // loadHosts serves the cached candidate set at any age and refreshes it in
-// the background once the TTL lapses; only the first call for a set and a
-// post-Invalidate call block on a load. Serving stale is safe because the
-// create path re-reads the chosen host before dispatch and re-selects after
-// an Invalidate when that read rejects it.
+// the background once the TTL lapses; only a cold set, an expired empty set
+// and a post-Invalidate call block on a load. Stale is safe: the create path
+// re-attests the chosen host and re-selects when that rejects it.
 func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []string) (hostCacheEntry, error) {
 	key, normalized := capabilityCacheKey(requiredCapabilities)
 	s.mu.RLock()
@@ -182,11 +179,9 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 		return entry, nil
 	}
 
-	// Blocking load: one fill per capability set and invalidation epoch at a
-	// time, run outside the mutex, so a slow fill for one set never stalls
-	// selects for the others. The epoch is part of the flight's identity so
-	// a caller arriving after an Invalidate never joins a fill that began
-	// before it and would hand back what that invalidation retired.
+	// Blocking load, one flight per capability set and invalidation epoch,
+	// run outside the mutex so a slow fill never stalls other sets. The epoch
+	// keeps a caller arriving after an Invalidate off an older flight.
 	ch := s.fills.DoChan(fmt.Sprintf("%s\x00%d", key, inv), func() (any, error) {
 		fillCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
 		defer cancel()
@@ -213,13 +208,10 @@ func (s *LeastLoaded) claimRefresh(key string) bool {
 	return !busy
 }
 
-// publish caches fresh for key under a new generation, unless it is stale:
-// an Invalidate landed after the load began (invalidations moved past inv),
-// or, for a background refresh of the set stamped refreshOf, that set is no
-// longer the cached one — a rejection or a blocking fill replaced it with
-// something newer, which an older snapshot must not overwrite. A set that
-// is not cached is still returned, to be served to the request that loaded
-// it. refreshOf is 0 for a blocking fill.
+// publish caches fresh for key under a new generation unless it is stale: an
+// Invalidate landed after the load began, or, for a background refresh of
+// the set stamped refreshOf (0 for a blocking fill), that set has since been
+// replaced. A stale set is still returned to the request that loaded it.
 func (s *LeastLoaded) publish(key string, fresh hostCacheEntry, inv, refreshOf uint64) hostCacheEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -240,11 +232,9 @@ func (s *LeastLoaded) publish(key string, fresh hostCacheEntry, inv, refreshOf u
 	return fresh
 }
 
-// cannotPlace reports whether this entry has no candidates. An empty set is
-// reloaded in line once expired even when the default-host fallback would
-// apply: that fallback is a host the capability-filtered load excluded, the
-// create pre-flight refuses it, and a rejection cannot evict it — so a reload
-// is the only way a host that has since gained the capability gets found.
+// cannotPlace reports whether this entry has no candidates. Such a set is
+// reloaded in line once expired even when the default-host fallback applies:
+// a reload is the only way a host that has since gained the capability is found.
 func (s *LeastLoaded) cannotPlace(e hostCacheEntry) bool {
 	return len(e.hosts) == 0
 }
@@ -268,12 +258,8 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 // SelectHost reflects status or capability changes immediately.
 // Reject drops the cached candidate set for requiredCapabilities if it is
 // still the set (gen) that produced the selection and still lists hostID,
-// because the create pre-flight for that set has just refused the host. A
-// set loaded since is kept even if it lists the host again — it is fresh
-// evidence, and the host is re-attested from it — so a burst of creates
-// that all drew the same stale host reloads once, not once per create.
-// Other capability sets are untouched, and a default-host fallback is never
-// reloaded for this, see names.
+// whose pre-flight has just refused it. A set loaded since is kept, so a
+// burst that all drew the same stale host reloads once, not once per create.
 func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen uint64) {
 	key, _ := capabilityCacheKey(requiredCapabilities)
 	s.mu.Lock()
@@ -283,10 +269,8 @@ func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen u
 	}
 }
 
-// names reports whether this entry's candidate set lists hostID. The
-// default-host fallback (an empty set) deliberately does not count: that
-// host is the one the capability-filtered load already excluded, so a
-// reload cannot change the answer and would only repeat the query.
+// names reports whether this entry lists hostID. The default-host fallback
+// (an empty set) does not count: a reload could not change that answer.
 func (s *LeastLoaded) names(e hostCacheEntry, hostID string) bool {
 	for _, h := range e.hosts {
 		if h.ID == hostID {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -56,6 +56,7 @@ type LeastLoaded struct {
 
 type hostCacheEntry struct {
 	hosts    []db.ListActiveHostsByLoadRow
+	ids      map[string]struct{} // hosts by ID, so Reject checks membership without scanning under the lock
 	cachedAt time.Time
 	gen      uint64 // the generation this set was loaded at; a Reject must carry it
 	// defaultStatus is the DefaultHostID row's status, resolved at fill time
@@ -129,6 +130,12 @@ func (s *LeastLoaded) fillEntry(ctx context.Context, normalized []string) (hostC
 		return hostCacheEntry{}, fmt.Errorf("list active hosts by load: %w", err)
 	}
 	entry := hostCacheEntry{hosts: hosts, cachedAt: time.Now()}
+	if len(hosts) > 0 {
+		entry.ids = make(map[string]struct{}, len(hosts))
+		for _, h := range hosts {
+			entry.ids[h.ID] = struct{}{}
+		}
+	}
 	if len(hosts) == 0 && s.DefaultHostID != "" {
 		host, err := s.DB.GetHost(ctx, s.DefaultHostID)
 		switch {
@@ -272,12 +279,8 @@ func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen u
 // names reports whether this entry lists hostID. The default-host fallback
 // (an empty set) does not count: a reload could not change that answer.
 func (s *LeastLoaded) names(e hostCacheEntry, hostID string) bool {
-	for _, h := range e.hosts {
-		if h.ID == hostID {
-			return true
-		}
-	}
-	return false
+	_, ok := e.ids[hostID]
+	return ok
 }
 
 func (s *LeastLoaded) Invalidate() {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -239,22 +239,20 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 
 // Invalidate drops all cached capability-specific candidate sets so the next
 // SelectHost reflects status or capability changes immediately.
-// Reject drops every cached candidate set that still lists hostID, because
-// the create pre-flight has just refused it. A set loaded since the host
-// left rotation no longer lists it and is kept, so a burst of creates that
-// all drew the same stale host reloads once, not once per create; a
+// Reject drops the cached candidate set for requiredCapabilities if it
+// still lists hostID, because the create pre-flight for that set has just
+// refused the host. Other capability sets are untouched: the rejection is
+// evidence about this set only, and evicting the rest would make unrelated
+// traffic refill each other's caches. A set loaded since the host left
+// rotation no longer lists it and is kept, so a burst of creates that all
+// drew the same stale host reloads once, not once per create; a
 // default-host fallback is never reloaded for this, see names.
-func (s *LeastLoaded) Reject(hostID string) {
+func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string) {
+	key, _ := capabilityCacheKey(requiredCapabilities)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	dropped := false
-	for key, entry := range s.cache {
-		if s.names(entry, hostID) {
-			delete(s.cache, key)
-			dropped = true
-		}
-	}
-	if dropped {
+	if entry, ok := s.cache[key]; ok && s.names(entry, hostID) {
+		delete(s.cache, key)
 		s.gen++
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -177,24 +177,25 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 						Msg("host list refresh failed; serving stale until the grace window expires")
 					return
 				}
-				s.publish(key, fresh, inv)
+				s.publish(key, fresh, inv, entry.gen)
 			}()
 		}
 		return entry, nil
 	}
 
-	// Blocking load: one fill per capability set at a time, run outside the
-	// mutex, so a slow fill for one set never stalls selects for the others.
-	// The flight publishes on the leader's invalidation snapshot, the most
-	// conservative one; every waiter shares its result.
-	ch := s.fills.DoChan(key, func() (any, error) {
+	// Blocking load: one fill per capability set and invalidation epoch at a
+	// time, run outside the mutex, so a slow fill for one set never stalls
+	// selects for the others. The epoch is part of the flight's identity so
+	// a caller arriving after an Invalidate never joins a fill that began
+	// before it and would hand back what that invalidation retired.
+	ch := s.fills.DoChan(fmt.Sprintf("%s\x00%d", key, inv), func() (any, error) {
 		fillCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
 		defer cancel()
 		fresh, err := s.fillEntry(fillCtx, normalized)
 		if err != nil {
 			return nil, err
 		}
-		return s.publish(key, fresh, inv), nil
+		return s.publish(key, fresh, inv, 0), nil
 	})
 	select {
 	case res := <-ch:
@@ -207,16 +208,23 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	}
 }
 
-// publish caches fresh for key under a new generation, unless an Invalidate
-// landed after the load began (invalidations moved past inv): a set read
-// before an invalidation may be what it invalidated, so it is served to the
-// request that loaded it but not cached. Returns the entry as it should be
-// served, stamped only if cached.
-func (s *LeastLoaded) publish(key string, fresh hostCacheEntry, inv uint64) hostCacheEntry {
+// publish caches fresh for key under a new generation, unless it is stale:
+// an Invalidate landed after the load began (invalidations moved past inv),
+// or, for a background refresh of the set stamped refreshOf, that set is no
+// longer the cached one — a rejection or a blocking fill replaced it with
+// something newer, which an older snapshot must not overwrite. A set that
+// is not cached is still returned, to be served to the request that loaded
+// it. refreshOf is 0 for a blocking fill.
+func (s *LeastLoaded) publish(key string, fresh hostCacheEntry, inv, refreshOf uint64) hostCacheEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.invalidations != inv {
 		return fresh
+	}
+	if refreshOf != 0 {
+		if cur, ok := s.cache[key]; !ok || cur.gen != refreshOf {
+			return fresh
+		}
 	}
 	s.gen++
 	fresh.gen = s.gen

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -25,11 +25,9 @@ type Scheduler interface {
 const defaultCacheTTL = 30 * time.Second
 
 // hostsFillTimeout bounds every candidate-set fill, blocking and background
-// alike. The candidate set is a placement hint served at any age; what keeps
-// a drained or retired host from taking a create is the per-create host
-// pre-flight (status and capabilities read fresh within its own TTL), so
-// this bound is hygiene for the fill itself rather than part of the drain
-// convergence budget.
+// alike. The candidate set is a placement hint; the per-create host
+// pre-flight is what keeps a drained host from taking a create, so this
+// bound is not part of the drain convergence budget.
 const hostsFillTimeout = 5 * time.Second
 
 // LeastLoaded picks the active host with the fewest running sandboxes
@@ -143,15 +141,11 @@ func (s *LeastLoaded) fillEntry(ctx context.Context, normalized []string) (hostC
 	return entry, nil
 }
 
-// loadHosts serves a cached capability-specific candidate set at any age and
-// refreshes it in the background once the TTL lapses. Only the first call for
-// a set and a post-Invalidate call block on a fresh load. A request that
-// finds the set expired never waits for the DB: it serves what it has and
-// the refresh rides along behind it. Serving a stale set is safe because the
-// create path re-reads the chosen host's status and capabilities before
-// dispatch and re-selects after an Invalidate when that read rejects it, so
-// a host that left rotation is at most one bounded pre-flight away from
-// being dropped, however old this cache is.
+// loadHosts serves the cached candidate set at any age and refreshes it in
+// the background once the TTL lapses; only the first call for a set and a
+// post-Invalidate call block on a load. Serving stale is safe because the
+// create path re-reads the chosen host before dispatch and re-selects after
+// an Invalidate when that read rejects it.
 func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []string) (hostCacheEntry, error) {
 	key, normalized := capabilityCacheKey(requiredCapabilities)
 	s.mu.RLock()
@@ -159,10 +153,8 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	startGen := s.gen
 	s.mu.RUnlock()
 
-	// An expired set that cannot place anything is reloaded in line rather
-	// than served: serving it would refuse a create the DB may already be
-	// able to place, and the refresh behind that refusal would only help the
-	// next one.
+	// An expired set with nothing to place on is reloaded in line: serving
+	// it would refuse a create the DB may already be able to place.
 	if cached && time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry) {
 		cached = false
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -246,15 +246,18 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 // traffic refill each other's caches. A set loaded since the host left
 // rotation no longer lists it and is kept, so a burst of creates that all
 // drew the same stale host reloads once, not once per create; a
-// default-host fallback is never reloaded for this, see names.
-func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string) {
+// default-host fallback is never reloaded for this, see names. Reports
+// whether a set was dropped, i.e. whether the next SelectHost loads fresh.
+func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string) bool {
 	key, _ := capabilityCacheKey(requiredCapabilities)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if entry, ok := s.cache[key]; ok && s.names(entry, hostID) {
 		delete(s.cache, key)
 		s.gen++
+		return true
 	}
+	return false
 }
 
 // names reports whether this entry's candidate set lists hostID. The

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -53,7 +52,7 @@ type LeastLoaded struct {
 	cache         map[string]hostCacheEntry
 	gen           uint64             // stamped on every published set; a Reject carries the set's stamp
 	invalidations uint64             // bumped by Invalidate; a load begun before it is not cached
-	refreshing    atomic.Bool        // one background refresh at a time across capability sets
+	refreshing    sync.Map           // capability keys with a background refresh in flight
 	fills         singleflight.Group // one blocking fill per capability set at a time
 }
 
@@ -164,17 +163,17 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 		cached = false
 	}
 	if cached {
-		if time.Since(entry.cachedAt) >= s.ttl() && s.refreshing.CompareAndSwap(false, true) {
+		if _, busy := s.refreshing.LoadOrStore(key, struct{}{}); time.Since(entry.cachedAt) >= s.ttl() && !busy {
 			// Detached: the refresh outlives the triggering request. On error the
 			// stale set stays servable and the next expired call retries.
 			qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
 			go func() {
 				defer cancel()
-				defer s.refreshing.Store(false)
+				defer s.refreshing.Delete(key)
 				fresh, err := s.fillEntry(qctx, normalized)
 				if err != nil {
 					log.Warn().Err(err).Strs("required_capabilities", normalized).
-						Msg("host list refresh failed; serving stale until the grace window expires")
+						Msg("host list refresh failed; serving stale, the next expired call retries")
 					return
 				}
 				s.publish(key, fresh, inv, entry.gen)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -17,9 +17,10 @@ import (
 	"github.com/superserve-ai/sandbox/internal/db"
 )
 
-// Scheduler selects a host for a new sandbox.
+// Scheduler selects a host for a new sandbox. gen identifies the candidate
+// set the selection came from, for Reject.
 type Scheduler interface {
-	SelectHost(ctx context.Context, requiredCapabilities []string) (hostID string, err error)
+	SelectHost(ctx context.Context, requiredCapabilities []string) (hostID string, gen uint64, err error)
 }
 
 const defaultCacheTTL = 30 * time.Second
@@ -56,6 +57,7 @@ type LeastLoaded struct {
 type hostCacheEntry struct {
 	hosts    []db.ListActiveHostsByLoadRow
 	cachedAt time.Time
+	gen      uint64 // the generation this set was loaded at; a Reject must carry it
 	// defaultStatus is the DefaultHostID row's status, resolved at fill time
 	// only when hosts is empty — so the fallback decision in SelectHost never
 	// queries on the per-create path. "missing" = no row (bootstrap mode,
@@ -70,10 +72,10 @@ func (s *LeastLoaded) ttl() time.Duration {
 	return defaultCacheTTL
 }
 
-func (s *LeastLoaded) SelectHost(ctx context.Context, requiredCapabilities []string) (string, error) {
+func (s *LeastLoaded) SelectHost(ctx context.Context, requiredCapabilities []string) (string, uint64, error) {
 	entry, err := s.loadHosts(ctx, requiredCapabilities)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	hosts := entry.hosts
 	if len(hosts) == 0 {
@@ -86,21 +88,21 @@ func (s *LeastLoaded) SelectHost(ctx context.Context, requiredCapabilities []str
 			// time (fillEntry); status changes invalidate the cache.
 			switch entry.defaultStatus {
 			case "missing": // unpopulated table: bootstrap path
-				return s.DefaultHostID, nil
+				return s.DefaultHostID, entry.gen, nil
 			case "active":
 				// Present but filtered out by capabilities; the create-time
 				// capability gate still enforces. Preserves prior behavior.
-				return s.DefaultHostID, nil
+				return s.DefaultHostID, entry.gen, nil
 			case "":
-				return "", fmt.Errorf("no active hosts available")
+				return "", 0, fmt.Errorf("no active hosts available")
 			default:
-				return "", fmt.Errorf("no active hosts available (default host is %s)", entry.defaultStatus)
+				return "", 0, fmt.Errorf("no active hosts available (default host is %s)", entry.defaultStatus)
 			}
 		}
-		return "", fmt.Errorf("no active hosts available")
+		return "", 0, fmt.Errorf("no active hosts available")
 	}
 	if len(hosts) == 1 {
-		return hosts[0].ID, nil
+		return hosts[0].ID, entry.gen, nil
 	}
 
 	// Power of two random choices: pick two random hosts, return the
@@ -113,9 +115,9 @@ func (s *LeastLoaded) SelectHost(ctx context.Context, requiredCapabilities []str
 		b++ // ensures b != a
 	}
 	if hosts[a].ActiveSandboxCount <= hosts[b].ActiveSandboxCount {
-		return hosts[a].ID, nil
+		return hosts[a].ID, entry.gen, nil
 	}
-	return hosts[b].ID, nil
+	return hosts[b].ID, entry.gen, nil
 }
 
 // fillEntry loads the candidate set and, when it comes back empty, resolves
@@ -179,6 +181,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 					if s.cache == nil {
 						s.cache = make(map[string]hostCacheEntry)
 					}
+					fresh.gen = startGen
 					s.cache[key] = fresh
 				}
 				s.mu.Unlock()
@@ -206,6 +209,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	if s.cache == nil {
 		s.cache = make(map[string]hostCacheEntry)
 	}
+	fresh.gen = s.gen
 	s.cache[key] = fresh
 	return fresh, nil
 }
@@ -236,20 +240,20 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 
 // Invalidate drops all cached capability-specific candidate sets so the next
 // SelectHost reflects status or capability changes immediately.
-// Reject drops the cached candidate set for requiredCapabilities if it
-// still lists hostID, because the create pre-flight for that set has just
-// refused the host. Other capability sets are untouched: the rejection is
-// evidence about this set only, and evicting the rest would make unrelated
-// traffic refill each other's caches. A set loaded since the host left
-// rotation no longer lists it and is kept, so a burst of creates that all
-// drew the same stale host reloads once, not once per create; a
-// default-host fallback is never reloaded for this, see names. Reports
-// whether a set was dropped, i.e. whether the next SelectHost loads fresh.
-func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string) bool {
+// Reject drops the cached candidate set for requiredCapabilities if it is
+// still the set (gen) that produced the selection and still lists hostID,
+// because the create pre-flight for that set has just refused the host. A
+// set loaded since is kept even if it lists the host again — it is fresh
+// evidence, and the host is re-attested from it — so a burst of creates
+// that all drew the same stale host reloads once, not once per create.
+// Other capability sets are untouched, and a default-host fallback is never
+// reloaded for this, see names. Reports whether a set was dropped, i.e.
+// whether the next SelectHost loads fresh.
+func (s *LeastLoaded) Reject(hostID string, requiredCapabilities []string, gen uint64) bool {
 	key, _ := capabilityCacheKey(requiredCapabilities)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if entry, ok := s.cache[key]; ok && s.names(entry, hostID) {
+	if entry, ok := s.cache[key]; ok && entry.gen == gen && s.names(entry, hostID) {
 		delete(s.cache, key)
 		s.gen++
 		return true

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -239,10 +239,11 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 
 // Invalidate drops all cached capability-specific candidate sets so the next
 // SelectHost reflects status or capability changes immediately.
-// Reject drops every cached candidate set that still names hostID, because
+// Reject drops every cached candidate set that still lists hostID, because
 // the create pre-flight has just refused it. A set loaded since the host
-// left rotation no longer names it and is kept, so a burst of creates that
-// all drew the same stale host reloads once, not once per create.
+// left rotation no longer lists it and is kept, so a burst of creates that
+// all drew the same stale host reloads once, not once per create; a
+// default-host fallback is never reloaded for this, see names.
 func (s *LeastLoaded) Reject(hostID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -258,15 +259,17 @@ func (s *LeastLoaded) Reject(hostID string) {
 	}
 }
 
-// names reports whether SelectHost could hand out hostID from this entry.
+// names reports whether this entry's candidate set lists hostID. The
+// default-host fallback (an empty set) deliberately does not count: that
+// host is the one the capability-filtered load already excluded, so a
+// reload cannot change the answer and would only repeat the query.
 func (s *LeastLoaded) names(e hostCacheEntry, hostID string) bool {
 	for _, h := range e.hosts {
 		if h.ID == hostID {
 			return true
 		}
 	}
-	return len(e.hosts) == 0 && hostID == s.DefaultHostID &&
-		(e.defaultStatus == "missing" || e.defaultStatus == "active")
+	return false
 }
 
 func (s *LeastLoaded) Invalidate() {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -210,16 +210,13 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	return fresh, nil
 }
 
-// cannotPlace reports whether SelectHost would refuse every create from this
-// entry: no candidates, and no default-host fallback that would apply.
+// cannotPlace reports whether this entry has no candidates. An empty set is
+// reloaded in line once expired even when the default-host fallback would
+// apply: that fallback is a host the capability-filtered load excluded, the
+// create pre-flight refuses it, and a rejection cannot evict it — so a reload
+// is the only way a host that has since gained the capability gets found.
 func (s *LeastLoaded) cannotPlace(e hostCacheEntry) bool {
-	if len(e.hosts) > 0 {
-		return false
-	}
-	if s.DefaultHostID == "" {
-		return true
-	}
-	return e.defaultStatus != "missing" && e.defaultStatus != "active"
+	return len(e.hosts) == 0
 }
 
 func capabilityCacheKey(capabilities []string) (string, []string) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -239,6 +239,36 @@ func capabilityCacheKey(capabilities []string) (string, []string) {
 
 // Invalidate drops all cached capability-specific candidate sets so the next
 // SelectHost reflects status or capability changes immediately.
+// Reject drops every cached candidate set that still names hostID, because
+// the create pre-flight has just refused it. A set loaded since the host
+// left rotation no longer names it and is kept, so a burst of creates that
+// all drew the same stale host reloads once, not once per create.
+func (s *LeastLoaded) Reject(hostID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dropped := false
+	for key, entry := range s.cache {
+		if s.names(entry, hostID) {
+			delete(s.cache, key)
+			dropped = true
+		}
+	}
+	if dropped {
+		s.gen++
+	}
+}
+
+// names reports whether SelectHost could hand out hostID from this entry.
+func (s *LeastLoaded) names(e hostCacheEntry, hostID string) bool {
+	for _, h := range e.hosts {
+		if h.ID == hostID {
+			return true
+		}
+	}
+	return len(e.hosts) == 0 && hostID == s.DefaultHostID &&
+		(e.defaultStatus == "missing" || e.defaultStatus == "active")
+}
+
 func (s *LeastLoaded) Invalidate() {
 	s.mu.Lock()
 	s.gen++

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -156,16 +156,7 @@ func (s *LeastLoaded) fillEntry(ctx context.Context, normalized []string) (hostC
 // re-attests the chosen host and re-selects when that rejects it.
 func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []string) (hostCacheEntry, error) {
 	key, normalized := capabilityCacheKey(requiredCapabilities)
-	s.mu.RLock()
-	entry, cached := s.cache[key]
-	inv := s.invalidations
-	s.mu.RUnlock()
-
-	// An expired set with nothing to place on is reloaded in line: serving
-	// it would refuse a create the DB may already be able to place.
-	if cached && time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry) {
-		cached = false
-	}
+	entry, cached, inv := s.snapshot(key)
 	if cached {
 		if time.Since(entry.cachedAt) >= s.ttl() && s.claimRefresh(key) {
 			// Detached: the refresh outlives the triggering request. On error the
@@ -190,13 +181,7 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	// run outside the mutex so a slow fill never stalls other sets. The epoch
 	// keeps a caller arriving after an Invalidate off an older flight.
 	ch := s.fills.DoChan(fmt.Sprintf("%s\x00%d", key, inv), func() (any, error) {
-		fillCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
-		defer cancel()
-		fresh, err := s.fillEntry(fillCtx, normalized)
-		if err != nil {
-			return nil, err
-		}
-		return s.publish(key, fresh, inv, 0), nil
+		return s.fill(ctx, key, normalized, inv)
 	})
 	select {
 	case res := <-ch:
@@ -207,6 +192,36 @@ func (s *LeastLoaded) loadHosts(ctx context.Context, requiredCapabilities []stri
 	case <-ctx.Done():
 		return hostCacheEntry{}, ctx.Err()
 	}
+}
+
+// snapshot returns the servable cached set for key, if any, and the current
+// invalidation epoch. An expired set with nothing to place on is not
+// servable: serving it would refuse a create the DB may already be able to
+// place, so it is reloaded in line instead.
+func (s *LeastLoaded) snapshot(key string) (entry hostCacheEntry, ok bool, inv uint64) {
+	s.mu.RLock()
+	entry, ok = s.cache[key]
+	inv = s.invalidations
+	s.mu.RUnlock()
+	if ok && time.Since(entry.cachedAt) >= s.ttl() && s.cannotPlace(entry) {
+		ok = false
+	}
+	return entry, ok, inv
+}
+
+// fill is one blocking load: it serves what an earlier flight for this key
+// published since the caller saw the miss, else reads the DB and publishes.
+func (s *LeastLoaded) fill(ctx context.Context, key string, normalized []string, inv uint64) (hostCacheEntry, error) {
+	if entry, ok, _ := s.snapshot(key); ok {
+		return entry, nil
+	}
+	fillCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostsFillTimeout)
+	defer cancel()
+	fresh, err := s.fillEntry(fillCtx, normalized)
+	if err != nil {
+		return hostCacheEntry{}, err
+	}
+	return s.publish(key, fresh, inv, 0), nil
 }
 
 // claimRefresh reserves the refresh slot for key; false if one is running.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/preview"
@@ -400,22 +400,45 @@ func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 	}
 }
 
-func TestLoadHostsPastGraceBlocksInsteadOfServingStale(t *testing.T) {
+// However old the cached set is, a select serves it without waiting on the
+// DB: an instance that has been idle for an hour must not pay a blocking
+// load on its next create, and the refresh rides behind the request.
+func TestLoadHostsAnyAgeServesStaleAndRefreshesBehind(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
 	if _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("prime: %v", err)
 	}
 
-	// Way past ttl+grace (refreshes never landed): must block on a fresh
-	// load, not keep serving a possibly-dead host list.
+	// Hold the refresh (query 2) so a select that blocked on it would hang.
+	store.block = make(chan struct{})
+	store.blockOnCall = 2
 	setCachedAtForTest(t, s, nil, time.Now().Add(-time.Hour))
 
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
-		t.Fatalf("past-grace select: %v", err)
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.SelectHost(context.Background(), nil)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("stale select: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("select blocked on the refresh instead of serving the stale set")
 	}
-	if n := store.calls.Load(); n != 2 {
-		t.Fatalf("past-grace select must reload synchronously, got %d queries", n)
+	close(store.block)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for s.refreshing.Load() || store.calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh never landed, calls=%d", store.calls.Load())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if _, cachedAt, cached := readCacheForTest(s, nil); !cached || time.Since(cachedAt) > time.Minute {
+		t.Fatal("refresh must restore a fresh cachedAt")
 	}
 }
 
@@ -441,11 +464,11 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	// Age past grace: the next call reloads synchronously (query 3) and must
+	// Invalidate: the next call reloads synchronously (query 3) and must
 	// retire the still-hanging refresh so its older result cannot land on top.
-	setCachedAtForTest(t, s, nil, time.Now().Add(-time.Hour))
+	s.Invalidate()
 	if _, err := s.SelectHost(context.Background(), nil); err != nil {
-		t.Fatalf("past-grace select: %v", err)
+		t.Fatalf("post-invalidate select: %v", err)
 	}
 	close(store.block) // the pre-reload refresh now returns
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -192,9 +192,10 @@ func TestLeastLoadedCachesCandidateSetsByCanonicalCapabilities(t *testing.T) {
 
 // hostStore is a fake db.DBTX serving one host row per Query and counting calls.
 type hostStore struct {
-	calls       atomic.Int64
-	block       chan struct{} // non-nil: Query waits until closed
-	blockOnCall int64         // 0 = block every call; N = block only the Nth
+	calls          atomic.Int64
+	block          chan struct{} // non-nil: Query waits until closed
+	blockOnCall    int64         // 0 = block every call; N = block only the Nth
+	emptyUntilCall int64         // calls up to and including this one return no hosts
 }
 
 func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
@@ -206,7 +207,7 @@ func (h *hostStore) Query(context.Context, string, ...interface{}) (pgx.Rows, er
 	if h.block != nil && (h.blockOnCall == 0 || n == h.blockOnCall) {
 		<-h.block
 	}
-	return &hostRows{id: fmt.Sprintf("host-%d", n)}, nil
+	return &hostRows{id: fmt.Sprintf("host-%d", n), done: n <= h.emptyUntilCall}, nil
 }
 
 // hostRows yields a single minimal host row whose ID names the query that
@@ -485,5 +486,25 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 	}
 	if id != "host-3" {
 		t.Fatalf("older refresh clobbered the blocking reload: cached %s, want host-3", id)
+	}
+}
+
+// A cached set with nothing to place on is not served past its TTL: the
+// next select reloads in line and places on what the DB has now, instead of
+// refusing the create and only refreshing behind the refusal.
+func TestLoadHostsExpiredEmptySetReloadsInline(t *testing.T) {
+	store := &hostStore{emptyUntilCall: 1}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if _, err := s.SelectHost(context.Background(), nil); err == nil {
+		t.Fatal("prime: expected no hosts available")
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+
+	id, err := s.SelectHost(context.Background(), nil)
+	if err != nil || id != "host-2" {
+		t.Fatalf("expired empty select = (%q, %v), want (host-2, nil)", id, err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2 (one in-line reload)", n)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -90,7 +90,8 @@ func TestSelectHostFallbackRefusesNonActiveDefault(t *testing.T) {
 	run := func(t *testing.T, row pgx.Row) (string, error) {
 		mock := &fallbackProbe{row: row}
 		s := &LeastLoaded{DB: db.New(mock), DefaultHostID: "default"}
-		return s.SelectHost(context.Background(), nil)
+		id, _, err := s.SelectHost(context.Background(), nil)
+		return id, err
 	}
 
 	for _, status := range []string{"provisioning", "draining", "unhealthy"} {
@@ -112,7 +113,7 @@ func TestSelectHostFallbackStatusIsCached(t *testing.T) {
 	mock := &fallbackProbe{row: schedulerErrorRow{err: pgx.ErrNoRows}}
 	s := &LeastLoaded{DB: db.New(mock), DefaultHostID: "default", TTL: time.Minute}
 	for i := 0; i < 5; i++ {
-		if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "default" {
+		if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "default" {
 			t.Fatalf("select %d: got (%q, %v)", i, id, err)
 		}
 	}
@@ -142,7 +143,7 @@ func TestLeastLoadedQueryExcludesHostsWithoutPreviewEnforcement(t *testing.T) {
 	capture := &queryCapture{}
 	s := &LeastLoaded{DB: db.New(capture), DefaultHostID: "fallback"}
 	required := []string{preview.HostCapabilityPorts}
-	got, err := s.SelectHost(context.Background(), required)
+	got, _, err := s.SelectHost(context.Background(), required)
 	if err != nil {
 		t.Fatalf("SelectHost: %v", err)
 	}
@@ -171,7 +172,7 @@ func TestLeastLoadedCachesCandidateSetsByCanonicalCapabilities(t *testing.T) {
 		preview.HostCapabilityPorts, preview.HostCapabilityPortTokens, preview.HostCapabilityPortAccess,
 		preview.HostCapabilityPortBrowserAuth, preview.HostCapabilityPorts, preview.HostCapabilityPortTokens,
 	}} {
-		if got, err := s.SelectHost(ctx, required); err != nil || got != "fallback" {
+		if got, _, err := s.SelectHost(ctx, required); err != nil || got != "fallback" {
 			t.Fatalf("SelectHost(%v) = (%q, %v), want fallback", required, got, err)
 		}
 	}
@@ -197,6 +198,7 @@ type hostStore struct {
 	blockOnCall    int64         // 0 = block every call; N = block only the Nth
 	emptyUntilCall int64         // calls up to and including this one return no hosts
 	defaultRow     pgx.Row       // answer for the default-host row read on an empty fill
+	fixedID        string        // when set, every fill returns this host instead of host-N
 }
 
 func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
@@ -208,7 +210,11 @@ func (h *hostStore) Query(context.Context, string, ...interface{}) (pgx.Rows, er
 	if h.block != nil && (h.blockOnCall == 0 || n == h.blockOnCall) {
 		<-h.block
 	}
-	return &hostRows{id: fmt.Sprintf("host-%d", n), done: n <= h.emptyUntilCall}, nil
+	id := fmt.Sprintf("host-%d", n)
+	if h.fixedID != "" {
+		id = h.fixedID
+	}
+	return &hostRows{id: id, done: n <= h.emptyUntilCall}, nil
 }
 
 // hostRows yields a single minimal host row whose ID names the query that
@@ -269,7 +275,7 @@ func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
 
 	// First call blocks and fills the cache.
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("first select: %v", err)
 	}
 	if n := store.calls.Load(); n != 1 {
@@ -280,7 +286,7 @@ func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
 	// the stale list and refresh behind it.
 	setCachedAtForTest(t, s, nil, time.Now().Add(-s.ttl()-5*time.Second)) // stale, inside grace
 
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("stale select: %v", err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -297,7 +303,7 @@ func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
 	if !fresh {
 		t.Fatal("refresh must restore a fresh cachedAt")
 	}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("post-refresh select: %v", err)
 	}
 	if n := store.calls.Load(); n != 2 {
@@ -308,7 +314,7 @@ func TestLoadHostsServesStaleAndRefreshesInBackground(t *testing.T) {
 func TestLoadHostsStaleServeDoesNotBlockOnSlowRefresh(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("prime: %v", err)
 	}
 
@@ -320,7 +326,7 @@ func TestLoadHostsStaleServeDoesNotBlockOnSlowRefresh(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 10; i++ {
-			_, _ = s.SelectHost(context.Background(), nil)
+			_, _, _ = s.SelectHost(context.Background(), nil)
 		}
 		close(done)
 	}()
@@ -347,12 +353,12 @@ func TestLoadHostsStaleServeDoesNotBlockOnSlowRefresh(t *testing.T) {
 func TestInvalidateForcesBlockingReload(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("prime: %v", err)
 	}
 
 	s.Invalidate()
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("post-invalidate select: %v", err)
 	}
 	if n := store.calls.Load(); n != 2 {
@@ -363,14 +369,14 @@ func TestInvalidateForcesBlockingReload(t *testing.T) {
 func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("prime: %v", err)
 	}
 
 	// Hold a background refresh in flight, then invalidate underneath it.
 	store.block = make(chan struct{})
 	setCachedAtForTest(t, s, nil, time.Now().Add(-s.ttl()-5*time.Second)) // stale, inside grace
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {    // triggers the refresh
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // triggers the refresh
 		t.Fatalf("stale select: %v", err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -408,7 +414,7 @@ func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 func TestLoadHostsAnyAgeServesStaleAndRefreshesBehind(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("prime: %v", err)
 	}
 
@@ -419,7 +425,7 @@ func TestLoadHostsAnyAgeServesStaleAndRefreshesBehind(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := s.SelectHost(context.Background(), nil)
+		_, _, err := s.SelectHost(context.Background(), nil)
 		done <- err
 	}()
 	select {
@@ -447,7 +453,7 @@ func TestLoadHostsAnyAgeServesStaleAndRefreshesBehind(t *testing.T) {
 func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err != nil { // query 1
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // query 1
 		t.Fatalf("prime: %v", err)
 	}
 
@@ -455,7 +461,7 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 	store.block = make(chan struct{})
 	store.blockOnCall = 2
 	setCachedAtForTest(t, s, nil, time.Now().Add(-s.ttl()-5*time.Second)) // stale, inside grace
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {    // kicks the refresh
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // kicks the refresh
 		t.Fatalf("stale select: %v", err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -469,7 +475,7 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 	// Invalidate: the next call reloads synchronously (query 3) and must
 	// retire the still-hanging refresh so its older result cannot land on top.
 	s.Invalidate()
-	if _, err := s.SelectHost(context.Background(), nil); err != nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("post-invalidate select: %v", err)
 	}
 	close(store.block) // the pre-reload refresh now returns
@@ -496,12 +502,12 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 func TestLoadHostsExpiredEmptySetReloadsInline(t *testing.T) {
 	store := &hostStore{emptyUntilCall: 1}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if _, err := s.SelectHost(context.Background(), nil); err == nil {
+	if _, _, err := s.SelectHost(context.Background(), nil); err == nil {
 		t.Fatal("prime: expected no hosts available")
 	}
 	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
 
-	id, err := s.SelectHost(context.Background(), nil)
+	id, _, err := s.SelectHost(context.Background(), nil)
 	if err != nil || id != "host-2" {
 		t.Fatalf("expired empty select = (%q, %v), want (host-2, nil)", id, err)
 	}
@@ -516,19 +522,20 @@ func TestLoadHostsExpiredEmptySetReloadsInline(t *testing.T) {
 func TestRejectDropsOnlySetsStillNamingTheHost(t *testing.T) {
 	store := &hostStore{}
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
-	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" {
+	id, gen, err := s.SelectHost(context.Background(), nil)
+	if err != nil || id != "host-1" {
 		t.Fatalf("prime = (%q, %v)", id, err)
 	}
-	if !s.Reject("host-1", nil) {
+	if !s.Reject("host-1", nil, gen) {
 		t.Fatal("rejecting the cached host must drop its set")
 	}
-	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
+	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after reject = (%q, %v), want host-2 from a fresh load", id, err)
 	}
-	if s.Reject("host-1", nil) { // the fresh set no longer names host-1: no-op
-		t.Fatal("rejecting a host the fresh set does not list must not drop it")
+	if s.Reject("host-1", nil, gen) { // a late waiter with the old set: no-op
+		t.Fatal("a rejection carrying a superseded generation must not drop the fresh set")
 	}
-	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
+	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after stale reject = (%q, %v), want the cached host-2", id, err)
 	}
 	if n := store.calls.Load(); n != 2 {
@@ -543,20 +550,21 @@ func TestRejectLeavesOtherCapabilitySetsCached(t *testing.T) {
 	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
 	public := []string{"preview_ports_v1"}
 	private := []string{"preview_ports_v1", "preview_port_browser_auth_v1"}
-	if _, err := s.SelectHost(context.Background(), public); err != nil { // query 1: host-1
+	if _, _, err := s.SelectHost(context.Background(), public); err != nil { // query 1: host-1
 		t.Fatalf("public prime: %v", err)
 	}
-	if _, err := s.SelectHost(context.Background(), private); err != nil { // query 2: host-2
+	_, privGen, err := s.SelectHost(context.Background(), private) // query 2: host-2
+	if err != nil {
 		t.Fatalf("private prime: %v", err)
 	}
-	s.Reject("host-2", private)
-	if _, err := s.SelectHost(context.Background(), public); err != nil {
+	s.Reject("host-2", private, privGen)
+	if _, _, err := s.SelectHost(context.Background(), public); err != nil {
 		t.Fatalf("public after private reject: %v", err)
 	}
 	if n := store.calls.Load(); n != 2 {
 		t.Fatalf("queries = %d, want 2 (the public set must not be reloaded)", n)
 	}
-	if id, err := s.SelectHost(context.Background(), private); err != nil || id != "host-3" {
+	if id, _, err := s.SelectHost(context.Background(), private); err != nil || id != "host-3" {
 		t.Fatalf("private after reject = (%q, %v), want host-3 from a fresh load", id, err)
 	}
 }
@@ -567,15 +575,45 @@ func TestRejectLeavesOtherCapabilitySetsCached(t *testing.T) {
 func TestLoadHostsExpiredFilteredDefaultReloadsInline(t *testing.T) {
 	store := &hostStore{emptyUntilCall: 1, defaultRow: schedulerHostRow("default-host", "active")}
 	s := &LeastLoaded{DB: db.New(store), DefaultHostID: "default-host", TTL: time.Minute}
-	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "default-host" {
+	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "default-host" {
 		t.Fatalf("prime = (%q, %v), want the filtered default as fallback", id, err)
 	}
 	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
-	id, err := s.SelectHost(context.Background(), nil)
+	id, _, err := s.SelectHost(context.Background(), nil)
 	if err != nil || id != "host-2" {
 		t.Fatalf("expired select = (%q, %v), want host-2 from an in-line reload", id, err)
 	}
 	if n := store.calls.Load(); n != 2 {
 		t.Fatalf("queries = %d, want 2", n)
+	}
+}
+
+// A fresh load may legitimately list the rejected host again (it regained
+// the capability). Waiters that shared the earlier negative pre-flight carry
+// the OLD set's generation, so their rejections cannot evict the fresh set:
+// the burst reloads once and the host is re-attested from the fresh set.
+func TestRejectWithSupersededGenerationKeepsTheFreshSet(t *testing.T) {
+	store := &hostStore{fixedID: "host-1"}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	_, oldGen, err := s.SelectHost(context.Background(), nil) // query 1
+	if err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	if !s.Reject("host-1", nil, oldGen) { // the first waiter drops the set
+		t.Fatal("first rejection must drop the set")
+	}
+	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" { // query 2: fresh, lists host-1 again
+		t.Fatalf("reload = (%q, %v)", id, err)
+	}
+	for i := 0; i < 5; i++ { // the other waiters, still holding the old generation
+		if s.Reject("host-1", nil, oldGen) {
+			t.Fatalf("waiter %d evicted the fresh set with a superseded generation", i)
+		}
+	}
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
+		t.Fatalf("select after stale rejections: %v", err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2 (one reload for the burst)", n)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -518,15 +518,40 @@ func TestRejectDropsOnlySetsStillNamingTheHost(t *testing.T) {
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" {
 		t.Fatalf("prime = (%q, %v)", id, err)
 	}
-	s.Reject("host-1")
+	s.Reject("host-1", nil)
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after reject = (%q, %v), want host-2 from a fresh load", id, err)
 	}
-	s.Reject("host-1") // the fresh set no longer names host-1: no-op
+	s.Reject("host-1", nil) // the fresh set no longer names host-1: no-op
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after stale reject = (%q, %v), want the cached host-2", id, err)
 	}
 	if n := store.calls.Load(); n != 2 {
 		t.Fatalf("queries = %d, want 2 (one reload for the whole burst)", n)
+	}
+}
+
+// A rejection is scoped to the capability set that produced the selection:
+// rejecting a host for a private-only set leaves the public set cached.
+func TestRejectLeavesOtherCapabilitySetsCached(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	public := []string{"preview_ports_v1"}
+	private := []string{"preview_ports_v1", "preview_port_browser_auth_v1"}
+	if _, err := s.SelectHost(context.Background(), public); err != nil { // query 1: host-1
+		t.Fatalf("public prime: %v", err)
+	}
+	if _, err := s.SelectHost(context.Background(), private); err != nil { // query 2: host-2
+		t.Fatalf("private prime: %v", err)
+	}
+	s.Reject("host-2", private)
+	if _, err := s.SelectHost(context.Background(), public); err != nil {
+		t.Fatalf("public after private reject: %v", err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2 (the public set must not be reloaded)", n)
+	}
+	if id, err := s.SelectHost(context.Background(), private); err != nil || id != "host-3" {
+		t.Fatalf("private after reject = (%q, %v), want host-3 from a fresh load", id, err)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -256,6 +256,14 @@ func setCachedAtForTest(t *testing.T, s *LeastLoaded, capabilities []string, at 
 	s.cache[key] = entry
 }
 
+// refreshInFlight reports whether any capability set has a background
+// refresh running.
+func refreshInFlight(s *LeastLoaded) bool {
+	busy := false
+	s.refreshing.Range(func(_, _ any) bool { busy = true; return false })
+	return busy
+}
+
 func readCacheForTest(s *LeastLoaded, capabilities []string) (hostID string, cachedAt time.Time, ok bool) {
 	key, _ := capabilityCacheKey(capabilities)
 	s.mu.RLock()
@@ -395,7 +403,7 @@ func TestInvalidateBeatsInFlightRefresh(t *testing.T) {
 	deadline = time.Now().Add(2 * time.Second)
 	for {
 		_, _, resurrected := readCacheForTest(s, nil)
-		if !resurrected && !s.refreshing.Load() {
+		if !resurrected && !refreshInFlight(s) {
 			break // refresh finished and stored nothing
 		}
 		if resurrected {
@@ -439,7 +447,7 @@ func TestLoadHostsAnyAgeServesStaleAndRefreshesBehind(t *testing.T) {
 	close(store.block)
 
 	deadline := time.Now().Add(2 * time.Second)
-	for s.refreshing.Load() || store.calls.Load() < 2 {
+	for refreshInFlight(s) || store.calls.Load() < 2 {
 		if time.Now().After(deadline) {
 			t.Fatalf("background refresh never landed, calls=%d", store.calls.Load())
 		}
@@ -481,7 +489,7 @@ func TestBlockingReloadNotClobberedBySlowRefresh(t *testing.T) {
 	close(store.block) // the pre-reload refresh now returns
 
 	deadline = time.Now().Add(2 * time.Second)
-	for s.refreshing.Load() { // wait until the refresh goroutine finished
+	for refreshInFlight(s) { // wait until the refresh goroutine finished
 		if time.Now().After(deadline) {
 			t.Fatal("refresh goroutine never finished")
 		}
@@ -672,7 +680,7 @@ func TestBackgroundRefreshPublishesANewGeneration(t *testing.T) {
 		t.Fatalf("stale select: %v", err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
-	for s.refreshing.Load() || store.calls.Load() < 2 {
+	for refreshInFlight(s) || store.calls.Load() < 2 {
 		if time.Now().After(deadline) {
 			t.Fatal("refresh never landed")
 		}
@@ -715,7 +723,7 @@ func TestOldRefreshCannotReplaceARejectionReload(t *testing.T) {
 	}
 	close(store.block) // the older refresh now returns host-2
 	deadline = time.Now().Add(2 * time.Second)
-	for s.refreshing.Load() {
+	for refreshInFlight(s) {
 		if time.Now().After(deadline) {
 			t.Fatal("refresh never finished")
 		}
@@ -766,5 +774,57 @@ func TestFillAfterInvalidateDoesNotJoinAnOlderFlight(t *testing.T) {
 	}
 	if id, _, _ := readCacheForTest(s, nil); id != "host-2" {
 		t.Fatalf("cached = %q, want host-2 (the pre-invalidate fill must not be cached)", id)
+	}
+}
+
+// Expired capability sets refresh independently: a slow refresh of one set
+// must not keep another expired set from refreshing.
+func TestExpiredSetsRefreshIndependently(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	gpu := []string{"gpu"}
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // query 1: host-1
+		t.Fatalf("prime nil: %v", err)
+	}
+	if _, _, err := s.SelectHost(context.Background(), gpu); err != nil { // query 2: host-2
+		t.Fatalf("prime gpu: %v", err)
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	setCachedAtForTest(t, s, gpu, time.Now().Add(-2*time.Minute))
+	store.block = make(chan struct{})
+	store.blockOnCall = 3                                                 // hold the nil set's refresh
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // stale serve; refresh (query 3) blocks
+		t.Fatalf("stale nil select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 3 { // the nil refresh is now held in the DB
+		if time.Now().After(deadline) {
+			t.Fatal("nil refresh never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, _, err := s.SelectHost(context.Background(), gpu); err != nil { // must start its own refresh: query 4
+		t.Fatalf("stale gpu select: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		if id, _, _ := readCacheForTest(s, gpu); id == "host-4" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gpu set never refreshed while the nil refresh was held, calls=%d", store.calls.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(store.block)
+	deadline = time.Now().Add(2 * time.Second)
+	for refreshInFlight(s) {
+		if time.Now().After(deadline) {
+			t.Fatal("refreshes never finished")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if id, _, _ := readCacheForTest(s, nil); id != "host-3" {
+		t.Fatalf("nil set = %q after its refresh, want host-3", id)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -686,3 +686,85 @@ func TestBackgroundRefreshPublishesANewGeneration(t *testing.T) {
 		t.Fatalf("queries = %d, want 2 (the refreshed set must survive the stale rejection)", n)
 	}
 }
+
+// A background refresh that started from a set later replaced by a
+// rejection reload must not land its older snapshot on top of the reload.
+func TestOldRefreshCannotReplaceARejectionReload(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	_, gen, err := s.SelectHost(context.Background(), nil) // query 1: host-1
+	if err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	store.block = make(chan struct{})
+	store.blockOnCall = 2                                                 // hold the refresh
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // stale serve; refresh (query 2) starts and blocks
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("refresh never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	s.Reject("host-1", nil, gen)                                                             // the served host failed its pre-flight
+	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-3" { // query 3: rejection reload
+		t.Fatalf("reload = (%q, %v), want host-3", id, err)
+	}
+	close(store.block) // the older refresh now returns host-2
+	deadline = time.Now().Add(2 * time.Second)
+	for s.refreshing.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("refresh never finished")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if id, _, _ := readCacheForTest(s, nil); id != "host-3" {
+		t.Fatalf("cached = %q after the old refresh landed, want host-3 kept", id)
+	}
+}
+
+// A create arriving after an Invalidate must not join a fill that began
+// before it: it starts its own, and gets what the DB says now.
+func TestFillAfterInvalidateDoesNotJoinAnOlderFlight(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	store.block = make(chan struct{})
+	store.blockOnCall = 1 // hold the cold fill
+	first := make(chan string, 1)
+	go func() {
+		id, _, _ := s.SelectHost(context.Background(), nil) // query 1, held
+		first <- id
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("cold fill never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	s.Invalidate() // a host status change lands while that fill is in flight
+
+	second := make(chan string, 1)
+	go func() {
+		id, _, _ := s.SelectHost(context.Background(), nil) // must run its own fill: query 2
+		second <- id
+	}()
+	select {
+	case id := <-second:
+		if id != "host-2" {
+			t.Fatalf("post-invalidate select = %q, want host-2 from its own fill", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("post-invalidate select joined the older, held fill")
+	}
+	close(store.block)
+	if id := <-first; id != "host-1" {
+		t.Fatalf("pre-invalidate select = %q, want its own host-1", id)
+	}
+	if id, _, _ := readCacheForTest(s, nil); id != "host-2" {
+		t.Fatalf("cached = %q, want host-2 (the pre-invalidate fill must not be cached)", id)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -518,11 +518,15 @@ func TestRejectDropsOnlySetsStillNamingTheHost(t *testing.T) {
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" {
 		t.Fatalf("prime = (%q, %v)", id, err)
 	}
-	s.Reject("host-1", nil)
+	if !s.Reject("host-1", nil) {
+		t.Fatal("rejecting the cached host must drop its set")
+	}
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after reject = (%q, %v), want host-2 from a fresh load", id, err)
 	}
-	s.Reject("host-1", nil) // the fresh set no longer names host-1: no-op
+	if s.Reject("host-1", nil) { // the fresh set no longer names host-1: no-op
+		t.Fatal("rejecting a host the fresh set does not list must not drop it")
+	}
 	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after stale reject = (%q, %v), want the cached host-2", id, err)
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -857,3 +857,40 @@ func TestFreshHitDoesNotBlockLaterRefresh(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 }
+
+// A caller that saw the miss just before an earlier flight for the same key
+// published must serve that entry, not run another DB fill.
+func TestLateFillServesWhatAnEarlierFlightPublished(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	key, normalized := capabilityCacheKey(nil)
+	_, _, inv := s.snapshot(key)                                          // the miss this caller saw
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // the earlier flight: query 1
+		t.Fatalf("prime: %v", err)
+	}
+	entry, err := s.fill(context.Background(), key, normalized, inv) // this caller's flight, started late
+	if err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if got := store.calls.Load(); got != 1 {
+		t.Fatalf("DB fills = %d, want 1 (the late flight must serve the published set)", got)
+	}
+	if entry.hosts[0].ID != "host-1" {
+		t.Fatalf("late fill served %q, want host-1", entry.hosts[0].ID)
+	}
+
+	// An expired empty set is not a usable answer: the late flight reloads.
+	store.emptyUntilCall = 2
+	s.Invalidate()
+	_, _, inv = s.snapshot(key)
+	if _, _, err := s.SelectHost(context.Background(), nil); err == nil { // query 2: empty
+		t.Fatal("empty set placed a host")
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	if _, err := s.fill(context.Background(), key, normalized, inv); err != nil { // query 3: host-3
+		t.Fatalf("fill after expired empty set: %v", err)
+	}
+	if got := store.calls.Load(); got != 3 {
+		t.Fatalf("DB fills = %d, want 3 (an expired empty set is reloaded)", got)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -508,3 +508,25 @@ func TestLoadHostsExpiredEmptySetReloadsInline(t *testing.T) {
 		t.Fatalf("queries = %d, want 2 (one in-line reload)", n)
 	}
 }
+
+// A rejected host drops only the candidate sets that still name it. Once a
+// fresh load no longer includes it, further rejections of that host are
+// no-ops, so concurrent creates that all drew it share one reload.
+func TestRejectDropsOnlySetsStillNamingTheHost(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" {
+		t.Fatalf("prime = (%q, %v)", id, err)
+	}
+	s.Reject("host-1")
+	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
+		t.Fatalf("after reject = (%q, %v), want host-2 from a fresh load", id, err)
+	}
+	s.Reject("host-1") // the fresh set no longer names host-1: no-op
+	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
+		t.Fatalf("after stale reject = (%q, %v), want the cached host-2", id, err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2 (one reload for the whole burst)", n)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -196,12 +196,13 @@ type hostStore struct {
 	block          chan struct{} // non-nil: Query waits until closed
 	blockOnCall    int64         // 0 = block every call; N = block only the Nth
 	emptyUntilCall int64         // calls up to and including this one return no hosts
+	defaultRow     pgx.Row       // answer for the default-host row read on an empty fill
 }
 
 func (h *hostStore) Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
 }
-func (h *hostStore) QueryRow(context.Context, string, ...interface{}) pgx.Row { return nil }
+func (h *hostStore) QueryRow(context.Context, string, ...interface{}) pgx.Row { return h.defaultRow }
 func (h *hostStore) Query(context.Context, string, ...interface{}) (pgx.Rows, error) {
 	n := h.calls.Add(1)
 	if h.block != nil && (h.blockOnCall == 0 || n == h.blockOnCall) {
@@ -557,5 +558,24 @@ func TestRejectLeavesOtherCapabilitySetsCached(t *testing.T) {
 	}
 	if id, err := s.SelectHost(context.Background(), private); err != nil || id != "host-3" {
 		t.Fatalf("private after reject = (%q, %v), want host-3 from a fresh load", id, err)
+	}
+}
+
+// An expired empty set whose fallback is a capability-filtered default host
+// reloads in line too: the fallback will be refused by the pre-flight, and
+// only a fresh load can find a host that has since gained the capability.
+func TestLoadHostsExpiredFilteredDefaultReloadsInline(t *testing.T) {
+	store := &hostStore{emptyUntilCall: 1, defaultRow: schedulerHostRow("default-host", "active")}
+	s := &LeastLoaded{DB: db.New(store), DefaultHostID: "default-host", TTL: time.Minute}
+	if id, err := s.SelectHost(context.Background(), nil); err != nil || id != "default-host" {
+		t.Fatalf("prime = (%q, %v), want the filtered default as fallback", id, err)
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	id, err := s.SelectHost(context.Background(), nil)
+	if err != nil || id != "host-2" {
+		t.Fatalf("expired select = (%q, %v), want host-2 from an in-line reload", id, err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2", n)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -526,15 +526,11 @@ func TestRejectDropsOnlySetsStillNamingTheHost(t *testing.T) {
 	if err != nil || id != "host-1" {
 		t.Fatalf("prime = (%q, %v)", id, err)
 	}
-	if !s.Reject("host-1", nil, gen) {
-		t.Fatal("rejecting the cached host must drop its set")
-	}
+	s.Reject("host-1", nil, gen)
 	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after reject = (%q, %v), want host-2 from a fresh load", id, err)
 	}
-	if s.Reject("host-1", nil, gen) { // a late waiter with the old set: no-op
-		t.Fatal("a rejection carrying a superseded generation must not drop the fresh set")
-	}
+	s.Reject("host-1", nil, gen) // a late waiter with the old set: no-op
 	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" {
 		t.Fatalf("after stale reject = (%q, %v), want the cached host-2", id, err)
 	}
@@ -599,21 +595,94 @@ func TestRejectWithSupersededGenerationKeepsTheFreshSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prime: %v", err)
 	}
-	if !s.Reject("host-1", nil, oldGen) { // the first waiter drops the set
-		t.Fatal("first rejection must drop the set")
-	}
+	s.Reject("host-1", nil, oldGen)                                                          // the first waiter drops the set
 	if id, _, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-1" { // query 2: fresh, lists host-1 again
 		t.Fatalf("reload = (%q, %v)", id, err)
 	}
 	for i := 0; i < 5; i++ { // the other waiters, still holding the old generation
-		if s.Reject("host-1", nil, oldGen) {
-			t.Fatalf("waiter %d evicted the fresh set with a superseded generation", i)
-		}
+		s.Reject("host-1", nil, oldGen)
 	}
 	if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
 		t.Fatalf("select after stale rejections: %v", err)
 	}
 	if n := store.calls.Load(); n != 2 {
 		t.Fatalf("queries = %d, want 2 (one reload for the burst)", n)
+	}
+}
+
+// A blocking fill for one capability set runs outside the scheduler mutex:
+// while it is stuck on a slow query, selects for another set that is cached
+// and usable must not wait behind it.
+func TestBlockingFillDoesNotBlockOtherCapabilitySets(t *testing.T) {
+	store := &hostStore{emptyUntilCall: 1}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	setA, setB := []string{"a"}, []string{"b"}
+	if _, _, err := s.SelectHost(context.Background(), setA); err == nil { // query 1: empty, no host
+		t.Fatal("prime A: expected no hosts")
+	}
+	if id, _, err := s.SelectHost(context.Background(), setB); err != nil || id != "host-2" { // query 2
+		t.Fatalf("prime B = (%q, %v)", id, err)
+	}
+	setCachedAtForTest(t, s, setA, time.Now().Add(-2*time.Minute)) // A: expired and empty → in-line reload
+	store.block = make(chan struct{})
+	store.blockOnCall = 3 // hold A's reload
+	aDone := make(chan error, 1)
+	go func() {
+		_, _, err := s.SelectHost(context.Background(), setA)
+		aDone <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for store.calls.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatal("A's reload never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	bDone := make(chan string, 1)
+	go func() {
+		id, _, _ := s.SelectHost(context.Background(), setB)
+		bDone <- id
+	}()
+	select {
+	case id := <-bDone:
+		if id != "host-2" {
+			t.Fatalf("B during A's reload = %q, want the cached host-2", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("a select for B blocked behind A's reload")
+	}
+	close(store.block)
+	if err := <-aDone; err != nil {
+		t.Fatalf("A after reload: %v", err)
+	}
+}
+
+// A background refresh publishes under a new generation: a rejection that
+// carries the stale set's generation cannot evict the refreshed set.
+func TestBackgroundRefreshPublishesANewGeneration(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	_, oldGen, err := s.SelectHost(context.Background(), nil) // query 1: host-1
+	if err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // stale serve, refresh behind
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for s.refreshing.Load() || store.calls.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("refresh never landed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	s.Reject("host-1", nil, oldGen) // a late negative result from the old set
+	if id, gen, err := s.SelectHost(context.Background(), nil); err != nil || id != "host-2" || gen == oldGen {
+		t.Fatalf("after stale reject = (%q, gen %d, %v), want the refreshed host-2 under a new generation", id, gen, err)
+	}
+	if n := store.calls.Load(); n != 2 {
+		t.Fatalf("queries = %d, want 2 (the refreshed set must survive the stale rejection)", n)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -828,3 +828,32 @@ func TestExpiredSetsRefreshIndependently(t *testing.T) {
 		t.Fatalf("nil set = %q after its refresh, want host-3", id)
 	}
 }
+
+// Serving a set before its TTL lapses must not claim the refresh slot: the
+// set has to refresh once it does expire.
+func TestFreshHitDoesNotBlockLaterRefresh(t *testing.T) {
+	store := &hostStore{}
+	s := &LeastLoaded{DB: db.New(store), TTL: time.Minute}
+	for i := 0; i < 3; i++ { // query 1 primes; the rest are fresh hits
+		if _, _, err := s.SelectHost(context.Background(), nil); err != nil {
+			t.Fatalf("select %d: %v", i, err)
+		}
+	}
+	if refreshInFlight(s) {
+		t.Fatal("a fresh hit left a refresh marker behind")
+	}
+	setCachedAtForTest(t, s, nil, time.Now().Add(-2*time.Minute))
+	if _, _, err := s.SelectHost(context.Background(), nil); err != nil { // stale serve; refresh (query 2) behind
+		t.Fatalf("stale select: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if id, _, _ := readCacheForTest(s, nil); id == "host-2" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expired set never refreshed, calls=%d", store.calls.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}


### PR DESCRIPTION
A create's scheduling step walked three caches that only refresh when a request touches them, so on an idle instance every create paid three database reads before dispatch, and concurrent creates on that instance queued behind the first one's refills.

Now the scheduler serves its candidate set at any age and refreshes behind the request (an expired set with nothing to place on reloads in line instead), the capability pre-flight's single row read also verifies the host's address for the registry, and a rejected host triggers one re-selection on a fresh load. An idle instance's next create is one row read; a stale candidate set can never place on a non-active host, and the pre-flight's TTL, now capped, is the bound drain convergence is derived from.