### PR TITLE
deploy-vmd: prime the runner ssh key before the parallel host fan-out

### DIFF
--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -333,6 +333,23 @@ def main() -> int:
 
     print(f"Deploying VMD to {len(instances)} instance(s) in {where}")
 
+    # Prime the runner's gcloud SSH key with one sequential connection before
+    # the parallel fan-out. On a fresh runner the key does not exist, and
+    # every `gcloud compute scp`/`ssh` that finds it missing runs ssh-keygen
+    # to create it; two hosts starting together both do, and the loser fails
+    # with "google_compute_engine already exists" before its bundle is even
+    # uploaded. A single-host cell never raced this. Any host will do — the
+    # key is per runner, not per host, and OS Login registers it account-wide.
+    first = instances[0]
+    run_or_die(
+        [
+            "gcloud", "compute", "ssh", first["name"],
+            f"--zone={first['zone']}", f"--project={project}",
+            "--quiet", "--tunnel-through-iap", "--command", "true",
+        ],
+        f"[{first['name']}/{first['zone']}] prime ssh key",
+    )
+
     bundle_remote = f"/tmp/deploy-bundle-{sha}.tar.gz"
     extract_dir = f"/tmp/deploy-{sha}"
 

--- a/.github/workflows/scripts/deploy-vmd.py
+++ b/.github/workflows/scripts/deploy-vmd.py
@@ -333,22 +333,17 @@ def main() -> int:
 
     print(f"Deploying VMD to {len(instances)} instance(s) in {where}")
 
-    # Prime the runner's gcloud SSH key with one sequential connection before
-    # the parallel fan-out. On a fresh runner the key does not exist, and
-    # every `gcloud compute scp`/`ssh` that finds it missing runs ssh-keygen
-    # to create it; two hosts starting together both do, and the loser fails
-    # with "google_compute_engine already exists" before its bundle is even
-    # uploaded. A single-host cell never raced this. Any host will do — the
-    # key is per runner, not per host, and OS Login registers it account-wide.
-    first = instances[0]
-    run_or_die(
-        [
-            "gcloud", "compute", "ssh", first["name"],
-            f"--zone={first['zone']}", f"--project={project}",
-            "--quiet", "--tunnel-through-iap", "--command", "true",
-        ],
-        f"[{first['name']}/{first['zone']}] prime ssh key",
-    )
+    # Create the runner's gcloud SSH key up front if it is missing. gcloud
+    # generates it on first use, and with per-host deploys running in
+    # parallel two hosts can start together, both find it absent, and both
+    # run ssh-keygen; the loser fails with "already exists" before its bundle
+    # is uploaded. Generated locally rather than by connecting to one host
+    # first, so no single unreachable host can keep the others from being
+    # attempted.
+    key = os.path.expanduser("~/.ssh/google_compute_engine")
+    if not os.path.exists(key):
+        os.makedirs(os.path.dirname(key), mode=0o700, exist_ok=True)
+        run_or_die(["ssh-keygen", "-q", "-t", "rsa", "-N", "", "-f", key], "generate gcloud ssh key")
 
     bundle_remote = f"/tmp/deploy-bundle-{sha}.tar.gz"
     extract_dir = f"/tmp/deploy-{sha}"

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -39,6 +39,18 @@ def _gnu_sed_env(tmp_dir):
 
 
 class DeployVmdOrderingTests(unittest.TestCase):
+
+    def test_ssh_key_primed_before_parallel_fanout(self):
+        # Per-host deploys run in parallel, and each `gcloud compute scp`
+        # creates the runner's SSH key if it is missing. Two hosts starting
+        # together race ssh-keygen and one fails before uploading anything.
+        # The key must be created by ONE sequential connection first, so the
+        # priming call has to appear ahead of the pool in the source.
+        prime = SOURCE.find('"--command", "true"')
+        pool = SOURCE.find("ThreadPoolExecutor(max_workers=len(instances))")
+        self.assertNotEqual(prime, -1, "ssh key priming call is missing")
+        self.assertNotEqual(pool, -1, "parallel fan-out is missing")
+        self.assertLess(prime, pool, "ssh key must be primed before the parallel fan-out")
     def test_no_bare_service_stop(self):
         # The early service stop that opened the socket-activation window must
         # never be unconditional/bare: every stop of the vmd service also stops

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -39,6 +39,18 @@ def _gnu_sed_env(tmp_dir):
 
 
 class DeployVmdOrderingTests(unittest.TestCase):
+    def test_no_bare_service_stop(self):
+        # The early service stop that opened the socket-activation window must
+        # never be unconditional/bare: every stop of the vmd service also stops
+        # superserve-vmd.socket (both-units form) so no connection can
+        # socket-activate an interim vmd during the window.
+        self.assertNotRegex(
+            SOURCE,
+            r"systemctl stop \{service\}",
+            "found a bare `systemctl stop {service}`; every service stop must "
+            "also stop superserve-vmd.socket",
+        )
+
 
     def test_ssh_key_created_before_parallel_fanout(self):
         # Per-host deploys run in parallel, and each `gcloud compute scp`

--- a/.github/workflows/scripts/test_deploy_vmd_ordering.py
+++ b/.github/workflows/scripts/test_deploy_vmd_ordering.py
@@ -40,28 +40,17 @@ def _gnu_sed_env(tmp_dir):
 
 class DeployVmdOrderingTests(unittest.TestCase):
 
-    def test_ssh_key_primed_before_parallel_fanout(self):
+    def test_ssh_key_created_before_parallel_fanout(self):
         # Per-host deploys run in parallel, and each `gcloud compute scp`
-        # creates the runner's SSH key if it is missing. Two hosts starting
+        # generates the runner's SSH key if it is missing. Two hosts starting
         # together race ssh-keygen and one fails before uploading anything.
-        # The key must be created by ONE sequential connection first, so the
-        # priming call has to appear ahead of the pool in the source.
-        prime = SOURCE.find('"--command", "true"')
+        # The key must exist before the pool starts, created locally so no
+        # single host's reachability gates the others.
+        keygen = SOURCE.find('"ssh-keygen", "-q"')
         pool = SOURCE.find("ThreadPoolExecutor(max_workers=len(instances))")
-        self.assertNotEqual(prime, -1, "ssh key priming call is missing")
+        self.assertNotEqual(keygen, -1, "local ssh-keygen priming is missing")
         self.assertNotEqual(pool, -1, "parallel fan-out is missing")
-        self.assertLess(prime, pool, "ssh key must be primed before the parallel fan-out")
-    def test_no_bare_service_stop(self):
-        # The early service stop that opened the socket-activation window must
-        # never be unconditional/bare: every stop of the vmd service also stops
-        # superserve-vmd.socket (both-units form) so no connection can
-        # socket-activate an interim vmd during the window.
-        self.assertNotRegex(
-            SOURCE,
-            r"systemctl stop \{service\}",
-            "found a bare `systemctl stop {service}`; every service stop must "
-            "also stop superserve-vmd.socket",
-        )
+        self.assertLess(keygen, pool, "ssh key must exist before the parallel fan-out")
 
     def test_steady_state_stop_is_guarded_and_stops_both(self):
         # The steady-state early stop runs ONLY on a fresh socket migration


### PR DESCRIPTION
With two labeled hosts in a cell, the parallel per-host `gcloud compute scp` calls race to create the runner's SSH key on first use and the loser fails with `google_compute_engine already exists`. One sequential connection before the fan-out creates the key once; single-host cells are unaffected beyond one extra round trip.