### PR TITLE
vmd: wake-protocol guest client, record fields and manifest helpers, unused until the lifecycle wiring lands

### DIFF
--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -222,7 +222,10 @@ const defaultGuestFreezeBudget = 500 * time.Millisecond
 // caller must refuse on.
 func resumeImageFacts(memPath, pausedMemPath string, recordedCorrects, recordedFrozen *bool, recordedToken string) (correctsWallClock, workloadFrozen bool, token string, err error) {
 	if memPath == pausedMemPath {
-		if recordedFrozen != nil {
+		// A recorded frozen fact answers only when the record is complete:
+		// a rewrite by an older binary can keep the flag and drop the token
+		// or the capability, and a wake with an empty token is refused.
+		if recordedFrozen != nil && (!*recordedFrozen || (recordedToken != "" && recordedCorrects != nil)) {
 			return recordedCorrects != nil && *recordedCorrects, *recordedFrozen, recordedToken, nil
 		}
 		if recordedCorrects != nil && !*recordedCorrects {

--- a/internal/vm/clock_policy.go
+++ b/internal/vm/clock_policy.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -199,4 +201,92 @@ func (m *Manager) restoreWithClockFallback(policy *bool, restore func(clockRealt
 		m.log.Warn().Msg("firecracker rejected the clock option; falling back to legacy clock behaviour for every restore")
 	}
 	return false, restore(nil)
+}
+
+// defaultGuestFreezeBudget bounds the pause-side wait for the guest to stop
+// its workload. Only ever paid when the restore would freeze the clock.
+const defaultGuestFreezeBudget = 500 * time.Millisecond
+
+// resumeImageFacts returns what the image being resumed says about its guest
+// and its workload, preferring the durable record to the filesystem.
+//
+// An ordinary resume reloads the exact image the VM was paused into, and that
+// pause wrote the facts to the record and the manifest together — so the
+// record is already the answer and the resume path need not go to disk for
+// it. The image fact is what decides: a record that carries it answers, and a
+// guest that cannot correct its clock is never frozen, so its record answers
+// too. Only an explicit override, supplying an image this VM was never paused
+// into, or a record that never carried the fact (a rollback to a binary
+// without the field drops it on rewrite, and its silence must not be read as
+// "no") has to look. A manifest this binary cannot trust is an error the
+// caller must refuse on.
+func resumeImageFacts(memPath, pausedMemPath string, recordedCorrects, recordedFrozen *bool, recordedToken string) (correctsWallClock, workloadFrozen bool, token string, err error) {
+	if memPath == pausedMemPath {
+		if recordedFrozen != nil {
+			return recordedCorrects != nil && *recordedCorrects, *recordedFrozen, recordedToken, nil
+		}
+		if recordedCorrects != nil && !*recordedCorrects {
+			return false, false, "", nil
+		}
+	}
+	m, err := imageManifest(memPath)
+	if err != nil {
+		return false, false, "", err
+	}
+	if m != nil {
+		return m.GuestCorrectsClock, m.WorkloadFrozen, m.FreezeToken, nil
+	}
+	// No manifest of its own: the image holds no frozen workload, which an
+	// overlay never inherits, but its guest came from the template beneath
+	// it, so the capability is read from there, as the pause-time check does.
+	if base, ok := readLayeredBase(memPath); ok {
+		if bm, berr := imageManifest(base); berr == nil && bm != nil {
+			return bm.GuestCorrectsClock, false, "", nil
+		}
+	}
+	return false, false, "", nil
+}
+
+// freezeGuestForPause freezes the workload ahead of a snapshot. A failed freeze
+// is ambiguous, so the guest is thawed and that must confirm, else the pause
+// aborts. A retry, if any, mints a new token: the guest refuses a released one.
+func (m *Manager) freezeGuestForPause(ctx context.Context, ip, token string, log zerolog.Logger) (frozen bool, err error) {
+	budget := m.cfg.GuestFreezeBudget
+	if budget <= 0 {
+		budget = defaultGuestFreezeBudget
+	}
+	fctx, cancel := context.WithTimeout(ctx, budget)
+	echo, ferr := boxdFreezeGuest(fctx, ip, token)
+	cancel()
+	if ferr == nil && (echo.Token != token || echo.Version != WakeProtocolVersion) {
+		// The guest froze, but not as this protocol understands it: release it.
+		ferr = fmt.Errorf("freeze reply names protocol %d token %q, asked %d %q", echo.Version, echo.Token, WakeProtocolVersion, token)
+	}
+	if ferr == nil {
+		return true, nil
+	}
+	tctx, tcancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer tcancel()
+	terr := boxdThawGuest(tctx, ip, token)
+	if errors.Is(terr, ErrGuestTokenMismatch) {
+		// The guest holds no freeze under this token, which says nothing about
+		// an earlier one: only a workload confirmed running is unfrozen. Its
+		// own budget: a thaw that spent this one must not fail the check.
+		rctx, rcancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		terr = boxdGuestRunning(rctx, ip)
+		rcancel()
+	}
+	if terr != nil {
+		return false, fmt.Errorf("guest workload state unknown after failed freeze (%v); thaw not confirmed: %w", ferr, terr)
+	}
+	log.Warn().Err(ferr).Msg("pause: guest workload not frozen; this image will wake the slower way")
+	return false, nil
+}
+
+// noteGuestClockUnready latches this host to unfrozen restores: host time is a
+// host property, so the caller's retry takes the path that does not need it.
+func (m *Manager) noteGuestClockUnready(log zerolog.Logger, cause error) {
+	if m.guestClockUnready.CompareAndSwap(false, true) {
+		log.Error().Err(cause).Msg("guest could not correct its clock; this host will restore with the clock unfrozen until vmd restarts")
+	}
 }

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -442,4 +443,239 @@ func TestResumeWallClockPropertyUnresolvedRecordConsultsTheManifest(t *testing.T
 	if corrects, _, err := resumeWallClockProperty(bare, bare, nil, nil); corrects || err != nil {
 		t.Errorf("corrects=%v err=%v; unresolved with no manifest must still be false", corrects, err)
 	}
+}
+
+// Resume latency is a critical path, so the ordinary case must answer from the
+// durable record rather than the filesystem. Each case seeds a marker that
+// contradicts the record: if the record is used, the marker is irrelevant, which
+// is what proves the lookup was skipped.
+func TestResumeImageFacts(t *testing.T) {
+	seed := func(t *testing.T, mem string, m WallClockManifest) {
+		t.Helper()
+		m.Version = WallClockManifestVersion
+		if m.ArtifactID == "" {
+			m.ArtifactID = "a"
+		}
+		if err := WriteWallClockManifest(mem, m); err != nil {
+			t.Fatalf("seed manifest: %v", err)
+		}
+	}
+	t.Run("same_image_trusts_a_record_that_carries_the_image_fact", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "disk"})
+		// Manifest says frozen, record says not. The record wins ⇒ no read happened.
+		corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(false), boolPtr(false), "")
+		if corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the recorded facts, a manifest on disk means the record was not used", corrects, frozen, token, err)
+		}
+		// A guest that cannot correct its clock is never frozen: no read either.
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(false), nil, ""); corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the record's no without a read", corrects, frozen, token, err)
+		}
+		// And the inverse: no manifest on disk, record says frozen under a token.
+		bare := filepath.Join(t.TempDir(), "mem.snap")
+		corrects, frozen, token, err = resumeImageFacts(bare, bare, boolPtr(true), boolPtr(true), "rec")
+		if !corrects || !frozen || token != "rec" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the recorded facts even with no manifest beside the image", corrects, frozen, token, err)
+		}
+	})
+
+	// The guest's capability does not encode the image fact: a record that
+	// carries the first but not the second reads the manifest, and a frozen
+	// one is reported rather than assumed away.
+	t.Run("same_image_without_the_image_fact_reads_the_manifest", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(true), nil, ""); !corrects || !frozen || token != "tok" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the frozen workload seen", corrects, frozen, token, err)
+		}
+	})
+
+	// An override supplies an image this VM was never paused into, so the record
+	// describes a different artifact and the manifest is the only evidence.
+	t.Run("override_image_reads_the_manifest", func(t *testing.T) {
+		dir := t.TempDir()
+		override := filepath.Join(dir, "restored.snap")
+		seed(t, override, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "disk"})
+		corrects, frozen, token, err := resumeImageFacts(override, filepath.Join(dir, "mem.snap"), boolPtr(false), boolPtr(false), "rec")
+		if !corrects || !frozen || token != "disk" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the manifest consulted when the image is not the paused one", corrects, frozen, token, err)
+		}
+	})
+
+	// An overlay without a manifest of its own holds no frozen workload, but
+	// its guest came from the template beneath it: the capability is read
+	// from there, never the frozen fact.
+	t.Run("override_overlay_takes_the_capability_from_its_base_only", func(t *testing.T) {
+		dir := t.TempDir()
+		base := filepath.Join(dir, "template.snap")
+		seed(t, base, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})
+		overlay := filepath.Join(dir, "restored.diff")
+		if err := os.WriteFile(layeredBaseSidecarPath(overlay), []byte(base+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		corrects, frozen, token, err := resumeImageFacts(overlay, filepath.Join(dir, "mem.diff"), nil, nil, "")
+		if !corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; want the base's capability and no inherited freeze", corrects, frozen, token, err)
+		}
+	})
+
+	t.Run("override_without_a_manifest_stays_legacy", func(t *testing.T) {
+		dir := t.TempDir()
+		corrects, frozen, token, err := resumeImageFacts(filepath.Join(dir, "restored.snap"), filepath.Join(dir, "mem.snap"), boolPtr(true), boolPtr(true), "rec")
+		if corrects || frozen || token != "" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; a stale record must not carry over to a different image", corrects, frozen, token, err)
+		}
+	})
+
+	// A record that lost the image fact goes to the disk, even for the same
+	// image: a rollback to a binary without the field drops it on rewrite.
+	t.Run("unresolved_record_consults_the_manifest", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true})
+		corrects, frozen, _, err := resumeImageFacts(mem, mem, nil, nil, "")
+		if !corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; an unresolved record must fall back to the manifest", corrects, frozen, err)
+		}
+		bare := filepath.Join(t.TempDir(), "mem.snap")
+		if corrects, frozen, _, err := resumeImageFacts(bare, bare, nil, nil, ""); corrects || frozen || err != nil {
+			t.Errorf("corrects=%v frozen=%v err=%v; unresolved with no manifest must still be legacy", corrects, frozen, err)
+		}
+	})
+
+	t.Run("override_with_an_untrusted_manifest_is_an_error", func(t *testing.T) {
+		dir := t.TempDir()
+		override := filepath.Join(dir, "restored.snap")
+		if err := os.WriteFile(WallClockMarkerPath(override), []byte(`{"version":2}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, _, err := resumeImageFacts(override, filepath.Join(dir, "mem.snap"), nil, nil, ""); !errors.Is(err, ErrWallClockManifest) {
+			t.Errorf("err=%v, want ErrWallClockManifest", err)
+		}
+	})
+}
+func TestFreezeGuestForPause(t *testing.T) {
+	origF, origT, origR := boxdFreezeGuest, boxdThawGuest, boxdGuestRunning
+	t.Cleanup(func() { boxdFreezeGuest, boxdThawGuest, boxdGuestRunning = origF, origT, origR })
+	m := &Manager{log: zerolog.Nop()}
+
+	t.Run("frozen", func(t *testing.T) {
+		boxdFreezeGuest = func(_ context.Context, _, token string) (freezeEcho, error) {
+			return freezeEcho{Version: 1, Token: token}, nil
+		}
+		thawed := false
+		boxdThawGuest = func(context.Context, string, string) error { thawed = true; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || !frozen || thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; want frozen, no error, no thaw", frozen, err, thawed)
+		}
+	})
+
+	t.Run("refused_then_thaw_confirmed_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("504: budget")
+		}
+		thawed := false
+		boxdThawGuest = func(context.Context, string, string) error { thawed = true; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen || !thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; want unfrozen, no error, thaw issued", frozen, err, thawed)
+		}
+	})
+
+	// A freeze the guest never took answers the follow-up thaw with a token
+	// mismatch: once the workload is confirmed running there is nothing to
+	// release, and the pause goes on unfrozen.
+	t.Run("never_frozen_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error {
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		boxdGuestRunning = func(context.Context, string) error { return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want unfrozen and no error", frozen, err)
+		}
+	})
+
+	// The running check after a mismatch has its own budget: a thaw that
+	// spent most of the shared one must not make the check fail on time.
+	t.Run("running_check_after_a_slow_thaw_has_its_own_budget", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(ctx context.Context, _, _ string) error {
+			time.Sleep(1500 * time.Millisecond)
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		boxdGuestRunning = func(ctx context.Context, _ string) error {
+			if dl, ok := ctx.Deadline(); !ok || time.Until(dl) < time.Second {
+				return errors.New("no time left to confirm")
+			}
+			return nil
+		}
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want the running workload confirmed with a fresh budget", frozen, err)
+		}
+	})
+
+	// The same mismatch from a guest still frozen under an earlier token must
+	// not be read as running: a snapshot of that guest marked unfrozen would
+	// never be woken. The pause aborts instead.
+	t.Run("mismatch_without_a_running_workload_aborts_the_pause", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error {
+			return fmt.Errorf("%w: status token", ErrGuestTokenMismatch)
+		}
+		boxdGuestRunning = func(context.Context, string) error { return errors.New(`guest workload status "frozen"`) }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err == nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want an error that aborts the pause", frozen, err)
+		}
+	})
+
+	t.Run("echo_naming_another_protocol_or_token_demotes", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{Version: 1, Token: "other"}, nil
+		}
+		thawed := false
+		boxdThawGuest = func(_ context.Context, _, token string) error { thawed = token == "tok"; return nil }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err != nil || frozen || !thawed {
+			t.Fatalf("frozen=%v err=%v thawed=%v; a guest that froze under another token must be released with ours", frozen, err, thawed)
+		}
+	})
+
+	t.Run("thaw_unconfirmed_aborts_the_pause", func(t *testing.T) {
+		boxdFreezeGuest = func(context.Context, string, string) (freezeEcho, error) {
+			return freezeEcho{}, errors.New("connection reset")
+		}
+		boxdThawGuest = func(context.Context, string, string) error { return errors.New("500: thaw not confirmed") }
+		frozen, err := m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if err == nil || frozen {
+			t.Fatalf("frozen=%v err=%v; want an error that aborts the pause", frozen, err)
+		}
+	})
+
+	t.Run("call_is_bounded_by_the_budget", func(t *testing.T) {
+		m := &Manager{log: zerolog.Nop(), cfg: ManagerConfig{GuestFreezeBudget: 300 * time.Millisecond}}
+		var seen time.Duration
+		boxdFreezeGuest = func(ctx context.Context, _, token string) (freezeEcho, error) {
+			dl, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("freeze must carry a deadline; it sits on the pause path")
+			}
+			seen = time.Until(dl)
+			return freezeEcho{Version: 1, Token: token}, nil
+		}
+		m.freezeGuestForPause(context.Background(), "10.0.0.2", "tok", zerolog.Nop())
+		if seen <= 0 || seen > 300*time.Millisecond {
+			t.Errorf("deadline %v from now, want within (0, 300ms]", seen)
+		}
+	})
 }

--- a/internal/vm/clock_policy_test.go
+++ b/internal/vm/clock_policy_test.go
@@ -483,6 +483,19 @@ func TestResumeImageFacts(t *testing.T) {
 	// The guest's capability does not encode the image fact: a record that
 	// carries the first but not the second reads the manifest, and a frozen
 	// one is reported rather than assumed away.
+	// A record that says frozen but lost its token or its capability is
+	// incomplete: the manifest is read, so the wake carries the real token.
+	t.Run("incomplete_frozen_record_reads_the_manifest", func(t *testing.T) {
+		mem := filepath.Join(t.TempDir(), "mem.snap")
+		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "disk"})
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, boolPtr(true), boolPtr(true), ""); !corrects || !frozen || token != "disk" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; a frozen record without a token must take the manifest's", corrects, frozen, token, err)
+		}
+		if corrects, frozen, token, err := resumeImageFacts(mem, mem, nil, boolPtr(true), "rec"); !corrects || !frozen || token != "disk" || err != nil {
+			t.Errorf("corrects=%v frozen=%v token=%q err=%v; a frozen record without the capability must read the manifest", corrects, frozen, token, err)
+		}
+	})
+
 	t.Run("same_image_without_the_image_fact_reads_the_manifest", func(t *testing.T) {
 		mem := filepath.Join(t.TempDir(), "mem.snap")
 		seed(t, mem, WallClockManifest{GuestCorrectsClock: true, WorkloadFrozen: true, FreezeToken: "tok"})

--- a/internal/vm/firecracker.go
+++ b/internal/vm/firecracker.go
@@ -496,6 +496,36 @@ func UnpauseVM(socketPath string) error {
 	return nil
 }
 
+// UnpauseVMContext resumes a paused VM's vCPUs within ctx. A bare request over
+// a context-honouring dial, as VMState: it runs on failure and recovery paths,
+// where a stuck API must not hang the caller. A VM that is not paused refuses
+// it, which callers treat as nothing to do.
+func UnpauseVMContext(ctx context.Context, socketPath string) error {
+	tr := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+		DisableKeepAlives: true,
+	}
+	defer tr.CloseIdleConnections()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, "http://localhost/vm", strings.NewReader(`{"state":"Resumed"}`))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Transport: tr}).Do(req)
+	if err != nil {
+		return fmt.Errorf("unpause VM: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("unpause VM: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
 // LoadSnapshotNoResume loads a snapshot but leaves the vCPUs paused — used to
 // re-snapshot it (SnapshotPausedVM) and verify the memory round-trips. The TAP
 // override mirrors RestoreSnapshot* so device restore succeeds.

--- a/internal/vm/manager.go
+++ b/internal/vm/manager.go
@@ -129,10 +129,20 @@ type VMInstance struct {
 	ArtifactID string
 	// SnapshotWorkloadFrozen: see VMRecord.
 	SnapshotWorkloadFrozen *bool
-	CreatedAt              time.Time
-	Metadata               map[string]string
-	TeamID                 string // owning team; carried for data-plane usage attribution
-	OwnerID                string // creating user; empty when unknown
+	// WakePending / ClockFrozen / WakeOwedFromPaused: see VMRecord.
+	WakePending        bool
+	ClockFrozen        bool
+	WakeOwedFromPaused bool
+	// FreezeToken is the token the image's freeze carries; a wake must present it.
+	FreezeToken string
+	// WakeToken, WakeSnapshotPath, WakeMemPath: see VMRecord.
+	WakeToken        string
+	WakeSnapshotPath string
+	WakeMemPath      string
+	CreatedAt        time.Time
+	Metadata         map[string]string
+	TeamID           string // owning team; carried for data-plane usage attribution
+	OwnerID          string // creating user; empty when unknown
 	// PausedAt records when this VM last entered the paused state. It drives
 	// oldest-first pressure reclamation. Zero means the field is unset on a
 	// legacy record; callers fall back to CreatedAt and then place any fully
@@ -363,6 +373,9 @@ type ManagerConfig struct {
 	// its own wall clock on wake; everything else stays on legacy behaviour whatever
 	// this says. Default false.
 	GuestClockFreezeEnabled bool
+	// GuestFreezeBudget bounds the pause-side wait for a guest to stop its
+	// workload before a frozen snapshot; only paid when a pause freezes.
+	GuestFreezeBudget time.Duration
 
 	// RequirePresenceSidecar controls refusing a layered UFFD restore whose
 	// overlay has no .presence side-car next to it. Without the side-car,
@@ -705,6 +718,9 @@ type Manager struct {
 	// older Firecracker under a running daemon, and the first restore it refuses
 	// clears this for good.
 	clockRealtimeCapable atomic.Bool
+	// guestClockUnready latches once a guest reported it cannot correct its
+	// clock: every later restore takes the unfrozen path until vmd restarts.
+	guestClockUnready atomic.Bool
 	// dirtyTrackingSessionCapable is the same probe for the guarded-session
 	// fields, demoted on the first refusal exactly like the clock flag.
 	dirtyTrackingSessionCapable atomic.Bool

--- a/internal/vm/state.go
+++ b/internal/vm/state.go
@@ -219,6 +219,28 @@ type VMRecord struct {
 	// cannot leave an older answer for the next resume to act on. Tri-state
 	// for the same reason as CorrectsWallClock; nil means "ask the disk".
 	SnapshotWorkloadFrozen *bool `json:"snapshot_workload_frozen,omitempty"`
+	// WakePending: restored, the guest not yet told to correct its clock and
+	// release its workload; written with the Running record so a crash between
+	// the two completes the wake on recovery. ClockFrozen is the policy the
+	// restore used; FreezeToken the token the image's freeze carries.
+	WakePending bool   `json:"wake_pending,omitempty"`
+	ClockFrozen bool   `json:"clock_frozen,omitempty"`
+	FreezeToken string `json:"freeze_token,omitempty"`
+	// WakeToken is the token the owed wake must present: that of the image
+	// being loaded, kept apart from FreezeToken, which describes the image the
+	// record names, until the commit. A resume from an override that dies
+	// between the two returns to Paused with its own image and token intact.
+	WakeToken string `json:"wake_token,omitempty"`
+	// WakeSnapshotPath / WakeMemPath name the image an owed wake is for when
+	// it is not the record's own: a resume from an override. A wake completed
+	// by recovery commits them as the record's image; a failed one drops them.
+	WakeSnapshotPath string `json:"wake_snapshot_path,omitempty"`
+	WakeMemPath      string `json:"wake_mem_path,omitempty"`
+	// WakeOwedFromPaused: the record owing the wake was Paused before this
+	// resume began, so its image is intact. A crash before the launch, or a
+	// wake that never completes, returns it to Paused; a create in the same
+	// state is a failed create and is reaped.
+	WakeOwedFromPaused bool `json:"wake_owed_from_paused,omitempty"`
 	// ArtifactID names the manifest beside the image this VM was last paused
 	// into; see VMInstance.
 	ArtifactID string            `json:"artifact_id,omitempty"`
@@ -915,6 +937,13 @@ func toRecordLocked(inst *VMInstance) VMRecord {
 		CorrectsWallClock:          inst.CorrectsWallClock,
 		ArtifactID:                 inst.ArtifactID,
 		SnapshotWorkloadFrozen:     inst.SnapshotWorkloadFrozen,
+		WakePending:                inst.WakePending,
+		ClockFrozen:                inst.ClockFrozen,
+		FreezeToken:                inst.FreezeToken,
+		WakeToken:                  inst.WakeToken,
+		WakeSnapshotPath:           inst.WakeSnapshotPath,
+		WakeMemPath:                inst.WakeMemPath,
+		WakeOwedFromPaused:         inst.WakeOwedFromPaused,
 		CreatedAt:                  inst.CreatedAt,
 		Metadata:                   inst.Metadata,
 		VCPU:                       inst.Config.VCPU,
@@ -1018,6 +1047,13 @@ func toInstance(rec VMRecord) *VMInstance {
 		CorrectsWallClock:          rec.CorrectsWallClock,
 		ArtifactID:                 rec.ArtifactID,
 		SnapshotWorkloadFrozen:     rec.SnapshotWorkloadFrozen,
+		WakePending:                rec.WakePending,
+		ClockFrozen:                rec.ClockFrozen,
+		FreezeToken:                rec.FreezeToken,
+		WakeToken:                  rec.WakeToken,
+		WakeSnapshotPath:           rec.WakeSnapshotPath,
+		WakeMemPath:                rec.WakeMemPath,
+		WakeOwedFromPaused:         rec.WakeOwedFromPaused,
 		CreatedAt:                  rec.CreatedAt,
 		Metadata:                   rec.Metadata,
 		TeamID:                     rec.TeamID,

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/superserve-ai/sandbox/proto/boxdpb/boxdpbconnect"
@@ -131,6 +133,221 @@ func postBoxdInit(ctx context.Context, vmIP string, envVars map[string]string, h
 	}
 	return nil
 }
+
+// ErrGuestClockUnready: the guest cannot correct its clock; waiting longer
+// cannot help, and this host should restore the unfrozen way.
+var ErrGuestClockUnready = errors.New("guest clock could not be corrected")
+
+// ErrGuestThawFailed: the guest corrected its clock but could not release its
+// workload. Not a clock problem; retrying unfrozen would not help.
+var ErrGuestThawFailed = errors.New("guest workload could not be released")
+
+// ErrGuestTokenMismatch: the guest holds no freeze this wake names — a torn or
+// mismatched artifact, never retried.
+var ErrGuestTokenMismatch = errors.New("guest freeze token mismatch")
+
+// clockUnreadyPolls is how many consecutive such answers make it final: the
+// first may be mid-correction.
+const clockUnreadyPolls = 3
+
+// freezeEcho is what the guest answers a freeze with: the protocol it speaks
+// and the token it now holds, so the pause needs no separate probe.
+type freezeEcho struct {
+	Version    int    `json:"version"`
+	Capability string `json:"capability"`
+	Token      string `json:"token"`
+}
+
+// postBoxdFreeze asks the guest to stop its workload ahead of a snapshot.
+func postBoxdFreeze(ctx context.Context, vmIP, token string) (freezeEcho, error) {
+	// The guest's budget is shorter than ours, so it gives up and thaws first.
+	req := struct {
+		BudgetMs int64  `json:"budget_ms,omitempty"`
+		Token    string `json:"token"`
+	}{Token: token}
+	if dl, ok := ctx.Deadline(); ok {
+		// The reserve is what the guest's reply needs to reach us after it
+		// gives up; it never eats the whole budget, so a short budget still
+		// asks the guest for most of it rather than nothing.
+		remaining := time.Until(dl)
+		reserve := min(200*time.Millisecond, remaining/4)
+		budget := remaining - reserve
+		if budget <= 0 {
+			return freezeEcho{}, context.DeadlineExceeded
+		}
+		req.BudgetMs = max(budget.Milliseconds(), 1)
+	}
+	body, _ := json.Marshal(req)
+	reply, err := postBoxd(ctx, vmIP, "/freeze", body)
+	if err != nil {
+		return freezeEcho{}, err
+	}
+	var echo freezeEcho
+	if err := json.Unmarshal(reply, &echo); err != nil {
+		return freezeEcho{}, fmt.Errorf("POST /freeze: reply: %w", err)
+	}
+	return echo, nil
+}
+
+// postBoxdThaw undoes a freeze whose snapshot did not happen. A refusal that
+// the token names no freeze the guest holds is ErrGuestTokenMismatch.
+func postBoxdThaw(ctx context.Context, vmIP, token string) error {
+	body, _ := json.Marshal(struct {
+		Token string `json:"token"`
+	}{token})
+	_, err := postBoxd(ctx, vmIP, "/thaw", body)
+	var se *boxdStatusError
+	if errors.As(err, &se) && se.Code == http.StatusConflict {
+		return fmt.Errorf("%w: %s", ErrGuestTokenMismatch, se.Body)
+	}
+	return err
+}
+
+// guestWorkloadRunning asks the guest whether its workload runs. Health
+// answers ok only while nothing is frozen, so a thaw refused for a token the
+// guest does not hold is read as "never frozen" only once this confirms it:
+// the guest may still be frozen under an earlier token.
+func guestWorkloadRunning(ctx context.Context, vmIP string) error {
+	url := fmt.Sprintf("http://%s:%d/health", vmIP, boxdPort)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create /health request: %w", err)
+	}
+	resp, err := boxdHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET /health: %w", err)
+	}
+	defer resp.Body.Close()
+	reply, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return &boxdStatusError{Path: "/health", Code: resp.StatusCode, Body: strings.TrimSpace(string(reply))}
+	}
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(reply, &body); err != nil {
+		return fmt.Errorf("decode /health: %w", err)
+	}
+	if body.Status != "ok" {
+		return fmt.Errorf("guest workload status %q", body.Status)
+	}
+	return nil
+}
+
+// boxdStatusError is a non-200 answer from the guest agent.
+type boxdStatusError struct {
+	Path string
+	Code int
+	Body string
+}
+
+func (e *boxdStatusError) Error() string {
+	return fmt.Sprintf("POST %s: status %d: %s", e.Path, e.Code, e.Body)
+}
+
+func postBoxd(ctx context.Context, vmIP, path string, body []byte) ([]byte, error) {
+	url := fmt.Sprintf("http://%s:%d%s", vmIP, boxdPort, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create %s request: %w", path, err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := boxdHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	reply, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return nil, &boxdStatusError{Path: path, Code: resp.StatusCode, Body: strings.TrimSpace(string(reply))}
+	}
+	return reply, nil
+}
+
+// waitForGuestWake tells a restored guest to correct its clock and release its
+// workload, and waits for it to confirm. Returns ErrGuestClockUnready as soon
+// as the guest reports it cannot, so the caller retries the unfrozen way.
+func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, clockFrozen bool, token string) error {
+	url := fmt.Sprintf("http://%s:%d/wake", vmIP, boxdPort)
+	body, _ := json.Marshal(struct {
+		ClockFrozen bool   `json:"clock_frozen"`
+		Token       string `json:"token"`
+	}{clockFrozen, token})
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	const maxProbeInterval = 10 * time.Millisecond
+	interval := time.Millisecond
+	var lastErr error
+	// Consecutive answers of one kind make the verdict; anything else in
+	// between starts the count over. The first may be mid-correction, and
+	// non-consecutive failures would park a guest that was recovering.
+	streakKind, streak := "", 0
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		kind, detail := "", ""
+		if err == nil {
+			reply, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			err = fmt.Errorf("unexpected status %d", resp.StatusCode)
+			if resp.StatusCode == http.StatusConflict {
+				// Definitive: the guest holds no freeze this token names, so
+				// this image and this wake describe different snapshots.
+				return fmt.Errorf("%w: %s", ErrGuestTokenMismatch, strings.TrimSpace(string(reply)))
+			}
+			if resp.StatusCode == http.StatusServiceUnavailable {
+				var r struct {
+					Status    string `json:"status"`
+					WallClock struct {
+						Error string `json:"error"`
+					} `json:"wall_clock"`
+				}
+				if json.Unmarshal(reply, &r) == nil && (r.Status == "clock" || r.Status == "thaw") {
+					kind, detail = r.Status, r.WallClock.Error
+				}
+			}
+		}
+		if kind != streakKind {
+			streakKind, streak = kind, 0
+		}
+		if kind != "" {
+			if streak++; streak >= clockUnreadyPolls {
+				sentinel := ErrGuestClockUnready
+				if kind == "thaw" {
+					sentinel = ErrGuestThawFailed
+				}
+				return fmt.Errorf("%w (%s)", sentinel, detail)
+			}
+		}
+		lastErr = err
+		time.Sleep(interval)
+		interval = min(interval*2, maxProbeInterval)
+	}
+	if lastErr != nil {
+		return fmt.Errorf("guest not awake after %s: %w", timeout, lastErr)
+	}
+	return fmt.Errorf("guest not awake after %s", timeout)
+}
+
+// Seams so the pause and restore paths can be tested without a guest.
+var (
+	boxdFreezeGuest  = postBoxdFreeze
+	boxdThawGuest    = postBoxdThaw
+	boxdWakeGuest    = waitForGuestWake
+	boxdGuestRunning = guestWorkloadRunning
+)
 
 // boxdFilesystemClient returns a Connect RPC client for boxd's
 // FilesystemService, used for metadata ops (Remove, Move, etc.) inside

--- a/internal/vm/vsock_exec.go
+++ b/internal/vm/vsock_exec.go
@@ -276,6 +276,12 @@ func waitForGuestWake(ctx context.Context, vmIP string, timeout time.Duration, c
 		Token       string `json:"token"`
 	}{clockFrozen, token})
 	deadline := time.Now().Add(timeout)
+	// Every request is bounded by the wait's own deadline as well as the
+	// caller's context, so a guest that accepts the connection and never
+	// answers cannot carry the wait past its advertised bound; the client
+	// timeout caps a single request within a longer wait.
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
 	client := &http.Client{
 		Timeout:   2 * time.Second,
 		Transport: &http.Transport{DisableKeepAlives: true},

--- a/internal/vm/wake_client_test.go
+++ b/internal/vm/wake_client_test.go
@@ -1,0 +1,156 @@
+package vm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// A guest that reports it cannot correct its clock must fail the wait fast and
+// typed, so the restore can be retried the unfrozen way instead of waiting out
+// the budget with the customer's processes frozen.
+func TestWaitForGuestWakeFailsFastOnUncorrectableClock(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	calls := 0
+	var sawPolicy bool
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/wake" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var b struct {
+			ClockFrozen bool `json:"clock_frozen"`
+		}
+		_ = jsonDecode(r, &b)
+		sawPolicy = b.ClockFrozen
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"status":"clock","wall_clock":{"source":"unavailable","error":"open /dev/ptp0: no such file"}}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	start := time.Now()
+	err = waitForGuestWake(context.Background(), "127.0.0.1", 10*time.Second, true, "tok")
+	if !errors.Is(err, ErrGuestClockUnready) {
+		t.Fatalf("err = %v, want ErrGuestClockUnready", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Errorf("took %v; must not wait out the budget", time.Since(start))
+	}
+	if calls < clockUnreadyPolls {
+		t.Errorf("gave up after %d polls, want at least %d", calls, clockUnreadyPolls)
+	}
+	if !sawPolicy {
+		t.Error("the guest must be told the clock was frozen")
+	}
+}
+
+// The verdict needs consecutive answers of one kind: an answer of another
+// kind, or another status, in between starts the count over, so a guest
+// that was recovering is not parked on failures that were not consecutive.
+func TestWaitForGuestWakeVerdictNeedsAConsecutiveStreak(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		answers []int // 0: clock, 1: thaw, 2: HTTP 500
+		want    error
+		calls   int
+	}{
+		{"a_thaw_answer_breaks_a_clock_streak", []int{0, 0, 1, 0, 0, 0}, ErrGuestClockUnready, 6},
+		{"another_status_breaks_the_streak", []int{1, 1, 2, 1, 1, 1}, ErrGuestThawFailed, 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+			if err != nil {
+				t.Skipf("port %d busy: %v", boxdPort, err)
+			}
+			calls := 0
+			srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				i := calls
+				calls++
+				if i >= len(tc.answers) {
+					i = len(tc.answers) - 1
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch tc.answers[i] {
+				case 0:
+					w.WriteHeader(http.StatusServiceUnavailable)
+					w.Write([]byte(`{"status":"clock","wall_clock":{"error":"no ptp"}}`))
+				case 1:
+					w.WriteHeader(http.StatusServiceUnavailable)
+					w.Write([]byte(`{"status":"thaw","wall_clock":{"error":"cgroup busy"}}`))
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+			srv.Listener = ln
+			srv.Start()
+			defer srv.Close()
+			err = waitForGuestWake(context.Background(), "127.0.0.1", 10*time.Second, true, "tok")
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			if calls != tc.calls {
+				t.Fatalf("verdict after %d answers, want %d: the streak must restart at the interruption", calls, tc.calls)
+			}
+		})
+	}
+}
+func TestWaitForGuestWakeReadyIsNil(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok","wall_clock":{"source":"ptp"}}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	if err := waitForGuestWake(context.Background(), "127.0.0.1", 2*time.Second, false, "tok"); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+func jsonDecode(r *http.Request, v any) error { return json.NewDecoder(r.Body).Decode(v) }
+
+// A short freeze budget still reaches the guest as a positive budget: the
+// reserve for the reply scales down with it instead of consuming it whole.
+func TestFreezeRequestKeepsAPositiveGuestBudget(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	var seen int64 = -1
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b struct {
+			BudgetMs int64  `json:"budget_ms"`
+			Token    string `json:"token"`
+		}
+		_ = jsonDecode(r, &b)
+		seen = b.BudgetMs
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":1,"capability":"wake","token":"` + b.Token + `"}`))
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	echo, err := postBoxdFreeze(ctx, "127.0.0.1", "tok")
+	if err != nil || echo.Token != "tok" {
+		t.Fatalf("echo=%+v err=%v; want the freeze sent and echoed under a 100ms budget", echo, err)
+	}
+	if seen <= 0 || seen >= 100 {
+		t.Fatalf("guest budget %dms, want positive and below the caller's 100ms", seen)
+	}
+}

--- a/internal/vm/wake_client_test.go
+++ b/internal/vm/wake_client_test.go
@@ -154,3 +154,30 @@ func TestFreezeRequestKeepsAPositiveGuestBudget(t *testing.T) {
 		t.Fatalf("guest budget %dms, want positive and below the caller's 100ms", seen)
 	}
 }
+
+// The wait's bound holds even when a guest accepts the connection and never
+// answers: each request is cut off by the wait's deadline, not only by the
+// per-request client timeout.
+func TestWaitForGuestWakeHonoursAShortTimeoutAgainstAHungGuest(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(boxdPort))
+	if err != nil {
+		t.Skipf("port %d busy: %v", boxdPort, err)
+	}
+	release := make(chan struct{})
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // never answers within the test's budget
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer func() { close(release); srv.Close() }()
+
+	start := time.Now()
+	err = waitForGuestWake(context.Background(), "127.0.0.1", 300*time.Millisecond, false, "tok")
+	took := time.Since(start)
+	if err == nil {
+		t.Fatal("want an error from a guest that never answers")
+	}
+	if took > time.Second {
+		t.Fatalf("took %v against a 300ms bound; a hung request must not carry the wait past it", took)
+	}
+}

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -243,18 +243,18 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 }
 
 // removeWallClockManifest removes the manifest beside an image, if any. One
-// that said frozen is removed with a directory sync so a crash cannot bring
-// it back; any other marker is simply removed. Only a host whose floor is up
-// reads before removing. Nothing to remove is not an error. A marker that
-// will not go is blocking unless it is known harmless: readable and not
-// frozen, or empty. One a restore could not read would refuse the image.
+// that said frozen, or one that cannot be read and so may have, is removed
+// with a directory sync so a crash cannot bring it back; any other marker is
+// simply removed. Only a host whose floor is up reads before removing.
+// Nothing to remove is not an error. A marker that will not go is blocking
+// unless it is known harmless: readable and not frozen, or empty. One a
+// restore could not read would refuse the image.
 func removeWallClockManifest(memPath string) (blocking bool, err error) {
 	path := WallClockMarkerPath(memPath)
 	frozen := false
 	if wakeProtocolFloorRaised() {
-		if man, rerr := ReadWallClockManifest(memPath); rerr == nil && man != nil && man.WorkloadFrozen {
-			frozen = true
-		}
+		man, rerr := ReadWallClockManifest(memPath)
+		frozen = rerr != nil || (man != nil && man.WorkloadFrozen)
 	}
 	if err := os.Remove(path); err != nil {
 		if os.IsNotExist(err) {

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -455,7 +455,7 @@ func watchTemplateTree(w *fsnotify.Watcher, dir string) {
 // floor for a frozen one. Returns 1 if it was frozen.
 func (m *Manager) noteTemplateManifest(path string) int {
 	man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
-	if err != nil || man == nil || !man.WorkloadFrozen {
+	if err == nil && (man == nil || !man.WorkloadFrozen) {
 		return 0
 	}
 	if err := noteWakeProtocolEvidence(); err != nil {
@@ -478,8 +478,11 @@ func (m *Manager) scanTemplateManifests() int {
 	shallow, _ := filepath.Glob(filepath.Join(root, "*", "*"+clockFreezeMarkerSuffix))
 	n := 0
 	for _, path := range append(deep, shallow...) {
+		// A manifest this binary cannot read or trust may still describe a
+		// frozen workload; it counts as evidence, the safe direction. Only an
+		// absent or empty marker, or one that says unfrozen, does not.
 		man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
-		if err != nil || man == nil || !man.WorkloadFrozen {
+		if err == nil && (man == nil || !man.WorkloadFrozen) {
 			continue
 		}
 		// Counted only once the floor is durably up: the host guard trusts

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -1,16 +1,22 @@
 package vm
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/fsnotify/fsnotify"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // WallClockManifest sits beside a memory image and says what a supervisor may
@@ -39,6 +45,10 @@ const WallClockManifestVersion = 1
 // echo. A different version space from the manifest's: the two are both 1
 // today by coincidence, and a bump to either must not pass for the other.
 const WakeProtocolVersion = 1
+
+// WakeProtocolCapability is the string a vmd that can wake a frozen image
+// carries; the host guard and the deploy check grep the binary for it.
+const WakeProtocolCapability = "wake-protocol-1"
 
 // wakeProtocolEvidencePath records that this host has held an image that
 // owes a wake, so the host-resident guard refuses a vmd without the wake
@@ -79,10 +89,49 @@ func RecognizeWakeProtocolFloor() bool {
 	return false
 }
 
+// PrimeWakeProtocolFloor proves recognised evidence durable in the
+// background, so the first request needing the floor after a restart pays no
+// directory sync. Without evidence it primes nothing: proven here, never raised.
+func PrimeWakeProtocolFloor(log zerolog.Logger) {
+	if !wakeProtocolEvidenceSeen.Load() || wakeProtocolEvidenceDurable.Load() {
+		return
+	}
+	go func() {
+		if err := ensureWakeProtocolFloor(); err != nil {
+			log.Warn().Err(err).Msg("wake-protocol floor could not be proven durable at startup; the first frozen restore will retry")
+		}
+	}()
+}
+
 // wakeProtocolFloorRaised reports what startup recognised, without I/O. A
 // pause intent is only ever written on a host whose floor is up, so on any
 // other host the checks for one are skipped, at no cost.
 func wakeProtocolFloorRaised() bool { return wakeProtocolEvidenceSeen.Load() }
+
+// wakeProtocolEvidenceMu makes concurrent first raises share one write
+// instead of each paying the sync.
+var wakeProtocolEvidenceMu sync.Mutex
+
+// ensureWakeProtocolFloor is the form a supervisor uses before it acts on an
+// image that owes a wake — freezing one, restoring one: durable once, then
+// free. Never on a request path for an image that owes nothing.
+func ensureWakeProtocolFloor() error {
+	if wakeProtocolEvidenceDurable.Load() {
+		return nil
+	}
+	wakeProtocolEvidenceMu.Lock()
+	defer wakeProtocolEvidenceMu.Unlock()
+	return RaiseWakeProtocolFloor()
+}
+
+// noteWakeProtocolEvidence is the best-effort form, for the template scan: a
+// host without the directory is not a fleet host.
+func noteWakeProtocolEvidence() {
+	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
+		return
+	}
+	_ = ensureWakeProtocolFloor()
+}
 
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
 // hold, an image that owes a wake. The template builder calls it before it
@@ -193,6 +242,36 @@ func WriteWallClockManifest(memPath string, m WallClockManifest) error {
 	return writeWallClockManifest(memPath, m, true)
 }
 
+// removeWallClockManifest removes the manifest beside an image, if any. One
+// that said frozen is removed with a directory sync so a crash cannot bring
+// it back; any other marker is simply removed. Only a host whose floor is up
+// reads before removing. Nothing to remove is not an error. A marker that
+// will not go is blocking unless it is known harmless: readable and not
+// frozen, or empty. One a restore could not read would refuse the image.
+func removeWallClockManifest(memPath string) (blocking bool, err error) {
+	path := WallClockMarkerPath(memPath)
+	frozen := false
+	if wakeProtocolFloorRaised() {
+		if man, rerr := ReadWallClockManifest(memPath); rerr == nil && man != nil && man.WorkloadFrozen {
+			frozen = true
+		}
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		if frozen {
+			return true, err
+		}
+		man, rerr := ReadWallClockManifest(memPath)
+		return rerr != nil || (man != nil && man.WorkloadFrozen), err
+	}
+	if !frozen {
+		return false, nil
+	}
+	return true, syncDir(filepath.Dir(path))
+}
+
 // writeWallClockManifestLazy publishes atomically but with no durability
 // barrier, for a manifest whose loss costs only a slower resume: an unfrozen
 // one. Nothing on a lifecycle path waits on a sync for it.
@@ -257,4 +336,151 @@ func randomHex() string {
 // clock.
 func imageManifest(memPath string) (*WallClockManifest, error) {
 	return ReadWallClockManifest(memPath)
+}
+
+// WatchTemplateManifests raises the rollback floor for frozen templates as
+// they land, so no restore has to happen first: a scan at start and every few
+// minutes plus a watch on the tree, off every request path. The returned
+// channel closes once the watcher has stopped.
+func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger) (stopped <-chan struct{}) {
+	done := make(chan struct{})
+	// Only a host that may act on frozen images watches: with the switch off
+	// this does no filesystem work. A frozen template must not reach such a
+	// host, which is enforced where templates are admitted.
+	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
+		close(done)
+		return done
+	}
+	scan := func() {
+		if n := m.scanTemplateManifests(); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
+			log.Info().Int("templates", n).Msg("this host holds images that owe a wake; a vmd without the wake protocol is refused from now on")
+		}
+	}
+	go func() {
+		defer close(done)
+		scan()
+		// A template lands by copy, between scans. The tree is watched so a
+		// frozen one is witnessed as it lands, with the periodic scan as the
+		// fallback for anything the watch missed; a host that cannot watch
+		// keeps the scan alone.
+		root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+		// The root is created if absent, so the watch has something to
+		// attach to before the first template lands rather than after.
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			log.Warn().Err(err).Str("path", root).Msg("template root cannot be created; frozen templates are witnessed by the periodic scan alone")
+		}
+		var events <-chan fsnotify.Event
+		var errs <-chan error
+		if w, werr := fsnotify.NewWatcher(); werr == nil {
+			defer w.Close()
+			watchTemplateTree(w, root)
+			events, errs = w.Events, w.Errors
+			// Anything that landed while the watches were being added.
+			scan()
+			t := time.NewTicker(firecrackerCapabilityRefreshInterval)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					scan()
+				case ev := <-events:
+					// Writes too: an importer that creates the path and then
+					// streams the manifest into it is complete only at its
+					// last write, and a partial file simply fails to parse.
+					if !ev.Has(fsnotify.Create) && !ev.Has(fsnotify.Rename) && !ev.Has(fsnotify.Write) {
+						continue
+					}
+					if info, serr := os.Stat(ev.Name); serr == nil && info.IsDir() {
+						// A new template or build directory: watch it, and
+						// read what may already be inside.
+						watchTemplateTree(w, ev.Name)
+						scan()
+						continue
+					}
+					if strings.HasSuffix(ev.Name, clockFreezeMarkerSuffix) {
+						if n := m.noteTemplateManifest(ev.Name); n > 0 && !wakeProtocolEvidenceLogged.Swap(true) {
+							log.Info().Str("path", ev.Name).Msg("a frozen template landed; a vmd without the wake protocol is refused from now on")
+						}
+					}
+				case <-errs:
+				}
+			}
+		} else {
+			log.Warn().Err(werr).Msg("template tree cannot be watched; frozen templates are witnessed by the periodic scan alone")
+		}
+		t := time.NewTicker(firecrackerCapabilityRefreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				scan()
+			}
+		}
+	}()
+	return done
+}
+
+// watchTemplateTree watches dir and every directory beneath it to the depth
+// templates live at (templates/<template>/<build>); inotify watches are not
+// recursive, so each level is added, and what is already there is added now.
+func watchTemplateTree(w *fsnotify.Watcher, dir string) {
+	_ = w.Add(dir)
+	if rel, err := filepath.Rel(filepath.Dir(dir), dir); err != nil || rel == "" {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			sub := filepath.Join(dir, e.Name())
+			_ = w.Add(sub)
+			if subs, err := os.ReadDir(sub); err == nil {
+				for _, b := range subs {
+					if b.IsDir() {
+						_ = w.Add(filepath.Join(sub, b.Name()))
+					}
+				}
+			}
+		}
+	}
+}
+
+// noteTemplateManifest reads one manifest that just landed and raises the
+// floor for a frozen one. Returns 1 if it was frozen.
+func (m *Manager) noteTemplateManifest(path string) int {
+	man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
+	if err != nil || man == nil || !man.WorkloadFrozen {
+		return 0
+	}
+	noteWakeProtocolEvidence()
+	return 1
+}
+
+var wakeProtocolEvidenceLogged atomic.Bool
+
+// scanTemplateManifests reads every template manifest under the snapshot
+// directory, raises the floor for each frozen one, and returns how many
+// frozen ones it found.
+func (m *Manager) scanTemplateManifests() int {
+	// Templates live at templates/<template>/<build>/; the shallower pattern
+	// is kept so a flattened layout could never hide one.
+	root := filepath.Join(m.cfg.SnapshotDir, TemplatesDirName)
+	deep, _ := filepath.Glob(filepath.Join(root, "*", "*", "*"+clockFreezeMarkerSuffix))
+	shallow, _ := filepath.Glob(filepath.Join(root, "*", "*"+clockFreezeMarkerSuffix))
+	n := 0
+	for _, path := range append(deep, shallow...) {
+		man, err := ReadWallClockManifest(strings.TrimSuffix(path, clockFreezeMarkerSuffix))
+		if err != nil || man == nil || !man.WorkloadFrozen {
+			continue
+		}
+		n++
+		noteWakeProtocolEvidence()
+	}
+	return n
 }

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -126,11 +126,11 @@ func ensureWakeProtocolFloor() error {
 
 // noteWakeProtocolEvidence is the best-effort form, for the template scan: a
 // host without the directory is not a fleet host.
-func noteWakeProtocolEvidence() {
+func noteWakeProtocolEvidence() error {
 	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
-		return
+		return nil
 	}
-	_ = ensureWakeProtocolFloor()
+	return ensureWakeProtocolFloor()
 }
 
 // RaiseWakeProtocolFloor durably records that this host holds, or is about to
@@ -458,7 +458,10 @@ func (m *Manager) noteTemplateManifest(path string) int {
 	if err != nil || man == nil || !man.WorkloadFrozen {
 		return 0
 	}
-	noteWakeProtocolEvidence()
+	if err := noteWakeProtocolEvidence(); err != nil {
+		m.log.Error().Err(err).Str("path", path).Msg("frozen template landed but the wake-protocol floor could not be raised; the periodic scan retries")
+		return 0
+	}
 	return 1
 }
 
@@ -479,8 +482,14 @@ func (m *Manager) scanTemplateManifests() int {
 		if err != nil || man == nil || !man.WorkloadFrozen {
 			continue
 		}
+		// Counted only once the floor is durably up: the host guard trusts
+		// the evidence file alone, so a failed raise is a template not yet
+		// witnessed. Logged, and retried by the next scan.
+		if err := noteWakeProtocolEvidence(); err != nil {
+			m.log.Error().Err(err).Str("path", path).Msg("frozen template found but the wake-protocol floor could not be raised; a rollback would not be refused until it is")
+			continue
+		}
 		n++
-		noteWakeProtocolEvidence()
 	}
 	return n
 }

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -346,7 +346,8 @@ func (m *Manager) WatchTemplateManifests(ctx context.Context, log zerolog.Logger
 	done := make(chan struct{})
 	// Only a host that may act on frozen images watches: with the switch off
 	// this does no filesystem work. A frozen template must not reach such a
-	// host, which is enforced where templates are admitted.
+	// host; that is owed by the paths that admit templates, before the first
+	// frozen image is ever produced, and is not enforced here.
 	if m.cfg.SnapshotDir == "" || !m.cfg.GuestClockFreezeEnabled {
 		close(done)
 		return done

--- a/internal/vm/wallclock_manifest.go
+++ b/internal/vm/wallclock_manifest.go
@@ -128,7 +128,10 @@ func ensureWakeProtocolFloor() error {
 // host without the directory is not a fleet host.
 func noteWakeProtocolEvidence() error {
 	if _, err := os.Stat(filepath.Dir(wakeProtocolEvidencePath)); err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil // not a fleet host
+		}
+		return err // a lookup that failed is not evidence written
 	}
 	return ensureWakeProtocolFloor()
 }

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -589,3 +589,27 @@ func TestUntrustedTemplateManifestRaisesTheFloor(t *testing.T) {
 		t.Fatalf("n=%d raised=%v; an untrusted manifest must raise the floor", n, wakeProtocolFloorRaised())
 	}
 }
+
+// A lookup of the evidence directory that fails for any reason but absence
+// is not "not a fleet host": the template is not counted as witnessed, and
+// the next scan retries.
+func TestTemplateScanDoesNotCountAnEvidenceLookupThatFailed(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	// The evidence directory's own parent is a file: the lookup fails with
+	// something other than absence.
+	notADir := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wakeProtocolEvidencePath = filepath.Join(notADir, "sub", "evidence")
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 0 || wakeProtocolFloorRaised() {
+		t.Fatalf("n=%d raised=%v; a failed lookup must not count the template as witnessed", n, wakeProtocolFloorRaised())
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -570,3 +570,22 @@ func TestTemplateScanDoesNotCountAFloorItCouldNotRaise(t *testing.T) {
 		t.Fatalf("evidence not written on the retry: %v", err)
 	}
 }
+
+// A template manifest this binary cannot trust may still describe a frozen
+// workload: it counts as rollback evidence, so a supervisor without the wake
+// protocol is refused rather than left to restore the image as legacy.
+func TestUntrustedTemplateManifestRaisesTheFloor(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(WallClockMarkerPath(filepath.Join(tpl, "mem.snap")), []byte(`{"version":2}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 1 || !wakeProtocolFloorRaised() {
+		t.Fatalf("n=%d raised=%v; an untrusted manifest must raise the floor", n, wakeProtocolFloorRaised())
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -508,3 +508,32 @@ func TestPrimeWakeProtocolFloor(t *testing.T) {
 	})
 
 }
+
+// A manifest that cannot be read may have described a frozen image, so its
+// removal is made durable like a frozen one's: where the directory cannot be
+// synced, the removal is reported as failed rather than as done.
+func TestRemovingAnUnreadableManifestIsDurable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("needs a directory the process cannot open for sync; root can")
+	}
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	raiseFloorForTest(t)
+	imgDir := filepath.Join(dir, "img")
+	if err := os.MkdirAll(imgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mem := filepath.Join(imgDir, "mem.snap")
+	if err := os.WriteFile(WallClockMarkerPath(mem), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Writable and searchable but not readable: the unlink succeeds, the
+	// directory sync cannot open it.
+	if err := os.Chmod(imgDir, 0o333); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(imgDir, 0o755) })
+	if _, err := removeWallClockManifest(mem); err == nil {
+		t.Fatal("removing an unreadable manifest without a durable sync must not report success")
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -537,3 +537,36 @@ func TestRemovingAnUnreadableManifestIsDurable(t *testing.T) {
 		t.Fatal("removing an unreadable manifest without a durable sync must not report success")
 	}
 }
+
+// A frozen template counts as witnessed only once the floor is durably up:
+// the host guard trusts the evidence file alone, so a raise that fails must
+// not be reported as a template witnessed. The next scan retries.
+func TestTemplateScanDoesNotCountAFloorItCouldNotRaise(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	// The evidence path's parent is a file: the directory exists to a stat,
+	// but nothing can be created beneath it.
+	notADir := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	good := wakeProtocolEvidencePath
+	wakeProtocolEvidencePath = filepath.Join(notADir, "evidence")
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 0 || wakeProtocolFloorRaised() {
+		t.Fatalf("n=%d raised=%v; a floor that could not be raised must not count the template as witnessed", n, wakeProtocolFloorRaised())
+	}
+	// The next scan, once the path can be written, raises it.
+	wakeProtocolEvidencePath = good
+	if n := m.scanTemplateManifests(); n != 1 {
+		t.Fatalf("n=%d, want the template witnessed once the floor can be raised", n)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
+		t.Fatalf("evidence not written on the retry: %v", err)
+	}
+}

--- a/internal/vm/wallclock_manifest_test.go
+++ b/internal/vm/wallclock_manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
@@ -258,4 +259,252 @@ func TestFrozenImageIsRefusedBeforeLaunch(t *testing.T) {
 	if status.Code(cerr) != codes.FailedPrecondition || launched {
 		t.Fatalf("restore: err=%v launched=%v, want FailedPrecondition before launch", cerr, launched)
 	}
+}
+
+// Templates are seeded while the daemon runs; the first frozen one to land
+// raises the floor here, at the builder's real layout depth. An unfrozen
+// manifest raises nothing.
+func TestTemplateManifestsLeaveEvidence(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	if n := m.scanTemplateManifests(); n != 0 {
+		t.Fatalf("found %d frozen manifests in an empty tree", n)
+	}
+	// The builder's layout: templates/<template>/<build>/mem.snap.
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteWallClockManifest(filepath.Join(tpl, "mem.snap"), WallClockManifest{Version: WallClockManifestVersion, ArtifactID: "a", GuestCorrectsClock: true}); err != nil {
+		t.Fatal(err)
+	}
+	if n := m.scanTemplateManifests(); n != 0 || wakeProtocolFloorRaised() {
+		t.Fatalf("n=%d raised=%v; an unfrozen manifest is not evidence", n, wakeProtocolFloorRaised())
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	if n := m.scanTemplateManifests(); n != 1 {
+		t.Fatalf("found %d frozen manifests, want 1", n)
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err != nil {
+		t.Fatalf("evidence not written after a frozen template landed: %v", err)
+	}
+}
+
+// The daemon's own raise is durable once and then free; a raise that cannot
+// land is not remembered, so the next one tries again.
+func TestEnsureWakeProtocolFloor(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	if err := os.WriteFile(wakeProtocolEvidencePath, []byte("older-process\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v durable=%v", err, wakeProtocolEvidenceDurable.Load())
+	}
+	if b, _ := os.ReadFile(wakeProtocolEvidencePath); string(b) != "older-process\n" {
+		t.Errorf("existing evidence rewritten: %q", b)
+	}
+
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wakeProtocolEvidencePath = filepath.Join(blocker, "evidence")
+	wakeProtocolEvidenceSeen.Store(false)
+	wakeProtocolEvidenceDurable.Store(false)
+	if err := ensureWakeProtocolFloor(); err == nil || wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("err=%v durable=%v; a failed raise must not be remembered as done", err, wakeProtocolEvidenceDurable.Load())
+	}
+	wakeProtocolEvidencePath = filepath.Join(dir, "evidence2")
+	if err := ensureWakeProtocolFloor(); err != nil || !wakeProtocolEvidenceDurable.Load() {
+		t.Fatalf("retry: err=%v durable=%v", err, wakeProtocolEvidenceDurable.Load())
+	}
+}
+
+// A host with the switch off does no work for the watch: a frozen template
+// already on disk raises nothing until the switch is on.
+func TestTemplateWatchRunsOnlyWhenTheSwitchIsOn(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	off := &Manager{cfg: ManagerConfig{SnapshotDir: dir}}
+	select {
+	case <-off.WatchTemplateManifests(ctx, zerolog.Nop()):
+	default:
+		t.Fatal("a watch with the switch off must start nothing")
+	}
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		t.Fatal("the watch scanned the templates with the switch off")
+	}
+
+	on := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := on.WatchTemplateManifests(ctx, zerolog.Nop())
+	// The watcher must be gone before the evidence path is restored by the
+	// cleanup, or it would read a path being rewritten under it.
+	defer func() { cancel(); <-stopped }()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the watch never raised the floor with the switch on")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A frozen template that lands after the watch started is witnessed as it
+// lands, not at the next periodic scan: the floor is up within moments.
+func TestTemplateWatchWitnessesATemplateAsItLands(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, TemplatesDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+	if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+		t.Fatal("nothing had landed yet")
+	}
+	// The copy: directories first, then the manifest, renamed into place.
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the frozen template that landed was not witnessed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A manifest streamed into its final path, created empty and written after,
+// is witnessed at its last write, not left for the next periodic scan.
+func TestTemplateWatchWitnessesAManifestStreamedIntoPlace(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+
+	path := WallClockMarkerPath(filepath.Join(tpl, "mem.snap"))
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond) // the create is seen while the file is empty
+	body := `{"version":1,"artifact_id":"a","workload_frozen":true,"guest_corrects_clock":true,"freeze_token":"tok"}`
+	if _, err := f.WriteString(body[:20]); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond) // a partial write does not parse
+	if _, err := f.WriteString(body[20:]); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the streamed frozen manifest was not witnessed at its last write")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A watch started before the templates root exists still witnesses the first
+// template to land: the root is created so the watch attaches to it.
+func TestTemplateWatchAttachesBeforeTheRootExists(t *testing.T) {
+	dir := t.TempDir()
+	isolateEvidence(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m := &Manager{cfg: ManagerConfig{SnapshotDir: dir, GuestClockFreezeEnabled: true}}
+	stopped := m.WatchTemplateManifests(ctx, zerolog.Nop())
+	defer func() { cancel(); <-stopped }()
+	time.Sleep(50 * time.Millisecond)
+	tpl := filepath.Join(dir, TemplatesDirName, "tpl", "build-1")
+	if err := os.MkdirAll(tpl, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	seedFrozenManifest(t, filepath.Join(tpl, "mem.snap"), "tok")
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a template landing under a root created after the watch started was not witnessed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Recognised evidence is proven durable in the background at startup, so the
+// first request that needs the floor after a restart pays nothing; a host
+// without evidence primes nothing and raises nothing.
+func TestPrimeWakeProtocolFloor(t *testing.T) {
+	t.Run("recognised_evidence_becomes_durable_off_the_request_path", func(t *testing.T) {
+		dir := t.TempDir()
+		isolateEvidence(t, dir)
+		if err := os.WriteFile(wakeProtocolEvidencePath, []byte(wakeProtocolEvidenceNote), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !RecognizeWakeProtocolFloor() || wakeProtocolEvidenceDurable.Load() {
+			t.Fatal("precondition: seen at startup, not yet durable")
+		}
+		PrimeWakeProtocolFloor(zerolog.Nop())
+		deadline := time.Now().Add(3 * time.Second)
+		for !wakeProtocolEvidenceDurable.Load() {
+			if time.Now().After(deadline) {
+				t.Fatal("priming never proved the recognised floor durable")
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	})
+
+	t.Run("no_evidence_primes_nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		isolateEvidence(t, dir)
+		if RecognizeWakeProtocolFloor() {
+			t.Fatal("precondition: nothing to recognise")
+		}
+		PrimeWakeProtocolFloor(zerolog.Nop())
+		time.Sleep(50 * time.Millisecond)
+		if _, err := os.Stat(wakeProtocolEvidencePath); err == nil || wakeProtocolEvidenceDurable.Load() {
+			t.Fatal("priming raised a floor on a host that had none")
+		}
+	})
+
 }


### PR DESCRIPTION
The building blocks the frozen-workload lifecycle needs, with nothing calling them yet: the guest client for freeze, thaw, wake and the running check; the record fields an owed wake is tracked in; the manifest, rollback-floor and template-watch helpers; the resume-facts and freeze helpers with their tests.

No lifecycle path changes and the daemon does not advertise the wake capability, so a host running this behaves exactly as today. The pause, resume, restore and recovery wiring follows in its own PR, switches off.