### PR TITLE
deploy-proxy, deploy-otel-collector: prime the runner ssh key before the parallel host fan-out

### DIFF
--- a/.github/workflows/scripts/deploy-otel-collector.py
+++ b/.github/workflows/scripts/deploy-otel-collector.py
@@ -181,6 +181,15 @@ def main() -> int:
     collector_binaries = prepare_collector_binaries()
     print(f"Deploying OTEL Collector to {len(instances)} instance(s) in {where}")
 
+    # gcloud generates the runner's SSH key on first use. With per-host deploys
+    # running in parallel, two hosts can both find it missing and both run
+    # ssh-keygen; the loser fails with "already exists". Create it up front,
+    # locally, so no single host's reachability gates the others.
+    key = os.path.expanduser("~/.ssh/google_compute_engine")
+    if not os.path.exists(key):
+        os.makedirs(os.path.dirname(key), mode=0o700, exist_ok=True)
+        subprocess.run(["ssh-keygen", "-q", "-t", "rsa", "-N", "", "-f", key], check=True)
+
     def deploy(instance: dict[str, str]) -> None:
         name = instance["name"]
         zone = instance["zone"]

--- a/.github/workflows/scripts/deploy-proxy.py
+++ b/.github/workflows/scripts/deploy-proxy.py
@@ -115,6 +115,15 @@ def main() -> int:
 
     print(f"Deploying proxy to {len(instances)} instance(s) in {where}")
 
+    # gcloud generates the runner's SSH key on first use. With per-host deploys
+    # running in parallel, two hosts can both find it missing and both run
+    # ssh-keygen; the loser fails with "already exists". Create it up front,
+    # locally, so no single host's reachability gates the others.
+    key = os.path.expanduser("~/.ssh/google_compute_engine")
+    if not os.path.exists(key):
+        os.makedirs(os.path.dirname(key), mode=0o700, exist_ok=True)
+        subprocess.run(["ssh-keygen", "-q", "-t", "rsa", "-N", "", "-f", key], check=True)
+
     def deploy(inst):
         name, zone = inst["name"], inst["zone"]
         tag = f"{name}/{zone}"

--- a/.github/workflows/scripts/test_deploy_otel_collector.py
+++ b/.github/workflows/scripts/test_deploy_otel_collector.py
@@ -12,6 +12,18 @@ SPEC.loader.exec_module(MODULE)
 
 
 class DeployOtelCollectorTests(unittest.TestCase):
+    def test_ssh_key_created_before_parallel_fanout(self):
+        # Per-host deploys run in parallel, and gcloud generates the runner's
+        # SSH key on first use. Two hosts starting together race ssh-keygen and
+        # one fails before uploading anything, so the key must exist before
+        # the pool starts.
+        source = SCRIPT.read_text()
+        keygen = source.find('"ssh-keygen", "-q"')
+        pool = source.find("ThreadPoolExecutor(max_workers=len(instances))")
+        self.assertNotEqual(keygen, -1)
+        self.assertNotEqual(pool, -1)
+        self.assertLess(keygen, pool)
+
     def test_probe_parser_returns_architecture_and_unique_staging_directory(self):
         self.assertEqual(
             MODULE._parse_remote_probe(

--- a/.github/workflows/scripts/test_deploy_proxy.py
+++ b/.github/workflows/scripts/test_deploy_proxy.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).with_name("deploy-proxy.py").read_text()
+
+
+class DeployProxyOrderingTest(unittest.TestCase):
+    def test_ssh_key_created_before_parallel_fanout(self):
+        # Per-host deploys run in parallel, and gcloud generates the runner's
+        # SSH key on first use. Two hosts starting together race ssh-keygen and
+        # one fails before uploading anything, so the key must exist before
+        # the pool starts.
+        keygen = SOURCE.find('"ssh-keygen", "-q"')
+        pool = SOURCE.find("ThreadPoolExecutor(max_workers=len(instances))")
+        self.assertNotEqual(keygen, -1)
+        self.assertNotEqual(pool, -1)
+        self.assertLess(keygen, pool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Same fix as the vmd deploy, for the proxy and collector deploys: create the runner's gcloud SSH key locally before the per-host pool starts, so parallel first-use ssh-keygen runs can't collide. Adds an ordering test for each script.