### PR TITLE
deploy-vmd: enable BACKUP_STAGING_DIR on the usw production host

### DIFF
--- a/.github/workflows/deploy-vmd.yml
+++ b/.github/workflows/deploy-vmd.yml
@@ -375,19 +375,19 @@ jobs:
           # continuously while backups drain and can stall the uploader
           # if the (small) root disk fills.
           BACKUP_JOURNAL_PATH: /mnt/localssd/backup.db
-          # BACKUP_STAGING_DIR (moves staged generations off the
-          # local-SSD array onto the host's dedicated background-data
-          # disk — at BACKUP_UPLOAD_CONCURRENCY workers below, the
-          # sharpest remaining contention risk against tenant VM disk
-          # I/O on that array) is deliberately NOT set here yet. The
-          # Terraform disk is attached but not formatted or mounted —
-          # that step is manual (see host-dr-runbook.md) — and
-          # deploy-vmd.py's mount precondition refuses to deploy with
-          # this set against an absent mount, which would block every
-          # future deploy to this host until someone notices and preps
-          # it out of band. Enable once /mnt/sandbox-data is confirmed
-          # mounted here, matching the staged rollout already used for
-          # BACKUP_UPLOAD_CONCURRENCY below (validated on staging first).
+          # Moves staged generations off the local-SSD array onto the
+          # host's dedicated background-data disk — at
+          # BACKUP_UPLOAD_CONCURRENCY workers below, the sharpest
+          # contention risk against tenant VM disk I/O on that array,
+          # confirmed live in production: pause snapshot writes to
+          # md0 stalled from ~3s to 27-135s under a concurrent backfill
+          # sweep, exceeding the control plane's deadline and failing
+          # pauses outright. The disk is formatted (XFS) and mounted at
+          # /mnt/sandbox-data (fstab, not the staging host's migration
+          # unit — this disk holds only backup staging, nothing to
+          # migrate). deploy-vmd.py's mount precondition would refuse
+          # this deploy outright if that were not true.
+          BACKUP_STAGING_DIR: /mnt/sandbox-data/backup-staging
           # Drain workers to clear the cell's pause-backup backlog:
           # arrivals outpace the single-worker default here. Workers
           # share one bandwidth cap (task throughput rises, egress does


### PR DESCRIPTION
## Summary
- Today, pause snapshot writes on usw2 stalled from a ~3s baseline up to 27-135s under a concurrent backup backfill sweep, exceeding the control plane's pause deadline and failing 2 sandbox pauses outright. Root cause: pause writes and the backup uploader/backfill both contend for `/dev/md0`, the array that also serves live VM disk I/O.
- The intended fix (a dedicated background-data disk, attached via Terraform in an earlier PR) was never turned on for this host — the disk was attached but left unformatted/unmounted, deliberately deferred to a manual follow-up step.
- This PR turns it on: the disk is now formatted (XFS) and mounted at `/mnt/sandbox-data` on usw2, and this sets `BACKUP_STAGING_DIR` so the uploader stages generations there instead of on `md0`.

## Technical decisions / tradeoffs
- Formatted and mounted directly via a plain `mkfs.xfs` + fstab entry, not the staging host's existing data-disk migration unit — that unit performs a one-time migration of `rundir`/`snapshots` themselves onto the disk (staging's only large disk serves both roles). usw2's `rundir`/`snapshots` already correctly live on `md0`; this disk holds only backup staging, so there's nothing to migrate and no need for that machinery.
- Left `BACKUP_UPLOAD_CONCURRENCY` unchanged (12) — the contention was against `md0`, not concurrency itself; moving staging off that array is the fix, not reducing worker count.
- `use4` has the same deferred gap (disk attached, not activated) but isn't under the same contention (no heavy backfill there) — left as a separate follow-up, not bundled into this incident fix.

## Testing
- Confirmed on the live host before this PR: the target disk (`/dev/nvme0n2`, stable path `/dev/disk/by-id/google-superserve-sandbox-data`) was blank (no `blkid` signature, no partitions) and fully separate from `md0` before formatting.
- Formatted, mounted, and verified via `findmnt`/`df` on usw2; survives reboot via `/etc/fstab`.
- `deploy-vmd.py`'s existing mount precondition (refuses to deploy `BACKUP_STAGING_DIR` against a non-mounted path) now passes against the real mount.
- Local Codex review: clean, no findings.