### PR TITLE
api: Prefer: respond-async lets a pause return 202 pausing instead of holding the connection

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1097,11 +1097,44 @@ paths:
         Snapshots the sandbox's full state (memory + disk), suspends the VM,
         and transitions to `paused`. Resume it later to continue exactly where
         it left off — same memory, same running processes, same files.
+
+        The request holds until the pause is decided. Send
+        `Prefer: respond-async` to be released with `202 Accepted` instead if
+        the host has not finished within the request's wait budget; the pause
+        continues, and `GET /sandboxes/{sandbox_id}` reports `paused` once it
+        lands (or `failed` if the VM turned out to be gone).
       security:
         - apiKey: []
+      parameters:
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum: [respond-async]
+          description: >
+            Accept `202` with `{"status":"pausing"}` over a held connection.
       responses:
         "204":
           description: Sandbox paused
+        "202":
+          description: >
+            Pause still in progress; poll the sandbox until it is `paused`.
+            Only with `Prefer: respond-async`.
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+              description: Seconds to wait before polling.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    enum: [pausing]
         "404":
           $ref: "#/components/responses/NotFound"
         "409":

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3049,84 +3049,31 @@ func (h *Handlers) PauseSandbox(c *gin.Context) {
 		return
 	}
 
-	// Call VMD to pause and snapshot the VM. The pause's identity rides the
-	// RPC into the host's backup pipeline and returns in the upload report,
-	// naming this exact pause for coverage linkage.
-	pauseToken := pauseOp.String()
-	snapshotPath, memPath, manifest, ackedPauseToken, err := pauseWithRetry(c.Request.Context(), vmd, sandboxID.String(), pauseToken)
-	if err != nil {
-		// VMD says the VM doesn't exist — it crashed or was removed out-of-band.
-		// Mark the sandbox failed and return 410 Gone. No revert — the VM is
-		// already dead, "active" was a lie.
-		if isVMDNotFound(err) {
-			l.Warn().Err(err).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
-			h.markSandboxFailedAsync(c.Request.Context(), sandboxID, teamID, sandbox.HostID, false)
-			respondError(c, ErrSandboxGone)
-			return
-		}
+	// Read from the request here: past this point the dispatch may outlive
+	// it, and nothing on another goroutine may touch c.
+	actorID := actorIDFromContext(c)
 
-		// Timeout, unavailable, or any other error after dispatch says
-		// nothing about whether the VM still runs; the row stays 'pausing'
-		// and the reconciler asks the host again (see pause_reconcile.go).
-		l.Warn().Err(err).Msg("VMD PauseInstance undecided — left pausing for reconciliation")
-		lease := pauseLease{id: sandbox.PauseOpID, version: sandbox.PauseOpLeaseVersion}
-		releaseCtx := context.WithoutCancel(c.Request.Context())
-		h.asyncBookkeeping("release-pause-lease", func() { h.releasePauseLease(releaseCtx, sandboxID, lease, 0, l) })
-		respondError(c, ErrInternal)
+	if !prefersAsync(c) {
+		respondPause(c, h.dispatchPause(c.Request.Context(), vmd, sandbox, actorID, l))
 		return
 	}
 
-	l.Debug().
-		Str("snapshot_path", snapshotPath).
-		Str("mem_path", memPath).
-		Msg("VMD pause complete")
-
-	// Past this point the snapshot already exists on disk — the pause has
-	// physically happened, so the bookkeeping (snapshot row upsert + status
-	// flip pausing → paused in a single CTE) is fire-and-forget. BeginPause's
-	// gate write owns the row and every other transition is status-gated, so
-	// a racing resume sees 'pausing' and 409s until this lands. Detached from
-	// cancellation so a client disconnect cannot orphan the bookkeeping;
-	// trace/span context preserved. The upsert replaces the old "insert a new
-	// row + delete the previous" flow, so there's no explicit prev-snapshot
-	// cleanup to schedule here.
-	finalizeCtx := context.WithoutCancel(c.Request.Context())
-	h.asyncBookkeeping("finalize-pause", func() {
-		fctx, fcancel := context.WithTimeout(finalizeCtx, asyncTimeout)
-		defer fcancel()
-		params := db.FinalizePauseParams{
-			ID:                  sandboxID,
-			TeamID:              teamID,
-			PauseOpID:           sandbox.PauseOpID,
-			PauseOpLeaseVersion: &sandbox.PauseOpLeaseVersion,
-			Path:                snapshotPath,
-			MemPath:             &memPath,
-			Trigger:             "pause",
-			// Store only what the daemon ECHOED: an older daemon drops the
-			// token, and storing it anyway would demand of its reports an
-			// identity they can never carry.
-			PauseToken: ackedPauseToken,
-		}
-		applyManifest(&params, manifest)
-		if _, err := h.finalizePause(fctx, params); err != nil {
-			// ErrNoRows means the sandbox was soft-deleted between BeginPause
-			// and FinalizePause (a rare race with DeleteSandbox). The VM is
-			// already stopped and its snapshot files are on disk — nothing to
-			// finalize for a sandbox that no longer exists.
-			if err == pgx.ErrNoRows {
-				l.Warn().Msg("FinalizePause: sandbox deleted mid-pause")
-				return
-			}
-			l.Error().Err(err).Msg("async DB FinalizePause failed — sandbox may be stuck in 'pausing'")
-			return
-		}
-	})
-
-	// Interval was already closed at BeginPause; FinalizePause is the
-	// end of the VMD pause work, not the moment the sandbox left active.
-	h.logSandboxActivity(c.Request.Context(), sandboxID, teamID, actorIDFromContext(c), "sandbox", "paused", "success", &sandbox.Name, nil, nil)
-	h.capture(c, "sandbox_paused", map[string]any{"sandbox_id": sandboxID.String()})
-	c.Status(http.StatusNoContent)
+	// The caller will poll rather than hold the connection. The dispatch is
+	// detached from the request so a client that stops waiting does not
+	// abandon the host call: it finishes on its own bounded deadline and
+	// records its answer, and the reconciler covers what it cannot decide.
+	outcome := make(chan pauseOutcome, 1)
+	bg := context.WithoutCancel(c.Request.Context())
+	h.asyncBookkeeping("pause-dispatch", func() { outcome <- h.dispatchPause(bg, vmd, sandbox, actorID, l) })
+	timer := time.NewTimer(pauseAcceptBudget)
+	defer timer.Stop()
+	select {
+	case o := <-outcome:
+		respondPause(c, o)
+	case <-timer.C:
+		c.Header("Retry-After", "1")
+		c.JSON(http.StatusAccepted, gin.H{"status": db.SandboxStatusPausing})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3604,6 +3604,125 @@ func TestPauseSandbox_VMDError(t *testing.T) {
 	}
 }
 
+// pauseMocks is the DB script shared by the async-answer tests: BeginPause
+// and reads return the sandbox, finalize is counted, everything else is inert.
+func pauseMocks(sb db.Sandbox, finalizes *int32) *mockDBTX {
+	return &mockDBTX{
+		queryRowFn: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			switch {
+			// Finalize first: its fence also mentions 'pausing'.
+			case strings.Contains(sql, "upserted AS"), strings.Contains(sql, "INSERT INTO snapshot"):
+				atomic.AddInt32(finalizes, 1)
+				return finalizePauseRow(uuid.New())
+			case strings.Contains(sql, "'pausing'"), strings.Contains(sql, "FROM sandbox"):
+				return sandboxRow(sb)
+			}
+			return activityRow()
+		},
+		execFn: func(context.Context, string, ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+}
+
+// gatedPause is a host that answers only once release is closed.
+func gatedPause(release <-chan struct{}) *stubVMD {
+	return &stubVMD{pauseFn: func(ctx context.Context, _, _ string) (string, string, error) {
+		select {
+		case <-release:
+			return "/snapshots/vmstate.snap", "/snapshots/mem.snap", nil
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		}
+	}}
+}
+
+// A client that prefers an asynchronous answer is told 'pausing' once the
+// budget runs out; the host call keeps going and its answer is still recorded.
+func TestPauseSandbox_RespondAsync_AcceptedWhenHostIsSlow(t *testing.T) {
+	prev := pauseAcceptBudget
+	pauseAcceptBudget = 20 * time.Millisecond
+	defer func() { pauseAcceptBudget = prev }()
+
+	sandboxID, teamID := uuid.New(), uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
+	release := make(chan struct{})
+	var finalizes int32
+	h := &Handlers{VMD: gatedPause(release), DB: db.New(pauseMocks(sb, &finalizes))}
+
+	req := pauseRequest(sandboxID.String())
+	req.Header.Set("Prefer", "respond-async")
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
+	}
+	if w.Header().Get("Retry-After") != "1" || !strings.Contains(w.Body.String(), `"status":"pausing"`) {
+		t.Fatalf("202 response = %v %s, want Retry-After: 1 and a pausing status", w.Header(), w.Body.String())
+	}
+	if atomic.LoadInt32(&finalizes) != 0 {
+		t.Fatal("finalized before the host answered")
+	}
+
+	close(release)
+	h.WaitAsyncBookkeeping()
+	if atomic.LoadInt32(&finalizes) != 1 {
+		t.Fatalf("finalize calls after the host answered = %d, want 1", atomic.LoadInt32(&finalizes))
+	}
+}
+
+// Preferring an asynchronous answer costs nothing when the host is quick:
+// the response is the usual 204.
+func TestPauseSandbox_RespondAsync_FastHostStill204(t *testing.T) {
+	sandboxID, teamID := uuid.New(), uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
+	var finalizes int32
+	h := &Handlers{VMD: &stubVMD{}, DB: db.New(pauseMocks(sb, &finalizes))}
+
+	req := pauseRequest(sandboxID.String())
+	req.Header.Set("Prefer", "respond-async")
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, req)
+	h.WaitAsyncBookkeeping()
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if atomic.LoadInt32(&finalizes) != 1 {
+		t.Fatalf("finalize calls = %d, want 1", atomic.LoadInt32(&finalizes))
+	}
+}
+
+// Without the preference the request waits for the host as it always has,
+// however long that takes relative to the async budget.
+func TestPauseSandbox_NoPreference_WaitsForHost(t *testing.T) {
+	prev := pauseAcceptBudget
+	pauseAcceptBudget = time.Millisecond
+	defer func() { pauseAcceptBudget = prev }()
+
+	sandboxID, teamID := uuid.New(), uuid.New()
+	sb := db.Sandbox{ID: sandboxID, TeamID: teamID, Name: "sb", Status: db.SandboxStatusActive}
+	release := make(chan struct{})
+	var finalizes int32
+	h := &Handlers{VMD: gatedPause(release), DB: db.New(pauseMocks(sb, &finalizes))}
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		close(release)
+	}()
+
+	w := httptest.NewRecorder()
+	setupTestRouter(h, teamID.String()).ServeHTTP(w, pauseRequest(sandboxID.String()))
+	h.WaitAsyncBookkeeping()
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if atomic.LoadInt32(&finalizes) != 1 {
+		t.Fatalf("finalize calls = %d, want 1", atomic.LoadInt32(&finalizes))
+	}
+}
+
 func TestPauseSandbox_MissingTeamID(t *testing.T) {
 	vmd := &stubVMD{}
 	mock := &mockDBTX{

--- a/internal/api/pause_dispatch.go
+++ b/internal/api/pause_dispatch.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/superserve-ai/sandbox/internal/db"
+)
+
+// pauseAcceptBudget is how long a request that prefers an asynchronous answer
+// (Prefer: respond-async) waits for the host before it is told 'pausing' and
+// left to poll. Long enough that a normal pause still returns 204. A variable
+// so tests can shorten it.
+var pauseAcceptBudget = 20 * time.Second
+
+// prefersAsync reports whether the client asked for a 202 over a held
+// connection (RFC 7240 Prefer: respond-async).
+func prefersAsync(c *gin.Context) bool {
+	for _, v := range c.Request.Header.Values("Prefer") {
+		for _, p := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(p), "respond-async") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type pauseOutcome int
+
+const (
+	pauseDone      pauseOutcome = iota // snapshot taken; bookkeeping in flight
+	pauseGone                          // host has no such VM; row marked failed
+	pauseUndecided                     // no answer; row left 'pausing' for the reconciler
+)
+
+func respondPause(c *gin.Context, o pauseOutcome) {
+	switch o {
+	case pauseDone:
+		c.Status(http.StatusNoContent)
+	case pauseGone:
+		respondError(c, ErrSandboxGone)
+	default:
+		respondError(c, ErrInternal)
+	}
+}
+
+// dispatchPause runs the host RPC for a claimed pause and the bookkeeping its
+// answer calls for. It knows nothing of the HTTP request: ctx is whatever the
+// caller is willing to wait on, every write runs detached, and the outcome is
+// the same whether or not anyone is still listening.
+func (h *Handlers) dispatchPause(ctx context.Context, vmd VMDClient, sandbox db.BeginPauseRow, actorID *uuid.UUID, l zerolog.Logger) pauseOutcome {
+	sandboxID, teamID := sandbox.ID, sandbox.TeamID
+	// The pause's identity rides the RPC into the host's backup pipeline and
+	// returns in the upload report, naming this exact pause.
+	pauseToken := uuid.UUID(sandbox.PauseOpID.Bytes).String()
+	snapshotPath, memPath, manifest, ackedPauseToken, err := pauseWithRetry(ctx, vmd, sandboxID.String(), pauseToken)
+	if err != nil {
+		// The resolved host has no such VM: it crashed or was removed
+		// out-of-band, so 'active' was already a lie.
+		if isVMDNotFound(err) {
+			l.Warn().Err(err).Msg("VMD PauseInstance: VM unavailable, marking sandbox failed")
+			h.markSandboxFailedAsync(ctx, sandboxID, teamID, sandbox.HostID, false)
+			return pauseGone
+		}
+		// Timeout, unavailable, or any other error after dispatch says
+		// nothing about whether the VM still runs; the row stays 'pausing'
+		// and the reconciler asks the host again (see pause_reconcile.go).
+		l.Warn().Err(err).Msg("VMD PauseInstance undecided — left pausing for reconciliation")
+		lease := pauseLease{id: sandbox.PauseOpID, version: sandbox.PauseOpLeaseVersion}
+		releaseCtx := context.WithoutCancel(ctx)
+		h.asyncBookkeeping("release-pause-lease", func() { h.releasePauseLease(releaseCtx, sandboxID, lease, 0, l) })
+		return pauseUndecided
+	}
+
+	l.Debug().
+		Str("snapshot_path", snapshotPath).
+		Str("mem_path", memPath).
+		Msg("VMD pause complete")
+
+	// The snapshot exists on disk, so the bookkeeping (snapshot row upsert +
+	// pausing → paused in one CTE) is fire-and-forget: every other
+	// transition is status-gated and a racing resume 409s until it lands.
+	finalizeCtx := context.WithoutCancel(ctx)
+	h.asyncBookkeeping("finalize-pause", func() {
+		fctx, fcancel := context.WithTimeout(finalizeCtx, asyncTimeout)
+		defer fcancel()
+		params := db.FinalizePauseParams{
+			ID:                  sandboxID,
+			TeamID:              teamID,
+			PauseOpID:           sandbox.PauseOpID,
+			PauseOpLeaseVersion: &sandbox.PauseOpLeaseVersion,
+			Path:                snapshotPath,
+			MemPath:             &memPath,
+			Trigger:             "pause",
+			// Store only what the daemon echoed: an older daemon drops the
+			// token, and storing it anyway would demand of its reports an
+			// identity they can never carry.
+			PauseToken: ackedPauseToken,
+		}
+		applyManifest(&params, manifest)
+		if _, err := h.finalizePause(fctx, params); err != nil {
+			// The row left 'pausing' first (deleted mid-pause): the VM is
+			// stopped and its files are on disk, nothing left to record.
+			if err == pgx.ErrNoRows {
+				l.Warn().Msg("FinalizePause: sandbox deleted mid-pause")
+				return
+			}
+			l.Error().Err(err).Msg("async DB FinalizePause failed — sandbox stays 'pausing' for reconciliation")
+			return
+		}
+	})
+
+	// The interval closed at BeginPause; this is the end of the host work,
+	// not the moment the sandbox left active.
+	h.logSandboxActivity(ctx, sandboxID, teamID, actorID, "sandbox", "paused", "success", &sandbox.Name, nil, nil)
+	h.captureFor(actorID, teamID, "sandbox_paused", map[string]any{"sandbox_id": sandboxID.String()})
+	return pauseDone
+}
+
+// captureFor is capture for code that no longer holds the request.
+func (h *Handlers) captureFor(actorID *uuid.UUID, teamID uuid.UUID, event string, props map[string]any) {
+	if h.Analytics == nil {
+		return
+	}
+	var actor string
+	if actorID != nil {
+		actor = actorID.String()
+	}
+	h.Analytics.Capture(actor, teamID.String(), event, props)
+}


### PR DESCRIPTION
With `Prefer: respond-async`, a pause the host has not finished within 20s returns `202 {"status":"pausing"}` with `Retry-After: 1`, and the caller polls the sandbox until it is `paused`; the host call keeps running on its own deadline and records its answer exactly as before. Without the header nothing changes: the request holds until the pause is decided.

Based on the pause-operation branch; retarget to main once that merges.