### PR TITLE
fix(api): fail closed when egress rules cannot be applied and normalize bare IPs to /32

### DIFF
--- a/internal/api/egress_rules_test.go
+++ b/internal/api/egress_rules_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeCIDR(t *testing.T) {
+	cases := map[string]string{
+		"1.1.1.1":             "1.1.1.1/32",
+		"8.8.8.8/32":          "8.8.8.8/32",
+		"0.0.0.0/0":           "0.0.0.0/0",
+		"203.0.113.0/24":      "203.0.113.0/24",
+		"api.example.com":     "api.example.com",
+		"*.example.com":       "*.example.com",
+		"not an address":      "not an address",
+		"2001:db8::1":         "2001:db8::1/128", // rejected upstream by validateEgressRules; still canonical
+		"2001:db8::/32":       "2001:db8::/32",
+		"::ffff:10.0.0.1":     "10.0.0.1/32",
+		"::ffff:10.0.0.0/120": "10.0.0.0/24",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := normalizeCIDR(in); got != want {
+			t.Errorf("normalizeCIDR(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSplitEgressEntriesNormalizesBothLists(t *testing.T) {
+	allowedCIDRs, deniedCIDRs, allowedDomains := splitEgressEntries(
+		[]string{"1.1.1.1", "8.8.8.8/32", "api.example.com", "*.example.com"},
+		[]string{"0.0.0.0/0", "9.9.9.9"},
+	)
+	if want := []string{"1.1.1.1/32", "8.8.8.8/32"}; !reflect.DeepEqual(allowedCIDRs, want) {
+		t.Errorf("allowedCIDRs = %v, want %v", allowedCIDRs, want)
+	}
+	if want := []string{"0.0.0.0/0", "9.9.9.9/32"}; !reflect.DeepEqual(deniedCIDRs, want) {
+		t.Errorf("deniedCIDRs = %v, want %v", deniedCIDRs, want)
+	}
+	if want := []string{"api.example.com", "*.example.com"}; !reflect.DeepEqual(allowedDomains, want) {
+		t.Errorf("allowedDomains = %v, want %v", allowedDomains, want)
+	}
+}
+
+func TestSplitEgressEntriesEmpty(t *testing.T) {
+	a, d, dom := splitEgressEntries(nil, nil)
+	if a != nil || d != nil || dom != nil {
+		t.Errorf("expected nil slices, got %v %v %v", a, d, dom)
+	}
+}
+
+// The persisted network_config must carry the normalized entries: it is what
+// reapplyNetworkConfig pushes to VMD after every resume.
+func TestEgressConfigJSONPersistsNormalizedEntries(t *testing.T) {
+	_, _, _, raw := egressConfigJSON(&networkConfigRequest{
+		AllowOut: []string{"1.1.1.1", "api.example.com"},
+		DenyOut:  []string{"0.0.0.0/0"},
+	})
+	got := string(raw)
+	for _, want := range []string{`"1.1.1.1/32"`, `"api.example.com"`, `"0.0.0.0/0"`} {
+		if !contains(got, want) {
+			t.Errorf("persisted config %s missing %s", got, want)
+		}
+	}
+	if contains(got, `"1.1.1.1"`) {
+		t.Errorf("persisted config %s still carries the bare IP", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1173,22 +1173,18 @@ type persistedEgressConfig struct {
 
 // egressConfigJSON splits the request's egress entries into CIDRs and domains
 // and marshals the network_config jsonb shape persisted on the sandbox row.
-func egressConfigJSON(network *networkConfigRequest) (allowedCIDRs, allowedDomains []string, raw []byte) {
-	for _, entry := range network.AllowOut {
-		if isIPOrCIDR(entry) {
-			allowedCIDRs = append(allowedCIDRs, entry)
-		} else {
-			allowedDomains = append(allowedDomains, entry)
-		}
-	}
+// Entries are normalized (a bare IP becomes a /32) so what is persisted is
+// exactly what VMD can apply; see splitEgressEntries.
+func egressConfigJSON(network *networkConfigRequest) (allowedCIDRs, deniedCIDRs, allowedDomains []string, raw []byte) {
+	allowedCIDRs, deniedCIDRs, allowedDomains = splitEgressEntries(network.AllowOut, network.DenyOut)
 	raw, _ = json.Marshal(map[string]any{
 		"egress": map[string]any{
 			"allowed_cidrs":   allowedCIDRs,
-			"denied_cidrs":    network.DenyOut,
+			"denied_cidrs":    deniedCIDRs,
 			"allowed_domains": allowedDomains,
 		},
 	})
-	return allowedCIDRs, allowedDomains, raw
+	return allowedCIDRs, deniedCIDRs, allowedDomains, raw
 }
 
 // reapplyNetworkConfig reads the sandbox's persisted egress config and pushes
@@ -2698,7 +2694,7 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	// rule fetch sees them before the agent can issue a proxied request. The
 	// nftables push happens later (it needs the booted VM); the DB write does not.
 	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
-		_, _, networkConfig := egressConfigJSON(req.Network)
+		_, _, _, networkConfig := egressConfigJSON(req.Network)
 		if err := h.DB.UpdateSandboxNetworkConfig(postCtx, db.UpdateSandboxNetworkConfigParams{
 			ID:            sandbox.ID,
 			NetworkConfig: networkConfig,
@@ -2753,6 +2749,23 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				l.Warn().Err(err).Msg("prime egress rules cache failed (fetch fallback)")
 			}
 		}()
+	}
+
+	// Network rules stay blocking: a 201 must imply "egress rules applied",
+	// so the client can't reach the sandbox before its policy is in place.
+	// This runs before the row goes active, and a failure tears the VM down.
+	// A sandbox that boots without the egress policy it was asked for would
+	// otherwise run with the default allow-all and still report success.
+	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
+		// network_config was persisted above (before env injection); this
+		// only pushes the nftables rules, which need the booted VM.
+		allowedCIDRs, deniedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
+		if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, deniedCIDRs, allowedDomains); err != nil {
+			l.Error().Err(err).Msg("failed to apply network rules at creation")
+			h.failSandboxAfterBoot(postCtx, vmd, sandbox.ID, teamID, sandboxID.String(), hostID)
+			respondError(c, ErrInternal)
+			return
+		}
 	}
 
 	// Single atomic transition: starting → active with real resources
@@ -2841,16 +2854,6 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 		billingCancel()
 	})
 
-	// Network rules stay blocking: a 201 must imply "egress rules applied",
-	// so the client can't reach the sandbox before its policy is in place.
-	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
-		// network_config was persisted above (before env injection); this
-		// only pushes the nftables rules, which need the booted VM.
-		allowedCIDRs, allowedDomains, _ := egressConfigJSON(req.Network)
-		if err := vmd.UpdateSandboxNetwork(postCtx, sandbox.ID.String(), allowedCIDRs, req.Network.DenyOut, allowedDomains); err != nil {
-			l.Error().Err(err).Msg("failed to apply network rules at creation")
-		}
-	}
 	tPostDone = time.Now()
 
 	var createdMeta []byte
@@ -3278,15 +3281,8 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 	}
 
 	if body.Network != nil {
-		// Separate CIDRs and domains from allow_out.
-		var allowedCIDRs, allowedDomains []string
-		for _, entry := range body.Network.AllowOut {
-			if isIPOrCIDR(entry) {
-				allowedCIDRs = append(allowedCIDRs, entry)
-			} else {
-				allowedDomains = append(allowedDomains, entry)
-			}
-		}
+		// Separate CIDRs and domains from allow_out and normalize every CIDR.
+		allowedCIDRs, deniedCIDRs, allowedDomains := splitEgressEntries(body.Network.AllowOut, body.Network.DenyOut)
 
 		// Resolve the VMD client for this sandbox's host.
 		vmd, vmdLookupErr := h.vmdForHost(c.Request.Context(), sandbox.HostID)
@@ -3299,7 +3295,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		// Apply rules to the running VM via VMD.
 		vmdCtx, vmdCancel := context.WithTimeout(c.Request.Context(), vmdTimeout)
 		defer vmdCancel()
-		if err := vmd.UpdateSandboxNetwork(vmdCtx, sandboxID.String(), allowedCIDRs, body.Network.DenyOut, allowedDomains); err != nil {
+		if err := vmd.UpdateSandboxNetwork(vmdCtx, sandboxID.String(), allowedCIDRs, deniedCIDRs, allowedDomains); err != nil {
 			l.Error().Err(err).Msg("VMD UpdateSandboxNetwork failed")
 			respondError(c, ErrInternal)
 			return
@@ -3309,7 +3305,7 @@ func (h *Handlers) PatchSandbox(c *gin.Context) {
 		networkConfig, _ := json.Marshal(map[string]any{
 			"egress": map[string]any{
 				"allowed_cidrs":   allowedCIDRs,
-				"denied_cidrs":    body.Network.DenyOut,
+				"denied_cidrs":    deniedCIDRs,
 				"allowed_domains": allowedDomains,
 			},
 		})
@@ -3524,6 +3520,44 @@ func isIPOrCIDR(s string) bool {
 		return true
 	}
 	return false
+}
+
+// normalizeCIDR canonicalizes an IP or CIDR entry for the firewall. A bare
+// address becomes a single-host prefix ("1.1.1.1" -> "1.1.1.1/32"). The API
+// accepts both forms, but VMD's rule builder only parses prefixes, so an
+// entry that validates here and fails there would leave the sandbox with no
+// rules at all. Domains and unparseable strings are returned unchanged.
+func normalizeCIDR(s string) string {
+	if addr, err := netip.ParseAddr(s); err == nil {
+		// An IPv4-mapped address (::ffff:a.b.c.d) passes validation as v4 but
+		// would otherwise become a /128 the IPv4-only firewall skips.
+		addr = addr.Unmap()
+		return netip.PrefixFrom(addr, addr.BitLen()).String()
+	}
+	if prefix, err := netip.ParsePrefix(s); err == nil {
+		if prefix.Addr().Is4In6() && prefix.Bits() >= 96 {
+			prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
+		}
+		return prefix.String()
+	}
+	return s
+}
+
+// splitEgressEntries separates allow_out into CIDRs and domains and
+// normalizes every CIDR (allow and deny) so the persisted config and the
+// rules pushed to VMD are the same canonical strings.
+func splitEgressEntries(allowOut, denyOut []string) (allowedCIDRs, deniedCIDRs, allowedDomains []string) {
+	for _, entry := range allowOut {
+		if isIPOrCIDR(entry) {
+			allowedCIDRs = append(allowedCIDRs, normalizeCIDR(entry))
+		} else {
+			allowedDomains = append(allowedDomains, entry)
+		}
+	}
+	for _, entry := range denyOut {
+		deniedCIDRs = append(deniedCIDRs, normalizeCIDR(entry))
+	}
+	return allowedCIDRs, deniedCIDRs, allowedDomains
 }
 
 // validateEgressRules enforces the rules shared between CreateSandbox and

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2874,7 +2874,13 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 	resp := h.sandboxToResponseWithToken(sandbox)
 	resp.PreviewAccess = previewAccess
 	if req.Network != nil && (len(req.Network.AllowOut) > 0 || len(req.Network.DenyOut) > 0) {
-		resp.Network = req.Network
+		// Echo the normalized rules, not the raw request, so the create
+		// response matches what a subsequent GET returns (bare IPs as /32).
+		allowedCIDRs, deniedCIDRs, allowedDomains := splitEgressEntries(req.Network.AllowOut, req.Network.DenyOut)
+		resp.Network = &networkConfigRequest{
+			AllowOut: append(allowedCIDRs, allowedDomains...),
+			DenyOut:  deniedCIDRs,
+		}
 	}
 	l.Info().
 		Int64("auth_ms", c.GetInt64("auth_ms")).

--- a/internal/integration/egress_rules_test.go
+++ b/internal/integration/egress_rules_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+const egressTestSeed = "integration-egress-seed-32-bytes!!"
+
+// A create that asks for egress rules must not succeed when the rules could
+// not be applied: the VM would otherwise run with the default allow-all and
+// the caller would never know.
+func TestIntegration_CreateSandbox_NetworkApplyFailure_FailsClosed(t *testing.T) {
+	teamID, apiKey := seedTeamAndKey(t)
+	r := previewTokenIntegrationRouter(t, &stubVMD{updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
+		return errors.New("forced rule application failure")
+	}}, []byte(egressTestSeed))
+
+	cw := do(r, "POST", "/sandboxes", apiKey,
+		`{"name":"net-fail-closed","network":{"allow_out":["api.example.com"],"deny_out":["0.0.0.0/0"]}}`)
+	if cw.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when rules cannot be applied, got %d: %s", cw.Code, cw.Body.String())
+	}
+
+	var status string
+	if err := testPool.QueryRow(context.Background(),
+		`SELECT status FROM sandbox WHERE team_id=$1 AND name=$2`, teamID, "net-fail-closed",
+	).Scan(&status); err != nil {
+		t.Fatalf("read sandbox row: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("sandbox status = %q, want failed", status)
+	}
+}
+
+// Bare IPs are accepted on the wire but reach VMD (and the persisted config)
+// as single-host prefixes, so the firewall can always apply them.
+func TestIntegration_CreateSandbox_NetworkBareIPNormalized(t *testing.T) {
+	_, apiKey := seedTeamAndKey(t)
+	var mu sync.Mutex
+	var gotAllowed, gotDenied, gotDomains []string
+	r := previewTokenIntegrationRouter(t, &stubVMD{updateNetworkFn: func(_ context.Context, _ string, allowed, denied, domains []string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotAllowed, gotDenied, gotDomains = allowed, denied, domains
+		return nil
+	}}, []byte(egressTestSeed))
+
+	cw := do(r, "POST", "/sandboxes", apiKey,
+		`{"name":"net-bare-ip","network":{"allow_out":["203.0.113.7","198.51.100.0/24","api.example.com"],"deny_out":["0.0.0.0/0","203.0.113.9"]}}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+
+	mu.Lock()
+	allowed, denied, domains := gotAllowed, gotDenied, gotDomains
+	mu.Unlock()
+	if want := []string{"203.0.113.7/32", "198.51.100.0/24"}; !reflect.DeepEqual(allowed, want) {
+		t.Errorf("VMD allowed CIDRs = %v, want %v", allowed, want)
+	}
+	if want := []string{"0.0.0.0/0", "203.0.113.9/32"}; !reflect.DeepEqual(denied, want) {
+		t.Errorf("VMD denied CIDRs = %v, want %v", denied, want)
+	}
+	if want := []string{"api.example.com"}; !reflect.DeepEqual(domains, want) {
+		t.Errorf("VMD domains = %v, want %v", domains, want)
+	}
+
+	// The read-back reflects the canonical form, and it is what a resume replays.
+	sid := mustJSON(t, cw)["id"].(string)
+	gw := do(r, "GET", "/sandboxes/"+sid, apiKey, "")
+	if gw.Code != http.StatusOK {
+		t.Fatalf("get: %d %s", gw.Code, gw.Body.String())
+	}
+	network, _ := mustJSON(t, gw)["network"].(map[string]interface{})
+	if network == nil {
+		t.Fatalf("no network in response: %s", gw.Body.String())
+	}
+	allowOut := stringsOf(network["allow_out"])
+	for _, want := range []string{"203.0.113.7/32", "198.51.100.0/24", "api.example.com"} {
+		if !containsString(allowOut, want) {
+			t.Errorf("allow_out %v missing %q", allowOut, want)
+		}
+	}
+	if containsString(allowOut, "203.0.113.7") {
+		t.Errorf("allow_out %v still carries the bare IP", allowOut)
+	}
+}
+
+func TestIntegration_PatchSandbox_NetworkBareIPNormalized(t *testing.T) {
+	_, apiKey := seedTeamAndKey(t)
+	var mu sync.Mutex
+	var gotAllowed, gotDenied []string
+	r := previewTokenIntegrationRouter(t, &stubVMD{updateNetworkFn: func(_ context.Context, _ string, allowed, denied, _ []string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotAllowed, gotDenied = allowed, denied
+		return nil
+	}}, []byte(egressTestSeed))
+
+	cw := do(r, "POST", "/sandboxes", apiKey, `{"name":"net-patch-bare-ip"}`)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", cw.Code, cw.Body.String())
+	}
+	sid := mustJSON(t, cw)["id"].(string)
+
+	pw := do(r, "PATCH", "/sandboxes/"+sid, apiKey,
+		`{"network":{"allow_out":["203.0.113.7"],"deny_out":["203.0.113.9"]}}`)
+	if pw.Code != http.StatusNoContent {
+		t.Fatalf("patch: %d %s", pw.Code, pw.Body.String())
+	}
+	mu.Lock()
+	allowed, denied := gotAllowed, gotDenied
+	mu.Unlock()
+	if want := []string{"203.0.113.7/32"}; !reflect.DeepEqual(allowed, want) {
+		t.Errorf("VMD allowed CIDRs = %v, want %v", allowed, want)
+	}
+	if want := []string{"203.0.113.9/32"}; !reflect.DeepEqual(denied, want) {
+		t.Errorf("VMD denied CIDRs = %v, want %v", denied, want)
+	}
+}
+
+func stringsOf(v interface{}) []string {
+	items, _ := v.([]interface{})
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/integration/egress_rules_test.go
+++ b/internal/integration/egress_rules_test.go
@@ -71,8 +71,22 @@ func TestIntegration_CreateSandbox_NetworkBareIPNormalized(t *testing.T) {
 		t.Errorf("VMD domains = %v, want %v", domains, want)
 	}
 
+	// The create response already carries the canonical form, so POST and a
+	// subsequent GET describe the resource identically.
+	created := mustJSON(t, cw)
+	createdNetwork, _ := created["network"].(map[string]interface{})
+	if createdNetwork == nil {
+		t.Fatalf("no network in create response: %s", cw.Body.String())
+	}
+	if got, want := stringsOf(createdNetwork["allow_out"]), []string{"203.0.113.7/32", "198.51.100.0/24", "api.example.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("create response allow_out = %v, want %v", got, want)
+	}
+	if got, want := stringsOf(createdNetwork["deny_out"]), []string{"0.0.0.0/0", "203.0.113.9/32"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("create response deny_out = %v, want %v", got, want)
+	}
+
 	// The read-back reflects the canonical form, and it is what a resume replays.
-	sid := mustJSON(t, cw)["id"].(string)
+	sid := created["id"].(string)
 	gw := do(r, "GET", "/sandboxes/"+sid, apiKey, "")
 	if gw.Code != http.StatusOK {
 		t.Fatalf("get: %d %s", gw.Code, gw.Body.String())

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -295,6 +295,7 @@ func applyMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 // values so that HTTP handlers can complete and write to the DB.
 type stubVMD struct {
 	updatePreviewFn func(context.Context, string, string, map[int32]vmdclient.PortPolicy, int64) error
+	updateNetworkFn func(ctx context.Context, instanceID string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error
 }
 
 func (s *stubVMD) DestroyInstance(_ context.Context, _ string, _ bool) error { return nil }
@@ -313,7 +314,10 @@ func (s *stubVMD) InjectSandboxEnv(_ context.Context, _ string, _ map[string]str
 func (s *stubVMD) ListDir(_ context.Context, _, _ string) ([]vmdclient.DirEntry, error) {
 	return nil, nil
 }
-func (s *stubVMD) UpdateSandboxNetwork(_ context.Context, _ string, _, _, _ []string) error {
+func (s *stubVMD) UpdateSandboxNetwork(ctx context.Context, instanceID string, allowedCIDRs, deniedCIDRs, allowedDomains []string) error {
+	if s.updateNetworkFn != nil {
+		return s.updateNetworkFn(ctx, instanceID, allowedCIDRs, deniedCIDRs, allowedDomains)
+	}
 	return nil
 }
 

--- a/internal/network/firewall.go
+++ b/internal/network/firewall.go
@@ -721,7 +721,21 @@ func cidrsToElements(cidrs []string) ([]nftables.SetElement, error) {
 	for _, cidr := range cidrs {
 		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+			// Accept a bare address as a single-host prefix. The API
+			// normalizes these before they get here, but rows persisted
+			// before that normalization (and any other caller) must still
+			// apply cleanly rather than fail the whole rule set.
+			addr, addrErr := netip.ParseAddr(cidr)
+			if addrErr != nil {
+				return nil, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+			}
+			addr = addr.Unmap()
+			prefix = netip.PrefixFrom(addr, addr.BitLen())
+		}
+		if prefix.Addr().Is4In6() && prefix.Bits() >= 96 {
+			// IPv4-mapped prefixes are IPv4 rules in disguise; apply them
+			// rather than dropping them with the real IPv6 entries.
+			prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-96)
 		}
 		if !prefix.Addr().Is4() {
 			continue

--- a/internal/network/firewall_test.go
+++ b/internal/network/firewall_test.go
@@ -74,3 +74,56 @@ func TestCidrsToElementsCoalesces(t *testing.T) {
 		t.Errorf("got %d set elements, want 2 (one start/end pair)", len(elems))
 	}
 }
+
+func TestCidrsToElementsAcceptsBareIP(t *testing.T) {
+	// A bare address must produce the same interval as its /32. Rows written
+	// before the API normalized entries still carry the bare form, and one
+	// unparseable entry would otherwise fail the whole rule set.
+	bare, err := cidrsToElements([]string{"1.1.1.1"})
+	if err != nil {
+		t.Fatalf("bare IP rejected: %v", err)
+	}
+	cidr, err := cidrsToElements([]string{"1.1.1.1/32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bare) != 2 || len(cidr) != 2 {
+		t.Fatalf("got %d and %d elements, want 2 and 2", len(bare), len(cidr))
+	}
+	for i := range bare {
+		if string(bare[i].Key) != string(cidr[i].Key) || bare[i].IntervalEnd != cidr[i].IntervalEnd {
+			t.Errorf("element %d differs: bare=%v cidr=%v", i, bare[i], cidr[i])
+		}
+	}
+	if _, err := cidrsToElements([]string{"not-an-ip"}); err == nil {
+		t.Error("garbage entry should still be rejected")
+	}
+}
+
+func TestCidrsToElementsUnmapsIPv4Mapped(t *testing.T) {
+	// ::ffff:a.b.c.d is an IPv4 rule; it must apply, not be skipped as v6.
+	mapped, err := cidrsToElements([]string{"::ffff:203.0.113.9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := cidrsToElements([]string{"203.0.113.9/32"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mapped) != 2 {
+		t.Fatalf("mapped address produced %d elements, want 2", len(mapped))
+	}
+	for i := range mapped {
+		if string(mapped[i].Key) != string(plain[i].Key) {
+			t.Errorf("element %d differs: mapped=%v plain=%v", i, mapped[i], plain[i])
+		}
+	}
+	mappedPrefix, err := cidrsToElements([]string{"::ffff:203.0.113.0/120"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plainPrefix, _ := cidrsToElements([]string{"203.0.113.0/24"})
+	if len(mappedPrefix) != 2 || string(mappedPrefix[1].Key) != string(plainPrefix[1].Key) {
+		t.Errorf("mapped prefix not applied as its IPv4 equivalent: %v vs %v", mappedPrefix, plainPrefix)
+	}
+}


### PR DESCRIPTION
## Summary

A sandbox created with egress rules could come up with no rules at all and still return 201. Bare IPs (`1.1.1.1`) pass API validation, which accepts addresses and prefixes, but the firewall's rule builder only parses prefixes and rejected them. CreateSandbox logged the failure and returned success, so the sandbox ran with the default allow-all policy. Reproduced live: `allowOut: ["1.1.1.1", ...], denyOut: ["0.0.0.0/0"]` produced a sandbox whose network log showed every connection `allowed default`, including destinations no rule permitted.

This makes the create path fail closed and normalizes the input so the failure can't happen for this reason in the first place.

## Technical decisions

- **Normalize at the API boundary.** `splitEgressEntries` canonicalizes every CIDR in `allow_out` and `deny_out` (bare IP → `/32`, IPv4-mapped → plain IPv4) before persisting and before pushing to VMD, so the stored config, the PATCH path, and the resume replay all carry the same strings. API-visible effect: a sandbox created with `1.1.1.1` reads back `1.1.1.1/32`.
- **Fail closed on create.** The rule push now runs before the row goes active and, on error, tears the VM down via `failSandboxAfterBoot` and returns 500, matching how env injection and preview policy failures are handled. The push was already synchronous per the existing comment; this only moves it ahead of the async activation so the two can't race.
- **Defense in depth in the firewall.** `cidrsToElements` accepts a bare address as a single-host prefix and applies IPv4-mapped prefixes as IPv4, so rows persisted before this change still apply cleanly on resume instead of failing the whole set.
- Not changed here: a deny-all rule also blocks DNS to the sandbox resolvers, so a domain-only strict allowlist cannot resolve anything. That is a docs fix for now and a separate product decision on whether to exempt resolver traffic.

## Testing

- Unit: `normalizeCIDR` / `splitEgressEntries` / persisted config shape; firewall bare-IP and IPv4-mapped parsing. Full unit suite passes on Linux.
- Integration (Postgres + stub VMD): create fails with 500 and the row is `failed` when rule application errors; create and PATCH deliver normalized CIDRs to VMD and read back `/32`. Full integration suite passes.
- Local Codex review iterated to a clean pass.