### PR TITLE
api: keep asking the host until a pause is decided instead of reverting on a timeout

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2903,8 +2903,10 @@ const (
 )
 
 // pauseWithRetry pauses a VM and keeps asking, each attempt parking behind
-// the pause in flight, until the host answers definitively. NotFound and
-// every other non-timeout error are terminal.
+// the pause in flight, until the host answers definitively. NotFound is
+// terminal. Any other failure gets one more attempt: the host may have
+// saved the snapshot and stopped the VM before failing to record it, and
+// the repeat lands on the already-paused guard and returns that snapshot.
 func pauseWithRetry(reqCtx context.Context, vmd vmdclient.Client, id, pauseToken string) (snapshotPath, memPath string, manifest []vmdclient.ManifestEntry, ackedToken string, err error) {
 	return pauseUntilDecided(reqCtx, vmd, id, pauseToken, pauseAttemptTimeout, pauseReconcileBudget)
 }
@@ -2914,12 +2916,23 @@ func pauseUntilDecided(reqCtx context.Context, vmd vmdclient.Client, id, pauseTo
 	// The first attempt follows the caller; later ones detach, since the
 	// client giving up must not leave the row drifting against the host.
 	ctx := reqCtx
+	recovered := false
 	for {
 		actx, cancel := context.WithTimeout(ctx, attempt)
 		snapshotPath, memPath, manifest, ackedToken, err = vmd.PauseInstance(actx, id, "", pauseToken)
 		cancel()
-		if err == nil || !pauseUndecided(err) || time.Now().After(deadline) {
+		switch {
+		case err == nil || isVMDNotFound(err):
 			return snapshotPath, memPath, manifest, ackedToken, err
+		case pauseUndecided(err):
+			if time.Now().After(deadline) {
+				return snapshotPath, memPath, manifest, ackedToken, err
+			}
+		default:
+			if recovered {
+				return snapshotPath, memPath, manifest, ackedToken, err
+			}
+			recovered = true
 		}
 		ctx = context.WithoutCancel(reqCtx)
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2891,23 +2891,45 @@ func (h *Handlers) CreateSandbox(c *gin.Context) {
 // Sandbox Pause
 // ---------------------------------------------------------------------------
 
-// pauseWithRetry pauses a VM, retrying once on a non-NotFound failure. A
-// timed-out pause may have actually completed on the host, so reverting the
-// row to active would drift it against a paused VM; PauseVM is idempotent, so
-// the retry returns the recorded snapshot and the row converges to paused.
-// NotFound is terminal — the VM is genuinely gone.
+// A pause writes the guest's dirty memory before it answers, so one attempt
+// gets longer than other daemon calls, and a pause that outruns it is still
+// running on the host rather than failed. The daemon holds the VM's lock
+// until the snapshot lands and answers a repeat request with that snapshot,
+// so the row is only reverted once the host has given a definite answer or
+// the reconcile budget is spent.
+const (
+	pauseAttemptTimeout  = 60 * time.Second
+	pauseReconcileBudget = 10 * time.Minute
+)
+
+// pauseWithRetry pauses a VM and keeps asking, each attempt parking behind
+// the pause in flight, until the host answers definitively. NotFound and
+// every other non-timeout error are terminal.
 func pauseWithRetry(reqCtx context.Context, vmd vmdclient.Client, id, pauseToken string) (snapshotPath, memPath string, manifest []vmdclient.ManifestEntry, ackedToken string, err error) {
-	ctx, cancel := context.WithTimeout(reqCtx, vmdTimeout)
-	snapshotPath, memPath, manifest, ackedToken, err = vmd.PauseInstance(ctx, id, "", pauseToken)
-	cancel()
-	if err == nil || isVMDNotFound(err) {
-		return snapshotPath, memPath, manifest, ackedToken, err
+	return pauseUntilDecided(reqCtx, vmd, id, pauseToken, pauseAttemptTimeout, pauseReconcileBudget)
+}
+
+func pauseUntilDecided(reqCtx context.Context, vmd vmdclient.Client, id, pauseToken string, attempt, budget time.Duration) (snapshotPath, memPath string, manifest []vmdclient.ManifestEntry, ackedToken string, err error) {
+	deadline := time.Now().Add(budget)
+	// The first attempt follows the caller; later ones detach, since the
+	// client giving up must not leave the row drifting against the host.
+	ctx := reqCtx
+	for {
+		actx, cancel := context.WithTimeout(ctx, attempt)
+		snapshotPath, memPath, manifest, ackedToken, err = vmd.PauseInstance(actx, id, "", pauseToken)
+		cancel()
+		if err == nil || !pauseUndecided(err) || time.Now().After(deadline) {
+			return snapshotPath, memPath, manifest, ackedToken, err
+		}
+		ctx = context.WithoutCancel(reqCtx)
 	}
-	// Detach from the request ctx: the client's deadline may already have
-	// fired, but the reconciliation to a consistent state must still run.
-	rctx, rcancel := context.WithTimeout(context.WithoutCancel(reqCtx), vmdTimeout)
-	defer rcancel()
-	return vmd.PauseInstance(rctx, id, "", pauseToken)
+}
+
+// pauseUndecided reports whether err leaves the pause's outcome unknown: the
+// attempt ran out of time or the daemon could not be reached, as opposed to
+// the daemon answering.
+func pauseUndecided(err error) bool {
+	return isVMDDeadline(err) || isVMDUnavailable(err) || isVMDCanceled(err)
 }
 
 func (h *Handlers) PauseSandbox(c *gin.Context) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4255,3 +4255,98 @@ func TestResumeSandbox_CapabilityRefusalRevertsWithoutReachingDaemon(t *testing.
 		t.Fatalf("revert args = %v, want id and team only", reverted)
 	}
 }
+
+func TestPauseWithRetry_WaitsOutAPauseThatOutrunsItsAttempt(t *testing.T) {
+	var calls atomic.Int32
+	vmd := &stubVMD{pauseFn: func(ctx context.Context, _, _ string) (string, string, error) {
+		if calls.Add(1) < 3 {
+			// Still writing the snapshot: this attempt times out.
+			<-ctx.Done()
+			return "", "", status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+		}
+		// Parked behind the lock, then handed the snapshot that landed.
+		return "/snap/vmstate.snap", "/snap/mem.diff", nil
+	}}
+
+	snap, mem, _, token, err := pauseUntilDecided(context.Background(), vmd, "vm-a", "tok", 10*time.Millisecond, time.Second)
+	if err != nil {
+		t.Fatalf("pause failed: %v", err)
+	}
+	if snap == "" || mem == "" || token != "tok" {
+		t.Fatalf("got %q %q %q, want the landed snapshot and the echoed token", snap, mem, token)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+}
+
+func TestPauseWithRetry_StopsOnADefiniteAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"not found", status.Error(codes.NotFound, "gone")},
+		{"failed precondition", status.Error(codes.FailedPrecondition, "error state")},
+		{"internal", status.Error(codes.Internal, "snapshot failed")},
+	} {
+		var calls atomic.Int32
+		vmd := &stubVMD{pauseFn: func(context.Context, string, string) (string, string, error) {
+			calls.Add(1)
+			return "", "", tc.err
+		}}
+		_, _, _, _, err := pauseUntilDecided(context.Background(), vmd, "vm-a", "tok", 10*time.Millisecond, time.Second)
+		if status.Code(err) != status.Code(tc.err) {
+			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.err)
+		}
+		if got := calls.Load(); got != 1 {
+			t.Fatalf("%s: attempts = %d, want 1", tc.name, got)
+		}
+	}
+}
+
+func TestPauseWithRetry_GivesUpOnlyOnceTheBudgetIsSpent(t *testing.T) {
+	var calls atomic.Int32
+	vmd := &stubVMD{pauseFn: func(ctx context.Context, _, _ string) (string, string, error) {
+		calls.Add(1)
+		<-ctx.Done()
+		return "", "", status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	}}
+
+	start := time.Now()
+	_, _, _, _, err := pauseUntilDecided(context.Background(), vmd, "vm-a", "tok", 10*time.Millisecond, 60*time.Millisecond)
+	if !isVMDDeadline(err) {
+		t.Fatalf("err = %v, want the last timeout", err)
+	}
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("attempts = %d, want the attempt repeated", got)
+	}
+	if time.Since(start) < 60*time.Millisecond {
+		t.Fatal("gave up before the budget was spent")
+	}
+}
+
+func TestPauseWithRetry_KeepsConvergingAfterTheCallerGivesUp(t *testing.T) {
+	reqCtx, giveUp := context.WithCancel(context.Background())
+	defer giveUp()
+	var calls atomic.Int32
+	vmd := &stubVMD{pauseFn: func(ctx context.Context, _, _ string) (string, string, error) {
+		if calls.Add(1) == 1 {
+			// The client walks away mid-pause.
+			giveUp()
+			<-ctx.Done()
+			return "", "", status.Error(codes.Canceled, "context canceled")
+		}
+		if ctx.Err() != nil {
+			return "", "", status.Error(codes.Canceled, "context canceled")
+		}
+		return "/snap/vmstate.snap", "/snap/mem.diff", nil
+	}}
+
+	snap, _, _, _, err := pauseUntilDecided(reqCtx, vmd, "vm-a", "tok", time.Second, time.Second)
+	if err != nil || snap == "" {
+		t.Fatalf("got %q, %v; want the pause to converge after the caller left", snap, err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -4282,12 +4282,16 @@ func TestPauseWithRetry_WaitsOutAPauseThatOutrunsItsAttempt(t *testing.T) {
 
 func TestPauseWithRetry_StopsOnADefiniteAnswer(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		err  error
+		name      string
+		err       error
+		wantCalls int32
 	}{
-		{"not found", status.Error(codes.NotFound, "gone")},
-		{"failed precondition", status.Error(codes.FailedPrecondition, "error state")},
-		{"internal", status.Error(codes.Internal, "snapshot failed")},
+		// The VM is gone: nothing to repair.
+		{"not found", status.Error(codes.NotFound, "gone"), 1},
+		// Refused twice is refused.
+		{"failed precondition", status.Error(codes.FailedPrecondition, "error state"), 2},
+		{"internal", status.Error(codes.Internal, "snapshot failed"), 2},
+		{"plain error", errors.New("record paused state: disk full"), 2},
 	} {
 		var calls atomic.Int32
 		vmd := &stubVMD{pauseFn: func(context.Context, string, string) (string, string, error) {
@@ -4298,9 +4302,29 @@ func TestPauseWithRetry_StopsOnADefiniteAnswer(t *testing.T) {
 		if status.Code(err) != status.Code(tc.err) {
 			t.Fatalf("%s: err = %v, want %v", tc.name, err, tc.err)
 		}
-		if got := calls.Load(); got != 1 {
-			t.Fatalf("%s: attempts = %d, want 1", tc.name, got)
+		if got := calls.Load(); got != tc.wantCalls {
+			t.Fatalf("%s: attempts = %d, want %d", tc.name, got, tc.wantCalls)
 		}
+	}
+}
+
+func TestPauseWithRetry_RepairsAPauseTheHostFinishedButCouldNotRecord(t *testing.T) {
+	// The snapshot landed and the VM stopped, but recording the paused state
+	// failed. The repeat lands on the already-paused guard.
+	var calls atomic.Int32
+	vmd := &stubVMD{pauseFn: func(context.Context, string, string) (string, string, error) {
+		if calls.Add(1) == 1 {
+			return "", "", errors.New("record paused state for vm: write failed")
+		}
+		return "/snap/vmstate.snap", "/snap/mem.diff", nil
+	}}
+
+	snap, _, _, _, err := pauseUntilDecided(context.Background(), vmd, "vm-a", "tok", 10*time.Millisecond, time.Second)
+	if err != nil || snap == "" {
+		t.Fatalf("got %q, %v; want the recorded snapshot", snap, err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
 	}
 }
 

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -237,12 +237,13 @@ func TestReaper_VMDFails(t *testing.T) {
 
 	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
-	// Both sandboxes are attempted once: a definite failure from the daemon
-	// is terminal, and only a timed-out or unreachable attempt is repeated.
-	if got := atomic.LoadInt32(&pauseCallCount); got != 2 {
-		t.Fatalf("expected 2 PauseInstance calls (one per sandbox), got %d", got)
+	// Both sandboxes are attempted, and each failure gets one recovery
+	// attempt (the host may have paused the VM before failing to record it),
+	// so 2 sandboxes × 2 attempts = 4 calls.
+	if got := atomic.LoadInt32(&pauseCallCount); got != 4 {
+		t.Fatalf("expected 4 PauseInstance calls (2 sandboxes × recovery attempt), got %d", got)
 	}
-	// A definite failure reverts to active.
+	// A failure the recovery attempt does not repair reverts to active.
 	if got := atomic.LoadInt32(&revertCallCount); got != 2 {
 		t.Fatalf("expected 2 revert-to-active calls, got %d", got)
 	}

--- a/internal/api/reaper_test.go
+++ b/internal/api/reaper_test.go
@@ -237,13 +237,12 @@ func TestReaper_VMDFails(t *testing.T) {
 
 	h.reapOnce(context.Background(), 10, 1, zerolog.Nop())
 
-	// Both sandboxes are attempted, and pauseWithRetry retries each failure
-	// once (a timed-out pause may have completed on the host), so 2 sandboxes
-	// × 2 attempts = 4 calls.
-	if got := atomic.LoadInt32(&pauseCallCount); got != 4 {
-		t.Fatalf("expected 4 PauseInstance calls (2 sandboxes × retry), got %d", got)
+	// Both sandboxes are attempted once: a definite failure from the daemon
+	// is terminal, and only a timed-out or unreachable attempt is repeated.
+	if got := atomic.LoadInt32(&pauseCallCount); got != 2 {
+		t.Fatalf("expected 2 PauseInstance calls (one per sandbox), got %d", got)
 	}
-	// A failure that doesn't converge after the retry reverts to active.
+	// A definite failure reverts to active.
 	if got := atomic.LoadInt32(&revertCallCount); got != 2 {
 		t.Fatalf("expected 2 revert-to-active calls, got %d", got)
 	}

--- a/internal/api/vmd_errors.go
+++ b/internal/api/vmd_errors.go
@@ -74,6 +74,15 @@ func isVMDUnavailable(err error) bool {
 	return status.Code(err) == codes.Unavailable
 }
 
+// isVMDCanceled reports a call abandoned by the caller's context rather than
+// answered by the daemon.
+func isVMDCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	return status.Code(err) == codes.Canceled || errors.Is(err, context.Canceled)
+}
+
 // isVMDFileMissing returns true when vmd returned a FailedPrecondition
 // indicating a snapshot/mem file is missing on disk. The caller maps
 // this to a 503 with `host_state_missing` rather than a generic 500 so


### PR DESCRIPTION
A pause that outran its 30s attempt and one 30s retry was reverted to active even though the host went on to complete it, leaving the row and the VM disagreeing. Pause now gets a 60s attempt and keeps repeating it, parking behind the pause in flight, until the host answers definitively or a 10 minute budget is spent; only then is it reverted.