### PR TITLE
api: raise the per-host storage measurement cap to 300000

### DIFF
--- a/internal/api/hosts.go
+++ b/internal/api/hosts.go
@@ -18,7 +18,7 @@ const (
 	maxHostCapabilities     = 32
 	maxHostCapabilityLength = 64
 	maxHostFieldLength      = 256
-	maxHostStorageSamples   = 200000
+	maxHostStorageSamples   = 300000
 )
 
 type hostStorageMeasurement struct {


### PR DESCRIPTION
Hosts above 200000 storage measurements had every heartbeat rejected as bad_request and were marked unhealthy. Raise the cap to 300000.