### PR TITLE
boxd: create the parent only when absent and surface filesystem errors with their mount

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4357,7 +4357,10 @@ components:
           properties:
             error:
               type: object
+              required: [code, errno]
               properties:
+                code:
+                  const: sandbox_filesystem_error
                 errno:
                   type: string
                 path:
@@ -4433,7 +4436,7 @@ components:
       content:
         application/json:
           schema:
-            oneOf:
+            anyOf:
               - $ref: "#/components/schemas/Error"
               - $ref: "#/components/schemas/FilesystemError"
     ServiceUnavailable:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1904,7 +1904,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
-          $ref: "#/components/responses/InternalError"
+          $ref: "#/components/responses/FilesInternalError"
 
     post:
       operationId: writeFile
@@ -1934,7 +1934,7 @@ paths:
         "507":
           $ref: "#/components/responses/StorageFull"
         "500":
-          $ref: "#/components/responses/InternalError"
+          $ref: "#/components/responses/FilesInternalError"
 
   /templates:
     get:
@@ -4343,6 +4343,32 @@ components:
               type: string
             message:
               type: string
+    FilesystemError:
+      description: >
+        Error envelope for a failure raised by the sandbox's own filesystem
+        rather than by the platform — typically a network or FUSE mount
+        attached inside the sandbox. `error.code` is
+        `sandbox_filesystem_error`; `errno` names the failure (for example
+        `ESTALE` or `EIO`) and `mount` identifies the mountpoint and
+        filesystem type that served the path.
+      allOf:
+        - $ref: "#/components/schemas/Error"
+        - type: object
+          properties:
+            error:
+              type: object
+              properties:
+                errno:
+                  type: string
+                path:
+                  type: string
+                mount:
+                  type: object
+                  properties:
+                    mountpoint:
+                      type: string
+                    fstype:
+                      type: string
 
   responses:
     BadRequest:
@@ -4398,6 +4424,18 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    FilesInternalError:
+      description: >
+        Internal server error. When `error.code` is
+        `sandbox_filesystem_error`, the sandbox's own filesystem rejected the
+        operation and the body also carries `errno`, `path`, and the `mount`
+        that served it.
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/Error"
+              - $ref: "#/components/schemas/FilesystemError"
     ServiceUnavailable:
       description: >
         The sandbox is not currently running (for example, paused) or is

--- a/cmd/boxd/fserror.go
+++ b/cmd/boxd/fserror.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -69,19 +70,24 @@ func writeFSError(w http.ResponseWriter, path string, err error) {
 }
 
 // mountFor returns the mount serving path, or nil when it cannot be
-// determined. Symlinks are followed by name only: the target of a link
-// into a mount is matched even when that mount no longer answers stat.
+// determined. Symlinks are followed by name only, and the walk stops at
+// the first mountpoint it enters, so a failing mount is identified without
+// ever being touched again.
 func mountFor(path string) *fsErrorMount {
 	data, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
 		return nil
 	}
-	return mountForIn(string(data), resolveByName(path))
+	mounts := parseMountinfo(string(data))
+	return longestMount(mounts, resolveByName(path, mounts))
 }
 
-// mountForIn picks the longest mountpoint in mountinfo that contains path.
 func mountForIn(mountinfo, path string) *fsErrorMount {
-	var best *fsErrorMount
+	return longestMount(parseMountinfo(mountinfo), path)
+}
+
+func parseMountinfo(mountinfo string) []fsErrorMount {
+	var mounts []fsErrorMount
 	for _, line := range strings.Split(mountinfo, "\n") {
 		fields := strings.Fields(line)
 		sep := -1
@@ -94,28 +100,75 @@ func mountForIn(mountinfo, path string) *fsErrorMount {
 		if len(fields) < 5 || sep < 0 || sep+1 >= len(fields) {
 			continue
 		}
-		mp := strings.ReplaceAll(fields[4], `\040`, " ")
-		if path != mp && !strings.HasPrefix(path, strings.TrimSuffix(mp, "/")+"/") {
-			continue
-		}
-		if best == nil || len(mp) > len(best.Mountpoint) {
-			best = &fsErrorMount{Mountpoint: mp, Fstype: fields[sep+1]}
+		mounts = append(mounts, fsErrorMount{Mountpoint: unescapeMountinfo(fields[4]), Fstype: fields[sep+1]})
+	}
+	return mounts
+}
+
+// longestMount picks the deepest mountpoint that contains path.
+func longestMount(mounts []fsErrorMount, path string) *fsErrorMount {
+	var best *fsErrorMount
+	for i := range mounts {
+		m := &mounts[i]
+		if pathWithin(path, m.Mountpoint) && (best == nil || len(m.Mountpoint) > len(best.Mountpoint)) {
+			best = m
 		}
 	}
 	return best
 }
 
-// resolveByName expands the symlinks in path using readlink alone. Unlike
-// filepath.EvalSymlinks it never stats a link's target, so a link pointing
-// into a broken mount still resolves to that mount's path; components that
-// cannot be inspected are kept as written.
-func resolveByName(path string) string {
+func pathWithin(path, dir string) bool {
+	return path == dir || strings.HasPrefix(path, strings.TrimSuffix(dir, "/")+"/")
+}
+
+// insideMount reports whether p sits at or below a mountpoint other than
+// the root filesystem.
+func insideMount(mounts []fsErrorMount, p string) bool {
+	for _, m := range mounts {
+		if m.Mountpoint != "/" && pathWithin(p, m.Mountpoint) {
+			return true
+		}
+	}
+	return false
+}
+
+// unescapeMountinfo decodes the octal escapes the kernel writes for special
+// characters in mountinfo fields, such as \040 for a space.
+func unescapeMountinfo(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) {
+			if n, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
+				b.WriteByte(byte(n))
+				i += 3
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// resolveByName expands the symlinks in path using readlink alone, and
+// only for components outside any mount in mounts. Unlike
+// filepath.EvalSymlinks it never stats a link's target, and it never looks
+// inside a mount: once the path enters one, the rest is kept as written,
+// which is all the mount match needs and keeps a hung mount from stalling
+// the error response. Components that cannot be inspected are also kept.
+func resolveByName(path string, mounts []fsErrorMount) string {
 	path = filepath.Clean(path)
 	for hops := 0; hops < 40; hops++ {
 		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 		relinked := false
 		for i := range parts {
 			prefix := "/" + filepath.Join(parts[:i+1]...)
+			if insideMount(mounts, prefix) {
+				return path
+			}
 			fi, err := os.Lstat(prefix)
 			if err != nil {
 				return path

--- a/cmd/boxd/fserror.go
+++ b/cmd/boxd/fserror.go
@@ -47,8 +47,8 @@ type fsErrorBody struct {
 // the filesystem itself carries its errno and the mount that served the
 // path; any other error keeps the plain `{"error": message}` body.
 func writeFSError(w http.ResponseWriter, path string, err error) {
-	var errno syscall.Errno
-	if !errors.As(err, &errno) || !fsErrnos[errno] {
+	errno, ok := fsErrno(err)
+	if !ok {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -62,6 +62,15 @@ func writeFSError(w http.ResponseWriter, path string, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusInternalServerError)
 	_ = json.NewEncoder(w).Encode(map[string]any{"error": body})
+}
+
+// fsErrno reports whether err was raised by the filesystem itself.
+func fsErrno(err error) (syscall.Errno, bool) {
+	var errno syscall.Errno
+	if errors.As(err, &errno) && fsErrnos[errno] {
+		return errno, true
+	}
+	return 0, false
 }
 
 // mountFor returns the mount serving path, or nil when unknown. Symlinks

--- a/cmd/boxd/fserror.go
+++ b/cmd/boxd/fserror.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// fsErrorCode marks a failure raised by the sandbox's own filesystem — a
+// stale handle, an I/O error, an unreachable mount — as opposed to boxd
+// itself failing. Callers branch on `error.code` the same way they do for
+// sandbox_storage_full.
+const fsErrorCode = "sandbox_filesystem_error"
+
+// fsErrnos are the errors a filesystem returns when it, rather than the
+// request, is the problem. They are typical of network and FUSE mounts a
+// workload attaches inside the sandbox.
+var fsErrnos = map[syscall.Errno]bool{
+	syscall.ESTALE:       true,
+	syscall.EIO:          true,
+	syscall.ENOTCONN:     true,
+	syscall.ETIMEDOUT:    true,
+	syscall.EHOSTDOWN:    true,
+	syscall.EHOSTUNREACH: true,
+	syscall.ENETDOWN:     true,
+	syscall.ENETUNREACH:  true,
+}
+
+type fsErrorMount struct {
+	Mountpoint string `json:"mountpoint"`
+	Fstype     string `json:"fstype"`
+}
+
+type fsErrorBody struct {
+	Code    string        `json:"code"`
+	Message string        `json:"message"`
+	Errno   string        `json:"errno"`
+	Path    string        `json:"path,omitempty"`
+	Mount   *fsErrorMount `json:"mount,omitempty"`
+}
+
+// writeFSError reports a failed filesystem operation on path. A failure
+// that came from the filesystem itself gets the sandbox_filesystem_error
+// code, the errno, and the mount that served the path, so the caller can
+// tell a misbehaving mount from a boxd fault. Any other error keeps the
+// plain `{"error": message}` body.
+func writeFSError(w http.ResponseWriter, path string, err error) {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) || !fsErrnos[errno] {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	body := fsErrorBody{
+		Code:    fsErrorCode,
+		Message: err.Error(),
+		Errno:   unix.ErrnoName(errno),
+		Path:    path,
+		Mount:   mountFor(path),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": body})
+}
+
+// mountFor returns the mount serving path, or nil when it cannot be
+// determined. Symlinks are followed by name only: the target of a link
+// into a mount is matched even when that mount no longer answers stat.
+func mountFor(path string) *fsErrorMount {
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return nil
+	}
+	return mountForIn(string(data), resolveByName(path))
+}
+
+// mountForIn picks the longest mountpoint in mountinfo that contains path.
+func mountForIn(mountinfo, path string) *fsErrorMount {
+	var best *fsErrorMount
+	for _, line := range strings.Split(mountinfo, "\n") {
+		fields := strings.Fields(line)
+		sep := -1
+		for i, f := range fields {
+			if f == "-" {
+				sep = i
+				break
+			}
+		}
+		if len(fields) < 5 || sep < 0 || sep+1 >= len(fields) {
+			continue
+		}
+		mp := strings.ReplaceAll(fields[4], `\040`, " ")
+		if path != mp && !strings.HasPrefix(path, strings.TrimSuffix(mp, "/")+"/") {
+			continue
+		}
+		if best == nil || len(mp) > len(best.Mountpoint) {
+			best = &fsErrorMount{Mountpoint: mp, Fstype: fields[sep+1]}
+		}
+	}
+	return best
+}
+
+// resolveByName expands the symlinks in path using readlink alone. Unlike
+// filepath.EvalSymlinks it never stats a link's target, so a link pointing
+// into a broken mount still resolves to that mount's path; components that
+// cannot be inspected are kept as written.
+func resolveByName(path string) string {
+	path = filepath.Clean(path)
+	for hops := 0; hops < 40; hops++ {
+		parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+		relinked := false
+		for i := range parts {
+			prefix := "/" + filepath.Join(parts[:i+1]...)
+			fi, err := os.Lstat(prefix)
+			if err != nil {
+				return path
+			}
+			if fi.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, err := os.Readlink(prefix)
+			if err != nil {
+				return path
+			}
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(filepath.Dir(prefix), target)
+			}
+			path = filepath.Clean(filepath.Join(append([]string{target}, parts[i+1:]...)...))
+			relinked = true
+			break
+		}
+		if !relinked {
+			return path
+		}
+	}
+	return path
+}
+
+// ensureParentDir creates path's parent only when it is genuinely absent.
+// An existing entry — including a symlink into another filesystem — is
+// left alone, and any other lookup failure is returned as-is. os.MkdirAll
+// treats every stat error as "missing" and then trips over the existing
+// entry with EEXIST, hiding the filesystem's real error.
+func ensureParentDir(path string) error {
+	dir := filepath.Dir(path)
+	_, err := os.Lstat(dir)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/cmd/boxd/fserror.go
+++ b/cmd/boxd/fserror.go
@@ -13,15 +13,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// fsErrorCode marks a failure raised by the sandbox's own filesystem — a
-// stale handle, an I/O error, an unreachable mount — as opposed to boxd
-// itself failing. Callers branch on `error.code` the same way they do for
-// sandbox_storage_full.
+// fsErrorCode marks a failure raised by the sandbox's own filesystem rather
+// than by boxd; callers branch on it like sandbox_storage_full.
 const fsErrorCode = "sandbox_filesystem_error"
 
-// fsErrnos are the errors a filesystem returns when it, rather than the
-// request, is the problem. They are typical of network and FUSE mounts a
-// workload attaches inside the sandbox.
+// fsErrnos are the errors a filesystem returns when it, not the request, is
+// the problem — typical of network and FUSE mounts.
 var fsErrnos = map[syscall.Errno]bool{
 	syscall.ESTALE:       true,
 	syscall.EIO:          true,
@@ -46,11 +43,9 @@ type fsErrorBody struct {
 	Mount   *fsErrorMount `json:"mount,omitempty"`
 }
 
-// writeFSError reports a failed filesystem operation on path. A failure
-// that came from the filesystem itself gets the sandbox_filesystem_error
-// code, the errno, and the mount that served the path, so the caller can
-// tell a misbehaving mount from a boxd fault. Any other error keeps the
-// plain `{"error": message}` body.
+// writeFSError reports a failed filesystem operation. A failure raised by
+// the filesystem itself carries its errno and the mount that served the
+// path; any other error keeps the plain `{"error": message}` body.
 func writeFSError(w http.ResponseWriter, path string, err error) {
 	var errno syscall.Errno
 	if !errors.As(err, &errno) || !fsErrnos[errno] {
@@ -69,10 +64,9 @@ func writeFSError(w http.ResponseWriter, path string, err error) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"error": body})
 }
 
-// mountFor returns the mount serving path, or nil when it cannot be
-// determined. Symlinks are followed by name only, and the walk stops at
-// the first mountpoint it enters, so a failing mount is identified without
-// ever being touched again.
+// mountFor returns the mount serving path, or nil when unknown. Symlinks
+// are followed by name only and the walk stops at the first mountpoint, so
+// a failing mount is identified without being touched again.
 func mountFor(path string) *fsErrorMount {
 	data, err := os.ReadFile("/proc/self/mountinfo")
 	if err != nil {
@@ -153,12 +147,10 @@ func unescapeMountinfo(s string) string {
 	return b.String()
 }
 
-// resolveByName expands the symlinks in path using readlink alone, and
-// only for components outside any mount in mounts. Unlike
-// filepath.EvalSymlinks it never stats a link's target, and it never looks
-// inside a mount: once the path enters one, the rest is kept as written,
-// which is all the mount match needs and keeps a hung mount from stalling
-// the error response. Components that cannot be inspected are also kept.
+// resolveByName expands symlinks with readlink alone and stops once the
+// path enters a mount: unlike filepath.EvalSymlinks it never stats a
+// link's target or looks inside a mount, so a hung mount cannot stall the
+// error response. Anything it cannot inspect is kept as written.
 func resolveByName(path string, mounts []fsErrorMount) string {
 	path = filepath.Clean(path)
 	for hops := 0; hops < 40; hops++ {
@@ -195,10 +187,9 @@ func resolveByName(path string, mounts []fsErrorMount) string {
 }
 
 // ensureParentDir creates path's parent only when it is genuinely absent.
-// An existing entry — including a symlink into another filesystem — is
-// left alone, and any other lookup failure is returned as-is. os.MkdirAll
-// treats every stat error as "missing" and then trips over the existing
-// entry with EEXIST, hiding the filesystem's real error.
+// os.MkdirAll treats any stat error as "missing" and then trips over the
+// existing entry (often a symlink into a mount) with EEXIST, hiding the
+// filesystem's real error; here that error is returned as-is instead.
 func ensureParentDir(path string) error {
 	dir := filepath.Dir(path)
 	_, err := os.Lstat(dir)

--- a/cmd/boxd/fserror_test.go
+++ b/cmd/boxd/fserror_test.go
@@ -92,9 +92,29 @@ func TestResolveByName(t *testing.T) {
 		filepath.Join(root, "real", "plain"):      filepath.Join(real, "plain"),
 	}
 	for in, want := range cases {
-		if got := resolveByName(in); got != want {
+		if got := resolveByName(in, nil); got != want {
 			t.Errorf("resolveByName(%q) = %q, want %q", in, got, want)
 		}
+	}
+
+	// A mount is never looked inside: a link within it stays unresolved,
+	// while a link from outside that points into it still lands there.
+	mnt := filepath.Join(root, "mnt")
+	if err := os.Mkdir(mnt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(mnt, "inner")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(mnt, "sub"), filepath.Join(root, "into")); err != nil {
+		t.Fatal(err)
+	}
+	mounts := []fsErrorMount{{Mountpoint: "/", Fstype: "ext4"}, {Mountpoint: mnt, Fstype: "fuse.example"}}
+	if got, want := resolveByName(filepath.Join(mnt, "inner", "f"), mounts), filepath.Join(mnt, "inner", "f"); got != want {
+		t.Errorf("walked inside the mount: got %q, want %q", got, want)
+	}
+	if got, want := resolveByName(filepath.Join(root, "into", "f"), mounts), filepath.Join(mnt, "sub", "f"); got != want {
+		t.Errorf("link into the mount: got %q, want %q", got, want)
 	}
 }
 
@@ -103,6 +123,7 @@ func TestMountForIn(t *testing.T) {
 40 22 0:35 / /mnt rw,relatime shared:2 - tmpfs tmpfs rw
 41 40 0:36 / /mnt/data rw,nosuid shared:3 master:1 - fuse.example example rw,user_id=0
 42 22 0:37 / /with\040space rw - nfs4 host:/x rw
+43 22 0:38 / /back\134slash rw - ext4 /dev/x rw
 `
 	cases := []struct {
 		path string
@@ -112,6 +133,7 @@ func TestMountForIn(t *testing.T) {
 		{"/mnt/data", &fsErrorMount{"/mnt/data", "fuse.example"}},
 		{"/mnt/datastore/f", &fsErrorMount{"/mnt", "tmpfs"}},
 		{"/with space/f", &fsErrorMount{"/with space", "nfs4"}},
+		{`/back\slash/f`, &fsErrorMount{`/back\slash`, "ext4"}},
 		{"/etc/hosts", &fsErrorMount{"/", "ext4"}},
 	}
 	for _, c := range cases {

--- a/cmd/boxd/fserror_test.go
+++ b/cmd/boxd/fserror_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestEnsureParentDir(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("creates a missing parent", func(t *testing.T) {
+		p := filepath.Join(root, "a", "b", "f.txt")
+		if err := ensureParentDir(p); err != nil {
+			t.Fatal(err)
+		}
+		if fi, err := os.Stat(filepath.Dir(p)); err != nil || !fi.IsDir() {
+			t.Fatalf("parent not created: %v", err)
+		}
+	})
+
+	t.Run("leaves an existing parent alone", func(t *testing.T) {
+		if err := ensureParentDir(filepath.Join(root, "f.txt")); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("does not mkdir over a symlinked parent", func(t *testing.T) {
+		target := filepath.Join(root, "target")
+		if err := os.Mkdir(target, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(root, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if err := ensureParentDir(filepath.Join(link, "f.txt")); err != nil {
+			t.Fatal(err)
+		}
+		if fi, err := os.Lstat(link); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("symlink was replaced: %v %v", fi, err)
+		}
+	})
+
+	t.Run("defers a dangling symlink to the open", func(t *testing.T) {
+		link := filepath.Join(root, "dangling")
+		if err := os.Symlink(filepath.Join(root, "nowhere"), link); err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(link, "f.txt")
+		if err := ensureParentDir(p); err != nil {
+			t.Fatalf("helper should not fail on an existing link: %v", err)
+		}
+		_, err := os.OpenFile(p, os.O_WRONLY|os.O_CREATE, 0o644)
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("open should surface the real error, got %v", err)
+		}
+	})
+}
+
+func TestResolveByName(t *testing.T) {
+	// Canonicalize first: on some systems the temp root is itself behind a
+	// symlink, which the resolver correctly expands.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(root, "real")
+	if err := os.Mkdir(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(root, "abs")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "rel")); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(root, "missing-mount")
+	if err := os.Symlink(missing, filepath.Join(root, "broken")); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]string{
+		filepath.Join(root, "abs", "x", "y"):      filepath.Join(real, "x", "y"),
+		filepath.Join(root, "rel", "x"):           filepath.Join(real, "x"),
+		filepath.Join(root, "broken", "out", "f"): filepath.Join(missing, "out", "f"),
+		filepath.Join(root, "real", "plain"):      filepath.Join(real, "plain"),
+	}
+	for in, want := range cases {
+		if got := resolveByName(in); got != want {
+			t.Errorf("resolveByName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMountForIn(t *testing.T) {
+	const info = `22 1 0:21 / / rw,relatime shared:1 - ext4 /dev/root rw
+40 22 0:35 / /mnt rw,relatime shared:2 - tmpfs tmpfs rw
+41 40 0:36 / /mnt/data rw,nosuid shared:3 master:1 - fuse.example example rw,user_id=0
+42 22 0:37 / /with\040space rw - nfs4 host:/x rw
+`
+	cases := []struct {
+		path string
+		want *fsErrorMount
+	}{
+		{"/mnt/data/out/f.json", &fsErrorMount{"/mnt/data", "fuse.example"}},
+		{"/mnt/data", &fsErrorMount{"/mnt/data", "fuse.example"}},
+		{"/mnt/datastore/f", &fsErrorMount{"/mnt", "tmpfs"}},
+		{"/with space/f", &fsErrorMount{"/with space", "nfs4"}},
+		{"/etc/hosts", &fsErrorMount{"/", "ext4"}},
+	}
+	for _, c := range cases {
+		got := mountForIn(info, c.path)
+		if got == nil || *got != *c.want {
+			t.Errorf("mountForIn(%q) = %+v, want %+v", c.path, got, c.want)
+		}
+	}
+	if got := mountForIn("bad line\n", "/x"); got != nil {
+		t.Errorf("unparseable mountinfo should yield nil, got %+v", got)
+	}
+}
+
+func TestWriteFSError(t *testing.T) {
+	stale := &os.PathError{Op: "write", Path: "/m/f", Err: syscall.ESTALE}
+	rec := httptest.NewRecorder()
+	writeFSError(rec, "/m/f", stale)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var got struct{ Error fsErrorBody }
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body %q: %v", rec.Body.String(), err)
+	}
+	if got.Error.Code != fsErrorCode || got.Error.Errno != "ESTALE" || got.Error.Path != "/m/f" {
+		t.Fatalf("unexpected body: %+v", got.Error)
+	}
+
+	for _, err := range []error{
+		errors.New("boom"),
+		&os.PathError{Op: "open", Path: "/m/f", Err: syscall.EACCES},
+	} {
+		rec := httptest.NewRecorder()
+		writeFSError(rec, "/m/f", err)
+		var plain map[string]string
+		if jerr := json.Unmarshal(rec.Body.Bytes(), &plain); jerr != nil || plain["error"] != err.Error() {
+			t.Fatalf("%v should keep the plain body, got %q", err, rec.Body.String())
+		}
+	}
+}

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1014,8 +1014,7 @@ func handleFileDownload(w http.ResponseWriter, r *http.Request, path string) {
 		if os.IsNotExist(err) {
 			http.Error(w, `{"error":"file not found"}`, http.StatusNotFound)
 		} else {
-			errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
-			http.Error(w, string(errJSON), http.StatusInternalServerError)
+			writeFSError(w, path, err)
 		}
 		return
 	}
@@ -1062,7 +1061,7 @@ func handleFileDownload(w http.ResponseWriter, r *http.Request, path string) {
 		case errors.Is(err, errNotRegularFile):
 			writeJSONError(w, http.StatusBadRequest, "not a regular file")
 		default:
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeFSError(w, realPath, err)
 		}
 		return
 	}
@@ -1129,7 +1128,7 @@ func serveDirAsJSON(w http.ResponseWriter, dirPath string) {
 		if os.IsNotExist(err) {
 			writeJSONError(w, http.StatusNotFound, "file not found")
 		} else {
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeFSError(w, realPath, err)
 		}
 		return
 	}
@@ -1310,7 +1309,7 @@ func serveDirAsZip(ctx context.Context, w http.ResponseWriter, dirPath string) {
 		if os.IsNotExist(err) {
 			writeJSONError(w, http.StatusNotFound, "file not found")
 		} else {
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeFSError(w, dirPath, err)
 		}
 		return
 	}
@@ -1325,7 +1324,7 @@ func serveDirAsZip(ctx context.Context, w http.ResponseWriter, dirPath string) {
 
 	parent, err := os.OpenRoot(realParent)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		writeFSError(w, realParent, err)
 		return
 	}
 	defer parent.Close()
@@ -1334,7 +1333,7 @@ func serveDirAsZip(ctx context.Context, w http.ResponseWriter, dirPath string) {
 		if os.IsNotExist(err) {
 			writeJSONError(w, http.StatusNotFound, "file not found")
 		} else {
-			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			writeFSError(w, realDir, err)
 		}
 		return
 	} else if li.Mode()&fs.ModeSymlink != 0 {
@@ -1346,7 +1345,7 @@ func serveDirAsZip(ctx context.Context, w http.ResponseWriter, dirPath string) {
 	// validates it before we commit a 200 + headers and confines the walk.
 	root, err := parent.OpenRoot(base)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		writeFSError(w, realDir, err)
 		return
 	}
 	defer root.Close()
@@ -1570,15 +1569,15 @@ func isStaleHandle(err error) bool {
 	return errors.Is(err, syscall.ESTALE)
 }
 
-// writeFileAttempt performs one mkdir+open+write+close cycle, copying
-// body into the file. It's split out so handleFileUpload can retry the
-// whole sequence on ESTALE — the mkdir and the open can each
+// writeFileAttempt performs one parent-check+open+write+close cycle,
+// copying body into the file. It's split out so handleFileUpload can retry
+// the whole sequence on ESTALE — the parent lookup and the open can each
 // independently observe a stale handle on the same mount. body is an
 // io.Reader rather than a []byte so the same function serves both the
 // buffered (retryable) and streamed (large-upload) paths.
 func writeFileAttempt(path string, body io.Reader) (int64, error) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return 0, fmt.Errorf("mkdir: %w", err)
+	if err := ensureParentDir(path); err != nil {
+		return 0, fmt.Errorf("parent dir: %w", err)
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
@@ -1638,8 +1637,7 @@ func handleFileUpload(w http.ResponseWriter, r *http.Request, path string) {
 			writeStorageFull(w, "")
 			return
 		}
-		errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
-		http.Error(w, string(errJSON), http.StatusInternalServerError)
+		writeFSError(w, path, err)
 		return
 	}
 

--- a/cmd/boxd/main.go
+++ b/cmd/boxd/main.go
@@ -1046,9 +1046,13 @@ func handleFileDownload(w http.ResponseWriter, r *http.Request, path string) {
 	// TOCTOU swap, and the FIFO/device block-or-stream-forever holes.
 	realPath, err := resolveWithinBlocklist(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		_, fsErr := fsErrno(err)
+		switch {
+		case os.IsNotExist(err):
 			http.Error(w, `{"error":"file not found"}`, http.StatusNotFound)
-		} else {
+		case fsErr:
+			writeFSError(w, path, err)
+		default:
 			writeJSONError(w, http.StatusBadRequest, err.Error())
 		}
 		return
@@ -1116,9 +1120,13 @@ func serveDirAsJSON(w http.ResponseWriter, dirPath string) {
 	// (export -> /proc, /sys, /dev) would otherwise be listed wholesale.
 	realPath, err := resolveWithinBlocklist(dirPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		_, fsErr := fsErrno(err)
+		switch {
+		case os.IsNotExist(err):
 			writeJSONError(w, http.StatusNotFound, "file not found")
-		} else {
+		case fsErr:
+			writeFSError(w, dirPath, err)
+		default:
 			writeJSONError(w, http.StatusBadRequest, err.Error())
 		}
 		return


### PR DESCRIPTION
os.MkdirAll treats any stat error as "missing" and then fails with EEXIST on the existing entry, hiding the filesystem's real error. boxd now creates a parent only when it is genuinely absent and lets any other lookup error surface, so it reaches the ESTALE retry instead of failing outright.

Failures raised by the filesystem itself (ESTALE, EIO, an unreachable mount) now return `error.code = sandbox_filesystem_error` with the errno and the mount that served the path, alongside the existing `sandbox_storage_full` shape. Status codes are unchanged.