### PR TITLE
feat(infra): add shared Terraform module for hosted QM

### DIFF
--- a/infra/envs/staging/us-central1/.terraform.lock.hcl
+++ b/infra/envs/staging/us-central1/.terraform.lock.hcl
@@ -21,3 +21,26 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:ff18322b786ad6216ee3aebb02e6374223eaa16b5f181109089786128718afc3",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.1"
+  constraints = ">= 3.5.0"
+  hashes = [
+    "h1:PYbnOqRuGn4c0/Ae1f7yOS/0zvmXNHFJRZjuF4KECnM=",
+    "h1:PlW+UZ4EElQF3NQwf41KQwavFujab3Czc51zu9dyVM8=",
+    "h1:g40qr7yDmIpaur4SsK5BcOda3HSo1RJ6zHVMqN4EJ+0=",
+    "zh:05f4734c1f0be840b711b3eff259ebc5fca436784c728955b1678078466f48d7",
+    "zh:0b91bf19371d012434eba1deeb6aab77158def9b39601dcbd94450b3974a2a26",
+    "zh:0ee6eacd47ec00183d55d726a4b6c4ce951a199f944bf22f1aa58392ebdfa7a2",
+    "zh:19388a4074b76a89a43a6c8328d7ae8ee2e7de3d346af51e80d3e6d3d12925f1",
+    "zh:23e74d48c5e2ac2e823fd527f49fee9db37d32a1990c9e3bf126ead697b843eb",
+    "zh:3cabf7fbd096c520064aae3aba61aba670af83ab91291a71fa1b1332929c2b7f",
+    "zh:5c0a3b8af0be60be4eca12ddee385cfa8babc1ec8e98cdf9de2f2274c73eabfa",
+    "zh:60b4f8a8ef18f52bf8e19215229dae408bee732825964092db7c989fd2de4097",
+    "zh:7359015acfedcbd6366f2329c854cf8d3c8ca5cd0faa89d2d37db358d6eba6c5",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b38758402f0e13a1071162da28994023cd2ac676e54af350c9ffd8dfa73fa7b",
+    "zh:7c7fbb8895eb75bb4de1f933e98553bd99c8d048c89a925ddba490aa5a67f7dc",
+    "zh:8c2b8c6a7ccdec16b73e2fb9f3700ea097f58c592571e4c5de60c93d2301732c",
+  ]
+}

--- a/infra/envs/staging/us-central1/main.tf
+++ b/infra/envs/staging/us-central1/main.tf
@@ -25,6 +25,15 @@ locals {
   region          = var.region
   zone            = var.zone
   resource_suffix = coalesce(var.resource_suffix, var.environment)
+  # Used by the qm module only; the existing staging accounts predate the
+  # suffix convention and keep their imported names.
+  service_account_suffix = coalesce(var.service_account_suffix, local.resource_suffix)
+
+  # deploy-qm-api.yml pushes the qm-api image (service and provisioner job
+  # share it) to the existing superserve repository; the placeholder tags
+  # below are overridden by qm_*_image in terraform.tfvars before the first
+  # apply. Tenant images live in the qm-<suffix> repository the module creates.
+  qm_image_prefix = "${local.region}-docker.pkg.dev/${local.project_id}/superserve"
 
   common_labels = {
     environment = local.environment
@@ -670,5 +679,54 @@ module "backup_storage" {
 
   labels = merge(local.common_labels, {
     component = "backup"
+  })
+}
+
+# Hosted QM shared infrastructure (Cloud SQL, wildcard edge, provisioner and
+# qm-api identities and workloads). Off by default so the standing staging
+# plan is unchanged; enable_qm plus the qm_* values in terraform.tfvars turn
+# it on. The provisioner creates per-tenant resources at runtime; nothing
+# tenant-specific is declared here.
+module "qm" {
+  source = "../../../modules/qm"
+  count  = var.enable_qm ? 1 : 0
+
+  project_id             = local.project_id
+  environment            = local.environment
+  region                 = local.region
+  resource_suffix        = local.resource_suffix
+  service_account_suffix = local.service_account_suffix
+
+  domain        = var.qm_domain
+  marketing_url = var.qm_marketing_url
+
+  # Matches deploy/environments.yaml and the deploy workflow's QM_API_SERVICE
+  # variable; staging's existing services carry no suffix either.
+  api_service_name = "superserve-qm-api"
+
+  # Cloud SQL private IP peers with the staging VPC; qm-api and the
+  # provisioner reach it over Direct VPC egress on the primary subnet (the
+  # staging Cloud Run connector is ip_cidr_range mode and has no subnet of
+  # its own). Tagged so firewall rules can select this traffic separately
+  # from the connector's 10.8.0.0/28 range.
+  network_self_link = module.network.network_self_link
+  vpc_network       = module.network.network_name
+  vpc_subnetwork    = module.network.subnetwork_name
+  vpc_tags          = ["qm-cr"]
+
+  create_private_service_connection = var.qm_create_private_service_connection
+
+  sql_tier          = var.qm_sql_tier
+  api_min_instances = var.qm_api_min_instances
+
+  api_image         = coalesce(var.qm_api_image, "${local.qm_image_prefix}/qm-api:replace-me")
+  provisioner_image = var.qm_provisioner_image
+  redirect_image    = coalesce(var.qm_redirect_image, "${local.qm_image_prefix}/qm-redirect:replace-me")
+  tenant_image      = var.qm_tenant_image
+
+  dns_managed_zone = var.qm_dns_managed_zone
+
+  labels = merge(local.common_labels, {
+    component = "qm"
   })
 }

--- a/infra/envs/staging/us-central1/outputs.tf
+++ b/infra/envs/staging/us-central1/outputs.tf
@@ -26,3 +26,13 @@ output "supabase" {
     database_url_secret_name = coalesce(var.database_url_secret_name, "database-url-${coalesce(var.resource_suffix, var.environment)}")
   }
 }
+
+output "qm_contract" {
+  description = "Rendered QM shared-infrastructure contract; null while enable_qm is false."
+  value       = one(module.qm[*].contract)
+}
+
+output "qm_dns_authorization" {
+  description = "DNS record to publish for the QM wildcard certificate; null while enable_qm is false."
+  value       = one(module.qm[*].dns_authorization)
+}

--- a/infra/envs/staging/us-central1/terraform.tfvars
+++ b/infra/envs/staging/us-central1/terraform.tfvars
@@ -9,3 +9,16 @@ database_url_secret_name              = "database-url-staging"
 internal_api_token_secret_name        = "internal-api-token-staging"
 sandbox_access_token_seed_secret_name = "sandbox-access-token-seed-staging"
 secrets_signing_key_secret_name       = "secretsproxy-signing-key-staging"
+
+# Hosted QM shared infrastructure (module qm). Disabled by default; set the
+# images to tags that exist in the tenant image repository before enabling.
+# enable_qm                            = true
+# qm_domain                            = "qm.staging.superserve.ai"
+# qm_marketing_url                     = "https://superserve.ai"
+# qm_api_image                         = "us-central1-docker.pkg.dev/rayai-dev/superserve/qm-api:<sha>"
+# qm_redirect_image                    = "us-central1-docker.pkg.dev/rayai-dev/superserve/qm-redirect:<tag>"
+# qm_tenant_image                      = "us-central1-docker.pkg.dev/rayai-dev/qm-staging-usc1/qm:<tag>"
+# qm_api_min_instances                 = 1
+# qm_sql_tier                          = "db-custom-2-7680"
+# qm_create_private_service_connection = true
+# qm_dns_managed_zone                  = null

--- a/infra/envs/staging/us-central1/variables.tf
+++ b/infra/envs/staging/us-central1/variables.tf
@@ -75,3 +75,69 @@ variable "system_team_id_secret_name" {
   type        = string
   default     = null
 }
+
+variable "enable_qm" {
+  description = "Create the hosted QM shared infrastructure (module qm). Off by default so the standing plan is a no-op."
+  type        = bool
+  default     = false
+}
+
+variable "qm_domain" {
+  description = "Base hostname for QM tenant stacks (qm.<env-domain>); tenants are served at https://<slug>.<qm_domain>. Required when enable_qm is true."
+  type        = string
+  default     = null
+}
+
+variable "qm_marketing_url" {
+  description = "Where the QM redirect service sends a bare request for /."
+  type        = string
+  default     = "https://superserve.ai"
+}
+
+variable "qm_api_image" {
+  description = "qm-api container image. Must exist before the first apply; null keeps a placeholder that Cloud Run will reject."
+  type        = string
+  default     = null
+}
+
+variable "qm_provisioner_image" {
+  description = "Provisioner job container image. Null uses qm_api_image: the service and the job are the same binary and deploy together."
+  type        = string
+  default     = null
+}
+
+variable "qm_tenant_image" {
+  description = "Tagged QM image the provisioner deploys for new tenants (QM_TENANT_IMAGE). Null uses <tenant repository>/qm:latest."
+  type        = string
+  default     = null
+}
+
+variable "qm_redirect_image" {
+  description = "qm-redirect container image. Same existence requirement as qm_api_image."
+  type        = string
+  default     = null
+}
+
+variable "qm_api_min_instances" {
+  description = "qm-api minimum instance count."
+  type        = number
+  default     = 0
+}
+
+variable "qm_sql_tier" {
+  description = "Cloud SQL tier for the shared QM tenant instance."
+  type        = string
+  default     = "db-custom-2-7680"
+}
+
+variable "qm_create_private_service_connection" {
+  description = "Whether the qm module allocates the Private Service Access range and peering on the staging VPC. Set false if the VPC already has a servicenetworking connection and add the QM range to it out of band."
+  type        = bool
+  default     = true
+}
+
+variable "qm_dns_managed_zone" {
+  description = "Cloud DNS managed zone (in this project) owning qm_domain, if Terraform should write the certificate authorization and load balancer records. Null leaves DNS to the zone owner."
+  type        = string
+  default     = null
+}

--- a/infra/modules/qm/README.md
+++ b/infra/modules/qm/README.md
@@ -56,6 +56,15 @@ resources, slug validation on the Go side must reserve at least `api`,
 module names `qm-<word>`), or a tenant could collide with `qm-api-*`,
 `qm-sql-admin-*`, or `qm-tenants-<suffix>`.
 
+It must also bound slug length. Terraform never fills `{slug}`, so the module
+computes the budget from its own prefixes and exports it as the
+`tenant_slug_max_length` output and `QM_TENANT_SLUG_MAX_LENGTH`: the smallest
+of the bucket (`<project>-qm-<slug>`, 63), service account (`qm-<slug>`, 30),
+Cloud Run service (`qm-<slug>`, 49) and database (`qm_<slug>`, 63) limits. The
+service account is normally the binding one; a long project ID makes it the
+bucket. Enforce that value rather than recomputing it, or a long slug fails
+partway through a provision with some resources already created.
+
 ## Deletion safety
 
 Every tenant's database is on the one `qm-tenants-<suffix>` instance, so it
@@ -67,6 +76,10 @@ apply starts, which is also what catches a *replacement* — a changed
 the other two flags do not make that obvious). Removing the instance is
 deliberately three changes: drop `prevent_destroy`, set both
 `deletion_protection` flags to false and apply, then remove the resource.
+
+The qm-api Cloud Run service carries Cloud Run deletion protection as well, so
+set `api_deletion_protection = false` and apply before removing the module or
+setting `enable_qm` back to false; otherwise the destroy fails on the service.
 
 Backups are on by default: daily automated backups at `sql_backup_start_time`
 with `sql_backup_retained_count` (14) retained, plus point-in-time recovery

--- a/infra/modules/qm/README.md
+++ b/infra/modules/qm/README.md
@@ -56,6 +56,27 @@ resources, slug validation on the Go side must reserve at least `api`,
 module names `qm-<word>`), or a tenant could collide with `qm-api-*`,
 `qm-sql-admin-*`, or `qm-tenants-<suffix>`.
 
+## Deletion safety
+
+Every tenant's database is on the one `qm-tenants-<suffix>` instance, so it
+carries three independent guards: `deletion_protection` (Terraform refuses the
+delete call), `settings.deletion_protection_enabled` (the API refuses it from
+the console and `gcloud` too), and `prevent_destroy` (the plan fails before an
+apply starts, which is also what catches a *replacement* — a changed
+`resource_suffix`, `region`, or `private_network` plans destroy-then-create and
+the other two flags do not make that obvious). Removing the instance is
+deliberately three changes: drop `prevent_destroy`, set both
+`deletion_protection` flags to false and apply, then remove the resource.
+
+Backups are on by default: daily automated backups at `sql_backup_start_time`
+with `sql_backup_retained_count` (14) retained, plus point-in-time recovery
+with `sql_transaction_log_retention_days` (7) of write-ahead log.
+
+Note that `prevent_destroy` also applies to turning the module off again:
+once `enable_qm` has been applied as true, flipping it back to false fails at
+plan time. That is intentional for an instance holding tenant data, and the
+teardown above is the way through it.
+
 ## Connection sizing
 
 `max_connections` on the instance is

--- a/infra/modules/qm/README.md
+++ b/infra/modules/qm/README.md
@@ -65,6 +65,25 @@ service account is normally the binding one; a long project ID makes it the
 bucket. Enforce that value rather than recomputing it, or a long slug fails
 partway through a provision with some resources already created.
 
+## One environment per project
+
+The per-tenant names the provisioner derives — `qm-<slug>` service account and
+Cloud Run service, `<project>-qm-<slug>` bucket, `qm-<slug>-<name>` secrets —
+carry no `resource_suffix`, and service accounts, buckets and secrets are all
+project-global. Two instances of this module in one project would therefore
+collide on any slug they both provision, and the prefix-conditioned IAM grants
+would let each environment's qm-api read the other's tenant secrets. Platform
+secrets (`qm-sql-admin-*`, `qm-api-database-url-*`) are excluded from those
+grants for exactly that reason, but tenant secrets cannot be without a suffix
+in the name.
+
+So: one enabled QM environment per GCP project. Staging is in `rayai-dev` and
+production in `rayai-prod`, which satisfies that today. Putting a second one
+in either project means adding `resource_suffix` to the tenant naming in
+`internal/qm/provisioner/steps` and `internal/qm/secrets` first, then to the
+prefixes in `main.tf` and the IAM conditions in `iam.tf` together — the Go
+side and this module have to agree on those names.
+
 ## Deletion safety
 
 Every tenant's database is on the one `qm-tenants-<suffix>` instance, so it
@@ -170,6 +189,8 @@ Before `tenant_capacity` approaches that, request an increase for the IAM API
 
 Later qm-api image rollouts are owned by deploy tooling (`deploy-qm-api.yml`
 updates the service and the job to the same SHA), so Terraform ignores image
-drift on those two, matching the `api` module. The redirect service has no
+drift on those two, matching the `api` module. That workflow lands with the
+qm-api change, not with this module; until it does there is nothing to enable
+`enable_qm` for, which is why the flag ships off. The redirect service has no
 deploy-tooling path, so Terraform owns its image: change `redirect_image` and
 apply to roll it.

--- a/infra/modules/qm/README.md
+++ b/infra/modules/qm/README.md
@@ -168,6 +168,8 @@ Before `tenant_capacity` approaches that, request an increase for the IAM API
    add the version, then apply the rest.
 5. **Service-account quota** as above, before onboarding tenants at scale.
 
-Later image rollouts are owned by deploy tooling (`deploy-qm-api.yml` updates
-the service and the job to the same SHA): Terraform ignores image drift on
-all three workloads, matching the `api` module.
+Later qm-api image rollouts are owned by deploy tooling (`deploy-qm-api.yml`
+updates the service and the job to the same SHA), so Terraform ignores image
+drift on those two, matching the `api` module. The redirect service has no
+deploy-tooling path, so Terraform owns its image: change `redirect_image` and
+apply to roll it.

--- a/infra/modules/qm/README.md
+++ b/infra/modules/qm/README.md
@@ -1,0 +1,139 @@
+# qm
+
+Shared, tenant-independent infrastructure for hosted QM. One instance per
+environment, in the same GCP project as the rest of the platform. The
+consumer is `cmd/qm-api`: the Cloud Run service serves `/v1/qm`, and the
+same binary runs as the provisioner job (`qm-api provision`) for one tenant
+per execution.
+
+## Shared vs per-tenant
+
+Terraform (this module) owns:
+
+- the Cloud SQL Postgres 16 instance `qm-tenants-<suffix>` (private IP on the
+  environment VPC, automated backups, point-in-time recovery, deletion
+  protection) and its admin role
+- the admin password in Secret Manager (`qm-sql-admin-<suffix>`, readable
+  only by the provisioner) and the empty `qm-api-database-url-<suffix>` secret
+  both workloads read `DATABASE_URL` from
+- the wildcard edge: DNS authorization, managed certificate for `<domain>` and
+  `*.<domain>`, certificate map, global HTTPS load balancer with the
+  `qm-redirect` service as its default route, and the `:80` to `:443` redirect
+- the provisioner, qm-api and redirect service accounts and their grants
+- the qm-api Cloud Run service, the provisioner Cloud Run job, and the
+  `qm-redirect` Cloud Run service
+- the `qm-<suffix>` Artifact Registry repository tenant images are pulled
+  from, and the fleet-default tenant image (`tenant_image`, exported as
+  `QM_TENANT_IMAGE`)
+- Cloud DNS records for the authorization, apex and wildcard, only when
+  `dns_managed_zone` is set
+
+The tenant registry (tenants, runs, secret refs) is a set of tables in the
+control-plane Postgres, reached as the `qm_api` role; it is not on the Cloud
+SQL instance here, which holds only tenant databases.
+
+The provisioner job creates, at runtime and outside Terraform state, for each
+tenant `<slug>` (names from `internal/qm/provisioner/steps`):
+
+- a Cloud Run service `qm-<slug>` running the tenant image as its own
+  `qm-<slug>` service account
+- a database `qm_<slug>` and role on the shared instance, through the SQL
+  Admin API
+- a bucket `<project>-qm-<slug>` in `tenant_bucket_location`, with the
+  lifecycle policy from `tenant_bucket_lifecycle_policy_json` and bucket IAM
+  for the tenant account
+- `qm-<slug>-<name>` secrets (qm-api itself writes the model key a tenant
+  hands it before the run starts)
+- a serverless NEG, backend service, and host rule on the shared URL map so
+  `https://<slug>.<domain>` reaches the tenant service. Terraform ignores
+  `host_rule` and `path_matcher` on the URL map for this reason.
+
+There is deliberately no shared tenant runtime service account.
+
+Because tenant names share the `qm-` / `qm_` prefixes with the platform's own
+resources, slug validation on the Go side must reserve at least `api`,
+`redirect`, `provisioner`, `sql`, and `tenants` (and anything else this
+module names `qm-<word>`), or a tenant could collide with `qm-api-*`,
+`qm-sql-admin-*`, or `qm-tenants-<suffix>`.
+
+## Connection sizing
+
+`max_connections` on the instance is
+
+```
+tenant_capacity x sql_connections_per_tenant x sql_connection_headroom
+= 25 x 17 x 1.3 = 552.5, rounded up to the 560 default
+```
+
+17 is one QM container's steady-state pool plus workers; 1.3 leaves room for
+the provisioner, migrations, and operator sessions. A `check` block warns
+when `sql_max_connections` falls below the formula for the configured
+`tenant_capacity`. Raise `sql_tier` with the flag: the default
+`db-custom-2-7680` is sized for the default, not for a much larger fleet.
+
+## Service-account quota
+
+Every tenant adds a `qm-<slug>` service account. A project's default quota
+is 100 service accounts, and the platform's own accounts count against it.
+Before `tenant_capacity` approaches that, request an increase for the IAM API
+"Service accounts" quota on the project (IAM & Admin > Quotas, service
+`iam.googleapis.com`). Terraform cannot raise it.
+
+## IAM scoping
+
+- Secret Manager: `roles/secretmanager.admin` (provisioner) and
+  `roles/secretmanager.secretAccessor` + `secretVersionAdder` (qm-api) are
+  project-level bindings with a `resource.name` condition limited to `qm-*`
+  secrets; qm-api's conditions additionally exclude `qm-sql-admin-*`.
+- Buckets: a custom role with bucket-level permissions plus object
+  list/delete for teardown (no object read), conditioned on the
+  `<project>-qm-` name prefix.
+- Create permissions (`storage.buckets.create`, `secretmanager.secrets.create`)
+  are evaluated against the project, so they cannot be conditioned on the
+  eventual name; they sit in separate unconditional custom roles (one for
+  the provisioner, one with secret creation only for qm-api).
+- Cloud SQL: a project-level custom role with database and user create,
+  update, delete, list and instance get. Cloud SQL has no instance-level
+  IAM, so it cannot be narrowed to the QM instance.
+- `run.admin`, `cloudsql.client`, `compute.loadBalancerAdmin`,
+  `iam.serviceAccountAdmin`, and `iam.serviceAccountUser` are project-level.
+  `serviceAccountUser` is the broadest; the follow-up if it needs to shrink is
+  for the provisioner to grant itself `actAs` per tenant account after
+  creating it.
+- `roles/compute.networkUser` is granted on the Direct VPC egress subnet only,
+  so the provisioner can deploy tenant services onto it.
+- qm-api gets `roles/run.jobsExecutorWithOverrides` (the trigger passes the
+  team, tenant and mode as container args) and `roles/run.viewer` on the
+  provisioner job only.
+
+## Apply order
+
+1. **Images.** `deploy-qm-api.yml` pushes the qm-api image (service and job
+   share it) to the existing `superserve` repository; set `api_image` to a
+   tag that exists there, and `redirect_image` likewise. Cloud Run rejects a
+   revision whose image cannot be pulled, so placeholders fail the apply.
+   Tenant images go in the `qm-<suffix>` repository this module creates; on a
+   brand-new environment apply it first with `-target` on
+   `google_artifact_registry_repository.tenant_images`, push, then continue.
+2. **Private Service Access.** If the VPC already has a servicenetworking
+   connection, set `create_private_service_connection = false` and add a
+   reserved range for QM to that connection out of band; otherwise the module
+   creates both.
+3. **Certificate DNS authorization.** Apply. Publish the CNAME from the
+   `dns_authorization` output (done automatically when `dns_managed_zone` is
+   set) before expecting the certificate to become `ACTIVE`; the load balancer
+   serves nothing until it does. Then point `<domain>` and `*.<domain>` at the
+   `address` output.
+4. **`qm_api` role and `DATABASE_URL`.** The role and its grants come from
+   the control-plane schema migrations; its password is set out of band.
+   Add a version to `qm-api-database-url-<suffix>` with the control-plane
+   connection string for that role. Both the qm-api service and the
+   provisioner job mount this secret, and neither will start until the
+   version exists, so on a first apply create the secrets first
+   (`-target=module.qm[0].google_secret_manager_secret.api_database_url`),
+   add the version, then apply the rest.
+5. **Service-account quota** as above, before onboarding tenants at scale.
+
+Later image rollouts are owned by deploy tooling (`deploy-qm-api.yml` updates
+the service and the job to the same SHA): Terraform ignores image drift on
+all three workloads, matching the `api` module.

--- a/infra/modules/qm/edge.tf
+++ b/infra/modules/qm/edge.tf
@@ -14,6 +14,18 @@ resource "google_certificate_manager_dns_authorization" "this" {
   domain   = var.domain
   labels   = var.labels
 
+  # The first resource to consume var.domain, so an unset domain stops here
+  # with a readable message instead of a null interpolation failure inside the
+  # certificate. A precondition rather than a variable validation because the
+  # root's qm_domain is legitimately null while enable_qm is false, and
+  # preconditions are only evaluated for module instances that exist.
+  lifecycle {
+    precondition {
+      condition     = var.domain != null && var.domain != ""
+      error_message = "domain must be set when the qm module is enabled: tenant hostnames, the wildcard certificate, and the redirect service are all derived from it."
+    }
+  }
+
   depends_on = [google_project_service.required]
 }
 

--- a/infra/modules/qm/edge.tf
+++ b/infra/modules/qm/edge.tf
@@ -1,0 +1,191 @@
+# Wildcard edge for tenant hostnames. Mirrors cloud-run-cert-lb (serverless
+# NEG -> backend -> URL map -> HTTPS proxy with a Certificate Manager map) but
+# the URL map's per-tenant host rules and their serverless NEGs are added by
+# the provisioner at runtime, so Terraform owns only the default route and
+# ignores host_rule/path_matcher drift. cloud-run-lb's :80 -> :443 redirect is
+# kept so a bare http://<slug>.<domain> still lands somewhere useful.
+
+# A single DNS authorization for <domain> covers both <domain> and *.<domain>
+# in a managed certificate, so tenant hostnames need no per-tenant issuance.
+resource "google_certificate_manager_dns_authorization" "this" {
+  project  = var.project_id
+  location = "global"
+  name     = "${local.name}-dnsauth"
+  domain   = var.domain
+  labels   = var.labels
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_certificate_manager_certificate" "wildcard" {
+  project  = var.project_id
+  location = "global"
+  name     = "${local.name}-wildcard"
+  labels   = var.labels
+
+  managed {
+    domains            = [var.domain, "*.${var.domain}"]
+    dns_authorizations = [google_certificate_manager_dns_authorization.this.id]
+  }
+}
+
+resource "google_certificate_manager_certificate_map" "this" {
+  project = var.project_id
+  name    = local.name
+  labels  = var.labels
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_certificate_manager_certificate_map_entry" "wildcard" {
+  project      = var.project_id
+  name         = "${local.name}-wildcard"
+  map          = google_certificate_manager_certificate_map.this.name
+  hostname     = "*.${var.domain}"
+  certificates = [google_certificate_manager_certificate.wildcard.id]
+  labels       = var.labels
+}
+
+resource "google_certificate_manager_certificate_map_entry" "apex" {
+  project      = var.project_id
+  name         = "${local.name}-apex"
+  map          = google_certificate_manager_certificate_map.this.name
+  hostname     = var.domain
+  certificates = [google_certificate_manager_certificate.wildcard.id]
+  labels       = var.labels
+}
+
+resource "google_compute_global_address" "edge" {
+  project = var.project_id
+  name    = "${local.name}-edge"
+  labels  = var.labels
+}
+
+resource "google_compute_region_network_endpoint_group" "redirect" {
+  project               = var.project_id
+  name                  = "${local.name}-redirect"
+  region                = var.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.redirect.name
+  }
+}
+
+resource "google_compute_backend_service" "redirect" {
+  project               = var.project_id
+  name                  = "${local.name}-redirect"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  timeout_sec           = var.backend_timeout_sec
+
+  backend {
+    group = google_compute_region_network_endpoint_group.redirect.id
+  }
+}
+
+# Default route only. Tenant host rules (<slug>.<domain> -> that tenant's
+# backend service) are appended by the provisioner with
+# compute.loadBalancerAdmin; a Terraform apply must never strip them.
+resource "google_compute_url_map" "https" {
+  project         = var.project_id
+  name            = "${local.name}-https"
+  default_service = google_compute_backend_service.redirect.id
+
+  lifecycle {
+    ignore_changes = [
+      host_rule,
+      path_matcher,
+    ]
+  }
+}
+
+resource "google_compute_url_map" "http_redirect" {
+  project = var.project_id
+  name    = "${local.name}-http-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+resource "google_compute_target_https_proxy" "this" {
+  project = var.project_id
+  name    = "${local.name}-https"
+  url_map = google_compute_url_map.https.id
+  # Same versioned resource URL form cloud-run-cert-lb uses; the API stores
+  # the map reference that way and a bare .id would plan a perpetual diff.
+  certificate_map = "https://certificatemanager.googleapis.com/v1/${google_certificate_manager_certificate_map.this.id}"
+}
+
+resource "google_compute_target_http_proxy" "redirect" {
+  project = var.project_id
+  name    = "${local.name}-http"
+  url_map = google_compute_url_map.http_redirect.id
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  project               = var.project_id
+  name                  = "${local.name}-https"
+  ip_address            = google_compute_global_address.edge.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  network_tier          = "PREMIUM"
+  target                = google_compute_target_https_proxy.this.id
+  labels                = var.labels
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  project               = var.project_id
+  name                  = "${local.name}-http"
+  ip_address            = google_compute_global_address.edge.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  network_tier          = "PREMIUM"
+  target                = google_compute_target_http_proxy.redirect.id
+  labels                = var.labels
+}
+
+# Cloud DNS, only when the environment's zone lives in this project and is
+# passed in. The authorization CNAME must resolve before Certificate Manager
+# will issue, which is why the README applies the edge in two steps when DNS
+# is managed elsewhere.
+locals {
+  manage_dns               = var.dns_managed_zone != null
+  dns_authorization_record = try(google_certificate_manager_dns_authorization.this.dns_resource_record[0], null)
+}
+
+resource "google_dns_record_set" "dns_authorization" {
+  count = local.manage_dns ? 1 : 0
+
+  project      = var.project_id
+  managed_zone = var.dns_managed_zone
+  name         = local.dns_authorization_record.name
+  type         = local.dns_authorization_record.type
+  ttl          = var.dns_ttl
+  rrdatas      = [local.dns_authorization_record.data]
+}
+
+resource "google_dns_record_set" "apex" {
+  count = local.manage_dns ? 1 : 0
+
+  project      = var.project_id
+  managed_zone = var.dns_managed_zone
+  name         = "${var.domain}."
+  type         = "A"
+  ttl          = var.dns_ttl
+  rrdatas      = [google_compute_global_address.edge.address]
+}
+
+resource "google_dns_record_set" "wildcard" {
+  count = local.manage_dns ? 1 : 0
+
+  project      = var.project_id
+  managed_zone = var.dns_managed_zone
+  name         = "*.${var.domain}."
+  type         = "A"
+  ttl          = var.dns_ttl
+  rrdatas      = [google_compute_global_address.edge.address]
+}

--- a/infra/modules/qm/iam.tf
+++ b/infra/modules/qm/iam.tf
@@ -44,8 +44,11 @@ locals {
   # to the tenant prefixes. Project-level create permissions are checked
   # against the project itself, where a name prefix cannot match, so those
   # live in an unconditional custom role that carries nothing else.
-  secret_name_prefix           = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
-  sql_admin_secret_name_prefix = "projects/${local.project_number}/secrets/${local.sql_admin_secret_id}"
+  secret_name_prefix = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
+  # Every environment's admin secret, not just this one's: two environments of
+  # this module in one project would otherwise leave each qm-api able to read
+  # the other's instance admin password, since the qm-* allow is project wide.
+  sql_admin_secret_name_prefix = "projects/${local.project_number}/secrets/${local.sql_admin_secret_prefix}"
   tenant_bucket_name_prefix    = "projects/_/buckets/${local.tenant_bucket_prefix}"
 
   # Shared by every qm-api secret grant that IAM evaluates against the secret
@@ -241,7 +244,7 @@ resource "google_project_iam_member" "api_secrets" {
 
   condition {
     title       = "qm secrets except sql admin"
-    description = "qm-* secrets only; the instance admin password stays with the provisioner."
+    description = "qm-* secrets only; instance admin passwords stay with the provisioner."
     expression  = local.api_secret_condition
   }
 }
@@ -284,7 +287,7 @@ resource "google_project_iam_member" "api_secret_delete" {
 
   condition {
     title       = "qm secrets except sql admin"
-    description = "qm-* secrets only; the instance admin password stays with the provisioner."
+    description = "qm-* secrets only; instance admin passwords stay with the provisioner."
     expression  = local.api_secret_condition
   }
 }

--- a/infra/modules/qm/iam.tf
+++ b/infra/modules/qm/iam.tf
@@ -47,6 +47,10 @@ locals {
   secret_name_prefix           = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
   sql_admin_secret_name_prefix = "projects/${local.project_number}/secrets/${local.sql_admin_secret_id}"
   tenant_bucket_name_prefix    = "projects/_/buckets/${local.tenant_bucket_prefix}"
+
+  # Shared by every qm-api secret grant that IAM evaluates against the secret
+  # itself, so accessor, version-adder and delete cannot drift apart.
+  api_secret_condition = "resource.name.startsWith(\"${local.secret_name_prefix}\") && !resource.name.startsWith(\"${local.sql_admin_secret_name_prefix}\")"
 }
 
 # Project-level roles the provisioner needs and that cannot be narrowed by
@@ -238,7 +242,7 @@ resource "google_project_iam_member" "api_secrets" {
   condition {
     title       = "qm secrets except sql admin"
     description = "qm-* secrets only; the instance admin password stays with the provisioner."
-    expression  = "resource.name.startsWith(\"${local.secret_name_prefix}\") && !resource.name.startsWith(\"${local.sql_admin_secret_name_prefix}\")"
+    expression  = local.api_secret_condition
   }
 }
 
@@ -256,6 +260,33 @@ resource "google_project_iam_member" "api_secret_create" {
   project = var.project_id
   role    = google_project_iam_custom_role.api_secret_create.id
   member  = local.api_member
+}
+
+# qm-api stores a tenant's model key before the run starts and deletes it again
+# when it cannot record the reference (internal/qm handlers roll the Put back
+# on a failed SetSecretRef). secrets.delete is carried by neither
+# secretAccessor nor secretVersionAdder, and without it that rollback fails
+# with PERMISSION_DENIED and leaves an unreferenced credential in the project.
+# Unlike create, delete is evaluated against the secret, so it takes the same
+# condition as the grants above rather than an unconditional role.
+resource "google_project_iam_custom_role" "api_secret_delete" {
+  project     = var.project_id
+  role_id     = "qmApiSecretDelete_${local.custom_role_suffix}"
+  title       = "QM API secret delete (${var.environment})"
+  description = "Delete a qm-* tenant secret qm-api created but could not record."
+  permissions = ["secretmanager.secrets.delete"]
+}
+
+resource "google_project_iam_member" "api_secret_delete" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.api_secret_delete.id
+  member  = local.api_member
+
+  condition {
+    title       = "qm secrets except sql admin"
+    description = "qm-* secrets only; the instance admin password stays with the provisioner."
+    expression  = local.api_secret_condition
+  }
 }
 
 # Explicit secret-level grant for DATABASE_URL in addition to the conditional

--- a/infra/modules/qm/iam.tf
+++ b/infra/modules/qm/iam.tf
@@ -44,16 +44,26 @@ locals {
   # to the tenant prefixes. Project-level create permissions are checked
   # against the project itself, where a name prefix cannot match, so those
   # live in an unconditional custom role that carries nothing else.
-  secret_name_prefix = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
-  # Every environment's admin secret, not just this one's: two environments of
-  # this module in one project would otherwise leave each qm-api able to read
-  # the other's instance admin password, since the qm-* allow is project wide.
-  sql_admin_secret_name_prefix = "projects/${local.project_number}/secrets/${local.sql_admin_secret_prefix}"
-  tenant_bucket_name_prefix    = "projects/_/buckets/${local.tenant_bucket_prefix}"
+  secret_name_prefix        = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
+  tenant_bucket_name_prefix = "projects/_/buckets/${local.tenant_bucket_prefix}"
+
+  # The qm-* allow below is project wide, so it would otherwise reach the
+  # platform secrets of every environment of this module in the project, not
+  # just this one's: another environment's instance admin password and
+  # control-plane DATABASE_URL. qm-api holds an explicit secret-level accessor
+  # binding on its own DATABASE_URL, so excluding the whole family costs it
+  # nothing.
+  platform_secret_exclusions = [
+    for prefix in local.platform_secret_prefixes :
+    "!resource.name.startsWith(\"projects/${local.project_number}/secrets/${prefix}\")"
+  ]
 
   # Shared by every qm-api secret grant that IAM evaluates against the secret
   # itself, so accessor, version-adder and delete cannot drift apart.
-  api_secret_condition = "resource.name.startsWith(\"${local.secret_name_prefix}\") && !resource.name.startsWith(\"${local.sql_admin_secret_name_prefix}\")"
+  api_secret_condition = join(" && ", concat(
+    ["resource.name.startsWith(\"${local.secret_name_prefix}\")"],
+    local.platform_secret_exclusions,
+  ))
 }
 
 # Project-level roles the provisioner needs and that cannot be narrowed by
@@ -243,8 +253,8 @@ resource "google_project_iam_member" "api_secrets" {
   member  = local.api_member
 
   condition {
-    title       = "qm secrets except sql admin"
-    description = "qm-* secrets only; instance admin passwords stay with the provisioner."
+    title       = "qm tenant secrets only"
+    description = "qm-* secrets except the platform ones; qm-api reaches its own DATABASE_URL through a secret-level binding instead."
     expression  = local.api_secret_condition
   }
 }
@@ -286,8 +296,8 @@ resource "google_project_iam_member" "api_secret_delete" {
   member  = local.api_member
 
   condition {
-    title       = "qm secrets except sql admin"
-    description = "qm-* secrets only; instance admin passwords stay with the provisioner."
+    title       = "qm tenant secrets only"
+    description = "qm-* secrets except the platform ones; qm-api reaches its own DATABASE_URL through a secret-level binding instead."
     expression  = local.api_secret_condition
   }
 }

--- a/infra/modules/qm/iam.tf
+++ b/infra/modules/qm/iam.tf
@@ -1,0 +1,287 @@
+# Identities. Two, deliberately: the provisioner holds the broad create-and-
+# grant permissions and serves no traffic; qm-api holds only what it needs to
+# read its own config, store the secrets a tenant hands it, and start
+# provisioner executions. There is no shared tenant runtime identity: every
+# tenant service runs as its own qm-<slug> account, created by the
+# provisioner, so a tenant container can reach only its own bucket and
+# secrets.
+#
+# Service-account quota: each tenant adds one account, and a project's default
+# quota is 100 service accounts. Before tenant_capacity gets within reach of
+# that (platform accounts count too), request an increase for the IAM API's
+# "Service accounts" quota on the project; the README has the step. Nothing
+# here can raise it.
+resource "google_service_account" "provisioner" {
+  project      = var.project_id
+  account_id   = "qm-provisioner-${var.service_account_suffix}"
+  display_name = "QM tenant provisioner (${var.environment})"
+  description  = "Runs the provisioner job: creates per-tenant Cloud Run services, databases, buckets, secrets, qm-<slug> service accounts, and load balancer host rules."
+}
+
+resource "google_service_account" "api" {
+  project      = var.project_id
+  account_id   = "qm-api-${var.service_account_suffix}"
+  display_name = "QM API (${var.environment})"
+  description  = "Runtime identity of the qm-api Cloud Run service."
+}
+
+resource "google_service_account" "redirect" {
+  project      = var.project_id
+  account_id   = "qm-redirect-${var.service_account_suffix}"
+  display_name = "QM redirect (${var.environment})"
+  description  = "Runtime identity of the qm-redirect Cloud Run service. Holds no grants."
+}
+
+locals {
+  provisioner_member = "serviceAccount:${google_service_account.provisioner.email}"
+  api_member         = "serviceAccount:${google_service_account.api.email}"
+
+  # Custom role IDs allow only [a-zA-Z0-9_.].
+  custom_role_suffix = replace(var.resource_suffix, "-", "_")
+
+  # IAM condition prefixes. Secret Manager and Cloud Storage both expose
+  # resource.name to conditions, so grants on existing resources can be held
+  # to the tenant prefixes. Project-level create permissions are checked
+  # against the project itself, where a name prefix cannot match, so those
+  # live in an unconditional custom role that carries nothing else.
+  secret_name_prefix           = "projects/${local.project_number}/secrets/${local.qm_secret_prefix}"
+  sql_admin_secret_name_prefix = "projects/${local.project_number}/secrets/${local.sql_admin_secret_id}"
+  tenant_bucket_name_prefix    = "projects/_/buckets/${local.tenant_bucket_prefix}"
+}
+
+# Project-level roles the provisioner needs and that cannot be narrowed by
+# resource name in a way that still lets it create things:
+#   run.admin              create/update/delete tenant services and jobs
+#   cloudsql.client        connect to the shared instance (private IP)
+#   compute.loadBalancerAdmin
+#                          append host rules, backend services and serverless
+#                          NEGs to the tenant URL map
+#   iam.serviceAccountAdmin
+#                          create qm-<slug> accounts and set their IAM
+#   iam.serviceAccountUser project-wide actAs, required to deploy a tenant
+#                          service as its qm-<slug> account. Not
+#                          conditioned: a qm- name-prefix condition would
+#                          have to match the resource name IAM evaluates for
+#                          service accounts, which is not guaranteed to be
+#                          the email form. The narrower shape, where the
+#                          provisioner grants itself actAs on each account
+#                          right after creating it (serviceAccountAdmin
+#                          allows that), is a runtime change for the Go side
+#                          and the follow-up if this grant needs to shrink.
+resource "google_project_iam_member" "provisioner" {
+  for_each = toset([
+    "roles/run.admin",
+    "roles/cloudsql.client",
+    "roles/compute.loadBalancerAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = local.provisioner_member
+}
+
+# Tenant databases and roles are created through the SQL Admin API
+# (internal/qm/provisioner/steps DatabaseAdmin), which needs database and
+# user permissions the client role does not carry. Cloud SQL has no
+# instance-level IAM and no resource-name conditions, so this is project
+# level; the custom role keeps it to databases and users, without instance
+# create/delete or settings changes.
+resource "google_project_iam_custom_role" "tenant_database_admin" {
+  project     = var.project_id
+  role_id     = "qmTenantDatabaseAdmin_${local.custom_role_suffix}"
+  title       = "QM tenant database admin (${var.environment})"
+  description = "Create and drop per-tenant databases and users on the shared Cloud SQL instance."
+  permissions = [
+    "cloudsql.instances.get",
+    "cloudsql.databases.create",
+    "cloudsql.databases.delete",
+    "cloudsql.databases.get",
+    "cloudsql.databases.list",
+    "cloudsql.users.create",
+    "cloudsql.users.delete",
+    "cloudsql.users.list",
+    "cloudsql.users.update",
+  ]
+}
+
+resource "google_project_iam_member" "provisioner_tenant_database_admin" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.tenant_database_admin.id
+  member  = local.provisioner_member
+}
+
+# Tenant services use Direct VPC egress on the same subnet as qm-api so they
+# can reach the private-only instance, and deploying a service onto a subnet
+# checks compute.subnetworks.use on the deployer. Scoped to that one subnet.
+resource "google_compute_subnetwork_iam_member" "provisioner_network_user" {
+  project    = var.project_id
+  region     = var.region
+  subnetwork = var.vpc_subnetwork
+  role       = "roles/compute.networkUser"
+  member     = local.provisioner_member
+}
+
+# Full Secret Manager control, but only over qm-* secrets: tenant secrets
+# (create versions, grant the tenant account accessor, delete on teardown)
+# and the shared qm-sql-admin secret.
+resource "google_project_iam_member" "provisioner_secret_admin" {
+  project = var.project_id
+  role    = "roles/secretmanager.admin"
+  member  = local.provisioner_member
+
+  condition {
+    title       = "qm secrets only"
+    description = "Limits Secret Manager admin to secrets named qm-*."
+    expression  = "resource.name.startsWith(\"${local.secret_name_prefix}\")"
+  }
+}
+
+# Bucket lifecycle for tenant buckets only: create, configure (lifecycle,
+# labels), set per-bucket IAM for the tenant account, delete on teardown.
+# Delete must empty the bucket first (BucketAdmin.Delete), hence the object
+# list/delete pair; no object read, so the provisioner never sees tenant data.
+resource "google_project_iam_custom_role" "tenant_bucket_admin" {
+  project     = var.project_id
+  role_id     = "qmTenantBucketAdmin_${local.custom_role_suffix}"
+  title       = "QM tenant bucket admin (${var.environment})"
+  description = "Bucket-level control over <project>-qm-* tenant buckets, plus object delete for teardown, without object read."
+  permissions = [
+    "storage.buckets.get",
+    "storage.buckets.update",
+    "storage.buckets.delete",
+    "storage.buckets.getIamPolicy",
+    "storage.buckets.setIamPolicy",
+    "storage.objects.list",
+    "storage.objects.delete",
+  ]
+}
+
+resource "google_project_iam_member" "provisioner_tenant_bucket_admin" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.tenant_bucket_admin.id
+  member  = local.provisioner_member
+
+  condition {
+    title       = "qm tenant buckets only"
+    description = "Limits bucket administration to buckets named <project>-qm-*."
+    expression  = "resource.name.startsWith(\"${local.tenant_bucket_name_prefix}\")"
+  }
+}
+
+# Create permissions are evaluated against the project, so they cannot be
+# conditioned on the eventual resource name. Kept in their own role so the
+# unconditional grant carries nothing else.
+resource "google_project_iam_custom_role" "provisioner_create" {
+  project     = var.project_id
+  role_id     = "qmProvisionerCreate_${local.custom_role_suffix}"
+  title       = "QM provisioner create (${var.environment})"
+  description = "Project-level create permissions for tenant buckets and secrets."
+  permissions = [
+    "storage.buckets.create",
+    "secretmanager.secrets.create",
+  ]
+}
+
+resource "google_project_iam_member" "provisioner_create" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.provisioner_create.id
+  member  = local.provisioner_member
+}
+
+resource "google_secret_manager_secret_iam_member" "provisioner_sql_admin" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.sql_admin.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.provisioner_member
+}
+
+# The conditional secretmanager.admin grant above already covers this; the
+# explicit binding is what the job depends on so a first apply orders the
+# grant before Cloud Run validates the mounted secret.
+resource "google_secret_manager_secret_iam_member" "provisioner_database_url" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.api_database_url.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.provisioner_member
+}
+
+resource "google_artifact_registry_repository_iam_member" "provisioner_reader" {
+  project    = var.project_id
+  location   = var.region
+  repository = google_artifact_registry_repository.tenant_images.name
+  role       = "roles/artifactregistry.reader"
+  member     = local.provisioner_member
+}
+
+# qm-api: read the shared instance, read and write qm-* secrets except the
+# admin credentials (it stores the model key a tenant hands it before the
+# provisioner runs: secrets.GCP.Put creates the secret and adds a version),
+# and start (and watch) provisioner executions.
+resource "google_project_iam_member" "api_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = local.api_member
+}
+
+resource "google_project_iam_member" "api_secrets" {
+  for_each = toset([
+    "roles/secretmanager.secretAccessor",
+    "roles/secretmanager.secretVersionAdder",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = local.api_member
+
+  condition {
+    title       = "qm secrets except sql admin"
+    description = "qm-* secrets only; the instance admin password stays with the provisioner."
+    expression  = "resource.name.startsWith(\"${local.secret_name_prefix}\") && !resource.name.startsWith(\"${local.sql_admin_secret_name_prefix}\")"
+  }
+}
+
+# Same project-level create caveat as the provisioner's role above; this one
+# carries only secret creation.
+resource "google_project_iam_custom_role" "api_secret_create" {
+  project     = var.project_id
+  role_id     = "qmApiSecretCreate_${local.custom_role_suffix}"
+  title       = "QM API secret create (${var.environment})"
+  description = "Project-level secret creation for tenant-supplied secrets."
+  permissions = ["secretmanager.secrets.create"]
+}
+
+resource "google_project_iam_member" "api_secret_create" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.api_secret_create.id
+  member  = local.api_member
+}
+
+# Explicit secret-level grant for DATABASE_URL in addition to the conditional
+# project grant above: Cloud Run checks the runtime account can read every
+# mounted secret at deploy time, and this is the binding the service depends
+# on so a first apply orders correctly.
+resource "google_secret_manager_secret_iam_member" "api_database_url" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.api_database_url.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.api_member
+}
+
+resource "google_cloud_run_v2_job_iam_member" "api_runs_provisioner" {
+  for_each = toset([
+    # run.jobs.run plus run.jobs.runWithOverrides: qm-api passes the tenant
+    # slug and action as per-execution overrides, which roles/run.invoker
+    # alone does not permit.
+    "roles/run.jobsExecutorWithOverrides",
+    # run.executions.get / list to follow an execution to completion
+    "roles/run.viewer",
+  ])
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_job.provisioner.name
+  role     = each.value
+  member   = local.api_member
+}

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -61,7 +61,11 @@ locals {
     63 - length("qm_"),
   )
 
-  sql_admin_secret_id        = "qm-sql-admin-${var.resource_suffix}"
+  # The prefix is shared with the IAM exclusion in iam.tf, which has to match
+  # every environment's admin secret rather than just this one's: several
+  # environments of this module can live in one project.
+  sql_admin_secret_prefix    = "qm-sql-admin-"
+  sql_admin_secret_id        = "${local.sql_admin_secret_prefix}${var.resource_suffix}"
   api_database_url_secret_id = "qm-api-database-url-${var.resource_suffix}"
 
   tenant_image_repository_id = local.name

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -1,0 +1,261 @@
+# Shared, tenant-independent infrastructure for hosted QM. One instance of this
+# module per environment owns everything a tenant stack depends on but does
+# not own: the Cloud SQL instance tenant databases live on, the wildcard edge
+# (certificate, certificate map, HTTPS load balancer), the provisioner and
+# qm-api identities, and the image repository tenant containers are pulled
+# from. Per-tenant resources (Cloud Run service, database + role, bucket,
+# qm-<slug> service account, URL-map host rule + serverless NEG) are created
+# at runtime by the provisioner job (cmd/qm-api provision) through the GCP
+# APIs and never appear in Terraform state. The tenant registry itself is a
+# set of tables in the control-plane Postgres, read as the qm_api role; the
+# Cloud SQL instance here holds only tenant databases.
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
+locals {
+  name           = "qm-${var.resource_suffix}"
+  project_number = data.google_project.this.number
+
+  sql_instance_name = "qm-tenants-${var.resource_suffix}"
+
+  # Per-tenant naming, mirroring internal/qm/provisioner/steps (ServiceName,
+  # BucketName, ServiceAccountID) and internal/qm/secrets (TenantSecretName).
+  # The IAM conditions in iam.tf are scoped to these prefixes, so a naming
+  # change on the Go side has to land here too.
+  tenant_service_account_prefix = "qm-"
+  tenant_bucket_prefix          = "${var.project_id}-qm-"
+  tenant_bucket_name_pattern    = "${local.tenant_bucket_prefix}{slug}"
+  tenant_bucket_location        = coalesce(var.tenant_bucket_location, var.region)
+  qm_secret_prefix              = "qm-"
+
+  sql_admin_secret_id        = "qm-sql-admin-${var.resource_suffix}"
+  api_database_url_secret_id = "qm-api-database-url-${var.resource_suffix}"
+
+  tenant_image_repository_id = local.name
+  tenant_image_repository    = "${var.region}-docker.pkg.dev/${var.project_id}/${local.tenant_image_repository_id}"
+
+  # Lifecycle rules in the JSON API shape (`{"rule": [...]}`) so the
+  # provisioner can hand them to buckets.patch or `gcloud storage buckets
+  # update --lifecycle-file` unchanged. Null condition fields are dropped so
+  # the API does not see them as explicit zero values.
+  lifecycle_condition_keys = {
+    age                        = "age"
+    days_since_noncurrent_time = "daysSinceNoncurrentTime"
+    num_newer_versions         = "numNewerVersions"
+    matches_prefix             = "matchesPrefix"
+    matches_storage_class      = "matchesStorageClass"
+  }
+  tenant_bucket_lifecycle_policy = {
+    rule = [
+      for rule in var.tenant_bucket_lifecycle_rules : {
+        action = merge(
+          { type = rule.action.type },
+          rule.action.storage_class == null ? {} : { storageClass = rule.action.storage_class },
+        )
+        condition = {
+          for key, value in rule.condition : local.lifecycle_condition_keys[key] => value
+          if value != null
+        }
+      }
+    ]
+  }
+
+  required_apis = [
+    "artifactregistry.googleapis.com",
+    "certificatemanager.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "sqladmin.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "required" {
+  for_each = toset(local.required_apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# Private Service Access for the Cloud SQL private IP. The peering is per VPC
+# and per service, so an environment whose VPC already carries a
+# servicenetworking connection must reuse it (create_private_service_connection
+# = false) rather than let this module fight over the reserved-range list.
+resource "google_compute_global_address" "private_service_range" {
+  count = var.create_private_service_connection ? 1 : 0
+
+  project       = var.project_id
+  name          = "${local.name}-psa"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = var.private_service_range_prefix_length
+  address       = var.private_service_range_address
+  network       = var.network_self_link
+  labels        = var.labels
+}
+
+resource "google_service_networking_connection" "private_service_access" {
+  count = var.create_private_service_connection ? 1 : 0
+
+  network                 = var.network_self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_range[0].name]
+  # The peering outlives this module: other Google services on the VPC may
+  # attach to it later, and deleting it while a Cloud SQL instance still
+  # holds an address in the range fails anyway.
+  deletion_policy = "ABANDON"
+
+  depends_on = [google_project_service.required]
+}
+
+check "sql_max_connections_covers_tenant_capacity" {
+  assert {
+    condition     = var.sql_max_connections >= ceil(var.tenant_capacity * var.sql_connections_per_tenant * var.sql_connection_headroom)
+    error_message = "sql_max_connections (${var.sql_max_connections}) is below tenant_capacity x sql_connections_per_tenant x sql_connection_headroom (${ceil(var.tenant_capacity * var.sql_connections_per_tenant * var.sql_connection_headroom)}). Raise the flag or lower tenant_capacity."
+  }
+}
+
+# One Postgres instance shared by every tenant: each tenant gets its own
+# database and role on it (created by the provisioner as sql_admin_user), not
+# its own instance. Private IP only, reached over Direct VPC egress.
+resource "google_sql_database_instance" "tenants" {
+  project             = var.project_id
+  name                = local.sql_instance_name
+  region              = var.region
+  database_version    = var.sql_database_version
+  deletion_protection = true
+
+  settings {
+    tier              = var.sql_tier
+    edition           = "ENTERPRISE"
+    availability_type = var.sql_availability_type
+    disk_type         = "PD_SSD"
+    disk_size         = var.sql_disk_size_gb
+    disk_autoresize   = true
+
+    # API-side guard in addition to Terraform's deletion_protection above:
+    # blocks deletion from the console and gcloud too.
+    deletion_protection_enabled = true
+
+    backup_configuration {
+      enabled                        = true
+      start_time                     = var.sql_backup_start_time
+      point_in_time_recovery_enabled = true
+      transaction_log_retention_days = var.sql_transaction_log_retention_days
+
+      backup_retention_settings {
+        retained_backups = var.sql_backup_retained_count
+        retention_unit   = "COUNT"
+      }
+    }
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = var.network_self_link
+      # TLS required, client certificates not: clients connect with
+      # sslmode=require over the private IP.
+      ssl_mode = "ENCRYPTED_ONLY"
+    }
+
+    # tenant_capacity x sql_connections_per_tenant x sql_connection_headroom;
+    # see the variable descriptions and README for the sizing formula.
+    database_flags {
+      name  = "max_connections"
+      value = tostring(var.sql_max_connections)
+    }
+
+    insights_config {
+      query_insights_enabled  = true
+      record_application_tags = true
+    }
+
+    user_labels = var.labels
+  }
+
+  depends_on = [
+    google_project_service.required,
+    google_service_networking_connection.private_service_access,
+  ]
+}
+
+resource "random_password" "sql_admin" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_user" "admin" {
+  project  = var.project_id
+  name     = var.sql_admin_user
+  instance = google_sql_database_instance.tenants.name
+  password = random_password.sql_admin.result
+}
+
+# Instance admin credentials, readable only by the provisioner (see iam.tf):
+# tenant databases and roles are created through the SQL Admin API, but
+# anything that has to run SQL against a tenant database from the job
+# (extensions, ownership fixes) connects as this role over the private IP.
+resource "google_secret_manager_secret" "sql_admin" {
+  project   = var.project_id
+  secret_id = local.sql_admin_secret_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret_version" "sql_admin" {
+  secret      = google_secret_manager_secret.sql_admin.id
+  secret_data = random_password.sql_admin.result
+}
+
+# DATABASE_URL for qm-api and the provisioner: the control-plane Postgres as
+# the qm_api role (the tenant registry lives there, not on the instance
+# above). Only the secret is managed here; the version is added out of band
+# once the role exists (see README apply order), and neither workload will
+# start a revision until it does.
+resource "google_secret_manager_secret" "api_database_url" {
+  project   = var.project_id
+  secret_id = local.api_database_url_secret_id
+
+  replication {
+    auto {}
+  }
+
+  labels = var.labels
+
+  depends_on = [google_project_service.required]
+}
+
+# Tenant container images. The provisioner deploys every tenant service from
+# this repository; the platform's own images stay in the existing superserve
+# repository.
+resource "google_artifact_registry_repository" "tenant_images" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = local.tenant_image_repository_id
+  format        = "DOCKER"
+  description   = "Hosted QM tenant images (${var.environment})."
+  labels        = var.labels
+
+  depends_on = [google_project_service.required]
+}

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -64,9 +64,19 @@ locals {
   # The prefix is shared with the IAM exclusion in iam.tf, which has to match
   # every environment's admin secret rather than just this one's: several
   # environments of this module can live in one project.
-  sql_admin_secret_prefix    = "qm-sql-admin-"
-  sql_admin_secret_id        = "${local.sql_admin_secret_prefix}${var.resource_suffix}"
-  api_database_url_secret_id = "qm-api-database-url-${var.resource_suffix}"
+  sql_admin_secret_prefix        = "qm-sql-admin-"
+  sql_admin_secret_id            = "${local.sql_admin_secret_prefix}${var.resource_suffix}"
+  api_database_url_secret_prefix = "qm-api-database-url-"
+  api_database_url_secret_id     = "${local.api_database_url_secret_prefix}${var.resource_suffix}"
+
+  # Platform secrets, as opposed to the qm-<slug>-<name> tenant secrets the
+  # broad prefix grants in iam.tf are for. Every environment's, not just this
+  # one's: both identities reach their own through an explicit secret-level
+  # binding, so the prefix grants can exclude the whole family.
+  platform_secret_prefixes = [
+    local.sql_admin_secret_prefix,
+    local.api_database_url_secret_prefix,
+  ]
 
   tenant_image_repository_id = local.name
   tenant_image_repository    = "${var.region}-docker.pkg.dev/${var.project_id}/${local.tenant_image_repository_id}"

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -43,6 +43,24 @@ locals {
   tenant_bucket_location        = coalesce(var.tenant_bucket_location, var.region)
   qm_secret_prefix              = "qm-"
 
+  # Longest slug every per-tenant name derived from the prefixes above still
+  # fits in. Terraform never fills {slug} itself, so this is exported (as an
+  # output and as QM_TENANT_SLUG_MAX_LENGTH) for the Go-side slug validator:
+  # the limits move when a prefix or the project ID does, and the provisioner
+  # should not carry its own copy of the arithmetic.
+  #   bucket           <project>-qm-<slug>  <= 63
+  #   service account  qm-<slug>            <= 30
+  #   Cloud Run        qm-<slug>            <= 49
+  #   database         qm_<slug>            <= 63
+  # The service account is usually the binding one; a long project ID makes it
+  # the bucket.
+  tenant_slug_max_length = min(
+    63 - length(local.tenant_bucket_prefix),
+    30 - length(local.tenant_service_account_prefix),
+    49 - length(local.tenant_service_account_prefix),
+    63 - length("qm_"),
+  )
+
   sql_admin_secret_id        = "qm-sql-admin-${var.resource_suffix}"
   api_database_url_secret_id = "qm-api-database-url-${var.resource_suffix}"
 
@@ -122,6 +140,16 @@ resource "google_service_networking_connection" "private_service_access" {
   deletion_policy = "ABANDON"
 
   depends_on = [google_project_service.required]
+}
+
+# A project ID long enough to squeeze the bucket prefix leaves no room for a
+# usable tenant slug, and the failure would otherwise surface as a rejected
+# bucket name during a tenant provision rather than here.
+check "tenant_slug_budget_is_usable" {
+  assert {
+    condition     = local.tenant_slug_max_length >= var.tenant_slug_min_length
+    error_message = "Per-tenant names derived from project ${var.project_id} leave only ${local.tenant_slug_max_length} characters for a tenant slug, below tenant_slug_min_length (${var.tenant_slug_min_length}). Shorten the naming prefixes or use a shorter project."
+  }
 }
 
 check "sql_max_connections_covers_tenant_capacity" {

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -126,6 +126,12 @@ resource "google_compute_global_address" "private_service_range" {
   address       = var.private_service_range_address
   network       = var.network_self_link
   labels        = var.labels
+
+  # Abandoned for the same reason as the peering below: the peering keeps
+  # holding this range after it is abandoned, and GCP refuses to delete a
+  # range an active peering still references, so a DELETE policy would wedge
+  # the destroy partway through.
+  deletion_policy = "ABANDON"
 }
 
 resource "google_service_networking_connection" "private_service_access" {

--- a/infra/modules/qm/main.tf
+++ b/infra/modules/qm/main.tf
@@ -188,6 +188,18 @@ resource "google_sql_database_instance" "tenants" {
     user_labels = var.labels
   }
 
+  # Every tenant's database lives on this one instance, so the two API-side
+  # guards above are backed by a plan-time one: prevent_destroy rejects the
+  # plan rather than failing partway through an apply. It also catches the
+  # replacement case the deletion_protection flags do not make obvious, where
+  # a changed name, region, or private_network plans destroy-then-create.
+  # Tearing the instance down is deliberately a three-step change: drop
+  # prevent_destroy, set both deletion_protection flags to false and apply,
+  # then remove the resource.
+  lifecycle {
+    prevent_destroy = true
+  }
+
   depends_on = [
     google_project_service.required,
     google_service_networking_connection.private_service_access,

--- a/infra/modules/qm/outputs.tf
+++ b/infra/modules/qm/outputs.tf
@@ -1,0 +1,159 @@
+output "contract" {
+  description = "Rendered QM shared-infrastructure contract."
+  value       = local.qm_contract
+}
+
+output "domain" {
+  description = "Base hostname tenants are served under (<slug>.<domain>)."
+  value       = var.domain
+}
+
+output "sql_instance_name" {
+  description = "Shared Cloud SQL instance name."
+  value       = google_sql_database_instance.tenants.name
+}
+
+output "sql_connection_name" {
+  description = "Cloud SQL connection name (project:region:instance)."
+  value       = google_sql_database_instance.tenants.connection_name
+}
+
+output "sql_private_ip" {
+  description = "Private IP of the shared Cloud SQL instance."
+  value       = google_sql_database_instance.tenants.private_ip_address
+}
+
+output "sql_admin_secret_id" {
+  description = "Secret Manager secret holding the instance admin password. Readable only by the provisioner."
+  value       = google_secret_manager_secret.sql_admin.secret_id
+}
+
+output "api_database_url_secret_id" {
+  description = "Secret Manager secret qm-api and the provisioner read DATABASE_URL (control-plane Postgres, qm_api role) from. Its version is added out of band."
+  value       = google_secret_manager_secret.api_database_url.secret_id
+}
+
+output "address" {
+  description = "Global external IPv4 address of the tenant load balancer."
+  value       = google_compute_global_address.edge.address
+}
+
+output "url_map_name" {
+  description = "HTTPS URL map the provisioner appends tenant host rules to."
+  value       = google_compute_url_map.https.name
+}
+
+output "https_proxy_name" {
+  description = "Target HTTPS proxy in front of the URL map."
+  value       = google_compute_target_https_proxy.this.name
+}
+
+output "redirect_backend_service_name" {
+  description = "Backend service serving the URL map default route."
+  value       = google_compute_backend_service.redirect.name
+}
+
+output "certificate_map_id" {
+  description = "Certificate Manager certificate map resource ID."
+  value       = google_certificate_manager_certificate_map.this.id
+}
+
+output "dns_authorization" {
+  description = "DNS record the domain owner must publish before the wildcard certificate can be issued. Written automatically when dns_managed_zone is set."
+  value = {
+    name        = google_certificate_manager_dns_authorization.this.name
+    record_data = local.dns_authorization_record
+  }
+}
+
+output "provisioner_service_account_email" {
+  description = "Provisioner job identity."
+  value       = google_service_account.provisioner.email
+}
+
+output "api_service_account_email" {
+  description = "qm-api runtime identity."
+  value       = google_service_account.api.email
+}
+
+output "api_service_name" {
+  description = "qm-api Cloud Run service name."
+  value       = google_cloud_run_v2_service.api.name
+}
+
+output "api_service_uri" {
+  description = "qm-api Cloud Run service URI."
+  value       = google_cloud_run_v2_service.api.uri
+}
+
+output "provisioner_job_name" {
+  description = "Provisioner Cloud Run job name."
+  value       = google_cloud_run_v2_job.provisioner.name
+}
+
+output "tenant_image_repository" {
+  description = "Artifact Registry path tenant images are pulled from."
+  value       = local.tenant_image_repository
+}
+
+output "tenant_image" {
+  description = "Tagged image the provisioner deploys for new tenant services."
+  value       = local.tenant_image
+}
+
+output "tenant_service_account_prefix" {
+  description = "Account-ID prefix of runtime-created tenant service accounts."
+  value       = local.tenant_service_account_prefix
+}
+
+output "tenant_bucket_name_pattern" {
+  description = "Bucket name pattern the provisioner fills per tenant ({slug} placeholder)."
+  value       = local.tenant_bucket_name_pattern
+}
+
+output "tenant_bucket_location" {
+  description = "Location the provisioner creates tenant buckets in."
+  value       = local.tenant_bucket_location
+}
+
+output "tenant_bucket_lifecycle_policy_json" {
+  description = "Lifecycle policy (JSON API shape) the provisioner applies to every tenant bucket."
+  value       = jsonencode(local.tenant_bucket_lifecycle_policy)
+}
+
+locals {
+  qm_contract = {
+    project_id                    = var.project_id
+    environment                   = var.environment
+    region                        = var.region
+    domain                        = var.domain
+    sql_instance_name             = google_sql_database_instance.tenants.name
+    sql_connection_name           = google_sql_database_instance.tenants.connection_name
+    sql_private_ip                = google_sql_database_instance.tenants.private_ip_address
+    sql_tier                      = var.sql_tier
+    sql_availability_type         = var.sql_availability_type
+    sql_max_connections           = var.sql_max_connections
+    tenant_capacity               = var.tenant_capacity
+    sql_admin_secret_id           = google_secret_manager_secret.sql_admin.secret_id
+    api_database_url_secret_id    = google_secret_manager_secret.api_database_url.secret_id
+    address                       = google_compute_global_address.edge.address
+    url_map_name                  = google_compute_url_map.https.name
+    https_proxy_name              = google_compute_target_https_proxy.this.name
+    redirect_backend_service_name = google_compute_backend_service.redirect.name
+    certificate_map_id            = google_certificate_manager_certificate_map.this.id
+    dns_managed_zone              = var.dns_managed_zone
+    provisioner_service_account   = google_service_account.provisioner.email
+    api_service_account           = google_service_account.api.email
+    redirect_service_account      = google_service_account.redirect.email
+    api_service_name              = google_cloud_run_v2_service.api.name
+    redirect_service_name         = google_cloud_run_v2_service.redirect.name
+    provisioner_job_name          = google_cloud_run_v2_job.provisioner.name
+    tenant_image_repository       = local.tenant_image_repository
+    tenant_image                  = local.tenant_image
+    tenant_service_account_prefix = local.tenant_service_account_prefix
+    tenant_bucket_name_pattern    = local.tenant_bucket_name_pattern
+    tenant_bucket_location        = local.tenant_bucket_location
+    tenant_bucket_lifecycle_rules = var.tenant_bucket_lifecycle_rules
+    labels                        = var.labels
+  }
+}

--- a/infra/modules/qm/outputs.tf
+++ b/infra/modules/qm/outputs.tf
@@ -111,6 +111,11 @@ output "tenant_bucket_name_pattern" {
   value       = local.tenant_bucket_name_pattern
 }
 
+output "tenant_slug_max_length" {
+  description = "Longest tenant slug every per-tenant name derived from this module's prefixes still fits in. The Go-side slug validator should enforce it rather than recompute it."
+  value       = local.tenant_slug_max_length
+}
+
 output "tenant_bucket_location" {
   description = "Location the provisioner creates tenant buckets in."
   value       = local.tenant_bucket_location
@@ -152,6 +157,7 @@ locals {
     tenant_image                  = local.tenant_image
     tenant_service_account_prefix = local.tenant_service_account_prefix
     tenant_bucket_name_pattern    = local.tenant_bucket_name_pattern
+    tenant_slug_max_length        = local.tenant_slug_max_length
     tenant_bucket_location        = local.tenant_bucket_location
     tenant_bucket_lifecycle_rules = var.tenant_bucket_lifecycle_rules
     labels                        = var.labels

--- a/infra/modules/qm/run.tf
+++ b/infra/modules/qm/run.tf
@@ -1,0 +1,315 @@
+# Cloud Run workloads. Shapes follow the api module: Direct VPC egress, image
+# and label drift owned by deploy tooling, secrets mounted as env from Secret
+# Manager. Names are locals rather than resource references because the job
+# and service both carry the full QM_* set, including their own names.
+locals {
+  api_service_name      = coalesce(var.api_service_name, "superserve-qm-api-${var.resource_suffix}")
+  redirect_service_name = coalesce(var.redirect_service_name, "qm-redirect-${var.resource_suffix}")
+  provisioner_job_name  = var.provisioner_job_name
+  provisioner_image     = coalesce(var.provisioner_image, var.api_image)
+
+  tenant_image = coalesce(var.tenant_image, "${local.tenant_image_repository}/qm:latest")
+
+  # Everything qm-api and the provisioner need to find the shared pieces.
+  # Both get the same map so a tenant provisioned by the job and one
+  # inspected by the API agree on names. GCP_PROJECT, QM_BASE_DOMAIN,
+  # QM_PROVISIONER_JOB, QM_PROVISIONER_REGION and QM_TENANT_IMAGE are what
+  # internal/qm.LoadConfig reads today; the rest is for the step clients
+  # behind internal/qm/provisioner/steps as they land.
+  runtime_env = {
+    GCP_PROJECT                      = var.project_id
+    QM_BASE_DOMAIN                   = var.domain
+    QM_PROVISIONER_REGION            = var.region
+    QM_ENVIRONMENT                   = var.environment
+    QM_VPC_NETWORK                   = var.vpc_network
+    QM_VPC_SUBNETWORK                = var.vpc_subnetwork
+    QM_SQL_INSTANCE                  = google_sql_database_instance.tenants.name
+    QM_SQL_CONNECTION_NAME           = google_sql_database_instance.tenants.connection_name
+    QM_SQL_PRIVATE_IP                = google_sql_database_instance.tenants.private_ip_address
+    QM_SQL_ADMIN_USER                = var.sql_admin_user
+    QM_SQL_ADMIN_SECRET              = google_secret_manager_secret.sql_admin.secret_id
+    QM_LB_ADDRESS                    = google_compute_global_address.edge.address
+    QM_LB_URL_MAP                    = google_compute_url_map.https.name
+    QM_LB_HTTPS_PROXY                = google_compute_target_https_proxy.this.name
+    QM_LB_REDIRECT_BACKEND           = google_compute_backend_service.redirect.name
+    QM_CERTIFICATE_MAP               = google_certificate_manager_certificate_map.this.name
+    QM_PROVISIONER_JOB               = local.provisioner_job_name
+    QM_PROVISIONER_SERVICE_ACCOUNT   = google_service_account.provisioner.email
+    QM_TENANT_SERVICE_ACCOUNT_PREFIX = local.tenant_service_account_prefix
+    QM_TENANT_BUCKET_NAME_PATTERN    = local.tenant_bucket_name_pattern
+    QM_TENANT_BUCKET_LOCATION        = local.tenant_bucket_location
+    QM_TENANT_BUCKET_LIFECYCLE_JSON  = jsonencode(local.tenant_bucket_lifecycle_policy)
+    QM_TENANT_IMAGE_REPOSITORY       = local.tenant_image_repository
+    QM_TENANT_IMAGE                  = local.tenant_image
+  }
+
+  api_env         = merge(local.runtime_env, var.api_env)
+  provisioner_env = merge(local.runtime_env, var.provisioner_env)
+
+  # The tenant registry lives in the control-plane Postgres, and both the
+  # API and the provisioner (which records what it created) connect to it as
+  # qm_api. The instance admin credentials are separate and provisioner-only.
+  database_url_secret = {
+    DATABASE_URL = {
+      secret  = google_secret_manager_secret.api_database_url.secret_id
+      version = "latest"
+    }
+  }
+
+  api_secrets         = merge(local.database_url_secret, var.api_secrets)
+  provisioner_secrets = local.database_url_secret
+}
+
+resource "google_cloud_run_v2_service" "api" {
+  project             = var.project_id
+  name                = local.api_service_name
+  location            = var.region
+  ingress             = var.api_ingress
+  deletion_protection = true
+
+  template {
+    service_account = google_service_account.api.email
+    timeout         = "300s"
+
+    scaling {
+      min_instance_count = var.api_min_instances
+      max_instance_count = var.api_max_instances
+    }
+
+    vpc_access {
+      egress = var.vpc_egress
+
+      network_interfaces {
+        network    = var.vpc_network
+        subnetwork = var.vpc_subnetwork
+        tags       = var.vpc_tags
+      }
+    }
+
+    containers {
+      image = var.api_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = var.api_cpu_limit
+          memory = var.api_memory_limit
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.api_env
+
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = local.api_secrets
+
+        content {
+          name = env.key
+
+          value_source {
+            secret_key_ref {
+              secret  = env.value.secret
+              version = env.value.version
+            }
+          }
+        }
+      }
+    }
+
+    labels = var.labels
+  }
+
+  labels = var.labels
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      labels,
+      template[0].containers[0].image,
+      traffic,
+    ]
+  }
+
+  depends_on = [
+    google_project_service.required,
+    google_secret_manager_secret_iam_member.api_database_url,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "api_public_invoker" {
+  count = var.api_allow_public_invoker ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# Default backend of the tenant load balancer: 302s /<slug> to
+# https://<slug>.<domain> and / to the marketing page. Reachable only through
+# the load balancer, which forwards as allUsers.
+resource "google_cloud_run_v2_service" "redirect" {
+  project             = var.project_id
+  name                = local.redirect_service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  deletion_protection = false
+
+  template {
+    service_account = google_service_account.redirect.email
+    timeout         = "30s"
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 3
+    }
+
+    containers {
+      image = var.redirect_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+      }
+
+      dynamic "env" {
+        for_each = merge({
+          QM_BASE_DOMAIN   = var.domain
+          QM_MARKETING_URL = var.marketing_url
+        }, var.redirect_env)
+
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+
+    labels = var.labels
+  }
+
+  labels = var.labels
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      labels,
+      template[0].containers[0].image,
+      traffic,
+    ]
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "redirect_public_invoker" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.redirect.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# The provisioner runs as a job rather than inside qm-api so tenant creation
+# (minutes of Cloud SQL, Cloud Run, and load balancer operations) survives API
+# deploys, and so the broad provisioning grants sit on an identity that
+# serves no request traffic. qm-api triggers executions with run.jobs.run.
+resource "google_cloud_run_v2_job" "provisioner" {
+  project             = var.project_id
+  name                = local.provisioner_job_name
+  location            = var.region
+  deletion_protection = false
+
+  template {
+    task_count  = 1
+    parallelism = 1
+    labels      = var.labels
+
+    template {
+      service_account = google_service_account.provisioner.email
+      timeout         = "${var.provisioner_timeout_seconds}s"
+      # Provisioning is not idempotent across a blind retry; qm-api decides
+      # whether to re-run a failed execution.
+      max_retries = 0
+
+      vpc_access {
+        egress = var.vpc_egress
+
+        network_interfaces {
+          network    = var.vpc_network
+          subnetwork = var.vpc_subnetwork
+          tags       = var.vpc_tags
+        }
+      }
+
+      containers {
+        image = local.provisioner_image
+
+        resources {
+          limits = {
+            cpu    = var.provisioner_cpu_limit
+            memory = var.provisioner_memory_limit
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.provisioner_env
+
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+
+        dynamic "env" {
+          for_each = local.provisioner_secrets
+
+          content {
+            name = env.key
+
+            value_source {
+              secret_key_ref {
+                secret  = env.value.secret
+                version = env.value.version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  labels = var.labels
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      labels,
+      template[0].template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [
+    google_project_service.required,
+    google_secret_manager_secret_iam_member.provisioner_database_url,
+  ]
+}

--- a/infra/modules/qm/run.tf
+++ b/infra/modules/qm/run.tf
@@ -208,12 +208,14 @@ resource "google_cloud_run_v2_service" "redirect" {
 
   labels = var.labels
 
+  # Unlike qm-api and the provisioner job, nothing in deploy tooling updates
+  # the redirect service, so Terraform owns its image: ignoring image drift
+  # here would pin the first revision forever with no way to roll a fix out.
   lifecycle {
     ignore_changes = [
       client,
       client_version,
       labels,
-      template[0].containers[0].image,
       traffic,
     ]
   }

--- a/infra/modules/qm/run.tf
+++ b/infra/modules/qm/run.tf
@@ -37,6 +37,7 @@ locals {
     QM_PROVISIONER_SERVICE_ACCOUNT   = google_service_account.provisioner.email
     QM_TENANT_SERVICE_ACCOUNT_PREFIX = local.tenant_service_account_prefix
     QM_TENANT_BUCKET_NAME_PATTERN    = local.tenant_bucket_name_pattern
+    QM_TENANT_SLUG_MAX_LENGTH        = tostring(local.tenant_slug_max_length)
     QM_TENANT_BUCKET_LOCATION        = local.tenant_bucket_location
     QM_TENANT_BUCKET_LIFECYCLE_JSON  = jsonencode(local.tenant_bucket_lifecycle_policy)
     QM_TENANT_IMAGE_REPOSITORY       = local.tenant_image_repository
@@ -65,7 +66,7 @@ resource "google_cloud_run_v2_service" "api" {
   name                = local.api_service_name
   location            = var.region
   ingress             = var.api_ingress
-  deletion_protection = true
+  deletion_protection = var.api_deletion_protection
 
   template {
     service_account = google_service_account.api.email

--- a/infra/modules/qm/variables.tf
+++ b/infra/modules/qm/variables.tf
@@ -193,6 +193,12 @@ variable "tenant_bucket_lifecycle_rules" {
   ]
 }
 
+variable "tenant_slug_min_length" {
+  description = "Shortest tenant-slug budget the derived per-tenant names must still allow. Only used by the tenant_slug_budget_is_usable check, which catches naming prefixes or a project ID long enough to leave no usable slug."
+  type        = number
+  default     = 16
+}
+
 variable "tenant_image" {
   description = "Tagged image the provisioner deploys for every new tenant service (QM_TENANT_IMAGE). Null uses <tenant_image_repository>/qm:latest. Per-tenant pinning is the provisioner's concern; this is the fleet default."
   type        = string
@@ -220,6 +226,12 @@ variable "redirect_service_name" {
 variable "api_image" {
   description = "qm-api container image. Must exist before the first apply: Cloud Run rejects a revision whose image cannot be pulled. Later image rollouts are owned by deploy tooling and ignored by Terraform."
   type        = string
+}
+
+variable "api_deletion_protection" {
+  description = "Cloud Run deletion protection on qm-api. On by default; set false as the first step of tearing an environment down, otherwise removing the module (or setting enable_qm back to false) fails on the service delete."
+  type        = bool
+  default     = true
 }
 
 variable "api_min_instances" {

--- a/infra/modules/qm/variables.tf
+++ b/infra/modules/qm/variables.tf
@@ -29,12 +29,8 @@ variable "service_account_suffix" {
 }
 
 variable "domain" {
-  description = "Base hostname for tenant stacks: each tenant is served at https://<slug>.<domain>, so pass qm.<env-domain>. The wildcard certificate, certificate map, and DNS authorization are all derived from it."
+  description = "Base hostname for tenant stacks: each tenant is served at https://<slug>.<domain>, so pass qm.<env-domain>. The wildcard certificate, certificate map, and DNS authorization are all derived from it. Required, but may be passed as null by a root whose enable_qm flag is off."
   type        = string
-  # Rejected at the module boundary rather than as an interpolation error
-  # several resources deep: the root's qm_domain defaults to null, so enabling
-  # the module without setting it is the likely mistake.
-  nullable = false
 }
 
 variable "marketing_url" {

--- a/infra/modules/qm/variables.tf
+++ b/infra/modules/qm/variables.tf
@@ -1,0 +1,335 @@
+variable "project_id" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name."
+  type        = string
+}
+
+variable "region" {
+  description = "Region for the Cloud SQL instance, Cloud Run services, the provisioner job, and the tenant image repository."
+  type        = string
+}
+
+variable "resource_suffix" {
+  description = "Project-global naming suffix shared with the rest of the environment (e.g. staging-usc1)."
+  type        = string
+}
+
+variable "service_account_suffix" {
+  description = "Service-account naming suffix. Keep it short: account IDs are capped at 30 characters and the longest prefix here is qm-provisioner-."
+  type        = string
+
+  validation {
+    condition     = length("qm-provisioner-${var.service_account_suffix}") <= 30
+    error_message = "service_account_suffix is too long: qm-provisioner-<suffix> must be at most 30 characters."
+  }
+}
+
+variable "domain" {
+  description = "Base hostname for tenant stacks: each tenant is served at https://<slug>.<domain>, so pass qm.<env-domain>. The wildcard certificate, certificate map, and DNS authorization are all derived from it."
+  type        = string
+}
+
+variable "marketing_url" {
+  description = "Absolute URL the redirect service sends a bare request for / to."
+  type        = string
+}
+
+variable "network_self_link" {
+  description = "Self link of the VPC the Cloud SQL private IP is attached to (the environment's existing VPC)."
+  type        = string
+}
+
+variable "vpc_network" {
+  description = "VPC name for Cloud Run Direct VPC egress on the qm-api service and the provisioner job."
+  type        = string
+}
+
+variable "vpc_subnetwork" {
+  description = "Subnetwork name for Cloud Run Direct VPC egress. Must be in var.region and on var.vpc_network."
+  type        = string
+}
+
+variable "vpc_tags" {
+  description = "Network tags applied to Direct VPC egress traffic so firewall rules can select it."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_egress" {
+  description = "Cloud Run VPC egress mode. PRIVATE_RANGES_ONLY sends only RFC 1918 traffic (the Cloud SQL private IP) through the VPC; Google APIs stay on their public path."
+  type        = string
+  default     = "PRIVATE_RANGES_ONLY"
+}
+
+variable "create_private_service_connection" {
+  description = "Whether to allocate a Private Service Access range and create the servicenetworking peering on var.network_self_link. Set false when the VPC already has a servicenetworking connection: creating a second one fails, and updating the existing one from here would replace its reserved-range list. In that case add the QM range to the existing connection out of band."
+  type        = bool
+  default     = true
+}
+
+variable "private_service_range_prefix_length" {
+  description = "Prefix length of the Private Service Access range allocated for Cloud SQL. Google recommends at least /24 per instance; /20 leaves room for read replicas and future instances on the same peering."
+  type        = number
+  default     = 20
+}
+
+variable "private_service_range_address" {
+  description = "Optional fixed first address for the Private Service Access range. Null lets Google pick a free block in the VPC."
+  type        = string
+  default     = null
+}
+
+variable "sql_database_version" {
+  description = "Cloud SQL engine version for the shared tenant instance."
+  type        = string
+  default     = "POSTGRES_16"
+}
+
+variable "sql_tier" {
+  description = "Cloud SQL machine tier. db-custom-2-7680 (2 vCPU / 7.5 GiB) carries the default max_connections comfortably; raise it together with tenant_capacity."
+  type        = string
+  default     = "db-custom-2-7680"
+}
+
+variable "sql_availability_type" {
+  description = "ZONAL or REGIONAL. Production should run REGIONAL (synchronous standby in a second zone)."
+  type        = string
+  default     = "ZONAL"
+
+  validation {
+    condition     = contains(["ZONAL", "REGIONAL"], var.sql_availability_type)
+    error_message = "sql_availability_type must be ZONAL or REGIONAL."
+  }
+}
+
+variable "sql_disk_size_gb" {
+  description = "Initial data disk size in GiB. Autoresize is on, so this is a floor."
+  type        = number
+  default     = 20
+}
+
+variable "tenant_capacity" {
+  description = "Number of tenant stacks this shared instance is sized for. Drives the max_connections sizing check and is the number to raise the project's service-account quota to (plus platform accounts): every tenant gets its own qm-<slug> service account at runtime."
+  type        = number
+  default     = 25
+}
+
+variable "sql_connections_per_tenant" {
+  description = "Postgres connections one tenant's QM container holds at steady state (its pool plus workers)."
+  type        = number
+  default     = 17
+}
+
+variable "sql_connection_headroom" {
+  description = "Multiplier applied to tenant_capacity x sql_connections_per_tenant to leave room for qm-api, the provisioner, migrations, and operator sessions."
+  type        = number
+  default     = 1.3
+}
+
+variable "sql_max_connections" {
+  description = "Value of the Postgres max_connections flag. Sized as tenant_capacity x sql_connections_per_tenant x sql_connection_headroom = 25 x 17 x 1.3 = 552.5, rounded up to 560. A check block warns when the flag no longer covers the configured capacity."
+  type        = number
+  default     = 560
+}
+
+variable "sql_backup_start_time" {
+  description = "Daily automated backup window start (HH:MM, UTC)."
+  type        = string
+  default     = "03:00"
+}
+
+variable "sql_backup_retained_count" {
+  description = "Number of daily automated backups retained."
+  type        = number
+  default     = 14
+}
+
+variable "sql_transaction_log_retention_days" {
+  description = "Days of write-ahead log kept for point-in-time recovery (1-7 for Postgres)."
+  type        = number
+  default     = 7
+}
+
+variable "sql_admin_user" {
+  description = "Name of the instance-level admin role the provisioner connects as to create tenant databases and roles."
+  type        = string
+  default     = "qm_admin"
+}
+
+variable "tenant_bucket_location" {
+  description = "Location the provisioner creates tenant buckets in. Null uses var.region."
+  type        = string
+  default     = null
+}
+
+variable "tenant_bucket_lifecycle_rules" {
+  description = "Lifecycle rules the provisioner applies to every tenant bucket, rendered to the JSON API lifecycle shape (tenant_bucket_lifecycle_policy_json output). Defaults reap abandoned multipart uploads and bound versioning growth."
+  type = list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                        = optional(number)
+      days_since_noncurrent_time = optional(number)
+      num_newer_versions         = optional(number)
+      matches_prefix             = optional(list(string))
+      matches_storage_class      = optional(list(string))
+    })
+  }))
+  default = [
+    {
+      action    = { type = "AbortIncompleteMultipartUpload" }
+      condition = { age = 7 }
+    },
+    {
+      action    = { type = "Delete" }
+      condition = { days_since_noncurrent_time = 30 }
+    },
+  ]
+}
+
+variable "tenant_image" {
+  description = "Tagged image the provisioner deploys for every new tenant service (QM_TENANT_IMAGE). Null uses <tenant_image_repository>/qm:latest. Per-tenant pinning is the provisioner's concern; this is the fleet default."
+  type        = string
+  default     = null
+}
+
+variable "api_service_name" {
+  description = "qm-api Cloud Run service name. Null uses superserve-qm-api-<resource_suffix>; the deploy workflow reads the same name from its QM_API_SERVICE variable."
+  type        = string
+  default     = null
+}
+
+variable "provisioner_job_name" {
+  description = "Provisioner Cloud Run job name. qm-api's QM_PROVISIONER_JOB and the deploy workflow both default to qm-provisioner; jobs are regional, so the name is not suffixed."
+  type        = string
+  default     = "qm-provisioner"
+}
+
+variable "redirect_service_name" {
+  description = "qm-redirect Cloud Run service name. Null uses qm-redirect-<resource_suffix>."
+  type        = string
+  default     = null
+}
+
+variable "api_image" {
+  description = "qm-api container image. Must exist before the first apply: Cloud Run rejects a revision whose image cannot be pulled. Later image rollouts are owned by deploy tooling and ignored by Terraform."
+  type        = string
+}
+
+variable "api_min_instances" {
+  description = "qm-api minimum instance count."
+  type        = number
+  default     = 0
+}
+
+variable "api_max_instances" {
+  description = "qm-api maximum instance count."
+  type        = number
+  default     = 10
+}
+
+variable "api_cpu_limit" {
+  type    = string
+  default = "1"
+}
+
+variable "api_memory_limit" {
+  type    = string
+  default = "512Mi"
+}
+
+variable "api_ingress" {
+  description = "qm-api ingress setting."
+  type        = string
+  default     = "INGRESS_TRAFFIC_ALL"
+}
+
+variable "api_allow_public_invoker" {
+  description = "Grant allUsers roles/run.invoker on qm-api. Off by default: unlike the sandbox API, nothing fronts qm-api with a load balancer yet, so callers authenticate to Cloud Run with their own identity until the public ingress path is decided."
+  type        = bool
+  default     = false
+}
+
+variable "api_env" {
+  description = "Extra plaintext environment variables for qm-api, merged over the module-derived QM_* set (caller wins)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "api_secrets" {
+  description = "Extra secret-backed environment variables for qm-api keyed by env var name. The runtime SA must already be able to read them; the module only grants qm-* secrets."
+  type = map(object({
+    secret  = string
+    version = optional(string, "latest")
+  }))
+  default = {}
+}
+
+variable "provisioner_image" {
+  description = "Provisioner job container image. Null uses api_image: the service and the job are the same qm-api binary and are deployed together."
+  type        = string
+  default     = null
+}
+
+variable "provisioner_timeout_seconds" {
+  description = "Per-task timeout for a provisioner execution. A tenant provision waits on Cloud SQL, Cloud Run, and load balancer operations, so this is generous."
+  type        = number
+  default     = 1800
+}
+
+variable "provisioner_cpu_limit" {
+  type    = string
+  default = "1"
+}
+
+variable "provisioner_memory_limit" {
+  type    = string
+  default = "512Mi"
+}
+
+variable "provisioner_env" {
+  description = "Extra plaintext environment variables for the provisioner job, merged over the module-derived QM_* set (caller wins)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "redirect_image" {
+  description = "qm-redirect container image (302s /<slug> to https://<slug>.<domain> and / to marketing_url). Same existence requirement as api_image."
+  type        = string
+}
+
+variable "redirect_env" {
+  description = "Extra plaintext environment variables for the redirect service."
+  type        = map(string)
+  default     = {}
+}
+
+variable "backend_timeout_sec" {
+  description = "Backend timeout for the redirect backend service."
+  type        = number
+  default     = 30
+}
+
+variable "dns_managed_zone" {
+  description = "Optional Cloud DNS managed zone name (in var.project_id) that owns var.domain. When set, the module writes the certificate DNS-authorization CNAME plus A records for <domain> and *.<domain> pointing at the load balancer. Null leaves DNS to whoever owns the zone; the records to create are in the dns_authorization and address outputs."
+  type        = string
+  default     = null
+}
+
+variable "dns_ttl" {
+  description = "TTL for managed DNS records."
+  type        = number
+  default     = 300
+}
+
+variable "labels" {
+  description = "Labels applied to every resource that supports them."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/qm/variables.tf
+++ b/infra/modules/qm/variables.tf
@@ -31,6 +31,10 @@ variable "service_account_suffix" {
 variable "domain" {
   description = "Base hostname for tenant stacks: each tenant is served at https://<slug>.<domain>, so pass qm.<env-domain>. The wildcard certificate, certificate map, and DNS authorization are all derived from it."
   type        = string
+  # Rejected at the module boundary rather than as an interpolation error
+  # several resources deep: the root's qm_domain defaults to null, so enabling
+  # the module without setting it is the likely mistake.
+  nullable = false
 }
 
 variable "marketing_url" {


### PR DESCRIPTION
## Summary
Adds `infra/modules/qm`, the shared, tenant-independent infrastructure for hosted QM, and wires it into the staging root behind `enable_qm` (default off, so the staging plan stays a no-op). Per-tenant resources are created at runtime by the provisioner job, not by Terraform; this module owns everything a tenant service depends on.

## What the module creates
- Cloud SQL Postgres 16 (private IP on the environment VPC, PITR, deletion protection) plus its admin role and Secret Manager secrets for the admin password and the control-plane `DATABASE_URL`.
- Wildcard edge: DNS authorization, managed certificate for the apex and wildcard, certificate map, global HTTPS load balancer with the redirect service as its default route, and the `:80` to `:443` redirect. `host_rule` and `path_matcher` drift is ignored so applies never strip provisioner-added tenant routes.
- The qm-api Cloud Run service, the provisioner Cloud Run job, the redirect service, their service accounts, and an Artifact Registry repository for tenant images.

## Technical decisions
- Secret Manager bindings are project-level with `resource.name.startsWith` conditions on the `qm-` prefix, minus every environment's platform secrets (`qm-sql-admin-*`, `qm-api-database-url-*`) — both identities reach their own through explicit secret-level bindings, so excluding the whole family costs nothing and keeps two environments in one project from reading each other's credentials. Permissions that cannot be conditioned (secret create) live in tiny custom roles.
- The provisioner manages tenant databases through the SQL Admin API, so it gets a custom role limited to database and user CRUD rather than a broad Cloud SQL role. It also needs `run.jobsExecutorWithOverrides` and subnet-scoped `compute.networkUser` for Direct VPC egress on tenant services.
- The shared instance carries three independent destroy guards: `deletion_protection`, `deletion_protection_enabled`, and `prevent_destroy`. The third is what catches a *replacement* — a changed suffix, region, or private network plans destroy-then-create, which the first two do not make obvious at plan time. Teardown is deliberately a staged edit; the README has the order.
- Private Service Access is created by default and can be disabled where the VPC already has a servicenetworking peering, because updating an existing peering from Terraform would replace its range list. The reserved range is abandoned along with the peering, since GCP refuses to delete a range an active peering still holds.
- Terraform owns the redirect service's image (nothing in deploy tooling updates it) but ignores image drift on qm-api and the provisioner job, which the qm-api deploy workflow rolls together.
- Env names and tenant naming follow `internal/qm` and the provisioner steps so Terraform serves the code as written. The module exports the derived tenant slug length budget rather than leaving the Go side to recompute it. The README lists the reserved slugs, the one-environment-per-project constraint, and the first-apply ordering (images, secret versions, certificate DNS).

## Testing
- `terraform fmt -check -recursive infra/` clean; `scripts/terraform-validate.sh` passes for all four roots.
- Real read-only plan of the staging root against live state: zero `module.qm` resources, confirming `enable_qm = false` gates the module completely.
- The module planned standalone against the staging project with every input set: 62 to add, no errors, every attribute accepted by the provider.
- Local Codex review iterated to two consecutive passes with no findings.

## Note on CI
`terraform-plan (staging-us-central1)` is red for a reason that predates this branch and is not caused by it — the same failure reproduces on other open infra PRs. Staging state was written by a newer google provider than the lockfile pins, and the root also carries drift from out-of-band applies (a sandbox host that now plans as a replacement, plus CA and VMD resources in state with no config). Reproduced locally: bumping the provider clears the version error and then fails on the host replacement, so it needs its own change rather than being folded in here.


## Tenant runtime configuration (added later on this branch)

The module now also owns everything a provisioned tenant is configured with, so a deploy supplies none of it out of band and there is no second owner to fight the next apply (this module does not ignore environment drift on the service or job):

- `QM_RESEND_SECRET` — an empty `qm-resend-<suffix>` secret, the platform's one Resend key for the whole fleet. The provisioner holds a three-permission role on it (`secrets.get`, `getIamPolicy`, `setIamPolicy`): enough to grant and revoke tenant access, not enough to read the key or delete it. Both identities are excluded from it by exact name *and* from its `/versions/` subtree — a version's access check is evaluated against the version's own resource name, so an inequality on the secret alone is true for exactly the operation that reads the key. By name rather than prefix because a `qm-resend-` prefix would also swallow the secrets of a tenant slugged `resend`. No override: every tenant mounts this one by name, so a second supported location means an apply that moves the name can delete a secret the fleet is still reading. Rotation is a new version.
- `QM_EMAIL_FROM` — default `QM <no-reply@mail.qm.superserve.ai>`. Not derived from `var.domain`: the verified sending domain belongs to the Resend account, not to an environment, so staging and production share it.
- `QM_SANDBOX_API_URL` — no default; the staging root supplies `https://api-staging.superserve.ai`. The only one that genuinely differs per environment, because the sandbox key the provisioner issues a tenant is bound to the cell that issued it.
- `QM_SANDBOX_TEMPLATE` — default `qm-agent-0.1.0`.
- `QM_SANDBOX_KEY_REGION` — optional; null leaves issued keys untagged, which is today's behaviour. Added because it was the one qm-api setting reachable only by hand-editing the Cloud Run service, which this module would then silently revert.

Plus the storage HMAC-key role the provisioner needs: QM reaches its bucket through an S3 client, so every tenant gets an interoperability key. Without it, every real provision 403s at the bucket step *after* its secrets, identity and database already exist.

The apply order was also corrected: the unqualified apply used to come before the `DATABASE_URL` version existed, and both workloads mount it at `latest`, so that apply could not bring up a revision. The secret bootstrap is now its own step ahead of it.

### CI position — this PR is not green

`terraform-plan (staging-us-central1)` is **red**, and was already red on `ff7dc89a` before these commits. The plan is byte-identical on both — `Plan: 0 to add, 5 to change, 18 to destroy` — and the destroys are unrelated vmd peer / host2 / peer-CA drift; `module.qm` appears nowhere in either failure log. That identity is also the confirmation that `enable_qm = false` still plans empty.

`Terraform Fmt` and `Terraform Validate` pass. Variable validations were exercised against a real `terraform plan` (11 accept/reject cases). Local `codex exec review` clean over the whole change.

A fresh environment still needs a human for: a version on `qm-resend-<suffix>` and on `qm-api-database-url-<suffix>`, the certificate DNS authorization CNAME and the apex/wildcard A records, image tags that exist, and a service-account quota increase before scale.
