### PR TITLE
resume: one daemon call carrying the preview policy, rules acked on adoption, and no secrets re-injection when the guest already holds the current environment

### DIFF
--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -533,8 +533,9 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 		actualMemMiB = rl.GetMemoryMib()
 	}
 	return resp.IpAddress, actualVcpu, actualMemMiB, vmdclient.ResumeAttestation{
-		PreviewProtocol:     resp.GetPreviewProtocol(),
-		NetworkRulesApplied: resp.GetNetworkRulesApplied(),
+		PreviewProtocol:       resp.GetPreviewProtocol(),
+		PreviewPolicyRevision: resp.GetPreviewPolicyRevision(),
+		NetworkRulesApplied:   resp.GetNetworkRulesApplied(),
 	}, nil
 }
 

--- a/cmd/controlplane/main.go
+++ b/cmd/controlplane/main.go
@@ -493,11 +493,14 @@ func (c *grpcVMDClient) PauseInstance(ctx context.Context, vmID, snapshotDir, pa
 	return resp.SnapshotPath, resp.MemFilePath, manifest, acked, nil
 }
 
-func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string, networkConfig []byte) (string, uint32, uint32, error) {
+func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, memPath string, networkConfig []byte, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64) (string, uint32, uint32, vmdclient.ResumeAttestation, error) {
 	req := &vmdpb.ResumeVMRequest{
-		VmId:         vmID,
-		SnapshotPath: snapshotPath,
-		MemFilePath:  memPath,
+		VmId:                  vmID,
+		SnapshotPath:          snapshotPath,
+		MemFilePath:           memPath,
+		PreviewAccess:         previewAccess,
+		PreviewPorts:          previewPortsToProto(previewPorts),
+		PreviewPolicyRevision: previewPolicyRevision,
 	}
 	if len(networkConfig) > 0 {
 		var persisted struct {
@@ -508,7 +511,7 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 			} `json:"egress"`
 		}
 		if err := json.Unmarshal(networkConfig, &persisted); err != nil {
-			return "", 0, 0, fmt.Errorf("parse persisted network_config: %w", err)
+			return "", 0, 0, vmdclient.ResumeAttestation{}, fmt.Errorf("parse persisted network_config: %w", err)
 		}
 		if len(persisted.Egress.AllowedCIDRs) != 0 || len(persisted.Egress.DeniedCIDRs) != 0 || len(persisted.Egress.AllowedDomains) != 0 {
 			req.SandboxNetwork = &vmdpb.SandboxNetworkConfig{
@@ -522,14 +525,17 @@ func (c *grpcVMDClient) ResumeInstance(ctx context.Context, vmID, snapshotPath, 
 	}
 	resp, err := c.client.ResumeVM(ctx, req)
 	if err != nil {
-		return "", 0, 0, fmt.Errorf("gRPC ResumeVM: %w", err)
+		return "", 0, 0, vmdclient.ResumeAttestation{}, fmt.Errorf("gRPC ResumeVM: %w", err)
 	}
 	var actualVcpu, actualMemMiB uint32
 	if rl := resp.GetResourceLimits(); rl != nil {
 		actualVcpu = rl.GetVcpuCount()
 		actualMemMiB = rl.GetMemoryMib()
 	}
-	return resp.IpAddress, actualVcpu, actualMemMiB, nil
+	return resp.IpAddress, actualVcpu, actualMemMiB, vmdclient.ResumeAttestation{
+		PreviewProtocol:     resp.GetPreviewProtocol(),
+		NetworkRulesApplied: resp.GetNetworkRulesApplied(),
+	}, nil
 }
 
 // RestoreSnapshot is the stateless restore path — VMD creates a fresh VM

--- a/db/queries/sandboxes.sql
+++ b/db/queries/sandboxes.sql
@@ -90,7 +90,7 @@ WITH tpl AS (
   SELECT ins.id, (@secret_ids::uuid[])[i], (@env_keys::text[])[i], (@proxy_tokens::text[])[i]
   FROM ins, generate_subscripts(@secret_ids::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings, ins.secret_env_fingerprint, ins.secret_env_ip, ins.secret_env_injected_at, ins.secret_env_expires_at
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id;
 
@@ -514,6 +514,7 @@ FROM (
   SELECT sb.id,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
+         s.created_at AS snap_created_at,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
          COALESCE(p.access, 'legacy_public')::text AS wire_access,
          COALESCE(p.revision, 0)::bigint AS revision,
@@ -539,10 +540,21 @@ FROM (
 WHERE sandbox.id = lk.id AND sandbox.id = x.id
   AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
 RETURNING sqlc.embed(sandbox),
-          x.snap_path, x.snap_mem_path,
+          x.snap_path, x.snap_mem_path, x.snap_created_at,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
           x.template_base_path;
+
+-- name: RecordSandboxSecretEnv :exec
+-- Bookkeeping after a successful secrets injection: what the guest now
+-- holds, for the resume-time reuse check. Off the hot path; a lost write
+-- only costs one re-injection.
+UPDATE sandbox
+SET secret_env_fingerprint = $2,
+    secret_env_ip = $3,
+    secret_env_injected_at = now(),
+    secret_env_expires_at = $4
+WHERE id = $1 AND destroyed_at IS NULL;
 
 -- name: RevertResumeToPaused :exec
 -- Compensate a failed resume attempt by flipping status back to 'paused'.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1119,15 +1119,23 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			return "", false
 		}
 	case attested.PreviewProtocol == preview.HostCapabilityPorts:
-		// Stamped before the guest ran. A record that already held a newer
-		// policy kept it, and the reply must report that one.
-		if attested.PreviewPolicyRevision != resumePolicy.Revision {
-			currentPolicy, policyErr := h.loadPreviewPolicy(postCtx, sandboxID, teamID)
-			if policyErr != nil {
-				failPost(policyErr, "reload preview policy after resume failed")
+		// Stamped before the guest ran, or a newer policy the record already
+		// held and kept. The database may be newer still: a mutation that
+		// committed after the claim and whose own push failed. One revision
+		// read proves what is current and names the policy the reply
+		// reports; only a daemon behind it gets the full read and push.
+		currentPolicy, policyErr := h.loadPreviewPolicy(postCtx, sandboxID, teamID)
+		if policyErr != nil {
+			failPost(policyErr, "reload preview policy after resume failed")
+			return "", false
+		}
+		effectivePolicy = currentPolicy
+		if currentPolicy.Revision > attested.PreviewPolicyRevision {
+			l.Warn().Int64("db_revision", currentPolicy.Revision).Int64("vmd_revision", attested.PreviewPolicyRevision).
+				Msg("daemon preview policy behind the database after resume; pushing")
+			if !reapplyPolicy() {
 				return "", false
 			}
-			effectivePolicy = currentPolicy
 		}
 	case attested.PreviewProtocol == "":
 		// A daemon from before the resume request carried the policy. It may

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1130,10 +1130,22 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			return "", false
 		}
 		effectivePolicy = currentPolicy
-		if currentPolicy.Revision > attested.PreviewPolicyRevision {
+		switch {
+		case currentPolicy.Revision > attested.PreviewPolicyRevision:
 			l.Warn().Int64("db_revision", currentPolicy.Revision).Int64("vmd_revision", attested.PreviewPolicyRevision).
 				Msg("daemon preview policy behind the database after resume; pushing")
 			if !reapplyPolicy() {
+				return "", false
+			}
+		case resumePolicy.requiresBrowserCapability():
+			// The policy is the claim's. The host's browser heartbeat can
+			// lapse during the boot, so re-check it before activation the
+			// way the reapply does; otherwise a resume could activate a
+			// browser policy on a downgraded host.
+			if capabilityErr := validateHostPreviewBrowserCapabilities(postCtx, h.DB, sandbox.HostID); capabilityErr != nil {
+				markRevert()
+				pauseAndRevert()
+				h.handlePreviewMutationResult(c, sandboxID, "ReapplyPreviewBrowserAuthAfterResume", capabilityErr)
 				return "", false
 			}
 		}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -942,12 +942,21 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	tVmdStart = time.Now()
 	bootCtx, bootCancel := context.WithTimeout(c.Request.Context(), 2*vmdBootTimeout)
 	defer bootCancel()
+	// The policy rides the request so the daemon stamps it before the guest
+	// runs; the attestation says what it applied. A retry that adopts the
+	// earlier attempt's VM attests the same way.
+	var attested vmdclient.ResumeAttestation
+	statelessFallback := false
 	ipAddress, actualVcpu, actualMemMiB, _, err := retryTransientBoot(bootCtx, sandboxID.String(), sandbox.HostID, func(ctx context.Context) (string, uint32, uint32, error) {
-		return vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath, sandbox.NetworkConfig)
+		ip, vcpu, memMiB, att, rerr := vmd.ResumeInstance(ctx, sandboxID.String(), snapshotPath, memPath, sandbox.NetworkConfig, resumeVMDAccess, resumePolicy.vmdPorts(), resumePolicy.Revision)
+		attested = att
+		return ip, vcpu, memMiB, rerr
 	})
 	tVmdEnd = time.Now()
 	if err != nil {
 		if isVMDNotFound(err) {
+			statelessFallback = true
+			attested = vmdclient.ResumeAttestation{}
 			l.Warn().Err(err).
 				Msg("VMD ResumeInstance: VM not in map, falling back to stateless RestoreSnapshot")
 			// RestoreSnapshot takes an optional envVars map; we pass nil here
@@ -1057,10 +1066,6 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		}
 	}
 
-	// Re-read and push after the VM is present. A publication mutation can race
-	// the stateless restore while VMD returns NotFound to the mutation push; this
-	// final authoritative snapshot closes that window. If a later mutation wins,
-	// VMD's monotonic revision check rejects this older snapshot.
 	// Post-stage failure: the VM is up, so re-pause rather than destroy.
 	failPost := func(err error, msg string) {
 		markRevert()
@@ -1068,49 +1073,86 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 		pauseAndRevert()
 		respondError(c, ErrInternal)
 	}
-	currentPolicy, policyErr := h.loadPreviewPolicySnapshot(postCtx, sandboxID, teamID)
-	if policyErr != nil {
-		failPost(policyErr, "reload preview policy after resume failed")
-		return "", false
+
+	// The policy the claim read rode the resume request. A mutation that
+	// raced the claim converges on the daemon's record: its push lands on
+	// the paused record, and the daemon keeps the higher revision of the two.
+	// Only a missing record loses that push, so the stateless fallback still
+	// re-reads and pushes after the VM is present, as does a daemon from
+	// before the request carried the policy.
+	effectivePolicy := resumePolicy
+	reapplyPolicy := func() bool {
+		currentPolicy, policyErr := h.loadPreviewPolicySnapshot(postCtx, sandboxID, teamID)
+		if policyErr != nil {
+			failPost(policyErr, "reload preview policy after resume failed")
+			return false
+		}
+		effectivePolicy = currentPolicy
+		// A private publication may have changed while the VM was restoring.
+		// Gate the reapply against the host's current browser heartbeat too;
+		// otherwise a resume that began public could activate a
+		// concurrently-added browser policy on a downgraded host.
+		if currentPolicy.requiresBrowserCapability() {
+			if capabilityErr := validateHostPreviewBrowserCapabilities(postCtx, h.DB, sandbox.HostID); capabilityErr != nil {
+				markRevert()
+				pauseAndRevert()
+				h.handlePreviewMutationResult(c, sandboxID, "ReapplyPreviewBrowserAuthAfterResume", capabilityErr)
+				return false
+			}
+		}
+		if policyErr = vmd.UpdateSandboxPreviewPolicy(postCtx, sandboxID.String(), currentPolicy.vmdAccess(), currentPolicy.vmdPorts(), currentPolicy.Revision); policyErr != nil {
+			if currentPolicy.vmdAccess() == preview.AccessLegacyPublic && isVMDUnimplemented(policyErr) {
+				// Legacy sandboxes remain compatible with a VMD from before policy
+				// updates existed. Strict resumes were capability-gated above and may
+				// never take this fallback.
+				l.Warn().Msg("vmd lacks preview policy update for legacy resume")
+			} else {
+				failPost(policyErr, "reapply preview policy after resume failed")
+				return false
+			}
+		}
+		return true
 	}
-	// A private publication may have changed while the VM was restoring. Gate
-	// the final authoritative reapply against the host's current browser
-	// heartbeat too; otherwise a resume that began public could activate a
-	// concurrently-added browser policy on a downgraded host.
-	if currentPolicy.requiresBrowserCapability() {
-		if capabilityErr := validateHostPreviewBrowserCapabilities(postCtx, h.DB, sandbox.HostID); capabilityErr != nil {
-			markRevert()
-			pauseAndRevert()
-			h.handlePreviewMutationResult(c, sandboxID, "ReapplyPreviewBrowserAuthAfterResume", capabilityErr)
+	switch {
+	case statelessFallback:
+		if !reapplyPolicy() {
 			return "", false
 		}
+	case attested.PreviewProtocol == preview.HostCapabilityPorts:
+		// Stamped before the guest ran.
+	case attested.PreviewProtocol == "":
+		// A daemon from before the resume request carried the policy. It may
+		// still enforce, so attest the way its generation supports. Remove
+		// once the fleet echoes.
+		l.Warn().Msg("vmd resume response carries no preview attestation; attesting via the policy RPC (version skew)")
+		if !reapplyPolicy() {
+			return "", false
+		}
+	default:
+		// An unrecognized echo: fail closed rather than guess what it enforces.
+		failPost(fmt.Errorf("preview protocol %q", attested.PreviewProtocol), "VMD attested an unknown preview protocol at resume")
+		return "", false
 	}
-	if policyErr = vmd.UpdateSandboxPreviewPolicy(postCtx, sandboxID.String(), currentPolicy.vmdAccess(), currentPolicy.vmdPorts(), currentPolicy.Revision); policyErr != nil {
-		if currentPolicy.vmdAccess() == preview.AccessLegacyPublic && isVMDUnimplemented(policyErr) {
-			// Legacy sandboxes remain compatible with a VMD from before policy
-			// updates existed. Strict resumes were capability-gated above and may
-			// never take this fallback.
-			l.Warn().Msg("vmd lacks preview policy update for legacy resume")
-		} else {
-			failPost(policyErr, "reapply preview policy after resume failed")
+
+	// Egress rules must be in place before the row commits to 'active'. The
+	// daemon applies the request's rules and says so, on a VM it adopted from
+	// an earlier attempt too; the stateless restore carries none, so that
+	// path and a daemon from before the ack get them pushed here.
+	if !attested.NetworkRulesApplied {
+		if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
+			failPost(err, "reapply network config on resume failed")
 			return "", false
 		}
 	}
 
-	// Apply egress rules before committing to 'active' so "active ⇒ rules
-	// applied" holds by construction. ResumeInstance carries the same rules,
-	// but the daemon's retry adoption returns a running VM without applying
-	// them, and its proxy rules do not survive a restart.
-	if err := h.reapplyNetworkConfig(postCtx, vmd, sandboxID.String(), sandbox.NetworkConfig); err != nil {
-		failPost(err, "reapply network config on resume failed")
-		return "", false
-	}
-
-	// Re-apply the current binding set before committing to 'active', so a secret
-	// attached or detached while paused takes effect — the snapshot froze the old
-	// JWT. The fresh IP binds the re-minted JWT. had_secret_bindings is
-	// trigger-set on first attach, never cleared, and was read under the lock
-	// attach takes, so false proves an empty set; NULL predates the column.
+	// The current binding set must be in the guest before the row commits to
+	// 'active', so a secret attached or detached while paused takes effect.
+	// The snapshot froze the environment as last injected; when that is the
+	// current set, bound to the IP the guest came back on, with a JWT well
+	// within its life, the guest already holds it and the re-mint and guest
+	// round trip are skipped. had_secret_bindings is trigger-set on first
+	// attach, never cleared, and was read under the lock attach takes, so
+	// false proves an empty set; NULL predates the column.
 	sandbox.IpAddress = ipAddr
 	if sandbox.HadSecretBindings == nil || *sandbox.HadSecretBindings {
 		meta, merr := h.loadSecretBindingMeta(postCtx, sandboxID)
@@ -1118,7 +1160,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			failPost(merr, "load secret bindings on resume failed")
 			return "", false
 		}
-		if len(meta) > 0 {
+		if len(meta) > 0 && !guestHoldsSecretEnv(*sandbox, claimed.SnapCreatedAt, meta) {
 			if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
 				failPost(aerr, "reapply secret bindings on resume failed")
 				return "", false
@@ -1162,7 +1204,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 	// ActivateSandbox's CTE opens the sandbox_active_interval row (async).
 	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "resumed", "success", &sandbox.Name, nil, nil)
 	h.capture(c, "sandbox_resumed", map[string]any{"sandbox_id": sandboxID.String()})
-	return currentPolicy.Access, true
+	return effectivePolicy.Access, true
 }
 
 // resolveMemPath returns the memory snapshot path from a Snapshot record.
@@ -2777,6 +2819,9 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 				respondError(c, ErrInternal)
 				return
 			}
+		}
+		if secretsJWT != "" {
+			h.recordSecretEnv(sandboxID, ipAddress, secretMeta)
 		}
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1119,7 +1119,16 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			return "", false
 		}
 	case attested.PreviewProtocol == preview.HostCapabilityPorts:
-		// Stamped before the guest ran.
+		// Stamped before the guest ran. A record that already held a newer
+		// policy kept it, and the reply must report that one.
+		if attested.PreviewPolicyRevision != resumePolicy.Revision {
+			currentPolicy, policyErr := h.loadPreviewPolicy(postCtx, sandboxID, teamID)
+			if policyErr != nil {
+				failPost(policyErr, "reload preview policy after resume failed")
+				return "", false
+			}
+			effectivePolicy = currentPolicy
+		}
 	case attested.PreviewProtocol == "":
 		// A daemon from before the resume request carried the policy. It may
 		// still enforce, so attest the way its generation supports. Remove
@@ -1160,7 +1169,7 @@ func (h *Handlers) resumePausedSandbox(c *gin.Context, sandbox *db.Sandbox, team
 			failPost(merr, "load secret bindings on resume failed")
 			return "", false
 		}
-		if len(meta) > 0 && !guestHoldsSecretEnv(*sandbox, claimed.SnapCreatedAt, meta) {
+		if len(meta) > 0 && !h.guestHoldsSecretEnv(*sandbox, claimed.SnapCreatedAt, meta) {
 			if aerr := h.applySecretBindings(postCtx, *sandbox, meta); aerr != nil {
 				failPost(aerr, "reapply secret bindings on resume failed")
 				return "", false

--- a/internal/api/handlers_sandbox_secret_test.go
+++ b/internal/api/handlers_sandbox_secret_test.go
@@ -121,7 +121,11 @@ func TestApplySecretBindings_InjectsJWTAndEnv(t *testing.T) {
 		gotEnv, gotJWT = env, jwt
 		return nil
 	}}
-	h := &Handlers{VMD: vmd, Signer: newTestSigner(t, "v1")}
+	// The injection records what the guest holds, off the response path.
+	mock := &mockDBTX{execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+		return pgconn.NewCommandTag("UPDATE 1"), nil
+	}}
+	h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, "v1")}
 
 	ip := netip.MustParseAddr("10.0.0.5")
 	sb := db.Sandbox{ID: uuid.New(), TeamID: uuid.New(), HostID: "host-1", IpAddress: &ip}

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1196,7 +1198,71 @@ func (h *Handlers) applySecretBindings(ctx context.Context, sandbox db.Sandbox, 
 	if err := vmd.InjectSandboxEnv(ctx, sandbox.ID.String(), mergeEnvVarsWithSecrets(nil, meta), jwt); err != nil {
 		return fmt.Errorf("inject sandbox env: %w", err)
 	}
+	if jwt != "" {
+		sourceIP := ""
+		if sandbox.IpAddress != nil {
+			sourceIP = sandbox.IpAddress.String()
+		}
+		h.recordSecretEnv(sandbox.ID, sourceIP, meta)
+	}
 	return nil
+}
+
+// secretEnvExpiryMargin is how much JWT life a resume requires before it
+// lets the guest keep the injected environment instead of re-minting.
+const secretEnvExpiryMargin = 24 * time.Hour
+
+// secretBindingFingerprint digests the binding set as injected: which secret
+// under which key, with which proxy token and auth shape. A change to any of
+// them changes the digest; order does not.
+func secretBindingFingerprint(meta []SecretBindingMeta) string {
+	items := append([]SecretBindingMeta(nil), meta...)
+	sort.Slice(items, func(i, j int) bool { return items[i].EnvKey < items[j].EnvKey })
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+// recordSecretEnv notes what the guest holds after a successful injection,
+// off the response path. A lost write only costs the next resume a
+// re-injection, so the write is not awaited.
+func (h *Handlers) recordSecretEnv(sandboxID uuid.UUID, sourceIP string, meta []SecretBindingMeta) {
+	fingerprint := secretBindingFingerprint(meta)
+	if fingerprint == "" || len(meta) == 0 {
+		return
+	}
+	expiresAt := pgtype.Timestamptz{Time: time.Now().Add(SecretsJWTLifetime), Valid: true}
+	h.asyncBookkeeping("record-secret-env", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), asyncTimeout)
+		defer cancel()
+		if err := h.DB.RecordSandboxSecretEnv(ctx, db.RecordSandboxSecretEnvParams{
+			ID:                   sandboxID,
+			SecretEnvFingerprint: &fingerprint,
+			SecretEnvIp:          &sourceIP,
+			SecretEnvExpiresAt:   expiresAt,
+		}); err != nil {
+			log.Warn().Err(err).Str("sandbox_id", sandboxID.String()).Msg("record injected secret env")
+		}
+	})
+}
+
+// guestHoldsSecretEnv reports whether the snapshot's guest already holds the
+// environment the current bindings would inject: the same binding set,
+// bound to the IP the guest came back on, with a JWT well within its
+// lifetime, captured by a snapshot taken after that injection. Any doubt
+// means inject.
+func guestHoldsSecretEnv(sb db.Sandbox, snapshotAt pgtype.Timestamptz, meta []SecretBindingMeta) bool {
+	if sb.SecretEnvFingerprint == nil || sb.SecretEnvIp == nil || sb.IpAddress == nil ||
+		!sb.SecretEnvInjectedAt.Valid || !sb.SecretEnvExpiresAt.Valid || !snapshotAt.Valid {
+		return false
+	}
+	return *sb.SecretEnvFingerprint == secretBindingFingerprint(meta) &&
+		*sb.SecretEnvIp == sb.IpAddress.String() &&
+		time.Now().Add(secretEnvExpiryMargin).Before(sb.SecretEnvExpiresAt.Time) &&
+		!snapshotAt.Time.Before(sb.SecretEnvInjectedAt.Time)
 }
 
 // mintSecretsJWT builds the per-sandbox secrets JWT. Returns the signed JWT

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -1213,16 +1213,17 @@ func (h *Handlers) applySecretBindings(ctx context.Context, sandbox db.Sandbox, 
 const secretEnvExpiryMargin = 24 * time.Hour
 
 // secretEnvFingerprint digests the environment as injected: the key that
-// signed the JWT, and the binding set with each secret's env key, proxy
-// token, and auth shape. A change to any of them changes the digest, so a
-// rotated signing key reads as a new environment; binding order does not.
-func secretEnvFingerprint(signingKeyID string, meta []SecretBindingMeta) string {
+// signed the JWT, by its material rather than its label, and the binding
+// set with each secret's env key, proxy token, and auth shape. A change to
+// any of them changes the digest, so a replaced signing key reads as a new
+// environment even under the same kid; binding order does not.
+func secretEnvFingerprint(signingKeyFingerprint string, meta []SecretBindingMeta) string {
 	items := append([]SecretBindingMeta(nil), meta...)
 	sort.Slice(items, func(i, j int) bool { return items[i].EnvKey < items[j].EnvKey })
 	encoded, err := json.Marshal(struct {
-		KeyID    string
-		Bindings []SecretBindingMeta
-	}{signingKeyID, items})
+		SigningKey string
+		Bindings   []SecretBindingMeta
+	}{signingKeyFingerprint, items})
 	if err != nil {
 		return ""
 	}
@@ -1230,20 +1231,20 @@ func secretEnvFingerprint(signingKeyID string, meta []SecretBindingMeta) string 
 	return hex.EncodeToString(sum[:])
 }
 
-// signerKeyID names the key minting JWTs now; empty without a signer, which
-// matches no recorded environment.
-func (h *Handlers) signerKeyID() string {
+// signerKeyFingerprint names the key minting JWTs now; empty without a
+// signer, which matches no recorded environment.
+func (h *Handlers) signerKeyFingerprint() string {
 	if h.Signer == nil {
 		return ""
 	}
-	return h.Signer.KeyID()
+	return h.Signer.KeyFingerprint()
 }
 
 // recordSecretEnv notes what the guest holds after a successful injection,
 // off the response path. A lost write only costs the next resume a
 // re-injection, so the write is not awaited.
 func (h *Handlers) recordSecretEnv(sandboxID uuid.UUID, sourceIP string, meta []SecretBindingMeta) {
-	fingerprint := secretEnvFingerprint(h.signerKeyID(), meta)
+	fingerprint := secretEnvFingerprint(h.signerKeyFingerprint(), meta)
 	if fingerprint == "" || len(meta) == 0 || h.Signer == nil {
 		return
 	}
@@ -1272,7 +1273,7 @@ func (h *Handlers) guestHoldsSecretEnv(sb db.Sandbox, snapshotAt pgtype.Timestam
 		!sb.SecretEnvInjectedAt.Valid || !sb.SecretEnvExpiresAt.Valid || !snapshotAt.Valid {
 		return false
 	}
-	return *sb.SecretEnvFingerprint == secretEnvFingerprint(h.signerKeyID(), meta) &&
+	return *sb.SecretEnvFingerprint == secretEnvFingerprint(h.signerKeyFingerprint(), meta) &&
 		*sb.SecretEnvIp == sb.IpAddress.String() &&
 		time.Now().Add(secretEnvExpiryMargin).Before(sb.SecretEnvExpiresAt.Time) &&
 		!snapshotAt.Time.Before(sb.SecretEnvInjectedAt.Time)

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -1212,13 +1212,17 @@ func (h *Handlers) applySecretBindings(ctx context.Context, sandbox db.Sandbox, 
 // lets the guest keep the injected environment instead of re-minting.
 const secretEnvExpiryMargin = 24 * time.Hour
 
-// secretBindingFingerprint digests the binding set as injected: which secret
-// under which key, with which proxy token and auth shape. A change to any of
-// them changes the digest; order does not.
-func secretBindingFingerprint(meta []SecretBindingMeta) string {
+// secretEnvFingerprint digests the environment as injected: the key that
+// signed the JWT, and the binding set with each secret's env key, proxy
+// token, and auth shape. A change to any of them changes the digest, so a
+// rotated signing key reads as a new environment; binding order does not.
+func secretEnvFingerprint(signingKeyID string, meta []SecretBindingMeta) string {
 	items := append([]SecretBindingMeta(nil), meta...)
 	sort.Slice(items, func(i, j int) bool { return items[i].EnvKey < items[j].EnvKey })
-	encoded, err := json.Marshal(items)
+	encoded, err := json.Marshal(struct {
+		KeyID    string
+		Bindings []SecretBindingMeta
+	}{signingKeyID, items})
 	if err != nil {
 		return ""
 	}
@@ -1226,12 +1230,21 @@ func secretBindingFingerprint(meta []SecretBindingMeta) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// signerKeyID names the key minting JWTs now; empty without a signer, which
+// matches no recorded environment.
+func (h *Handlers) signerKeyID() string {
+	if h.Signer == nil {
+		return ""
+	}
+	return h.Signer.KeyID()
+}
+
 // recordSecretEnv notes what the guest holds after a successful injection,
 // off the response path. A lost write only costs the next resume a
 // re-injection, so the write is not awaited.
 func (h *Handlers) recordSecretEnv(sandboxID uuid.UUID, sourceIP string, meta []SecretBindingMeta) {
-	fingerprint := secretBindingFingerprint(meta)
-	if fingerprint == "" || len(meta) == 0 {
+	fingerprint := secretEnvFingerprint(h.signerKeyID(), meta)
+	if fingerprint == "" || len(meta) == 0 || h.Signer == nil {
 		return
 	}
 	expiresAt := pgtype.Timestamptz{Time: time.Now().Add(SecretsJWTLifetime), Valid: true}
@@ -1250,16 +1263,16 @@ func (h *Handlers) recordSecretEnv(sandboxID uuid.UUID, sourceIP string, meta []
 }
 
 // guestHoldsSecretEnv reports whether the snapshot's guest already holds the
-// environment the current bindings would inject: the same binding set,
-// bound to the IP the guest came back on, with a JWT well within its
-// lifetime, captured by a snapshot taken after that injection. Any doubt
-// means inject.
-func guestHoldsSecretEnv(sb db.Sandbox, snapshotAt pgtype.Timestamptz, meta []SecretBindingMeta) bool {
+// environment the current bindings would inject: the same binding set
+// signed by the current key, bound to the IP the guest came back on, with
+// a JWT well within its lifetime, captured by a snapshot taken after that
+// injection. Any doubt means inject.
+func (h *Handlers) guestHoldsSecretEnv(sb db.Sandbox, snapshotAt pgtype.Timestamptz, meta []SecretBindingMeta) bool {
 	if sb.SecretEnvFingerprint == nil || sb.SecretEnvIp == nil || sb.IpAddress == nil ||
 		!sb.SecretEnvInjectedAt.Valid || !sb.SecretEnvExpiresAt.Valid || !snapshotAt.Valid {
 		return false
 	}
-	return *sb.SecretEnvFingerprint == secretBindingFingerprint(meta) &&
+	return *sb.SecretEnvFingerprint == secretEnvFingerprint(h.signerKeyID(), meta) &&
 		*sb.SecretEnvIp == sb.IpAddress.String() &&
 		time.Now().Add(secretEnvExpiryMargin).Before(sb.SecretEnvExpiresAt.Time) &&
 		!snapshotAt.Time.Before(sb.SecretEnvInjectedAt.Time)

--- a/internal/api/handlers_secret.go
+++ b/internal/api/handlers_secret.go
@@ -1213,10 +1213,11 @@ func (h *Handlers) applySecretBindings(ctx context.Context, sandbox db.Sandbox, 
 const secretEnvExpiryMargin = 24 * time.Hour
 
 // secretEnvFingerprint digests the environment as injected: the key that
-// signed the JWT, by its material rather than its label, and the binding
-// set with each secret's env key, proxy token, and auth shape. A change to
-// any of them changes the digest, so a replaced signing key reads as a new
-// environment even under the same kid; binding order does not.
+// signed the JWT, by both the kid a verifier looks it up under and its
+// material, and the binding set with each secret's env key, proxy token,
+// and auth shape. A change to any of them changes the digest, so a key
+// replaced under the same kid or relabeled under a new one reads as a new
+// environment; binding order does not.
 func secretEnvFingerprint(signingKeyFingerprint string, meta []SecretBindingMeta) string {
 	items := append([]SecretBindingMeta(nil), meta...)
 	sort.Slice(items, func(i, j int) bool { return items[i].EnvKey < items[j].EnvKey })

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4448,17 +4448,19 @@ func TestResumeSandbox_AttestationDecidesReapply(t *testing.T) {
 	cases := []struct {
 		name         string
 		attest       vmdclient.ResumeAttestation
+		dbRevision   int64
 		wantCode     int
 		policyReads  int
 		policyPushes int
 		rulePushes   int
 		paused       bool
 	}{
-		{"attested policy and rules", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7, NetworkRulesApplied: true}, http.StatusOK, 0, 0, 0, false},
-		{"daemon before the request carried either", vmdclient.ResumeAttestation{}, http.StatusOK, 1, 1, 1, false},
-		{"policy attested, rules not acked", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7}, http.StatusOK, 0, 0, 1, false},
-		{"record already held a newer policy", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 9, NetworkRulesApplied: true}, http.StatusOK, 1, 0, 0, false},
-		{"unknown attestation", vmdclient.ResumeAttestation{PreviewProtocol: "preview_ports_v9", NetworkRulesApplied: true}, http.StatusInternalServerError, 0, 0, 0, true},
+		{"attested policy and rules", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7, NetworkRulesApplied: true}, 7, http.StatusOK, 1, 0, 0, false},
+		{"daemon before the request carried either", vmdclient.ResumeAttestation{}, 7, http.StatusOK, 1, 1, 1, false},
+		{"policy attested, rules not acked", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7}, 7, http.StatusOK, 1, 0, 1, false},
+		{"record already held a newer policy", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 9, NetworkRulesApplied: true}, 7, http.StatusOK, 1, 0, 0, false},
+		{"database ahead of the daemon after a failed push", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7, NetworkRulesApplied: true}, 9, http.StatusOK, 2, 1, 0, false},
+		{"unknown attestation", vmdclient.ResumeAttestation{PreviewProtocol: "preview_ports_v9", NetworkRulesApplied: true}, 7, http.StatusInternalServerError, 0, 0, 0, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4499,7 +4501,7 @@ func TestResumeSandbox_AttestationDecidesReapply(t *testing.T) {
 						return scalarBoolRow(true)
 					case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
 						policyReads++
-						return previewPolicyRow(preview.AccessPublic, 7)
+						return previewPolicyRow(preview.AccessPublic, tc.dbRevision)
 					case strings.Contains(sql, "FinalizePause"):
 						return uuidRow(snapshotID)
 					case strings.Contains(sql, "FROM sandbox"):
@@ -4554,26 +4556,29 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load meta: %v", err)
 	}
-	current := secretEnvFingerprint("v1", meta)
+	// Production pins the kid; a replaced key keeps the label, so the check
+	// must bind the key itself.
+	signer, replaced := newTestSigner(t, "v1"), newTestSigner(t, "v1")
+	current := secretEnvFingerprint(signer.KeyFingerprint(), meta)
 	other := "0000"
 	injectedAt := time.Now().Add(-time.Hour)
 	ip, otherIP := "10.0.0.5", "10.0.0.9"
 
 	cases := []struct {
 		name       string
-		kid        string
+		signer     *SecretsSigner
 		set        func(sb *db.Sandbox, snap *db.Snapshot)
 		wantInject bool
 	}{
-		{"guest holds the current environment", "v1", func(*db.Sandbox, *db.Snapshot) {}, false},
-		{"signing key rotated since injection", "v2", func(*db.Sandbox, *db.Snapshot) {}, true},
-		{"bindings changed since injection", "v1", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
-		{"guest came back on another ip", "v1", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
-		{"snapshot predates the injection", "v1", func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
-		{"jwt near expiry", "v1", func(sb *db.Sandbox, _ *db.Snapshot) {
+		{"guest holds the current environment", signer, func(*db.Sandbox, *db.Snapshot) {}, false},
+		{"signing key replaced under the same kid", replaced, func(*db.Sandbox, *db.Snapshot) {}, true},
+		{"bindings changed since injection", signer, func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
+		{"guest came back on another ip", signer, func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
+		{"snapshot predates the injection", signer, func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
+		{"jwt near expiry", signer, func(sb *db.Sandbox, _ *db.Snapshot) {
 			sb.SecretEnvExpiresAt = pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}
 		}, true},
-		{"nothing recorded", "v1", func(sb *db.Sandbox, _ *db.Snapshot) {
+		{"nothing recorded", signer, func(sb *db.Sandbox, _ *db.Snapshot) {
 			sb.SecretEnvFingerprint, sb.SecretEnvIp = nil, nil
 			sb.SecretEnvInjectedAt, sb.SecretEnvExpiresAt = pgtype.Timestamptz{}, pgtype.Timestamptz{}
 		}, true},
@@ -4617,7 +4622,7 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 					return pgconn.NewCommandTag("UPDATE 1"), nil
 				},
 			}
-			h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, tc.kid)}
+			h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: tc.signer}
 			w := httptest.NewRecorder()
 			setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
 			h.WaitAsyncBookkeeping()
@@ -4649,7 +4654,10 @@ func TestSecretBindingFingerprint(t *testing.T) {
 		t.Fatal("an added binding must change the fingerprint")
 	}
 	if secretEnvFingerprint("v1", []SecretBindingMeta{a}) == secretEnvFingerprint("v2", []SecretBindingMeta{a}) {
-		t.Fatal("a rotated signing key must change the fingerprint")
+		t.Fatal("a different signing key must change the fingerprint")
+	}
+	if newTestSigner(t, "v1").KeyFingerprint() == newTestSigner(t, "v1").KeyFingerprint() {
+		t.Fatal("two keys under the same kid must not share a fingerprint")
 	}
 }
 
@@ -4680,7 +4688,7 @@ func TestApplySecretBindings_RecordsInjectedEnv(t *testing.T) {
 	if len(recorded) != 4 {
 		t.Fatalf("record args = %v, want id, fingerprint, ip, expiry", recorded)
 	}
-	if fp, ok := recorded[1].(*string); !ok || fp == nil || *fp != secretEnvFingerprint("v1", meta) {
+	if fp, ok := recorded[1].(*string); !ok || fp == nil || *fp != secretEnvFingerprint(h.Signer.KeyFingerprint(), meta) {
 		t.Fatalf("recorded fingerprint = %v, want the injected set's", recorded[1])
 	}
 	if ip, ok := recorded[2].(*string); !ok || ip == nil || *ip != "10.0.0.5" {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -4556,9 +4557,10 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load meta: %v", err)
 	}
-	// Production pins the kid; a replaced key keeps the label, so the check
-	// must bind the key itself.
+	// The proxy looks the key up by kid. A replaced key keeps the label and
+	// a relabel keeps the key; either strands the snapshot's JWT.
 	signer, replaced := newTestSigner(t, "v1"), newTestSigner(t, "v1")
+	relabeled := sameKeyUnderKid(t, signer, "v2")
 	current := secretEnvFingerprint(signer.KeyFingerprint(), meta)
 	other := "0000"
 	injectedAt := time.Now().Add(-time.Hour)
@@ -4572,6 +4574,7 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 	}{
 		{"guest holds the current environment", signer, func(*db.Sandbox, *db.Snapshot) {}, false},
 		{"signing key replaced under the same kid", replaced, func(*db.Sandbox, *db.Snapshot) {}, true},
+		{"signing key relabeled under a new kid", relabeled, func(*db.Sandbox, *db.Snapshot) {}, true},
 		{"bindings changed since injection", signer, func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
 		{"guest came back on another ip", signer, func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
 		{"snapshot predates the injection", signer, func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
@@ -4658,6 +4661,9 @@ func TestSecretBindingFingerprint(t *testing.T) {
 	}
 	if newTestSigner(t, "v1").KeyFingerprint() == newTestSigner(t, "v1").KeyFingerprint() {
 		t.Fatal("two keys under the same kid must not share a fingerprint")
+	}
+	if s := newTestSigner(t, "v1"); s.KeyFingerprint() == sameKeyUnderKid(t, s, "v2").KeyFingerprint() {
+		t.Fatal("one key under two kids must not share a fingerprint")
 	}
 }
 
@@ -4746,4 +4752,14 @@ func TestActivateSandbox_ReportsPolicyTheDaemonKept(t *testing.T) {
 	if got := parseJSON(t, w)["preview_access"]; got != preview.AccessPrivate {
 		t.Fatalf("preview_access = %v, want the policy the daemon kept (%q)", got, preview.AccessPrivate)
 	}
+}
+
+// sameKeyUnderKid rebuilds a signer's key under another kid.
+func sameKeyUnderKid(t *testing.T, s *SecretsSigner, kid string) *SecretsSigner {
+	t.Helper()
+	relabeled, err := NewSecretsSigner(base64.StdEncoding.EncodeToString(s.priv.Seed()), kid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return relabeled
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4763,3 +4763,72 @@ func sameKeyUnderKid(t *testing.T, s *SecretsSigner, kid string) *SecretsSigner 
 	}
 	return relabeled
 }
+
+// A browser policy is gated on the host's capability before the claim and
+// again before activation, since the heartbeat can lapse during the boot.
+// The second check runs even when nothing moved the policy meanwhile.
+func TestResumeSandbox_AttestedBrowserPolicyRechecksHostBeforeActivation(t *testing.T) {
+	sandboxID, teamID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	sb.HostID = "token-host-" + uuid.NewString()
+	snap := db.Snapshot{ID: snapshotID, SandboxID: sandboxID, TeamID: teamID, Path: "/snapshots/test/vmstate.snap", Trigger: "pause"}
+	port := publishedPortResponse{Port: 3000, Access: preview.AccessPrivate, TokenVersion: 12}
+
+	paused := false
+	vmd := &stubVMD{
+		resumeAttest: vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 8, NetworkRulesApplied: true},
+		pauseFn: func(context.Context, string, string) (string, string, error) {
+			paused = true
+			return "/snapshots/test/vmstate.snap", "/snapshots/test/mem.snap", nil
+		},
+	}
+	// The pre-boot chain validates under the row lock and passes; the host
+	// has lost the capability by the time the post-boot check reads it.
+	lockedChecks := 0
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+				return scalarBoolRow(true)
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one"):
+				lockedChecks++
+				return scalarBoolRow(lockedChecks == 1)
+			case strings.Contains(sql, "-- name: LockSandboxForPreviewMutation :one"):
+				return scalarUUIDRow(sandboxID)
+			case strings.Contains(sql, "-- name: AdvanceSandboxPreviewPolicy :one"), strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
+				return previewPolicyRow(preview.AccessPrivate, 8)
+			case strings.Contains(sql, "-- name: ClaimResume :one"):
+				return claimResumeRow(sb, &snap, preview.AccessPrivate, 8, port)
+			case strings.Contains(sql, "FinalizePause"):
+				return uuidRow(snapshotID)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+			if strings.Contains(sql, "-- name: ListPublishedPorts :many") {
+				return previewPortPolicyRows(port), nil
+			}
+			return emptyRows{}, nil
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+	h := &Handlers{VMD: vmd, DB: db.New(mock)}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+	h.WaitAsyncBookkeeping()
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 for a host that lost browser capability during the boot: %s", w.Code, w.Body.String())
+	}
+	if lockedChecks != 2 {
+		t.Fatalf("authoritative capability checks = %d, want the pre-boot chain's and the post-boot one", lockedChecks)
+	}
+	if !paused {
+		t.Fatal("the resumed VM must be re-paused, not left active on a downgraded host")
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -35,10 +35,14 @@ import (
 )
 
 type stubVMD struct {
-	restoreLimits    vmdclient.ResourceLimits
-	destroyFn        func(ctx context.Context, id string, force bool) error
-	pauseFn          func(ctx context.Context, id, snapshotDir string) (string, string, error)
-	resumeFn         func(ctx context.Context, id, snapshotPath, memPath string, networkConfig []byte) (string, error)
+	restoreLimits vmdclient.ResourceLimits
+	destroyFn     func(ctx context.Context, id string, force bool) error
+	pauseFn       func(ctx context.Context, id, snapshotDir string) (string, string, error)
+	resumeFn      func(ctx context.Context, id, snapshotPath, memPath string, networkConfig []byte) (string, error)
+	// resumePolicyFn sees the policy the resume request carried; resumeAttest
+	// is what the stubbed daemon claims to have applied (zero = old daemon).
+	resumePolicyFn   func(access string, ports map[int32]vmdclient.PortPolicy, revision int64)
+	resumeAttest     vmdclient.ResumeAttestation
 	restoreFn        func(ctx context.Context, id, snapshotPath, memPath string) (string, error)
 	restorePolicyFn  func(access string, ports map[int32]vmdclient.PortPolicy, revision int64)
 	deleteSnapshotFn func(ctx context.Context, id, snapshotPath, memPath string) error
@@ -102,12 +106,15 @@ func (s *stubVMD) PauseInstance(ctx context.Context, id, snapshotDir, pauseToken
 	}
 	return "/snapshots/vmstate.snap", "/snapshots/mem.snap", nil, pauseToken, nil
 }
-func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string, networkConfig []byte) (string, uint32, uint32, error) {
+func (s *stubVMD) ResumeInstance(ctx context.Context, id, snapshotPath, memPath string, networkConfig []byte, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64) (string, uint32, uint32, vmdclient.ResumeAttestation, error) {
+	if s.resumePolicyFn != nil {
+		s.resumePolicyFn(previewAccess, previewPorts, previewPolicyRevision)
+	}
 	if s.resumeFn != nil {
 		ip, err := s.resumeFn(ctx, id, snapshotPath, memPath, networkConfig)
-		return ip, 1, 1024, err
+		return ip, 1, 1024, s.resumeAttest, err
 	}
-	return "10.0.0.1", 1, 1024, nil
+	return "10.0.0.1", 1, 1024, s.resumeAttest, nil
 }
 func (s *stubVMD) RestoreSnapshot(ctx context.Context, id, snapshotPath, memPath, _, _, _, _, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, _ map[string]string, limits vmdclient.ResourceLimits) (string, uint32, uint32, string, error) {
 	s.restoreLimits = limits
@@ -289,9 +296,13 @@ func sandboxRow(s db.Sandbox) *mockRow {
 		*dest[23].(*pgtype.Timestamptz) = s.AutoDeleteAt
 		*dest[24].(*pgtype.Timestamptz) = s.FailedAt
 		*dest[25].(**bool) = s.HadSecretBindings
-		if len(dest) == 27 {
+		*dest[26].(**string) = s.SecretEnvFingerprint
+		*dest[27].(**string) = s.SecretEnvIp
+		*dest[28].(*pgtype.Timestamptz) = s.SecretEnvInjectedAt
+		*dest[29].(*pgtype.Timestamptz) = s.SecretEnvExpiresAt
+		if len(dest) == 31 {
 			// GetSandboxWithPreviewPolicy: trailing COALESCE'd effective access.
-			*dest[26].(*string) = "legacy_public"
+			*dest[30].(*string) = "legacy_public"
 		}
 		return nil
 	}}
@@ -1007,22 +1018,25 @@ func snapshotRow(s db.Snapshot) *mockRow {
 // missing snapshot row.
 func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision int64, ports ...publishedPortResponse) *mockRow {
 	return &mockRow{scanFn: func(dest ...any) error {
-		if err := sandboxRow(sb).scanFn(dest[:26]...); err != nil {
+		if err := sandboxRow(sb).scanFn(dest[:30]...); err != nil {
 			return err
 		}
 		var snapPath, snapMemPath *string
+		var snapCreatedAt pgtype.Timestamptz
 		if snap != nil {
 			p := snap.Path
 			snapPath, snapMemPath = &p, snap.MemPath
+			snapCreatedAt = pgtype.Timestamptz{Time: snap.CreatedAt, Valid: true}
 		}
-		*dest[26].(**string) = snapPath
-		*dest[27].(**string) = snapMemPath
+		*dest[30].(**string) = snapPath
+		*dest[31].(**string) = snapMemPath
+		*dest[32].(*pgtype.Timestamptz) = snapCreatedAt
 		if access == "" {
 			access = preview.AccessLegacyPublic
 		}
-		*dest[28].(*string) = access
-		*dest[29].(*string) = access
-		*dest[30].(*int64) = revision
+		*dest[33].(*string) = access
+		*dest[34].(*string) = access
+		*dest[35].(*int64) = revision
 		numbers, accesses, versions := []int32{}, []string{}, []int64{}
 		for _, port := range ports {
 			version := port.TokenVersion
@@ -1033,10 +1047,10 @@ func claimResumeRow(sb db.Sandbox, snap *db.Snapshot, access string, revision in
 			accesses = append(accesses, port.Access)
 			versions = append(versions, version)
 		}
-		*dest[31].(*[]int32) = numbers
-		*dest[32].(*[]string) = accesses
-		*dest[33].(*[]int64) = versions
-		*dest[34].(**string) = nil
+		*dest[36].(*[]int32) = numbers
+		*dest[37].(*[]string) = accesses
+		*dest[38].(*[]int64) = versions
+		*dest[39].(**string) = nil
 		return nil
 	}}
 }
@@ -4423,5 +4437,251 @@ func TestPlaceCreateRechecksTheSameHostAfterAFreshLoad(t *testing.T) {
 	}
 	if reads != 2 || scheduler.selects != 2 {
 		t.Fatalf("pre-flight reads=%d selects=%d, want 2 and 2", reads, scheduler.selects)
+	}
+}
+
+// The claim's policy rides the resume request. What the daemon attests
+// decides the post stage: an attested policy needs no re-read and push, an
+// acked rule set needs no replay, a daemon from before either gets both as
+// before, and an unknown attestation re-pauses rather than guessing.
+func TestResumeSandbox_AttestationDecidesReapply(t *testing.T) {
+	cases := []struct {
+		name         string
+		attest       vmdclient.ResumeAttestation
+		wantCode     int
+		policyReads  int
+		policyPushes int
+		rulePushes   int
+		paused       bool
+	}{
+		{"attested policy and rules", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, NetworkRulesApplied: true}, http.StatusOK, 0, 0, 0, false},
+		{"daemon before the request carried either", vmdclient.ResumeAttestation{}, http.StatusOK, 1, 1, 1, false},
+		{"policy attested, rules not acked", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts}, http.StatusOK, 0, 0, 1, false},
+		{"unknown attestation", vmdclient.ResumeAttestation{PreviewProtocol: "preview_ports_v9", NetworkRulesApplied: true}, http.StatusInternalServerError, 0, 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandboxID, teamID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+			sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+			sb.NetworkConfig = []byte(`{"egress":{"allowed_cidrs":["10.0.0.0/8"]}}`)
+			snap := db.Snapshot{ID: snapshotID, SandboxID: sandboxID, TeamID: teamID, Path: "/snapshots/test/vmstate.snap", Trigger: "pause"}
+
+			var carriedAccess string
+			var carriedPorts map[int32]vmdclient.PortPolicy
+			var carriedRevision int64
+			policyReads, policyPushes, rulePushes := 0, 0, 0
+			paused := false
+			vmd := &stubVMD{
+				resumeAttest: tc.attest,
+				resumePolicyFn: func(access string, ports map[int32]vmdclient.PortPolicy, revision int64) {
+					carriedAccess, carriedPorts, carriedRevision = access, ports, revision
+				},
+				updatePreviewFn: func(context.Context, string, string, map[int32]vmdclient.PortPolicy, int64) error {
+					policyPushes++
+					return nil
+				},
+				updateNetworkFn: func(context.Context, string, []string, []string, []string) error {
+					rulePushes++
+					return nil
+				},
+				pauseFn: func(context.Context, string, string) (string, string, error) {
+					paused = true
+					return "/snapshots/test/vmstate.snap", "/snapshots/test/mem.snap", nil
+				},
+			}
+			mock := &mockDBTX{
+				queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+					switch {
+					case strings.Contains(sql, "-- name: ClaimResume :one"):
+						return claimResumeRow(sb, &snap, preview.AccessPublic, 7, publishedPortResponse{Port: 3000, Access: preview.AccessPublic})
+					case strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+						return scalarBoolRow(true)
+					case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
+						policyReads++
+						return previewPolicyRow(preview.AccessPublic, 7)
+					case strings.Contains(sql, "FinalizePause"):
+						return uuidRow(snapshotID)
+					case strings.Contains(sql, "FROM sandbox"):
+						return sandboxRow(sb)
+					default:
+						return activityRow()
+					}
+				},
+				queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+					if strings.Contains(sql, "-- name: ListPublishedPorts :many") {
+						return previewPortRows(3000), nil
+					}
+					return emptyRows{}, nil
+				},
+				execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+					return pgconn.NewCommandTag("UPDATE 1"), nil
+				},
+			}
+			h := &Handlers{VMD: vmd, DB: db.New(mock)}
+			w := httptest.NewRecorder()
+			setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+			h.WaitAsyncBookkeeping()
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			if carriedAccess != preview.AccessPublic || carriedRevision != 7 || carriedPorts[3000].Access != preview.AccessPublic {
+				t.Fatalf("resume request carried access=%q rev=%d ports=%v, want the claim's policy", carriedAccess, carriedRevision, carriedPorts)
+			}
+			if policyReads != tc.policyReads || policyPushes != tc.policyPushes || rulePushes != tc.rulePushes {
+				t.Fatalf("policy reads/pushes = %d/%d, rule pushes = %d; want %d/%d and %d", policyReads, policyPushes, rulePushes, tc.policyReads, tc.policyPushes, tc.rulePushes)
+			}
+			if paused != tc.paused {
+				t.Fatalf("re-paused = %v, want %v", paused, tc.paused)
+			}
+		})
+	}
+}
+
+// The guest keeps the injected environment across a pause. A resume skips
+// the re-mint and guest round trip only while the binding set, the guest
+// IP, the JWT's remaining life, and the snapshot's age all say the guest
+// holds the current environment; any doubt re-injects.
+func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
+	secretID := uuid.New()
+	metaRows := func() (pgx.Rows, error) {
+		return &scanRows{rows: []func(...any) error{bindingMetaRow(secretID, "ANTHROPIC_API_KEY", "bearer", "ssrv_proxy_x")}}, nil
+	}
+	// The fingerprint of exactly what the handler loads from that row.
+	probe := &Handlers{DB: db.New(&mockDBTX{queryFn: func(context.Context, string, ...any) (pgx.Rows, error) { return metaRows() }})}
+	meta, err := probe.loadSecretBindingMeta(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("load meta: %v", err)
+	}
+	current := secretBindingFingerprint(meta)
+	other := "0000"
+	injectedAt := time.Now().Add(-time.Hour)
+	ip, otherIP := "10.0.0.5", "10.0.0.9"
+
+	cases := []struct {
+		name       string
+		set        func(sb *db.Sandbox, snap *db.Snapshot)
+		wantInject bool
+	}{
+		{"guest holds the current environment", func(*db.Sandbox, *db.Snapshot) {}, false},
+		{"bindings changed since injection", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
+		{"guest came back on another ip", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
+		{"snapshot predates the injection", func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
+		{"jwt near expiry", func(sb *db.Sandbox, _ *db.Snapshot) {
+			sb.SecretEnvExpiresAt = pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}
+		}, true},
+		{"nothing recorded", func(sb *db.Sandbox, _ *db.Snapshot) {
+			sb.SecretEnvFingerprint, sb.SecretEnvIp = nil, nil
+			sb.SecretEnvInjectedAt, sb.SecretEnvExpiresAt = pgtype.Timestamptz{}, pgtype.Timestamptz{}
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandboxID, teamID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+			sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+			had := true
+			sb.HadSecretBindings = &had
+			fp, envIP := current, ip
+			sb.SecretEnvFingerprint, sb.SecretEnvIp = &fp, &envIP
+			sb.SecretEnvInjectedAt = pgtype.Timestamptz{Time: injectedAt, Valid: true}
+			sb.SecretEnvExpiresAt = pgtype.Timestamptz{Time: time.Now().Add(30 * 24 * time.Hour), Valid: true}
+			snap := db.Snapshot{ID: snapshotID, SandboxID: sandboxID, TeamID: teamID, Path: "/snapshots/test/vmstate.snap", Trigger: "pause", CreatedAt: injectedAt.Add(time.Minute)}
+			tc.set(&sb, &snap)
+
+			injected := false
+			vmd := &stubVMD{
+				resumeFn:    func(context.Context, string, string, string, []byte) (string, error) { return ip, nil },
+				injectEnvFn: func(context.Context, string, map[string]string, string) error { injected = true; return nil },
+			}
+			mock := &mockDBTX{
+				queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+					switch {
+					case strings.Contains(sql, "-- name: ClaimResume :one"):
+						return claimResumeRow(sb, &snap, "", 0)
+					case strings.Contains(sql, "FROM sandbox"):
+						return sandboxRow(sb)
+					default:
+						return activityRow()
+					}
+				},
+				queryFn: func(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+					if strings.Contains(sql, "ListSandboxSecretBindingMeta") {
+						return metaRows()
+					}
+					return &scanRows{}, nil
+				},
+				execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+					return pgconn.NewCommandTag("UPDATE 1"), nil
+				},
+			}
+			h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, "v1")}
+			w := httptest.NewRecorder()
+			setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
+			h.WaitAsyncBookkeeping()
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+			if injected != tc.wantInject {
+				t.Fatalf("injected = %v, want %v", injected, tc.wantInject)
+			}
+		})
+	}
+}
+
+// The fingerprint names the binding set as injected: order does not matter,
+// a token change does.
+func TestSecretBindingFingerprint(t *testing.T) {
+	a := SecretBindingMeta{SecretID: uuid.New(), EnvKey: "A_KEY", AuthType: "bearer", ProxyToken: "tok-a", Hosts: []string{"a.example"}}
+	b := SecretBindingMeta{SecretID: uuid.New(), EnvKey: "B_KEY", AuthType: "bearer", ProxyToken: "tok-b", Hosts: []string{"b.example"}}
+	if secretBindingFingerprint([]SecretBindingMeta{a, b}) != secretBindingFingerprint([]SecretBindingMeta{b, a}) {
+		t.Fatal("fingerprint must not depend on binding order")
+	}
+	rotated := a
+	rotated.ProxyToken = "tok-a2"
+	if secretBindingFingerprint([]SecretBindingMeta{a}) == secretBindingFingerprint([]SecretBindingMeta{rotated}) {
+		t.Fatal("a rotated proxy token must change the fingerprint")
+	}
+	if secretBindingFingerprint([]SecretBindingMeta{a}) == secretBindingFingerprint([]SecretBindingMeta{a, b}) {
+		t.Fatal("an added binding must change the fingerprint")
+	}
+}
+
+// A successful injection records what the guest now holds, off the
+// response path, so the next resume can tell whether to inject again.
+func TestApplySecretBindings_RecordsInjectedEnv(t *testing.T) {
+	sandboxID, teamID := uuid.New(), uuid.New()
+	addr := netip.MustParseAddr("10.0.0.5")
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, HostID: "host-1", IpAddress: &addr}
+	meta := []SecretBindingMeta{{SecretID: uuid.New(), EnvKey: "A_KEY", AuthType: "bearer", ProxyToken: "tok-a", Hosts: []string{"a.example"}}}
+
+	var recorded []any
+	mock := &mockDBTX{
+		queryRowFn: func(context.Context, string, ...any) pgx.Row { return activityRow() },
+		execFn: func(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+			if strings.Contains(sql, "-- name: RecordSandboxSecretEnv :exec") {
+				recorded = args
+			}
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(mock), Signer: newTestSigner(t, "v1")}
+	if err := h.applySecretBindings(context.Background(), sb, meta); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	h.WaitAsyncBookkeeping()
+
+	if len(recorded) != 4 {
+		t.Fatalf("record args = %v, want id, fingerprint, ip, expiry", recorded)
+	}
+	if fp, ok := recorded[1].(*string); !ok || fp == nil || *fp != secretBindingFingerprint(meta) {
+		t.Fatalf("recorded fingerprint = %v, want the injected set's", recorded[1])
+	}
+	if ip, ok := recorded[2].(*string); !ok || ip == nil || *ip != "10.0.0.5" {
+		t.Fatalf("recorded ip = %v, want the guest's", recorded[2])
+	}
+	expires, ok := recorded[3].(pgtype.Timestamptz)
+	if !ok || !expires.Valid || expires.Time.Before(time.Now().Add(SecretsJWTLifetime-time.Minute)) {
+		t.Fatalf("recorded expiry = %v, want about one JWT lifetime out", recorded[3])
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4454,9 +4454,10 @@ func TestResumeSandbox_AttestationDecidesReapply(t *testing.T) {
 		rulePushes   int
 		paused       bool
 	}{
-		{"attested policy and rules", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, NetworkRulesApplied: true}, http.StatusOK, 0, 0, 0, false},
+		{"attested policy and rules", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7, NetworkRulesApplied: true}, http.StatusOK, 0, 0, 0, false},
 		{"daemon before the request carried either", vmdclient.ResumeAttestation{}, http.StatusOK, 1, 1, 1, false},
-		{"policy attested, rules not acked", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts}, http.StatusOK, 0, 0, 1, false},
+		{"policy attested, rules not acked", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 7}, http.StatusOK, 0, 0, 1, false},
+		{"record already held a newer policy", vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 9, NetworkRulesApplied: true}, http.StatusOK, 1, 0, 0, false},
 		{"unknown attestation", vmdclient.ResumeAttestation{PreviewProtocol: "preview_ports_v9", NetworkRulesApplied: true}, http.StatusInternalServerError, 0, 0, 0, true},
 	}
 	for _, tc := range cases {
@@ -4553,24 +4554,26 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load meta: %v", err)
 	}
-	current := secretBindingFingerprint(meta)
+	current := secretEnvFingerprint("v1", meta)
 	other := "0000"
 	injectedAt := time.Now().Add(-time.Hour)
 	ip, otherIP := "10.0.0.5", "10.0.0.9"
 
 	cases := []struct {
 		name       string
+		kid        string
 		set        func(sb *db.Sandbox, snap *db.Snapshot)
 		wantInject bool
 	}{
-		{"guest holds the current environment", func(*db.Sandbox, *db.Snapshot) {}, false},
-		{"bindings changed since injection", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
-		{"guest came back on another ip", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
-		{"snapshot predates the injection", func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
-		{"jwt near expiry", func(sb *db.Sandbox, _ *db.Snapshot) {
+		{"guest holds the current environment", "v1", func(*db.Sandbox, *db.Snapshot) {}, false},
+		{"signing key rotated since injection", "v2", func(*db.Sandbox, *db.Snapshot) {}, true},
+		{"bindings changed since injection", "v1", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvFingerprint = &other }, true},
+		{"guest came back on another ip", "v1", func(sb *db.Sandbox, _ *db.Snapshot) { sb.SecretEnvIp = &otherIP }, true},
+		{"snapshot predates the injection", "v1", func(_ *db.Sandbox, snap *db.Snapshot) { snap.CreatedAt = injectedAt.Add(-time.Minute) }, true},
+		{"jwt near expiry", "v1", func(sb *db.Sandbox, _ *db.Snapshot) {
 			sb.SecretEnvExpiresAt = pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}
 		}, true},
-		{"nothing recorded", func(sb *db.Sandbox, _ *db.Snapshot) {
+		{"nothing recorded", "v1", func(sb *db.Sandbox, _ *db.Snapshot) {
 			sb.SecretEnvFingerprint, sb.SecretEnvIp = nil, nil
 			sb.SecretEnvInjectedAt, sb.SecretEnvExpiresAt = pgtype.Timestamptz{}, pgtype.Timestamptz{}
 		}, true},
@@ -4614,7 +4617,7 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 					return pgconn.NewCommandTag("UPDATE 1"), nil
 				},
 			}
-			h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, "v1")}
+			h := &Handlers{VMD: vmd, DB: db.New(mock), Signer: newTestSigner(t, tc.kid)}
 			w := httptest.NewRecorder()
 			setupTestRouter(h, teamID.String()).ServeHTTP(w, resumeRequest(sandboxID.String()))
 			h.WaitAsyncBookkeeping()
@@ -4629,21 +4632,24 @@ func TestResumeSandbox_GuestHoldsSecretEnvSkipsInjection(t *testing.T) {
 	}
 }
 
-// The fingerprint names the binding set as injected: order does not matter,
-// a token change does.
+// The fingerprint names the environment as injected: binding order does
+// not matter; a token change or a signing-key rotation does.
 func TestSecretBindingFingerprint(t *testing.T) {
 	a := SecretBindingMeta{SecretID: uuid.New(), EnvKey: "A_KEY", AuthType: "bearer", ProxyToken: "tok-a", Hosts: []string{"a.example"}}
 	b := SecretBindingMeta{SecretID: uuid.New(), EnvKey: "B_KEY", AuthType: "bearer", ProxyToken: "tok-b", Hosts: []string{"b.example"}}
-	if secretBindingFingerprint([]SecretBindingMeta{a, b}) != secretBindingFingerprint([]SecretBindingMeta{b, a}) {
+	if secretEnvFingerprint("v1", []SecretBindingMeta{a, b}) != secretEnvFingerprint("v1", []SecretBindingMeta{b, a}) {
 		t.Fatal("fingerprint must not depend on binding order")
 	}
 	rotated := a
 	rotated.ProxyToken = "tok-a2"
-	if secretBindingFingerprint([]SecretBindingMeta{a}) == secretBindingFingerprint([]SecretBindingMeta{rotated}) {
+	if secretEnvFingerprint("v1", []SecretBindingMeta{a}) == secretEnvFingerprint("v1", []SecretBindingMeta{rotated}) {
 		t.Fatal("a rotated proxy token must change the fingerprint")
 	}
-	if secretBindingFingerprint([]SecretBindingMeta{a}) == secretBindingFingerprint([]SecretBindingMeta{a, b}) {
+	if secretEnvFingerprint("v1", []SecretBindingMeta{a}) == secretEnvFingerprint("v1", []SecretBindingMeta{a, b}) {
 		t.Fatal("an added binding must change the fingerprint")
+	}
+	if secretEnvFingerprint("v1", []SecretBindingMeta{a}) == secretEnvFingerprint("v2", []SecretBindingMeta{a}) {
+		t.Fatal("a rotated signing key must change the fingerprint")
 	}
 }
 
@@ -4674,7 +4680,7 @@ func TestApplySecretBindings_RecordsInjectedEnv(t *testing.T) {
 	if len(recorded) != 4 {
 		t.Fatalf("record args = %v, want id, fingerprint, ip, expiry", recorded)
 	}
-	if fp, ok := recorded[1].(*string); !ok || fp == nil || *fp != secretBindingFingerprint(meta) {
+	if fp, ok := recorded[1].(*string); !ok || fp == nil || *fp != secretEnvFingerprint("v1", meta) {
 		t.Fatalf("recorded fingerprint = %v, want the injected set's", recorded[1])
 	}
 	if ip, ok := recorded[2].(*string); !ok || ip == nil || *ip != "10.0.0.5" {
@@ -4683,5 +4689,53 @@ func TestApplySecretBindings_RecordsInjectedEnv(t *testing.T) {
 	expires, ok := recorded[3].(pgtype.Timestamptz)
 	if !ok || !expires.Valid || expires.Time.Before(time.Now().Add(SecretsJWTLifetime-time.Minute)) {
 		t.Fatalf("recorded expiry = %v, want about one JWT lifetime out", recorded[3])
+	}
+}
+
+// When the daemon's record already held a newer policy than the claim read,
+// the stamp leaves it in place and the activation reply must report that
+// policy rather than the claim's.
+func TestActivateSandbox_ReportsPolicyTheDaemonKept(t *testing.T) {
+	sandboxID, teamID, snapshotID := uuid.New(), uuid.New(), uuid.New()
+	sb := pausedSandboxWithSnapshot(sandboxID, teamID, snapshotID)
+	snap := db.Snapshot{ID: snapshotID, SandboxID: sandboxID, TeamID: teamID, Path: "/snapshots/test/vmstate.snap", Trigger: "pause"}
+
+	vmd := &stubVMD{
+		resumeAttest: vmdclient.ResumeAttestation{PreviewProtocol: preview.HostCapabilityPorts, PreviewPolicyRevision: 9, NetworkRulesApplied: true},
+	}
+	mock := &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			case strings.Contains(sql, "-- name: ClaimResume :one"):
+				return claimResumeRow(sb, &snap, preview.AccessPublic, 7)
+			case strings.Contains(sql, "-- name: HostHasCapabilities :one") || strings.Contains(sql, "-- name: HostHasCapabilitiesUnlocked :one"):
+				return scalarBoolRow(true)
+			case strings.Contains(sql, "-- name: GetSandboxPreviewPolicy :one"):
+				return previewPolicyRow(preview.AccessPrivate, 9)
+			case strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			default:
+				return activityRow()
+			}
+		},
+		queryFn: func(context.Context, string, ...any) (pgx.Rows, error) { return emptyRows{}, nil },
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+	h := &Handlers{
+		VMD:    vmd,
+		DB:     db.New(mock),
+		Config: &config.Config{SandboxAccessTokenSeed: []byte("test-seed-for-hmac-32-bytes-min!!")},
+	}
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, activateRequest(sandboxID.String()))
+	h.WaitAsyncBookkeeping()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := parseJSON(t, w)["preview_access"]; got != preview.AccessPrivate {
+		t.Fatalf("preview_access = %v, want the policy the daemon kept (%q)", got, preview.AccessPrivate)
 	}
 }

--- a/internal/api/jwt.go
+++ b/internal/api/jwt.go
@@ -66,8 +66,10 @@ type SecretsClaims struct {
 type SecretsSigner struct {
 	priv ed25519.PrivateKey
 	kid  string
-	// fingerprint names the key material itself; the kid is a label that
-	// can stay put across a key replacement.
+	// fingerprint names the key as a verifier sees it: the kid it is served
+	// under and the key material. The label can stay put across a key
+	// replacement, and the key can stay put across a relabel; either
+	// change strands a JWT minted before it.
 	fingerprint string
 }
 
@@ -90,12 +92,12 @@ func NewSecretsSigner(seedBase64, kid string) (*SecretsSigner, error) {
 	return &SecretsSigner{
 		priv:        priv,
 		kid:         kid,
-		fingerprint: hex.EncodeToString(sum[:]),
+		fingerprint: kid + ":" + hex.EncodeToString(sum[:]),
 	}, nil
 }
 
-// KeyFingerprint digests the verification key. Two signers with the same
-// kid but different keys have different fingerprints.
+// KeyFingerprint names the verification key by kid and key digest. Signers
+// differing in either have different fingerprints.
 func (s *SecretsSigner) KeyFingerprint() string { return s.fingerprint }
 
 // Sign returns a serialized JWT with the supplied claims. iss, iat, exp are

--- a/internal/api/jwt.go
+++ b/internal/api/jwt.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -64,6 +66,9 @@ type SecretsClaims struct {
 type SecretsSigner struct {
 	priv ed25519.PrivateKey
 	kid  string
+	// fingerprint names the key material itself; the kid is a label that
+	// can stay put across a key replacement.
+	fingerprint string
 }
 
 // NewSecretsSigner builds a signer from a base64-encoded 32-byte Ed25519 seed.
@@ -80,11 +85,18 @@ func NewSecretsSigner(seedBase64, kid string) (*SecretsSigner, error) {
 	if len(seed) != ed25519.SeedSize {
 		return nil, fmt.Errorf("signing key seed has %d bytes, want %d", len(seed), ed25519.SeedSize)
 	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	sum := sha256.Sum256(priv.Public().(ed25519.PublicKey))
 	return &SecretsSigner{
-		priv: ed25519.NewKeyFromSeed(seed),
-		kid:  kid,
+		priv:        priv,
+		kid:         kid,
+		fingerprint: hex.EncodeToString(sum[:]),
 	}, nil
 }
+
+// KeyFingerprint digests the verification key. Two signers with the same
+// kid but different keys have different fingerprints.
+func (s *SecretsSigner) KeyFingerprint() string { return s.fingerprint }
 
 // Sign returns a serialized JWT with the supplied claims. iss, iat, exp are
 // filled in automatically; the caller supplies sandbox-specific fields.

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superserve-ai/sandbox/internal/db"
 	"github.com/superserve-ai/sandbox/internal/sentrylog"
 	"github.com/superserve-ai/sandbox/internal/telemetry"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
 const defaultSweepInterval = 10 * time.Minute
@@ -445,8 +446,10 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	// sandbox failed.
 	// No policy carried: the record keeps the one it has, which this
 	// rollback never changed.
+	var attested vmdclient.ResumeAttestation
 	ipAddr, _, _, _, err := retryTransientBoot(ctx, sbx.ID.String(), sbx.HostID, func(rctx context.Context) (string, uint32, uint32, error) {
-		ip, vcpu, memMiB, _, rerr := vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath, sbx.NetworkConfig, "", nil, 0)
+		ip, vcpu, memMiB, att, rerr := vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath, sbx.NetworkConfig, "", nil, 0)
+		attested = att
 		return ip, vcpu, memMiB, rerr
 	})
 	if err != nil {
@@ -468,6 +471,17 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 		rl.Error().Err(parseErr).Str("ip", ipAddr).Msg("reaper: rollback resume returned invalid IP")
 		h.markSandboxFailed(ctx, sbx, "rollback resume returned invalid IP after pause DB error", rl)
 		return
+	}
+
+	// A rollback that adopts a VM the earlier attempt left running can come
+	// back with only the firewall half of the egress rules in place. Push
+	// them before the row goes active, as the resume handler does.
+	if !attested.NetworkRulesApplied {
+		if err := h.reapplyNetworkConfig(ctx, vmd, sbx.ID.String(), sbx.NetworkConfig); err != nil {
+			rl.Error().Err(err).Msg("reaper: rollback egress rules replay failed")
+			h.markSandboxFailed(ctx, sbx, "rollback egress rules replay failed after pause DB error", rl)
+			return
+		}
 	}
 
 	// VM is running again — revert DB to active so reaper retries cleanly.

--- a/internal/api/reaper.go
+++ b/internal/api/reaper.go
@@ -443,8 +443,11 @@ func (h *Handlers) rollbackPausedVM(ctx context.Context, sbx db.ClaimExpiredSand
 	// retry as the user-facing boots — the background ctx never reads dead,
 	// which is right: a rollback landing late still beats marking the
 	// sandbox failed.
+	// No policy carried: the record keeps the one it has, which this
+	// rollback never changed.
 	ipAddr, _, _, _, err := retryTransientBoot(ctx, sbx.ID.String(), sbx.HostID, func(rctx context.Context) (string, uint32, uint32, error) {
-		return vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath, sbx.NetworkConfig)
+		ip, vcpu, memMiB, _, rerr := vmd.ResumeInstance(rctx, sbx.ID.String(), snapshotPath, memPath, sbx.NetworkConfig, "", nil, 0)
+		return ip, vcpu, memMiB, rerr
 	})
 	if err != nil {
 		rl.Error().Err(err).Msg("reaper: rollback resume failed")

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/superserve-ai/sandbox/internal/db"
+	"github.com/superserve-ai/sandbox/internal/vmdclient"
 )
 
 // ---------------------------------------------------------------------------
@@ -450,5 +451,48 @@ func TestRollbackPausedVM_PersistsReplacementHostAndIP(t *testing.T) {
 	}
 	if strings.Join(callOrder, ",") != "host,status" {
 		t.Fatalf("rollback write order = %v, want host then status", callOrder)
+	}
+}
+
+// A rollback that adopts a VM left running by the earlier attempt can come
+// back with the daemon reporting the egress rules only partly applied; the
+// rollback must push them itself before the row goes active, and leave
+// them alone when the daemon reports them in place.
+func TestRollbackPausedVM_ReplaysEgressRulesUnlessAcked(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		acked       bool
+		wantReplays int
+	}{
+		{"unacked rules are pushed", false, 1},
+		{"acked rules are left alone", true, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			replays := 0
+			h := &Handlers{
+				VMD: &stubVMD{
+					resumeFn:     func(context.Context, string, string, string, []byte) (string, error) { return "10.11.0.99", nil },
+					resumeAttest: vmdclient.ResumeAttestation{NetworkRulesApplied: tc.acked},
+					updateNetworkFn: func(_ context.Context, _ string, allowed, _, _ []string) error {
+						replays++
+						if len(allowed) != 1 || allowed[0] != "10.0.0.0/8" {
+							t.Errorf("replayed allow list = %v, want the persisted CIDR", allowed)
+						}
+						return nil
+					},
+				},
+				DB: db.New(&reaperMockDBTX{
+					execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) { return pgconn.CommandTag{}, nil },
+				}),
+			}
+			sbx := db.ClaimExpiredSandboxesRow{
+				ID: uuid.New(), TeamID: uuid.New(), HostID: "host-1", Name: "sbx",
+				NetworkConfig: []byte(`{"egress":{"allowed_cidrs":["10.0.0.0/8"]}}`),
+			}
+			h.rollbackPausedVM(context.Background(), sbx, "/snapshots/vmstate.snap", "/snapshots/mem.snap", errors.New("pause write failed"), zerolog.Nop())
+			if replays != tc.wantReplays {
+				t.Fatalf("rule replays = %d, want %d", replays, tc.wantReplays)
+			}
+		})
 	}
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -589,6 +589,14 @@ type Sandbox struct {
 	FailedAt          pgtype.Timestamptz `json:"failed_at"`
 	// True once any secret binding has existed for this sandbox; false when the sandbox was created without one; NULL for rows predating the column. Never cleared — a detached or failure-cleared binding may still have had a JWT minted against it. Destroy revokes unless this is false.
 	HadSecretBindings *bool `json:"had_secret_bindings"`
+	// Digest of the binding set last injected into the guest; a resume re-injects when the current set differs.
+	SecretEnvFingerprint *string `json:"secret_env_fingerprint"`
+	// Guest IP the injected proxy JWT is bound to; a resume re-injects when the guest comes back on another.
+	SecretEnvIp *string `json:"secret_env_ip"`
+	// When the last injection landed; only a snapshot taken after it holds the injected environment.
+	SecretEnvInjectedAt pgtype.Timestamptz `json:"secret_env_injected_at"`
+	// Expiry of the injected proxy JWT; a resume re-injects when it is near.
+	SecretEnvExpiresAt pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 type SandboxActiveInterval struct {

--- a/internal/db/sandboxes.sql.go
+++ b/internal/db/sandboxes.sql.go
@@ -112,7 +112,7 @@ WITH paused AS (
     AND sandbox.team_id = $2
     AND sandbox.destroyed_at IS NULL
     AND sandbox.status = 'active'
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 ),
 closed_interval AS (
   UPDATE sandbox_active_interval
@@ -128,7 +128,7 @@ closed_billing_compute AS (
     AND ended_at IS NULL
   RETURNING sandbox_id
 )
-SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at, p.failed_at, p.had_secret_bindings
+SELECT p.id, p.team_id, p.name, p.status, p.vcpu_count, p.memory_mib, p.host_id, p.ip_address, p.pid, p.snapshot_id, p.created_at, p.updated_at, p.destroyed_at, p.network_config, p.timeout_seconds, p.metadata, p.template_id, p.snapshot_path, p.mem_path, p.base_path, p.delta_path, p.disk_mib, p.auto_delete_seconds, p.auto_delete_at, p.failed_at, p.had_secret_bindings, p.secret_env_fingerprint, p.secret_env_ip, p.secret_env_injected_at, p.secret_env_expires_at
 FROM paused p
 LEFT JOIN closed_interval ci ON ci.sandbox_id = p.id
 `
@@ -139,32 +139,36 @@ type BeginPauseParams struct {
 }
 
 type BeginPauseRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
-	FailedAt          pgtype.Timestamptz `json:"failed_at"`
-	HadSecretBindings *bool              `json:"had_secret_bindings"`
+	ID                   uuid.UUID          `json:"id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Name                 string             `json:"name"`
+	Status               SandboxStatus      `json:"status"`
+	VcpuCount            int32              `json:"vcpu_count"`
+	MemoryMib            int32              `json:"memory_mib"`
+	HostID               string             `json:"host_id"`
+	IpAddress            *netip.Addr        `json:"ip_address"`
+	Pid                  *int32             `json:"pid"`
+	SnapshotID           pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt            time.Time          `json:"created_at"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	DestroyedAt          pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	Metadata             []byte             `json:"metadata"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	SnapshotPath         *string            `json:"snapshot_path"`
+	MemPath              *string            `json:"mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	DiskMib              int32              `json:"disk_mib"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt         pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt             pgtype.Timestamptz `json:"failed_at"`
+	HadSecretBindings    *bool              `json:"had_secret_bindings"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvInjectedAt  pgtype.Timestamptz `json:"secret_env_injected_at"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 // Atomic ownership + state check + transition to 'pausing' AND close of any
@@ -207,6 +211,10 @@ func (q *Queries) BeginPause(ctx context.Context, arg BeginPauseParams) (BeginPa
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -215,7 +223,7 @@ const beginResume = `-- name: BeginResume :one
 UPDATE sandbox
 SET status = 'resuming', auto_delete_at = NULL, updated_at = now()
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL AND status = 'paused'
-RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 `
 
 type BeginResumeParams struct {
@@ -257,6 +265,10 @@ func (q *Queries) BeginResume(ctx context.Context, arg BeginResumeParams) (Sandb
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -555,6 +567,7 @@ FROM (
   SELECT sb.id,
          s.path AS snap_path,
          s.mem_path AS snap_mem_path,
+         s.created_at AS snap_created_at,
          COALESCE(p.default_access, p.access, 'legacy_public')::text AS access,
          COALESCE(p.access, 'legacy_public')::text AS wire_access,
          COALESCE(p.revision, 0)::bigint AS revision,
@@ -579,8 +592,8 @@ FROM (
 ) x
 WHERE sandbox.id = lk.id AND sandbox.id = x.id
   AND sandbox.destroyed_at IS NULL AND sandbox.status = 'paused'
-RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcpu_count, sandbox.memory_mib, sandbox.host_id, sandbox.ip_address, sandbox.pid, sandbox.snapshot_id, sandbox.created_at, sandbox.updated_at, sandbox.destroyed_at, sandbox.network_config, sandbox.timeout_seconds, sandbox.metadata, sandbox.template_id, sandbox.snapshot_path, sandbox.mem_path, sandbox.base_path, sandbox.delta_path, sandbox.disk_mib, sandbox.auto_delete_seconds, sandbox.auto_delete_at, sandbox.failed_at, sandbox.had_secret_bindings,
-          x.snap_path, x.snap_mem_path,
+RETURNING sandbox.id, sandbox.team_id, sandbox.name, sandbox.status, sandbox.vcpu_count, sandbox.memory_mib, sandbox.host_id, sandbox.ip_address, sandbox.pid, sandbox.snapshot_id, sandbox.created_at, sandbox.updated_at, sandbox.destroyed_at, sandbox.network_config, sandbox.timeout_seconds, sandbox.metadata, sandbox.template_id, sandbox.snapshot_path, sandbox.mem_path, sandbox.base_path, sandbox.delta_path, sandbox.disk_mib, sandbox.auto_delete_seconds, sandbox.auto_delete_at, sandbox.failed_at, sandbox.had_secret_bindings, sandbox.secret_env_fingerprint, sandbox.secret_env_ip, sandbox.secret_env_injected_at, sandbox.secret_env_expires_at,
+          x.snap_path, x.snap_mem_path, x.snap_created_at,
           x.access, x.wire_access, x.revision,
           x.port_numbers, x.port_accesses, x.port_token_versions,
           x.template_base_path
@@ -593,16 +606,17 @@ type ClaimResumeParams struct {
 }
 
 type ClaimResumeRow struct {
-	Sandbox           Sandbox  `json:"sandbox"`
-	SnapPath          *string  `json:"snap_path"`
-	SnapMemPath       *string  `json:"snap_mem_path"`
-	Access            string   `json:"access"`
-	WireAccess        string   `json:"wire_access"`
-	Revision          int64    `json:"revision"`
-	PortNumbers       []int32  `json:"port_numbers"`
-	PortAccesses      []string `json:"port_accesses"`
-	PortTokenVersions []int64  `json:"port_token_versions"`
-	TemplateBasePath  *string  `json:"template_base_path"`
+	Sandbox           Sandbox            `json:"sandbox"`
+	SnapPath          *string            `json:"snap_path"`
+	SnapMemPath       *string            `json:"snap_mem_path"`
+	SnapCreatedAt     pgtype.Timestamptz `json:"snap_created_at"`
+	Access            string             `json:"access"`
+	WireAccess        string             `json:"wire_access"`
+	Revision          int64              `json:"revision"`
+	PortNumbers       []int32            `json:"port_numbers"`
+	PortAccesses      []string           `json:"port_accesses"`
+	PortTokenVersions []int64            `json:"port_token_versions"`
+	TemplateBasePath  *string            `json:"template_base_path"`
 }
 
 // The paused→resuming claim plus the boot inputs in one round trip:
@@ -647,8 +661,13 @@ func (q *Queries) ClaimResume(ctx context.Context, arg ClaimResumeParams) (Claim
 		&i.Sandbox.AutoDeleteAt,
 		&i.Sandbox.FailedAt,
 		&i.Sandbox.HadSecretBindings,
+		&i.Sandbox.SecretEnvFingerprint,
+		&i.Sandbox.SecretEnvIp,
+		&i.Sandbox.SecretEnvInjectedAt,
+		&i.Sandbox.SecretEnvExpiresAt,
 		&i.SnapPath,
 		&i.SnapMemPath,
+		&i.SnapCreatedAt,
 		&i.Access,
 		&i.WireAccess,
 		&i.Revision,
@@ -709,13 +728,13 @@ const createSandbox = `-- name: CreateSandbox :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds, had_secret_bindings)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, false)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings, ins.secret_env_fingerprint, ins.secret_env_ip, ins.secret_env_injected_at, ins.secret_env_expires_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -742,32 +761,36 @@ type CreateSandboxParams struct {
 }
 
 type CreateSandboxRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
-	FailedAt          pgtype.Timestamptz `json:"failed_at"`
-	HadSecretBindings *bool              `json:"had_secret_bindings"`
+	ID                   uuid.UUID          `json:"id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Name                 string             `json:"name"`
+	Status               SandboxStatus      `json:"status"`
+	VcpuCount            int32              `json:"vcpu_count"`
+	MemoryMib            int32              `json:"memory_mib"`
+	HostID               string             `json:"host_id"`
+	IpAddress            *netip.Addr        `json:"ip_address"`
+	Pid                  *int32             `json:"pid"`
+	SnapshotID           pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt            time.Time          `json:"created_at"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	DestroyedAt          pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	Metadata             []byte             `json:"metadata"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	SnapshotPath         *string            `json:"snapshot_path"`
+	MemPath              *string            `json:"mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	DiskMib              int32              `json:"disk_mib"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt         pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt             pgtype.Timestamptz `json:"failed_at"`
+	HadSecretBindings    *bool              `json:"had_secret_bindings"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvInjectedAt  pgtype.Timestamptz `json:"secret_env_injected_at"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 // ID is supplied by the caller (generated in Go via uuid.New()) rather
@@ -830,6 +853,10 @@ func (q *Queries) CreateSandbox(ctx context.Context, arg CreateSandboxParams) (C
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -844,13 +871,13 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, had_secret_bindings)
   SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, tpl_id, $16, $17, $18, $19, disk_mib, $20, false FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $21::text, 0 FROM ins
   RETURNING sandbox_id
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings, ins.secret_env_fingerprint, ins.secret_env_ip, ins.secret_env_injected_at, ins.secret_env_expires_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -879,32 +906,36 @@ type CreateSandboxFromTemplateParams struct {
 }
 
 type CreateSandboxFromTemplateRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
-	FailedAt          pgtype.Timestamptz `json:"failed_at"`
-	HadSecretBindings *bool              `json:"had_secret_bindings"`
+	ID                   uuid.UUID          `json:"id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Name                 string             `json:"name"`
+	Status               SandboxStatus      `json:"status"`
+	VcpuCount            int32              `json:"vcpu_count"`
+	MemoryMib            int32              `json:"memory_mib"`
+	HostID               string             `json:"host_id"`
+	IpAddress            *netip.Addr        `json:"ip_address"`
+	Pid                  *int32             `json:"pid"`
+	SnapshotID           pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt            time.Time          `json:"created_at"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	DestroyedAt          pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	Metadata             []byte             `json:"metadata"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	SnapshotPath         *string            `json:"snapshot_path"`
+	MemPath              *string            `json:"mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	DiskMib              int32              `json:"disk_mib"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt         pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt             pgtype.Timestamptz `json:"failed_at"`
+	HadSecretBindings    *bool              `json:"had_secret_bindings"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvInjectedAt  pgtype.Timestamptz `json:"secret_env_injected_at"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 // CreateSandbox variant that holds FOR KEY SHARE on the template row
@@ -963,6 +994,10 @@ func (q *Queries) CreateSandboxFromTemplate(ctx context.Context, arg CreateSandb
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -977,7 +1012,7 @@ WITH tpl AS (
 ), ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, had_secret_bindings)
   SELECT $4, $2, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, tpl_id, $15, $16, $17, $18, disk_mib, $19, true FROM tpl
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $20::text, 0 FROM ins
@@ -987,7 +1022,7 @@ WITH tpl AS (
   SELECT ins.id, ($21::uuid[])[i], ($22::text[])[i], ($23::text[])[i]
   FROM ins, generate_subscripts($21::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings, ins.secret_env_fingerprint, ins.secret_env_ip, ins.secret_env_injected_at, ins.secret_env_expires_at
 FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
@@ -1019,32 +1054,36 @@ type CreateSandboxFromTemplateWithSecretsParams struct {
 }
 
 type CreateSandboxFromTemplateWithSecretsRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
-	FailedAt          pgtype.Timestamptz `json:"failed_at"`
-	HadSecretBindings *bool              `json:"had_secret_bindings"`
+	ID                   uuid.UUID          `json:"id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Name                 string             `json:"name"`
+	Status               SandboxStatus      `json:"status"`
+	VcpuCount            int32              `json:"vcpu_count"`
+	MemoryMib            int32              `json:"memory_mib"`
+	HostID               string             `json:"host_id"`
+	IpAddress            *netip.Addr        `json:"ip_address"`
+	Pid                  *int32             `json:"pid"`
+	SnapshotID           pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt            time.Time          `json:"created_at"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	DestroyedAt          pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	Metadata             []byte             `json:"metadata"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	SnapshotPath         *string            `json:"snapshot_path"`
+	MemPath              *string            `json:"mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	DiskMib              int32              `json:"disk_mib"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt         pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt             pgtype.Timestamptz `json:"failed_at"`
+	HadSecretBindings    *bool              `json:"had_secret_bindings"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvInjectedAt  pgtype.Timestamptz `json:"secret_env_injected_at"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 // CreateSandboxFromTemplate plus secret bindings in one statement (see
@@ -1105,6 +1144,10 @@ func (q *Queries) CreateSandboxFromTemplateWithSecrets(ctx context.Context, arg 
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -1113,7 +1156,7 @@ const createSandboxWithSecrets = `-- name: CreateSandboxWithSecrets :one
 WITH ins AS (
   INSERT INTO sandbox (id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, auto_delete_seconds, had_secret_bindings)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, true)
-  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings
+  RETURNING id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at
 ), preview_policy AS (
   INSERT INTO sandbox_preview_policy (sandbox_id, access, revision)
   SELECT ins.id, $19::text, 0 FROM ins
@@ -1123,7 +1166,7 @@ WITH ins AS (
   SELECT ins.id, ($20::uuid[])[i], ($21::text[])[i], ($22::text[])[i]
   FROM ins, generate_subscripts($20::uuid[], 1) AS g(i)
 )
-SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings FROM ins
+SELECT ins.id, ins.team_id, ins.name, ins.status, ins.vcpu_count, ins.memory_mib, ins.host_id, ins.ip_address, ins.pid, ins.snapshot_id, ins.created_at, ins.updated_at, ins.destroyed_at, ins.network_config, ins.timeout_seconds, ins.metadata, ins.template_id, ins.snapshot_path, ins.mem_path, ins.base_path, ins.delta_path, ins.disk_mib, ins.auto_delete_seconds, ins.auto_delete_at, ins.failed_at, ins.had_secret_bindings, ins.secret_env_fingerprint, ins.secret_env_ip, ins.secret_env_injected_at, ins.secret_env_expires_at FROM ins
 JOIN preview_policy ON preview_policy.sandbox_id = ins.id
 `
 
@@ -1153,32 +1196,36 @@ type CreateSandboxWithSecretsParams struct {
 }
 
 type CreateSandboxWithSecretsRow struct {
-	ID                uuid.UUID          `json:"id"`
-	TeamID            uuid.UUID          `json:"team_id"`
-	Name              string             `json:"name"`
-	Status            SandboxStatus      `json:"status"`
-	VcpuCount         int32              `json:"vcpu_count"`
-	MemoryMib         int32              `json:"memory_mib"`
-	HostID            string             `json:"host_id"`
-	IpAddress         *netip.Addr        `json:"ip_address"`
-	Pid               *int32             `json:"pid"`
-	SnapshotID        pgtype.UUID        `json:"snapshot_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-	UpdatedAt         time.Time          `json:"updated_at"`
-	DestroyedAt       pgtype.Timestamptz `json:"destroyed_at"`
-	NetworkConfig     []byte             `json:"network_config"`
-	TimeoutSeconds    *int32             `json:"timeout_seconds"`
-	Metadata          []byte             `json:"metadata"`
-	TemplateID        pgtype.UUID        `json:"template_id"`
-	SnapshotPath      *string            `json:"snapshot_path"`
-	MemPath           *string            `json:"mem_path"`
-	BasePath          *string            `json:"base_path"`
-	DeltaPath         *string            `json:"delta_path"`
-	DiskMib           int32              `json:"disk_mib"`
-	AutoDeleteSeconds *int32             `json:"auto_delete_seconds"`
-	AutoDeleteAt      pgtype.Timestamptz `json:"auto_delete_at"`
-	FailedAt          pgtype.Timestamptz `json:"failed_at"`
-	HadSecretBindings *bool              `json:"had_secret_bindings"`
+	ID                   uuid.UUID          `json:"id"`
+	TeamID               uuid.UUID          `json:"team_id"`
+	Name                 string             `json:"name"`
+	Status               SandboxStatus      `json:"status"`
+	VcpuCount            int32              `json:"vcpu_count"`
+	MemoryMib            int32              `json:"memory_mib"`
+	HostID               string             `json:"host_id"`
+	IpAddress            *netip.Addr        `json:"ip_address"`
+	Pid                  *int32             `json:"pid"`
+	SnapshotID           pgtype.UUID        `json:"snapshot_id"`
+	CreatedAt            time.Time          `json:"created_at"`
+	UpdatedAt            time.Time          `json:"updated_at"`
+	DestroyedAt          pgtype.Timestamptz `json:"destroyed_at"`
+	NetworkConfig        []byte             `json:"network_config"`
+	TimeoutSeconds       *int32             `json:"timeout_seconds"`
+	Metadata             []byte             `json:"metadata"`
+	TemplateID           pgtype.UUID        `json:"template_id"`
+	SnapshotPath         *string            `json:"snapshot_path"`
+	MemPath              *string            `json:"mem_path"`
+	BasePath             *string            `json:"base_path"`
+	DeltaPath            *string            `json:"delta_path"`
+	DiskMib              int32              `json:"disk_mib"`
+	AutoDeleteSeconds    *int32             `json:"auto_delete_seconds"`
+	AutoDeleteAt         pgtype.Timestamptz `json:"auto_delete_at"`
+	FailedAt             pgtype.Timestamptz `json:"failed_at"`
+	HadSecretBindings    *bool              `json:"had_secret_bindings"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvInjectedAt  pgtype.Timestamptz `json:"secret_env_injected_at"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
 }
 
 // CreateSandbox plus its strict preview policy and secret bindings in ONE
@@ -1239,6 +1286,10 @@ func (q *Queries) CreateSandboxWithSecrets(ctx context.Context, arg CreateSandbo
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -1624,7 +1675,7 @@ func (q *Queries) GetPublishedPreviewPort(ctx context.Context, arg GetPublishedP
 }
 
 const getSandbox = `-- name: GetSandbox :one
-SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings FROM sandbox
+SELECT id, team_id, name, status, vcpu_count, memory_mib, host_id, ip_address, pid, snapshot_id, created_at, updated_at, destroyed_at, network_config, timeout_seconds, metadata, template_id, snapshot_path, mem_path, base_path, delta_path, disk_mib, auto_delete_seconds, auto_delete_at, failed_at, had_secret_bindings, secret_env_fingerprint, secret_env_ip, secret_env_injected_at, secret_env_expires_at FROM sandbox
 WHERE id = $1 AND team_id = $2 AND destroyed_at IS NULL
 `
 
@@ -1663,6 +1714,10 @@ func (q *Queries) GetSandbox(ctx context.Context, arg GetSandboxParams) (Sandbox
 		&i.AutoDeleteAt,
 		&i.FailedAt,
 		&i.HadSecretBindings,
+		&i.SecretEnvFingerprint,
+		&i.SecretEnvIp,
+		&i.SecretEnvInjectedAt,
+		&i.SecretEnvExpiresAt,
 	)
 	return i, err
 }
@@ -1753,7 +1808,7 @@ func (q *Queries) GetSandboxStatusForPreviewMutation(ctx context.Context, arg Ge
 }
 
 const getSandboxWithPreviewPolicy = `-- name: GetSandboxWithPreviewPolicy :one
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings,
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings, s.secret_env_fingerprint, s.secret_env_ip, s.secret_env_injected_at, s.secret_env_expires_at,
   COALESCE(p.default_access, p.access, 'legacy_public')::text AS access
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
@@ -1802,6 +1857,10 @@ func (q *Queries) GetSandboxWithPreviewPolicy(ctx context.Context, arg GetSandbo
 		&i.Sandbox.AutoDeleteAt,
 		&i.Sandbox.FailedAt,
 		&i.Sandbox.HadSecretBindings,
+		&i.Sandbox.SecretEnvFingerprint,
+		&i.Sandbox.SecretEnvIp,
+		&i.Sandbox.SecretEnvInjectedAt,
+		&i.Sandbox.SecretEnvExpiresAt,
 		&i.Access,
 	)
 	return i, err
@@ -1996,7 +2055,7 @@ func (q *Queries) ListSandboxesByHost(ctx context.Context, hostID string) ([]Lis
 }
 
 const listSandboxesByTeamCreatedAsc = `-- name: ListSandboxesByTeamCreatedAsc :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings,
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings, s.secret_env_fingerprint, s.secret_env_ip, s.secret_env_injected_at, s.secret_env_expires_at,
   COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
@@ -2068,6 +2127,10 @@ func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSan
 			&i.Sandbox.AutoDeleteAt,
 			&i.Sandbox.FailedAt,
 			&i.Sandbox.HadSecretBindings,
+			&i.Sandbox.SecretEnvFingerprint,
+			&i.Sandbox.SecretEnvIp,
+			&i.Sandbox.SecretEnvInjectedAt,
+			&i.Sandbox.SecretEnvExpiresAt,
 			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
@@ -2082,7 +2145,7 @@ func (q *Queries) ListSandboxesByTeamCreatedAsc(ctx context.Context, arg ListSan
 
 const listSandboxesByTeamCreatedDesc = `-- name: ListSandboxesByTeamCreatedDesc :many
 
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings,
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings, s.secret_env_fingerprint, s.secret_env_ip, s.secret_env_injected_at, s.secret_env_expires_at,
   COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
@@ -2167,6 +2230,10 @@ func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSa
 			&i.Sandbox.AutoDeleteAt,
 			&i.Sandbox.FailedAt,
 			&i.Sandbox.HadSecretBindings,
+			&i.Sandbox.SecretEnvFingerprint,
+			&i.Sandbox.SecretEnvIp,
+			&i.Sandbox.SecretEnvInjectedAt,
+			&i.Sandbox.SecretEnvExpiresAt,
 			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
@@ -2180,7 +2247,7 @@ func (q *Queries) ListSandboxesByTeamCreatedDesc(ctx context.Context, arg ListSa
 }
 
 const listSandboxesByTeamPaged = `-- name: ListSandboxesByTeamPaged :many
-SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings,
+SELECT s.id, s.team_id, s.name, s.status, s.vcpu_count, s.memory_mib, s.host_id, s.ip_address, s.pid, s.snapshot_id, s.created_at, s.updated_at, s.destroyed_at, s.network_config, s.timeout_seconds, s.metadata, s.template_id, s.snapshot_path, s.mem_path, s.base_path, s.delta_path, s.disk_mib, s.auto_delete_seconds, s.auto_delete_at, s.failed_at, s.had_secret_bindings, s.secret_env_fingerprint, s.secret_env_ip, s.secret_env_injected_at, s.secret_env_expires_at,
   COALESCE(p.default_access, p.access, 'legacy_public')::text AS preview_access
 FROM sandbox s
 LEFT JOIN sandbox_preview_policy p ON p.sandbox_id = s.id
@@ -2275,6 +2342,10 @@ func (q *Queries) ListSandboxesByTeamPaged(ctx context.Context, arg ListSandboxe
 			&i.Sandbox.AutoDeleteAt,
 			&i.Sandbox.FailedAt,
 			&i.Sandbox.HadSecretBindings,
+			&i.Sandbox.SecretEnvFingerprint,
+			&i.Sandbox.SecretEnvIp,
+			&i.Sandbox.SecretEnvInjectedAt,
+			&i.Sandbox.SecretEnvExpiresAt,
 			&i.PreviewAccess,
 		); err != nil {
 			return nil, err
@@ -2432,6 +2503,35 @@ func (q *Queries) PublishPort(ctx context.Context, arg PublishPortParams) (Publi
 	var i PublishPortRow
 	err := row.Scan(&i.Port, &i.Access)
 	return i, err
+}
+
+const recordSandboxSecretEnv = `-- name: RecordSandboxSecretEnv :exec
+UPDATE sandbox
+SET secret_env_fingerprint = $2,
+    secret_env_ip = $3,
+    secret_env_injected_at = now(),
+    secret_env_expires_at = $4
+WHERE id = $1 AND destroyed_at IS NULL
+`
+
+type RecordSandboxSecretEnvParams struct {
+	ID                   uuid.UUID          `json:"id"`
+	SecretEnvFingerprint *string            `json:"secret_env_fingerprint"`
+	SecretEnvIp          *string            `json:"secret_env_ip"`
+	SecretEnvExpiresAt   pgtype.Timestamptz `json:"secret_env_expires_at"`
+}
+
+// Bookkeeping after a successful secrets injection: what the guest now
+// holds, for the resume-time reuse check. Off the hot path; a lost write
+// only costs one re-injection.
+func (q *Queries) RecordSandboxSecretEnv(ctx context.Context, arg RecordSandboxSecretEnvParams) error {
+	_, err := q.db.Exec(ctx, recordSandboxSecretEnv,
+		arg.ID,
+		arg.SecretEnvFingerprint,
+		arg.SecretEnvIp,
+		arg.SecretEnvExpiresAt,
+	)
+	return err
 }
 
 const revertPauseToActive = `-- name: RevertPauseToActive :one

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -302,8 +302,8 @@ func (s *stubVMD) DestroyInstance(_ context.Context, _ string, _ bool) error { r
 func (s *stubVMD) PauseInstance(_ context.Context, _, _, pauseToken string) (string, string, []vmdclient.ManifestEntry, string, error) {
 	return "/snapshots/disk.snap", "/snapshots/mem.snap", nil, pauseToken, nil
 }
-func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ []byte) (string, uint32, uint32, error) {
-	return "10.0.0.1", 1, 1024, nil
+func (s *stubVMD) ResumeInstance(_ context.Context, _, _, _ string, _ []byte, _ string, _ map[int32]vmdclient.PortPolicy, _ int64) (string, uint32, uint32, vmdclient.ResumeAttestation, error) {
+	return "10.0.0.1", 1, 1024, vmdclient.ResumeAttestation{}, nil
 }
 func (s *stubVMD) RestoreSnapshot(_ context.Context, _, _, _, _, _, _, _, _ string, _ map[int32]vmdclient.PortPolicy, _ int64, _ map[string]string, _ vmdclient.ResourceLimits) (string, uint32, uint32, string, error) {
 	return "10.0.0.1", 1, 1024, preview.HostCapabilityPorts, nil

--- a/internal/integration/resume_claim_test.go
+++ b/internal/integration/resume_claim_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/superserve-ai/sandbox/internal/db"
 )
@@ -210,5 +211,35 @@ func TestIntegration_RevertResumeToPaused_ArmsPatchedWindow(t *testing.T) {
 		if !row.AutoDeleteAt.Valid || !row.AutoDeleteAt.Time.After(time.Now()) {
 			t.Fatalf("window %d patched while resuming, after revert at=%v, want a fresh deadline in the future", window, row.AutoDeleteAt.Time)
 		}
+	}
+}
+
+// The claim carries the snapshot's timestamp, and the injection record
+// lands on the row: the two sides of the resume-time secrets reuse check.
+func TestIntegration_ClaimResume_CarriesSnapshotTimeAndSecretEnvRecord(t *testing.T) {
+	ctx := context.Background()
+	teamID, apiKey := seedTeamAndKey(t)
+	sandboxID := seedPausedSandbox(t, apiKey)
+
+	fingerprint, ip := "abc123", "10.0.0.5"
+	if err := testQueries.RecordSandboxSecretEnv(ctx, db.RecordSandboxSecretEnvParams{
+		ID: sandboxID, SecretEnvFingerprint: &fingerprint, SecretEnvIp: &ip,
+		SecretEnvExpiresAt: pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true},
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	claimed, err := testQueries.ClaimResume(ctx, db.ClaimResumeParams{
+		ID: sandboxID, TeamID: teamID, LockKey: sandboxID.String(),
+	})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !claimed.SnapCreatedAt.Valid || claimed.SnapCreatedAt.Time.After(time.Now()) {
+		t.Fatalf("snap_created_at = %v, want the pause's timestamp", claimed.SnapCreatedAt)
+	}
+	sb := claimed.Sandbox
+	if sb.SecretEnvFingerprint == nil || *sb.SecretEnvFingerprint != fingerprint || sb.SecretEnvIp == nil || *sb.SecretEnvIp != ip ||
+		!sb.SecretEnvInjectedAt.Valid || !sb.SecretEnvExpiresAt.Valid {
+		t.Fatalf("claimed row secret env = %v/%v/%v/%v, want the recorded values", sb.SecretEnvFingerprint, sb.SecretEnvIp, sb.SecretEnvInjectedAt, sb.SecretEnvExpiresAt)
 	}
 }

--- a/internal/telemetry/vmd_client.go
+++ b/internal/telemetry/vmd_client.go
@@ -50,10 +50,10 @@ func (c *instrumentedVMDClient) PauseInstance(ctx context.Context, instanceID, s
 	return c.next.PauseInstance(ctx, instanceID, snapshotDir, pauseToken)
 }
 
-func (c *instrumentedVMDClient) ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, networkConfig []byte) (ipAddress string, actualVcpu, actualMemMiB uint32, err error) {
+func (c *instrumentedVMDClient) ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, networkConfig []byte, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64) (ipAddress string, actualVcpu, actualMemMiB uint32, attested vmdclient.ResumeAttestation, err error) {
 	started := time.Now()
 	defer func() { c.record(ctx, "ResumeVM", started, err) }()
-	return c.next.ResumeInstance(ctx, instanceID, snapshotPath, memPath, networkConfig)
+	return c.next.ResumeInstance(ctx, instanceID, snapshotPath, memPath, networkConfig, previewAccess, previewPorts, previewPolicyRevision)
 }
 
 func (c *instrumentedVMDClient) RestoreSnapshot(ctx context.Context, instanceID, snapshotPath, memPath, basePath, deltaDir, teamID, ownerID string, previewAccess string, previewPorts map[int32]vmdclient.PortPolicy, previewPolicyRevision int64, envVars map[string]string, limits vmdclient.ResourceLimits) (ipAddress string, actualVcpu, actualMemMiB uint32, previewProtocol string, err error) {

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -53,11 +53,11 @@ func (a *GRPCAdapter) PauseVM(ctx context.Context, req *vmdpb.PauseVMRequest) (*
 	entries := make([]*vmdpb.ArtifactManifestEntry, 0, len(manifest))
 	for _, e := range manifest {
 		entry := &vmdpb.ArtifactManifestEntry{
-			FileName:  e.FileName,
-			Path:      e.Path,
-			SizeBytes: e.SizeBytes,
-			Sha256:    e.SHA256,
-			BasePath:  e.BasePath,
+			FileName:       e.FileName,
+			Path:           e.Path,
+			SizeBytes:      e.SizeBytes,
+			Sha256:         e.SHA256,
+			BasePath:       e.BasePath,
 			AllocatedBytes: e.AllocatedBytes,
 		}
 		entries = append(entries, entry)
@@ -95,7 +95,27 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 			}
 		}
 	}
-	inst, err := a.mgr.resumeVMLocked(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), resumeNetworkRules)
+	// The preview policy rides the request (see vmd.proto). Stamped before the
+	// guest runs, through the same monotonic check a policy push takes, so a
+	// revision behind the record leaves the newer policy in place.
+	previewAccess := req.GetPreviewAccess()
+	if previewAccess != "" {
+		if previewAccess != preview.AccessLegacyPublic && previewAccess != preview.AccessPublic && previewAccess != preview.AccessPrivate {
+			return nil, status.Errorf(codes.InvalidArgument, "preview_access must be empty, %q, %q or %q, got %q", preview.AccessLegacyPublic, preview.AccessPublic, preview.AccessPrivate, previewAccess)
+		}
+		previewPorts, perr := previewPortsFromProto(req.GetPreviewPorts())
+		if perr != nil {
+			return nil, perr
+		}
+		if previewPortsContainTokenizedAccess(previewPorts) && req.GetPreviewPolicyRevision() <= 0 {
+			return nil, status.Error(codes.InvalidArgument, "tokenized preview policy requires a positive preview_policy_revision")
+		}
+		if err := a.mgr.UpdateSandboxPreviewPolicy(req.GetVmId(), previewAccess, previewPorts, req.GetPreviewPolicyRevision()); err != nil {
+			return nil, err
+		}
+	}
+
+	inst, rulesApplied, err := a.mgr.resumeVMLocked(ctx, req.GetVmId(), req.GetSnapshotPath(), req.GetMemFilePath(), resumeNetworkRules)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +142,7 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 		return nil, status.Errorf(codes.Internal, "env vars injection failed: %v", err)
 	}
 
-	return &vmdpb.ResumeVMResponse{
+	resp := &vmdpb.ResumeVMResponse{
 		VmId:       inst.ID,
 		SocketPath: inst.SocketPath,
 		IpAddress:  inst.IP,
@@ -131,7 +151,13 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 			VcpuCount: inst.Config.VCPU,
 			MemoryMib: inst.Config.MemoryMiB,
 		},
-	}, nil
+		NetworkRulesApplied: rulesApplied,
+	}
+	if previewAccess != "" {
+		// Attests the request's policy fields were applied (see vmd.proto).
+		resp.PreviewProtocol = preview.HostCapabilityPorts
+	}
+	return resp, nil
 }
 
 func (a *GRPCAdapter) CreateSnapshot(ctx context.Context, req *vmdpb.CreateSnapshotRequest) (*vmdpb.CreateSnapshotResponse, error) {

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -154,8 +154,12 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 		NetworkRulesApplied: rulesApplied,
 	}
 	if previewAccess != "" {
-		// Attests the request's policy fields were applied (see vmd.proto).
+		// Attests the request's policy fields were applied, and which
+		// revision the record holds now (see vmd.proto).
 		resp.PreviewProtocol = preview.HostCapabilityPorts
+		inst.mu.RLock()
+		resp.PreviewPolicyRevision = inst.PreviewPolicyRevision
+		inst.mu.RUnlock()
 	}
 	return resp, nil
 }

--- a/internal/vm/grpc_adapter.go
+++ b/internal/vm/grpc_adapter.go
@@ -111,7 +111,15 @@ func (a *GRPCAdapter) ResumeVM(ctx context.Context, req *vmdpb.ResumeVMRequest) 
 			return nil, status.Error(codes.InvalidArgument, "tokenized preview policy requires a positive preview_policy_revision")
 		}
 		if err := a.mgr.UpdateSandboxPreviewPolicy(req.GetVmId(), previewAccess, previewPorts, req.GetPreviewPolicyRevision()); err != nil {
-			return nil, err
+			if status.Code(err) != codes.FailedPrecondition {
+				return nil, err
+			}
+			// Same revision, different content: the record keeps what it
+			// enforces at that revision, as a restore would. Not fatal, since
+			// a resume refused here would be refused the same way on every
+			// retry; the attestation reports the record's revision.
+			a.mgr.log.Warn().Err(err).Str("vm_id", req.GetVmId()).
+				Msg("resume: preview policy differs from the record's at the same revision; keeping the record's")
 		}
 	}
 

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -889,6 +889,27 @@ func (m *Manager) SetEgressProxy(proxy *network.EgressProxy) {
 	m.egressProxy = proxy
 }
 
+// applyAdoptedNetworkRules re-applies the request's egress rules to a VM a
+// retried resume adopts. The earlier attempt applied them before launch,
+// but the proxy's per-sandbox rules live in memory and a daemon restart
+// drops them, so the adopting resume applies them again. Reports whether
+// they are fully in place; otherwise the caller pushes them itself.
+func (m *Manager) applyAdoptedNetworkRules(vmID string, rules *sandboxNetworkRules) bool {
+	if rules == nil {
+		return true
+	}
+	if m.netMgr == nil {
+		return false
+	}
+	netInfo := m.netMgr.GetVMNetInfo(vmID)
+	if err := m.applySandboxNetworkRules(vmID, netInfo, rules); err != nil {
+		m.log.Warn().Err(err).Str("vm_id", vmID).Msg("resume: egress rules not applied on adoption")
+		return false
+	}
+	// The proxy half needs the slot; without it only the firewall landed.
+	return netInfo != nil
+}
+
 func (m *Manager) applySandboxNetworkRules(vmID string, netInfo *network.VMNetInfo, rules *sandboxNetworkRules) error {
 	if rules == nil {
 		return nil
@@ -2034,7 +2055,7 @@ func fileExists(path string) bool {
 // this returning and those steps acting on it. The gRPC adapter is the sole
 // caller and owns that lock scope; there is deliberately no self-locking
 // wrapper, which would release the lock before those steps and reopen the race.
-func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPath string, networkRules *sandboxNetworkRules) (*VMInstance, error) {
+func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPath string, networkRules *sandboxNetworkRules) (*VMInstance, bool, error) {
 	log := m.log.With().Str("vm_id", vmID).Logger()
 	tEntry := time.Now()
 	var tSlot, tVerify, tFcStart, tFcDone, tRestore, tRestoreDone time.Time
@@ -2099,7 +2120,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 
 	inst, err := m.getInstance(vmID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if snapshotPath == "" {
@@ -2109,7 +2130,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		memPath = inst.MemFilePath
 	}
 	if snapshotPath == "" || memPath == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "snapshot_path and mem_file_path are required")
+		return nil, false, status.Errorf(codes.InvalidArgument, "snapshot_path and mem_file_path are required")
 	}
 
 	// Retried resume (response lost mid-RPC): the VM may already be up from
@@ -2122,7 +2143,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			// detached telemetry), so adoption matches: record + live unit
 			// suffice.
 			log.Info().Msg("resume: VM already running and healthy, returning it")
-			return existing, nil
+			return existing, m.applyAdoptedNetworkRules(vmID, networkRules), nil
 		}
 		// An unverified target is the one case where blindness is unsafe in
 		// BOTH directions: blind adoption hands back a corpse, blind refusal
@@ -2148,17 +2169,17 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			// instead — the next attempt re-derives the verdict.
 			switch wrote, perr := m.persistStateIfPresent(existing); {
 			case perr != nil:
-				return nil, fmt.Errorf("record readiness verdict for vm %s: %w", vmID, perr)
+				return nil, false, fmt.Errorf("record readiness verdict for vm %s: %w", vmID, perr)
 			case !wrote:
-				return nil, status.Errorf(codes.NotFound, "vm %s was destroyed during resume", vmID)
+				return nil, false, status.Errorf(codes.NotFound, "vm %s was destroyed during resume", vmID)
 			}
 			log.Warn().Err(verr).Msg("resume: unverified VM failed readiness — relaunching")
 		} else {
 			if cerr := m.commitVerifiedAdoption(existing); cerr != nil {
-				return nil, cerr
+				return nil, false, cerr
 			}
 			log.Info().Msg("resume: unverified VM verified and adopted")
-			return existing, nil
+			return existing, m.applyAdoptedNetworkRules(vmID, networkRules), nil
 		}
 	}
 
@@ -2175,15 +2196,15 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// pause-sourced restore.
 	if _, err := os.Stat(snapshotPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, status.Errorf(codes.FailedPrecondition, "snapshot file missing on host: %s", snapshotPath)
+			return nil, false, status.Errorf(codes.FailedPrecondition, "snapshot file missing on host: %s", snapshotPath)
 		}
-		return nil, status.Errorf(codes.FailedPrecondition, "stat snapshot %s: %v", snapshotPath, err)
+		return nil, false, status.Errorf(codes.FailedPrecondition, "stat snapshot %s: %v", snapshotPath, err)
 	}
 	if _, err := os.Stat(memPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, status.Errorf(codes.FailedPrecondition, "memory file missing on host: %s", memPath)
+			return nil, false, status.Errorf(codes.FailedPrecondition, "memory file missing on host: %s", memPath)
 		}
-		return nil, status.Errorf(codes.FailedPrecondition, "stat mem file %s: %v", memPath, err)
+		return nil, false, status.Errorf(codes.FailedPrecondition, "stat mem file %s: %v", memPath, err)
 	}
 	// What the image says about its guest, read before anything is launched.
 	// An ordinary resume reloads the exact image this VM was paused into, and
@@ -2198,15 +2219,15 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.mu.RUnlock()
 	if wakeProtocolFloorRaised() {
 		if blocked, why := pauseIntentBlocks(filepath.Dir(memPath), recordedArtifact); blocked {
-			return nil, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
+			return nil, false, status.Errorf(codes.FailedPrecondition, "image %q: %s; refusing resume until it is inspected", memPath, why)
 		}
 	}
 	resumeCorrectsWallClock, resumeWorkloadFrozen, merr := resumeWallClockProperty(memPath, pausedMemPath, recordedCorrects, recordedFrozen)
 	if merr != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%v", merr)
+		return nil, false, status.Errorf(codes.FailedPrecondition, "%v", merr)
 	}
 	if resumeWorkloadFrozen {
-		return nil, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing resume", memPath)
+		return nil, false, status.Errorf(codes.FailedPrecondition, "image %q holds a frozen workload that this supervisor cannot wake; refusing resume", memPath)
 	}
 	// Presence gate for layered overlays. Deterministic from a stat, so it
 	// belongs here with the other precondition checks — a post-boot refusal
@@ -2214,7 +2235,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	// auto-resume retry of a sandbox whose side-car was lost in transfer.
 	if isOverlayMemFile(memPath) {
 		if gerr := m.gateOverlayPresence(memPath, log); gerr != nil {
-			return nil, status.Errorf(codes.FailedPrecondition, "%v", gerr)
+			return nil, false, status.Errorf(codes.FailedPrecondition, "%v", gerr)
 		}
 	}
 
@@ -2245,19 +2266,19 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		var nsErr error
 		netInfo, nsErr = m.netMgr.EnsureVMSlot(ctx, vmID, nsName, inst.IP, inst.MACAddress)
 		if nsErr != nil {
-			return nil, fmt.Errorf("ensure network slot for resume: %w", nsErr)
+			return nil, false, fmt.Errorf("ensure network slot for resume: %w", nsErr)
 		}
 	} else {
 		var netErr error
 		netInfo, netErr = m.netMgr.SetupVM(ctx, vmID, nil)
 		if netErr != nil {
-			return nil, fmt.Errorf("setup network for resume: %w", netErr)
+			return nil, false, fmt.Errorf("setup network for resume: %w", netErr)
 		}
 		nsName = netInfo.Namespace
 		needsNetworkCleanup = true
 	}
 	if err := m.applySandboxNetworkRules(vmID, netInfo, networkRules); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	tFcStart = time.Now()
@@ -2274,7 +2295,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.Supervision = resumeSupervision
 	inst.mu.Unlock()
 	if err != nil {
-		return nil, fmt.Errorf("start firecracker for restore: %w", err)
+		return nil, false, fmt.Errorf("start firecracker for restore: %w", err)
 	}
 	tFcDone = time.Now()
 
@@ -2296,7 +2317,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		}
 		if basePath == "" {
 			m.stopUnitDuringRestoreError(vmID)
-			return nil, status.Errorf(codes.FailedPrecondition,
+			return nil, false, status.Errorf(codes.FailedPrecondition,
 				"layered overlay %q has no recoverable base; refusing standalone restore", memPath)
 		}
 	}
@@ -2319,7 +2340,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		// Firecracker is already running; stop the unit before returning or it leaks.
 		m.stopUnitDuringRestoreError(vmID)
 		if errors.Is(restoreErr, ErrTornSnapshot) {
-			return nil, status.Errorf(codes.DataLoss,
+			return nil, false, status.Errorf(codes.DataLoss,
 				"snapshot %q is torn (overlay side-car empty); re-snapshot from a healthy source: %v",
 				snapshotPath, restoreErr)
 		}
@@ -2327,11 +2348,11 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			// Permanent: the overlay/base pairing is structurally invalid, so retrying
 			// the layered restore can't succeed. FailedPrecondition tells the caller not
 			// to retry (vs the generic Internal below, which it may).
-			return nil, status.Errorf(codes.FailedPrecondition,
+			return nil, false, status.Errorf(codes.FailedPrecondition,
 				"snapshot %q has an invalid layered overlay/base pairing; do not retry: %v",
 				snapshotPath, restoreErr)
 		}
-		return nil, fmt.Errorf("restore snapshot: %w", restoreErr)
+		return nil, false, fmt.Errorf("restore snapshot: %w", restoreErr)
 	}
 
 	inst.mu.RLock()
@@ -2353,7 +2374,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 		if verr != nil {
 			m.stopUnitDuringRestoreError(vmID)
 			m.setStatus(vmID, StatusError)
-			return nil, fmt.Errorf("boxd not ready after relaunch of unverified vm %s: %w", vmID, verr)
+			return nil, false, fmt.Errorf("boxd not ready after relaunch of unverified vm %s: %w", vmID, verr)
 		}
 	}
 
@@ -2380,7 +2401,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 	inst.mu.Unlock()
 
 	if cerr := m.commitResumeState(inst); cerr != nil {
-		return nil, cerr
+		return nil, false, cerr
 	}
 	// A legacy paused record is the one case reattach cannot recover:
 	// it skips paused VMs because a paused VM has no Firecracker to ask.
@@ -2433,7 +2454,7 @@ func (m *Manager) resumeVMLocked(ctx context.Context, vmID, snapshotPath, memPat
 			Msg("boxd reachable after resume")
 		m.recordPhases("resume", "", map[string]time.Duration{"wait_boxd": time.Since(probeStart)})
 	}()
-	return inst, nil
+	return inst, true, nil
 }
 
 // restoreForResume picks the resume memory backend: UFFD (reusing the existing tap

--- a/internal/vm/manager_test.go
+++ b/internal/vm/manager_test.go
@@ -1625,7 +1625,7 @@ func TestResumeVM_AlreadyRunningHealthy_ReturnsExisting(t *testing.T) {
 	}
 	mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}}
 
-	inst, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	inst, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	if err != nil {
 		t.Fatalf("retried resume of a healthy running VM should succeed, got %v", err)
 	}
@@ -1656,7 +1656,7 @@ func TestResumeVM_UnverifiedRecord_NotAdopted(t *testing.T) {
 
 	// The fallthrough fails on the missing snapshot files — the assertion is
 	// only that the corpse was not returned as a healthy VM.
-	inst, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	inst, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	if err == nil && inst == existing {
 		t.Fatal("an unverified record that fails verification must not be adopted")
 	}
@@ -1732,7 +1732,7 @@ func TestResumeVM_RebuildsNetworkSlotWhenNamespaceMissingAndCleansUpOnLaunchFail
 	}
 	defer unlock()
 
-	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", resumeRules); err == nil {
+	if _, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", resumeRules); err == nil {
 		t.Fatal("expected launch failure")
 	}
 	if got := fake.setupCalls; len(got) != 1 || got[0] != "vm-1" {
@@ -2087,7 +2087,7 @@ func TestResumeVM_UnverifiedTarget_VerifiedAndAdopted(t *testing.T) {
 	}
 	mgr := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}}
 
-	inst, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	inst, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	if err != nil {
 		t.Fatalf("verified adoption must succeed, got %v", err)
 	}
@@ -2180,7 +2180,7 @@ func TestResumeVM_UnverifiedRelaunchVerifiesReplacementIP(t *testing.T) {
 	}
 	defer unlock()
 
-	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil {
+	if _, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil {
 		t.Fatalf("resumeVMLocked: %v", err)
 	}
 	if verifiedIP != "10.11.0.99" {
@@ -2412,7 +2412,7 @@ func TestResumeVM_CorpseVerdict_ClearsRunningBeforeRelaunch(t *testing.T) {
 	}
 	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}}
 
-	if _, err := m.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err == nil {
+	if _, _, err := m.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err == nil {
 		t.Fatal("a relaunch with missing artifacts must fail")
 	}
 	existing.mu.RLock()
@@ -2581,7 +2581,7 @@ func TestResumeVM_CorpseVerdictUnrecordable_RefusesRelaunch(t *testing.T) {
 	store.Close() // every later write fails — the store is broken
 
 	m := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}}
-	_, err = m.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	_, _, err = m.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	if err == nil {
 		t.Fatal("an unrecordable verdict must fail the resume")
 	}

--- a/internal/vm/pause_intent_test.go
+++ b/internal/vm/pause_intent_test.go
@@ -98,7 +98,7 @@ func TestInterruptedPauseRefusesResumeAndRestore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	_, _, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	unlock()
 	if status.Code(rerr) != codes.FailedPrecondition || launched {
 		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)
@@ -164,7 +164,7 @@ func TestFloorDownLooksForNoIntent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer unlock()
-	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
+	if _, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
 		t.Fatalf("resume: err=%v launched=%v, want the resume to proceed without looking", err, launched)
 	}
 	if _, err := os.Stat(pauseIntentPath(dir)); err != nil {
@@ -200,7 +200,7 @@ func TestCompletedPauseIntentClearsItself(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer unlock()
-	if _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
+	if _, _, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil); err != nil || !launched {
 		t.Fatalf("resume: err=%v launched=%v, want the completed pause's intent cleared and the resume to proceed", err, launched)
 	}
 	if _, err := os.Stat(pauseIntentPath(dir)); !os.IsNotExist(err) {

--- a/internal/vm/resume_request_policy_test.go
+++ b/internal/vm/resume_request_policy_test.go
@@ -118,6 +118,9 @@ func TestGRPCAdapterResumeVM_StampsAndAttestsPolicy(t *testing.T) {
 		if resp.GetPreviewProtocol() != preview.HostCapabilityPorts {
 			t.Fatalf("preview_protocol = %q, want %q", resp.GetPreviewProtocol(), preview.HostCapabilityPorts)
 		}
+		if resp.GetPreviewPolicyRevision() != 3 {
+			t.Fatalf("preview_policy_revision = %d, want the request's 3", resp.GetPreviewPolicyRevision())
+		}
 		if !resp.GetNetworkRulesApplied() {
 			t.Fatal("a request without rules must report nothing left to apply")
 		}
@@ -125,6 +128,24 @@ func TestGRPCAdapterResumeVM_StampsAndAttestsPolicy(t *testing.T) {
 		defer existing.mu.Unlock()
 		if existing.PreviewPolicyRevision != 3 || existing.PreviewAccess != preview.AccessPublic || existing.PreviewPorts[3000].Access != preview.AccessPublic {
 			t.Fatalf("record policy = %q rev %d ports %+v, want the request's", existing.PreviewAccess, existing.PreviewPolicyRevision, existing.PreviewPorts)
+		}
+	})
+	t.Run("record already newer keeps its policy and reports it", func(t *testing.T) {
+		a, existing := newAdapter(t)
+		existing.PreviewAccess, existing.PreviewPolicyRevision = preview.AccessPrivate, 5
+		resp, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{
+			VmId: "vm-1", PreviewAccess: preview.AccessPublic, PreviewPolicyRevision: 3,
+		})
+		if err != nil {
+			t.Fatalf("ResumeVM: %v", err)
+		}
+		if resp.GetPreviewProtocol() != preview.HostCapabilityPorts || resp.GetPreviewPolicyRevision() != 5 {
+			t.Fatalf("attestation = %q rev %d, want attested at the record's 5", resp.GetPreviewProtocol(), resp.GetPreviewPolicyRevision())
+		}
+		existing.mu.Lock()
+		defer existing.mu.Unlock()
+		if existing.PreviewAccess != preview.AccessPrivate || existing.PreviewPolicyRevision != 5 {
+			t.Fatalf("record policy = %q rev %d, want the newer one kept", existing.PreviewAccess, existing.PreviewPolicyRevision)
 		}
 	})
 	t.Run("no policy carried", func(t *testing.T) {

--- a/internal/vm/resume_request_policy_test.go
+++ b/internal/vm/resume_request_policy_test.go
@@ -148,6 +148,24 @@ func TestGRPCAdapterResumeVM_StampsAndAttestsPolicy(t *testing.T) {
 			t.Fatalf("record policy = %q rev %d, want the newer one kept", existing.PreviewAccess, existing.PreviewPolicyRevision)
 		}
 	})
+	t.Run("same revision, different content keeps the record", func(t *testing.T) {
+		a, existing := newAdapter(t)
+		existing.PreviewAccess, existing.PreviewPolicyRevision = preview.AccessPrivate, 3
+		resp, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{
+			VmId: "vm-1", PreviewAccess: preview.AccessPublic, PreviewPolicyRevision: 3,
+		})
+		if err != nil {
+			t.Fatalf("ResumeVM must not refuse a same-revision mismatch: %v", err)
+		}
+		if resp.GetPreviewProtocol() != preview.HostCapabilityPorts || resp.GetPreviewPolicyRevision() != 3 {
+			t.Fatalf("attestation = %q rev %d, want attested at the record's 3", resp.GetPreviewProtocol(), resp.GetPreviewPolicyRevision())
+		}
+		existing.mu.Lock()
+		defer existing.mu.Unlock()
+		if existing.PreviewAccess != preview.AccessPrivate {
+			t.Fatalf("record access = %q, want the record's private kept", existing.PreviewAccess)
+		}
+	})
 	t.Run("no policy carried", func(t *testing.T) {
 		a, existing := newAdapter(t)
 		resp, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{VmId: "vm-1"})

--- a/internal/vm/resume_request_policy_test.go
+++ b/internal/vm/resume_request_policy_test.go
@@ -1,0 +1,145 @@
+package vm
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/superserve-ai/sandbox/internal/network"
+	"github.com/superserve-ai/sandbox/internal/preview"
+	"github.com/superserve-ai/sandbox/proto/vmdpb"
+)
+
+// slotNetMgr is fakeNetMgr with a live slot, so egress rules can land.
+type slotNetMgr struct {
+	fakeNetMgr
+	info *network.VMNetInfo
+}
+
+func (s *slotNetMgr) GetVMNetInfo(string) *network.VMNetInfo { return s.info }
+
+func runningForAdoption(t *testing.T) *VMInstance {
+	t.Helper()
+	orig := vmDeadForRetry
+	vmDeadForRetry = func(*Manager, string) bool { return false }
+	t.Cleanup(func() { vmDeadForRetry = orig })
+	return &VMInstance{
+		ID: "vm-1", Status: StatusRunning, IP: "192.0.2.5",
+		SnapshotPath: "/snapshots/vm-1/vmstate.snap",
+		MemFilePath:  "/snapshots/vm-1/mem.snap",
+	}
+}
+
+// A retried resume that adopts the running VM applies the request's egress
+// rules again and reports it, since the proxy's copy does not survive a
+// daemon restart. Without a slot to hang the proxy rules on it reports
+// nothing applied, so the caller pushes them itself.
+func TestResumeVM_AdoptionAppliesRequestRules(t *testing.T) {
+	rules := &sandboxNetworkRules{allowedCIDRs: []string{"10.0.0.0/8"}}
+
+	t.Run("no rules", func(t *testing.T) {
+		existing := runningForAdoption(t)
+		mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}}
+		inst, applied, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+		if err != nil || inst != existing || !applied {
+			t.Fatalf("got inst=%v applied=%v err=%v, want the existing VM with nothing left to apply", inst == existing, applied, err)
+		}
+	})
+	t.Run("slot present", func(t *testing.T) {
+		existing := runningForAdoption(t)
+		net := &slotNetMgr{info: &network.VMNetInfo{HostIP: "10.11.0.5"}}
+		mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}, netMgr: net}
+		_, applied, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", rules)
+		if err != nil || !applied {
+			t.Fatalf("applied=%v err=%v, want the rules applied on adoption", applied, err)
+		}
+		if len(net.firewallCalls) != 1 || net.firewallCalls[0].vmID != "vm-1" || len(net.firewallCalls[0].allowedCIDRs) != 1 {
+			t.Fatalf("firewall calls = %+v, want one for vm-1 with the request's CIDR", net.firewallCalls)
+		}
+	})
+	t.Run("slot missing", func(t *testing.T) {
+		existing := runningForAdoption(t)
+		net := &fakeNetMgr{}
+		mgr := &Manager{log: zerolog.Nop(), vms: map[string]*VMInstance{"vm-1": existing}, netMgr: net}
+		inst, applied, err := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", rules)
+		if err != nil || inst != existing {
+			t.Fatalf("adoption must still return the VM, got inst=%v err=%v", inst == existing, err)
+		}
+		if applied {
+			t.Fatal("rules cannot be fully applied without a slot for the proxy half; must not be reported applied")
+		}
+	})
+}
+
+// The resume RPC stamps the request's policy on the record before the
+// guest runs and attests it; a request without one leaves the record alone
+// and attests nothing; an unknown access mode is refused before anything.
+func TestGRPCAdapterResumeVM_StampsAndAttestsPolicy(t *testing.T) {
+	origProbe := boxdHealthProbe
+	boxdHealthProbe = func(context.Context, string, time.Duration) error { return nil }
+	t.Cleanup(func() { boxdHealthProbe = origProbe })
+
+	newAdapter := func(t *testing.T) (*GRPCAdapter, *VMInstance) {
+		existing := runningForAdoption(t)
+		// The readiness gate re-checks IP ownership: a Running record and a live slot.
+		store, err := OpenStateStore(filepath.Join(t.TempDir(), "state.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { store.Close() })
+		if err := store.Put(VMRecord{ID: existing.ID, Status: StatusRunning, IP: existing.IP}); err != nil {
+			t.Fatal(err)
+		}
+		mgr := &Manager{log: zerolog.Nop(), state: store, vms: map[string]*VMInstance{"vm-1": existing}, netMgr: &slotNetMgr{info: &network.VMNetInfo{HostIP: existing.IP}}}
+		return &GRPCAdapter{mgr: mgr}, existing
+	}
+
+	t.Run("unknown access refused", func(t *testing.T) {
+		a, _ := newAdapter(t)
+		_, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{VmId: "vm-1", PreviewAccess: "sideways"})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("err = %v, want InvalidArgument", err)
+		}
+	})
+	t.Run("policy stamped and attested", func(t *testing.T) {
+		a, existing := newAdapter(t)
+		resp, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{
+			VmId: "vm-1", PreviewAccess: preview.AccessPublic, PreviewPolicyRevision: 3,
+			PreviewPorts: []*vmdpb.PreviewPort{{Port: 3000, Access: preview.AccessPublic}},
+		})
+		if err != nil {
+			t.Fatalf("ResumeVM: %v", err)
+		}
+		if resp.GetPreviewProtocol() != preview.HostCapabilityPorts {
+			t.Fatalf("preview_protocol = %q, want %q", resp.GetPreviewProtocol(), preview.HostCapabilityPorts)
+		}
+		if !resp.GetNetworkRulesApplied() {
+			t.Fatal("a request without rules must report nothing left to apply")
+		}
+		existing.mu.Lock()
+		defer existing.mu.Unlock()
+		if existing.PreviewPolicyRevision != 3 || existing.PreviewAccess != preview.AccessPublic || existing.PreviewPorts[3000].Access != preview.AccessPublic {
+			t.Fatalf("record policy = %q rev %d ports %+v, want the request's", existing.PreviewAccess, existing.PreviewPolicyRevision, existing.PreviewPorts)
+		}
+	})
+	t.Run("no policy carried", func(t *testing.T) {
+		a, existing := newAdapter(t)
+		resp, err := a.ResumeVM(context.Background(), &vmdpb.ResumeVMRequest{VmId: "vm-1"})
+		if err != nil {
+			t.Fatalf("ResumeVM: %v", err)
+		}
+		if resp.GetPreviewProtocol() != "" {
+			t.Fatalf("preview_protocol = %q, want none without a policy in the request", resp.GetPreviewProtocol())
+		}
+		existing.mu.Lock()
+		defer existing.mu.Unlock()
+		if existing.PreviewPolicyRevision != 0 || existing.PreviewAccess != "" {
+			t.Fatalf("record policy changed to %q rev %d without a policy in the request", existing.PreviewAccess, existing.PreviewPolicyRevision)
+		}
+	})
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -247,7 +247,7 @@ func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
+	_, _, rerr := mgr.resumeVMLocked(context.Background(), "vm-1", "", "", nil)
 	unlock()
 	if status.Code(rerr) != codes.FailedPrecondition || launched {
 		t.Fatalf("resume: err=%v launched=%v, want FailedPrecondition before launch", rerr, launched)

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -18,6 +18,16 @@ type ResourceLimits struct {
 // PortPolicy is the control-plane representation of one published preview
 // port. Tokenized wire modes require a positive TokenVersion; raw private and
 // public policies leave TokenVersion at zero.
+// ResumeAttestation is what a resume response proves the daemon applied.
+// PreviewProtocol is the value RestoreSnapshot echoes, empty for a daemon
+// from before the resume request carried the policy. NetworkRulesApplied is
+// true when the request's egress rules are fully in place, including on a VM
+// the daemon adopted from an earlier attempt.
+type ResumeAttestation struct {
+	PreviewProtocol     string
+	NetworkRulesApplied bool
+}
+
 type PortPolicy struct {
 	Access       string
 	TokenVersion int64
@@ -51,8 +61,10 @@ type Client interface {
 	// what came back, or it would demand of reports an identity the host
 	// can never produce.
 	PauseInstance(ctx context.Context, instanceID, snapshotDir, pauseToken string) (snapshotPath, memPath string, manifest []ManifestEntry, ackedToken string, err error)
-	// ResumeInstance restores a paused VM.
-	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, networkConfig []byte) (ipAddress string, actualVcpu, actualMemMiB uint32, err error)
+	// ResumeInstance restores a paused VM. The preview policy rides along so
+	// the daemon stamps it before the guest runs; the attestation reports
+	// what the daemon applied, with empty fields for a daemon from before it.
+	ResumeInstance(ctx context.Context, instanceID, snapshotPath, memPath string, networkConfig []byte, previewAccess string, previewPorts map[int32]PortPolicy, previewPolicyRevision int64) (ipAddress string, actualVcpu, actualMemMiB uint32, attested ResumeAttestation, err error)
 	// RestoreSnapshot is the stateless restore path used as a fallback when
 	// ResumeInstance fails with NotFound (e.g. after a VMD crash lost the
 	// in-memory map but the snapshot files are still on disk). basePath +

--- a/internal/vmdclient/client.go
+++ b/internal/vmdclient/client.go
@@ -24,8 +24,12 @@ type ResourceLimits struct {
 // true when the request's egress rules are fully in place, including on a VM
 // the daemon adopted from an earlier attempt.
 type ResumeAttestation struct {
-	PreviewProtocol     string
-	NetworkRulesApplied bool
+	PreviewProtocol string
+	// PreviewPolicyRevision is the revision the daemon's record holds after
+	// the stamp; higher than the request's when the record already held a
+	// newer policy and kept it.
+	PreviewPolicyRevision int64
+	NetworkRulesApplied   bool
 }
 
 type PortPolicy struct {

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -406,6 +406,10 @@ message ResumeVMResponse {
   // including one adopted from an earlier attempt. False means the caller
   // must push them itself.
   bool network_rules_applied = 7;
+  // The policy revision the record holds after the stamp: the request's
+  // when it was applied, higher when the record already held a newer
+  // policy and kept it. Set only with preview_protocol.
+  int64 preview_policy_revision = 8;
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/vmd.proto
+++ b/proto/vmd.proto
@@ -383,6 +383,13 @@ message ResumeVMRequest {
   map<string, string> env_vars = 5;          // Re-inject env vars after resume.
   reserved 6;                                 // was secrets_broker (SecretsBrokerConfig)
   reserved "secrets_broker";
+  // Preview policy stamped on the record before the guest runs, with the
+  // same fields and rules as RestoreSnapshotRequest. Empty preview_access
+  // means a sender from before these fields: the record keeps its policy
+  // and the response carries no attestation.
+  string preview_access = 7;
+  repeated PreviewPort preview_ports = 8;
+  int64 preview_policy_revision = 9;
 }
 
 message ResumeVMResponse {
@@ -391,6 +398,14 @@ message ResumeVMResponse {
   string ip_address = 3;
   uint32 pid = 4;
   ResourceLimits resource_limits = 5;
+  // Attests that the request's preview policy fields were applied; same
+  // value and rules as RestoreSnapshotResponse.preview_protocol. Empty
+  // means the request carried no policy or the vmd predates this field.
+  string preview_protocol = 6;
+  // True when the request's egress rules are fully in place on the VM,
+  // including one adopted from an earlier attempt. False means the caller
+  // must push them itself.
+  bool network_rules_applied = 7;
 }
 
 // ---------------------------------------------------------------------------

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -1820,8 +1820,12 @@ type ResumeVMResponse struct {
 	// including one adopted from an earlier attempt. False means the caller
 	// must push them itself.
 	NetworkRulesApplied bool `protobuf:"varint,7,opt,name=network_rules_applied,json=networkRulesApplied,proto3" json:"network_rules_applied,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// The policy revision the record holds after the stamp: the request's
+	// when it was applied, higher when the record already held a newer
+	// policy and kept it. Set only with preview_protocol.
+	PreviewPolicyRevision int64 `protobuf:"varint,8,opt,name=preview_policy_revision,json=previewPolicyRevision,proto3" json:"preview_policy_revision,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ResumeVMResponse) Reset() {
@@ -1901,6 +1905,13 @@ func (x *ResumeVMResponse) GetNetworkRulesApplied() bool {
 		return x.NetworkRulesApplied
 	}
 	return false
+}
+
+func (x *ResumeVMResponse) GetPreviewPolicyRevision() int64 {
+	if x != nil {
+		return x.PreviewPolicyRevision
+	}
+	return 0
 }
 
 type CreateSnapshotRequest struct {
@@ -4010,7 +4021,7 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x17preview_policy_revision\x18\t \x01(\x03R\x15previewPolicyRevision\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aR\x0esecrets_broker\"\xa4\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aR\x0esecrets_broker\"\xdc\x02\n" +
 	"\x10ResumeVMResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vsocket_path\x18\x02 \x01(\tR\n" +
@@ -4020,7 +4031,8 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\x03pid\x18\x04 \x01(\rR\x03pid\x12J\n" +
 	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12)\n" +
 	"\x10preview_protocol\x18\x06 \x01(\tR\x0fpreviewProtocol\x122\n" +
-	"\x15network_rules_applied\x18\a \x01(\bR\x13networkRulesApplied\"O\n" +
+	"\x15network_rules_applied\x18\a \x01(\bR\x13networkRulesApplied\x126\n" +
+	"\x17preview_policy_revision\x18\b \x01(\x03R\x15previewPolicyRevision\"O\n" +
 	"\x15CreateSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12!\n" +
 	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\x9e\x01\n" +

--- a/proto/vmdpb/vmd.pb.go
+++ b/proto/vmdpb/vmd.pb.go
@@ -1708,8 +1708,15 @@ type ResumeVMRequest struct {
 	MemFilePath    string                 `protobuf:"bytes,3,opt,name=mem_file_path,json=memFilePath,proto3" json:"mem_file_path,omitempty"`
 	SandboxNetwork *SandboxNetworkConfig  `protobuf:"bytes,4,opt,name=sandbox_network,json=sandboxNetwork,proto3" json:"sandbox_network,omitempty"`                                                      // Reapply egress rules after resume.
 	EnvVars        map[string]string      `protobuf:"bytes,5,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Re-inject env vars after resume.
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Preview policy stamped on the record before the guest runs, with the
+	// same fields and rules as RestoreSnapshotRequest. Empty preview_access
+	// means a sender from before these fields: the record keeps its policy
+	// and the response carries no attestation.
+	PreviewAccess         string         `protobuf:"bytes,7,opt,name=preview_access,json=previewAccess,proto3" json:"preview_access,omitempty"`
+	PreviewPorts          []*PreviewPort `protobuf:"bytes,8,rep,name=preview_ports,json=previewPorts,proto3" json:"preview_ports,omitempty"`
+	PreviewPolicyRevision int64          `protobuf:"varint,9,opt,name=preview_policy_revision,json=previewPolicyRevision,proto3" json:"preview_policy_revision,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ResumeVMRequest) Reset() {
@@ -1777,6 +1784,27 @@ func (x *ResumeVMRequest) GetEnvVars() map[string]string {
 	return nil
 }
 
+func (x *ResumeVMRequest) GetPreviewAccess() string {
+	if x != nil {
+		return x.PreviewAccess
+	}
+	return ""
+}
+
+func (x *ResumeVMRequest) GetPreviewPorts() []*PreviewPort {
+	if x != nil {
+		return x.PreviewPorts
+	}
+	return nil
+}
+
+func (x *ResumeVMRequest) GetPreviewPolicyRevision() int64 {
+	if x != nil {
+		return x.PreviewPolicyRevision
+	}
+	return 0
+}
+
 type ResumeVMResponse struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	VmId           string                 `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
@@ -1784,8 +1812,16 @@ type ResumeVMResponse struct {
 	IpAddress      string                 `protobuf:"bytes,3,opt,name=ip_address,json=ipAddress,proto3" json:"ip_address,omitempty"`
 	Pid            uint32                 `protobuf:"varint,4,opt,name=pid,proto3" json:"pid,omitempty"`
 	ResourceLimits *ResourceLimits        `protobuf:"bytes,5,opt,name=resource_limits,json=resourceLimits,proto3" json:"resource_limits,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Attests that the request's preview policy fields were applied; same
+	// value and rules as RestoreSnapshotResponse.preview_protocol. Empty
+	// means the request carried no policy or the vmd predates this field.
+	PreviewProtocol string `protobuf:"bytes,6,opt,name=preview_protocol,json=previewProtocol,proto3" json:"preview_protocol,omitempty"`
+	// True when the request's egress rules are fully in place on the VM,
+	// including one adopted from an earlier attempt. False means the caller
+	// must push them itself.
+	NetworkRulesApplied bool `protobuf:"varint,7,opt,name=network_rules_applied,json=networkRulesApplied,proto3" json:"network_rules_applied,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ResumeVMResponse) Reset() {
@@ -1851,6 +1887,20 @@ func (x *ResumeVMResponse) GetResourceLimits() *ResourceLimits {
 		return x.ResourceLimits
 	}
 	return nil
+}
+
+func (x *ResumeVMResponse) GetPreviewProtocol() string {
+	if x != nil {
+		return x.PreviewProtocol
+	}
+	return ""
+}
+
+func (x *ResumeVMResponse) GetNetworkRulesApplied() bool {
+	if x != nil {
+		return x.NetworkRulesApplied
+	}
+	return false
 }
 
 type CreateSnapshotRequest struct {
@@ -3948,16 +3998,19 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\x12\x16\n" +
 	"\x06sha256\x18\x04 \x01(\tR\x06sha256\x12\x1b\n" +
 	"\tbase_path\x18\x05 \x01(\tR\bbasePath\x12'\n" +
-	"\x0fallocated_bytes\x18\x06 \x01(\x03R\x0eallocatedBytes\"\xdf\x02\n" +
+	"\x0fallocated_bytes\x18\x06 \x01(\x03R\x0eallocatedBytes\"\x83\x04\n" +
 	"\x0fResumeVMRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12#\n" +
 	"\rsnapshot_path\x18\x02 \x01(\tR\fsnapshotPath\x12\"\n" +
 	"\rmem_file_path\x18\x03 \x01(\tR\vmemFilePath\x12P\n" +
 	"\x0fsandbox_network\x18\x04 \x01(\v2'.superserve.vmd.v1.SandboxNetworkConfigR\x0esandboxNetwork\x12J\n" +
-	"\benv_vars\x18\x05 \x03(\v2/.superserve.vmd.v1.ResumeVMRequest.EnvVarsEntryR\aenvVars\x1a:\n" +
+	"\benv_vars\x18\x05 \x03(\v2/.superserve.vmd.v1.ResumeVMRequest.EnvVarsEntryR\aenvVars\x12%\n" +
+	"\x0epreview_access\x18\a \x01(\tR\rpreviewAccess\x12C\n" +
+	"\rpreview_ports\x18\b \x03(\v2\x1e.superserve.vmd.v1.PreviewPortR\fpreviewPorts\x126\n" +
+	"\x17preview_policy_revision\x18\t \x01(\x03R\x15previewPolicyRevision\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aR\x0esecrets_broker\"\xc5\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x06\x10\aR\x0esecrets_broker\"\xa4\x02\n" +
 	"\x10ResumeVMResponse\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
 	"\vsocket_path\x18\x02 \x01(\tR\n" +
@@ -3965,7 +4018,9 @@ const file_proto_vmd_proto_rawDesc = "" +
 	"\n" +
 	"ip_address\x18\x03 \x01(\tR\tipAddress\x12\x10\n" +
 	"\x03pid\x18\x04 \x01(\rR\x03pid\x12J\n" +
-	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\"O\n" +
+	"\x0fresource_limits\x18\x05 \x01(\v2!.superserve.vmd.v1.ResourceLimitsR\x0eresourceLimits\x12)\n" +
+	"\x10preview_protocol\x18\x06 \x01(\tR\x0fpreviewProtocol\x122\n" +
+	"\x15network_rules_applied\x18\a \x01(\bR\x13networkRulesApplied\"O\n" +
 	"\x15CreateSnapshotRequest\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12!\n" +
 	"\fsnapshot_dir\x18\x02 \x01(\tR\vsnapshotDir\"\x9e\x01\n" +
@@ -4230,74 +4285,75 @@ var file_proto_vmd_proto_depIdxs = []int32{
 	22, // 5: superserve.vmd.v1.PauseVMResponse.manifest:type_name -> superserve.vmd.v1.ArtifactManifestEntry
 	14, // 6: superserve.vmd.v1.ResumeVMRequest.sandbox_network:type_name -> superserve.vmd.v1.SandboxNetworkConfig
 	61, // 7: superserve.vmd.v1.ResumeVMRequest.env_vars:type_name -> superserve.vmd.v1.ResumeVMRequest.EnvVarsEntry
-	12, // 8: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	12, // 9: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	13, // 10: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	62, // 11: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
-	28, // 12: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	12, // 13: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	63, // 14: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
-	41, // 15: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
-	45, // 16: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
-	0,  // 17: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
-	12, // 18: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
-	64, // 19: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
-	13, // 20: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
-	15, // 21: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
-	28, // 22: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
-	16, // 23: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
-	20, // 24: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
-	23, // 25: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
-	25, // 26: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
-	27, // 27: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
-	30, // 28: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
-	32, // 29: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
-	34, // 30: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
-	36, // 31: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
-	38, // 32: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
-	40, // 33: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
-	43, // 34: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
-	46, // 35: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
-	48, // 36: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
-	18, // 37: superserve.vmd.v1.VMDaemon.ReviveVM:input_type -> superserve.vmd.v1.ReviveVMRequest
-	50, // 38: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
-	52, // 39: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
-	54, // 40: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
-	56, // 41: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
-	58, // 42: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
-	1,  // 43: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
-	6,  // 44: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
-	8,  // 45: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
-	10, // 46: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
-	17, // 47: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
-	21, // 48: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
-	24, // 49: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
-	26, // 50: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
-	29, // 51: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
-	31, // 52: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
-	33, // 53: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
-	35, // 54: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
-	37, // 55: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
-	39, // 56: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
-	42, // 57: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
-	44, // 58: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
-	47, // 59: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
-	49, // 60: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
-	19, // 61: superserve.vmd.v1.VMDaemon.ReviveVM:output_type -> superserve.vmd.v1.ReviveVMResponse
-	51, // 62: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
-	53, // 63: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
-	55, // 64: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
-	57, // 65: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
-	59, // 66: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
-	5,  // 67: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
-	7,  // 68: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
-	9,  // 69: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
-	11, // 70: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
-	47, // [47:71] is the sub-list for method output_type
-	23, // [23:47] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	28, // 8: superserve.vmd.v1.ResumeVMRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	12, // 9: superserve.vmd.v1.ResumeVMResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	12, // 10: superserve.vmd.v1.RestoreSnapshotRequest.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	13, // 11: superserve.vmd.v1.RestoreSnapshotRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	62, // 12: superserve.vmd.v1.RestoreSnapshotRequest.env_vars:type_name -> superserve.vmd.v1.RestoreSnapshotRequest.EnvVarsEntry
+	28, // 13: superserve.vmd.v1.RestoreSnapshotRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	12, // 14: superserve.vmd.v1.RestoreSnapshotResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	63, // 15: superserve.vmd.v1.InjectSandboxEnvRequest.env_vars:type_name -> superserve.vmd.v1.InjectSandboxEnvRequest.EnvVarsEntry
+	41, // 16: superserve.vmd.v1.ListBuildArtifactsResponse.entries:type_name -> superserve.vmd.v1.BuildArtifactEntry
+	45, // 17: superserve.vmd.v1.ListDirResponse.entries:type_name -> superserve.vmd.v1.ListDirEntry
+	0,  // 18: superserve.vmd.v1.GetVMInfoResponse.status:type_name -> superserve.vmd.v1.VMStatus
+	12, // 19: superserve.vmd.v1.GetVMInfoResponse.resource_limits:type_name -> superserve.vmd.v1.ResourceLimits
+	64, // 20: superserve.vmd.v1.GetVMInfoResponse.metadata:type_name -> superserve.vmd.v1.GetVMInfoResponse.MetadataEntry
+	13, // 21: superserve.vmd.v1.SetupNetworkRequest.network_config:type_name -> superserve.vmd.v1.NetworkConfig
+	15, // 22: superserve.vmd.v1.UpdateSandboxNetworkRequest.egress:type_name -> superserve.vmd.v1.SandboxNetworkEgressConfig
+	28, // 23: superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest.preview_ports:type_name -> superserve.vmd.v1.PreviewPort
+	16, // 24: superserve.vmd.v1.VMDaemon.DestroyVM:input_type -> superserve.vmd.v1.DestroyVMRequest
+	20, // 25: superserve.vmd.v1.VMDaemon.PauseVM:input_type -> superserve.vmd.v1.PauseVMRequest
+	23, // 26: superserve.vmd.v1.VMDaemon.ResumeVM:input_type -> superserve.vmd.v1.ResumeVMRequest
+	25, // 27: superserve.vmd.v1.VMDaemon.CreateSnapshot:input_type -> superserve.vmd.v1.CreateSnapshotRequest
+	27, // 28: superserve.vmd.v1.VMDaemon.RestoreSnapshot:input_type -> superserve.vmd.v1.RestoreSnapshotRequest
+	30, // 29: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:input_type -> superserve.vmd.v1.InjectSandboxEnvRequest
+	32, // 30: superserve.vmd.v1.VMDaemon.DeleteSnapshot:input_type -> superserve.vmd.v1.DeleteSnapshotRequest
+	34, // 31: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:input_type -> superserve.vmd.v1.DeleteSandboxSnapshotsRequest
+	36, // 32: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:input_type -> superserve.vmd.v1.DeleteTemplateArtifactsRequest
+	38, // 33: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:input_type -> superserve.vmd.v1.DeleteBuildArtifactsRequest
+	40, // 34: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:input_type -> superserve.vmd.v1.ListBuildArtifactsRequest
+	43, // 35: superserve.vmd.v1.VMDaemon.ListDir:input_type -> superserve.vmd.v1.ListDirRequest
+	46, // 36: superserve.vmd.v1.VMDaemon.GetVMInfo:input_type -> superserve.vmd.v1.GetVMInfoRequest
+	48, // 37: superserve.vmd.v1.VMDaemon.SetupNetwork:input_type -> superserve.vmd.v1.SetupNetworkRequest
+	18, // 38: superserve.vmd.v1.VMDaemon.ReviveVM:input_type -> superserve.vmd.v1.ReviveVMRequest
+	50, // 39: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:input_type -> superserve.vmd.v1.UpdateSandboxNetworkRequest
+	52, // 40: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:input_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyRequest
+	54, // 41: superserve.vmd.v1.VMDaemon.InvalidateSecret:input_type -> superserve.vmd.v1.InvalidateSecretRequest
+	56, // 42: superserve.vmd.v1.VMDaemon.RevokeSandbox:input_type -> superserve.vmd.v1.RevokeSandboxRequest
+	58, // 43: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:input_type -> superserve.vmd.v1.InvalidateSandboxRulesRequest
+	1,  // 44: superserve.vmd.v1.VMDaemon.BuildTemplate:input_type -> superserve.vmd.v1.BuildTemplateRequest
+	6,  // 45: superserve.vmd.v1.VMDaemon.GetBuildStatus:input_type -> superserve.vmd.v1.GetBuildStatusRequest
+	8,  // 46: superserve.vmd.v1.VMDaemon.CancelBuild:input_type -> superserve.vmd.v1.CancelBuildRequest
+	10, // 47: superserve.vmd.v1.VMDaemon.StreamBuildLogs:input_type -> superserve.vmd.v1.StreamBuildLogsRequest
+	17, // 48: superserve.vmd.v1.VMDaemon.DestroyVM:output_type -> superserve.vmd.v1.DestroyVMResponse
+	21, // 49: superserve.vmd.v1.VMDaemon.PauseVM:output_type -> superserve.vmd.v1.PauseVMResponse
+	24, // 50: superserve.vmd.v1.VMDaemon.ResumeVM:output_type -> superserve.vmd.v1.ResumeVMResponse
+	26, // 51: superserve.vmd.v1.VMDaemon.CreateSnapshot:output_type -> superserve.vmd.v1.CreateSnapshotResponse
+	29, // 52: superserve.vmd.v1.VMDaemon.RestoreSnapshot:output_type -> superserve.vmd.v1.RestoreSnapshotResponse
+	31, // 53: superserve.vmd.v1.VMDaemon.InjectSandboxEnv:output_type -> superserve.vmd.v1.InjectSandboxEnvResponse
+	33, // 54: superserve.vmd.v1.VMDaemon.DeleteSnapshot:output_type -> superserve.vmd.v1.DeleteSnapshotResponse
+	35, // 55: superserve.vmd.v1.VMDaemon.DeleteSandboxSnapshots:output_type -> superserve.vmd.v1.DeleteSandboxSnapshotsResponse
+	37, // 56: superserve.vmd.v1.VMDaemon.DeleteTemplateArtifacts:output_type -> superserve.vmd.v1.DeleteTemplateArtifactsResponse
+	39, // 57: superserve.vmd.v1.VMDaemon.DeleteBuildArtifacts:output_type -> superserve.vmd.v1.DeleteBuildArtifactsResponse
+	42, // 58: superserve.vmd.v1.VMDaemon.ListBuildArtifacts:output_type -> superserve.vmd.v1.ListBuildArtifactsResponse
+	44, // 59: superserve.vmd.v1.VMDaemon.ListDir:output_type -> superserve.vmd.v1.ListDirResponse
+	47, // 60: superserve.vmd.v1.VMDaemon.GetVMInfo:output_type -> superserve.vmd.v1.GetVMInfoResponse
+	49, // 61: superserve.vmd.v1.VMDaemon.SetupNetwork:output_type -> superserve.vmd.v1.SetupNetworkResponse
+	19, // 62: superserve.vmd.v1.VMDaemon.ReviveVM:output_type -> superserve.vmd.v1.ReviveVMResponse
+	51, // 63: superserve.vmd.v1.VMDaemon.UpdateSandboxNetwork:output_type -> superserve.vmd.v1.UpdateSandboxNetworkResponse
+	53, // 64: superserve.vmd.v1.VMDaemon.UpdateSandboxPreviewPolicy:output_type -> superserve.vmd.v1.UpdateSandboxPreviewPolicyResponse
+	55, // 65: superserve.vmd.v1.VMDaemon.InvalidateSecret:output_type -> superserve.vmd.v1.InvalidateSecretResponse
+	57, // 66: superserve.vmd.v1.VMDaemon.RevokeSandbox:output_type -> superserve.vmd.v1.RevokeSandboxResponse
+	59, // 67: superserve.vmd.v1.VMDaemon.InvalidateSandboxRules:output_type -> superserve.vmd.v1.InvalidateSandboxRulesResponse
+	5,  // 68: superserve.vmd.v1.VMDaemon.BuildTemplate:output_type -> superserve.vmd.v1.BuildTemplateResponse
+	7,  // 69: superserve.vmd.v1.VMDaemon.GetBuildStatus:output_type -> superserve.vmd.v1.GetBuildStatusResponse
+	9,  // 70: superserve.vmd.v1.VMDaemon.CancelBuild:output_type -> superserve.vmd.v1.CancelBuildResponse
+	11, // 71: superserve.vmd.v1.VMDaemon.StreamBuildLogs:output_type -> superserve.vmd.v1.BuildLogEvent
+	48, // [48:72] is the sub-list for method output_type
+	24, // [24:48] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_proto_vmd_proto_init() }

--- a/supabase/migrations/20260909000001_sandbox_secret_env_marker.sql
+++ b/supabase/migrations/20260909000001_sandbox_secret_env_marker.sql
@@ -1,0 +1,19 @@
+-- What the guest currently holds from the last secrets injection, so a
+-- resume can tell whether the environment captured in the snapshot is still
+-- the right one and skip the re-mint and guest round trip when it is.
+-- Written after each successful injection; NULL means unknown, which a
+-- resume treats as "inject".
+ALTER TABLE sandbox
+    ADD COLUMN IF NOT EXISTS secret_env_fingerprint text,
+    ADD COLUMN IF NOT EXISTS secret_env_ip text,
+    ADD COLUMN IF NOT EXISTS secret_env_injected_at timestamptz,
+    ADD COLUMN IF NOT EXISTS secret_env_expires_at timestamptz;
+
+COMMENT ON COLUMN sandbox.secret_env_fingerprint IS
+    'Digest of the binding set last injected into the guest; a resume re-injects when the current set differs.';
+COMMENT ON COLUMN sandbox.secret_env_ip IS
+    'Guest IP the injected proxy JWT is bound to; a resume re-injects when the guest comes back on another.';
+COMMENT ON COLUMN sandbox.secret_env_injected_at IS
+    'When the last injection landed; only a snapshot taken after it holds the injected environment.';
+COMMENT ON COLUMN sandbox.secret_env_expires_at IS
+    'Expiry of the injected proxy JWT; a resume re-injects when it is near.';


### PR DESCRIPTION
Resume makes one daemon call: the preview policy the claim read rides the resume request, the daemon stamps it before the guest runs and attests it, so the post-boot policy re-read and push remain only for the stateless fallback and for daemons from before the echo. The daemon also applies the request's egress rules when a retried resume adopts an earlier attempt's VM and acks it, so the control plane replays them only when unacked.
A resume with secret bindings skips the JWT re-mint and guest round trip while the recorded binding set, guest IP, JWT life, and snapshot age all say the guest still holds the current environment; any doubt injects. Either deploy order is safe; the migration adds four nullable columns to the sandbox row.